### PR TITLE
Batch LLM: write the same reasoning as streaming LLMs

### DIFF
--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -483,7 +483,9 @@ function eventToStoredStepContent(
         type: "reasoning",
         value: {
           reasoning: event.content.text,
-          metadata: event.metadata.encrypted_content ?? "",
+          // Same JSON shape as the streaming path (get_output_from_llm.ts), so
+          // replay can extract `id` / `encrypted_content` from it.
+          metadata: JSON.stringify(event.metadata),
           tokens: 0,
           provider: event.metadata.clientId,
         },


### PR DESCRIPTION
## Description

This should fix an issue where reasoning could not be read

```
Error: Failed to parse reasoning metadata JSON: Unexpected token 'E', "Eu0MCosBCB"... is not valid JSON at extractEncryptedContentFromMetadata (/app/front/dist/start_worker.js:128354:11)
```

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
