### PR TITLE
Require a reason message on member-initiated upgrade requests

### DIFF
--- a/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
@@ -106,6 +106,52 @@ describe("/api/w/[wId]/credits/upgrade-requests", () => {
       expect(body.request.requester.sId).toBe(user.sId);
     });
 
+    it("stores the reason when provided", async () => {
+      const workspace = await creditPricedWorkspace();
+      await createPrivateApiMockRequest({
+        method: "POST",
+        role: "user",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        upgradeRequestsUrl(workspace.sId),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            reason: "Running a large one-off backfill this week.",
+          }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const { request } = await response.json();
+      expect(request.reason).toBe(
+        "Running a large one-off backfill this week."
+      );
+    });
+
+    it("rejects a reason shorter than the minimum length", async () => {
+      const workspace = await creditPricedWorkspace();
+      await createPrivateApiMockRequest({
+        method: "POST",
+        role: "user",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        upgradeRequestsUrl(workspace.sId),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ reason: "short" }),
+        }
+      );
+
+      expect(response.status).toBe(400);
+    });
+
     it("is idempotent — a second request reuses the pending one", async () => {
       const workspace = await creditPricedWorkspace();
       const { membership, response: first } =

--- a/front-api/routes/w/[wId]/credits/upgrade-requests.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.ts
@@ -11,6 +11,10 @@ import type {
   PostUpgradeRequestResponseBody,
 } from "@app/types/api/credits/upgrade_requests";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+import {
+  MAX_UPGRADE_REQUEST_REASON_LENGTH,
+  MIN_UPGRADE_REQUEST_REASON_LENGTH,
+} from "@app/types/memberships";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
@@ -24,6 +28,19 @@ const ParamsSchema = z.object({
 
 const ResolveBodySchema = z.object({
   status: z.union([z.literal("approved"), z.literal("denied")]),
+});
+
+// TODO(BACK12): make `reason` required once the client update that always
+// sends it (front's upgrade-request modal) has rolled out to all users.
+// Optional for now so the existing client, which posts an empty body, keeps
+// working until then.
+const CreateUpgradeRequestBodySchema = z.object({
+  reason: z
+    .string()
+    .trim()
+    .min(MIN_UPGRADE_REQUEST_REASON_LENGTH)
+    .max(MAX_UPGRADE_REQUEST_REASON_LENGTH)
+    .optional(),
 });
 
 function upgradeRequestErrorToApiError(
@@ -79,16 +96,22 @@ app.get(
 
 // Member-initiated: request an upgrade of the current user's spend limit.
 /** @ignoreswagger */
-app.post("/", async (ctx): HandlerResult<PostUpgradeRequestResponseBody> => {
-  const auth = ctx.get("auth");
-  const result = await createUpgradeRequest(auth, {
-    auditContext: getAuditLogContext(auth),
-  });
-  if (result.isErr()) {
-    return apiError(ctx, upgradeRequestErrorToApiError(result.error));
+app.post(
+  "/",
+  validate("json", CreateUpgradeRequestBodySchema),
+  async (ctx): HandlerResult<PostUpgradeRequestResponseBody> => {
+    const auth = ctx.get("auth");
+    const { reason } = ctx.req.valid("json");
+    const result = await createUpgradeRequest(auth, {
+      reason: reason ?? null,
+      auditContext: getAuditLogContext(auth),
+    });
+    if (result.isErr()) {
+      return apiError(ctx, upgradeRequestErrorToApiError(result.error));
+    }
+    return ctx.json({ request: result.value });
   }
-  return ctx.json({ request: result.value });
-});
+);
 
 /** @ignoreswagger */
 app.patch(

--- a/front-api/routes/w/[wId]/credits/upgrade-requests.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.ts
@@ -12,8 +12,8 @@ import type {
 } from "@app/types/api/credits/upgrade_requests";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import {
-  MAX_UPGRADE_REQUEST_REASON_LENGTH,
-  MIN_UPGRADE_REQUEST_REASON_LENGTH,
+  MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS,
+  MIN_UPGRADE_REQUEST_REASON_LENGTH_CHARS,
 } from "@app/types/memberships";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -38,8 +38,8 @@ const CreateUpgradeRequestBodySchema = z.object({
   reason: z
     .string()
     .trim()
-    .min(MIN_UPGRADE_REQUEST_REASON_LENGTH)
-    .max(MAX_UPGRADE_REQUEST_REASON_LENGTH)
+    .min(MIN_UPGRADE_REQUEST_REASON_LENGTH_CHARS)
+    .max(MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS)
     .optional(),
 });
 

--- a/front/admin/audit_log_schemas/membership.upgrade_request_created.json
+++ b/front/admin/audit_log_schemas/membership.upgrade_request_created.json
@@ -9,6 +9,7 @@
     }
   ],
   "metadata": {
-    "request_sid": "string"
+    "request_sid": "string",
+    "reason": "string"
   }
 }

--- a/front/components/credits/UsageUpgradeButton.tsx
+++ b/front/components/credits/UsageUpgradeButton.tsx
@@ -164,23 +164,24 @@ export function UsageUpgradeButton({
                     onChange,
                     errorMessage,
                     fieldState,
-                  }) => (
-                    <TextArea
-                      ref={registerRef}
-                      placeholder="e.g. running a large one-off backfill this week"
-                      rows={3}
-                      showErrorLabel={
-                        fieldState.isDirty || fieldState.isTouched
-                      }
-                      error={
-                        fieldState.isDirty || fieldState.isTouched
-                          ? errorMessage
-                          : undefined
-                      }
-                      onChange={onChange}
-                      {...registerProps}
-                    />
-                  )}
+                  }) => {
+                    const showError =
+                      fieldState.isDirty ||
+                      fieldState.isTouched ||
+                      form.formState.isSubmitted;
+
+                    return (
+                      <TextArea
+                        ref={registerRef}
+                        placeholder="e.g. running a large one-off backfill this week"
+                        rows={3}
+                        showErrorLabel={showError}
+                        error={showError ? errorMessage : undefined}
+                        onChange={onChange}
+                        {...registerProps}
+                      />
+                    );
+                  }}
                 </BaseFormFieldSection>
               </div>
             </DialogContainer>
@@ -195,7 +196,13 @@ export function UsageUpgradeButton({
                 variant: "primary",
                 isLoading: form.formState.isSubmitting,
                 disabled: form.formState.isSubmitting,
-                onClick: () => void form.handleSubmit(onSubmit)(),
+                onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
+                  // The button is wrapped in Radix's DialogClose, which closes the
+                  // dialog on click unless prevented. Closing must instead happen
+                  // only after a successful submit, inside `onSubmit`.
+                  event.preventDefault();
+                  void form.handleSubmit(onSubmit)();
+                },
               }}
             />
           </FormProvider>

--- a/front/components/credits/UsageUpgradeButton.tsx
+++ b/front/components/credits/UsageUpgradeButton.tsx
@@ -2,8 +2,8 @@ import { BaseFormFieldSection } from "@app/components/shared/BaseFormFieldSectio
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRequestUpgrade } from "@app/lib/swr/upgrade_requests";
 import {
-  MAX_UPGRADE_REQUEST_REASON_LENGTH,
-  MIN_UPGRADE_REQUEST_REASON_LENGTH,
+  MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS,
+  MIN_UPGRADE_REQUEST_REASON_LENGTH_CHARS,
 } from "@app/types/memberships";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -27,10 +27,10 @@ const requestUpgradeFormSchema = z.object({
     .string()
     .trim()
     .min(
-      MIN_UPGRADE_REQUEST_REASON_LENGTH,
+      MIN_UPGRADE_REQUEST_REASON_LENGTH_CHARS,
       "Tell your admin why you need this."
     )
-    .max(MAX_UPGRADE_REQUEST_REASON_LENGTH),
+    .max(MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS),
 });
 
 type RequestUpgradeFormValues = z.infer<typeof requestUpgradeFormSchema>;

--- a/front/components/credits/UsageUpgradeButton.tsx
+++ b/front/components/credits/UsageUpgradeButton.tsx
@@ -1,5 +1,10 @@
+import { BaseFormFieldSection } from "@app/components/shared/BaseFormFieldSection";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRequestUpgrade } from "@app/lib/swr/upgrade_requests";
+import {
+  MAX_UPGRADE_REQUEST_REASON_LENGTH,
+  MIN_UPGRADE_REQUEST_REASON_LENGTH,
+} from "@app/types/memberships";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -10,8 +15,25 @@ import {
   DialogHeader,
   DialogTitle,
   Hoverable,
+  TextArea,
 } from "@dust-tt/sparkle";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useState } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { z } from "zod";
+
+const requestUpgradeFormSchema = z.object({
+  reason: z
+    .string()
+    .trim()
+    .min(
+      MIN_UPGRADE_REQUEST_REASON_LENGTH,
+      "Tell your admin why you need this."
+    )
+    .max(MAX_UPGRADE_REQUEST_REASON_LENGTH),
+});
+
+type RequestUpgradeFormValues = z.infer<typeof requestUpgradeFormSchema>;
 
 type UsageUpgradeButtonVariant = "link" | "button";
 
@@ -37,21 +59,21 @@ export function UsageUpgradeButton({
   const isAdminGovernanceEnabled = hasFeature("admin_governance");
   const { doRequestUpgrade } = useRequestUpgrade({ workspaceId: owner.sId });
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [requested, setRequested] = useState(false);
+
+  const form = useForm<RequestUpgradeFormValues>({
+    resolver: zodResolver(requestUpgradeFormSchema),
+    defaultValues: { reason: "" },
+  });
 
   const alreadyRequested = hasPendingUpgradeRequest || requested;
 
-  async function handleConfirm() {
-    setIsSubmitting(true);
-    try {
-      const ok = await doRequestUpgrade();
-      if (ok) {
-        setRequested(true);
-        setIsDialogOpen(false);
-      }
-    } finally {
-      setIsSubmitting(false);
+  async function onSubmit(values: RequestUpgradeFormValues) {
+    const ok = await doRequestUpgrade(values);
+    if (ok) {
+      setRequested(true);
+      setIsDialogOpen(false);
+      form.reset();
     }
   }
 
@@ -120,31 +142,63 @@ export function UsageUpgradeButton({
         onOpenChange={(open) => !open && setIsDialogOpen(false)}
       >
         <DialogContent size="md">
-          <DialogHeader>
-            <DialogTitle>Request a usage limit upgrade</DialogTitle>
-          </DialogHeader>
-          <DialogContainer>
-            <p className="text-sm text-muted-foreground">
-              Your workspace{" "}
-              {isAdminGovernanceEnabled ? "admins and managers" : "admins"} will
-              be notified that you'd like your usage limit increased. They'll
-              review your request and get back to you.
-            </p>
-          </DialogContainer>
-          <DialogFooter
-            leftButtonProps={{
-              label: "Cancel",
-              variant: "outline",
-              onClick: () => setIsDialogOpen(false),
-            }}
-            rightButtonProps={{
-              label: "Send request",
-              variant: "primary",
-              isLoading: isSubmitting,
-              disabled: isSubmitting,
-              onClick: () => void handleConfirm(),
-            }}
-          />
+          <FormProvider {...form}>
+            <DialogHeader>
+              <DialogTitle>Request a usage limit upgrade</DialogTitle>
+            </DialogHeader>
+            <DialogContainer>
+              <div className="flex flex-col gap-4">
+                <p className="text-sm text-muted-foreground">
+                  Your workspace{" "}
+                  {isAdminGovernanceEnabled ? "admins and managers" : "admins"}{" "}
+                  will be notified that you'd like your usage limit increased.
+                  They'll review your request and get back to you.
+                </p>
+                <BaseFormFieldSection<HTMLTextAreaElement>
+                  fieldName="reason"
+                  title="Why do you need this?"
+                >
+                  {({
+                    registerRef,
+                    registerProps,
+                    onChange,
+                    errorMessage,
+                    fieldState,
+                  }) => (
+                    <TextArea
+                      ref={registerRef}
+                      placeholder="e.g. running a large one-off backfill this week"
+                      rows={3}
+                      showErrorLabel={
+                        fieldState.isDirty || fieldState.isTouched
+                      }
+                      error={
+                        fieldState.isDirty || fieldState.isTouched
+                          ? errorMessage
+                          : undefined
+                      }
+                      onChange={onChange}
+                      {...registerProps}
+                    />
+                  )}
+                </BaseFormFieldSection>
+              </div>
+            </DialogContainer>
+            <DialogFooter
+              leftButtonProps={{
+                label: "Cancel",
+                variant: "outline",
+                onClick: () => setIsDialogOpen(false),
+              }}
+              rightButtonProps={{
+                label: "Send request",
+                variant: "primary",
+                isLoading: form.formState.isSubmitting,
+                disabled: form.formState.isSubmitting,
+                onClick: () => void form.handleSubmit(onSubmit)(),
+              }}
+            />
+          </FormProvider>
         </DialogContent>
       </Dialog>
     </>

--- a/front/components/workspace/UpgradeRequestsTable.tsx
+++ b/front/components/workspace/UpgradeRequestsTable.tsx
@@ -11,7 +11,6 @@ import {
   DataTable,
   LoadingBlock,
   Spinner,
-  Tooltip,
   X,
 } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
@@ -62,18 +61,19 @@ const reasonColumn: ColumnDef<RowData, string> = {
   enableSorting: false,
   cell: (info: Info) => {
     const { reason } = info.row.original.request;
-    const label = (
-      <span className="text-sm text-muted-foreground">{REASON_LABEL}</span>
-    );
     return (
       <DataTable.CellContent>
-        {reason ? (
-          <Tooltip tooltipTriggerAsChild label={reason} trigger={label} />
-        ) : (
-          label
-        )}
+        <span
+          className="line-clamp-2 text-sm text-muted-foreground"
+          title={reason ?? undefined}
+        >
+          {reason || REASON_LABEL}
+        </span>
       </DataTable.CellContent>
     );
+  },
+  meta: {
+    className: "max-w-64",
   },
 };
 

--- a/front/components/workspace/UpgradeRequestsTable.tsx
+++ b/front/components/workspace/UpgradeRequestsTable.tsx
@@ -11,6 +11,7 @@ import {
   DataTable,
   LoadingBlock,
   Spinner,
+  Tooltip,
   X,
 } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
@@ -59,11 +60,21 @@ const reasonColumn: ColumnDef<RowData, string> = {
   id: "reason" as const,
   header: "",
   enableSorting: false,
-  cell: () => (
-    <DataTable.CellContent>
+  cell: (info: Info) => {
+    const { reason } = info.row.original.request;
+    const label = (
       <span className="text-sm text-muted-foreground">{REASON_LABEL}</span>
-    </DataTable.CellContent>
-  ),
+    );
+    return (
+      <DataTable.CellContent>
+        {reason ? (
+          <Tooltip tooltipTriggerAsChild label={reason} trigger={label} />
+        ) : (
+          label
+        )}
+      </DataTable.CellContent>
+    );
+  },
 };
 
 const requestedColumn: ColumnDef<RowData, string> = {

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -80,6 +80,7 @@ async function notifyManagersAndAdminsOfUpgradeRequest(
       requestId: request.sId,
       requesterName: requester.fullName() ?? requester.name,
       requesterEmail: requester.email ?? null,
+      reason: request.reason,
     });
   } catch (err) {
     logger.error(
@@ -94,7 +95,10 @@ async function notifyManagersAndAdminsOfUpgradeRequest(
 // actually being near/at their limit.
 export async function createUpgradeRequest(
   auth: Authenticator,
-  { auditContext }: { auditContext?: AuditLogContext } = {}
+  {
+    reason,
+    auditContext,
+  }: { reason: string | null; auditContext?: AuditLogContext }
 ): Promise<Result<MembershipUpgradeRequestType, UpgradeRequestError>> {
   const subscription = auth.getNonNullableSubscriptionResource();
   if (
@@ -142,6 +146,7 @@ export async function createUpgradeRequest(
 
   const result = await MembershipUpgradeRequestResource.createPending(auth, {
     user,
+    reason,
   });
   if (result.isErr()) {
     return new Err(
@@ -161,7 +166,10 @@ export async function createUpgradeRequest(
       }),
     ],
     context: auditContext,
-    metadata: { request_sid: request.sId },
+    metadata: {
+      request_sid: request.sId,
+      reason: request.reason ?? "",
+    },
   });
 
   void notifyManagersAndAdminsOfUpgradeRequest(auth, { request });

--- a/front/lib/notifications/workflows/upgrade-request-created.ts
+++ b/front/lib/notifications/workflows/upgrade-request-created.ts
@@ -15,6 +15,7 @@ const UpgradeRequestCreatedPayloadSchema = z.object({
   workspaceName: z.string(),
   requesterName: z.string(),
   requesterEmail: z.string().nullable(),
+  reason: z.string().nullable(),
 });
 
 type UpgradeRequestCreatedPayloadType = z.infer<
@@ -32,6 +33,12 @@ function formatRequester(payload: UpgradeRequestCreatedPayloadType): string {
     : payload.requesterName;
 }
 
+function formatRequestDetails(
+  payload: UpgradeRequestCreatedPayloadType
+): string {
+  return payload.reason ? ` (reason: ${payload.reason})` : "";
+}
+
 export const upgradeRequestCreatedWorkflow = workflow(
   UPGRADE_REQUEST_CREATED_TRIGGER_ID,
   async ({ step, payload, subscriber }) => {
@@ -47,7 +54,10 @@ export const upgradeRequestCreatedWorkflow = workflow(
       async () => {
         // Dedupe by requester (a member could re-request across the window) and
         // keep insertion order so the email lists distinct people once.
-        const requesterByKey = new Map<string, string>();
+        const requesterByKey = new Map<
+          string,
+          { label: string; details: string }
+        >();
         for (const event of events) {
           if (!isUpgradeRequestCreatedPayload(event.payload)) {
             continue;
@@ -55,7 +65,10 @@ export const upgradeRequestCreatedWorkflow = workflow(
           const key =
             event.payload.requesterEmail ?? event.payload.requesterName;
           if (!requesterByKey.has(key)) {
-            requesterByKey.set(key, formatRequester(event.payload));
+            requesterByKey.set(key, {
+              label: formatRequester(event.payload),
+              details: formatRequestDetails(event.payload),
+            });
           }
         }
         const requesters = Array.from(requesterByKey.values());
@@ -64,14 +77,16 @@ export const upgradeRequestCreatedWorkflow = workflow(
         const subject =
           count > 1
             ? `[Dust] ${count} members requested a spend-limit upgrade`
-            : `[Dust] ${requesters[0]} requested a spend-limit upgrade`;
+            : `[Dust] ${requesters[0].label} requested a spend-limit upgrade`;
 
         const intro =
           count > 1
             ? `${count} members have reached their per-user spend limit and are requesting an upgrade:`
-            : `${requesters[0]} has reached their per-user spend limit and is requesting an upgrade.`;
+            : `${requesters[0].label} has reached their per-user spend limit and is requesting an upgrade${requesters[0].details}.`;
         const list =
-          count > 1 ? requesters.map((r) => `• ${r}`).join("\n") : "";
+          count > 1
+            ? requesters.map((r) => `• ${r.label}${r.details}`).join("\n")
+            : "";
         const outro =
           count > 1
             ? `Review the requests and adjust their limits from your workspace usage page.`
@@ -119,6 +134,7 @@ export function notifyUpgradeRequested({
   requestId,
   requesterName,
   requesterEmail,
+  reason,
 }: {
   users: Array<{
     sId: string;
@@ -131,6 +147,7 @@ export function notifyUpgradeRequested({
   requestId: string;
   requesterName: string;
   requesterEmail: string | null;
+  reason: string | null;
 }): void {
   if (users.length === 0) {
     return;
@@ -141,6 +158,7 @@ export function notifyUpgradeRequested({
     workspaceName,
     requesterName,
     requesterEmail,
+    reason,
   };
 
   void getNovuClient()

--- a/front/lib/resources/membership_upgrade_request_resource.ts
+++ b/front/lib/resources/membership_upgrade_request_resource.ts
@@ -69,7 +69,7 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
   // against concurrent duplicates.
   static async createPending(
     auth: Authenticator,
-    { user }: { user: UserResource }
+    { user, reason }: { user: UserResource; reason: string | null }
   ): Promise<Result<MembershipUpgradeRequestResource, Error>> {
     const workspace = auth.getNonNullableWorkspace();
     const row = await withTransaction(async (transaction) => {
@@ -89,6 +89,7 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
           workspaceId: workspace.id,
           userId: user.id,
           status: "pending",
+          reason,
         },
         { transaction }
       );
@@ -249,6 +250,7 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
       status: this.status,
       createdAt: this.createdAt.getTime(),
       resolvedAt: this.resolvedAt ? this.resolvedAt.getTime() : null,
+      reason: this.reason,
       requester: {
         sId: this.requester.sId,
         name: this.requester.fullName() || this.requester.name,

--- a/front/lib/resources/storage/models/membership_upgrade_requests.ts
+++ b/front/lib/resources/storage/models/membership_upgrade_requests.ts
@@ -21,6 +21,11 @@ export class MembershipUpgradeRequestModel extends WorkspaceAwareModel<Membershi
   declare status: CreationOptional<MembershipUpgradeRequestStatus>;
   declare resolvedAt: Date | null;
 
+  // Why the member needs the raised limit. Required for new requests
+  // (enforced in application code, not at the DB level, so existing rows
+  // are unaffected).
+  declare reason: string | null;
+
   // The member who requested the upgrade.
   declare userId: ForeignKey<UserModel["id"]>;
   // The admin who approved/denied the request (null while pending).
@@ -49,6 +54,11 @@ MembershipUpgradeRequestModel.init(
     },
     resolvedAt: {
       type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
+    },
+    reason: {
+      type: DataTypes.STRING(1000),
       allowNull: true,
       defaultValue: null,
     },

--- a/front/lib/swr/upgrade_requests.ts
+++ b/front/lib/swr/upgrade_requests.ts
@@ -28,31 +28,34 @@ export function useRequestUpgrade({ workspaceId }: { workspaceId: string }) {
   const sendNotification = useSendNotification();
   const { mutate } = useSWRWithDefaults(usageStatusUrl(workspaceId), null);
 
-  const doRequestUpgrade = useCallback(async (): Promise<boolean> => {
-    const res = await clientFetch(upgradeRequestsUrl(workspaceId), {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({}),
-    });
-
-    if (!res.ok) {
-      const errorData = await getErrorFromResponse(res);
-      sendNotification({
-        type: "error",
-        title: "Failed to request an upgrade",
-        description: errorData.message,
+  const doRequestUpgrade = useCallback(
+    async ({ reason }: { reason: string }): Promise<boolean> => {
+      const res = await clientFetch(upgradeRequestsUrl(workspaceId), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reason }),
       });
-      return false;
-    }
 
-    await mutate();
-    sendNotification({
-      type: "success",
-      title: "Upgrade requested",
-      description: "Your workspace admins have been notified.",
-    });
-    return true;
-  }, [workspaceId, sendNotification, mutate]);
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Failed to request an upgrade",
+          description: errorData.message,
+        });
+        return false;
+      }
+
+      await mutate();
+      sendNotification({
+        type: "success",
+        title: "Upgrade requested",
+        description: "Your workspace admins have been notified.",
+      });
+      return true;
+    },
+    [workspaceId, sendNotification, mutate]
+  );
 
   return { doRequestUpgrade };
 }

--- a/front/migrations/pre-deploy/20260727135138_add_reason_to_membership_upgrade_requests.sql
+++ b/front/migrations/pre-deploy/20260727135138_add_reason_to_membership_upgrade_requests.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."membership_upgrade_requests" ADD COLUMN "reason" character varying(1000) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying;

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -300,11 +300,17 @@ export const MEMBERSHIP_UPGRADE_REQUEST_STATUSES = [
 export type MembershipUpgradeRequestStatus =
   (typeof MEMBERSHIP_UPGRADE_REQUEST_STATUSES)[number];
 
+export const MIN_UPGRADE_REQUEST_REASON_LENGTH = 10;
+export const MAX_UPGRADE_REQUEST_REASON_LENGTH = 1000;
+
 export interface MembershipUpgradeRequestType {
   sId: string;
   status: MembershipUpgradeRequestStatus;
   createdAt: number;
   resolvedAt: number | null;
+  // Why the member needs the raised limit. Null only for requests created
+  // before this field existed.
+  reason: string | null;
   requester: {
     sId: string;
     name: string;

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -300,8 +300,8 @@ export const MEMBERSHIP_UPGRADE_REQUEST_STATUSES = [
 export type MembershipUpgradeRequestStatus =
   (typeof MEMBERSHIP_UPGRADE_REQUEST_STATUSES)[number];
 
-export const MIN_UPGRADE_REQUEST_REASON_LENGTH = 10;
-export const MAX_UPGRADE_REQUEST_REASON_LENGTH = 1000;
+export const MIN_UPGRADE_REQUEST_REASON_LENGTH_CHARS = 10;
+export const MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS = 1000;
 
 export interface MembershipUpgradeRequestType {
   sId: string;


### PR DESCRIPTION
## Summary
- Members must now provide a free-text reason (validated with min/max length 10/1000) when requesting a spend-limit upgrade; admins see it in the requests table (hover tooltip), and it's included in the notification email and audit log.

## Test plan
- [ ] `npm run test -- upgrade-requests.test.ts` (front-api)
- [ ] Manually open the "Request an upgrade" dialog, click "Send request" with an empty reason — verify the dialog stays open and the "Tell your admin why you need this." error appears immediately.
- [ ] Fill in a reason and submit — verify the dialog closes and the request appears in the admin's UpgradeRequestsTable with the reason visible on hover.

## Deploy plan
 - [ ] Register the updated `membership.upgrade_request_created` audit log schema with WorkOS **before deploying**: `npx tsx front/admin/register_audit_log_schemas.ts --execute --changed`, **then commit the regenerated** `front/lib/api/audit/schema_versions.json`.
 - [ ] Apply the pre-deploy migration (both regions)
 - [ ] Deploy front