### PR TITLE
[AGENT-LOOP] Don't fail the message when a step comes back empty

### DIFF
--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -36,6 +36,9 @@ import { Context } from "@temporalio/activity";
 export type RunModelAndCreateActionsResult = {
   actionBlobs: ActionBlob[];
   runId: string | null;
+  // The model returned nothing at all: the loop should run one more step with
+  // tool use disabled to force a final answer.
+  retryWithoutTools?: boolean;
 };
 
 const AGENT_LOOP_COST_CAP_ERROR_CODE = "agent_loop_cost_cap_exceeded";
@@ -67,12 +70,14 @@ export async function runModelAndCreateActionsActivity({
   runAgentArgs,
   runIds,
   step,
+  forceDisableToolUse = false,
 }: {
   authType: AuthenticatorType;
   checkForResume?: boolean;
   runAgentArgs: AgentLoopArgsWithTiming;
   runIds: string[];
   step: number;
+  forceDisableToolUse?: boolean;
 }): Promise<RunModelAndCreateActionsResult | null> {
   return tracer.trace("runModelAndCreateActionsActivity", async () =>
     _runModelAndCreateActionsActivity({
@@ -81,6 +86,7 @@ export async function runModelAndCreateActionsActivity({
       runAgentArgs,
       runIds,
       step,
+      forceDisableToolUse,
     })
   );
 }
@@ -91,12 +97,14 @@ async function _runModelAndCreateActionsActivity({
   runAgentArgs,
   runIds,
   step,
+  forceDisableToolUse,
 }: {
   authType: AuthenticatorType;
   checkForResume: boolean;
   runAgentArgs: AgentLoopArgsWithTiming;
   runIds: string[];
   step: number;
+  forceDisableToolUse: boolean;
 }): Promise<RunModelAndCreateActionsResult | null> {
   const activityTimeoutDeadlineMs = getActivityTimeoutDeadlineMs();
   const durationRecorder = DurationRecorder.create([]);
@@ -248,6 +256,7 @@ async function _runModelAndCreateActionsActivity({
     functionCallStepContentIds,
     durationRecorder,
     activityTimeoutDeadlineMs,
+    forceDisableToolUse,
   });
 
   if (!modelResult) {
@@ -259,12 +268,13 @@ async function _runModelAndCreateActionsActivity({
     functionCallStepContentIds: updatedFunctionCallStepContentIds,
     runId,
     stepContexts,
+    retryWithoutTools,
   } = modelResult;
 
   // Generation completed (text response, no tool calls) — runModel returns
   // { actions: [], runId } so we still capture the runId for tracking.
   if (actions.length === 0) {
-    return { runId, actionBlobs: [] };
+    return { runId, actionBlobs: [], retryWithoutTools };
   }
 
   // Enforce a limit on actions per step, reducing by depth (8/8/4/2)

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -365,6 +365,7 @@ export async function runModel(
     functionCallStepContentIds,
     durationRecorder,
     activityTimeoutDeadlineMs,
+    forceDisableToolUse = false,
   }: {
     runAgentData: AgentLoopExecutionData;
     runIds: string[];
@@ -372,12 +373,17 @@ export async function runModel(
     functionCallStepContentIds: Record<string, ModelId>;
     durationRecorder: DurationRecorder;
     activityTimeoutDeadlineMs: number;
+    // Set when the previous step came back empty: force the final generation.
+    forceDisableToolUse?: boolean;
   }
 ): Promise<{
   actions: AgentActionsEvent["actions"];
   runId: string;
   functionCallStepContentIds: Record<string, ModelId>;
   stepContexts: StepContext[];
+  // The step produced nothing at all: the loop should run one more step with
+  // tool use disabled to force a final answer.
+  retryWithoutTools?: boolean;
 } | null> {
   const {
     agentConfiguration,
@@ -555,8 +561,8 @@ export async function runModel(
   // still sent, so the request keeps the same shape as previous steps (stable
   // tool definitions preserve prompt caching and keep tool references in the
   // replayed history resolvable), but the model is forbidden from calling them
-  // (tool choice "none").
-  const disableToolUse = isLastStep;
+  // (tool choice "none"). Same treatment after an empty step.
+  const disableToolUse = isLastStep || forceDisableToolUse;
   const availableActions = filteredMcpActions.flatMap((s) => s.tools);
 
   let fallbackPrompt = "You are a conversational agent";
@@ -1022,6 +1028,25 @@ export async function runModel(
     // Surface a retryable error, since publishing a success would silently end
     // the run.
     if (!answerSoFar.length) {
+      // Nothing at all came back: no tool call, no text here, no text in an
+      // earlier step. Rather than failing the message, run one more step with
+      // tool use disabled to force a final answer. The retry is a new step so
+      // it gets its own trace and run id.
+      if (!disableToolUse) {
+        localLogger.warn(
+          { modelId: modelConfig.modelId },
+          "Empty model turn, retrying in a new step without tool use."
+        );
+
+        return {
+          actions: [],
+          runId: dustRunId,
+          functionCallStepContentIds: updatedFunctionCallStepContentIds,
+          stepContexts: [],
+          retryWithoutTools: true,
+        };
+      }
+
       localLogger.warn(
         {
           modelId: modelConfig.modelId,

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -1010,10 +1010,18 @@ export async function runModel(
     // Successful generation.
     const processedContent = contentParser.getContent() ?? "";
 
-    // No tool call and no text: the model produced no answer, either because it
-    // ran out of iterations or because the turn came back empty. Surface a
-    // retryable error, since publishing a success would silently end the run.
-    if (!processedContent.length) {
+    // The answer may have been streamed in an earlier step (text emitted before
+    // a tool call), so an empty step is not an empty message.
+    const answerSoFar = concatWithNewlineBoundary(
+      agentMessage.content,
+      processedContent
+    );
+
+    // No tool call and no text at all: the model produced no answer, either
+    // because it ran out of iterations or because the turn came back empty.
+    // Surface a retryable error, since publishing a success would silently end
+    // the run.
+    if (!answerSoFar.length) {
       localLogger.warn(
         {
           modelId: modelConfig.modelId,
@@ -1057,10 +1065,7 @@ export async function runModel(
     const updatedAgentMessage = {
       ...agentMessage,
       chainOfThought: (agentMessage.chainOfThought ?? "") + chainOfThought,
-      content: concatWithNewlineBoundary(
-        agentMessage.content,
-        processedContent
-      ),
+      content: answerSoFar,
       completedTs,
       status: "succeeded",
       completionDurationMs: getCompletionDuration(

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -241,6 +241,9 @@ export async function agentLoopWorkflow({
     await executionScope.run(async () => {
       const syncStartTime = Date.now();
       let currentStep = startStep;
+      // Set when the previous step returned nothing at all: the next step runs with tool use
+      // disabled to force a final answer.
+      let forceDisableToolUse = false;
       let childWorkflowHandle: ChildWorkflowHandle<
         typeof agentLoopConversationTitleWorkflow
       > | null = null;
@@ -257,16 +260,20 @@ export async function agentLoopWorkflow({
 
         const stepStartTime = Date.now();
 
-        const { runId, shouldContinue } = await executeStepIteration({
-          authType,
-          agentLoopArgs: {
-            ...agentLoopArgs,
-            initialStartTime,
-          },
-          currentStep,
-          runIds,
-          startStep,
-        });
+        const { runId, shouldContinue, retryWithoutTools } =
+          await executeStepIteration({
+            authType,
+            agentLoopArgs: {
+              ...agentLoopArgs,
+              initialStartTime,
+            },
+            currentStep,
+            runIds,
+            startStep,
+            forceDisableToolUse,
+          });
+
+        forceDisableToolUse = retryWithoutTools ?? false;
 
         // Update state with results.
         if (runId) {
@@ -415,15 +422,18 @@ async function executeStepIteration({
   agentLoopArgs,
   runIds,
   startStep,
+  forceDisableToolUse,
 }: {
   authType: AuthenticatorType;
   currentStep: number;
   agentLoopArgs: AgentLoopArgsWithTiming;
   runIds: string[];
   startStep: number;
+  forceDisableToolUse: boolean;
 }): Promise<{
   runId: string | null;
   shouldContinue: boolean;
+  retryWithoutTools?: boolean;
 }> {
   const result = await runModelAndCreateActionsActivity({
     authType,
@@ -431,6 +441,7 @@ async function executeStepIteration({
     runAgentArgs: agentLoopArgs,
     runIds,
     step: currentStep,
+    forceDisableToolUse,
   });
 
   if (!result) {
@@ -441,7 +452,7 @@ async function executeStepIteration({
     };
   }
 
-  const { runId, actionBlobs } = result;
+  const { runId, actionBlobs, retryWithoutTools = false } = result;
 
   // Generation completed or the loop unpaused and no new tools were generated.
   if (actionBlobs.length === 0) {
@@ -449,7 +460,10 @@ async function executeStepIteration({
       runId,
       // If runId is null that means we unpaused the loop with no new tools (eg: they were all
       // denied) and no LLM call, so we need to continue as the agent loop is not finished.
-      shouldContinue: runId === null,
+      // retryWithoutTools means the model returned nothing: run one more step with tool use
+      // disabled to force a final answer.
+      shouldContinue: runId === null || retryWithoutTools,
+      retryWithoutTools,
     };
   }
 


### PR DESCRIPTION
## Description

An agent step that came back with no tool call and no text failed the whole message with `empty_content`, even when the answer had already been written in an earlier step — the check only looked at the text streamed in the current step. It now checks the answer accumulated on the agent message, and when there is genuinely nothing anywhere it re-runs the step once with tool use disabled to force a final answer before erroring.

## Tests

Existing agent-loop unit tests pass; validated against a production trace where the answer was written in step 1 and step 2 came back empty.

## Risk

Low — the forced re-call only happens on a step that would otherwise have failed.

### No Temporal patching needed

Patching is only required when new workflow code, replaying an old history, would emit a different sequence of commands.

- Most of the change is in activity code (`run_model.ts`, the activity wrapper). Activities are never re-executed on replay — only their recorded result is read — so changing them is always safe.
- The workflow change is a no-op on old histories. An activity result recorded before this deploy has no `hasNoContent` field, so on replay it reads `undefined → ?? false`, and `shouldContinue: runId === null || false` is exactly the old `runId === null`. The new branch is only reachable when the field is present, which only happens in results produced by the new code.
- The new `forceDisableToolUse` argument is fine too: replay matches scheduled activities by their position in the command sequence, not by comparing payloads.

The flag is optional and negative on purpose. A required `hasContent` would read as `undefined → falsy → "no content"` on every old history and trigger a spurious extra step — that would need a patch.

A workflow started on old code and still alive (e.g. parked on a tool approval) picks up the new behaviour for its future steps. That is not a determinism issue: those commands are not in history yet, so replay has nothing to disagree with.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`
