### PR TITLE
[front] Support fixed windows in the plan fair-use AWU limiter

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -31,6 +31,7 @@ import {
 import { isProviderWhitelistedForAuth } from "@app/lib/api/assistant/models";
 import { gracefullyStopAgentLoop } from "@app/lib/api/assistant/pubsub";
 import {
+  getFairUseAwuCreditsCount,
   MESSAGE_RATE_LIMIT_PER_ACTOR_PER_HOUR,
   MESSAGE_RATE_LIMIT_PER_ACTOR_PER_HOUR_WINDOW_SECONDS,
   MESSAGE_RATE_LIMIT_PER_ACTOR_PER_MINUTE,
@@ -111,7 +112,6 @@ import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import {
-  getRateLimiterCount,
   getTimeframeSecondsFromLiteral,
   rateLimiter,
 } from "@app/lib/utils/rate_limiter";
@@ -2967,13 +2967,13 @@ async function isMessagesLimitReached(
 
   const user = auth.user();
   if (user && maxAwuCredits !== -1) {
-    const result = await getRateLimiterCount({
+    const result = await getFairUseAwuCreditsCount({
       key: makeFairUseAwuCreditsRateLimitKeyForUser(
         owner,
         user.toJSON(),
         maxAwuCreditsTimeframe
       ),
-      timeframeSeconds: getTimeframeSecondsFromLiteral(maxAwuCreditsTimeframe),
+      timeframe: maxAwuCreditsTimeframe,
     });
 
     if (result.isOk() && result.value >= maxAwuCredits) {

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -2,7 +2,10 @@ import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_ac
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import { getToolNameFromFunctionCallName } from "@app/lib/actions/tool_display_labels";
-import { makeFairUseAwuCreditsRateLimitKeyForUser } from "@app/lib/api/assistant/rate_limits";
+import {
+  makeFairUseAwuCreditsRateLimitKeyForUser,
+  recordFairUseAwuCredits,
+} from "@app/lib/api/assistant/rate_limits";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
 import type { ToolCostCategory } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
@@ -16,10 +19,6 @@ import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_reso
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
-import {
-  addRateLimiterCount,
-  getTimeframeSecondsFromLiteral,
-} from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import type {
   AgentMessageAnalyticsData,
@@ -273,19 +272,17 @@ export async function computeAndStoreAgentMessageCredits(
     assistantLimits.maxAwuCredits !== -1
   ) {
     // Always record the credit cost unconditionally. The limit guard lives in
-    // isMessagesLimitReached (pre-message), which reads the count via getRateLimiterCount and
-    // blocks the next message once the total reaches maxAwuCredits. Using rateLimiter here was
-    // incorrect: its Lua script silently drops the write when count + costCredits > limit,
-    // causing the counter to stall below the limit and never trigger enforcement.
-    await addRateLimiterCount({
+    // isMessagesLimitReached (pre-message), which reads the count via
+    // getFairUseAwuCreditsCount and blocks the next message once the total
+    // reaches maxAwuCredits. recordFairUseAwuCredits dispatches to the rolling
+    // limiter or the fixed-window counter based on the plan timeframe.
+    await recordFairUseAwuCredits({
       key: makeFairUseAwuCreditsRateLimitKeyForUser(
         auth.getNonNullableWorkspace(),
         user.toJSON(),
         assistantLimits.maxAwuCreditsTimeframe
       ),
-      timeframeSeconds: getTimeframeSecondsFromLiteral(
-        assistantLimits.maxAwuCreditsTimeframe
-      ),
+      timeframe: assistantLimits.maxAwuCreditsTimeframe,
       incrementBy: costCredits,
       logger,
     });

--- a/front/lib/api/assistant/fair_use_window.test.ts
+++ b/front/lib/api/assistant/fair_use_window.test.ts
@@ -1,0 +1,98 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+vi.unmock("@app/lib/api/redis");
+
+vi.mock("@app/lib/utils/statsd", () => ({
+  getStatsDClient: () => ({
+    decrement: vi.fn(),
+    distribution: vi.fn(),
+    increment: vi.fn(),
+  }),
+}));
+
+const logger = {
+  error: () => undefined,
+  warn: () => undefined,
+  info: () => undefined,
+  debug: () => undefined,
+  trace: () => undefined,
+};
+
+type RateLimitsModule = typeof import("@app/lib/api/assistant/rate_limits");
+type RateLimiterModule = typeof import("@app/lib/utils/rate_limiter");
+type RedisModule = typeof import("@app/lib/api/redis");
+
+let getFairUseAwuCreditsCount: RateLimitsModule["getFairUseAwuCreditsCount"];
+let recordFairUseAwuCredits: RateLimitsModule["recordFairUseAwuCredits"];
+let computeCalendarWindowBounds: RateLimiterModule["computeCalendarWindowBounds"];
+let expireRateLimiterKey: RateLimiterModule["expireRateLimiterKey"];
+let closeRedisClients: RedisModule["closeRedisClients"];
+
+const keysToExpire = new Set<string>();
+
+describe("fair-use AWU window dispatch", () => {
+  beforeAll(async () => {
+    const rl = await import("@app/lib/api/assistant/rate_limits");
+    const rlim = await import("@app/lib/utils/rate_limiter");
+    const redis = await import("@app/lib/api/redis");
+
+    getFairUseAwuCreditsCount = rl.getFairUseAwuCreditsCount;
+    recordFairUseAwuCredits = rl.recordFairUseAwuCredits;
+    computeCalendarWindowBounds = rlim.computeCalendarWindowBounds;
+    expireRateLimiterKey = rlim.expireRateLimiterKey;
+    closeRedisClients = redis.closeRedisClients;
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      [...keysToExpire].map((key) => expireRateLimiterKey({ key }))
+    );
+    keysToExpire.clear();
+  });
+
+  afterAll(async () => {
+    await closeRedisClients();
+  });
+
+  it("round-trips a rolling timeframe via the rolling limiter", async () => {
+    const key = `test:${crypto.randomUUID()}`;
+    keysToExpire.add(key);
+
+    await recordFairUseAwuCredits({
+      key,
+      timeframe: "day",
+      incrementBy: 5,
+      logger,
+    });
+
+    const result = await getFairUseAwuCreditsCount({ key, timeframe: "day" });
+    expect(result.isOk() && result.value).toBe(5);
+  });
+
+  it("round-trips a calendar (fixed) timeframe via the fixed-window counter", async () => {
+    const key = `test:${crypto.randomUUID()}`;
+    const { label } = computeCalendarWindowBounds("calendar_week", new Date());
+    keysToExpire.add(`${key}:${label}`);
+
+    await recordFairUseAwuCredits({
+      key,
+      timeframe: "calendar_week",
+      incrementBy: 7,
+      logger,
+    });
+
+    const result = await getFairUseAwuCreditsCount({
+      key,
+      timeframe: "calendar_week",
+    });
+    expect(result.isOk() && result.value).toBe(7);
+  });
+});

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -2,7 +2,11 @@ import type { Authenticator } from "@app/lib/auth";
 import { computeEffectiveMessageLimit } from "@app/lib/plans/usage/limits";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import {
+  addFixedWindowCount,
+  addRateLimiterCount,
+  computeCalendarWindowBounds,
   expireRateLimiterKey,
+  getFixedWindowCount,
   getRateLimiterCount,
   getTimeframeSecondsFromLiteral,
 } from "@app/lib/utils/rate_limiter";
@@ -10,6 +14,9 @@ import type {
   MaxAwuCreditsTimeframeType,
   MaxMessagesTimeframeType,
 } from "@app/types/plan";
+import { isRollingAwuCreditsTimeframeType } from "@app/types/rate_limiter";
+import type { LoggerInterface } from "@app/types/shared/logger";
+import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 
@@ -78,6 +85,75 @@ export const makeKeyCapRateLimitKey = (keyId: number) => {
   return `api_key:${keyId}:cap_rate_limit`;
 };
 
+// Read the current fair-use AWU count for `key`, dispatching to the rolling
+// limiter for rolling timeframes and the fixed-window counter (calendar) for
+// fixed ones.
+export async function getFairUseAwuCreditsCount({
+  key,
+  timeframe,
+}: {
+  key: string;
+  timeframe: MaxAwuCreditsTimeframeType;
+}): Promise<Result<number, Error>> {
+  if (isRollingAwuCreditsTimeframeType(timeframe)) {
+    return getRateLimiterCount({
+      key,
+      timeframeSeconds: getTimeframeSecondsFromLiteral(timeframe),
+    });
+  }
+  return getFixedWindowCount({
+    key,
+    bounds: computeCalendarWindowBounds(timeframe, new Date()),
+  });
+}
+
+// Record `incrementBy` against the fair-use AWU counter for `key`, dispatching
+// on the timeframe the same way as `getFairUseAwuCreditsCount`.
+export async function recordFairUseAwuCredits({
+  key,
+  timeframe,
+  incrementBy,
+  logger,
+}: {
+  key: string;
+  timeframe: MaxAwuCreditsTimeframeType;
+  incrementBy: number;
+  logger: LoggerInterface;
+}): Promise<void> {
+  if (isRollingAwuCreditsTimeframeType(timeframe)) {
+    await addRateLimiterCount({
+      key,
+      timeframeSeconds: getTimeframeSecondsFromLiteral(timeframe),
+      incrementBy,
+      logger,
+    });
+    return;
+  }
+  await addFixedWindowCount({
+    key,
+    bounds: computeCalendarWindowBounds(timeframe, new Date()),
+    incrementBy,
+    logger,
+  });
+}
+
+// Expire the current fair-use AWU window for `key`. Fixed (calendar) windows
+// carry the window-boundary label suffix on the live Redis key, so expire that
+// rather than the base key.
+async function expireFairUseAwuCreditsWindow({
+  key,
+  timeframe,
+}: {
+  key: string;
+  timeframe: MaxAwuCreditsTimeframeType;
+}): Promise<Result<boolean, Error>> {
+  if (isRollingAwuCreditsTimeframeType(timeframe)) {
+    return expireRateLimiterKey({ key });
+  }
+  const bounds = computeCalendarWindowBounds(timeframe, new Date());
+  return expireRateLimiterKey({ key: `${key}:${bounds.label}` });
+}
+
 export async function resetMessageRateLimitForWorkspace(auth: Authenticator) {
   const workspace = auth.getNonNullableWorkspace();
   const plan = auth.getNonNullablePlan();
@@ -110,12 +186,13 @@ export async function resetFairUseAwuCreditsRateLimitForUser({
     return new Err(new Error("The workspace plan has no AWU fair-use limit."));
   }
 
-  const resetResult = await expireRateLimiterKey({
+  const resetResult = await expireFairUseAwuCreditsWindow({
     key: makeFairUseAwuCreditsRateLimitKeyForUser(
       workspace,
       user,
       maxAwuCreditsTimeframe
     ),
+    timeframe: maxAwuCreditsTimeframe,
   });
   if (resetResult.isErr()) {
     return resetResult;

--- a/front/lib/client/credits.ts
+++ b/front/lib/client/credits.ts
@@ -22,6 +22,12 @@ export function formatFairUseTimeframe(
       return "per month";
     case "lifetime":
       return "";
+    case "calendar_day":
+      return "per day";
+    case "calendar_week":
+      return "per week";
+    case "calendar_month":
+      return "per month";
     default:
       assertNeverAndIgnore(timeframe);
       return "";

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -20,15 +20,14 @@
 // DB transaction commit via `invalidateCacheAfterCommit`, and cache misses fall
 // back to DB and repopulate the relevant keys.
 //
-import { makeFairUseAwuCreditsRateLimitKeyForUser } from "@app/lib/api/assistant/rate_limits";
+import {
+  getFairUseAwuCreditsCount,
+  makeFairUseAwuCreditsRateLimitKeyForUser,
+} from "@app/lib/api/assistant/rate_limits";
 import { runOnRedis } from "@app/lib/api/redis";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import {
-  getRateLimiterCount,
-  getTimeframeSecondsFromLiteral,
-} from "@app/lib/utils/rate_limiter";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import type {
@@ -252,9 +251,9 @@ export async function getFairUseAwuCreditsStatus({
     };
   }
 
-  const result = await getRateLimiterCount({
+  const result = await getFairUseAwuCreditsCount({
     key: makeFairUseAwuCreditsRateLimitKeyForUser(workspace, user, timeframe),
-    timeframeSeconds: getTimeframeSecondsFromLiteral(timeframe),
+    timeframe,
   });
 
   if (result.isErr()) {

--- a/front/lib/utils/fixed_window.test.ts
+++ b/front/lib/utils/fixed_window.test.ts
@@ -1,0 +1,104 @@
+import { computeCalendarWindowBounds } from "@app/lib/utils/rate_limiter";
+import { describe, expect, it } from "vitest";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe("computeCalendarWindowBounds", () => {
+  describe("calendar_day", () => {
+    it("labels by UTC date and expires at the next UTC midnight", () => {
+      const now = new Date("2026-07-28T13:45:00.000Z");
+      const { label, windowEndMs } = computeCalendarWindowBounds(
+        "calendar_day",
+        now
+      );
+
+      expect(label).toBe("2026-07-28");
+      expect(windowEndMs).toBe(Date.UTC(2026, 6, 29));
+      expect(now.getTime()).toBeLessThan(windowEndMs);
+      expect(windowEndMs - Date.UTC(2026, 6, 28)).toBe(DAY_MS);
+    });
+
+    it("rolls over year boundaries", () => {
+      const now = new Date("2026-12-31T23:59:59.000Z");
+      const { label, windowEndMs } = computeCalendarWindowBounds(
+        "calendar_day",
+        now
+      );
+
+      expect(label).toBe("2026-12-31");
+      expect(windowEndMs).toBe(Date.UTC(2027, 0, 1));
+    });
+  });
+
+  describe("calendar_week", () => {
+    it("anchors on the ISO Monday and spans exactly 7 days", () => {
+      const now = new Date("2026-07-28T13:45:00.000Z"); // A Tuesday.
+      const { label, windowEndMs } = computeCalendarWindowBounds(
+        "calendar_week",
+        now
+      );
+
+      // Label encodes the week's Monday.
+      const [y, m, d] = label.replace("-w", "").split("-").map(Number);
+      const mondayMs = Date.UTC(y, m - 1, d);
+      const monday = new Date(mondayMs);
+
+      expect(monday.getUTCDay()).toBe(1); // Monday.
+      expect(mondayMs).toBeLessThanOrEqual(now.getTime());
+      expect(now.getTime()).toBeLessThan(windowEndMs);
+      expect(windowEndMs - mondayMs).toBe(7 * DAY_MS);
+    });
+
+    it("puts a Sunday in the week that ends that same day", () => {
+      const now = new Date("2026-08-02T10:00:00.000Z"); // A Sunday.
+      const { windowEndMs } = computeCalendarWindowBounds("calendar_week", now);
+      const { windowEndMs: mondayWindowEndMs } = computeCalendarWindowBounds(
+        "calendar_week",
+        // The Monday six days earlier belongs to the same window.
+        new Date("2026-07-27T10:00:00.000Z")
+      );
+
+      expect(windowEndMs).toBe(mondayWindowEndMs);
+    });
+
+    it("handles a week that straddles a month/year boundary", () => {
+      const now = new Date("2027-01-01T00:00:00.000Z"); // A Friday.
+      const { label, windowEndMs } = computeCalendarWindowBounds(
+        "calendar_week",
+        now
+      );
+
+      const [y, m, d] = label.replace("-w", "").split("-").map(Number);
+      const monday = new Date(Date.UTC(y, m - 1, d));
+
+      expect(monday.getUTCDay()).toBe(1);
+      // The Monday is in the previous year/month.
+      expect(monday.getTime()).toBeLessThan(now.getTime());
+      expect(windowEndMs - monday.getTime()).toBe(7 * DAY_MS);
+    });
+  });
+
+  describe("calendar_month", () => {
+    it("labels by UTC month and expires at the first of the next month", () => {
+      const now = new Date("2026-07-28T13:45:00.000Z");
+      const { label, windowEndMs } = computeCalendarWindowBounds(
+        "calendar_month",
+        now
+      );
+
+      expect(label).toBe("2026-07");
+      expect(windowEndMs).toBe(Date.UTC(2026, 7, 1));
+    });
+
+    it("rolls December over to the next January", () => {
+      const now = new Date("2026-12-15T00:00:00.000Z");
+      const { label, windowEndMs } = computeCalendarWindowBounds(
+        "calendar_month",
+        now
+      );
+
+      expect(label).toBe("2026-12");
+      expect(windowEndMs).toBe(Date.UTC(2027, 0, 1));
+    });
+  });
+});

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -1,9 +1,9 @@
 import { getRedisStreamClient } from "@app/lib/api/redis";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import type {
-  MaxAwuCreditsTimeframeType,
-  MaxMessagesTimeframeType,
-} from "@app/types/plan";
+  CalendarAwuCreditsTimeframeType,
+  RollingAwuCreditsTimeframeType,
+} from "@app/types/rate_limiter";
 import type { LoggerInterface } from "@app/types/shared/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -24,8 +24,8 @@ const FIXED_WINDOW_EXPIRE_GRACE_MS = 60_000;
 // the absolute UTC end of that window. The label is appended to the Redis key
 // so each window is a distinct key that naturally expires; `windowEndMs` drives
 // `PEXPIREAT`. Callers resolve these bounds however they like — pure calendar
-// math or an external anchor such as a billing contract — keeping this counter
-// agnostic of window semantics.
+// math (`computeCalendarWindowBounds`) or an external anchor such as a billing
+// contract — keeping this counter agnostic of window semantics.
 export type FixedWindowBounds = { label: string; windowEndMs: number };
 
 const makeRateLimiterKey = (key: string) => `${RATE_LIMITER_PREFIX}:${key}`;
@@ -240,7 +240,10 @@ export async function getRateLimiterCount({
 }
 
 export function getTimeframeSecondsFromLiteral(
-  timeframeLiteral: MaxMessagesTimeframeType | MaxAwuCreditsTimeframeType
+  // Message timeframes ("day" / "lifetime") are a subset of the rolling AWU
+  // timeframes, so this covers both. Fixed (calendar) windows have no
+  // trailing-seconds meaning and are handled by the fixed-window counter.
+  timeframeLiteral: RollingAwuCreditsTimeframeType
 ): number {
   switch (timeframeLiteral) {
     case "day":
@@ -255,7 +258,49 @@ export function getTimeframeSecondsFromLiteral(
       return 60 * 60 * 24 * 30; // 30 days.
 
     default:
-      assertNever(timeframeLiteral);
+      return assertNever(timeframeLiteral);
+  }
+}
+
+// Start-of-window and end-of-window (exclusive) in UTC for a calendar
+// timeframe.
+export function computeCalendarWindowBounds(
+  timeframe: CalendarAwuCreditsTimeframeType,
+  now: Date
+): FixedWindowBounds {
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  const day = now.getUTCDate();
+
+  const pad = (n: number) => n.toString().padStart(2, "0");
+
+  switch (timeframe) {
+    case "calendar_day": {
+      const label = `${year}-${pad(month + 1)}-${pad(day)}`;
+      const windowEndMs = Date.UTC(year, month, day + 1);
+      return { label, windowEndMs };
+    }
+    case "calendar_week": {
+      // ISO week: Monday-based. getUTCDay() returns 0 (Sun)..6 (Sat).
+      const dayOfWeek = now.getUTCDay();
+      const daysSinceMonday = (dayOfWeek + 6) % 7;
+      const mondayMs = Date.UTC(year, month, day - daysSinceMonday);
+      const monday = new Date(mondayMs);
+      const label = `${monday.getUTCFullYear()}-${pad(monday.getUTCMonth() + 1)}-${pad(monday.getUTCDate())}-w`;
+      const windowEndMs = Date.UTC(
+        monday.getUTCFullYear(),
+        monday.getUTCMonth(),
+        monday.getUTCDate() + 7
+      );
+      return { label, windowEndMs };
+    }
+    case "calendar_month": {
+      const label = `${year}-${pad(month + 1)}`;
+      const windowEndMs = Date.UTC(year, month + 1, 1);
+      return { label, windowEndMs };
+    }
+    default:
+      assertNever(timeframe);
   }
 }
 

--- a/front/types/plan.ts
+++ b/front/types/plan.ts
@@ -1,4 +1,8 @@
 import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
+import {
+  CALENDAR_AWU_CREDITS_TIMEFRAMES,
+  ROLLING_AWU_CREDITS_TIMEFRAMES,
+} from "@app/types/rate_limiter";
 import { z } from "zod";
 
 export const MAX_MESSAGE_TIMEFRAMES = ["day", "lifetime"] as const;
@@ -10,11 +14,20 @@ export function isMaxMessagesTimeframeType(
   return (MAX_MESSAGE_TIMEFRAMES as unknown as string[]).includes(value);
 }
 
+// Fixed-window timeframes a plan's fair-use limit can use. For plans this is the
+// calendar (clock-boundary) set; the contract-billing-cycle window is specific
+// to the per-user spend cap and is not offered here.
+export const FIXED_AWU_CREDITS_TIMEFRAMES = [
+  ...CALENDAR_AWU_CREDITS_TIMEFRAMES,
+] as const;
+export type FixedAwuCreditsTimeframeType =
+  (typeof FIXED_AWU_CREDITS_TIMEFRAMES)[number];
+
+// The full set of timeframes a plan's fair-use limit can be configured with:
+// rolling windows plus the fixed (calendar) windows.
 export const MAX_AWU_CREDITS_TIMEFRAMES = [
-  "day",
-  "week",
-  "month",
-  "lifetime",
+  ...ROLLING_AWU_CREDITS_TIMEFRAMES,
+  ...FIXED_AWU_CREDITS_TIMEFRAMES,
 ] as const;
 export type MaxAwuCreditsTimeframeType =
   (typeof MAX_AWU_CREDITS_TIMEFRAMES)[number];

--- a/front/types/rate_limiter.ts
+++ b/front/types/rate_limiter.ts
@@ -1,0 +1,30 @@
+// Timeframe groupings for the Redis rate limiter's window mechanics.
+
+// Rolling windows: the counter looks back over the trailing period from "now"
+// (`lifetime` is mapped to a 30-day rolling window).
+export const ROLLING_AWU_CREDITS_TIMEFRAMES = [
+  "day",
+  "week",
+  "month",
+  "lifetime",
+] as const;
+export type RollingAwuCreditsTimeframeType =
+  (typeof ROLLING_AWU_CREDITS_TIMEFRAMES)[number];
+
+export function isRollingAwuCreditsTimeframeType(
+  value: string
+): value is RollingAwuCreditsTimeframeType {
+  return (ROLLING_AWU_CREDITS_TIMEFRAMES as unknown as string[]).includes(
+    value
+  );
+}
+
+// Calendar (fixed) windows: the counter resets at a UTC clock boundary (start
+// of day / ISO week / month), computed with pure date math.
+export const CALENDAR_AWU_CREDITS_TIMEFRAMES = [
+  "calendar_day",
+  "calendar_week",
+  "calendar_month",
+] as const;
+export type CalendarAwuCreditsTimeframeType =
+  (typeof CALENDAR_AWU_CREDITS_TIMEFRAMES)[number];


### PR DESCRIPTION
## Description

> ⚠️ **POC — may not merge.** Exploratory work to see how the plan-level fair-use limiter would look on calendar fixed windows. The rate-limiter primitive it builds on (#29575) is what's actually needed for the spend-cap backup (#29576); this PR is the sibling that stress-tests the vocabulary.

Extends the plan-level fair-use AWU limiter (`plan.limits.assistant.maxAwuCredits` / `maxAwuCreditsTimeframe`) to support **calendar fixed windows** (`calendar_day` / `calendar_week` / `calendar_month`) in addition to the existing rolling windows (`day` / `week` / `month` / `lifetime`).

Because only fair-use consumes this, the PR **owns the rate-limiter window vocabulary** rather than putting it in the base primitive:

- `front/types/rate_limiter.ts` — `ROLLING_AWU_CREDITS_TIMEFRAMES` vs `CALENDAR_AWU_CREDITS_TIMEFRAMES` groupings + `isRollingAwuCreditsTimeframeType`.
- `computeCalendarWindowBounds` (UTC day / ISO-week / month boundaries) and the `RollingAwuCreditsTimeframeType` narrowing of `getTimeframeSecondsFromLiteral`.
- `MAX_AWU_CREDITS_TIMEFRAMES` gains the `calendar_*` variants; enforcement (conversation), recording (`credit_cost`), status (`user_block`) and reset dispatch to the rolling limiter or the fixed-window counter via `isRollingAwuCreditsTimeframeType`. The contract-billing-cycle window is intentionally **not** offered here — it stays in the per-user spend cap (#29576).

## Tests

- `fixed_window.test.ts` — `computeCalendarWindowBounds` (day/week/month, ISO-week Monday anchoring, month/year rollover).
- `fair_use_window.test.ts` — fair-use window resolution across rolling vs calendar.
- `tsgo` clean.

## Risk

Low, and inert unless a plan is configured with a `calendar_*` timeframe — no plan uses fair-use fixed windows today, and the rolling path is unchanged. Being a POC, it is not intended to ship without a follow-up decision. Safe to roll back by revert.

## Deploy Plan

None planned yet — POC. If adopted: standard deploy, no migration; the new timeframes become selectable in the poke plan form, opt-in per plan.
