### PR TITLE
Optimize MCP output persistence to write DB rows once

### DIFF
--- a/front/lib/resources/agent_mcp_action/output_storage.ts
+++ b/front/lib/resources/agent_mcp_action/output_storage.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { REDIS_CACHE_CONCURRENCY } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
@@ -36,31 +37,21 @@ function getActionOutputGcsPrefix(
 function getGcsPath(
   auth: Authenticator,
   action: AgentMCPActionResource,
-  itemId: ModelId
+  objectName: string
 ): string {
-  return `${getActionOutputGcsPrefix(auth, action.id)}${itemId}.json`;
+  return `${getActionOutputGcsPrefix(auth, action.id)}${objectName}.json`;
 }
 
-/**
- * Writes multiple output items to GCS concurrently.
- * Returns Ok with a map of itemId -> gcsPath, or Err on failure.
- */
-export async function batchWriteContentsToGcs(
-  auth: Authenticator,
+async function batchWriteContentsToGcsAtPaths(
   action: AgentMCPActionResource,
-  items: Array<{
-    itemId: ModelId;
-    content: OutputContent;
-  }>
-): Promise<Result<Map<ModelId, string>, Error>> {
-  const results = new Map<ModelId, string>();
-
+  itemsWithPaths: Array<{ content: OutputContent; gcsPath: string }>
+): Promise<Result<string[], Error>> {
   let firstError: Error | null = null;
+  let successCount = 0;
 
   await concurrentExecutor(
-    items,
-    async ({ itemId, content }) => {
-      const gcsPath = getGcsPath(auth, action, itemId);
+    itemsWithPaths,
+    async ({ content, gcsPath }) => {
       const bucket = getPrivateUploadBucket();
       const file = bucket.file(gcsPath);
       const json = JSON.stringify(content);
@@ -77,7 +68,8 @@ export async function batchWriteContentsToGcs(
         }
         return;
       }
-      results.set(itemId, gcsPath);
+
+      successCount += 1;
     },
     { concurrency: GCS_CONCURRENCY }
   );
@@ -86,16 +78,63 @@ export async function batchWriteContentsToGcs(
     logger.error(
       {
         err: firstError,
-        itemCount: items.length,
-        successCount: results.size,
+        itemCount: itemsWithPaths.length,
+        successCount,
       },
       "Failed to write MCP output items to GCS"
     );
 
+    // A failed save may still have persisted its object before returning an error. Delete every
+    // attempted path so callers never have to reason about partial GCS writes.
+    const cleanupResult = await deleteContentsFromGcs(
+      itemsWithPaths.map(({ gcsPath }) => gcsPath)
+    );
+    if (cleanupResult.isErr()) {
+      logger.error(
+        { err: cleanupResult.error, actionId: action.sId },
+        "Failed to clean up partially written MCP output items"
+      );
+    }
+
     return new Err(firstError);
   }
 
-  return new Ok(results);
+  return new Ok(itemsWithPaths.map(({ gcsPath }) => gcsPath));
+}
+
+/**
+ * Writes new output contents to UUID-backed GCS objects concurrently.
+ * Paths are returned in the same order as the provided contents.
+ */
+export async function batchWriteContentsToGcs(
+  auth: Authenticator,
+  action: AgentMCPActionResource,
+  contents: OutputContent[]
+): Promise<Result<string[], Error>> {
+  return batchWriteContentsToGcsAtPaths(
+    action,
+    contents.map((content) => ({
+      content,
+      gcsPath: getGcsPath(auth, action, randomUUID()),
+    }))
+  );
+}
+
+/**
+ * Rewrites existing output items at deterministic paths so backfill retries are idempotent.
+ */
+export async function batchRewriteContentsToGcs(
+  auth: Authenticator,
+  action: AgentMCPActionResource,
+  items: Array<{ itemId: ModelId; content: OutputContent }>
+): Promise<Result<string[], Error>> {
+  return batchWriteContentsToGcsAtPaths(
+    action,
+    items.map(({ itemId, content }) => ({
+      content,
+      gcsPath: getGcsPath(auth, action, itemId.toString()),
+    }))
+  );
 }
 
 /**
@@ -294,10 +333,6 @@ export async function deleteActionOutputsFromGcs(
   actionIds: ModelId[],
   gcsPaths: string[]
 ): Promise<Result<void, Error>> {
-  if (gcsPaths.length === 0) {
-    return new Ok(undefined);
-  }
-
   const prefixResult = await deleteActionOutputPrefixesFromGcs(auth, actionIds);
   if (prefixResult.isErr()) {
     return prefixResult;

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -12,10 +12,12 @@ import {
 } from "@app/lib/resources/agent_mcp_action/output_storage";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { getNamespace } from "@app/tests/utils/test_cls";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   ConversationType,
@@ -27,12 +29,19 @@ import { assert, beforeEach, describe, expect, it, vi } from "vitest";
 
 // In-memory GCS mock: writes persist content that reads can return.
 const gcsStore = new Map<string, Buffer>();
+let gcsSaveFailureMarker: string | null = null;
 
 vi.mock("@app/lib/file_storage", () => ({
   getPrivateUploadBucket: vi.fn(() => ({
     file: vi.fn((path: string) => ({
       copy: vi.fn().mockResolvedValue(undefined),
       save: vi.fn(async (data: Buffer) => {
+        if (
+          gcsSaveFailureMarker &&
+          data.toString("utf-8").includes(gcsSaveFailureMarker)
+        ) {
+          throw new Error("Simulated GCS write failure");
+        }
         gcsStore.set(path, data);
       }),
       download: vi.fn(async () => {
@@ -397,6 +406,7 @@ describe("Output items with GCS storage", () => {
 
   beforeEach(async () => {
     gcsStore.clear();
+    gcsSaveFailureMarker = null;
 
     const setup = await createResourceTest({});
     workspace = setup.workspace;
@@ -416,9 +426,7 @@ describe("Output items with GCS storage", () => {
     });
   });
 
-  const createActionWithOutputItems = async (
-    contents: Array<{ type: "text"; text: string }>
-  ) => {
+  const createAction = async () => {
     const { action } = await ConversationFactory.createAgentMessage(auth, {
       workspace,
       conversation,
@@ -426,9 +434,16 @@ describe("Output items with GCS storage", () => {
       mcpAction: { toolConfiguration },
     });
 
-    expect(action).toBeDefined();
+    assert(action, "Action should be defined.");
+    return action;
+  };
 
-    const outputRes = await action!.createOutputItems(
+  const createActionWithOutputItems = async (
+    contents: Array<{ type: "text"; text: string }>
+  ) => {
+    const action = await createAction();
+
+    const outputRes = await action.createOutputItems(
       auth,
       contents.map((c) => ({ content: c }))
     );
@@ -440,11 +455,11 @@ describe("Output items with GCS storage", () => {
     // createOutputItems returns the generic content view; fetch the created rows for assertions
     // on persistence-side fields.
     const outputItemRows = await AgentMCPActionOutputItemModel.findAll({
-      where: { workspaceId: workspace.id, agentMCPActionId: action!.id },
+      where: { workspaceId: workspace.id, agentMCPActionId: action.id },
       order: [["id", "ASC"]],
     });
 
-    return { action: action!, outputItems, outputItemRows };
+    return { action, outputItems, outputItemRows };
   };
 
   it("should create output items in both DB and GCS", async () => {
@@ -460,9 +475,92 @@ describe("Output items with GCS storage", () => {
 
     // contentGcsPath should be set (GCS write succeeded).
     expect(outputItemRows[0].contentGcsPath).toBeTruthy();
+    expect(outputItemRows[0].contentGcsPath).toMatch(
+      /\/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.json$/
+    );
 
     // GCS store should have one entry.
     expect(gcsStore.size).toBe(1);
+  });
+
+  it("uses distinct GCS objects across multiple writes for the same action", async () => {
+    const action = await createAction();
+
+    const firstResult = await action.createOutputItems(auth, [
+      { content: { type: "text", text: "first" } },
+    ]);
+    const secondResult = await action.createOutputItems(auth, [
+      { content: { type: "text", text: "second" } },
+    ]);
+
+    expect(firstResult.isOk()).toBe(true);
+    expect(secondResult.isOk()).toBe(true);
+
+    const outputItemRows = await AgentMCPActionOutputItemModel.findAll({
+      where: { workspaceId: workspace.id, agentMCPActionId: action.id },
+    });
+    expect(outputItemRows).toHaveLength(2);
+    expect(
+      new Set(outputItemRows.map((item) => item.contentGcsPath)).size
+    ).toBe(2);
+    expect(gcsStore.size).toBe(2);
+  });
+
+  it("cleans up GCS and creates no rows when a batch GCS write fails", async () => {
+    const action = await createAction();
+    gcsSaveFailureMarker = "fail-this-write";
+
+    const result = await action.createOutputItems(auth, [
+      { content: { type: "text", text: "successful write" } },
+      { content: { type: "text", text: "fail-this-write" } },
+    ]);
+
+    expect(result.isErr()).toBe(true);
+    const outputItemRows = await AgentMCPActionOutputItemModel.findAll({
+      where: { workspaceId: workspace.id, agentMCPActionId: action.id },
+    });
+    expect(outputItemRows).toHaveLength(0);
+    expect(gcsStore.size).toBe(0);
+  });
+
+  it("retains ambiguous DB-failure objects until action-prefix cleanup", async () => {
+    const action = await createAction();
+    const namespace = getNamespace("test-namespace");
+    const parentTransaction = namespace?.get("transaction");
+    expect(parentTransaction).toBeDefined();
+
+    await expect(
+      frontSequelize.transaction(
+        { transaction: parentTransaction },
+        async () => {
+          const result = await action.createOutputItems(auth, [
+            {
+              content: { type: "text", text: "orphan candidate" },
+              fileId: -1,
+            },
+          ]);
+          expect(result.isErr()).toBe(true);
+
+          // Roll back the savepoint so the expected FK violation does not abort the test's
+          // enclosing transaction.
+          throw result.isErr()
+            ? result.error
+            : new Error("Expected output item creation to fail.");
+        }
+      )
+    ).rejects.toThrow();
+
+    const outputItemRows = await AgentMCPActionOutputItemModel.findAll({
+      where: { workspaceId: workspace.id, agentMCPActionId: action.id },
+    });
+    expect(outputItemRows).toHaveLength(0);
+    expect(gcsStore.size).toBe(1);
+
+    await AgentMCPActionResource.destroyOutputItemsByActionIds(auth, [
+      action.id,
+    ]);
+
+    expect(gcsStore.size).toBe(0);
   });
 
   it("should read content from GCS, not from DB", async () => {
@@ -508,6 +606,23 @@ describe("Output items with GCS storage", () => {
         { PX: GCS_CONTENT_CACHE_TTL_MS },
       ]);
     }
+  });
+
+  it("succeeds when Redis cache warming fails", async () => {
+    const action = await createAction();
+    const redis = await getRedisCacheClient({ origin: "cache_with_redis" });
+    vi.mocked(redis.set).mockRejectedValueOnce(new Error("redis down"));
+
+    const result = await action.createOutputItems(auth, [
+      { content: { type: "text", text: "persisted" } },
+    ]);
+
+    expect(result.isOk()).toBe(true);
+    const outputItemRows = await AgentMCPActionOutputItemModel.findAll({
+      where: { workspaceId: workspace.id, agentMCPActionId: action.id },
+    });
+    expect(outputItemRows).toHaveLength(1);
+    expect(gcsStore.size).toBe(1);
   });
 
   it("should destroy output items from both DB and GCS", async () => {

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -90,8 +90,6 @@ const OUTPUT_ITEMS_BATCH_SIZE = 32;
 
 const FETCH_OUTPUT_ITEMS_CONCURRENCY = 2;
 
-const CONCURRENCY_UPDATE_OUTPUT_ITEMS = 16;
-
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -839,7 +837,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   }
 
   /**
-   * Creates output items in DB and writes their content to GCS.
+   * Writes output content to GCS and creates its DB rows.
    * Content is also written to DB to ease rollback during the migration period.
    */
   async createOutputItems(
@@ -849,72 +847,74 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       fileId?: ModelId;
     }>
   ): Promise<Result<ToolOutputItemType[], Error>> {
-    const outputItems = await AgentMCPActionOutputItemModel.bulkCreate(
-      contents.map((c) => {
-        const { generatedFilePath, generatedFileContentType } =
-          isToolGeneratedFilePath(c.content)
-            ? {
-                generatedFilePath: c.content.resource.path,
-                generatedFileContentType: c.content.resource.contentType,
-              }
-            : { generatedFilePath: null, generatedFileContentType: null };
-
-        return {
-          agentMCPActionId: this.id,
-          // Write content to DB (kept during migration period to ease rollback).
-          content: c.content,
-          citations: getCitationsFromToolOutput([c.content]),
-          fileId: c.fileId,
-          workspaceId: this.workspaceId,
-          generatedFilePath,
-          generatedFileContentType,
-        };
-      })
-    );
-
+    // Write GCS first: the helper retries and cleans up partial batches, and DB insertion only
+    // starts once every object has been persisted.
     const gcsResult = await batchWriteContentsToGcs(
       auth,
       this,
-      outputItems.map((item) => ({
-        itemId: item.id,
-        content: item.content,
-      }))
+      contents.map(({ content }) => content)
     );
 
-    // GCS write is retried internally. If it still fails we surface the error rather than leaving
-    // rows with no `contentGcsPath`. There is no acceptable degraded state.
     if (gcsResult.isErr()) {
       return new Err(gcsResult.error);
     }
 
-    await warmGcsContentCache(
-      auth,
-      removeNulls(
-        outputItems.map((item) => {
-          const gcsPath = gcsResult.value.get(item.id);
-          return gcsPath
-            ? { itemId: item.id, gcsPath, content: item.content }
-            : null;
-        })
-      )
-    );
+    let outputItems: AgentMCPActionOutputItemModel[];
+    try {
+      outputItems = await AgentMCPActionOutputItemModel.bulkCreate(
+        contents.map((c, index) => {
+          const contentGcsPath = gcsResult.value[index];
+          assert(contentGcsPath, "GCS path not found for output item.");
 
-    // Update DB rows with their GCS paths.
-    // TODO(2026-02-25 PERF): Optimize by writing items only once.
-    await concurrentExecutor(
-      outputItems,
-      async (item) => {
-        const gcsPath = gcsResult.value.get(item.id);
-        if (gcsPath) {
-          await AgentMCPActionOutputItemModel.update(
-            { contentGcsPath: gcsPath },
-            { where: { id: item.id, workspaceId: this.workspaceId } }
-          );
-          item.contentGcsPath = gcsPath;
-        }
-      },
-      { concurrency: CONCURRENCY_UPDATE_OUTPUT_ITEMS }
-    );
+          const { generatedFilePath, generatedFileContentType } =
+            isToolGeneratedFilePath(c.content)
+              ? {
+                  generatedFilePath: c.content.resource.path,
+                  generatedFileContentType: c.content.resource.contentType,
+                }
+              : { generatedFilePath: null, generatedFileContentType: null };
+
+          return {
+            agentMCPActionId: this.id,
+            // Write content to DB (kept during migration period to ease rollback).
+            content: c.content,
+            contentGcsPath,
+            citations: getCitationsFromToolOutput([c.content]),
+            fileId: c.fileId,
+            workspaceId: this.workspaceId,
+            generatedFilePath,
+            generatedFileContentType,
+          };
+        })
+      );
+    } catch (err) {
+      // A DB error can be ambiguous after commit, so keep the GCS objects rather than risk
+      // deleting content referenced by committed rows. Action-prefix cleanup removes orphans.
+      return new Err(normalizeError(err));
+    }
+
+    try {
+      await warmGcsContentCache(
+        auth,
+        removeNulls(
+          outputItems.map((item) =>
+            item.contentGcsPath
+              ? {
+                  itemId: item.id,
+                  gcsPath: item.contentGcsPath,
+                  content: item.content,
+                }
+              : null
+          )
+        )
+      );
+    } catch (err) {
+      // Cache warming is best-effort and must not turn a successful persistence into a retry.
+      logger.warn(
+        { err: normalizeError(err), actionId: this.sId },
+        "Failed to warm MCP output content cache"
+      );
+    }
 
     // Return the stored contents in the generic tool output item shape.
     return new Ok(
@@ -1099,10 +1099,9 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
     const gcsPaths = removeNulls(gcsItems.map((item) => item.contentGcsPath));
 
-    if (gcsPaths.length > 0) {
-      // Results intentionally unused — failures must not block DB cleanup.
-      await deleteActionOutputsFromGcs(auth, actionIds, gcsPaths);
-    }
+    // Results intentionally unused — failures must not block DB cleanup. Prefixes are deleted even
+    // without persisted paths to clean objects orphaned between the GCS and DB writes.
+    await deleteActionOutputsFromGcs(auth, actionIds, gcsPaths);
 
     // Delete all output items from DB.
     await AgentMCPActionOutputItemModel.destroy({

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1099,7 +1099,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
     const gcsPaths = removeNulls(gcsItems.map((item) => item.contentGcsPath));
 
-    // Results intentionally unused — failures must not block DB cleanup. Prefixes are deleted even
+    // Results intentionally unused. Failures must not block DB cleanup. Prefixes are deleted even
     // without persisted paths to clean objects orphaned between the GCS and DB writes.
     await deleteActionOutputsFromGcs(auth, actionIds, gcsPaths);
 

--- a/front/scripts/backfill_mcp_action_output_item_gcs_paths.ts
+++ b/front/scripts/backfill_mcp_action_output_item_gcs_paths.ts
@@ -1,7 +1,7 @@
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
-import { batchWriteContentsToGcs } from "@app/lib/resources/agent_mcp_action/output_storage";
+import { batchRewriteContentsToGcs } from "@app/lib/resources/agent_mcp_action/output_storage";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -144,9 +144,11 @@ makeScript(
               // Re-write content from DB to the new GCS path. The DB column is NOT NULL during the
               // migration period, so it's available even for items that already have a
               // (legacy-prefix) GCS object.
-              const writeResult = await batchWriteContentsToGcs(auth, action, [
-                { itemId: item.id, content: item.content },
-              ]);
+              const writeResult = await batchRewriteContentsToGcs(
+                auth,
+                action,
+                [{ itemId: item.id, content: item.content }]
+              );
               if (writeResult.isErr()) {
                 scriptLogger.error(
                   {
@@ -160,7 +162,7 @@ makeScript(
                 return;
               }
 
-              const newPath = writeResult.value.get(item.id);
+              const newPath = writeResult.value[0];
               if (!newPath) {
                 scriptLogger.error(
                   { workspaceId: workspaceId, itemId: item.id },


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1785255327670479?thread_ts=1785251882.524509&cid=C050SM8NSPK).

MCP action output items were previously inserted before their GCS paths were known, then updated individually after uploading their content. For a batch of N outputs, this resulted in one bulk insert followed by N update queries.

These updates were more expensive than the query count alone suggests. PostgreSQL had to create new row versions, keep indexes up-to-date. They also introduced extra database round trips and increased table bloat.

This change gives each new GCS object a storage-only UUID. Contents are uploaded first, allowing the final GCS paths to be included directly in a single `bulkCreate`. Each output row is therefore written once with its complete state.

GCS writes retain their existing per-object retries. If part of a batch still fails, every attempted path is cleaned up and no database rows are created. Database errors preserve the uploaded objects because the outcome of an interrupted
commit can be ambiguous. Action-prefix cleanup removes any resulting orphan safely. Cache warming is now best-effort so a Redis failure cannot cause an already-persisted output batch to be retried.

Action deletion now clears the complete GCS prefix even when no output path reached the database, covering crashes between GCS upload and database insertion. The migration backfill continues using deterministic item-based paths so rerunning it remains idempotent (still need one week end of backfill).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
