### PR TITLE
[Activation] Frames embedding in email

### DIFF
--- a/front/lib/api/files/frame_email_preview.ts
+++ b/front/lib/api/files/frame_email_preview.ts
@@ -1,0 +1,114 @@
+import { screenshotInteractiveContentFile } from "@app/lib/api/files/screenshot";
+import type { Authenticator } from "@app/lib/auth";
+import { getPublicUploadBucket } from "@app/lib/file_storage";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+function buildFramePreviewStoragePath({
+  workspaceId,
+  fileId,
+}: {
+  workspaceId: string;
+  fileId: string;
+}): string {
+  return `w/${workspaceId}/frame-email-previews/${fileId}.png`;
+}
+
+export interface ConversationFramePreview {
+  // Public URL of the hosted PNG screenshot, embedded as an <img> in the email.
+  imageUrl: string;
+  // Public share URL of the live, interactive Frame, so the email can link the
+  // preview back to the real thing.
+  frameUrl: string;
+}
+
+// Resolves the Frame pinned to the conversation's Pod, renders it to a PNG, and
+// hosts it on the public bucket so it can be embedded as a remote <img> in
+// notification emails. Also returns the Frame's public share URL so the email
+// can link the static preview to the live interactive Frame.
+//
+// Best-effort: returns null on any failure so callers can fall back to an email
+// without a preview image rather than failing to send.
+export async function getConversationFramePreview(
+  auth: Authenticator,
+  { conversationId }: { conversationId: string }
+): Promise<ConversationFramePreview | null> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+  if (!conversation?.spaceId) {
+    return null;
+  }
+
+  const [space] = await SpaceResource.fetchByModelIds(auth, [
+    conversation.spaceId,
+  ]);
+  if (!space || !space.isProject()) {
+    return null;
+  }
+
+  const metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
+  if (!metadata?.pinnedFramePath) {
+    return null;
+  }
+
+  const frame = await FileResource.fetchPinnedPodFrame(auth, {
+    spaceId: space.sId,
+    pinnedFramePath: metadata.pinnedFramePath,
+  });
+  if (!frame) {
+    return null;
+  }
+
+  const shareInfo = await frame.getShareInfo();
+  if (!shareInfo) {
+    logger.info(
+      { conversationId, workspaceId: workspace.sId, fileId: frame.sId },
+      "[activation] Pinned Frame has no shareable link; email falls back to no preview image."
+    );
+    return null;
+  }
+
+  const screenshotResult = await screenshotInteractiveContentFile(auth, {
+    fileId: frame.sId,
+  });
+  if (screenshotResult.isErr()) {
+    return null;
+  }
+
+  const storagePath = buildFramePreviewStoragePath({
+    workspaceId: workspace.sId,
+    fileId: frame.sId,
+  });
+
+  try {
+    const bucket = getPublicUploadBucket();
+    await bucket.uploadBufferToBucket({
+      buffer: screenshotResult.value.buffer,
+      contentType: "image/png",
+      filePath: storagePath,
+    });
+    return {
+      imageUrl: bucket.file(storagePath).publicUrl(),
+      frameUrl: shareInfo.shareUrl,
+    };
+  } catch (err) {
+    logger.error(
+      {
+        conversationId,
+        workspaceId: workspace.sId,
+        fileId: frame.sId,
+        error: normalizeError(err),
+      },
+      "[activation] Failed to upload Frame PNG preview; email falls back to no preview image."
+    );
+    return null;
+  }
+}

--- a/front/lib/notifications/email-templates/activation-new-conversation.tsx
+++ b/front/lib/notifications/email-templates/activation-new-conversation.tsx
@@ -11,6 +11,8 @@ export const ActivationNewConversationEmailTemplatePropsSchema = z.object({
   podName: z.string(),
   purpose: z.string().nullable(),
   summary: z.string().nullable(),
+  frameImageUrl: z.string().nullable(),
+  frameUrl: z.string().nullable(),
   action: z.object({
     label: z.string(),
     url: z.string(),
@@ -27,8 +29,11 @@ const ActivationNewConversationEmailTemplate = ({
   podName,
   purpose,
   summary,
+  frameImageUrl,
+  frameUrl,
   action,
 }: ActivationNewConversationEmailTemplateProps) => {
+  const frameLink = frameUrl ?? action.url;
   return (
     <EmailLayout workspace={workspace}>
       <p style={{ fontSize: "15px", color: "#111418", margin: "0 0 4px 0" }}>
@@ -58,13 +63,51 @@ const ActivationNewConversationEmailTemplate = ({
         </a>
       </p>
 
+      {/* Frame preview: a static PNG screenshot of the pod Frame generated for
+          this conversation, linked to the live interactive Frame.*/}
+      {frameImageUrl && (
+        <div style={{ margin: "0 0 20px 0" }}>
+          <a
+            href={frameLink}
+            target="_blank"
+            style={{ textDecoration: "none" }}
+          >
+            <img
+              alt={`${podName} preview`}
+              src={frameImageUrl}
+              style={{
+                display: "block",
+                width: "100%",
+                maxWidth: "600px",
+                height: "auto",
+                border: "1px solid #E5E7EB",
+                borderRadius: "8px",
+                margin: "0 0 5px 0",
+              }}
+            />
+          </a>
+          <a
+            href={frameLink}
+            target="_blank"
+            style={{
+              fontSize: "14px",
+              color: "#1C91FF",
+              textDecoration: "none",
+              fontWeight: 600,
+            }}
+          >
+            ▶ Open interactive view
+          </a>
+        </div>
+      )}
+
       {summary && (
         <p
           style={{
             fontSize: "14px",
             color: "#64707D",
             margin: "0 0 20px 0",
-            lineHeight: "1.55",
+            lineHeight: "1.5",
           }}
         >
           {summary}

--- a/front/lib/notifications/helpers.ts
+++ b/front/lib/notifications/helpers.ts
@@ -7,6 +7,8 @@ import {
   renderConversationAsText,
 } from "@app/lib/api/assistant/conversation/render_as_text";
 import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
+import type { ConversationFramePreview } from "@app/lib/api/files/frame_email_preview";
+import { getConversationFramePreview } from "@app/lib/api/files/frame_email_preview";
 import type { LLMTraceContext } from "@app/lib/api/llm/traces/types";
 import { Authenticator } from "@app/lib/auth";
 import {
@@ -761,4 +763,35 @@ export const getActivationRecommendation = async ({
   }
 
   return result.value;
+};
+
+export const getActivationFramePreview = async ({
+  details,
+  subscriberId,
+  payload,
+}: {
+  details: ConversationDetailsType;
+  subscriberId: string;
+  payload: ConversationDetailsPayload;
+}): Promise<ConversationFramePreview | null> => {
+  if (!subscriberId) {
+    return null;
+  }
+
+  // Do not render/host the Frame preview when data retention policies apply.
+  if (
+    details.hasConversationRetentionPolicy ||
+    details.hasAgentRetentionPolicies
+  ) {
+    return null;
+  }
+
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    subscriberId,
+    payload.workspaceId
+  );
+
+  return getConversationFramePreview(auth, {
+    conversationId: payload.conversationId,
+  });
 };

--- a/front/lib/notifications/workflows/activation-new-conversation.ts
+++ b/front/lib/notifications/workflows/activation-new-conversation.ts
@@ -9,6 +9,7 @@ import {
 import { hasUnreadSucceededAgentReply } from "@app/lib/notifications/conversation_fetch";
 import { renderEmail } from "@app/lib/notifications/email-templates/activation-new-conversation";
 import {
+  getActivationFramePreview,
   getActivationRecommendation,
   getConversationDetails,
 } from "@app/lib/notifications/helpers";
@@ -45,6 +46,8 @@ const activationNewConversationDetailsSchema = z.object({
   podName: z.string(),
   purpose: z.string().nullable(),
   summary: z.string().nullable(),
+  frameImageUrl: z.string().nullable(),
+  frameUrl: z.string().nullable(),
 });
 
 export type activationNewConversationDetailsType = z.infer<
@@ -100,14 +103,23 @@ const getActivationNewConversationDetails = async ({
       podName: "your pod",
       purpose: null,
       summary: null,
+      frameImageUrl: null,
+      frameUrl: null,
     };
   }
 
-  const { purpose, summary } = await getActivationRecommendation({
-    details: detailsResult.value,
-    subscriberId: subscriberId ?? "",
-    payload,
-  });
+  const [{ purpose, summary }, framePreview] = await Promise.all([
+    getActivationRecommendation({
+      details: detailsResult.value,
+      subscriberId: subscriberId ?? "",
+      payload,
+    }),
+    getActivationFramePreview({
+      details: detailsResult.value,
+      subscriberId: subscriberId ?? "",
+      payload,
+    }),
+  ]);
 
   return {
     subject: detailsResult.value.subject,
@@ -115,6 +127,8 @@ const getActivationNewConversationDetails = async ({
     podName: detailsResult.value.projectName ?? "your pod",
     purpose,
     summary,
+    frameImageUrl: framePreview?.imageUrl ?? null,
+    frameUrl: framePreview?.frameUrl ?? null,
   };
 };
 
@@ -166,6 +180,8 @@ export const activationNewConversationWorkflow = workflow(
           podName: details.podName,
           purpose: details.purpose,
           summary: details.summary,
+          frameImageUrl: details.frameImageUrl,
+          frameUrl: details.frameUrl,
           action: {
             label: details.subject,
             url:

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -416,6 +416,35 @@ export class FileResource extends BaseResource<FileModel> {
     return files.map((f) => new this(this.model, f.get()));
   }
 
+  static async fetchPinnedPodFrame(
+    auth: Authenticator,
+    { spaceId, pinnedFramePath }: { spaceId: string; pinnedFramePath: string }
+  ): Promise<FileResource | null> {
+    const target = resolveCanonicalScopedPath(pinnedFramePath, {
+      conversationId: null,
+      spaceId,
+    });
+    if (!target) {
+      return null;
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+    const files = await this.model.findAll({
+      where: {
+        workspaceId: owner.id,
+        status: "ready",
+        useCase: "project_context",
+        useCaseMetadata: { spaceId },
+        contentType: {
+          [Op.in]: [frameContentType, frameSlideshowContentType],
+        },
+      },
+    });
+
+    const resources = files.map((f) => new this(this.model, f.get()));
+    return resources.find((f) => f.toScopedPath(auth) === target) ?? null;
+  }
+
   static async fetchByMountFilePaths(
     auth: Authenticator,
     mountFilePaths: string[]


### PR DESCRIPTION
## Description
Embedded the pod_overview.tsx frame generated by the activation skill into the email to encourage users to view the recommendation.

The frame is a static png "screenshot" of the generated frame that is taken after the skill has finished running. Clicking on the image or the "Open interactive view" button right below directs the user to the sharable frame link.

Falls back to no image in any case where the frame is not generated, accessible, etc.

## Tests
Local tests

## Risk
Low risk, part of the email notif for activation nudge conversations.

## Deploy Plan
Deploy front.
