### PR TITLE
[front] enh: hide skills-only MCP servers from direct selection

### DIFF
--- a/front-api/routes/w/[wId]/mcp/available.ts
+++ b/front-api/routes/w/[wId]/mcp/available.ts
@@ -29,8 +29,10 @@ app.get("/", async (ctx): HandlerResult<GetMCPServersResponseBody> => {
     )
   ).map((r) => r.toJSON());
 
+  const systemMCPServerViews =
+    await MCPServerViewResource.listForSystemSpace(auth);
   const restrictedServerIds = new Set(
-    (await MCPServerViewResource.listForSystemSpace(auth))
+    systemMCPServerViews
       .filter((view) => view.isRestrictedToSkills)
       .map((view) => view.mcpServerId)
   );

--- a/front-api/routes/w/[wId]/mcp/available.ts
+++ b/front-api/routes/w/[wId]/mcp/available.ts
@@ -1,6 +1,7 @@
 import type { MCPServerType } from "@app/lib/api/mcp";
 import { DefaultRemoteMCPServerInMemoryResource } from "@app/lib/resources/default_remote_mcp_server_in_memory_resource";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
@@ -28,9 +29,17 @@ app.get("/", async (ctx): HandlerResult<GetMCPServersResponseBody> => {
     )
   ).map((r) => r.toJSON());
 
+  const restrictedServerIds = new Set(
+    (await MCPServerViewResource.listForSystemSpace(auth))
+      .filter((view) => view.isRestrictedToSkills)
+      .map((view) => view.mcpServerId)
+  );
+
   return ctx.json({
     success: true,
-    servers: [...internalServers, ...defaultRemoteServers],
+    servers: [...internalServers, ...defaultRemoteServers].filter(
+      (server) => !restrictedServerIds.has(server.sId)
+    ),
   });
 });
 

--- a/front-api/routes/w/[wId]/mcp/views/index.test.ts
+++ b/front-api/routes/w/[wId]/mcp/views/index.test.ts
@@ -1,4 +1,5 @@
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
@@ -29,12 +30,14 @@ describe("GET /api/w/:wId/mcp/views", () => {
         },
       ],
     });
-    await MCPServerViewFactory.create(workspace, server.sId, globalSpace);
-
-    const response = await honoApp.request(
-      `/api/w/${workspace.sId}/mcp/views?spaceIds=${globalSpace.sId}` +
-        `&availabilities=manual,auto`
+    const view = await MCPServerViewFactory.create(
+      workspace,
+      server.sId,
+      globalSpace
     );
+
+    const url = `/api/w/${workspace.sId}/mcp/views?spaceIds=${globalSpace.sId}&availabilities=manual,auto`;
+    const response = await honoApp.request(url);
 
     expect(response.status).toBe(200);
     const body = await response.json();
@@ -49,5 +52,26 @@ describe("GET /api/w/:wId/mcp/views", () => {
     expect(serverView?.server.tools[0].inputSchema).toEqual(plainInputSchema);
     expect(serverView?.server).toHaveProperty("url");
     expect(serverView?.server).toHaveProperty("sharedSecret");
+
+    await MCPServerViewModel.update(
+      { isRestrictedToSkills: true },
+      { where: { id: view.id } }
+    );
+
+    const defaultResponse = await honoApp.request(url);
+    const defaultBody = await defaultResponse.json();
+    expect(
+      defaultBody.serverViews.some((v: MCPServerViewType) => v.sId === view.sId)
+    ).toBe(false);
+
+    const skillBuilderResponse = await honoApp.request(
+      `${url}&includeRestrictedToSkills=true`
+    );
+    const skillBuilderBody = await skillBuilderResponse.json();
+    const skillBuilderView = skillBuilderBody.serverViews.find(
+      (v: MCPServerViewType) => v.sId === view.sId
+    );
+    expect(skillBuilderView).toBeDefined();
+    expect(skillBuilderView).not.toHaveProperty("isRestrictedToSkills");
   });
 });

--- a/front-api/routes/w/[wId]/mcp/views/index.test.ts
+++ b/front-api/routes/w/[wId]/mcp/views/index.test.ts
@@ -36,7 +36,12 @@ describe("GET /api/w/:wId/mcp/views", () => {
       globalSpace
     );
 
-    const url = `/api/w/${workspace.sId}/mcp/views?spaceIds=${globalSpace.sId}&availabilities=manual,auto`;
+    const baseUrl = `/api/w/${workspace.sId}/mcp/views`;
+    const queryParams = new URLSearchParams({
+      spaceIds: globalSpace.sId,
+      availabilities: "manual,auto",
+    });
+    const url = `${baseUrl}?${queryParams.toString()}`;
     const response = await honoApp.request(url);
 
     expect(response.status).toBe(200);
@@ -64,9 +69,9 @@ describe("GET /api/w/:wId/mcp/views", () => {
       defaultBody.serverViews.some((v: MCPServerViewType) => v.sId === view.sId)
     ).toBe(false);
 
-    const skillBuilderResponse = await honoApp.request(
-      `${url}&includeRestrictedToSkills=true`
-    );
+    queryParams.set("includeRestrictedToSkills", "true");
+    const skillBuilderUrl = `${baseUrl}?${queryParams.toString()}`;
+    const skillBuilderResponse = await honoApp.request(skillBuilderUrl);
     const skillBuilderBody = await skillBuilderResponse.json();
     const skillBuilderView = skillBuilderBody.serverViews.find(
       (v: MCPServerViewType) => v.sId === view.sId

--- a/front-api/routes/w/[wId]/mcp/views/index.ts
+++ b/front-api/routes/w/[wId]/mcp/views/index.ts
@@ -81,6 +81,11 @@ app.get("/", async (ctx): HandlerResult<GetMCPServerViewsListResponseBody> => {
   );
 
   const flattenedServerViews = views
+    .filter(
+      (view) =>
+        ctx.req.query("includeRestrictedToSkills") === "true" ||
+        !view.isRestrictedToSkills
+    )
     .map((v) => v.toJSON())
     .filter(
       (v) =>

--- a/front-api/routes/w/[wId]/mcp/views/jit.test.ts
+++ b/front-api/routes/w/[wId]/mcp/views/jit.test.ts
@@ -119,6 +119,41 @@ describe("GET /api/w/:wId/mcp/views/jit", () => {
     }
   });
 
+  it("filters out views restricted to skills", async () => {
+    const { workspace, globalSpace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const server = await RemoteMCPServerFactory.create(workspace, {
+      name: "Skills-only Server",
+      url: "https://skills-only-server.example.com",
+      tools: [
+        {
+          name: "search",
+          description: "Search things",
+          inputSchema: plainInputSchema,
+        },
+      ],
+    });
+    const view = await MCPServerViewFactory.create(
+      workspace,
+      server.sId,
+      globalSpace
+    );
+    const updateResult = await view.updateIsRestrictedToSkills(auth, true);
+    expect(updateResult.isOk()).toBe(true);
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/mcp/views/jit?spaceIds=${globalSpace.sId}`
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    const serverViews: MCPServerViewLightType[] = body.serverViews;
+    expect(
+      serverViews.some((serverView) => serverView.server.sId === server.sId)
+    ).toBe(false);
+  });
+
   it("returns 400 without spaceIds", async () => {
     const { workspace } = await createPrivateApiMockRequest({ role: "user" });
 

--- a/front-api/routes/w/[wId]/mcp/views/jit.ts
+++ b/front-api/routes/w/[wId]/mcp/views/jit.ts
@@ -59,6 +59,7 @@ app.get(
         const { availability } = v.getServerDisplayMetadata();
         return availability === "manual" || availability === "auto";
       })
+      .filter((v) => !v.isRestrictedToSkills)
       .filter((v) => v.isJITAttachable())
       .map((v) => v.toJSONLight());
 

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -142,7 +142,9 @@ app.get(
           "sharedSecret",
         ],
       })
-    ).map((view) => view.toJSON());
+    )
+      .filter((view) => auth.isAdmin() || !view.isRestrictedToSkills)
+      .map((view) => view.toJSON());
 
     const filteredServerViews = serverViews.filter(
       (s) => availability === "all" || s.server.availability === availability

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -142,9 +142,7 @@ app.get(
           "sharedSecret",
         ],
       })
-    )
-      .filter((view) => auth.isAdmin() || !view.isRestrictedToSkills)
-      .map((view) => view.toJSON());
+    ).map((view) => view.toJSON());
 
     const filteredServerViews = serverViews.filter(
       (s) => availability === "all" || s.server.availability === availability

--- a/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
@@ -130,7 +130,9 @@ export function useSkillBuilderSlashCommandCapabilities({
     status: "active",
   });
   const { serverViews, isLoading: isServerViewsLoading } =
-    useMCPServerViewsFromSpaces(owner, spaces);
+    useMCPServerViewsFromSpaces(owner, spaces, {
+      includeRestrictedToSkills: true,
+    });
 
   const tools = useMemo(
     () => getSkillBuilderSlashCommandTools({ serverViews, spaces }),

--- a/front/components/shared/tools_picker/MCPServerViewsContext.tsx
+++ b/front/components/shared/tools_picker/MCPServerViewsContext.tsx
@@ -137,11 +137,13 @@ export const useMaybeMCPServerViewsContext = () => {
 interface MCPServerViewsProviderProps {
   owner: LightWorkspaceType;
   children: ReactNode;
+  includeRestrictedToSkills?: boolean;
 }
 
 export const MCPServerViewsProvider = ({
   owner,
   children,
+  includeRestrictedToSkills = false,
 }: MCPServerViewsProviderProps) => {
   const { spaces, isSpacesLoading } = useSpacesContext();
 
@@ -150,6 +152,7 @@ export const MCPServerViewsProvider = ({
     isLoading,
     isError: isMCPServerViewsError,
   } = useMCPServerViewsFromSpaces(owner, spaces, {
+    includeRestrictedToSkills,
     revalidateIfStale: false,
     revalidateOnFocus: false,
   });

--- a/front/components/skill_builder/SkillBuilderContext.tsx
+++ b/front/components/skill_builder/SkillBuilderContext.tsx
@@ -71,7 +71,7 @@ export function SkillBuilderProvider({
   return (
     <SkillBuilderContext.Provider value={value}>
       <SpacesProvider owner={owner}>
-        <MCPServerViewsProvider owner={owner}>
+        <MCPServerViewsProvider owner={owner} includeRestrictedToSkills>
           {children}
         </MCPServerViewsProvider>
       </SpacesProvider>

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -1261,12 +1261,15 @@ function useMCPServerViewsFromSpacesBase(
   const configFetcher: Fetcher<GetMCPServerViewsListResponseBody> = fetcher;
   const { includeRestrictedToSkills = false, ...swrOptions } = options ?? {};
 
-  const spaceIds = spaces.map((s) => s.sId).join(",");
-  const availabilitiesParam = availabilities.join(",");
+  const queryParams = new URLSearchParams({
+    spaceIds: spaces.map((s) => s.sId).join(","),
+    availabilities: availabilities.join(","),
+  });
+  if (includeRestrictedToSkills) {
+    queryParams.set("includeRestrictedToSkills", "true");
+  }
 
-  const url =
-    `/api/w/${owner.sId}/mcp/views?spaceIds=${spaceIds}&availabilities=${availabilitiesParam}` +
-    (includeRestrictedToSkills ? "&includeRestrictedToSkills=true" : "");
+  const url = `/api/w/${owner.sId}/mcp/views?${queryParams.toString()}`;
   const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
     ...swrOptions,
     ...(!spaces.length ? { disabled: true } : {}),

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -1253,15 +1253,20 @@ function useMCPServerViewsFromSpacesBase(
   owner: LightWorkspaceType,
   spaces: SpaceType[],
   availabilities: MCPServerAvailability[],
-  swrOptions?: SWRConfiguration
+  options?: SWRConfiguration & {
+    includeRestrictedToSkills?: boolean;
+  }
 ) {
   const { fetcher } = useFetcher();
   const configFetcher: Fetcher<GetMCPServerViewsListResponseBody> = fetcher;
+  const { includeRestrictedToSkills = false, ...swrOptions } = options ?? {};
 
   const spaceIds = spaces.map((s) => s.sId).join(",");
   const availabilitiesParam = availabilities.join(",");
 
-  const url = `/api/w/${owner.sId}/mcp/views?spaceIds=${spaceIds}&availabilities=${availabilitiesParam}`;
+  const url =
+    `/api/w/${owner.sId}/mcp/views?spaceIds=${spaceIds}&availabilities=${availabilitiesParam}` +
+    (includeRestrictedToSkills ? "&includeRestrictedToSkills=true" : "");
   const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
     ...swrOptions,
     ...(!spaces.length ? { disabled: true } : {}),
@@ -1278,13 +1283,16 @@ function useMCPServerViewsFromSpacesBase(
 export function useMCPServerViewsFromSpaces(
   owner: LightWorkspaceType,
   spaces: SpaceType[],
-  swrOptions?: SWRConfiguration & { disabled?: boolean }
+  options?: SWRConfiguration & {
+    disabled?: boolean;
+    includeRestrictedToSkills?: boolean;
+  }
 ) {
   return useMCPServerViewsFromSpacesBase(
     owner,
     spaces,
     ["manual", "auto"],
-    swrOptions
+    options
   );
 }
 


### PR DESCRIPTION
## Overall goal

Some MCP tools rely on skill instructions for workspace-specific guidance, safety rules, or shortcuts that avoid unnecessary runtime research and credit spend. Exposing the raw tool directly lets agents bypass that context. The overall goal here is to let admins keep an MCP server available only through skills.

Part of https://github.com/dust-tt/tasks/issues/9792

## Description

This PR hides skills-only MCP servers from the list in agent builder and in the input bar.

## Tests

- Updated existing tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
