### PR TITLE
Add user_memory internal MCP server behind feature flag

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2387,6 +2387,16 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "toolCostCategory": "basic",
     },
   },
+  "user_memory": {
+    "edit": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "read": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
   "user_mentions": {
     "get_mention_markdown": {
       "freeUsage": true,
@@ -3304,6 +3314,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   "user_analytics": {
     "get_personal_usage": "never_ask",
     "get_workspace_activity": "never_ask",
+  },
+  "user_memory": {
+    "edit": "never_ask",
+    "read": "never_ask",
   },
   "user_mentions": {
     "get_mention_markdown": "never_ask",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -89,6 +89,7 @@ import { STATUSPAGE_SERVER } from "@app/lib/api/actions/servers/statuspage/metad
 import { TOOLSETS_SERVER } from "@app/lib/api/actions/servers/toolsets/metadata";
 import { UKG_READY_SERVER } from "@app/lib/api/actions/servers/ukg_ready/metadata";
 import { USER_ANALYTICS_SERVER } from "@app/lib/api/actions/servers/user_analytics/metadata";
+import { USER_MEMORY_SERVER } from "@app/lib/api/actions/servers/user_memory/metadata";
 import { USER_MENTIONS_SERVER } from "@app/lib/api/actions/servers/user_mentions/metadata";
 import { VAL_TOWN_SERVER } from "@app/lib/api/actions/servers/val_town/metadata";
 import { VANTA_SERVER } from "@app/lib/api/actions/servers/vanta/metadata";
@@ -158,6 +159,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   // We'll prefix all tools with the server name to avoid conflicts.
   // It's okay to change the name of the server as we don't refer to it directly.
   "user_analytics",
+  "user_memory",
   "agent_sidekick_agent_state",
   "agent_sidekick_context",
   "agent_templates",
@@ -1260,6 +1262,19 @@ export const INTERNAL_MCP_SERVERS = ensureUniqueToolNames({
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     metadata: SERVICENOW_SERVER,
+  },
+  user_memory: {
+    id: 1043,
+    availability: "auto_hidden_builder",
+    allowMultipleInstances: false,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("user_memory");
+    },
+    isPreview: true,
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    metadata: USER_MEMORY_SERVER,
   },
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
 } satisfies {

--- a/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
+++ b/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
@@ -37,7 +37,8 @@
     { "name": "sandbox_functions", "id": 1037 },
     { "name": "user_analytics", "id": 1039 },
     { "name": "activation_recommendations", "id": 1040 },
-    { "name": "agent_templates", "id": 1041 }
+    { "name": "agent_templates", "id": 1041 },
+    { "name": "user_memory", "id": 1043 }
   ],
   "manual": [
     { "name": "github", "id": 1 },

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -78,6 +78,7 @@ import { default as statuspageServer } from "@app/lib/api/actions/servers/status
 import { default as toolsetsServer } from "@app/lib/api/actions/servers/toolsets";
 import { default as ukgReadyServer } from "@app/lib/api/actions/servers/ukg_ready";
 import { default as userAnalyticsServer } from "@app/lib/api/actions/servers/user_analytics";
+import { default as userMemoryServer } from "@app/lib/api/actions/servers/user_memory";
 import { default as userMentionsServer } from "@app/lib/api/actions/servers/user_mentions";
 import { default as valtownServer } from "@app/lib/api/actions/servers/val_town";
 import { default as vantaServer } from "@app/lib/api/actions/servers/vanta";
@@ -289,6 +290,8 @@ export async function getInternalMCPServer(
       return workdayServer(auth, toolContext);
     case "user_analytics":
       return userAnalyticsServer(auth, toolContext);
+    case "user_memory":
+      return userMemoryServer(auth, toolContext);
     case "activation_recommendations":
       return activationRecommendationsServer(auth, toolContext);
     default:

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -25,6 +25,28 @@ const QUERIES: LabeledQuery[] = [
     expected: "agent_memory.compact_memory",
   },
 
+  // --- user_memory ---
+  {
+    query: "read my personal memory",
+    expected: "user_memory.read",
+  },
+  {
+    query: "open my personal memory and show its full contents",
+    expected: "user_memory.read",
+  },
+  {
+    query: "update my personal memory by replacing a snippet of text",
+    expected: "user_memory.edit",
+  },
+  {
+    query: "delete a line of text from my personal memory",
+    expected: "user_memory.edit",
+  },
+  {
+    query: "add a new line to my personal memory",
+    expected: "user_memory.edit",
+  },
+
   // --- conversation_files ---
   {
     query: "list the files attached to this conversation",

--- a/front/lib/api/actions/servers/bm25_tool_search_utils.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search_utils.test.ts
@@ -59,6 +59,7 @@ import { SOUND_STUDIO_SERVER } from "@app/lib/api/actions/servers/sound_studio/m
 import { SPEECH_GENERATOR_SERVER } from "@app/lib/api/actions/servers/speech_generator/metadata";
 import { STATUSPAGE_SERVER } from "@app/lib/api/actions/servers/statuspage/metadata";
 import { UKG_READY_SERVER } from "@app/lib/api/actions/servers/ukg_ready/metadata";
+import { USER_MEMORY_SERVER } from "@app/lib/api/actions/servers/user_memory/metadata";
 import { VAL_TOWN_SERVER } from "@app/lib/api/actions/servers/val_town/metadata";
 import { VANTA_SERVER } from "@app/lib/api/actions/servers/vanta/metadata";
 import { WAKEUPS_SERVER } from "@app/lib/api/actions/servers/wakeups/metadata";
@@ -200,6 +201,7 @@ const SERVER_SOURCES: Array<{
     name: "data_sources_file_system",
     tools: DATA_SOURCES_FILE_SYSTEM_SERVER.tools,
   },
+  { name: "user_memory", tools: USER_MEMORY_SERVER.tools },
 ];
 
 export const SERVERS: ServerEntry[] = SERVER_SOURCES.map(({ name, tools }) => ({

--- a/front/lib/api/actions/servers/user_memory/index.ts
+++ b/front/lib/api/actions/servers/user_memory/index.ts
@@ -1,0 +1,45 @@
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { ToolContext } from "@app/lib/actions/types";
+import { USER_MEMORY_SERVER_NAME } from "@app/lib/api/actions/servers/user_memory/metadata";
+import { TOOLS } from "@app/lib/api/actions/servers/user_memory/tools";
+import type { Authenticator } from "@app/lib/auth";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+function createServer(
+  auth: Authenticator,
+  toolContext?: ToolContext
+): McpServer {
+  const server = makeInternalMCPServer(USER_MEMORY_SERVER_NAME);
+
+  const user = auth.user();
+  if (!user) {
+    server.tool(
+      "memory_not_available",
+      "User memory is scoped to a user but no user is currently authenticated.",
+      {},
+      async () => {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: "No user memory available as there is no user authenticated.",
+            },
+          ],
+        };
+      }
+    );
+    return server;
+  }
+
+  for (const tool of TOOLS) {
+    registerTool(auth, toolContext, server, tool, {
+      monitoringName: USER_MEMORY_SERVER_NAME,
+    });
+  }
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/actions/servers/user_memory/metadata.ts
+++ b/front/lib/api/actions/servers/user_memory/metadata.ts
@@ -1,0 +1,59 @@
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { z } from "zod";
+
+export const USER_MEMORY_SERVER_NAME = "user_memory" as const;
+export const USER_MEMORY_READ_TOOL_NAME = "read";
+export const USER_MEMORY_EDIT_TOOL_NAME = "edit";
+
+export const USER_MEMORY_TOOLS_METADATA = [
+  {
+    name: USER_MEMORY_READ_TOOL_NAME,
+    description:
+      "Read and recall the current user's personal memory: the full contents of their personal MEMORY.md, including preferences, facts, notes, and prior context.",
+    schema: {},
+    stake: "never_ask",
+    displayLabels: {
+      running: "Reading memory",
+      done: "Read memory",
+    },
+    toolCostCategory: "basic",
+    freeUsage: true,
+  },
+  {
+    name: USER_MEMORY_EDIT_TOOL_NAME,
+    description:
+      "Update, change, correct, add, or delete text in the current user's personal memory by replacing an exact snippet of their MEMORY.md with new text.",
+    schema: {
+      oldStr: z
+        .string()
+        .describe(
+          "The exact, contiguous text to find in the user's personal memory and replace. It must match a unique span of the current memory. Pass an empty string to initialize memory that is currently empty."
+        ),
+      newStr: z
+        .string()
+        .describe(
+          "The replacement text. Pass an empty string to delete the matched text."
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Editing memory",
+      done: "Edit memory",
+    },
+    toolCostCategory: "basic",
+    freeUsage: true,
+  },
+] as const;
+
+export const USER_MEMORY_SERVER = {
+  serverInfo: {
+    name: USER_MEMORY_SERVER_NAME,
+    version: "1.0.0",
+    description:
+      "Store and retrieve the current user's personal memory in a single MEMORY.md file, shared across the user's agents.",
+    authorization: null,
+    icon: "ActionLightbulbIcon",
+    documentationUrl: null,
+  },
+  tools: USER_MEMORY_TOOLS_METADATA,
+} as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/user_memory/tools/index.ts
+++ b/front/lib/api/actions/servers/user_memory/tools/index.ts
@@ -1,0 +1,153 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {
+  USER_MEMORY_EDIT_TOOL_NAME,
+  USER_MEMORY_READ_TOOL_NAME,
+  USER_MEMORY_TOOLS_METADATA,
+} from "@app/lib/api/actions/servers/user_memory/metadata";
+import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import { SCOPED_PREFIX_USER } from "@app/lib/api/file_system/types";
+import { getUpdatedContentAndOccurrences } from "@app/lib/api/files/utils";
+import type { Authenticator } from "@app/lib/auth";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+const MEMORY_CONTENT_TYPE = "text/markdown";
+
+function userMemoryPath(userId: string): string {
+  return `${SCOPED_PREFIX_USER}${userId}/MEMORY.md`;
+}
+
+async function openUserMemory(
+  auth: Authenticator
+): Promise<Result<{ fs: DustFileSystem; path: string }, MCPError>> {
+  const user = auth.user();
+  if (!user) {
+    return new Err(
+      new MCPError("No personal memory available: no user is authenticated.", {
+        tracked: false,
+      })
+    );
+  }
+
+  const fsResult = await DustFileSystem.forUser(auth);
+  if (fsResult.isErr()) {
+    return new Err(new MCPError(fsResult.error.message, { tracked: false }));
+  }
+
+  return new Ok({ fs: fsResult.value, path: userMemoryPath(user.sId) });
+}
+
+const handlers: ToolHandlers<typeof USER_MEMORY_TOOLS_METADATA> = {
+  [USER_MEMORY_READ_TOOL_NAME]: async (_, { auth }) => {
+    const memoryResult = await openUserMemory(auth);
+    if (memoryResult.isErr()) {
+      return memoryResult;
+    }
+    const { fs, path } = memoryResult.value;
+
+    const readResult = await fs.readBuffer(path);
+    if (readResult.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to read the user's personal memory: ${readResult.error.message}`
+        )
+      );
+    }
+
+    const content = readResult.value?.toString("utf-8") ?? "";
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: content.length > 0 ? content : "(memory empty)",
+      },
+    ]);
+  },
+
+  [USER_MEMORY_EDIT_TOOL_NAME]: async ({ oldStr, newStr }, { auth }) => {
+    const memoryResult = await openUserMemory(auth);
+    if (memoryResult.isErr()) {
+      return memoryResult;
+    }
+    const { fs, path } = memoryResult.value;
+
+    const readResult = await fs.readBuffer(path);
+    if (readResult.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to read the user's personal memory: ${readResult.error.message}`
+        )
+      );
+    }
+    const currentContent = readResult.value?.toString("utf-8") ?? "";
+
+    let nextContent: string;
+    if (currentContent.length === 0) {
+      if (oldStr.length > 0) {
+        return new Err(
+          new MCPError(
+            "The user's personal memory is empty. Pass an empty `oldStr` to initialize it with `newStr`.",
+            { tracked: false }
+          )
+        );
+      }
+      nextContent = newStr;
+    } else {
+      if (oldStr.length === 0) {
+        return new Err(
+          new MCPError(
+            "`oldStr` must not be empty when the personal memory already has content. Provide the exact text to replace.",
+            { tracked: false }
+          )
+        );
+      }
+
+      const { updatedContent, occurrences } = getUpdatedContentAndOccurrences({
+        oldString: oldStr,
+        newString: newStr,
+        currentContent,
+      });
+      if (occurrences === 0) {
+        return new Err(
+          new MCPError(
+            "`oldStr` was not found in the user's personal memory. Read the memory first and copy an exact snippet.",
+            { tracked: false }
+          )
+        );
+      }
+      if (occurrences > 1) {
+        return new Err(
+          new MCPError(
+            `\`oldStr\` matched ${occurrences} times in the user's personal memory. Provide a longer, unique snippet.`,
+            { tracked: false }
+          )
+        );
+      }
+
+      nextContent = updatedContent;
+    }
+
+    const writeResult = await fs.write(path, nextContent, MEMORY_CONTENT_TYPE);
+    if (writeResult.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to write the user's personal memory: ${writeResult.error.message}`
+        )
+      );
+    }
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text:
+          nextContent.length > 0
+            ? `Memory updated.\n\n${nextContent}`
+            : "Memory updated (now empty).",
+      },
+    ]);
+  },
+};
+
+export const TOOLS = buildTools(USER_MEMORY_TOOLS_METADATA, handlers);

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -2,7 +2,7 @@
  * DustFileSystem is the single entry point for all file system operations in the Dust platform.
  *
  * Scoped path: the agent/API-visible path format, e.g. `conversation-{cId}/report.pdf`,
- * `pod-{pId}/data.csv`, or `user-{uId}/memory.md`. Every public method accepts and returns
+ * `pod-{pId}/data.csv`, or `user-{uId}/MEMORY.md`. Every public method accepts and returns
  * scoped paths. Legacy paths (`conversation/...`, `project/...`) are accepted for backward compat.
  *
  * Factories:

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -333,6 +333,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Admin Governance: evaluate the new group_permissions checks alongside the legacy ones and log mismatches (shadow mode). Serves the legacy result; safe to toggle.",
     stage: "dust_only",
   },
+  user_memory: {
+    description:
+      "Enable the user_memory internal MCP server: agents can store and retrieve per-user memory in a user-scoped filesystem.",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -807,6 +807,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "workspace_default_agent"
   | "whitelabel_frames"
   | "workday_mcp"
+  | "user_memory"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Added the user_memory internal MCP server with two tools (retrieve and edit) backed by the user-scoped DustFileSystem (memory.md). Gated it behind a new user_memory feature flag and added BM25 tool-search coverage.

## Tests

Added bm25 tests. 

## Risk

Low

## Deploy Plan

Deploy front and sdk