### PR TITLE
Add requested-duration field and spend-limit timeframe to upgrade requests

### DIFF
--- a/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
@@ -106,7 +106,7 @@ describe("/api/w/[wId]/credits/upgrade-requests", () => {
       expect(body.request.requester.sId).toBe(user.sId);
     });
 
-    it("stores the reason when provided", async () => {
+    it("stores the reason and requested duration when provided", async () => {
       const workspace = await creditPricedWorkspace();
       await createPrivateApiMockRequest({
         method: "POST",
@@ -121,6 +121,7 @@ describe("/api/w/[wId]/credits/upgrade-requests", () => {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             reason: "Running a large one-off backfill this week.",
+            requestedDurationDays: 7,
           }),
         }
       );
@@ -130,6 +131,7 @@ describe("/api/w/[wId]/credits/upgrade-requests", () => {
       expect(request.reason).toBe(
         "Running a large one-off backfill this week."
       );
+      expect(request.requestedDurationDays).toBe(7);
     });
 
     it("rejects a reason shorter than the minimum length", async () => {
@@ -145,7 +147,7 @@ describe("/api/w/[wId]/credits/upgrade-requests", () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ reason: "short" }),
+          body: JSON.stringify({ reason: "short", requestedDurationDays: 1 }),
         }
       );
 

--- a/front-api/routes/w/[wId]/credits/upgrade-requests.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.ts
@@ -12,7 +12,9 @@ import type {
 } from "@app/types/api/credits/upgrade_requests";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import {
+  MAX_UPGRADE_REQUEST_DURATION_DAYS,
   MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS,
+  MIN_UPGRADE_REQUEST_DURATION_DAYS,
   MIN_UPGRADE_REQUEST_REASON_LENGTH_CHARS,
 } from "@app/types/memberships";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -30,16 +32,22 @@ const ResolveBodySchema = z.object({
   status: z.union([z.literal("approved"), z.literal("denied")]),
 });
 
-// TODO(BACK12): make `reason` required once the client update that always
-// sends it (front's upgrade-request modal) has rolled out to all users.
-// Optional for now so the existing client, which posts an empty body, keeps
-// working until then.
+// TODO(BACK12): make `reason`/`requestedDurationDays` required once the
+// client update that always sends them (front's upgrade-request modal) has
+// rolled out to all users. Optional for now so the existing client, which
+// posts an empty body, keeps working until then.
 const CreateUpgradeRequestBodySchema = z.object({
   reason: z
     .string()
     .trim()
     .min(MIN_UPGRADE_REQUEST_REASON_LENGTH_CHARS)
     .max(MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS)
+    .optional(),
+  requestedDurationDays: z
+    .number()
+    .int()
+    .min(MIN_UPGRADE_REQUEST_DURATION_DAYS)
+    .max(MAX_UPGRADE_REQUEST_DURATION_DAYS)
     .optional(),
 });
 
@@ -101,9 +109,10 @@ app.post(
   validate("json", CreateUpgradeRequestBodySchema),
   async (ctx): HandlerResult<PostUpgradeRequestResponseBody> => {
     const auth = ctx.get("auth");
-    const { reason } = ctx.req.valid("json");
+    const { reason, requestedDurationDays } = ctx.req.valid("json");
     const result = await createUpgradeRequest(auth, {
       reason: reason ?? null,
+      requestedDurationDays: requestedDurationDays ?? null,
       auditContext: getAuditLogContext(auth),
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -116,6 +116,47 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
       expect(await getResponse.json()).toEqual({
         kind: "limited",
         awuCredits: 1500,
+        timeframe: null,
+      });
+    });
+
+    it("persists and returns the override timeframe when provided", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+      });
+
+      await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "manager",
+        workspace,
+      });
+
+      const putResponse = await honoApp.request(
+        spendLimitUrl(workspace.sId, targetUser.sId),
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            kind: "limited",
+            awuCredits: 500,
+            timeframe: "week",
+          }),
+        }
+      );
+      expect(putResponse.status).toBe(200);
+      expect(await putResponse.json()).toEqual({
+        limit: { kind: "limited", awuCredits: 500, timeframe: "week" },
+      });
+
+      const getResponse = await honoApp.request(
+        spendLimitUrl(workspace.sId, targetUser.sId)
+      );
+      expect(await getResponse.json()).toEqual({
+        kind: "limited",
+        awuCredits: 500,
+        timeframe: "week",
       });
     });
 
@@ -262,7 +303,9 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
         targetUser,
         { role: "user" }
       );
-      await membership.updatePoolCapOverride(2500);
+      await membership.updatePoolCapOverride({
+        poolCapOverrideAwuCredits: 2500,
+      });
 
       await createPrivateApiMockRequest({
         method: "GET",
@@ -278,6 +321,7 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
       expect(await response.json()).toEqual({
         kind: "limited",
         awuCredits: 2500,
+        timeframe: null,
       });
     });
   });
@@ -291,7 +335,9 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
         targetUser,
         { role: "user" }
       );
-      await membership.updatePoolCapOverride(1200);
+      await membership.updatePoolCapOverride({
+        poolCapOverrideAwuCredits: 1200,
+      });
 
       await createPrivateApiMockRequest({
         method: "PUT",

--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
@@ -10,6 +10,7 @@ import type {
   GetUserSpendLimitResponseBody,
   PutUserSpendLimitResponseBody,
 } from "@app/types/api/users/spend_limit";
+import { SPEND_LIMIT_OVERRIDE_TIMEFRAMES } from "@app/types/credits";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -27,6 +28,7 @@ const UpdateUserSpendLimitBodySchema = z.discriminatedUnion("kind", [
       .int()
       .min(MIN_USER_SPEND_LIMIT_AWU_CREDITS)
       .max(MAX_USER_SPEND_LIMIT_AWU_CREDITS),
+    timeframe: z.enum(SPEND_LIMIT_OVERRIDE_TIMEFRAMES).nullable().optional(),
   }),
 ]);
 

--- a/front-api/routes/w/[wId]/members/bulk-spend-limit.ts
+++ b/front-api/routes/w/[wId]/members/bulk-spend-limit.ts
@@ -7,6 +7,7 @@ import {
   MIN_USER_SPEND_LIMIT_AWU_CREDITS,
 } from "@app/lib/api/users/spend_limit";
 import { runBulkSetUserSpendLimitWorkflow } from "@app/temporal/bulk_spend_limit/client";
+import { SPEND_LIMIT_OVERRIDE_TIMEFRAMES } from "@app/types/credits";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -22,6 +23,7 @@ const LimitSchema = z.discriminatedUnion("kind", [
       .int()
       .min(MIN_USER_SPEND_LIMIT_AWU_CREDITS)
       .max(MAX_USER_SPEND_LIMIT_AWU_CREDITS),
+    timeframe: z.enum(SPEND_LIMIT_OVERRIDE_TIMEFRAMES).nullable().optional(),
   }),
 ]);
 

--- a/front/admin/audit_log_schemas/member.spend_limit_updated.json
+++ b/front/admin/audit_log_schemas/member.spend_limit_updated.json
@@ -10,6 +10,7 @@
   ],
   "metadata": {
     "kind": "string",
-    "awu_credits": "string"
+    "awu_credits": "string",
+    "timeframe": "string"
   }
 }

--- a/front/admin/audit_log_schemas/membership.upgrade_request_created.json
+++ b/front/admin/audit_log_schemas/membership.upgrade_request_created.json
@@ -10,6 +10,7 @@
   ],
   "metadata": {
     "request_sid": "string",
-    "reason": "string"
+    "reason": "string",
+    "requested_duration_days": "string"
   }
 }

--- a/front/components/credits/UsageUpgradeButton.tsx
+++ b/front/components/credits/UsageUpgradeButton.tsx
@@ -53,26 +53,34 @@ function durationLabel(days: number): string {
   }
 }
 
+const DURATION_FIELD_LABEL_ID = "upgrade-request-duration-label";
+
 function DurationField() {
   const { field } = useController<RequestUpgradeFormValues>({
     name: "requestedDurationDays",
   });
 
   return (
-    <RadioGroup
-      value={String(field.value)}
-      onValueChange={(v) => field.onChange(Number(v))}
-      className="flex flex-row gap-4"
-    >
-      {DURATION_PRESETS_DAYS.map((days) => (
-        <RadioGroupItem
-          key={days}
-          value={String(days)}
-          id={`upgrade-request-duration-${days}`}
-          label={durationLabel(days)}
-        />
-      ))}
-    </RadioGroup>
+    <div className="flex flex-col gap-2">
+      <label id={DURATION_FIELD_LABEL_ID} className="text-sm font-medium">
+        How long do you need it?
+      </label>
+      <RadioGroup
+        aria-labelledby={DURATION_FIELD_LABEL_ID}
+        value={String(field.value)}
+        onValueChange={(v) => field.onChange(Number(v))}
+        className="flex flex-row gap-4"
+      >
+        {DURATION_PRESETS_DAYS.map((days) => (
+          <RadioGroupItem
+            key={days}
+            value={String(days)}
+            id={`upgrade-request-duration-${days}`}
+            label={durationLabel(days)}
+          />
+        ))}
+      </RadioGroup>
+    </div>
   );
 }
 
@@ -224,12 +232,7 @@ export function UsageUpgradeButton({
                     );
                   }}
                 </BaseFormFieldSection>
-                <div className="flex flex-col gap-2">
-                  <label className="text-sm font-medium">
-                    How long do you need it?
-                  </label>
-                  <DurationField />
-                </div>
+                <DurationField />
               </div>
             </DialogContainer>
             <DialogFooter

--- a/front/components/credits/UsageUpgradeButton.tsx
+++ b/front/components/credits/UsageUpgradeButton.tsx
@@ -15,12 +15,16 @@ import {
   DialogHeader,
   DialogTitle,
   Hoverable,
+  RadioGroup,
+  RadioGroupItem,
   TextArea,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useState } from "react";
-import { FormProvider, useForm } from "react-hook-form";
+import { FormProvider, useController, useForm } from "react-hook-form";
 import { z } from "zod";
+
+const DURATION_PRESETS_DAYS = [1, 7, 30] as const;
 
 const requestUpgradeFormSchema = z.object({
   reason: z
@@ -31,9 +35,46 @@ const requestUpgradeFormSchema = z.object({
       "Tell your admin why you need this."
     )
     .max(MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS),
+  requestedDurationDays: z.number().int().min(1),
 });
 
 type RequestUpgradeFormValues = z.infer<typeof requestUpgradeFormSchema>;
+
+function durationLabel(days: number): string {
+  switch (days) {
+    case 1:
+      return "A day";
+    case 7:
+      return "A week";
+    case 30:
+      return "A month";
+    default:
+      return `${days} days`;
+  }
+}
+
+function DurationField() {
+  const { field } = useController<RequestUpgradeFormValues>({
+    name: "requestedDurationDays",
+  });
+
+  return (
+    <RadioGroup
+      value={String(field.value)}
+      onValueChange={(v) => field.onChange(Number(v))}
+      className="flex flex-row gap-4"
+    >
+      {DURATION_PRESETS_DAYS.map((days) => (
+        <RadioGroupItem
+          key={days}
+          value={String(days)}
+          id={`upgrade-request-duration-${days}`}
+          label={durationLabel(days)}
+        />
+      ))}
+    </RadioGroup>
+  );
+}
 
 type UsageUpgradeButtonVariant = "link" | "button";
 
@@ -63,7 +104,7 @@ export function UsageUpgradeButton({
 
   const form = useForm<RequestUpgradeFormValues>({
     resolver: zodResolver(requestUpgradeFormSchema),
-    defaultValues: { reason: "" },
+    defaultValues: { reason: "", requestedDurationDays: 7 },
   });
 
   const alreadyRequested = hasPendingUpgradeRequest || requested;
@@ -183,6 +224,12 @@ export function UsageUpgradeButton({
                     );
                   }}
                 </BaseFormFieldSection>
+                <div className="flex flex-col gap-2">
+                  <label className="text-sm font-medium">
+                    How long do you need it?
+                  </label>
+                  <DurationField />
+                </div>
               </div>
             </DialogContainer>
             <DialogFooter

--- a/front/components/workspace/BulkEditSpendLimitModal.tsx
+++ b/front/components/workspace/BulkEditSpendLimitModal.tsx
@@ -1,3 +1,6 @@
+import type { UserSpendLimit } from "@app/types/api/users/spend_limit";
+import type { SpendLimitOverrideTimeframeType } from "@app/types/credits";
+import { isSpendLimitOverrideTimeframeType } from "@app/types/credits";
 import {
   Dialog,
   DialogContainer,
@@ -20,9 +23,7 @@ function isSpendLimitKind(value: string): value is SpendLimitKind {
   return value === "default" || value === "override";
 }
 
-type SpendLimit =
-  | { kind: "unlimited" }
-  | { kind: "limited"; awuCredits: number };
+type SpendLimit = UserSpendLimit;
 
 interface BulkEditSpendLimitModalProps {
   isOpen: boolean;
@@ -65,6 +66,8 @@ function BulkEditSpendLimitForm({
 }: BulkEditSpendLimitFormProps) {
   const [kind, setKind] = useState<SpendLimitKind>("override");
   const [creditsInput, setCreditsInput] = useState<string>("");
+  const [timeframe, setTimeframe] =
+    useState<SpendLimitOverrideTimeframeType | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [validationMessage, setValidationMessage] = useState<string | null>(
     null
@@ -92,7 +95,7 @@ function BulkEditSpendLimitForm({
       );
       return null;
     }
-    return { kind: "limited", awuCredits: parsed };
+    return { kind: "limited", awuCredits: parsed, timeframe };
   }
 
   async function handleValidate() {
@@ -171,9 +174,37 @@ function BulkEditSpendLimitForm({
                   className="pr-28 text-right"
                 />
                 <span className="copy-sm pointer-events-none absolute right-3 top-0 flex h-9 items-center text-muted-foreground dark:text-muted-foreground-night">
-                  credits/month
+                  credits
                 </span>
               </div>
+              <RadioGroup
+                value={timeframe ?? "billing_cycle"}
+                onValueChange={(v) =>
+                  setTimeframe(isSpendLimitOverrideTimeframeType(v) ? v : null)
+                }
+                className="flex flex-row gap-4 pt-1"
+              >
+                <RadioGroupItem
+                  value="billing_cycle"
+                  id="bulk-spend-limit-timeframe-billing-cycle"
+                  label="Per billing cycle"
+                />
+                <RadioGroupItem
+                  value="day"
+                  id="bulk-spend-limit-timeframe-day"
+                  label="Per day"
+                />
+                <RadioGroupItem
+                  value="week"
+                  id="bulk-spend-limit-timeframe-week"
+                  label="Per week"
+                />
+                <RadioGroupItem
+                  value="month"
+                  id="bulk-spend-limit-timeframe-month"
+                  label="Per rolling month"
+                />
+              </RadioGroup>
             </div>
           )}
         </RadioGroup>

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -3,6 +3,9 @@ import {
   useUpdateUserSpendLimit,
   useUserSpendLimit,
 } from "@app/lib/swr/memberships";
+import type { UserSpendLimit } from "@app/types/api/users/spend_limit";
+import type { SpendLimitOverrideTimeframeType } from "@app/types/credits";
+import { isSpendLimitOverrideTimeframeType } from "@app/types/credits";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -74,6 +77,8 @@ export function EditSpendLimitModal({
 
   const [kind, setKind] = useState<SpendLimitKind>("override");
   const [creditsInput, setCreditsInput] = useState<string>("");
+  const [timeframe, setTimeframe] =
+    useState<SpendLimitOverrideTimeframeType | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [validationMessage, setValidationMessage] = useState<string | null>(
     null
@@ -92,10 +97,12 @@ export function EditSpendLimitModal({
       case "limited":
         setKind("override");
         setCreditsInput(String(spendLimit.awuCredits));
+        setTimeframe(spendLimit.timeframe ?? null);
         break;
       case "unlimited":
         setKind("default");
         setCreditsInput("");
+        setTimeframe(null);
         break;
       default:
         assertNeverAndIgnore(spendLimit);
@@ -154,15 +161,17 @@ export function EditSpendLimitModal({
     setIsSaving(true);
     onSavingChange?.(displayedMember.sId, true);
     try {
-      let limit:
-        | { kind: "unlimited" }
-        | { kind: "limited"; awuCredits: number };
+      let limit: UserSpendLimit;
       switch (kind) {
         case "default":
           limit = { kind: "unlimited" };
           break;
         case "override":
-          limit = { kind: "limited", awuCredits: result.awuCredits };
+          limit = {
+            kind: "limited",
+            awuCredits: result.awuCredits,
+            timeframe,
+          };
           break;
         default:
           assertNeverAndIgnore(kind);
@@ -207,9 +216,9 @@ export function EditSpendLimitModal({
                 Edit spend limit for {displayedMember?.name}
               </DialogTitle>
               <p className="text-sm text-muted-foreground">
-                Maximum pool credits this member can consume during a billing
-                cycle. This limit is added on top of the seat&apos;s built-in
-                allowance.
+                Maximum pool credits this member can consume, on top of the
+                seat&apos;s built-in allowance. Optionally enforced over a
+                shorter rolling window than the billing cycle.
               </p>
             </div>
           </div>
@@ -274,9 +283,39 @@ export function EditSpendLimitModal({
                       className="pr-28 text-right"
                     />
                     <span className="copy-sm pointer-events-none absolute right-3 top-0 flex h-9 items-center text-muted-foreground">
-                      credits/month
+                      credits
                     </span>
                   </div>
+                  <RadioGroup
+                    value={timeframe ?? "billing_cycle"}
+                    onValueChange={(v) =>
+                      setTimeframe(
+                        isSpendLimitOverrideTimeframeType(v) ? v : null
+                      )
+                    }
+                    className="flex flex-row gap-4 pt-1"
+                  >
+                    <RadioGroupItem
+                      value="billing_cycle"
+                      id="spend-limit-timeframe-billing-cycle"
+                      label="Per billing cycle"
+                    />
+                    <RadioGroupItem
+                      value="day"
+                      id="spend-limit-timeframe-day"
+                      label="Per day"
+                    />
+                    <RadioGroupItem
+                      value="week"
+                      id="spend-limit-timeframe-week"
+                      label="Per week"
+                    />
+                    <RadioGroupItem
+                      value="month"
+                      id="spend-limit-timeframe-month"
+                      label="Per rolling month"
+                    />
+                  </RadioGroup>
                 </div>
               )}
             </RadioGroup>

--- a/front/components/workspace/UpgradeRequestsTable.tsx
+++ b/front/components/workspace/UpgradeRequestsTable.tsx
@@ -81,15 +81,19 @@ const requestedColumn: ColumnDef<RowData, string> = {
   id: "requested" as const,
   header: "",
   accessorFn: (row) => row.createdAt.toString(),
-  cell: (info: Info) => (
-    <DataTable.CellContent>
-      <span className="text-sm text-muted-foreground">
-        {timeAgoFrom(info.row.original.createdAt, { useLongFormat: true })} ago
-      </span>
-    </DataTable.CellContent>
-  ),
+  cell: (info: Info) => {
+    const { createdAt, requestedDurationDays } = info.row.original.request;
+    return (
+      <DataTable.CellContent>
+        <span className="text-sm text-muted-foreground">
+          {timeAgoFrom(createdAt, { useLongFormat: true })} ago
+          {requestedDurationDays ? ` · needs ~${requestedDurationDays}d` : ""}
+        </span>
+      </DataTable.CellContent>
+    );
+  },
   meta: {
-    className: "w-32",
+    className: "w-40",
   },
 };
 

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -1676,6 +1676,81 @@ describe("postUserMessage", () => {
     rateLimiterSpy.mockRestore();
   });
 
+  it("should reject messages once the per-user override rate limit is reached", async () => {
+    const overrideWorkspace = await WorkspaceFactory.creditPriced();
+    const overrideUser = await UserFactory.basic();
+    await SpaceFactory.defaults(
+      await Authenticator.internalAdminForWorkspace(overrideWorkspace.sId)
+    );
+    const overrideMembership = await MembershipFactory.associate(
+      overrideWorkspace,
+      overrideUser,
+      { role: "user" }
+    );
+    await overrideMembership.updatePoolCapOverride({
+      poolCapOverrideAwuCredits: 100,
+      overrideLimitTimeframe: "day",
+    });
+    const overrideAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      overrideUser.sId,
+      overrideWorkspace.sId
+    );
+
+    const overrideAgent = await AgentConfigurationFactory.createTestAgent(
+      overrideAuth,
+      {
+        name: "Override Test Agent",
+        description: "Override Test Agent Description",
+      }
+    );
+    const overrideConversation = await ConversationFactory.create(
+      overrideAuth,
+      {
+        agentConfigurationId: overrideAgent.sId,
+        messagesCreatedAt: [],
+        visibility: "unlisted",
+      }
+    );
+    const fetchedOverrideConversation = await getConversation(
+      overrideAuth,
+      overrideConversation.sId
+    );
+    if (fetchedOverrideConversation.isErr()) {
+      throw new Error("Failed to fetch conversation");
+    }
+
+    const getRateLimiterCountSpy = vi
+      .spyOn(rateLimiterModule, "getRateLimiterCount")
+      .mockResolvedValue(new Ok(100));
+
+    const overrideUserJson = overrideUser.toJSON();
+    const result = await postUserMessage(overrideAuth, {
+      conversationResource: await fetchConversationResource(
+        overrideAuth,
+        overrideConversation.sId
+      ),
+      content: "Hello",
+      mentions: [],
+      context: {
+        username: overrideUserJson.username,
+        timezone: "UTC",
+        fullName: overrideUserJson.fullName,
+        email: overrideUserJson.email,
+        profilePictureUrl: overrideUserJson.image,
+        origin: "web",
+      },
+      skipToolsValidation: false,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.status_code).toBe(403);
+      expect(result.error.api_error.type).toBe("per_user_spend_limit_exceeded");
+    }
+
+    getRateLimiterCountSpy.mockRestore();
+  });
+
   it("should reject mentions of a retired global agent", async () => {
     const user = auth.getNonNullableUser();
     const userJson = user.toJSON();

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -42,6 +42,7 @@ import {
   makeMessageRateLimitKeyForWorkspaceActor,
   makeMessageRateLimitKeyForWorkspaceActorPerHour,
   makeProgrammaticUsageRateLimitKeyForWorkspace,
+  makeUserOverrideAwuCreditsRateLimitKeyForUser,
 } from "@app/lib/api/assistant/rate_limits";
 import {
   publishAgentMessagesEvents,
@@ -2438,6 +2439,7 @@ interface MessageLimit {
     | "rate_limit_error"
     | "plan_message_limit_exceeded"
     | "credits_exhausted"
+    | "per_user_spend_limit_exceeded"
     | null;
   message?: string;
 }
@@ -2458,6 +2460,8 @@ function getMessageLimitErrorMessage({
       return "The message limit for this plan has been exceeded.";
     case "credits_exhausted":
       return "Your workspace has run out of credits. Please purchase more credits to continue.";
+    case "per_user_spend_limit_exceeded":
+      return "You have reached your temporary usage limit. Contact your admin to raise it.";
     case "rate_limit_error":
       return "Rate limit exceeded. Please retry later.";
   }
@@ -2542,6 +2546,57 @@ async function checkMessagesLimit(
             message: "Your workspace has run out of credits.",
           },
         });
+      }
+
+      // Rolling-window counterpart to the Metronome-billing-period-based
+      // `user_cap_reached` check above: an admin can additionally cap this
+      // user's spend over a day/week/month window independent of the
+      // billing period. Only active when that override is configured.
+      if (user) {
+        const membership =
+          await MembershipResource.getActiveMembershipOfUserInWorkspace({
+            user,
+            workspace: owner,
+          });
+        if (
+          membership?.overrideLimitTimeframe &&
+          membership.poolCapOverrideAwuCredits !== null
+        ) {
+          const result = await getRateLimiterCount({
+            key: makeUserOverrideAwuCreditsRateLimitKeyForUser(
+              owner,
+              user.toJSON(),
+              membership.overrideLimitTimeframe
+            ),
+            timeframeSeconds: getTimeframeSecondsFromLiteral(
+              membership.overrideLimitTimeframe
+            ),
+          });
+          if (
+            result.isOk() &&
+            result.value >= membership.poolCapOverrideAwuCredits
+          ) {
+            return new Err({
+              status_code: 403,
+              api_error: {
+                type: "per_user_spend_limit_exceeded",
+                message: getMessageLimitErrorMessage({
+                  limitType: "per_user_spend_limit_exceeded",
+                }),
+              },
+            });
+          }
+          if (result.isErr()) {
+            logger.error(
+              {
+                workspaceId: owner.sId,
+                userId: user.sId,
+                error: result.error,
+              },
+              "Failed to read per-user spend-limit override rate limit."
+            );
+          }
+        }
       }
 
       // Pre-emptive concurrency limit based on pool credit state. Prevents

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -2,7 +2,10 @@ import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_ac
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import { getToolNameFromFunctionCallName } from "@app/lib/actions/tool_display_labels";
-import { makeFairUseAwuCreditsRateLimitKeyForUser } from "@app/lib/api/assistant/rate_limits";
+import {
+  makeFairUseAwuCreditsRateLimitKeyForUser,
+  makeUserOverrideAwuCreditsRateLimitKeyForUser,
+} from "@app/lib/api/assistant/rate_limits";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
 import type { ToolCostCategory } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
@@ -14,6 +17,7 @@ import {
 } from "@app/lib/metronome/events";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import {
@@ -289,6 +293,28 @@ export async function computeAndStoreAgentMessageCredits(
       incrementBy: costCredits,
       logger,
     });
+  }
+
+  if (user && costCredits !== null && costCredits > 0) {
+    const membership =
+      await MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user,
+        workspace: auth.getNonNullableWorkspace(),
+      });
+    if (membership?.overrideLimitTimeframe) {
+      await addRateLimiterCount({
+        key: makeUserOverrideAwuCreditsRateLimitKeyForUser(
+          auth.getNonNullableWorkspace(),
+          user.toJSON(),
+          membership.overrideLimitTimeframe
+        ),
+        timeframeSeconds: getTimeframeSecondsFromLiteral(
+          membership.overrideLimitTimeframe
+        ),
+        incrementBy: costCredits,
+        logger,
+      });
+    }
   }
 
   return costCredits;

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -6,6 +6,7 @@ import {
   getRateLimiterCount,
   getTimeframeSecondsFromLiteral,
 } from "@app/lib/utils/rate_limiter";
+import type { SpendLimitOverrideTimeframeType } from "@app/types/credits";
 import type {
   MaxAwuCreditsTimeframeType,
   MaxMessagesTimeframeType,
@@ -66,6 +67,19 @@ export const makeFairUseAwuCreditsRateLimitKeyForUser = (
   maxAwuCreditsTimeframe: MaxAwuCreditsTimeframeType
 ) => {
   return `workspace:${owner.id}:user:${user.id}:fair_use_awu_credit_count:${maxAwuCreditsTimeframe}`;
+};
+
+// Rolling-window counterpart to `Membership.poolCapOverrideAwuCredits` +
+// `overrideLimitTimeframe`: tracks a user's AWU consumption over the
+// admin-configured window, independent of the Metronome-billing-period-based
+// `user_cap_reached` alert that already enforces the cap over the implicit
+// monthly window.
+export const makeUserOverrideAwuCreditsRateLimitKeyForUser = (
+  owner: LightWorkspaceType,
+  user: UserType,
+  overrideLimitTimeframe: SpendLimitOverrideTimeframeType
+) => {
+  return `workspace:${owner.id}:user:${user.id}:override_awu_credit_count:${overrideLimitTimeframe}`;
 };
 
 export const makeProgrammaticUsageRateLimitKeyForWorkspace = (

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -81,6 +81,7 @@ async function notifyManagersAndAdminsOfUpgradeRequest(
       requesterName: requester.fullName() ?? requester.name,
       requesterEmail: requester.email ?? null,
       reason: request.reason,
+      requestedDurationDays: request.requestedDurationDays,
     });
   } catch (err) {
     logger.error(
@@ -97,8 +98,13 @@ export async function createUpgradeRequest(
   auth: Authenticator,
   {
     reason,
+    requestedDurationDays,
     auditContext,
-  }: { reason: string | null; auditContext?: AuditLogContext }
+  }: {
+    reason: string | null;
+    requestedDurationDays: number | null;
+    auditContext?: AuditLogContext;
+  }
 ): Promise<Result<MembershipUpgradeRequestType, UpgradeRequestError>> {
   const subscription = auth.getNonNullableSubscriptionResource();
   if (
@@ -147,6 +153,7 @@ export async function createUpgradeRequest(
   const result = await MembershipUpgradeRequestResource.createPending(auth, {
     user,
     reason,
+    requestedDurationDays,
   });
   if (result.isErr()) {
     return new Err(
@@ -169,6 +176,7 @@ export async function createUpgradeRequest(
     metadata: {
       request_sid: request.sId,
       reason: request.reason ?? "",
+      requested_duration_days: String(request.requestedDurationDays ?? ""),
     },
   });
 

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -116,6 +116,7 @@ export async function getUserSpendLimit(
   return new Ok({
     kind: "limited",
     awuCredits: membership.poolCapOverrideAwuCredits,
+    timeframe: membership.overrideLimitTimeframe,
   });
 }
 
@@ -197,9 +198,11 @@ export async function setUserSpendLimit(
   // Persist the admin's intent first: the membership is the source of truth,
   // the Metronome alerts below are derived enforcement (a failed sync can be
   // retried and re-derives from this value).
-  await membership.updatePoolCapOverride(
-    limit.kind === "limited" ? limit.awuCredits : null
-  );
+  await membership.updatePoolCapOverride({
+    poolCapOverrideAwuCredits:
+      limit.kind === "limited" ? limit.awuCredits : null,
+    overrideLimitTimeframe: limit.kind === "limited" ? limit.timeframe : null,
+  });
 
   switch (limit.kind) {
     case "unlimited": {
@@ -322,6 +325,8 @@ export async function setUserSpendLimit(
       kind: limit.kind,
       awu_credits:
         limit.kind === "limited" ? String(limit.awuCredits) : "unlimited",
+      timeframe:
+        limit.kind === "limited" && limit.timeframe ? limit.timeframe : "",
     },
   });
 

--- a/front/lib/notifications/workflows/upgrade-request-created.ts
+++ b/front/lib/notifications/workflows/upgrade-request-created.ts
@@ -16,6 +16,7 @@ const UpgradeRequestCreatedPayloadSchema = z.object({
   requesterName: z.string(),
   requesterEmail: z.string().nullable(),
   reason: z.string().nullable(),
+  requestedDurationDays: z.number().nullable(),
 });
 
 type UpgradeRequestCreatedPayloadType = z.infer<
@@ -36,7 +37,14 @@ function formatRequester(payload: UpgradeRequestCreatedPayloadType): string {
 function formatRequestDetails(
   payload: UpgradeRequestCreatedPayloadType
 ): string {
-  return payload.reason ? ` (reason: ${payload.reason})` : "";
+  const parts: string[] = [];
+  if (payload.reason) {
+    parts.push(`reason: ${payload.reason}`);
+  }
+  if (payload.requestedDurationDays) {
+    parts.push(`needed for ~${payload.requestedDurationDays} day(s)`);
+  }
+  return parts.length > 0 ? ` (${parts.join(", ")})` : "";
 }
 
 export const upgradeRequestCreatedWorkflow = workflow(
@@ -135,6 +143,7 @@ export function notifyUpgradeRequested({
   requesterName,
   requesterEmail,
   reason,
+  requestedDurationDays,
 }: {
   users: Array<{
     sId: string;
@@ -148,6 +157,7 @@ export function notifyUpgradeRequested({
   requesterName: string;
   requesterEmail: string | null;
   reason: string | null;
+  requestedDurationDays: number | null;
 }): void {
   if (users.length === 0) {
     return;
@@ -159,6 +169,7 @@ export function notifyUpgradeRequested({
     requesterName,
     requesterEmail,
     reason,
+    requestedDurationDays,
   };
 
   void getNovuClient()

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -18,6 +18,7 @@ import {
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger, { auditLog } from "@app/logger/logger";
 import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
+import type { SpendLimitOverrideTimeframeType } from "@app/types/credits";
 import {
   initialCreditStateForSeatType,
   isMembershipSeatType,
@@ -1598,12 +1599,30 @@ export class MembershipResource extends BaseResource<MembershipModel> {
    * excluded) of an active membership in place. `null` clears the override,
    * letting the seat-type default apply. Callers are responsible for syncing
    * the derived Metronome alerts.
+   *
+   * `overrideLimitTimeframe` additionally enforces the cap over a rolling
+   * day/week/month window (see `makeUserOverrideAwuCreditsRateLimitKeyForUser`),
+   * on top of the implicit monthly/pool-lifetime window the override always
+   * applies over. Meaningless — and ignored by the enforcement check — when
+   * `poolCapOverrideAwuCredits` is null.
    */
   async updatePoolCapOverride(
-    poolCapOverrideAwuCredits: number | null,
+    {
+      poolCapOverrideAwuCredits,
+      overrideLimitTimeframe,
+    }: {
+      poolCapOverrideAwuCredits: number | null;
+      overrideLimitTimeframe?: SpendLimitOverrideTimeframeType | null;
+    },
     transaction?: Transaction
   ): Promise<void> {
-    await this.update({ poolCapOverrideAwuCredits }, transaction);
+    await this.update(
+      {
+        poolCapOverrideAwuCredits,
+        overrideLimitTimeframe: overrideLimitTimeframe ?? null,
+      },
+      transaction
+    );
   }
 
   /**
@@ -1653,9 +1672,11 @@ export class MembershipResource extends BaseResource<MembershipModel> {
           seatType: newSeatType,
           firstUsedAt: this.firstUsedAt,
           creditState: initialCreditStateForSeatType(newSeatType),
-          // The pool cap override survives the seat change: it's the
-          // pool-only portion, independent of the seat allowance.
+          // The pool cap override (and its timeframe) survives the seat
+          // change: it's the pool-only portion, independent of the seat
+          // allowance.
           poolCapOverrideAwuCredits: this.poolCapOverrideAwuCredits,
+          overrideLimitTimeframe: this.overrideLimitTimeframe,
         },
         { transaction }
       );

--- a/front/lib/resources/membership_upgrade_request_resource.ts
+++ b/front/lib/resources/membership_upgrade_request_resource.ts
@@ -69,7 +69,15 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
   // against concurrent duplicates.
   static async createPending(
     auth: Authenticator,
-    { user, reason }: { user: UserResource; reason: string | null }
+    {
+      user,
+      reason,
+      requestedDurationDays,
+    }: {
+      user: UserResource;
+      reason: string | null;
+      requestedDurationDays: number | null;
+    }
   ): Promise<Result<MembershipUpgradeRequestResource, Error>> {
     const workspace = auth.getNonNullableWorkspace();
     const row = await withTransaction(async (transaction) => {
@@ -90,6 +98,7 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
           userId: user.id,
           status: "pending",
           reason,
+          requestedDurationDays,
         },
         { transaction }
       );
@@ -251,6 +260,7 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
       createdAt: this.createdAt.getTime(),
       resolvedAt: this.resolvedAt ? this.resolvedAt.getTime() : null,
       reason: this.reason,
+      requestedDurationDays: this.requestedDurationDays,
       requester: {
         sId: this.requester.sId,
         name: this.requester.fullName() || this.requester.name,

--- a/front/lib/resources/storage/models/membership.ts
+++ b/front/lib/resources/storage/models/membership.ts
@@ -2,6 +2,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { SpendLimitOverrideTimeframeType } from "@app/types/credits";
 import type {
   MembershipOriginType,
   MembershipRoleType,
@@ -27,6 +28,11 @@ export class MembershipModel extends WorkspaceAwareModel<MembershipModel> {
   // `spend_threshold_reached` alert (threshold = override + seat allowance)
   // is derived from this value and remains the enforcement mechanism.
   declare poolCapOverrideAwuCredits: number | null;
+  // Rolling window `poolCapOverrideAwuCredits` is enforced over. NULL (the
+  // default) preserves today's behavior: the cap applies over the implicit
+  // monthly/pool-lifetime window. Meaningless when the override itself is
+  // NULL.
+  declare overrideLimitTimeframe: SpendLimitOverrideTimeframeType | null;
 
   declare userId: ForeignKey<UserModel["id"]>;
   declare user: NonAttribute<UserModel>;
@@ -76,6 +82,11 @@ MembershipModel.init(
     },
     poolCapOverrideAwuCredits: {
       type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
+    },
+    overrideLimitTimeframe: {
+      type: DataTypes.STRING(8),
       allowNull: true,
       defaultValue: null,
     },

--- a/front/lib/resources/storage/models/membership_upgrade_requests.ts
+++ b/front/lib/resources/storage/models/membership_upgrade_requests.ts
@@ -25,6 +25,9 @@ export class MembershipUpgradeRequestModel extends WorkspaceAwareModel<Membershi
   // (enforced in application code, not at the DB level, so existing rows
   // are unaffected).
   declare reason: string | null;
+  // How long the member expects to need it, in days. Informational only —
+  // surfaced to the admin for context, not auto-enforced.
+  declare requestedDurationDays: number | null;
 
   // The member who requested the upgrade.
   declare userId: ForeignKey<UserModel["id"]>;
@@ -59,6 +62,11 @@ MembershipUpgradeRequestModel.init(
     },
     reason: {
       type: DataTypes.STRING(1000),
+      allowNull: true,
+      defaultValue: null,
+    },
+    requestedDurationDays: {
+      type: DataTypes.INTEGER,
       allowNull: true,
       defaultValue: null,
     },

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -12,7 +12,9 @@ import type {
 import type {
   GetUserSpendLimitResponseBody,
   PutUserSpendLimitResponseBody,
+  UserSpendLimit,
 } from "@app/types/api/users/spend_limit";
+import { SPEND_LIMIT_OVERRIDE_TIMEFRAMES } from "@app/types/credits";
 import { SUPPORTED_CURRENCIES } from "@app/types/currency";
 import type { GroupKind } from "@app/types/groups";
 import { isGroupKind } from "@app/types/groups";
@@ -33,6 +35,7 @@ const SpendLimitResponseSchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("limited"),
     awuCredits: z.number(),
+    timeframe: z.enum(SPEND_LIMIT_OVERRIDE_TIMEFRAMES).nullable().optional(),
   }),
 ]);
 
@@ -261,7 +264,7 @@ export function useBulkSetUserSpendLimit({
       limit,
     }: {
       selection: BulkMemberSelectionBody;
-      limit: { kind: "unlimited" } | { kind: "limited"; awuCredits: number };
+      limit: UserSpendLimit;
     }): Promise<{ workflowId: string; memberCount: number } | null> => {
       const res = await clientFetch(bulkSpendLimitUrl(workspaceId), {
         method: "POST",
@@ -285,7 +288,7 @@ export function useBulkSetUserSpendLimit({
         title: "Spend limit updated",
         description:
           limit.kind === "limited"
-            ? `Applied a ${limit.awuCredits.toLocaleString("en-US")} credit limit to ${body.memberCount.toLocaleString("en-US")} members.`
+            ? `Applied a ${limit.awuCredits.toLocaleString("en-US")} credit${limit.timeframe ? `/${limit.timeframe}` : ""} limit to ${body.memberCount.toLocaleString("en-US")} members.`
             : `Removed the spend limit for ${body.memberCount.toLocaleString("en-US")} members.`,
       });
 
@@ -651,7 +654,7 @@ export function useUpdateUserSpendLimit({
     }: {
       memberId: string;
       memberName: string;
-      limit: { kind: "unlimited" } | { kind: "limited"; awuCredits: number };
+      limit: UserSpendLimit;
     }): Promise<PutUserSpendLimitResponseBody | null> => {
       const res = await clientFetch(spendLimitUrl(workspaceId, memberId), {
         method: "PUT",
@@ -676,7 +679,9 @@ export function useUpdateUserSpendLimit({
           description = `${memberName}'s spend limit has been removed.`;
           break;
         case "limited":
-          description = `${memberName}'s spend limit has been set to ${limit.awuCredits.toLocaleString("en-US")} credits.`;
+          description = limit.timeframe
+            ? `${memberName}'s spend limit has been set to ${limit.awuCredits.toLocaleString("en-US")} credits/${limit.timeframe}.`
+            : `${memberName}'s spend limit has been set to ${limit.awuCredits.toLocaleString("en-US")} credits.`;
           break;
         default:
           assertNeverAndIgnore(limit);

--- a/front/lib/swr/upgrade_requests.ts
+++ b/front/lib/swr/upgrade_requests.ts
@@ -29,11 +29,17 @@ export function useRequestUpgrade({ workspaceId }: { workspaceId: string }) {
   const { mutate } = useSWRWithDefaults(usageStatusUrl(workspaceId), null);
 
   const doRequestUpgrade = useCallback(
-    async ({ reason }: { reason: string }): Promise<boolean> => {
+    async ({
+      reason,
+      requestedDurationDays,
+    }: {
+      reason: string;
+      requestedDurationDays: number;
+    }): Promise<boolean> => {
       const res = await clientFetch(upgradeRequestsUrl(workspaceId), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ reason }),
+        body: JSON.stringify({ reason, requestedDurationDays }),
       });
 
       if (!res.ok) {

--- a/front/migrations/20260605_backfill_membership_pool_cap_overrides.ts
+++ b/front/migrations/20260605_backfill_membership_pool_cap_overrides.ts
@@ -123,7 +123,10 @@ makeScript(
               : "Would backfill pool cap override."
           );
           if (execute) {
-            await membership.updatePoolCapOverride(poolCapOverrideAwuCredits);
+            await membership.updatePoolCapOverride({
+              poolCapOverrideAwuCredits,
+              overrideLimitTimeframe: null,
+            });
           }
           updated++;
         }

--- a/front/migrations/pre-deploy/20260727135139_overage_duration_and_timeframe_fields.sql
+++ b/front/migrations/pre-deploy/20260727135139_overage_duration_and_timeframe_fields.sql
@@ -1,0 +1,13 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."membership_upgrade_requests" ADD COLUMN "requestedDurationDays" integer;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."memberships" ADD COLUMN "overrideLimitTimeframe" character varying(8) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying;

--- a/front/types/api/users/spend_limit.ts
+++ b/front/types/api/users/spend_limit.ts
@@ -1,6 +1,15 @@
+import type { SpendLimitOverrideTimeframeType } from "@app/types/credits";
+
 export type UserSpendLimit =
   | { kind: "unlimited" }
-  | { kind: "limited"; awuCredits: number };
+  | {
+      kind: "limited";
+      awuCredits: number;
+      // Rolling window the cap is additionally enforced over, on top of the
+      // implicit monthly/pool-lifetime window. Omitted/null preserves
+      // today's behavior.
+      timeframe?: SpendLimitOverrideTimeframeType | null;
+    };
 
 export type GetUserSpendLimitResponse = UserSpendLimit;
 

--- a/front/types/credits.ts
+++ b/front/types/credits.ts
@@ -83,6 +83,30 @@ export const CREDIT_EXPIRATION_DAYS = 365;
 export const MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS = 0;
 export const MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS = 1_000_000;
 
+// Rolling window over which a per-user spend limit override
+// (`Membership.poolCapOverrideAwuCredits`) is enforced. `null` on the
+// membership means the cap applies over the implicit monthly/pool-lifetime
+// window, as it always has.
+export const SPEND_LIMIT_OVERRIDE_TIMEFRAMES = [
+  "day",
+  "week",
+  "month",
+] as const;
+
+export type SpendLimitOverrideTimeframeType =
+  (typeof SPEND_LIMIT_OVERRIDE_TIMEFRAMES)[number];
+
+export function isSpendLimitOverrideTimeframeType(
+  value: unknown
+): value is SpendLimitOverrideTimeframeType {
+  return (
+    typeof value === "string" &&
+    SPEND_LIMIT_OVERRIDE_TIMEFRAMES.includes(
+      value as SpendLimitOverrideTimeframeType
+    )
+  );
+}
+
 export type CreditDisplayData = {
   sId: string;
   type: CreditType;

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -74,6 +74,7 @@ const API_ERROR_TYPES = [
   "plan_message_limit_exceeded",
   "credits_exhausted",
   "user_cap_reached",
+  "per_user_spend_limit_exceeded",
   "no_seat",
   "model_disabled",
   "global_agent_error",

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -302,6 +302,8 @@ export type MembershipUpgradeRequestStatus =
 
 export const MIN_UPGRADE_REQUEST_REASON_LENGTH_CHARS = 10;
 export const MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS = 1000;
+export const MIN_UPGRADE_REQUEST_DURATION_DAYS = 1;
+export const MAX_UPGRADE_REQUEST_DURATION_DAYS = 365;
 
 export interface MembershipUpgradeRequestType {
   sId: string;
@@ -311,6 +313,8 @@ export interface MembershipUpgradeRequestType {
   // Why the member needs the raised limit. Null only for requests created
   // before this field existed.
   reason: string | null;
+  // How long the member expects to need it, in days. Informational only.
+  requestedDurationDays: number | null;
   requester: {
     sId: string;
     name: string;


### PR DESCRIPTION
## Summary
- Stacked on #29591. Adds the requested-duration field (`requestedDurationDays`) to the upgrade-request flow: members pick how long they need the limit increase (day/week/month presets), and it's stored, surfaced in the admin requests table, and included in the notification email and audit log.
- Adds `overrideLimitTimeframe` (day/week/month/billing_cycle) on membership, letting an admin cap AWU credit spend over a rolling window instead of a flat all-time cap.
- Note: `requestedDurationDays` is currently informational only (not wired to `overrideLimitTimeframe`, and the raised cap does not auto-expire). Automatic expiration/reversion of the override once the requested period elapses is tracked as a stacked follow-up PR.

## Test plan
- [ ] Manually open the "Request an upgrade" dialog, verify the duration radio group (day/week/month) appears and defaults to a week.
- [ ] Submit a request and verify `requestedDurationDays` shows up in the admin's UpgradeRequestsTable, notification email, and audit log.

## Deploy plan
 - [ ] Apply the pre-deploy migration (both regions)
 - [ ] Deploy front

🤖 Generated with [Claude Code](https://claude.com/claude-code)