### PR TITLE
[front] perf: Set autovacuum_analyze_scale_factor to 5% on big row tables

### DIFF
--- a/front/migrations/pre-deploy/20260728162231_set_autovacuum_analyze_scale_factor_on_large_tables.sql
+++ b/front/migrations/pre-deploy/20260728162231_set_autovacuum_analyze_scale_factor_on_large_tables.sql
@@ -1,0 +1,19 @@
+-- Front DBs run with Cloud SQL flags autovacuum_analyze_threshold=10000 and
+-- autovacuum_analyze_scale_factor=0, i.e. ANALYZE after every 10k changed rows regardless of
+-- table size. On large tables this re-analyzes near-constantly for no statistics gain; scale
+-- the factor by table size instead.
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE agent_mcp_action_output_items SET (autovacuum_analyze_scale_factor = 0.005);
+ALTER TABLE files SET (autovacuum_analyze_scale_factor = 0.006);
+ALTER TABLE agent_step_contents SET (autovacuum_analyze_scale_factor = 0.008);
+ALTER TABLE runs SET (autovacuum_analyze_scale_factor = 0.011);
+ALTER TABLE run_usages SET (autovacuum_analyze_scale_factor = 0.012);
+ALTER TABLE agent_mcp_actions SET (autovacuum_analyze_scale_factor = 0.016);
+ALTER TABLE agent_step_content_tool_executions SET (autovacuum_analyze_scale_factor = 0.016);
+ALTER TABLE messages SET (autovacuum_analyze_scale_factor = 0.021);
+ALTER TABLE user_messages SET (autovacuum_analyze_scale_factor = 0.045);
+ALTER TABLE agent_messages SET (autovacuum_analyze_scale_factor = 0.045);
+ALTER TABLE mentions SET (autovacuum_analyze_scale_factor = 0.045);
+ALTER TABLE mcp_server_views SET (autovacuum_analyze_scale_factor = 0.057);
+ALTER TABLE conversations SET (autovacuum_analyze_scale_factor = 0.095);


### PR DESCRIPTION
## Description

We are currently running analyze with a scale factor of 0 and 10k rows threshold.
Introduced in https://github.com/dust-tt/dust-infra/pull/742, was supposed to fine tune the value for big table, never did it until today 🫠 .

Why now ? 

I believe on big tables, running analyze multiple time per hour is not only useless, but performance-wise detrimental.
Yes, pg is not going to lookup all rows, it samples 30k so it does not scale in that direction BUT we have huge columns (JSONB, TOASTED, as always) that are busting a lot of shared_buffer because of how big they are, very often, which is unhealthy for the DB, and because it's TOAST, we also spend CPU time to de-TOAST 30k rows every now and then.

## Tests

N/A

## RIsk

Low - very conservative values, based on the # of rows.

## Plan

Merge
Run the migrationn