### PR TITLE
Admin governance: checkbox for admins to show unpublished skills

### DIFF
--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -440,7 +440,7 @@ export function ManageSkillsPage() {
                 {isAdmin &&
                   hasSkillPublicationGovernance &&
                   activeTab === "active" && (
-                    <div className="ml-auto flex flex-row items-center gap-2 self-center text-sm text-muted-foreground dark:text-muted-foreground-night">
+                    <div className="ml-auto flex flex-row items-center gap-2 self-center text-sm text-muted-foreground">
                       <label className="flex cursor-pointer flex-row items-center gap-2 whitespace-nowrap">
                         <Checkbox
                           checked={bypassEditorVisibility}
@@ -451,7 +451,7 @@ export function ManageSkillsPage() {
                         Show hidden skills
                       </label>
                       <Tooltip
-                        label="Also displays skills you are not an editor of but can access as an admin."
+                        label="Shows skills you can access as an admin, even if you’re not an editor"
                         trigger={
                           <InfoCircle className="h-4 w-4 text-muted-foreground" />
                         }

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -35,11 +35,13 @@ import type {
 import { isEmptyString } from "@app/types/shared/utils/general";
 import {
   Button,
+  Checkbox,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
   FolderOpen,
+  InfoCircle,
   ListSelect,
   Page,
   Plus,
@@ -48,6 +50,7 @@ import {
   Tabs,
   TabsList,
   TabsTrigger,
+  Tooltip,
 } from "@dust-tt/sparkle";
 import type { RowSelectionState } from "@tanstack/react-table";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -97,7 +100,7 @@ function sortSkillsByName(
 
 export function ManageSkillsPage() {
   const owner = useWorkspace();
-  const { user } = useAuth();
+  const { user, isAdmin } = useAuth();
   const { hasPermission } = useWorkspacePermissions();
   const { hasFeature } = useFeatureFlags();
   const [selectedSkill, setSelectedSkill] =
@@ -111,6 +114,7 @@ export function ManageSkillsPage() {
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [pendingBatchAction, setPendingBatchAction] =
     useState<BatchAvailabilityAction | null>(null);
+  const [bypassEditorVisibility, setBypassEditorVisibility] = useState(false);
 
   const hasSkillPublicationGovernance = hasFeature(
     "admin_governance_skill_publication"
@@ -132,6 +136,8 @@ export function ManageSkillsPage() {
   } = useSkillsWithRelations({
     owner,
     status: "active",
+    bypassEditorVisibility:
+      isAdmin && hasSkillPublicationGovernance && bypassEditorVisibility,
   });
 
   const {
@@ -431,6 +437,27 @@ export function ManageSkillsPage() {
                     counterValue={`${skillsByTab[tab.id].length}`}
                   />
                 ))}
+                {isAdmin &&
+                  hasSkillPublicationGovernance &&
+                  activeTab === "active" && (
+                    <div className="ml-auto flex flex-row items-center gap-2 self-center text-sm text-muted-foreground dark:text-muted-foreground-night">
+                      <label className="flex cursor-pointer flex-row items-center gap-2 whitespace-nowrap">
+                        <Checkbox
+                          checked={bypassEditorVisibility}
+                          onCheckedChange={(checked) =>
+                            setBypassEditorVisibility(checked === true)
+                          }
+                        />
+                        Show hidden skills
+                      </label>
+                      <Tooltip
+                        label="Also displays skills you are not an editor of but can access as an admin."
+                        trigger={
+                          <InfoCircle className="h-4 w-4 text-muted-foreground" />
+                        }
+                      />
+                    </div>
+                  )}
               </TabsList>
             </Tabs>
             {isLoading ? (

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -160,11 +160,15 @@ export function useSkillsWithRelations({
   disabled,
   status,
   onlyCustom,
+  bypassEditorVisibility,
 }: {
   owner: LightWorkspaceType;
   disabled?: boolean;
   status: SkillStatus;
   onlyCustom?: boolean;
+  // Admin-only: bypass the editor-visibility rule and also list unpublished
+  // (editors-only) skills the caller does not edit.
+  bypassEditorVisibility?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const skillsFetcher: Fetcher<GetSkillsWithRelationsResponseBody> = fetcher;
@@ -175,6 +179,9 @@ export function useSkillsWithRelations({
   });
   if (onlyCustom) {
     queryParams.set("onlyCustom", "true");
+  }
+  if (bypassEditorVisibility) {
+    queryParams.set("bypassEditorVisibility", "true");
   }
 
   const { data, isLoading, mutate } = useSWRWithDefaults(


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/9729

Add a new checkbox to display/hide the "hidden" skills, i.e. the one not published.

## Tests

tested locally


https://github.com/user-attachments/assets/fd684d90-1aa5-4301-80ab-dfc52b8779f5



## Risk

low

## Deploy Plan

deploy front
