### PR TITLE
[front] hide publish skill option when there is no skill publication ff

### DIFF
--- a/front/components/pages/workspace/governance/GovernancePage.tsx
+++ b/front/components/pages/workspace/governance/GovernancePage.tsx
@@ -102,6 +102,9 @@ function groupGovernancePermissionsBySection(
 export const GovernancePage = () => {
   const { hasFeature } = useFeatureFlags();
   const hasAdminGovernanceFeature = hasFeature("admin_governance");
+  const hasSkillPublicationFeature = hasFeature(
+    "admin_governance_skill_publication"
+  );
 
   const owner = useWorkspace();
   const { isAdmin } = useAuth();
@@ -129,6 +132,11 @@ export const GovernancePage = () => {
     isFrameCapabilityEnabled(permission.grantType, sharingPolicy)
   );
 
+  const skillPermissions = skills.filter(
+    (permission) =>
+      hasSkillPublicationFeature || permission.grantType !== "publish"
+  );
+
   const router = useAppRouter();
   const handleNavigateToGroups = () => {
     void router.push(`/w/${owner.sId}/members?tab=groups`);
@@ -150,7 +158,7 @@ export const GovernancePage = () => {
       id: "skills",
       label: "Skills",
       icon: PuzzlePiece01,
-      governancePermissions: skills,
+      governancePermissions: skillPermissions,
     },
     ...(framePermissions.length > 0 || isAdmin
       ? [


### PR DESCRIPTION
## Description
As the title says, we won't release it together so let's hide it behind the FF 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
