### PR TITLE
feat: add analytics breakdown per model

### DIFF
--- a/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
+++ b/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
@@ -54,7 +54,8 @@ export type AnalyticsGroupBy =
   | "agent"
   | "user"
   | "origin"
-  | "api_key";
+  | "api_key"
+  | "model";
 
 type GroupByOption = { value: AnalyticsGroupBy | undefined; label: string };
 
@@ -65,6 +66,7 @@ const GROUP_BY_OPTIONS: GroupByOption[] = [
   { value: "user", label: "By User" },
   { value: "origin", label: "By Source" },
   { value: "api_key", label: "By API Key" },
+  { value: "model", label: "By Model" },
 ];
 
 // "By User" is redundant when the chart is already scoped to a single user.

--- a/front/components/workspace/analytics/AnalyticsFilterDropdown.tsx
+++ b/front/components/workspace/analytics/AnalyticsFilterDropdown.tsx
@@ -12,7 +12,9 @@ import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useKeys } from "@app/lib/swr/apps";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useSearchMembers } from "@app/lib/swr/memberships";
+import { useModels } from "@app/lib/swr/models";
 import { useTags } from "@app/lib/swr/tags";
+import { isModelStreamId } from "@app/types/assistant/models/auto";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { DropdownMenuFilterOption } from "@dust-tt/sparkle";
 import {
@@ -30,7 +32,7 @@ import {
 import { useMemo, useState } from "react";
 
 const DIMENSION_FILTERS: DropdownMenuFilterOption<AnalyticsScopeDimension>[] = (
-  ["user", "agent", "origin", "api_key", "tag"] as const
+  ["user", "agent", "origin", "api_key", "tag", "model"] as const
 ).map((dimension) => ({
   value: dimension,
   label: SCOPE_DIMENSION_LABEL[dimension],
@@ -76,6 +78,11 @@ export function AnalyticsFilterDropdown({
     disabled: !isOpen || dimension !== "tag",
   });
 
+  const { models, isModelsLoading } = useModels({
+    owner,
+    disabled: !isOpen || dimension !== "model",
+  });
+
   const entities: AnalyticsEntityFilter[] = useMemo(() => {
     const search = searchText.toLowerCase();
     const matches = (name: string) => name.toLowerCase().includes(search);
@@ -103,11 +110,18 @@ export function AnalyticsFilterDropdown({
         return tags
           .filter((tag) => matches(tag.name))
           .map((tag) => ({ id: tag.sId, name: tag.name }));
+      case "model":
+        return models
+          .filter(
+            (model) =>
+              !isModelStreamId(model.modelId) && matches(model.displayName)
+          )
+          .map((model) => ({ id: model.modelId, name: model.displayName }));
       default:
         assertNeverAndIgnore(dimension);
         return [];
     }
-  }, [dimension, searchText, members, agentConfigurations, keys, tags]);
+  }, [dimension, searchText, members, agentConfigurations, keys, tags, models]);
 
   const selectedIds = useMemo(
     () => new Set((filter[dimension] ?? []).map((entity) => entity.id)),
@@ -118,7 +132,8 @@ export function AnalyticsFilterDropdown({
     (dimension === "user" && isMembersLoading) ||
     (dimension === "agent" && isAgentConfigurationsLoading) ||
     (dimension === "api_key" && isKeysLoading) ||
-    (dimension === "tag" && isTagsLoading);
+    (dimension === "tag" && isTagsLoading) ||
+    (dimension === "model" && isModelsLoading);
 
   return (
     <DropdownMenu

--- a/front/components/workspace/analytics/analyticsFilter.ts
+++ b/front/components/workspace/analytics/analyticsFilter.ts
@@ -20,6 +20,7 @@ export const SCOPE_DIMENSION_LABEL: Record<AnalyticsScopeDimension, string> = {
   origin: "Source",
   api_key: "API Key",
   tag: "Tag",
+  model: "Model",
 };
 
 export const SCOPE_DIMENSIONS = Object.keys(

--- a/front/lib/api/analytics/awu_usage_analytics.ts
+++ b/front/lib/api/analytics/awu_usage_analytics.ts
@@ -16,6 +16,7 @@ const TERMS_GROUP_BY_KEYS = [
   "user",
   "origin",
   "api_key",
+  "model",
 ] as const satisfies readonly CreditBreakdownBy[];
 
 // usage_type is derived (no stored field): User vs Programmatic, split on
@@ -102,6 +103,7 @@ export async function getAwuUsageFromAnalytics(
   const contextOrigin = filter?.origin;
   const apiKeyNames = filter?.api_key;
   const agentTagIds = filter?.tag;
+  const modelIds = filter?.model;
 
   if (!groupBy) {
     const result = await fetchCreditTimeseries(auth, {
@@ -115,6 +117,7 @@ export async function getAwuUsageFromAnalytics(
       contextOrigin,
       apiKeyNames,
       agentTagIds,
+      modelIds,
     });
     if (result.isErr()) {
       return new Err(toError(result.error));
@@ -144,6 +147,7 @@ export async function getAwuUsageFromAnalytics(
       contextOrigin,
       apiKeyNames,
       agentTagIds,
+      modelIds,
     });
     if (result.isErr()) {
       return new Err(toError(result.error));
@@ -180,6 +184,7 @@ export async function getAwuUsageFromAnalytics(
     contextOrigin,
     apiKeyNames,
     agentTagIds,
+    modelIds,
   });
   if (result.isErr()) {
     return new Err(toError(result.error));

--- a/front/lib/api/assistant/observability/credit_usage.ts
+++ b/front/lib/api/assistant/observability/credit_usage.ts
@@ -2,6 +2,7 @@ import { sourceLabelForOrigin } from "@app/lib/api/analytics/source_labels";
 import { resolveAnalyticsAgentLabels } from "@app/lib/api/assistant/observability/agent_labels";
 import {
   buildCreditsScopeQuery,
+  MODEL_ID_FIELD,
   NOT_API_GROUP_KEY,
   NOT_API_GROUP_NAME,
 } from "@app/lib/api/assistant/observability/utils";
@@ -13,6 +14,7 @@ import {
 } from "@app/lib/api/elasticsearch";
 import { getProgrammaticUsageFilterClause } from "@app/lib/api/programmatic_usage/common";
 import type { Authenticator } from "@app/lib/auth";
+import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { TopConversationCreditsRow } from "@app/types/api/credits/my_top_conversations";
@@ -21,7 +23,12 @@ import { Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { estypes } from "@elastic/elasticsearch";
 
-export type CreditBreakdownBy = "agent" | "user" | "origin" | "api_key";
+export type CreditBreakdownBy =
+  | "agent"
+  | "user"
+  | "origin"
+  | "api_key"
+  | "model";
 
 export type CreditGroupBy = CreditBreakdownBy | "none";
 
@@ -109,7 +116,12 @@ function totalCreditsFromSlice(slice: CreditSlice): number {
 
 function groupFieldFor(
   groupBy: CreditBreakdownBy
-): "agent_id" | "user_id" | "context_origin" | "api_key_name" {
+):
+  | "agent_id"
+  | "user_id"
+  | "context_origin"
+  | "api_key_name"
+  | typeof MODEL_ID_FIELD {
   switch (groupBy) {
     case "agent":
       return "agent_id";
@@ -119,6 +131,8 @@ function groupFieldFor(
       return "context_origin";
     case "api_key":
       return "api_key_name";
+    case "model":
+      return MODEL_ID_FIELD;
     default:
       return assertNever(groupBy);
   }
@@ -151,6 +165,8 @@ function fallbackGroupName(groupBy: CreditBreakdownBy): string {
       return "Unknown source";
     case "api_key":
       return "Unknown API key";
+    case "model":
+      return "Unknown model";
     default:
       return assertNever(groupBy);
   }
@@ -192,6 +208,12 @@ async function resolveGroupNames(
           id,
           id === NOT_API_GROUP_KEY ? NOT_API_GROUP_NAME : id,
         ])
+      );
+    case "model":
+      // The group key is the resolved model id; fall back to the raw id for
+      // models that are no longer part of the catalog.
+      return new Map(
+        ids.map((id) => [id, getModelConfigByModelId(id)?.displayName ?? id])
       );
     default:
       return assertNever(groupBy);
@@ -249,6 +271,7 @@ export async function fetchCreditUsage(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
   }: {
     startDate: string;
     endDate: string;
@@ -259,6 +282,7 @@ export async function fetchCreditUsage(
     userIds?: string[];
     apiKeyNames?: string[];
     agentTagIds?: string[];
+    modelIds?: string[];
   }
 ): Promise<Result<CreditUsageResult, ElasticsearchError>> {
   const aggregations: Record<string, estypes.AggregationsAggregationContainer> =
@@ -282,6 +306,7 @@ export async function fetchCreditUsage(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
     extraFilters:
       // api_key buckets missing values under "Not API" instead of dropping
       // them, so the rows keep summing to the total.
@@ -419,6 +444,7 @@ export async function fetchCreditTimeseries(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
     fillWindow,
   }: {
     startDate: string;
@@ -430,6 +456,7 @@ export async function fetchCreditTimeseries(
     userIds?: string[];
     apiKeyNames?: string[];
     agentTagIds?: string[];
+    modelIds?: string[];
     fillWindow?: boolean;
   }
 ): Promise<Result<CreditTimeseriesPoint[], ElasticsearchError>> {
@@ -441,6 +468,7 @@ export async function fetchCreditTimeseries(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
   });
 
   const result = await searchAnalytics<never, CreditTimeseriesAggs>(query, {
@@ -493,6 +521,7 @@ export async function fetchCreditTimeseriesByUsageType(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
     fillWindow,
   }: {
     startDate: string;
@@ -504,6 +533,7 @@ export async function fetchCreditTimeseriesByUsageType(
     userIds?: string[];
     apiKeyNames?: string[];
     agentTagIds?: string[];
+    modelIds?: string[];
     fillWindow?: boolean;
   }
 ): Promise<Result<CreditUsageTypePoint[], ElasticsearchError>> {
@@ -515,6 +545,7 @@ export async function fetchCreditTimeseriesByUsageType(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
   });
 
   const programmaticFilter = getProgrammaticUsageFilterClause();
@@ -580,6 +611,7 @@ export async function fetchCreditTimeseriesBreakdown(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
     fillWindow,
   }: {
     startDate: string;
@@ -593,6 +625,7 @@ export async function fetchCreditTimeseriesBreakdown(
     userIds?: string[];
     apiKeyNames?: string[];
     agentTagIds?: string[];
+    modelIds?: string[];
     fillWindow?: boolean;
   }
 ): Promise<Result<CreditTimeseriesBreakdown, ElasticsearchError>> {
@@ -606,6 +639,7 @@ export async function fetchCreditTimeseriesBreakdown(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
   });
   if (ranking.isErr()) {
     return ranking;
@@ -628,6 +662,7 @@ export async function fetchCreditTimeseriesBreakdown(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
   });
 
   const result = await searchAnalytics<never, CreditTimeseriesBreakdownAggs>(

--- a/front/lib/api/assistant/observability/utils.ts
+++ b/front/lib/api/assistant/observability/utils.ts
@@ -41,6 +41,9 @@ export function daysToInstantRange(
 export const NOT_API_GROUP_KEY = "__not_api__";
 export const NOT_API_GROUP_NAME = "Not API";
 
+// Model that actually ran the message, resolved at message creation.
+export const MODEL_ID_FIELD = "model.model_id";
+
 // api_key_name is only set on API-key authenticated messages. The sentinel
 // selects everything else (missing field), so a mixed selection becomes a
 // disjunction of the two.
@@ -95,6 +98,7 @@ export function buildAgentAnalyticsBaseQuery({
   userIds,
   apiKeyNames,
   contextOrigin,
+  modelIds,
   days,
   startDate,
   endDate,
@@ -106,6 +110,7 @@ export function buildAgentAnalyticsBaseQuery({
   userIds?: string[];
   apiKeyNames?: string[];
   contextOrigin?: string | string[];
+  modelIds?: string[];
   days?: number;
   startDate?: string;
   endDate?: string;
@@ -123,6 +128,7 @@ export function buildAgentAnalyticsBaseQuery({
     ...termFilter("user_id", userIds),
     ...apiKeyNamesFilter(apiKeyNames),
     ...contextOriginFilter(contextOrigin),
+    ...termFilter(MODEL_ID_FIELD, modelIds),
   ];
 
   if (startDate && endDate) {
@@ -166,6 +172,7 @@ export function buildCreditsScopeQuery(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
     extraFilters = [],
     extraMustNot = [],
   }: {
@@ -176,6 +183,7 @@ export function buildCreditsScopeQuery(
     userIds?: string[];
     apiKeyNames?: string[];
     agentTagIds?: string[];
+    modelIds?: string[];
     extraFilters?: estypes.QueryDslQueryContainer[];
     extraMustNot?: estypes.QueryDslQueryContainer[];
   }
@@ -189,6 +197,7 @@ export function buildCreditsScopeQuery(
     userIds,
     apiKeyNames,
     agentTagIds,
+    modelIds,
   });
   return {
     bool: {

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -610,7 +610,7 @@ export function useAwuUsageFromAnalytics({
   urlPrefix,
 }: {
   workspaceId: string;
-  groupBy?: "usage_type" | "agent" | "user" | "origin" | "api_key";
+  groupBy?: "usage_type" | "agent" | "user" | "origin" | "api_key" | "model";
   groupByCount?: number;
   granularity?: "day" | "week" | "month";
   days?: number;

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -98,7 +98,7 @@ export function usePokeAwuUsageFromAnalytics({
   filter,
   disabled,
 }: PokeConditionalFetchProps & {
-  groupBy?: "usage_type" | "agent" | "user" | "origin" | "api_key";
+  groupBy?: "usage_type" | "agent" | "user" | "origin" | "api_key" | "model";
   groupByCount?: number;
   granularity?: "day" | "week" | "month";
   days?: number;


### PR DESCRIPTION
## Description

Update analytics graph so they can be filtered and grouped by model.

Refs https://github.com/dust-tt/tasks/issues/9825

## Tests

<img width="1137" height="382" alt="Screenshot 2026-07-28 at 14 28 08" src="https://github.com/user-attachments/assets/5c503f1d-f856-43f8-ab97-1a23e1dc3a0d" />
<img width="1152" height="405" alt="Screenshot 2026-07-28 at 14 28 17" src="https://github.com/user-attachments/assets/e8bb700a-9015-4ef7-90c3-bc2fa2dfac5a" />


## Risk

Low. Safe to rollback.

## Deploy Plan

Front only.
