### PR TITLE
[Agent Loop] Prevent blocked actions across steps

### DIFF
--- a/front-api/lib/api/assistant/conversation/resolve_authentication.ts
+++ b/front-api/lib/api/assistant/conversation/resolve_authentication.ts
@@ -57,6 +57,14 @@ export function makeResolveAuthenticationApp(
               message: result.error.message,
             },
           });
+        case "invalid_request_error":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: result.error.message,
+            },
+          });
         case "action_not_found":
           return apiError(ctx, {
             status_code: 404,

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -2328,7 +2328,7 @@
             }
           },
           "400": {
-            "description": "Invalid request body"
+            "description": "Invalid request or action state"
           },
           "404": {
             "description": "Conversation, message, or workspace not found"

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/answer-question.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/answer-question.ts
@@ -143,6 +143,14 @@ app.post(
               message: result.error.message,
             },
           });
+        case "invalid_request_error":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: result.error.message,
+            },
+          });
         case "action_not_found":
           return apiError(ctx, {
             status_code: 404,

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -75,7 +75,7 @@ app.use("*", streamingTag);
  *                 success:
  *                   type: boolean
  *       400:
- *         description: Invalid request body
+ *         description: Invalid request or action state
  *       404:
  *         description: Conversation, message, or workspace not found
  *       500:
@@ -113,6 +113,14 @@ app.post(
 
     if (result.isErr()) {
       switch (result.error.code) {
+        case "invalid_request_error":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: result.error.message,
+            },
+          });
         case "action_not_blocked":
           return apiError(ctx, {
             status_code: 400,

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
@@ -93,6 +93,7 @@ app.post(
 
     const result = await createSandboxChildAction(auth, {
       parentActionId: claims.actionId,
+      execId: claims.execId,
       agentId: claims.aId,
       agentVersion: claims.aV,
       conversationId: claims.cId,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/answer-question.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/answer-question.ts
@@ -65,6 +65,14 @@ app.post(
               message: result.error.message,
             },
           });
+        case "invalid_request_error":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: result.error.message,
+            },
+          });
         case "action_not_found":
           return apiError(ctx, {
             status_code: 404,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.test.ts
@@ -1,0 +1,88 @@
+import { DustError } from "@app/lib/error";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { Err } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { validateActionMock } = vi.hoisted(() => ({
+  validateActionMock: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/assistant/conversation/validate_actions", () => ({
+  validateAction: validateActionMock,
+}));
+
+const ERROR_MESSAGE =
+  "This generation cannot resume because its pending actions belong to different steps. " +
+  "Cancel it and retry.";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(ConversationResource, "fetchById").mockResolvedValue(
+    {} as ConversationResource
+  );
+  validateActionMock.mockResolvedValue(
+    new Err(new DustError("invalid_request_error", ERROR_MESSAGE))
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("POST validate-action", () => {
+  it("returns the multi-step error from the private endpoint", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+    });
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/assistant/conversations/conversation/messages/message/validate-action`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          actionId: "action",
+          approved: "approved",
+        }),
+      }
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: ERROR_MESSAGE,
+      },
+    });
+  });
+
+  it("returns the multi-step error from the public endpoint", async () => {
+    const { workspace, key } = await createPublicApiMockRequest();
+
+    const response = await honoApp.request(
+      `/api/v1/w/${workspace.sId}/assistant/conversations/conversation/messages/message/validate-action`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${key.secret}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          actionId: "action",
+          approved: "approved",
+        }),
+      }
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: ERROR_MESSAGE,
+      },
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -48,6 +48,14 @@ app.post(
 
     if (result.isErr()) {
       switch (result.error.code) {
+        case "invalid_request_error":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: result.error.message,
+            },
+          });
         case "action_not_blocked":
           return apiError(ctx, {
             status_code: 400,

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -51,7 +51,6 @@ export function MCPToolValidationRequired({
     });
 
     if (!result.success) {
-      setErrorMessage("Failed to assess action approval. Please try again.");
       return false;
     }
     removeCompletedAction(blockedAction.actionId);

--- a/front/hooks/useAnswerUserQuestion.ts
+++ b/front/hooks/useAnswerUserQuestion.ts
@@ -48,7 +48,11 @@ export function useAnswerUserQuestion({ owner }: UseAnswerUserQuestionParams) {
         if (isAPIErrorResponse(e) && e.error.type === "action_not_blocked") {
           return { success: true };
         }
-        setErrorMessage("Failed to submit answer. Please try again.");
+        setErrorMessage(
+          isAPIErrorResponse(e) && e.error.type === "invalid_request_error"
+            ? e.error.message
+            : "Failed to submit answer. Please try again."
+        );
         return { success: false };
       } finally {
         setIsSubmitting(false);

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -33,6 +33,7 @@ import {
   extensionsForContentType,
   isSupportedFileContentType,
 } from "@app/types/files";
+import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
 import {
@@ -43,6 +44,20 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
 import { extname } from "path";
 import type { Logger } from "pino";
+
+type ToolResultArgs = {
+  localLogger: Logger;
+  toolCallResultContent: CallToolResult["content"];
+  toolContext: ToolContext;
+};
+
+export type PreparedToolResults = {
+  preparedOutputItems: Array<{
+    content: CallToolResult["content"][number];
+    fileId?: ModelId;
+  }>;
+  generatedFiles: ActionGeneratedFileType[];
+};
 
 /**
  * Recursively sanitizes all string values in an object by removing null bytes and lone surrogates.
@@ -179,21 +194,10 @@ export async function processToolNotification(
  * sandbox function invocation.
  * Returns the processed content and generated files.
  */
-export async function processToolResults(
+export async function prepareToolResults(
   auth: Authenticator,
-  {
-    localLogger,
-    toolCallResultContent,
-    toolContext,
-  }: {
-    localLogger: Logger;
-    toolCallResultContent: CallToolResult["content"];
-    toolContext: ToolContext;
-  }
-): Promise<{
-  outputItems: ToolOutputItemType[];
-  generatedFiles: ActionGeneratedFileType[];
-}> {
+  { localLogger, toolCallResultContent, toolContext }: ToolResultArgs
+): Promise<PreparedToolResults> {
   const { runContext } = toolContext;
   assert(runContext, "processToolResults requires a tool run context.");
   const { toolConfiguration } = runContext;
@@ -499,22 +503,52 @@ export async function processToolResults(
     })
   );
 
-  // Persist the processed contents on the run context's action: per-item rows for agent loop
-  // actions, a single output object for sandbox function actions.
-  const outputRes = await runContext.action.createOutputItems(
-    auth,
-    cleanContent.map((c) => ({
+  return {
+    preparedOutputItems: cleanContent.map((c) => ({
       content: sanitizeStringsDeep(c.content),
       fileId: c.file?.id,
-    }))
-  );
+    })),
+    generatedFiles,
+  };
+}
 
-  // Surfaced as an exception: there is no acceptable degraded state for unpersisted tool outputs.
+export async function persistToolResults(
+  auth: Authenticator,
+  {
+    preparedOutputItems,
+    toolContext,
+  }: Pick<PreparedToolResults, "preparedOutputItems"> & {
+    toolContext: ToolContext;
+  }
+): Promise<ToolOutputItemType[]> {
+  const { runContext } = toolContext;
+  assert(runContext, "persistToolResults requires a tool run context.");
+  const outputRes = await runContext.action.createOutputItems(
+    auth,
+    preparedOutputItems
+  );
   if (outputRes.isErr()) {
     throw outputRes.error;
   }
+  return outputRes.value;
+}
 
-  return { outputItems: outputRes.value, generatedFiles };
+export async function processToolResults(
+  auth: Authenticator,
+  args: ToolResultArgs
+): Promise<{
+  outputItems: ToolOutputItemType[];
+  generatedFiles: ActionGeneratedFileType[];
+}> {
+  const { preparedOutputItems, generatedFiles } = await prepareToolResults(
+    auth,
+    args
+  );
+  const outputItems = await persistToolResults(auth, {
+    preparedOutputItems,
+    toolContext: args.toolContext,
+  });
+  return { outputItems, generatedFiles };
 }
 
 /**

--- a/front/lib/actions/mcp_internal_actions/exit_events.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentLoopToolEarlyExitEvent,
   MCPApproveExecutionEvent,
   ToolAskUserQuestionEvent,
   ToolEarlyExitEvent,
@@ -6,7 +7,7 @@ import type {
   ToolPausedEvent,
   ToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
-import type { ToolContext } from "@app/lib/actions/types";
+import type { AgentLoopRunContext, ToolContext } from "@app/lib/actions/types";
 import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import { pauseSandboxBashForBlockedChild } from "@app/lib/api/sandbox/sandbox_child_block";
 import type { Authenticator } from "@app/lib/auth";
@@ -17,6 +18,21 @@ import assert from "assert";
 type MCPActionOutputItemWithContent = {
   content: CallToolResult["content"][number];
 };
+
+function makeStoppedChildEvent(
+  runContext: AgentLoopRunContext
+): AgentLoopToolEarlyExitEvent {
+  return {
+    type: "tool_early_exit",
+    created: Date.now(),
+    configurationId: runContext.agentConfiguration.sId,
+    conversationId: runContext.conversation.sId,
+    messageId: runContext.agentMessage.sId,
+    text: "Sandbox parent already finished.",
+    isError: false,
+    reason: "user_cancellation",
+  };
+}
 
 /**
  * Server-only utility for processing exit/pause events from MCP tool outputs.
@@ -155,11 +171,15 @@ export async function getExitOrPauseEvents(
           await runContext.action.updateStatus(
             "blocked_authentication_required"
           );
-          await pauseSandboxBashForBlockedChild(
-            auth,
-            runContext.action,
-            runContext.conversation
-          );
+          if (
+            !(await pauseSandboxBashForBlockedChild(
+              auth,
+              runContext.action,
+              runContext.conversation
+            ))
+          ) {
+            return [makeStoppedChildEvent(runContext)];
+          }
           break;
         case "sandbox_function":
           await runContext.action.updateStatus(
@@ -210,11 +230,15 @@ export async function getExitOrPauseEvents(
         await runContext.action.updateStatus(
           "blocked_file_authorization_required"
         );
-        await pauseSandboxBashForBlockedChild(
-          auth,
-          runContext.action,
-          runContext.conversation
-        );
+        if (
+          !(await pauseSandboxBashForBlockedChild(
+            auth,
+            runContext.action,
+            runContext.conversation
+          ))
+        ) {
+          return [makeStoppedChildEvent(runContext)];
+        }
 
         // Persisted here so the blocked action can be reconstructed on page reload.
         await runContext.action.updateStepContext({
@@ -261,11 +285,15 @@ export async function getExitOrPauseEvents(
       // invocations observe the returned event instead.
       if (isAgentLoopRunContext(runContext)) {
         await runContext.action.updateStatus("blocked_user_answer_required");
-        await pauseSandboxBashForBlockedChild(
-          auth,
-          runContext.action,
-          runContext.conversation
-        );
+        if (
+          !(await pauseSandboxBashForBlockedChild(
+            auth,
+            runContext.action,
+            runContext.conversation
+          ))
+        ) {
+          return [makeStoppedChildEvent(runContext)];
+        }
 
         await runContext.action.updateStepContext({
           ...runContext.action.stepContext,

--- a/front/lib/actions/mcp_internal_actions/exit_events.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.ts
@@ -41,7 +41,6 @@ function getRelaunchArgs(runContext: AgentLoopRunContext) {
   return {
     agentMessageId: runContext.agentMessage.sId,
     agentMessageVersion: runContext.agentMessage.version,
-    conversationBranchId: runContext.agentMessage.branchId,
     conversationId: runContext.conversation.sId,
     conversationTitle: runContext.conversation.title,
     userMessageId: runContext.userMessage.sId,

--- a/front/lib/actions/mcp_internal_actions/exit_events.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.ts
@@ -9,7 +9,10 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/events";
 import type { AgentLoopRunContext, ToolContext } from "@app/lib/actions/types";
 import { isAgentLoopRunContext } from "@app/lib/actions/types";
-import { pauseSandboxBashForBlockedChild } from "@app/lib/api/sandbox/sandbox_child_block";
+import {
+  pauseSandboxBashForBlockedChild,
+  persistActionPause,
+} from "@app/lib/api/sandbox/sandbox_child_block";
 import type { Authenticator } from "@app/lib/auth";
 import { assertNever, isAgentPauseOutputResourceType } from "@dust-tt/client";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -31,6 +34,19 @@ function makeStoppedChildEvent(
     text: "Sandbox parent already finished.",
     isError: false,
     reason: "user_cancellation",
+  };
+}
+
+function getRelaunchArgs(runContext: AgentLoopRunContext) {
+  return {
+    agentMessageId: runContext.agentMessage.sId,
+    agentMessageVersion: runContext.agentMessage.version,
+    conversationBranchId: runContext.agentMessage.branchId,
+    conversationId: runContext.conversation.sId,
+    conversationTitle: runContext.conversation.title,
+    userMessageId: runContext.userMessage.sId,
+    userMessageVersion: runContext.userMessage.version,
+    userMessageOrigin: runContext.userMessage.context.origin,
   };
 }
 
@@ -119,16 +135,16 @@ export async function getExitOrPauseEvents(
       const { blockingEvents, state } = exitOutputItem;
 
       if (isAgentLoopRunContext(runContext)) {
-        // Update the action status to blocked_child_action_input_required to break the agent loop.
-        await runContext.action.updateStatus(
-          "blocked_child_action_input_required"
-        );
-
-        // Update the step context to save the resume state.
-        await runContext.action.updateStepContext({
-          ...runContext.action.stepContext,
-          resumeState: state,
-        });
+        if (
+          !(await persistActionPause(
+            auth,
+            runContext.action,
+            runContext.conversation,
+            state
+          ))
+        ) {
+          return [makeStoppedChildEvent(runContext)];
+        }
       }
 
       // TODO(SANDBOX_FUNCTIONS): supporting run_agent from a sandbox function requires
@@ -175,7 +191,8 @@ export async function getExitOrPauseEvents(
             !(await pauseSandboxBashForBlockedChild(
               auth,
               runContext.action,
-              runContext.conversation
+              runContext.conversation,
+              getRelaunchArgs(runContext)
             ))
           ) {
             return [makeStoppedChildEvent(runContext)];
@@ -234,7 +251,8 @@ export async function getExitOrPauseEvents(
           !(await pauseSandboxBashForBlockedChild(
             auth,
             runContext.action,
-            runContext.conversation
+            runContext.conversation,
+            getRelaunchArgs(runContext)
           ))
         ) {
           return [makeStoppedChildEvent(runContext)];
@@ -289,7 +307,8 @@ export async function getExitOrPauseEvents(
           !(await pauseSandboxBashForBlockedChild(
             auth,
             runContext.action,
-            runContext.conversation
+            runContext.conversation,
+            getRelaunchArgs(runContext)
           ))
         ) {
           return [makeStoppedChildEvent(runContext)];

--- a/front/lib/actions/tool_approval_events.ts
+++ b/front/lib/actions/tool_approval_events.ts
@@ -17,22 +17,22 @@ type ApprovalToolConfiguration = Pick<
   | "toolServerId"
 >;
 
-export async function makeMCPApproveExecutionEventBase(
+type ApprovalEventArgs = {
+  toolConfiguration: ApprovalToolConfiguration;
+  inputs: Record<string, unknown>;
+  approvalLabelInputs?: Record<string, unknown>;
+  approvalSubjectName: string;
+};
+
+export async function prepareMCPApprovalEvent(
   auth: Authenticator,
   {
-    actionId,
     toolConfiguration,
     inputs,
     approvalLabelInputs = inputs,
     approvalSubjectName,
-  }: {
-    actionId: string;
-    toolConfiguration: ApprovalToolConfiguration;
-    inputs: Record<string, unknown>;
-    approvalLabelInputs?: Record<string, unknown>;
-    approvalSubjectName: string;
-  }
-): Promise<MCPApproveExecutionEventBase> {
+  }: ApprovalEventArgs
+): Promise<(actionId: string) => MCPApproveExecutionEventBase> {
   const argumentsRequiringApproval =
     toolConfiguration.argumentsRequiringApproval ?? [];
   const approvalArgsLabel = await getApprovalArgsLabel({
@@ -46,7 +46,7 @@ export async function makeMCPApproveExecutionEventBase(
     argumentsRequiringApproval,
   });
 
-  return {
+  return (actionId) => ({
     type: "tool_approve_execution",
     actionId,
     created: Date.now(),
@@ -64,5 +64,13 @@ export async function makeMCPApproveExecutionEventBase(
     },
     argumentsRequiringApproval,
     approvalArgsLabel,
-  };
+  });
+}
+
+export async function makeMCPApproveExecutionEventBase(
+  auth: Authenticator,
+  { actionId, ...args }: ApprovalEventArgs & { actionId: string }
+): Promise<MCPApproveExecutionEventBase> {
+  const makeEvent = await prepareMCPApprovalEvent(auth, args);
+  return makeEvent(actionId);
 }

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -101,6 +101,7 @@ export function isUserQuestionResumeState(
 
 const SandboxResumeStateSchema = z.object({
   execId: z.string(),
+  runId: z.string().optional(),
 });
 
 type SandboxResumeState = z.infer<typeof SandboxResumeStateSchema>;

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -36,6 +36,7 @@ export function isFileAuthorizationInfo(
 
 const SandboxChildActionInfoSchema = z.object({
   parentActionId: z.string(),
+  execId: z.string().optional(),
 });
 
 export type SandboxChildActionInfo = z.infer<

--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -20,6 +20,7 @@ const {
   mockLoggerInfo,
   mockLoggerWarn,
   mockFetchActionById,
+  mockHasBlockedSandboxChildren,
 } = vi.hoisted(() => ({
   mockAddOwnerPolicyDomain: vi.fn(),
   mockReadNewDenyLogEntries: vi.fn(),
@@ -35,6 +36,7 @@ const {
   mockLoggerInfo: vi.fn(),
   mockLoggerWarn: vi.fn(),
   mockFetchActionById: vi.fn(),
+  mockHasBlockedSandboxChildren: vi.fn(),
 }));
 
 vi.mock("@app/lib/api/config", () => ({
@@ -89,6 +91,7 @@ vi.mock("@app/lib/api/sandbox/image", async (importOriginal) => {
 vi.mock("@app/lib/resources/agent_mcp_action_resource", () => ({
   AgentMCPActionResource: {
     fetchById: mockFetchActionById,
+    hasBlockedSandboxChildren: mockHasBlockedSandboxChildren,
   },
 }));
 
@@ -224,6 +227,7 @@ describe("runSandboxBashTool", () => {
     mockRevokeExecToken.mockResolvedValue(undefined);
     // Default: no parent action found on refetch ⇒ not paused, normal path.
     mockFetchActionById.mockResolvedValue(null);
+    mockHasBlockedSandboxChildren.mockResolvedValue(true);
   });
 
   function makeExtra() {
@@ -630,6 +634,34 @@ describe("runSandboxBashTool", () => {
         status: "running",
         updateStepContext: vi.fn(),
       });
+
+      const result = await runSandboxBashTool(
+        { command: "echo ok", description: "Run command" },
+        makeExtra()
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value[0]).toMatchObject({ type: "text" });
+    });
+
+    it("returns the completed exec result after a pre-deploy child resolves", async () => {
+      const sandbox = {
+        providerId: "provider-id",
+        sId: "sandbox-id",
+        exec: vi
+          .fn()
+          .mockResolvedValue(new Ok({ exitCode: 0, stdout: "ok", stderr: "" })),
+      };
+      mockEnsureSandboxReady.mockResolvedValue(
+        new Ok({ sandbox, freshlyCreated: false })
+      );
+      mockFetchActionById.mockResolvedValue({
+        status: "blocked_child_action_input_required",
+      });
+      mockHasBlockedSandboxChildren.mockResolvedValue(false);
 
       const result = await runSandboxBashTool(
         { command: "echo ok", description: "Run command" },

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -399,9 +399,9 @@ export async function runSandboxBashTool(
   // `pauseSandboxBashForBlockedChild`, which atomically flips this bash
   // action's status from `running` → `blocked_child_action_input_required`
   // and calls `betaPause`. We observe the result here by refetching the
-  // parent action. The execId is persisted by the generic
-  // `tool_blocked_awaiting_input` exit_events path, which reads `state`
-  // off the resource we return below.
+  // parent action. The pause path persists execId before freezing the
+  // sandbox; the generic `tool_blocked_awaiting_input` exit path below
+  // confirms the same state when it processes this resource.
   const freshParent = await AgentMCPActionResource.fetchById(
     auth,
     sandboxAction.sId

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -407,7 +407,11 @@ export async function runSandboxBashTool(
     sandboxAction.sId
   );
   const wasPaused =
-    freshParent !== null && isToolExecutionStatusBlocked(freshParent.status);
+    freshParent !== null &&
+    isToolExecutionStatusBlocked(freshParent.status) &&
+    (await AgentMCPActionResource.hasBlockedSandboxChildren(auth, {
+      parentAction: freshParent,
+    }));
 
   if (!wasPaused) {
     const durationMs = performance.now() - startMs;

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -3076,16 +3076,11 @@ export async function updateAgentMessageWithFinalStatus(
     agentMessage,
     status,
     error,
-    dangerouslyBypassSameStepCheck = false,
   }: {
     conversation: ConversationWithoutContentType;
     agentMessage: AgentMessageType;
     status: Exclude<AgentMessageStatus, "created">;
     error?: ToolErrorEvent["error"];
-    // Force finalization even if the message is in an anomalous state (e.g. blocked actions
-    // spanning multiple steps). Used by the unstick-conversation poke plugin to rescue genuinely
-    // stuck conversations. Leave false everywhere else so invariant violations surface as errors.
-    dangerouslyBypassSameStepCheck?: boolean;
   }
 ): Promise<{
   completedTs: number;
@@ -3169,7 +3164,6 @@ export async function updateAgentMessageWithFinalStatus(
       ? await AgentMCPActionResource.denyBlockedActionsForAgentMessage(auth, {
           agentMessageId: agentMessage.agentMessageId,
           transaction: t,
-          dangerouslyBypassSameStepCheck,
         })
       : [];
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -3161,7 +3161,7 @@ export async function updateAgentMessageWithFinalStatus(
     }
 
     const deniedActions = UNRESUMABLE_AGENT_MESSAGE_STATUSES.includes(status)
-      ? await AgentMCPActionResource.denyBlockedActionsForAgentMessage(auth, {
+      ? await AgentMCPActionResource.denyPendingActionsForMessage(auth, {
           agentMessageId: agentMessage.agentMessageId,
           transaction: t,
         })

--- a/front/lib/api/assistant/conversation/answer_user_question.ts
+++ b/front/lib/api/assistant/conversation/answer_user_question.ts
@@ -1,7 +1,9 @@
 import { isToolAskUserQuestionEvent } from "@app/lib/actions/mcp";
 import type { UserQuestionAnswer } from "@app/lib/actions/types";
 import { isSandboxChildActionInfo } from "@app/lib/actions/types";
+import { validateBlockedSteps } from "@app/lib/api/assistant/conversation/blocked_actions";
 import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
+import { getConversationRankVersionLock } from "@app/lib/api/assistant/conversation/lock";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
 import { resumeAncestorConversations } from "@app/lib/api/assistant/conversation/resume_ancestor_conversations";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
@@ -11,6 +13,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import type { Result } from "@app/types/shared/result";
@@ -69,7 +72,7 @@ export async function registerUserAnswer(
     );
   }
 
-  const action = await AgentMCPActionResource.fetchById(auth, actionId);
+  let action = await AgentMCPActionResource.fetchById(auth, actionId);
   if (!action) {
     return new Err(
       new DustError("action_not_found", `Action not found: ${actionId}`)
@@ -85,31 +88,63 @@ export async function registerUserAnswer(
     );
   }
 
-  // A blocked action is only actionable while its agent message can still resume: answering one
-  // left behind by a non-resumable terminal message would relaunch an agent loop that was already
-  // terminated.
-  if (!(await action.canAgentMessageResume(auth))) {
-    return new Err(
-      new DustError(
-        "action_not_blocked",
-        "Action belongs to an agent message that can no longer resume"
-      )
+  const transitionRes = await withTransaction(async (transaction) => {
+    await getConversationRankVersionLock(auth, conversation, transaction);
+
+    const freshAction = await AgentMCPActionResource.fetchById(
+      auth,
+      actionId,
+      transaction
     );
+    if (!freshAction || freshAction.status !== "blocked_user_answer_required") {
+      return new Err(
+        new DustError(
+          "action_not_blocked",
+          "Action is no longer blocked for user question"
+        )
+      );
+    }
+    if (!(await freshAction.canAgentMessageResume(auth, transaction))) {
+      return new Err(
+        new DustError(
+          "action_not_blocked",
+          "Action belongs to an agent message that can no longer resume"
+        )
+      );
+    }
+
+    const stepValidation = await validateBlockedSteps(
+      auth,
+      freshAction,
+      transaction
+    );
+    if (stepValidation.isErr()) {
+      return stepValidation;
+    }
+
+    await freshAction.updateStepContext(
+      {
+        ...freshAction.stepContext,
+        resumeState: {
+          ...freshAction.stepContext.resumeState,
+          answer,
+        },
+      },
+      transaction
+    );
+
+    const [updatedCount] = await freshAction.updateStatusFromExpected(auth, {
+      status: "ready_allowed_explicitly",
+      expectedStatus: "blocked_user_answer_required",
+      transaction,
+    });
+    return new Ok({ action: freshAction, updatedCount });
+  });
+  if (transitionRes.isErr()) {
+    return transitionRes;
   }
-
-  await action.updateStepContext({
-    ...action.stepContext,
-    resumeState: {
-      ...action.stepContext.resumeState,
-      answer,
-    },
-  });
-
-  // Change status to ready so the tool re-runs.
-  const [updatedCount] = await action.updateStatusFromExpected(auth, {
-    status: "ready_allowed_explicitly",
-    expectedStatus: "blocked_user_answer_required",
-  });
+  const { action: freshAction, updatedCount } = transitionRes.value;
+  action = freshAction;
 
   if (updatedCount === 0) {
     logger.info(

--- a/front/lib/api/assistant/conversation/blocked_actions.test.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.test.ts
@@ -312,17 +312,16 @@ describe("blocked actions resolution", () => {
       return { agentMessage, step1Action, step3Action };
     }
 
-    it("force-denies blocked actions spanning several steps (unstick)", async () => {
-      // Anomalous multi-step blocked state: force finalization (as the unstick-conversation plugin
-      // does) must deny them all instead of throwing.
+    it("denies blocked actions spanning several steps", async () => {
+      // Terminal cleanup does not resume the loop from a step, so it can safely deny every action
+      // in an anomalous multi-step state.
       const { agentMessage, step1Action, step3Action } =
         await setupMultiStepBlockedMessage();
 
       await updateAgentMessageWithFinalStatus(auth, {
         conversation,
         agentMessage,
-        status: "failed",
-        dangerouslyBypassSameStepCheck: true,
+        status: "cancelled",
       });
 
       const reloadedStep1 = await AgentMCPActionResource.fetchById(
@@ -336,18 +335,6 @@ describe("blocked actions resolution", () => {
       expect(reloadedStep1?.status).toBe("denied");
       expect(reloadedStep3?.status).toBe("denied");
       expect(await getActionRequired()).toBe(false);
-    });
-
-    it("throws on multi-step blocked actions by default (invariant enforced)", async () => {
-      const { agentMessage } = await setupMultiStepBlockedMessage();
-
-      await expect(
-        updateAgentMessageWithFinalStatus(auth, {
-          conversation,
-          agentMessage,
-          status: "failed",
-        })
-      ).rejects.toThrow("All blocked actions must be from the same step");
     });
 
     it("commits the deny with the terminal status update", async () => {

--- a/front/lib/api/assistant/conversation/blocked_actions.test.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock Redis hybrid manager to prevent it from removing events
-const { emitAuditLogEventDirectMock, removeEventMock } = vi.hoisted(() => ({
-  emitAuditLogEventDirectMock: vi.fn().mockResolvedValue(undefined),
-  removeEventMock: vi.fn().mockResolvedValue(undefined),
-}));
+const { emitAuditLogEventDirectMock, removeEventMock, sleepSandboxMock } =
+  vi.hoisted(() => ({
+    emitAuditLogEventDirectMock: vi.fn().mockResolvedValue(undefined),
+    removeEventMock: vi.fn().mockResolvedValue(undefined),
+    sleepSandboxMock: vi.fn().mockResolvedValue({ isErr: () => false }),
+  }));
 vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
   getRedisHybridManager: vi.fn().mockReturnValue({
     removeEvent: removeEventMock,
@@ -19,6 +21,11 @@ vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
     emitAuditLogEventDirect: emitAuditLogEventDirectMock,
   };
 });
+vi.mock("@app/lib/resources/conversation_sandbox_adapter", () => ({
+  ConversationSandboxAdapter: {
+    dangerouslySleepSandboxIfPendingApproval: sleepSandboxMock,
+  },
+}));
 
 import { updateAgentMessageWithFinalStatus } from "@app/lib/api/assistant/conversation";
 import {
@@ -277,6 +284,7 @@ describe("blocked actions resolution", () => {
         action.sId
       );
       expect(reloadedAction?.status).toBe("denied");
+      expect(sleepSandboxMock).toHaveBeenCalledOnce();
     });
 
     it("denies a resumed sandbox parent that had not restarted", async () => {
@@ -302,6 +310,7 @@ describe("blocked actions resolution", () => {
         action.sId
       );
       expect(reloadedAction?.status).toBe("denied");
+      expect(sleepSandboxMock).toHaveBeenCalledOnce();
     });
 
     it("emits approval audit events only for actions actually denied", async () => {

--- a/front/lib/api/assistant/conversation/blocked_actions.test.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.test.ts
@@ -254,6 +254,31 @@ describe("blocked actions resolution", () => {
       expect(emitAuditLogEventDirectMock).not.toHaveBeenCalled();
     });
 
+    it("denies a sandbox child that was ready but had not started", async () => {
+      const { agentMessage, action } =
+        await AgentMCPActionFactory.createWithAgentMessage(auth, {
+          workspace,
+          conversation,
+          status: "ready_allowed_implicitly",
+        });
+      await action.updateStepContext({
+        ...action.stepContext,
+        sandboxChildActionInfo: { parentActionId: "parent_action" },
+      });
+
+      await updateAgentMessageWithFinalStatus(auth, {
+        conversation,
+        agentMessage,
+        status: "cancelled",
+      });
+
+      const reloadedAction = await AgentMCPActionResource.fetchById(
+        auth,
+        action.sId
+      );
+      expect(reloadedAction?.status).toBe("denied");
+    });
+
     it("emits approval audit events only for actions actually denied", async () => {
       const { agentMessage, action: deniedAction } =
         await AgentMCPActionFactory.createWithAgentMessage(auth, {

--- a/front/lib/api/assistant/conversation/blocked_actions.test.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.test.ts
@@ -279,6 +279,31 @@ describe("blocked actions resolution", () => {
       expect(reloadedAction?.status).toBe("denied");
     });
 
+    it("denies a resumed sandbox parent that had not restarted", async () => {
+      const { agentMessage, action } =
+        await AgentMCPActionFactory.createWithAgentMessage(auth, {
+          workspace,
+          conversation,
+          status: "ready_allowed_explicitly",
+        });
+      await action.updateStepContext({
+        ...action.stepContext,
+        resumeState: { execId: "0123456789abcdef" },
+      });
+
+      await updateAgentMessageWithFinalStatus(auth, {
+        conversation,
+        agentMessage,
+        status: "cancelled",
+      });
+
+      const reloadedAction = await AgentMCPActionResource.fetchById(
+        auth,
+        action.sId
+      );
+      expect(reloadedAction?.status).toBe("denied");
+    });
+
     it("emits approval audit events only for actions actually denied", async () => {
       const { agentMessage, action: deniedAction } =
         await AgentMCPActionFactory.createWithAgentMessage(auth, {

--- a/front/lib/api/assistant/conversation/blocked_actions.test.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.test.ts
@@ -1,12 +1,31 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock Redis hybrid manager to prevent it from removing events
-const { emitAuditLogEventDirectMock, removeEventMock, sleepSandboxMock } =
-  vi.hoisted(() => ({
+const {
+  emitAuditLogEventDirectMock,
+  removeEventMock,
+  sleepSandboxChecks,
+  sleepSandboxMock,
+} = vi.hoisted(() => {
+  const sleepSandboxChecks: boolean[] = [];
+  return {
     emitAuditLogEventDirectMock: vi.fn().mockResolvedValue(undefined),
     removeEventMock: vi.fn().mockResolvedValue(undefined),
-    sleepSandboxMock: vi.fn().mockResolvedValue({ isErr: () => false }),
-  }));
+    sleepSandboxChecks,
+    sleepSandboxMock: vi.fn(
+      async (
+        _auth: unknown,
+        _conversation: unknown,
+        opts?: { shouldSleep?: () => Promise<boolean> }
+      ) => {
+        if (opts?.shouldSleep) {
+          sleepSandboxChecks.push(await opts.shouldSleep());
+        }
+        return { isErr: () => false };
+      }
+    ),
+  };
+});
 vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
   getRedisHybridManager: vi.fn().mockReturnValue({
     removeEvent: removeEventMock,
@@ -49,6 +68,7 @@ describe("blocked actions resolution", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    sleepSandboxChecks.length = 0;
 
     const setup = await createResourceTest({});
     workspace = setup.workspace;
@@ -285,6 +305,41 @@ describe("blocked actions resolution", () => {
       );
       expect(reloadedAction?.status).toBe("denied");
       expect(sleepSandboxMock).toHaveBeenCalledOnce();
+      expect(sleepSandboxChecks).toEqual([true]);
+    });
+
+    it("keeps the sandbox paused while another child still needs approval", async () => {
+      const { agentMessage, action } =
+        await AgentMCPActionFactory.createWithAgentMessage(auth, {
+          workspace,
+          conversation,
+          status: "ready_allowed_implicitly",
+        });
+      await action.updateStepContext({
+        ...action.stepContext,
+        sandboxChildActionInfo: { parentActionId: "parent_action" },
+      });
+
+      const { agentMessageRowId: otherAgentMessageRowId } =
+        await createAgentMessageAtRank(3);
+      const { action: otherAction } = await AgentMCPActionFactory.create(auth, {
+        workspace,
+        conversationModelId: conversation.id,
+        agentMessageModelId: otherAgentMessageRowId,
+      });
+      await otherAction.updateStepContext({
+        ...otherAction.stepContext,
+        sandboxChildActionInfo: { parentActionId: "other_parent" },
+      });
+
+      await updateAgentMessageWithFinalStatus(auth, {
+        conversation,
+        agentMessage,
+        status: "cancelled",
+      });
+
+      expect(sleepSandboxMock).toHaveBeenCalledOnce();
+      expect(sleepSandboxChecks).toEqual([false]);
     });
 
     it("denies a resumed sandbox parent that had not restarted", async () => {

--- a/front/lib/api/assistant/conversation/blocked_actions.test.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.test.ts
@@ -518,6 +518,29 @@ describe("blocked actions resolution", () => {
   });
 
   describe("updateAgentMessageWithFinalStatus", () => {
+    it("denies blocked actions when the message succeeds", async () => {
+      const { agentMessage, action } =
+        await AgentMCPActionFactory.createWithAgentMessage(auth, {
+          workspace,
+          conversation,
+        });
+
+      await ConversationResource.markAsActionRequired(auth, { conversation });
+
+      await updateAgentMessageWithFinalStatus(auth, {
+        conversation,
+        agentMessage,
+        status: "succeeded",
+      });
+
+      const reloadedAction = await AgentMCPActionResource.fetchById(
+        auth,
+        action.sId
+      );
+      expect(reloadedAction?.status).toBe("denied");
+      expect(await getActionRequired()).toBe(false);
+    });
+
     it("denies blocked actions when the message is interrupted", async () => {
       const { agentMessage, action } =
         await AgentMCPActionFactory.createWithAgentMessage(auth, {

--- a/front/lib/api/assistant/conversation/blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.ts
@@ -9,8 +9,8 @@ import {
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import logger from "@app/logger/logger";
 import type {
   AgentMessageType,
@@ -64,9 +64,7 @@ export async function cleanupDeniedBlockedActions(
 
     if (
       deniedActions.some((action) =>
-        isSandboxChildActionInfo(
-          action.stepContext.sandboxChildActionInfo
-        )
+        isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)
       )
     ) {
       // Serializes with an in-flight pause. If cancellation won the race, the pause callback sees

--- a/front/lib/api/assistant/conversation/blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.ts
@@ -1,6 +1,9 @@
 import type { AgentLoopBlockedToolExecution } from "@app/lib/actions/mcp";
 import { isBlockedActionEvent } from "@app/lib/actions/mcp";
-import { isSandboxChildActionInfo } from "@app/lib/actions/types";
+import {
+  isSandboxChildActionInfo,
+  isSandboxResumeState,
+} from "@app/lib/actions/types";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import {
   buildAuditLogTarget,
@@ -63,12 +66,14 @@ export async function cleanupDeniedBlockedActions(
     });
 
     if (
-      deniedActions.some((action) =>
-        isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)
+      deniedActions.some(
+        (action) =>
+          isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo) ||
+          isSandboxResumeState(action.stepContext.resumeState)
       )
     ) {
       // Serializes with an in-flight pause. If cancellation won the race, the pause callback sees
-      // the denied child and no-ops; if the pause won, this converts pending_approval to regular
+      // the denied action and no-ops; if the pause won, this converts pending_approval to regular
       // sleeping state so the sandbox is not left waiting on an approval that no longer exists.
       const conversationResource = await ConversationResource.fetchById(
         auth,

--- a/front/lib/api/assistant/conversation/blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.ts
@@ -4,6 +4,7 @@ import {
   isSandboxChildActionInfo,
   isSandboxResumeState,
 } from "@app/lib/actions/types";
+import { getConversationRankVersionLock } from "@app/lib/api/assistant/conversation/lock";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import {
   buildAuditLogTarget,
@@ -14,6 +15,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type {
   AgentMessageType,
@@ -24,6 +26,66 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 export type GetBlockedActionsResponseType = {
   blockedActions: AgentLoopBlockedToolExecution[];
 };
+
+export async function releaseSandboxIfUnused(
+  auth: Authenticator,
+  {
+    conversation,
+    messageId,
+  }: {
+    conversation: ConversationWithoutContentType;
+    messageId: string;
+  }
+): Promise<void> {
+  const conversationResource = await ConversationResource.fetchById(
+    auth,
+    conversation.sId
+  );
+  if (!conversationResource) {
+    logger.warn(
+      {
+        conversationId: conversation.sId,
+        messageId,
+      },
+      "Conversation not found while releasing sandbox approval"
+    );
+    return;
+  }
+
+  const sleepResult =
+    await ConversationSandboxAdapter.dangerouslySleepSandboxIfPendingApproval(
+      auth,
+      conversationResource,
+      {
+        shouldSleep: () =>
+          withTransaction(async (transaction) => {
+            // Lifecycle cleanup and sandbox pausing both take these locks in this order.
+            await getConversationRankVersionLock(
+              auth,
+              conversation,
+              transaction
+            );
+            return !(await AgentMCPActionResource.hasBlockedSandboxActions(
+              auth,
+              {
+                conversationId: conversation.id,
+                transaction,
+              }
+            ));
+          }),
+      }
+    );
+  if (sleepResult.isErr()) {
+    logger.error(
+      {
+        err: sleepResult.error,
+        conversationId: conversation.sId,
+        messageId,
+      },
+      "Failed to release sandbox approval"
+    );
+  }
+}
 
 /**
  * Cleans up the blocked actions of an agent message that reached a terminal status
@@ -72,39 +134,10 @@ export async function cleanupDeniedBlockedActions(
           isSandboxResumeState(action.stepContext.resumeState)
       )
     ) {
-      // Serializes with an in-flight pause. If cancellation won the race, the pause callback sees
-      // the denied action and no-ops; if the pause won, this converts pending_approval to regular
-      // sleeping state so the sandbox is not left waiting on an approval that no longer exists.
-      const conversationResource = await ConversationResource.fetchById(
-        auth,
-        conversation.sId
-      );
-      const sleepResult = conversationResource
-        ? await ConversationSandboxAdapter.dangerouslySleepSandboxIfPendingApproval(
-            auth,
-            conversationResource
-          )
-        : null;
-      if (!sleepResult) {
-        logger.warn(
-          {
-            conversationId: conversation.sId,
-            messageId: agentMessage.sId,
-          },
-          "Conversation not found while releasing terminated child approval"
-        );
-        return;
-      }
-      if (sleepResult.isErr()) {
-        logger.error(
-          {
-            err: sleepResult.error,
-            conversationId: conversation.sId,
-            messageId: agentMessage.sId,
-          },
-          "Failed to release sandbox after terminated child approval"
-        );
-      }
+      await releaseSandboxIfUnused(auth, {
+        conversation,
+        messageId: agentMessage.sId,
+      });
     }
     return;
   }

--- a/front/lib/api/assistant/conversation/blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.ts
@@ -1,5 +1,6 @@
 import type { AgentLoopBlockedToolExecution } from "@app/lib/actions/mcp";
 import { isBlockedActionEvent } from "@app/lib/actions/mcp";
+import { isSandboxChildActionInfo } from "@app/lib/actions/types";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import {
   buildAuditLogTarget,
@@ -8,6 +9,7 @@ import {
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import type {
@@ -54,15 +56,54 @@ export async function cleanupDeniedBlockedActions(
       "Denied blocked actions of terminated agent message"
     );
 
-    // Remove the pending blocked-action events (approval requests, auth requests, user
-    // questions) from the message channel so live clients stop surfacing prompts for them.
-    const deniedActionIds = new Set(deniedActions.map((a) => a.sId));
-    await getRedisHybridManager().removeEvent((event) => {
-      const payload = JSON.parse(event.message["payload"]);
-      return (
-        isBlockedActionEvent(payload) && deniedActionIds.has(payload.actionId)
+    await clearBlockedActionEffects(auth, {
+      actionIds: deniedActions.map((a) => a.sId),
+      conversationId: conversation.sId,
+      messageId: agentMessage.sId,
+    });
+
+    if (
+      deniedActions.some((action) =>
+        isSandboxChildActionInfo(
+          action.stepContext.sandboxChildActionInfo
+        )
+      )
+    ) {
+      // Serializes with an in-flight pause. If cancellation won the race, the pause callback sees
+      // the denied child and no-ops; if the pause won, this converts pending_approval to regular
+      // sleeping state so the sandbox is not left waiting on an approval that no longer exists.
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
       );
-    }, getMessageChannelId(agentMessage.sId));
+      const sleepResult = conversationResource
+        ? await ConversationSandboxAdapter.dangerouslySleepSandboxIfPendingApproval(
+            auth,
+            conversationResource
+          )
+        : null;
+      if (!sleepResult) {
+        logger.warn(
+          {
+            conversationId: conversation.sId,
+            messageId: agentMessage.sId,
+          },
+          "Conversation not found while releasing terminated child approval"
+        );
+        return;
+      }
+      if (sleepResult.isErr()) {
+        logger.error(
+          {
+            err: sleepResult.error,
+            conversationId: conversation.sId,
+            messageId: agentMessage.sId,
+          },
+          "Failed to release sandbox after terminated child approval"
+        );
+      }
+    }
+    return;
   }
 
   // Always re-check the flag, even when no blocked action remains: a partial previous run may
@@ -70,6 +111,32 @@ export async function cleanupDeniedBlockedActions(
   await clearActionRequiredIfNoBlockedActions(auth, {
     conversationId: conversation.sId,
   });
+}
+
+export async function clearBlockedActionEffects(
+  auth: Authenticator,
+  {
+    actionIds,
+    conversationId,
+    messageId,
+  }: {
+    actionIds: string[];
+    conversationId: string;
+    messageId: string;
+  }
+): Promise<void> {
+  if (actionIds.length > 0) {
+    // Remove pending approval/auth/question events so live clients stop surfacing resolved prompts.
+    const deniedActionIds = new Set(actionIds);
+    await getRedisHybridManager().removeEvent((event) => {
+      const payload = JSON.parse(event.message["payload"]);
+      return (
+        isBlockedActionEvent(payload) && deniedActionIds.has(payload.actionId)
+      );
+    }, getMessageChannelId(messageId));
+  }
+
+  await clearActionRequiredIfNoBlockedActions(auth, { conversationId });
 }
 
 /**

--- a/front/lib/api/assistant/conversation/blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.ts
@@ -12,6 +12,7 @@ import {
 } from "@app/lib/api/audit/workos_audit";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
@@ -21,11 +22,51 @@ import type {
   AgentMessageType,
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { Transaction } from "sequelize";
 
 export type GetBlockedActionsResponseType = {
   blockedActions: AgentLoopBlockedToolExecution[];
 };
+
+export async function validateBlockedSteps(
+  auth: Authenticator,
+  action: AgentMCPActionResource,
+  transaction: Transaction
+): Promise<Result<void, DustError>> {
+  // Scoped by agentMessageId and blocked statuses, using the
+  // (workspaceId, agentMessageId, status) index.
+  const blockedActions =
+    await AgentMCPActionResource.listBlockedActionsForAgentMessage(auth, {
+      agentMessageId: action.agentMessageId,
+      skipSameStepCheck: true,
+      transaction,
+    });
+  const blockedSteps = new Set(
+    blockedActions.map((blockedAction) => blockedAction.stepContent.step)
+  );
+  if (blockedSteps.size <= 1) {
+    return new Ok(undefined);
+  }
+
+  logger.warn(
+    {
+      actionId: action.sId,
+      blockedSteps: [...blockedSteps],
+      workspaceId: auth.getNonNullableWorkspace().sId,
+    },
+    "Refusing to resume actions blocked across multiple steps"
+  );
+  return new Err(
+    new DustError(
+      "invalid_request_error",
+      "This generation cannot resume because its pending actions belong to different steps. " +
+        "Cancel it and retry."
+    )
+  );
+}
 
 export async function releaseSandboxIfUnused(
   auth: Authenticator,

--- a/front/lib/api/assistant/conversation/lock.ts
+++ b/front/lib/api/assistant/conversation/lock.ts
@@ -7,6 +7,21 @@ import type { ConversationWithoutContentType } from "@app/types/assistant/conver
 import { md5 } from "@app/types/shared/utils/encryption";
 import type { Transaction } from "sequelize";
 
+async function takeConversationLock(
+  conversationId: number,
+  transaction: Transaction
+): Promise<number> {
+  // Get a lock using the unique lock key (number within PostgreSQL's BigInt range).
+  const hash = md5(`conversation_message_rank_version_${conversationId}`);
+  const lockKey = parseInt(hash, 16) % 9999999999;
+  // biome-ignore lint/plugin/noRawSql: advisory lock requires raw SQL
+  await frontSequelize.query("SELECT pg_advisory_xact_lock(:key)", {
+    transaction,
+    replacements: { key: lockKey },
+  });
+  return lockKey;
+}
+
 /**
  * To avoid deadlocks when using Postgresql advisory locks, please make sure to not issue any other
  * SQL query outside of the transaction `t` that is holding the lock.
@@ -19,14 +34,7 @@ export async function getConversationRankVersionLock(
   t: Transaction
 ) {
   const startMs = performance.now();
-  // Get a lock using the unique lock key (number withing postgresql BigInt range).
-  const hash = md5(`conversation_message_rank_version_${conversation.id}`);
-  const lockKey = parseInt(hash, 16) % 9999999999;
-  // biome-ignore lint/plugin/noRawSql: advisory lock requires raw SQL
-  await frontSequelize.query("SELECT pg_advisory_xact_lock(:key)", {
-    transaction: t,
-    replacements: { key: lockKey },
-  });
+  const lockKey = await takeConversationLock(conversation.id, t);
 
   const acquiredAtMs = performance.now();
 
@@ -51,6 +59,13 @@ export async function getConversationRankVersionLock(
       "[ASSISTANT_TRACE] Advisory lock released"
     );
   });
+}
+
+export async function getConversationLockById(
+  conversationId: number,
+  transaction: Transaction
+): Promise<void> {
+  await takeConversationLock(conversationId, transaction);
 }
 
 export async function getNextConversationMessageRank(

--- a/front/lib/api/assistant/conversation/resolve_authentication.ts
+++ b/front/lib/api/assistant/conversation/resolve_authentication.ts
@@ -3,7 +3,9 @@ import {
   isToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp";
 import { isSandboxChildActionInfo } from "@app/lib/actions/types";
+import { validateBlockedSteps } from "@app/lib/api/assistant/conversation/blocked_actions";
 import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
+import { getConversationRankVersionLock } from "@app/lib/api/assistant/conversation/lock";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
 import { resumeAncestorConversations as resumeAncestorConversationsHelper } from "@app/lib/api/assistant/conversation/resume_ancestor_conversations";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
@@ -13,6 +15,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import type { Result } from "@app/types/shared/result";
@@ -101,7 +104,7 @@ export async function resolveAuthentication(
     );
   }
 
-  const action = await AgentMCPActionResource.fetchById(auth, actionId);
+  let action = await AgentMCPActionResource.fetchById(auth, actionId);
   if (!action) {
     return new Err(
       new DustError("action_not_found", `Action not found: ${actionId}`)
@@ -117,22 +120,52 @@ export async function resolveAuthentication(
     );
   }
 
-  // A blocked action is only actionable while its agent message can still resume: resolving one
-  // left behind by a non-resumable terminal message would relaunch an agent loop that was already
-  // terminated.
-  if (!(await action.canAgentMessageResume(auth))) {
-    return new Err(
-      new DustError(
-        "action_not_blocked",
-        "Action belongs to an agent message that can no longer resume"
-      )
-    );
-  }
+  const transitionRes = await withTransaction(async (transaction) => {
+    await getConversationRankVersionLock(auth, conversation, transaction);
 
-  const [updatedCount] = await action.updateStatusFromExpected(auth, {
-    status: outcome === "completed" ? "ready_allowed_explicitly" : "denied",
-    expectedStatus: blockedStatus,
+    const freshAction = await AgentMCPActionResource.fetchById(
+      auth,
+      actionId,
+      transaction
+    );
+    if (!freshAction || freshAction.status !== blockedStatus) {
+      return new Err(
+        new DustError(
+          "action_not_blocked",
+          `Action is no longer blocked for ${label}`
+        )
+      );
+    }
+    if (!(await freshAction.canAgentMessageResume(auth, transaction))) {
+      return new Err(
+        new DustError(
+          "action_not_blocked",
+          "Action belongs to an agent message that can no longer resume"
+        )
+      );
+    }
+
+    const stepValidation = await validateBlockedSteps(
+      auth,
+      freshAction,
+      transaction
+    );
+    if (stepValidation.isErr()) {
+      return stepValidation;
+    }
+
+    const [updatedCount] = await freshAction.updateStatusFromExpected(auth, {
+      status: outcome === "completed" ? "ready_allowed_explicitly" : "denied",
+      expectedStatus: blockedStatus,
+      transaction,
+    });
+    return new Ok({ action: freshAction, updatedCount });
   });
+  if (transitionRes.isErr()) {
+    return transitionRes;
+  }
+  const { action: freshAction, updatedCount } = transitionRes.value;
+  action = freshAction;
 
   if (updatedCount === 0) {
     logger.info(

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -815,6 +815,7 @@ describe("validateAction", () => {
     permission = "low",
     argumentsRequiringApproval,
     augmentedInputs = {},
+    step = 1,
   }: {
     agentMessageId: number;
     status?: ToolExecutionStatus;
@@ -823,6 +824,7 @@ describe("validateAction", () => {
     permission?: MCPToolStakeLevelType;
     argumentsRequiringApproval?: string[];
     augmentedInputs?: Record<string, unknown>;
+    step?: number;
   }) {
     const functionCallId = generateRandomModelSId();
     const currentIndex = stepContentIndex++;
@@ -831,7 +833,7 @@ describe("validateAction", () => {
     const stepContent = await AgentStepContentModel.create({
       workspaceId: workspace.id,
       agentMessageId,
-      step: 1,
+      step,
       index: currentIndex,
       version: 0,
       type: "function_call",
@@ -1384,6 +1386,44 @@ describe("validateAction", () => {
       if (result.isErr()) {
         expect(result.error.code).toBe("action_not_blocked");
       }
+    });
+
+    it("returns an error when blocked actions span multiple steps", async () => {
+      const { agentMessageMessage, agentMessageRow } =
+        await createAgentMessageWithNullUserParent();
+      const { action, actionId } = await createBlockedAction({
+        agentMessageId: agentMessageRow.id,
+        step: 1,
+      });
+      await createBlockedAction({
+        agentMessageId: agentMessageRow.id,
+        step: 3,
+      });
+
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      if (!conversationResource) {
+        throw new Error("Expected the conversation to exist.");
+      }
+
+      const result = await validateAction(auth, conversationResource, {
+        actionId,
+        approvalState: "approved",
+        messageId: agentMessageMessage.sId,
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.code).toBe("action_not_blocked");
+        expect(result.error.message).toContain(
+          "pending actions belong to different steps"
+        );
+      }
+      await action.reload();
+      expect(action.status).toBe("blocked_validation_required");
+      expect(vi.mocked(launchAgentLoopWorkflow)).not.toHaveBeenCalled();
     });
 
     it.each([

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -1416,7 +1416,7 @@ describe("validateAction", () => {
 
       expect(result.isErr()).toBe(true);
       if (result.isErr()) {
-        expect(result.error.code).toBe("action_not_blocked");
+        expect(result.error.code).toBe("invalid_request_error");
         expect(result.error.message).toContain(
           "pending actions belong to different steps"
         );

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -1427,6 +1427,60 @@ describe("validateAction", () => {
     });
 
     it.each([
+      ["authentication", "blocked_authentication_required"],
+      ["file authorization", "blocked_file_authorization_required"],
+      ["user question", "blocked_user_answer_required"],
+    ] as const)("rejects %s resolution when blocked actions span multiple steps", async (kind, status) => {
+      const { agentMessageMessage, agentMessageRow } =
+        await createAgentMessageWithNullUserParent();
+      const { action, actionId } = await createBlockedAction({
+        agentMessageId: agentMessageRow.id,
+        status,
+        step: 1,
+      });
+      await createBlockedAction({
+        agentMessageId: agentMessageRow.id,
+        step: 3,
+      });
+
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      if (!conversationResource) {
+        throw new Error("Expected the conversation to exist.");
+      }
+
+      const result =
+        kind === "user question"
+          ? await registerUserAnswer(auth, conversationResource, {
+              actionId,
+              messageId: agentMessageMessage.sId,
+              answer: { selectedOptions: [0] },
+            })
+          : await resolveAuthentication(auth, conversationResource, {
+              actionId,
+              messageId: agentMessageMessage.sId,
+              outcome: "completed",
+              ...(kind === "file authorization"
+                ? { kind: "file_authorization" as const }
+                : {}),
+            });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.code).toBe("invalid_request_error");
+        expect(result.error.message).toContain(
+          "pending actions belong to different steps"
+        );
+      }
+      await action.reload();
+      expect(action.status).toBe(status);
+      expect(vi.mocked(launchAgentLoopWorkflow)).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      "succeeded",
       "interrupted",
       "gracefully_stopped",
     ] as const)("rejects resolving an action whose agent message is %s", async (status) => {

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -8,7 +8,9 @@ import {
   setUserAlwaysApprovedTool,
 } from "@app/lib/actions/tool_status";
 import { isSandboxChildActionInfo } from "@app/lib/actions/types";
+import { validateBlockedSteps } from "@app/lib/api/assistant/conversation/blocked_actions";
 import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
+import { getConversationRankVersionLock } from "@app/lib/api/assistant/conversation/lock";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
 import { resumeAncestorConversations as resumeAncestorConversationsHelper } from "@app/lib/api/assistant/conversation/resume_ancestor_conversations";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
@@ -23,6 +25,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import type { Result } from "@app/types/shared/result";
@@ -82,7 +85,7 @@ export async function validateAction(
     );
   }
 
-  const action = await AgentMCPActionResource.fetchById(auth, actionId);
+  let action = await AgentMCPActionResource.fetchById(auth, actionId);
   if (!action) {
     return new Err(
       new DustError("action_not_found", `Action not found: ${actionId}`)
@@ -98,50 +101,49 @@ export async function validateAction(
     );
   }
 
-  // Stale approval links must not relaunch an already terminated agent message.
-  if (!(await action.canAgentMessageResume(auth))) {
-    return new Err(
-      new DustError(
-        "action_not_blocked",
-        "Action belongs to an agent message that can no longer resume"
-      )
-    );
-  }
+  const transitionRes = await withTransaction(async (transaction) => {
+    await getConversationRankVersionLock(auth, conversation, transaction);
 
-  // Scoped by agentMessageId and blocked statuses, using the
-  // (workspaceId, agentMessageId, status) index.
-  const messageBlockedActions =
-    await AgentMCPActionResource.listBlockedActionsForAgentMessage(auth, {
-      agentMessageId: action.agentMessageId,
-      skipSameStepCheck: true,
+    const freshAction = await AgentMCPActionResource.fetchById(
+      auth,
+      actionId,
+      transaction
+    );
+    if (!freshAction || freshAction.status !== "blocked_validation_required") {
+      return new Err(
+        new DustError("action_not_blocked", "Action is no longer blocked")
+      );
+    }
+    if (!(await freshAction.canAgentMessageResume(auth, transaction))) {
+      return new Err(
+        new DustError(
+          "action_not_blocked",
+          "Action belongs to an agent message that can no longer resume"
+        )
+      );
+    }
+
+    const stepValidation = await validateBlockedSteps(
+      auth,
+      freshAction,
+      transaction
+    );
+    if (stepValidation.isErr()) {
+      return stepValidation;
+    }
+
+    const [updatedCount] = await freshAction.updateStatusFromExpected(auth, {
+      status: getMCPApprovalStateFromUserApprovalState(approvalState),
+      expectedStatus: "blocked_validation_required",
+      transaction,
     });
-  const blockedSteps = new Set(
-    messageBlockedActions.map((blockedAction) => blockedAction.stepContent.step)
-  );
-  if (blockedSteps.size > 1) {
-    logger.warn(
-      {
-        actionId,
-        blockedSteps: [...blockedSteps],
-        conversationId,
-        messageId,
-        workspaceId: owner.sId,
-      },
-      "Refusing to resume actions blocked across multiple steps"
-    );
-    return new Err(
-      new DustError(
-        "invalid_request_error",
-        "This generation cannot resume because its pending actions belong to different steps. " +
-          "Cancel it and retry."
-      )
-    );
-  }
-
-  const [updatedCount] = await action.updateStatusFromExpected(auth, {
-    status: getMCPApprovalStateFromUserApprovalState(approvalState),
-    expectedStatus: "blocked_validation_required",
+    return new Ok({ action: freshAction, updatedCount });
   });
+  if (transitionRes.isErr()) {
+    return transitionRes;
+  }
+  const { action: freshAction, updatedCount } = transitionRes.value;
+  action = freshAction;
 
   if (updatedCount > 0 && approvalState === "always_approved" && user) {
     switch (action.toolConfiguration.permission) {

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -108,6 +108,36 @@ export async function validateAction(
     );
   }
 
+  // Scoped by agentMessageId and blocked statuses, using the
+  // (workspaceId, agentMessageId, status) index.
+  const messageBlockedActions =
+    await AgentMCPActionResource.listBlockedActionsForAgentMessage(auth, {
+      agentMessageId: action.agentMessageId,
+      skipSameStepCheck: true,
+    });
+  const blockedSteps = new Set(
+    messageBlockedActions.map((blockedAction) => blockedAction.stepContent.step)
+  );
+  if (blockedSteps.size > 1) {
+    logger.warn(
+      {
+        actionId,
+        blockedSteps: [...blockedSteps],
+        conversationId,
+        messageId,
+        workspaceId: owner.sId,
+      },
+      "Refusing to resume actions blocked across multiple steps"
+    );
+    return new Err(
+      new DustError(
+        "action_not_blocked",
+        "This generation cannot resume because its pending actions belong to different steps. " +
+          "Cancel it and retry."
+      )
+    );
+  }
+
   const [updatedCount] = await action.updateStatusFromExpected(auth, {
     status: getMCPApprovalStateFromUserApprovalState(approvalState),
     expectedStatus: "blocked_validation_required",

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -131,7 +131,7 @@ export async function validateAction(
     );
     return new Err(
       new DustError(
-        "action_not_blocked",
+        "invalid_request_error",
         "This generation cannot resume because its pending actions belong to different steps. " +
           "Cancel it and retry."
       )

--- a/front/lib/api/mcp/create_mcp.ts
+++ b/front/lib/api/mcp/create_mcp.ts
@@ -13,6 +13,7 @@ import type {
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
 import omit from "lodash/omit";
+import type { Transaction } from "sequelize";
 
 /**
  * Creates an MCP action in the database and returns both the DB record and the type object.
@@ -27,6 +28,7 @@ export async function createMCPAction(
     status,
     stepContent,
     stepContext,
+    transaction,
   }: {
     actionConfiguration: MCPToolConfigurationType;
     agentMessage: AgentMessageType;
@@ -35,6 +37,7 @@ export async function createMCPAction(
     status: ToolExecutionStatus;
     stepContent: AgentStepContentResource;
     stepContext: StepContext;
+    transaction?: Transaction;
   }
 ): Promise<AgentMCPActionResource> {
   const toolConfiguration = omit(
@@ -53,6 +56,7 @@ export async function createMCPAction(
       status,
       stepContext,
       toolConfiguration,
-    }
+    },
+    { transaction }
   );
 }

--- a/front/lib/api/mcp/run_tool.test.ts
+++ b/front/lib/api/mcp/run_tool.test.ts
@@ -1,6 +1,12 @@
 import { tryCallMCPTool } from "@app/lib/actions/mcp_actions";
-import type { SandboxFunctionRunContext } from "@app/lib/actions/types";
+import type {
+  AgentLoopRunContext,
+  SandboxFunctionRunContext,
+} from "@app/lib/actions/types";
+import { SANDBOX_TOOL_NAME } from "@app/lib/api/actions/servers/sandbox/metadata";
 import { runToolWithStreaming } from "@app/lib/api/mcp/run_tool";
+import { finishSandboxBash } from "@app/lib/api/sandbox/sandbox_child_block";
+import type { Authenticator } from "@app/lib/auth";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
@@ -16,6 +22,16 @@ vi.mock("@app/lib/actions/mcp_actions", async (importOriginal) => {
   return {
     ...actual,
     tryCallMCPTool: vi.fn(),
+  };
+});
+vi.mock("@app/lib/api/sandbox/sandbox_child_block", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@app/lib/api/sandbox/sandbox_child_block")
+    >();
+  return {
+    ...actual,
+    finishSandboxBash: vi.fn(),
   };
 });
 
@@ -126,5 +142,45 @@ describe("runToolWithStreaming (sandbox function run context)", () => {
     expect(JSON.parse(outputWrite?.content.toString() ?? "")).toEqual(
       errorContent
     );
+  });
+});
+
+describe("runToolWithStreaming (sandbox bash)", () => {
+  it("pauses a stale failed run after another workflow reserved the parent", async () => {
+    const auth = {
+      getNonNullableWorkspace: () => ({ sId: "w_test" }),
+    } as Authenticator;
+    const toolConfiguration = {
+      originalName: "bash",
+    };
+    const action = {
+      sId: "action_test",
+      status: "running",
+      augmentedInputs: {},
+      metadata: { internalMCPServerName: SANDBOX_TOOL_NAME },
+      stepContext: {},
+      toolConfiguration,
+      updateStatus: vi.fn().mockResolvedValue(undefined),
+    };
+    const runContext = {
+      contextType: "agent_loop",
+      action,
+      agentConfiguration: { sId: "agent_test" },
+      agentMessage: { sId: "message_test" },
+      conversation: { sId: "conversation_test" },
+      toolConfiguration,
+    } as unknown as AgentLoopRunContext;
+
+    mockToolCallResult({
+      isError: true,
+      content: [{ type: "text", text: "connection failed" }],
+    });
+    vi.mocked(finishSandboxBash).mockResolvedValueOnce(false);
+
+    const eventTypes = await collectEvents(
+      runToolWithStreaming(auth, { toolContext: { runContext } })
+    );
+
+    expect(eventTypes).toEqual(["tool_paused"]);
   });
 });

--- a/front/lib/api/mcp/run_tool.test.ts
+++ b/front/lib/api/mcp/run_tool.test.ts
@@ -5,6 +5,7 @@ import type { SandboxFunctionRunContext } from "@app/lib/actions/types";
 import { SANDBOX_TOOL_NAME } from "@app/lib/api/actions/servers/sandbox/metadata";
 import { runToolWithStreaming } from "@app/lib/api/mcp/run_tool";
 import { finishSandboxBash } from "@app/lib/api/sandbox/sandbox_child_block";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -149,7 +150,7 @@ describe("runToolWithStreaming (sandbox function run context)", () => {
 });
 
 describe("runToolWithStreaming (sandbox bash)", () => {
-  it("pauses a stale failed run after another workflow reserved the parent", async () => {
+  it("pauses stale failed and successful runs without persisting success output", async () => {
     const { workspace, authenticator: auth } = await createResourceTest({});
     const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
     const conversation = await ConversationFactory.create(auth, {
@@ -220,12 +221,43 @@ describe("runToolWithStreaming (sandbox bash)", () => {
       isError: true,
       content: [{ type: "text", text: "connection failed" }],
     });
-    vi.mocked(finishSandboxBash).mockResolvedValueOnce(false);
+    vi.mocked(finishSandboxBash).mockResolvedValueOnce({
+      completed: false,
+      outputItems: [],
+    });
 
     const eventTypes = await collectEvents(
       runToolWithStreaming(auth, { toolContext: { runContext } })
     );
 
     expect(eventTypes).toEqual(["tool_paused"]);
+
+    mockToolCallResult({
+      isError: false,
+      content: [{ type: "text", text: "stale output" }],
+    });
+    vi.mocked(finishSandboxBash).mockResolvedValueOnce({
+      completed: false,
+      outputItems: [],
+    });
+
+    const successEventTypes = await collectEvents(
+      runToolWithStreaming(auth, { toolContext: { runContext } })
+    );
+
+    expect(successEventTypes).toEqual(["tool_paused"]);
+    expect(vi.mocked(finishSandboxBash)).toHaveBeenLastCalledWith(
+      auth,
+      expect.objectContaining({
+        outputs: [{ content: { type: "text", text: "stale output" } }],
+        status: "succeeded",
+      })
+    );
+    const outputItems =
+      await AgentMCPActionResource.fetchOutputItemsByActionIds(auth, {
+        actionIds: [action.id],
+        ignoreContent: false,
+      });
+    expect(outputItems.get(action.id)).toBeUndefined();
   });
 });

--- a/front/lib/api/mcp/run_tool.test.ts
+++ b/front/lib/api/mcp/run_tool.test.ts
@@ -1,16 +1,19 @@
+import type { LightServerSideMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { tryCallMCPTool } from "@app/lib/actions/mcp_actions";
-import type {
-  AgentLoopRunContext,
-  SandboxFunctionRunContext,
-} from "@app/lib/actions/types";
+import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import type { SandboxFunctionRunContext } from "@app/lib/actions/types";
 import { SANDBOX_TOOL_NAME } from "@app/lib/api/actions/servers/sandbox/metadata";
 import { runToolWithStreaming } from "@app/lib/api/mcp/run_tool";
 import { finishSandboxBash } from "@app/lib/api/sandbox/sandbox_child_block";
-import type { Authenticator } from "@app/lib/auth";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { getTestStreamEndpoint } from "@app/tests/utils/models";
 import { SandboxFunctionMCPActionFactory } from "@app/tests/utils/SandboxFunctionMCPActionFactory";
 import { createPersistedSandboxFunctionInvocationTokenTestContext } from "@app/tests/utils/SandboxTokenFactory";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -147,29 +150,71 @@ describe("runToolWithStreaming (sandbox function run context)", () => {
 
 describe("runToolWithStreaming (sandbox bash)", () => {
   it("pauses a stale failed run after another workflow reserved the parent", async () => {
-    const auth = {
-      getNonNullableWorkspace: () => ({ sId: "w_test" }),
-    } as Authenticator;
-    const toolConfiguration = {
+    const { workspace, authenticator: auth } = await createResourceTest({});
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+    const sandboxServerId = autoInternalMCPServerNameToSId({
+      name: SANDBOX_TOOL_NAME,
+      workspaceId: workspace.id,
+    });
+    const toolConfiguration: LightServerSideMCPToolConfigurationType = {
+      id: -1,
+      sId: generateRandomModelSId(),
+      type: "mcp_configuration",
+      name: "bash",
       originalName: "bash",
+      mcpServerName: SANDBOX_TOOL_NAME,
+      dataSources: null,
+      tables: null,
+      childAgentId: null,
+      timeFrame: null,
+      jsonSchema: null,
+      additionalConfiguration: {},
+      mcpServerViewId: generateRandomModelSId(),
+      dustAppConfiguration: null,
+      internalMCPServerId: sandboxServerId,
+      secretName: null,
+      dustProject: null,
+      availability: "auto",
+      permission: "never_ask",
+      toolServerId: sandboxServerId,
+      retryPolicy: "no_retry",
     };
-    const action = {
-      sId: "action_test",
-      status: "running",
-      augmentedInputs: {},
-      metadata: { internalMCPServerName: SANDBOX_TOOL_NAME },
-      stepContext: {},
-      toolConfiguration,
-      updateStatus: vi.fn().mockResolvedValue(undefined),
-    };
+    const { action, agentMessage } =
+      await ConversationFactory.createAgentMessage(auth, {
+        workspace,
+        conversation,
+        agentConfig,
+        mcpAction: { toolConfiguration },
+      });
+    if (!action) {
+      throw new Error("Expected the sandbox action to exist.");
+    }
+    const { userMessage } = await ConversationFactory.createUserMessage({
+      auth,
+      workspace,
+      conversation,
+      content: "Test message",
+      rank: 1,
+    });
+    const { model, ...agentConfiguration } = agentConfig;
     const runContext = {
       contextType: "agent_loop",
       action,
-      agentConfiguration: { sId: "agent_test" },
-      agentMessage: { sId: "message_test" },
-      conversation: { sId: "conversation_test" },
+      agentConfiguration,
+      agentMessage,
+      conversation,
+      modelInfo: {
+        ...model,
+        endpoint: getTestStreamEndpoint(model.modelId),
+      },
+      stepContext: action.stepContext,
       toolConfiguration,
-    } as unknown as AgentLoopRunContext;
+      userMessage,
+    } as const;
 
     mockToolCallResult({
       isError: true,

--- a/front/lib/api/mcp/run_tool.test.ts
+++ b/front/lib/api/mcp/run_tool.test.ts
@@ -4,7 +4,10 @@ import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { SandboxFunctionRunContext } from "@app/lib/actions/types";
 import { SANDBOX_TOOL_NAME } from "@app/lib/api/actions/servers/sandbox/metadata";
 import { runToolWithStreaming } from "@app/lib/api/mcp/run_tool";
-import { finishSandboxBash } from "@app/lib/api/sandbox/sandbox_child_block";
+import {
+  canStoreSandboxOutput,
+  finishSandboxBash,
+} from "@app/lib/api/sandbox/sandbox_child_block";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
@@ -35,6 +38,7 @@ vi.mock("@app/lib/api/sandbox/sandbox_child_block", async (importOriginal) => {
     >();
   return {
     ...actual,
+    canStoreSandboxOutput: vi.fn().mockResolvedValue(true),
     finishSandboxBash: vi.fn(),
   };
 });
@@ -236,23 +240,19 @@ describe("runToolWithStreaming (sandbox bash)", () => {
       isError: false,
       content: [{ type: "text", text: "stale output" }],
     });
-    vi.mocked(finishSandboxBash).mockResolvedValueOnce({
-      completed: false,
-      outputItems: [],
-    });
+    vi.mocked(canStoreSandboxOutput).mockResolvedValueOnce(false);
 
     const successEventTypes = await collectEvents(
       runToolWithStreaming(auth, { toolContext: { runContext } })
     );
 
     expect(successEventTypes).toEqual(["tool_paused"]);
-    expect(vi.mocked(finishSandboxBash)).toHaveBeenLastCalledWith(
+    expect(vi.mocked(canStoreSandboxOutput)).toHaveBeenCalledWith(
       auth,
-      expect.objectContaining({
-        outputs: [{ content: { type: "text", text: "stale output" } }],
-        status: "succeeded",
-      })
+      action,
+      conversation
     );
+    expect(vi.mocked(finishSandboxBash)).toHaveBeenCalledTimes(1);
     const outputItems =
       await AgentMCPActionResource.fetchOutputItemsByActionIds(auth, {
         actionIds: [action.id],

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -131,13 +131,24 @@ export async function* runToolWithStreaming(
   if (toolCallResult.isError) {
     const endDate = performance.now();
     if (isSandboxBash) {
-      await finishSandboxBash(auth, {
+      const completed = await finishSandboxBash(auth, {
         action: runContext.action,
         conversation: runContext.conversation,
         executionDurationMs: endDate - startDate,
         messageId: runContext.agentMessage.sId,
         status: "errored",
       });
+      if (!completed) {
+        yield {
+          type: "tool_paused",
+          created: Date.now(),
+          actionId: action.sId,
+          configurationId: runContext.agentConfiguration.sId,
+          conversationId: runContext.conversation.sId,
+          messageId: runContext.agentMessage.sId,
+        };
+        return;
+      }
     }
     yield await handleMCPActionError(auth, {
       action,

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -27,6 +27,7 @@ import {
 import { SANDBOX_TOOL_NAME } from "@app/lib/api/actions/servers/sandbox/metadata";
 import { handleMCPActionError } from "@app/lib/api/mcp/error";
 import {
+  canStoreSandboxOutput,
   finishSandboxBash,
   persistSandboxBashOutput,
 } from "@app/lib/api/sandbox/sandbox_child_block";
@@ -186,9 +187,20 @@ export async function* runToolWithStreaming(
   };
 
   if (isSandboxBash) {
-    // File handling can legitimately take up to 5 minutes. Prepare everything first, but leave the
-    // action output uncommitted until the current workflow proves ownership under the conversation
-    // lock.
+    // File handling can create durable FileResources and legitimately take up to five minutes.
+    // Reject an orphaned workflow before that work, then re-check ownership when committing the
+    // authoritative output rows below.
+    if (
+      !(await canStoreSandboxOutput(
+        auth,
+        runContext.action,
+        runContext.conversation
+      ))
+    ) {
+      yield makeSandboxPausedEvent(runContext);
+      return;
+    }
+
     const { preparedOutputItems, generatedFiles } = await withPeriodicHeartbeat(
       () =>
         prepareToolResults(auth, {

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -153,16 +153,24 @@ export async function* runToolWithStreaming(
         conversation: runContext.conversation,
         executionDurationMs: endDate - startDate,
         messageId: runContext.agentMessage.sId,
+        outputs: toolCallResult.content.map((content) => ({ content })),
         status: "errored",
       });
       if (!completed) {
         yield makeSandboxPausedEvent(runContext);
         return;
       }
+      yield {
+        type: "tool_success",
+        created: Date.now(),
+        output: toolCallResult.content,
+        generatedFiles: [],
+      };
+      return;
     }
     yield await handleMCPActionError(auth, {
       action,
-      status: isSandboxBash ? "errored" : status,
+      status,
       errorContent: toolCallResult.content,
       executionDurationMs: endDate - startDate,
     });

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -8,7 +8,6 @@ import {
   processToolNotification,
   processToolResults,
 } from "@app/lib/actions/mcp_execution";
-import { SANDBOX_TOOL_NAME } from "@app/lib/api/actions/servers/sandbox/metadata";
 import type {
   MCPApproveExecutionEvent,
   ToolAskUserQuestionEvent,
@@ -24,6 +23,7 @@ import {
   isAgentLoopRunContext,
   isSandboxChildActionInfo,
 } from "@app/lib/actions/types";
+import { SANDBOX_TOOL_NAME } from "@app/lib/api/actions/servers/sandbox/metadata";
 import { handleMCPActionError } from "@app/lib/api/mcp/error";
 import { completeSandboxBash } from "@app/lib/api/sandbox/sandbox_child_block";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -5,6 +5,7 @@ import type {
 } from "@app/lib/actions/mcp";
 import { tryCallMCPTool } from "@app/lib/actions/mcp_actions";
 import {
+  prepareToolResults,
   processToolNotification,
   processToolResults,
 } from "@app/lib/actions/mcp_execution";
@@ -25,7 +26,10 @@ import {
 } from "@app/lib/actions/types";
 import { SANDBOX_TOOL_NAME } from "@app/lib/api/actions/servers/sandbox/metadata";
 import { handleMCPActionError } from "@app/lib/api/mcp/error";
-import { finishSandboxBash } from "@app/lib/api/sandbox/sandbox_child_block";
+import {
+  finishSandboxBash,
+  persistSandboxBashOutput,
+} from "@app/lib/api/sandbox/sandbox_child_block";
 import type { Authenticator } from "@app/lib/auth";
 import { withPeriodicHeartbeat } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -33,6 +37,19 @@ import { TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS } from "@app/temporal/agen
 import { removeNulls } from "@app/types/shared/utils/general";
 import { heartbeat } from "@temporalio/activity";
 import assert from "assert";
+
+function makeSandboxPausedEvent(
+  runContext: Extract<ToolContext["runContext"], { contextType: "agent_loop" }>
+): ToolPausedEvent {
+  return {
+    type: "tool_paused",
+    created: Date.now(),
+    actionId: runContext.action.sId,
+    configurationId: runContext.agentConfiguration.sId,
+    conversationId: runContext.conversation.sId,
+    messageId: runContext.agentMessage.sId,
+  };
+}
 
 /**
  * Runs a tool with streaming for the given tool context.
@@ -131,7 +148,7 @@ export async function* runToolWithStreaming(
   if (toolCallResult.isError) {
     const endDate = performance.now();
     if (isSandboxBash) {
-      const completed = await finishSandboxBash(auth, {
+      const { completed } = await finishSandboxBash(auth, {
         action: runContext.action,
         conversation: runContext.conversation,
         executionDurationMs: endDate - startDate,
@@ -139,14 +156,7 @@ export async function* runToolWithStreaming(
         status: "errored",
       });
       if (!completed) {
-        yield {
-          type: "tool_paused",
-          created: Date.now(),
-          actionId: action.sId,
-          configurationId: runContext.agentConfiguration.sId,
-          conversationId: runContext.conversation.sId,
-          messageId: runContext.agentMessage.sId,
-        };
+        yield makeSandboxPausedEvent(runContext);
         return;
       }
     }
@@ -159,6 +169,75 @@ export async function* runToolWithStreaming(
     return;
   }
 
+  const processingOptions = {
+    intervalMs: TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS,
+    heartbeatFn: () => {
+      heartbeat();
+      localLogger.info("MCP tool result processing heartbeat");
+    },
+  };
+
+  if (isSandboxBash) {
+    // File handling can legitimately take up to 5 minutes. Prepare everything first, but leave the
+    // action output uncommitted until the current workflow proves ownership under the conversation
+    // lock.
+    const { preparedOutputItems, generatedFiles } = await withPeriodicHeartbeat(
+      () =>
+        prepareToolResults(auth, {
+          localLogger,
+          toolCallResultContent: toolCallResult.content,
+          toolContext,
+        }),
+      processingOptions
+    );
+    const agentPauseEvents = await getExitOrPauseEvents(auth, {
+      outputItems: preparedOutputItems,
+      toolContext,
+    });
+
+    if (agentPauseEvents.length > 0) {
+      const outputItems = await persistSandboxBashOutput(auth, {
+        action: runContext.action,
+        conversation: runContext.conversation,
+        outputs: preparedOutputItems,
+      });
+      if (!outputItems) {
+        yield makeSandboxPausedEvent(runContext);
+        return;
+      }
+      for (const event of agentPauseEvents) {
+        yield event;
+      }
+      return;
+    }
+
+    const endDate = performance.now();
+    const { completed, outputItems } = await finishSandboxBash(auth, {
+      action: runContext.action,
+      conversation: runContext.conversation,
+      executionDurationMs: endDate - startDate,
+      messageId: runContext.agentMessage.sId,
+      outputs: preparedOutputItems,
+      status: "succeeded",
+    });
+    if (!completed) {
+      yield makeSandboxPausedEvent(runContext);
+      return;
+    }
+
+    yield {
+      type: "tool_success",
+      created: Date.now(),
+      output: removeNulls(
+        [...intermediateOutputItems, ...outputItems].map(
+          hideFileFromActionOutput
+        )
+      ),
+      generatedFiles,
+    };
+    return;
+  }
+
   // Tool result processing can legitimately take up to 5 minutes when processing files,
   // so heartbeat while this scoped post-processing phase is running.
   const { outputItems, generatedFiles } = await withPeriodicHeartbeat(
@@ -168,13 +247,7 @@ export async function* runToolWithStreaming(
         toolCallResultContent: toolCallResult.content,
         toolContext,
       }),
-    {
-      intervalMs: TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS,
-      heartbeatFn: () => {
-        heartbeat();
-        localLogger.info("MCP tool result processing heartbeat");
-      },
-    }
+    processingOptions
   );
 
   // Parse the output resources to check if we find special events that require the agent loop to pause.
@@ -192,28 +265,7 @@ export async function* runToolWithStreaming(
   }
 
   const endDate = performance.now();
-  if (isSandboxBash) {
-    const completed = await finishSandboxBash(auth, {
-      action: runContext.action,
-      conversation: runContext.conversation,
-      executionDurationMs: endDate - startDate,
-      messageId: runContext.agentMessage.sId,
-      status: "succeeded",
-    });
-    if (!completed) {
-      yield {
-        type: "tool_paused",
-        created: Date.now(),
-        actionId: action.sId,
-        configurationId: runContext.agentConfiguration.sId,
-        conversationId: runContext.conversation.sId,
-        messageId: runContext.agentMessage.sId,
-      };
-      return;
-    }
-  } else {
-    await action.markAsSucceeded({ executionDurationMs: endDate - startDate });
-  }
+  await action.markAsSucceeded({ executionDurationMs: endDate - startDate });
 
   yield {
     type: "tool_success",

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -8,6 +8,7 @@ import {
   processToolNotification,
   processToolResults,
 } from "@app/lib/actions/mcp_execution";
+import { SANDBOX_TOOL_NAME } from "@app/lib/api/actions/servers/sandbox/metadata";
 import type {
   MCPApproveExecutionEvent,
   ToolAskUserQuestionEvent,
@@ -19,8 +20,12 @@ import type {
 import { getExitOrPauseEvents } from "@app/lib/actions/mcp_internal_actions/exit_events";
 import { hideFileFromActionOutput } from "@app/lib/actions/mcp_utils";
 import type { ToolContext, ToolOutputItemType } from "@app/lib/actions/types";
-import { isAgentLoopRunContext } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  isSandboxChildActionInfo,
+} from "@app/lib/actions/types";
 import { handleMCPActionError } from "@app/lib/api/mcp/error";
+import { completeSandboxBash } from "@app/lib/api/sandbox/sandbox_child_block";
 import type { Authenticator } from "@app/lib/auth";
 import { withPeriodicHeartbeat } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -84,8 +89,19 @@ export async function* runToolWithStreaming(
 
   // Sandbox function actions and auto-allowed agent-loop actions are created in running
   // status; only approved or resumed actions still carry a pre-run status to transition.
-  if (isAgentLoopRunContext(runContext) && status !== "running") {
-    await runContext.action.updateStatus("running");
+  if (isAgentLoopRunContext(runContext)) {
+    if (
+      isSandboxChildActionInfo(
+        runContext.action.stepContext.sandboxChildActionInfo
+      )
+    ) {
+      assert(
+        runContext.action.status === "running",
+        "Sandbox child must be reserved before execution."
+      );
+    } else if (status !== "running") {
+      await runContext.action.updateStatus("running");
+    }
   }
   const startDate = performance.now();
 
@@ -152,7 +168,31 @@ export async function* runToolWithStreaming(
   }
 
   const endDate = performance.now();
-  await action.markAsSucceeded({ executionDurationMs: endDate - startDate });
+  if (
+    isAgentLoopRunContext(runContext) &&
+    runContext.action.metadata.internalMCPServerName === SANDBOX_TOOL_NAME &&
+    runContext.action.toolConfiguration.originalName === "bash"
+  ) {
+    const completed = await completeSandboxBash(auth, {
+      action: runContext.action,
+      conversation: runContext.conversation,
+      executionDurationMs: endDate - startDate,
+      messageId: runContext.agentMessage.sId,
+    });
+    if (!completed) {
+      yield {
+        type: "tool_paused",
+        created: Date.now(),
+        actionId: action.sId,
+        configurationId: runContext.agentConfiguration.sId,
+        conversationId: runContext.conversation.sId,
+        messageId: runContext.agentMessage.sId,
+      };
+      return;
+    }
+  } else {
+    await action.markAsSucceeded({ executionDurationMs: endDate - startDate });
+  }
 
   yield {
     type: "tool_success",

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -25,7 +25,7 @@ import {
 } from "@app/lib/actions/types";
 import { SANDBOX_TOOL_NAME } from "@app/lib/api/actions/servers/sandbox/metadata";
 import { handleMCPActionError } from "@app/lib/api/mcp/error";
-import { completeSandboxBash } from "@app/lib/api/sandbox/sandbox_child_block";
+import { finishSandboxBash } from "@app/lib/api/sandbox/sandbox_child_block";
 import type { Authenticator } from "@app/lib/auth";
 import { withPeriodicHeartbeat } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -86,6 +86,10 @@ export async function* runToolWithStreaming(
           invocationId: runContext.invocation.sId,
         }),
   });
+  const isSandboxBash =
+    isAgentLoopRunContext(runContext) &&
+    runContext.action.metadata.internalMCPServerName === SANDBOX_TOOL_NAME &&
+    runContext.action.toolConfiguration.originalName === "bash";
 
   // Sandbox function actions and auto-allowed agent-loop actions are created in running
   // status; only approved or resumed actions still carry a pre-run status to transition.
@@ -126,9 +130,18 @@ export async function* runToolWithStreaming(
   // as content.
   if (toolCallResult.isError) {
     const endDate = performance.now();
+    if (isSandboxBash) {
+      await finishSandboxBash(auth, {
+        action: runContext.action,
+        conversation: runContext.conversation,
+        executionDurationMs: endDate - startDate,
+        messageId: runContext.agentMessage.sId,
+        status: "errored",
+      });
+    }
     yield await handleMCPActionError(auth, {
       action,
-      status,
+      status: isSandboxBash ? "errored" : status,
       errorContent: toolCallResult.content,
       executionDurationMs: endDate - startDate,
     });
@@ -168,16 +181,13 @@ export async function* runToolWithStreaming(
   }
 
   const endDate = performance.now();
-  if (
-    isAgentLoopRunContext(runContext) &&
-    runContext.action.metadata.internalMCPServerName === SANDBOX_TOOL_NAME &&
-    runContext.action.toolConfiguration.originalName === "bash"
-  ) {
-    const completed = await completeSandboxBash(auth, {
+  if (isSandboxBash) {
+    const completed = await finishSandboxBash(auth, {
       action: runContext.action,
       conversation: runContext.conversation,
       executionDurationMs: endDate - startDate,
       messageId: runContext.agentMessage.sId,
+      status: "succeeded",
     });
     if (!completed) {
       yield {

--- a/front/lib/api/poke/plugins/conversations/unstick.ts
+++ b/front/lib/api/poke/plugins/conversations/unstick.ts
@@ -88,9 +88,6 @@ export const unstickConversationPlugin = createPlugin({
       conversation,
       agentMessage: stuck,
       status: "failed",
-      // Force finalization so we can rescue conversations stuck in an anomalous state (e.g. blocked
-      // actions spanning multiple steps) that would otherwise make finalization throw.
-      dangerouslyBypassSameStepCheck: true,
       error: {
         code: "unstuck_by_admin",
         message:

--- a/front/lib/api/sandbox/create_child_action.test.ts
+++ b/front/lib/api/sandbox/create_child_action.test.ts
@@ -364,6 +364,33 @@ describe("createSandboxChildAction", () => {
     expect(vi.mocked(launchSandboxChildToolWorkflow)).not.toHaveBeenCalled();
   });
 
+  it("removes a blocked child when cancellation wins during approval publication", async () => {
+    await setToolPermission("medium");
+    let childActionId: string | null = null;
+    vi.mocked(updateResourceAndPublishEvent).mockImplementationOnce(
+      async (_auth, { event }) => {
+        if ("actionId" in event) {
+          childActionId = event.actionId;
+        }
+        await ConversationFactory.setAgentMessageStatus({
+          workspace,
+          agentMessageModelId: agentMessage.agentMessageId,
+          status: "cancelled",
+        });
+      }
+    );
+
+    const result = await callChildTool();
+
+    expect(result.isErr()).toBe(true);
+    if (!childActionId) {
+      throw new Error("Expected the child approval event to be published.");
+    }
+    const child = await AgentMCPActionResource.fetchById(auth, childActionId);
+    expect(child?.status).toBe("denied");
+    expect(vi.mocked(launchSandboxChildToolWorkflow)).not.toHaveBeenCalled();
+  });
+
   it("keys approvals on the space-disambiguated name when same-named servers are attached", async () => {
     await setToolPermission("medium");
 

--- a/front/lib/api/sandbox/create_child_action.test.ts
+++ b/front/lib/api/sandbox/create_child_action.test.ts
@@ -324,6 +324,27 @@ describe("createSandboxChildAction", () => {
     expect(vi.mocked(launchSandboxChildToolWorkflow)).toHaveBeenCalledTimes(1);
   });
 
+  it("defers a ready child while its parent is blocked", async () => {
+    await setToolPermission("never_ask");
+    const parent = await AgentMCPActionResource.fetchById(auth, parentActionId);
+    if (!parent) {
+      throw new Error("Expected the parent action to exist.");
+    }
+    await parent.updateStatus("blocked_child_action_input_required");
+
+    const result = await callChildTool();
+
+    if (result.isErr()) {
+      throw result.error;
+    }
+    const child = await AgentMCPActionResource.fetchById(
+      auth,
+      result.value.actionId
+    );
+    expect(child?.status).toBe("ready_allowed_implicitly");
+    expect(vi.mocked(launchSandboxChildToolWorkflow)).not.toHaveBeenCalled();
+  });
+
   it("rejects child calls after the parent action finished", async () => {
     const parent = await AgentMCPActionResource.fetchById(auth, parentActionId);
     if (!parent) {

--- a/front/lib/api/sandbox/create_child_action.test.ts
+++ b/front/lib/api/sandbox/create_child_action.test.ts
@@ -11,12 +11,12 @@ vi.mock(import("@app/temporal/agent_loop/client"), async (importOriginal) => {
 
 // The blocked path publishes the approval event to Redis; keep it out of tests.
 vi.mock(
-  import("@app/temporal/agent_loop/activities/common"),
+  import("@app/lib/api/assistant/streaming/events"),
   async (importOriginal) => {
     const mod = await importOriginal();
     return {
       ...mod,
-      updateResourceAndPublishEvent: vi.fn().mockResolvedValue(undefined),
+      publishConversationRelatedEvent: vi.fn().mockResolvedValue(undefined),
     };
   }
 );
@@ -27,6 +27,7 @@ import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import { createSandboxChildAction } from "@app/lib/api/sandbox/create_child_action";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -35,7 +36,6 @@ import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_r
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
-import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
 import { launchSandboxChildToolWorkflow } from "@app/temporal/agent_loop/client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentMCPServerConfigurationFactory } from "@app/tests/utils/AgentMCPServerConfigurationFactory";
@@ -242,17 +242,15 @@ describe("createSandboxChildAction", () => {
     });
     expect(child?.toolConfiguration.permission).toBe("medium");
     expect(vi.mocked(launchSandboxChildToolWorkflow)).not.toHaveBeenCalled();
-    expect(vi.mocked(updateResourceAndPublishEvent)).toHaveBeenCalledWith(
-      auth,
+    expect(vi.mocked(publishConversationRelatedEvent)).toHaveBeenCalledWith(
       expect.objectContaining({
+        conversationId: conversation.sId,
         event: expect.objectContaining({
           type: "tool_approve_execution",
           actionId: child?.sId,
           inputs: { objectName: "Contact" },
           stake: "medium",
-          metadata: expect.objectContaining({
-            toolName: TOOL_NAME,
-          }),
+          metadata: expect.objectContaining({ toolName: TOOL_NAME }),
         }),
       })
     );
@@ -367,7 +365,7 @@ describe("createSandboxChildAction", () => {
     expect(result.error.message).toBe(
       "Parent sandbox action is no longer running."
     );
-    expect(vi.mocked(updateResourceAndPublishEvent)).not.toHaveBeenCalled();
+    expect(vi.mocked(publishConversationRelatedEvent)).not.toHaveBeenCalled();
     expect(vi.mocked(launchSandboxChildToolWorkflow)).not.toHaveBeenCalled();
   });
 
@@ -387,34 +385,7 @@ describe("createSandboxChildAction", () => {
     expect(result.error.message).toBe(
       "Agent message can no longer run sandbox child actions."
     );
-    expect(vi.mocked(updateResourceAndPublishEvent)).not.toHaveBeenCalled();
-    expect(vi.mocked(launchSandboxChildToolWorkflow)).not.toHaveBeenCalled();
-  });
-
-  it("removes a blocked child when cancellation wins during approval publication", async () => {
-    await setToolPermission("medium");
-    let childActionId: string | null = null;
-    vi.mocked(updateResourceAndPublishEvent).mockImplementationOnce(
-      async (_auth, { event }) => {
-        if ("actionId" in event) {
-          childActionId = event.actionId;
-        }
-        await ConversationFactory.setAgentMessageStatus({
-          workspace,
-          agentMessageModelId: agentMessage.agentMessageId,
-          status: "cancelled",
-        });
-      }
-    );
-
-    const result = await callChildTool();
-
-    expect(result.isErr()).toBe(true);
-    if (!childActionId) {
-      throw new Error("Expected the child approval event to be published.");
-    }
-    const child = await AgentMCPActionResource.fetchById(auth, childActionId);
-    expect(child?.status).toBe("denied");
+    expect(vi.mocked(publishConversationRelatedEvent)).not.toHaveBeenCalled();
     expect(vi.mocked(launchSandboxChildToolWorkflow)).not.toHaveBeenCalled();
   });
 

--- a/front/lib/api/sandbox/create_child_action.test.ts
+++ b/front/lib/api/sandbox/create_child_action.test.ts
@@ -256,6 +256,29 @@ describe("createSandboxChildAction", () => {
     );
   });
 
+  it("compensates the blocked child when approval publication fails", async () => {
+    await setToolPermission("medium");
+    vi.mocked(publishConversationRelatedEvent).mockRejectedValueOnce(
+      new Error("Redis unavailable")
+    );
+
+    const result = await callChildTool();
+
+    expect(result.isErr()).toBe(true);
+    const parent = await AgentMCPActionResource.fetchById(auth, parentActionId);
+    expect(parent?.status).toBe("running");
+    const actions = await AgentMCPActionResource.listByAgentMessageIds(auth, [
+      agentMessage.agentMessageId,
+    ]);
+    const child = actions.find(
+      (action) =>
+        action.stepContext.sandboxChildActionInfo?.parentActionId ===
+        parentActionId
+    );
+    expect(child?.status).toBe("denied");
+    expect(vi.mocked(launchSandboxChildToolWorkflow)).not.toHaveBeenCalled();
+  });
+
   it("auto-approves medium-stake tools when a direct-call approval exists", async () => {
     await setToolPermission("medium");
 

--- a/front/lib/api/sandbox/create_child_action.test.ts
+++ b/front/lib/api/sandbox/create_child_action.test.ts
@@ -53,6 +53,7 @@ import { slugify } from "@app/types/shared/utils/string_utils";
 import type { WorkspaceType } from "@app/types/user";
 
 const TOOL_NAME = "tool";
+const EXEC_ID = "0123456789abcdef";
 
 describe("createSandboxChildAction", () => {
   let workspace: WorkspaceType;
@@ -178,6 +179,7 @@ describe("createSandboxChildAction", () => {
   ) {
     return createSandboxChildAction(auth, {
       parentActionId,
+      execId: EXEC_ID,
       agentId: agentConfig.sId,
       agentVersion: agentConfig.version,
       conversationId: conversation.sId,
@@ -234,6 +236,10 @@ describe("createSandboxChildAction", () => {
       result.value.actionId
     );
     expect(child?.status).toBe("blocked_validation_required");
+    expect(child?.stepContext.sandboxChildActionInfo).toEqual({
+      parentActionId,
+      execId: EXEC_ID,
+    });
     expect(child?.toolConfiguration.permission).toBe("medium");
     expect(vi.mocked(launchSandboxChildToolWorkflow)).not.toHaveBeenCalled();
     expect(vi.mocked(updateResourceAndPublishEvent)).toHaveBeenCalledWith(

--- a/front/lib/api/sandbox/create_child_action.test.ts
+++ b/front/lib/api/sandbox/create_child_action.test.ts
@@ -321,6 +321,25 @@ describe("createSandboxChildAction", () => {
     expect(vi.mocked(launchSandboxChildToolWorkflow)).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects child calls after the parent action finished", async () => {
+    const parent = await AgentMCPActionResource.fetchById(auth, parentActionId);
+    if (!parent) {
+      throw new Error("Expected the parent action to exist.");
+    }
+    await parent.updateStatus("succeeded");
+
+    const result = await callChildTool();
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("Expected the child call to fail.");
+    }
+    expect(result.error.message).toBe(
+      "Parent sandbox action is no longer running."
+    );
+    expect(vi.mocked(launchSandboxChildToolWorkflow)).not.toHaveBeenCalled();
+  });
+
   it("keys approvals on the space-disambiguated name when same-named servers are attached", async () => {
     await setToolPermission("medium");
 

--- a/front/lib/api/sandbox/create_child_action.test.ts
+++ b/front/lib/api/sandbox/create_child_action.test.ts
@@ -302,7 +302,7 @@ describe("createSandboxChildAction", () => {
       auth,
       result.value.actionId
     );
-    expect(child?.status).toBe("running");
+    expect(child?.status).toBe("ready_allowed_implicitly");
     // The child configuration must carry the same function-call name as direct
     // calls so approval checks and recordings share one key.
     expect(child?.toolConfiguration.name).toBe(directCallToolName);
@@ -324,7 +324,7 @@ describe("createSandboxChildAction", () => {
       auth,
       result.value.actionId
     );
-    expect(child?.status).toBe("running");
+    expect(child?.status).toBe("ready_allowed_implicitly");
     expect(vi.mocked(launchSandboxChildToolWorkflow)).toHaveBeenCalledTimes(1);
   });
 
@@ -480,7 +480,7 @@ describe("createSandboxChildAction", () => {
       auth,
       result.value.actionId
     );
-    expect(child?.status).toBe("running");
+    expect(child?.status).toBe("ready_allowed_implicitly");
     expect(child?.toolConfiguration.name).toBe(disambiguatedKey);
   });
 

--- a/front/lib/api/sandbox/create_child_action.test.ts
+++ b/front/lib/api/sandbox/create_child_action.test.ts
@@ -226,6 +226,9 @@ describe("createSandboxChildAction", () => {
     }
     expect(result.value.pauseSandbox).toBeDefined();
 
+    const parent = await AgentMCPActionResource.fetchById(auth, parentActionId);
+    expect(parent?.status).toBe("blocked_child_action_input_required");
+
     const child = await AgentMCPActionResource.fetchById(
       auth,
       result.value.actionId
@@ -337,6 +340,27 @@ describe("createSandboxChildAction", () => {
     expect(result.error.message).toBe(
       "Parent sandbox action is no longer running."
     );
+    expect(vi.mocked(updateResourceAndPublishEvent)).not.toHaveBeenCalled();
+    expect(vi.mocked(launchSandboxChildToolWorkflow)).not.toHaveBeenCalled();
+  });
+
+  it("rejects child calls after the agent message was cancelled", async () => {
+    await ConversationFactory.setAgentMessageStatus({
+      workspace,
+      agentMessageModelId: agentMessage.agentMessageId,
+      status: "cancelled",
+    });
+
+    const result = await callChildTool();
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("Expected the child call to fail.");
+    }
+    expect(result.error.message).toBe(
+      "Agent message can no longer run sandbox child actions."
+    );
+    expect(vi.mocked(updateResourceAndPublishEvent)).not.toHaveBeenCalled();
     expect(vi.mocked(launchSandboxChildToolWorkflow)).not.toHaveBeenCalled();
   });
 

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -10,17 +10,19 @@ import { tryGetPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { getConversationRankVersionLock } from "@app/lib/api/assistant/conversation/lock";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import { resolveSkillMCPServers } from "@app/lib/api/assistant/skill_actions";
 import { createMCPAction } from "@app/lib/api/mcp/create_mcp";
-import { pauseSandboxBashForBlockedChild } from "@app/lib/api/sandbox/sandbox_child_block";
+import { pauseReservedSandboxBash } from "@app/lib/api/sandbox/sandbox_child_block";
 import type { Authenticator } from "@app/lib/auth";
 import { notifyManualActionRequired } from "@app/lib/notifications/workflows/manual-action-required";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
 import { launchSandboxChildToolWorkflow } from "@app/temporal/agent_loop/client";
 import { isAgentMessageType } from "@app/types/assistant/conversation";
@@ -221,35 +223,89 @@ export async function createSandboxChildAction(
   const persistedStatus =
     status === "ready_allowed_implicitly" ? "running" : status;
 
-  // Fetch the parent immediately before creating the child: a background sandbox call can reach
-  // this endpoint after its parent bash has already completed and the agent has moved on.
-  const parentAction = await AgentMCPActionResource.fetchById(
-    auth,
-    parentActionId
-  );
-  if (!parentAction) {
-    return new Err(new Error("Parent action not found."));
-  }
-  if (
-    parentAction.status !== "running" &&
-    parentAction.status !== "blocked_child_action_input_required"
-  ) {
-    return new Err(new Error("Parent sandbox action is no longer running."));
+  const creationRes = await withTransaction(async (transaction) => {
+    // Terminal message updates use the same lock. This prevents a delayed sandbox request from
+    // creating a child after cancellation while still letting terminal cleanup see any child
+    // committed immediately before it.
+    await getConversationRankVersionLock(auth, conversation, transaction);
+
+    const parentAction = await AgentMCPActionResource.fetchById(
+      auth,
+      parentActionId,
+      transaction
+    );
+    if (!parentAction) {
+      return new Err(new Error("Parent action not found."));
+    }
+    if (parentAction.agentMessageId !== agentMessage.agentMessageId) {
+      return new Err(
+        new Error("Parent action does not belong to the agent message.")
+      );
+    }
+    if (
+      parentAction.status !== "running" &&
+      parentAction.status !== "blocked_child_action_input_required"
+    ) {
+      return new Err(new Error("Parent sandbox action is no longer running."));
+    }
+    if (!(await parentAction.canAgentMessageResume(auth, transaction))) {
+      return new Err(
+        new Error("Agent message can no longer run sandbox child actions.")
+      );
+    }
+
+    let shouldPauseSandbox = false;
+    if (
+      status === "blocked_validation_required" &&
+      parentAction.status === "running"
+    ) {
+      const [updatedCount] = await parentAction.updateStatusFromExpected(auth, {
+        status: "blocked_child_action_input_required",
+        expectedStatus: "running",
+        transaction,
+      });
+      if (updatedCount === 0) {
+        return new Err(
+          new Error("Parent sandbox action is no longer running.")
+        );
+      }
+      shouldPauseSandbox = true;
+    }
+
+    const action = await createMCPAction(auth, {
+      actionConfiguration: fullToolConfiguration,
+      agentMessage,
+      augmentedInputs: rawInputs,
+      conversation,
+      status: persistedStatus,
+      stepContent: parentAction.stepContent,
+      stepContext: {
+        ...parentAction.stepContext,
+        resumeState: null,
+        sandboxChildActionInfo: { parentActionId: parentAction.sId },
+      },
+      transaction,
+    });
+
+    return new Ok({ action, parentAction, shouldPauseSandbox });
+  });
+  if (creationRes.isErr()) {
+    return creationRes;
   }
 
-  const action = await createMCPAction(auth, {
-    actionConfiguration: fullToolConfiguration,
-    agentMessage,
-    augmentedInputs: rawInputs,
-    conversation,
-    status: persistedStatus,
-    stepContent: parentAction.stepContent,
-    stepContext: {
-      ...parentAction.stepContext,
-      resumeState: null,
-      sandboxChildActionInfo: { parentActionId: parentAction.sId },
-    },
-  });
+  const { action, parentAction, shouldPauseSandbox } = creationRes.value;
+
+  // The lock above prevents creation after terminalization. Re-check before external side effects
+  // to cover terminalization immediately after the transaction committed.
+  if (!(await action.canAgentMessageResume(auth))) {
+    await action.updateStatusFromExpected(auth, {
+      status: "denied",
+      expectedStatus: action.status,
+    });
+    return new Err(
+      new Error("Agent message can no longer run sandbox child actions.")
+    );
+  }
 
   if (status === "blocked_validation_required") {
     const approvalRequirementEvent: AgentLoopMCPApproveExecutionEvent = {
@@ -282,7 +338,7 @@ export async function createSandboxChildAction(
     }
 
     // Hand the sandbox pause back to the caller instead of pausing here.
-    // `pauseSandboxBashForBlockedChild` freezes the whole sandbox via
+    // `pauseReservedSandboxBash` freezes the whole sandbox via
     // `betaPause` — including the `dsbx` client still blocked on this `/call`
     // request. Pausing before the response is flushed would mean `dsbx` never
     // receives `actionId`, so it could never poll for the result. The caller
@@ -291,8 +347,9 @@ export async function createSandboxChildAction(
     // wait-and-collect wake-up flow.
     return new Ok({
       actionId: action.sId,
-      pauseSandbox: () =>
-        pauseSandboxBashForBlockedChild(auth, action, conversation),
+      pauseSandbox: shouldPauseSandbox
+        ? () => pauseReservedSandboxBash(auth, action, conversation)
+        : () => Promise.resolve(),
     });
   }
 

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -10,6 +10,7 @@ import { tryGetPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { clearBlockedActionEffects } from "@app/lib/api/assistant/conversation/blocked_actions";
 import { getConversationRankVersionLock } from "@app/lib/api/assistant/conversation/lock";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
@@ -329,6 +330,45 @@ export async function createSandboxChildAction(
     });
 
     await ConversationResource.markAsActionRequired(auth, { conversation });
+
+    const canStillBlock = await withTransaction(async (transaction) => {
+      await getConversationRankVersionLock(auth, conversation, transaction);
+
+      const freshAction = await AgentMCPActionResource.fetchById(
+        auth,
+        action.sId,
+        transaction
+      );
+      if (
+        freshAction?.status === "blocked_validation_required" &&
+        (await freshAction.canAgentMessageResume(auth, transaction))
+      ) {
+        return true;
+      }
+
+      if (freshAction?.status === "blocked_validation_required") {
+        await freshAction.updateStatusFromExpected(auth, {
+          status: "denied",
+          expectedStatus: "blocked_validation_required",
+          transaction,
+        });
+      }
+      return false;
+    });
+    if (!canStillBlock) {
+      // Cancellation can commit immediately before the approval event is published. Its terminal
+      // cleanup then has nothing left to remove, so this post-publish check removes the late event
+      // and clears the denormalized actionRequired flag. If cancellation commits afterward, its
+      // normal cleanup performs the same idempotent work.
+      await clearBlockedActionEffects(auth, {
+        actionIds: [action.sId],
+        conversationId: conversation.sId,
+        messageId: agentMessage.sId,
+      });
+      return new Err(
+        new Error("Agent message can no longer run sandbox child actions.")
+      );
+    }
 
     if (!conversation.actionRequired) {
       notifyManualActionRequired(auth, {

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -86,14 +86,6 @@ export async function createSandboxChildAction(
     return new Err(new Error("Conversation not found."));
   }
 
-  const parentAction = await AgentMCPActionResource.fetchById(
-    auth,
-    parentActionId
-  );
-  if (!parentAction) {
-    return new Err(new Error("Parent action not found."));
-  }
-
   const agentMessageRes = await conversationResource.getMessageById(
     auth,
     agentMessageId
@@ -228,6 +220,22 @@ export async function createSandboxChildAction(
   // execution start.
   const persistedStatus =
     status === "ready_allowed_implicitly" ? "running" : status;
+
+  // Fetch the parent immediately before creating the child: a background sandbox call can reach
+  // this endpoint after its parent bash has already completed and the agent has moved on.
+  const parentAction = await AgentMCPActionResource.fetchById(
+    auth,
+    parentActionId
+  );
+  if (!parentAction) {
+    return new Err(new Error("Parent action not found."));
+  }
+  if (
+    parentAction.status !== "running" &&
+    parentAction.status !== "blocked_child_action_input_required"
+  ) {
+    return new Err(new Error("Parent sandbox action is no longer running."));
+  }
 
   const action = await createMCPAction(auth, {
     actionConfiguration: fullToolConfiguration,

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -10,12 +10,12 @@ import { tryGetPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import { clearBlockedActionEffects } from "@app/lib/api/assistant/conversation/blocked_actions";
 import { getConversationRankVersionLock } from "@app/lib/api/assistant/conversation/lock";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import { resolveSkillMCPServers } from "@app/lib/api/assistant/skill_actions";
+import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import { createMCPAction } from "@app/lib/api/mcp/create_mcp";
 import { pauseReservedSandboxBash } from "@app/lib/api/sandbox/sandbox_child_block";
 import type { Authenticator } from "@app/lib/auth";
@@ -24,7 +24,6 @@ import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_reso
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
-import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
 import { launchSandboxChildToolWorkflow } from "@app/temporal/agent_loop/client";
 import { isAgentMessageType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
@@ -340,16 +339,7 @@ export async function createSandboxChildAction(
       isLastBlockingEventForStep: true,
     };
 
-    await updateResourceAndPublishEvent(auth, {
-      event: approvalRequirementEvent,
-      agentMessage,
-      conversation,
-      step: parentAction.stepContent.step,
-    });
-
-    await ConversationResource.markAsActionRequired(auth, { conversation });
-
-    const canStillBlock = await withTransaction(async (transaction) => {
+    const eventPublished = await withTransaction(async (transaction) => {
       await getConversationRankVersionLock(auth, conversation, transaction);
 
       const freshAction = await AgentMCPActionResource.fetchById(
@@ -361,6 +351,18 @@ export async function createSandboxChildAction(
         freshAction?.status === "blocked_validation_required" &&
         (await freshAction.canAgentMessageResume(auth, transaction))
       ) {
+        await ConversationResource.markAsActionRequired(auth, {
+          conversation,
+          transaction,
+        });
+        // Keep publication under the same lock as message termination and action resolution.
+        // The prompt is therefore either published before their client-visible event, or skipped
+        // after their state transition; it can never become the final event after termination.
+        await publishConversationRelatedEvent({
+          conversationId: conversation.sId,
+          event: approvalRequirementEvent,
+          step: parentAction.stepContent.step,
+        });
         return true;
       }
 
@@ -373,16 +375,7 @@ export async function createSandboxChildAction(
       }
       return false;
     });
-    if (!canStillBlock) {
-      // Cancellation can commit immediately before the approval event is published. Its terminal
-      // cleanup then has nothing left to remove, so this post-publish check removes the late event
-      // and clears the denormalized actionRequired flag. If cancellation commits afterward, its
-      // normal cleanup performs the same idempotent work.
-      await clearBlockedActionEffects(auth, {
-        actionIds: [action.sId],
-        conversationId: conversation.sId,
-        messageId: agentMessage.sId,
-      });
+    if (!eventPublished) {
       return new Err(
         new Error("Agent message can no longer run sandbox child actions.")
       );

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -5,11 +5,12 @@ import {
 } from "@app/lib/actions/mcp_actions";
 import type { AgentLoopMCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
-import { makeMCPApproveExecutionEventBase } from "@app/lib/actions/tool_approval_events";
+import { prepareMCPApprovalEvent } from "@app/lib/actions/tool_approval_events";
 import { tryGetPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { clearBlockedActionEffects } from "@app/lib/api/assistant/conversation/blocked_actions";
 import { getConversationRankVersionLock } from "@app/lib/api/assistant/conversation/lock";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
@@ -24,10 +25,15 @@ import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_reso
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import logger from "@app/logger/logger";
 import { launchSandboxChildToolWorkflow } from "@app/temporal/agent_loop/client";
-import { isAgentMessageType } from "@app/types/assistant/conversation";
+import {
+  type ConversationWithoutContentType,
+  isAgentMessageType,
+} from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 type CreateSandboxChildActionResult = {
   actionId: string;
@@ -38,6 +44,55 @@ type CreateSandboxChildActionResult = {
   // `actionId` and can never poll for the result.
   pauseSandbox?: () => Promise<void>;
 };
+
+async function rollbackSandboxApproval(
+  auth: Authenticator,
+  {
+    actionId,
+    conversation,
+    parentActionId,
+  }: {
+    actionId: string;
+    conversation: ConversationWithoutContentType;
+    parentActionId: string;
+  }
+): Promise<void> {
+  await withTransaction(async (transaction) => {
+    await getConversationRankVersionLock(auth, conversation, transaction);
+
+    const action = await AgentMCPActionResource.fetchById(
+      auth,
+      actionId,
+      transaction
+    );
+    if (action?.status === "blocked_validation_required") {
+      await action.updateStatusFromExpected(auth, {
+        status: "denied",
+        expectedStatus: "blocked_validation_required",
+        transaction,
+      });
+    }
+
+    const parent = await AgentMCPActionResource.fetchById(
+      auth,
+      parentActionId,
+      transaction
+    );
+    if (
+      parent?.status === "blocked_child_action_input_required" &&
+      !(await AgentMCPActionResource.hasBlockedSandboxChildren(auth, {
+        parentAction: parent,
+        transaction,
+      }))
+    ) {
+      await parent.updateStatusFromExpected(auth, {
+        status: "running",
+        expectedStatus: "blocked_child_action_input_required",
+        transaction,
+      });
+    }
+  });
+}
 
 /**
  * Creates a sandbox child MCP action — the result of an LLM running inside a
@@ -225,75 +280,139 @@ export async function createSandboxChildAction(
   const persistedStatus =
     status === "ready_allowed_implicitly" ? "running" : status;
 
-  const creationRes = await withTransaction(async (transaction) => {
-    // Terminal message updates use the same lock. This prevents a delayed sandbox request from
-    // creating a child after cancellation while still letting terminal cleanup see any child
-    // committed immediately before it.
-    await getConversationRankVersionLock(auth, conversation, transaction);
+  // Approval labels may resolve file or project resources, so prepare them before taking the
+  // conversation lock. The returned factory adds the action ID after the child row is created.
+  const makeApprovalEvent =
+    status === "blocked_validation_required"
+      ? await prepareMCPApprovalEvent(auth, {
+          toolConfiguration: fullToolConfiguration,
+          inputs: rawInputs,
+          approvalSubjectName: agentConfiguration.name,
+        })
+      : null;
+  let approvalActionId: string | null = null;
+  const creationRes = await (async () => {
+    try {
+      return await withTransaction(async (transaction) => {
+        // Terminal message updates use the same lock. This prevents a delayed sandbox request from
+        // creating a child after cancellation while still letting terminal cleanup see any child
+        // committed immediately before it.
+        await getConversationRankVersionLock(auth, conversation, transaction);
 
-    const parentAction = await AgentMCPActionResource.fetchById(
-      auth,
-      parentActionId,
-      transaction
-    );
-    if (!parentAction) {
-      return new Err(new Error("Parent action not found."));
-    }
-    if (parentAction.agentMessageId !== agentMessage.agentMessageId) {
-      return new Err(
-        new Error("Parent action does not belong to the agent message.")
-      );
-    }
-    if (
-      parentAction.status !== "running" &&
-      parentAction.status !== "blocked_child_action_input_required"
-    ) {
-      return new Err(new Error("Parent sandbox action is no longer running."));
-    }
-    if (!(await parentAction.canAgentMessageResume(auth, transaction))) {
-      return new Err(
-        new Error("Agent message can no longer run sandbox child actions.")
-      );
-    }
-
-    let shouldPauseSandbox = false;
-    if (
-      status === "blocked_validation_required" &&
-      parentAction.status === "running"
-    ) {
-      const [updatedCount] = await parentAction.updateStatusFromExpected(auth, {
-        status: "blocked_child_action_input_required",
-        expectedStatus: "running",
-        transaction,
-      });
-      if (updatedCount === 0) {
-        return new Err(
-          new Error("Parent sandbox action is no longer running.")
+        const parentAction = await AgentMCPActionResource.fetchById(
+          auth,
+          parentActionId,
+          transaction
         );
+        if (!parentAction) {
+          return new Err(new Error("Parent action not found."));
+        }
+        if (parentAction.agentMessageId !== agentMessage.agentMessageId) {
+          return new Err(
+            new Error("Parent action does not belong to the agent message.")
+          );
+        }
+        if (
+          parentAction.status !== "running" &&
+          parentAction.status !== "blocked_child_action_input_required"
+        ) {
+          return new Err(
+            new Error("Parent sandbox action is no longer running.")
+          );
+        }
+        if (!(await parentAction.canAgentMessageResume(auth, transaction))) {
+          return new Err(
+            new Error("Agent message can no longer run sandbox child actions.")
+          );
+        }
+
+        let shouldPauseSandbox = false;
+        if (makeApprovalEvent && parentAction.status === "running") {
+          const [updatedCount] = await parentAction.updateStatusFromExpected(
+            auth,
+            {
+              status: "blocked_child_action_input_required",
+              expectedStatus: "running",
+              transaction,
+            }
+          );
+          if (updatedCount === 0) {
+            return new Err(
+              new Error("Parent sandbox action is no longer running.")
+            );
+          }
+          shouldPauseSandbox = true;
+        }
+
+        const action = await createMCPAction(auth, {
+          actionConfiguration: fullToolConfiguration,
+          agentMessage,
+          augmentedInputs: rawInputs,
+          conversation,
+          status: persistedStatus,
+          stepContent: parentAction.stepContent,
+          stepContext: {
+            ...parentAction.stepContext,
+            resumeState: null,
+            sandboxChildActionInfo: {
+              parentActionId: parentAction.sId,
+              execId,
+            },
+          },
+          transaction,
+        });
+
+        if (makeApprovalEvent) {
+          approvalActionId = action.sId;
+          const event: AgentLoopMCPApproveExecutionEvent = {
+            ...makeApprovalEvent(action.sId),
+            configurationId: fullToolConfiguration.sId,
+            conversationId: conversation.sId,
+            messageId: agentMessage.sId,
+            isLastBlockingEventForStep: true,
+          };
+          await ConversationResource.markAsActionRequired(auth, {
+            conversation,
+            transaction,
+          });
+          await publishConversationRelatedEvent({
+            conversationId: conversation.sId,
+            event,
+            step: parentAction.stepContent.step,
+          });
+        }
+
+        return new Ok({ action, parentAction, shouldPauseSandbox });
+      });
+    } catch (err) {
+      if (approvalActionId) {
+        try {
+          await rollbackSandboxApproval(auth, {
+            actionId: approvalActionId,
+            conversation,
+            parentActionId,
+          });
+          // Redis publication is not transactional. Remove a prompt if it was delivered before
+          // the transaction failed and rolled back the corresponding action.
+          await clearBlockedActionEffects(auth, {
+            actionIds: [approvalActionId],
+            conversationId: conversation.sId,
+            messageId: agentMessage.sId,
+          });
+        } catch (cleanupError) {
+          logger.error(
+            {
+              err: cleanupError,
+              actionId: approvalActionId,
+              conversationId: conversation.sId,
+            },
+            "Failed to clean up a rolled-back sandbox approval event"
+          );
+        }
       }
-      shouldPauseSandbox = true;
+      return new Err(normalizeError(err));
     }
-
-    const action = await createMCPAction(auth, {
-      actionConfiguration: fullToolConfiguration,
-      agentMessage,
-      augmentedInputs: rawInputs,
-      conversation,
-      status: persistedStatus,
-      stepContent: parentAction.stepContent,
-      stepContext: {
-        ...parentAction.stepContext,
-        resumeState: null,
-        sandboxChildActionInfo: {
-          parentActionId: parentAction.sId,
-          execId,
-        },
-      },
-      transaction,
-    });
-
-    return new Ok({ action, parentAction, shouldPauseSandbox });
-  });
+  })();
   if (creationRes.isErr()) {
     return creationRes;
   }
@@ -320,67 +439,19 @@ export async function createSandboxChildAction(
       status: "denied",
       expectedStatus: action.status,
     });
+    if (status === "blocked_validation_required") {
+      await clearBlockedActionEffects(auth, {
+        actionIds: [action.sId],
+        conversationId: conversation.sId,
+        messageId: agentMessage.sId,
+      });
+    }
     return new Err(
       new Error("Agent message can no longer run sandbox child actions.")
     );
   }
 
   if (status === "blocked_validation_required") {
-    const approvalRequirementEvent: AgentLoopMCPApproveExecutionEvent = {
-      ...(await makeMCPApproveExecutionEventBase(auth, {
-        actionId: action.sId,
-        toolConfiguration: fullToolConfiguration,
-        inputs: rawInputs,
-        approvalSubjectName: agentConfiguration.name,
-      })),
-      configurationId: fullToolConfiguration.sId,
-      conversationId: conversation.sId,
-      messageId: agentMessage.sId,
-      isLastBlockingEventForStep: true,
-    };
-
-    const eventPublished = await withTransaction(async (transaction) => {
-      await getConversationRankVersionLock(auth, conversation, transaction);
-
-      const freshAction = await AgentMCPActionResource.fetchById(
-        auth,
-        action.sId,
-        transaction
-      );
-      if (
-        freshAction?.status === "blocked_validation_required" &&
-        (await freshAction.canAgentMessageResume(auth, transaction))
-      ) {
-        await ConversationResource.markAsActionRequired(auth, {
-          conversation,
-          transaction,
-        });
-        // Keep publication under the same lock as message termination and action resolution.
-        // The prompt is therefore either published before their client-visible event, or skipped
-        // after their state transition; it can never become the final event after termination.
-        await publishConversationRelatedEvent({
-          conversationId: conversation.sId,
-          event: approvalRequirementEvent,
-          step: parentAction.stepContent.step,
-        });
-        return true;
-      }
-
-      if (freshAction?.status === "blocked_validation_required") {
-        await freshAction.updateStatusFromExpected(auth, {
-          status: "denied",
-          expectedStatus: "blocked_validation_required",
-          transaction,
-        });
-      }
-      return false;
-    });
-    if (!eventPublished) {
-      return new Err(
-        new Error("Agent message can no longer run sandbox child actions.")
-      );
-    }
-
     if (!conversation.actionRequired) {
       notifyManualActionRequired(auth, {
         conversationId: conversation.sId,

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -300,6 +300,19 @@ export async function createSandboxChildAction(
   }
 
   const { action, parentAction, shouldPauseSandbox } = creationRes.value;
+  const userMessageInfo = await getUserMessageIdFromMessageId(auth, {
+    messageId: agentMessage.sId,
+  });
+  const agentLoopArgs = {
+    agentMessageId: agentMessage.sId,
+    agentMessageVersion: agentMessage.version,
+    conversationId: conversation.sId,
+    conversationTitle: conversation.title,
+    userMessageId: userMessageInfo.userMessageId,
+    userMessageVersion: userMessageInfo.userMessageVersion,
+    userMessageOrigin: userMessageInfo.userMessageOrigin,
+    initialStartTime: Date.now(),
+  };
 
   // The lock above prevents creation after terminalization. Re-check before external side effects
   // to cover terminalization immediately after the transaction committed.
@@ -393,7 +406,8 @@ export async function createSandboxChildAction(
     return new Ok({
       actionId: action.sId,
       pauseSandbox: shouldPauseSandbox
-        ? () => pauseReservedSandboxBash(auth, action, conversation)
+        ? () =>
+            pauseReservedSandboxBash(auth, action, conversation, agentLoopArgs)
         : () => Promise.resolve(),
     });
   }
@@ -405,21 +419,8 @@ export async function createSandboxChildAction(
     });
   }
 
-  const userMessageInfo = await getUserMessageIdFromMessageId(auth, {
-    messageId: agentMessage.sId,
-  });
-
   await launchSandboxChildToolWorkflow(auth, {
-    agentLoopArgs: {
-      agentMessageId: agentMessage.sId,
-      agentMessageVersion: agentMessage.version,
-      conversationId: conversation.sId,
-      conversationTitle: conversation.title,
-      userMessageId: userMessageInfo.userMessageId,
-      userMessageVersion: userMessageInfo.userMessageVersion,
-      userMessageOrigin: userMessageInfo.userMessageOrigin,
-      initialStartTime: Date.now(),
-    },
+    agentLoopArgs,
     action,
     step: parentAction.stepContent.step,
   });

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -393,6 +393,13 @@ export async function createSandboxChildAction(
     });
   }
 
+  if (parentAction.status === "blocked_child_action_input_required") {
+    // The parent resume scans all non-final actions from its step and will launch this child.
+    return new Ok({
+      actionId: action.sId,
+    });
+  }
+
   const userMessageInfo = await getUserMessageIdFromMessageId(auth, {
     messageId: agentMessage.sId,
   });

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -331,12 +331,6 @@ export async function createSandboxChildAction(
     },
   });
 
-  // Auto-allowed child actions are launched right after creation: persist them as
-  // "running" directly (like sandbox function actions) instead of rewriting the row at
-  // execution start.
-  const persistedStatus =
-    status === "ready_allowed_implicitly" ? "running" : status;
-
   // Approval labels may resolve file or project resources, so prepare them before taking the
   // conversation lock. The returned factory adds the action ID after the child row is created.
   const makeApprovalEvent =
@@ -405,7 +399,9 @@ export async function createSandboxChildAction(
           agentMessage,
           augmentedInputs: rawInputs,
           conversation,
-          status: persistedStatus,
+          // Sandbox children stay ready until reserveSandboxChildRun claims them under the
+          // conversation lock. Persisting them as running would let duplicate workflows execute.
+          status,
           stepContent: parentAction.stepContent,
           stepContext: {
             ...parentAction.stepContext,

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -48,6 +48,7 @@ export async function createSandboxChildAction(
   auth: Authenticator,
   {
     parentActionId,
+    execId,
     agentId,
     agentVersion,
     conversationId,
@@ -57,6 +58,7 @@ export async function createSandboxChildAction(
     rawInputs,
   }: {
     parentActionId: string;
+    execId: string;
     agentId: string;
     agentVersion: number;
     conversationId: string;
@@ -283,7 +285,10 @@ export async function createSandboxChildAction(
       stepContext: {
         ...parentAction.stepContext,
         resumeState: null,
-        sandboxChildActionInfo: { parentActionId: parentAction.sId },
+        sandboxChildActionInfo: {
+          parentActionId: parentAction.sId,
+          execId,
+        },
       },
       transaction,
     });

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -34,6 +34,7 @@ import {
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { Transaction } from "sequelize";
 
 type CreateSandboxChildActionResult = {
   actionId: string;
@@ -49,49 +50,45 @@ async function rollbackSandboxApproval(
   auth: Authenticator,
   {
     actionId,
-    conversation,
     parentActionId,
+    transaction,
   }: {
     actionId: string;
-    conversation: ConversationWithoutContentType;
     parentActionId: string;
+    transaction: Transaction;
   }
 ): Promise<void> {
-  await withTransaction(async (transaction) => {
-    await getConversationRankVersionLock(auth, conversation, transaction);
+  const action = await AgentMCPActionResource.fetchById(
+    auth,
+    actionId,
+    transaction
+  );
+  if (action?.status === "blocked_validation_required") {
+    await action.updateStatusFromExpected(auth, {
+      status: "denied",
+      expectedStatus: "blocked_validation_required",
+      transaction,
+    });
+  }
 
-    const action = await AgentMCPActionResource.fetchById(
-      auth,
-      actionId,
-      transaction
-    );
-    if (action?.status === "blocked_validation_required") {
-      await action.updateStatusFromExpected(auth, {
-        status: "denied",
-        expectedStatus: "blocked_validation_required",
-        transaction,
-      });
-    }
-
-    const parent = await AgentMCPActionResource.fetchById(
-      auth,
-      parentActionId,
-      transaction
-    );
-    if (
-      parent?.status === "blocked_child_action_input_required" &&
-      !(await AgentMCPActionResource.hasBlockedSandboxChildren(auth, {
-        parentAction: parent,
-        transaction,
-      }))
-    ) {
-      await parent.updateStatusFromExpected(auth, {
-        status: "running",
-        expectedStatus: "blocked_child_action_input_required",
-        transaction,
-      });
-    }
-  });
+  const parent = await AgentMCPActionResource.fetchById(
+    auth,
+    parentActionId,
+    transaction
+  );
+  if (
+    parent?.status === "blocked_child_action_input_required" &&
+    !(await AgentMCPActionResource.hasBlockedSandboxChildren(auth, {
+      parentAction: parent,
+      transaction,
+    }))
+  ) {
+    await parent.updateStatusFromExpected(auth, {
+      status: "running",
+      expectedStatus: "blocked_child_action_input_required",
+      transaction,
+    });
+  }
 }
 
 async function publishSandboxApproval(
@@ -110,7 +107,7 @@ async function publishSandboxApproval(
     step: number;
   }
 ): Promise<void> {
-  await withTransaction(async (transaction) => {
+  const publishRes = await withTransaction(async (transaction) => {
     await getConversationRankVersionLock(auth, conversation, transaction);
 
     const freshAction = await AgentMCPActionResource.fetchById(
@@ -131,12 +128,27 @@ async function publishSandboxApproval(
       throw new Error("Agent message can no longer run sandbox child actions.");
     }
 
-    await publishConversationRelatedEvent({
-      conversationId: conversation.sId,
-      event,
-      step,
-    });
+    try {
+      await publishConversationRelatedEvent({
+        conversationId: conversation.sId,
+        event,
+        step,
+      });
+      return new Ok(undefined);
+    } catch (err) {
+      // Redis may expose an event before reporting failure. Deny the referenced child before
+      // releasing the lifecycle lock so an approval request cannot resolve it in between.
+      await rollbackSandboxApproval(auth, {
+        actionId: action.sId,
+        parentActionId,
+        transaction,
+      });
+      return new Err(normalizeError(err));
+    }
   });
+  if (publishRes.isErr()) {
+    throw publishRes.error;
+  }
 }
 
 /**
@@ -445,13 +457,29 @@ export async function createSandboxChildAction(
       });
     } catch (err) {
       try {
-        await rollbackSandboxApproval(auth, {
-          actionId: action.sId,
-          conversation,
-          parentActionId,
+        // Retry compensation in case its first attempt failed before the publication transaction
+        // committed. The updates are idempotent.
+        await withTransaction(async (transaction) => {
+          await getConversationRankVersionLock(auth, conversation, transaction);
+          await rollbackSandboxApproval(auth, {
+            actionId: action.sId,
+            parentActionId,
+            transaction,
+          });
         });
-        // Redis publication is not transactional. Remove a prompt if publication succeeded before
-        // the lifecycle transaction failed to commit.
+      } catch (cleanupError) {
+        logger.error(
+          {
+            err: cleanupError,
+            actionId: action.sId,
+            conversationId: conversation.sId,
+          },
+          "Failed to clean up a sandbox approval event"
+        );
+      }
+      try {
+        // Redis cleanup is independent from DB compensation: a partially published prompt must be
+        // removed even if the fallback transaction failed.
         await clearBlockedActionEffects(auth, {
           actionIds: [action.sId],
           conversationId: conversation.sId,
@@ -464,7 +492,7 @@ export async function createSandboxChildAction(
             actionId: action.sId,
             conversationId: conversation.sId,
           },
-          "Failed to clean up a sandbox approval event"
+          "Failed to remove a sandbox approval event"
         );
       }
       return new Err(normalizeError(err));

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -94,6 +94,51 @@ async function rollbackSandboxApproval(
   });
 }
 
+async function publishSandboxApproval(
+  auth: Authenticator,
+  {
+    action,
+    conversation,
+    event,
+    parentActionId,
+    step,
+  }: {
+    action: AgentMCPActionResource;
+    conversation: ConversationWithoutContentType;
+    event: AgentLoopMCPApproveExecutionEvent;
+    parentActionId: string;
+    step: number;
+  }
+): Promise<void> {
+  await withTransaction(async (transaction) => {
+    await getConversationRankVersionLock(auth, conversation, transaction);
+
+    const freshAction = await AgentMCPActionResource.fetchById(
+      auth,
+      action.sId,
+      transaction
+    );
+    const parentAction = await AgentMCPActionResource.fetchById(
+      auth,
+      parentActionId,
+      transaction
+    );
+    if (
+      freshAction?.status !== "blocked_validation_required" ||
+      parentAction?.status !== "blocked_child_action_input_required" ||
+      !(await freshAction.canAgentMessageResume(auth, transaction))
+    ) {
+      throw new Error("Agent message can no longer run sandbox child actions.");
+    }
+
+    await publishConversationRelatedEvent({
+      conversationId: conversation.sId,
+      event,
+      step,
+    });
+  });
+}
+
 /**
  * Creates a sandbox child MCP action — the result of an LLM running inside a
  * `sandbox` MCP tool invoking another MCP tool through the public sandbox API.
@@ -290,7 +335,6 @@ export async function createSandboxChildAction(
           approvalSubjectName: agentConfiguration.name,
         })
       : null;
-  let approvalActionId: string | null = null;
   const creationRes = await (async () => {
     try {
       return await withTransaction(async (transaction) => {
@@ -363,53 +407,15 @@ export async function createSandboxChildAction(
         });
 
         if (makeApprovalEvent) {
-          approvalActionId = action.sId;
-          const event: AgentLoopMCPApproveExecutionEvent = {
-            ...makeApprovalEvent(action.sId),
-            configurationId: fullToolConfiguration.sId,
-            conversationId: conversation.sId,
-            messageId: agentMessage.sId,
-            isLastBlockingEventForStep: true,
-          };
           await ConversationResource.markAsActionRequired(auth, {
             conversation,
             transaction,
-          });
-          await publishConversationRelatedEvent({
-            conversationId: conversation.sId,
-            event,
-            step: parentAction.stepContent.step,
           });
         }
 
         return new Ok({ action, parentAction, shouldPauseSandbox });
       });
     } catch (err) {
-      if (approvalActionId) {
-        try {
-          await rollbackSandboxApproval(auth, {
-            actionId: approvalActionId,
-            conversation,
-            parentActionId,
-          });
-          // Redis publication is not transactional. Remove a prompt if it was delivered before
-          // the transaction failed and rolled back the corresponding action.
-          await clearBlockedActionEffects(auth, {
-            actionIds: [approvalActionId],
-            conversationId: conversation.sId,
-            messageId: agentMessage.sId,
-          });
-        } catch (cleanupError) {
-          logger.error(
-            {
-              err: cleanupError,
-              actionId: approvalActionId,
-              conversationId: conversation.sId,
-            },
-            "Failed to clean up a rolled-back sandbox approval event"
-          );
-        }
-      }
       return new Err(normalizeError(err));
     }
   })();
@@ -418,6 +424,53 @@ export async function createSandboxChildAction(
   }
 
   const { action, parentAction, shouldPauseSandbox } = creationRes.value;
+
+  if (makeApprovalEvent) {
+    const event: AgentLoopMCPApproveExecutionEvent = {
+      ...makeApprovalEvent(action.sId),
+      configurationId: fullToolConfiguration.sId,
+      conversationId: conversation.sId,
+      messageId: agentMessage.sId,
+      isLastBlockingEventForStep: true,
+    };
+    try {
+      // Publish only after the child commits. Holding the lifecycle lock keeps terminal cleanup
+      // ordered with publication while ensuring consumers can already fetch the referenced row.
+      await publishSandboxApproval(auth, {
+        action,
+        conversation,
+        event,
+        parentActionId,
+        step: parentAction.stepContent.step,
+      });
+    } catch (err) {
+      try {
+        await rollbackSandboxApproval(auth, {
+          actionId: action.sId,
+          conversation,
+          parentActionId,
+        });
+        // Redis publication is not transactional. Remove a prompt if publication succeeded before
+        // the lifecycle transaction failed to commit.
+        await clearBlockedActionEffects(auth, {
+          actionIds: [action.sId],
+          conversationId: conversation.sId,
+          messageId: agentMessage.sId,
+        });
+      } catch (cleanupError) {
+        logger.error(
+          {
+            err: cleanupError,
+            actionId: action.sId,
+            conversationId: conversation.sId,
+          },
+          "Failed to clean up a sandbox approval event"
+        );
+      }
+      return new Err(normalizeError(err));
+    }
+  }
+
   const userMessageInfo = await getUserMessageIdFromMessageId(auth, {
     messageId: agentMessage.sId,
   });

--- a/front/lib/api/sandbox/sandbox_child_block.test.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.test.ts
@@ -491,7 +491,9 @@ describe("resolveSandboxChildBlock", () => {
       throw new Error("Expected the child action to exist.");
     }
 
-    const reserved = await reserveSandboxChildRun(auth, child, conversation);
+    const reserved = await reserveSandboxChildRun(auth, child, conversation, {
+      isRetry: false,
+    });
 
     const deniedChild = await AgentMCPActionResource.fetchById(auth, childId);
     expect(reserved).toBeNull();
@@ -513,9 +515,47 @@ describe("resolveSandboxChildBlock", () => {
       throw new Error("Expected the child action to exist.");
     }
 
-    const reserved = await reserveSandboxChildRun(auth, child, conversation);
+    const reserved = await reserveSandboxChildRun(auth, child, conversation, {
+      isRetry: false,
+    });
 
     expect(reserved?.status).toBe("running");
+  });
+
+  it("reuses a running child only for an activity retry", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "running",
+    });
+    const { sId: childId } = await createAction({
+      name: "child_tool",
+      status: "ready_allowed_implicitly",
+      sandboxChildActionInfo: { parentActionId: parentId },
+    });
+    const child = await AgentMCPActionResource.fetchById(auth, childId);
+    if (!child) {
+      throw new Error("Expected the child action to exist.");
+    }
+
+    const firstAttempt = await reserveSandboxChildRun(
+      auth,
+      child,
+      conversation,
+      { isRetry: false }
+    );
+    const competingRun = await reserveSandboxChildRun(
+      auth,
+      child,
+      conversation,
+      { isRetry: false }
+    );
+    const retry = await reserveSandboxChildRun(auth, child, conversation, {
+      isRetry: true,
+    });
+
+    expect(firstAttempt?.status).toBe("running");
+    expect(competingRun).toBeNull();
+    expect(retry?.status).toBe("running");
   });
 
   it("defers a ready child while its parent is blocked", async () => {
@@ -533,7 +573,9 @@ describe("resolveSandboxChildBlock", () => {
       throw new Error("Expected the child action to exist.");
     }
 
-    const reserved = await reserveSandboxChildRun(auth, child, conversation);
+    const reserved = await reserveSandboxChildRun(auth, child, conversation, {
+      isRetry: false,
+    });
 
     const deferredChild = await AgentMCPActionResource.fetchById(auth, childId);
     expect(reserved).toBeNull();
@@ -556,7 +598,9 @@ describe("resolveSandboxChildBlock", () => {
       throw new Error("Expected the child action to exist.");
     }
 
-    const reserved = await reserveSandboxChildRun(auth, child, conversation);
+    const reserved = await reserveSandboxChildRun(auth, child, conversation, {
+      isRetry: false,
+    });
 
     const parent = await AgentMCPActionResource.fetchById(auth, parentId);
     expect(reserved?.status).toBe("running");

--- a/front/lib/api/sandbox/sandbox_child_block.test.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.test.ts
@@ -14,7 +14,9 @@ vi.mock("@app/lib/resources/conversation_sandbox_adapter", () => ({
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import {
+  completeSandboxBash,
   pauseSandboxBashForBlockedChild,
+  reserveSandboxChildRun,
   resolveSandboxChildBlock,
 } from "@app/lib/api/sandbox/sandbox_child_block";
 import type { Authenticator } from "@app/lib/auth";
@@ -174,7 +176,10 @@ describe("resolveSandboxChildBlock", () => {
     await resolveSandboxChildBlock(auth, {
       action: child!,
       sandboxChildActionInfo: { parentActionId: parentId },
-      agentLoopArgs: AGENT_LOOP_ARGS,
+      agentLoopArgs: {
+        ...AGENT_LOOP_ARGS,
+        conversationId: conversation.sId,
+      },
     });
   }
 
@@ -199,7 +204,7 @@ describe("resolveSandboxChildBlock", () => {
         waitForCompletion: true,
         agentLoopArgs: expect.objectContaining({
           agentMessageId: AGENT_LOOP_ARGS.agentMessageId,
-          conversationId: AGENT_LOOP_ARGS.conversationId,
+          conversationId: conversation.sId,
           userMessageId: AGENT_LOOP_ARGS.userMessageId,
         }),
       })
@@ -248,6 +253,104 @@ describe("resolveSandboxChildBlock", () => {
     expect(
       vi.mocked(ConversationSandboxAdapter.pauseSandboxForApproval)
     ).not.toHaveBeenCalled();
+  });
+
+  it("denies a ready child when its parent finishes before the child starts", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "running",
+    });
+    const { sId: childId } = await createAction({
+      name: "child_tool",
+      status: "ready_allowed_implicitly",
+      sandboxChildActionInfo: { parentActionId: parentId },
+    });
+    const parent = await AgentMCPActionResource.fetchById(auth, parentId);
+    if (!parent) {
+      throw new Error("Expected the parent action to exist.");
+    }
+
+    const completed = await completeSandboxBash(auth, {
+      action: parent,
+      conversation,
+      executionDurationMs: 10,
+      messageId: AGENT_LOOP_ARGS.agentMessageId,
+    });
+
+    const child = await AgentMCPActionResource.fetchById(auth, childId);
+    expect(completed).toBe(true);
+    expect(parent.status).toBe("succeeded");
+    expect(child?.status).toBe("denied");
+  });
+
+  it("finishes the parent when a blocking child arrived after bash returned", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "blocked_child_action_input_required",
+    });
+    const { sId: childId } = await createAction({
+      name: "child_tool",
+      status: "blocked_validation_required",
+      sandboxChildActionInfo: { parentActionId: parentId },
+    });
+    const parent = await AgentMCPActionResource.fetchById(auth, parentId);
+    if (!parent) {
+      throw new Error("Expected the parent action to exist.");
+    }
+
+    const completed = await completeSandboxBash(auth, {
+      action: parent,
+      conversation,
+      executionDurationMs: 10,
+      messageId: AGENT_LOOP_ARGS.agentMessageId,
+    });
+
+    const child = await AgentMCPActionResource.fetchById(auth, childId);
+    expect(completed).toBe(true);
+    expect(parent.status).toBe("succeeded");
+    expect(child?.status).toBe("denied");
+  });
+
+  it("does not start a child whose parent already finished", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "succeeded",
+    });
+    const { sId: childId } = await createAction({
+      name: "child_tool",
+      status: "ready_allowed_implicitly",
+      sandboxChildActionInfo: { parentActionId: parentId },
+    });
+    const child = await AgentMCPActionResource.fetchById(auth, childId);
+    if (!child) {
+      throw new Error("Expected the child action to exist.");
+    }
+
+    const reserved = await reserveSandboxChildRun(auth, child, conversation);
+
+    const deniedChild = await AgentMCPActionResource.fetchById(auth, childId);
+    expect(reserved).toBeNull();
+    expect(deniedChild?.status).toBe("denied");
+  });
+
+  it("atomically reserves a child while its parent is running", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "running",
+    });
+    const { sId: childId } = await createAction({
+      name: "child_tool",
+      status: "ready_allowed_implicitly",
+      sandboxChildActionInfo: { parentActionId: parentId },
+    });
+    const child = await AgentMCPActionResource.fetchById(auth, childId);
+    if (!child) {
+      throw new Error("Expected the child action to exist.");
+    }
+
+    const reserved = await reserveSandboxChildRun(auth, child, conversation);
+
+    expect(reserved?.status).toBe("running");
   });
 
   it("skips relaunch when the parent is not in blocked_child_action_input_required", async () => {

--- a/front/lib/api/sandbox/sandbox_child_block.test.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.test.ts
@@ -412,16 +412,20 @@ describe("resolveSandboxChildBlock", () => {
       throw new Error("Expected the parent action to exist.");
     }
 
-    const completed = await finishSandboxBash(auth, {
+    const { completed, outputItems } = await finishSandboxBash(auth, {
       action: parent,
       conversation,
       executionDurationMs: 10,
       messageId: AGENT_LOOP_ARGS.agentMessageId,
+      outputs: [{ content: { type: "text", text: "done" } }],
       status: "succeeded",
     });
 
     const child = await AgentMCPActionResource.fetchById(auth, childId);
     expect(completed).toBe(true);
+    expect(outputItems.map(({ content }) => content)).toEqual([
+      { type: "text", text: "done" },
+    ]);
     expect(parent.status).toBe("succeeded");
     expect(child?.status).toBe("denied");
   });
@@ -441,7 +445,7 @@ describe("resolveSandboxChildBlock", () => {
       throw new Error("Expected the parent action to exist.");
     }
 
-    const completed = await finishSandboxBash(auth, {
+    const { completed } = await finishSandboxBash(auth, {
       action: parent,
       conversation,
       executionDurationMs: 10,
@@ -516,7 +520,7 @@ describe("resolveSandboxChildBlock", () => {
       throw new Error("Expected the parent action to exist.");
     }
 
-    const completed = await finishSandboxBash(auth, {
+    const { completed } = await finishSandboxBash(auth, {
       action: parent,
       conversation,
       executionDurationMs: 10,
@@ -550,11 +554,12 @@ describe("resolveSandboxChildBlock", () => {
       throw new Error("Expected the parent action to be reserved.");
     }
 
-    const completed = await finishSandboxBash(auth, {
+    const { completed, outputItems } = await finishSandboxBash(auth, {
       action: staleParent,
       conversation,
       executionDurationMs: 10,
       messageId: AGENT_LOOP_ARGS.agentMessageId,
+      outputs: [{ content: { type: "text", text: "stale" } }],
       status: "succeeded",
     });
     const competingReservation = await reserveSandboxParentRun(
@@ -564,14 +569,60 @@ describe("resolveSandboxChildBlock", () => {
       "old-workflow-run"
     );
     const freshParent = await AgentMCPActionResource.fetchById(auth, parentId);
+    if (!freshParent) {
+      throw new Error("Expected the parent action to exist.");
+    }
 
     expect(completed).toBe(false);
+    expect(outputItems).toEqual([]);
     expect(competingReservation).toBeNull();
     expect(freshParent?.status).toBe("running");
     expect(freshParent?.stepContext.resumeState).toEqual({
       execId: "0123456789abcdef",
       runId: "new-workflow-run",
     });
+    const persistedOutputs =
+      await AgentMCPActionResource.fetchOutputItemsByActionIds(auth, {
+        actionIds: [freshParent.id],
+        ignoreContent: false,
+      });
+    expect(persistedOutputs.get(freshParent.id)).toBeUndefined();
+  });
+
+  it("does not persist output after the agent message terminates", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "running",
+    });
+    const parent = await AgentMCPActionResource.fetchById(auth, parentId);
+    if (!parent) {
+      throw new Error("Expected the parent action to exist.");
+    }
+    await ConversationFactory.setAgentMessageStatus({
+      workspace,
+      agentMessageModelId: agentMessageId,
+      status: "cancelled",
+    });
+
+    const { completed, outputItems } = await finishSandboxBash(auth, {
+      action: parent,
+      conversation,
+      executionDurationMs: 10,
+      messageId: AGENT_LOOP_ARGS.agentMessageId,
+      outputs: [{ content: { type: "text", text: "stale" } }],
+      status: "succeeded",
+    });
+    const freshParent = await AgentMCPActionResource.fetchById(auth, parentId);
+    const persistedOutputs =
+      await AgentMCPActionResource.fetchOutputItemsByActionIds(auth, {
+        actionIds: [parent.id],
+        ignoreContent: false,
+      });
+
+    expect(completed).toBe(false);
+    expect(outputItems).toEqual([]);
+    expect(freshParent?.status).toBe("denied");
+    expect(persistedOutputs.get(parent.id)).toBeUndefined();
   });
 
   it("does not start a child whose parent already finished", async () => {
@@ -966,6 +1017,39 @@ describe("resolveSandboxChildBlock", () => {
     expect(freshAction?.stepContext.resumeState).toEqual({
       execId: "0123456789abcdef",
       runId: "workflow-run",
+    });
+  });
+
+  it("does not let an old workflow persist a pause for a newer run", async () => {
+    const { sId: actionId } = await createAction({
+      name: "bash",
+      status: "ready_allowed_explicitly",
+      resumeState: { execId: "0123456789abcdef" },
+    });
+    const staleAction = await AgentMCPActionResource.fetchById(auth, actionId);
+    if (!staleAction) {
+      throw new Error("Expected the action to exist.");
+    }
+    await reserveSandboxParentRun(
+      auth,
+      staleAction,
+      conversation,
+      "new-workflow-run"
+    );
+
+    const persisted = await persistActionPause(
+      auth,
+      staleAction,
+      conversation,
+      { execId: "fedcba9876543210" }
+    );
+    const freshAction = await AgentMCPActionResource.fetchById(auth, actionId);
+
+    expect(persisted).toBe(false);
+    expect(freshAction?.status).toBe("running");
+    expect(freshAction?.stepContext.resumeState).toEqual({
+      execId: "0123456789abcdef",
+      runId: "new-workflow-run",
     });
   });
 

--- a/front/lib/api/sandbox/sandbox_child_block.test.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.test.ts
@@ -20,6 +20,7 @@ import {
   finishSandboxBash,
   pauseReservedSandboxBash,
   pauseSandboxBashForBlockedChild,
+  persistActionPause,
   reserveSandboxChildRun,
   reserveSandboxParentRun,
   resolveSandboxChildBlock,
@@ -240,7 +241,12 @@ describe("resolveSandboxChildBlock", () => {
       throw new Error("Expected the child action to exist.");
     }
 
-    await pauseSandboxBashForBlockedChild(auth, child, conversation);
+    await pauseSandboxBashForBlockedChild(
+      auth,
+      child,
+      conversation,
+      AGENT_LOOP_ARGS
+    );
 
     const parent = await AgentMCPActionResource.fetchById(auth, parentId);
     const deniedChild = await AgentMCPActionResource.fetchById(auth, childId);
@@ -283,7 +289,8 @@ describe("resolveSandboxChildBlock", () => {
     const accepted = await pauseSandboxBashForBlockedChild(
       auth,
       child,
-      conversation
+      conversation,
+      AGENT_LOOP_ARGS
     );
 
     const parent = await AgentMCPActionResource.fetchById(auth, parentId);
@@ -325,7 +332,8 @@ describe("resolveSandboxChildBlock", () => {
     const accepted = await pauseSandboxBashForBlockedChild(
       auth,
       child,
-      conversation
+      conversation,
+      AGENT_LOOP_ARGS
     );
 
     const parent = await AgentMCPActionResource.fetchById(auth, parentId);
@@ -366,7 +374,8 @@ describe("resolveSandboxChildBlock", () => {
     const accepted = await pauseSandboxBashForBlockedChild(
       auth,
       child,
-      conversation
+      conversation,
+      AGENT_LOOP_ARGS
     );
 
     expect(accepted).toBe(false);
@@ -611,7 +620,7 @@ describe("resolveSandboxChildBlock", () => {
     expect(vi.mocked(launchAgentLoopWorkflow)).not.toHaveBeenCalled();
   });
 
-  it("does not pause or relaunch when approval wins before pause", async () => {
+  it("pauses and relaunches when approval wins before pause", async () => {
     const { sId: parentId } = await createAction({
       name: "bash",
       status: "blocked_child_action_input_required",
@@ -635,16 +644,46 @@ describe("resolveSandboxChildBlock", () => {
       if (!shouldPause) {
         throw new Error("Expected a pause condition.");
       }
-      expect(await shouldPause()).toBe(false);
+      expect(await shouldPause()).toBe(true);
       return new Ok(undefined);
     });
 
     await resolveChild(childId, parentId);
-    await pauseReservedSandboxBash(auth, child, conversation);
+    await pauseReservedSandboxBash(auth, child, conversation, {
+      ...AGENT_LOOP_ARGS,
+      conversationId: conversation.sId,
+    });
 
     const parent = await AgentMCPActionResource.fetchById(auth, parentId);
-    expect(parent?.stepContext.resumeState).toBeNull();
-    expect(vi.mocked(launchAgentLoopWorkflow)).not.toHaveBeenCalled();
+    expect(parent?.stepContext.resumeState).toEqual({
+      execId: "0123456789abcdef",
+    });
+    expect(parent?.status).toBe("ready_allowed_explicitly");
+    expect(vi.mocked(launchAgentLoopWorkflow)).toHaveBeenCalledOnce();
+  });
+
+  it("does not resurrect a cancelled action from a late pause result", async () => {
+    const resumeState = { execId: "0123456789abcdef" };
+    const { sId: actionId } = await createAction({
+      name: "bash",
+      status: "denied",
+    });
+    const action = await AgentMCPActionResource.fetchById(auth, actionId);
+    if (!action) {
+      throw new Error("Expected the action to exist.");
+    }
+
+    const persisted = await persistActionPause(
+      auth,
+      action,
+      conversation,
+      resumeState
+    );
+
+    const freshAction = await AgentMCPActionResource.fetchById(auth, actionId);
+    expect(persisted).toBe(false);
+    expect(freshAction?.status).toBe("denied");
+    expect(freshAction?.stepContext.resumeState).toBeNull();
   });
 
   it("does not defer relaunch because of an unrelated parent's blocked child", async () => {

--- a/front/lib/api/sandbox/sandbox_child_block.test.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.test.ts
@@ -33,6 +33,7 @@ import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import {
@@ -130,7 +131,7 @@ describe("resolveSandboxChildBlock", () => {
     name: string;
     status: ToolExecutionStatus;
     step?: number;
-    resumeState?: { execId: string } | null;
+    resumeState?: { execId: string; runId?: string } | null;
     sandboxChildActionInfo?: { parentActionId: string; execId?: string };
   }) {
     const stepContent = await AgentStepContentModel.create({
@@ -529,6 +530,50 @@ describe("resolveSandboxChildBlock", () => {
     expect(child?.status).toBe("denied");
   });
 
+  it("does not let an old workflow finish a newer parent reservation", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "ready_allowed_explicitly",
+      resumeState: { execId: "0123456789abcdef" },
+    });
+    const staleParent = await AgentMCPActionResource.fetchById(auth, parentId);
+    if (!staleParent) {
+      throw new Error("Expected the parent action to exist.");
+    }
+    const reservedParent = await reserveSandboxParentRun(
+      auth,
+      staleParent,
+      conversation,
+      "new-workflow-run"
+    );
+    if (!reservedParent) {
+      throw new Error("Expected the parent action to be reserved.");
+    }
+
+    const completed = await finishSandboxBash(auth, {
+      action: staleParent,
+      conversation,
+      executionDurationMs: 10,
+      messageId: AGENT_LOOP_ARGS.agentMessageId,
+      status: "succeeded",
+    });
+    const competingReservation = await reserveSandboxParentRun(
+      auth,
+      staleParent,
+      conversation,
+      "old-workflow-run"
+    );
+    const freshParent = await AgentMCPActionResource.fetchById(auth, parentId);
+
+    expect(completed).toBe(false);
+    expect(competingReservation).toBeNull();
+    expect(freshParent?.status).toBe("running");
+    expect(freshParent?.stepContext.resumeState).toEqual({
+      execId: "0123456789abcdef",
+      runId: "new-workflow-run",
+    });
+  });
+
   it("does not start a child whose parent already finished", async () => {
     const { sId: parentId } = await createAction({
       name: "bash",
@@ -662,7 +707,7 @@ describe("resolveSandboxChildBlock", () => {
     expect(parent?.status).toBe("running");
   });
 
-  it("reserves a ready parent and child together", async () => {
+  it("reserves a ready parent and child with separate ownership", async () => {
     const { sId: parentId } = await createAction({
       name: "bash",
       status: "ready_allowed_explicitly",
@@ -682,9 +727,23 @@ describe("resolveSandboxChildBlock", () => {
       isRetry: false,
     });
 
-    const parent = await AgentMCPActionResource.fetchById(auth, parentId);
+    const readyParent = await AgentMCPActionResource.fetchById(auth, parentId);
+    if (!readyParent) {
+      throw new Error("Expected the parent action to exist.");
+    }
+    const parent = await reserveSandboxParentRun(
+      auth,
+      readyParent,
+      conversation,
+      "workflow-run"
+    );
+
     expect(reserved?.status).toBe("running");
     expect(parent?.status).toBe("running");
+    expect(parent?.stepContext.resumeState).toEqual({
+      execId: "0123456789abcdef",
+      runId: "workflow-run",
+    });
   });
 
   it("denies a resumed parent when cancellation wins", async () => {
@@ -703,7 +762,12 @@ describe("resolveSandboxChildBlock", () => {
       throw new Error("Expected the parent action to exist.");
     }
 
-    const reserved = await reserveSandboxParentRun(auth, parent, conversation);
+    const reserved = await reserveSandboxParentRun(
+      auth,
+      parent,
+      conversation,
+      "workflow-run"
+    );
 
     const deniedParent = await AgentMCPActionResource.fetchById(auth, parentId);
     expect(reserved).toBeNull();
@@ -804,7 +868,7 @@ describe("resolveSandboxChildBlock", () => {
     await resolveChild(childId, parentId);
 
     const freshParent = await AgentMCPActionResource.fetchById(auth, parentId);
-    expect(freshParent?.status).toBe("blocked_child_action_input_required");
+    expect(freshParent?.status).toBe("running");
     expect(vi.mocked(launchAgentLoopWorkflow)).not.toHaveBeenCalled();
     expect(vi.mocked(launchSandboxChildToolWorkflow)).toHaveBeenCalledWith(
       auth,
@@ -814,6 +878,45 @@ describe("resolveSandboxChildBlock", () => {
         waitForCompletion: true,
       })
     );
+  });
+
+  it("runs every approved pre-deploy sibling and clears action required", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "blocked_child_action_input_required",
+    });
+    const { sId: childAId } = await createAction({
+      name: "child_a",
+      status: "ready_allowed_explicitly",
+      sandboxChildActionInfo: { parentActionId: parentId },
+    });
+    const { sId: childBId } = await createAction({
+      name: "child_b",
+      status: "ready_allowed_explicitly",
+      sandboxChildActionInfo: { parentActionId: parentId },
+    });
+    await ConversationResource.upsertParticipation(auth, {
+      conversation,
+      action: "posted",
+      user: auth.getNonNullableUser().toJSON(),
+    });
+    await ConversationResource.markAsActionRequired(auth, { conversation });
+
+    await resolveChild(childBId, parentId);
+
+    const launchedActionIds = vi
+      .mocked(launchSandboxChildToolWorkflow)
+      .mock.calls.map(([, { action }]) => action.sId);
+    expect(launchedActionIds).toEqual(
+      expect.arrayContaining([childAId, childBId])
+    );
+    expect(launchedActionIds).toHaveLength(2);
+    const { actionRequired } =
+      await ConversationResource.getActionRequiredAndLastReadAtForUser(
+        auth,
+        conversation.id
+      );
+    expect(actionRequired).toBe(false);
   });
 
   it("does not resurrect a cancelled action from a late pause result", async () => {
@@ -838,6 +941,32 @@ describe("resolveSandboxChildBlock", () => {
     expect(persisted).toBe(false);
     expect(freshAction?.status).toBe("denied");
     expect(freshAction?.stepContext.resumeState).toBeNull();
+  });
+
+  it("keeps the workflow owner while persisting another pause", async () => {
+    const { sId: actionId } = await createAction({
+      name: "bash",
+      status: "running",
+      resumeState: {
+        execId: "0123456789abcdef",
+        runId: "workflow-run",
+      },
+    });
+    const action = await AgentMCPActionResource.fetchById(auth, actionId);
+    if (!action) {
+      throw new Error("Expected the action to exist.");
+    }
+
+    const persisted = await persistActionPause(auth, action, conversation, {
+      execId: "0123456789abcdef",
+    });
+    const freshAction = await AgentMCPActionResource.fetchById(auth, actionId);
+
+    expect(persisted).toBe(true);
+    expect(freshAction?.stepContext.resumeState).toEqual({
+      execId: "0123456789abcdef",
+      runId: "workflow-run",
+    });
   });
 
   it("does not defer relaunch because of an unrelated parent's blocked child", async () => {

--- a/front/lib/api/sandbox/sandbox_child_block.test.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.test.ts
@@ -5,16 +5,25 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@app/temporal/agent_loop/client", () => ({
   launchAgentLoopWorkflow: vi.fn().mockResolvedValue(new Ok(undefined)),
 }));
+vi.mock("@app/lib/resources/conversation_sandbox_adapter", () => ({
+  ConversationSandboxAdapter: {
+    pauseSandboxForApproval: vi.fn().mockResolvedValue(new Ok(undefined)),
+  },
+}));
 
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
-import { resolveSandboxChildBlock } from "@app/lib/api/sandbox/sandbox_child_block";
+import {
+  pauseSandboxBashForBlockedChild,
+  resolveSandboxChildBlock,
+} from "@app/lib/api/sandbox/sandbox_child_block";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
 import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -101,18 +110,20 @@ describe("resolveSandboxChildBlock", () => {
   async function createAction({
     name,
     status,
+    step = 3,
     resumeState = null,
     sandboxChildActionInfo,
   }: {
     name: string;
     status: ToolExecutionStatus;
+    step?: number;
     resumeState?: { execId: string } | null;
     sandboxChildActionInfo?: { parentActionId: string };
   }) {
     const stepContent = await AgentStepContentModel.create({
       workspaceId: workspace.id,
       agentMessageId,
-      step: 3,
+      step,
       index: stepContentIndex++,
       version: 0,
       type: "function_call",
@@ -195,6 +206,48 @@ describe("resolveSandboxChildBlock", () => {
     );
     const parent = await AgentMCPActionResource.fetchById(auth, parentId);
     expect(parent!.status).toBe("ready_allowed_explicitly");
+  });
+
+  it("denies a late blocked child without re-blocking a finished parent", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "succeeded",
+      step: 1,
+    });
+    const { sId: childId } = await createAction({
+      name: "child_tool",
+      status: "blocked_validation_required",
+      step: 1,
+      sandboxChildActionInfo: { parentActionId: parentId },
+    });
+    const { sId: currentActionId } = await createAction({
+      name: "current_tool",
+      status: "blocked_validation_required",
+      step: 3,
+    });
+    const child = await AgentMCPActionResource.fetchById(auth, childId);
+    if (!child) {
+      throw new Error("Expected the child action to exist.");
+    }
+
+    await pauseSandboxBashForBlockedChild(auth, child, conversation);
+
+    const parent = await AgentMCPActionResource.fetchById(auth, parentId);
+    const deniedChild = await AgentMCPActionResource.fetchById(auth, childId);
+    expect(parent?.status).toBe("succeeded");
+    expect(deniedChild?.status).toBe("denied");
+    await expect(
+      AgentMCPActionResource.listBlockedActionsForAgentMessage(auth, {
+        agentMessageId,
+      })
+    ).resolves.toEqual([
+      expect.objectContaining({
+        sId: currentActionId,
+      }),
+    ]);
+    expect(
+      vi.mocked(ConversationSandboxAdapter.pauseSandboxForApproval)
+    ).not.toHaveBeenCalled();
   });
 
   it("skips relaunch when the parent is not in blocked_child_action_input_required", async () => {

--- a/front/lib/api/sandbox/sandbox_child_block.test.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.test.ts
@@ -1,4 +1,4 @@
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Prevent the Temporal agent loop from actually starting.
@@ -564,6 +564,42 @@ describe("resolveSandboxChildBlock", () => {
 
     expect(result.completed).toBe(true);
     expect(parent.status).toBe("succeeded");
+  });
+
+  it("keeps DB output readable when the GCS copy fails", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "running",
+    });
+    const parent = await AgentMCPActionResource.fetchById(auth, parentId);
+    if (!parent) {
+      throw new Error("Expected the parent action to exist.");
+    }
+    vi.spyOn(
+      AgentMCPActionResource.prototype,
+      "syncOutputRowsToGcs"
+    ).mockResolvedValueOnce(new Err(new Error("GCS unavailable")));
+    const output = { type: "text" as const, text: "completed" };
+
+    const result = await finishSandboxBash(auth, {
+      action: parent,
+      conversation,
+      executionDurationMs: 10,
+      messageId: AGENT_LOOP_ARGS.agentMessageId,
+      outputs: [{ content: output }],
+      status: "succeeded",
+    });
+    const persistedOutputs =
+      await AgentMCPActionResource.fetchOutputItemsByActionIds(auth, {
+        actionIds: [parent.id],
+        ignoreContent: false,
+      });
+
+    expect(result.completed).toBe(true);
+    expect(result.outputItems).toHaveLength(1);
+    expect(
+      persistedOutputs.get(parent.id)?.map(({ content }) => content)
+    ).toEqual([output]);
   });
 
   it("does not let an old workflow finish a newer parent reservation", async () => {

--- a/front/lib/api/sandbox/sandbox_child_block.test.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.test.ts
@@ -255,6 +255,41 @@ describe("resolveSandboxChildBlock", () => {
     ).not.toHaveBeenCalled();
   });
 
+  it("denies a child that blocks after its message was cancelled", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "running",
+    });
+    const { sId: childId } = await createAction({
+      name: "child_tool",
+      status: "blocked_user_answer_required",
+      sandboxChildActionInfo: { parentActionId: parentId },
+    });
+    await AgentMessageModel.update(
+      { status: "cancelled" },
+      { where: { id: agentMessageId } }
+    );
+    const child = await AgentMCPActionResource.fetchById(auth, childId);
+    if (!child) {
+      throw new Error("Expected the child action to exist.");
+    }
+
+    const accepted = await pauseSandboxBashForBlockedChild(
+      auth,
+      child,
+      conversation
+    );
+
+    const parent = await AgentMCPActionResource.fetchById(auth, parentId);
+    const deniedChild = await AgentMCPActionResource.fetchById(auth, childId);
+    expect(accepted).toBe(false);
+    expect(parent?.status).toBe("running");
+    expect(deniedChild?.status).toBe("denied");
+    expect(
+      vi.mocked(ConversationSandboxAdapter.pauseSandboxForApproval)
+    ).not.toHaveBeenCalled();
+  });
+
   it("denies a ready child when its parent finishes before the child starts", async () => {
     const { sId: parentId } = await createAction({
       name: "bash",

--- a/front/lib/api/sandbox/sandbox_child_block.test.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.test.ts
@@ -18,6 +18,7 @@ vi.mock("@app/lib/resources/conversation_sandbox_adapter", () => ({
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { isSandboxChildActionInfo } from "@app/lib/actions/types";
+import * as blockedActionHelpers from "@app/lib/api/assistant/conversation/blocked_actions";
 import {
   finishSandboxBash,
   pauseReservedSandboxBash,
@@ -534,6 +535,37 @@ describe("resolveSandboxChildBlock", () => {
     expect(child?.status).toBe("denied");
   });
 
+  it("keeps the parent final when denied-child cleanup fails", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "running",
+    });
+    await createAction({
+      name: "child_tool",
+      status: "blocked_validation_required",
+      sandboxChildActionInfo: { parentActionId: parentId },
+    });
+    const parent = await AgentMCPActionResource.fetchById(auth, parentId);
+    if (!parent) {
+      throw new Error("Expected the parent action to exist.");
+    }
+    vi.spyOn(
+      blockedActionHelpers,
+      "clearBlockedActionEffects"
+    ).mockRejectedValueOnce(new Error("Redis unavailable"));
+
+    const result = await finishSandboxBash(auth, {
+      action: parent,
+      conversation,
+      executionDurationMs: 10,
+      messageId: AGENT_LOOP_ARGS.agentMessageId,
+      status: "succeeded",
+    });
+
+    expect(result.completed).toBe(true);
+    expect(parent.status).toBe("succeeded");
+  });
+
   it("does not let an old workflow finish a newer parent reservation", async () => {
     const { sId: parentId } = await createAction({
       name: "bash",
@@ -598,6 +630,13 @@ describe("resolveSandboxChildBlock", () => {
     if (!parent) {
       throw new Error("Expected the parent action to exist.");
     }
+    const existingOutput = { type: "text" as const, text: "progress" };
+    const existingOutputRes = await parent.createOutputItems(auth, [
+      { content: existingOutput },
+    ]);
+    if (existingOutputRes.isErr()) {
+      throw existingOutputRes.error;
+    }
     await ConversationFactory.setAgentMessageStatus({
       workspace,
       agentMessageModelId: agentMessageId,
@@ -622,7 +661,9 @@ describe("resolveSandboxChildBlock", () => {
     expect(completed).toBe(false);
     expect(outputItems).toEqual([]);
     expect(freshParent?.status).toBe("denied");
-    expect(persistedOutputs.get(parent.id)).toBeUndefined();
+    expect(
+      persistedOutputs.get(parent.id)?.map(({ content }) => content)
+    ).toEqual([existingOutput]);
   });
 
   it("does not start a child whose parent already finished", async () => {

--- a/front/lib/api/sandbox/sandbox_child_block.test.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.test.ts
@@ -8,6 +8,9 @@ vi.mock("@app/temporal/agent_loop/client", () => ({
 vi.mock("@app/lib/resources/conversation_sandbox_adapter", () => ({
   ConversationSandboxAdapter: {
     pauseSandboxForApproval: vi.fn().mockResolvedValue(new Ok(undefined)),
+    dangerouslySleepSandboxIfPendingApproval: vi
+      .fn()
+      .mockResolvedValue(new Ok(undefined)),
   },
 }));
 
@@ -17,6 +20,7 @@ import {
   finishSandboxBash,
   pauseSandboxBashForBlockedChild,
   reserveSandboxChildRun,
+  reserveSandboxParentRun,
   resolveSandboxChildBlock,
 } from "@app/lib/api/sandbox/sandbox_child_block";
 import type { Authenticator } from "@app/lib/auth";
@@ -291,6 +295,48 @@ describe("resolveSandboxChildBlock", () => {
     ).not.toHaveBeenCalled();
   });
 
+  it("rechecks the child after acquiring the sandbox lifecycle lock", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "running",
+    });
+    const { sId: childId } = await createAction({
+      name: "child_tool",
+      status: "blocked_validation_required",
+      sandboxChildActionInfo: { parentActionId: parentId },
+    });
+    const child = await AgentMCPActionResource.fetchById(auth, childId);
+    if (!child) {
+      throw new Error("Expected the child action to exist.");
+    }
+    vi.mocked(
+      ConversationSandboxAdapter.pauseSandboxForApproval
+    ).mockImplementationOnce(async (_auth, _conversation, opts) => {
+      const shouldPause = opts?.shouldPause;
+      if (!shouldPause) {
+        throw new Error("Expected a pause condition.");
+      }
+      await ConversationFactory.setAgentMessageStatus({
+        workspace,
+        agentMessageModelId: agentMessageId,
+        status: "cancelled",
+      });
+      expect(await shouldPause()).toBe(false);
+      return new Ok(undefined);
+    });
+
+    const accepted = await pauseSandboxBashForBlockedChild(
+      auth,
+      child,
+      conversation
+    );
+
+    expect(accepted).toBe(false);
+    expect(
+      vi.mocked(ConversationSandboxAdapter.pauseSandboxForApproval)
+    ).toHaveBeenCalledOnce();
+  });
+
   it("denies a ready child when its parent finishes before the child starts", async () => {
     const { sId: parentId } = await createAction({
       name: "bash",
@@ -347,6 +393,11 @@ describe("resolveSandboxChildBlock", () => {
     expect(completed).toBe(true);
     expect(parent.status).toBe("succeeded");
     expect(child?.status).toBe("denied");
+    expect(
+      vi.mocked(
+        ConversationSandboxAdapter.dangerouslySleepSandboxIfPendingApproval
+      )
+    ).toHaveBeenCalledOnce();
   });
 
   it("denies a pending child when its parent errors", async () => {
@@ -418,6 +469,74 @@ describe("resolveSandboxChildBlock", () => {
     const reserved = await reserveSandboxChildRun(auth, child, conversation);
 
     expect(reserved?.status).toBe("running");
+  });
+
+  it("defers a ready child while its parent is blocked", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "blocked_child_action_input_required",
+    });
+    const { sId: childId } = await createAction({
+      name: "child_tool",
+      status: "ready_allowed_implicitly",
+      sandboxChildActionInfo: { parentActionId: parentId },
+    });
+    const child = await AgentMCPActionResource.fetchById(auth, childId);
+    if (!child) {
+      throw new Error("Expected the child action to exist.");
+    }
+
+    const reserved = await reserveSandboxChildRun(auth, child, conversation);
+
+    const deferredChild = await AgentMCPActionResource.fetchById(auth, childId);
+    expect(reserved).toBeNull();
+    expect(deferredChild?.status).toBe("ready_allowed_implicitly");
+  });
+
+  it("reserves a ready parent and child together", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "ready_allowed_explicitly",
+      resumeState: { execId: "0123456789abcdef" },
+    });
+    const { sId: childId } = await createAction({
+      name: "child_tool",
+      status: "ready_allowed_explicitly",
+      sandboxChildActionInfo: { parentActionId: parentId },
+    });
+    const child = await AgentMCPActionResource.fetchById(auth, childId);
+    if (!child) {
+      throw new Error("Expected the child action to exist.");
+    }
+
+    const reserved = await reserveSandboxChildRun(auth, child, conversation);
+
+    const parent = await AgentMCPActionResource.fetchById(auth, parentId);
+    expect(reserved?.status).toBe("running");
+    expect(parent?.status).toBe("running");
+  });
+
+  it("denies a resumed parent when cancellation wins", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "ready_allowed_explicitly",
+      resumeState: { execId: "0123456789abcdef" },
+    });
+    await ConversationFactory.setAgentMessageStatus({
+      workspace,
+      agentMessageModelId: agentMessageId,
+      status: "cancelled",
+    });
+    const parent = await AgentMCPActionResource.fetchById(auth, parentId);
+    if (!parent) {
+      throw new Error("Expected the parent action to exist.");
+    }
+
+    const reserved = await reserveSandboxParentRun(auth, parent, conversation);
+
+    const deniedParent = await AgentMCPActionResource.fetchById(auth, parentId);
+    expect(reserved).toBeNull();
+    expect(deniedParent?.status).toBe("denied");
   });
 
   it("skips relaunch when the parent is not in blocked_child_action_input_required", async () => {

--- a/front/lib/api/sandbox/sandbox_child_block.test.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.test.ts
@@ -14,7 +14,7 @@ vi.mock("@app/lib/resources/conversation_sandbox_adapter", () => ({
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import {
-  completeSandboxBash,
+  finishSandboxBash,
   pauseSandboxBashForBlockedChild,
   reserveSandboxChildRun,
   resolveSandboxChildBlock,
@@ -265,10 +265,11 @@ describe("resolveSandboxChildBlock", () => {
       status: "blocked_user_answer_required",
       sandboxChildActionInfo: { parentActionId: parentId },
     });
-    await AgentMessageModel.update(
-      { status: "cancelled" },
-      { where: { id: agentMessageId } }
-    );
+    await ConversationFactory.setAgentMessageStatus({
+      workspace,
+      agentMessageModelId: agentMessageId,
+      status: "cancelled",
+    });
     const child = await AgentMCPActionResource.fetchById(auth, childId);
     if (!child) {
       throw new Error("Expected the child action to exist.");
@@ -305,11 +306,12 @@ describe("resolveSandboxChildBlock", () => {
       throw new Error("Expected the parent action to exist.");
     }
 
-    const completed = await completeSandboxBash(auth, {
+    const completed = await finishSandboxBash(auth, {
       action: parent,
       conversation,
       executionDurationMs: 10,
       messageId: AGENT_LOOP_ARGS.agentMessageId,
+      status: "succeeded",
     });
 
     const child = await AgentMCPActionResource.fetchById(auth, childId);
@@ -333,16 +335,46 @@ describe("resolveSandboxChildBlock", () => {
       throw new Error("Expected the parent action to exist.");
     }
 
-    const completed = await completeSandboxBash(auth, {
+    const completed = await finishSandboxBash(auth, {
       action: parent,
       conversation,
       executionDurationMs: 10,
       messageId: AGENT_LOOP_ARGS.agentMessageId,
+      status: "succeeded",
     });
 
     const child = await AgentMCPActionResource.fetchById(auth, childId);
     expect(completed).toBe(true);
     expect(parent.status).toBe("succeeded");
+    expect(child?.status).toBe("denied");
+  });
+
+  it("denies a pending child when its parent errors", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "running",
+    });
+    const { sId: childId } = await createAction({
+      name: "child_tool",
+      status: "blocked_validation_required",
+      sandboxChildActionInfo: { parentActionId: parentId },
+    });
+    const parent = await AgentMCPActionResource.fetchById(auth, parentId);
+    if (!parent) {
+      throw new Error("Expected the parent action to exist.");
+    }
+
+    const completed = await finishSandboxBash(auth, {
+      action: parent,
+      conversation,
+      executionDurationMs: 10,
+      messageId: AGENT_LOOP_ARGS.agentMessageId,
+      status: "errored",
+    });
+
+    const child = await AgentMCPActionResource.fetchById(auth, childId);
+    expect(completed).toBe(true);
+    expect(parent.status).toBe("errored");
     expect(child?.status).toBe("denied");
   });
 

--- a/front/lib/api/sandbox/sandbox_child_block.test.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.test.ts
@@ -18,6 +18,7 @@ import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import {
   finishSandboxBash,
+  pauseReservedSandboxBash,
   pauseSandboxBashForBlockedChild,
   reserveSandboxChildRun,
   reserveSandboxParentRun,
@@ -124,7 +125,7 @@ describe("resolveSandboxChildBlock", () => {
     status: ToolExecutionStatus;
     step?: number;
     resumeState?: { execId: string } | null;
-    sandboxChildActionInfo?: { parentActionId: string };
+    sandboxChildActionInfo?: { parentActionId: string; execId?: string };
   }) {
     const stepContent = await AgentStepContentModel.create({
       workspaceId: workspace.id,
@@ -293,6 +294,43 @@ describe("resolveSandboxChildBlock", () => {
     expect(
       vi.mocked(ConversationSandboxAdapter.pauseSandboxForApproval)
     ).not.toHaveBeenCalled();
+  });
+
+  it("persists the execId before pausing the sandbox", async () => {
+    const execId = "0123456789abcdef";
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "running",
+    });
+    const { sId: childId } = await createAction({
+      name: "child_tool",
+      status: "blocked_validation_required",
+      sandboxChildActionInfo: { parentActionId: parentId, execId },
+    });
+    const child = await AgentMCPActionResource.fetchById(auth, childId);
+    if (!child) {
+      throw new Error("Expected the child action to exist.");
+    }
+    vi.mocked(
+      ConversationSandboxAdapter.pauseSandboxForApproval
+    ).mockImplementationOnce(async (_auth, _conversation, opts) => {
+      const shouldPause = opts?.shouldPause;
+      if (!shouldPause) {
+        throw new Error("Expected a pause condition.");
+      }
+      expect(await shouldPause()).toBe(true);
+      return new Ok(undefined);
+    });
+
+    const accepted = await pauseSandboxBashForBlockedChild(
+      auth,
+      child,
+      conversation
+    );
+
+    const parent = await AgentMCPActionResource.fetchById(auth, parentId);
+    expect(accepted).toBe(true);
+    expect(parent?.stepContext.resumeState).toEqual({ execId });
   });
 
   it("rechecks the child after acquiring the sandbox lifecycle lock", async () => {
@@ -570,6 +608,42 @@ describe("resolveSandboxChildBlock", () => {
 
     await resolveChild(childId, parentId);
 
+    expect(vi.mocked(launchAgentLoopWorkflow)).not.toHaveBeenCalled();
+  });
+
+  it("does not pause or relaunch when approval wins before pause", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "blocked_child_action_input_required",
+    });
+    const { sId: childId } = await createAction({
+      name: "child_tool",
+      status: "ready_allowed_explicitly",
+      sandboxChildActionInfo: {
+        parentActionId: parentId,
+        execId: "0123456789abcdef",
+      },
+    });
+    const child = await AgentMCPActionResource.fetchById(auth, childId);
+    if (!child) {
+      throw new Error("Expected the child action to exist.");
+    }
+    vi.mocked(
+      ConversationSandboxAdapter.pauseSandboxForApproval
+    ).mockImplementationOnce(async (_auth, _conversation, opts) => {
+      const shouldPause = opts?.shouldPause;
+      if (!shouldPause) {
+        throw new Error("Expected a pause condition.");
+      }
+      expect(await shouldPause()).toBe(false);
+      return new Ok(undefined);
+    });
+
+    await resolveChild(childId, parentId);
+    await pauseReservedSandboxBash(auth, child, conversation);
+
+    const parent = await AgentMCPActionResource.fetchById(auth, parentId);
+    expect(parent?.stepContext.resumeState).toBeNull();
     expect(vi.mocked(launchAgentLoopWorkflow)).not.toHaveBeenCalled();
   });
 

--- a/front/lib/api/sandbox/sandbox_child_block.test.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // Prevent the Temporal agent loop from actually starting.
 vi.mock("@app/temporal/agent_loop/client", () => ({
   launchAgentLoopWorkflow: vi.fn().mockResolvedValue(new Ok(undefined)),
+  launchSandboxChildToolWorkflow: vi.fn().mockResolvedValue(new Ok(undefined)),
 }));
 vi.mock("@app/lib/resources/conversation_sandbox_adapter", () => ({
   ConversationSandboxAdapter: {
@@ -16,6 +17,7 @@ vi.mock("@app/lib/resources/conversation_sandbox_adapter", () => ({
 
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
+import { isSandboxChildActionInfo } from "@app/lib/actions/types";
 import {
   finishSandboxBash,
   pauseReservedSandboxBash,
@@ -33,7 +35,10 @@ import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
-import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
+import {
+  launchAgentLoopWorkflow,
+  launchSandboxChildToolWorkflow,
+} from "@app/temporal/agent_loop/client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -178,10 +183,17 @@ describe("resolveSandboxChildBlock", () => {
   // the callers, which transition the child out of `blocked_*` before calling.
   async function resolveChild(childId: string, parentId: string) {
     const child = await AgentMCPActionResource.fetchById(auth, childId);
-    expect(child).not.toBeNull();
+    if (!child) {
+      throw new Error("Expected the child action to exist.");
+    }
+    const info = child.stepContext.sandboxChildActionInfo;
+    if (!isSandboxChildActionInfo(info)) {
+      throw new Error("Expected sandbox child action info.");
+    }
+    expect(info.parentActionId).toBe(parentId);
     await resolveSandboxChildBlock(auth, {
-      action: child!,
-      sandboxChildActionInfo: { parentActionId: parentId },
+      action: child,
+      sandboxChildActionInfo: info,
       agentLoopArgs: {
         ...AGENT_LOOP_ARGS,
         conversationId: conversation.sId,
@@ -447,6 +459,47 @@ describe("resolveSandboxChildBlock", () => {
     ).toHaveBeenCalledOnce();
   });
 
+  it("keeps a shared sandbox paused for another blocked child", async () => {
+    const { sId: parentAId } = await createAction({
+      name: "bash",
+      status: "blocked_child_action_input_required",
+    });
+    await createAction({
+      name: "child_tool",
+      status: "blocked_validation_required",
+      sandboxChildActionInfo: { parentActionId: parentAId },
+    });
+    const { sId: parentBId } = await createAction({
+      name: "bash",
+      status: "blocked_child_action_input_required",
+    });
+    await createAction({
+      name: "child_tool",
+      status: "blocked_validation_required",
+      sandboxChildActionInfo: { parentActionId: parentBId },
+    });
+    const parentA = await AgentMCPActionResource.fetchById(auth, parentAId);
+    if (!parentA) {
+      throw new Error("Expected the parent action to exist.");
+    }
+
+    await finishSandboxBash(auth, {
+      action: parentA,
+      conversation,
+      executionDurationMs: 10,
+      messageId: AGENT_LOOP_ARGS.agentMessageId,
+      status: "succeeded",
+    });
+
+    const sleepMock = vi.mocked(
+      ConversationSandboxAdapter.dangerouslySleepSandboxIfPendingApproval
+    );
+    expect(sleepMock).toHaveBeenCalledOnce();
+    const shouldSleep = sleepMock.mock.calls[0][2]?.shouldSleep;
+    expect(shouldSleep).toBeDefined();
+    expect(await shouldSleep?.()).toBe(false);
+  });
+
   it("denies a pending child when its parent errors", async () => {
     const { sId: parentId } = await createAction({
       name: "bash",
@@ -566,7 +619,10 @@ describe("resolveSandboxChildBlock", () => {
     const { sId: childId } = await createAction({
       name: "child_tool",
       status: "ready_allowed_implicitly",
-      sandboxChildActionInfo: { parentActionId: parentId },
+      sandboxChildActionInfo: {
+        parentActionId: parentId,
+        execId: "0123456789abcdef",
+      },
     });
     const child = await AgentMCPActionResource.fetchById(auth, childId);
     if (!child) {
@@ -580,6 +636,30 @@ describe("resolveSandboxChildBlock", () => {
     const deferredChild = await AgentMCPActionResource.fetchById(auth, childId);
     expect(reserved).toBeNull();
     expect(deferredChild?.status).toBe("ready_allowed_implicitly");
+  });
+
+  it("runs a ready pre-deploy child while its parent command continues", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "blocked_child_action_input_required",
+    });
+    const { sId: childId } = await createAction({
+      name: "child_tool",
+      status: "ready_allowed_explicitly",
+      sandboxChildActionInfo: { parentActionId: parentId },
+    });
+    const child = await AgentMCPActionResource.fetchById(auth, childId);
+    if (!child) {
+      throw new Error("Expected the child action to exist.");
+    }
+
+    const reserved = await reserveSandboxChildRun(auth, child, conversation, {
+      isRetry: false,
+    });
+
+    const parent = await AgentMCPActionResource.fetchById(auth, parentId);
+    expect(reserved?.status).toBe("running");
+    expect(parent?.status).toBe("running");
   });
 
   it("reserves a ready parent and child together", async () => {
@@ -664,7 +744,7 @@ describe("resolveSandboxChildBlock", () => {
     expect(vi.mocked(launchAgentLoopWorkflow)).not.toHaveBeenCalled();
   });
 
-  it("pauses and relaunches when approval wins before pause", async () => {
+  it("relaunches when approval wins before pause", async () => {
     const { sId: parentId } = await createAction({
       name: "bash",
       status: "blocked_child_action_input_required",
@@ -688,7 +768,7 @@ describe("resolveSandboxChildBlock", () => {
       if (!shouldPause) {
         throw new Error("Expected a pause condition.");
       }
-      expect(await shouldPause()).toBe(true);
+      expect(await shouldPause()).toBe(false);
       return new Ok(undefined);
     });
 
@@ -704,6 +784,36 @@ describe("resolveSandboxChildBlock", () => {
     });
     expect(parent?.status).toBe("ready_allowed_explicitly");
     expect(vi.mocked(launchAgentLoopWorkflow)).toHaveBeenCalledOnce();
+  });
+
+  it("runs a resolved pre-deploy child without restarting its parent", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "blocked_child_action_input_required",
+    });
+    const { sId: childId } = await createAction({
+      name: "child_tool",
+      status: "ready_allowed_explicitly",
+      sandboxChildActionInfo: { parentActionId: parentId },
+    });
+    const parent = await AgentMCPActionResource.fetchById(auth, parentId);
+    if (!parent) {
+      throw new Error("Expected the parent action to exist.");
+    }
+
+    await resolveChild(childId, parentId);
+
+    const freshParent = await AgentMCPActionResource.fetchById(auth, parentId);
+    expect(freshParent?.status).toBe("blocked_child_action_input_required");
+    expect(vi.mocked(launchAgentLoopWorkflow)).not.toHaveBeenCalled();
+    expect(vi.mocked(launchSandboxChildToolWorkflow)).toHaveBeenCalledWith(
+      auth,
+      expect.objectContaining({
+        action: expect.objectContaining({ sId: childId }),
+        step: 3,
+        waitForCompletion: true,
+      })
+    );
   });
 
   it("does not resurrect a cancelled action from a late pause result", async () => {

--- a/front/lib/api/sandbox/sandbox_child_block.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.ts
@@ -7,7 +7,10 @@ import {
   isSandboxChildActionInfo,
   isSandboxResumeState,
 } from "@app/lib/actions/types";
-import { clearBlockedActionEffects } from "@app/lib/api/assistant/conversation/blocked_actions";
+import {
+  clearBlockedActionEffects,
+  releaseSandboxIfUnused,
+} from "@app/lib/api/assistant/conversation/blocked_actions";
 import { getConversationRankVersionLock } from "@app/lib/api/assistant/conversation/lock";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -15,7 +18,10 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
-import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
+import {
+  launchAgentLoopWorkflow,
+  launchSandboxChildToolWorkflow,
+} from "@app/temporal/agent_loop/client";
 import type {
   ConversationWithoutContentType,
   UserMessageOrigin,
@@ -330,10 +336,23 @@ export async function reserveSandboxChildRun(
     }
 
     if (parentAction.status === "blocked_child_action_input_required") {
-      return null;
-    }
-
-    if (
+      // Pre-deploy children have no execId, so their sandbox was never paused. Run the resolved
+      // child independently and restore the parent's truthful running state.
+      if (info.execId) {
+        return null;
+      }
+      const [updatedParentCount] = await parentAction.updateStatusFromExpected(
+        auth,
+        {
+          status: "running",
+          expectedStatus: "blocked_child_action_input_required",
+          transaction,
+        }
+      );
+      if (updatedParentCount === 0) {
+        return null;
+      }
+    } else if (
       parentAction.status === "ready_allowed_explicitly" ||
       parentAction.status === "ready_allowed_implicitly"
     ) {
@@ -472,27 +491,7 @@ export async function finishSandboxBash(
         isToolExecutionStatusBlocked(child.status)
       )
     ) {
-      const conversationResource = await ConversationResource.fetchById(
-        auth,
-        conversation.sId
-      );
-      if (conversationResource) {
-        const sleepResult =
-          await ConversationSandboxAdapter.dangerouslySleepSandboxIfPendingApproval(
-            auth,
-            conversationResource
-          );
-        if (sleepResult.isErr()) {
-          logger.error(
-            {
-              err: sleepResult.error,
-              conversationId: conversation.sId,
-              messageId,
-            },
-            "Failed to release sandbox after parent completion"
-          );
-        }
-      }
+      await releaseSandboxIfUnused(auth, { conversation, messageId });
     }
 
     await clearBlockedActionEffects(auth, {
@@ -503,6 +502,68 @@ export async function finishSandboxBash(
   }
 
   return result.completed;
+}
+
+async function reserveParentRelaunch(
+  auth: Authenticator,
+  {
+    conversation,
+    sandboxChildActionInfo,
+  }: {
+    conversation: ConversationResource;
+    sandboxChildActionInfo: SandboxChildActionInfo;
+  }
+): Promise<{
+  parentAction: AgentMCPActionResource | null;
+  needsLegacyRun: boolean;
+}> {
+  return withTransaction(async (transaction) => {
+    await getConversationRankVersionLock(auth, conversation, transaction);
+
+    const { parentActionId, execId } = sandboxChildActionInfo;
+    const parent = await AgentMCPActionResource.fetchById(
+      auth,
+      parentActionId,
+      transaction
+    );
+    if (!parent || parent.status !== "blocked_child_action_input_required") {
+      return { parentAction: null, needsLegacyRun: false };
+    }
+
+    // Only the last blocked sibling resumes the parent. Keeping this read and the parent
+    // transition under the child-creation lock prevents a new sibling from slipping in between.
+    if (
+      await AgentMCPActionResource.hasBlockedSandboxChildren(auth, {
+        parentAction: parent,
+        transaction,
+      })
+    ) {
+      return { parentAction: null, needsLegacyRun: false };
+    }
+
+    if (!isSandboxResumeState(parent.stepContext.resumeState)) {
+      if (!execId) {
+        return { parentAction: null, needsLegacyRun: true };
+      }
+      await parent.updateStepContext(
+        {
+          ...parent.stepContext,
+          resumeState: { execId },
+        },
+        transaction
+      );
+    }
+
+    const [updatedCount] = await parent.updateStatusFromExpected(auth, {
+      status: "ready_allowed_explicitly",
+      expectedStatus: "blocked_child_action_input_required",
+      transaction,
+    });
+    return {
+      parentAction: updatedCount === 1 ? parent : null,
+      needsLegacyRun: false,
+    };
+  });
 }
 
 /**
@@ -549,46 +610,36 @@ export async function resolveSandboxChildBlock(
     return;
   }
 
-  const parentAction = await withTransaction(async (transaction) => {
-    await getConversationRankVersionLock(auth, conversation, transaction);
-
-    const parent = await AgentMCPActionResource.fetchById(
-      auth,
-      parentActionId,
-      transaction
-    );
-    if (!parent || parent.status !== "blocked_child_action_input_required") {
-      return null;
-    }
-
-    // Only the last blocked sibling resumes the parent. Keeping this read and the parent
-    // transition under the child-creation lock prevents a new sibling from slipping in between.
-    const blockedActions =
-      await AgentMCPActionResource.listBlockedActionsForAgentMessage(auth, {
-        agentMessageId: parent.agentMessageId,
-        transaction,
-        skipSameStepCheck: true,
-      });
-    const blockedSiblings = blockedActions.filter(
-      (blockedAction) =>
-        blockedAction.stepContext.sandboxChildActionInfo?.parentActionId ===
-        parentActionId
-    );
-    if (
-      blockedSiblings.length > 0 ||
-      !isSandboxResumeState(parent.stepContext.resumeState)
-    ) {
-      return null;
-    }
-
-    const [updatedCount] = await parent.updateStatusFromExpected(auth, {
-      status: "ready_allowed_explicitly",
-      expectedStatus: "blocked_child_action_input_required",
-      transaction,
-    });
-    return updatedCount === 1 ? parent : null;
+  const reservation = await reserveParentRelaunch(auth, {
+    conversation,
+    sandboxChildActionInfo,
   });
+  if (reservation.needsLegacyRun) {
+    const launchResult = await launchSandboxChildToolWorkflow(auth, {
+      action,
+      agentLoopArgs: {
+        ...agentLoopArgs,
+        initialStartTime: Date.now(),
+      },
+      step: action.stepContent.step,
+      waitForCompletion: true,
+    });
+    if (launchResult.isErr()) {
+      logger.error(
+        {
+          err: launchResult.error,
+          actionId: action.sId,
+          parentActionId,
+          conversationId: agentLoopArgs.conversationId,
+          workspaceId,
+        },
+        "Failed to run pre-deploy sandbox child after resolution"
+      );
+    }
+    return;
+  }
 
+  const { parentAction } = reservation;
   if (!parentAction) {
     return;
   }

--- a/front/lib/api/sandbox/sandbox_child_block.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.ts
@@ -8,6 +8,7 @@ import {
   isSandboxResumeState,
 } from "@app/lib/actions/types";
 import {
+  clearActionRequiredIfNoBlockedActions,
   clearBlockedActionEffects,
   releaseSandboxIfUnused,
 } from "@app/lib/api/assistant/conversation/blocked_actions";
@@ -186,10 +187,9 @@ export async function pauseReservedSandboxBash(
             return false;
           }
 
-          const execId = isSandboxResumeState(
-            parentAction.stepContext.resumeState
-          )
-            ? parentAction.stepContext.resumeState.execId
+          const currentResumeState = parentAction.stepContext.resumeState;
+          const execId = isSandboxResumeState(currentResumeState)
+            ? currentResumeState.execId
             : info.execId;
           if (!execId) {
             return false;
@@ -198,7 +198,13 @@ export async function pauseReservedSandboxBash(
           await parentAction.updateStepContext(
             {
               ...parentAction.stepContext,
-              resumeState: { execId },
+              resumeState: {
+                execId,
+                ...(isSandboxResumeState(currentResumeState) &&
+                currentResumeState.runId
+                  ? { runId: currentResumeState.runId }
+                  : {}),
+              },
             },
             transaction
           );
@@ -262,10 +268,17 @@ export async function persistActionPause(
       }
     }
 
+    const currentResumeState = freshAction.stepContext.resumeState;
+    const nextResumeState =
+      isSandboxResumeState(resumeState) &&
+      isSandboxResumeState(currentResumeState) &&
+      currentResumeState.runId
+        ? { ...resumeState, runId: currentResumeState.runId }
+        : resumeState;
     await freshAction.updateStepContext(
       {
         ...freshAction.stepContext,
-        resumeState,
+        resumeState: nextResumeState,
       },
       transaction
     );
@@ -352,23 +365,10 @@ export async function reserveSandboxChildRun(
       if (updatedParentCount === 0) {
         return null;
       }
-    } else if (
-      parentAction.status === "ready_allowed_explicitly" ||
-      parentAction.status === "ready_allowed_implicitly"
-    ) {
-      const [updatedParentCount] = await parentAction.updateStatusFromExpected(
-        auth,
-        {
-          status: "running",
-          expectedStatus: parentAction.status,
-          transaction,
-        }
-      );
-      if (updatedParentCount === 0) {
-        return null;
-      }
     }
 
+    // A ready parent is reserved by its own activity. Reserving it from a sibling activity would
+    // not provide an execution identity that distinguishes the new run from an orphaned old one.
     const [updatedCount] = await freshAction.updateStatusFromExpected(auth, {
       status: "running",
       expectedStatus: freshAction.status,
@@ -383,13 +383,14 @@ export async function reserveSandboxChildRun(
 }
 
 /**
- * Reserves a resumed sandbox parent at the tool-activity boundary. A child may have already
- * reserved the parent in the same batch, in which case the running parent is returned directly.
+ * Reserves a resumed sandbox parent at the tool-activity boundary. The Temporal workflow run ID
+ * identifies the owner across activity retries and rejects orphaned activities from older runs.
  */
 export async function reserveSandboxParentRun(
   auth: Authenticator,
   action: AgentMCPActionResource,
-  conversation: ConversationWithoutContentType
+  conversation: ConversationWithoutContentType,
+  runId: string
 ): Promise<AgentMCPActionResource | null> {
   return withTransaction(async (transaction) => {
     await getConversationRankVersionLock(auth, conversation, transaction);
@@ -403,7 +404,10 @@ export async function reserveSandboxParentRun(
       return null;
     }
     if (freshAction.status === "running") {
-      return freshAction;
+      const resumeState = freshAction.stepContext.resumeState;
+      return isSandboxResumeState(resumeState) && resumeState.runId === runId
+        ? freshAction
+        : null;
     }
     if (
       freshAction.status !== "ready_allowed_explicitly" &&
@@ -420,6 +424,17 @@ export async function reserveSandboxParentRun(
       return null;
     }
 
+    const resumeState = freshAction.stepContext.resumeState;
+    if (!isSandboxResumeState(resumeState)) {
+      return null;
+    }
+    await freshAction.updateStepContext(
+      {
+        ...freshAction.stepContext,
+        resumeState: { ...resumeState, runId },
+      },
+      transaction
+    );
     const [updatedCount] = await freshAction.updateStatusFromExpected(auth, {
       status: "running",
       expectedStatus: freshAction.status,
@@ -470,6 +485,18 @@ export async function finishSandboxBash(
       return { completed: false, deniedChildren: [] };
     }
 
+    const expectedResumeState = action.stepContext.resumeState;
+    const currentResumeState = parentAction.stepContext.resumeState;
+    const expectedRunId = isSandboxResumeState(expectedResumeState)
+      ? expectedResumeState.runId
+      : undefined;
+    const currentRunId = isSandboxResumeState(currentResumeState)
+      ? currentResumeState.runId
+      : undefined;
+    if (expectedRunId !== currentRunId) {
+      return { completed: false, deniedChildren: [] };
+    }
+
     const deniedChildren =
       await AgentMCPActionResource.denyPendingSandboxChildren(auth, {
         parentAction,
@@ -515,7 +542,7 @@ async function reserveParentRelaunch(
   }
 ): Promise<{
   parentAction: AgentMCPActionResource | null;
-  needsLegacyRun: boolean;
+  legacyActions: AgentMCPActionResource[] | null;
 }> {
   return withTransaction(async (transaction) => {
     await getConversationRankVersionLock(auth, conversation, transaction);
@@ -527,7 +554,7 @@ async function reserveParentRelaunch(
       transaction
     );
     if (!parent || parent.status !== "blocked_child_action_input_required") {
-      return { parentAction: null, needsLegacyRun: false };
+      return { parentAction: null, legacyActions: null };
     }
 
     // Only the last blocked sibling resumes the parent. Keeping this read and the parent
@@ -538,12 +565,25 @@ async function reserveParentRelaunch(
         transaction,
       })
     ) {
-      return { parentAction: null, needsLegacyRun: false };
+      return { parentAction: null, legacyActions: null };
     }
 
     if (!isSandboxResumeState(parent.stepContext.resumeState)) {
       if (!execId) {
-        return { parentAction: null, needsLegacyRun: true };
+        const legacyActions =
+          await AgentMCPActionResource.listReadySandboxChildren(auth, {
+            parentAction: parent,
+            transaction,
+          });
+        const [updatedCount] = await parent.updateStatusFromExpected(auth, {
+          status: "running",
+          expectedStatus: "blocked_child_action_input_required",
+          transaction,
+        });
+        return {
+          parentAction: null,
+          legacyActions: updatedCount === 1 ? legacyActions : null,
+        };
       }
       await parent.updateStepContext(
         {
@@ -561,7 +601,7 @@ async function reserveParentRelaunch(
     });
     return {
       parentAction: updatedCount === 1 ? parent : null,
-      needsLegacyRun: false,
+      legacyActions: null,
     };
   });
 }
@@ -614,28 +654,33 @@ export async function resolveSandboxChildBlock(
     conversation,
     sandboxChildActionInfo,
   });
-  if (reservation.needsLegacyRun) {
-    const launchResult = await launchSandboxChildToolWorkflow(auth, {
-      action,
-      agentLoopArgs: {
-        ...agentLoopArgs,
-        initialStartTime: Date.now(),
-      },
-      step: action.stepContent.step,
-      waitForCompletion: true,
-    });
-    if (launchResult.isErr()) {
-      logger.error(
-        {
-          err: launchResult.error,
-          actionId: action.sId,
-          parentActionId,
-          conversationId: agentLoopArgs.conversationId,
-          workspaceId,
+  if (reservation.legacyActions) {
+    for (const legacyAction of reservation.legacyActions) {
+      const launchResult = await launchSandboxChildToolWorkflow(auth, {
+        action: legacyAction,
+        agentLoopArgs: {
+          ...agentLoopArgs,
+          initialStartTime: Date.now(),
         },
-        "Failed to run pre-deploy sandbox child after resolution"
-      );
+        step: legacyAction.stepContent.step,
+        waitForCompletion: true,
+      });
+      if (launchResult.isErr()) {
+        logger.error(
+          {
+            err: launchResult.error,
+            actionId: legacyAction.sId,
+            parentActionId,
+            conversationId: agentLoopArgs.conversationId,
+            workspaceId,
+          },
+          "Failed to run pre-deploy sandbox child after resolution"
+        );
+      }
     }
+    await clearActionRequiredIfNoBlockedActions(auth, {
+      conversationId: agentLoopArgs.conversationId,
+    });
     return;
   }
 

--- a/front/lib/api/sandbox/sandbox_child_block.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.ts
@@ -47,6 +47,15 @@ export async function pauseSandboxBashForBlockedChild(
   const reservation = await withTransaction(async (transaction) => {
     await getConversationRankVersionLock(auth, conversation, transaction);
 
+    if (!(await action.canAgentMessageResume(auth, transaction))) {
+      await action.updateStatusFromExpected(auth, {
+        status: "denied",
+        expectedStatus: action.status,
+        transaction,
+      });
+      return { accepted: false, parentStatus: null, shouldPause: false };
+    }
+
     const parentAction = await AgentMCPActionResource.fetchById(
       auth,
       info.parentActionId,
@@ -111,7 +120,12 @@ export async function pauseSandboxBashForBlockedChild(
     await pauseReservedSandboxBash(auth, action, conversation);
   }
 
-  return true;
+  const freshAction = await AgentMCPActionResource.fetchById(auth, action.sId);
+  return (
+    freshAction !== null &&
+    isToolExecutionStatusBlocked(freshAction.status) &&
+    (await freshAction.canAgentMessageResume(auth))
+  );
 }
 
 /**

--- a/front/lib/api/sandbox/sandbox_child_block.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.ts
@@ -275,7 +275,8 @@ export async function persistActionPause(
 export async function reserveSandboxChildRun(
   auth: Authenticator,
   action: AgentMCPActionResource,
-  conversation: ConversationWithoutContentType
+  conversation: ConversationWithoutContentType,
+  { isRetry }: { isRetry: boolean }
 ): Promise<AgentMCPActionResource | null> {
   const info = action.stepContext.sandboxChildActionInfo;
   if (!isSandboxChildActionInfo(info)) {
@@ -299,10 +300,10 @@ export async function reserveSandboxChildRun(
       return null;
     }
 
-    if (
-      freshAction.status !== "ready_allowed_explicitly" &&
-      freshAction.status !== "ready_allowed_implicitly"
-    ) {
+    const isReady =
+      freshAction.status === "ready_allowed_explicitly" ||
+      freshAction.status === "ready_allowed_implicitly";
+    if (!isReady && !(isRetry && freshAction.status === "running")) {
       return null;
     }
 
@@ -320,6 +321,12 @@ export async function reserveSandboxChildRun(
         transaction,
       });
       return null;
+    }
+
+    // The previous activity attempt reserved the child before being interrupted. A distinct
+    // workflow reaches this boundary on its first attempt and must not run the same tool twice.
+    if (freshAction.status === "running") {
+      return freshAction;
     }
 
     if (parentAction.status === "blocked_child_action_input_required") {

--- a/front/lib/api/sandbox/sandbox_child_block.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.ts
@@ -1,17 +1,28 @@
+import { isToolExecutionStatusBlocked } from "@app/lib/actions/statuses";
 import type { SandboxChildActionInfo } from "@app/lib/actions/types";
 import {
   isSandboxChildActionInfo,
   isSandboxResumeState,
 } from "@app/lib/actions/types";
+import { clearBlockedActionEffects } from "@app/lib/api/assistant/conversation/blocked_actions";
+import { getConversationRankVersionLock } from "@app/lib/api/assistant/conversation/lock";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import type {
   ConversationWithoutContentType,
   UserMessageOrigin,
 } from "@app/types/assistant/conversation";
+
+const ACTIVE_SANDBOX_PARENT_STATUSES = [
+  "running",
+  "ready_allowed_explicitly",
+  "ready_allowed_implicitly",
+] as const;
 
 /**
  * Called when a sandbox-child action enters a blocked state. Flips the
@@ -26,49 +37,59 @@ export async function pauseSandboxBashForBlockedChild(
   auth: Authenticator,
   action: AgentMCPActionResource,
   conversation: ConversationWithoutContentType
-): Promise<void> {
+): Promise<boolean> {
   const info = action.stepContext.sandboxChildActionInfo;
   if (!isSandboxChildActionInfo(info)) {
-    return;
+    return true;
   }
 
   const workspaceId = auth.getNonNullableWorkspace().sId;
-  const parentAction = await AgentMCPActionResource.fetchById(
-    auth,
-    info.parentActionId
-  );
-  if (!parentAction) {
-    logger.warn(
-      {
-        actionId: action.sId,
-        parentActionId: info.parentActionId,
-        conversationId: conversation.sId,
-        workspaceId,
-      },
-      "Sandbox-child blocked but parent action not found"
-    );
-    return;
-  }
+  const reservation = await withTransaction(async (transaction) => {
+    await getConversationRankVersionLock(auth, conversation, transaction);
 
-  // Flip the action status BEFORE pausing the sandbox provider. If the
-  // provider pause then fails, the bash exec inside the sandbox is still
-  // synchronously blocked on the dust-call awaiting the child response —
-  // so when the child resolves, resolveSandboxChildBlock observes the
-  // parent as blocked, relaunches in resume mode, and the running bash
-  // reconnects via execId. DB-first is the self-converging shape.
-  const [updatedCount] = await parentAction.updateStatusFromExpected(auth, {
-    status: "blocked_child_action_input_required",
-    expectedStatus: "running",
-  });
-  if (updatedCount === 0) {
-    const freshParent = await AgentMCPActionResource.fetchById(
+    const parentAction = await AgentMCPActionResource.fetchById(
       auth,
-      info.parentActionId
+      info.parentActionId,
+      transaction
     );
-    if (freshParent?.status === "blocked_child_action_input_required") {
-      return;
+    if (!parentAction) {
+      return { accepted: false, parentStatus: null, shouldPause: false };
     }
 
+    if (parentAction.status === "blocked_child_action_input_required") {
+      return {
+        accepted: true,
+        parentStatus: parentAction.status,
+        shouldPause: false,
+      };
+    }
+
+    if (parentAction.status !== "running") {
+      await action.updateStatusFromExpected(auth, {
+        status: "denied",
+        expectedStatus: action.status,
+        transaction,
+      });
+      return {
+        accepted: false,
+        parentStatus: parentAction.status,
+        shouldPause: false,
+      };
+    }
+
+    const [updatedCount] = await parentAction.updateStatusFromExpected(auth, {
+      status: "blocked_child_action_input_required",
+      expectedStatus: "running",
+      transaction,
+    });
+    return {
+      accepted: updatedCount === 1,
+      parentStatus: parentAction.status,
+      shouldPause: updatedCount === 1,
+    };
+  });
+
+  if (!reservation.accepted) {
     await action.updateStatusFromExpected(auth, {
       status: "denied",
       expectedStatus: action.status,
@@ -77,16 +98,20 @@ export async function pauseSandboxBashForBlockedChild(
       {
         actionId: action.sId,
         parentActionId: info.parentActionId,
-        parentStatus: freshParent?.status,
+        parentStatus: reservation.parentStatus,
         conversationId: conversation.sId,
         workspaceId,
       },
       "Sandbox child blocked after its parent stopped"
     );
-    return;
+    return false;
   }
 
-  await pauseReservedSandboxBash(auth, action, conversation);
+  if (reservation.shouldPause) {
+    await pauseReservedSandboxBash(auth, action, conversation);
+  }
+
+  return true;
 }
 
 /**
@@ -98,6 +123,15 @@ export async function pauseReservedSandboxBash(
   action: AgentMCPActionResource,
   conversation: ConversationWithoutContentType
 ): Promise<void> {
+  const freshAction = await AgentMCPActionResource.fetchById(auth, action.sId);
+  if (
+    !freshAction ||
+    !isToolExecutionStatusBlocked(freshAction.status) ||
+    !(await freshAction.canAgentMessageResume(auth))
+  ) {
+    return;
+  }
+
   const pauseResult = await ConversationSandboxAdapter.pauseSandboxForApproval(
     auth,
     conversation
@@ -113,6 +147,132 @@ export async function pauseReservedSandboxBash(
       "Failed to pause sandbox for blocked sandbox-child"
     );
   }
+}
+
+/**
+ * Reserves a ready sandbox child at the tool-activity boundary. Message finalization, parent
+ * transitions, and child creation use the same lock, so cancellation or parent completion either
+ * denies the child first or observes it as already running.
+ */
+export async function reserveSandboxChildRun(
+  auth: Authenticator,
+  action: AgentMCPActionResource,
+  conversation: ConversationWithoutContentType
+): Promise<AgentMCPActionResource | null> {
+  const info = action.stepContext.sandboxChildActionInfo;
+  if (!isSandboxChildActionInfo(info)) {
+    return action;
+  }
+
+  return withTransaction(async (transaction) => {
+    await getConversationRankVersionLock(auth, conversation, transaction);
+
+    const freshAction = await AgentMCPActionResource.fetchById(
+      auth,
+      action.sId,
+      transaction
+    );
+    const parentAction = await AgentMCPActionResource.fetchById(
+      auth,
+      info.parentActionId,
+      transaction
+    );
+    if (
+      !freshAction ||
+      !parentAction ||
+      !ACTIVE_SANDBOX_PARENT_STATUSES.includes(
+        parentAction.status as (typeof ACTIVE_SANDBOX_PARENT_STATUSES)[number]
+      ) ||
+      !(await freshAction.canAgentMessageResume(auth, transaction))
+    ) {
+      if (freshAction) {
+        await freshAction.updateStatusFromExpected(auth, {
+          status: "denied",
+          expectedStatus: freshAction.status,
+          transaction,
+        });
+      }
+      return null;
+    }
+
+    if (
+      freshAction.status !== "ready_allowed_explicitly" &&
+      freshAction.status !== "ready_allowed_implicitly"
+    ) {
+      return null;
+    }
+
+    const [updatedCount] = await freshAction.updateStatusFromExpected(auth, {
+      status: "running",
+      expectedStatus: freshAction.status,
+      transaction,
+    });
+    if (updatedCount === 0) {
+      return null;
+    }
+
+    return AgentMCPActionResource.fetchById(auth, freshAction.sId, transaction);
+  });
+}
+
+/**
+ * Completes a sandbox bash under the same lock as child insertion. Any child that committed before
+ * the parent finished but has not started is denied; a later child sees the succeeded parent and is
+ * rejected.
+ */
+export async function completeSandboxBash(
+  auth: Authenticator,
+  {
+    action,
+    conversation,
+    executionDurationMs,
+    messageId,
+  }: {
+    action: AgentMCPActionResource;
+    conversation: ConversationWithoutContentType;
+    executionDurationMs: number;
+    messageId: string;
+  }
+): Promise<boolean> {
+  const result = await withTransaction(async (transaction) => {
+    await getConversationRankVersionLock(auth, conversation, transaction);
+
+    const parentAction = await AgentMCPActionResource.fetchById(
+      auth,
+      action.sId,
+      transaction
+    );
+    if (
+      !parentAction ||
+      (parentAction.status !== "running" &&
+        parentAction.status !== "blocked_child_action_input_required")
+    ) {
+      return { completed: false, deniedChildren: [] };
+    }
+
+    const deniedChildren =
+      await AgentMCPActionResource.denyPendingSandboxChildren(auth, {
+        parentAction,
+        transaction,
+      });
+    const [updatedCount] = await action.markSucceededFromExpected(auth, {
+      executionDurationMs,
+      expectedStatus: parentAction.status,
+      transaction,
+    });
+
+    return { completed: updatedCount === 1, deniedChildren };
+  });
+
+  if (result.deniedChildren.length > 0) {
+    await clearBlockedActionEffects(auth, {
+      actionIds: result.deniedChildren.map((child) => child.sId),
+      conversationId: conversation.sId,
+      messageId,
+    });
+  }
+
+  return result.completed;
 }
 
 interface AgentLoopRelaunchArgs {
@@ -152,89 +312,66 @@ export async function resolveSandboxChildBlock(
 ): Promise<void> {
   const workspaceId = auth.getNonNullableWorkspace().sId;
   const { parentActionId } = sandboxChildActionInfo;
-  const parentAction = await AgentMCPActionResource.fetchById(
+  const conversation = await ConversationResource.fetchById(
     auth,
-    parentActionId
+    agentLoopArgs.conversationId
   );
+  if (!conversation) {
+    logger.error(
+      {
+        actionId: action.sId,
+        parentActionId,
+        conversationId: agentLoopArgs.conversationId,
+        workspaceId,
+      },
+      "Sandbox-child resolved but conversation not found — cannot relaunch loop"
+    );
+    return;
+  }
+
+  const parentAction = await withTransaction(async (transaction) => {
+    await getConversationRankVersionLock(auth, conversation, transaction);
+
+    const parent = await AgentMCPActionResource.fetchById(
+      auth,
+      parentActionId,
+      transaction
+    );
+    if (!parent || parent.status !== "blocked_child_action_input_required") {
+      return null;
+    }
+
+    // Only the last blocked sibling resumes the parent. Keeping this read and the parent
+    // transition under the child-creation lock prevents a new sibling from slipping in between.
+    const blockedActions =
+      await AgentMCPActionResource.listBlockedActionsForAgentMessage(auth, {
+        agentMessageId: parent.agentMessageId,
+        transaction,
+        skipSameStepCheck: true,
+      });
+    const blockedSiblings = blockedActions.filter(
+      (blockedAction) =>
+        blockedAction.stepContext.sandboxChildActionInfo?.parentActionId ===
+        parentActionId
+    );
+    if (
+      blockedSiblings.length > 0 ||
+      !isSandboxResumeState(parent.stepContext.resumeState)
+    ) {
+      return null;
+    }
+
+    const [updatedCount] = await parent.updateStatusFromExpected(auth, {
+      status: "ready_allowed_explicitly",
+      expectedStatus: "blocked_child_action_input_required",
+      transaction,
+    });
+    return updatedCount === 1 ? parent : null;
+  });
 
   if (!parentAction) {
-    logger.error(
-      {
-        actionId: action.sId,
-        parentActionId,
-        conversationId: agentLoopArgs.conversationId,
-        workspaceId,
-      },
-      "Sandbox-child resolved but parent action not found — cannot relaunch loop"
-    );
     return;
   }
-
-  // Parent is set to `blocked_child_action_input_required` by the bash
-  // handler before pausing the sandbox, and stays there until the LAST
-  // sibling resolves (see sibling check below). Anything else means
-  // either a concurrent resolution already relaunched (harmless race) or
-  // the bash handler crashed mid-pause. Either way, skip.
-  if (parentAction.status !== "blocked_child_action_input_required") {
-    logger.info(
-      {
-        actionId: action.sId,
-        parentActionId,
-        conversationId: agentLoopArgs.conversationId,
-        workspaceId,
-        parentStatus: parentAction.status,
-      },
-      "Sandbox parent not in blocked_child_action_input_required — skipping relaunch"
-    );
-    return;
-  }
-
-  // Defer the relaunch if any sibling sandbox-child of the same parent is
-  // still blocked. The parent bash issued multiple in-flight tool calls
-  // (e.g. `dust call A & dust call B`); each blocked one paused the
-  // sandbox once, but the bash inside is still waiting on every response.
-  // We only resume once they're all resolved so the bash sees all
-  // approvals at once. The last resolution flips the parent and relaunches.
-  const blockedActions =
-    await AgentMCPActionResource.listBlockedActionsForAgentMessage(auth, {
-      agentMessageId: parentAction.agentMessageId,
-    });
-  const blockedSiblings = blockedActions.filter(
-    (a) =>
-      a.stepContext.sandboxChildActionInfo?.parentActionId === parentActionId
-  );
-  if (blockedSiblings.length > 0) {
-    logger.info(
-      {
-        actionId: action.sId,
-        parentActionId,
-        conversationId: agentLoopArgs.conversationId,
-        workspaceId,
-        remainingSiblings: blockedSiblings.length,
-      },
-      "Sandbox parent has other blocked children — deferring relaunch"
-    );
-    return;
-  }
-
-  if (!isSandboxResumeState(parentAction.stepContext.resumeState)) {
-    logger.error(
-      {
-        actionId: action.sId,
-        parentActionId,
-        conversationId: agentLoopArgs.conversationId,
-        workspaceId,
-      },
-      "Sandbox-paused child resolved but parent has no execId resumeState — skipping relaunch"
-    );
-    return;
-  }
-
-  // Flip the parent status BEFORE launching the workflow. If launch fails
-  // we log loudly below — the inverse order would risk launching against a
-  // parent still marked `blocked_child_action_input_required`, which the
-  // resume path treats as "still paused" and would no-op.
-  await parentAction.updateStatus("ready_allowed_explicitly");
 
   const launchResult = await launchAgentLoopWorkflow({
     auth,

--- a/front/lib/api/sandbox/sandbox_child_block.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.ts
@@ -1,5 +1,8 @@
 import { isToolExecutionStatusBlocked } from "@app/lib/actions/statuses";
-import type { SandboxChildActionInfo } from "@app/lib/actions/types";
+import type {
+  SandboxChildActionInfo,
+  StepContext,
+} from "@app/lib/actions/types";
 import {
   isSandboxChildActionInfo,
   isSandboxResumeState,
@@ -18,6 +21,16 @@ import type {
   UserMessageOrigin,
 } from "@app/types/assistant/conversation";
 
+interface AgentLoopRelaunchArgs {
+  agentMessageId: string;
+  agentMessageVersion: number;
+  conversationId: string;
+  conversationTitle: string | null;
+  userMessageId: string;
+  userMessageVersion: number;
+  userMessageOrigin: UserMessageOrigin;
+}
+
 /**
  * Called when a sandbox-child action enters a blocked state. Flips the
  * parent bash action's status to `blocked_child_action_input_required`
@@ -30,7 +43,8 @@ import type {
 export async function pauseSandboxBashForBlockedChild(
   auth: Authenticator,
   action: AgentMCPActionResource,
-  conversation: ConversationWithoutContentType
+  conversation: ConversationWithoutContentType,
+  agentLoopArgs: AgentLoopRelaunchArgs
 ): Promise<boolean> {
   const info = action.stepContext.sandboxChildActionInfo;
   if (!isSandboxChildActionInfo(info)) {
@@ -111,7 +125,7 @@ export async function pauseSandboxBashForBlockedChild(
   }
 
   if (reservation.shouldPause) {
-    await pauseReservedSandboxBash(auth, action, conversation);
+    await pauseReservedSandboxBash(auth, action, conversation, agentLoopArgs);
   }
 
   const freshAction = await AgentMCPActionResource.fetchById(auth, action.sId);
@@ -129,7 +143,8 @@ export async function pauseSandboxBashForBlockedChild(
 export async function pauseReservedSandboxBash(
   auth: Authenticator,
   action: AgentMCPActionResource,
-  conversation: ConversationWithoutContentType
+  conversation: ConversationWithoutContentType,
+  agentLoopArgs: AgentLoopRelaunchArgs
 ): Promise<void> {
   const info = action.stepContext.sandboxChildActionInfo;
   if (!isSandboxChildActionInfo(info)) {
@@ -159,7 +174,6 @@ export async function pauseReservedSandboxBash(
           if (
             !freshAction ||
             !parentAction ||
-            !isToolExecutionStatusBlocked(freshAction.status) ||
             parentAction.status !== "blocked_child_action_input_required" ||
             !(await freshAction.canAgentMessageResume(auth, transaction))
           ) {
@@ -197,6 +211,60 @@ export async function pauseReservedSandboxBash(
       "Failed to pause sandbox for blocked sandbox-child"
     );
   }
+
+  const freshAction = await AgentMCPActionResource.fetchById(auth, action.sId);
+  if (freshAction && !isToolExecutionStatusBlocked(freshAction.status)) {
+    await resolveSandboxChildBlock(auth, {
+      action: freshAction,
+      sandboxChildActionInfo: info,
+      agentLoopArgs,
+    });
+  }
+}
+
+export async function persistActionPause(
+  auth: Authenticator,
+  action: AgentMCPActionResource,
+  conversation: ConversationWithoutContentType,
+  resumeState: StepContext["resumeState"]
+): Promise<boolean> {
+  return withTransaction(async (transaction) => {
+    await getConversationRankVersionLock(auth, conversation, transaction);
+
+    const freshAction = await AgentMCPActionResource.fetchById(
+      auth,
+      action.sId,
+      transaction
+    );
+    if (
+      !freshAction ||
+      (freshAction.status !== "running" &&
+        freshAction.status !== "blocked_child_action_input_required") ||
+      !(await freshAction.canAgentMessageResume(auth, transaction))
+    ) {
+      return false;
+    }
+
+    if (freshAction.status === "running") {
+      const [updatedCount] = await freshAction.updateStatusFromExpected(auth, {
+        status: "blocked_child_action_input_required",
+        expectedStatus: "running",
+        transaction,
+      });
+      if (updatedCount === 0) {
+        return false;
+      }
+    }
+
+    await freshAction.updateStepContext(
+      {
+        ...freshAction.stepContext,
+        resumeState,
+      },
+      transaction
+    );
+    return true;
+  });
 }
 
 /**
@@ -428,16 +496,6 @@ export async function finishSandboxBash(
   }
 
   return result.completed;
-}
-
-interface AgentLoopRelaunchArgs {
-  agentMessageId: string;
-  agentMessageVersion: number;
-  conversationId: string;
-  conversationTitle: string | null;
-  userMessageId: string;
-  userMessageVersion: number;
-  userMessageOrigin: UserMessageOrigin;
 }
 
 /**

--- a/front/lib/api/sandbox/sandbox_child_block.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.ts
@@ -86,6 +86,18 @@ export async function pauseSandboxBashForBlockedChild(
     return;
   }
 
+  await pauseReservedSandboxBash(auth, action, conversation);
+}
+
+/**
+ * Pauses a sandbox whose parent was reserved before the blocked child action
+ * was returned to the in-sandbox caller.
+ */
+export async function pauseReservedSandboxBash(
+  auth: Authenticator,
+  action: AgentMCPActionResource,
+  conversation: ConversationWithoutContentType
+): Promise<void> {
   const pauseResult = await ConversationSandboxAdapter.pauseSandboxForApproval(
     auth,
     conversation
@@ -94,9 +106,9 @@ export async function pauseSandboxBashForBlockedChild(
     logger.error(
       {
         err: pauseResult.error,
-        parentActionId: parentAction.sId,
+        actionId: action.sId,
         conversationId: conversation.sId,
-        workspaceId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
       },
       "Failed to pause sandbox for blocked sandbox-child"
     );

--- a/front/lib/api/sandbox/sandbox_child_block.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.ts
@@ -317,43 +317,51 @@ export async function persistSandboxBashOutput(
     outputs: PreparedOutput[];
   }
 ): Promise<ToolOutputItemType[] | null> {
-  return withTransaction(async (transaction) => {
-    await getConversationRankVersionLock(auth, conversation, transaction);
+  const stagedRes = await action.stageOutputItems(auth, outputs);
+  if (stagedRes.isErr()) {
+    throw stagedRes.error;
+  }
+  const stagedOutputs = stagedRes.value;
 
-    const parentAction = await AgentMCPActionResource.fetchById(
-      auth,
-      action.sId,
-      transaction
-    );
-    if (
-      !parentAction ||
-      (parentAction.status !== "running" &&
-        parentAction.status !== "blocked_child_action_input_required") ||
-      !(await parentAction.canAgentMessageResume(auth, transaction))
-    ) {
-      return null;
-    }
+  let accepted: boolean;
+  try {
+    accepted = await withTransaction(async (transaction) => {
+      await getConversationRankVersionLock(auth, conversation, transaction);
 
-    const expectedResumeState = action.stepContext.resumeState;
-    const currentResumeState = parentAction.stepContext.resumeState;
-    const expectedRunId = isSandboxResumeState(expectedResumeState)
-      ? expectedResumeState.runId
-      : undefined;
-    const currentRunId = isSandboxResumeState(currentResumeState)
-      ? currentResumeState.runId
-      : undefined;
-    if (expectedRunId !== currentRunId) {
-      return null;
-    }
+      const parentAction = await AgentMCPActionResource.fetchById(
+        auth,
+        action.sId,
+        transaction
+      );
+      if (
+        !parentAction ||
+        (parentAction.status !== "running" &&
+          parentAction.status !== "blocked_child_action_input_required") ||
+        !(await parentAction.canAgentMessageResume(auth, transaction))
+      ) {
+        return false;
+      }
 
-    const outputRes = await parentAction.createOutputItems(auth, outputs, {
-      transaction,
+      const expectedResumeState = action.stepContext.resumeState;
+      const currentResumeState = parentAction.stepContext.resumeState;
+      const expectedRunId = isSandboxResumeState(expectedResumeState)
+        ? expectedResumeState.runId
+        : undefined;
+      const currentRunId = isSandboxResumeState(currentResumeState)
+        ? currentResumeState.runId
+        : undefined;
+      return expectedRunId === currentRunId;
     });
-    if (outputRes.isErr()) {
-      throw outputRes.error;
-    }
-    return outputRes.value;
-  });
+  } catch (err) {
+    await AgentMCPActionResource.discardOutputItems(auth, stagedOutputs);
+    throw err;
+  }
+
+  if (!accepted) {
+    await AgentMCPActionResource.discardOutputItems(auth, stagedOutputs);
+    return null;
+  }
+  return stagedOutputs.outputItems;
 }
 
 /**
@@ -541,84 +549,109 @@ export async function finishSandboxBash(
     status: "errored" | "succeeded";
   }
 ): Promise<{ completed: boolean; outputItems: ToolOutputItemType[] }> {
-  const result = await withTransaction(async (transaction) => {
-    await getConversationRankVersionLock(auth, conversation, transaction);
+  const stagedRes = await action.stageOutputItems(auth, outputs);
+  if (stagedRes.isErr()) {
+    throw stagedRes.error;
+  }
+  const stagedOutputs = stagedRes.value;
 
-    const parentAction = await AgentMCPActionResource.fetchById(
-      auth,
-      action.sId,
-      transaction
-    );
-    if (
-      !parentAction ||
-      (parentAction.status !== "running" &&
-        parentAction.status !== "blocked_child_action_input_required")
-    ) {
-      return { completed: false, deniedChildren: [], outputItems: [] };
-    }
+  let result: {
+    completed: boolean;
+    deniedChildren: AgentMCPActionResource[];
+  };
+  try {
+    result = await withTransaction(async (transaction) => {
+      await getConversationRankVersionLock(auth, conversation, transaction);
 
-    const expectedResumeState = action.stepContext.resumeState;
-    const currentResumeState = parentAction.stepContext.resumeState;
-    const expectedRunId = isSandboxResumeState(expectedResumeState)
-      ? expectedResumeState.runId
-      : undefined;
-    const currentRunId = isSandboxResumeState(currentResumeState)
-      ? currentResumeState.runId
-      : undefined;
-    if (expectedRunId !== currentRunId) {
-      return { completed: false, deniedChildren: [], outputItems: [] };
-    }
-    if (!(await parentAction.canAgentMessageResume(auth, transaction))) {
-      await parentAction.updateStatusFromExpected(auth, {
-        status: "denied",
+      const parentAction = await AgentMCPActionResource.fetchById(
+        auth,
+        action.sId,
+        transaction
+      );
+      if (
+        !parentAction ||
+        (parentAction.status !== "running" &&
+          parentAction.status !== "blocked_child_action_input_required")
+      ) {
+        return { completed: false, deniedChildren: [] };
+      }
+
+      const expectedResumeState = action.stepContext.resumeState;
+      const currentResumeState = parentAction.stepContext.resumeState;
+      const expectedRunId = isSandboxResumeState(expectedResumeState)
+        ? expectedResumeState.runId
+        : undefined;
+      const currentRunId = isSandboxResumeState(currentResumeState)
+        ? currentResumeState.runId
+        : undefined;
+      if (expectedRunId !== currentRunId) {
+        return { completed: false, deniedChildren: [] };
+      }
+      if (!(await parentAction.canAgentMessageResume(auth, transaction))) {
+        await parentAction.updateStatusFromExpected(auth, {
+          status: "denied",
+          expectedStatus: parentAction.status,
+          transaction,
+        });
+        return { completed: false, deniedChildren: [] };
+      }
+
+      const deniedChildren =
+        await AgentMCPActionResource.denyPendingSandboxChildren(auth, {
+          parentAction,
+          transaction,
+        });
+      const [updatedCount] = await action.markFinalFromExpected(auth, {
+        executionDurationMs,
         expectedStatus: parentAction.status,
+        status,
         transaction,
       });
-      return { completed: false, deniedChildren: [], outputItems: [] };
-    }
+      if (updatedCount !== 1) {
+        throw new Error("Sandbox parent changed while finishing.");
+      }
 
-    const deniedChildren =
-      await AgentMCPActionResource.denyPendingSandboxChildren(auth, {
-        parentAction,
-        transaction,
-      });
-    const outputRes = await parentAction.createOutputItems(auth, outputs, {
-      transaction,
+      return { completed: true, deniedChildren };
     });
-    if (outputRes.isErr()) {
-      throw outputRes.error;
-    }
-
-    const [updatedCount] = await action.markFinalFromExpected(auth, {
-      executionDurationMs,
-      expectedStatus: parentAction.status,
-      status,
-      transaction,
-    });
-    if (updatedCount !== 1) {
-      throw new Error("Sandbox parent changed while finishing.");
-    }
-
-    return { completed: true, deniedChildren, outputItems: outputRes.value };
-  });
-
-  if (result.deniedChildren.length > 0) {
-    if (
-      result.deniedChildren.some((child) =>
-        isToolExecutionStatusBlocked(child.status)
-      )
-    ) {
-      await releaseSandboxIfUnused(auth, { conversation, messageId });
-    }
-
-    await clearBlockedActionEffects(auth, {
-      actionIds: result.deniedChildren.map((child) => child.sId),
-      conversationId: conversation.sId,
-      messageId,
-    });
+  } catch (err) {
+    await AgentMCPActionResource.discardOutputItems(auth, stagedOutputs);
+    throw err;
   }
 
-  return { completed: result.completed, outputItems: result.outputItems };
+  if (!result.completed) {
+    await AgentMCPActionResource.discardOutputItems(auth, stagedOutputs);
+    return { completed: false, outputItems: [] };
+  }
+
+  if (result.deniedChildren.length > 0) {
+    try {
+      if (
+        result.deniedChildren.some((child) =>
+          isToolExecutionStatusBlocked(child.status)
+        )
+      ) {
+        await releaseSandboxIfUnused(auth, { conversation, messageId });
+      }
+
+      await clearBlockedActionEffects(auth, {
+        actionIds: result.deniedChildren.map((child) => child.sId),
+        conversationId: conversation.sId,
+        messageId,
+      });
+    } catch (err) {
+      logger.error(
+        {
+          err,
+          actionId: action.sId,
+          conversationId: conversation.sId,
+          deniedActionIds: result.deniedChildren.map((child) => child.sId),
+        },
+        "Failed to clean up denied sandbox children"
+      );
+    }
+  }
+
+  return { completed: true, outputItems: stagedOutputs.outputItems };
 }
 
 async function reserveParentRelaunch(

--- a/front/lib/api/sandbox/sandbox_child_block.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.ts
@@ -15,6 +15,7 @@ import {
 } from "@app/lib/api/assistant/conversation/blocked_actions";
 import { getConversationRankVersionLock } from "@app/lib/api/assistant/conversation/lock";
 import type { Authenticator } from "@app/lib/auth";
+import type { ActionOutputRows } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
@@ -30,6 +31,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { Transaction } from "sequelize";
 
 interface AgentLoopRelaunchArgs {
   agentMessageId: string;
@@ -305,6 +307,72 @@ type PreparedOutput = {
   fileId?: ModelId;
 };
 
+async function ownsSandboxRun(
+  auth: Authenticator,
+  expectedAction: AgentMCPActionResource,
+  currentAction: AgentMCPActionResource,
+  transaction: Transaction
+): Promise<boolean> {
+  if (
+    currentAction.status !== "running" &&
+    currentAction.status !== "blocked_child_action_input_required"
+  ) {
+    return false;
+  }
+  if (!(await currentAction.canAgentMessageResume(auth, transaction))) {
+    return false;
+  }
+
+  const expectedResumeState = expectedAction.stepContext.resumeState;
+  const currentResumeState = currentAction.stepContext.resumeState;
+  const expectedRunId = isSandboxResumeState(expectedResumeState)
+    ? expectedResumeState.runId
+    : undefined;
+  const currentRunId = isSandboxResumeState(currentResumeState)
+    ? currentResumeState.runId
+    : undefined;
+  return expectedRunId === currentRunId;
+}
+
+export async function canStoreSandboxOutput(
+  auth: Authenticator,
+  action: AgentMCPActionResource,
+  conversation: ConversationWithoutContentType
+): Promise<boolean> {
+  return withTransaction(async (transaction) => {
+    await getConversationRankVersionLock(auth, conversation, transaction);
+
+    const currentAction = await AgentMCPActionResource.fetchById(
+      auth,
+      action.sId,
+      transaction
+    );
+    return currentAction
+      ? ownsSandboxRun(auth, action, currentAction, transaction)
+      : false;
+  });
+}
+
+async function syncSandboxOutputs(
+  auth: Authenticator,
+  action: AgentMCPActionResource,
+  outputRows: ActionOutputRows
+): Promise<void> {
+  const syncResult = await action.syncOutputRowsToGcs(auth, outputRows.rows);
+  if (syncResult.isErr()) {
+    // Content remains readable from the DB migration fallback. The authoritative rows were
+    // committed atomically with the owning action transition and must not be rolled back.
+    logger.error(
+      {
+        err: syncResult.error,
+        actionId: action.sId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+      },
+      "Failed to copy sandbox output rows to GCS"
+    );
+  }
+}
+
 export async function persistSandboxBashOutput(
   auth: Authenticator,
   {
@@ -317,51 +385,29 @@ export async function persistSandboxBashOutput(
     outputs: PreparedOutput[];
   }
 ): Promise<ToolOutputItemType[] | null> {
-  const stagedRes = await action.stageOutputItems(auth, outputs);
-  if (stagedRes.isErr()) {
-    throw stagedRes.error;
-  }
-  const stagedOutputs = stagedRes.value;
+  const outputRows = await withTransaction(async (transaction) => {
+    await getConversationRankVersionLock(auth, conversation, transaction);
 
-  let accepted: boolean;
-  try {
-    accepted = await withTransaction(async (transaction) => {
-      await getConversationRankVersionLock(auth, conversation, transaction);
+    const currentAction = await AgentMCPActionResource.fetchById(
+      auth,
+      action.sId,
+      transaction
+    );
+    if (
+      !currentAction ||
+      !(await ownsSandboxRun(auth, action, currentAction, transaction))
+    ) {
+      return null;
+    }
 
-      const parentAction = await AgentMCPActionResource.fetchById(
-        auth,
-        action.sId,
-        transaction
-      );
-      if (
-        !parentAction ||
-        (parentAction.status !== "running" &&
-          parentAction.status !== "blocked_child_action_input_required") ||
-        !(await parentAction.canAgentMessageResume(auth, transaction))
-      ) {
-        return false;
-      }
-
-      const expectedResumeState = action.stepContext.resumeState;
-      const currentResumeState = parentAction.stepContext.resumeState;
-      const expectedRunId = isSandboxResumeState(expectedResumeState)
-        ? expectedResumeState.runId
-        : undefined;
-      const currentRunId = isSandboxResumeState(currentResumeState)
-        ? currentResumeState.runId
-        : undefined;
-      return expectedRunId === currentRunId;
-    });
-  } catch (err) {
-    await AgentMCPActionResource.discardOutputItems(auth, stagedOutputs);
-    throw err;
-  }
-
-  if (!accepted) {
-    await AgentMCPActionResource.discardOutputItems(auth, stagedOutputs);
+    return currentAction.createOutputRows(outputs, { transaction });
+  });
+  if (!outputRows) {
     return null;
   }
-  return stagedOutputs.outputItems;
+
+  await syncSandboxOutputs(auth, action, outputRows);
+  return outputRows.outputItems;
 }
 
 /**
@@ -549,77 +595,58 @@ export async function finishSandboxBash(
     status: "errored" | "succeeded";
   }
 ): Promise<{ completed: boolean; outputItems: ToolOutputItemType[] }> {
-  const stagedRes = await action.stageOutputItems(auth, outputs);
-  if (stagedRes.isErr()) {
-    throw stagedRes.error;
-  }
-  const stagedOutputs = stagedRes.value;
-
-  let result: {
+  const result: {
     completed: boolean;
     deniedChildren: AgentMCPActionResource[];
-  };
-  try {
-    result = await withTransaction(async (transaction) => {
-      await getConversationRankVersionLock(auth, conversation, transaction);
+    outputRows: ActionOutputRows | null;
+  } = await withTransaction(async (transaction) => {
+    await getConversationRankVersionLock(auth, conversation, transaction);
 
-      const parentAction = await AgentMCPActionResource.fetchById(
-        auth,
-        action.sId,
-        transaction
-      );
-      if (
-        !parentAction ||
-        (parentAction.status !== "running" &&
-          parentAction.status !== "blocked_child_action_input_required")
-      ) {
-        return { completed: false, deniedChildren: [] };
-      }
+    const parentAction = await AgentMCPActionResource.fetchById(
+      auth,
+      action.sId,
+      transaction
+    );
+    if (
+      !parentAction ||
+      (parentAction.status !== "running" &&
+        parentAction.status !== "blocked_child_action_input_required")
+    ) {
+      return { completed: false, deniedChildren: [], outputRows: null };
+    }
 
-      const expectedResumeState = action.stepContext.resumeState;
-      const currentResumeState = parentAction.stepContext.resumeState;
-      const expectedRunId = isSandboxResumeState(expectedResumeState)
-        ? expectedResumeState.runId
-        : undefined;
-      const currentRunId = isSandboxResumeState(currentResumeState)
-        ? currentResumeState.runId
-        : undefined;
-      if (expectedRunId !== currentRunId) {
-        return { completed: false, deniedChildren: [] };
-      }
+    if (!(await ownsSandboxRun(auth, action, parentAction, transaction))) {
       if (!(await parentAction.canAgentMessageResume(auth, transaction))) {
         await parentAction.updateStatusFromExpected(auth, {
           status: "denied",
           expectedStatus: parentAction.status,
           transaction,
         });
-        return { completed: false, deniedChildren: [] };
       }
+      return { completed: false, deniedChildren: [], outputRows: null };
+    }
 
-      const deniedChildren =
-        await AgentMCPActionResource.denyPendingSandboxChildren(auth, {
-          parentAction,
-          transaction,
-        });
-      const [updatedCount] = await action.markFinalFromExpected(auth, {
-        executionDurationMs,
-        expectedStatus: parentAction.status,
-        status,
+    const deniedChildren =
+      await AgentMCPActionResource.denyPendingSandboxChildren(auth, {
+        parentAction,
         transaction,
       });
-      if (updatedCount !== 1) {
-        throw new Error("Sandbox parent changed while finishing.");
-      }
-
-      return { completed: true, deniedChildren };
+    const outputRows = await parentAction.createOutputRows(outputs, {
+      transaction,
     });
-  } catch (err) {
-    await AgentMCPActionResource.discardOutputItems(auth, stagedOutputs);
-    throw err;
-  }
+    const [updatedCount] = await action.markFinalFromExpected(auth, {
+      executionDurationMs,
+      expectedStatus: parentAction.status,
+      status,
+      transaction,
+    });
+    if (updatedCount !== 1) {
+      throw new Error("Sandbox parent changed while finishing.");
+    }
 
+    return { completed: true, deniedChildren, outputRows };
+  });
   if (!result.completed) {
-    await AgentMCPActionResource.discardOutputItems(auth, stagedOutputs);
     return { completed: false, outputItems: [] };
   }
 
@@ -651,7 +678,11 @@ export async function finishSandboxBash(
     }
   }
 
-  return { completed: true, outputItems: stagedOutputs.outputItems };
+  if (!result.outputRows) {
+    throw new Error("Completed sandbox action has no output rows.");
+  }
+  await syncSandboxOutputs(auth, action, result.outputRows);
+  return { completed: true, outputItems: result.outputRows.outputItems };
 }
 
 async function reserveParentRelaunch(

--- a/front/lib/api/sandbox/sandbox_child_block.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.ts
@@ -56,7 +56,35 @@ export async function pauseSandboxBashForBlockedChild(
   // so when the child resolves, resolveSandboxChildBlock observes the
   // parent as blocked, relaunches in resume mode, and the running bash
   // reconnects via execId. DB-first is the self-converging shape.
-  await parentAction.updateStatus("blocked_child_action_input_required");
+  const [updatedCount] = await parentAction.updateStatusFromExpected(auth, {
+    status: "blocked_child_action_input_required",
+    expectedStatus: "running",
+  });
+  if (updatedCount === 0) {
+    const freshParent = await AgentMCPActionResource.fetchById(
+      auth,
+      info.parentActionId
+    );
+    if (freshParent?.status === "blocked_child_action_input_required") {
+      return;
+    }
+
+    await action.updateStatusFromExpected(auth, {
+      status: "denied",
+      expectedStatus: action.status,
+    });
+    logger.warn(
+      {
+        actionId: action.sId,
+        parentActionId: info.parentActionId,
+        parentStatus: freshParent?.status,
+        conversationId: conversation.sId,
+        workspaceId,
+      },
+      "Sandbox child blocked after its parent stopped"
+    );
+    return;
+  }
 
   const pauseResult = await ConversationSandboxAdapter.pauseSandboxForApproval(
     auth,

--- a/front/lib/api/sandbox/sandbox_child_block.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.ts
@@ -131,21 +131,59 @@ export async function pauseReservedSandboxBash(
   action: AgentMCPActionResource,
   conversation: ConversationWithoutContentType
 ): Promise<void> {
+  const info = action.stepContext.sandboxChildActionInfo;
+  if (!isSandboxChildActionInfo(info)) {
+    return;
+  }
+
   const pauseResult = await ConversationSandboxAdapter.pauseSandboxForApproval(
     auth,
     conversation,
     {
-      shouldPause: async () => {
-        const freshAction = await AgentMCPActionResource.fetchById(
-          auth,
-          action.sId
-        );
-        return (
-          freshAction !== null &&
-          isToolExecutionStatusBlocked(freshAction.status) &&
-          (await freshAction.canAgentMessageResume(auth))
-        );
-      },
+      shouldPause: () =>
+        withTransaction(async (transaction) => {
+          // Conversation mutations release their DB lock before lifecycle cleanup, so taking the
+          // conversation lock from inside this lifecycle callback does not invert a nested lock.
+          await getConversationRankVersionLock(auth, conversation, transaction);
+
+          const freshAction = await AgentMCPActionResource.fetchById(
+            auth,
+            action.sId,
+            transaction
+          );
+          const parentAction = await AgentMCPActionResource.fetchById(
+            auth,
+            info.parentActionId,
+            transaction
+          );
+          if (
+            !freshAction ||
+            !parentAction ||
+            !isToolExecutionStatusBlocked(freshAction.status) ||
+            parentAction.status !== "blocked_child_action_input_required" ||
+            !(await freshAction.canAgentMessageResume(auth, transaction))
+          ) {
+            return false;
+          }
+
+          const execId = isSandboxResumeState(
+            parentAction.stepContext.resumeState
+          )
+            ? parentAction.stepContext.resumeState.execId
+            : info.execId;
+          if (!execId) {
+            return false;
+          }
+
+          await parentAction.updateStepContext(
+            {
+              ...parentAction.stepContext,
+              resumeState: { execId },
+            },
+            transaction
+          );
+          return true;
+        }),
     }
   );
   if (pauseResult.isErr()) {

--- a/front/lib/api/sandbox/sandbox_child_block.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.ts
@@ -18,12 +18,6 @@ import type {
   UserMessageOrigin,
 } from "@app/types/assistant/conversation";
 
-const ACTIVE_SANDBOX_PARENT_STATUSES = [
-  "running",
-  "ready_allowed_explicitly",
-  "ready_allowed_implicitly",
-] as const;
-
 /**
  * Called when a sandbox-child action enters a blocked state. Flips the
  * parent bash action's status to `blocked_child_action_input_required`
@@ -194,9 +188,9 @@ export async function reserveSandboxChildRun(
     if (
       !freshAction ||
       !parentAction ||
-      !ACTIVE_SANDBOX_PARENT_STATUSES.includes(
-        parentAction.status as (typeof ACTIVE_SANDBOX_PARENT_STATUSES)[number]
-      ) ||
+      (parentAction.status !== "running" &&
+        parentAction.status !== "ready_allowed_explicitly" &&
+        parentAction.status !== "ready_allowed_implicitly") ||
       !(await freshAction.canAgentMessageResume(auth, transaction))
     ) {
       if (freshAction) {
@@ -230,22 +224,24 @@ export async function reserveSandboxChildRun(
 }
 
 /**
- * Completes a sandbox bash under the same lock as child insertion. Any child that committed before
- * the parent finished but has not started is denied; a later child sees the succeeded parent and is
+ * Finishes a sandbox bash under the same lock as child insertion. Any child that committed before
+ * the parent finished but has not started is denied; a later child sees the final parent and is
  * rejected.
  */
-export async function completeSandboxBash(
+export async function finishSandboxBash(
   auth: Authenticator,
   {
     action,
     conversation,
     executionDurationMs,
     messageId,
+    status,
   }: {
     action: AgentMCPActionResource;
     conversation: ConversationWithoutContentType;
     executionDurationMs: number;
     messageId: string;
+    status: "errored" | "succeeded";
   }
 ): Promise<boolean> {
   const result = await withTransaction(async (transaction) => {
@@ -269,9 +265,10 @@ export async function completeSandboxBash(
         parentAction,
         transaction,
       });
-    const [updatedCount] = await action.markSucceededFromExpected(auth, {
+    const [updatedCount] = await action.markFinalFromExpected(auth, {
       executionDurationMs,
       expectedStatus: parentAction.status,
+      status,
       transaction,
     });
 

--- a/front/lib/api/sandbox/sandbox_child_block.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.ts
@@ -131,18 +131,22 @@ export async function pauseReservedSandboxBash(
   action: AgentMCPActionResource,
   conversation: ConversationWithoutContentType
 ): Promise<void> {
-  const freshAction = await AgentMCPActionResource.fetchById(auth, action.sId);
-  if (
-    !freshAction ||
-    !isToolExecutionStatusBlocked(freshAction.status) ||
-    !(await freshAction.canAgentMessageResume(auth))
-  ) {
-    return;
-  }
-
   const pauseResult = await ConversationSandboxAdapter.pauseSandboxForApproval(
     auth,
-    conversation
+    conversation,
+    {
+      shouldPause: async () => {
+        const freshAction = await AgentMCPActionResource.fetchById(
+          auth,
+          action.sId
+        );
+        return (
+          freshAction !== null &&
+          isToolExecutionStatusBlocked(freshAction.status) &&
+          (await freshAction.canAgentMessageResume(auth))
+        );
+      },
+    }
   );
   if (pauseResult.isErr()) {
     logger.error(
@@ -185,21 +189,7 @@ export async function reserveSandboxChildRun(
       info.parentActionId,
       transaction
     );
-    if (
-      !freshAction ||
-      !parentAction ||
-      (parentAction.status !== "running" &&
-        parentAction.status !== "ready_allowed_explicitly" &&
-        parentAction.status !== "ready_allowed_implicitly") ||
-      !(await freshAction.canAgentMessageResume(auth, transaction))
-    ) {
-      if (freshAction) {
-        await freshAction.updateStatusFromExpected(auth, {
-          status: "denied",
-          expectedStatus: freshAction.status,
-          transaction,
-        });
-      }
+    if (!freshAction) {
       return null;
     }
 
@@ -207,6 +197,94 @@ export async function reserveSandboxChildRun(
       freshAction.status !== "ready_allowed_explicitly" &&
       freshAction.status !== "ready_allowed_implicitly"
     ) {
+      return null;
+    }
+
+    if (
+      !parentAction ||
+      (parentAction.status !== "running" &&
+        parentAction.status !== "ready_allowed_explicitly" &&
+        parentAction.status !== "ready_allowed_implicitly" &&
+        parentAction.status !== "blocked_child_action_input_required") ||
+      !(await freshAction.canAgentMessageResume(auth, transaction))
+    ) {
+      await freshAction.updateStatusFromExpected(auth, {
+        status: "denied",
+        expectedStatus: freshAction.status,
+        transaction,
+      });
+      return null;
+    }
+
+    if (parentAction.status === "blocked_child_action_input_required") {
+      return null;
+    }
+
+    if (
+      parentAction.status === "ready_allowed_explicitly" ||
+      parentAction.status === "ready_allowed_implicitly"
+    ) {
+      const [updatedParentCount] = await parentAction.updateStatusFromExpected(
+        auth,
+        {
+          status: "running",
+          expectedStatus: parentAction.status,
+          transaction,
+        }
+      );
+      if (updatedParentCount === 0) {
+        return null;
+      }
+    }
+
+    const [updatedCount] = await freshAction.updateStatusFromExpected(auth, {
+      status: "running",
+      expectedStatus: freshAction.status,
+      transaction,
+    });
+    if (updatedCount === 0) {
+      return null;
+    }
+
+    return AgentMCPActionResource.fetchById(auth, freshAction.sId, transaction);
+  });
+}
+
+/**
+ * Reserves a resumed sandbox parent at the tool-activity boundary. A child may have already
+ * reserved the parent in the same batch, in which case the running parent is returned directly.
+ */
+export async function reserveSandboxParentRun(
+  auth: Authenticator,
+  action: AgentMCPActionResource,
+  conversation: ConversationWithoutContentType
+): Promise<AgentMCPActionResource | null> {
+  return withTransaction(async (transaction) => {
+    await getConversationRankVersionLock(auth, conversation, transaction);
+
+    const freshAction = await AgentMCPActionResource.fetchById(
+      auth,
+      action.sId,
+      transaction
+    );
+    if (!freshAction) {
+      return null;
+    }
+    if (freshAction.status === "running") {
+      return freshAction;
+    }
+    if (
+      freshAction.status !== "ready_allowed_explicitly" &&
+      freshAction.status !== "ready_allowed_implicitly"
+    ) {
+      return null;
+    }
+    if (!(await freshAction.canAgentMessageResume(auth, transaction))) {
+      await freshAction.updateStatusFromExpected(auth, {
+        status: "denied",
+        expectedStatus: freshAction.status,
+        transaction,
+      });
       return null;
     }
 
@@ -276,6 +354,34 @@ export async function finishSandboxBash(
   });
 
   if (result.deniedChildren.length > 0) {
+    if (
+      result.deniedChildren.some((child) =>
+        isToolExecutionStatusBlocked(child.status)
+      )
+    ) {
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      if (conversationResource) {
+        const sleepResult =
+          await ConversationSandboxAdapter.dangerouslySleepSandboxIfPendingApproval(
+            auth,
+            conversationResource
+          );
+        if (sleepResult.isErr()) {
+          logger.error(
+            {
+              err: sleepResult.error,
+              conversationId: conversation.sId,
+              messageId,
+            },
+            "Failed to release sandbox after parent completion"
+          );
+        }
+      }
+    }
+
     await clearBlockedActionEffects(auth, {
       actionIds: result.deniedChildren.map((child) => child.sId),
       conversationId: conversation.sId,

--- a/front/lib/api/sandbox/sandbox_child_block.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.ts
@@ -2,6 +2,7 @@ import { isToolExecutionStatusBlocked } from "@app/lib/actions/statuses";
 import type {
   SandboxChildActionInfo,
   StepContext,
+  ToolOutputItemType,
 } from "@app/lib/actions/types";
 import {
   isSandboxChildActionInfo,
@@ -27,6 +28,8 @@ import type {
   ConversationWithoutContentType,
   UserMessageOrigin,
 } from "@app/types/assistant/conversation";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 interface AgentLoopRelaunchArgs {
   agentMessageId: string;
@@ -257,6 +260,18 @@ export async function persistActionPause(
       return false;
     }
 
+    const currentResumeState = freshAction.stepContext.resumeState;
+    const expectedResumeState = action.stepContext.resumeState;
+    const expectedRunId = isSandboxResumeState(expectedResumeState)
+      ? expectedResumeState.runId
+      : undefined;
+    const currentRunId = isSandboxResumeState(currentResumeState)
+      ? currentResumeState.runId
+      : undefined;
+    if (expectedRunId !== currentRunId) {
+      return false;
+    }
+
     if (freshAction.status === "running") {
       const [updatedCount] = await freshAction.updateStatusFromExpected(auth, {
         status: "blocked_child_action_input_required",
@@ -268,7 +283,6 @@ export async function persistActionPause(
       }
     }
 
-    const currentResumeState = freshAction.stepContext.resumeState;
     const nextResumeState =
       isSandboxResumeState(resumeState) &&
       isSandboxResumeState(currentResumeState) &&
@@ -283,6 +297,62 @@ export async function persistActionPause(
       transaction
     );
     return true;
+  });
+}
+
+type PreparedOutput = {
+  content: CallToolResult["content"][number];
+  fileId?: ModelId;
+};
+
+export async function persistSandboxBashOutput(
+  auth: Authenticator,
+  {
+    action,
+    conversation,
+    outputs,
+  }: {
+    action: AgentMCPActionResource;
+    conversation: ConversationWithoutContentType;
+    outputs: PreparedOutput[];
+  }
+): Promise<ToolOutputItemType[] | null> {
+  return withTransaction(async (transaction) => {
+    await getConversationRankVersionLock(auth, conversation, transaction);
+
+    const parentAction = await AgentMCPActionResource.fetchById(
+      auth,
+      action.sId,
+      transaction
+    );
+    if (
+      !parentAction ||
+      (parentAction.status !== "running" &&
+        parentAction.status !== "blocked_child_action_input_required") ||
+      !(await parentAction.canAgentMessageResume(auth, transaction))
+    ) {
+      return null;
+    }
+
+    const expectedResumeState = action.stepContext.resumeState;
+    const currentResumeState = parentAction.stepContext.resumeState;
+    const expectedRunId = isSandboxResumeState(expectedResumeState)
+      ? expectedResumeState.runId
+      : undefined;
+    const currentRunId = isSandboxResumeState(currentResumeState)
+      ? currentResumeState.runId
+      : undefined;
+    if (expectedRunId !== currentRunId) {
+      return null;
+    }
+
+    const outputRes = await parentAction.createOutputItems(auth, outputs, {
+      transaction,
+    });
+    if (outputRes.isErr()) {
+      throw outputRes.error;
+    }
+    return outputRes.value;
   });
 }
 
@@ -460,15 +530,17 @@ export async function finishSandboxBash(
     conversation,
     executionDurationMs,
     messageId,
+    outputs = [],
     status,
   }: {
     action: AgentMCPActionResource;
     conversation: ConversationWithoutContentType;
     executionDurationMs: number;
     messageId: string;
+    outputs?: PreparedOutput[];
     status: "errored" | "succeeded";
   }
-): Promise<boolean> {
+): Promise<{ completed: boolean; outputItems: ToolOutputItemType[] }> {
   const result = await withTransaction(async (transaction) => {
     await getConversationRankVersionLock(auth, conversation, transaction);
 
@@ -482,7 +554,7 @@ export async function finishSandboxBash(
       (parentAction.status !== "running" &&
         parentAction.status !== "blocked_child_action_input_required")
     ) {
-      return { completed: false, deniedChildren: [] };
+      return { completed: false, deniedChildren: [], outputItems: [] };
     }
 
     const expectedResumeState = action.stepContext.resumeState;
@@ -494,7 +566,15 @@ export async function finishSandboxBash(
       ? currentResumeState.runId
       : undefined;
     if (expectedRunId !== currentRunId) {
-      return { completed: false, deniedChildren: [] };
+      return { completed: false, deniedChildren: [], outputItems: [] };
+    }
+    if (!(await parentAction.canAgentMessageResume(auth, transaction))) {
+      await parentAction.updateStatusFromExpected(auth, {
+        status: "denied",
+        expectedStatus: parentAction.status,
+        transaction,
+      });
+      return { completed: false, deniedChildren: [], outputItems: [] };
     }
 
     const deniedChildren =
@@ -502,14 +582,24 @@ export async function finishSandboxBash(
         parentAction,
         transaction,
       });
+    const outputRes = await parentAction.createOutputItems(auth, outputs, {
+      transaction,
+    });
+    if (outputRes.isErr()) {
+      throw outputRes.error;
+    }
+
     const [updatedCount] = await action.markFinalFromExpected(auth, {
       executionDurationMs,
       expectedStatus: parentAction.status,
       status,
       transaction,
     });
+    if (updatedCount !== 1) {
+      throw new Error("Sandbox parent changed while finishing.");
+    }
 
-    return { completed: updatedCount === 1, deniedChildren };
+    return { completed: true, deniedChildren, outputItems: outputRes.value };
   });
 
   if (result.deniedChildren.length > 0) {
@@ -528,7 +618,7 @@ export async function finishSandboxBash(
     });
   }
 
-  return result.completed;
+  return { completed: result.completed, outputItems: result.outputItems };
 }
 
 async function reserveParentRelaunch(

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -132,6 +132,36 @@ describe("listBlockedActionsForConversation", () => {
     expect(result).toEqual([]);
   });
 
+  it("fetches blocked action IDs in one workspace batch", async () => {
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+    });
+    const agentMessage = await AgentMessageModel.create({
+      conversationId: conversation.id,
+      workspaceId: workspace.id,
+      status: "created",
+      agentConfigurationId: agentConfig.sId,
+      agentConfigurationVersion: agentConfig.version,
+      skipToolsValidation: false,
+    });
+    const { action: blockedAction } = await createBlockedAction({
+      agentMessageModelId: agentMessage.id,
+    });
+    const { action: succeededAction } = await createBlockedAction({
+      agentMessageModelId: agentMessage.id,
+      status: "succeeded",
+    });
+
+    const blockedActionIds = await AgentMCPActionResource.fetchBlockedActionIds(
+      {
+        actionIds: [blockedAction.sId, succeededAction.sId],
+        workspaceModelId: workspace.id,
+      }
+    );
+
+    expect(blockedActionIds).toEqual(new Set([blockedAction.sId]));
+  });
+
   it("should return blocked actions for conversation", async () => {
     const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
       name: "Test Agent",

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1707,11 +1707,15 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   }
 
   async updateStepContext(
-    stepContext: StepContext
+    stepContext: StepContext,
+    transaction?: Transaction
   ): Promise<[affectedCount: number]> {
-    return this.update({
-      stepContext,
-    });
+    return this.update(
+      {
+        stepContext,
+      },
+      transaction
+    );
   }
 
   static async deleteByAgentMessageId(

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -45,7 +45,6 @@ import {
   batchFetchContentsFromGcs,
   batchWriteContentsToGcs,
   deleteActionOutputsFromGcs,
-  deleteContentsFromGcs,
   warmGcsContentCache,
 } from "@app/lib/resources/agent_mcp_action/output_storage";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
@@ -100,6 +99,7 @@ type ConversationGeneratedFileType = ActionGeneratedDBFileType & {
 const OUTPUT_ITEMS_BATCH_SIZE = 32;
 
 const FETCH_OUTPUT_ITEMS_CONCURRENCY = 2;
+const SYNC_OUTPUT_ROWS_CONCURRENCY = 16;
 
 const DENIABLE_PENDING_STATUSES = [
   "ready_allowed_explicitly",
@@ -107,9 +107,8 @@ const DENIABLE_PENDING_STATUSES = [
   ...TOOL_EXECUTION_BLOCKED_STATUSES,
 ] as const satisfies readonly ToolExecutionStatus[];
 
-export type StagedActionOutputs = {
-  gcsPaths: string[];
-  itemIds: ModelId[];
+export type ActionOutputRows = {
+  rows: AgentMCPActionOutputItemModel[];
   outputItems: ToolOutputItemType[];
 };
 
@@ -1230,97 +1229,51 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     }>,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<ToolOutputItemType[], Error>> {
-    const result = await this.stageOutputItems(auth, contents, { transaction });
-    if (result.isErr()) {
-      return result;
+    const outputRows = await this.createOutputRows(contents, { transaction });
+    const syncResult = await this.syncOutputRowsToGcs(auth, outputRows.rows, {
+      transaction,
+    });
+    if (syncResult.isErr()) {
+      return syncResult;
     }
-    return new Ok(result.value.outputItems);
+    return new Ok(outputRows.outputItems);
   }
 
-  async stageOutputItems(
-    auth: Authenticator,
+  async createOutputRows(
     contents: Array<{
       content: CallToolResult["content"][number];
       fileId?: ModelId;
     }>,
     { transaction }: { transaction?: Transaction } = {}
-  ): Promise<Result<StagedActionOutputs, Error>> {
-    // Write GCS first: the helper retries and cleans up partial batches, and DB insertion only
-    // starts once every object has been persisted.
-    const gcsResult = await batchWriteContentsToGcs(
-      auth,
-      this,
-      contents.map(({ content }) => content)
+  ): Promise<ActionOutputRows> {
+    const rows = await AgentMCPActionOutputItemModel.bulkCreate(
+      contents.map((c) => {
+        const { generatedFilePath, generatedFileContentType } =
+          isToolGeneratedFilePath(c.content)
+            ? {
+                generatedFilePath: c.content.resource.path,
+                generatedFileContentType: c.content.resource.contentType,
+              }
+            : { generatedFilePath: null, generatedFileContentType: null };
+
+        return {
+          agentMCPActionId: this.id,
+          // Write content to DB (kept during migration period to ease rollback).
+          content: c.content,
+          citations: getCitationsFromToolOutput([c.content]),
+          fileId: c.fileId,
+          workspaceId: this.workspaceId,
+          generatedFilePath,
+          generatedFileContentType,
+        };
+      }),
+      { transaction }
     );
 
-    if (gcsResult.isErr()) {
-      return new Err(gcsResult.error);
-    }
-
-    let outputItems: AgentMCPActionOutputItemModel[];
-    try {
-      outputItems = await AgentMCPActionOutputItemModel.bulkCreate(
-        contents.map((c, index) => {
-          const contentGcsPath = gcsResult.value[index];
-          assert(contentGcsPath, "GCS path not found for output item.");
-
-          const { generatedFilePath, generatedFileContentType } =
-            isToolGeneratedFilePath(c.content)
-              ? {
-                  generatedFilePath: c.content.resource.path,
-                  generatedFileContentType: c.content.resource.contentType,
-                }
-              : { generatedFilePath: null, generatedFileContentType: null };
-
-          return {
-            agentMCPActionId: this.id,
-            // Write content to DB (kept during migration period to ease rollback).
-            content: c.content,
-            contentGcsPath,
-            citations: getCitationsFromToolOutput([c.content]),
-            fileId: c.fileId,
-            workspaceId: this.workspaceId,
-            generatedFilePath,
-            generatedFileContentType,
-          };
-        }),
-        { transaction }
-      );
-    } catch (err) {
-      // A DB error can be ambiguous after commit, so keep the GCS objects rather than risk
-      // deleting content referenced by committed rows. Action-prefix cleanup removes orphans.
-      return new Err(normalizeError(err));
-    }
-
-    try {
-      await warmGcsContentCache(
-        auth,
-        removeNulls(
-          outputItems.map((item) =>
-            item.contentGcsPath
-              ? {
-                  itemId: item.id,
-                  gcsPath: item.contentGcsPath,
-                  content: item.content,
-                }
-              : null
-          )
-        )
-      );
-    } catch (err) {
-      // Cache warming is best-effort and must not turn a successful persistence into a retry.
-      logger.warn(
-        { err: normalizeError(err), actionId: this.sId },
-        "Failed to warm MCP output content cache"
-      );
-    }
-
-    // Return the stored contents in the generic tool output item shape.
-    return new Ok({
-      gcsPaths: removeNulls(outputItems.map((item) => item.contentGcsPath)),
-      itemIds: outputItems.map((item) => item.id),
+    return {
+      rows,
       outputItems: removeNulls(
-        outputItems.map((item) =>
+        rows.map((item) =>
           item.content
             ? {
                 content: item.content,
@@ -1331,31 +1284,67 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
             : null
         )
       ),
-    });
+    };
   }
 
-  static async discardOutputItems(
+  async syncOutputRowsToGcs(
     auth: Authenticator,
-    stagedOutputs: StagedActionOutputs
-  ): Promise<void> {
-    const deleteResult = await deleteContentsFromGcs(stagedOutputs.gcsPaths);
-    if (deleteResult.isErr()) {
-      logger.error(
-        {
-          err: deleteResult.error,
-          itemIds: stagedOutputs.itemIds,
-          workspaceId: auth.getNonNullableWorkspace().sId,
+    rows: AgentMCPActionOutputItemModel[],
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<void, Error>> {
+    const gcsResult = await batchWriteContentsToGcs(
+      auth,
+      this,
+      rows.map((item) => item.content)
+    );
+
+    if (gcsResult.isErr()) {
+      return gcsResult;
+    }
+
+    const rowsWithPaths = rows.map((item, index) => {
+      const gcsPath = gcsResult.value[index];
+      assert(gcsPath, "GCS path not found for output item.");
+      return { item, gcsPath };
+    });
+
+    try {
+      await concurrentExecutor(
+        rowsWithPaths,
+        async ({ item, gcsPath }) => {
+          await AgentMCPActionOutputItemModel.update(
+            { contentGcsPath: gcsPath },
+            {
+              where: { id: item.id, workspaceId: this.workspaceId },
+              transaction,
+            }
+          );
+          item.contentGcsPath = gcsPath;
         },
-        "Failed to delete discarded MCP output content"
+        { concurrency: SYNC_OUTPUT_ROWS_CONCURRENCY }
+      );
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+
+    try {
+      await warmGcsContentCache(
+        auth,
+        rowsWithPaths.map(({ item, gcsPath }) => ({
+          itemId: item.id,
+          gcsPath,
+          content: item.content,
+        }))
+      );
+    } catch (err) {
+      // Cache warming is best-effort and must not turn a successful persistence into a retry.
+      logger.warn(
+        { err: normalizeError(err), actionId: this.sId },
+        "Failed to warm MCP output content cache"
       );
     }
 
-    await AgentMCPActionOutputItemModel.destroy({
-      where: {
-        id: { [Op.in]: stagedOutputs.itemIds },
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
-    });
+    return new Ok(undefined);
   }
 
   static async fetchOutputItemsByActionIds(

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -264,18 +264,19 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
   static async fetchById(
     auth: Authenticator,
-    sId: string
+    sId: string,
+    transaction?: Transaction
   ): Promise<AgentMCPActionResource | null> {
     const modelId = getResourceIdFromSId(sId);
     if (!modelId) {
       return null;
     }
 
-    const [action] = await AgentMCPActionResource.fetchByModelIds(auth, [
+    return AgentMCPActionResource.fetchByModelIdWithAuth(
+      auth,
       modelId,
-    ]);
-
-    return action;
+      transaction
+    );
   }
 
   static async fetchByModelIds(
@@ -997,13 +998,17 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
    * (approving, denying, answering, retrying) is only allowed while the message can resume:
    * otherwise it would relaunch an agent loop that was already terminated.
    */
-  async canAgentMessageResume(auth: Authenticator): Promise<boolean> {
+  async canAgentMessageResume(
+    auth: Authenticator,
+    transaction?: Transaction
+  ): Promise<boolean> {
     const agentMessage = await AgentMessageModel.findOne({
       attributes: ["status"],
       where: {
         id: this.agentMessageId,
         workspaceId: auth.getNonNullableWorkspace().id,
       },
+      transaction,
     });
 
     return (
@@ -1509,9 +1514,11 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     {
       status,
       expectedStatus,
+      transaction,
     }: {
       status: ToolExecutionStatus;
       expectedStatus: ToolExecutionStatus;
+      transaction?: Transaction;
     }
   ): Promise<[affectedCount: number]> {
     return AgentMCPActionModel.update(
@@ -1522,6 +1529,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
           workspaceId: auth.getNonNullableWorkspace().id,
           status: expectedStatus,
         },
+        transaction,
       }
     );
   }

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -23,6 +23,7 @@ import type {
 import {
   isFileAuthorizationInfo,
   isSandboxChildActionInfo,
+  isSandboxResumeState,
   isUserQuestionResumeState,
 } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
@@ -99,7 +100,7 @@ const OUTPUT_ITEMS_BATCH_SIZE = 32;
 
 const FETCH_OUTPUT_ITEMS_CONCURRENCY = 2;
 
-const DENIABLE_SANDBOX_CHILD_STATUSES = [
+const DENIABLE_PENDING_STATUSES = [
   "ready_allowed_explicitly",
   "ready_allowed_implicitly",
   ...TOOL_EXECUTION_BLOCKED_STATUSES,
@@ -987,7 +988,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         where: {
           id: { [Op.in]: actions.map((a) => a.id) },
           workspaceId: auth.getNonNullableWorkspace().id,
-          status: { [Op.in]: DENIABLE_SANDBOX_CHILD_STATUSES },
+          status: { [Op.in]: DENIABLE_PENDING_STATUSES },
         },
         returning: true,
         transaction,
@@ -1001,9 +1002,9 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
   /**
    * Denies actions that cannot start or resume after an agent message terminates: all blocked
-   * actions, plus not-yet-started sandbox children. Must run in the message finalization
-   * transaction so a child workflow can atomically reserve a ready child before termination, or
-   * observe it as denied afterward.
+   * actions, plus not-yet-started sandbox children and resumed sandbox parents. Must run in the
+   * message finalization transaction so a workflow can atomically reserve an action before
+   * termination, or observe it as denied afterward.
    */
   static async denyPendingActionsForMessage(
     auth: Authenticator,
@@ -1022,7 +1023,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       {
         where: {
           agentMessageId,
-          status: { [Op.in]: DENIABLE_SANDBOX_CHILD_STATUSES },
+          status: { [Op.in]: DENIABLE_PENDING_STATUSES },
         },
       },
       transaction
@@ -1031,7 +1032,8 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     const deniableActions = pendingActions.filter(
       (action) =>
         isToolExecutionStatusBlocked(action.status) ||
-        isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)
+        isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo) ||
+        isSandboxResumeState(action.stepContext.resumeState)
     );
 
     return this.denyActions(auth, deniableActions, transaction);
@@ -1059,7 +1061,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       {
         where: {
           agentMessageId: parentAction.agentMessageId,
-          status: { [Op.in]: DENIABLE_SANDBOX_CHILD_STATUSES },
+          status: { [Op.in]: DENIABLE_PENDING_STATUSES },
         },
       },
       transaction

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -285,6 +285,27 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     );
   }
 
+  static async isBlockedForWorkspace({
+    actionId,
+    workspaceModelId,
+  }: {
+    actionId: string;
+    workspaceModelId: ModelId;
+  }): Promise<boolean> {
+    const actionModelId = getResourceIdFromSId(actionId);
+    assert(actionModelId, "Agent MCP action ID is invalid.");
+
+    const action = await AgentMCPActionModel.findOne({
+      attributes: ["status"],
+      where: {
+        id: actionModelId,
+        workspaceId: workspaceModelId,
+      },
+    });
+
+    return action !== null && isToolExecutionStatusBlocked(action.status);
+  }
+
   static async fetchByModelIds(
     auth: Authenticator,
     ids: ModelId[]

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -99,6 +99,12 @@ const OUTPUT_ITEMS_BATCH_SIZE = 32;
 
 const FETCH_OUTPUT_ITEMS_CONCURRENCY = 2;
 
+const DENIABLE_SANDBOX_CHILD_STATUSES = [
+  "ready_allowed_explicitly",
+  "ready_allowed_implicitly",
+  ...TOOL_EXECUTION_BLOCKED_STATUSES,
+] as const satisfies readonly ToolExecutionStatus[];
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -945,14 +951,40 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     return actions;
   }
 
+  private static async denyActions(
+    auth: Authenticator,
+    actions: AgentMCPActionResource[],
+    transaction: Transaction
+  ): Promise<AgentMCPActionResource[]> {
+    if (actions.length === 0) {
+      return [];
+    }
+
+    const [, affectedRows] = await AgentMCPActionModel.update(
+      { status: "denied" },
+      {
+        where: {
+          id: { [Op.in]: actions.map((a) => a.id) },
+          workspaceId: auth.getNonNullableWorkspace().id,
+          status: { [Op.in]: DENIABLE_SANDBOX_CHILD_STATUSES },
+        },
+        returning: true,
+        transaction,
+      }
+    );
+
+    const deniedActionIds = new Set(affectedRows.map((a) => a.id));
+
+    return actions.filter((a) => deniedActionIds.has(a.id));
+  }
+
   /**
-   * Denies all still-blocked actions of an agent message. Must run inside the same
-   * transaction as the message's terminal status update so that "message terminal" and
-   * "blocked actions denied" commit atomically. Guarded on blocked statuses so a concurrent
-   * approval that already transitioned the action is not clobbered. Returns the actions
-   * actually denied, with their pre-deny resources.
+   * Denies actions that cannot start or resume after an agent message terminates: all blocked
+   * actions, plus not-yet-started sandbox children. Must run in the message finalization
+   * transaction so a child workflow can atomically reserve a ready child before termination, or
+   * observe it as denied afterward.
    */
-  static async denyBlockedActionsForAgentMessage(
+  static async denyPendingActionsForMessage(
     auth: Authenticator,
     {
       agentMessageId,
@@ -962,35 +994,62 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       transaction: Transaction;
     }
   ): Promise<AgentMCPActionResource[]> {
-    const blockedActions = await this.listBlockedActionsForAgentMessage(auth, {
-      agentMessageId,
-      transaction,
-      skipSameStepCheck: true,
-    });
-
-    if (blockedActions.length === 0) {
-      return [];
-    }
-
-    const [, affectedRows] = await AgentMCPActionModel.update(
-      { status: "denied" },
+    // The (workspaceId, agentMessageId, status) index narrows the candidate rows before the
+    // sandbox-child check, avoiding a scan over the message's completed actions.
+    const pendingActions = await this.baseFetch(
+      auth,
       {
         where: {
-          // Scoping by agentMessageId lets the (workspaceId, agentMessageId, status) index
-          // drive the update; the id list keeps it restricted to the rows fetched above.
           agentMessageId,
-          id: { [Op.in]: blockedActions.map((a) => a.id) },
-          workspaceId: auth.getNonNullableWorkspace().id,
-          status: { [Op.in]: TOOL_EXECUTION_BLOCKED_STATUSES },
+          status: { [Op.in]: DENIABLE_SANDBOX_CHILD_STATUSES },
         },
-        returning: true,
-        transaction,
-      }
+      },
+      transaction
     );
 
-    const deniedActionIds = new Set(affectedRows.map((a) => a.id));
+    const deniableActions = pendingActions.filter(
+      (action) =>
+        isToolExecutionStatusBlocked(action.status) ||
+        isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)
+    );
 
-    return blockedActions.filter((a) => deniedActionIds.has(a.id));
+    return this.denyActions(auth, deniableActions, transaction);
+  }
+
+  /**
+   * Denies children that have not started when their parent bash finishes. Child insertion and
+   * parent completion use the same conversation lock, so the child is either rejected after the
+   * parent finishes or committed early enough to be denied here.
+   */
+  static async denyPendingSandboxChildren(
+    auth: Authenticator,
+    {
+      parentAction,
+      transaction,
+    }: {
+      parentAction: AgentMCPActionResource;
+      transaction: Transaction;
+    }
+  ): Promise<AgentMCPActionResource[]> {
+    // The (workspaceId, agentMessageId, status) index narrows this to unfinished actions of the
+    // parent's message; the JSON parent link is then checked on that small result set.
+    const pendingActions = await this.baseFetch(
+      auth,
+      {
+        where: {
+          agentMessageId: parentAction.agentMessageId,
+          status: { [Op.in]: DENIABLE_SANDBOX_CHILD_STATUSES },
+        },
+      },
+      transaction
+    );
+    const children = pendingActions.filter(
+      (action) =>
+        action.stepContext.sandboxChildActionInfo?.parentActionId ===
+        parentAction.sId
+    );
+
+    return this.denyActions(auth, children, transaction);
   }
 
   /**
@@ -1585,6 +1644,41 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       status: "succeeded",
       executionDurationMs: Math.round(executionDurationMs),
     });
+  }
+
+  async markSucceededFromExpected(
+    auth: Authenticator,
+    {
+      executionDurationMs,
+      expectedStatus,
+      transaction,
+    }: {
+      executionDurationMs: number;
+      expectedStatus: ToolExecutionStatus;
+      transaction: Transaction;
+    }
+  ): Promise<[affectedCount: number]> {
+    const [affectedCount, affectedRows] = await AgentMCPActionModel.update(
+      {
+        status: "succeeded",
+        executionDurationMs: Math.round(executionDurationMs),
+      },
+      {
+        where: {
+          id: this.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+          status: expectedStatus,
+        },
+        returning: true,
+        transaction,
+      }
+    );
+
+    if (affectedRows[0]) {
+      Object.assign(this, affectedRows[0].get());
+    }
+
+    return [affectedCount];
   }
 
   async updateStepContext(

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -45,6 +45,7 @@ import {
   batchFetchContentsFromGcs,
   batchWriteContentsToGcs,
   deleteActionOutputsFromGcs,
+  deleteContentsFromGcs,
   warmGcsContentCache,
 } from "@app/lib/resources/agent_mcp_action/output_storage";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
@@ -105,6 +106,12 @@ const DENIABLE_PENDING_STATUSES = [
   "ready_allowed_implicitly",
   ...TOOL_EXECUTION_BLOCKED_STATUSES,
 ] as const satisfies readonly ToolExecutionStatus[];
+
+export type StagedActionOutputs = {
+  gcsPaths: string[];
+  itemIds: ModelId[];
+  outputItems: ToolOutputItemType[];
+};
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -1223,6 +1230,21 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     }>,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<ToolOutputItemType[], Error>> {
+    const result = await this.stageOutputItems(auth, contents, { transaction });
+    if (result.isErr()) {
+      return result;
+    }
+    return new Ok(result.value.outputItems);
+  }
+
+  async stageOutputItems(
+    auth: Authenticator,
+    contents: Array<{
+      content: CallToolResult["content"][number];
+      fileId?: ModelId;
+    }>,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<StagedActionOutputs, Error>> {
     // Write GCS first: the helper retries and cleans up partial batches, and DB insertion only
     // starts once every object has been persisted.
     const gcsResult = await batchWriteContentsToGcs(
@@ -1294,8 +1316,10 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     }
 
     // Return the stored contents in the generic tool output item shape.
-    return new Ok(
-      removeNulls(
+    return new Ok({
+      gcsPaths: removeNulls(outputItems.map((item) => item.contentGcsPath)),
+      itemIds: outputItems.map((item) => item.id),
+      outputItems: removeNulls(
         outputItems.map((item) =>
           item.content
             ? {
@@ -1306,8 +1330,32 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
               }
             : null
         )
-      )
-    );
+      ),
+    });
+  }
+
+  static async discardOutputItems(
+    auth: Authenticator,
+    stagedOutputs: StagedActionOutputs
+  ): Promise<void> {
+    const deleteResult = await deleteContentsFromGcs(stagedOutputs.gcsPaths);
+    if (deleteResult.isErr()) {
+      logger.error(
+        {
+          err: deleteResult.error,
+          itemIds: stagedOutputs.itemIds,
+          workspaceId: auth.getNonNullableWorkspace().sId,
+        },
+        "Failed to delete discarded MCP output content"
+      );
+    }
+
+    await AgentMCPActionOutputItemModel.destroy({
+      where: {
+        id: { [Op.in]: stagedOutputs.itemIds },
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
   }
 
   static async fetchOutputItemsByActionIds(

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -289,9 +289,11 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   static async fetchBlockedActionIds({
     actionIds,
     workspaceModelId,
+    transaction,
   }: {
     actionIds: string[];
     workspaceModelId: ModelId;
+    transaction?: Transaction;
   }): Promise<Set<string>> {
     if (actionIds.length === 0) {
       return new Set();
@@ -310,6 +312,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         id: { [Op.in]: actionModelIds },
         status: { [Op.in]: TOOL_EXECUTION_BLOCKED_STATUSES },
       },
+      transaction,
     });
 
     return new Set(
@@ -1217,7 +1220,8 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     contents: Array<{
       content: CallToolResult["content"][number];
       fileId?: ModelId;
-    }>
+    }>,
+    { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<ToolOutputItemType[], Error>> {
     // Write GCS first: the helper retries and cleans up partial batches, and DB insertion only
     // starts once every object has been persisted.
@@ -1257,7 +1261,8 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
             generatedFilePath,
             generatedFileContentType,
           };
-        })
+        }),
+        { transaction }
       );
     } catch (err) {
       // A DB error can be ambiguous after commit, so keep the GCS objects rather than risk

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1226,17 +1226,88 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     contents: Array<{
       content: CallToolResult["content"][number];
       fileId?: ModelId;
-    }>,
-    { transaction }: { transaction?: Transaction } = {}
+    }>
   ): Promise<Result<ToolOutputItemType[], Error>> {
-    const outputRows = await this.createOutputRows(contents, { transaction });
-    const syncResult = await this.syncOutputRowsToGcs(auth, outputRows.rows, {
-      transaction,
-    });
-    if (syncResult.isErr()) {
-      return syncResult;
+    // Write GCS first: the helper retries and cleans up partial batches, and DB insertion only
+    // starts once every object has been persisted.
+    const gcsResult = await batchWriteContentsToGcs(
+      auth,
+      this,
+      contents.map(({ content }) => content)
+    );
+
+    if (gcsResult.isErr()) {
+      return new Err(gcsResult.error);
     }
-    return new Ok(outputRows.outputItems);
+
+    let outputItems: AgentMCPActionOutputItemModel[];
+    try {
+      outputItems = await AgentMCPActionOutputItemModel.bulkCreate(
+        contents.map((c, index) => {
+          const contentGcsPath = gcsResult.value[index];
+          assert(contentGcsPath, "GCS path not found for output item.");
+
+          const { generatedFilePath, generatedFileContentType } =
+            isToolGeneratedFilePath(c.content)
+              ? {
+                  generatedFilePath: c.content.resource.path,
+                  generatedFileContentType: c.content.resource.contentType,
+                }
+              : { generatedFilePath: null, generatedFileContentType: null };
+
+          return {
+            agentMCPActionId: this.id,
+            // Write content to DB (kept during migration period to ease rollback).
+            content: c.content,
+            contentGcsPath,
+            citations: getCitationsFromToolOutput([c.content]),
+            fileId: c.fileId,
+            workspaceId: this.workspaceId,
+            generatedFilePath,
+            generatedFileContentType,
+          };
+        })
+      );
+    } catch (err) {
+      // A DB error can be ambiguous after commit, so keep the GCS objects rather than risk
+      // deleting content referenced by committed rows. Action-prefix cleanup removes orphans.
+      return new Err(normalizeError(err));
+    }
+
+    try {
+      await warmGcsContentCache(
+        auth,
+        outputItems.map((item) => {
+          assert(item.contentGcsPath, "GCS path not found for output item.");
+          return {
+            itemId: item.id,
+            gcsPath: item.contentGcsPath,
+            content: item.content,
+          };
+        })
+      );
+    } catch (err) {
+      // Cache warming is best-effort and must not turn a successful persistence into a retry.
+      logger.warn(
+        { err: normalizeError(err), actionId: this.sId },
+        "Failed to warm MCP output content cache"
+      );
+    }
+
+    return new Ok(
+      removeNulls(
+        outputItems.map((item) =>
+          item.content
+            ? {
+                content: item.content,
+                fileId: item.fileId ?? null,
+                file: item.file ?? null,
+                workspaceId: item.workspaceId,
+              }
+            : null
+        )
+      )
+    );
   }
 
   async createOutputRows(

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -286,25 +286,37 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     );
   }
 
-  static async isBlockedForWorkspace({
-    actionId,
+  static async fetchBlockedActionIds({
+    actionIds,
     workspaceModelId,
   }: {
-    actionId: string;
+    actionIds: string[];
     workspaceModelId: ModelId;
-  }): Promise<boolean> {
-    const actionModelId = getResourceIdFromSId(actionId);
-    assert(actionModelId, "Agent MCP action ID is invalid.");
+  }): Promise<Set<string>> {
+    if (actionIds.length === 0) {
+      return new Set();
+    }
 
-    const action = await AgentMCPActionModel.findOne({
-      attributes: ["status"],
+    const actionModelIds = actionIds.map((actionId) => {
+      const actionModelId = getResourceIdFromSId(actionId);
+      assert(actionModelId, "Agent MCP action ID is invalid.");
+      return actionModelId;
+    });
+    const blockedActions = await AgentMCPActionModel.findAll({
+      attributes: ["id", "workspaceId"],
       where: {
-        id: actionModelId,
         workspaceId: workspaceModelId,
+        // Action IDs are primary keys, so this remains an indexed point lookup as the batch grows.
+        id: { [Op.in]: actionModelIds },
+        status: { [Op.in]: TOOL_EXECUTION_BLOCKED_STATUSES },
       },
     });
 
-    return action !== null && isToolExecutionStatusBlocked(action.status);
+    return new Set(
+      blockedActions.map(({ id, workspaceId }) =>
+        AgentMCPActionResource.modelIdToSId({ id, workspaceId })
+      )
+    );
   }
 
   static async fetchByModelIds(

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -398,6 +398,37 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     );
   }
 
+  static async listReadySandboxChildren(
+    auth: Authenticator,
+    {
+      parentAction,
+      transaction,
+    }: {
+      parentAction: AgentMCPActionResource;
+      transaction: Transaction;
+    }
+  ): Promise<AgentMCPActionResource[]> {
+    // The message/status index narrows this to runnable actions before the JSON parent filter.
+    const readyActions = await this.baseFetch(
+      auth,
+      {
+        where: {
+          agentMessageId: parentAction.agentMessageId,
+          status: {
+            [Op.in]: ["ready_allowed_explicitly", "ready_allowed_implicitly"],
+          },
+        },
+      },
+      transaction
+    );
+
+    return readyActions.filter(
+      (action) =>
+        action.stepContext.sandboxChildActionInfo?.parentActionId ===
+        parentAction.sId
+    );
+  }
+
   static async listBlockedActionsForConversation(
     auth: Authenticator,
     conversation: ConversationResource

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -900,21 +900,19 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
   /**
    * A message should never have blocked actions from more than one step, and resume paths rely
-   * on that to resume the agent loop from a single, unambiguous step. By default this enforces the
-   * invariant and throws on a violation, surfacing the bug. `dangerouslyBypassSameStepCheck` (used
-   * by the unstick-conversation poke plugin) skips the check so a genuinely stuck conversation can
-   * still be finalized.
+   * on that to resume the agent loop from a single, unambiguous step. Terminal cleanup and anomaly
+   * detection can skip the check because they do not choose a step to resume from.
    */
   static async listBlockedActionsForAgentMessage(
     auth: Authenticator,
     {
       agentMessageId,
       transaction,
-      dangerouslyBypassSameStepCheck = false,
+      skipSameStepCheck = false,
     }: {
       agentMessageId: ModelId;
       transaction?: Transaction;
-      dangerouslyBypassSameStepCheck?: boolean;
+      skipSameStepCheck?: boolean;
     }
   ): Promise<AgentMCPActionResource[]> {
     const actions = await this.baseFetch(
@@ -934,7 +932,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       return [];
     }
 
-    if (!dangerouslyBypassSameStepCheck) {
+    if (!skipSameStepCheck) {
       const steps = actions.map((a) => a.stepContent.step);
       const uniqueSteps = [...new Set(steps)];
       assert(
@@ -952,27 +950,21 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
    * "blocked actions denied" commit atomically. Guarded on blocked statuses so a concurrent
    * approval that already transitioned the action is not clobbered. Returns the actions
    * actually denied, with their pre-deny resources.
-   *
-   * `dangerouslyBypassSameStepCheck` is forwarded to listBlockedActionsForAgentMessage: leave it
-   * false to enforce the single-step invariant; the unstick-conversation poke plugin passes true to
-   * finalize an anomalous, genuinely stuck conversation instead of throwing.
    */
   static async denyBlockedActionsForAgentMessage(
     auth: Authenticator,
     {
       agentMessageId,
       transaction,
-      dangerouslyBypassSameStepCheck = false,
     }: {
       agentMessageId: ModelId;
       transaction: Transaction;
-      dangerouslyBypassSameStepCheck?: boolean;
     }
   ): Promise<AgentMCPActionResource[]> {
     const blockedActions = await this.listBlockedActionsForAgentMessage(auth, {
       agentMessageId,
       transaction,
-      dangerouslyBypassSameStepCheck,
+      skipSameStepCheck: true,
     });
 
     if (blockedActions.length === 0) {

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1667,21 +1667,23 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     });
   }
 
-  async markSucceededFromExpected(
+  async markFinalFromExpected(
     auth: Authenticator,
     {
       executionDurationMs,
       expectedStatus,
+      status,
       transaction,
     }: {
       executionDurationMs: number;
       expectedStatus: ToolExecutionStatus;
+      status: "errored" | "succeeded";
       transaction: Transaction;
     }
   ): Promise<[affectedCount: number]> {
     const [affectedCount, affectedRows] = await AgentMCPActionModel.update(
       {
-        status: "succeeded",
+        status,
         executionDurationMs: Math.round(executionDurationMs),
       },
       {

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -332,6 +332,72 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     });
   }
 
+  static async hasBlockedSandboxActions(
+    auth: Authenticator,
+    {
+      conversationId,
+      transaction,
+    }: {
+      conversationId: ModelId;
+      transaction: Transaction;
+    }
+  ): Promise<boolean> {
+    // This lifecycle-only query is infrequent and uses the workspace/conversation index before
+    // narrowing to resumable messages.
+    const agentMessages = await AgentMessageModel.findAll({
+      attributes: ["id"],
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId,
+        status: "created",
+      },
+      transaction,
+    });
+    if (agentMessages.length === 0) {
+      return false;
+    }
+
+    const actions = await this.baseFetch(
+      auth,
+      {
+        where: {
+          agentMessageId: {
+            [Op.in]: agentMessages.map((message) => message.id),
+          },
+          status: { [Op.in]: TOOL_EXECUTION_BLOCKED_STATUSES },
+        },
+      },
+      transaction
+    );
+    return actions.some(
+      (action) =>
+        isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo) ||
+        isSandboxResumeState(action.stepContext.resumeState)
+    );
+  }
+
+  static async hasBlockedSandboxChildren(
+    auth: Authenticator,
+    {
+      parentAction,
+      transaction,
+    }: {
+      parentAction: AgentMCPActionResource;
+      transaction?: Transaction;
+    }
+  ): Promise<boolean> {
+    const blockedActions = await this.listBlockedActionsForAgentMessage(auth, {
+      agentMessageId: parentAction.agentMessageId,
+      transaction,
+      skipSameStepCheck: true,
+    });
+    return blockedActions.some(
+      (action) =>
+        action.stepContext.sandboxChildActionInfo?.parentActionId ===
+        parentAction.sId
+    );
+  }
+
   static async listBlockedActionsForConversation(
     auth: Authenticator,
     conversation: ConversationResource

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2849,7 +2849,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
   static async getActionRequiredAndLastReadAtForUser(
     auth: Authenticator,
-    id: number
+    id: number,
+    transaction?: Transaction
   ) {
     if (!auth.user()) {
       return {
@@ -2865,6 +2866,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           workspaceId: auth.getNonNullableWorkspace().id,
           userId: auth.getNonNullableUser().id,
         },
+        transaction,
       }),
       UserConversationReadsModel.findOne({
         where: {
@@ -2872,6 +2874,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           workspaceId: auth.getNonNullableWorkspace().id,
           userId: auth.getNonNullableUser().id,
         },
+        transaction,
       }),
     ]);
 

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2630,7 +2630,13 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
   static async markAsActionRequired(
     auth: Authenticator,
-    { conversation }: { conversation: ConversationWithoutContentType }
+    {
+      conversation,
+      transaction,
+    }: {
+      conversation: ConversationWithoutContentType;
+      transaction?: Transaction;
+    }
   ) {
     const user = auth.user();
     if (!user) {
@@ -2649,6 +2655,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           userId: user.id,
           actionRequired: { [Op.ne]: true },
         },
+        transaction,
       }
     );
 

--- a/front/lib/resources/conversation_sandbox_adapter.ts
+++ b/front/lib/resources/conversation_sandbox_adapter.ts
@@ -151,10 +151,14 @@ export class ConversationSandboxAdapter {
     conversation: ConversationSandboxOwner,
     opts: { shouldPause?: () => Promise<boolean> } = {}
   ): Promise<Result<void, Error>> {
-    return SandboxResource.pauseForApproval(auth, {
-      lockKey: conversation.sId,
-      fetchSandbox: () => this.fetchSandboxByConversation(auth, conversation),
-    }, opts);
+    return SandboxResource.pauseForApproval(
+      auth,
+      {
+        lockKey: conversation.sId,
+        fetchSandbox: () => this.fetchSandboxByConversation(auth, conversation),
+      },
+      opts
+    );
   }
 
   static async deleteSandbox(

--- a/front/lib/resources/conversation_sandbox_adapter.ts
+++ b/front/lib/resources/conversation_sandbox_adapter.ts
@@ -183,11 +183,13 @@ export class ConversationSandboxAdapter {
 
   static async dangerouslySleepSandboxIfPendingApproval(
     auth: Authenticator,
-    conversation: ConversationSandboxLifecycleOwner
+    conversation: ConversationSandboxLifecycleOwner,
+    opts: { shouldSleep?: () => Promise<boolean> } = {}
   ): Promise<Result<void, Error>> {
     return SandboxResource.dangerouslySleepIfPendingApproval(
       auth,
-      this.toSandboxLifecycleOwner(conversation)
+      this.toSandboxLifecycleOwner(conversation),
+      opts
     );
   }
 

--- a/front/lib/resources/conversation_sandbox_adapter.ts
+++ b/front/lib/resources/conversation_sandbox_adapter.ts
@@ -148,12 +148,13 @@ export class ConversationSandboxAdapter {
 
   static async pauseSandboxForApproval(
     auth: Authenticator,
-    conversation: ConversationSandboxOwner
+    conversation: ConversationSandboxOwner,
+    opts: { shouldPause?: () => Promise<boolean> } = {}
   ): Promise<Result<void, Error>> {
     return SandboxResource.pauseForApproval(auth, {
       lockKey: conversation.sId,
       fetchSandbox: () => this.fetchSandboxByConversation(auth, conversation),
-    });
+    }, opts);
   }
 
   static async deleteSandbox(

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -769,11 +769,17 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   static async pauseForApproval(
     auth: Authenticator,
     owner: SandboxLifecycleOwner,
-    opts: { beforeSleep?: SandboxPreSleepCheck } = {}
+    opts: {
+      beforeSleep?: SandboxPreSleepCheck;
+      shouldPause?: () => Promise<boolean>;
+    } = {}
   ): Promise<Result<void, Error>> {
     return this.withLifecycleLock(owner.lockKey, async (provider) => {
       const sandbox = await owner.fetchSandbox();
       if (!sandbox || sandbox.status !== "running") {
+        return new Ok(undefined);
+      }
+      if (opts.shouldPause && !(await opts.shouldPause())) {
         return new Ok(undefined);
       }
 

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -842,11 +842,15 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    */
   static async dangerouslySleepIfPendingApproval(
     auth: Authenticator,
-    owner: SandboxLifecycleOwner
+    owner: SandboxLifecycleOwner,
+    opts: { shouldSleep?: () => Promise<boolean> } = {}
   ): Promise<Result<void, Error>> {
     return this.withLifecycleLock(owner.lockKey, async () => {
       const sandbox = await owner.fetchSandbox();
       if (!sandbox || sandbox.status !== "pending_approval") {
+        return new Ok(undefined);
+      }
+      if (opts.shouldSleep && !(await opts.shouldSleep())) {
         return new Ok(undefined);
       }
 

--- a/front/lib/swr/tool_actions.ts
+++ b/front/lib/swr/tool_actions.ts
@@ -192,6 +192,7 @@ export function useValidateAction({ owner, onError }: UseValidateActionParams) {
       try {
         const request = getValidateActionRequest(owner.sId, validation);
         if (!request) {
+          onError("Failed to assess action approval. Please try again.");
           return { success: false };
         }
         await fetcher(request.url, {
@@ -207,7 +208,12 @@ export function useValidateAction({ owner, onError }: UseValidateActionParams) {
         if (isAlreadyResolvedError(error)) {
           return { success: true };
         }
-        onError("Failed to assess action approval. Please try again.");
+        onError(
+          isAPIErrorResponse(error) &&
+            error.error.type === "invalid_request_error"
+            ? error.error.message
+            : "Failed to assess action approval. Please try again."
+        );
         return { success: false };
       } finally {
         setIsValidating(false);

--- a/front/lib/swr/tool_actions.ts
+++ b/front/lib/swr/tool_actions.ts
@@ -163,7 +163,11 @@ export function useResolveAuthentication({
         sendNotification({
           type: "error",
           title: `Failed to complete ${label}`,
-          description: `The tool could not resume after ${label}. Please try again.`,
+          description:
+            isAPIErrorResponse(error) &&
+            error.error.type === "invalid_request_error"
+              ? error.error.message
+              : `The tool could not resume after ${label}. Please try again.`,
         });
         return { success: false };
       } finally {

--- a/front/temporal/agent_loop/activities/publish_deferred_events.test.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.test.ts
@@ -1,17 +1,13 @@
 import type { DeferredEvent } from "@app/temporal/agent_loop/lib/deferred_events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const {
-  isBlockedMock,
-  messageFindMock,
-  publishEventMock,
-  removeEventMock,
-} = vi.hoisted(() => ({
-  isBlockedMock: vi.fn(),
-  messageFindMock: vi.fn(),
-  publishEventMock: vi.fn(),
-  removeEventMock: vi.fn(),
-}));
+const { isBlockedMock, messageFindMock, publishEventMock, removeEventMock } =
+  vi.hoisted(() => ({
+    isBlockedMock: vi.fn(),
+    messageFindMock: vi.fn(),
+    publishEventMock: vi.fn(),
+    removeEventMock: vi.fn(),
+  }));
 
 vi.mock("@app/lib/api/assistant/streaming/events", () => ({
   publishConversationRelatedEvent: publishEventMock,
@@ -69,12 +65,46 @@ describe("publishDeferredEventsActivity", () => {
   });
 
   it("removes an event denied while it is being published", async () => {
-    isBlockedMock.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    isBlockedMock
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
 
     const shouldPause = await publishDeferredEventsActivity([DEFERRED_EVENT]);
 
     expect(publishEventMock).toHaveBeenCalledTimes(1);
     expect(removeEventMock).toHaveBeenCalledTimes(1);
     expect(shouldPause).toBe(false);
+  });
+
+  it("marks the last active event as the last blocking event", async () => {
+    const staleEvent: DeferredEvent = {
+      ...DEFERRED_EVENT,
+      event: {
+        ...DEFERRED_EVENT.event,
+        actionId: "stale_action_id",
+      },
+    };
+    isBlockedMock
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true);
+
+    const shouldPause = await publishDeferredEventsActivity([
+      DEFERRED_EVENT,
+      staleEvent,
+    ]);
+
+    expect(publishEventMock).toHaveBeenCalledOnce();
+    expect(publishEventMock).toHaveBeenCalledWith({
+      conversationId: "conversation_id",
+      event: expect.objectContaining({
+        actionId: "action_id",
+        isLastBlockingEventForStep: true,
+      }),
+      step: 2,
+    });
+    expect(shouldPause).toBe(true);
   });
 });

--- a/front/temporal/agent_loop/activities/publish_deferred_events.test.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.test.ts
@@ -1,0 +1,80 @@
+import type { DeferredEvent } from "@app/temporal/agent_loop/lib/deferred_events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  isBlockedMock,
+  messageFindMock,
+  publishEventMock,
+  removeEventMock,
+} = vi.hoisted(() => ({
+  isBlockedMock: vi.fn(),
+  messageFindMock: vi.fn(),
+  publishEventMock: vi.fn(),
+  removeEventMock: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/assistant/streaming/events", () => ({
+  publishConversationRelatedEvent: publishEventMock,
+}));
+vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
+  getRedisHybridManager: () => ({ removeEvent: removeEventMock }),
+}));
+vi.mock("@app/lib/models/agent/conversation", () => ({
+  AgentMessageModel: { findOne: messageFindMock },
+}));
+vi.mock("@app/lib/resources/agent_mcp_action_resource", () => ({
+  AgentMCPActionResource: {
+    isBlockedForWorkspace: isBlockedMock,
+  },
+}));
+
+import { publishDeferredEventsActivity } from "@app/temporal/agent_loop/activities/publish_deferred_events";
+
+const DEFERRED_EVENT: DeferredEvent = {
+  context: {
+    agentMessageId: "message_id",
+    agentMessageRowId: 1,
+    conversationId: "conversation_id",
+    step: 2,
+    workspaceId: 3,
+  },
+  event: {
+    type: "tool_ask_user_question",
+    actionId: "action_id",
+    configurationId: "configuration_id",
+    conversationId: "conversation_id",
+    created: 1,
+    inputs: {},
+    messageId: "message_id",
+    metadata: {
+      agentName: "agent",
+      mcpServerName: "server",
+      toolName: "tool",
+    },
+    question: {
+      multiSelect: false,
+      options: [],
+      question: "Continue?",
+    },
+  },
+  shouldPauseAgentLoop: true,
+};
+
+describe("publishDeferredEventsActivity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    messageFindMock.mockResolvedValue({});
+    publishEventMock.mockResolvedValue(undefined);
+    removeEventMock.mockResolvedValue(undefined);
+  });
+
+  it("removes an event denied while it is being published", async () => {
+    isBlockedMock.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    const shouldPause = await publishDeferredEventsActivity([DEFERRED_EVENT]);
+
+    expect(publishEventMock).toHaveBeenCalledTimes(1);
+    expect(removeEventMock).toHaveBeenCalledTimes(1);
+    expect(shouldPause).toBe(false);
+  });
+});

--- a/front/temporal/agent_loop/activities/publish_deferred_events.test.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.test.ts
@@ -59,16 +59,14 @@ const DEFERRED_EVENT: DeferredEvent = {
 describe("publishDeferredEventsActivity", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    isBlockedMock.mockReset();
     messageFindMock.mockResolvedValue({});
     publishEventMock.mockResolvedValue(undefined);
     removeEventMock.mockResolvedValue(undefined);
   });
 
   it("removes an event denied while it is being published", async () => {
-    isBlockedMock
-      .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce(false);
+    isBlockedMock.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
 
     const shouldPause = await publishDeferredEventsActivity([DEFERRED_EVENT]);
 
@@ -105,6 +103,38 @@ describe("publishDeferredEventsActivity", () => {
       }),
       step: 2,
     });
+    expect(shouldPause).toBe(true);
+  });
+
+  it("publishes a last marker when the last action resolves during publication", async () => {
+    const lastEvent: DeferredEvent = {
+      ...DEFERRED_EVENT,
+      event: {
+        ...DEFERRED_EVENT.event,
+        actionId: "last_action_id",
+      },
+    };
+    isBlockedMock
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+
+    const shouldPause = await publishDeferredEventsActivity([
+      DEFERRED_EVENT,
+      lastEvent,
+    ]);
+
+    expect(publishEventMock).toHaveBeenCalledTimes(2);
+    expect(publishEventMock).toHaveBeenLastCalledWith({
+      conversationId: "conversation_id",
+      event: expect.objectContaining({
+        actionId: "last_action_id",
+        isLastBlockingEventForStep: true,
+      }),
+      step: 2,
+    });
+    expect(removeEventMock).toHaveBeenCalledOnce();
     expect(shouldPause).toBe(true);
   });
 });

--- a/front/temporal/agent_loop/activities/publish_deferred_events.test.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.test.ts
@@ -1,9 +1,9 @@
 import type { DeferredEvent } from "@app/temporal/agent_loop/lib/deferred_events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { isBlockedMock, messageFindMock, publishEventMock, removeEventMock } =
+const { fetchBlockedMock, messageFindMock, publishEventMock, removeEventMock } =
   vi.hoisted(() => ({
-    isBlockedMock: vi.fn(),
+    fetchBlockedMock: vi.fn(),
     messageFindMock: vi.fn(),
     publishEventMock: vi.fn(),
     removeEventMock: vi.fn(),
@@ -20,7 +20,7 @@ vi.mock("@app/lib/models/agent/conversation", () => ({
 }));
 vi.mock("@app/lib/resources/agent_mcp_action_resource", () => ({
   AgentMCPActionResource: {
-    isBlockedForWorkspace: isBlockedMock,
+    fetchBlockedActionIds: fetchBlockedMock,
   },
 }));
 
@@ -59,17 +59,20 @@ const DEFERRED_EVENT: DeferredEvent = {
 describe("publishDeferredEventsActivity", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    isBlockedMock.mockReset();
+    fetchBlockedMock.mockReset();
     messageFindMock.mockResolvedValue({});
     publishEventMock.mockResolvedValue(undefined);
     removeEventMock.mockResolvedValue(undefined);
   });
 
   it("removes an event denied while it is being published", async () => {
-    isBlockedMock.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    fetchBlockedMock
+      .mockResolvedValueOnce(new Set(["action_id"]))
+      .mockResolvedValueOnce(new Set());
 
     const shouldPause = await publishDeferredEventsActivity([DEFERRED_EVENT]);
 
+    expect(fetchBlockedMock).toHaveBeenCalledTimes(2);
     expect(publishEventMock).toHaveBeenCalledTimes(1);
     expect(removeEventMock).toHaveBeenCalledTimes(1);
     expect(shouldPause).toBe(false);
@@ -83,11 +86,9 @@ describe("publishDeferredEventsActivity", () => {
         actionId: "stale_action_id",
       },
     };
-    isBlockedMock
-      .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce(false)
-      .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce(true);
+    fetchBlockedMock
+      .mockResolvedValueOnce(new Set(["action_id"]))
+      .mockResolvedValueOnce(new Set(["action_id"]));
 
     const shouldPause = await publishDeferredEventsActivity([
       DEFERRED_EVENT,
@@ -114,11 +115,9 @@ describe("publishDeferredEventsActivity", () => {
         actionId: "last_action_id",
       },
     };
-    isBlockedMock
-      .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce(false);
+    fetchBlockedMock
+      .mockResolvedValueOnce(new Set(["action_id", "last_action_id"]))
+      .mockResolvedValueOnce(new Set(["action_id"]));
 
     const shouldPause = await publishDeferredEventsActivity([
       DEFERRED_EVENT,

--- a/front/temporal/agent_loop/activities/publish_deferred_events.test.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.test.ts
@@ -1,16 +1,37 @@
+import type { AuthenticatorType } from "@app/lib/auth";
 import type { DeferredEvent } from "@app/temporal/agent_loop/lib/deferred_events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
+  actionRequiredMock,
+  authMock,
+  authTypeMock,
+  conversationFetchMock,
   fetchBlockedMock,
   lockMock,
+  markRequiredMock,
   messageFindMock,
+  notifyMock,
   publishEventMock,
   transaction,
 } = vi.hoisted(() => ({
+  actionRequiredMock: vi.fn(),
+  authMock: {},
+  authTypeMock: {
+    authMethod: "session",
+    workspaceId: "workspace_id",
+    userId: "user_id",
+    role: "user",
+    groupIds: [],
+    subscriptionId: null,
+    isByok: false,
+  },
+  conversationFetchMock: vi.fn(),
   fetchBlockedMock: vi.fn(),
   lockMock: vi.fn(),
+  markRequiredMock: vi.fn(),
   messageFindMock: vi.fn(),
+  notifyMock: vi.fn(),
   publishEventMock: vi.fn(),
   transaction: {},
 }));
@@ -29,6 +50,21 @@ vi.mock("@app/lib/resources/string_ids", () => ({
 }));
 vi.mock("@app/lib/models/agent/conversation", () => ({
   AgentMessageModel: { findAll: messageFindMock },
+}));
+vi.mock("@app/lib/auth", () => ({
+  Authenticator: {
+    fromJsonWithRefrehedGroups: vi.fn().mockResolvedValue(authMock),
+  },
+}));
+vi.mock("@app/lib/notifications/workflows/manual-action-required", () => ({
+  notifyManualActionRequired: notifyMock,
+}));
+vi.mock("@app/lib/resources/conversation_resource", () => ({
+  ConversationResource: {
+    fetchById: conversationFetchMock,
+    getActionRequiredAndLastReadAtForUser: actionRequiredMock,
+    markAsActionRequired: markRequiredMock,
+  },
 }));
 vi.mock("@app/lib/resources/agent_mcp_action_resource", () => ({
   AgentMCPActionResource: {
@@ -76,6 +112,15 @@ describe("publishDeferredEventsActivity", () => {
     messageFindMock.mockResolvedValue([{ id: 1 }]);
     publishEventMock.mockResolvedValue(undefined);
     lockMock.mockResolvedValue(undefined);
+    conversationFetchMock.mockResolvedValue({
+      id: 42,
+      toJSON: () => ({ sId: "conversation_id" }),
+    });
+    actionRequiredMock.mockResolvedValue({
+      actionRequired: false,
+      lastReadAt: null,
+    });
+    markRequiredMock.mockResolvedValue(undefined);
   });
 
   it("skips a nested event whose originating action is no longer blocked", async () => {
@@ -132,5 +177,51 @@ describe("publishDeferredEventsActivity", () => {
     expect(lockMock).toHaveBeenCalledWith(expect.any(Number), transaction);
     expect(publishEventMock).not.toHaveBeenCalled();
     expect(shouldPause).toBe(false);
+  });
+
+  it("marks action required only after retaining a current event", async () => {
+    fetchBlockedMock.mockResolvedValueOnce(
+      new Set(["action_id", "origin_action_id"])
+    );
+    const event = {
+      ...DEFERRED_EVENT,
+      context: {
+        ...DEFERRED_EVENT.context,
+        authType: authTypeMock as AuthenticatorType,
+      },
+    };
+
+    await publishDeferredEventsActivity([event]);
+
+    expect(markRequiredMock).toHaveBeenCalledWith(authMock, {
+      conversation: expect.objectContaining({
+        actionRequired: false,
+        sId: "conversation_id",
+      }),
+      transaction,
+    });
+    expect(notifyMock).toHaveBeenCalledWith(authMock, {
+      actionId: "action_id",
+      conversationId: "conversation_id",
+    });
+  });
+
+  it("does not restore action required for a terminated message", async () => {
+    messageFindMock.mockResolvedValueOnce([]);
+    fetchBlockedMock.mockResolvedValueOnce(
+      new Set(["action_id", "origin_action_id"])
+    );
+    const event = {
+      ...DEFERRED_EVENT,
+      context: {
+        ...DEFERRED_EVENT.context,
+        authType: authTypeMock as AuthenticatorType,
+      },
+    };
+
+    await publishDeferredEventsActivity([event]);
+
+    expect(markRequiredMock).not.toHaveBeenCalled();
+    expect(notifyMock).not.toHaveBeenCalled();
   });
 });

--- a/front/temporal/agent_loop/activities/publish_deferred_events.test.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.test.ts
@@ -1,22 +1,34 @@
 import type { DeferredEvent } from "@app/temporal/agent_loop/lib/deferred_events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { fetchBlockedMock, messageFindMock, publishEventMock, removeEventMock } =
-  vi.hoisted(() => ({
-    fetchBlockedMock: vi.fn(),
-    messageFindMock: vi.fn(),
-    publishEventMock: vi.fn(),
-    removeEventMock: vi.fn(),
-  }));
+const {
+  fetchBlockedMock,
+  lockMock,
+  messageFindMock,
+  publishEventMock,
+  transaction,
+} = vi.hoisted(() => ({
+  fetchBlockedMock: vi.fn(),
+  lockMock: vi.fn(),
+  messageFindMock: vi.fn(),
+  publishEventMock: vi.fn(),
+  transaction: {},
+}));
 
 vi.mock("@app/lib/api/assistant/streaming/events", () => ({
   publishConversationRelatedEvent: publishEventMock,
 }));
-vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
-  getRedisHybridManager: () => ({ removeEvent: removeEventMock }),
+vi.mock("@app/lib/api/assistant/conversation/lock", () => ({
+  getConversationLockById: lockMock,
+}));
+vi.mock("@app/lib/utils/sql_utils", () => ({
+  withTransaction: (fn: (transaction: unknown) => unknown) => fn(transaction),
+}));
+vi.mock("@app/lib/resources/string_ids", () => ({
+  getResourceIdFromSId: () => 42,
 }));
 vi.mock("@app/lib/models/agent/conversation", () => ({
-  AgentMessageModel: { findOne: messageFindMock },
+  AgentMessageModel: { findAll: messageFindMock },
 }));
 vi.mock("@app/lib/resources/agent_mcp_action_resource", () => ({
   AgentMCPActionResource: {
@@ -31,6 +43,7 @@ const DEFERRED_EVENT: DeferredEvent = {
     agentMessageId: "message_id",
     agentMessageRowId: 1,
     conversationId: "conversation_id",
+    originActionId: "origin_action_id",
     step: 2,
     workspaceId: 3,
   },
@@ -60,21 +73,22 @@ describe("publishDeferredEventsActivity", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     fetchBlockedMock.mockReset();
-    messageFindMock.mockResolvedValue({});
+    messageFindMock.mockResolvedValue([{ id: 1 }]);
     publishEventMock.mockResolvedValue(undefined);
-    removeEventMock.mockResolvedValue(undefined);
+    lockMock.mockResolvedValue(undefined);
   });
 
-  it("removes an event denied while it is being published", async () => {
-    fetchBlockedMock
-      .mockResolvedValueOnce(new Set(["action_id"]))
-      .mockResolvedValueOnce(new Set());
+  it("skips a nested event whose originating action is no longer blocked", async () => {
+    fetchBlockedMock.mockResolvedValueOnce(new Set(["action_id"]));
 
     const shouldPause = await publishDeferredEventsActivity([DEFERRED_EVENT]);
 
-    expect(fetchBlockedMock).toHaveBeenCalledTimes(2);
-    expect(publishEventMock).toHaveBeenCalledTimes(1);
-    expect(removeEventMock).toHaveBeenCalledTimes(1);
+    expect(fetchBlockedMock).toHaveBeenCalledWith({
+      actionIds: ["action_id", "origin_action_id"],
+      workspaceModelId: 3,
+      transaction,
+    });
+    expect(publishEventMock).not.toHaveBeenCalled();
     expect(shouldPause).toBe(false);
   });
 
@@ -86,9 +100,9 @@ describe("publishDeferredEventsActivity", () => {
         actionId: "stale_action_id",
       },
     };
-    fetchBlockedMock
-      .mockResolvedValueOnce(new Set(["action_id"]))
-      .mockResolvedValueOnce(new Set(["action_id"]));
+    fetchBlockedMock.mockResolvedValueOnce(
+      new Set(["action_id", "origin_action_id"])
+    );
 
     const shouldPause = await publishDeferredEventsActivity([
       DEFERRED_EVENT,
@@ -107,33 +121,16 @@ describe("publishDeferredEventsActivity", () => {
     expect(shouldPause).toBe(true);
   });
 
-  it("publishes a last marker when the last action resolves during publication", async () => {
-    const lastEvent: DeferredEvent = {
-      ...DEFERRED_EVENT,
-      event: {
-        ...DEFERRED_EVENT.event,
-        actionId: "last_action_id",
-      },
-    };
-    fetchBlockedMock
-      .mockResolvedValueOnce(new Set(["action_id", "last_action_id"]))
-      .mockResolvedValueOnce(new Set(["action_id"]));
+  it("skips publication after the agent message terminated", async () => {
+    messageFindMock.mockResolvedValueOnce([]);
+    fetchBlockedMock.mockResolvedValueOnce(
+      new Set(["action_id", "origin_action_id"])
+    );
 
-    const shouldPause = await publishDeferredEventsActivity([
-      DEFERRED_EVENT,
-      lastEvent,
-    ]);
+    const shouldPause = await publishDeferredEventsActivity([DEFERRED_EVENT]);
 
-    expect(publishEventMock).toHaveBeenCalledTimes(2);
-    expect(publishEventMock).toHaveBeenLastCalledWith({
-      conversationId: "conversation_id",
-      event: expect.objectContaining({
-        actionId: "last_action_id",
-        isLastBlockingEventForStep: true,
-      }),
-      step: 2,
-    });
-    expect(removeEventMock).toHaveBeenCalledOnce();
-    expect(shouldPause).toBe(true);
+    expect(lockMock).toHaveBeenCalledWith(expect.any(Number), transaction);
+    expect(publishEventMock).not.toHaveBeenCalled();
+    expect(shouldPause).toBe(false);
   });
 });

--- a/front/temporal/agent_loop/activities/publish_deferred_events.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.ts
@@ -1,8 +1,11 @@
 import { getConversationLockById } from "@app/lib/api/assistant/conversation/lock";
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
+import { Authenticator } from "@app/lib/auth";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
+import { notifyManualActionRequired } from "@app/lib/notifications/workflows/manual-action-required";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { DeferredEvent } from "@app/temporal/agent_loop/lib/deferred_events";
@@ -74,6 +77,11 @@ export async function publishDeferredEventsActivity(
   if (!conversationModelId) {
     throw new Error(`Invalid conversation ID: ${conversationId}`);
   }
+  const authType = deferredEvents.find(({ context }) => context.authType)
+    ?.context.authType;
+  const auth = authType
+    ? await Authenticator.fromJsonWithRefrehedGroups(authType)
+    : null;
 
   // Termination, sandbox-parent completion, and action resolution take this same lock. Publishing
   // inside it gives clients a stable ordering: a prompt is either skipped after the state change,
@@ -107,6 +115,28 @@ export async function publishDeferredEventsActivity(
         blockedActionIds.has(event.actionId) &&
         blockedActionIds.has(context.originActionId ?? event.actionId)
     );
+    let shouldNotify = false;
+    if (activeDeferredEvents.length > 0 && auth) {
+      const conversation = await ConversationResource.fetchById(
+        auth,
+        conversationId,
+        { transaction }
+      );
+      if (!conversation) {
+        throw new Error(`Conversation not found: ${conversationId}`);
+      }
+      const { actionRequired } =
+        await ConversationResource.getActionRequiredAndLastReadAtForUser(
+          auth,
+          conversation.id,
+          transaction
+        );
+      shouldNotify = !actionRequired;
+      await ConversationResource.markAsActionRequired(auth, {
+        conversation: { ...conversation.toJSON(), actionRequired },
+        transaction,
+      });
+    }
 
     for (const [index, deferredEvent] of activeDeferredEvents.entries()) {
       const { event, context } = deferredEvent;
@@ -169,6 +199,12 @@ export async function publishDeferredEventsActivity(
         conversationId: context.conversationId,
         event: eventToPublish,
         step: context.step,
+      });
+    }
+    if (shouldNotify && auth) {
+      notifyManualActionRequired(auth, {
+        conversationId,
+        actionId: activeDeferredEvents[0].event.actionId,
       });
     }
 

--- a/front/temporal/agent_loop/activities/publish_deferred_events.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.ts
@@ -72,10 +72,6 @@ export async function publishDeferredEventsActivity(
       );
     }
 
-    if (!(await isDeferredActionBlocked(deferredEvent))) {
-      continue;
-    }
-
     let eventToPublish: AgentMessageEvents;
 
     switch (event.type) {

--- a/front/temporal/agent_loop/activities/publish_deferred_events.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.ts
@@ -1,6 +1,6 @@
 import { isBlockedActionEvent } from "@app/lib/actions/mcp";
-import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
+import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
@@ -42,10 +42,17 @@ export async function publishDeferredEventsActivity(
   deferredEvents: DeferredEvent[]
 ): Promise<boolean> {
   let shouldPauseWorkflow = false;
+  const activeDeferredEvents: DeferredEvent[] = [];
 
-  for (const [index, deferredEvent] of deferredEvents.entries()) {
+  for (const deferredEvent of deferredEvents) {
+    if (await isDeferredActionBlocked(deferredEvent)) {
+      activeDeferredEvents.push(deferredEvent);
+    }
+  }
+
+  for (const [index, deferredEvent] of activeDeferredEvents.entries()) {
     const { event, context } = deferredEvent;
-    const isLastEvent = index === deferredEvents.length - 1;
+    const isLastEvent = index === activeDeferredEvents.length - 1;
 
     const where: WhereOptions<AgentMessageModel> = {
       id: context.agentMessageRowId,

--- a/front/temporal/agent_loop/activities/publish_deferred_events.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.ts
@@ -9,12 +9,25 @@ import type { DeferredEvent } from "@app/temporal/agent_loop/lib/deferred_events
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WhereOptions } from "sequelize";
 
-async function isDeferredActionBlocked(
-  deferredEvent: DeferredEvent
-): Promise<boolean> {
-  return AgentMCPActionResource.isBlockedForWorkspace({
-    actionId: deferredEvent.event.actionId,
-    workspaceModelId: deferredEvent.context.workspaceId,
+async function fetchBlockedActionIds(
+  deferredEvents: DeferredEvent[]
+): Promise<Set<string>> {
+  if (deferredEvents.length === 0) {
+    return new Set();
+  }
+
+  const workspaceModelId = deferredEvents[0].context.workspaceId;
+  if (
+    deferredEvents.some(
+      ({ context }) => context.workspaceId !== workspaceModelId
+    )
+  ) {
+    throw new Error("Deferred events must belong to the same workspace.");
+  }
+
+  return AgentMCPActionResource.fetchBlockedActionIds({
+    actionIds: deferredEvents.map(({ event }) => event.actionId),
+    workspaceModelId,
   });
 }
 
@@ -42,13 +55,10 @@ export async function publishDeferredEventsActivity(
   deferredEvents: DeferredEvent[]
 ): Promise<boolean> {
   let shouldPauseWorkflow = false;
-  const activeDeferredEvents: DeferredEvent[] = [];
-
-  for (const deferredEvent of deferredEvents) {
-    if (await isDeferredActionBlocked(deferredEvent)) {
-      activeDeferredEvents.push(deferredEvent);
-    }
-  }
+  const initiallyBlockedIds = await fetchBlockedActionIds(deferredEvents);
+  const activeDeferredEvents = deferredEvents.filter(({ event }) =>
+    initiallyBlockedIds.has(event.actionId)
+  );
 
   for (const [index, deferredEvent] of activeDeferredEvents.entries()) {
     const { event, context } = deferredEvent;
@@ -133,8 +143,11 @@ export async function publishDeferredEventsActivity(
       event: eventToPublish,
       step: context.step,
     });
+  }
 
-    if (!(await isDeferredActionBlocked(deferredEvent))) {
+  const stillBlockedIds = await fetchBlockedActionIds(activeDeferredEvents);
+  for (const deferredEvent of activeDeferredEvents) {
+    if (!stillBlockedIds.has(deferredEvent.event.actionId)) {
       // The action can be denied by message termination or parent completion between the first
       // status check and publication. Remove the just-published prompt; if denial happens after
       // this check, the denial path performs the same idempotent cleanup.

--- a/front/temporal/agent_loop/activities/publish_deferred_events.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.ts
@@ -1,9 +1,34 @@
+import { isBlockedActionEvent } from "@app/lib/actions/mcp";
+import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
+import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { DeferredEvent } from "@app/temporal/agent_loop/lib/deferred_events";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WhereOptions } from "sequelize";
+
+async function isDeferredActionBlocked(
+  deferredEvent: DeferredEvent
+): Promise<boolean> {
+  return AgentMCPActionResource.isBlockedForWorkspace({
+    actionId: deferredEvent.event.actionId,
+    workspaceModelId: deferredEvent.context.workspaceId,
+  });
+}
+
+async function removeDeferredEvent(
+  deferredEvent: DeferredEvent
+): Promise<void> {
+  await getRedisHybridManager().removeEvent((event) => {
+    const payload = JSON.parse(event.message["payload"]);
+    return (
+      isBlockedActionEvent(payload) &&
+      payload.actionId === deferredEvent.event.actionId
+    );
+  }, getMessageChannelId(deferredEvent.context.agentMessageId));
+}
 
 /**
  * Activity to publish events that were deferred during tool execution.
@@ -38,6 +63,10 @@ export async function publishDeferredEventsActivity(
       throw new Error(
         `Agent message row not found: ${context.agentMessageRowId}`
       );
+    }
+
+    if (!(await isDeferredActionBlocked(deferredEvent))) {
+      continue;
     }
 
     let eventToPublish: AgentMessageEvents;
@@ -101,6 +130,14 @@ export async function publishDeferredEventsActivity(
       event: eventToPublish,
       step: context.step,
     });
+
+    if (!(await isDeferredActionBlocked(deferredEvent))) {
+      // The action can be denied by message termination or parent completion between the first
+      // status check and publication. Remove the just-published prompt; if denial happens after
+      // this check, the denial path performs the same idempotent cleanup.
+      await removeDeferredEvent(deferredEvent);
+      continue;
+    }
 
     // Check if this event should pause the workflow.
     if (deferredEvent.shouldPauseAgentLoop) {

--- a/front/temporal/agent_loop/activities/publish_deferred_events.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.ts
@@ -1,16 +1,19 @@
-import { isBlockedActionEvent } from "@app/lib/actions/mcp";
+import { getConversationLockById } from "@app/lib/api/assistant/conversation/lock";
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
-import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
-import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { DeferredEvent } from "@app/temporal/agent_loop/lib/deferred_events";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type { WhereOptions } from "sequelize";
+import { Op } from "sequelize";
 
 async function fetchBlockedActionIds(
-  deferredEvents: DeferredEvent[]
+  deferredEvents: DeferredEvent[],
+  transaction: Parameters<
+    typeof AgentMCPActionResource.fetchBlockedActionIds
+  >[0]["transaction"]
 ): Promise<Set<string>> {
   if (deferredEvents.length === 0) {
     return new Set();
@@ -26,21 +29,18 @@ async function fetchBlockedActionIds(
   }
 
   return AgentMCPActionResource.fetchBlockedActionIds({
-    actionIds: deferredEvents.map(({ event }) => event.actionId),
+    actionIds: [
+      ...new Set(
+        deferredEvents.flatMap(({ context, event }) => [
+          event.actionId,
+          // TODO(2026-08-28): Remove the fallback after pre-deploy workflows have drained.
+          context.originActionId ?? event.actionId,
+        ])
+      ),
+    ],
     workspaceModelId,
+    transaction,
   });
-}
-
-async function removeDeferredEvent(
-  deferredEvent: DeferredEvent
-): Promise<void> {
-  await getRedisHybridManager().removeEvent((event) => {
-    const payload = JSON.parse(event.message["payload"]);
-    return (
-      isBlockedActionEvent(payload) &&
-      payload.actionId === deferredEvent.event.actionId
-    );
-  }, getMessageChannelId(deferredEvent.context.agentMessageId));
 }
 
 /**
@@ -54,112 +54,126 @@ async function removeDeferredEvent(
 export async function publishDeferredEventsActivity(
   deferredEvents: DeferredEvent[]
 ): Promise<boolean> {
-  let shouldPauseWorkflow = false;
-  const initiallyBlockedIds = await fetchBlockedActionIds(deferredEvents);
-  const activeDeferredEvents = deferredEvents.filter(({ event }) =>
-    initiallyBlockedIds.has(event.actionId)
-  );
-
-  for (const [index, deferredEvent] of activeDeferredEvents.entries()) {
-    const { event, context } = deferredEvent;
-    const isLastEvent = index === activeDeferredEvents.length - 1;
-
-    const where: WhereOptions<AgentMessageModel> = {
-      id: context.agentMessageRowId,
-    };
-
-    // TODO(2025-12-19 FLAV): Remove this check once all ongoing workflows have terminated.
-    if (context.workspaceId) {
-      where.workspaceId = context.workspaceId;
-    }
-
-    const agentMessageRow = await AgentMessageModel.findOne({
-      where,
-    });
-    if (!agentMessageRow) {
-      throw new Error(
-        `Agent message row not found: ${context.agentMessageRowId}`
-      );
-    }
-
-    let eventToPublish: AgentMessageEvents;
-
-    switch (event.type) {
-      case "tool_personal_auth_required":
-        eventToPublish = {
-          ...event,
-          isLastBlockingEventForStep: isLastEvent,
-          metadata: {
-            ...event.metadata,
-            // Override the message id to root the event to the right channel.
-            pubsubMessageId: deferredEvent.context.agentMessageId,
-          },
-        };
-        break;
-
-      case "tool_file_auth_required":
-        // Publish the file auth required event.
-        // Similar to tool_personal_auth_required but for file-specific authorization.
-        eventToPublish = {
-          ...event,
-          isLastBlockingEventForStep: isLastEvent,
-          metadata: {
-            ...event.metadata,
-            // Override the message id to root the event to the right channel.
-            pubsubMessageId: deferredEvent.context.agentMessageId,
-          },
-        };
-        break;
-
-      case "tool_approve_execution":
-        eventToPublish = {
-          ...event,
-          metadata: {
-            ...event.metadata,
-            // Override the message id to root the event to the right channel.
-            pubsubMessageId: deferredEvent.context.agentMessageId,
-          },
-        };
-        break;
-
-      case "tool_ask_user_question":
-        eventToPublish = {
-          ...event,
-          isLastBlockingEventForStep: isLastEvent,
-          metadata: {
-            ...event.metadata,
-            // Override the message id to root the event to the right channel.
-            pubsubMessageId: deferredEvent.context.agentMessageId,
-          },
-        };
-        break;
-
-      default:
-        assertNever(event);
-    }
-
-    await publishConversationRelatedEvent({
-      conversationId: context.conversationId,
-      event: eventToPublish,
-      step: context.step,
-    });
+  if (deferredEvents.length === 0) {
+    return false;
   }
 
-  const stillBlockedIds = await fetchBlockedActionIds(activeDeferredEvents);
-  for (const deferredEvent of activeDeferredEvents) {
-    if (!stillBlockedIds.has(deferredEvent.event.actionId)) {
-      // The action can be denied by message termination or parent completion between the first
-      // status check and publication. Remove the just-published prompt; if denial happens after
-      // this check, the denial path performs the same idempotent cleanup.
-      await removeDeferredEvent(deferredEvent);
-      continue;
-    }
-
-    // Check if this event should pause the workflow.
-    if (deferredEvent.shouldPauseAgentLoop) {
-      shouldPauseWorkflow = true;
-    }
+  const { conversationId, workspaceId } = deferredEvents[0].context;
+  if (
+    deferredEvents.some(
+      ({ context }) =>
+        context.conversationId !== conversationId ||
+        context.workspaceId !== workspaceId
+    )
+  ) {
+    throw new Error(
+      "Deferred events must belong to the same conversation and workspace."
+    );
+  }
+  const conversationModelId = getResourceIdFromSId(conversationId);
+  if (!conversationModelId) {
+    throw new Error(`Invalid conversation ID: ${conversationId}`);
   }
 
-  return shouldPauseWorkflow;
+  // Termination, sandbox-parent completion, and action resolution take this same lock. Publishing
+  // inside it gives clients a stable ordering: a prompt is either skipped after the state change,
+  // or appears before the later resolution/terminal event.
+  return withTransaction(async (transaction) => {
+    await getConversationLockById(conversationModelId, transaction);
+
+    const messageRows = await AgentMessageModel.findAll({
+      attributes: ["id"],
+      where: {
+        id: {
+          [Op.in]: [
+            ...new Set(
+              deferredEvents.map(({ context }) => context.agentMessageRowId)
+            ),
+          ],
+        },
+        workspaceId,
+        status: "created",
+      },
+      transaction,
+    });
+    const resumableMessageIds = new Set(messageRows.map(({ id }) => id));
+    const blockedActionIds = await fetchBlockedActionIds(
+      deferredEvents,
+      transaction
+    );
+    const activeDeferredEvents = deferredEvents.filter(
+      ({ context, event }) =>
+        resumableMessageIds.has(context.agentMessageRowId) &&
+        blockedActionIds.has(event.actionId) &&
+        blockedActionIds.has(context.originActionId ?? event.actionId)
+    );
+
+    for (const [index, deferredEvent] of activeDeferredEvents.entries()) {
+      const { event, context } = deferredEvent;
+      const isLastEvent = index === activeDeferredEvents.length - 1;
+      let eventToPublish: AgentMessageEvents;
+
+      switch (event.type) {
+        case "tool_personal_auth_required":
+          eventToPublish = {
+            ...event,
+            isLastBlockingEventForStep: isLastEvent,
+            metadata: {
+              ...event.metadata,
+              // Override the message id to root the event to the right channel.
+              pubsubMessageId: context.agentMessageId,
+            },
+          };
+          break;
+
+        case "tool_file_auth_required":
+          eventToPublish = {
+            ...event,
+            isLastBlockingEventForStep: isLastEvent,
+            metadata: {
+              ...event.metadata,
+              // Override the message id to root the event to the right channel.
+              pubsubMessageId: context.agentMessageId,
+            },
+          };
+          break;
+
+        case "tool_approve_execution":
+          eventToPublish = {
+            ...event,
+            metadata: {
+              ...event.metadata,
+              // Override the message id to root the event to the right channel.
+              pubsubMessageId: context.agentMessageId,
+            },
+          };
+          break;
+
+        case "tool_ask_user_question":
+          eventToPublish = {
+            ...event,
+            isLastBlockingEventForStep: isLastEvent,
+            metadata: {
+              ...event.metadata,
+              // Override the message id to root the event to the right channel.
+              pubsubMessageId: context.agentMessageId,
+            },
+          };
+          break;
+
+        default:
+          assertNever(event);
+      }
+
+      await publishConversationRelatedEvent({
+        conversationId: context.conversationId,
+        event: eventToPublish,
+        step: context.step,
+      });
+    }
+
+    return activeDeferredEvents.some(
+      ({ shouldPauseAgentLoop }) => shouldPauseAgentLoop
+    );
+  });
 }

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -1,13 +1,19 @@
 import { isAgentLoopToolEvent } from "@app/lib/actions/mcp";
 import type { ToolContext } from "@app/lib/actions/types";
-import { isSandboxChildActionInfo } from "@app/lib/actions/types";
+import {
+  isSandboxChildActionInfo,
+  isSandboxResumeState,
+} from "@app/lib/actions/types";
 import { isLightClientSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import {
   buildAuditLogTarget,
   emitAuditLogEventDirect,
 } from "@app/lib/api/audit/workos_audit";
 import { runToolWithStreaming } from "@app/lib/api/mcp/run_tool";
-import { reserveSandboxChildRun } from "@app/lib/api/sandbox/sandbox_child_block";
+import {
+  reserveSandboxChildRun,
+  reserveSandboxParentRun,
+} from "@app/lib/api/sandbox/sandbox_child_block";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { notifyManualActionRequired } from "@app/lib/notifications/workflows/manual-action-required";
@@ -178,11 +184,20 @@ export async function runToolActivity(
     userMessage,
   } = runAgentDataRes.value;
 
-  const actionToRun = isSandboxChildActionInfo(
-    action.stepContext.sandboxChildActionInfo
-  )
-    ? await reserveSandboxChildRun(auth, action, originalConversation)
-    : action;
+  let actionToRun: AgentMCPActionResource | null = action;
+  if (isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)) {
+    actionToRun = await reserveSandboxChildRun(
+      auth,
+      action,
+      originalConversation
+    );
+  } else if (isSandboxResumeState(action.stepContext.resumeState)) {
+    actionToRun = await reserveSandboxParentRun(
+      auth,
+      action,
+      originalConversation
+    );
+  }
   if (!actionToRun) {
     logger.info(
       {
@@ -191,7 +206,7 @@ export async function runToolActivity(
         agentMessageId: runAgentArgs.agentMessageId,
         workspaceId: authType.workspaceId,
       },
-      "Skipping sandbox child that can no longer run"
+      "Skipping sandbox action that can no longer run"
     );
     return { deferredEvents };
   }

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -197,7 +197,8 @@ export async function runToolActivity(
     actionToRun = await reserveSandboxParentRun(
       auth,
       action,
-      originalConversation
+      originalConversation,
+      Context.current().info.workflowExecution.runId
     );
   }
   if (!actionToRun) {

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -16,10 +16,8 @@ import {
 } from "@app/lib/api/sandbox/sandbox_child_block";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
-import { notifyManualActionRequired } from "@app/lib/notifications/workflows/manual-action-required";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { getShutdownSignal } from "@app/lib/shutdown_signal";
 import { withPeriodicHeartbeat } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -244,6 +242,7 @@ export async function runToolActivity(
       return executeToolStreaming(auth, {
         action: actionToRun,
         agentConfiguration,
+        authType,
         model,
         agentMessage,
         conversation,
@@ -262,6 +261,7 @@ async function executeToolStreaming(
   {
     action,
     agentConfiguration,
+    authType,
     model: modelInfo,
     agentMessage,
     conversation,
@@ -272,6 +272,7 @@ async function executeToolStreaming(
   }: {
     action: AgentMCPActionResource;
     agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
+    authType: AuthenticatorType;
     model: AgentLoopExecutionData["modelInfo"];
     agentMessage: AgentLoopExecutionData["agentMessage"];
     conversation: AgentLoopExecutionData["conversation"];
@@ -472,6 +473,7 @@ async function executeToolStreaming(
           context: {
             agentMessageId: agentMessage.sId,
             agentMessageRowId: agentMessage.agentMessageId,
+            authType,
             conversationId: conversation.sId,
             originActionId: action.sId,
             step,
@@ -479,17 +481,6 @@ async function executeToolStreaming(
           },
           shouldPauseAgentLoop: true,
         });
-
-        await ConversationResource.markAsActionRequired(auth, {
-          conversation,
-        });
-
-        if (!conversation.actionRequired) {
-          notifyManualActionRequired(auth, {
-            conversationId: conversation.sId,
-            actionId: action.sId,
-          });
-        }
 
         return { deferredEvents };
 

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -46,6 +46,7 @@ import { Context, heartbeat } from "@temporalio/activity";
 import assert from "assert";
 
 const CONVERSATION_CACHE_TTL_MS = 5000;
+const INITIAL_ACTIVITY_ATTEMPT = 1;
 
 // Extracts sIds of accessed datasources/tables from tool augmentedInputs.
 // Dust-internal MCP servers receive { uri } objects whose last path segment is
@@ -189,7 +190,8 @@ export async function runToolActivity(
     actionToRun = await reserveSandboxChildRun(
       auth,
       action,
-      originalConversation
+      originalConversation,
+      { isRetry: Context.current().info.attempt > INITIAL_ACTIVITY_ATTEMPT }
     );
   } else if (isSandboxResumeState(action.stepContext.resumeState)) {
     actionToRun = await reserveSandboxParentRun(

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -473,6 +473,7 @@ async function executeToolStreaming(
             agentMessageId: agentMessage.sId,
             agentMessageRowId: agentMessage.agentMessageId,
             conversationId: conversation.sId,
+            originActionId: action.sId,
             step,
             workspaceId: conversation.owner.id,
           },

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -7,6 +7,7 @@ import {
   emitAuditLogEventDirect,
 } from "@app/lib/api/audit/workos_audit";
 import { runToolWithStreaming } from "@app/lib/api/mcp/run_tool";
+import { reserveSandboxChildRun } from "@app/lib/api/sandbox/sandbox_child_block";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { notifyManualActionRequired } from "@app/lib/notifications/workflows/manual-action-required";
@@ -177,6 +178,24 @@ export async function runToolActivity(
     userMessage,
   } = runAgentDataRes.value;
 
+  const actionToRun = isSandboxChildActionInfo(
+    action.stepContext.sandboxChildActionInfo
+  )
+    ? await reserveSandboxChildRun(auth, action, originalConversation)
+    : action;
+  if (!actionToRun) {
+    logger.info(
+      {
+        actionId,
+        conversationId: runAgentArgs.conversationId,
+        agentMessageId: runAgentArgs.agentMessageId,
+        workspaceId: authType.workspaceId,
+      },
+      "Skipping sandbox child that can no longer run"
+    );
+    return { deferredEvents };
+  }
+
   const { slicedConversation: conversation, slicedAgentMessage: agentMessage } =
     sliceConversationForAgentMessage(originalConversation, {
       agentMessageId: originalAgentMessage.sId,
@@ -191,21 +210,21 @@ export async function runToolActivity(
     });
 
   return startActiveObservation(
-    `${action.toolConfiguration.mcpServerName}/${action.toolConfiguration.name}`,
+    `${actionToRun.toolConfiguration.mcpServerName}/${actionToRun.toolConfiguration.name}`,
     () => {
       updateActiveObservation(
         {
           input: {
             actionId,
-            toolName: action.toolConfiguration.name,
-            mcpServerName: action.toolConfiguration.mcpServerName,
+            toolName: actionToRun.toolConfiguration.name,
+            mcpServerName: actionToRun.toolConfiguration.mcpServerName,
           },
         },
         { asType: "tool" }
       );
 
       return executeToolStreaming(auth, {
-        action,
+        action: actionToRun,
         agentConfiguration,
         model,
         agentMessage,

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -216,11 +216,6 @@ export async function launchSandboxChildToolWorkflow(
     actionModelId: action.id,
   });
 
-  await ConversationResource.clearActionRequired(
-    auth,
-    agentLoopArgs.conversationId
-  );
-
   if (waitForCompletion) {
     try {
       const handle = client.workflow.getHandle(workflowId);

--- a/front/temporal/agent_loop/lib/deferred_events.ts
+++ b/front/temporal/agent_loop/lib/deferred_events.ts
@@ -4,6 +4,7 @@ import type {
   AgentLoopToolFileAuthRequiredEvent,
   AgentLoopToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
+import type { AuthenticatorType } from "@app/lib/auth";
 import type { ModelId } from "@app/types/shared/model_id";
 
 /**
@@ -24,6 +25,8 @@ type DeferrableEvent =
 type DeferredEventContext = {
   agentMessageId: string;
   agentMessageRowId: ModelId;
+  // Optional until workflows started before action-required marking moved to publication drain.
+  authType?: AuthenticatorType;
   conversationId: string;
   // The action whose activity produced the event. Nested run_agent events can carry a descendant
   // action ID in the event itself, while this ID remains the sandbox child owned by this workflow.

--- a/front/temporal/agent_loop/lib/deferred_events.ts
+++ b/front/temporal/agent_loop/lib/deferred_events.ts
@@ -25,6 +25,10 @@ type DeferredEventContext = {
   agentMessageId: string;
   agentMessageRowId: ModelId;
   conversationId: string;
+  // The action whose activity produced the event. Nested run_agent events can carry a descendant
+  // action ID in the event itself, while this ID remains the sandbox child owned by this workflow.
+  // Optional until workflows started before this field was deployed have drained.
+  originActionId?: string;
   step: number;
   workspaceId: ModelId;
 };

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -262,6 +262,7 @@ export const AGENT_MESSAGE_STATUSES_TO_TRACK: AgentMessageStatus[] = [
 // ends the loop in place, so resolving a leftover approval would relaunch a direction the loop
 // already stopped (and that steering, if any, has since superseded via a newly promoted message).
 export const UNRESUMABLE_AGENT_MESSAGE_STATUSES: AgentMessageStatus[] = [
+  "succeeded",
   "failed",
   "cancelled",
   "interrupted",


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9802

Sandbox child actions inherit their parent tool's step. A delayed or background sandbox child call
could arrive after its parent had already finished; the pause path then moved that finished parent
back to blocked. If the agent had reached another blocked step meanwhile, one message ended up with
blocked actions from multiple steps, and the same-step assertion made cancel and validate-action
return 500.

This change serializes child creation/start, parent finish/pause/resume, and message cancellation on
the conversation lifecycle lock. A child either starts before its parent/message terminates, or is
atomically denied. Approval events, actionRequired, and sandbox pauses also converge when
cancellation overlaps their side effects.

Terminal cleanup can safely deny anomalous actions across steps because it never resumes execution,
while validate-action returns a visible instruction to cancel and retry.

## Risks

Blast radius: sandbox child lifecycle and cleanup of pending agent actions
Risk: standard

## Deploy Plan

- deploy front

## Tests

- [x] sandbox child creation, start, parent completion, pause, and resume regression tests
- [x] cancellation during child creation and approval publication regression tests
- [x] terminal cleanup of blocked and not-yet-started sandbox child actions
- [x] multi-step cancel cleanup and validate-action regression tests
- [x] front type-check and changed-file formatting
