### PR TITLE
[front] Remove global_disable_metronome_billing kill switch

### DIFF
--- a/front-api/routes/w/[wId]/subscriptions/checkout/business-activation.test.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/business-activation.test.ts
@@ -1,9 +1,8 @@
-import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { grantWorkspacePermission } from "@app/tests/utils/permissions";
 import { honoApp } from "@front-api/app";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 function get(workspace: { sId: string }, query: Record<string, string> = {}) {
   const qs = new URLSearchParams(query).toString();
@@ -17,28 +16,6 @@ function get(workspace: { sId: string }, query: Record<string, string> = {}) {
 describe("GET /api/w/:wId/subscriptions/checkout/business-activation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  afterEach(async () => {
-    await KillSwitchResource.disableKillSwitch(
-      "global_disable_metronome_billing"
-    );
-  });
-
-  it("returns 403 when metronome billing is killed", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
-      method: "GET",
-      role: "admin",
-    });
-
-    await KillSwitchResource.enableKillSwitch(
-      "global_disable_metronome_billing"
-    );
-
-    const response = await get(workspace, { setup_session_id: "cs_test" });
-
-    expect(response.status).toBe(403);
-    expect((await response.json()).error.type).toBe("workspace_auth_error");
   });
 
   it("returns 403 when the legacy_billing flag is set", async () => {

--- a/front-api/routes/w/[wId]/subscriptions/index.test.ts
+++ b/front-api/routes/w/[wId]/subscriptions/index.test.ts
@@ -1,10 +1,9 @@
-import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { grantWorkspacePermission } from "@app/tests/utils/permissions";
 import { honoApp } from "@front-api/app";
 import type { Stripe } from "stripe";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const TEST_CHECKOUT_URL = "https://checkout.stripe.com/test-session";
 const TEST_CLIENT_SECRET = "cs_test_client_secret";
@@ -49,12 +48,6 @@ describe("POST /api/w/:wId/subscriptions", () => {
     vi.clearAllMocks();
   });
 
-  afterEach(async () => {
-    await KillSwitchResource.disableKillSwitch(
-      "global_disable_metronome_billing"
-    );
-  });
-
   it("returns 400 on invalid request body", async () => {
     const { workspace } = await createPrivateApiMockRequest({
       method: "POST",
@@ -65,42 +58,6 @@ describe("POST /api/w/:wId/subscriptions", () => {
 
     expect(response.status).toBe(400);
     expect((await response.json()).error.type).toBe("invalid_request_error");
-  });
-
-  it("returns hosted checkoutUrl and plan details for legacy subscription when metronome billing is killed", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
-      method: "POST",
-      role: "admin",
-    });
-
-    await KillSwitchResource.enableKillSwitch(
-      "global_disable_metronome_billing"
-    );
-
-    const response = await post(workspace, { billingPeriod: "monthly" });
-
-    expect(response.status).toBe(200);
-    const data = await response.json();
-    expect(data.mode).toEqual("hosted");
-    expect(data.checkoutUrl).toEqual(TEST_CHECKOUT_URL);
-  });
-
-  it("handles yearly billing period for legacy subscription when metronome billing is killed", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
-      method: "POST",
-      role: "admin",
-    });
-
-    await KillSwitchResource.enableKillSwitch(
-      "global_disable_metronome_billing"
-    );
-
-    const response = await post(workspace, { billingPeriod: "yearly" });
-
-    expect(response.status).toBe(200);
-    const data = await response.json();
-    expect(data.mode).toEqual("hosted");
-    expect(data.checkoutUrl).toEqual(TEST_CHECKOUT_URL);
   });
 
   it("returns embedded clientSecret and sessionId by default", async () => {
@@ -133,7 +90,7 @@ describe("POST /api/w/:wId/subscriptions", () => {
     expect(response.status).toBe(400);
   });
 
-  it("returns hosted checkoutUrl when legacy_billing flag is set even without the kill switch", async () => {
+  it("returns hosted checkoutUrl when legacy_billing flag is set", async () => {
     const { workspace, auth } = await createPrivateApiMockRequest({
       method: "POST",
       role: "admin",

--- a/front-spa/src/app/layouts/WorkspacePage.tsx
+++ b/front-spa/src/app/layouts/WorkspacePage.tsx
@@ -1,7 +1,6 @@
 import { ProfileOnboardingDialog } from "@dust-tt/front/components/onboarding/ProfileOnboardingDialog";
 import { AppAuthContextLayout } from "@dust-tt/front/components/sparkle/AppAuthContextLayout";
 import { computeIsMetronomeCheckout } from "@dust-tt/front/lib/client/subscription";
-import { useKillSwitches } from "@dust-tt/front/lib/swr/kill";
 import { useAuthContext } from "@dust-tt/front/lib/swr/workspaces";
 import { AuthErrorPage } from "@spa/app/components/AuthErrorPage";
 import { useAppReadyContext } from "@spa/app/contexts/AppReadyContext";
@@ -29,7 +28,6 @@ export function WorkspacePage({ children }: WorkspacePageProps) {
   const { authContext, isAuthenticated, authContextError } = useAuthContext({
     workspaceId: wId,
   });
-  const { killSwitches } = useKillSwitches();
 
   const signalAppReady = useAppReadyContext();
 
@@ -56,7 +54,6 @@ export function WorkspacePage({ children }: WorkspacePageProps) {
   // the auth context provider, which this component is about to mount.
   const isMetronomeCheckout = computeIsMetronomeCheckout({
     featureFlags: authContext.featureFlags,
-    killSwitches,
   });
 
   // Paywall enforcement: redirect when canUseProduct is false

--- a/front/components/pages/onboarding/TrialPage.tsx
+++ b/front/components/pages/onboarding/TrialPage.tsx
@@ -1,6 +1,5 @@
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
-import { useKillSwitches } from "@app/lib/swr/kill";
 import { Button, Check, DustLogoSquare, Icon, Page } from "@dust-tt/sparkle";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
 import React from "react";
@@ -9,11 +8,8 @@ export function TrialPage() {
   const { workspace } = useAuth();
   const router = useAppRouter();
   const { hasFeature } = useFeatureFlags();
-  const { killSwitches } = useKillSwitches();
 
-  const isMetronome =
-    !hasFeature("legacy_billing") &&
-    !killSwitches?.includes("global_disable_metronome_billing");
+  const isMetronome = !hasFeature("legacy_billing");
 
   const skip = async () => {
     void router.push(`/w/${workspace.sId}/subscribe`);

--- a/front/components/poke/pages/KillPage.tsx
+++ b/front/components/poke/pages/KillPage.tsx
@@ -14,7 +14,6 @@ import {
   AnthropicLogo,
   Button,
   CloudArrowLeftRight,
-  CreditCard01,
   Fire,
   OpenaiLogo,
   PauseCircle,
@@ -68,13 +67,6 @@ const KILL_SWITCH_DEFINITIONS: Record<KillSwitchType, KillSwitchDefinition> = {
       "Force Dust and Deep Dive agents to use non-Anthropic providers.",
     note: "Use only when the latest Sonnet or Opus models are down.",
     icon: RefreshCw02,
-  },
-  global_disable_metronome_billing: {
-    title: "Metronome Billing",
-    description:
-      "Disable Metronome billing globally and fall back to legacy Stripe subscriptions.",
-    note: "Workspaces with the `legacy_billing` feature flag are always on legacy billing regardless of this switch.",
-    icon: CreditCard01,
   },
   pause_upsert_queue: {
     title: "Upsert Queue",

--- a/front/lib/api/subscription.ts
+++ b/front/lib/api/subscription.ts
@@ -16,7 +16,6 @@ import {
   resolvePackageAliasForCurrency,
 } from "@app/lib/plans/billing_currency";
 import { CREDIT_PRICED_FREE_PLAN_CODE } from "@app/lib/plans/plan_codes";
-import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
@@ -27,16 +26,11 @@ import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { removeNulls } from "@app/types/shared/utils/general";
 
 // Metronome billing is enabled by default for all workspaces. The
-// `global_disable_metronome_billing` kill switch turns it off globally; the
 // `legacy_billing` feature flag forces it off for individual workspaces.
 export async function isMetronomeBillingEnabled(
   auth: Authenticator
 ): Promise<boolean> {
-  const [hasLegacyFlag, killed] = await Promise.all([
-    hasFeatureFlag(auth, "legacy_billing"),
-    KillSwitchResource.isKillSwitchEnabled("global_disable_metronome_billing"),
-  ]);
-  return !hasLegacyFlag && !killed;
+  return !(await hasFeatureFlag(auth, "legacy_billing"));
 }
 
 /**

--- a/front/lib/client/subscription.ts
+++ b/front/lib/client/subscription.ts
@@ -2,13 +2,11 @@ import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { getBillingCurrencyForCountry } from "@app/lib/plans/billing_currency";
 import { isFreePlan } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
-import type { KillSwitchType } from "@app/lib/poke/types";
 import { useGeolocation } from "@app/lib/swr/geo";
 import type { SupportedCurrency } from "@app/types/currency";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import { useEffect, useState } from "react";
-import { useKillSwitches } from "../swr/kill";
 
 // If mention the price of the PRO plan in a few different places in the code base,
 // so this is just a way to have that value hardcoded in one place.
@@ -28,30 +26,23 @@ export const CP_MAX_SEAT_COST_YEARLY = 120;
 /**
  * Client-side mirror of the server-side `isMetronomeBillingEnabled` gate: the
  * credit-priced checkout flow follows Metronome billing, which is enabled by
- * default for all workspaces. The `global_disable_metronome_billing` kill
- * switch turns it off globally; the `legacy_billing` feature flag forces it
- * off for individual workspaces.
+ * default for all workspaces. The `legacy_billing` feature flag forces it off
+ * for individual workspaces.
  *
  * Prefer the `useIsMetronomeCheckout` hook; this helper is for components that
  * render outside the auth context provider (e.g. the SPA workspace layout).
  */
 export function computeIsMetronomeCheckout({
   featureFlags,
-  killSwitches,
 }: {
   featureFlags: WhitelistableFeature[];
-  killSwitches: KillSwitchType[] | null | undefined;
 }): boolean {
-  return (
-    !featureFlags.includes("legacy_billing") &&
-    !killSwitches?.includes("global_disable_metronome_billing")
-  );
+  return !featureFlags.includes("legacy_billing");
 }
 
 export function useIsMetronomeCheckout(): boolean {
   const { featureFlags } = useFeatureFlags();
-  const { killSwitches } = useKillSwitches();
-  return computeIsMetronomeCheckout({ featureFlags, killSwitches });
+  return computeIsMetronomeCheckout({ featureFlags });
 }
 
 /**
@@ -67,10 +58,7 @@ export function useIsMetronomeCheckout(): boolean {
 export function useUserBillingCurrency(): SupportedCurrency {
   const { geoData } = useGeolocation();
   const { hasFeature } = useFeatureFlags();
-  const { killSwitches } = useKillSwitches();
-  const isMetronomeBillingEnabled =
-    !hasFeature("legacy_billing") &&
-    !killSwitches?.includes("global_disable_metronome_billing");
+  const isMetronomeBillingEnabled = !hasFeature("legacy_billing");
 
   if (geoData?.countryCode) {
     return getBillingCurrencyForCountry(

--- a/front/lib/poke/types.ts
+++ b/front/lib/poke/types.ts
@@ -5,7 +5,6 @@ export const KILL_SWITCH_TYPES = [
   "global_blacklist_openai",
   "global_disable_firecrawl",
   "global_dust_agents_fallback",
-  "global_disable_metronome_billing",
   "pause_upsert_queue",
 ] as const;
 export type KillSwitchType = (typeof KILL_SWITCH_TYPES)[number];

--- a/x/spolu/credit_pricing/billing/overview.md
+++ b/x/spolu/credit_pricing/billing/overview.md
@@ -40,21 +40,20 @@ on legacy plans*; they must continue to see the current page until they're migra
 
 Two flags declared in `front/types/shared/feature_flags.ts:267-325`, both `dust_only`. Neither
 flag is the source of truth for the Billing-page gate above; Metronome billing is default-on
-unless the global kill switch is active, and the Usage-page flag is temporary.
+unless the `legacy_billing` flag is set on the workspace, and the Usage-page flag is temporary.
 
 | Flag | What it controls |
 | --- | --- |
-| `metronome_billing` | Metronome billing is default-on. The `global_disable_metronome_billing` kill switch turns it off globally; this flag only re-enables it for an individual workspace while the kill switch is active. Also gates Metronome usage event emission (`llm_usage`, `tool_use`). |
+| `metronome_billing` | Metronome billing is default-on. The `legacy_billing` feature flag forces it off for an individual workspace. Also gates Metronome usage event emission (`llm_usage`, `tool_use`). |
 | `metronome_billing_usage_page` | Temporary gate for the new "Usage" admin page (`UsagePage`) and its sidebar entry. Used at `front/components/navigation/config.ts:268` and inside `front/components/pages/workspace/UsagePage.tsx:152, 221`. There is a follow-up task to replace it with `!isLegacyPlan(workspace.sId)` so Usage and Billing share the same credit-pricing gate. |
 
 ### Enabling locally in dev
 
 The full setup to get a Metronome-backed subscription on a dev workspace:
 
-1. **Verify the `global_disable_metronome_billing` kill switch is disabled locally** so
+1. **Verify the workspace does not have the `legacy_billing` feature flag set** so
    subscription creation goes through the Metronome path by default. You no longer need to enable
-   `metronome_billing` on the workspace in normal local dev; only use that feature flag if the
-   global kill switch is intentionally enabled and this one workspace must bypass it.
+   `metronome_billing` on the workspace in normal local dev.
 
    To see the current Usage admin page before it is migrated to `!isLegacyPlan`, enable
    `metronome_billing_usage_page`:
@@ -85,8 +84,7 @@ The full setup to get a Metronome-backed subscription on a dev workspace:
 
 If the workspace has no active Metronome contract yet, `getActiveContract(workspace.sId)` returns
 null and several endpoints (`/seats/plan`, `/metronome/contract`, etc.) return `null` or 400 —
-typically the symptom of step 3 not having been done. The `global_disable_metronome_billing` kill
-switch is managed from Poke (`front/components/poke/pages/KillPage.tsx`); provisioning helpers
+typically the symptom of step 3 not having been done. Provisioning helpers
 live at `scripts/provision_metronome_customers.ts` and `scripts/metronome_setup.ts`.
 
 ---
@@ -266,8 +264,6 @@ is to expose the Stripe hosted URL.
   Enterprise upsell, billing info, and invoices sections are the new pieces.
 - `front/components/plans/SubscriptionPlanCards.tsx` — plan cards / pricing dialogs used today.
 - `front/components/workspace/MetronomeUsageChart.tsx` — Usage page chart, not on Billing.
-- `front/components/poke/pages/KillPage.tsx` — where the `global_disable_metronome_billing`
-  kill switch is managed.
 
 ---
 
@@ -311,7 +307,7 @@ keep business logic in `lib/api/*` and HTTP shaping in handlers.
 
 ## 6. Suggested implementation order
 
-1. Verify `global_disable_metronome_billing` is disabled locally, create/upgrade a workspace,
+1. Verify the workspace lacks the `legacy_billing` flag, create/upgrade a workspace,
    and flip `metronomeContractId` in Poke so `useMetronomeContract`, `useMetronomeInvoice`, and
    `useSeatPlan` return the expected data.
 2. Add the billing-eligibility endpoint + SWR hook over the existing

--- a/x/spolu/credit_pricing/billing/plan.md
+++ b/x/spolu/credit_pricing/billing/plan.md
@@ -21,9 +21,8 @@ working state for both gate-true and gate-false workspaces.
   before the UI PR that consumes it. Per `[BACK16]/[BACK18]` keep handlers thin, put logic in
   `lib/api/billing/*` returning domain types — never `APIErrorWithStatusCode`.
 - **Don't introduce a feature flag for the page** — the gate is contract-based per the Slack
-  decision. Local dev only requires the `global_disable_metronome_billing` kill switch to be
-  disabled plus the Poke flip as documented in `overview.md`; `metronome_billing` is only a
-  per-workspace bypass when the global kill switch is active.
+  decision. Local dev only requires the workspace to lack the `legacy_billing` feature flag
+  plus the Poke flip as documented in `overview.md`.
 - **Every PR is reviewable in isolation**: include a 1-2 line `## Tests` section in the PR
   body matching the template in `AGENTS.local.md`. Use `[TEST1]/[TEST2]` factory-based
   functional tests for endpoints; add Vitest unit tests for pure helpers.


### PR DESCRIPTION
## Description

Removes the `global_disable_metronome_billing` kill switch, which forced all workspaces onto legacy Stripe billing. Metronome billing is now default-on in prod, so the switch is no longer needed; the per-workspace `legacy_billing` feature flag remains the only way to opt a workspace out. This drops the switch from `KILL_SWITCH_TYPES` and the Poke KillPage, and simplifies both the server (`isMetronomeBillingEnabled`) and client billing gates to check only `legacy_billing`.

## Tests

Updated the existing functional tests in `front-api/routes/w/[wId]/subscriptions/` to remove the kill-switch scenarios; the `legacy_billing`-flag paths remain covered. Type-checks pass across `front`, `front-api`, and `front-spa`.

## Risk

Low. Behavior only changes if the kill switch was actively enabled in an environment (it is not, in prod). Fully rollback-safe by reverting. The now-dead `kill_switches` row with this type is harmless and can be cleaned up separately.

## Deploy Plan

Standard deploy, no migration or coordination required.