### PR TITLE
Admin governance: rename page to "Settings & Governance" and polish setting copy

### DIFF
--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -307,7 +307,7 @@ export const subNavigationAdmin = ({
         ? [
             {
               id: "governance" as const,
-              label: "Workspace & Governance",
+              label: "Settings & Governance",
               icon: Toggle01Left,
               href: `/w/${owner.sId}/governance`,
               current: isCurrent("governance"),

--- a/front/components/pages/workspace/governance/GovernancePageLayout.tsx
+++ b/front/components/pages/workspace/governance/GovernancePageLayout.tsx
@@ -9,7 +9,7 @@ export function GovernancePageLayout({ children }: GovernancePageLayoutProps) {
   return (
     <div className="flex flex-col gap-6">
       <Page.Header
-        title="Workspace & Governance"
+        title="Settings & Governance"
         description="Manage what members can do in your workspace."
         icon={Toggle01Left}
       />

--- a/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
+++ b/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
@@ -31,39 +31,38 @@ const GOVERNANCE_SETTING_METADATA: Partial<
 > = {
   "create:agent": {
     label: "Create agents",
-    description: "Control who can build agents in the Agent Builder.",
+    description: "Who can create agents in the Agent Builder.",
   },
   "publish:agent": {
     label: "Publish agents",
-    description: "Control who can publish agents to the whole workspace.",
+    description: "Who can publish agents to the whole workspace.",
   },
   "create:skill": {
     label: "Create skills",
-    description: "Control who can build custom skills.",
+    description: "Who can create custom skills.",
   },
   "publish:skill": {
     label: "Manage skill availability",
-    description: "Control who can share skills across the workspace.",
+    description: "Who can share skills across the workspace.",
   },
   "invite:frame": {
     label: "Invite people by email",
     description:
-      "Control who can share frames by email with people outside your organization.",
+      "Who can share frames by email with people outside your organization.",
   },
   "publish:frame": {
     label: "Share by public link",
-    description: "Control who can create public links to frames.",
+    description: "Who can create public links to frames.",
   },
   "admin:billing": {
-    label: "Billing access",
+    label: "Access Billing features",
     description:
-      "Control who can manage billing settings, invoices, and payment methods.",
+      "Who can manage billing settings, invoices, and payment methods.",
     isGroupsOnly: true,
   },
   "admin:security": {
-    label: "Security access",
-    description:
-      "Control who can manage user access, identities, and provisioning.",
+    label: "Access Security features",
+    description: "Who can manage user access, identities, and provisioning.",
     isGroupsOnly: true,
   },
 };

--- a/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
+++ b/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
@@ -55,13 +55,13 @@ const GOVERNANCE_SETTING_METADATA: Partial<
     description: "Who can create public links to frames.",
   },
   "admin:billing": {
-    label: "Access Billing features",
+    label: "Access billing features",
     description:
       "Who can manage billing settings, invoices, and payment methods.",
     isGroupsOnly: true,
   },
   "admin:security": {
-    label: "Access Security features",
+    label: "Access security features",
     description: "Who can manage user access, identities, and provisioning.",
     isGroupsOnly: true,
   },

--- a/front/components/workspace/ExtensionMcpToolsSection.tsx
+++ b/front/components/workspace/ExtensionMcpToolsSection.tsx
@@ -8,7 +8,7 @@ import { WorkspaceSection } from "./WorkspaceSection";
 
 const LABEL = "Browser Extension Tools";
 const DESCRIPTION =
-  "Control whether the Dust browser extension can use MCP tools such as " +
+  "Whether the Dust browser extension can use MCP tools such as " +
   "listing and reading browser tabs.";
 
 interface ExtensionMcpToolsSectionProps {

--- a/front/components/workspace/settings/AuditLogsToggle.tsx
+++ b/front/components/workspace/settings/AuditLogsToggle.tsx
@@ -63,7 +63,7 @@ export function AuditLogsGovernanceSection({ owner }: AuditLogsToggleProps) {
     <GovernanceSettingSection label="Audit" icon={LayerSingle}>
       <GovernanceSettingRowLayout
         label="Audit logs"
-        description="Control whether audit events are emitted to WorkOS and the audit logs section is shown in IT & Security."
+        description="Whether audit events are emitted to WorkOS and the audit logs section is shown in IT & Security."
         action={
           <SliderToggle
             selected={isEnabled}

--- a/front/components/workspace/settings/DustMcpServerSettingsItem.tsx
+++ b/front/components/workspace/settings/DustMcpServerSettingsItem.tsx
@@ -19,7 +19,7 @@ interface DustMcpServerSettingsItemProps {
 
 const LABEL = "MCP server";
 const DESCRIPTION =
-  "Control whether external MCP clients can connect to this workspace.";
+  "Whether external MCP clients can connect to this workspace.";
 
 export function DustMcpServerSettingsItem({
   owner,

--- a/front/components/workspace/settings/EmailAgentsToggle.tsx
+++ b/front/components/workspace/settings/EmailAgentsToggle.tsx
@@ -25,7 +25,7 @@ const ENABLE_EMAIL_AGENTS_CONFIRMATION_MESSAGE =
   "prompt injection.";
 
 const LABEL = "Email agents";
-const DESCRIPTION = `Control whether members can reach agents by email at AGENT_NAME@${ASSISTANT_EMAIL_SUBDOMAIN}.`;
+const DESCRIPTION = `Whether members can reach agents by email at AGENT_NAME@${ASSISTANT_EMAIL_SUBDOMAIN}.`;
 const DOCUMENTATION_URL = "https://docs.dust.tt/docs/email-agents";
 
 interface EmailAgentsToggleProps {

--- a/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
+++ b/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
@@ -44,7 +44,7 @@ const SHARING_POLICY_OPTIONS: {
   },
 ];
 
-const LABEL = "Frame sharing policy";
+const LABEL = "Frame sharing";
 const DESCRIPTION = "Whether frames are shareable outside the workspace.";
 
 interface InteractiveContentSharingToggleProps {

--- a/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
+++ b/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
@@ -119,7 +119,7 @@ export function InteractiveContentSharing({
         />
       ) : (
         <ContextItem
-          title="Frame sharing policy"
+          title={LABEL}
           subElement="Control how Frames can be shared in this workspace"
           visual={<ActionFrame className="h-6 w-6" />}
           hasSeparatorIfLast={true}

--- a/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
+++ b/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
@@ -44,8 +44,8 @@ const SHARING_POLICY_OPTIONS: {
   },
 ];
 
-const LABEL = "Frame access";
-const DESCRIPTION = "Control who can access frames in this workspace.";
+const LABEL = "Frame sharing policy";
+const DESCRIPTION = "Whether frames are shareable outside the workspace.";
 
 interface InteractiveContentSharingToggleProps {
   owner: WorkspaceType;

--- a/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
+++ b/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
@@ -39,7 +39,7 @@ const SHARING_POLICY_OPTIONS: {
   {
     label: "No restrictions",
     description:
-      "Members can share Frames publicly, with the workspace, or via email invite",
+      "Members can share frames publicly, with the workspace, or via email invite",
     value: "all_scopes",
   },
 ];

--- a/front/components/workspace/settings/MessagingAppToggles.tsx
+++ b/front/components/workspace/settings/MessagingAppToggles.tsx
@@ -48,7 +48,7 @@ export function MessagingAppToggles({ owner }: MessagingAppTogglesProps) {
         name="Slack Bot"
         description={
           hasAdminGovernanceFeature
-            ? "Control whether the Dust Bot can be used in Slack."
+            ? "Whether the Dust Bot can be used in Slack."
             : "Use Dust Agents in Slack with the Dust Slack app"
         }
         visual={<SlackLogo className="h-6 w-6" />}
@@ -67,7 +67,7 @@ export function MessagingAppToggles({ owner }: MessagingAppTogglesProps) {
         name="Microsoft Teams Bot"
         description={
           hasAdminGovernanceFeature
-            ? "Control whether the Dust Bot can be used in Microsoft Teams."
+            ? "Whether the Dust Bot can be used in Microsoft Teams."
             : "Use Dust Agents in Teams with the Dust Microsoft Teams Bot"
         }
         visual={<MicrosoftLogo className="h-6 w-6" />}
@@ -87,7 +87,7 @@ export function MessagingAppToggles({ owner }: MessagingAppTogglesProps) {
           name="Discord Bot"
           description={
             hasAdminGovernanceFeature
-              ? "Control whether the Dust Bot can be used in Discord."
+              ? "Whether the Dust Bot can be used in Discord."
               : "Use Dust Agents in Discord with the Dust Discord app"
           }
           visual={<DiscordLogo className="h-6 w-6" />}

--- a/front/components/workspace/settings/OpenPodsPolicy.tsx
+++ b/front/components/workspace/settings/OpenPodsPolicy.tsx
@@ -28,7 +28,7 @@ const OPEN_PODS_POLICIES = [
   },
 ] as const;
 
-const LABEL = "Pod access";
+const LABEL = "Pod sharing policy";
 const DESCRIPTION = "Whether Pods are restricted only, or restricted and open.";
 
 type OpenPodPolicy = (typeof OPEN_PODS_POLICIES)[number];

--- a/front/components/workspace/settings/OpenPodsPolicy.tsx
+++ b/front/components/workspace/settings/OpenPodsPolicy.tsx
@@ -29,8 +29,7 @@ const OPEN_PODS_POLICIES = [
 ] as const;
 
 const LABEL = "Pod access";
-const DESCRIPTION =
-  "Control whether Pods can be restricted only or restricted and open.";
+const DESCRIPTION = "Whether Pods are restricted only, or restricted and open.";
 
 type OpenPodPolicy = (typeof OPEN_PODS_POLICIES)[number];
 

--- a/front/components/workspace/settings/OpenPodsPolicy.tsx
+++ b/front/components/workspace/settings/OpenPodsPolicy.tsx
@@ -28,8 +28,8 @@ const OPEN_PODS_POLICIES = [
   },
 ] as const;
 
-const LABEL = "Pod sharing policy";
-const DESCRIPTION = "Whether Pods are restricted only, or restricted and open.";
+const LABEL = "Restricted and Open Pods";
+const DESCRIPTION = "Whether members are allowed to create open pods.";
 
 type OpenPodPolicy = (typeof OPEN_PODS_POLICIES)[number];
 

--- a/front/components/workspace/settings/PodKnowledgePolicy.tsx
+++ b/front/components/workspace/settings/PodKnowledgePolicy.tsx
@@ -31,7 +31,7 @@ const POD_KNOWLEDGE_POLICIES = [
 type PodKnowledgePolicy = (typeof POD_KNOWLEDGE_POLICIES)[number];
 
 const LABEL = "Pod files";
-const DESCRIPTION = "Control whether members can manually add files to Pods.";
+const DESCRIPTION = "Whether members can manually add files to Pods.";
 
 export function PodKnowledgePolicy({ owner }: { owner: WorkspaceType }) {
   const {

--- a/front/components/workspace/settings/PrivateConversationUrlsToggle.tsx
+++ b/front/components/workspace/settings/PrivateConversationUrlsToggle.tsx
@@ -6,7 +6,7 @@ import { ContextItem, Lock01, SliderToggle } from "@dust-tt/sparkle";
 
 const LABEL = "Private conversation URLs by default";
 const DESCRIPTION =
-  "Control whether conversation URLs are private by default, limiting access to participants.";
+  "Whether conversation URLs are private by default, limiting access to participants.";
 
 interface PrivateConversationUrlsToggleProps {
   owner: WorkspaceType;

--- a/front/components/workspace/settings/SlackPersonalFooterRemovalToggle.tsx
+++ b/front/components/workspace/settings/SlackPersonalFooterRemovalToggle.tsx
@@ -6,7 +6,7 @@ import { ContextItem, SlackLogo, SliderToggle } from "@dust-tt/sparkle";
 
 const LABEL = '"Sent via Agent" Slack footer';
 const DESCRIPTION =
-  'Control whether agents can remove the "Sent via Agent" footer on Slack messages posted with user credentials.';
+  'Whether agents can remove the "Sent via Agent" footer on Slack messages posted with user credentials.';
 
 export function SlackPersonalFooterRemovalToggle({
   owner,

--- a/front/components/workspace/settings/VoiceTranscriptionToggle.tsx
+++ b/front/components/workspace/settings/VoiceTranscriptionToggle.tsx
@@ -6,7 +6,7 @@ import { ContextItem, Microphone01, SliderToggle } from "@dust-tt/sparkle";
 
 const LABEL = "Voice transcription";
 const DESCRIPTION =
-  "Control whether members can use voice transcription in conversations.";
+  "Whether members can use voice transcription in conversations.";
 
 export function VoiceTranscriptionToggle({ owner }: { owner: WorkspaceType }) {
   const { isEnabled, isChanging, doToggleVoiceTranscription } =

--- a/front/components/workspace/settings/WorkspaceAnalyticsToggle.tsx
+++ b/front/components/workspace/settings/WorkspaceAnalyticsToggle.tsx
@@ -6,7 +6,7 @@ import { BarChart01, ContextItem, SliderToggle } from "@dust-tt/sparkle";
 
 const LABEL = "Workspace Analyst";
 const DESCRIPTION =
-  "Control whether workspace admins get the Analyst agent and analytics tools to explore how the workspace is used.";
+  "Whether workspace admins get the Analyst agent and analytics tools to explore how the workspace is used.";
 
 interface WorkspaceAnalyticsToggleProps {
   owner: WorkspaceType;

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -144,7 +144,7 @@ export function capabilityKey({
 }
 
 /**
- * Catalog of the governance capabilities the Workspace & Governance page manages, grouped by the
+ * Catalog of the governance capabilities the Settings & Governance page manages, grouped by the
  * section they belong to.
  */
 export const GOVERNANCE_CAPABILITIES = {


### PR DESCRIPTION
## Description

Copy-only changes on the Settings & Governance page (behind the `admin_governance` feature flag):

- Page title and nav item renamed from "Workspace & Governance" to "Settings & Governance".
- "Create agents" / "Create skills" descriptions now say "who can create" instead of "who can build".
- "Billing access" / "Security access" rows renamed to "Access billing features" / "Access security features".
- "Frame access" renamed to "Frame sharing", with tagline "Whether frames are shareable outside the workspace."
- "Pod access" renamed to "Restricted and Open Pods", with tagline "Whether members are allowed to create open pods."
- All taglines on the page drop the leading "Control": "Control whether…" → "Whether…", "Control who can…" → "Who can…".

Some of the edited description constants are shared with the legacy (non-governance) workspace settings views (e.g. Pods policies), so the reworded taglines show there too — reads fine in both contexts.

## Risks

Blast radius: labels/descriptions on the Settings & Governance page (and shared legacy settings taglines).
Risk: none (copy only, no logic changes)

## Deploy Plan
- pmrr (reviewer: not urgent)
- deploy front