### PR TITLE
[front] fix: register DOCX global skill

### DIFF
--- a/front/lib/resources/skill/code_defined/global/index.ts
+++ b/front/lib/resources/skill/code_defined/global/index.ts
@@ -1,4 +1,5 @@
 import { activationSkill } from "@app/lib/resources/skill/code_defined/global/activation";
+import { docxSkill } from "@app/lib/resources/skill/code_defined/global/docx";
 import { framesSkill } from "@app/lib/resources/skill/code_defined/global/frames";
 import { goDeepSkill } from "@app/lib/resources/skill/code_defined/global/go_deep";
 import { mentionUsersSkill } from "@app/lib/resources/skill/code_defined/global/mention_users";
@@ -14,6 +15,7 @@ import { ensureUniqueSIds } from "@app/lib/resources/skill/code_defined/shared";
 
 export const GLOBAL_SKILLS_ARRAY = ensureUniqueSIds([
   activationSkill,
+  docxSkill,
   framesSkill,
   goDeepSkill,
   mentionUsersSkill,


### PR DESCRIPTION
## Description

The DOCX skill is defined but missing from the global skills registry, so it's nowhere to be seen.

This PR registers `docxSkill` in `GLOBAL_SKILLS_ARRAY` alongside the other code-defined global skills.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
