### PR TITLE
[FILES] Fix stale Office document previews in conversations

### DIFF
--- a/front/components/assistant/conversation/FilePreviewContext.tsx
+++ b/front/components/assistant/conversation/FilePreviewContext.tsx
@@ -83,7 +83,9 @@ export function FilePreviewProvider({
           fileId: file.fileId ?? null,
           thumbnailUrl: null,
           sizeBytes: 0,
-          lastModifiedMs: 0,
+          // No mtime here: stands in to cache-bust the per-URL cached PDF
+          // conversion, so an edited file stops rendering its stale one.
+          lastModifiedMs: Date.now(),
         },
         fileUrl,
         downloadUrl,


### PR DESCRIPTION
## Description

Fixes https://github.com/orgs/dust-tt/projects/2/views/1?pane=issue&itemId=218870553&issue=dust-tt%7Ctasks%7C9807

Office previews opened from a conversation kept rendering a stale PDF conversion after
the agent updated the file: the `?preview=pdf` URL is path-based and its response is
cached for an hour, and the `v=` cache-buster was never emitted because
`FilePreviewContext` hardcoded `lastModifiedMs: 0` (falsy). Stamping the open time makes
each open a distinct URL, so the request reaches the server and LibreOffice converts the
current bytes.

Deliberately the 80/20 fix rather than plumbing a real mtime (`lastModifiedMs` on
`stat()` → `Last-Modified` on the HEAD route → a client-side stat before opening): the
blast radius is one line in one provider, mounted only in `ConversationLayout`, and only
the Office→PDF conversion path reads that value. The cost is that immutable Office
attachments now re-convert on every open instead of hitting the browser cache for an
hour — a few seconds of Gotenberg work on a user-initiated click. The mtime version is
the upgrade if that load ever becomes visible.

## Tests

Tested locally: opened an agent-generated `.pptx` preview across turns and confirmed the
updated deck renders instead of the previous version.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`
