### PR TITLE
[front] fix: refresh invitations list after edit/revoke

### DIFF
--- a/front/components/members/InviteEmailButtonWithModal.tsx
+++ b/front/components/members/InviteEmailButtonWithModal.tsx
@@ -21,6 +21,7 @@ import { getPriceAsString } from "@app/lib/client/subscription";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY,
+  mutateWorkspaceInvitations,
   sendInvitations,
 } from "@app/lib/invitations";
 import { useSeatPlan } from "@app/lib/swr/credits";
@@ -340,7 +341,7 @@ export function InviteEmailButtonWithModal({
         });
         await mutate(`/api/w/${owner.sId}/members`);
       }
-      await mutate(`/api/w/${owner.sId}/invitations`);
+      await mutateWorkspaceInvitations(owner);
       setOpen(false);
     }
   }

--- a/front/lib/invitations.ts
+++ b/front/lib/invitations.ts
@@ -8,21 +8,17 @@ import type {
 } from "@app/types/api/invitation";
 import type { MembershipInvitationType } from "@app/types/membership_invitation";
 import type { MembershipSeatType } from "@app/types/memberships";
+import { isString } from "@app/types/shared/utils/general";
 import type { ActiveRoleType, RoleType, WorkspaceType } from "@app/types/user";
 import type { NotificationType } from "@dust-tt/sparkle";
 import { mutate } from "swr";
 
 export const MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY = 300;
 
-// Revalidates every cached invitations list for the workspace, regardless of the
-// query params (e.g. `?includeExpired=true`). A plain `mutate(url)` only matches the
-// exact key and would miss lists fetched with query params.
+// Matches the invitations list regardless of query params (e.g. `?includeExpired=true`).
 export async function mutateWorkspaceInvitations(owner: WorkspaceType) {
   const invitationsPath = `/api/w/${owner.sId}/invitations`;
-  await mutate(
-    (key) =>
-      typeof key === "string" && key.split("?")[0] === invitationsPath
-  );
+  await mutate((key) => isString(key) && key.split("?")[0] === invitationsPath);
 }
 
 export async function updateInvitation({

--- a/front/lib/invitations.ts
+++ b/front/lib/invitations.ts
@@ -14,6 +14,17 @@ import { mutate } from "swr";
 
 export const MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY = 300;
 
+// Revalidates every cached invitations list for the workspace, regardless of the
+// query params (e.g. `?includeExpired=true`). A plain `mutate(url)` only matches the
+// exact key and would miss lists fetched with query params.
+export async function mutateWorkspaceInvitations(owner: WorkspaceType) {
+  const invitationsPath = `/api/w/${owner.sId}/invitations`;
+  await mutate(
+    (key) =>
+      typeof key === "string" && key.split("?")[0] === invitationsPath
+  );
+}
+
 export async function updateInvitation({
   owner,
   invitation,
@@ -76,7 +87,7 @@ export async function updateInvitation({
     title: `${newRole ? "Role updated" : "Invitation Revoked"}`,
     description: `${successMessage} for ${invitation.inviteEmail}.`,
   });
-  await mutate(`/api/w/${owner.sId}/invitations`);
+  await mutateWorkspaceInvitations(owner);
 }
 
 export async function sendInvitations({


### PR DESCRIPTION
## Problem

On the workspace **Invitations** tab, editing an invitation's role (admin/member) returned to the list without showing the updated role. Revoking an invitation had the same issue — the list wasn't reliably reloaded.

## Root cause

`InvitationsList` fetches via `useWorkspaceInvitations(owner, { includeExpired: true })`, so its SWR cache key is:

```
/api/w/{sId}/invitations?includeExpired=true
```

But `updateInvitation()` revalidated with a query-param-less key:

```js
await mutate(`/api/w/${owner.sId}/invitations`);
```

SWR's string-key `mutate` does an **exact** match, so it never matched the `?includeExpired=true` key and the list was never revalidated. Because both edit and revoke go through `updateInvitation`, both were affected. The identical latent bug existed in `InviteEmailButtonWithModal` after sending new invites.

## Fix

Added a shared `mutateWorkspaceInvitations(owner)` helper in `front/lib/invitations.ts` that revalidates every invitations key for the workspace regardless of query params (matched by pathname), and used it at both call sites.

## Testing

- `npx tsgo --noEmit` passes
- `npm run format:changed` passes

No tests added: this is client-side SWR wiring, and the repo's testing convention is functional endpoint tests rather than UI unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)