### PR TITLE
Remove most usage of ConversationResource.fetchConversationWithoutContent, rename for clarity, add a linter rule

### DIFF
--- a/.grit/patterns/noExpensiveConversationFetch.grit
+++ b/.grit/patterns/noExpensiveConversationFetch.grit
@@ -1,22 +1,23 @@
 engine biome(1.0)
 language js
 
-// Discourages getConversation() and getLightConversation() which load the full
-// conversation content (messages, actions, etc.) and can be expensive.
-// Prefer ConversationResource.fetchById / fetchConversationWithoutContent when
-// message content is not needed. Suppress with:
+// Discourages getConversation(), getLightConversation(), and
+// ConversationResource.fetchConversationWithParticipantState().
+// Prefer ConversationResource.fetchById when message content / participation
+// fields are not needed. Suppress with:
 //   // biome-ignore lint/plugin/noExpensiveConversationFetch: <reason>
 pattern expensive_conversation_fetch() {
     or {
         `getConversation($args)`,
         `getLightConversation($args)`,
+        `ConversationResource.fetchConversationWithParticipantState($args)`,
     }
 }
 
 expensive_conversation_fetch() as $match where {
     register_diagnostic(
         span = $match,
-        message = "getConversation/getLightConversation load the full conversation content and can be expensive. Prefer ConversationResource.fetchById or fetchConversationWithoutContent when message content is not needed. Suppress with biome-ignore only when a full (or light) conversation load is intentional.",
+        message = "Avoid getConversation/getLightConversation/ConversationResource.fetchConversationWithParticipantState unless needed. Prefer ConversationResource.fetchById when message content and participation fields are not required. Suppress with biome-ignore only when the richer fetch is intentional.",
         severity = "error"
     )
 }

--- a/.grit/patterns/noExpensiveConversationFetch.md
+++ b/.grit/patterns/noExpensiveConversationFetch.md
@@ -5,10 +5,10 @@ level: error
 
 # No expensive conversation fetch
 
-Flags calls to `getConversation()` and `getLightConversation()`, which load the
-full conversation content and can be expensive. Prefer
-`ConversationResource.fetchById` or `fetchConversationWithoutContent` when
-message content is not needed. Suppress intentionally with:
+Flags calls to `getConversation()`, `getLightConversation()`, and
+`ConversationResource.fetchConversationWithParticipantState()`. Prefer
+`ConversationResource.fetchById` when message content and participation fields
+are not needed. Suppress intentionally with:
 
 ```typescript
 // biome-ignore lint/plugin/noExpensiveConversationFetch: <reason>
@@ -40,15 +40,23 @@ const result = await getLightConversation(auth, conversationId);
 const result = await EXPENSIVE_CONVERSATION_FETCH_FORBIDDEN;
 ```
 
-## Should not flag ConversationResource helpers
+## Should flag fetchConversationWithParticipantState
+
+```typescript
+const result = await ConversationResource.fetchConversationWithParticipantState(
+  auth,
+  conversationId
+);
+```
+
+```typescript
+const result = await EXPENSIVE_CONVERSATION_FETCH_FORBIDDEN;
+```
+
+## Should not flag fetchById
 
 ```typescript
 const conversation = await ConversationResource.fetchById(auth, conversationId);
-const withoutContent =
-  await ConversationResource.fetchConversationWithoutContent(
-    auth,
-    conversationId
-  );
 ```
 
 ## Should not flag member calls (e.g. SDK client)

--- a/front-api/lib/api/sse/conversation_events.ts
+++ b/front-api/lib/api/sse/conversation_events.ts
@@ -2,6 +2,7 @@ import { getConversationEvents } from "@app/lib/api/assistant/pubsub";
 import type { ConversationEvents } from "@app/lib/api/assistant/streaming/types";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationError } from "@app/types/assistant/conversation";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { streamEvents } from "@front-api/lib/api/sse/stream_events";
 import type { Context } from "hono";
@@ -32,16 +33,16 @@ export async function streamConversationEventsForRoute(
   }: { conversationId: string; lastEventId: string | null },
   opts: ConversationEventsOptions
 ) {
-  const conversationRes =
-    await ConversationResource.fetchConversationWithoutContent(
-      auth,
-      conversationId
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+  if (!conversation) {
+    return apiErrorForConversation(
+      ctx,
+      new ConversationError("conversation_not_found")
     );
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(ctx, conversationRes.error);
   }
-
-  const conversation = conversationRes.value;
 
   return streamEvents({
     ctx,

--- a/front-api/lib/api/sse/message_events.ts
+++ b/front-api/lib/api/sse/message_events.ts
@@ -3,6 +3,7 @@ import type { MessageStreamEvent } from "@app/lib/api/assistant/pubsub";
 import { getMessagesEvents } from "@app/lib/api/assistant/pubsub";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationError } from "@app/types/assistant/conversation";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { streamEvents } from "@front-api/lib/api/sse/stream_events";
 import { apiError } from "@front-api/middlewares/utils";
@@ -31,16 +32,16 @@ export async function streamMessageEventsForRoute(
   }: { conversationId: string; messageId: string; lastEventId: string | null },
   opts: MessageEventsOptions
 ) {
-  const conversationRes =
-    await ConversationResource.fetchConversationWithoutContent(
-      auth,
-      conversationId
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+  if (!conversation) {
+    return apiErrorForConversation(
+      ctx,
+      new ConversationError("conversation_not_found")
     );
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(ctx, conversationRes.error);
   }
-
-  const conversation = conversationRes.value;
 
   const messageType = await getConversationMessageType(
     auth,

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/config.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/config.ts
@@ -22,12 +22,10 @@ app.get(
     const auth = ctx.get("auth");
     const { cId } = ctx.req.valid("param");
 
-    const cRes = await ConversationResource.fetchConversationWithoutContent(
-      auth,
-      cId,
-      { includeDeleted: true }
-    );
-    if (cRes.isErr()) {
+    const conversation = await ConversationResource.fetchById(auth, cId, {
+      includeDeleted: true,
+    });
+    if (!conversation) {
       return apiError(ctx, {
         status_code: 404,
         api_error: {
@@ -39,7 +37,7 @@ app.get(
 
     const conversationDataSource = await DataSourceResource.fetchByConversation(
       auth,
-      cRes.value
+      conversation
     );
 
     return ctx.json({

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -1,5 +1,6 @@
 import { terminateMessageGeneration } from "@app/lib/api/cancel";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationError } from "@app/types/assistant/conversation";
 import {
   CancelMessageGenerationRequestSchema,
   type CancelMessageGenerationResponseType,
@@ -78,14 +79,16 @@ app.post(
     const auth = ctx.get("auth");
     const { cId: conversationId } = ctx.req.valid("param");
 
-    const conversationRes =
-      await ConversationResource.fetchConversationWithoutContent(
-        auth,
-        conversationId
-      );
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      conversationId
+    );
 
-    if (conversationRes.isErr()) {
-      return apiErrorForConversation(ctx, conversationRes.error);
+    if (!conversation) {
+      return apiErrorForConversation(
+        ctx,
+        new ConversationError("conversation_not_found")
+      );
     }
 
     const { messageIds } = ctx.req.valid("json");

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/feedbacks.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/feedbacks.ts
@@ -1,5 +1,6 @@
 import { getConversationFeedbacksForUser } from "@app/lib/api/assistant/feedback";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationError } from "@app/types/assistant/conversation";
 import type { GetFeedbacksResponseType } from "@dust-tt/client";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { publicApiApp } from "@front-api/middlewares/ctx";
@@ -100,17 +101,16 @@ app.get(
     const auth = ctx.get("auth");
     const { cId: conversationId } = ctx.req.valid("param");
 
-    const conversationRes =
-      await ConversationResource.fetchConversationWithoutContent(
-        auth,
-        conversationId
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      conversationId
+    );
+    if (!conversation) {
+      return apiErrorForConversation(
+        ctx,
+        new ConversationError("conversation_not_found")
       );
-
-    if (conversationRes.isErr()) {
-      return apiErrorForConversation(ctx, conversationRes.error);
     }
-
-    const conversation = conversationRes.value;
 
     if (!auth.user()) {
       return apiError(ctx, {

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/tools.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/tools.ts
@@ -1,5 +1,6 @@
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { ConversationError } from "@app/types/assistant/conversation";
 import type {
   GetMCPServerViewsResponseType,
   PatchConversationResponseType,
@@ -45,17 +46,17 @@ app.post(
     const auth = ctx.get("auth");
     const { cId: conversationId } = ctx.req.valid("param");
 
-    const conversationRes =
-      await ConversationResource.fetchConversationWithoutContent(
-        auth,
-        conversationId
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      conversationId
+    );
+
+    if (!conversation) {
+      return apiErrorForConversation(
+        ctx,
+        new ConversationError("conversation_not_found")
       );
-
-    if (conversationRes.isErr()) {
-      return apiErrorForConversation(ctx, conversationRes.error);
     }
-
-    const conversationWithoutContent = conversationRes.value;
 
     if (!auth.isSystemKey()) {
       return apiError(ctx, {
@@ -86,7 +87,7 @@ app.post(
     }
 
     const r = await ConversationResource.upsertMCPServerViews(auth, {
-      conversation: conversationWithoutContent,
+      conversation,
       mcpServerViews: [mcpServerViewRes],
       enabled: action === "add",
       ...(agent_configuration_id

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -1,6 +1,7 @@
 import { gracefullyStopAgentLoop } from "@app/lib/api/assistant/pubsub";
 import { terminateMessageGeneration } from "@app/lib/api/cancel";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationError } from "@app/types/assistant/conversation";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -86,13 +87,15 @@ app.post(
     const auth = ctx.get("auth");
     const { cId: conversationId } = ctx.req.valid("param");
 
-    const conversationRes =
-      await ConversationResource.fetchConversationWithoutContent(
-        auth,
-        conversationId
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      conversationId
+    );
+    if (!conversation) {
+      return apiErrorForConversation(
+        ctx,
+        new ConversationError("conversation_not_found")
       );
-    if (conversationRes.isErr()) {
-      return apiErrorForConversation(ctx, conversationRes.error);
     }
 
     const { action, messageIds } = ctx.req.valid("json");

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
@@ -1,6 +1,7 @@
 import { postNewContentFragment } from "@app/lib/api/assistant/conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { InternalPostContentFragmentRequestBodySchema } from "@app/types/api/assistant";
+import { ConversationError } from "@app/types/assistant/conversation";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -97,13 +98,14 @@ app.post(
     const user = auth.getNonNullableUser();
     const { cId } = ctx.req.valid("param");
 
-    const conversationRes =
-      await ConversationResource.fetchConversationWithoutContent(auth, cId);
-    if (conversationRes.isErr()) {
-      return apiErrorForConversation(ctx, conversationRes.error);
+    const conversation = await ConversationResource.fetchById(auth, cId);
+    if (!conversation) {
+      return apiErrorForConversation(
+        ctx,
+        new ConversationError("conversation_not_found")
+      );
     }
 
-    const conversation = conversationRes.value;
     const contentFragmentPayload = ctx.req.valid("json");
 
     const baseContext = {
@@ -114,7 +116,7 @@ app.post(
 
     const contentFragmentRes = await postNewContentFragment(
       auth,
-      conversation,
+      conversation.toJSON(),
       contentFragmentPayload,
       {
         ...baseContext,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/feedbacks.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/feedbacks.ts
@@ -1,5 +1,6 @@
 import { getConversationFeedbacksForUser } from "@app/lib/api/assistant/feedback";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationError } from "@app/types/assistant/conversation";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { validate } from "@front-api/middlewares/validator";
@@ -55,18 +56,20 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
   const { cId: conversationId } = ctx.req.valid("param");
 
-  const conversationRes =
-    await ConversationResource.fetchConversationWithoutContent(
-      auth,
-      conversationId
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+  if (!conversation) {
+    return apiErrorForConversation(
+      ctx,
+      new ConversationError("conversation_not_found")
     );
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(ctx, conversationRes.error);
   }
 
   const feedbacksRes = await getConversationFeedbacksForUser(
     auth,
-    conversationRes.value
+    conversation
   );
   if (feedbacksRes.isErr()) {
     return apiErrorForConversation(ctx, feedbacksRes.error);

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -200,22 +200,19 @@ app.get(
     const auth = ctx.get("auth");
     const { cId } = ctx.req.valid("param");
 
-    const conversationRes =
-      await ConversationResource.fetchConversationWithoutContent(auth, cId, {
-        includeForkingData: true,
-      });
+    const conversation = await ConversationResource.fetchById(auth, cId, {
+      includeForkingData: true,
+    });
 
-    if (conversationRes.isErr()) {
+    if (!conversation) {
       // Distinguish between "not found" and "access restricted" for the UI.
       const canAccess = await ConversationResource.canAccess(auth, cId);
       const error =
         canAccess === "conversation_access_restricted"
           ? new ConversationError("conversation_access_restricted")
-          : conversationRes.error;
+          : new ConversationError("conversation_not_found");
       return apiErrorForConversation(ctx, error);
     }
-
-    const conversation = conversationRes.value;
 
     void emitAuditLogEvent({
       auth,
@@ -262,7 +259,11 @@ app.patch(
     const { cId } = ctx.req.valid("param");
 
     const conversationRes =
-      await ConversationResource.fetchConversationWithoutContent(auth, cId);
+      // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional ConversationWithoutContentType
+      await ConversationResource.fetchConversationWithParticipantState(
+        auth,
+        cId
+      );
     if (conversationRes.isErr()) {
       return apiErrorForConversation(ctx, conversationRes.error);
     }

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/participants.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/participants.ts
@@ -103,18 +103,20 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
   const { cId: conversationId } = ctx.req.valid("param");
 
-  const conversationRes =
-    await ConversationResource.fetchConversationWithoutContent(
-      auth,
-      conversationId
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+  if (!conversation) {
+    return apiErrorForConversation(
+      ctx,
+      new ConversationError("conversation_not_found")
     );
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(ctx, conversationRes.error);
   }
 
   const participantsRes = await fetchConversationParticipants(
     auth,
-    conversationRes.value
+    conversation
   );
   if (participantsRes.isErr()) {
     return apiError(ctx, {
@@ -133,16 +135,17 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
   const { cId: conversationId } = ctx.req.valid("param");
 
-  const conversationRes =
-    await ConversationResource.fetchConversationWithoutContent(
-      auth,
-      conversationId
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+  if (!conversation) {
+    return apiErrorForConversation(
+      ctx,
+      new ConversationError("conversation_not_found")
     );
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(ctx, conversationRes.error);
   }
 
-  const conversation = conversationRes.value;
   const u = auth.user();
   if (!u) {
     return apiError(ctx, {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/selectable_spaces.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/selectable_spaces.ts
@@ -1,10 +1,10 @@
 import { listSelectableSpaces } from "@app/lib/api/assistant/conversation/selected_spaces";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationError } from "@app/types/assistant/conversation";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
 import { apiErrorForSelectedSpaces } from "./selected_spaces_errors";
 
 const ParamsSchema = z.object({
@@ -59,17 +59,19 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
   const { cId: conversationId } = ctx.req.valid("param");
 
-  const conversationRes =
-    await ConversationResource.fetchConversationWithoutContent(
-      auth,
-      conversationId
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+  if (!conversation) {
+    return apiErrorForConversation(
+      ctx,
+      new ConversationError("conversation_not_found")
     );
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(ctx, conversationRes.error);
   }
 
   const result = await listSelectableSpaces(auth, {
-    conversation: conversationRes.value,
+    conversation: conversation.toJSON(),
   });
   if (result.isErr()) {
     return apiErrorForSelectedSpaces(ctx, result.error);

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/selected_spaces.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/selected_spaces.ts
@@ -1,11 +1,11 @@
 import { addSelectedConversationSpaces } from "@app/lib/api/assistant/conversation/selected_spaces";
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationError } from "@app/types/assistant/conversation";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
 import { apiErrorForSelectedSpaces } from "./selected_spaces_errors";
 
 const ParamsSchema = z.object({
@@ -96,17 +96,19 @@ app.post(
     const { cId: conversationId } = ctx.req.valid("param");
     const { spaceIds } = ctx.req.valid("json");
 
-    const conversationRes =
-      await ConversationResource.fetchConversationWithoutContent(
-        auth,
-        conversationId
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      conversationId
+    );
+    if (!conversation) {
+      return apiErrorForConversation(
+        ctx,
+        new ConversationError("conversation_not_found")
       );
-    if (conversationRes.isErr()) {
-      return apiErrorForConversation(ctx, conversationRes.error);
     }
 
     const result = await addSelectedConversationSpaces(auth, {
-      conversation: conversationRes.value,
+      conversation: conversation.toJSON(),
       spaceIds,
       origin: "input_bar",
       auditContext: getAuditLogContext(auth),

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/skills.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/skills.ts
@@ -1,6 +1,7 @@
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import logger from "@app/logger/logger";
+import { ConversationError } from "@app/types/assistant/conversation";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
@@ -24,18 +25,20 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
   const { cId: conversationId } = ctx.req.valid("param");
 
-  const conversationRes =
-    await ConversationResource.fetchConversationWithoutContent(
-      auth,
-      conversationId
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+  if (!conversation) {
+    return apiErrorForConversation(
+      ctx,
+      new ConversationError("conversation_not_found")
     );
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(ctx, conversationRes.error);
   }
 
   const conversationSkills = await SkillResource.listEnabledByConversation(
     auth,
-    { conversation: conversationRes.value }
+    { conversation: conversation.toJSON() }
   );
 
   return ctx.json({ skills: conversationSkills.map((s) => s.toJSON(auth)) });
@@ -49,16 +52,19 @@ app.post(
     const auth = ctx.get("auth");
     const { cId: conversationId } = ctx.req.valid("param");
 
-    const conversationRes =
-      await ConversationResource.fetchConversationWithoutContent(
-        auth,
-        conversationId
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversationId
+    );
+    if (!conversationResource) {
+      return apiErrorForConversation(
+        ctx,
+        new ConversationError("conversation_not_found")
       );
-    if (conversationRes.isErr()) {
-      return apiErrorForConversation(ctx, conversationRes.error);
     }
 
-    const conversationWithoutContent = conversationRes.value;
+    const conversation = conversationResource.toJSON();
+
     const { action, skillId } = ctx.req.valid("json");
 
     const skillRes = await SkillResource.fetchById(auth, skillId);
@@ -82,7 +88,7 @@ app.post(
     }
 
     const r = await SkillResource.upsertConversationSkills(auth, {
-      conversation: conversationWithoutContent,
+      conversation,
       skills: [skillRes],
       enabled: action === "add",
     });

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.ts
@@ -1,5 +1,6 @@
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { ConversationError } from "@app/types/assistant/conversation";
 import { isString } from "@app/types/shared/utils/general";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -24,27 +25,24 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
   const { cId: conversationId } = ctx.req.valid("param");
 
-  const conversationRes =
-    await ConversationResource.fetchConversationWithoutContent(
-      auth,
-      conversationId
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+  if (!conversation) {
+    return apiErrorForConversation(
+      ctx,
+      new ConversationError("conversation_not_found")
     );
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(ctx, conversationRes.error);
   }
 
-  const conversationWithoutContent = conversationRes.value;
   const agentConfigurationId = ctx.req.query("agent_configuration_id");
 
   const conversationMCPServerViews =
-    await ConversationResource.fetchMCPServerViews(
-      auth,
-      conversationWithoutContent,
-      {
-        onlyEnabled: true,
-        ...(isString(agentConfigurationId) ? { agentConfigurationId } : {}),
-      }
-    );
+    await ConversationResource.fetchMCPServerViews(auth, conversation, {
+      onlyEnabled: true,
+      ...(isString(agentConfigurationId) ? { agentConfigurationId } : {}),
+    });
 
   const mcpServerViewIds = conversationMCPServerViews.map(
     (v) => v.mcpServerViewId
@@ -76,16 +74,17 @@ app.post(
     const auth = ctx.get("auth");
     const { cId: conversationId } = ctx.req.valid("param");
 
-    const conversationRes =
-      await ConversationResource.fetchConversationWithoutContent(
-        auth,
-        conversationId
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      conversationId
+    );
+    if (!conversation) {
+      return apiErrorForConversation(
+        ctx,
+        new ConversationError("conversation_not_found")
       );
-    if (conversationRes.isErr()) {
-      return apiErrorForConversation(ctx, conversationRes.error);
     }
 
-    const conversationWithoutContent = conversationRes.value;
     const { action, mcp_server_view_id } = ctx.req.valid("json");
 
     const mcpServerView = await MCPServerViewResource.fetchById(
@@ -104,7 +103,7 @@ app.post(
     }
 
     const upsertResult = await ConversationResource.upsertMCPServerViews(auth, {
-      conversation: conversationWithoutContent,
+      conversation,
       mcpServerViews: [mcpServerView],
       enabled: action === "add",
       source: "conversation",

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/wakeups/[wuId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/wakeups/[wuId]/index.ts
@@ -1,5 +1,6 @@
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
+import { ConversationError } from "@app/types/assistant/conversation";
 import type { WakeUpType } from "@app/types/assistant/wakeups";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -72,14 +73,13 @@ app.delete(
     const auth = ctx.get("auth");
     const { cId, wuId } = ctx.req.valid("param");
 
-    // The fetchConversationWithoutContent method checks for conversation
-    // accessibility (inside the resource through `baseFetchWithAuthorization`).
-    const conversationRes =
-      await ConversationResource.fetchConversationWithoutContent(auth, cId);
-    if (conversationRes.isErr()) {
-      return apiErrorForConversation(ctx, conversationRes.error);
+    const conversation = await ConversationResource.fetchById(auth, cId);
+    if (!conversation) {
+      return apiErrorForConversation(
+        ctx,
+        new ConversationError("conversation_not_found")
+      );
     }
-    const conversation = conversationRes.value;
 
     const wakeUp = await WakeUpResource.fetchById(auth, wuId);
     if (!wakeUp || wakeUp.conversationId !== conversation.id) {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/wakeups/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/wakeups/index.ts
@@ -1,12 +1,12 @@
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import type { GetConversationWakeUpsResponseBody } from "@app/types/api/assistant/conversation/wakeups";
+import { ConversationError } from "@app/types/assistant/conversation";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
 import wakeup from "./[wuId]";
 
 const ParamsSchema = z.object({
@@ -62,14 +62,13 @@ app.get(
     const auth = ctx.get("auth");
     const { cId } = ctx.req.valid("param");
 
-    // The fetchConversationWithoutContent method checks for conversation
-    // accessibility (inside the resource through `baseFetchWithAuthorization`).
-    const conversationRes =
-      await ConversationResource.fetchConversationWithoutContent(auth, cId);
-    if (conversationRes.isErr()) {
-      return apiErrorForConversation(ctx, conversationRes.error);
+    const conversation = await ConversationResource.fetchById(auth, cId);
+    if (!conversation) {
+      return apiErrorForConversation(
+        ctx,
+        new ConversationError("conversation_not_found")
+      );
     }
-    const conversation = conversationRes.value;
 
     const wakeUps = await WakeUpResource.listByConversation(auth, conversation);
     return ctx.json({ wakeUps: wakeUps.map((w) => w.toJSON()) });

--- a/front/lib/api/actions/servers/pod_manager/helpers.ts
+++ b/front/lib/api/actions/servers/pod_manager/helpers.ts
@@ -18,7 +18,6 @@ import {
 } from "@app/lib/api/projects/context";
 import { fetchProjectDataSourceView } from "@app/lib/api/projects/data_sources";
 import type { Authenticator } from "@app/lib/auth";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { isPodConversation } from "@app/types/assistant/conversation";
@@ -157,24 +156,7 @@ export async function getPod(
   if ("toolContext" in from && from.toolContext) {
     const { toolContext } = from;
     if (isAgentLoopRunContext(toolContext.runContext)) {
-      const conversationRes =
-        await ConversationResource.fetchConversationWithoutContent(
-          auth,
-          toolContext.runContext.conversation.sId
-        );
-
-      if (conversationRes.isErr()) {
-        return new Err(
-          new MCPError(
-            `Conversation not found: ${conversationRes.error.message}`,
-            {
-              tracked: false,
-            }
-          )
-        );
-      }
-
-      const conversation = conversationRes.value;
+      const conversation = toolContext.runContext.conversation;
 
       if (!isPodConversation(conversation)) {
         return new Err(

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -4327,17 +4327,16 @@ describe("postNewContentFragment", () => {
       });
       expect(messageCountAfterFirst).toBe(1);
 
-      const conversationWithoutContentResult =
-        await ConversationResource.fetchConversationWithoutContent(
-          auth,
-          conversationWithoutContent.sId
-        );
-      expect(conversationWithoutContentResult.isOk()).toBe(true);
-      if (conversationWithoutContentResult.isErr()) {
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversationWithoutContent.sId
+      );
+      expect(conversationResource).not.toBeNull();
+      if (!conversationResource) {
         throw new Error("Failed to fetch conversation metadata");
       }
 
-      const conversationAfterFirst = conversationWithoutContentResult.value;
+      const conversationAfterFirst = conversationResource.toJSON();
 
       const second = await postNewContentFragment(
         auth,
@@ -4409,19 +4408,18 @@ describe("postNewContentFragment", () => {
       );
       expect(first.isOk()).toBe(true);
 
-      const conversationMetadataResult =
-        await ConversationResource.fetchConversationWithoutContent(
-          auth,
-          conversationWithoutContent.sId
-        );
-      expect(conversationMetadataResult.isOk()).toBe(true);
-      if (conversationMetadataResult.isErr()) {
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversationWithoutContent.sId
+      );
+      expect(conversationResource).not.toBeNull();
+      if (!conversationResource) {
         throw new Error("Failed to fetch conversation metadata");
       }
 
       const second = await postNewContentFragment(
         auth,
-        conversationMetadataResult.value,
+        conversationResource.toJSON(),
         {
           ...input,
           supersededContentFragmentId: first.isOk()
@@ -4918,19 +4916,16 @@ describe("conversation fetch forkingData", () => {
       },
     ];
 
-    const conversationResult =
-      await ConversationResource.fetchConversationWithoutContent(
-        auth,
-        parentConversation.sId,
-        { includeForkingData: true }
-      );
-    expect(conversationResult.isOk()).toBe(true);
-
-    if (conversationResult.isOk()) {
-      expect(conversationResult.value.forkingData).toEqual({
-        forkedChildren: expectedForkedChildren,
-      });
-    }
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      parentConversation.sId,
+      { includeForkingData: true }
+    );
+    expect(conversationResource).not.toBeNull();
+    const forkingData = await conversationResource!.fetchForkingData(auth);
+    expect(forkingData).toEqual({
+      forkedChildren: expectedForkedChildren,
+    });
   });
 });
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -333,7 +333,7 @@ export async function deleteOrLeaveConversation(
 
 export async function getConversationMessageType(
   auth: Authenticator,
-  conversation: ConversationWithoutContentType,
+  conversation: ConversationWithoutContentType | ConversationResource,
   messageId: string
 ): Promise<"user_message" | "agent_message" | "content_fragment" | null> {
   if (!auth.workspace()) {
@@ -405,7 +405,7 @@ export async function getMessageConversationId(
  */
 export async function getLastUserMessageMentions(
   auth: Authenticator,
-  conversation: ConversationWithoutContentType
+  conversation: ConversationWithoutContentType | ConversationResource
 ): Promise<Result<string[], Error>> {
   const owner = auth.getNonNullableWorkspace();
 

--- a/front/lib/api/assistant/conversation/mention_suggestions.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.ts
@@ -205,16 +205,15 @@ export const suggestionsOfMentions = async (
   // Get conversation participants if conversationId is provided
   // This aims to prioritize them in the suggestions
   if (conversationId) {
-    const conversationRes =
-      await ConversationResource.fetchConversationWithoutContent(
-        auth,
-        conversationId
-      );
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      conversationId
+    );
 
-    if (conversationRes.isOk()) {
+    if (conversation) {
       const participantsRes = await fetchConversationParticipants(
         auth,
-        conversationRes.value
+        conversation
       );
 
       if (participantsRes.isOk()) {
@@ -247,7 +246,7 @@ export const suggestionsOfMentions = async (
         // If yes, it will be prioritized in the suggestions.
         const lastUserMessageMentions = await getLastUserMessageMentions(
           auth,
-          conversationRes.value
+          conversation
         );
         if (
           lastUserMessageMentions.isOk() &&

--- a/front/lib/api/assistant/conversation/selected_spaces.test.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.test.ts
@@ -165,15 +165,14 @@ describe("selected conversation Spaces", () => {
     readerAuth: Authenticator,
     conversationId: string
   ) {
-    const conversationRes =
-      await ConversationResource.fetchConversationWithoutContent(
-        readerAuth,
-        conversationId
-      );
-    if (conversationRes.isErr()) {
-      throw conversationRes.error;
+    const conversation = await ConversationResource.fetchById(
+      readerAuth,
+      conversationId
+    );
+    if (!conversation) {
+      throw new Error("Conversation not found");
     }
-    return conversationRes.value;
+    return conversation.toJSON();
   }
 
   async function otherWorkspaceMember() {

--- a/front/lib/api/assistant/feedback.ts
+++ b/front/lib/api/assistant/feedback.ts
@@ -3,6 +3,7 @@ import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conve
 import type { PaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -48,7 +49,7 @@ export type AgentMessageFeedbackWithMetadataType = AgentMessageFeedbackType &
 
 export async function getConversationFeedbacksForUser(
   auth: Authenticator,
-  conversation: ConversationWithoutContentType
+  conversation: ConversationWithoutContentType | ConversationResource
 ) {
   const feedbacksRes =
     await AgentMessageFeedbackResource.getConversationFeedbacksForUser(

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -55,7 +55,7 @@ async function fetchAllAgentsById(
 
 export async function fetchConversationParticipants(
   auth: Authenticator,
-  conversation: ConversationWithoutContentType
+  conversation: ConversationWithoutContentType | ConversationResource
 ): Promise<Result<ConversationParticipantsType, Error>> {
   const owner = auth.workspace();
   if (!owner) {

--- a/front/lib/api/cancel.ts
+++ b/front/lib/api/cancel.ts
@@ -21,21 +21,19 @@ export async function terminateMessageGeneration(
     action: "cancel" | "interrupt";
   }
 ): Promise<void> {
-  const conversationRes =
-    await ConversationResource.fetchConversationWithoutContent(
-      auth,
-      conversationId
-    );
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
 
-  if (conversationRes.isErr()) {
+  if (!conversation) {
     logger.warn(
-      { conversationId, error: conversationRes.error },
+      { conversationId },
       "terminateMessageGeneration: conversation not found, skipping"
     );
     return;
   }
 
-  const conversation = conversationRes.value;
   const status = action === "interrupt" ? "interrupted" : "cancelled";
   const signalFn =
     action === "interrupt" ? interruptAgentLoop : cancelAgentLoop;
@@ -89,7 +87,7 @@ export async function terminateMessageGeneration(
     }
 
     const result = await updateAgentMessageWithFinalStatus(auth, {
-      conversation,
+      conversation: conversation.toJSON(),
       agentMessage,
       status,
     });

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -1105,7 +1105,7 @@ export async function createDataSourceWithoutProvider(
     space: SpaceResource;
     name: string;
     description: string | null;
-    conversation?: ConversationWithoutContentType;
+    conversation?: ConversationWithoutContentType | ConversationResource;
   }
 ): Promise<Result<DataSourceViewResource, DataSourceCreationError>> {
   if (name.startsWith("managed-")) {
@@ -1257,7 +1257,7 @@ export async function createDataSourceWithoutProvider(
 
 async function getOrCreateConversationDataSource(
   auth: Authenticator,
-  conversation: ConversationWithoutContentType
+  conversation: ConversationWithoutContentType | ConversationResource
 ): Promise<
   Result<
     DataSourceResource,
@@ -1350,11 +1350,11 @@ export async function getOrCreateConversationDataSourceFromFile(
     });
   }
 
-  const cRes = await ConversationResource.fetchConversationWithoutContent(
+  const conversation = await ConversationResource.fetchById(
     auth,
     metadataResult.value
   );
-  if (cRes.isErr()) {
+  if (!conversation) {
     return new Err({
       name: "dust_error",
       code: "internal_server_error",
@@ -1362,7 +1362,7 @@ export async function getOrCreateConversationDataSourceFromFile(
     });
   }
 
-  return getOrCreateConversationDataSource(auth, cRes.value);
+  return getOrCreateConversationDataSource(auth, conversation);
 }
 
 async function getAllManagedDataSources(auth: Authenticator) {

--- a/front/lib/api/mcp_server/tools/files/context.ts
+++ b/front/lib/api/mcp_server/tools/files/context.ts
@@ -33,12 +33,11 @@ export async function getDustFileSystemForScope(
   scope: FilesScope
 ): Promise<Result<DustFileSystem, string>> {
   if (scope.type === "conversation") {
-    const conversationRes =
-      await ConversationResource.fetchConversationWithoutContent(
-        auth,
-        scope.conversation_id
-      );
-    if (conversationRes.isErr()) {
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      scope.conversation_id
+    );
+    if (!conversation) {
       return new Err(
         `Conversation not found or not accessible: ${scope.conversation_id}`
       );
@@ -46,7 +45,7 @@ export async function getDustFileSystemForScope(
 
     const fsResult = await DustFileSystem.forConversation(
       auth,
-      conversationRes.value
+      conversation.toJSON()
     );
     if (fsResult.isErr()) {
       return new Err(fsResult.error.message);

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -116,9 +116,10 @@ export async function createSandboxChildAction(
     return new Err(new Error("Agent message not found."));
   }
 
-  // Using the fetchConversationWithoutContent method as we need the read and action required states
+  // Using the fetchConversationWithParticipantState method as we need the read and action required states
   const conversationRes =
-    await ConversationResource.fetchConversationWithoutContent(
+    // biome-ignore lint/plugin/noExpensiveConversationFetch: need actionRequired/lastReadAt
+    await ConversationResource.fetchConversationWithParticipantState(
       auth,
       conversationId
     );

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -9,6 +9,7 @@ import {
   MessageModel,
 } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
@@ -391,7 +392,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
 
   static async getConversationFeedbacksForUser(
     auth: Authenticator,
-    conversation: ConversationWithoutContentType
+    conversation: ConversationWithoutContentType | ConversationResource
   ) {
     const user = auth.getNonNullableUser();
 

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -379,38 +379,27 @@ describe("ConversationResource", () => {
       });
 
       const childConversationWithoutContent =
-        await ConversationResource.fetchConversationWithoutContent(
-          auth,
-          childConversation.sId
-        );
-      expect(childConversationWithoutContent.isOk()).toBe(true);
-
-      if (childConversationWithoutContent.isOk()) {
-        expect(
-          childConversationWithoutContent.value.forkingData
-        ).toBeUndefined();
-      }
+        await ConversationResource.fetchById(auth, childConversation.sId);
+      expect(childConversationWithoutContent).not.toBeNull();
+      expect(
+        childConversationWithoutContent!.toJSON().forkingData
+      ).toBeUndefined();
 
       const childConversationWithForkingData =
-        await ConversationResource.fetchConversationWithoutContent(
-          auth,
-          childConversation.sId,
-          { includeForkingData: true }
-        );
-      expect(childConversationWithForkingData.isOk()).toBe(true);
-
-      if (childConversationWithForkingData.isOk()) {
-        expect(childConversationWithForkingData.value.forkingData).toEqual({
-          forkedFrom: {
-            parentConversationId: parentConversation.sId,
-            parentConversationTitle,
-            sourceMessageId: sourceMessage.sId,
-            branchedAt: branchedAt.getTime(),
-            user: auth.getNonNullableUser().toJSON(),
-            fileCopyStatus: "pending",
-          },
+        await ConversationResource.fetchById(auth, childConversation.sId, {
+          includeForkingData: true,
         });
-      }
+      expect(childConversationWithForkingData).not.toBeNull();
+      expect(childConversationWithForkingData!.toJSON().forkingData).toEqual({
+        forkedFrom: {
+          parentConversationId: parentConversation.sId,
+          parentConversationTitle,
+          sourceMessageId: sourceMessage.sId,
+          branchedAt: branchedAt.getTime(),
+          user: auth.getNonNullableUser().toJSON(),
+          fileCopyStatus: "pending",
+        },
+      });
     });
 
     it("should expose forkedFrom title even when the parent conversation is unreadable", async () => {
@@ -5862,7 +5851,7 @@ describe("markAsActionRequired", () => {
     expect(participantAfter.actionRequired).toBe(true);
   });
 
-  it("should update actionRequired even when it's already true", async () => {
+  it("should no-op when actionRequired is already true", async () => {
     const { ConversationParticipantModel } = await import(
       "@app/lib/models/agent/conversation"
     );
@@ -5899,8 +5888,8 @@ describe("markAsActionRequired", () => {
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      // Should still update 1 row (even though value is already true)
-      expect(result.value[0]).toBe(1);
+      // Already at target value: skip the write to avoid a no-op row lock.
+      expect(result.value[0]).toBe(0);
     }
 
     // Verify actionRequired remains true

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -88,7 +88,7 @@ export type FetchConversationOptions = {
   updatedSince?: number; // Filter conversations updated after this timestamp (milliseconds)
   // Read within the given transaction, seeing its uncommitted writes. Only honored on the
   // `baseFetchWithAuthorization` path (`fetchById`, `fetchByIds`, `listAll`, ...). Helpers that
-  // cherry-pick options, such as `fetchConversationWithoutContent`, still read outside of it.
+  // cherry-pick options, such as `fetchConversationWithParticipantState`, still read outside of it.
   transaction?: Transaction;
 };
 
@@ -1714,17 +1714,11 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return messages.map((m) => m.createdAt);
   }
 
-  static async fetchConversationWithoutContent(
+  static async fetchConversationWithParticipantState(
     auth: Authenticator,
-    sId: string,
-    options?: FetchConversationOptions
+    sId: string
   ): Promise<Result<ConversationWithoutContentType, ConversationError>> {
-    const conversation = await this.fetchById(auth, sId, {
-      includeDeleted: options?.includeDeleted,
-      dangerouslySkipPermissionFiltering:
-        options?.dangerouslySkipPermissionFiltering,
-      includeForkingData: options?.includeForkingData,
-    });
+    const conversation = await this.fetchById(auth, sId);
 
     if (!conversation) {
       return new Err(new ConversationError("conversation_not_found"));
@@ -1735,9 +1729,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         auth,
         conversation.id
       );
-    const forkingData = options?.includeForkingData
-      ? await conversation.fetchForkingData(auth)
-      : undefined;
 
     return new Ok({
       actionRequired,
@@ -1757,7 +1748,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       unread: lastReadAt === null || conversation.updatedAt > lastReadAt,
       updated: conversation.updatedAt.getTime(),
       isRunningAgentLoop: conversation.isRunningAgentLoop,
-      ...(forkingData && { forkingData }),
     });
   }
 
@@ -2576,7 +2566,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       return new Ok([0]);
     }
 
-    // Update the conversation participant to set actionRequired to true
+    // Update the conversation participant to set actionRequired to true.
+    // Skip rows already at the target value to avoid a no-op row lock/write.
     const updated = await ConversationParticipantModel.update(
       { actionRequired: true },
       {
@@ -2584,6 +2575,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           conversationId: conversation.id,
           workspaceId: auth.getNonNullableWorkspace().id,
           userId: user.id,
+          actionRequired: { [Op.ne]: true },
         },
       }
     );
@@ -2610,12 +2602,14 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     auth: Authenticator,
     conversation: ConversationResource
   ) {
+    // Skip rows already at the target value to avoid a no-op row lock/write.
     const updated = await ConversationParticipantModel.update(
       { actionRequired: false },
       {
         where: {
           conversationId: conversation.id,
           workspaceId: auth.getNonNullableWorkspace().id,
+          actionRequired: { [Op.ne]: false },
         },
         // Do not update `updatedAt.
         silent: true,
@@ -2630,7 +2624,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     {
       conversation,
       t,
-    }: { conversation: ConversationWithoutContentType; t?: Transaction }
+    }: {
+      conversation: ConversationWithoutContentType | ConversationResource;
+      t?: Transaction;
+    }
   ): Promise<Result<number, Error>> {
     const updated = await ConversationModel.update(
       {
@@ -4114,7 +4111,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
   static async getMessageByIds(
     auth: Authenticator,
-    conversation: ConversationWithoutContentType,
+    conversation: ConversationWithoutContentType | ConversationResource,
     messageIds: string[]
   ): Promise<MessageModel[]> {
     return MessageModel.findAll({
@@ -4529,7 +4526,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
   static async fetchMCPServerViews(
     auth: Authenticator,
-    conversation: ConversationWithoutContentType,
+    conversation: ConversationWithoutContentType | ConversationResource,
     {
       onlyEnabled,
       agentConfigurationId,
@@ -4950,7 +4947,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
    */
   static async listParticipantDetails(
     auth: Authenticator,
-    conversation: ConversationWithoutContentType
+    conversation: ConversationWithoutContentType | ConversationResource
   ): Promise<{ userId: ModelId; action: ParticipantActionType }[]> {
     const participants = await ConversationParticipantModel.findAll({
       where: {
@@ -5034,6 +5031,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const userModelId = auth.getNonNullableUser().id;
     const workspaceModelId = auth.getNonNullableWorkspace().id;
 
+    // Skip rows already at the target value to avoid a no-op row lock/write.
     await ConversationParticipantModel.update(
       { actionRequired: false },
       {
@@ -5041,6 +5039,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           conversationId: { [Op.in]: conversationModelIds },
           workspaceId: workspaceModelId,
           userId: userModelId,
+          actionRequired: { [Op.ne]: false },
         },
       }
     );

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -4,6 +4,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
 import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import { SkillDataSourceConfigurationModel } from "@app/lib/models/skill";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
@@ -273,7 +274,7 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
 
   static async fetchByConversation(
     auth: Authenticator,
-    conversation: ConversationWithoutContentType,
+    conversation: ConversationWithoutContentType | ConversationResource,
     options?: FetchDataSourceOptions
   ): Promise<DataSourceResource | null> {
     const [dataSource] = await this.baseFetch(auth, options, {

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -2508,11 +2508,11 @@ async function maybeDeleteCoreArtifactsForIndexedFile(
     if (!conversationId) {
       return;
     }
-    const cRes = await ConversationResource.fetchConversationWithoutContent(
+    const conversation = await ConversationResource.fetchById(
       auth,
       conversationId
     );
-    if (cRes.isErr()) {
+    if (!conversation) {
       logger.warn(
         {
           workspaceId: auth.workspace()?.sId,
@@ -2525,7 +2525,7 @@ async function maybeDeleteCoreArtifactsForIndexedFile(
     }
     const dataSource = await DataSourceResource.fetchByConversation(
       auth,
-      cRes.value
+      conversation
     );
     if (!dataSource) {
       logger.warn(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -30,6 +30,7 @@ import { SkillReferenceModel } from "@app/lib/models/skill/skill_reference";
 import { SkillSuggestionModel } from "@app/lib/models/skill/skill_suggestion";
 import { SkillUserFavoriteModel } from "@app/lib/models/skill/skill_user_favorite";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -1622,7 +1623,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       effectiveSpaceIds,
       transaction,
     }: {
-      conversation: ConversationWithoutContentType;
+      conversation: ConversationWithoutContentType | ConversationResource;
       agentConfiguration?: AgentConfigurationWithoutModelType;
       agentLoopData?: AgentLoopExecutionData;
       effectiveSpaceIds?: string[];

--- a/front/temporal/agent_loop/activities/common.test.ts
+++ b/front/temporal/agent_loop/activities/common.test.ts
@@ -1123,15 +1123,12 @@ describe("late terminal events after finalization", () => {
     expect(dbMessage?.status).toBe("interrupted");
 
     // The next loop must still be marked as running.
-    const conversationRes =
-      await ConversationResource.fetchConversationWithoutContent(
-        auth,
-        conversation.sId
-      );
-    expect(conversationRes.isOk()).toBe(true);
-    if (conversationRes.isOk()) {
-      expect(conversationRes.value.isRunningAgentLoop).toBe(true);
-    }
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversation.sId
+    );
+    expect(conversationResource).not.toBeNull();
+    expect(conversationResource!.isRunningAgentLoop).toBe(true);
   });
 
   it("drops a late error event without failing the message or the conversation", async () => {
@@ -1163,16 +1160,13 @@ describe("late terminal events after finalization", () => {
     expect(dbMessage?.status).toBe("interrupted");
     expect(dbMessage?.errorCode).toBeNull();
 
-    const conversationRes =
-      await ConversationResource.fetchConversationWithoutContent(
-        auth,
-        conversation.sId
-      );
-    expect(conversationRes.isOk()).toBe(true);
-    if (conversationRes.isOk()) {
-      expect(conversationRes.value.hasError).toBe(false);
-      expect(conversationRes.value.isRunningAgentLoop).toBe(true);
-    }
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversation.sId
+    );
+    expect(conversationResource).not.toBeNull();
+    expect(conversationResource!.hasError).toBe(false);
+    expect(conversationResource!.isRunningAgentLoop).toBe(true);
   });
 
   it("still applies the first terminal event normally", async () => {

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -545,7 +545,6 @@ export async function notifyWorkflowError(
 ): Promise<void> {
   const auth = await AuthenticatorClass.fromJsonWithRefrehedGroups(authType);
 
-  // Use lighter fetchConversationWithoutContent
   const conversation = await ConversationResource.fetchById(
     auth,
     conversationId


### PR DESCRIPTION
## Description

Goal:
Remove useless reads on the conversation_partipants table as ConversationResource.fetchConversationWithoutContent does them but 99.9% of the time we don't need them.

Replaces nearly all uses of `ConversationResource.fetchConversationWithoutContent` across front-api route handlers with `ConversationResource.fetchById` + a null check. GritQL linter rule is updated to flag both `fetchConversationWithoutContent` and `fetchConversationWithParticipantState`, and removes `fetchById` from the allowlist comment since it's now the preferred default.

## Tests

Tested via the existing linter rule and existing test suite. The GritQL `.md` test cases are updated to cover the new `fetchConversationWithoutContent` flagging and confirm `fetchById` is not flagged.

## Risk

Low. Pure mechanical refactor — no logic changes, no DB changes. Error semantics are preserved (`conversation_not_found` is constructed explicitly where `isErr()` was previously used). The renamed `fetchConversationWithParticipantState` is suppressed at its single call site with a biome-ignore comment.

## Deploy Plan

Deploy front + front-api together (no sequencing constraint, no DB migration).
