### PR TITLE
feat: add model (modelId, providerId) to elastic search message index

### DIFF
--- a/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
+++ b/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
@@ -54,7 +54,8 @@ export type AnalyticsGroupBy =
   | "agent"
   | "user"
   | "origin"
-  | "api_key";
+  | "api_key"
+  | "model";
 
 type GroupByOption = { value: AnalyticsGroupBy | undefined; label: string };
 
@@ -65,6 +66,7 @@ const GROUP_BY_OPTIONS: GroupByOption[] = [
   { value: "user", label: "By User" },
   { value: "origin", label: "By Source" },
   { value: "api_key", label: "By API Key" },
+  { value: "model", label: "By Model" },
 ];
 
 // "By User" is redundant when the chart is already scoped to a single user.

--- a/front/components/workspace/analytics/AnalyticsFilterDropdown.tsx
+++ b/front/components/workspace/analytics/AnalyticsFilterDropdown.tsx
@@ -12,7 +12,9 @@ import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useKeys } from "@app/lib/swr/apps";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useSearchMembers } from "@app/lib/swr/memberships";
+import { useModels } from "@app/lib/swr/models";
 import { useTags } from "@app/lib/swr/tags";
+import { isModelStreamId } from "@app/types/assistant/models/auto";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { DropdownMenuFilterOption } from "@dust-tt/sparkle";
 import {
@@ -30,7 +32,7 @@ import {
 import { useMemo, useState } from "react";
 
 const DIMENSION_FILTERS: DropdownMenuFilterOption<AnalyticsScopeDimension>[] = (
-  ["user", "agent", "origin", "api_key", "tag"] as const
+  ["user", "agent", "origin", "api_key", "tag", "model"] as const
 ).map((dimension) => ({
   value: dimension,
   label: SCOPE_DIMENSION_LABEL[dimension],
@@ -76,6 +78,11 @@ export function AnalyticsFilterDropdown({
     disabled: !isOpen || dimension !== "tag",
   });
 
+  const { models, isModelsLoading } = useModels({
+    owner,
+    disabled: !isOpen || dimension !== "model",
+  });
+
   const entities: AnalyticsEntityFilter[] = useMemo(() => {
     const search = searchText.toLowerCase();
     const matches = (name: string) => name.toLowerCase().includes(search);
@@ -103,11 +110,18 @@ export function AnalyticsFilterDropdown({
         return tags
           .filter((tag) => matches(tag.name))
           .map((tag) => ({ id: tag.sId, name: tag.name }));
+      case "model":
+        return models
+          .filter(
+            (model) =>
+              !isModelStreamId(model.modelId) && matches(model.displayName)
+          )
+          .map((model) => ({ id: model.modelId, name: model.displayName }));
       default:
         assertNeverAndIgnore(dimension);
         return [];
     }
-  }, [dimension, searchText, members, agentConfigurations, keys, tags]);
+  }, [dimension, searchText, members, agentConfigurations, keys, tags, models]);
 
   const selectedIds = useMemo(
     () => new Set((filter[dimension] ?? []).map((entity) => entity.id)),
@@ -118,7 +132,8 @@ export function AnalyticsFilterDropdown({
     (dimension === "user" && isMembersLoading) ||
     (dimension === "agent" && isAgentConfigurationsLoading) ||
     (dimension === "api_key" && isKeysLoading) ||
-    (dimension === "tag" && isTagsLoading);
+    (dimension === "tag" && isTagsLoading) ||
+    (dimension === "model" && isModelsLoading);
 
   return (
     <DropdownMenu

--- a/front/components/workspace/analytics/analyticsFilter.ts
+++ b/front/components/workspace/analytics/analyticsFilter.ts
@@ -20,6 +20,7 @@ export const SCOPE_DIMENSION_LABEL: Record<AnalyticsScopeDimension, string> = {
   origin: "Source",
   api_key: "API Key",
   tag: "Tag",
+  model: "Model",
 };
 
 export const SCOPE_DIMENSIONS = Object.keys(

--- a/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
+++ b/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
@@ -21,6 +21,23 @@
     "agent_tag_ids": {
       "type": "keyword"
     },
+    "model": {
+      "type": "object",
+      "properties": {
+        "provider_id": {
+          "type": "keyword"
+        },
+        "model_id": {
+          "type": "keyword"
+        },
+        "reasoning_effort": {
+          "type": "keyword"
+        },
+        "resolution_method": {
+          "type": "keyword"
+        }
+      }
+    },
     "ancestor_message_ids": {
       "type": "keyword"
     },

--- a/front/lib/analytics/migrations/20260727_add_model_to_agent_message_analytics_2.http
+++ b/front/lib/analytics/migrations/20260727_add_model_to_agent_message_analytics_2.http
@@ -1,0 +1,22 @@
+PUT /front.agent_message_analytics_2/_mapping
+{
+  "properties": {
+    "model": {
+      "type": "object",
+      "properties": {
+        "provider_id": {
+          "type": "keyword"
+        },
+        "model_id": {
+          "type": "keyword"
+        },
+        "reasoning_effort": {
+          "type": "keyword"
+        },
+        "resolution_method": {
+          "type": "keyword"
+        }
+      }
+    }
+  }
+}

--- a/front/lib/api/analytics/awu_usage_analytics.ts
+++ b/front/lib/api/analytics/awu_usage_analytics.ts
@@ -16,6 +16,7 @@ const TERMS_GROUP_BY_KEYS = [
   "user",
   "origin",
   "api_key",
+  "model",
 ] as const satisfies readonly CreditBreakdownBy[];
 
 // usage_type is derived (no stored field): User vs Programmatic, split on
@@ -102,6 +103,7 @@ export async function getAwuUsageFromAnalytics(
   const contextOrigin = filter?.origin;
   const apiKeyNames = filter?.api_key;
   const agentTagIds = filter?.tag;
+  const modelIds = filter?.model;
 
   if (!groupBy) {
     const result = await fetchCreditTimeseries(auth, {
@@ -115,6 +117,7 @@ export async function getAwuUsageFromAnalytics(
       contextOrigin,
       apiKeyNames,
       agentTagIds,
+      modelIds,
     });
     if (result.isErr()) {
       return new Err(toError(result.error));
@@ -144,6 +147,7 @@ export async function getAwuUsageFromAnalytics(
       contextOrigin,
       apiKeyNames,
       agentTagIds,
+      modelIds,
     });
     if (result.isErr()) {
       return new Err(toError(result.error));
@@ -180,6 +184,7 @@ export async function getAwuUsageFromAnalytics(
     contextOrigin,
     apiKeyNames,
     agentTagIds,
+    modelIds,
   });
   if (result.isErr()) {
     return new Err(toError(result.error));

--- a/front/lib/api/assistant/observability/credit_usage.ts
+++ b/front/lib/api/assistant/observability/credit_usage.ts
@@ -2,6 +2,7 @@ import { sourceLabelForOrigin } from "@app/lib/api/analytics/source_labels";
 import { resolveAnalyticsAgentLabels } from "@app/lib/api/assistant/observability/agent_labels";
 import {
   buildCreditsScopeQuery,
+  MODEL_ID_FIELD,
   NOT_API_GROUP_KEY,
   NOT_API_GROUP_NAME,
 } from "@app/lib/api/assistant/observability/utils";
@@ -13,6 +14,7 @@ import {
 } from "@app/lib/api/elasticsearch";
 import { getProgrammaticUsageFilterClause } from "@app/lib/api/programmatic_usage/common";
 import type { Authenticator } from "@app/lib/auth";
+import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { TopConversationCreditsRow } from "@app/types/api/credits/my_top_conversations";
@@ -21,7 +23,12 @@ import { Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { estypes } from "@elastic/elasticsearch";
 
-export type CreditBreakdownBy = "agent" | "user" | "origin" | "api_key";
+export type CreditBreakdownBy =
+  | "agent"
+  | "user"
+  | "origin"
+  | "api_key"
+  | "model";
 
 export type CreditGroupBy = CreditBreakdownBy | "none";
 
@@ -109,7 +116,12 @@ function totalCreditsFromSlice(slice: CreditSlice): number {
 
 function groupFieldFor(
   groupBy: CreditBreakdownBy
-): "agent_id" | "user_id" | "context_origin" | "api_key_name" {
+):
+  | "agent_id"
+  | "user_id"
+  | "context_origin"
+  | "api_key_name"
+  | typeof MODEL_ID_FIELD {
   switch (groupBy) {
     case "agent":
       return "agent_id";
@@ -119,6 +131,8 @@ function groupFieldFor(
       return "context_origin";
     case "api_key":
       return "api_key_name";
+    case "model":
+      return MODEL_ID_FIELD;
     default:
       return assertNever(groupBy);
   }
@@ -151,6 +165,8 @@ function fallbackGroupName(groupBy: CreditBreakdownBy): string {
       return "Unknown source";
     case "api_key":
       return "Unknown API key";
+    case "model":
+      return "Unknown model";
     default:
       return assertNever(groupBy);
   }
@@ -192,6 +208,12 @@ async function resolveGroupNames(
           id,
           id === NOT_API_GROUP_KEY ? NOT_API_GROUP_NAME : id,
         ])
+      );
+    case "model":
+      // The group key is the resolved model id; fall back to the raw id for
+      // models that are no longer part of the catalog.
+      return new Map(
+        ids.map((id) => [id, getModelConfigByModelId(id)?.displayName ?? id])
       );
     default:
       return assertNever(groupBy);
@@ -249,6 +271,7 @@ export async function fetchCreditUsage(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
   }: {
     startDate: string;
     endDate: string;
@@ -259,6 +282,7 @@ export async function fetchCreditUsage(
     userIds?: string[];
     apiKeyNames?: string[];
     agentTagIds?: string[];
+    modelIds?: string[];
   }
 ): Promise<Result<CreditUsageResult, ElasticsearchError>> {
   const aggregations: Record<string, estypes.AggregationsAggregationContainer> =
@@ -282,6 +306,7 @@ export async function fetchCreditUsage(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
     extraFilters:
       // api_key buckets missing values under "Not API" instead of dropping
       // them, so the rows keep summing to the total.
@@ -419,6 +444,7 @@ export async function fetchCreditTimeseries(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
     fillWindow,
   }: {
     startDate: string;
@@ -430,6 +456,7 @@ export async function fetchCreditTimeseries(
     userIds?: string[];
     apiKeyNames?: string[];
     agentTagIds?: string[];
+    modelIds?: string[];
     fillWindow?: boolean;
   }
 ): Promise<Result<CreditTimeseriesPoint[], ElasticsearchError>> {
@@ -441,6 +468,7 @@ export async function fetchCreditTimeseries(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
   });
 
   const result = await searchAnalytics<never, CreditTimeseriesAggs>(query, {
@@ -493,6 +521,7 @@ export async function fetchCreditTimeseriesByUsageType(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
     fillWindow,
   }: {
     startDate: string;
@@ -504,6 +533,7 @@ export async function fetchCreditTimeseriesByUsageType(
     userIds?: string[];
     apiKeyNames?: string[];
     agentTagIds?: string[];
+    modelIds?: string[];
     fillWindow?: boolean;
   }
 ): Promise<Result<CreditUsageTypePoint[], ElasticsearchError>> {
@@ -515,6 +545,7 @@ export async function fetchCreditTimeseriesByUsageType(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
   });
 
   const programmaticFilter = getProgrammaticUsageFilterClause();
@@ -580,6 +611,7 @@ export async function fetchCreditTimeseriesBreakdown(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
     fillWindow,
   }: {
     startDate: string;
@@ -593,6 +625,7 @@ export async function fetchCreditTimeseriesBreakdown(
     userIds?: string[];
     apiKeyNames?: string[];
     agentTagIds?: string[];
+    modelIds?: string[];
     fillWindow?: boolean;
   }
 ): Promise<Result<CreditTimeseriesBreakdown, ElasticsearchError>> {
@@ -606,6 +639,7 @@ export async function fetchCreditTimeseriesBreakdown(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
   });
   if (ranking.isErr()) {
     return ranking;
@@ -628,6 +662,7 @@ export async function fetchCreditTimeseriesBreakdown(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
   });
 
   const result = await searchAnalytics<never, CreditTimeseriesBreakdownAggs>(

--- a/front/lib/api/assistant/observability/utils.ts
+++ b/front/lib/api/assistant/observability/utils.ts
@@ -41,6 +41,9 @@ export function daysToInstantRange(
 export const NOT_API_GROUP_KEY = "__not_api__";
 export const NOT_API_GROUP_NAME = "Not API";
 
+// Model that actually ran the message, resolved at message creation.
+export const MODEL_ID_FIELD = "model.model_id";
+
 // api_key_name is only set on API-key authenticated messages. The sentinel
 // selects everything else (missing field), so a mixed selection becomes a
 // disjunction of the two.
@@ -95,6 +98,7 @@ export function buildAgentAnalyticsBaseQuery({
   userIds,
   apiKeyNames,
   contextOrigin,
+  modelIds,
   days,
   startDate,
   endDate,
@@ -106,6 +110,7 @@ export function buildAgentAnalyticsBaseQuery({
   userIds?: string[];
   apiKeyNames?: string[];
   contextOrigin?: string | string[];
+  modelIds?: string[];
   days?: number;
   startDate?: string;
   endDate?: string;
@@ -123,6 +128,7 @@ export function buildAgentAnalyticsBaseQuery({
     ...termFilter("user_id", userIds),
     ...apiKeyNamesFilter(apiKeyNames),
     ...contextOriginFilter(contextOrigin),
+    ...termFilter(MODEL_ID_FIELD, modelIds),
   ];
 
   if (startDate && endDate) {
@@ -166,6 +172,7 @@ export function buildCreditsScopeQuery(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
     extraFilters = [],
     extraMustNot = [],
   }: {
@@ -176,6 +183,7 @@ export function buildCreditsScopeQuery(
     userIds?: string[];
     apiKeyNames?: string[];
     agentTagIds?: string[];
+    modelIds?: string[];
     extraFilters?: estypes.QueryDslQueryContainer[];
     extraMustNot?: estypes.QueryDslQueryContainer[];
   }
@@ -189,6 +197,7 @@ export function buildCreditsScopeQuery(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
   });
   return {
     bool: {

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -610,7 +610,7 @@ export function useAwuUsageFromAnalytics({
   urlPrefix,
 }: {
   workspaceId: string;
-  groupBy?: "usage_type" | "agent" | "user" | "origin" | "api_key";
+  groupBy?: "usage_type" | "agent" | "user" | "origin" | "api_key" | "model";
   groupByCount?: number;
   granularity?: "day" | "week" | "month";
   days?: number;

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -98,7 +98,7 @@ export function usePokeAwuUsageFromAnalytics({
   filter,
   disabled,
 }: PokeConditionalFetchProps & {
-  groupBy?: "usage_type" | "agent" | "user" | "origin" | "api_key";
+  groupBy?: "usage_type" | "agent" | "user" | "origin" | "api_key" | "model";
   groupByCount?: number;
   granularity?: "day" | "week" | "month";
   days?: number;

--- a/front/scripts/dev/seed_programmatic_usage.ts
+++ b/front/scripts/dev/seed_programmatic_usage.ts
@@ -6,6 +6,7 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import type { AgentMessageAnalyticsData } from "@app/types/assistant/analytics";
+import { CLAUDE_SONNET_4_6_MODEL_ID } from "@app/types/assistant/models/anthropic";
 
 const MICRO_USD_PER_DOLLAR = 1_000_000;
 const TOKEN_PROMPT_RANGE = { min: 100, max: 5000 };
@@ -101,6 +102,12 @@ async function seedProgrammaticUsage(
       agent_id: `seed-agent-${i % AGENT_COUNT}`,
       agent_version: "1",
       agent_tag_ids: [],
+      model: {
+        provider_id: "anthropic",
+        model_id: CLAUDE_SONNET_4_6_MODEL_ID,
+        reasoning_effort: "medium",
+        resolution_method: "agent",
+      },
       ancestor_message_ids: [],
       conversation_id: `seed-conv-${i}`,
       space_id: null,

--- a/front/scripts/seed/factories/seedAnalytics.ts
+++ b/front/scripts/seed/factories/seedAnalytics.ts
@@ -1,3 +1,4 @@
+import { resolvedModelFromAgentMessageRow } from "@app/lib/api/assistant/models";
 import { ANALYTICS_ALIAS_NAME, withEs } from "@app/lib/api/elasticsearch";
 import {
   AgentMessageFeedbackModel,
@@ -12,7 +13,6 @@ import type {
   AgentMessageAnalyticsFeedback,
 } from "@app/types/assistant/analytics";
 import { Op } from "sequelize";
-
 import type { SeedContext } from "./types";
 
 /**
@@ -116,11 +116,21 @@ export async function seedAnalytics(
       created_at: f.createdAt.toISOString(),
     }));
 
+    const resolvedModel = resolvedModelFromAgentMessageRow(agentMessage);
+
     // Build analytics document with zero values for tokens/tools (seeded data has none).
     const document: AgentMessageAnalyticsData = {
       agent_id: agentMessage.agentConfigurationId,
       agent_version: agentMessage.agentConfigurationVersion.toString(),
       agent_tag_ids: [],
+      model: resolvedModel
+        ? {
+            provider_id: resolvedModel.providerId,
+            model_id: resolvedModel.modelId,
+            reasoning_effort: resolvedModel.reasoningEffort,
+            resolution_method: agentMessage.modelResolutionMethod,
+          }
+        : null,
       ancestor_message_ids: [],
       conversation_id: conversationId,
       space_id: null,

--- a/front/temporal/analytics_queue/activities.test.ts
+++ b/front/temporal/analytics_queue/activities.test.ts
@@ -14,7 +14,12 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { TagFactory } from "@app/tests/utils/TagFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { CLAUDE_SONNET_4_6_MODEL_ID } from "@app/types/assistant/models/anthropic";
 import { GPT_5_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
+import type {
+  ModelResolutionMethodType,
+  ResolvedRequestedModel,
+} from "@app/types/assistant/models/types";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -64,10 +69,14 @@ async function seedMessages(
     agentConfigurationId,
     agentConfigurationVersion,
     spaceModelId,
+    resolvedModel,
+    modelResolutionMethod,
   }: {
     agentConfigurationId: string;
     agentConfigurationVersion: number;
     spaceModelId?: ModelId;
+    resolvedModel?: ResolvedRequestedModel | null;
+    modelResolutionMethod?: ModelResolutionMethodType | null;
   }
 ): Promise<{
   conversationSId: string;
@@ -96,6 +105,8 @@ async function seedMessages(
     rank: 1,
     agentConfigurationId,
     agentConfigurationVersion,
+    resolvedModel,
+    modelResolutionMethod,
   });
 
   return {
@@ -243,6 +254,83 @@ describe("storeAgentAnalyticsActivity - agent_tag_ids", () => {
     indexed = captureIndexedDocs();
     await runAnalytics(auth, seededV1);
     expect(analyticsDoc(indexed)?.agent_tag_ids).toEqual([]);
+  });
+});
+
+describe("storeAgentAnalyticsActivity - model", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stamps the model that actually ran the message", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const seeded = await seedMessages(auth, {
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+      resolvedModel: {
+        providerId: "anthropic",
+        modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+        reasoningEffort: "medium",
+      },
+      modelResolutionMethod: "agent",
+    });
+
+    const indexed = captureIndexedDocs();
+    await runAnalytics(auth, seeded);
+
+    const doc = analyticsDoc(indexed);
+    expect(doc).toBeDefined();
+    expect(doc?.model).toEqual({
+      provider_id: "anthropic",
+      model_id: CLAUDE_SONNET_4_6_MODEL_ID,
+      reasoning_effort: "medium",
+      resolution_method: "agent",
+    });
+  });
+
+  it("stamps the concrete model a stream tier resolved to, not the stream id", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const seeded = await seedMessages(auth, {
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+      resolvedModel: {
+        providerId: "anthropic",
+        modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+        reasoningEffort: "high",
+      },
+      modelResolutionMethod: "auto_complex",
+    });
+
+    const indexed = captureIndexedDocs();
+    await runAnalytics(auth, seeded);
+
+    const doc = analyticsDoc(indexed);
+    expect(doc?.model?.model_id).toBe(CLAUDE_SONNET_4_6_MODEL_ID);
+    expect(doc?.model?.resolution_method).toBe("auto_complex");
+  });
+
+  it("stamps null when the agent message has no resolved model", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const seeded = await seedMessages(auth, {
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+    });
+
+    const indexed = captureIndexedDocs();
+    await runAnalytics(auth, seeded);
+
+    const doc = analyticsDoc(indexed);
+    expect(doc).toBeDefined();
+    expect(doc?.model).toBeNull();
   });
 });
 

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -9,6 +9,7 @@ import { isSearchResultResourceType } from "@app/lib/actions/mcp_internal_action
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import { updateAnalyticsFeedback } from "@app/lib/analytics/feedback";
+import { resolvedModelFromAgentMessageRow } from "@app/lib/api/assistant/models";
 import {
   AGENT_DOCUMENT_OUTPUTS_ALIAS_NAME,
   ANALYTICS_ALIAS_NAME,
@@ -55,6 +56,7 @@ import type {
 import type {
   AgentMessageAnalyticsData,
   AgentMessageAnalyticsFeedback,
+  AgentMessageAnalyticsModel,
   AgentMessageAnalyticsSkillUsed,
   AgentMessageAnalyticsTokens,
   AgentMessageAnalyticsToolUsed,
@@ -212,6 +214,9 @@ export async function storeAgentAnalytics(
   // NOTE: may not be stable over time, see `collectAgentTagIds` for details.
   const agentTagIds = await collectAgentTagIds(auth, agentAgentMessageRow);
 
+  // Model that actually ran the message (resolved at message creation).
+  const model = collectResolvedModel(agentAgentMessageRow);
+
   const llmAwu = intelligenceAwuFromRunUsagesGroupedByRunKey(
     runUsages,
     contextOrigin
@@ -264,6 +269,7 @@ export async function storeAgentAnalytics(
     agent_id: agentAgentMessageRow.agentConfigurationId,
     agent_version: agentAgentMessageRow.agentConfigurationVersion.toString(),
     agent_tag_ids: agentTagIds,
+    model,
     ancestor_message_ids: ancestorMessageIds,
     conversation_id: conversationRow.sId,
     space_id: spaceId,
@@ -452,6 +458,26 @@ async function collectAgentTagIds(
   );
 
   return tags.map((tag) => tag.sId);
+}
+
+/**
+ * Collect the model that actually ran this message, if available.
+ */
+function collectResolvedModel(
+  agentAgentMessageRow: AgentMessageModel
+): AgentMessageAnalyticsModel | null {
+  const resolvedModel = resolvedModelFromAgentMessageRow(agentAgentMessageRow);
+
+  if (!resolvedModel) {
+    return null;
+  }
+
+  return {
+    provider_id: resolvedModel.providerId,
+    model_id: resolvedModel.modelId,
+    reasoning_effort: resolvedModel.reasoningEffort,
+    resolution_method: agentAgentMessageRow.modelResolutionMethod,
+  };
 }
 
 /**

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -30,6 +30,10 @@ import type {
   UserMessageOrigin,
   UserMessageType,
 } from "@app/types/assistant/conversation";
+import type {
+  ModelResolutionMethodType,
+  ResolvedRequestedModel,
+} from "@app/types/assistant/models/types";
 import type { SupportedContentFragmentType } from "@app/types/content_fragment";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { WorkspaceType } from "@app/types/user";
@@ -366,6 +370,8 @@ export class ConversationFactory {
     agentConfigurationVersion = 0,
     parentId = null,
     version = 0,
+    resolvedModel = null,
+    modelResolutionMethod = null,
   }: {
     workspace: WorkspaceType;
     conversationId: ModelId;
@@ -374,6 +380,8 @@ export class ConversationFactory {
     agentConfigurationVersion?: number;
     parentId?: ModelId | null;
     version?: number;
+    resolvedModel?: ResolvedRequestedModel | null;
+    modelResolutionMethod?: ModelResolutionMethodType | null;
   }): Promise<MessageModel> {
     const agentMessageRow = await AgentMessageModel.create({
       status: "created",
@@ -382,6 +390,10 @@ export class ConversationFactory {
       conversationId,
       workspaceId: workspace.id,
       skipToolsValidation: false,
+      resolvedProviderId: resolvedModel?.providerId ?? null,
+      resolvedModelId: resolvedModel?.modelId ?? null,
+      resolvedReasoningEffort: resolvedModel?.reasoningEffort ?? null,
+      modelResolutionMethod,
     });
 
     return MessageModel.create({

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -3,6 +3,12 @@ import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
 
 import type { AgentMessageStatus, UserMessageOrigin } from "./conversation";
 import type { ConversationSkillOrigin } from "./conversation_skills";
+import type {
+  ModelIdType,
+  ModelProviderIdType,
+  ModelResolutionMethodType,
+  ReasoningEffort,
+} from "./models/types";
 
 /**
  * Types for agent analytics data stored in Elasticsearch
@@ -49,12 +55,20 @@ export interface AgentMessageAnalyticsSkillUsed {
   source: ConversationSkillOrigin;
 }
 
+export interface AgentMessageAnalyticsModel {
+  provider_id: ModelProviderIdType;
+  model_id: ModelIdType;
+  reasoning_effort: ReasoningEffort;
+  resolution_method: ModelResolutionMethodType | null;
+}
+
 export interface AgentMessageAnalyticsData extends ElasticsearchBaseDocument {
   agent_id: string;
   agent_version: string;
   // Tag sIds attached to the agent configuration version that produced this
   // message, captured at index time (reflects the agent's tags at message time).
   agent_tag_ids: string[];
+  model: AgentMessageAnalyticsModel | null;
   ancestor_message_ids: string[];
   conversation_id: string;
   // sId of the space the conversation lives in (any kind), null when the


### PR DESCRIPTION
## Description

Add `providerId`, `modelId`, `reasoningEffort` and `resolutionMethod` into the ES message index so we can get analytics per model.

Refs https://github.com/dust-tt/tasks/issues/9825

## Tests

Tested manually that ES index now contain the new object:
```
GET front.agent_message_analytics/_search
{
  "size": 3,
  "sort": [{ "timestamp": "desc" }]
}
```

## Risk

Low. Safe to rollback.

## Deploy Plan

ES mapping should be updated before deploying
