### PR TITLE
[poke] Reactivate revoked members from the members table

### DIFF
--- a/front/components/poke/members/columns.tsx
+++ b/front/components/poke/members/columns.tsx
@@ -119,18 +119,22 @@ export function makeColumnsForMembers({
       },
       cell: ({ row }) => {
         const member = row.original;
-        if (member.role === "none") {
-          return <span className="py-2 pl-3 italic">revoked</span>;
-        }
+        const isRevoked = member.role === "none";
 
         if (readonly) {
-          return <span>{member.role}</span>;
+          return (
+            <span className={isRevoked ? "italic" : undefined}>
+              {isRevoked ? "revoked" : member.role}
+            </span>
+          );
         }
 
+        // Revoked members get the dropdown too: picking a role reactivates the
+        // membership in place (the plugin's update_role uses allowTerminated).
         return (
           <select
             className="rounded-lg border border-gray-300 bg-gray-50 text-sm text-gray-900"
-            value={member.role}
+            value={isRevoked ? "" : member.role}
             onChange={async (e) => {
               await onUpdateMemberRole(
                 member,
@@ -138,6 +142,11 @@ export function makeColumnsForMembers({
               );
             }}
           >
+            {isRevoked && (
+              <option value="" disabled>
+                revoked
+              </option>
+            )}
             {ACTIVE_ROLES.map((role) => (
               <option key={role} value={role}>
                 {role}
@@ -159,6 +168,11 @@ export function makeColumnsForMembers({
     },
     cell: ({ row }) => {
       const member = row.original;
+
+      // Revoked members have no active seat — don't surface a seat control.
+      if (member.role === "none") {
+        return null;
+      }
 
       const seatTypes = availableSeatTypes ?? MEMBERSHIP_SEAT_TYPES;
       // Keep the member's current seat selectable even if it is no longer
@@ -221,12 +235,14 @@ export function makeColumnsForMembers({
       cell: ({ row }) => {
         const member = row.original;
 
-        // Hide the revoke button for provisioned users and users with no role.
+        // Revoked members have no revoke action; reactivation is done via the
+        // role dropdown. Hide the revoke button for provisioned users.
         return member.role !== "none" && member.origin !== "provisioned" ? (
           <IconButton
             icon={Trash01}
             size="xs"
             variant="outline"
+            tooltip="Revoke member"
             onClick={async () => {
               await onRevokeMember(member);
             }}

--- a/front/components/poke/members/table.tsx
+++ b/front/components/poke/members/table.tsx
@@ -140,6 +140,9 @@ export function MembersDataTable({
           data={prepareMembersForDisplay(members)}
           enableRowSelection={!readonly}
           getRowId={(row) => row.sId}
+          getRowClassName={(row) =>
+            row.role === "none" ? "text-gray-400" : undefined
+          }
           renderBulkActions={
             readonly
               ? undefined

--- a/front/components/poke/shadcn/ui/data_table.tsx
+++ b/front/components/poke/shadcn/ui/data_table.tsx
@@ -74,6 +74,9 @@ interface DataTableProps<TData, TValue> {
     selectedRows: TData[];
     resetSelection: () => void;
   }) => React.ReactNode;
+  // Optional per-row CSS classes, computed from the row data (e.g. to mute
+  // revoked members).
+  getRowClassName?: (row: TData) => string | undefined;
 }
 
 export function PokeDataTable<TData, TValue>({
@@ -94,6 +97,7 @@ export function PokeDataTable<TData, TValue>({
   enableRowSelection,
   getRowId,
   renderBulkActions,
+  getRowClassName,
 }: DataTableProps<TData, TValue>) {
   const isServerSide = serverSideRowCount !== undefined;
   const isServerSearch = onSearchChange !== undefined;
@@ -273,7 +277,14 @@ export function PokeDataTable<TData, TValue>({
                 <PokeTableRow
                   key={row.id}
                   data-state={row.getIsSelected() && "selected"}
-                  className={onRowClick ? "cursor-pointer" : undefined}
+                  className={
+                    [
+                      onRowClick ? "cursor-pointer" : "",
+                      getRowClassName?.(row.original) ?? "",
+                    ]
+                      .filter(Boolean)
+                      .join(" ") || undefined
+                  }
                   onClick={
                     onRowClick ? () => onRowClick(row.original) : undefined
                   }


### PR DESCRIPTION
## Description

In the Poke members list, revoked members (workspace role `none`) can now be **reactivated in place**, and are visually muted.

## Changes

- **Role dropdown enabled for revoked members.** Previously the role cell showed a plain "revoked" label; it's now the same `<select>` (with a disabled "revoked" placeholder as the current value). Picking a role reactivates the membership via the `batch-update-members` plugin's `update_role` (which uses `allowTerminated`), preserving the previous origin/seat.
- **Revoked rows are muted** — the whole row's text renders grey (`text-gray-400`). The role/seat dropdowns keep their default color. Implemented via a new optional `getRowClassName` prop on `PokeDataTable`.
- **Seat type hidden** for revoked members (they have no active seat).

## Notes
- No new backend — reactivation reuses the existing plugin path.
- Read-only member tables (Space/Project/Group) still just show the "revoked" text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
