### PR TITLE
[front] enh: Add per-class QoS task queues and workers for the agent loop

### DIFF
--- a/front/scripts/temporal-build/build-temporal-bundles.ts
+++ b/front/scripts/temporal-build/build-temporal-bundles.ts
@@ -12,11 +12,20 @@ interface WorkerInfo {
 }
 
 function discoverWorkers(): WorkerInfo[] {
-  return ALL_WORKERS.map((workerName): WorkerInfo => {
+  // Workers sharing a workflows directory (the agent-loop pools) share one bundle, keyed by
+  // the first worker name — their Worker.create calls all load the agent_loop bundle.
+  const seenPaths = new Set<string>();
+  const workers: WorkerInfo[] = [];
+  for (const workerName of ALL_WORKERS) {
     const name = workerName as WorkerName;
     const workflowsPath = getWorkerWorkflowsPath(name);
-    return { name, workflowsPath };
-  });
+    if (seenPaths.has(workflowsPath)) {
+      continue;
+    }
+    seenPaths.add(workflowsPath);
+    workers.push({ name, workflowsPath });
+  }
+  return workers;
 }
 
 function getWorkerWorkflowsPath(workerName: WorkerName): string {
@@ -35,6 +44,10 @@ function getWorkerDirectory(workerName: WorkerName): string | null {
     case "activation_scheduler":
       return path.join(baseDir, "temporal/activation_scheduler");
     case "agent_loop":
+    case "agent_loop_batch":
+    case "agent_loop_interactive":
+    case "agent_loop_programmatic":
+    case "agent_loop_schedules":
       return path.join(baseDir, "temporal/agent_loop");
     case "agent_schedule":
       return path.join(baseDir, "temporal/triggers");

--- a/front/temporal/agent_loop/config.test.ts
+++ b/front/temporal/agent_loop/config.test.ts
@@ -1,0 +1,66 @@
+import {
+  BATCH_QUEUE_NAME,
+  getQueueForUserMessageOrigin,
+  getQueueName,
+  INTERACTIVE_QUEUE_NAME,
+  PROGRAMMATIC_QUEUE_NAME,
+  SCHEDULES_QUEUE_NAME,
+} from "@app/temporal/agent_loop/config";
+import type { UserMessageOrigin } from "@app/types/assistant/conversation";
+import { describe, expect, it } from "vitest";
+
+describe("getQueueName", () => {
+  it("maps each queue to its task queue name", () => {
+    expect(getQueueName("schedules")).toBe(SCHEDULES_QUEUE_NAME);
+    expect(getQueueName("interactive")).toBe(INTERACTIVE_QUEUE_NAME);
+    expect(getQueueName("programmatic")).toBe(PROGRAMMATIC_QUEUE_NAME);
+    expect(getQueueName("batch")).toBe(BATCH_QUEUE_NAME);
+  });
+});
+
+describe("getQueueForUserMessageOrigin", () => {
+  it("routes product UI origins to the interactive queue", () => {
+    const origins: UserMessageOrigin[] = [
+      "web",
+      "agent_sidekick",
+      "project_kickoff",
+    ];
+    for (const origin of origins) {
+      expect(getQueueForUserMessageOrigin(origin)).toBe("interactive");
+    }
+  });
+
+  it("routes public API origins to the programmatic queue", () => {
+    const origins: UserMessageOrigin[] = [
+      "api",
+      "zapier",
+      "extension",
+      "gsheet",
+      "zendesk",
+    ];
+    for (const origin of origins) {
+      expect(getQueueForUserMessageOrigin(origin)).toBe("programmatic");
+    }
+  });
+
+  it("routes chat platform bot origins to the interactive queue", () => {
+    const origins: UserMessageOrigin[] = ["slack", "slack_workflow", "teams"];
+    for (const origin of origins) {
+      expect(getQueueForUserMessageOrigin(origin)).toBe("interactive");
+    }
+  });
+
+  it("routes scheduled triggers and wake-ups to the schedules queue", () => {
+    expect(getQueueForUserMessageOrigin("triggered")).toBe("schedules");
+    expect(getQueueForUserMessageOrigin("wakeup")).toBe("schedules");
+  });
+
+  it("routes webhook triggers and internal batch origins to the batch queue", () => {
+    expect(getQueueForUserMessageOrigin("triggered_programmatic")).toBe(
+      "batch"
+    );
+    expect(getQueueForUserMessageOrigin("reinforcement")).toBe("batch");
+    expect(getQueueForUserMessageOrigin("system_activation")).toBe("batch");
+    expect(getQueueForUserMessageOrigin("transcript")).toBe("batch");
+  });
+});

--- a/front/temporal/agent_loop/config.ts
+++ b/front/temporal/agent_loop/config.ts
@@ -1,6 +1,96 @@
+import type { UserMessageOrigin } from "@app/types/assistant/conversation";
+import {
+  assertNever,
+  assertNeverAndIgnore,
+} from "@app/types/shared/utils/assert_never";
+
 const QUEUE_VERSION = 2;
 
+// Agent loop workflows are partitioned across task queues (isolation domains) so one traffic
+// class cannot starve another. Each queue's worker deployment is sized by infra to a QoS tier
+// (replicas, cpu, memory; per-pod activity slots are hardcoded per worker):
+// - schedules (high): scheduled triggers and wake-ups, i.e. time commitments.
+// - interactive (high): humans waiting on an answer, in the product UI or in a chat platform
+//   (Slack/Teams bots, via connectors with system keys).
+// - programmatic (medium): the public API surface (integrations, automations).
+// - batch (low): webhook-fired triggers and internal batch work.
+// Queue names are decoupled from tiers so re-tiering a queue never migrates workflows.
+export type AgentLoopQueue =
+  | "schedules"
+  | "interactive"
+  | "programmatic"
+  | "batch";
+
+// The legacy queue, not a routing target: everything lands here while routing is off, keeping
+// the historical name so in-flight workflows and the existing worker deployment are
+// unaffected. Slated for removal once routing is fully rolled out.
 export const QUEUE_NAME = `agent-loop-queue-v${QUEUE_VERSION}`;
+export const SCHEDULES_QUEUE_NAME = `agent-loop-schedules-queue-v${QUEUE_VERSION}`;
+export const INTERACTIVE_QUEUE_NAME = `agent-loop-interactive-queue-v${QUEUE_VERSION}`;
+export const PROGRAMMATIC_QUEUE_NAME = `agent-loop-programmatic-queue-v${QUEUE_VERSION}`;
+export const BATCH_QUEUE_NAME = `agent-loop-batch-queue-v${QUEUE_VERSION}`;
+
+export function getQueueName(queue: AgentLoopQueue): string {
+  switch (queue) {
+    case "schedules":
+      return SCHEDULES_QUEUE_NAME;
+    case "interactive":
+      return INTERACTIVE_QUEUE_NAME;
+    case "programmatic":
+      return PROGRAMMATIC_QUEUE_NAME;
+    case "batch":
+      return BATCH_QUEUE_NAME;
+    default:
+      return assertNever(queue);
+  }
+}
+
+// The QoS policy: which queue serves each user message origin. The origin is validated
+// against the auth method when the message is posted (e.g. only system API keys can claim
+// slack/teams origins), so it is trustworthy as a routing key.
+export function getQueueForUserMessageOrigin(
+  origin: UserMessageOrigin
+): AgentLoopQueue {
+  switch (origin) {
+    case "api":
+    case "cli":
+    case "cli_programmatic":
+    case "email":
+    case "excel":
+    case "extension":
+    case "gsheet":
+    case "make":
+    case "n8n":
+    case "powerpoint":
+    case "raycast":
+    case "zapier":
+    case "zendesk":
+      return "programmatic";
+    case "agent_sidekick":
+    case "onboarding_conversation":
+    case "project_kickoff":
+    case "reinforced_skill_notification":
+    case "slack":
+    case "slack_workflow":
+    case "teams":
+    case "web":
+      return "interactive";
+    case "triggered":
+    case "wakeup":
+      return "schedules";
+    case "triggered_programmatic":
+    case "reinforcement":
+    case "system_activation":
+    case "transcript":
+      return "batch";
+    default:
+      // Origins are persisted: during a rolling deploy an older pod can read an origin value
+      // introduced by a newer one. Unknown origins degrade to batch, away from the pools
+      // serving humans.
+      assertNeverAndIgnore(origin);
+      return "batch";
+  }
+}
 
 // Max retry attempts for the runModelAndCreateActions activity.
 export const RUN_MODEL_MAX_RETRIES = 5;

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -24,10 +24,17 @@ import {
 import { publishDeferredEventsActivity } from "@app/temporal/agent_loop/activities/publish_deferred_events";
 import { runModelAndCreateActionsActivity } from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
 import { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
-import { QUEUE_NAME } from "@app/temporal/agent_loop/config";
+import {
+  BATCH_QUEUE_NAME,
+  INTERACTIVE_QUEUE_NAME,
+  PROGRAMMATIC_QUEUE_NAME,
+  QUEUE_NAME,
+  SCHEDULES_QUEUE_NAME,
+} from "@app/temporal/agent_loop/config";
 import { instrumentationSinks } from "@app/temporal/agent_loop/sinks";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import { isDevelopment } from "@app/types/shared/env";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { Context } from "@temporalio/activity";
 import {
@@ -45,6 +52,53 @@ const SHUTDOWN_TOOL_ABORT_DELAY_MS =
   SHUTDOWN_GRACE_TIME_MS - SHUTDOWN_ABORT_BUFFER_MS;
 
 export async function runAgentLoopWorker() {
+  return runAgentLoopWorkerForQueue({
+    taskQueue: QUEUE_NAME,
+    maxConcurrentActivityTaskExecutions: 75,
+  });
+}
+
+export async function runAgentLoopBatchWorker() {
+  return runAgentLoopWorkerForQueue({
+    taskQueue: BATCH_QUEUE_NAME,
+    // Deliberately low: the batch queue is the load-shedding tier, backlog is the
+    // intended backpressure.
+    maxConcurrentActivityTaskExecutions: 20,
+  });
+}
+
+export async function runAgentLoopInteractiveWorker() {
+  return runAgentLoopWorkerForQueue({
+    taskQueue: INTERACTIVE_QUEUE_NAME,
+    maxConcurrentActivityTaskExecutions: 60,
+  });
+}
+
+export async function runAgentLoopProgrammaticWorker() {
+  return runAgentLoopWorkerForQueue({
+    taskQueue: PROGRAMMATIC_QUEUE_NAME,
+    // Between the human-facing pools (60) and batch (20): programmatic callers tolerate
+    // queueing better than humans.
+    maxConcurrentActivityTaskExecutions: 40,
+  });
+}
+
+export async function runAgentLoopSchedulesWorker() {
+  return runAgentLoopWorkerForQueue({
+    taskQueue: SCHEDULES_QUEUE_NAME,
+    maxConcurrentActivityTaskExecutions: 60,
+  });
+}
+
+async function runAgentLoopWorkerForQueue({
+  taskQueue,
+  maxConcurrentActivityTaskExecutions,
+}: {
+  taskQueue: string;
+  // Per-pod activity slots: the per-queue backpressure knob (bounds concurrent
+  // activities, and with them CPU and DB connection pressure).
+  maxConcurrentActivityTaskExecutions: number;
+}) {
   const { connection, namespace } = await getTemporalAgentWorkerConnection();
 
   // Initialize LLMs instrumentation for the worker.
@@ -54,6 +108,8 @@ export async function runAgentLoopWorker() {
 
   const worker = await Worker.create({
     ...getWorkflowConfig({
+      // All agent-loop pools run the same workflow code and share the agent_loop bundle
+      // (build-temporal-bundles dedupes by workflows directory).
       workerName: "agent_loop",
       getWorkflowsPath: () => require.resolve("./workflows"),
     }),
@@ -72,14 +128,14 @@ export async function runAgentLoopWorker() {
       runModelAndCreateActionsActivity,
       runToolActivity,
     },
-    taskQueue: QUEUE_NAME,
+    taskQueue,
     connection,
     namespace,
     shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     // This also bounds the time until an activity may receive a cancellation signal.
     // See https://docs.temporal.io/encyclopedia/detecting-activity-failures#throttling
     maxHeartbeatThrottleInterval: "20 seconds",
-    maxConcurrentActivityTaskExecutions: 75,
+    maxConcurrentActivityTaskExecutions,
     interceptors: {
       workflowModules: removeNulls([
         !isDevelopment() || process.env.USE_TEMPORAL_BUNDLES === "true"
@@ -126,7 +182,10 @@ export async function runAgentLoopWorker() {
   try {
     await worker.run(); // this resolves after shutdown completes
   } catch (error) {
-    logger.error({ error }, "Agent loop worker error");
+    logger.error(
+      { err: normalizeError(error), taskQueue },
+      "Agent loop worker error"
+    );
   } finally {
     await connection.close();
     process.exit(0);

--- a/front/temporal/worker_registry.ts
+++ b/front/temporal/worker_registry.ts
@@ -1,6 +1,12 @@
 import { runPokeWorker } from "@app/poke/temporal/worker";
 import { runActivationSchedulerWorker } from "@app/temporal/activation_scheduler/worker";
-import { runAgentLoopWorker } from "@app/temporal/agent_loop/worker";
+import {
+  runAgentLoopBatchWorker,
+  runAgentLoopInteractiveWorker,
+  runAgentLoopProgrammaticWorker,
+  runAgentLoopSchedulesWorker,
+  runAgentLoopWorker,
+} from "@app/temporal/agent_loop/worker";
 import { runAnalyticsWorker } from "@app/temporal/analytics_queue/worker";
 import { runConversationForkQueueWorker } from "@app/temporal/conversation_fork_queue/worker";
 import { runCreditAlertsWorker } from "@app/temporal/credit_alerts/worker";
@@ -31,6 +37,10 @@ import { runWorkOSEventsWorker } from "@app/temporal/workos_events_queue/worker"
 export type WorkerName =
   | "activation_scheduler"
   | "agent_loop"
+  | "agent_loop_batch"
+  | "agent_loop_interactive"
+  | "agent_loop_programmatic"
+  | "agent_loop_schedules"
   | "agent_schedule"
   | "agent_trigger_webhook"
   | "analytics_queue"
@@ -62,6 +72,10 @@ export type WorkerName =
 export const workerFunctions: Record<WorkerName, () => Promise<void>> = {
   activation_scheduler: runActivationSchedulerWorker,
   agent_loop: runAgentLoopWorker,
+  agent_loop_batch: runAgentLoopBatchWorker,
+  agent_loop_interactive: runAgentLoopInteractiveWorker,
+  agent_loop_programmatic: runAgentLoopProgrammaticWorker,
+  agent_loop_schedules: runAgentLoopSchedulesWorker,
   agent_schedule: runAgentTriggerWorker,
   agent_trigger_webhook: runAgentTriggerWebhookWorker,
   analytics_queue: runAnalyticsWorker,


### PR DESCRIPTION
## Description

Currently, we mix all agent-loops in a single pool of workers, which mixes problem such as 
- CPU throttling ~ 300ms per CPU second
- Connection pool starving (due to idle in tx)
- DB latency spikes
- I/O spikes
- LLM provider rate limitting

This stack is about splitting the agent-loop per QoS (quality of service) commitments we want to impose on ourselves, which falls in the following buckets by order of priority
  - interactive : human in the loop - as fast as possible, high number of workers, more resources
  - schedules : time commitments - we try as much as possible to honor them
  - programmatic : most of /api/v1 surface - limited throughput compared to the two above
  - batch : reinforcement, webhooks, transcripts etc .. best effort throughput.

An additional perk of doing this is to limit the blast radius of one source bursting us (eg schedules, programmatic or batch) on all the resources that are finite like DB connection/cpu, LLM rate limits, with a knob we can control (# of deployments + activitySlots) 

## Plan

This PR: introduce the machinery and the different pools - but no-op, we still map everything to the current agent-loop
Infra PR : create the workers with the "right" sizing and the scale ups

Next PRs: 
- Add the routing logic gated by a feature flag
- Remove jitter in schedules
- Remove jitter in reinforcement


## Risks

- on this PR it's mostly about bug in the codepath, not too much concerned though, will frontedge it
- the real risks is not sizing properly the different worker pools and either or both of:
   - blast the db
   - create un-wanted back-pressure (schedule to start will start flying to the roof)

