### PR TITLE
[Front MCP] Show conversation inboxes

### DIFF
--- a/front/lib/api/actions/servers/front/helpers.test.ts
+++ b/front/lib/api/actions/servers/front/helpers.test.ts
@@ -2,6 +2,7 @@ import {
   formatConversationForLLM,
   getConversationInboxes,
 } from "@app/lib/api/actions/servers/front/helpers";
+import { TOOLS } from "@app/lib/api/actions/servers/front/tools";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 afterEach(() => {
@@ -67,5 +68,94 @@ describe("formatConversationForLLM", () => {
     );
 
     expect(formatted).toContain("INBOX: Support, Escalations");
+  });
+});
+
+function getTool(name: string) {
+  const tool = TOOLS.find((candidate) => candidate.name === name);
+  if (!tool) {
+    throw new Error(`Tool ${name} not found`);
+  }
+  return tool;
+}
+
+function createTestExtra() {
+  return {
+    authInfo: { token: "front-token" },
+  } as Parameters<(typeof TOOLS)[0]["handler"]>[1];
+}
+
+describe("search_conversations", () => {
+  it("stops loading inboxes when the token lacks permission", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            _results: [
+              { id: "cnv_1", status: "open" },
+              { id: "cnv_2", status: "open" },
+              { id: "cnv_3", status: "open" },
+            ],
+          }),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValue(new Response("Forbidden", { status: 403 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getTool("search_conversations").handler(
+      { q: "support", limit: 20 },
+      createTestExtra()
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    if (result.isOk()) {
+      expect(result.value[0]).toMatchObject({
+        type: "text",
+        text: expect.stringContaining(
+          "INBOX: Unknown (Front token needs inboxes:read)"
+        ),
+      });
+    }
+  });
+
+  it("keeps conversations when one inbox lookup fails", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            _results: [
+              { id: "cnv_1", status: "open" },
+              { id: "cnv_2", status: "open" },
+            ],
+          }),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ _results: [{ name: "Support" }] }), {
+          status: 200,
+        })
+      )
+      .mockResolvedValueOnce(new Response("Unavailable", { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getTool("search_conversations").handler(
+      { q: "support", limit: 20 },
+      createTestExtra()
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value[0]).toMatchObject({
+        type: "text",
+        text: expect.stringContaining(
+          "INBOX: Unknown (Front inboxes could not be loaded)"
+        ),
+      });
+    }
   });
 });

--- a/front/lib/api/actions/servers/front/helpers.test.ts
+++ b/front/lib/api/actions/servers/front/helpers.test.ts
@@ -1,0 +1,51 @@
+import {
+  formatConversationForLLM,
+  getConversationInboxes,
+} from "@app/lib/api/actions/servers/front/helpers";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("getConversationInboxes", () => {
+  it("fetches the inboxes attached to a conversation", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          _results: [{ id: "inb_support", name: "Support", is_private: false }],
+        }),
+        { status: 200 }
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      getConversationInboxes("front-token", "cnv_123")
+    ).resolves.toEqual([{ name: "Support" }]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api2.frontapp.com/conversations/cnv_123/inboxes",
+      {
+        method: "GET",
+        headers: {
+          Authorization: "Bearer front-token",
+          "Content-Type": "application/json",
+        },
+      }
+    );
+  });
+});
+
+describe("formatConversationForLLM", () => {
+  it("includes every inbox containing the conversation", () => {
+    const formatted = formatConversationForLLM(
+      {
+        id: "cnv_123",
+        status: "open",
+      },
+      [{ name: "Support" }, { name: "Escalations" }]
+    );
+
+    expect(formatted).toContain("INBOX: Support, Escalations");
+  });
+});

--- a/front/lib/api/actions/servers/front/helpers.test.ts
+++ b/front/lib/api/actions/servers/front/helpers.test.ts
@@ -1,8 +1,8 @@
 import {
   formatConversationForLLM,
+  formatConversationsForLLM,
   getConversationInboxes,
 } from "@app/lib/api/actions/servers/front/helpers";
-import { TOOLS } from "@app/lib/api/actions/servers/front/tools";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 afterEach(() => {
@@ -71,70 +71,29 @@ describe("formatConversationForLLM", () => {
   });
 });
 
-function getTool(name: string) {
-  const tool = TOOLS.find((candidate) => candidate.name === name);
-  if (!tool) {
-    throw new Error(`Tool ${name} not found`);
-  }
-  return tool;
-}
-
-function createTestExtra() {
-  return {
-    authInfo: { token: "front-token" },
-  } as Parameters<(typeof TOOLS)[0]["handler"]>[1];
-}
-
-describe("search_conversations", () => {
+describe("formatConversationsForLLM", () => {
   it("stops loading inboxes when the token lacks permission", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            _results: [
-              { id: "cnv_1", status: "open" },
-              { id: "cnv_2", status: "open" },
-              { id: "cnv_3", status: "open" },
-            ],
-          }),
-          { status: 200 }
-        )
-      )
-      .mockResolvedValue(new Response("Forbidden", { status: 403 }));
+    const fetchMock = vi.fn(async () => {
+      return new Response("Forbidden", { status: 403 });
+    });
     vi.stubGlobal("fetch", fetchMock);
 
-    const result = await getTool("search_conversations").handler(
-      { q: "support", limit: 20 },
-      createTestExtra()
-    );
+    const formatted = await formatConversationsForLLM("front-token", [
+      { id: "cnv_1", status: "open" },
+      { id: "cnv_2", status: "open" },
+      { id: "cnv_3", status: "open" },
+    ]);
 
-    expect(result.isOk()).toBe(true);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    if (result.isOk()) {
-      expect(result.value[0]).toMatchObject({
-        type: "text",
-        text: expect.stringContaining(
-          "INBOX: Unknown (Front token needs inboxes:read)"
-        ),
-      });
-    }
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(formatted).toHaveLength(3);
+    expect(formatted.join("\n")).toContain(
+      "INBOX: Unknown (Front token needs inboxes:read)"
+    );
   });
 
   it("keeps conversations when one inbox lookup fails", async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            _results: [
-              { id: "cnv_1", status: "open" },
-              { id: "cnv_2", status: "open" },
-            ],
-          }),
-          { status: 200 }
-        )
-      )
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ _results: [{ name: "Support" }] }), {
           status: 200,
@@ -143,19 +102,15 @@ describe("search_conversations", () => {
       .mockResolvedValueOnce(new Response("Unavailable", { status: 503 }));
     vi.stubGlobal("fetch", fetchMock);
 
-    const result = await getTool("search_conversations").handler(
-      { q: "support", limit: 20 },
-      createTestExtra()
-    );
+    const formatted = await formatConversationsForLLM("front-token", [
+      { id: "cnv_1", status: "open" },
+      { id: "cnv_2", status: "open" },
+    ]);
 
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      expect(result.value[0]).toMatchObject({
-        type: "text",
-        text: expect.stringContaining(
-          "INBOX: Unknown (Front inboxes could not be loaded)"
-        ),
-      });
-    }
+    expect(formatted).toHaveLength(2);
+    expect(formatted[0]).toContain("INBOX: Support");
+    expect(formatted[1]).toContain(
+      "INBOX: Unknown (Front inboxes could not be loaded)"
+    );
   });
 });

--- a/front/lib/api/actions/servers/front/helpers.test.ts
+++ b/front/lib/api/actions/servers/front/helpers.test.ts
@@ -2,6 +2,7 @@ import {
   formatConversationForLLM,
   formatConversationsForLLM,
   getConversationInboxes,
+  parseFrontConversation,
 } from "@app/lib/api/actions/servers/front/helpers";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -68,6 +69,21 @@ describe("formatConversationForLLM", () => {
     );
 
     expect(formatted).toContain("INBOX: Support, Escalations");
+  });
+
+  it("accepts a recipient without a name", () => {
+    const conversation = parseFrontConversation({
+      id: "cnv_123",
+      status: "open",
+      recipient: {
+        handle: "customer@example.com",
+        name: null,
+      },
+    });
+
+    expect(formatConversationForLLM(conversation, [])).toContain(
+      "RECIPIENT: customer@example.com"
+    );
   });
 });
 

--- a/front/lib/api/actions/servers/front/helpers.test.ts
+++ b/front/lib/api/actions/servers/front/helpers.test.ts
@@ -34,6 +34,26 @@ describe("getConversationInboxes", () => {
       }
     );
   });
+
+  it("keeps metadata available without inbox permissions", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("Forbidden", { status: 403 }))
+    );
+
+    const inboxes = await getConversationInboxes("front-token", "cnv_123");
+    const formatted = formatConversationForLLM(
+      {
+        id: "cnv_123",
+        status: "open",
+      },
+      inboxes
+    );
+
+    expect(formatted).toContain(
+      "INBOX: Unknown (Front token needs inboxes:read)"
+    );
+  });
 });
 
 describe("formatConversationForLLM", () => {

--- a/front/lib/api/actions/servers/front/helpers.ts
+++ b/front/lib/api/actions/servers/front/helpers.ts
@@ -146,13 +146,32 @@ interface FrontConversation {
   recipient?: { handle?: string; name?: string };
 }
 
+const FrontInboxesResponseSchema = z.object({
+  _results: z.array(z.object({ name: z.string() })),
+});
+
+export async function getConversationInboxes(
+  apiToken: string,
+  conversationId: string
+) {
+  const data = await makeFrontAPIRequest({
+    method: "GET",
+    endpoint: `conversations/${conversationId}/inboxes`,
+    apiToken,
+  });
+
+  return FrontInboxesResponseSchema.parse(data)._results;
+}
+
 export function formatConversationForLLM(
-  conversation: FrontConversation
+  conversation: FrontConversation,
+  inboxes: Array<{ name: string }>
 ): string {
   const assigneeEmail = conversation.assignee
     ? conversation.assignee.email
     : "Unassigned";
-  const inboxName = conversation.inbox?.name ?? "Unknown";
+  const inboxNames =
+    inboxes.length > 0 ? inboxes.map(({ name }) => name).join(", ") : "None";
   const tagNames = conversation.tags?.map((t) => t.name).join(", ") ?? "None";
   const createdAt = conversation.created_at
     ? new Date(conversation.created_at * 1000).toISOString()
@@ -168,7 +187,7 @@ export function formatConversationForLLM(
   SUBJECT: ${conversation.subject ?? "(No subject)"}
   STATUS: ${conversation.status}
   ASSIGNEE: ${assigneeEmail}
-  INBOX: ${inboxName}
+  INBOX: ${inboxNames}
   TAGS: ${tagNames}
   CREATED: ${createdAt}
   LAST_MESSAGE: ${lastMessageAt}

--- a/front/lib/api/actions/servers/front/helpers.ts
+++ b/front/lib/api/actions/servers/front/helpers.ts
@@ -154,24 +154,36 @@ export async function getConversationInboxes(
   apiToken: string,
   conversationId: string
 ) {
-  const data = await makeFrontAPIRequest({
-    method: "GET",
-    endpoint: `conversations/${conversationId}/inboxes`,
-    apiToken,
-  });
+  let data: unknown;
+  try {
+    data = await makeFrontAPIRequest({
+      method: "GET",
+      endpoint: `conversations/${conversationId}/inboxes`,
+      apiToken,
+    });
+  } catch (error) {
+    if (error instanceof MCPError && error.code === 403) {
+      return null;
+    }
+    throw error;
+  }
 
   return FrontInboxesResponseSchema.parse(data)._results;
 }
 
 export function formatConversationForLLM(
   conversation: FrontConversation,
-  inboxes: Array<{ name: string }>
+  inboxes: Array<{ name: string }> | null
 ): string {
   const assigneeEmail = conversation.assignee
     ? conversation.assignee.email
     : "Unassigned";
   const inboxNames =
-    inboxes.length > 0 ? inboxes.map(({ name }) => name).join(", ") : "None";
+    inboxes === null
+      ? "Unknown (Front token needs inboxes:read)"
+      : inboxes.length > 0
+        ? inboxes.map(({ name }) => name).join(", ")
+        : "None";
   const tagNames = conversation.tags?.map((t) => t.name).join(", ") ?? "None";
   const createdAt = conversation.created_at
     ? new Date(conversation.created_at * 1000).toISOString()

--- a/front/lib/api/actions/servers/front/helpers.ts
+++ b/front/lib/api/actions/servers/front/helpers.ts
@@ -134,16 +134,38 @@ export function getFrontAPITokenFromExtra(extra: ToolHandlerExtra): string {
   return apiToken;
 }
 
-interface FrontConversation {
-  id: string;
-  status: string;
-  subject?: string;
-  assignee?: { email: string };
-  inbox?: { name: string; address?: string };
-  tags?: Array<{ name: string }>;
-  created_at?: number;
-  last_message?: { received_at?: number };
-  recipient?: { handle?: string; name?: string };
+const FrontConversationSchema = z.object({
+  id: z.string(),
+  status: z.string(),
+  subject: z.string().optional(),
+  assignee: z.object({ email: z.string() }).nullable().optional(),
+  inbox: z
+    .object({ name: z.string(), address: z.string().optional() })
+    .optional(),
+  tags: z.array(z.object({ name: z.string() })).optional(),
+  created_at: z.number().optional(),
+  last_message: z
+    .object({ received_at: z.number().optional() })
+    .nullable()
+    .optional(),
+  recipient: z
+    .object({ handle: z.string().optional(), name: z.string().optional() })
+    .nullable()
+    .optional(),
+});
+
+const FrontConversationsResponseSchema = z.object({
+  _results: z.array(FrontConversationSchema),
+});
+
+export type FrontConversation = z.infer<typeof FrontConversationSchema>;
+
+export function parseFrontConversation(data: unknown): FrontConversation {
+  return FrontConversationSchema.parse(data);
+}
+
+export function parseFrontConversations(data: unknown): FrontConversation[] {
+  return FrontConversationsResponseSchema.parse(data)._results;
 }
 
 const FrontInboxesResponseSchema = z.object({

--- a/front/lib/api/actions/servers/front/helpers.ts
+++ b/front/lib/api/actions/servers/front/helpers.ts
@@ -195,17 +195,20 @@ export async function getConversationInboxes(
 
 export function formatConversationForLLM(
   conversation: FrontConversation,
-  inboxes: Array<{ name: string }> | null
+  inboxes: Array<{ name: string }> | null | undefined
 ): string {
   const assigneeEmail = conversation.assignee
     ? conversation.assignee.email
     : "Unassigned";
-  const inboxNames =
-    inboxes === null
-      ? "Unknown (Front token needs inboxes:read)"
-      : inboxes.length > 0
-        ? inboxes.map(({ name }) => name).join(", ")
-        : "None";
+  let inboxNames: string;
+  if (inboxes === null) {
+    inboxNames = "Unknown (Front token needs inboxes:read)";
+  } else if (inboxes === undefined) {
+    inboxNames = "Unknown (Front inboxes could not be loaded)";
+  } else {
+    inboxNames =
+      inboxes.length > 0 ? inboxes.map(({ name }) => name).join(", ") : "None";
+  }
   const tagNames = conversation.tags?.map((t) => t.name).join(", ") ?? "None";
   const createdAt = conversation.created_at
     ? new Date(conversation.created_at * 1000).toISOString()

--- a/front/lib/api/actions/servers/front/helpers.ts
+++ b/front/lib/api/actions/servers/front/helpers.ts
@@ -1,5 +1,6 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { marked } from "marked";
@@ -11,6 +12,7 @@ const FRONT_API_BASE_URL = "https://api2.frontapp.com";
 export const MAX_RETRIES = 3;
 const INITIAL_RETRY_DELAY_MS = 1000;
 const MAX_RETRY_DELAY_MS = 10000;
+const FRONT_API_CONCURRENCY = 5;
 
 interface FrontAPIOptions {
   method: string;
@@ -232,6 +234,53 @@ export function formatConversationForLLM(
   </conversation>`;
 
   return metadata;
+}
+
+async function loadInboxes(apiToken: string, conversation: FrontConversation) {
+  try {
+    return await getConversationInboxes(apiToken, conversation.id);
+  } catch (error) {
+    logger.warn(
+      {
+        conversationId: conversation.id,
+        error: normalizeError(error),
+      },
+      "[FrontMCP] Failed to load conversation inboxes"
+    );
+    return undefined;
+  }
+}
+
+export async function formatConversationsForLLM(
+  apiToken: string,
+  conversations: FrontConversation[]
+) {
+  const [firstConversation, ...remainingConversations] = conversations;
+  if (!firstConversation) {
+    return [];
+  }
+
+  const firstInboxes = await loadInboxes(apiToken, firstConversation);
+  if (firstInboxes === null) {
+    return conversations.map((conversation) =>
+      formatConversationForLLM(conversation, null)
+    );
+  }
+
+  const remainingFormatted = await concurrentExecutor(
+    remainingConversations,
+    async (conversation) =>
+      formatConversationForLLM(
+        conversation,
+        await loadInboxes(apiToken, conversation)
+      ),
+    { concurrency: FRONT_API_CONCURRENCY }
+  );
+
+  return [
+    formatConversationForLLM(firstConversation, firstInboxes),
+    ...remainingFormatted,
+  ];
 }
 
 interface FrontRecipient {

--- a/front/lib/api/actions/servers/front/helpers.ts
+++ b/front/lib/api/actions/servers/front/helpers.ts
@@ -151,7 +151,7 @@ const FrontConversationSchema = z.object({
     .nullable()
     .optional(),
   recipient: z
-    .object({ handle: z.string().optional(), name: z.string().optional() })
+    .object({ handle: z.string(), name: z.string().nullable() })
     .nullable()
     .optional(),
 });

--- a/front/lib/api/actions/servers/front/metadata.ts
+++ b/front/lib/api/actions/servers/front/metadata.ts
@@ -17,7 +17,7 @@ export const FRONT_TOOLS_METADATA = [
         .optional()
         .default(20)
         .describe(
-          "Maximum number of conversations to return (default: 20, max: 100)"
+          "Maximum number of conversations to return (default: 20, max: 20)"
         ),
     },
     stake: "never_ask",
@@ -125,7 +125,7 @@ export const FRONT_TOOLS_METADATA = [
         .optional()
         .default(10)
         .describe(
-          "Maximum number of past conversations to return (default: 10)"
+          "Maximum number of past conversations to return (default: 10, max: 20)"
         ),
     },
     stake: "never_ask",

--- a/front/lib/api/actions/servers/front/tools/index.ts
+++ b/front/lib/api/actions/servers/front/tools/index.ts
@@ -7,16 +7,22 @@ import {
   formatConversationForLLM,
   formatDraftsForLLM,
   formatMessagesForLLM,
+  getConversationInboxes,
   getFrontAPITokenFromExtra,
   makeFrontAPIRequest,
   parseFrontDraftsResponse,
 } from "@app/lib/api/actions/servers/front/helpers";
 import { FRONT_TOOLS_METADATA } from "@app/lib/api/actions/servers/front/metadata";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
-interface FrontListResponse {
-  _results?: unknown[];
+const FRONT_API_CONCURRENCY = 5;
+
+type FrontConversation = Parameters<typeof formatConversationForLLM>[0];
+
+interface FrontListResponse<T = unknown> {
+  _results?: T[];
 }
 
 interface FrontTag {
@@ -39,6 +45,14 @@ interface FrontInbox {
   is_private: boolean;
 }
 
+async function formatConversation(
+  apiToken: string,
+  conversation: FrontConversation
+) {
+  const inboxes = await getConversationInboxes(apiToken, conversation.id);
+  return formatConversationForLLM(conversation, inboxes);
+}
+
 const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
   search_conversations: async ({ q, limit = 20 }, extra) => {
     try {
@@ -49,7 +63,7 @@ const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
         endpoint: `conversations/search/${encodeURIComponent(q)}`,
         apiToken,
         params: { limit: Math.min(limit, 100) },
-      })) as FrontListResponse;
+      })) as FrontListResponse<FrontConversation>;
 
       const conversations = data._results ?? [];
 
@@ -62,13 +76,13 @@ const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
         ]);
       }
 
-      const formatted = conversations
-        .map((conv) =>
-          formatConversationForLLM(
-            conv as Parameters<typeof formatConversationForLLM>[0]
-          )
+      const formatted = (
+        await concurrentExecutor(
+          conversations,
+          (conversation) => formatConversation(apiToken, conversation),
+          { concurrency: FRONT_API_CONCURRENCY }
         )
-        .join("\n\n");
+      ).join("\n\n");
 
       return new Ok([
         {
@@ -95,15 +109,13 @@ const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
     try {
       const apiToken = await getFrontAPITokenFromExtra(extra);
 
-      const data = await makeFrontAPIRequest({
+      const data = (await makeFrontAPIRequest({
         method: "GET",
         endpoint: `conversations/${conversation_id}`,
         apiToken,
-      });
+      })) as FrontConversation;
 
-      const formatted = formatConversationForLLM(
-        data as Parameters<typeof formatConversationForLLM>[0]
-      );
+      const formatted = await formatConversation(apiToken, data);
 
       return new Ok([
         {
@@ -281,7 +293,7 @@ const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
         params: {
           limit: Math.min(limit, 100),
         },
-      })) as FrontListResponse;
+      })) as FrontListResponse<FrontConversation>;
 
       const conversations = data._results ?? [];
 
@@ -294,13 +306,13 @@ const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
         ]);
       }
 
-      const formatted = conversations
-        .map((conv) =>
-          formatConversationForLLM(
-            conv as Parameters<typeof formatConversationForLLM>[0]
-          )
+      const formatted = (
+        await concurrentExecutor(
+          conversations,
+          (conversation) => formatConversation(apiToken, conversation),
+          { concurrency: FRONT_API_CONCURRENCY }
         )
-        .join("\n\n");
+      ).join("\n\n");
 
       return new Ok([
         {

--- a/front/lib/api/actions/servers/front/tools/index.ts
+++ b/front/lib/api/actions/servers/front/tools/index.ts
@@ -3,12 +3,10 @@ import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   convertMarkdownToHTML,
-  type FrontConversation,
   findChannelAddress,
-  formatConversationForLLM,
+  formatConversationsForLLM,
   formatDraftsForLLM,
   formatMessagesForLLM,
-  getConversationInboxes,
   getFrontAPITokenFromExtra,
   makeFrontAPIRequest,
   parseFrontConversation,
@@ -16,12 +14,10 @@ import {
   parseFrontDraftsResponse,
 } from "@app/lib/api/actions/servers/front/helpers";
 import { FRONT_TOOLS_METADATA } from "@app/lib/api/actions/servers/front/metadata";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import assert from "assert";
 
-const FRONT_API_CONCURRENCY = 5;
 const MAX_CONVERSATIONS = 20;
 
 interface FrontListResponse {
@@ -48,53 +44,6 @@ interface FrontInbox {
   is_private: boolean;
 }
 
-async function loadInboxes(apiToken: string, conversation: FrontConversation) {
-  try {
-    return await getConversationInboxes(apiToken, conversation.id);
-  } catch (error) {
-    logger.warn(
-      {
-        conversationId: conversation.id,
-        error: normalizeError(error),
-      },
-      "[FrontMCP] Failed to load conversation inboxes"
-    );
-    return undefined;
-  }
-}
-
-async function formatConversations(
-  apiToken: string,
-  conversations: FrontConversation[]
-) {
-  const [firstConversation, ...remainingConversations] = conversations;
-  if (!firstConversation) {
-    return [];
-  }
-
-  const firstInboxes = await loadInboxes(apiToken, firstConversation);
-  if (firstInboxes === null) {
-    return conversations.map((conversation) =>
-      formatConversationForLLM(conversation, null)
-    );
-  }
-
-  const remainingFormatted = await concurrentExecutor(
-    remainingConversations,
-    async (conversation) =>
-      formatConversationForLLM(
-        conversation,
-        await loadInboxes(apiToken, conversation)
-      ),
-    { concurrency: FRONT_API_CONCURRENCY }
-  );
-
-  return [
-    formatConversationForLLM(firstConversation, firstInboxes),
-    ...remainingFormatted,
-  ];
-}
-
 const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
   search_conversations: async ({ q, limit = 20 }, extra) => {
     try {
@@ -118,7 +67,7 @@ const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
       }
 
       const formatted = (
-        await formatConversations(apiToken, conversations)
+        await formatConversationsForLLM(apiToken, conversations)
       ).join("\n\n");
 
       return new Ok([
@@ -154,10 +103,8 @@ const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
         })
       );
 
-      const formatted = formatConversationForLLM(
-        data,
-        await loadInboxes(apiToken, data)
-      );
+      const [formatted] = await formatConversationsForLLM(apiToken, [data]);
+      assert(formatted);
 
       return new Ok([
         {
@@ -348,7 +295,7 @@ const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
       }
 
       const formatted = (
-        await formatConversations(apiToken, conversations)
+        await formatConversationsForLLM(apiToken, conversations)
       ).join("\n\n");
 
       return new Ok([

--- a/front/lib/api/actions/servers/front/tools/index.ts
+++ b/front/lib/api/actions/servers/front/tools/index.ts
@@ -17,6 +17,7 @@ import {
 } from "@app/lib/api/actions/servers/front/helpers";
 import { FRONT_TOOLS_METADATA } from "@app/lib/api/actions/servers/front/metadata";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
@@ -47,12 +48,51 @@ interface FrontInbox {
   is_private: boolean;
 }
 
-async function formatConversation(
+async function loadInboxes(apiToken: string, conversation: FrontConversation) {
+  try {
+    return await getConversationInboxes(apiToken, conversation.id);
+  } catch (error) {
+    logger.warn(
+      {
+        conversationId: conversation.id,
+        error: normalizeError(error),
+      },
+      "[FrontMCP] Failed to load conversation inboxes"
+    );
+    return undefined;
+  }
+}
+
+async function formatConversations(
   apiToken: string,
-  conversation: FrontConversation
+  conversations: FrontConversation[]
 ) {
-  const inboxes = await getConversationInboxes(apiToken, conversation.id);
-  return formatConversationForLLM(conversation, inboxes);
+  const [firstConversation, ...remainingConversations] = conversations;
+  if (!firstConversation) {
+    return [];
+  }
+
+  const firstInboxes = await loadInboxes(apiToken, firstConversation);
+  if (firstInboxes === null) {
+    return conversations.map((conversation) =>
+      formatConversationForLLM(conversation, null)
+    );
+  }
+
+  const remainingFormatted = await concurrentExecutor(
+    remainingConversations,
+    async (conversation) =>
+      formatConversationForLLM(
+        conversation,
+        await loadInboxes(apiToken, conversation)
+      ),
+    { concurrency: FRONT_API_CONCURRENCY }
+  );
+
+  return [
+    formatConversationForLLM(firstConversation, firstInboxes),
+    ...remainingFormatted,
+  ];
 }
 
 const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
@@ -78,11 +118,7 @@ const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
       }
 
       const formatted = (
-        await concurrentExecutor(
-          conversations,
-          (conversation) => formatConversation(apiToken, conversation),
-          { concurrency: FRONT_API_CONCURRENCY }
-        )
+        await formatConversations(apiToken, conversations)
       ).join("\n\n");
 
       return new Ok([
@@ -118,7 +154,10 @@ const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
         })
       );
 
-      const formatted = await formatConversation(apiToken, data);
+      const formatted = formatConversationForLLM(
+        data,
+        await loadInboxes(apiToken, data)
+      );
 
       return new Ok([
         {
@@ -309,11 +348,7 @@ const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
       }
 
       const formatted = (
-        await concurrentExecutor(
-          conversations,
-          (conversation) => formatConversation(apiToken, conversation),
-          { concurrency: FRONT_API_CONCURRENCY }
-        )
+        await formatConversations(apiToken, conversations)
       ).join("\n\n");
 
       return new Ok([

--- a/front/lib/api/actions/servers/front/tools/index.ts
+++ b/front/lib/api/actions/servers/front/tools/index.ts
@@ -18,6 +18,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 const FRONT_API_CONCURRENCY = 5;
+const MAX_CONVERSATIONS = 20;
 
 type FrontConversation = Parameters<typeof formatConversationForLLM>[0];
 
@@ -62,7 +63,7 @@ const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
         method: "GET",
         endpoint: `conversations/search/${encodeURIComponent(q)}`,
         apiToken,
-        params: { limit: Math.min(limit, 100) },
+        params: { limit: Math.min(limit, MAX_CONVERSATIONS) },
       })) as FrontListResponse<FrontConversation>;
 
       const conversations = data._results ?? [];
@@ -291,7 +292,7 @@ const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
         endpoint: `conversations/search/${encodeURIComponent(`from:${customer_email}`)}`,
         apiToken,
         params: {
-          limit: Math.min(limit, 100),
+          limit: Math.min(limit, MAX_CONVERSATIONS),
         },
       })) as FrontListResponse<FrontConversation>;
 

--- a/front/lib/api/actions/servers/front/tools/index.ts
+++ b/front/lib/api/actions/servers/front/tools/index.ts
@@ -3,6 +3,7 @@ import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   convertMarkdownToHTML,
+  type FrontConversation,
   findChannelAddress,
   formatConversationForLLM,
   formatDraftsForLLM,
@@ -10,6 +11,8 @@ import {
   getConversationInboxes,
   getFrontAPITokenFromExtra,
   makeFrontAPIRequest,
+  parseFrontConversation,
+  parseFrontConversations,
   parseFrontDraftsResponse,
 } from "@app/lib/api/actions/servers/front/helpers";
 import { FRONT_TOOLS_METADATA } from "@app/lib/api/actions/servers/front/metadata";
@@ -20,10 +23,8 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 const FRONT_API_CONCURRENCY = 5;
 const MAX_CONVERSATIONS = 20;
 
-type FrontConversation = Parameters<typeof formatConversationForLLM>[0];
-
-interface FrontListResponse<T = unknown> {
-  _results?: T[];
+interface FrontListResponse {
+  _results?: unknown[];
 }
 
 interface FrontTag {
@@ -59,14 +60,13 @@ const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
     try {
       const apiToken = await getFrontAPITokenFromExtra(extra);
 
-      const data = (await makeFrontAPIRequest({
+      const data = await makeFrontAPIRequest({
         method: "GET",
         endpoint: `conversations/search/${encodeURIComponent(q)}`,
         apiToken,
         params: { limit: Math.min(limit, MAX_CONVERSATIONS) },
-      })) as FrontListResponse<FrontConversation>;
-
-      const conversations = data._results ?? [];
+      });
+      const conversations = parseFrontConversations(data);
 
       if (conversations.length === 0) {
         return new Ok([
@@ -110,11 +110,13 @@ const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
     try {
       const apiToken = await getFrontAPITokenFromExtra(extra);
 
-      const data = (await makeFrontAPIRequest({
-        method: "GET",
-        endpoint: `conversations/${conversation_id}`,
-        apiToken,
-      })) as FrontConversation;
+      const data = parseFrontConversation(
+        await makeFrontAPIRequest({
+          method: "GET",
+          endpoint: `conversations/${conversation_id}`,
+          apiToken,
+        })
+      );
 
       const formatted = await formatConversation(apiToken, data);
 
@@ -287,16 +289,15 @@ const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
     try {
       const apiToken = await getFrontAPITokenFromExtra(extra);
 
-      const data = (await makeFrontAPIRequest({
+      const data = await makeFrontAPIRequest({
         method: "GET",
         endpoint: `conversations/search/${encodeURIComponent(`from:${customer_email}`)}`,
         apiToken,
         params: {
           limit: Math.min(limit, MAX_CONVERSATIONS),
         },
-      })) as FrontListResponse<FrontConversation>;
-
-      const conversations = data._results ?? [];
+      });
+      const conversations = parseFrontConversations(data);
 
       if (conversations.length === 0) {
         return new Ok([


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9821

Front conversation responses do not include an inline inbox object. Inbox membership is exposed through a separate endpoint, so the formatter was always reading a missing property and displaying `INBOX: Unknown`.

Fetch the conversation inboxes from the documented endpoint and include every inbox name in the formatted metadata. Search and customer-history results use bounded concurrency and a 20-conversation cap to stay within the Front API company-wide rate limit. Existing tokens without `inboxes:read` are probed once and still receive conversation results with an actionable inbox-permission note. Other inbox lookup failures are isolated so that they do not discard valid conversation results.

## Tests

- [x] Focused Front MCP helper tests

## Risks

Blast radius: Front MCP tools that return formatted conversation metadata.
Risk: low

## Deploy Plan

- deploy front
