### PR TITLE
feat: expose models to analyst through mcp

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2562,6 +2562,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": false,
       "toolCostCategory": "basic",
     },
+    "get_top_models": {
+      "freeUsage": false,
+      "toolCostCategory": "basic",
+    },
     "get_top_skills": {
       "freeUsage": false,
       "toolCostCategory": "basic",
@@ -3370,6 +3374,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_source_breakdown": "never_ask",
     "get_top_agent_tags": "never_ask",
     "get_top_agents": "never_ask",
+    "get_top_models": "never_ask",
     "get_top_skills": "never_ask",
     "get_top_tools": "never_ask",
     "get_top_users": "never_ask",

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1110,6 +1110,10 @@ const QUERIES: LabeledQuery[] = [
     maxRank: 10,
   },
   {
+    query: "which models did the workspace use most this month",
+    expected: "workspace_analytics.get_top_models",
+  },
+  {
     query: "how many AWU credits did the workspace consume this month",
     expected: "workspace_analytics.get_credit_usage",
   },

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1112,6 +1112,7 @@ const QUERIES: LabeledQuery[] = [
   {
     query: "which models did the workspace use most this month",
     expected: "workspace_analytics.get_top_models",
+    maxRank: 5,
   },
   {
     query: "how many AWU credits did the workspace consume this month",

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -29,12 +29,14 @@ const getTopUsersSchema = topListSchema("users");
 const getTopSkillsSchema = topListSchema("skills");
 const getTopToolsSchema = topListSchema("tools");
 const getTopAgentTagsSchema = topListSchema("agent tags");
+const getTopModelsSchema = topListSchema("models");
 
 const getSourceBreakdownSchema = {
   ...timeWindowSchemaShape,
   agentIds: usageFilterSchema.agentIds,
   userIds: usageFilterSchema.userIds,
   agentTagIds: usageFilterSchema.agentTagIds,
+  modelIds: usageFilterSchema.modelIds,
 };
 
 const getAgentDetailsSchema = {
@@ -49,11 +51,12 @@ const getCreditUsageSchema = {
   ...timeWindowSchemaShape,
   ...usageFilterSchema,
   groupBy: z
-    .enum(["agent", "user", "none"])
+    .enum(["agent", "user", "model", "none"])
     .optional()
     .describe(
-      "Break the estimated credits down by top 'agent' or 'user', or 'none' " +
-        "(default) for the workspace total only."
+      "Break the estimated credits down by top 'agent', 'user' or 'model' " +
+        "(the model that answered the message), or 'none' (default) for the " +
+        "workspace total only."
     ),
   limit: z
     .number()
@@ -75,11 +78,12 @@ const getCreditTimeseriesSchema = {
     .optional()
     .describe("Bucket granularity for the credit trend (default day)."),
   breakdownBy: z
-    .enum(["agent", "user"])
+    .enum(["agent", "user", "model"])
     .optional()
     .describe(
-      "Split each bucket into the top agents or users by credits, plus an " +
-        "'other' series for the rest. Omit for a single total-credits trend."
+      "Split each bucket into the top agents, users or models by credits, " +
+        "plus an 'other' series for the rest. Omit for a single total-credits " +
+        "trend."
     ),
   breakdownLimit: z
     .number()
@@ -169,6 +173,26 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
     freeUsage: false,
   },
   {
+    name: "get_top_models",
+    description:
+      "List which LLM models (Claude, GPT, Gemini, ...) answered messages over " +
+      "a time window (defaults to the current calendar month), ranked by " +
+      "message volume, with each model's provider and its distinct agent and " +
+      "user counts. Use this to answer which model is used most, and to " +
+      "discover the model ids to pass as the modelIds filter of the other " +
+      "analytics tools; for credits per model use get_credit_usage with " +
+      "groupBy 'model'. Models come from historical message data, so retired " +
+      "models may appear. Admin-only.",
+    schema: getTopModelsSchema,
+    stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving top models",
+      done: "Retrieved top models",
+    },
+    toolCostCategory: "basic",
+    freeUsage: false,
+  },
+  {
     name: "get_agent_details",
     description:
       "Return an agent's full configuration: name, description, scope, model, " +
@@ -189,8 +213,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
     description:
       "Return the workspace's most-used skills over a time window (defaults " +
       "to the current calendar month), ranked by execution count. Optionally " +
-      "filter by source (context_origin), agent, user, or tag. Use this to " +
-      "answer which skills are used most. Admin-only.",
+      "filter by source (context_origin), agent, user, tag, or model. Use this " +
+      "to answer which skills are used most. Admin-only.",
     schema: getTopSkillsSchema,
     stake: "never_ask",
     displayLabels: {
@@ -206,8 +230,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
       "Return the workspace's most-used MCP tools and integrations over a " +
       "time window (defaults to the current calendar month), ranked by " +
       "execution count. Shows which MCP server tools are called most. Optionally " +
-      "filter by source (context_origin), agent, user, or tag. Use this to " +
-      "answer which tools are used most or which integrations agents " +
+      "filter by source (context_origin), agent, user, tag, or model. Use this " +
+      "to answer which tools are used most or which integrations agents " +
       "rely on. Admin-only.",
     schema: getTopToolsSchema,
     stake: "never_ask",
@@ -229,8 +253,8 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
       "dashboard. Use this to discover and compare which channels or " +
       "integrations drive usage (including programmatic ones like API and " +
       "triggers) — the source filter on the other tools only narrows to one " +
-      "source, this enumerates them all. Optionally filter by agent, user, or " +
-      "tag. Admin-only.",
+      "source, this enumerates them all. Optionally filter by agent, user, " +
+      "tag, or model. Admin-only.",
     schema: getSourceBreakdownSchema,
     stake: "never_ask",
     displayLabels: {
@@ -244,14 +268,15 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
     name: "get_credit_usage",
     description:
       "Estimate AWU credit consumption over a time window (defaults to the " +
-      "current calendar month), optionally broken down by the top agents or " +
-      "users. Credits combine model compute and tool usage, mirroring how " +
-      "billing computes them. IMPORTANT: these figures are ESTIMATES derived " +
-      "from usage logs — always tell the user they are approximate and point " +
-      "them to the workspace Usage page for exact, billed credit amounts. " +
-      "Optionally filter by source (context_origin), agent, user, or tag — " +
-      "e.g. filter by tag to attribute credits to all agents with a given " +
-      "tag. Admin-only.",
+      "current calendar month), optionally broken down by the top agents, " +
+      "users or models. Credits combine model compute and tool usage, " +
+      "mirroring how billing computes them. IMPORTANT: these figures are " +
+      "ESTIMATES derived from usage logs — always tell the user they are " +
+      "approximate and point them to the workspace Usage page for exact, " +
+      "billed credit amounts. Optionally filter by source (context_origin), " +
+      "agent, user, tag, or model — e.g. filter by tag to attribute credits " +
+      "to all agents with a given tag, or group by model to see which models " +
+      "drive spend. Admin-only.",
     schema: getCreditUsageSchema,
     stake: "never_ask",
     displayLabels: {
@@ -267,13 +292,14 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
       "Return estimated AWU credit consumption as a time series over a window " +
       "(defaults to the last 30 days), bucketed by day, week, or month. Set " +
       "breakdownBy to split each " +
-      "bucket into the top agents or users plus an 'other' series (a stacked " +
-      "trend). Use this for credit/spend TRENDS over time; use get_credit_usage " +
-      "for a single window's totals and top agent/user attribution. IMPORTANT: " +
+      "bucket into the top agents, users or models plus an 'other' series (a " +
+      "stacked trend). Use this for credit/spend TRENDS over time; use " +
+      "get_credit_usage for a single window's totals and top " +
+      "agent/user/model attribution. IMPORTANT: " +
       "these figures are ESTIMATES — always tell the user they are approximate " +
       "and point them to the workspace Usage page for exact, billed credit " +
       "amounts. Chart the result. Optionally filter by source (context_origin), " +
-      "agent, user, or tag. Admin-only.",
+      "agent, user, tag, or model. Admin-only.",
     schema: getCreditTimeseriesSchema,
     stake: "never_ask",
     displayLabels: {

--- a/front/lib/api/actions/servers/workspace_analytics/query_input.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/query_input.ts
@@ -86,6 +86,13 @@ export const usageFilterSchema = {
       "Restrict to messages from agents carrying any of these agent tag " +
         "sIds, as returned by get_top_agent_tags."
     ),
+  modelIds: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Restrict to messages answered by these models, identified by their " +
+        "model id (e.g. 'claude-sonnet-4-5'), as returned by get_top_models."
+    ),
 };
 
 export type TimeWindowInput = z.input<typeof timeWindowInputSchema>;

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
@@ -27,6 +27,7 @@ describe("workspace_analytics tools", () => {
     "get_top_agents",
     "get_top_users",
     "get_top_agent_tags",
+    "get_top_models",
     "get_agent_details",
     "get_top_skills",
     "get_top_tools",

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -34,6 +34,7 @@ import {
 } from "@app/lib/api/assistant/observability/tool_usage";
 import { fetchTopAgentTags } from "@app/lib/api/assistant/observability/top_agent_tags";
 import { fetchTopAgents } from "@app/lib/api/assistant/observability/top_agents";
+import { fetchTopModels } from "@app/lib/api/assistant/observability/top_models";
 import { fetchTopUsers } from "@app/lib/api/assistant/observability/top_users";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import type { Authenticator } from "@app/lib/auth";
@@ -50,11 +51,13 @@ function scopedBaseQuery(
     agentIds,
     userIds,
     agentTagIds,
+    modelIds,
   }: {
     source?: string;
     agentIds?: string[];
     userIds?: string[];
     agentTagIds?: string[];
+    modelIds?: string[];
   }
 ) {
   return buildAgentAnalyticsBaseQuery({
@@ -65,6 +68,7 @@ function scopedBaseQuery(
     agentIds,
     userIds,
     agentTagIds,
+    modelIds,
   });
 }
 
@@ -118,6 +122,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       agentIds,
       userIds,
       agentTagIds,
+      modelIds,
     },
     { auth }
   ) => {
@@ -139,6 +144,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       agentIds,
       userIds,
       agentTagIds,
+      modelIds,
     });
 
     if (result.isErr()) {
@@ -185,6 +191,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       agentIds,
       userIds,
       agentTagIds,
+      modelIds,
     },
     { auth }
   ) => {
@@ -206,6 +213,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       agentIds,
       userIds,
       agentTagIds,
+      modelIds,
     });
 
     if (result.isErr()) {
@@ -252,6 +260,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       agentIds,
       userIds,
       agentTagIds,
+      modelIds,
     },
     { auth }
   ) => {
@@ -273,6 +282,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       agentIds,
       userIds,
       agentTagIds,
+      modelIds,
     });
 
     if (result.isErr()) {
@@ -303,6 +313,78 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
         type: "text" as const,
         text:
           `Top agent tags for ${label} (${tz}), most used first:\n` +
+          lines.join("\n"),
+      },
+    ]);
+  },
+
+  get_top_models: async (
+    {
+      limit,
+      period,
+      startDate,
+      endDate,
+      timezone,
+      source,
+      agentIds,
+      userIds,
+      agentTagIds,
+      modelIds,
+    },
+    { auth }
+  ) => {
+    const denied = workspaceAdminGuard(auth);
+    if (denied) {
+      return new Err(denied);
+    }
+
+    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
+    if (window.isErr()) {
+      return new Err(new MCPError(window.error, { tracked: false }));
+    }
+
+    const result = await fetchTopModels(auth, {
+      startDate: window.value.startDate,
+      endDate: window.value.endDate,
+      limit: limit ?? DEFAULT_RESULTS,
+      contextOrigin: source,
+      agentIds,
+      userIds,
+      agentTagIds,
+      modelIds,
+    });
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(`Failed to retrieve top models: ${result.error.message}`)
+      );
+    }
+
+    const { label, timezone: tz } = window.value;
+
+    if (result.value.length === 0) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `No model activity recorded for ${label} (${tz}).`,
+        },
+      ]);
+    }
+
+    const lines = result.value.map((model, index) => {
+      const provider = model.providerId ? ` (${model.providerId})` : "";
+      return (
+        `${index + 1}. ${model.name}${provider} [${model.modelId}] — ` +
+        `${model.messageCount} messages, ${model.agentCount} agents, ` +
+        `${model.userCount} users`
+      );
+    });
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text:
+          `Top models for ${label} (${tz}), most used first:\n` +
           lines.join("\n"),
       },
     ]);
@@ -376,6 +458,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       agentIds,
       userIds,
       agentTagIds,
+      modelIds,
     },
     { auth }
   ) => {
@@ -394,6 +477,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       agentIds,
       userIds,
       agentTagIds,
+      modelIds,
     });
 
     const result = await fetchAvailableSkills(baseQuery);
@@ -441,6 +525,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       agentIds,
       userIds,
       agentTagIds,
+      modelIds,
     },
     { auth }
   ) => {
@@ -459,6 +544,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       agentIds,
       userIds,
       agentTagIds,
+      modelIds,
     });
 
     const result = await fetchAvailableTools(baseQuery);
@@ -505,7 +591,16 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
   },
 
   get_source_breakdown: async (
-    { period, startDate, endDate, timezone, agentIds, userIds, agentTagIds },
+    {
+      period,
+      startDate,
+      endDate,
+      timezone,
+      agentIds,
+      userIds,
+      agentTagIds,
+      modelIds,
+    },
     { auth }
   ) => {
     const denied = workspaceAdminGuard(auth);
@@ -522,6 +617,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       agentIds,
       userIds,
       agentTagIds,
+      modelIds,
     });
 
     const result = await fetchContextOriginBreakdown(baseQuery);
@@ -573,6 +669,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       agentIds,
       userIds,
       agentTagIds,
+      modelIds,
     },
     { auth }
   ) => {
@@ -596,6 +693,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       agentIds,
       userIds,
       agentTagIds,
+      modelIds,
     });
 
     if (result.isErr()) {
@@ -654,6 +752,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       agentIds,
       userIds,
       agentTagIds,
+      modelIds,
     },
     { auth }
   ) => {
@@ -688,6 +787,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
         agentIds,
         userIds,
         agentTagIds,
+        modelIds,
       });
 
       if (result.isErr()) {
@@ -741,6 +841,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       agentIds,
       userIds,
       agentTagIds,
+      modelIds,
     });
 
     if (result.isErr()) {
@@ -787,6 +888,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       agentIds,
       userIds,
       agentTagIds,
+      modelIds,
     },
     { auth }
   ) => {
@@ -808,6 +910,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       agentIds,
       userIds,
       agentTagIds,
+      modelIds,
     });
     const { label, timezone: tz } = window.value;
     const selectedMetric = metric ?? "messages";

--- a/front/lib/api/assistant/observability/top_agent_tags.ts
+++ b/front/lib/api/assistant/observability/top_agent_tags.ts
@@ -27,8 +27,8 @@ type TopAgentTagsAggs = {
 // Ranks agent tags by message count over a time window, with the count of
 // distinct agents carrying each tag.
 // Backs the top-agent-tags analytics endpoint.
-// Either `days` or `startDate`/`endDate` bounds the window; source/agent/user
-// filters are optional.
+// Either `days` or `startDate`/`endDate` bounds the window;
+// source/agent/user/model filters are optional.
 // Since agents can have multiple tags, counts overlap and can sum to more than
 // the total message volume.
 export async function fetchTopAgentTags(
@@ -42,6 +42,7 @@ export async function fetchTopAgentTags(
     agentIds,
     userIds,
     agentTagIds,
+    modelIds,
   }: {
     days?: number;
     startDate?: string;
@@ -51,6 +52,7 @@ export async function fetchTopAgentTags(
     agentIds?: string[];
     userIds?: string[];
     agentTagIds?: string[];
+    modelIds?: string[];
   }
 ): Promise<Result<TopAgentTagRow[], ElasticsearchError>> {
   const owner = auth.getNonNullableWorkspace();
@@ -64,6 +66,7 @@ export async function fetchTopAgentTags(
     agentIds,
     userIds,
     agentTagIds,
+    modelIds,
   });
 
   const result = await searchAnalytics<never, TopAgentTagsAggs>(

--- a/front/lib/api/assistant/observability/top_agents.ts
+++ b/front/lib/api/assistant/observability/top_agents.ts
@@ -28,7 +28,7 @@ type TopAgentsAggs = {
 // Ranks agents by message count over a time window, with unique-user counts and
 // name/picture resolution. Backs both the top-agents analytics endpoint and the
 // workspace_analytics get_top_agents tool. Either `days` or `startDate`/`endDate`
-// bounds the window; the source/agent/user filters are optional.
+// bounds the window; the source/agent/user/model filters are optional.
 export async function fetchTopAgents(
   auth: Authenticator,
   {
@@ -40,6 +40,7 @@ export async function fetchTopAgents(
     agentIds,
     userIds,
     agentTagIds,
+    modelIds,
   }: {
     days?: number;
     startDate?: string;
@@ -49,6 +50,7 @@ export async function fetchTopAgents(
     agentIds?: string[];
     userIds?: string[];
     agentTagIds?: string[];
+    modelIds?: string[];
   }
 ): Promise<Result<WorkspaceTopAgentRow[], ElasticsearchError>> {
   const owner = auth.getNonNullableWorkspace();
@@ -62,6 +64,7 @@ export async function fetchTopAgents(
     agentIds,
     userIds,
     agentTagIds,
+    modelIds,
   });
 
   const result = await searchAnalytics<never, TopAgentsAggs>(

--- a/front/lib/api/assistant/observability/top_models.ts
+++ b/front/lib/api/assistant/observability/top_models.ts
@@ -1,0 +1,121 @@
+import {
+  buildAgentAnalyticsBaseQuery,
+  MODEL_ID_FIELD,
+} from "@app/lib/api/assistant/observability/utils";
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import type { estypes } from "@elastic/elasticsearch";
+
+export type TopModelRow = {
+  modelId: string;
+  name: string;
+  providerId: string | null;
+  messageCount: number;
+  agentCount: number;
+  userCount: number;
+};
+
+type TopModelBucket = {
+  key: string;
+  doc_count: number;
+  unique_agents?: estypes.AggregationsCardinalityAggregate;
+  unique_users?: estypes.AggregationsCardinalityAggregate;
+};
+
+type TopModelsAggs = {
+  by_model?: estypes.AggregationsMultiBucketAggregateBase<TopModelBucket>;
+};
+
+// Ranks the models that actually answered messages over a time window, with the
+// count of distinct agents and users behind each. Backs the
+// workspace_analytics get_top_models tool, which also serves as the discovery
+// path for the `modelIds` filter of the other tools. Either `days` or
+// `startDate`/`endDate` bounds the window; the source/agent/user/model filters
+// are optional.
+export async function fetchTopModels(
+  auth: Authenticator,
+  {
+    days,
+    startDate,
+    endDate,
+    limit,
+    contextOrigin,
+    agentIds,
+    userIds,
+    agentTagIds,
+    modelIds,
+  }: {
+    days?: number;
+    startDate?: string;
+    endDate?: string;
+    limit: number;
+    contextOrigin?: string | string[];
+    agentIds?: string[];
+    userIds?: string[];
+    agentTagIds?: string[];
+    modelIds?: string[];
+  }
+): Promise<Result<TopModelRow[], ElasticsearchError>> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    days,
+    startDate,
+    endDate,
+    contextOrigin,
+    agentIds,
+    userIds,
+    agentTagIds,
+    modelIds,
+  });
+
+  const result = await searchAnalytics<never, TopModelsAggs>(
+    {
+      bool: {
+        filter: [baseQuery, { exists: { field: MODEL_ID_FIELD } }],
+      },
+    },
+    {
+      aggregations: {
+        by_model: {
+          terms: { field: MODEL_ID_FIELD, size: limit },
+          aggs: {
+            unique_agents: { cardinality: { field: "agent_id" } },
+            unique_users: { cardinality: { field: "user_id" } },
+          },
+        },
+      },
+      size: 0,
+    }
+  );
+
+  if (result.isErr()) {
+    return result;
+  }
+
+  const buckets = bucketsToArray<TopModelBucket>(
+    result.value.aggregations?.by_model?.buckets
+  );
+
+  const rows = buckets.map((bucket) => {
+    const modelId = String(bucket.key);
+    // Models leave the catalog while their messages stay indexed; fall back to
+    // the raw id so the row is still readable and filterable.
+    const modelConfig = getModelConfigByModelId(modelId);
+    return {
+      modelId,
+      name: modelConfig?.displayName ?? modelId,
+      providerId: modelConfig?.providerId ?? null,
+      messageCount: bucket.doc_count ?? 0,
+      agentCount: Math.round(bucket.unique_agents?.value ?? 0),
+      userCount: Math.round(bucket.unique_users?.value ?? 0),
+    };
+  });
+
+  return new Ok(rows);
+}

--- a/front/lib/api/assistant/observability/top_users.ts
+++ b/front/lib/api/assistant/observability/top_users.ts
@@ -43,6 +43,7 @@ export async function fetchTopUsers(
     agentIds,
     userIds,
     agentTagIds,
+    modelIds,
   }: {
     days?: number;
     startDate?: string;
@@ -52,6 +53,7 @@ export async function fetchTopUsers(
     agentIds?: string[];
     userIds?: string[];
     agentTagIds?: string[];
+    modelIds?: string[];
   }
 ): Promise<Result<WorkspaceTopUserRow[], ElasticsearchError>> {
   const owner = auth.getNonNullableWorkspace();
@@ -65,6 +67,7 @@ export async function fetchTopUsers(
     agentIds,
     userIds,
     agentTagIds,
+    modelIds,
   });
 
   const result = await searchAnalytics<never, TopUsersAggs>(

--- a/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
+++ b/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
@@ -29,17 +29,21 @@ export const workspaceAnalyticsSkill = {
     "get_top_*) once per day or in parallel per period — it is slower and " +
     "unnecessary, the timeseries tools already bucket over time.\n" +
     "- Use get_credit_usage for a single window's total credits or to " +
-    "attribute spend to the top agents or users, not for per-day trends.\n" +
-    "- For a credit trend split by agent or user (e.g. 'how did each agent's " +
-    "spend evolve'), set breakdownBy on get_credit_timeseries — one call " +
-    "returns the top groups plus an 'other' series. Do not make one filtered " +
-    "call per agent or user.\n" +
+    "attribute spend to the top agents, users or models, not for per-day " +
+    "trends.\n" +
+    "- For a credit trend split by agent, user or model (e.g. 'how did each " +
+    "agent's spend evolve'), set breakdownBy on get_credit_timeseries — one " +
+    "call returns the top groups plus an 'other' series. Do not make one " +
+    "filtered call per agent, user or model.\n" +
+    "- To scope any tool to specific models, call get_top_models first to get " +
+    "the exact model ids in use, then pass them as modelIds — never guess a " +
+    "model id from its display name.\n" +
     "- Chart timeseries results so the admin can see the trend.\n" +
     "- Credit figures are estimates; when reporting them, tell the admin they " +
     "are approximate and point to the workspace Usage page for exact billed " +
     "amounts.",
   mcpServers: [{ name: "workspace_analytics" }],
-  version: 2,
+  version: 3,
   icon: "ActionPieChartIcon",
   isRestricted: async (auth: Authenticator) => {
     if (!auth.isAdmin()) {


### PR DESCRIPTION
## Description

- Add a new mcp function `get_top_models`
- Update existing mcp analytics function prototype so they accept `model_ids`

This enables the analyst agent to answer questions like "what's the usage per models" or "how many credits were consumed by model X in the last 30 days"

Refs https://github.com/dust-tt/tasks/issues/9825.


## Tests

Queried the `analyst` agent and saw it use the new function/parameters:

<img width="1185" height="561" alt="Screenshot 2026-07-28 at 14 29 15" src="https://github.com/user-attachments/assets/c0607799-c664-425f-a06b-9fe4f5778fc9" />

## Risk

Low. Safe to rollback.

## Deploy Plan

Front only
