### PR TITLE
[front] fix: skip blobs whose space cannot be resolved in baseFetchWithAuthorization

### DIFF
--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -124,7 +124,7 @@ export abstract class ResourceWithSpace<
         .map((b) => {
           const space = spaces.find((space) => space.id === b.vaultId);
           if (!space) {
-            throw new Error("Unreachable: space not found.");
+            return null;
           }
 
           // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -160,6 +160,8 @@ export abstract class ResourceWithSpace<
             includedResults
           );
         })
+        // Drop blobs whose space could not be resolved (skipped above).
+        .filter((cls): cls is T => cls !== null)
         // Filter out resources that the user cannot fetch.
         .filter((cls) => cls.canFetch(auth))
     );


### PR DESCRIPTION
## Summary

- In `ResourceWithSpace.baseFetchWithAuthorization`, change the `throw new Error("Unreachable: space not found.")` to a `return null` + filter, so a single blob pointing at a soft-deleted space no longer crashes the entire fetch.
- `softDeleteSpace` did not soft-delete webhook source views — only `hardDeleteSpace` (run by the scrub workflow) cleaned them up. So between a pod's soft-deletion and its scrub, a live `WebhookSourcesView` pointed at a dead space.

Will have a separate change fixing the soft-delete, but want to just fix this first in order to unblock user feedback sessions since poke tools are broken because of it.

## Testing
* Validated fix locally

## Risk

Low. The change is purely additive.

## Deploy
1. Deploy front