### PR TITLE
Opt: refactor content fragments deletion.

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -1,6 +1,7 @@
 import { hardDeleteDataSource } from "@app/lib/api/data_sources";
 import { deleteOwnerPolicy } from "@app/lib/api/sandbox/egress_policy";
 import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { AgentSuggestionModel } from "@app/lib/models/agent/agent_suggestion";
 import {
   AgentMessageFeedbackModel,
@@ -18,12 +19,13 @@ import {
 } from "@app/lib/models/skill/conversation_skill";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
-import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
+import { getContentFragmentBaseCloudStorageForWorkspace } from "@app/lib/resources/content_fragment_resource";
 import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { ConversationSelectedSpaceResource } from "@app/lib/resources/conversation_selected_space_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import {
   ProjectTaskConversationModel,
   ProjectTaskSourceModel,
@@ -110,50 +112,20 @@ async function destroyMessageRelatedResources(
 
 async function destroyContentFragments(
   auth: Authenticator,
-  messageAndContentFragmentIds: Array<{
-    contentFragmentId: ModelId;
-    messageId: string;
-  }>,
-  {
-    conversationId,
-  }: {
-    conversationId: string;
-  }
+  contentFragmentIds: ModelId[]
 ) {
-  const contentFragmentIds = messageAndContentFragmentIds.map(
-    (c) => c.contentFragmentId
-  );
   if (contentFragmentIds.length === 0) {
     return;
   }
 
-  const contentFragments = await ContentFragmentResource.fetchManyByModelIds(
-    auth,
-    contentFragmentIds
-  );
-
-  for (const contentFragment of contentFragments) {
-    const messageContentFragmentId = messageAndContentFragmentIds.find(
-      (c) => c.contentFragmentId === contentFragment.id
-    );
-
-    if (!messageContentFragmentId) {
-      throw new Error(
-        `Failed to destroy content fragment with id ${contentFragment.id}.`
-      );
-    }
-
-    const { messageId } = messageContentFragmentId;
-
-    const deletionRes = await contentFragment.destroy({
-      conversationId,
-      messageId,
-      workspaceId: auth.getNonNullableWorkspace().sId,
-    });
-    if (deletionRes.isErr()) {
-      throw deletionRes;
-    }
-  }
+  // GCS objects for this conversation were already removed via a single prefix
+  // delete in destroyConversation.
+  await ContentFragmentModel.destroy({
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      id: contentFragmentIds,
+    },
+  });
 }
 
 async function destroyConversationDataSource(
@@ -219,10 +191,16 @@ export async function destroyConversation(
       },
     });
 
+    // One prefix covers every content-fragment attachment for this conversation
+    // (`.../conversations/{conversationId}/content_fragment/{messageId}/{text|raw}`).
+    // Failures abort destroy before DB rows are touched so Temporal can retry.
+    await getPrivateUploadBucket().deleteByPrefix(
+      `${getContentFragmentBaseCloudStorageForWorkspace(owner.sId)}${conversation.sId}/`
+    );
+
     const messages = await MessageModel.findAll({
       attributes: [
         "id",
-        "sId",
         "userMessageId",
         "agentMessageId",
         "contentFragmentId",
@@ -247,14 +225,8 @@ export async function destroyConversation(
       const compactionMessageIds = removeNulls(
         messagesChunk.map((m) => m.compactionMessageId)
       );
-      const messageAndContentFragmentIds = removeNulls(
-        messagesChunk.map((m) => {
-          if (m.contentFragmentId) {
-            return { contentFragmentId: m.contentFragmentId, messageId: m.sId };
-          }
-
-          return null;
-        })
+      const contentFragmentIds = removeNulls(
+        messagesChunk.map((m) => m.contentFragmentId)
       );
 
       await destroyActionsRelatedResources(auth, agentMessageIds);
@@ -290,9 +262,7 @@ export async function destroyConversation(
         },
       });
 
-      await destroyContentFragments(auth, messageAndContentFragmentIds, {
-        conversationId: conversation.sId,
-      });
+      await destroyContentFragments(auth, contentFragmentIds);
 
       await CompactionMessageModel.destroy({
         where: {

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -58,7 +58,6 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 import assert from "assert";
 import type {
@@ -681,54 +680,11 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
   }
 
   /**
-   * Temporary workaround until we can call this method from the MessageResource.
-   * @deprecated use the destroy method.
+   * Content fragment GCS + DB cleanup lives in destroyConversation (one
+   * conversation-level GCS prefix delete, then batched DB deletes).
    */
   delete(): Promise<Result<undefined, Error>> {
     throw new Error("Method not implemented.");
-  }
-
-  async destroy(
-    {
-      conversationId,
-      messageId,
-      workspaceId,
-    }: { conversationId: string; messageId: string; workspaceId: string },
-    transaction?: Transaction
-  ): Promise<Result<undefined, Error>> {
-    try {
-      const { filePath: textFilePath } = fileAttachmentLocation({
-        conversationId,
-        workspaceId,
-        messageId,
-        contentFormat: "text",
-      });
-
-      const { filePath: rawFilePath } = fileAttachmentLocation({
-        conversationId,
-        workspaceId,
-        messageId,
-        contentFormat: "raw",
-      });
-
-      const privateUploadGcs = getPrivateUploadBucket();
-
-      // First, we delete the doc from the file storage.
-      await privateUploadGcs.delete(textFilePath, { ignoreNotFound: true });
-      await privateUploadGcs.delete(rawFilePath, { ignoreNotFound: true });
-
-      // Then, we delete the record from the DB.
-      await this.model.destroy({
-        where: {
-          id: this.id,
-        },
-        transaction,
-      });
-
-      return new Ok(undefined);
-    } catch (err) {
-      return new Err(normalizeError(err));
-    }
   }
 
   async setSourceUrl(sourceUrl: string | null) {

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -299,6 +299,13 @@ class FileStorageMock {
         this._objectStore.delete(filePath);
         return Promise.resolve(undefined);
       }),
+      deleteByPrefix: vi.fn(async (prefix: string) => {
+        for (const path of [...this._objectStore.keys()]) {
+          if (path.startsWith(prefix)) {
+            this._objectStore.delete(path);
+          }
+        }
+      }),
       deleteFiles: vi.fn().mockResolvedValue(undefined),
       getAllFilesByPrefix: vi
         .fn()


### PR DESCRIPTION
## Description

Replace per-fragment GCS + DB deletion in `destroyConversation` with a single `getPrivateUploadBucket().deleteByPrefix()` call on the conversation's GCS path prefix, followed by a batched `ContentFragmentModel.destroy()` WHERE IN. Previously `destroyContentFragments` fetched each `ContentFragmentResource`, issued 2 individual GCS deletes (`text` + `raw`) and 1 DB delete per fragment — O(N) round trips for conversations with many attachments. Now a single prefix delete covers all `conversations/{conversationId}/content_fragment/` objects upfront, before any DB rows are touched, so Temporal can safely retry on GCS failure.

Also removes `ContentFragmentResource.destroy()`, the per-item method that drove the old flow.

## Tests

- Added `deleteByPrefix` to `FileStorageMock` so existing `destroyConversation` tests cover the new GCS path.
- Tested locally.

## Risk

Low. GCS prefix delete runs before any DB rows are removed, keeping the operation Temporal-retry-safe. The only behavioral change is that a GCS error now aborts destroy cleanly before touching DB — strictly safer than the previous partial-deletion scenario. Rollback is straightforward (no schema changes).

## Deploy Plan

Deploy front.