### PR TITLE
Auto-expire pool cap overrides once their requested period lapses

### DIFF
--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -117,6 +117,7 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
         kind: "limited",
         awuCredits: 1500,
         timeframe: null,
+        expiresAt: null,
       });
     });
 
@@ -157,6 +158,7 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
         kind: "limited",
         awuCredits: 500,
         timeframe: "week",
+        expiresAt: null,
       });
     });
 
@@ -322,6 +324,7 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
         kind: "limited",
         awuCredits: 2500,
         timeframe: null,
+        expiresAt: null,
       });
     });
   });
@@ -416,6 +419,96 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
           workspace,
         });
       expect(updatedMembership?.poolCapOverrideAwuCredits).toBe(1500);
+    });
+
+    it("persists and returns expiresAt when provided", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+      });
+
+      await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+
+      const expiresAt = Date.now() + 7 * 24 * 60 * 60 * 1000;
+      const response = await honoApp.request(
+        spendLimitUrl(workspace.sId, targetUser.sId),
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            kind: "limited",
+            awuCredits: 1500,
+            expiresAt,
+          }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        limit: { kind: "limited", awuCredits: 1500, expiresAt },
+      });
+
+      const getResponse = await honoApp.request(
+        spendLimitUrl(workspace.sId, targetUser.sId)
+      );
+      expect(await getResponse.json()).toEqual({
+        kind: "limited",
+        awuCredits: 1500,
+        timeframe: null,
+        expiresAt,
+      });
+
+      const updatedMembership =
+        await MembershipResource.getActiveMembershipOfUserInWorkspace({
+          user: targetUser,
+          workspace,
+        });
+      expect(updatedMembership?.poolCapOverrideExpiresAt).toEqual(
+        new Date(expiresAt)
+      );
+    });
+
+    it("clears expiresAt when reverting to unlimited", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const targetUser = await UserFactory.basic();
+      const membership = await MembershipFactory.associate(
+        workspace,
+        targetUser,
+        { role: "user" }
+      );
+      await membership.updatePoolCapOverride({
+        poolCapOverrideAwuCredits: 1200,
+        poolCapOverrideExpiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      });
+
+      await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        spendLimitUrl(workspace.sId, targetUser.sId),
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ kind: "unlimited" }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const updatedMembership =
+        await MembershipResource.getActiveMembershipOfUserInWorkspace({
+          user: targetUser,
+          workspace,
+        });
+      expect(updatedMembership?.poolCapOverrideAwuCredits).toBeNull();
+      expect(updatedMembership?.poolCapOverrideExpiresAt).toBeNull();
     });
   });
 });

--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
@@ -29,6 +29,7 @@ const UpdateUserSpendLimitBodySchema = z.discriminatedUnion("kind", [
       .min(MIN_USER_SPEND_LIMIT_AWU_CREDITS)
       .max(MAX_USER_SPEND_LIMIT_AWU_CREDITS),
     timeframe: z.enum(SPEND_LIMIT_OVERRIDE_TIMEFRAMES).nullable().optional(),
+    expiresAt: z.number().int().positive().nullable().optional(),
   }),
 ]);
 

--- a/front/admin/audit_log_schemas/membership.pool_cap_override_expired.json
+++ b/front/admin/audit_log_schemas/membership.pool_cap_override_expired.json
@@ -1,0 +1,15 @@
+{
+  "action": "membership.pool_cap_override_expired",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "user"
+    }
+  ],
+  "metadata": {
+    "previous_awu_credits": "string",
+    "previous_timeframe": "string"
+  }
+}

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -1215,6 +1215,10 @@ export function UsagePage() {
         }}
         member={editSpendLimitMember}
         owner={owner}
+        requestedDurationDays={
+          upgradeRequests.find((r) => r.sId === pendingApproveRequestId)
+            ?.requestedDurationDays ?? null
+        }
         onSavingChange={handleUsagePendingChange}
         onSaved={handleApproveOnModalSaved}
       />

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -27,6 +27,7 @@ import { useEffect, useRef, useState } from "react";
 
 const MIN_AWU_CREDITS = 0;
 const MAX_AWU_CREDITS = 1_000_000;
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 type SpendLimitKind = "default" | "override";
 
@@ -34,11 +35,30 @@ function isSpendLimitKind(value: string): value is SpendLimitKind {
   return value === "default" || value === "override";
 }
 
+// `<input type="date">` values are calendar dates ("YYYY-MM-DD") with no
+// timezone; treating them as UTC midnight in both directions keeps the
+// round-trip stable regardless of the admin's local timezone.
+function epochMsToDateInputValue(epochMs: number): string {
+  return new Date(epochMs).toISOString().slice(0, 10);
+}
+
+function dateInputValueToEpochMs(value: string): number | null {
+  if (!value) {
+    return null;
+  }
+  const parsed = new Date(value).getTime();
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
 interface EditSpendLimitModalProps {
   isOpen: boolean;
   onClose: () => void;
   member: MemberUsageType | null;
   owner: WorkspaceType;
+  // How many days the linked upgrade request asked for, if the modal was
+  // opened to resolve one. Pre-fills the expiry date; the admin can still
+  // change it. Null when opened from the members table directly.
+  requestedDurationDays?: number | null;
   onSavingChange?: (memberId: string, isSaving: boolean) => void;
   // Fired once the spend limit has been persisted successfully (not on cancel
   // or a load error). Used to resolve a linked upgrade request as approved.
@@ -50,6 +70,7 @@ export function EditSpendLimitModal({
   onClose,
   member,
   owner,
+  requestedDurationDays,
   onSavingChange,
   onSaved,
 }: EditSpendLimitModalProps) {
@@ -79,6 +100,7 @@ export function EditSpendLimitModal({
   const [creditsInput, setCreditsInput] = useState<string>("");
   const [timeframe, setTimeframe] =
     useState<SpendLimitOverrideTimeframeType | null>(null);
+  const [expiresAtInput, setExpiresAtInput] = useState<string>("");
   const [isSaving, setIsSaving] = useState(false);
   const [validationMessage, setValidationMessage] = useState<string | null>(
     null
@@ -98,17 +120,29 @@ export function EditSpendLimitModal({
         setKind("override");
         setCreditsInput(String(spendLimit.awuCredits));
         setTimeframe(spendLimit.timeframe ?? null);
+        setExpiresAtInput(
+          spendLimit.expiresAt
+            ? epochMsToDateInputValue(spendLimit.expiresAt)
+            : ""
+        );
         break;
       case "unlimited":
         setKind("default");
         setCreditsInput("");
         setTimeframe(null);
+        setExpiresAtInput(
+          requestedDurationDays
+            ? epochMsToDateInputValue(
+                Date.now() + requestedDurationDays * ONE_DAY_MS
+              )
+            : ""
+        );
         break;
       default:
         assertNeverAndIgnore(spendLimit);
     }
     setValidationMessage(null);
-  }, [isOpen, spendLimit]);
+  }, [isOpen, spendLimit, requestedDurationDays]);
 
   function handleSelectKind(next: SpendLimitKind) {
     setKind(next);
@@ -171,6 +205,7 @@ export function EditSpendLimitModal({
             kind: "limited",
             awuCredits: result.awuCredits,
             timeframe,
+            expiresAt: dateInputValueToEpochMs(expiresAtInput),
           };
           break;
         default:
@@ -316,6 +351,24 @@ export function EditSpendLimitModal({
                       label="Per rolling month"
                     />
                   </RadioGroup>
+                  <div className="flex flex-col gap-1.5 pt-2">
+                    <label
+                      htmlFor="spend-limit-expires-at"
+                      className="text-sm font-medium"
+                    >
+                      Expires (optional)
+                    </label>
+                    <Input
+                      id="spend-limit-expires-at"
+                      type="date"
+                      value={expiresAtInput}
+                      onChange={(e) => setExpiresAtInput(e.target.value)}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      On this date, the limit automatically reverts to the
+                      workspace default. Leave blank for a permanent override.
+                    </p>
+                  </div>
                 </div>
               )}
             </RadioGroup>

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -53,6 +53,7 @@ export const AUDIT_ACTIONS = [
   "membership.upgrade_request_created",
   "membership.upgrade_request_resolved",
   "membership.seat_auto_upgraded",
+  "membership.pool_cap_override_expired",
   // Domains & SSO.
   "domain.verified",
   "domain.verification_failed",

--- a/front/lib/api/users/spend_limit.test.ts
+++ b/front/lib/api/users/spend_limit.test.ts
@@ -1,0 +1,138 @@
+import * as workosAudit from "@app/lib/api/audit/workos_audit";
+import { expireUserSpendLimitOverride } from "@app/lib/api/users/spend_limit";
+import { Authenticator } from "@app/lib/auth";
+import * as spendLimits from "@app/lib/metronome/alerts/spend_limits";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
+  const actual = await vi.importActual<typeof spendLimits>(
+    "@app/lib/metronome/alerts/spend_limits"
+  );
+  return {
+    ...actual,
+    clearMetronomePerUserCapAlert: vi.fn(),
+    clearMetronomePerUserWarningAlert: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/api/audit/workos_audit", async () => {
+  const actual = await vi.importActual<typeof workosAudit>(
+    "@app/lib/api/audit/workos_audit"
+  );
+  return { ...actual, emitAuditLogEventDirect: vi.fn() };
+});
+
+const TEST_METRONOME_CUSTOMER_ID = "cust_test_xxx";
+
+beforeEach(() => {
+  vi.mocked(spendLimits.clearMetronomePerUserCapAlert).mockResolvedValue(
+    new Ok(undefined)
+  );
+  vi.mocked(spendLimits.clearMetronomePerUserWarningAlert).mockResolvedValue(
+    new Ok(undefined)
+  );
+  vi.mocked(workosAudit.emitAuditLogEventDirect).mockResolvedValue(undefined);
+});
+
+describe("expireUserSpendLimitOverride", () => {
+  it("reverts an active override, clears the alert, and emits a system-actored audit event", async () => {
+    const workspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+    });
+    const user = await UserFactory.basic();
+    const membership = await MembershipFactory.associate(workspace, user, {
+      role: "user",
+    });
+    await membership.updatePoolCapOverride({
+      poolCapOverrideAwuCredits: 2000,
+      overrideLimitTimeframe: "week",
+      poolCapOverrideExpiresAt: new Date(Date.now() - 1000),
+    });
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const result = await expireUserSpendLimitOverride(auth, {
+      userId: user.sId,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({
+        reverted: true,
+        previousAwuCredits: 2000,
+        previousTimeframe: "week",
+      });
+    }
+
+    expect(spendLimits.clearMetronomePerUserCapAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+        workspaceId: workspace.sId,
+        userId: user.sId,
+      })
+    );
+    expect(workosAudit.emitAuditLogEventDirect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "membership.pool_cap_override_expired",
+        actor: expect.objectContaining({ type: "system" }),
+        metadata: {
+          previous_awu_credits: "2000",
+          previous_timeframe: "week",
+        },
+      })
+    );
+
+    const updatedMembership =
+      await MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user,
+        workspace,
+      });
+    expect(updatedMembership?.poolCapOverrideAwuCredits).toBeNull();
+    expect(updatedMembership?.overrideLimitTimeframe).toBeNull();
+    expect(updatedMembership?.poolCapOverrideExpiresAt).toBeNull();
+  });
+
+  it("no-ops without touching Metronome or emitting audit when there is no override", async () => {
+    const workspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+    });
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const result = await expireUserSpendLimitOverride(auth, {
+      userId: user.sId,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({
+        reverted: false,
+        previousAwuCredits: null,
+        previousTimeframe: null,
+      });
+    }
+    expect(spendLimits.clearMetronomePerUserCapAlert).not.toHaveBeenCalled();
+    expect(workosAudit.emitAuditLogEventDirect).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when the workspace is not on Metronome billing", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const result = await expireUserSpendLimitOverride(auth, {
+      userId: user.sId,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.type).toBe("workspace_not_metronome_billed");
+    }
+  });
+});

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -1,6 +1,7 @@
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,
+  emitAuditLogEventDirect,
 } from "@app/lib/api/audit/workos_audit";
 import { reconcileUser } from "@app/lib/api/metronome/reconcile_credit_state";
 import { getUserForWorkspace } from "@app/lib/api/user";
@@ -14,6 +15,7 @@ import {
 } from "@app/lib/metronome/alerts/spend_limits";
 import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import type {
@@ -21,6 +23,7 @@ import type {
   SetUserSpendLimitResponse,
   UserSpendLimit,
 } from "@app/types/api/users/spend_limit";
+import type { SpendLimitOverrideTimeframeType } from "@app/types/credits";
 import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -78,6 +81,53 @@ async function resolveUserSeatAllowance(
   return seatAllowance;
 }
 
+/**
+ * Clear the Metronome per-user cap/warning alerts for a user reverted to the
+ * unlimited (seat-default) spend limit. Shared by the admin-driven "use
+ * workspace default" path and the automated expiration sweep.
+ */
+async function clearMetronomeSpendLimitAlerts({
+  metronomeCustomerId,
+  workspaceId,
+  userId,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+  userId: string;
+}): Promise<Result<void, UserSpendLimitError>> {
+  const clearResult = await clearMetronomePerUserCapAlert({
+    metronomeCustomerId,
+    workspaceId,
+    userId,
+  });
+  if (clearResult.isErr()) {
+    logger.error(
+      {
+        workspaceId,
+        metronomeCustomerId,
+        userId,
+        err: clearResult.error,
+      },
+      "[Metronome PerUserCap] set(unlimited): failed to clear per-user cap alert"
+    );
+    return new Err(
+      new UserSpendLimitError("metronome_error", clearResult.error.message)
+    );
+  }
+  const clearWarningResult = await clearMetronomePerUserWarningAlert({
+    metronomeCustomerId,
+    workspaceId,
+    userId,
+  });
+  if (clearWarningResult.isErr()) {
+    logger.warn(
+      { workspaceId, userId, err: clearWarningResult.error },
+      "[Metronome PerUserCap] Failed to clear warning alert; continuing"
+    );
+  }
+  return new Ok(undefined);
+}
+
 export async function getUserSpendLimit(
   auth: Authenticator,
   { userId }: { userId: string }
@@ -117,6 +167,7 @@ export async function getUserSpendLimit(
     kind: "limited",
     awuCredits: membership.poolCapOverrideAwuCredits,
     timeframe: membership.overrideLimitTimeframe,
+    expiresAt: membership.poolCapOverrideExpiresAt?.getTime() ?? null,
   });
 }
 
@@ -202,43 +253,21 @@ export async function setUserSpendLimit(
     poolCapOverrideAwuCredits:
       limit.kind === "limited" ? limit.awuCredits : null,
     overrideLimitTimeframe: limit.kind === "limited" ? limit.timeframe : null,
+    poolCapOverrideExpiresAt:
+      limit.kind === "limited" && limit.expiresAt
+        ? new Date(limit.expiresAt)
+        : null,
   });
 
   switch (limit.kind) {
     case "unlimited": {
-      const clearResult = await clearMetronomePerUserCapAlert({
+      const clearResult = await clearMetronomeSpendLimitAlerts({
         metronomeCustomerId: workspace.metronomeCustomerId,
         workspaceId: workspace.sId,
         userId: user.sId,
       });
       if (clearResult.isErr()) {
-        logger.error(
-          {
-            workspaceId: workspace.sId,
-            metronomeCustomerId: workspace.metronomeCustomerId,
-            userId: user.sId,
-            err: clearResult.error,
-          },
-          "[Metronome PerUserCap] set(unlimited): failed to clear per-user cap alert"
-        );
-        return new Err(
-          new UserSpendLimitError("metronome_error", clearResult.error.message)
-        );
-      }
-      const clearWarningResult = await clearMetronomePerUserWarningAlert({
-        metronomeCustomerId: workspace.metronomeCustomerId,
-        workspaceId: workspace.sId,
-        userId: user.sId,
-      });
-      if (clearWarningResult.isErr()) {
-        logger.warn(
-          {
-            workspaceId: workspace.sId,
-            userId: user.sId,
-            err: clearWarningResult.error,
-          },
-          "[Metronome PerUserCap] Failed to clear warning alert; continuing"
-        );
+        return new Err(clearResult.error);
       }
       break;
     }
@@ -327,8 +356,127 @@ export async function setUserSpendLimit(
         limit.kind === "limited" ? String(limit.awuCredits) : "unlimited",
       timeframe:
         limit.kind === "limited" && limit.timeframe ? limit.timeframe : "",
+      expires_at:
+        limit.kind === "limited" && limit.expiresAt
+          ? new Date(limit.expiresAt).toISOString()
+          : "",
     },
   });
 
   return new Ok({ limit });
+}
+
+/**
+ * Revert an expired pool cap override back to the seat-type default. Called
+ * by the expiration sweep (`@app/temporal/spend_limit_expiration`) — never by
+ * an admin action, hence the system-actored, dedicated audit event rather
+ * than reusing `setUserSpendLimit`'s `member.spend_limit_updated`. A no-op
+ * (idempotent `Ok`) if the override was already cleared or never expires,
+ * e.g. an admin manually reverted it before the sweep ran.
+ */
+export async function expireUserSpendLimitOverride(
+  auth: Authenticator,
+  { userId }: { userId: string }
+): Promise<
+  Result<
+    {
+      reverted: boolean;
+      previousAwuCredits: number | null;
+      previousTimeframe: SpendLimitOverrideTimeframeType | null;
+    },
+    UserSpendLimitError
+  >
+> {
+  const workspace = auth.getNonNullableWorkspace();
+  if (!workspace.metronomeCustomerId) {
+    return new Err(
+      new UserSpendLimitError(
+        "workspace_not_metronome_billed",
+        "Workspace is not on Metronome billing."
+      )
+    );
+  }
+
+  // `getUserForWorkspace` requires `auth.user()`, which the system-actored
+  // `Authenticator` the expiration sweep runs as does not have. Fetch
+  // directly instead — the caller already scoped `userId` to this workspace.
+  const user = await UserResource.fetchById(userId);
+  if (!user) {
+    return new Err(
+      new UserSpendLimitError(
+        "user_not_found",
+        "Could not find the user in this workspace."
+      )
+    );
+  }
+
+  const membership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user,
+      workspace,
+    });
+  if (!membership || membership.poolCapOverrideAwuCredits === null) {
+    return new Ok({
+      reverted: false,
+      previousAwuCredits: null,
+      previousTimeframe: null,
+    });
+  }
+
+  const previousAwuCredits = membership.poolCapOverrideAwuCredits;
+  const previousTimeframe = membership.overrideLimitTimeframe;
+
+  await membership.updatePoolCapOverride({
+    poolCapOverrideAwuCredits: null,
+    overrideLimitTimeframe: null,
+    poolCapOverrideExpiresAt: null,
+  });
+
+  const clearResult = await clearMetronomeSpendLimitAlerts({
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    workspaceId: workspace.sId,
+    userId: user.sId,
+  });
+  if (clearResult.isErr()) {
+    return new Err(clearResult.error);
+  }
+
+  const metronomeContractId = auth.subscription()?.metronomeContractId ?? null;
+  if (metronomeContractId) {
+    const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+    if (workspaceResource) {
+      void reconcileUser({
+        auth,
+        workspace: workspaceResource,
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        userId: user.sId,
+        execute: true,
+      }).catch((err) => {
+        logger.warn(
+          { workspaceId: workspace.sId, userId: user.sId, err },
+          "[Metronome PerUserCap] reconcileUser after spend-limit expiration failed; webhook will reconcile"
+        );
+      });
+    }
+  }
+
+  void emitAuditLogEventDirect({
+    workspace,
+    action: "membership.pool_cap_override_expired",
+    actor: { type: "system", id: "spend-limit-expiration", name: "Dust" },
+    targets: [
+      buildAuditLogTarget("workspace", workspace),
+      buildAuditLogTarget("user", {
+        sId: user.sId,
+        name: user.fullName() ?? "unknown",
+      }),
+    ],
+    context: { location: "internal" },
+    metadata: {
+      previous_awu_credits: String(previousAwuCredits),
+      previous_timeframe: previousTimeframe ?? "",
+    },
+  });
+
+  return new Ok({ reverted: true, previousAwuCredits, previousTimeframe });
 }

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -42,7 +42,7 @@ import type {
   Transaction,
   WhereOptions,
 } from "sequelize";
-import { Op } from "sequelize";
+import { Op, QueryTypes } from "sequelize";
 
 type GetMembershipsOptions = RequireAtLeastOne<{
   users: UserResource[];
@@ -1610,9 +1610,13 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     {
       poolCapOverrideAwuCredits,
       overrideLimitTimeframe,
+      poolCapOverrideExpiresAt,
     }: {
       poolCapOverrideAwuCredits: number | null;
       overrideLimitTimeframe?: SpendLimitOverrideTimeframeType | null;
+      // When the override should auto-revert to unlimited. `undefined`/`null`
+      // means it never expires.
+      poolCapOverrideExpiresAt?: Date | null;
     },
     transaction?: Transaction
   ): Promise<void> {
@@ -1620,8 +1624,68 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       {
         poolCapOverrideAwuCredits,
         overrideLimitTimeframe: overrideLimitTimeframe ?? null,
+        poolCapOverrideExpiresAt: poolCapOverrideExpiresAt ?? null,
       },
       transaction
+    );
+  }
+
+  /**
+   * Workspaces (sorted by id ascending) that have at least one active
+   * membership whose pool cap override has expired. Global, cross-workspace
+   * lookup for the expiration sweep — mirrors
+   * `WebhookRequestResource.getWorkspacesWithTooManyRequests`: raw SQL to find
+   * affected workspaces, then per-workspace scoped work from the caller.
+   */
+  static async getWorkspacesWithExpiredPoolCapOverride(
+    now: Date
+  ): Promise<WorkspaceResource[]> {
+    // biome-ignore lint/plugin/noRawSql: cross-workspace lookup, see WORKSPACE_ISOLATION_BYPASS below
+    const rows = await frontSequelize.query<{ workspaceId: ModelId }>(
+      `
+      SELECT DISTINCT "workspaceId"
+      FROM public.memberships
+      WHERE "poolCapOverrideExpiresAt" IS NOT NULL
+        AND "poolCapOverrideExpiresAt" <= :now
+        AND "poolCapOverrideAwuCredits" IS NOT NULL
+        AND "endAt" IS NULL
+      ORDER BY "workspaceId" ASC;
+    `,
+      {
+        type: QueryTypes.SELECT,
+        replacements: { now: now.toISOString() },
+      }
+    );
+
+    const workspaces = await WorkspaceResource.fetchByModelIds(
+      rows.map((row) => row.workspaceId)
+    );
+    return workspaces.sort((a, b) => a.id - b.id);
+  }
+
+  /**
+   * Active memberships within `workspace` whose pool cap override has
+   * expired as of `now`. Scoped counterpart to
+   * `getWorkspacesWithExpiredPoolCapOverride`, called once per affected
+   * workspace by the expiration sweep.
+   */
+  static async listActiveWithExpiredPoolCapOverride({
+    workspace,
+    now,
+  }: {
+    workspace: LightWorkspaceType;
+    now: Date;
+  }): Promise<MembershipResource[]> {
+    const rows = await MembershipModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        endAt: null,
+        poolCapOverrideAwuCredits: { [Op.ne]: null },
+        poolCapOverrideExpiresAt: { [Op.lte]: now },
+      },
+    });
+    return rows.map(
+      (row) => new MembershipResource(MembershipModel, row.get())
     );
   }
 
@@ -1672,11 +1736,12 @@ export class MembershipResource extends BaseResource<MembershipModel> {
           seatType: newSeatType,
           firstUsedAt: this.firstUsedAt,
           creditState: initialCreditStateForSeatType(newSeatType),
-          // The pool cap override (and its timeframe) survives the seat
-          // change: it's the pool-only portion, independent of the seat
+          // The pool cap override (and its timeframe/expiry) survives the
+          // seat change: it's the pool-only portion, independent of the seat
           // allowance.
           poolCapOverrideAwuCredits: this.poolCapOverrideAwuCredits,
           overrideLimitTimeframe: this.overrideLimitTimeframe,
+          poolCapOverrideExpiresAt: this.poolCapOverrideExpiresAt,
         },
         { transaction }
       );

--- a/front/lib/resources/storage/models/membership.ts
+++ b/front/lib/resources/storage/models/membership.ts
@@ -33,6 +33,12 @@ export class MembershipModel extends WorkspaceAwareModel<MembershipModel> {
   // monthly/pool-lifetime window. Meaningless when the override itself is
   // NULL.
   declare overrideLimitTimeframe: SpendLimitOverrideTimeframeType | null;
+  // When set, the pool cap override (and its timeframe) is reverted to
+  // unlimited once this timestamp passes — see the sweep workflow in
+  // `@app/temporal/spend_limit_expiration`. NULL means the override never
+  // expires (today's behavior). Meaningless when the override itself is
+  // NULL.
+  declare poolCapOverrideExpiresAt: Date | null;
 
   declare userId: ForeignKey<UserModel["id"]>;
   declare user: NonAttribute<UserModel>;
@@ -90,6 +96,11 @@ MembershipModel.init(
       allowNull: true,
       defaultValue: null,
     },
+    poolCapOverrideExpiresAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
+    },
   },
   {
     modelName: "membership",
@@ -109,6 +120,13 @@ MembershipModel.init(
       {
         fields: ["workspaceId", "firstUsedAt"],
         where: { firstUsedAt: { [Op.ne]: null } },
+        concurrently: true,
+      },
+      // Lets the expiration sweep find expiring overrides without scanning
+      // every membership row.
+      {
+        fields: ["poolCapOverrideExpiresAt"],
+        where: { poolCapOverrideExpiresAt: { [Op.ne]: null } },
         concurrently: true,
       },
     ],

--- a/front/migrations/pre-deploy/20260728145725_add_pool_cap_override_expires_at_to_memberships.sql
+++ b/front/migrations/pre-deploy/20260728145725_add_pool_cap_override_expires_at_to_memberships.sql
@@ -1,0 +1,14 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."memberships" ADD COLUMN "poolCapOverrideExpiresAt" timestamp with time zone;
+
+/*
+Statement 1
+  - Partial index for memberships.poolCapOverrideExpiresAt
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY memberships_pool_cap_override_expires_at ON public.memberships USING btree ("poolCapOverrideExpiresAt") WHERE ("poolCapOverrideExpiresAt" IS NOT NULL);

--- a/front/scripts/temporal-build/build-temporal-bundles.ts
+++ b/front/scripts/temporal-build/build-temporal-bundles.ts
@@ -76,6 +76,8 @@ function getWorkerDirectory(workerName: WorkerName): string | null {
       return path.join(baseDir, "temporal/remote_tools");
     case "scrub_workspace_queue":
       return path.join(baseDir, "temporal/scrub_workspace");
+    case "spend_limit_expiration":
+      return path.join(baseDir, "temporal/spend_limit_expiration");
     case "update_workspace_usage":
       return path.join(baseDir, "temporal/usage_queue");
     case "upsert_queue":

--- a/front/temporal/spend_limit_expiration/activities.test.ts
+++ b/front/temporal/spend_limit_expiration/activities.test.ts
@@ -1,0 +1,92 @@
+import * as spendLimits from "@app/lib/metronome/alerts/spend_limits";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { expirePoolCapOverridesActivity } from "@app/temporal/spend_limit_expiration/activities";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
+  const actual = await vi.importActual<typeof spendLimits>(
+    "@app/lib/metronome/alerts/spend_limits"
+  );
+  return {
+    ...actual,
+    clearMetronomePerUserCapAlert: vi.fn(),
+    clearMetronomePerUserWarningAlert: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.mocked(spendLimits.clearMetronomePerUserCapAlert).mockResolvedValue(
+    new Ok(undefined)
+  );
+  vi.mocked(spendLimits.clearMetronomePerUserWarningAlert).mockResolvedValue(
+    new Ok(undefined)
+  );
+});
+
+describe("expirePoolCapOverridesActivity", () => {
+  it("reverts an expired override and leaves an unexpired one untouched, across workspaces", async () => {
+    const expiredWorkspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: "cust_expired_xxx",
+    });
+    const expiredUser = await UserFactory.basic();
+    const expiredMembership = await MembershipFactory.associate(
+      expiredWorkspace,
+      expiredUser,
+      { role: "user" }
+    );
+    await expiredMembership.updatePoolCapOverride({
+      poolCapOverrideAwuCredits: 500,
+      poolCapOverrideExpiresAt: new Date(Date.now() - 60 * 60 * 1000),
+    });
+
+    const activeWorkspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: "cust_active_xxx",
+    });
+    const activeUser = await UserFactory.basic();
+    const activeMembership = await MembershipFactory.associate(
+      activeWorkspace,
+      activeUser,
+      { role: "user" }
+    );
+    await activeMembership.updatePoolCapOverride({
+      poolCapOverrideAwuCredits: 900,
+      poolCapOverrideExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+
+    await expirePoolCapOverridesActivity();
+
+    const revertedMembership =
+      await MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user: expiredUser,
+        workspace: expiredWorkspace,
+      });
+    expect(revertedMembership?.poolCapOverrideAwuCredits).toBeNull();
+    expect(revertedMembership?.poolCapOverrideExpiresAt).toBeNull();
+
+    const untouchedMembership =
+      await MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user: activeUser,
+        workspace: activeWorkspace,
+      });
+    expect(untouchedMembership?.poolCapOverrideAwuCredits).toBe(900);
+    expect(untouchedMembership?.poolCapOverrideExpiresAt).not.toBeNull();
+
+    expect(spendLimits.clearMetronomePerUserCapAlert).toHaveBeenCalledTimes(1);
+    expect(spendLimits.clearMetronomePerUserCapAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: expiredWorkspace.sId,
+        userId: expiredUser.sId,
+      })
+    );
+  });
+
+  it("is a no-op when nothing has expired", async () => {
+    await expirePoolCapOverridesActivity();
+
+    expect(spendLimits.clearMetronomePerUserCapAlert).not.toHaveBeenCalled();
+  });
+});

--- a/front/temporal/spend_limit_expiration/activities.ts
+++ b/front/temporal/spend_limit_expiration/activities.ts
@@ -1,0 +1,74 @@
+import { expireUserSpendLimitOverride } from "@app/lib/api/users/spend_limit";
+import { Authenticator } from "@app/lib/auth";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+
+/**
+ * Revert every active membership's pool cap override whose
+ * `poolCapOverrideExpiresAt` has passed, back to the seat-type default.
+ * Global sweep across all workspaces, run on a schedule (see `client.ts`).
+ */
+export async function expirePoolCapOverridesActivity(): Promise<void> {
+  const now = new Date();
+  const workspaces =
+    await MembershipResource.getWorkspacesWithExpiredPoolCapOverride(now);
+
+  if (workspaces.length === 0) {
+    logger.info("[SpendLimitExpiration] No expired pool cap overrides found");
+    return;
+  }
+
+  let revertedCount = 0;
+
+  for (const workspace of workspaces) {
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const lightWorkspace = auth.getNonNullableWorkspace();
+
+    const memberships =
+      await MembershipResource.listActiveWithExpiredPoolCapOverride({
+        workspace: lightWorkspace,
+        now,
+      });
+    if (memberships.length === 0) {
+      continue;
+    }
+
+    const users = await UserResource.fetchByModelIds(
+      memberships.map((membership) => membership.userId)
+    );
+    const userSIdByModelId = new Map(users.map((user) => [user.id, user.sId]));
+
+    const results = await concurrentExecutor(
+      memberships,
+      async (membership) => {
+        const userId = userSIdByModelId.get(membership.userId);
+        if (!userId) {
+          logger.error(
+            { workspaceId: workspace.sId, membershipUserId: membership.userId },
+            "[SpendLimitExpiration] User not found for expired membership override"
+          );
+          return false;
+        }
+        const result = await expireUserSpendLimitOverride(auth, { userId });
+        if (result.isErr()) {
+          logger.error(
+            { workspaceId: workspace.sId, userId, err: result.error },
+            "[SpendLimitExpiration] Failed to revert expired pool cap override"
+          );
+          return false;
+        }
+        return result.value.reverted;
+      },
+      { concurrency: 4 }
+    );
+
+    revertedCount += results.filter(Boolean).length;
+  }
+
+  logger.info(
+    { workspaceCount: workspaces.length, revertedCount },
+    "[SpendLimitExpiration] Completed expired pool cap override sweep"
+  );
+}

--- a/front/temporal/spend_limit_expiration/admin/cli.sh
+++ b/front/temporal/spend_limit_expiration/admin/cli.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+npx tsx temporal/spend_limit_expiration/admin/cli.ts "$@"

--- a/front/temporal/spend_limit_expiration/admin/cli.ts
+++ b/front/temporal/spend_limit_expiration/admin/cli.ts
@@ -1,0 +1,30 @@
+import { createOrUpdateSpendLimitExpirationSchedule } from "@app/temporal/spend_limit_expiration/client";
+import parseArgs from "minimist";
+
+const main = async () => {
+  const argv = parseArgs(process.argv.slice(2));
+
+  const [command] = argv._;
+
+  console.log(`Running command: ${command}`);
+
+  switch (command) {
+    case "start":
+      await createOrUpdateSpendLimitExpirationSchedule();
+      return;
+    default:
+      console.log("Unknown command, possible values: `start`");
+      return;
+  }
+};
+
+main()
+  .then(() => {
+    console.error("\x1b[32m%s\x1b[0m", `Done`);
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+    console.log(err);
+    process.exit(1);
+  });

--- a/front/temporal/spend_limit_expiration/client.ts
+++ b/front/temporal/spend_limit_expiration/client.ts
@@ -1,0 +1,72 @@
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+import { QUEUE_NAME } from "@app/temporal/spend_limit_expiration/config";
+import { expirePoolCapOverridesWorkflow } from "@app/temporal/spend_limit_expiration/workflows";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import {
+  ScheduleNotFoundError,
+  ScheduleOverlapPolicy,
+} from "@temporalio/client";
+
+export const SPEND_LIMIT_EXPIRATION_SCHEDULE_ID =
+  "spend-limit-expiration-schedule";
+
+export async function createOrUpdateSpendLimitExpirationSchedule(): Promise<
+  Result<void, Error>
+> {
+  const client = await getTemporalClientForFrontNamespace();
+  const scheduleId = SPEND_LIMIT_EXPIRATION_SCHEDULE_ID;
+  const scheduleOptions = {
+    action: {
+      type: "startWorkflow" as const,
+      workflowType: expirePoolCapOverridesWorkflow,
+      args: [],
+      taskQueue: QUEUE_NAME,
+    },
+    scheduleId,
+    policies: {
+      overlap: ScheduleOverlapPolicy.SKIP,
+    },
+    spec: {
+      // Every hour at minute 0 — bounds how long an expired override can
+      // linger before being reverted.
+      cronExpressions: ["0 * * * *"] as string[],
+      timezone: "UTC",
+    },
+  } as const;
+
+  const existingSchedule = client.schedule.getHandle(scheduleId);
+  try {
+    await existingSchedule.update((previous) => {
+      return {
+        ...scheduleOptions,
+        state: previous.state,
+      };
+    });
+
+    logger.info("Updated existing spend limit expiration schedule.");
+    return new Ok(undefined);
+  } catch (err) {
+    if (!(err instanceof ScheduleNotFoundError)) {
+      logger.error(
+        { err },
+        "Failed to update existing spend limit expiration schedule."
+      );
+      return new Err(normalizeError(err));
+    }
+  }
+
+  try {
+    await client.schedule.create(scheduleOptions);
+    logger.info("Created new spend limit expiration schedule.");
+    return new Ok(undefined);
+  } catch (error) {
+    logger.error(
+      { error },
+      "Failed to create new spend limit expiration schedule."
+    );
+    return new Err(normalizeError(error));
+  }
+}

--- a/front/temporal/spend_limit_expiration/config.ts
+++ b/front/temporal/spend_limit_expiration/config.ts
@@ -1,0 +1,3 @@
+const QUEUE_VERSION = 1;
+
+export const QUEUE_NAME = `spend-limit-expiration-queue-v${QUEUE_VERSION}`;

--- a/front/temporal/spend_limit_expiration/worker.ts
+++ b/front/temporal/spend_limit_expiration/worker.ts
@@ -1,0 +1,44 @@
+import {
+  getTemporalWorkerConnection,
+  TEMPORAL_MAXED_CACHED_WORKFLOWS,
+} from "@app/lib/temporal";
+import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import logger from "@app/logger/logger";
+import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import * as activities from "@app/temporal/spend_limit_expiration/activities";
+import type { Context } from "@temporalio/activity";
+import { Worker } from "@temporalio/worker";
+
+import { QUEUE_NAME } from "./config";
+
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
+export async function runSpendLimitExpirationWorker() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+
+  const worker = await Worker.create({
+    ...getWorkflowConfig({
+      workerName: "spend_limit_expiration",
+      getWorkflowsPath: () => require.resolve("./workflows"),
+    }),
+    activities,
+    taskQueue: QUEUE_NAME,
+    maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
+    maxConcurrentActivityTaskExecutions: 4,
+    connection,
+    namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
+    interceptors: {
+      activity: [
+        (ctx: Context) => {
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
+        },
+      ],
+    },
+  });
+
+  await worker.run();
+}

--- a/front/temporal/spend_limit_expiration/workflows.ts
+++ b/front/temporal/spend_limit_expiration/workflows.ts
@@ -1,0 +1,10 @@
+import type * as activities from "@app/temporal/spend_limit_expiration/activities";
+import { proxyActivities } from "@temporalio/workflow";
+
+const { expirePoolCapOverridesActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "5 minutes",
+});
+
+export async function expirePoolCapOverridesWorkflow(): Promise<void> {
+  await expirePoolCapOverridesActivity();
+}

--- a/front/temporal/worker_registry.ts
+++ b/front/temporal/worker_registry.ts
@@ -21,6 +21,7 @@ import { runRemoteToolsSyncWorker } from "@app/temporal/remote_tools/worker";
 import { runSandboxFunctionsWorker } from "@app/temporal/sandbox_functions/worker";
 import { runSandboxReaperWorker } from "@app/temporal/sandbox_reaper/worker";
 import { runScrubWorkspaceQueueWorker } from "@app/temporal/scrub_workspace/worker";
+import { runSpendLimitExpirationWorker } from "@app/temporal/spend_limit_expiration/worker";
 import { runAgentTriggerWorker } from "@app/temporal/triggers/worker";
 import { runAgentTriggerWebhookWorker } from "@app/temporal/triggers_garbage_collect/worker";
 import { runUpsertQueueWorker } from "@app/temporal/upsert_queue/worker";
@@ -54,6 +55,7 @@ export type WorkerName =
   | "sandbox_reaper"
   | "remote_tools_sync"
   | "scrub_workspace_queue"
+  | "spend_limit_expiration"
   | "update_workspace_usage"
   | "upsert_queue"
   | "upsert_table_queue"
@@ -84,6 +86,7 @@ export const workerFunctions: Record<WorkerName, () => Promise<void>> = {
   sandbox_reaper: runSandboxReaperWorker,
   remote_tools_sync: runRemoteToolsSyncWorker,
   scrub_workspace_queue: runScrubWorkspaceQueueWorker,
+  spend_limit_expiration: runSpendLimitExpirationWorker,
   update_workspace_usage: runUpdateWorkspaceUsageWorker,
   upsert_queue: runUpsertQueueWorker,
   upsert_table_queue: runUpsertTableQueueWorker,

--- a/front/types/api/users/spend_limit.ts
+++ b/front/types/api/users/spend_limit.ts
@@ -9,6 +9,9 @@ export type UserSpendLimit =
       // implicit monthly/pool-lifetime window. Omitted/null preserves
       // today's behavior.
       timeframe?: SpendLimitOverrideTimeframeType | null;
+      // Epoch ms at which the override auto-reverts to unlimited. Omitted/null
+      // means it never expires.
+      expiresAt?: number | null;
     };
 
 export type GetUserSpendLimitResponse = UserSpendLimit;


### PR DESCRIPTION
## Summary
- Stacked on #29600. Adds `poolCapOverrideExpiresAt` on `membership`: an optional expiry an admin can set on a per-user spend-limit override (pre-filled from the linked upgrade request's `requestedDurationDays` when the modal is opened to resolve one, but always editable).
- Adds a new Temporal worker (`spend_limit_expiration`) with an hourly schedule that sweeps all workspaces for expired overrides and reverts them to the seat-type default: nulls `poolCapOverrideAwuCredits`/`overrideLimitTimeframe`/`poolCapOverrideExpiresAt`, clears the Metronome per-user cap/warning alert, and reconciles the user's credit state — mirroring exactly what happens when an admin manually reverts to "workspace default" today.
- Emits a new system-actored `membership.pool_cap_override_expired` audit event (distinct from the admin-driven `member.spend_limit_updated`), since no human triggers the revert.
- No stacking: the override is a single overwritable value per membership (as it already was before this PR) — approving a second request while an earlier grant is still active replaces its terms rather than accumulating. Flagged as a known limitation, not addressed here.

## Test plan
- [ ] `npm run test -- lib/api/users/spend_limit.test.ts` (front) — `expireUserSpendLimitOverride` reverts/no-ops/errors correctly.
- [ ] `npm run test -- temporal/spend_limit_expiration/activities.test.ts` (front) — sweep reverts an expired override across workspaces and leaves unexpired ones untouched.
- [ ] `npm run test -- "members/[uId]/spend_limit.test.ts"` (front-api) — `expiresAt` persists and round-trips through GET/PUT.
- [ ] Manually open "Edit limit" from a pending upgrade request — verify the expiry date pre-fills from the request's requested duration and can be changed or cleared.

## Deploy plan
- [ ] Register the new `membership.pool_cap_override_expired` audit log schema with WorkOS before deploying: `npx tsx front/admin/register_audit_log_schemas.ts --execute --changed`, then commit the regenerated `front/lib/api/audit/schema_versions.json`. Must land before the next front deploy — WorkOS validates events against the version we send, and `audit_log_schemas.test.ts` will fail CI until this is done.
- [ ] Apply the pre-deploy migration (both regions).
- [ ] Deploy front (new code + `spend_limit_expiration` worker).
- [ ] After deploy, register the sweep schedule once: `front/temporal/spend_limit_expiration/admin/cli.sh start` (creates the hourly Temporal Schedule). This is a new worker/queue — confirm ops has it wired into whatever deploys/scales Temporal workers, since that config lives outside this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)