### PR TITLE
Opt: batch remove GCS content from actions.

### DIFF
--- a/front/lib/resources/agent_mcp_action/output_storage.ts
+++ b/front/lib/resources/agent_mcp_action/output_storage.ts
@@ -2,6 +2,7 @@ import { REDIS_CACHE_CONCURRENCY } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { makeSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor, withRetry } from "@app/lib/utils/async_utils";
 import { cacheWithRedis, warmCacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
@@ -20,12 +21,24 @@ type OutputContent = CallToolResult["content"][number];
 
 // Writes live under the workspace prefix `w/<wsId>/...` so they are included by the
 // workspace-relocation file transfer.
+function getActionOutputGcsPrefix(
+  auth: Authenticator,
+  actionId: ModelId
+): string {
+  const workspace = auth.getNonNullableWorkspace();
+  const actionIdString = makeSId("mcp_action", {
+    id: actionId,
+    workspaceId: workspace.id,
+  });
+  return `w/${workspace.sId}/${MCP_OUTPUT_ITEMS_PREFIX}/${actionIdString}/`;
+}
+
 function getGcsPath(
   auth: Authenticator,
   action: AgentMCPActionResource,
   itemId: ModelId
 ): string {
-  return `w/${auth.getNonNullableWorkspace().sId}/${MCP_OUTPUT_ITEMS_PREFIX}/${action.sId}/${itemId}.json`;
+  return `${getActionOutputGcsPrefix(auth, action.id)}${itemId}.json`;
 }
 
 /**
@@ -204,6 +217,9 @@ export async function batchFetchContentsFromGcs(
 /**
  * Deletes GCS files by path. Not-found errors are ignored (already deleted).
  * Returns Err if any deletion fails for other reasons.
+ *
+ * Prefer {@link deleteActionOutputsFromGcs} when deleting all outputs for
+ * one or more actions — prefix delete is far cheaper than per-object deletes.
  */
 export async function deleteContentsFromGcs(
   gcsPaths: string[]
@@ -230,4 +246,69 @@ export async function deleteContentsFromGcs(
   }
 
   return new Ok(undefined);
+}
+
+/**
+ * Deletes all GCS objects under each action's output prefix via a single
+ * `deleteFiles({ prefix })` call per action (GCS batches internally).
+ * Empty prefixes are a no-op. Failures are logged and returned as Err.
+ */
+async function deleteActionOutputPrefixesFromGcs(
+  auth: Authenticator,
+  actionIds: ModelId[]
+): Promise<Result<void, Error>> {
+  if (actionIds.length === 0) {
+    return new Ok(undefined);
+  }
+
+  const prefixes = actionIds.map((actionId) =>
+    getActionOutputGcsPrefix(auth, actionId)
+  );
+
+  try {
+    const bucket = getPrivateUploadBucket();
+    await concurrentExecutor(
+      prefixes,
+      async (prefix) => {
+        await bucket.deleteByPrefix(prefix);
+      },
+      { concurrency: GCS_CONCURRENCY }
+    );
+  } catch (err) {
+    logger.error(
+      { err: normalizeError(err), actionCount: actionIds.length },
+      "Failed to delete MCP output prefixes from GCS"
+    );
+    return new Err(normalizeError(err));
+  }
+
+  return new Ok(undefined);
+}
+
+/**
+ * Deletes GCS outputs for the given actions: one prefix delete per action,
+ * plus per-object deletes for leftover/legacy paths outside those prefixes.
+ */
+export async function deleteActionOutputsFromGcs(
+  auth: Authenticator,
+  actionIds: ModelId[],
+  gcsPaths: string[]
+): Promise<Result<void, Error>> {
+  if (gcsPaths.length === 0) {
+    return new Ok(undefined);
+  }
+
+  const prefixResult = await deleteActionOutputPrefixesFromGcs(auth, actionIds);
+  if (prefixResult.isErr()) {
+    return prefixResult;
+  }
+
+  const prefixes = actionIds.map((actionId) =>
+    getActionOutputGcsPrefix(auth, actionId)
+  );
+  const uncoveredPaths = gcsPaths.filter(
+    (gcsPath) => !prefixes.some((prefix) => gcsPath.startsWith(prefix))
+  );
+
+  return deleteContentsFromGcs(uncoveredPaths);
 }

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -49,6 +49,13 @@ vi.mock("@app/lib/file_storage", () => ({
       }
       gcsStore.delete(path);
     }),
+    deleteByPrefix: vi.fn(async (prefix: string) => {
+      for (const path of [...gcsStore.keys()]) {
+        if (path.startsWith(prefix)) {
+          gcsStore.delete(path);
+        }
+      }
+    }),
   })),
 }));
 
@@ -518,6 +525,34 @@ describe("Output items with GCS storage", () => {
     expect(gcsStore.size).toBe(0);
 
     // DB rows should be deleted.
+    const remainingItems = await AgentMCPActionOutputItemModel.findAll({
+      where: { workspaceId: workspace.id, agentMCPActionId: action.id },
+    });
+    expect(remainingItems).toHaveLength(0);
+  });
+
+  it("should delete legacy GCS paths that are outside the action prefix", async () => {
+    const { action, outputItemRows } = await createActionWithOutputItems([
+      { type: "text", text: "canonical" },
+      { type: "text", text: "legacy" },
+    ]);
+
+    expect(gcsStore.size).toBe(2);
+
+    // Point the second item at a legacy path that is not under the action prefix.
+    const legacyPath = `mcp_output_items/${action.sId}/${outputItemRows[1].id}.json`;
+    const legacyContent = gcsStore.get(outputItemRows[1].contentGcsPath!);
+    assert(legacyContent);
+    gcsStore.delete(outputItemRows[1].contentGcsPath!);
+    gcsStore.set(legacyPath, legacyContent);
+    await outputItemRows[1].update({ contentGcsPath: legacyPath });
+
+    await AgentMCPActionResource.destroyOutputItemsByActionIds(auth, [
+      action.id,
+    ]);
+
+    expect(gcsStore.size).toBe(0);
+
     const remainingItems = await AgentMCPActionOutputItemModel.findAll({
       where: { workspaceId: workspace.id, agentMCPActionId: action.id },
     });

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -39,7 +39,7 @@ import {
 import {
   batchFetchContentsFromGcs,
   batchWriteContentsToGcs,
-  deleteContentsFromGcs,
+  deleteActionOutputsFromGcs,
   warmGcsContentCache,
 } from "@app/lib/resources/agent_mcp_action/output_storage";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
@@ -1072,38 +1072,42 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
   /**
    * Destroys output items by action IDs, cleaning up GCS files first.
-   * GCS deletion failures are logged but do not block DB cleanup — orphaned
-   * GCS files can be cleaned up later and don't cause data issues.
+   * Paths under the canonical action prefix are removed with one prefix delete
+   * per action that has GCS content. Any leftover paths (e.g. legacy layouts)
+   * are deleted individually. Failures are logged but do not block DB cleanup —
+   * orphaned GCS files can be cleaned up later and don't cause data issues.
    */
   static async destroyOutputItemsByActionIds(
     auth: Authenticator,
     actionIds: ModelId[]
   ): Promise<void> {
-    const workspaceId = auth.getNonNullableWorkspace().id;
+    if (actionIds.length === 0) {
+      return;
+    }
 
-    // Fetch items with GCS paths (only need id + contentGcsPath — no TOAST hit).
+    const workspace = auth.getNonNullableWorkspace();
+
+    // Fetch items with GCS paths (only need contentGcsPath — no TOAST hit).
     const gcsItems = await AgentMCPActionOutputItemModel.findAll({
       attributes: ["id", "contentGcsPath"],
       where: {
-        workspaceId,
+        workspaceId: workspace.id,
         agentMCPActionId: { [Op.in]: actionIds },
         contentGcsPath: { [Op.ne]: null },
       },
     });
 
-    // TODO(2026-02-25 PERF): Remove this post-migration.
-    // Delete GCS files. Failures are logged inside deleteContentsFromGcs but do not block DB
-    // cleanup.
-    if (gcsItems.length > 0) {
-      await deleteContentsFromGcs(
-        removeNulls(gcsItems.map((item) => item.contentGcsPath))
-      );
+    const gcsPaths = removeNulls(gcsItems.map((item) => item.contentGcsPath));
+
+    if (gcsPaths.length > 0) {
+      // Results intentionally unused — failures must not block DB cleanup.
+      await deleteActionOutputsFromGcs(auth, actionIds, gcsPaths);
     }
 
     // Delete all output items from DB.
     await AgentMCPActionOutputItemModel.destroy({
       where: {
-        workspaceId,
+        workspaceId: workspace.id,
         agentMCPActionId: { [Op.in]: actionIds },
       },
     });


### PR DESCRIPTION
## Description

`destroyOutputItemsByActionIds` was deleting MCP action GCS content one file at a time. Replaced with prefix-based deletion via `deleteActionOutputPrefixesFromGcs`, which issues one `bucket.deleteByPrefix()` call per action (GCS batches internally) — far cheaper at scale. Added `getActionOutputGcsPrefix` to canonicalize the prefix computation. For any leftover paths that don't match the canonical prefix (legacy layout from before the migration), we fall back to the existing per-object `deleteContentsFromGcs`. Removes the stale `TODO(2026-02-25 PERF)` comment.

## Tests

Added `deleteByPrefix` mock to the GCS store in the existing test suite. Added a unit test covering the legacy-path fallback: simulates an output item stored at an old path outside the action prefix and verifies it is still fully cleaned up.

## Risk

Low. GCS deletion failures were already non-blocking (logged, don't block DB cleanup). The legacy-path fallback ensures no orphaned files from old layouts. Pure optimization with no behavioral change for callers.

## Deploy Plan

Deploy front.
