### PR TITLE
Add an admin history view for resolved upgrade requests

### DIFF
--- a/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
@@ -252,4 +252,56 @@ describe("/api/w/[wId]/credits/upgrade-requests", () => {
       expect(response.status).toBe(403);
     });
   });
+
+  describe("GET ?status=resolved (history)", () => {
+    it("excludes pending requests and includes resolvedBy once resolved", async () => {
+      const workspace = await creditPricedWorkspace();
+      const { user: member } = await createMemberRequest(workspace);
+
+      const { user: admin } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+
+      const pendingBefore = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}?status=resolved`
+      );
+      expect((await pendingBefore.json()).requests).toHaveLength(0);
+
+      const listResponse = await honoApp.request(
+        upgradeRequestsUrl(workspace.sId)
+      );
+      const requestId = (await listResponse.json()).requests[0].sId;
+
+      await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}/${requestId}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "denied" }),
+        }
+      );
+
+      const historyResponse = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}?status=resolved`
+      );
+      expect(historyResponse.status).toBe(200);
+      const { requests: history } = await historyResponse.json();
+      expect(history).toHaveLength(1);
+      expect(history[0].status).toBe("denied");
+      expect(history[0].requester.sId).toBe(member.sId);
+      expect(history[0].resolvedBy).toEqual({
+        sId: admin.sId,
+        name: admin.fullName(),
+      });
+      expect(history[0].grantedAwuCredits).toBeNull();
+
+      // Still absent from the pending list.
+      const pendingAfter = await honoApp.request(
+        upgradeRequestsUrl(workspace.sId)
+      );
+      expect((await pendingAfter.json()).requests).toHaveLength(0);
+    });
+  });
 });

--- a/front-api/routes/w/[wId]/credits/upgrade-requests.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.ts
@@ -3,6 +3,7 @@ import type { UpgradeRequestError } from "@app/lib/api/credits/upgrade_requests"
 import {
   createUpgradeRequest,
   listPendingUpgradeRequests,
+  listResolvedUpgradeRequests,
   resolveUpgradeRequest,
 } from "@app/lib/api/credits/upgrade_requests";
 import type {
@@ -30,6 +31,12 @@ const ParamsSchema = z.object({
 
 const ResolveBodySchema = z.object({
   status: z.union([z.literal("approved"), z.literal("denied")]),
+});
+
+// Omitted/"pending" preserves the existing behavior (the requests queue);
+// "resolved" switches to the admin history view.
+const ListUpgradeRequestsQuerySchema = z.object({
+  status: z.union([z.literal("pending"), z.literal("resolved")]).optional(),
 });
 
 // TODO(BACK12): make `reason`/`requestedDurationDays` required once the
@@ -95,9 +102,14 @@ const app = workspaceApp();
 app.get(
   "/",
   ensureIsManager(),
+  validate("query", ListUpgradeRequestsQuerySchema),
   async (ctx): HandlerResult<GetUpgradeRequestsResponseBody> => {
     const auth = ctx.get("auth");
-    const requests = await listPendingUpgradeRequests(auth);
+    const { status } = ctx.req.valid("query");
+    const requests =
+      status === "resolved"
+        ? await listResolvedUpgradeRequests(auth)
+        : await listPendingUpgradeRequests(auth);
     return ctx.json({ requests });
   }
 );

--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -1,7 +1,9 @@
+import { Authenticator } from "@app/lib/auth";
 import * as spendLimits from "@app/lib/metronome/alerts/spend_limits";
 import * as planType from "@app/lib/metronome/plan_type";
 import * as seatTypes from "@app/lib/metronome/seat_types";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { MembershipUpgradeRequestResource } from "@app/lib/resources/membership_upgrade_request_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -516,6 +518,76 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
         });
       expect(updatedMembership?.poolCapOverrideAwuCredits).toBeNull();
       expect(updatedMembership?.poolCapOverrideExpiresAt).toBeNull();
+    });
+  });
+
+  describe("PUT with requestId (linked upgrade request)", () => {
+    it("snapshots the grant onto the request, then closes it out when superseded", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+      });
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+      const requestAResult =
+        await MembershipUpgradeRequestResource.createPending(auth, {
+          user: targetUser,
+          reason: "backfill",
+          requestedDurationDays: 7,
+        });
+      if (requestAResult.isErr()) {
+        throw requestAResult.error;
+      }
+      const requestA = requestAResult.value;
+
+      await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+
+      const expiresAtA = Date.now() + 7 * 24 * 60 * 60 * 1000;
+      const putA = await honoApp.request(
+        spendLimitUrl(workspace.sId, targetUser.sId),
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            kind: "limited",
+            awuCredits: 2000,
+            expiresAt: expiresAtA,
+            requestId: requestA.sId,
+          }),
+        }
+      );
+      expect(putA.status).toBe(200);
+
+      const afterA = await MembershipUpgradeRequestResource.fetchById(
+        auth,
+        requestA.sId
+      );
+      expect(afterA?.grantedAwuCredits).toBe(2000);
+      expect(afterA?.grantedExpiresAt?.getTime()).toBe(expiresAtA);
+      expect(afterA?.expiredAt).toBeNull();
+
+      // A second, unrelated save for the same member supersedes request A's
+      // grant, even though it isn't itself linked to any request.
+      const putB = await honoApp.request(
+        spendLimitUrl(workspace.sId, targetUser.sId),
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ kind: "limited", awuCredits: 500 }),
+        }
+      );
+      expect(putB.status).toBe(200);
+
+      const afterB = await MembershipUpgradeRequestResource.fetchById(
+        auth,
+        requestA.sId
+      );
+      expect(afterB?.grantedAwuCredits).toBe(2000);
+      expect(afterB?.expiredAt).not.toBeNull();
     });
   });
 });

--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
@@ -19,8 +19,12 @@ import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
+// `requestId`, set when this save resolves a specific upgrade request, is
+// not part of `UserSpendLimit` itself — it's stripped out in the handler and
+// passed to `setUserSpendLimit` separately so the granted amount/expiry can
+// be snapshotted onto that request for the admin history view.
 const UpdateUserSpendLimitBodySchema = z.discriminatedUnion("kind", [
-  z.object({ kind: z.literal("unlimited") }),
+  z.object({ kind: z.literal("unlimited"), requestId: z.string().optional() }),
   z.object({
     kind: z.literal("limited"),
     awuCredits: z
@@ -30,6 +34,7 @@ const UpdateUserSpendLimitBodySchema = z.discriminatedUnion("kind", [
       .max(MAX_USER_SPEND_LIMIT_AWU_CREDITS),
     timeframe: z.enum(SPEND_LIMIT_OVERRIDE_TIMEFRAMES).nullable().optional(),
     expiresAt: z.number().int().positive().nullable().optional(),
+    requestId: z.string().optional(),
   }),
 ]);
 
@@ -122,12 +127,14 @@ app.put(
     }
 
     const { uId } = ctx.req.valid("param");
+    const { requestId, ...limit } = ctx.req.valid("json");
 
     const auditContext = getAuditLogContext(auth);
     const result = await setUserSpendLimit(auth, {
       userId: uId,
-      limit: ctx.req.valid("json"),
+      limit,
       auditContext,
+      requestId,
     });
     if (result.isErr()) {
       return apiError(ctx, spendLimitErrorToApiError(result.error));

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -18,6 +18,7 @@ import { MembersSelectionBanner } from "@app/components/workspace/MembersSelecti
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import { getSeatIconColorClass } from "@app/components/workspace/seat_styles";
 import { TopUpsHistoryTable } from "@app/components/workspace/TopUpsHistoryTable";
+import { UpgradeRequestsHistoryTable } from "@app/components/workspace/UpgradeRequestsHistoryTable";
 import { UpgradeRequestsTable } from "@app/components/workspace/UpgradeRequestsTable";
 import { LockedSection } from "@app/components/workspace/usage/LockedSection";
 import { ModelTiersSettingsCard } from "@app/components/workspace/usage/ModelTiersSettingsCard";
@@ -73,6 +74,7 @@ import {
 import {
   useResolveUpgradeRequest,
   useUpgradeRequests,
+  useUpgradeRequestsHistory,
 } from "@app/lib/swr/upgrade_requests";
 import { useUsageSettings } from "@app/lib/swr/usage_settings";
 import {
@@ -250,12 +252,17 @@ export function UsagePage() {
   );
   const isWorkspaceAdmin = isAdmin(owner);
   const modelsPickerEnabled = hasFeature("models_picker") && isWorkspaceAdmin;
-  const [membersTab, setMembersTab] = useState<"members" | "requests">(
-    "members"
-  );
+  const [membersTab, setMembersTab] = useState<
+    "members" | "requests" | "history"
+  >("members");
   const { upgradeRequests, isUpgradeRequestsLoading } = useUpgradeRequests({
     workspaceId: owner.sId,
   });
+  const { upgradeRequestsHistory, isUpgradeRequestsHistoryLoading } =
+    useUpgradeRequestsHistory({
+      workspaceId: owner.sId,
+      disabled: membersTab !== "history",
+    });
 
   const filteredUpgradeRequests = useMemo(() => {
     const normalizedSearch = searchTerm.trim().toLowerCase();
@@ -1085,9 +1092,13 @@ export function UsagePage() {
                   <ButtonsSwitchList
                     size="xs"
                     defaultValue="members"
-                    onValueChange={(v: string) =>
-                      setMembersTab(v === "requests" ? "requests" : "members")
-                    }
+                    onValueChange={(v: string) => {
+                      if (v === "requests" || v === "history") {
+                        setMembersTab(v);
+                      } else {
+                        setMembersTab("members");
+                      }
+                    }}
                   >
                     <ButtonsSwitch value="members" label="Members" />
                     <ButtonsSwitch
@@ -1100,6 +1111,7 @@ export function UsagePage() {
                           : undefined
                       }
                     />
+                    <ButtonsSwitch value="history" label="History" />
                   </ButtonsSwitchList>
                   {membersTab === "members" && (
                     <div className="flex flex-row items-center gap-2">
@@ -1116,12 +1128,13 @@ export function UsagePage() {
                   )}
                 </div>
                 <div className="flex flex-col gap-2 pt-2">
-                  {membersTab === "members" ? (
+                  {membersTab === "members" && (
                     <>
                       {selectionBanner}
                       {membersTable}
                     </>
-                  ) : (
+                  )}
+                  {membersTab === "requests" && (
                     <UpgradeRequestsTable
                       requests={filteredUpgradeRequests}
                       isLoading={isUpgradeRequestsLoading}
@@ -1130,6 +1143,12 @@ export function UsagePage() {
                       onUpgradePlan={handleUpgradePlanRequest}
                       onEditLimit={handleEditLimitRequest}
                       onDeny={handleDenyRequest}
+                    />
+                  )}
+                  {membersTab === "history" && (
+                    <UpgradeRequestsHistoryTable
+                      requests={upgradeRequestsHistory}
+                      isLoading={isUpgradeRequestsHistoryLoading}
                     />
                   )}
                 </div>
@@ -1219,6 +1238,7 @@ export function UsagePage() {
           upgradeRequests.find((r) => r.sId === pendingApproveRequestId)
             ?.requestedDurationDays ?? null
         }
+        linkedRequestId={pendingApproveRequestId}
         onSavingChange={handleUsagePendingChange}
         onSaved={handleApproveOnModalSaved}
       />

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -74,6 +74,9 @@ interface EditSpendLimitModalProps {
   // opened to resolve one. Pre-fills the expiry date; the admin can still
   // change it. Null when opened from the members table directly.
   requestedDurationDays?: number | null;
+  // sId of the linked upgrade request, if any — forwarded on save so the
+  // granted amount/expiry gets recorded on it for the admin history view.
+  linkedRequestId?: string | null;
   onSavingChange?: (memberId: string, isSaving: boolean) => void;
   // Fired once the spend limit has been persisted successfully (not on cancel
   // or a load error). Used to resolve a linked upgrade request as approved.
@@ -86,6 +89,7 @@ export function EditSpendLimitModal({
   member,
   owner,
   requestedDurationDays,
+  linkedRequestId,
   onSavingChange,
   onSaved,
 }: EditSpendLimitModalProps) {
@@ -254,6 +258,7 @@ export function EditSpendLimitModal({
         memberId: displayedMember.sId,
         memberName: displayedMember.name,
         limit,
+        requestId: linkedRequestId,
       });
       if (body) {
         onSaved?.();

--- a/front/components/workspace/UpgradeRequestsHistoryTable.tsx
+++ b/front/components/workspace/UpgradeRequestsHistoryTable.tsx
@@ -1,0 +1,197 @@
+import { buildMemberNameColumn } from "@app/components/workspace/member_name_column";
+import { timeAgoFrom } from "@app/lib/utils";
+import type { MembershipUpgradeRequestType } from "@app/types/memberships";
+import { Chip, DataTable, LoadingBlock } from "@dust-tt/sparkle";
+import type { CellContext, ColumnDef } from "@tanstack/react-table";
+import { useMemo } from "react";
+
+type RowData = {
+  sId: string;
+  name: string;
+  email: string | null;
+  image: string | null;
+  createdAt: number;
+  request: MembershipUpgradeRequestType;
+  // Rows are not clickable, but DataTable's row type requires at least one
+  // of its optional fields to be present.
+  onClick?: () => void;
+};
+
+type Info = CellContext<RowData, string>;
+
+const nameColumn = buildMemberNameColumn<RowData>();
+
+const REASON_LABEL = "Reached credit limit";
+
+function formatDate(epochMs: number): string {
+  return new Date(epochMs).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+const statusColumn: ColumnDef<RowData, string> = {
+  id: "status" as const,
+  header: "",
+  enableSorting: false,
+  cell: (info: Info) => {
+    const { status } = info.row.original.request;
+    return (
+      <DataTable.CellContent>
+        {status === "approved" ? (
+          <Chip size="xs" color="success" label="Approved" />
+        ) : (
+          <Chip size="xs" color="warning" label="Denied" />
+        )}
+      </DataTable.CellContent>
+    );
+  },
+  meta: {
+    className: "w-28",
+  },
+};
+
+const reasonColumn: ColumnDef<RowData, string> = {
+  id: "reason" as const,
+  header: "",
+  enableSorting: false,
+  cell: (info: Info) => {
+    const { reason } = info.row.original.request;
+    return (
+      <DataTable.CellContent>
+        <span
+          className="line-clamp-2 text-sm text-muted-foreground"
+          title={reason ?? undefined}
+        >
+          {reason || REASON_LABEL}
+        </span>
+      </DataTable.CellContent>
+    );
+  },
+  meta: {
+    className: "max-w-64",
+  },
+};
+
+// The pool-cap override this request actually resulted in, if any (only set
+// when approved through the linked "Edit limit" flow — see
+// `MembershipUpgradeRequestResource.recordGrant`). A denied request, or one
+// approved through a different flow (e.g. a seat upgrade), has no grant to
+// show.
+const grantedColumn: ColumnDef<RowData, string> = {
+  id: "granted" as const,
+  header: "",
+  enableSorting: false,
+  cell: (info: Info) => {
+    const { grantedAwuCredits, grantedExpiresAt, expiredAt } =
+      info.row.original.request;
+    if (grantedAwuCredits === null) {
+      return (
+        <DataTable.CellContent>
+          <span className="text-sm text-muted-foreground">—</span>
+        </DataTable.CellContent>
+      );
+    }
+
+    const isExpired = expiredAt !== null;
+    const expiryLabel = grantedExpiresAt
+      ? `${isExpired ? "Expired" : "Expires"} ${formatDate(isExpired ? expiredAt : grantedExpiresAt)}`
+      : isExpired
+        ? `Superseded ${formatDate(expiredAt)}`
+        : "No expiry";
+
+    return (
+      <DataTable.CellContent className={isExpired ? "opacity-50" : undefined}>
+        <div className="flex flex-col">
+          <span className="text-sm">
+            {grantedAwuCredits.toLocaleString("en-US")} credits
+          </span>
+          <span className="text-xs text-muted-foreground">{expiryLabel}</span>
+        </div>
+      </DataTable.CellContent>
+    );
+  },
+  meta: {
+    className: "w-40",
+  },
+};
+
+const resolvedColumn: ColumnDef<RowData, string> = {
+  id: "resolved" as const,
+  header: "",
+  accessorFn: (row) => (row.request.resolvedAt ?? row.createdAt).toString(),
+  cell: (info: Info) => {
+    const { resolvedAt, resolvedBy } = info.row.original.request;
+    return (
+      <DataTable.CellContent>
+        <span className="text-sm text-muted-foreground">
+          {resolvedAt
+            ? `${timeAgoFrom(resolvedAt, { useLongFormat: true })} ago`
+            : "—"}
+          {resolvedBy ? ` by ${resolvedBy.name}` : ""}
+        </span>
+      </DataTable.CellContent>
+    );
+  },
+  meta: {
+    className: "w-48",
+  },
+};
+
+interface UpgradeRequestsHistoryTableProps {
+  requests: MembershipUpgradeRequestType[];
+  isLoading: boolean;
+}
+
+export function UpgradeRequestsHistoryTable({
+  requests,
+  isLoading,
+}: UpgradeRequestsHistoryTableProps) {
+  const rows: RowData[] = useMemo(
+    () =>
+      requests.map((request) => ({
+        sId: request.sId,
+        name: request.requester.name,
+        email: request.requester.email,
+        image: request.requester.image,
+        createdAt: request.createdAt,
+        request,
+      })),
+    [requests]
+  );
+
+  const columns = useMemo(
+    () => [
+      nameColumn,
+      statusColumn,
+      reasonColumn,
+      grantedColumn,
+      resolvedColumn,
+    ],
+    []
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex w-full flex-col space-y-2">
+        <LoadingBlock className="h-8 w-full rounded-xl" />
+        <LoadingBlock className="h-8 w-full rounded-xl" />
+        <LoadingBlock className="h-8 w-full rounded-xl" />
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="flex w-full justify-center py-8">
+        <span className="text-sm text-muted-foreground">
+          No resolved upgrade requests yet.
+        </span>
+      </div>
+    );
+  }
+
+  return <DataTable<RowData> data={rows} columns={columns} />;
+}

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -242,6 +242,22 @@ export async function listPendingUpgradeRequests(
   return requests.map((r) => r.toJSON());
 }
 
+const RESOLVED_UPGRADE_REQUESTS_HISTORY_LIMIT = 50;
+
+// Admin-only: history of resolved (approved/denied) upgrade requests for the
+// workspace, most recently resolved first. Bounded to the most recent
+// `RESOLVED_UPGRADE_REQUESTS_HISTORY_LIMIT` — see
+// `MembershipUpgradeRequestResource.listResolvedByWorkspace`.
+export async function listResolvedUpgradeRequests(
+  auth: Authenticator
+): Promise<MembershipUpgradeRequestType[]> {
+  const requests =
+    await MembershipUpgradeRequestResource.listResolvedByWorkspace(auth, {
+      limit: RESOLVED_UPGRADE_REQUESTS_HISTORY_LIMIT,
+    });
+  return requests.map((r) => r.toJSON());
+}
+
 // Admin-only: record the outcome of a request. The actual spend-limit / seat
 // change is performed by the existing flows; this only marks the request.
 export async function resolveUpgradeRequest(

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -17,6 +17,7 @@ import { toFreeMetronomeUserId } from "@app/lib/metronome/constants";
 import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
 import { getCachedSeatDataByUserId } from "@app/lib/metronome/seats";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { MembershipUpgradeRequestResource } from "@app/lib/resources/membership_upgrade_request_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
@@ -226,10 +227,16 @@ export async function setUserSpendLimit(
     userId,
     limit,
     auditContext,
+    requestId,
   }: {
     userId: string;
     limit: UserSpendLimit;
     auditContext: AuditLogContext;
+    // Set when this save resolves a specific upgrade request (the admin
+    // opened "Edit limit" from that request in the requests table).
+    // Snapshots the granted amount/expiry onto that request for history —
+    // see `MembershipUpgradeRequestResource.recordGrant`.
+    requestId?: string | null;
   }
 ): Promise<Result<SetUserSpendLimitResponse, UserSpendLimitError>> {
   const workspace = auth.getNonNullableWorkspace();
@@ -295,6 +302,13 @@ export async function setUserSpendLimit(
     );
   }
 
+  // Any override change (whether or not this save is itself request-linked)
+  // supersedes whatever grant was previously tracked as active for this
+  // user — close it out before applying the new value.
+  await MembershipUpgradeRequestResource.expireActiveGrantsForUser(auth, {
+    user,
+  });
+
   // Persist the admin's intent first: the membership is the source of truth,
   // the Metronome alerts below are derived enforcement (a failed sync can be
   // retried and re-derives from this value).
@@ -307,6 +321,24 @@ export async function setUserSpendLimit(
         ? new Date(limit.expiresAt)
         : null,
   });
+
+  if (requestId && limit.kind === "limited") {
+    const request = await MembershipUpgradeRequestResource.fetchById(
+      auth,
+      requestId
+    );
+    if (request) {
+      await request.recordGrant({
+        awuCredits: limit.awuCredits,
+        expiresAt: limit.expiresAt ? new Date(limit.expiresAt) : null,
+      });
+    } else {
+      logger.warn(
+        { workspaceId: workspace.sId, userId: user.sId, requestId },
+        "[Metronome PerUserCap] Linked upgrade request not found; grant not recorded on it"
+      );
+    }
+  }
 
   switch (limit.kind) {
     case "unlimited": {
@@ -474,6 +506,10 @@ export async function expireUserSpendLimitOverride(
 
   const previousAwuCredits = membership.poolCapOverrideAwuCredits;
   const previousTimeframe = membership.overrideLimitTimeframe;
+
+  await MembershipUpgradeRequestResource.expireActiveGrantsForUser(auth, {
+    user,
+  });
 
   await membership.updatePoolCapOverride({
     poolCapOverrideAwuCredits: null,

--- a/front/lib/resources/membership_upgrade_request_resource.ts
+++ b/front/lib/resources/membership_upgrade_request_resource.ts
@@ -18,6 +18,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
+import { Op } from "sequelize";
 
 export interface MembershipUpgradeRequestResource
   extends ReadonlyAttributesType<MembershipUpgradeRequestModel> {}
@@ -29,6 +30,7 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
 
   readonly requester: UserResource;
   readonly requesterSeatType: MembershipSeatType | null;
+  readonly resolvedByUser: UserResource | null;
 
   constructor(
     _: ModelStatic<MembershipUpgradeRequestModel>,
@@ -36,14 +38,17 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
     {
       requester,
       requesterSeatType,
+      resolvedByUser,
     }: {
       requester: UserResource;
       requesterSeatType: MembershipSeatType | null;
+      resolvedByUser?: UserResource | null;
     }
   ) {
     super(MembershipUpgradeRequestModel, blob);
     this.requester = requester;
     this.requesterSeatType = requesterSeatType;
+    this.resolvedByUser = resolvedByUser ?? null;
   }
 
   get sId(): string {
@@ -138,6 +143,17 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
     );
     const requesterByModelId = new Map(requesters.map((u) => [u.id, u]));
 
+    const resolvedByUserModelIds = rows.flatMap((r) =>
+      r.resolvedByUserId !== null ? [r.resolvedByUserId] : []
+    );
+    const resolvedByUsers =
+      resolvedByUserModelIds.length > 0
+        ? await UserResource.fetchByModelIds(resolvedByUserModelIds)
+        : [];
+    const resolvedByUserByModelId = new Map(
+      resolvedByUsers.map((u) => [u.id, u])
+    );
+
     const { memberships } = await MembershipResource.getActiveMemberships({
       users: requesters,
       workspace: auth.getNonNullableWorkspace(),
@@ -155,6 +171,10 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
         new this(this.model, r.get(), {
           requester,
           requesterSeatType: seatTypeByUserModelId.get(r.userId) ?? null,
+          resolvedByUser:
+            r.resolvedByUserId !== null
+              ? (resolvedByUserByModelId.get(r.resolvedByUserId) ?? null)
+              : null,
         }),
       ];
     });
@@ -179,6 +199,24 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
     return this.baseFetch(auth, {
       where: { status: "pending" },
       order: [["createdAt", "DESC"]],
+    });
+  }
+
+  // Admin history: most recently resolved requests (approved or denied),
+  // newest first. Bounded rather than paginated — a first cut for the
+  // history view; revisit with cursor pagination if workspaces need to see
+  // further back than `limit`.
+  static async listResolvedByWorkspace(
+    auth: Authenticator,
+    { limit }: { limit: number }
+  ): Promise<MembershipUpgradeRequestResource[]> {
+    if (!auth.isManager()) {
+      return [];
+    }
+    return this.baseFetch(auth, {
+      where: { status: { [Op.ne]: "pending" } },
+      order: [["resolvedAt", "DESC"]],
+      limit,
     });
   }
 
@@ -226,6 +264,51 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
     return new Ok(undefined);
   }
 
+  // Snapshot the spend-limit override actually granted when this (approved)
+  // request was resolved via the linked "Edit limit" flow. Called from
+  // `setUserSpendLimit` right after the override is persisted — see
+  // `expireActiveGrantsForUser` for how this grant later gets closed out.
+  async recordGrant(
+    { awuCredits, expiresAt }: { awuCredits: number; expiresAt: Date | null },
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    await this.update(
+      {
+        grantedAwuCredits: awuCredits,
+        grantedExpiresAt: expiresAt,
+        expiredAt: null,
+      },
+      transaction
+    );
+  }
+
+  // Close out any grant(s) still tracked as active for `user` — stamps
+  // `expiredAt` on every request row with a recorded grant that hasn't
+  // already been closed. Called both by the expiration sweep (the grant
+  // naturally lapsed) and by `setUserSpendLimit` before applying *any* new
+  // override for this user (a manual change supersedes it early, whether or
+  // not the new value is itself request-linked). Because the override is a
+  // single overwritable slot per membership, at most one row is normally
+  // still open, but this closes all of them defensively.
+  static async expireActiveGrantsForUser(
+    auth: Authenticator,
+    { user }: { user: UserResource },
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    await this.model.update(
+      { expiredAt: new Date() },
+      {
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          userId: user.id,
+          grantedAwuCredits: { [Op.ne]: null },
+          expiredAt: null,
+        },
+        transaction,
+      }
+    );
+  }
+
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
@@ -268,6 +351,17 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
         image: this.requester.imageUrl ?? null,
         seatType: this.requesterSeatType,
       },
+      resolvedBy: this.resolvedByUser
+        ? {
+            sId: this.resolvedByUser.sId,
+            name: this.resolvedByUser.fullName() || this.resolvedByUser.name,
+          }
+        : null,
+      grantedAwuCredits: this.grantedAwuCredits,
+      grantedExpiresAt: this.grantedExpiresAt
+        ? this.grantedExpiresAt.getTime()
+        : null,
+      expiredAt: this.expiredAt ? this.expiredAt.getTime() : null,
     };
   }
 

--- a/front/lib/resources/storage/models/membership_upgrade_requests.ts
+++ b/front/lib/resources/storage/models/membership_upgrade_requests.ts
@@ -1,5 +1,5 @@
 import { frontSequelize } from "@app/lib/resources/storage";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
+import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import {
@@ -28,6 +28,18 @@ export class MembershipUpgradeRequestModel extends WorkspaceAwareModel<Membershi
   // How long the member expects to need it, in days. Informational only —
   // surfaced to the admin for context, not auto-enforced.
   declare requestedDurationDays: number | null;
+
+  // Snapshot of the spend-limit override actually granted when this request
+  // was approved via the linked "Edit limit" flow (see
+  // `MembershipUpgradeRequestResource.recordGrant`). NULL when the request
+  // was denied, or approved through a different flow (e.g. a seat upgrade)
+  // that isn't tied to a pool-cap override.
+  declare grantedAwuCredits: number | null;
+  declare grantedExpiresAt: Date | null;
+  // Stamped once the granted override stops being in effect — either the
+  // expiration sweep reverted it, or a later spend-limit change superseded
+  // it before its own expiry. NULL while the grant (if any) is still active.
+  declare expiredAt: Date | null;
 
   // The member who requested the upgrade.
   declare userId: ForeignKey<UserModel["id"]>;
@@ -70,6 +82,21 @@ MembershipUpgradeRequestModel.init(
       allowNull: true,
       defaultValue: null,
     },
+    grantedAwuCredits: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
+    },
+    grantedExpiresAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
+    },
+    expiredAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
+    },
   },
   {
     modelName: "membership_upgrade_request",
@@ -91,6 +118,20 @@ MembershipUpgradeRequestModel.init(
       {
         fields: ["resolvedByUserId"],
         name: "membership_upgrade_requests_resolved_by_user_idx",
+      },
+      // Admin history listing (resolved requests, most recent first).
+      {
+        fields: ["workspaceId", "resolvedAt"],
+        name: "membership_upgrade_requests_workspace_resolved_at_idx",
+        concurrently: true,
+      },
+      // Finds a user's still-active grant(s) to close out when superseded or
+      // swept.
+      {
+        fields: ["userId", "expiredAt"],
+        where: { grantedAwuCredits: { [Op.ne]: null } },
+        name: "membership_upgrade_requests_user_active_grant_idx",
+        concurrently: true,
       },
     ],
   }

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -651,15 +651,19 @@ export function useUpdateUserSpendLimit({
       memberId,
       memberName,
       limit,
+      requestId,
     }: {
       memberId: string;
       memberName: string;
       limit: UserSpendLimit;
+      // Set when this save resolves a specific upgrade request, so the
+      // granted amount/expiry gets snapshotted onto it for history.
+      requestId?: string | null;
     }): Promise<PutUserSpendLimitResponseBody | null> => {
       const res = await clientFetch(spendLimitUrl(workspaceId, memberId), {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(limit),
+        body: JSON.stringify(requestId ? { ...limit, requestId } : limit),
       });
 
       if (!res.ok) {

--- a/front/lib/swr/upgrade_requests.ts
+++ b/front/lib/swr/upgrade_requests.ts
@@ -12,9 +12,24 @@ import type { MembershipUpgradeRequestStatus } from "@app/types/memberships";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { useCallback } from "react";
 import type { Fetcher } from "swr";
+import { mutate as globalMutate } from "swr";
 
 function upgradeRequestsUrl(workspaceId: string): string {
   return `/api/w/${workspaceId}/credits/upgrade-requests`;
+}
+
+function upgradeRequestsHistoryUrl(workspaceId: string): string {
+  return `${upgradeRequestsUrl(workspaceId)}?status=resolved`;
+}
+
+async function invalidateUpgradeRequestsHistory(
+  workspaceId: string
+): Promise<void> {
+  await globalMutate(
+    (key) =>
+      typeof key === "string" &&
+      key.startsWith(upgradeRequestsHistoryUrl(workspaceId))
+  );
 }
 
 function usageStatusUrl(workspaceId: string): string {
@@ -96,6 +111,37 @@ export function useUpgradeRequests({
   };
 }
 
+// Admin-only: history of resolved (approved/denied) upgrade requests for the
+// workspace. Separate endpoint call (same route, `status=resolved`) so the
+// pending-requests fetch above stays cheap and isn't gated behind history
+// being visible.
+export function useUpgradeRequestsHistory({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const upgradeRequestsHistoryFetcher: Fetcher<GetUpgradeRequestsResponseBody> =
+    fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    upgradeRequestsHistoryUrl(workspaceId),
+    upgradeRequestsHistoryFetcher,
+    { disabled }
+  );
+
+  const requests = data?.requests ?? emptyArray();
+
+  return {
+    upgradeRequestsHistory: requests,
+    isUpgradeRequestsHistoryLoading: !error && !data && !disabled,
+    isUpgradeRequestsHistoryError: !!error,
+    mutateUpgradeRequestsHistory: mutate,
+  };
+}
+
 export function useResolveUpgradeRequest({
   workspaceId,
 }: {
@@ -133,11 +179,12 @@ export function useResolveUpgradeRequest({
         return false;
       }
 
-      // Resolving always removes the request from the pending list. Only an
-      // approval edits the member's seat / limit, so the members-usage surface
-      // only needs refreshing on approve.
+      // Resolving always removes the request from the pending list and adds
+      // it to history. Only an approval edits the member's seat / limit, so
+      // the members-usage surface only needs refreshing on approve.
       await Promise.all([
         mutate(),
+        invalidateUpgradeRequestsHistory(workspaceId),
         status === "approved"
           ? invalidateMembersUsage(workspaceId)
           : Promise.resolve(),

--- a/front/migrations/pre-deploy/20260728161200_add_grant_snapshot_to_membership_upgrade_requests.sql
+++ b/front/migrations/pre-deploy/20260728161200_add_grant_snapshot_to_membership_upgrade_requests.sql
@@ -1,0 +1,35 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."membership_upgrade_requests" ADD COLUMN "grantedAwuCredits" integer;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."membership_upgrade_requests" ADD COLUMN "grantedExpiresAt" timestamp with time zone;
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."membership_upgrade_requests" ADD COLUMN "expiredAt" timestamp with time zone;
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY membership_upgrade_requests_workspace_resolved_at_idx ON public.membership_upgrade_requests USING btree ("workspaceId", "resolvedAt");
+
+/*
+Statement 4
+  - Partial index for membership_upgrade_requests active grants
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY membership_upgrade_requests_user_active_grant_idx ON public.membership_upgrade_requests USING btree ("userId", "expiredAt") WHERE ("grantedAwuCredits" IS NOT NULL);

--- a/front/temporal/spend_limit_expiration/activities.test.ts
+++ b/front/temporal/spend_limit_expiration/activities.test.ts
@@ -1,5 +1,7 @@
+import { Authenticator } from "@app/lib/auth";
 import * as spendLimits from "@app/lib/metronome/alerts/spend_limits";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { MembershipUpgradeRequestResource } from "@app/lib/resources/membership_upgrade_request_resource";
 import { expirePoolCapOverridesActivity } from "@app/temporal/spend_limit_expiration/activities";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -88,5 +90,41 @@ describe("expirePoolCapOverridesActivity", () => {
     await expirePoolCapOverridesActivity();
 
     expect(spendLimits.clearMetronomePerUserCapAlert).not.toHaveBeenCalled();
+  });
+
+  it("stamps expiredAt on the upgrade request that granted the reverted override", async () => {
+    const workspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: "cust_linked_xxx",
+    });
+    const user = await UserFactory.basic();
+    const membership = await MembershipFactory.associate(workspace, user, {
+      role: "user",
+    });
+    await membership.updatePoolCapOverride({
+      poolCapOverrideAwuCredits: 1500,
+      poolCapOverrideExpiresAt: new Date(Date.now() - 1000),
+    });
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const requestResult = await MembershipUpgradeRequestResource.createPending(
+      auth,
+      { user, reason: "backfill", requestedDurationDays: 1 }
+    );
+    if (requestResult.isErr()) {
+      throw requestResult.error;
+    }
+    await requestResult.value.recordGrant({
+      awuCredits: 1500,
+      expiresAt: new Date(Date.now() - 1000),
+    });
+
+    await expirePoolCapOverridesActivity();
+
+    const afterSweep = await MembershipUpgradeRequestResource.fetchById(
+      auth,
+      requestResult.value.sId
+    );
+    expect(afterSweep?.grantedAwuCredits).toBe(1500);
+    expect(afterSweep?.expiredAt).not.toBeNull();
   });
 });

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -322,6 +322,17 @@ export interface MembershipUpgradeRequestType {
     image: string | null;
     seatType: MembershipSeatType | null;
   };
+  // The admin who approved/denied the request. Null while pending.
+  resolvedBy: { sId: string; name: string } | null;
+  // Snapshot of the spend-limit override granted when this request was
+  // approved via the linked "Edit limit" flow. Null when denied, or approved
+  // through a flow not tied to a pool-cap override (e.g. a seat upgrade).
+  grantedAwuCredits: number | null;
+  grantedExpiresAt: number | null;
+  // When the grant above stopped being in effect (swept, or superseded by a
+  // later spend-limit change). Null while a recorded grant is still active,
+  // and always null when there is no recorded grant.
+  expiredAt: number | null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Stacked on #29623. Admins could only ever see *pending* upgrade requests — the moment one was resolved it vanished from the UI, with no way to see who requested what, who approved/denied it, or whether the resulting grant is still active.
- Adds `grantedAwuCredits` / `grantedExpiresAt` / `expiredAt` to `membership_upgrade_requests`: a snapshot of what was actually granted, taken when a request is approved through the linked "Edit limit" flow (`recordGrant`).
- Since the override is a single overwritable slot per membership (no stacking — see prior discussion), `setUserSpendLimit` now closes out any previously-tracked grant for that member (`expireActiveGrantsForUser`) *before* applying any new override, whether or not the new save is itself request-linked. The expiration sweep does the same when it reverts naturally. This means a request's history row accurately reflects "expired naturally" vs. "superseded early by a later change" — both surface as the grant no longer being active, with the actual end date.
- Adds a "History" tab (admin requests table) showing requester, status (Approved/Denied), reason, resolver + resolution time, and the grant's status (active/expires on X/expired on X/superseded on X/no grant). Bounded to the 50 most recently resolved requests for now (no cursor pagination yet).

## Test plan
- [ ] `npm run test -- lib/api/users/spend_limit.test.ts` (front)
- [ ] `npm run test -- temporal/spend_limit_expiration/activities.test.ts` (front) — sweep stamps `expiredAt` on the linked request.
- [ ] `npm run test -- "members/[uId]/spend_limit.test.ts"` (front-api) — grant snapshot + supersede-on-new-save.
- [ ] `npm run test -- "credits/upgrade-requests.test.ts"` (front-api) — `?status=resolved` history listing.
- [ ] Manually: approve an upgrade request via "Edit limit", switch to the "History" tab, verify the row shows the granted amount/expiry and resolver. Approve a second request for the same member with a smaller/shorter grant, verify the first row now shows "Superseded".

## Deploy plan
- [ ] Apply the pre-deploy migration from this PR (both regions), on top of the ones from #29618/#29623.
- [ ] Deploy front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)