### PR TITLE
Let admins expire a spend-limit override at the next credit refresh

### DIFF
--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -118,6 +118,7 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
         awuCredits: 1500,
         timeframe: null,
         expiresAt: null,
+        nextCreditResetAt: null,
       });
     });
 
@@ -159,6 +160,7 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
         awuCredits: 500,
         timeframe: "week",
         expiresAt: null,
+        nextCreditResetAt: null,
       });
     });
 
@@ -294,7 +296,10 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
       );
 
       expect(response.status).toBe(200);
-      expect(await response.json()).toEqual({ kind: "unlimited" });
+      expect(await response.json()).toEqual({
+        kind: "unlimited",
+        nextCreditResetAt: null,
+      });
     });
 
     it("returns limited with the override persisted on the membership", async () => {
@@ -325,6 +330,7 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
         awuCredits: 2500,
         timeframe: null,
         expiresAt: null,
+        nextCreditResetAt: null,
       });
     });
   });
@@ -461,6 +467,7 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
         awuCredits: 1500,
         timeframe: null,
         expiresAt,
+        nextCreditResetAt: null,
       });
 
       const updatedMembership =

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -50,6 +50,21 @@ function dateInputValueToEpochMs(value: string): number | null {
   return Number.isNaN(parsed) ? null : parsed;
 }
 
+function formatShortDate(epochMs: number): string {
+  return new Date(epochMs).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+type ExpiryMode = "never" | "date" | "next_credit_reset";
+
+function isExpiryMode(value: string): value is ExpiryMode {
+  return value === "never" || value === "date" || value === "next_credit_reset";
+}
+
 interface EditSpendLimitModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -100,6 +115,7 @@ export function EditSpendLimitModal({
   const [creditsInput, setCreditsInput] = useState<string>("");
   const [timeframe, setTimeframe] =
     useState<SpendLimitOverrideTimeframeType | null>(null);
+  const [expiryMode, setExpiryMode] = useState<ExpiryMode>("never");
   const [expiresAtInput, setExpiresAtInput] = useState<string>("");
   const [isSaving, setIsSaving] = useState(false);
   const [validationMessage, setValidationMessage] = useState<string | null>(
@@ -120,23 +136,29 @@ export function EditSpendLimitModal({
         setKind("override");
         setCreditsInput(String(spendLimit.awuCredits));
         setTimeframe(spendLimit.timeframe ?? null);
-        setExpiresAtInput(
-          spendLimit.expiresAt
-            ? epochMsToDateInputValue(spendLimit.expiresAt)
-            : ""
-        );
+        if (spendLimit.expiresAt) {
+          setExpiryMode("date");
+          setExpiresAtInput(epochMsToDateInputValue(spendLimit.expiresAt));
+        } else {
+          setExpiryMode("never");
+          setExpiresAtInput("");
+        }
         break;
       case "unlimited":
         setKind("default");
         setCreditsInput("");
         setTimeframe(null);
-        setExpiresAtInput(
-          requestedDurationDays
-            ? epochMsToDateInputValue(
-                Date.now() + requestedDurationDays * ONE_DAY_MS
-              )
-            : ""
-        );
+        if (requestedDurationDays) {
+          setExpiryMode("date");
+          setExpiresAtInput(
+            epochMsToDateInputValue(
+              Date.now() + requestedDurationDays * ONE_DAY_MS
+            )
+          );
+        } else {
+          setExpiryMode("never");
+          setExpiresAtInput("");
+        }
         break;
       default:
         assertNeverAndIgnore(spendLimit);
@@ -200,14 +222,30 @@ export function EditSpendLimitModal({
         case "default":
           limit = { kind: "unlimited" };
           break;
-        case "override":
+        case "override": {
+          let expiresAt: number | null;
+          switch (expiryMode) {
+            case "never":
+              expiresAt = null;
+              break;
+            case "date":
+              expiresAt = dateInputValueToEpochMs(expiresAtInput);
+              break;
+            case "next_credit_reset":
+              expiresAt = spendLimit?.nextCreditResetAt ?? null;
+              break;
+            default:
+              assertNeverAndIgnore(expiryMode);
+              expiresAt = null;
+          }
           limit = {
             kind: "limited",
             awuCredits: result.awuCredits,
             timeframe,
-            expiresAt: dateInputValueToEpochMs(expiresAtInput),
+            expiresAt,
           };
           break;
+        }
         default:
           assertNeverAndIgnore(kind);
           return;
@@ -352,21 +390,46 @@ export function EditSpendLimitModal({
                     />
                   </RadioGroup>
                   <div className="flex flex-col gap-1.5 pt-2">
-                    <label
-                      htmlFor="spend-limit-expires-at"
-                      className="text-sm font-medium"
+                    <span className="text-sm font-medium">Expires</span>
+                    <RadioGroup
+                      value={expiryMode}
+                      onValueChange={(v) => {
+                        if (isExpiryMode(v)) {
+                          setExpiryMode(v);
+                        }
+                      }}
+                      className="flex flex-col gap-2"
                     >
-                      Expires (optional)
-                    </label>
-                    <Input
-                      id="spend-limit-expires-at"
-                      type="date"
-                      value={expiresAtInput}
-                      onChange={(e) => setExpiresAtInput(e.target.value)}
-                    />
+                      <RadioGroupItem
+                        value="never"
+                        id="spend-limit-expiry-never"
+                        label="Never"
+                      />
+                      <RadioGroupItem
+                        value="date"
+                        id="spend-limit-expiry-date"
+                        label="On a specific date"
+                      />
+                      {spendLimit?.nextCreditResetAt && (
+                        <RadioGroupItem
+                          value="next_credit_reset"
+                          id="spend-limit-expiry-next-credit-reset"
+                          label={`At next credit refresh (${formatShortDate(spendLimit.nextCreditResetAt)})`}
+                        />
+                      )}
+                    </RadioGroup>
+                    {expiryMode === "date" && (
+                      <Input
+                        id="spend-limit-expires-at"
+                        type="date"
+                        value={expiresAtInput}
+                        onChange={(e) => setExpiresAtInput(e.target.value)}
+                        className="mt-1"
+                      />
+                    )}
                     <p className="text-xs text-muted-foreground">
                       On this date, the limit automatically reverts to the
-                      workspace default. Leave blank for a permanent override.
+                      workspace default. "Never" is a permanent override.
                     </p>
                   </div>
                 </div>

--- a/front/lib/api/users/spend_limit.test.ts
+++ b/front/lib/api/users/spend_limit.test.ts
@@ -1,7 +1,12 @@
 import * as workosAudit from "@app/lib/api/audit/workos_audit";
-import { expireUserSpendLimitOverride } from "@app/lib/api/users/spend_limit";
+import {
+  expireUserSpendLimitOverride,
+  getUserSpendLimit,
+} from "@app/lib/api/users/spend_limit";
 import { Authenticator } from "@app/lib/auth";
 import * as spendLimits from "@app/lib/metronome/alerts/spend_limits";
+import type { SeatData } from "@app/lib/metronome/seats";
+import * as metronomeSeats from "@app/lib/metronome/seats";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -18,6 +23,13 @@ vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
     clearMetronomePerUserCapAlert: vi.fn(),
     clearMetronomePerUserWarningAlert: vi.fn(),
   };
+});
+
+vi.mock("@app/lib/metronome/seats", async () => {
+  const actual = await vi.importActual<typeof metronomeSeats>(
+    "@app/lib/metronome/seats"
+  );
+  return { ...actual, getCachedSeatDataByUserId: vi.fn() };
 });
 
 vi.mock("@app/lib/api/audit/workos_audit", async () => {
@@ -37,6 +49,7 @@ beforeEach(() => {
     new Ok(undefined)
   );
   vi.mocked(workosAudit.emitAuditLogEventDirect).mockResolvedValue(undefined);
+  vi.mocked(metronomeSeats.getCachedSeatDataByUserId).mockResolvedValue({});
 });
 
 describe("expireUserSpendLimitOverride", () => {
@@ -133,6 +146,78 @@ describe("expireUserSpendLimitOverride", () => {
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error.type).toBe("workspace_not_metronome_billed");
+    }
+  });
+});
+
+describe("getUserSpendLimit", () => {
+  it("includes nextCreditResetAt resolved from Metronome seat data", async () => {
+    const workspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+    });
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, {
+      role: "user",
+      seatType: "pro",
+    });
+    const nextCreditResetAt = "2026-09-01T00:00:00.000Z";
+    vi.mocked(metronomeSeats.getCachedSeatDataByUserId).mockResolvedValue({
+      [user.sId]: {
+        awuAllocation: 1000,
+        billingFrequency: null,
+        nextCreditResetAt,
+      } satisfies SeatData,
+    });
+
+    // `getUserSpendLimit` is only ever called from a real request (an
+    // admin/manager acting on another member), which requires `auth.user()` —
+    // build a request-shaped Authenticator rather than the userless
+    // `internalAdminForWorkspace` used by the system-actored sweep above.
+    const admin = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, admin, { role: "admin" });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      admin.sId,
+      workspace.sId
+    );
+    const result = await getUserSpendLimit(auth, { userId: user.sId });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({
+        kind: "unlimited",
+        nextCreditResetAt: new Date(nextCreditResetAt).getTime(),
+      });
+    }
+  });
+
+  it("degrades to a null nextCreditResetAt when the Metronome lookup fails", async () => {
+    const workspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+    });
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    vi.mocked(metronomeSeats.getCachedSeatDataByUserId).mockRejectedValue(
+      new Error("Metronome is down")
+    );
+
+    // `getUserSpendLimit` is only ever called from a real request (an
+    // admin/manager acting on another member), which requires `auth.user()` —
+    // build a request-shaped Authenticator rather than the userless
+    // `internalAdminForWorkspace` used by the system-actored sweep above.
+    const admin = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, admin, { role: "admin" });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      admin.sId,
+      workspace.sId
+    );
+    const result = await getUserSpendLimit(auth, { userId: user.sId });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({
+        kind: "unlimited",
+        nextCreditResetAt: null,
+      });
     }
   });
 });

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -13,7 +13,9 @@ import {
   upsertMetronomePerUserCapAlert,
   upsertMetronomePerUserWarningAlert,
 } from "@app/lib/metronome/alerts/spend_limits";
+import { toFreeMetronomeUserId } from "@app/lib/metronome/constants";
 import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
+import { getCachedSeatDataByUserId } from "@app/lib/metronome/seats";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -24,6 +26,7 @@ import type {
   UserSpendLimit,
 } from "@app/types/api/users/spend_limit";
 import type { SpendLimitOverrideTimeframeType } from "@app/types/credits";
+import type { MembershipSeatType } from "@app/types/memberships";
 import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -159,8 +162,14 @@ export async function getUserSpendLimit(
       user,
       workspace,
     });
+
+  const nextCreditResetAt = await resolveNextCreditResetAt(auth, {
+    userId: user.sId,
+    seatType: membership?.seatType ?? null,
+  });
+
   if (!membership || membership.poolCapOverrideAwuCredits === null) {
-    return new Ok({ kind: "unlimited" });
+    return new Ok({ kind: "unlimited", nextCreditResetAt });
   }
 
   return new Ok({
@@ -168,7 +177,47 @@ export async function getUserSpendLimit(
     awuCredits: membership.poolCapOverrideAwuCredits,
     timeframe: membership.overrideLimitTimeframe,
     expiresAt: membership.poolCapOverrideExpiresAt?.getTime() ?? null,
+    nextCreditResetAt,
   });
+}
+
+/**
+ * Resolve the next time this user's AWU credit pool resets (the Metronome
+ * billing-period boundary), in epoch ms. Null when there is no active
+ * Metronome contract to derive it from. Backed by
+ * `getCachedSeatDataByUserId` (Redis-cached), the same primitive the members
+ * usage table uses — a single cached workspace-wide fetch, not a per-user
+ * Metronome round trip.
+ */
+async function resolveNextCreditResetAt(
+  auth: Authenticator,
+  { userId, seatType }: { userId: string; seatType: MembershipSeatType | null }
+): Promise<number | null> {
+  const workspace = auth.getNonNullableWorkspace();
+  const metronomeContractId = auth.subscription()?.metronomeContractId ?? null;
+  if (!workspace.metronomeCustomerId || !metronomeContractId) {
+    return null;
+  }
+
+  // Best-effort: a Metronome outage should not break reads of the DB-backed
+  // override/timeframe/expiresAt fields above, only degrade this hint to null.
+  try {
+    const seatDataByUserId = await getCachedSeatDataByUserId({
+      metronomeCustomerId: workspace.metronomeCustomerId,
+      contractId: metronomeContractId,
+    });
+    const metronomeUserId =
+      seatType === "free" ? toFreeMetronomeUserId(userId) : userId;
+    const nextCreditResetAt =
+      seatDataByUserId[metronomeUserId]?.nextCreditResetAt;
+    return nextCreditResetAt ? new Date(nextCreditResetAt).getTime() : null;
+  } catch (err) {
+    logger.warn(
+      { workspaceId: workspace.sId, userId, err },
+      "[Metronome PerUserCap] Failed to resolve next credit reset date"
+    );
+    return null;
+  }
 }
 
 export async function setUserSpendLimit(

--- a/front/types/api/users/spend_limit.ts
+++ b/front/types/api/users/spend_limit.ts
@@ -14,7 +14,13 @@ export type UserSpendLimit =
       expiresAt?: number | null;
     };
 
-export type GetUserSpendLimitResponse = UserSpendLimit;
+export type GetUserSpendLimitResponse = UserSpendLimit & {
+  // Epoch ms of this user's next AWU credit pool reset (Metronome billing
+  // period boundary), if resolvable from an active Metronome contract.
+  // Read-only context for admins choosing an override's expiry — never sent
+  // on PUT.
+  nextCreditResetAt: number | null;
+};
 
 export type GetUserSpendLimitResponseBody = GetUserSpendLimitResponse;
 


### PR DESCRIPTION
## Summary
- Stacked on #29618. Adds `nextCreditResetAt` to `GetUserSpendLimitResponse`, resolved from the same Metronome billing-period data the members usage table already uses (`getCachedSeatDataByUserId`, Redis-cached) — no new Metronome plumbing needed, and it degrades to `null` (not an error) on any Metronome fetch failure so a spend-limit read never breaks on a Metronome outage.
- In `EditSpendLimitModal`, replaces the single "expires on" date field with a three-way choice: **Never** / **On a specific date** / **At next credit refresh**. The third option is only shown when a next-reset date is actually resolvable, and pins the override's `expiresAt` to that resolved date at save time.

## Test plan
- [ ] `npm run test -- lib/api/users/spend_limit.test.ts` (front) — `nextCreditResetAt` resolves from mocked Metronome seat data and degrades to `null` on failure.
- [ ] `npm run test -- "members/[uId]/spend_limit.test.ts"` (front-api) — `nextCreditResetAt` round-trips through GET.
- [ ] Manually open "Edit limit" for a Metronome-billed member with an active seat/contract — verify the "At next credit refresh" option appears with the correct formatted date, and saving with it selected persists that date as `expiresAt`.
- [ ] Verify the option is hidden (not shown, not a broken/empty option) for a workspace with no Metronome contract.

## Deploy plan
- [ ] Apply the pre-deploy migration from #29618 (both regions) if not already applied.
- [ ] Deploy front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)