### PR TITLE
[front] enh: filter skills-only tools from agents and JIT tools

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -191,7 +191,8 @@ app.post(
 
       const mcpServerViews = await MCPServerViewResource.fetchByIds(
         auth,
-        context.selectedMCPServerViewIds
+        context.selectedMCPServerViewIds,
+        { isRestrictedToSkills: false }
       );
 
       const upsertRes = await ConversationResource.upsertMCPServerViews(auth, {

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/tools.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/tools.ts
@@ -87,7 +87,14 @@ app.post(
     }
 
     if (action === "add" && mcpServerViewRes.isRestrictedToSkills) {
-      return ctx.json({ success: true });
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "This MCP server is restricted to skills and cannot be added directly to a conversation.",
+        },
+      });
     }
 
     const r = await ConversationResource.upsertMCPServerViews(auth, {

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/tools.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/tools.ts
@@ -86,6 +86,10 @@ app.post(
       });
     }
 
+    if (action === "add" && mcpServerViewRes.isRestrictedToSkills) {
+      return ctx.json({ success: true });
+    }
+
     const r = await ConversationResource.upsertMCPServerViews(auth, {
       conversation,
       mcpServerViews: [mcpServerViewRes],

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
@@ -451,7 +451,8 @@ app.post(
 
         const mcpServerViews = await MCPServerViewResource.fetchByIds(
           auth,
-          message.context.selectedMCPServerViewIds
+          message.context.selectedMCPServerViewIds,
+          { isRestrictedToSkills: false }
         );
 
         const r = await ConversationResource.upsertMCPServerViews(auth, {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/index.test.ts
@@ -482,14 +482,14 @@ describe("POST /api/w/:wId/assistant/agent_configurations - additionalRequestedS
     expect(data.agentConfiguration.requestedSpaceIds).not.toContain(
       openSpace.sId
     );
-    expect(
+    const agentMCPServerConfigurationCount =
       await AgentMCPServerConfigurationModel.count({
         where: {
           workspaceId: workspace.id,
           agentConfigurationId: data.agentConfiguration.id,
         },
-      })
-    ).toBe(0);
+      });
+    expect(agentMCPServerConfigurationCount).toBe(0);
   });
 });
 

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/index.test.ts
@@ -1,5 +1,7 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { Authenticator } from "@app/lib/auth";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
+import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -416,6 +418,78 @@ describe("POST /api/w/:wId/assistant/agent_configurations - additionalRequestedS
     const actualRequestedSpaceIds = data.agentConfiguration.requestedSpaceIds;
     expect(actualRequestedSpaceIds).toHaveLength(1);
     expect(actualRequestedSpaceIds).toContain(openSpace.sId);
+  });
+
+  it("filters skills-only tools when saving an agent", async () => {
+    const { workspace, user, auth, globalGroup } =
+      await createPrivateApiMockRequest({
+        role: "admin",
+        method: "POST",
+      });
+
+    await SpaceFactory.defaults(auth);
+
+    const openSpace = await SpaceFactory.regular(workspace);
+    await GroupSpaceFactory.associate(openSpace, globalGroup);
+    const remoteMCPServer = await RemoteMCPServerFactory.create(workspace);
+    const systemView =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        auth,
+        remoteMCPServer.sId
+      );
+    if (!systemView) {
+      throw new Error("Expected system MCP server view.");
+    }
+
+    const { view: mcpServerView } = await MCPServerViewResource.create(auth, {
+      systemView,
+      space: openSpace,
+    });
+    const [updatedViewCount] = await MCPServerViewModel.update(
+      { isRestrictedToSkills: true },
+      { where: { id: mcpServerView.id } }
+    );
+    expect(updatedViewCount).toBe(1);
+
+    const response = await postAgent(workspace, {
+      assistant: {
+        ...TEST_AGENT_PARAMS,
+        name: "Test Agent with Skills-only Tool",
+        actions: [
+          {
+            type: "mcp_server_configuration",
+            mcpServerViewId: mcpServerView.sId,
+            name: "search",
+            description: "Search data",
+            dataSources: null,
+            tables: null,
+            childAgentId: null,
+            timeFrame: null,
+            jsonSchema: null,
+            additionalConfiguration: {},
+            dustAppConfiguration: null,
+            secretName: null,
+            dustProject: null,
+          },
+        ],
+        editors: [{ sId: user.sId }],
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.agentConfiguration.actions).toEqual([]);
+    expect(data.agentConfiguration.requestedSpaceIds).not.toContain(
+      openSpace.sId
+    );
+    expect(
+      await AgentMCPServerConfigurationModel.count({
+        where: {
+          workspaceId: workspace.id,
+          agentConfigurationId: data.agentConfiguration.id,
+        },
+      })
+    ).toBe(0);
   });
 });
 

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -333,7 +333,8 @@ app.post(
     if (context.selectedMCPServerViewIds?.length) {
       const mcpServerViews = await MCPServerViewResource.fetchByIds(
         auth,
-        context.selectedMCPServerViewIds
+        context.selectedMCPServerViewIds,
+        { isRestrictedToSkills: false }
       );
 
       const upsertRes = await ConversationResource.upsertMCPServerViews(auth, {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.test.ts
@@ -1,4 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
+import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -140,6 +141,42 @@ describe("POST /api/w/:wId/assistant/conversations/:cId/tools", () => {
       );
       expect(relationship).toHaveLength(1);
       expect(relationship[0].enabled).toBe(true);
+    });
+
+    it("should ignore a skills-only tool", async () => {
+      const { workspace, conversation, auth, globalSpace } =
+        await setupTest("admin");
+
+      const remoteMCPServer = await RemoteMCPServerFactory.create(workspace);
+      const systemView =
+        await MCPServerViewResource.getMCPServerViewForSystemSpace(
+          auth,
+          remoteMCPServer.sId
+        );
+      assert(systemView, "MCP server view not found");
+      const { view: mcpServerView } = await MCPServerViewResource.create(auth, {
+        systemView,
+        space: globalSpace,
+      });
+      const [updatedViewCount] = await MCPServerViewModel.update(
+        { isRestrictedToSkills: true },
+        { where: { id: mcpServerView.id } }
+      );
+      expect(updatedViewCount).toBe(1);
+
+      const response = await postTools(workspace, conversation.sId, {
+        action: "add",
+        mcp_server_view_id: mcpServerView.sId,
+      });
+
+      expect(response.status).toBe(200);
+      expect((await response.json()).success).toBe(true);
+
+      const relationships = await ConversationResource.fetchMCPServerViews(
+        auth,
+        conversation
+      );
+      expect(relationships).toEqual([]);
     });
 
     it("should enable existing disabled tool", async () => {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.test.ts
@@ -170,7 +170,8 @@ describe("POST /api/w/:wId/assistant/conversations/:cId/tools", () => {
       });
 
       expect(response.status).toBe(200);
-      expect((await response.json()).success).toBe(true);
+      const body = await response.json();
+      expect(body.success).toBe(true);
 
       const relationships = await ConversationResource.fetchMCPServerViews(
         auth,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.test.ts
@@ -170,8 +170,7 @@ describe("POST /api/w/:wId/assistant/conversations/:cId/tools", () => {
       });
 
       expect(response.status).toBe(200);
-      const body = await response.json();
-      expect(body.success).toBe(true);
+      expect((await response.json()).success).toBe(true);
 
       const relationships = await ConversationResource.fetchMCPServerViews(
         auth,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.test.ts
@@ -143,7 +143,7 @@ describe("POST /api/w/:wId/assistant/conversations/:cId/tools", () => {
       expect(relationship[0].enabled).toBe(true);
     });
 
-    it("should ignore a skills-only tool", async () => {
+    it("should reject a skills-only tool", async () => {
       const { workspace, conversation, auth, globalSpace } =
         await setupTest("admin");
 
@@ -169,8 +169,12 @@ describe("POST /api/w/:wId/assistant/conversations/:cId/tools", () => {
         mcp_server_view_id: mcpServerView.sId,
       });
 
-      expect(response.status).toBe(200);
-      expect((await response.json()).success).toBe(true);
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body.error.type).toBe("invalid_request_error");
+      expect(body.error.message).toBe(
+        "This MCP server is restricted to skills and cannot be added directly to a conversation."
+      );
 
       const relationships = await ConversationResource.fetchMCPServerViews(
         auth,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.ts
@@ -103,7 +103,14 @@ app.post(
     }
 
     if (action === "add" && mcpServerView.isRestrictedToSkills) {
-      return ctx.json({ success: true });
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "This MCP server is restricted to skills and cannot be added directly to a conversation.",
+        },
+      });
     }
 
     const upsertResult = await ConversationResource.upsertMCPServerViews(auth, {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.ts
@@ -102,6 +102,10 @@ app.post(
       });
     }
 
+    if (action === "add" && mcpServerView.isRestrictedToSkills) {
+      return ctx.json({ success: true });
+    }
+
     const upsertResult = await ConversationResource.upsertMCPServerViews(auth, {
       conversation,
       mcpServerViews: [mcpServerView],

--- a/front-api/routes/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/index.ts
@@ -387,7 +387,8 @@ app.post(
       if (message.context.selectedMCPServerViewIds) {
         const mcpServerViews = await MCPServerViewResource.fetchByIds(
           auth,
-          message.context.selectedMCPServerViewIds
+          message.context.selectedMCPServerViewIds,
+          { isRestrictedToSkills: false }
         );
 
         const r = await ConversationResource.upsertMCPServerViews(auth, {

--- a/front/lib/api/assistant/configuration/create_or_upgrade.ts
+++ b/front/lib/api/assistant/configuration/create_or_upgrade.ts
@@ -15,6 +15,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { getModelTierAccessErrorForAgentConfiguration } from "@app/lib/model_tiers/access";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
@@ -46,7 +47,19 @@ export async function createOrUpgradeAgentConfiguration({
   agentConfigurationId?: string;
   authorId?: ModelId;
 }): Promise<Result<AgentConfigurationType, Error>> {
-  const { actions } = assistant;
+  const skillsOnlyViewIds = new Set(
+    (
+      await MCPServerViewResource.fetchByIds(
+        auth,
+        assistant.actions.map((action) => action.mcpServerViewId)
+      )
+    )
+      .filter((view) => view.isRestrictedToSkills)
+      .map((view) => view.sId)
+  );
+  const actions = assistant.actions.filter(
+    (action) => !skillsOnlyViewIds.has(action.mcpServerViewId)
+  );
 
   // Tools mode:
   // Enforce that every action has a name and a description and that every name is unique.

--- a/front/lib/api/assistant/configuration/create_or_upgrade.ts
+++ b/front/lib/api/assistant/configuration/create_or_upgrade.ts
@@ -47,13 +47,12 @@ export async function createOrUpgradeAgentConfiguration({
   agentConfigurationId?: string;
   authorId?: ModelId;
 }): Promise<Result<AgentConfigurationType, Error>> {
+  const mcpServerViews = await MCPServerViewResource.fetchByIds(
+    auth,
+    assistant.actions.map((action) => action.mcpServerViewId)
+  );
   const skillsOnlyViewIds = new Set(
-    (
-      await MCPServerViewResource.fetchByIds(
-        auth,
-        assistant.actions.map((action) => action.mcpServerViewId)
-      )
-    )
+    mcpServerViews
       .filter((view) => view.isRestrictedToSkills)
       .map((view) => view.sId)
   );

--- a/front/lib/api/assistant/configuration/create_or_upgrade.ts
+++ b/front/lib/api/assistant/configuration/create_or_upgrade.ts
@@ -47,15 +47,12 @@ export async function createOrUpgradeAgentConfiguration({
   agentConfigurationId?: string;
   authorId?: ModelId;
 }): Promise<Result<AgentConfigurationType, Error>> {
-  const mcpServerViews = await MCPServerViewResource.fetchByIds(
+  const skillsOnlyViews = await MCPServerViewResource.fetchByIds(
     auth,
-    assistant.actions.map((action) => action.mcpServerViewId)
+    assistant.actions.map((action) => action.mcpServerViewId),
+    { isRestrictedToSkills: true }
   );
-  const skillsOnlyViewIds = new Set(
-    mcpServerViews
-      .filter((view) => view.isRestrictedToSkills)
-      .map((view) => view.sId)
-  );
+  const skillsOnlyViewIds = new Set(skillsOnlyViews.map((view) => view.sId));
   const actions = assistant.actions.filter(
     (action) => !skillsOnlyViewIds.has(action.mcpServerViewId)
   );

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -4621,11 +4621,16 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       | { source: "conversation"; agentConfigurationId: null }
     )
   ): Promise<Result<undefined, Error>> {
+    const mcpServerViewsToUpsert =
+      source === "conversation" && enabled
+        ? mcpServerViews.filter((view) => !view.isRestrictedToSkills)
+        : mcpServerViews;
+
     // For now we only allow MCP server views from the Company Space.
     // It's blocked in the UI but it's a last line of defense.
     // If we lift this limit, we should handle the requestedSpaceIds on the conversation.
     if (
-      mcpServerViews.some(
+      mcpServerViewsToUpsert.some(
         (mcpServerViewResource) => mcpServerViewResource.space.kind !== "global"
       )
     ) {
@@ -4649,7 +4654,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       });
 
     // Cycle through the mcpServerViewIds and create or update the conversationMCPServerView
-    for (const mcpServerView of mcpServerViews) {
+    for (const mcpServerView of mcpServerViewsToUpsert) {
       const existingConversationMCPServerView =
         existingConversationMCPServerViews.find(
           (view) => view.mcpServerViewId === mcpServerView.id

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -4621,16 +4621,11 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       | { source: "conversation"; agentConfigurationId: null }
     )
   ): Promise<Result<undefined, Error>> {
-    const mcpServerViewsToUpsert =
-      source === "conversation" && enabled
-        ? mcpServerViews.filter((view) => !view.isRestrictedToSkills)
-        : mcpServerViews;
-
     // For now we only allow MCP server views from the Company Space.
     // It's blocked in the UI but it's a last line of defense.
     // If we lift this limit, we should handle the requestedSpaceIds on the conversation.
     if (
-      mcpServerViewsToUpsert.some(
+      mcpServerViews.some(
         (mcpServerViewResource) => mcpServerViewResource.space.kind !== "global"
       )
     ) {
@@ -4654,7 +4649,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       });
 
     // Cycle through the mcpServerViewIds and create or update the conversationMCPServerView
-    for (const mcpServerView of mcpServerViewsToUpsert) {
+    for (const mcpServerView of mcpServerViews) {
       const existingConversationMCPServerView =
         existingConversationMCPServerViews.find(
           (view) => view.mcpServerViewId === mcpServerView.id

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -424,10 +424,12 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     {
       includeMetadata = true,
       includeHeavyAttributes,
+      isRestrictedToSkills,
       transaction,
     }: {
       includeMetadata?: boolean;
       includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+      isRestrictedToSkills?: boolean;
       transaction?: Transaction;
     } = {}
   ) {
@@ -437,6 +439,9 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         ...options,
         where: {
           ...options.where,
+          ...(isRestrictedToSkills !== undefined
+            ? { isRestrictedToSkills }
+            : {}),
           workspaceId: auth.getNonNullableWorkspace().id,
         },
         includes: [
@@ -576,6 +581,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     id: string,
     options?: ResourceFindOptions<MCPServerViewModel> & {
       includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+      isRestrictedToSkills?: boolean;
     }
   ): Promise<MCPServerViewResource | null> {
     const [mcpServerView] = await this.fetchByIds(auth, [id], options);
@@ -588,10 +594,12 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     ids: string[],
     options?: ResourceFindOptions<MCPServerViewModel> & {
       includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
+      isRestrictedToSkills?: boolean;
     }
   ): Promise<MCPServerViewResource[]> {
     const viewModelIds = removeNulls(ids.map((id) => getResourceIdFromSId(id)));
-    const { includeHeavyAttributes, ...findOptions } = options ?? {};
+    const { includeHeavyAttributes, isRestrictedToSkills, ...findOptions } =
+      options ?? {};
 
     const views = await this.baseFetch(
       auth,
@@ -604,7 +612,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
           },
         },
       },
-      { includeHeavyAttributes }
+      { includeHeavyAttributes, isRestrictedToSkills }
     );
 
     return views ?? [];


### PR DESCRIPTION
## Overall goal

Some MCP tools rely on skill instructions for workspace-specific guidance, safety rules, or shortcuts that avoid unnecessary runtime research and credit spend. Exposing the raw tool directly lets agents bypass that context. The overall goal here is to let admins keep an MCP server available only through skills.

Part of https://github.com/dust-tt/tasks/issues/9792

## Description

This PR adds a backend check to prevent saving an agent with tools that are restricted to skills + same for adding tools from the input bar.

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
