### PR TITLE
Fix Gong MCP calls for non-default regions

### DIFF
--- a/core/src/oauth/providers/gong.rs
+++ b/core/src/oauth/providers/gong.rs
@@ -14,7 +14,10 @@ use async_trait::async_trait;
 use base64::{engine::general_purpose, Engine as _};
 use lazy_static::lazy_static;
 use std::env;
+use url::Url;
 use urlencoding;
+
+const DEFAULT_GONG_API_BASE_URL: &str = "https://api.gong.io";
 
 lazy_static! {
     static ref OAUTH_GONG_CLIENT_ID: String = env::var("OAUTH_GONG_CLIENT_ID").unwrap();
@@ -37,6 +40,39 @@ impl GongConnectionProvider {
     pub fn new() -> Self {
         GongConnectionProvider {}
     }
+}
+
+fn api_base_url_metadata(
+    raw_json: &serde_json::Value,
+) -> Result<serde_json::Map<String, serde_json::Value>> {
+    let raw_api_base_url = raw_json["api_base_url_for_customer"]
+        .as_str()
+        .unwrap_or(DEFAULT_GONG_API_BASE_URL);
+
+    let api_base_url = Url::parse(raw_api_base_url)
+        .map_err(|_| anyhow!("Invalid `api_base_url_for_customer` in response from Gong"))?;
+    let hostname = api_base_url
+        .host_str()
+        .ok_or_else(|| anyhow!("Invalid `api_base_url_for_customer` in response from Gong"))?;
+
+    if api_base_url.scheme() != "https"
+        || !(hostname == "api.gong.io" || hostname.ends_with(".api.gong.io"))
+        || api_base_url.port().is_some()
+        || !api_base_url.username().is_empty()
+        || api_base_url.password().is_some()
+        || api_base_url.path() != "/"
+        || api_base_url.query().is_some()
+        || api_base_url.fragment().is_some()
+    {
+        return Err(anyhow!(
+            "Invalid `api_base_url_for_customer` in response from Gong"
+        ));
+    }
+
+    Ok(serde_json::Map::from_iter([(
+        "api_base_url_for_customer".to_string(),
+        serde_json::Value::String(api_base_url.origin().ascii_serialization()),
+    )]))
 }
 
 #[async_trait]
@@ -90,6 +126,8 @@ impl Provider for GongConnectionProvider {
             None => Err(anyhow!("Missing `refresh_token` in response from Gong"))?,
         };
 
+        let extra_metadata = api_base_url_metadata(&raw_json)?;
+
         Ok(FinalizeResult {
             redirect_uri: redirect_uri.to_string(),
             code: code.to_string(),
@@ -99,7 +137,7 @@ impl Provider for GongConnectionProvider {
             ),
             refresh_token: Some(refresh_token.to_string()),
             raw_json,
-            extra_metadata: None,
+            extra_metadata: Some(extra_metadata),
         })
     }
 
@@ -172,5 +210,44 @@ impl Provider for GongConnectionProvider {
         };
 
         Ok(raw_json)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{api_base_url_metadata, DEFAULT_GONG_API_BASE_URL};
+    use serde_json::json;
+
+    #[test]
+    fn extracts_api_base_url_as_connection_metadata() {
+        let metadata = api_base_url_metadata(&json!({
+            "api_base_url_for_customer": "https://eu-2086.api.gong.io/"
+        }))
+        .expect("Gong API base URL should be extracted");
+
+        assert_eq!(
+            metadata.get("api_base_url_for_customer"),
+            Some(&json!("https://eu-2086.api.gong.io"))
+        );
+    }
+
+    #[test]
+    fn falls_back_to_the_default_api_base_url() {
+        let metadata =
+            api_base_url_metadata(&json!({})).expect("Default Gong API base URL should be used");
+
+        assert_eq!(
+            metadata.get("api_base_url_for_customer"),
+            Some(&json!(DEFAULT_GONG_API_BASE_URL))
+        );
+    }
+
+    #[test]
+    fn rejects_api_base_urls_outside_gong() {
+        let result = api_base_url_metadata(&json!({
+            "api_base_url_for_customer": "https://example.com"
+        }));
+
+        assert!(result.is_err());
     }
 }

--- a/front/lib/api/actions/servers/gong/client.test.ts
+++ b/front/lib/api/actions/servers/gong/client.test.ts
@@ -1,0 +1,78 @@
+import {
+  type GongClient,
+  getGongClient,
+} from "@app/lib/api/actions/servers/gong/client";
+import { untrustedFetch } from "@app/lib/egress/server";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import { Response } from "undici";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/egress/server", () => ({
+  untrustedFetch: vi.fn(),
+}));
+
+function makeAuthInfo(apiBaseUrl?: string): AuthInfo {
+  return {
+    token: "gong-access-token",
+    clientId: "",
+    scopes: [],
+    extra: apiBaseUrl ? { api_base_url_for_customer: apiBaseUrl } : undefined,
+  };
+}
+
+function getClient(apiBaseUrl?: string): GongClient {
+  const result = getGongClient(makeAuthInfo(apiBaseUrl));
+  expect(result.isOk()).toBe(true);
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+}
+
+describe("GongClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the customer-specific Gong API base URL", async () => {
+    vi.mocked(untrustedFetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({ calls: [], records: { totalRecords: 0 } }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      )
+    );
+
+    const client = getClient("https://eu-2086.api.gong.io");
+    const result = await client.listCalls({});
+
+    expect(result.isOk()).toBe(true);
+    expect(untrustedFetch).toHaveBeenCalledWith(
+      "https://eu-2086.api.gong.io/v2/calls?",
+      expect.objectContaining({ method: "GET" })
+    );
+  });
+
+  it("uses the global Gong API base URL for legacy connections", async () => {
+    vi.mocked(untrustedFetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({ calls: [], records: { totalRecords: 0 } }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      )
+    );
+
+    const client = getClient();
+    const result = await client.listCalls({});
+
+    expect(result.isOk()).toBe(true);
+    expect(untrustedFetch).toHaveBeenCalledWith(
+      "https://api.gong.io/v2/calls?",
+      expect.objectContaining({ method: "GET" })
+    );
+  });
+});

--- a/front/lib/api/actions/servers/gong/client.ts
+++ b/front/lib/api/actions/servers/gong/client.ts
@@ -11,10 +11,11 @@ import { untrustedFetch } from "@app/lib/egress/server";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { isString } from "@app/types/shared/utils/general";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { z } from "zod";
 
-const GONG_API_BASE_URL = "https://api.gong.io/v2";
+const DEFAULT_GONG_API_BASE_URL = "https://api.gong.io";
 
 export class GongApiError extends Error {
   public readonly isInvalidInput: boolean;
@@ -43,11 +44,25 @@ export function getGongClient(
     );
   }
 
-  return new Ok(new GongClient(accessToken));
+  const rawApiBaseUrl = authInfo.extra?.api_base_url_for_customer;
+  // Temporary fallback to avoid breaking existing Gong integrations created
+  // before the customer-specific base URL was persisted.
+  const apiBaseUrl = isString(rawApiBaseUrl)
+    ? rawApiBaseUrl
+    : DEFAULT_GONG_API_BASE_URL;
+
+  return new Ok(new GongClient(accessToken, apiBaseUrl));
 }
 
 export class GongClient {
-  constructor(private accessToken: string) {}
+  private readonly baseUrl: string;
+
+  constructor(
+    private readonly accessToken: string,
+    baseUrlForCustomer: string
+  ) {
+    this.baseUrl = `${baseUrlForCustomer}/v2`;
+  }
 
   private async request<T extends z.Schema>(
     endpoint: string,
@@ -58,7 +73,7 @@ export class GongClient {
       queryParams?: Record<string, string>;
     } = { method: "GET" }
   ): Promise<Result<z.infer<T>, Error>> {
-    let url = `${GONG_API_BASE_URL}${endpoint}`;
+    let url = `${this.baseUrl}${endpoint}`;
 
     if (options.queryParams) {
       const params = new URLSearchParams(options.queryParams);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/9819.

Gong OAuth returns a customer-specific API base URL because accounts may be hosted on different cells. PR https://github.com/dust-tt/dust/pull/27851 fixed this for connectors, but the Gong MCP client still used the
global endpoint.

This persists the validated customer base URL in OAuth connection metadata and uses it for MCP requests. The
global endpoint remains the fallback for legacy connections. Existing regional connections must reconnect to
receive the new metadata.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
