### PR TITLE
[front] Add Redis fixed-window counter to the rate limiter

### DIFF
--- a/front/lib/utils/rate_limiter.test.ts
+++ b/front/lib/utils/rate_limiter.test.ts
@@ -292,3 +292,82 @@ describe("addRateLimiterCount", () => {
     }
   });
 });
+
+describe("fixed-window counter", () => {
+  let addFixedWindowCount: RateLimiterModule["addFixedWindowCount"];
+  let getFixedWindowCount: RateLimiterModule["getFixedWindowCount"];
+
+  const fixedWindowKeysToExpire = new Set<string>();
+
+  // A far-future window boundary so entries persist for the whole test run.
+  const boundsFor = (label: string) => ({
+    label,
+    windowEndMs: Date.UTC(2999, 0, 1),
+  });
+
+  beforeAll(async () => {
+    const redisModule = await import("@app/lib/api/redis");
+    const rateLimiterModule = await import("@app/lib/utils/rate_limiter");
+
+    closeRedisClients = redisModule.closeRedisClients;
+    expireRateLimiterKey = rateLimiterModule.expireRateLimiterKey;
+    addFixedWindowCount = rateLimiterModule.addFixedWindowCount;
+    getFixedWindowCount = rateLimiterModule.getFixedWindowCount;
+  });
+
+  afterEach(async () => {
+    // Fixed-window keys are suffixed with the window label, so expire the
+    // fully-qualified key rather than the base.
+    await Promise.all(
+      [...fixedWindowKeysToExpire].map((key) => expireRateLimiterKey({ key }))
+    );
+    fixedWindowKeysToExpire.clear();
+  });
+
+  afterAll(async () => {
+    await closeRedisClients();
+  });
+
+  it("accumulates increments within the same window", async () => {
+    const key = `test:${crypto.randomUUID()}`;
+    const bounds = boundsFor("w1");
+    fixedWindowKeysToExpire.add(`${key}:${bounds.label}`);
+
+    await addFixedWindowCount({ key, bounds, incrementBy: 9, logger });
+    await addFixedWindowCount({ key, bounds, incrementBy: 2, logger });
+
+    const count = await getFixedWindowCount({ key, bounds });
+    expect(count.isOk()).toBe(true);
+    if (count.isOk()) {
+      // Unlike the limit-guarded rolling limiter, the fixed-window counter
+      // records the full amount even past any threshold.
+      expect(count.value).toBe(11);
+    }
+  });
+
+  it("returns 0 for a window with no entries", async () => {
+    const key = `test:${crypto.randomUUID()}`;
+
+    const count = await getFixedWindowCount({ key, bounds: boundsFor("w1") });
+    expect(count.isOk()).toBe(true);
+    if (count.isOk()) {
+      expect(count.value).toBe(0);
+    }
+  });
+
+  it("keeps separate counts per window label", async () => {
+    const key = `test:${crypto.randomUUID()}`;
+    const windowA = boundsFor("wA");
+    const windowB = boundsFor("wB");
+    fixedWindowKeysToExpire.add(`${key}:${windowA.label}`);
+    fixedWindowKeysToExpire.add(`${key}:${windowB.label}`);
+
+    await addFixedWindowCount({ key, bounds: windowA, incrementBy: 4, logger });
+    await addFixedWindowCount({ key, bounds: windowB, incrementBy: 7, logger });
+
+    const countA = await getFixedWindowCount({ key, bounds: windowA });
+    const countB = await getFixedWindowCount({ key, bounds: windowB });
+    expect(countA.isOk() && countA.value).toBe(4);
+    expect(countB.isOk() && countB.value).toBe(7);
+  });
+});

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -15,6 +15,19 @@ export class RateLimitError extends Error {}
 
 export const RATE_LIMITER_PREFIX = "rate_limiter";
 
+// Grace period kept after the window boundary before the Redis key expires, so
+// a read straddling the boundary still sees a just-closed window rather than a
+// premature miss.
+const FIXED_WINDOW_EXPIRE_GRACE_MS = 60_000;
+
+// A resolved fixed window: a stable label identifying the current window and
+// the absolute UTC end of that window. The label is appended to the Redis key
+// so each window is a distinct key that naturally expires; `windowEndMs` drives
+// `PEXPIREAT`. Callers resolve these bounds however they like — pure calendar
+// math or an external anchor such as a billing contract — keeping this counter
+// agnostic of window semantics.
+export type FixedWindowBounds = { label: string; windowEndMs: number };
+
 const makeRateLimiterKey = (key: string) => `${RATE_LIMITER_PREFIX}:${key}`;
 
 type RateLimiterArgs = {
@@ -243,5 +256,97 @@ export function getTimeframeSecondsFromLiteral(
 
     default:
       assertNever(timeframeLiteral);
+  }
+}
+
+/**
+ * Unconditionally records `incrementBy` units against a fixed-window counter
+ * identified by `bounds`. Unlike the rolling `addRateLimiterCount`, the key
+ * encodes the current window (via `bounds.label`) and is a plain `INCRBY` with
+ * `PEXPIREAT` set to `bounds.windowEndMs` — enforcement (reading the count and
+ * comparing to a limit) happens beforehand via `getFixedWindowCount`, not here.
+ */
+export async function addFixedWindowCount({
+  key,
+  bounds,
+  incrementBy,
+  logger,
+}: {
+  key: string;
+  bounds: FixedWindowBounds;
+  incrementBy: number;
+  logger: LoggerInterface;
+}): Promise<void> {
+  // Fail open on invalid input, matching the Redis-error path below: recording
+  // runs on the message-send path, so a bad increment must never throw and
+  // break the send — log and skip instead.
+  if (!Number.isInteger(incrementBy) || incrementBy <= 0) {
+    getStatsDClient().increment("ratelimiter.error.count", 1, [
+      "operation:add_fixed_window",
+    ]);
+    logger.error(
+      { key, label: bounds.label, incrementBy },
+      "addFixedWindowCount: incrementBy must be a positive integer, skipping"
+    );
+    return;
+  }
+
+  const redisKey = makeRateLimiterKey(`${key}:${bounds.label}`);
+  const expireAtMs = bounds.windowEndMs + FIXED_WINDOW_EXPIRE_GRACE_MS;
+
+  const luaScript = `
+    local key = KEYS[1]
+    local increment_by = tonumber(ARGV[1])
+    local expire_at_ms = tonumber(ARGV[2])
+
+    local total = redis.call('INCRBY', key, increment_by)
+    redis.call('PEXPIREAT', key, expire_at_ms)
+    return total
+  `;
+
+  try {
+    const redis = await getRedisStreamClient({ origin: "rate_limiter" });
+    await redis.eval(luaScript, {
+      keys: [redisKey],
+      arguments: [incrementBy.toString(), expireAtMs.toString()],
+    });
+  } catch (e) {
+    getStatsDClient().increment("ratelimiter.error.count", 1, [
+      "operation:add_fixed_window",
+    ]);
+    logger.error(
+      { key, label: bounds.label, incrementBy, error: e },
+      "addFixedWindowCount error"
+    );
+  }
+}
+
+/**
+ * Reads the current fixed-window count for `key` in the window identified by
+ * `bounds`. Returns 0 when the window has no entries yet. Mirrors
+ * `getRateLimiterCount` but for the boundary-bucketed counter written by
+ * `addFixedWindowCount`.
+ */
+export async function getFixedWindowCount({
+  key,
+  bounds,
+}: {
+  key: string;
+  bounds: FixedWindowBounds;
+}): Promise<Result<number, Error>> {
+  try {
+    const redis = await getRedisStreamClient({ origin: "rate_limiter" });
+    const redisKey = makeRateLimiterKey(`${key}:${bounds.label}`);
+
+    const raw = await redis.get(redisKey);
+    const count = raw === null ? 0 : Number(raw);
+
+    if (!Number.isFinite(count)) {
+      return new Err(new Error(`Non-numeric fixed-window count: ${raw}`));
+    }
+
+    return new Ok(count);
+  } catch (err) {
+    return new Err(normalizeError(err));
   }
 }


### PR DESCRIPTION
## Description

Adds a window-agnostic **fixed-window Redis counter** to the rate limiter, alongside the existing rolling (`ZADD`/`ZCOUNT`) limiter:

- `addFixedWindowCount` — additive `INCRBY` + `PEXPIREAT`, for recording a cost that already happened (enforcement happens beforehand via a read).
- `getFixedWindowCount` — reads the current count (0 when the window has no entries yet).
- Both operate over explicit `FixedWindowBounds` (`{ label, windowEndMs }`) supplied by the caller, so the primitive stays agnostic of window semantics — the label distinguishes each window as its own key that expires at `windowEndMs`, and callers decide how bounds are computed (calendar math, a billing-cycle anchor, etc.).

Foundation only — nothing calls these yet. The first consumer is the per-user spend-cap backup (#29576, stacked on this).

## Tests

- `rate_limiter.test.ts` — unit tests for `addFixedWindowCount` / `getFixedWindowCount` (increment, expiry bounds, empty-window read).

## Risk

Minimal. Purely additive: two new functions and a type, no existing code path changed, nothing wired to callers in this PR. Safe to roll back by revert.

## Deploy Plan

Standard deploy. No migration, no config, no feature flag.
