### PR TITLE
[front] Rate-limiter backup for the per-user spend cap

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -63,6 +63,7 @@ import {
 } from "@app/lib/api/programmatic_usage/tracking";
 import { fetchLatestProjectContextFileContentFragment } from "@app/lib/api/projects/context";
 import { config as regionConfig } from "@app/lib/api/regions/config";
+import { isUserSpendLimitRateCapReached } from "@app/lib/api/users/spend_limit";
 import { isModelAvailable } from "@app/lib/assistant";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
@@ -2533,6 +2534,27 @@ async function checkMessagesLimit(
             message: "You have reached your personal usage cap.",
           },
         });
+      }
+      // Redis fixed-window per-user spend cap: a synchronous backup of the
+      // Metronome per-user cap over the current contract billing cycle. Only
+      // applies to real users (API keys are gated by pool / programmatic caps
+      // instead). Enforcement is gated behind a feature flag while we validate
+      // the counter; usage is recorded regardless (in credit_cost), so the flag
+      // only controls blocking.
+      if (user) {
+        const featureFlags = await getFeatureFlags(auth);
+        if (
+          featureFlags.includes("enforce_user_spend_limit_rate_cap") &&
+          (await isUserSpendLimitRateCapReached(auth, { user }))
+        ) {
+          return new Err({
+            status_code: 403,
+            api_error: {
+              type: "user_cap_reached",
+              message: "You have reached your personal usage cap.",
+            },
+          });
+        }
       }
       if (blockedReason === "credits_exhausted") {
         return new Err({

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -5,7 +5,9 @@ import { getToolNameFromFunctionCallName } from "@app/lib/actions/tool_display_l
 import { makeFairUseAwuCreditsRateLimitKeyForUser } from "@app/lib/api/assistant/rate_limits";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
 import type { ToolCostCategory } from "@app/lib/api/mcp";
+import { recordUserSpendLimitUsage } from "@app/lib/api/users/spend_limit";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import {
   computeRunKey,
   getToolBillingInfo,
@@ -224,8 +226,13 @@ export async function computeAndStoreAgentMessageCredits(
     return null;
   }
 
-  const { agentMessageModelId, status, runIds, triggeringUserMessageOrigin } =
-    creditContext;
+  const {
+    agentMessageModelId,
+    status,
+    runIds,
+    triggeringUserMessageOrigin,
+    previousCostCredits,
+  } = creditContext;
 
   if (!AGENT_MESSAGE_STATUSES_TO_TRACK.includes(status)) {
     return null;
@@ -262,21 +269,28 @@ export async function computeAndStoreAgentMessageCredits(
     costCredits,
   });
 
+  // `costCredits` is the message-level running total (recomputed from all
+  // accumulated runIds + actions), and a message can be finalized multiple
+  // times (agent-loop early exit, tool confirmation, authentication resume,
+  // Temporal retry). The stored column is overwritten with the total, but the
+  // usage counters are additive — so only the newly-accrued delta since the
+  // last finalize (`total − previouslyStored`) may be recorded, or repeated
+  // finalizes would over-count. A retry with no new usage yields a 0 delta.
+  const recordedCostDelta =
+    costCredits !== null ? costCredits - (previousCostCredits ?? 0) : 0;
+
   const user = auth.user();
   const plan = auth.plan();
   const assistantLimits = plan?.limits.assistant;
   if (
     user &&
     assistantLimits &&
-    costCredits !== null &&
-    costCredits > 0 &&
+    recordedCostDelta > 0 &&
     assistantLimits.maxAwuCredits !== -1
   ) {
-    // Always record the credit cost unconditionally. The limit guard lives in
-    // isMessagesLimitReached (pre-message), which reads the count via getRateLimiterCount and
-    // blocks the next message once the total reaches maxAwuCredits. Using rateLimiter here was
-    // incorrect: its Lua script silently drops the write when count + costCredits > limit,
-    // causing the counter to stall below the limit and never trigger enforcement.
+    // The limit guard lives in isMessagesLimitReached (pre-message), which reads
+    // the count via getRateLimiterCount and blocks the next message once the
+    // total reaches maxAwuCredits.
     await addRateLimiterCount({
       key: makeFairUseAwuCreditsRateLimitKeyForUser(
         auth.getNonNullableWorkspace(),
@@ -286,9 +300,24 @@ export async function computeAndStoreAgentMessageCredits(
       timeframeSeconds: getTimeframeSecondsFromLiteral(
         assistantLimits.maxAwuCreditsTimeframe
       ),
-      incrementBy: costCredits,
+      incrementBy: recordedCostDelta,
       logger,
     });
+  }
+
+  // Record against the per-user spend-cap backup (Redis fixed-window counter
+  // over the contract billing cycle). Independent of the plan-level fair-use
+  // limiter above. Gated behind the same feature flag as enforcement so the
+  // counter only accrues where the backup is active; enforcement happens
+  // pre-message in `checkMessagesLimit`.
+  if (user && recordedCostDelta > 0) {
+    const featureFlags = await getFeatureFlags(auth);
+    if (featureFlags.includes("enforce_user_spend_limit_rate_cap")) {
+      await recordUserSpendLimitUsage(auth, {
+        user,
+        incrementBy: recordedCostDelta,
+      });
+    }
   }
 
   return costCredits;

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -3,6 +3,7 @@ import { computeEffectiveMessageLimit } from "@app/lib/plans/usage/limits";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import {
   expireRateLimiterKey,
+  type FixedWindowBounds,
   getRateLimiterCount,
   getTimeframeSecondsFromLiteral,
 } from "@app/lib/utils/rate_limiter";
@@ -66,6 +67,32 @@ export const makeFairUseAwuCreditsRateLimitKeyForUser = (
   maxAwuCreditsTimeframe: MaxAwuCreditsTimeframeType
 ) => {
   return `workspace:${owner.id}:user:${user.id}:fair_use_awu_credit_count:${maxAwuCreditsTimeframe}`;
+};
+
+// Fixed-window counter backing the admin-configured per-user spend cap. Always
+// bucketed on the Metronome contract billing cycle (the fixed-window counter
+// appends the cycle-boundary label). Distinct from the rolling plan-level
+// fair-use key above.
+export const makeSpendLimitAwuCreditsRateLimitKeyForUser = (
+  owner: LightWorkspaceType,
+  user: UserType
+) => {
+  return `workspace:${owner.id}:user:${user.id}:spend_limit_awu_credit_count`;
+};
+
+// Fixed-window bounds for the per-user spend cap over a Metronome contract
+// billing cycle. Pure — both the recorder/enforcer (`spend_limit.ts`) and the
+// poke read (`members_usage.ts`) derive the window from the same cycle so they
+// hit the same Redis key. Labelled by the cycle start so each recurrence is a
+// distinct key.
+export const makeSpendLimitCycleWindowBounds = (
+  cycleStart: Date,
+  cycleEnd: Date
+): FixedWindowBounds => {
+  return {
+    label: `cycle-${cycleStart.getTime()}`,
+    windowEndMs: cycleEnd.getTime(),
+  };
 };
 
 export const makeProgrammaticUsageRateLimitKeyForWorkspace = (

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -843,6 +843,78 @@ export async function fetchRemainingCapCreditsPercentageForUser({
   return Math.max(0, (spendLimitAwuCredits - consumed) / spendLimitAwuCredits);
 }
 
+/**
+ * Resolves a single user's effective per-user spend cap in AWU credits (incl.
+ * the seat allowance): per-user override > max group cap > seat-type/workspace
+ * default. Returns `null` when no cap applies (e.g. "none"/free seats with no
+ * pool cap). Mirrors the resolution used to populate the members-usage table —
+ * the canonical cap resolution (workspace default / group / user override).
+ */
+export async function getEffectiveSpendCapAwuCreditsForUser(
+  auth: Authenticator,
+  { user }: { user: UserResource }
+): Promise<number | null> {
+  const workspace = auth.getNonNullableWorkspace();
+  const { metronomeCustomerId } = workspace;
+
+  const membership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user,
+      workspace,
+    });
+  if (!membership) {
+    return null;
+  }
+
+  const creditUsageConfig =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+
+  const [
+    { defaultCapAwuCreditsBySeatType, seatAllowanceBySeatType },
+    groupCapByUserModelId,
+  ] = await Promise.all([
+    fetchEffectivePerUserSpendLimits({
+      metronomeCustomerId: metronomeCustomerId ?? null,
+      workspaceId: workspace.sId,
+      defaultPoolCapAwuCredits:
+        creditUsageConfig?.defaultPoolCapAwuCredits ?? 0,
+      includeAlertLinks: false,
+    }),
+    GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+      workspace,
+      userModelIds: [user.id],
+    }),
+  ]);
+
+  const normalizedSeatType = normalizeToPoolLimitSeatType(membership.seatType);
+  const seatAllowance = normalizedSeatType
+    ? (seatAllowanceBySeatType[normalizedSeatType] ?? 0)
+    : 0;
+
+  const defaultAwuCredits = normalizedSeatType
+    ? (defaultCapAwuCreditsBySeatType[normalizedSeatType] ?? null)
+    : null;
+
+  // "none" seat users have no pool access, so their override is irrelevant.
+  const overrideAwuCredits =
+    membership.poolCapOverrideAwuCredits !== null &&
+    membership.seatType !== "none"
+      ? membership.poolCapOverrideAwuCredits + seatAllowance
+      : null;
+
+  const groupPoolCapAwuCredits = groupCapByUserModelId.get(user.id) ?? null;
+  const groupCapAwuCredits =
+    groupPoolCapAwuCredits !== null && normalizedSeatType !== null
+      ? groupPoolCapAwuCredits + seatAllowance
+      : null;
+
+  return resolveEffectiveSpendLimitAwuCredits({
+    overrideAwuCredits,
+    groupCapAwuCredits,
+    defaultAwuCredits,
+  });
+}
+
 export type GetMemberUsageResponseBody = {
   member: MemberUsageType | null;
 };

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -1,7 +1,12 @@
 import {
+  makeSpendLimitAwuCreditsRateLimitKeyForUser,
+  makeSpendLimitCycleWindowBounds,
+} from "@app/lib/api/assistant/rate_limits";
+import {
   buildAuditLogTarget,
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
+import { getEffectiveSpendCapAwuCreditsForUser } from "@app/lib/api/credits/members_usage";
 import { reconcileUser } from "@app/lib/api/metronome/reconcile_credit_state";
 import { getUserForWorkspace } from "@app/lib/api/user";
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
@@ -12,9 +17,16 @@ import {
   upsertMetronomePerUserCapAlert,
   upsertMetronomePerUserWarningAlert,
 } from "@app/lib/metronome/alerts/spend_limits";
+import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
 import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import {
+  addFixedWindowCount,
+  type FixedWindowBounds,
+  getFixedWindowCount,
+} from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import type {
   GetUserSpendLimitResponse,
@@ -25,6 +37,7 @@ import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { LightWorkspaceType } from "@app/types/user";
 
 export const MIN_USER_SPEND_LIMIT_AWU_CREDITS = 0;
 export const MAX_USER_SPEND_LIMIT_AWU_CREDITS = 1_000_000;
@@ -326,4 +339,106 @@ export async function setUserSpendLimit(
   });
 
   return new Ok({ limit });
+}
+
+// Fixed-window bounds for the current Metronome contract billing cycle (the
+// window the per-user spend cap is bucketed on). `null` when no billing period
+// can be resolved — callers treat that as a no-op (fail-open, matching the rest
+// of the rate-limiter callers).
+async function resolveSpendLimitCycleBounds(
+  workspace: LightWorkspaceType
+): Promise<FixedWindowBounds | null> {
+  const periodResult = await getCachedMetronomeCurrentBillingPeriod(
+    workspace.sId
+  );
+  if (periodResult.isErr() || !periodResult.value) {
+    logger.warn(
+      {
+        workspaceId: workspace.sId,
+        err: periodResult.isErr() ? periodResult.error : undefined,
+      },
+      "[SpendLimitRateCap] Could not resolve contract billing period; skipping fixed-window cap"
+    );
+    return null;
+  }
+  const { cycleStart, cycleEnd } = periodResult.value;
+  return makeSpendLimitCycleWindowBounds(cycleStart, cycleEnd);
+}
+
+/**
+ * Synchronous, Metronome-independent enforcement of the per-user spend cap, read
+ * at message-send time from the Redis fixed-window counter over the current
+ * contract billing cycle. The threshold is the user's *effective* cap resolved
+ * the standard way (per-user override > group cap > seat-type/workspace
+ * default, each incl. the seat allowance) — the same resolution the usage table
+ * uses. Runs alongside the Metronome per-user cap (`isUserBlocked`) as a faster,
+ * independent backup. Returns `false` (does not block) when there is no cap, the
+ * billing period can't be resolved, or on a Redis read error (fail-open).
+ */
+export async function isUserSpendLimitRateCapReached(
+  auth: Authenticator,
+  { user }: { user: UserResource }
+): Promise<boolean> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const threshold = await getEffectiveSpendCapAwuCreditsForUser(auth, { user });
+  if (threshold === null) {
+    return false;
+  }
+
+  const bounds = await resolveSpendLimitCycleBounds(workspace);
+  if (!bounds) {
+    return false;
+  }
+
+  const countResult = await getFixedWindowCount({
+    key: makeSpendLimitAwuCreditsRateLimitKeyForUser(workspace, user.toJSON()),
+    bounds,
+  });
+  if (countResult.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        userId: user.sId,
+        err: countResult.error,
+      },
+      "[SpendLimitRateCap] Failed to read fixed-window count; allowing message"
+    );
+    return false;
+  }
+
+  return countResult.value >= threshold;
+}
+
+/**
+ * Adds `incrementBy` AWU credits to the per-user fixed-window spend-cap counter
+ * for the current contract billing cycle. Records for every user (all users are
+ * capped; the cap is resolved at enforcement/read time, not here). `incrementBy`
+ * is the newly-accrued delta for a message (not its running total — the caller
+ * diffs against the previously-recorded amount so repeated finalizes don't
+ * over-count). No-op when the billing period can't be resolved.
+ */
+export async function recordUserSpendLimitUsage(
+  auth: Authenticator,
+  { user, incrementBy }: { user: UserResource; incrementBy: number }
+): Promise<void> {
+  // Only whole positive credits are recordable (the counter is an integer
+  // INCRBY); skip anything else rather than letting it reach the counter.
+  if (!Number.isInteger(incrementBy) || incrementBy <= 0) {
+    return;
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+
+  const bounds = await resolveSpendLimitCycleBounds(workspace);
+  if (!bounds) {
+    return;
+  }
+
+  await addFixedWindowCount({
+    key: makeSpendLimitAwuCreditsRateLimitKeyForUser(workspace, user.toJSON()),
+    bounds,
+    incrementBy,
+    logger,
+  });
 }

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -734,6 +734,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     status: AgentMessageStatus;
     runIds: string[] | null;
     triggeringUserMessageOrigin: UserMessageOrigin | null;
+    // The total cost already stored (and already recorded to the usage
+    // counters) by a prior finalize of this message. Used to record only the
+    // newly-accrued delta on re-finalize.
+    previousCostCredits: number | null;
   } | null> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
@@ -766,6 +770,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       status: agentMessage.status,
       runIds: agentMessage.runIds,
       triggeringUserMessageOrigin,
+      previousCostCredits: agentMessage.costCredits,
     };
   }
 

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -325,6 +325,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Warn users about similar existing agents before they create a duplicate in the agent builder.",
     stage: "dust_only",
   },
+  enforce_user_spend_limit_rate_cap: {
+    description:
+      "Enable the per-user spend-cap backup: record per-user AWU usage into the Redis fixed-window counter and enforce it at message send (blocks with user_cap_reached). When off, usage is neither recorded nor enforced.",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -805,6 +805,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "workday_mcp"
   | "user_memory"
   | "similar_agents_check"
+  | "enforce_user_spend_limit_rate_cap"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Backs up the Metronome per-user spend cap with a **synchronous Redis fixed-window counter**, enforced at message send independently of Metronome. This guards against the case where Metronome's per-user usage lags or is unavailable, so a user can't blow far past their cap before the async signal catches up.

Built on the fixed-window primitive from #29575 (this PR is stacked on it).

- **Counter anchored on the Metronome contract billing cycle.** The window bounds come from `getCachedMetronomeCurrentBillingPeriod`, so the counter resets exactly when the contract cycle does — no separate/configurable period.
- **Records the cost delta, not the total.** On each agent-message finalize, `computeAndStoreAgentMessageCredits` recomputes the message's running total; we add only `costCredits − previousCostCredits` to the additive counter, so repeated finalizes (agent-loop early exit, confirmation, retries) don't double-count. A retry with no new usage yields a 0 delta.
- **Both recording and enforcement are behind one feature flag** (`enforce_user_spend_limit_rate_cap`): when off, the counter neither accrues nor blocks; when on, usage is recorded on finalize and `isUserSpendLimitRateCapReached` blocks the send with `user_cap_reached` once the cap is reached. Reads and writes fail open (a Redis/resolution error never blocks a message).
- **Effective cap resolution** reuses the canonical path: per-user override > max group cap > seat-type/workspace default, each including the seat allowance (`getEffectiveSpendCapAwuCreditsForUser`).
- Mirrors the new flag into the SDK's `WhitelistableFeaturesSchema`.

Admin/observability tooling (poke resync + the counter column) is in the follow-up #29640 — run the resync to seed the counter from usage before enabling the flag, so users aren't measured from 0 mid-cycle.

## Tests

- `tsgo` clean across `front` + `front-api`; SDK types rebuilt for the new flag.
- Existing rate-limiter / spend-limit suites pass.
- Manually in dev: posted messages and confirmed the per-user counter accrues the cost delta once per finalize (no double-count on re-finalize), and that enabling the flag blocks sends once the cap is reached.

## Risk

Low, and fully gated. With `enforce_user_spend_limit_rate_cap` off (the default), this PR is inert — no recording, no enforcement. When on, recording is a best-effort Redis `INCRBY` on the finalize path (a Redis failure is logged and swallowed, never blocking a message) and the enforcement read fails open. Delta recording is idempotent under retries. Safe to roll back by revert.

## Deploy Plan

Standard deploy, no migration. The flag is off everywhere, so nothing changes on deploy. To activate the backup for a workspace: **first** run the resync plugin (#29640) to seed the counter from Elasticsearch usage, **then** enable `enforce_user_spend_limit_rate_cap` — in that order, so recording+enforcement start from the real mid-cycle total rather than 0.
