### PR TITLE
[Admin Gov] Emit audit log events on group member add/remove

### DIFF
--- a/front-api/routes/w/[wId]/groups/[groupId]/index.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/index.ts
@@ -1,3 +1,4 @@
+import { emitGroupMemberAuditLogs } from "@app/lib/api/groups/audit";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import type {
   DeleteGroupResponseBody,
@@ -190,6 +191,8 @@ app.patch(
           assertNever(updateRes.error.code);
       }
     }
+
+    emitGroupMemberAuditLogs(auth, group, updateRes.value);
 
     const members = await group.getActiveMembers(auth);
 

--- a/front-api/routes/w/[wId]/groups/index.ts
+++ b/front-api/routes/w/[wId]/groups/index.ts
@@ -1,3 +1,4 @@
+import { emitGroupMemberAuditLogs } from "@app/lib/api/groups/audit";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import {
   CreateGroupBodySchema,
@@ -112,9 +113,11 @@ app.post(
           assertNever(groupRes.error.code);
       }
     }
-    const group = await groupRes.value.toJSONWithMemberCount(auth);
+    const { group, addedUsers } = groupRes.value;
 
-    return ctx.json({ group });
+    emitGroupMemberAuditLogs(auth, group, { addedUsers, removedUsers: [] });
+
+    return ctx.json({ group: await group.toJSONWithMemberCount(auth) });
   }
 );
 

--- a/front/admin/audit_log_schemas/group.member_added.json
+++ b/front/admin/audit_log_schemas/group.member_added.json
@@ -1,0 +1,19 @@
+{
+  "action": "group.member_added",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "group"
+    },
+    {
+      "type": "user"
+    }
+  ],
+  "metadata": {
+    "group_name": "string",
+    "user_email": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/admin/audit_log_schemas/group.member_removed.json
+++ b/front/admin/audit_log_schemas/group.member_removed.json
@@ -1,0 +1,19 @@
+{
+  "action": "group.member_removed",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "group"
+    },
+    {
+      "type": "user"
+    }
+  ],
+  "metadata": {
+    "group_name": "string",
+    "user_email": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -31,6 +31,8 @@
   "file.moved": 1,
   "frame.authorized_files_updated": 1,
   "group.advanced_model_access_updated": 1,
+  "group.member_added": 1,
+  "group.member_removed": 1,
   "group.spend_limit_updated": 1,
   "invitation.revoked": 3,
   "invitation.role_updated": 3,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -52,6 +52,8 @@ export const AUDIT_ACTIONS = [
   "membership.bulk_seat_updated",
   "member.spend_limit_updated",
   "group.advanced_model_access_updated",
+  "group.member_added",
+  "group.member_removed",
   "group.spend_limit_updated",
   "membership.upgrade_request_created",
   "membership.upgrade_request_resolved",

--- a/front/lib/api/groups/audit.ts
+++ b/front/lib/api/groups/audit.ts
@@ -1,0 +1,61 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
+import type { Authenticator } from "@app/lib/auth";
+import type { GroupResource } from "@app/lib/resources/group_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { UserType } from "@app/types/user";
+
+// Bounds the fire-and-forget WorkOS calls: memberIds payloads are unbounded, so a large group
+// update could otherwise burst hundreds of concurrent requests.
+const EMIT_CONCURRENCY = 8;
+
+export function emitGroupMemberAuditLogs(
+  auth: Authenticator,
+  group: GroupResource,
+  {
+    addedUsers,
+    removedUsers,
+  }: { addedUsers: UserType[]; removedUsers: UserType[] }
+): void {
+  void concurrentExecutor(
+    addedUsers,
+    async (user) =>
+      emitAuditLogEvent({
+        auth,
+        action: "group.member_added",
+        targets: [
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("group", group),
+          buildAuditLogTarget("user", { sId: user.sId, name: user.fullName }),
+        ],
+        context: getAuditLogContext(auth),
+        metadata: {
+          group_name: group.name,
+          user_email: user.email,
+        },
+      }),
+    { concurrency: EMIT_CONCURRENCY }
+  );
+  void concurrentExecutor(
+    removedUsers,
+    async (user) =>
+      emitAuditLogEvent({
+        auth,
+        action: "group.member_removed",
+        targets: [
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("group", group),
+          buildAuditLogTarget("user", { sId: user.sId, name: user.fullName }),
+        ],
+        context: getAuditLogContext(auth),
+        metadata: {
+          group_name: group.name,
+          user_email: user.email,
+        },
+      }),
+    { concurrency: EMIT_CONCURRENCY }
+  );
+}

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -263,6 +263,36 @@ describe("GroupResource", () => {
     });
   });
 
+  describe("dangerouslySetMembers", () => {
+    it("returns the diff of added and removed users", async () => {
+      const keptUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, keptUser, { role: "user" });
+      const addedUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, addedUser, { role: "user" });
+
+      const group = await GroupResource.makeNew({
+        name: "Set Members Test Group",
+        workspaceId: workspace.id,
+        kind: "regular_manual",
+      });
+      await group.dangerouslyAddMembers(authenticator, {
+        users: [user.toJSON(), keptUser.toJSON()],
+      });
+
+      const result = await group.dangerouslySetMembers(authenticator, {
+        users: [keptUser.toJSON(), addedUser.toJSON()],
+      });
+
+      if (result.isErr()) {
+        throw new Error(`dangerouslySetMembers failed: ${result.error}`);
+      }
+      expect(result.value.addedUsers.map((u) => u.sId)).toEqual([
+        addedUser.sId,
+      ]);
+      expect(result.value.removedUsers.map((u) => u.sId)).toEqual([user.sId]);
+    });
+  });
+
   describe("suspendMembers", () => {
     it("suspends active members and returns affected user IDs", async () => {
       const regularGroup = await GroupResource.makeNew({

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1,3 +1,8 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import type { AgentConfigurationModel } from "@app/lib/models/agent/agent";
@@ -484,12 +489,15 @@ export class GroupResource extends BaseResource<GroupModel> {
         new DustError("user_not_found", "Some users were not found.")
       );
     }
+    const memberUsers = users.map((u) => u.toJSON());
     const addResult = await group.dangerouslyAddMembers(auth, {
-      users: users.map((u) => u.toJSON()),
+      users: memberUsers,
     });
     if (addResult.isErr()) {
       return new Err(addResult.error);
     }
+
+    group.emitMemberAuditLogs(auth, "group.member_added", memberUsers);
 
     return new Ok(group);
   }
@@ -1938,7 +1946,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     }
   ): Promise<
     Result<
-      undefined,
+      { addedUsers: UserType[]; removedUsers: UserType[] },
       DustError<
         | "unauthorized"
         | "user_not_found"
@@ -1981,7 +1989,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       }
     }
 
-    return new Ok(undefined);
+    return new Ok({ addedUsers: usersToAdd, removedUsers: usersToRemove });
   }
 
   /**
@@ -2276,9 +2284,39 @@ export class GroupResource extends BaseResource<GroupModel> {
       if (setResult.isErr()) {
         return new Err(setResult.error);
       }
+
+      const { addedUsers, removedUsers } = setResult.value;
+      this.emitMemberAuditLogs(auth, "group.member_added", addedUsers);
+      this.emitMemberAuditLogs(auth, "group.member_removed", removedUsers);
     }
 
     return new Ok(undefined);
+  }
+
+  private emitMemberAuditLogs(
+    auth: Authenticator,
+    action: "group.member_added" | "group.member_removed",
+    users: UserType[]
+  ): void {
+    for (const user of users) {
+      void emitAuditLogEvent({
+        auth,
+        action,
+        targets: [
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("group", this),
+          buildAuditLogTarget("user", {
+            sId: user.sId,
+            name: user.fullName,
+          }),
+        ],
+        context: getAuditLogContext(auth),
+        metadata: {
+          group_name: this.name,
+          user_email: user.email,
+        },
+      });
+    }
   }
 
   async deleteRegularManualGroup(

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1,8 +1,3 @@
-import {
-  buildAuditLogTarget,
-  emitAuditLogEvent,
-  getAuditLogContext,
-} from "@app/lib/api/audit/workos_audit";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import type { AgentConfigurationModel } from "@app/lib/models/agent/agent";
@@ -444,7 +439,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     { name, memberIds }: { name: string; memberIds: string[] }
   ): Promise<
     Result<
-      GroupResource,
+      { group: GroupResource; addedUsers: UserType[] },
       DustError<
         | "unauthorized"
         | "name_conflict"
@@ -497,9 +492,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       return new Err(addResult.error);
     }
 
-    group.emitMemberAuditLogs(auth, "group.member_added", memberUsers);
-
-    return new Ok(group);
+    return new Ok({ group, addedUsers: memberUsers });
   }
 
   static async findAgentIdsForGroups(
@@ -2226,7 +2219,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     { name, memberIds }: { name?: string; memberIds?: string[] }
   ): Promise<
     Result<
-      undefined,
+      { addedUsers: UserType[]; removedUsers: UserType[] },
       DustError<
         | "unauthorized"
         | "name_conflict"
@@ -2285,38 +2278,10 @@ export class GroupResource extends BaseResource<GroupModel> {
         return new Err(setResult.error);
       }
 
-      const { addedUsers, removedUsers } = setResult.value;
-      this.emitMemberAuditLogs(auth, "group.member_added", addedUsers);
-      this.emitMemberAuditLogs(auth, "group.member_removed", removedUsers);
+      return new Ok(setResult.value);
     }
 
-    return new Ok(undefined);
-  }
-
-  private emitMemberAuditLogs(
-    auth: Authenticator,
-    action: "group.member_added" | "group.member_removed",
-    users: UserType[]
-  ): void {
-    for (const user of users) {
-      void emitAuditLogEvent({
-        auth,
-        action,
-        targets: [
-          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
-          buildAuditLogTarget("group", this),
-          buildAuditLogTarget("user", {
-            sId: user.sId,
-            name: user.fullName,
-          }),
-        ],
-        context: getAuditLogContext(auth),
-        metadata: {
-          group_name: this.name,
-          user_email: user.email,
-        },
-      });
-    }
+    return new Ok({ addedUsers: [], removedUsers: [] });
   }
 
   async deleteRegularManualGroup(

--- a/front/lib/resources/group_space_resource.ts
+++ b/front/lib/resources/group_space_resource.ts
@@ -195,7 +195,7 @@ export abstract class GroupSpaceBaseResource extends BaseResource<GroupSpaceMode
     if (setMembersRes.isErr()) {
       return new Err(setMembersRes.error);
     }
-    return new Ok(setMembersRes.value);
+    return new Ok(undefined);
   }
 
   /**


### PR DESCRIPTION
## Description

Group membership changes made through the manual group management API (group creation with initial members, and \`PATCH\` of a group's \`memberIds\`) were not audit-logged. SCIM-provisioned membership changes already emit \`scim.group_user_added\` / \`scim.group_user_removed\`, but manual changes by admins/managers left no trace.

This adds two audit actions, \`group.member_added\` and \`group.member_removed\`, emitted once per affected user (targets: workspace, group, user; metadata: group name, user email) from the two group management handlers, via a shared \`emitGroupMemberAuditLogs\` helper in \`lib/api/groups/audit.ts\`. Emission is fire-and-forget with bounded concurrency since \`memberIds\` payloads are unbounded.

To know which users actually changed, \`dangerouslySetMembers\` now returns the \`{ addedUsers, removedUsers }\` diff it already computes internally (covered by a new resource test), \`updateRegularManualGroup\` propagates it, and \`makeNewRegularManual\` returns the created group along with the users added at creation. Existing callers only check for errors, so this is non-breaking (one call site in \`group_space_resource.ts\` adjusted to keep returning \`undefined\`).

Note: emission lives in the handlers rather than \`GroupResource\` because importing \`workos_audit\` from \`group_resource.ts\` creates a module-initialization cycle (\`group_resource → workos_audit → lib/auth → resources\`) that breaks the temporal bundles build.

Schemas are registered with WorkOS (v1) and the version map is committed in this PR.

## Risks

Blast radius: manual group management API (group create/update); audit logging only, fire-and-forget.
Risk: low

## Deploy Plan

- deploy front