### PR TITLE
Opt: rewrite listBySpaceIds to avoid the OR and make it index friendly.

### DIFF
--- a/front/lib/resources/data_source_view_resource.test.ts
+++ b/front/lib/resources/data_source_view_resource.test.ts
@@ -147,7 +147,7 @@ describe("DataSourceViewResource", () => {
   });
 
   describe("listBySpaceIds", () => {
-    it("includes global space views without fetching spaces", async () => {
+    it("includes global space views via resolved global vaultId", async () => {
       const workspace = await WorkspaceFactory.basic();
       const adminAuth = await Authenticator.internalAdminForWorkspace(
         workspace.sId
@@ -168,7 +168,6 @@ describe("DataSourceViewResource", () => {
         SpaceResource,
         "fetchWorkspaceGlobalSpace"
       );
-      const spacesFetch = vi.spyOn(SpaceResource, "fetchByIds");
 
       try {
         const views = await DataSourceViewResource.listBySpaceIds(
@@ -180,11 +179,9 @@ describe("DataSourceViewResource", () => {
         expect(views.map((v) => v.sId).sort()).toEqual(
           [globalDsv.sId, regularDsv.sId].sort()
         );
-        expect(globalSpaceFetch).not.toHaveBeenCalled();
-        expect(spacesFetch).not.toHaveBeenCalled();
+        expect(globalSpaceFetch).toHaveBeenCalled();
       } finally {
         globalSpaceFetch.mockRestore();
-        spacesFetch.mockRestore();
       }
     });
 

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -337,31 +337,23 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     spaceIds: string[],
     { includeGlobalSpace = false }: { includeGlobalSpace?: boolean } = {}
   ) {
-    const spaceModelIds = removeNulls(spaceIds.map(getResourceIdFromSId));
+    // Resolve global space to a vaultId so we can filter with vaultId IN (...)
+    // (index-friendly) instead of joining vaults with (id IN OR kind = 'global').
+    const spaceModelIds = [
+      ...removeNulls(spaceIds.map(getResourceIdFromSId)),
+      ...(includeGlobalSpace
+        ? [(await SpaceResource.fetchWorkspaceGlobalSpace(auth)).id]
+        : []),
+    ];
 
-    if (spaceModelIds.length === 0 && !includeGlobalSpace) {
+    if (spaceModelIds.length === 0) {
       return [];
     }
 
     return this.baseFetch(auth, undefined, {
-      includes: [
-        {
-          model: SpaceResource.model,
-          as: "space",
-          attributes: [],
-          required: true,
-          where: {
-            workspaceId: auth.getNonNullableWorkspace().id,
-            deletedAt: null,
-            [Op.or]: [
-              { id: { [Op.in]: spaceModelIds } },
-              ...(includeGlobalSpace ? [{ kind: "global" }] : []),
-            ],
-          },
-        },
-      ],
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
+        vaultId: [...new Set(spaceModelIds)],
       },
     });
   }


### PR DESCRIPTION
## Description

`DataSourceViewResource.listBySpaceIds` previously filtered via a JOIN on `vaults` with an `Op.or` clause (`id IN (spaceModelIds) OR kind = 'global'`). The OR prevents the DB from using an index on `vaultId`, forcing a full-scan join on every call.

Rewrote to resolve the global space's numeric `vaultId` upfront via `SpaceResource.fetchWorkspaceGlobalSpace(auth)` when `includeGlobalSpace=true`, then issue a single `WHERE vaultId IN (...)` on `data_source_views` — no JOIN needed, fully index-friendly.

## Tests

Updated the existing unit test for `listBySpaceIds`: adjusted the spy assertion to expect `fetchWorkspaceGlobalSpace` to be called (it now is), and removed the now-irrelevant `fetchByIds` spy. Tested locally.

## Risk

Low. Pure query rewrite with identical semantics — same rows returned, no schema or API change. Adds one extra DB read (global space lookup) per call with `includeGlobalSpace=true`, but this is a small indexed lookup that replaces a heavier OR-join.

## Deploy Plan

Deploy front.
