### PR TITLE
Persist reasoning token usage on model runs

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/context-usage.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/context-usage.test.ts
@@ -24,6 +24,7 @@ function makeRunUsage({
     completionTokens,
     cachedTokens: null,
     cacheCreationTokens: null,
+    reasoningTokens: null,
     costMicroUsd: 1,
     isBatch: false,
   };

--- a/front/lib/api/assistant/credit_cost.test.ts
+++ b/front/lib/api/assistant/credit_cost.test.ts
@@ -16,6 +16,7 @@ function usage(
 ): RunUsageType & { runKey: string | null } {
   return {
     completionTokens: 0,
+    reasoningTokens: null,
     promptTokens: 0,
     cachedTokens: 0,
     cacheCreationTokens: 0,

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -904,6 +904,7 @@ export class NoopStreamTransition extends StreamEndpointTransition {
           modelId: NOOP_MODEL,
           promptTokens: 0,
           completionTokens: 0,
+          reasoningTokens: null,
           cachedTokens: null,
           costMicroUsd,
           isBatch: false,

--- a/front/lib/api/run.ts
+++ b/front/lib/api/run.ts
@@ -59,6 +59,7 @@ export function extractUsageFromExecutions(
         if (token_usage) {
           const promptTokens = token_usage.prompt_tokens;
           const completionTokens = token_usage.completion_tokens;
+          const reasoningTokens = token_usage.reasoning_tokens;
           const cachedTokens = token_usage.cached_tokens;
           const cacheCreationTokens = token_usage.cache_creation_input_tokens;
 
@@ -75,6 +76,7 @@ export function extractUsageFromExecutions(
             modelId: block.model_id,
             promptTokens,
             completionTokens,
+            reasoningTokens: reasoningTokens ?? null,
             cachedTokens: cachedTokens ?? null,
             cacheCreationTokens: cacheCreationTokens ?? null,
             costMicroUsd: usageCostMicroUsd,

--- a/front/lib/resources/run_resource.test.ts
+++ b/front/lib/resources/run_resource.test.ts
@@ -1,0 +1,62 @@
+import { RunResource } from "@app/lib/resources/run_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { GPT_5_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
+import { describe, expect, it } from "vitest";
+
+describe("RunResource reasoning token usage", () => {
+  it("persists provider-reported reasoning as a subset of completion tokens", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const run = await RunResource.makeNew({
+      appId: null,
+      dustRunId: generateRandomModelSId(),
+      runType: "deploy",
+      useWorkspaceCredentials: false,
+      workspaceId: workspace.id,
+    });
+
+    await run.recordTokenUsage(
+      auth,
+      {
+        inputTokens: 1_000,
+        totalOutputTokens: 300,
+        reasoningTokens: 200,
+        totalTokens: 1_300,
+      },
+      GPT_5_MINI_MODEL_CONFIG.modelId
+    );
+
+    const usages = await run.listRunUsages(auth);
+
+    expect(usages).toHaveLength(1);
+    expect(usages[0]).toMatchObject({
+      completionTokens: 300,
+      reasoningTokens: 200,
+    });
+  });
+
+  it("stores null when the provider does not report reasoning tokens", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const run = await RunResource.makeNew({
+      appId: null,
+      dustRunId: generateRandomModelSId(),
+      runType: "deploy",
+      useWorkspaceCredentials: false,
+      workspaceId: workspace.id,
+    });
+
+    await run.recordTokenUsage(
+      auth,
+      {
+        inputTokens: 1_000,
+        totalOutputTokens: 100,
+        totalTokens: 1_100,
+      },
+      GPT_5_MINI_MODEL_CONFIG.modelId
+    );
+
+    const usages = await run.listRunUsages(auth);
+
+    expect(usages[0]?.reasoningTokens).toBeNull();
+  });
+});

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -226,6 +226,7 @@ export class RunResource extends BaseResource<RunModel> {
       runModelId: usage.runId,
       runKey: runKeyByModelId.get(usage.runId) ?? null,
       completionTokens: usage.completionTokens,
+      reasoningTokens: usage.reasoningTokens,
       modelId: usage.modelId as ModelIdType,
       promptTokens: usage.promptTokens,
       providerId: usage.providerId as ModelProviderIdType,
@@ -353,6 +354,7 @@ export class RunResource extends BaseResource<RunModel> {
           modelId,
           promptTokens,
           completionTokens,
+          reasoningTokens,
           cachedTokens,
           cacheCreationTokens,
           costMicroUsd,
@@ -364,6 +366,7 @@ export class RunResource extends BaseResource<RunModel> {
           modelId,
           promptTokens,
           completionTokens,
+          reasoningTokens,
           cachedTokens,
           cacheCreationTokens: cacheCreationTokens ?? null,
           costMicroUsd,
@@ -408,6 +411,13 @@ export class RunResource extends BaseResource<RunModel> {
           tags
         );
       }
+      if (usage.reasoningTokens) {
+        getStatsDClient().increment(
+          "run_usage.reasoning_tokens",
+          usage.reasoningTokens,
+          tags
+        );
+      }
     }
   }
 
@@ -445,6 +455,7 @@ export class RunResource extends BaseResource<RunModel> {
         cacheCreationTokens: usage.cacheCreationTokens,
         cachedTokens: usage.cachedTokens ?? null,
         completionTokens: usage.totalOutputTokens,
+        reasoningTokens: usage.reasoningTokens ?? null,
         modelId: modelConfig.modelId,
         promptTokens: usage.inputTokens,
         providerId: modelConfig.providerId,
@@ -474,6 +485,8 @@ function addCreatedAtClause(where: WhereOptions<RunModel>) {
 
 export interface RunUsageType {
   completionTokens: number;
+  // Provider-reported reasoning subset of completionTokens.
+  reasoningTokens: number | null;
   modelId: ModelIdType;
   promptTokens: number;
   providerId: ModelProviderIdType;

--- a/front/lib/resources/storage/models/runs.ts
+++ b/front/lib/resources/storage/models/runs.ts
@@ -78,6 +78,8 @@ export class RunUsageModel extends WorkspaceAwareModel<RunUsageModel> {
 
   declare promptTokens: number;
   declare completionTokens: number;
+  // Subset of completionTokens when reported by the provider.
+  declare reasoningTokens: number | null;
   declare cachedTokens: number | null;
   declare cacheCreationTokens: number | null;
 
@@ -102,6 +104,11 @@ RunUsageModel.init(
     completionTokens: {
       type: DataTypes.INTEGER,
       allowNull: false,
+    },
+    reasoningTokens: {
+      type: DataTypes.INTEGER,
+      defaultValue: null,
+      allowNull: true,
     },
     cachedTokens: {
       type: DataTypes.INTEGER,

--- a/front/migrations/pre-deploy/20260728151011_add_reasoning_tokens_to_run_usages.sql
+++ b/front/migrations/pre-deploy/20260728151011_add_reasoning_tokens_to_run_usages.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."run_usages" ADD COLUMN "reasoningTokens" integer;

--- a/front/temporal/analytics_queue/activities.test.ts
+++ b/front/temporal/analytics_queue/activities.test.ts
@@ -1,6 +1,12 @@
 import { ANALYTICS_ALIAS_NAME, withEs } from "@app/lib/api/elasticsearch";
 
 import type { Authenticator } from "@app/lib/auth";
+import {
+  AgentMessageModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
+import { RunResource } from "@app/lib/resources/run_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { storeAgentAnalyticsActivity } from "@app/temporal/analytics_queue/activities";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -8,6 +14,7 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { TagFactory } from "@app/tests/utils/TagFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { GPT_5_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -285,5 +292,65 @@ describe("storeAgentAnalyticsActivity - space_id", () => {
     const doc = analyticsDoc(indexed);
     expect(doc).toBeDefined();
     expect(doc?.space_id).toBeNull();
+  });
+});
+
+describe("storeAgentAnalyticsActivity - reasoning tokens", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("aggregates provider-reported reasoning tokens from run usages", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+    const workspace = auth.getNonNullableWorkspace();
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const seeded = await seedMessages(auth, {
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+    });
+    const message = await MessageModel.findOne({
+      where: {
+        sId: seeded.agentMessageId,
+        workspaceId: workspace.id,
+      },
+    });
+    if (!message?.agentMessageId) {
+      throw new Error("Expected an agent message.");
+    }
+
+    const run = await RunResource.makeNew({
+      appId: null,
+      dustRunId: generateRandomModelSId(),
+      runType: "deploy",
+      useWorkspaceCredentials: false,
+      workspaceId: workspace.id,
+    });
+    await run.recordTokenUsage(
+      auth,
+      {
+        inputTokens: 1_000,
+        totalOutputTokens: 300,
+        reasoningTokens: 200,
+        totalTokens: 1_300,
+      },
+      GPT_5_MINI_MODEL_CONFIG.modelId
+    );
+    await AgentMessageModel.update(
+      { runIds: [run.dustRunId] },
+      {
+        where: {
+          id: message.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      }
+    );
+
+    const indexed = captureIndexedDocs();
+    await runAnalytics(auth, seeded);
+
+    expect(analyticsDoc(indexed)?.tokens).toMatchObject({
+      completion: 300,
+      reasoning: 200,
+    });
   });
 });

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -336,7 +336,7 @@ function aggregateTokenUsage(
       return {
         prompt: acc.prompt + usage.promptTokens,
         completion: acc.completion + usage.completionTokens,
-        reasoning: acc.reasoning, // No reasoning tokens in RunUsageType yet.
+        reasoning: acc.reasoning + (usage.reasoningTokens ?? 0),
         cached: acc.cached + (usage.cachedTokens ?? 0),
         cost_micro_usd: acc.cost_micro_usd + usage.costMicroUsd,
       };


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Providers report reasoning tokens as part of completion usage, but this information was previously discarded before persisting `RunUsage`.

This change stores reasoning tokens as a nullable provider fact while keeping completion tokens inclusive and leaving pricing unchanged (completionTokens = output + reasonning). It propagates the value through recording, tracing, analytics, and simulated usage paths.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] Run SQL migration
- [ ] Deploy front
