### PR TITLE
[front] Hide admin-role invitation revoke/resend from managers

### DIFF
--- a/front/components/members/EditInvitationModal.tsx
+++ b/front/components/members/EditInvitationModal.tsx
@@ -10,6 +10,7 @@ import { sendInvitations, updateInvitation } from "@app/lib/invitations";
 import { useProvisioningStatus } from "@app/lib/swr/workos";
 import type { MembershipInvitationType } from "@app/types/membership_invitation";
 import type { ActiveRoleType, WorkspaceType } from "@app/types/user";
+import { isAdmin } from "@app/types/user";
 import {
   Button,
   Mail01,
@@ -63,6 +64,11 @@ export function EditInvitationModal({
   const { hasFeature } = useFeatureFlags();
 
   const isAdminGovernanceEnabled = hasFeature("admin_governance");
+
+  // Managers cannot revoke or resend invitations targeting the admin role
+  // (matches the server-side escalation guard); only admins can.
+  const canManageAdminInvitation =
+    invitation?.initialRole !== "admin" || isAdmin(owner);
 
   const { roleProvisioningStatus } = useProvisioningStatus({
     workspaceId: owner.sId,
@@ -144,36 +150,38 @@ export function EditInvitationModal({
                 <div className="text-muted-foreground">{roleMessage}</div>
               </div>
 
-              <div className="flex items-center gap-2">
-                <Button
-                  variant="primary"
-                  label="Send invitation again"
-                  icon={Mail01}
-                  onClick={async () => {
-                    await sendInvitations({
-                      owner,
-                      emails: [invitation.inviteEmail],
-                      invitationRole: selectedRole,
-                      sendNotification,
-                      isNewInvitation: false,
-                    });
-                  }}
-                />
-                <Button
-                  variant="warning"
-                  label="Revoke invitation"
-                  icon={XClose}
-                  disabled={owner.ssoEnforced}
-                  onClick={async () => {
-                    await updateInvitation({
-                      invitation,
-                      owner,
-                      sendNotification,
-                      confirm,
-                    });
-                  }}
-                />
-              </div>
+              {canManageAdminInvitation && (
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="primary"
+                    label="Send invitation again"
+                    icon={Mail01}
+                    onClick={async () => {
+                      await sendInvitations({
+                        owner,
+                        emails: [invitation.inviteEmail],
+                        invitationRole: selectedRole,
+                        sendNotification,
+                        isNewInvitation: false,
+                      });
+                    }}
+                  />
+                  <Button
+                    variant="warning"
+                    label="Revoke invitation"
+                    icon={XClose}
+                    disabled={owner.ssoEnforced}
+                    onClick={async () => {
+                      await updateInvitation({
+                        invitation,
+                        owner,
+                        sendNotification,
+                        confirm,
+                      });
+                    }}
+                  />
+                </div>
+              )}
             </div>
           )}
         </SheetContainer>

--- a/front/components/members/InvitationsList.tsx
+++ b/front/components/members/InvitationsList.tsx
@@ -10,6 +10,7 @@ import { sendInvitations } from "@app/lib/invitations";
 import { useWorkspaceInvitations } from "@app/lib/swr/memberships";
 import type { MembershipInvitationType } from "@app/types/membership_invitation";
 import type { WorkspaceType } from "@app/types/user";
+import { isAdmin } from "@app/types/user";
 import {
   Avatar,
   Button,
@@ -43,6 +44,10 @@ export function InvitationsList({
   const sendNotification = useSendNotification();
   const { hasFeature } = useFeatureFlags();
 
+  // Managers cannot resend invitations targeting the admin role (matches the
+  // server-side escalation guard); only admins can.
+  const canManageAdminRole = isAdmin(owner);
+
   const filteredInvitations = useMemo(
     () =>
       invitations
@@ -72,6 +77,8 @@ export function InvitationsList({
       accessorKey: "inviteEmail",
       cell: (info: CellContext<RowData, string>) => {
         const isExpired = info.row.original.isExpired;
+        const canResend =
+          info.row.original.initialRole !== "admin" || canManageAdminRole;
         return (
           <DataTable.CellContent>
             <div className="flex items-center gap-2">
@@ -79,22 +86,24 @@ export function InvitationsList({
               {isExpired && (
                 <>
                   <span className="text-red-500">(expired)</span>
-                  <Button
-                    size="xs"
-                    variant="outline"
-                    icon={Mail01}
-                    label="Resend"
-                    onClick={async (e: React.MouseEvent) => {
-                      e.stopPropagation();
-                      await sendInvitations({
-                        owner,
-                        emails: [info.row.original.inviteEmail],
-                        invitationRole: info.row.original.initialRole,
-                        sendNotification,
-                        isNewInvitation: false,
-                      });
-                    }}
-                  />
+                  {canResend && (
+                    <Button
+                      size="xs"
+                      variant="outline"
+                      icon={Mail01}
+                      label="Resend"
+                      onClick={async (e: React.MouseEvent) => {
+                        e.stopPropagation();
+                        await sendInvitations({
+                          owner,
+                          emails: [info.row.original.inviteEmail],
+                          invitationRole: info.row.original.initialRole,
+                          sendNotification,
+                          isNewInvitation: false,
+                        });
+                      }}
+                    />
+                  )}
                 </>
               )}
             </div>


### PR DESCRIPTION
## Description

Managers (non-admins) must not be able to revoke or resend workspace invitations that target the **admin** role, mirroring the existing server-side escalation guard in the invitations API. This gates the revoke and "send again" actions in `EditInvitationModal`, and the inline resend action for expired invitations in `InvitationsList`, on `isAdmin(owner)` — so those buttons no longer render for admin invitations when the current user is only a manager.

## Tests

Manually reasoned against the existing `RoleDropDown` locking pattern and the server-side guard; no automated tests added (pure UI conditional rendering). Type-checked with `tsgo --noEmit` and formatted with biome.

## Risk

Low — UI-only change hiding buttons; the backend already rejects these actions for non-admins, so this only aligns the frontend affordances. Safe to roll back.

## Deploy Plan

Standard `front` deploy, no migrations or coordination required.