### PR TITLE
[front] Poke tooling for the per-user spend-cap counters

### DIFF
--- a/front-api/routes/w/[wId]/credits/members-usage.test.ts
+++ b/front-api/routes/w/[wId]/credits/members-usage.test.ts
@@ -36,6 +36,8 @@ const MEMBER_USAGE = {
   seatBalanceAwu: 100,
   spendLimitAlertId: null,
   spendLimitAwuCredits: null,
+  rateLimiterSpendAwuCredits: null,
+  metronomeConsumedAwuCredits: null,
   spendLimitSource: "default" as const,
   spendLimitWarningAlertId: null,
 };

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -142,6 +142,8 @@ function memberFromUpgradeRequest(
     scheduledSeatType: null,
     scheduledSeatChangeAt: null,
     spendLimitAwuCredits: null,
+    rateLimiterSpendAwuCredits: null,
+    metronomeConsumedAwuCredits: null,
     spendLimitSource: "none",
     spendLimitAlertId: null,
     spendLimitWarningAlertId: null,

--- a/front/components/poke/credits/PokeMembersUsageTable.tsx
+++ b/front/components/poke/credits/PokeMembersUsageTable.tsx
@@ -133,11 +133,34 @@ function makeColumns({
     },
     {
       accessorKey: "consumedAwuCredits",
-      header: "Consumed",
+      // ES = Elasticsearch, RL = Redis rate-limiter counter, MT = Metronome.
+      // The three should agree; divergence points at a counter/metric issue.
+      header: "Consumed (ES / RL / MT)",
       enableSorting: false,
-      cell: ({ row }) => (
-        <span>{formatCredits(row.original.consumedAwuCredits)}</span>
-      ),
+      cell: ({ row }) => {
+        const {
+          consumedAwuCredits,
+          rateLimiterSpendAwuCredits,
+          metronomeConsumedAwuCredits,
+        } = row.original;
+        return (
+          <div className="flex flex-col text-xs">
+            <span>ES {formatCredits(consumedAwuCredits)}</span>
+            <span className="text-muted-foreground">
+              RL{" "}
+              {rateLimiterSpendAwuCredits !== null
+                ? formatCredits(rateLimiterSpendAwuCredits)
+                : "-"}
+            </span>
+            <span className="text-muted-foreground">
+              MT{" "}
+              {metronomeConsumedAwuCredits !== null
+                ? formatCredits(metronomeConsumedAwuCredits)
+                : "-"}
+            </span>
+          </div>
+        );
+      },
     },
     {
       accessorKey: "spendLimitAwuCredits",

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1,3 +1,7 @@
+import {
+  makeSpendLimitAwuCreditsRateLimitKeyForUser,
+  makeSpendLimitCycleWindowBounds,
+} from "@app/lib/api/assistant/rate_limits";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import { listPerUserCreditBalanceAlertsForWorkspace } from "@app/lib/metronome/alerts/per_user_credit_balance";
@@ -47,6 +51,10 @@ import {
   resolveEffectiveSpendLimitSource,
 } from "@app/lib/spend_limits/effective";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import {
+  getFixedWindowCount,
+  setFixedWindowCount,
+} from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
@@ -63,7 +71,7 @@ import {
   toBaseSeatType,
 } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -111,6 +119,16 @@ export type MemberUsageType = {
   scheduledSeatChangeAt: string | null;
   // Per-user total spend cap in AWU credits for the billing period
   spendLimitAwuCredits: number | null;
+  // AWU credits recorded in the Redis fixed-window spend-cap counter for the
+  // current billing cycle — the value enforcement reads, shown alongside the
+  // Elasticsearch-derived `consumedAwuCredits` to compare the two. Poke-only
+  // (null otherwise, or when the billing period can't be resolved).
+  rateLimiterSpendAwuCredits: number | null;
+  // Metronome-side per-user AWU consumption for the current billing cycle (the
+  // value reconcile and the per-user cap check read). Shown next to the ES and
+  // rate-limiter figures to spot divergence. Poke-only (null otherwise, or when
+  // Metronome isn't configured).
+  metronomeConsumedAwuCredits: number | null;
   // Where `spendLimitAwuCredits` comes from: a user-specific `override`, the
   // seat-type `default`, or `none` (no cap configured / unlimited).
   spendLimitSource: EffectiveSpendLimitSource;
@@ -915,6 +933,84 @@ export async function getEffectiveSpendCapAwuCreditsForUser(
   });
 }
 
+/**
+ * Backfills/resyncs every active member's Redis fixed-window spend-cap counter
+ * for the current billing cycle from the authoritative Elasticsearch usage,
+ * overwriting the counter (SET) so it matches ES. Use after enabling the cap or
+ * to repair drift (the counter otherwise only accrues from live messages and
+ * starts at 0 mid-cycle). Returns the number of users whose counter was written.
+ */
+export async function resyncSpendLimitCountersFromEsUsage(
+  auth: Authenticator
+): Promise<Result<{ updatedUserCount: number }, Error>> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const periodResult = await getCachedMetronomeCurrentBillingPeriod(
+    workspace.sId
+  );
+  if (periodResult.isErr()) {
+    return new Err(periodResult.error);
+  }
+  if (!periodResult.value) {
+    return new Err(
+      new Error("No active Metronome billing period to resync against.")
+    );
+  }
+  const bounds = makeSpendLimitCycleWindowBounds(
+    periodResult.value.cycleStart,
+    periodResult.value.cycleEnd
+  );
+
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace,
+  });
+  if (memberships.length === 0) {
+    return new Ok({ updatedUserCount: 0 });
+  }
+
+  const users = await UserResource.fetchByModelIds(
+    memberships.map((m) => m.userId)
+  );
+  const userByModelId = new Map(users.map((u) => [u.id, u]));
+
+  // Read the same Elasticsearch-derived consumption the members table shows as
+  // "Consumed (ES)": keyed by user sId, with the free/paid split applied per
+  // seat. This is the source of truth we overwrite the counter with.
+  const freeSeatUserIds = memberships.flatMap((m) => {
+    const u = userByModelId.get(m.userId);
+    return u && m.seatType === "free" ? [u.sId] : [];
+  });
+  const consumedByUserId = await fetchConsumedAwuCreditsByUserId({
+    workspace,
+    userIds: users.map((u) => u.sId),
+    freeSeatUserIds,
+  });
+
+  const results = await concurrentExecutor(
+    memberships,
+    async (membership) => {
+      const user = userByModelId.get(membership.userId);
+      if (!user) {
+        return false;
+      }
+      const consumed = consumedByUserId.get(user.sId) ?? 0;
+      const setResult = await setFixedWindowCount({
+        key: makeSpendLimitAwuCreditsRateLimitKeyForUser(
+          workspace,
+          user.toJSON()
+        ),
+        bounds,
+        value: Math.max(0, Math.round(consumed)),
+        logger,
+      });
+      return setResult.isOk();
+    },
+    { concurrency: 8 }
+  );
+
+  return new Ok({ updatedUserCount: results.filter(Boolean).length });
+}
+
 export type GetMemberUsageResponseBody = {
   member: MemberUsageType | null;
 };
@@ -1097,6 +1193,8 @@ export async function getMemberUsage({
         groupCapAwuCredits,
         defaultAwuCredits: effectiveDefaultAwuCredits,
       }),
+      rateLimiterSpendAwuCredits: null,
+      metronomeConsumedAwuCredits: null,
       spendLimitSource,
       spendLimitAlertId: null,
       spendLimitWarningAlertId: null,
@@ -1480,6 +1578,59 @@ export async function getMembersUsage({
       )
     : new Map<string, boolean>();
 
+  // Bulk-fetch the Redis fixed-window spend-cap counter per user (poke-only), to
+  // display beside the Elasticsearch-derived usage. The counter is bucketed on
+  // the current contract billing cycle — resolve the window once, then read each
+  // user's key.
+  const rateLimiterSpendByUserId = new Map<string, number>();
+  if (includeAlertLinks) {
+    const periodResult = await getCachedMetronomeCurrentBillingPeriod(
+      workspace.sId
+    );
+    if (periodResult.isOk() && periodResult.value) {
+      const bounds = makeSpendLimitCycleWindowBounds(
+        periodResult.value.cycleStart,
+        periodResult.value.cycleEnd
+      );
+      const entries = await concurrentExecutor(
+        users,
+        async (u) => {
+          const result = await getFixedWindowCount({
+            key: makeSpendLimitAwuCreditsRateLimitKeyForUser(
+              workspace,
+              u.toJSON()
+            ),
+            bounds,
+          });
+          return [u.sId, result.isOk() ? result.value : 0] as const;
+        },
+        { concurrency: 8 }
+      );
+      for (const [sId, value] of entries) {
+        rateLimiterSpendByUserId.set(sId, value);
+      }
+    }
+  }
+
+  // Bulk-fetch each user's Metronome-side per-user AWU consumption (poke-only),
+  // shown next to the ES and rate-limiter figures to spot divergence. Reuses the
+  // resilient wrapper (empty map when Metronome isn't configured or on error).
+  const metronomeConsumedByUserId = new Map<string, number>();
+  if (includeAlertLinks) {
+    const usage = await fetchPerUserUsageCreditsForMembersTable({
+      workspaceId: workspace.sId,
+      metronomeCustomerId: metronomeCustomerId ?? null,
+      metronomeContractId,
+      userIds: users.flatMap((u) => [u.sId, toFreeMetronomeUserId(u.sId)]),
+    });
+    for (const u of users) {
+      const membership = membershipByUserId.get(u.id);
+      const metronomeUserId =
+        membership?.seatType === "free" ? toFreeMetronomeUserId(u.sId) : u.sId;
+      metronomeConsumedByUserId.set(u.sId, usage.get(metronomeUserId) ?? 0);
+    }
+  }
+
   const membersUsage: MemberUsageType[] = users.flatMap((u) => {
     const membership = membershipByUserId.get(u.id);
     if (!membership) {
@@ -1613,6 +1764,12 @@ export async function getMembersUsage({
           groupCapAwuCredits,
           defaultAwuCredits: effectiveDefaultAwuCredits,
         }),
+        rateLimiterSpendAwuCredits: includeAlertLinks
+          ? (rateLimiterSpendByUserId.get(userId) ?? 0)
+          : null,
+        metronomeConsumedAwuCredits: includeAlertLinks
+          ? (metronomeConsumedByUserId.get(userId) ?? 0)
+          : null,
         spendLimitSource,
         spendLimitAlertId,
         spendLimitWarningAlertId,

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -33,6 +33,7 @@ export * from "./rename_workspace";
 export * from "./reset_message_rate_limit";
 export * from "./reset_provisioned_members_not_in_directory";
 export * from "./restore_conversation";
+export * from "./resync_spend_limit_counters";
 export * from "./revoke_coupon";
 export * from "./revoke_users";
 export * from "./run_reinforcement_workflow";

--- a/front/lib/api/poke/plugins/workspaces/resync_spend_limit_counters.ts
+++ b/front/lib/api/poke/plugins/workspaces/resync_spend_limit_counters.ts
@@ -1,0 +1,35 @@
+import { resyncSpendLimitCountersFromEsUsage } from "@app/lib/api/credits/members_usage";
+import { createPlugin } from "@app/lib/api/poke/types";
+import { isCreditPricedPlan } from "@app/types/plan";
+import { Err, Ok } from "@app/types/shared/result";
+
+export const resyncSpendLimitCountersPlugin = createPlugin({
+  manifest: {
+    id: "resync-spend-limit-counters",
+    name: "Resync Spend-Limit Counters from Usage",
+    description:
+      "Overwrite each member's Redis fixed-window per-user spend-cap counter " +
+      "for the current billing cycle with their Elasticsearch-derived AWU " +
+      "consumption. Use to backfill the counter after enabling the cap, or to " +
+      "repair drift (the counter otherwise only accrues from live messages).",
+    resourceTypes: ["workspaces"],
+    args: {},
+    requiredRoles: ["billing"],
+  },
+
+  isApplicableTo: (auth) => {
+    const plan = auth.plan();
+    return plan !== null && isCreditPricedPlan(plan);
+  },
+
+  execute: async (auth, _resource, _args) => {
+    const result = await resyncSpendLimitCountersFromEsUsage(auth);
+    if (result.isErr()) {
+      return new Err(new Error(result.error.message));
+    }
+    return new Ok({
+      display: "text",
+      value: `Resynced spend-limit counters for ${result.value.updatedUserCount} user(s) from usage.`,
+    });
+  },
+});

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -322,6 +322,58 @@ export async function addFixedWindowCount({
 }
 
 /**
+ * Overwrites the fixed-window counter for `key` in the window identified by
+ * `bounds` with an absolute `value` (SET, not INCRBY). Use for backfill /
+ * resync from an external source of truth — regular accounting should use
+ * `addFixedWindowCount`. Returns a Result so callers can report failures.
+ */
+export async function setFixedWindowCount({
+  key,
+  bounds,
+  value,
+  logger,
+}: {
+  key: string;
+  bounds: FixedWindowBounds;
+  value: number;
+  logger: LoggerInterface;
+}): Promise<Result<void, Error>> {
+  if (!Number.isInteger(value) || value < 0) {
+    return new Err(new Error("value must be a non-negative integer."));
+  }
+
+  const redisKey = makeRateLimiterKey(`${key}:${bounds.label}`);
+  const expireAtMs = bounds.windowEndMs + FIXED_WINDOW_EXPIRE_GRACE_MS;
+
+  const luaScript = `
+    local key = KEYS[1]
+    local value = tonumber(ARGV[1])
+    local expire_at_ms = tonumber(ARGV[2])
+
+    redis.call('SET', key, value)
+    redis.call('PEXPIREAT', key, expire_at_ms)
+  `;
+
+  try {
+    const redis = await getRedisStreamClient({ origin: "rate_limiter" });
+    await redis.eval(luaScript, {
+      keys: [redisKey],
+      arguments: [value.toString(), expireAtMs.toString()],
+    });
+    return new Ok(undefined);
+  } catch (e) {
+    getStatsDClient().increment("ratelimiter.error.count", 1, [
+      "operation:set_fixed_window",
+    ]);
+    logger.error(
+      { key, label: bounds.label, value, error: e },
+      "setFixedWindowCount error"
+    );
+    return new Err(normalizeError(e));
+  }
+}
+
+/**
  * Reads the current fixed-window count for `key` in the window identified by
  * `bounds`. Returns 0 when the window has no entries yet. Mirrors
  * `getRateLimiterCount` but for the boundary-bucketed counter written by


### PR DESCRIPTION
## Description

Poke-only admin & observability tooling layered on top of the per-user spend-cap backup (stacked on #29576). Nothing here runs on the customer or message-send path.

**Members usage table — single `Consumed (ES / RL / MT)` column.** Shows the three per-user AWU consumption figures side by side so divergence is obvious at a glance:
- **ES** — Elasticsearch-derived consumption (the table's existing source of truth).
- **RL** — the Redis fixed-window rate-limiter counter (what enforcement reads).
- **MT** — Metronome per-user usage (what reconcile and the per-user cap read).

<img width="1509" height="205" alt="Screenshot 2026-07-29 at 09 51 15" src="https://github.com/user-attachments/assets/2daa22c1-ab80-428c-887a-e5cf478dea5a" />

**"Resync Spend-Limit Counters from Usage" poke plugin** (billing role, credit-priced workspaces). Overwrites every active member's current-cycle counter from the ES-derived consumption. Use it to seed the counter after enabling the cap — it otherwise starts at 0 mid-cycle and only accrues from live messages — or to repair drift.

**`setFixedWindowCount` primitive** (`SET` + `PEXPIREAT`) — overwrite a fixed-window counter from an external source of truth (the resync's building block), as opposed to the additive `addFixedWindowCount` used for live accounting.

Adds `rateLimiterSpendAwuCredits` and `metronomeConsumedAwuCredits` to `MemberUsageType`, populated only when alert links are requested (poke); `null` everywhere else.

## Tests

- `front-api` `members-usage` endpoint test updated for the new fields — green.
- `rate_limiter` unit tests cover the fixed-window primitives (`add`/`get`/`set`).
- Manually exercised in dev via poke: ran the resync plugin and confirmed the **RL** column matches **ES** afterwards, and that the three-value column renders correctly.

## Risk

Low. Poke-only surface — no customer-facing or message-path changes. The new `MemberUsageType` fields are additive and default to `null` off the poke path. The resync plugin only `SET`s Redis counters for the current cycle, so a bad run merely rewrites the observability/enforcement counter and is fully re-runnable/idempotent. Metronome and ES read failures degrade gracefully (empty map → `0` / `-`) rather than throwing. Safe to roll back by revert.

## Deploy Plan

Standard deploy, no migration. To activate the backup for a workspace afterwards: **first** run the resync plugin to seed counters from usage, **then** enable the `enforce_user_spend_limit_rate_cap` flag (from #29576) — in that order, so users aren't measured from 0 mid-cycle.
