### PR TITLE
feat: add modelId, providerId and resolutionMethod to analytics message export

### DIFF
--- a/front/lib/api/analytics/messages_export.test.ts
+++ b/front/lib/api/analytics/messages_export.test.ts
@@ -155,6 +155,63 @@ describe("fetchMessageExportRows", () => {
     expect(result.value[0].credits).toBe(0);
   });
 
+  it("reports the resolved model columns", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    mockMessageHits([
+      messageDoc({
+        model: {
+          provider_id: "anthropic",
+          model_id: "claude-opus-5",
+          reasoning_effort: "medium",
+          resolution_method: "agent",
+        },
+      }),
+    ]);
+
+    const result = await fetchMessageExportRows({
+      auth: authenticator,
+      owner: workspace,
+      startDate: "2026-07-01",
+      endDate: "2026-07-02",
+      timezone: "UTC",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value[0].modelId).toBe("claude-opus-5");
+    expect(result.value[0].modelProviderId).toBe("anthropic");
+    expect(result.value[0].modelResolutionMethod).toBe("agent");
+  });
+
+  it("leaves the model columns empty for docs indexed before the model fields shipped", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    mockMessageHits([messageDoc()]);
+
+    const result = await fetchMessageExportRows({
+      auth: authenticator,
+      owner: workspace,
+      startDate: "2026-07-01",
+      endDate: "2026-07-02",
+      timezone: "UTC",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value[0].modelId).toBe("");
+    expect(result.value[0].modelProviderId).toBe("");
+    expect(result.value[0].modelResolutionMethod).toBe("");
+  });
+
   it("reports the direct parent in parentMessageId and defaults to empty", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",

--- a/front/lib/api/analytics/messages_export.ts
+++ b/front/lib/api/analytics/messages_export.ts
@@ -8,7 +8,10 @@ import { resolveServerDisplayNames } from "@app/lib/api/assistant/observability/
 import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
-import type { AgentMessageAnalyticsCost } from "@app/types/assistant/analytics";
+import type {
+  AgentMessageAnalyticsCost,
+  AgentMessageAnalyticsModel,
+} from "@app/types/assistant/analytics";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
@@ -34,6 +37,8 @@ interface AgentMessageDocument extends ElasticsearchBaseDocument {
   skills_used?: { skill_name: string }[];
   // Optional: docs indexed before the cost fields shipped don't carry it.
   cost?: AgentMessageAnalyticsCost;
+  // Optional: docs indexed before the model fields shipped don't carry it.
+  model?: AgentMessageAnalyticsModel | null;
 }
 
 export interface MessageExportRow {
@@ -50,6 +55,9 @@ export interface MessageExportRow {
   source: string;
   toolsUsed: string;
   skillsUsed: string;
+  modelId: string;
+  modelProviderId: string;
+  modelResolutionMethod: string;
   credits: number;
 }
 
@@ -67,6 +75,9 @@ export const MESSAGE_EXPORT_HEADERS: (keyof MessageExportRow)[] = [
   "source",
   "toolsUsed",
   "skillsUsed",
+  "modelId",
+  "modelProviderId",
+  "modelResolutionMethod",
   "credits",
 ];
 
@@ -191,6 +202,9 @@ export async function fetchMessageExportRows({
       skillsUsed: joinDistinctSorted(
         (doc.skills_used ?? []).map((s) => s.skill_name)
       ),
+      modelId: doc.model?.model_id ?? "",
+      modelProviderId: doc.model?.provider_id ?? "",
+      modelResolutionMethod: doc.model?.resolution_method ?? "",
       credits: Math.round(doc.cost?.full_awu ?? 0),
     };
   });


### PR DESCRIPTION
## Description

Add those new fields to the CSV/JSON analytics export.

Refs https://github.com/dust-tt/tasks/issues/9825.

## Tests

ut + manually tested by downloading the `messages` export and seeing the new fields populated

## Risk

Low. Safe to rollback

## Deploy Plan

Front only
