### PR TITLE
[front] feat: add `isRestrictedToSkills` column to MCP server views table

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/index.test.ts
@@ -74,6 +74,7 @@ describe("DELETE /api/w/:wId/spaces/:spaceId/apps/:aId", () => {
       name: null,
       description: null,
       oAuthUseCase: null,
+      isRestrictedToSkills: false,
     });
 
     await AgentMCPServerConfigurationModel.create({

--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -556,6 +556,7 @@ describe("tryCallMCPTool", () => {
         editedAt: new Date(),
         editedByUserId: auth.user()?.id ?? null,
         oAuthUseCase: null,
+        isRestrictedToSkills: false,
       });
       systemView = new MCPServerViewResource(
         MCPServerViewModel,

--- a/front/lib/models/agent/actions/mcp_server_view.ts
+++ b/front/lib/models/agent/actions/mcp_server_view.ts
@@ -28,6 +28,8 @@ export class MCPServerViewModel extends SoftDeletableWorkspaceAwareModel<MCPServ
   declare name: string | null;
   declare description: string | null;
 
+  declare isRestrictedToSkills: CreationOptional<boolean>;
+
   declare vaultId: ForeignKey<SpaceModel["id"]>;
 
   declare editedByUser: NonAttribute<UserModel>;
@@ -72,6 +74,11 @@ MCPServerViewModel.init(
     description: {
       type: DataTypes.STRING,
       allowNull: true,
+    },
+    isRestrictedToSkills: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
     internalMCPServerId: {
       type: DataTypes.STRING,

--- a/front/lib/models/agent/actions/mcp_server_view.ts
+++ b/front/lib/models/agent/actions/mcp_server_view.ts
@@ -28,7 +28,7 @@ export class MCPServerViewModel extends SoftDeletableWorkspaceAwareModel<MCPServ
   declare name: string | null;
   declare description: string | null;
 
-  declare isRestrictedToSkills: CreationOptional<boolean>;
+  declare isRestrictedToSkills: boolean;
 
   declare vaultId: ForeignKey<SpaceModel["id"]>;
 

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -234,6 +234,7 @@ export class InternalMCPServerInMemoryResource {
       editedByUserId: auth.user()?.id,
       oAuthUseCase: useCase ?? null,
       oauthScope: oauthScope ?? null,
+      isRestrictedToSkills: false,
       ...(viewName ? { name: viewName } : {}),
     });
 

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -1583,6 +1583,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
             description: systemView?.description ?? null,
             oAuthUseCase: systemView?.oAuthUseCase ?? null,
             oauthScope: systemView?.oauthScope ?? null,
+            isRestrictedToSkills: systemView?.isRestrictedToSkills ?? false,
           });
         }
       }

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -284,7 +284,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       name: systemView.name,
       description: systemView.description,
       oauthScope: systemView.oauthScope,
-      isRestrictedToSkills: systemView.isRestrictedToSkills,
+      isRestrictedToSkills: false,
     };
 
     if (space.kind === "global") {
@@ -1583,7 +1583,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
             description: systemView?.description ?? null,
             oAuthUseCase: systemView?.oAuthUseCase ?? null,
             oauthScope: systemView?.oauthScope ?? null,
-            isRestrictedToSkills: systemView?.isRestrictedToSkills ?? false,
+            isRestrictedToSkills: false,
           });
         }
       }

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -47,6 +47,7 @@ import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticSoftDeletable } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type {
   InferIncludeType,
@@ -70,12 +71,7 @@ import {
 } from "@app/types/user";
 import assert from "assert";
 import uniq from "lodash/uniq";
-import type {
-  Attributes,
-  CreationAttributes,
-  ModelStatic,
-  Transaction,
-} from "sequelize";
+import type { Attributes, CreationAttributes, Transaction } from "sequelize";
 import { Op } from "sequelize";
 import { z } from "zod";
 
@@ -129,7 +125,9 @@ const inflightHydrations = new Map<ModelId, Promise<void>>();
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel> {
-  static model: ModelStatic<MCPServerViewModel> = MCPServerViewModel;
+  static model: ModelStaticSoftDeletable<MCPServerViewModel> =
+    MCPServerViewModel;
+  declare readonly model: ModelStaticSoftDeletable<MCPServerViewModel>;
   readonly editedByUser?: Attributes<UserModel>;
   private internalToolsMetadata?: Attributes<RemoteMCPServerToolMetadataModel>[];
   private remoteToolsMetadata?: Attributes<RemoteMCPServerToolMetadataModel>[];
@@ -137,12 +135,12 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   private internalMCPServer?: InternalMCPServerInMemoryResource;
 
   constructor(
-    model: ModelStatic<MCPServerViewModel>,
+    model: ModelStaticSoftDeletable<MCPServerViewModel>,
     blob: Attributes<MCPServerViewModel>,
     space: SpaceResource,
     includes?: Partial<InferIncludeType<MCPServerViewModel>>
   ) {
-    super(MCPServerViewModel, blob, space);
+    super(model, blob, space);
 
     this.editedByUser = includes?.editedByUser;
     this.internalToolsMetadata = includes?.internalToolsMetadata;
@@ -171,7 +169,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       );
     }
 
-    const server = await MCPServerViewModel.create(
+    const server = await this.model.create(
       {
         ...blob,
         workspaceId: auth.getNonNullableWorkspace().id,
@@ -182,7 +180,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       { transaction }
     );
 
-    const resource = new this(MCPServerViewResource.model, server.get(), space);
+    const resource = new this(this.model, server.get(), space);
 
     if (blob.remoteMCPServerId) {
       const remoteServer = await RemoteMCPServerResource.findByPk(
@@ -1155,7 +1153,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       "Can only delete MCP server views for the current workspace"
     );
 
-    const deletedCount = await MCPServerViewModel.destroy({
+    const deletedCount = await this.model.destroy({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         id: this.id,
@@ -1176,7 +1174,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       transaction,
     });
 
-    const deletedCount = await MCPServerViewModel.destroy({
+    const deletedCount = await this.model.destroy({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         id: this.id,
@@ -1527,7 +1525,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       }
 
       // There should be a MCPServerView for these ids both in system and global spaces.
-      const views = await MCPServerViewModel.findAll({
+      const views = await this.model.findAll({
         where: {
           workspaceId: workspace.id,
           serverType: "internal",
@@ -1596,7 +1594,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       // same workspace) can race on the inserts; ignoreDuplicates (ON CONFLICT DO NOTHING on
       // the unique constraint on workspaceId/internalMCPServerId/vaultId) makes the loser a
       // no-op.
-      const createdViews = await MCPServerViewModel.bulkCreate(missingRows, {
+      const createdViews = await this.model.bulkCreate(missingRows, {
         ignoreDuplicates: true,
       });
 
@@ -1611,7 +1609,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         // race (a concurrent call inserted the same rows; they exist now) or a conflict on
         // another unique constraint (e.g. name uniqueness per space) that leaves a view
         // genuinely missing. Re-read to tell them apart; only the latter is an anomaly.
-        const viewsAfterInsert = await MCPServerViewModel.findAll({
+        const viewsAfterInsert = await this.model.findAll({
           where: {
             workspaceId: workspace.id,
             serverType: "internal",

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -284,6 +284,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       name: systemView.name,
       description: systemView.description,
       oauthScope: systemView.oauthScope,
+      isRestrictedToSkills: systemView.isRestrictedToSkills,
     };
 
     if (space.kind === "global") {

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -264,6 +264,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
         editedAt: new Date(),
         editedByUserId: auth.user()?.id,
         oAuthUseCase: blob.oAuthUseCase,
+        isRestrictedToSkills: false,
       },
       {
         transaction,

--- a/front/lib/resources/storage/wrappers/workspace_models.ts
+++ b/front/lib/resources/storage/wrappers/workspace_models.ts
@@ -310,6 +310,7 @@ export class SoftDeletableWorkspaceAwareModel<
   // Delete.
 
   private static async softDelete<M extends Model>(
+    this: ModelStatic<M>,
     options: DestroyOptions<Attributes<M>>
   ): Promise<number> {
     const updateOptions: UpdateOptions<Attributes<M>> = {
@@ -328,13 +329,14 @@ export class SoftDeletableWorkspaceAwareModel<
   }
 
   public static override async destroy<M extends Model>(
+    this: ModelStatic<M>,
     options: WithHardDelete<DestroyOptions<Attributes<M>>>
   ): Promise<number> {
     if (options.hardDelete) {
       return super.destroy(options);
     }
 
-    return this.softDelete(options);
+    return SoftDeletableWorkspaceAwareModel.softDelete.call(this, options);
   }
 
   // Fetch.

--- a/front/lib/resources/storage/wrappers/workspace_models.ts
+++ b/front/lib/resources/storage/wrappers/workspace_models.ts
@@ -252,6 +252,9 @@ export type ModelStaticWorkspaceAware<M extends WorkspaceAwareModel> =
 export type ModelStaticSoftDeletable<
   M extends SoftDeletableWorkspaceAwareModel,
 > = ModelStatic<M> & {
+  destroy(
+    options: WithHardDelete<DestroyOptions<Attributes<M>>>
+  ): Promise<number>;
   findAll(
     options: WithIncludeDeleted<
       WorkspaceTenantIsolationSecurityBypassOptions<Attributes<M>>

--- a/front/migrations/pre-deploy/20260727092332_add_is_restricted_to_skills_to_mcp_server_views.sql
+++ b/front/migrations/pre-deploy/20260727092332_add_is_restricted_to_skills_to_mcp_server_views.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."mcp_server_views" ADD COLUMN "isRestrictedToSkills" boolean DEFAULT false NOT NULL;


### PR DESCRIPTION
## Overall goal

Some MCP tools rely on skill instructions for workspace-specific guidance, safety rules, or shortcuts that avoid unnecessary runtime research and credit spend. Exposing the raw tool directly lets agents bypass that context. The overall goal here is to let admins keep an MCP server available only through skills.

Part of https://github.com/dust-tt/tasks/issues/9792

## Description

This PR adds the `isRestrictedToSkills` column in db + migration.
The column is a boolean, it defaults to false.
No index added, 99% of the time it's be false, which means no filtering.

## Tests

- Migration ran locally.

## Risk

- Low.

## Deploy Plan

- Run pre-deploy migration
- Deploy front.
