### PR TITLE
[front] Fix stale dev Metronome metric ids (AWU v2 + tool invocations v2)

### DIFF
--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -8,9 +8,9 @@ import { isDevelopment } from "@app/types/shared/env";
 // Metrics
 const DEV_METRIC_LLM_PROVIDER_COST_PROGRAMMATIC =
   "e02846b3-956c-48bc-9fd1-162061aed624";
-const DEV_METRIC_TOOL_INVOCATIONS_V2 = "ac310e71-f9a3-40b1-ba7c-82d781287e7d";
+const DEV_METRIC_TOOL_INVOCATIONS_V2 = "0a35a534-0d1c-4ed5-8177-358d9dff71a5";
 const DEV_METRIC_LLM_PROVIDER_COST_AWU_V2 =
-  "5a94e956-cd7f-4e31-8720-194c76ebba44";
+  "a6abefc5-d749-4757-a139-336b53c837f5";
 
 // Products
 const DEV_PRODUCT_PROGRAMMATIC_USAGE = "daaf92ec-d0a7-444d-972e-a2d48c7edd0c";


### PR DESCRIPTION
## Description

Fixes stale **dev** Metronome metric ids. The dev `llm_provider_cost_awu_v2` and `tool_invocations_v2` billable metrics were recreated with new ids, but the `DEV_METRIC_*` constants still pointed at the old (now dataless) metrics:

- `DEV_METRIC_LLM_PROVIDER_COST_AWU_V2`: `5a94e956…` → `a6abefc5…`
- `DEV_METRIC_TOOL_INVOCATIONS_V2`: `ac310e71…` → `0a35a534…`

Because per-user usage reads (`fetchPerUserAwuUsage`) query by metric id, they hit the stale metrics and returned **0** in dev — so reconcile never capped a user, and the spend-cap resync seeded 0 — even though the dashboard showed spend under the current metrics (events flow by `event_type`, not metric id, so they still landed correctly). Prod ids are unchanged and verified valid; the dev programmatic-cost id already matched.

## Tests

- `tsgo` clean.
- Verified the two ids against the dev Metronome dashboard; after the change, dev per-user usage reads return the real consumption instead of 0.

## Risk

Minimal. Two dev-only constant values; prod untouched. Worst case is dev-only. Safe to roll back by revert.

## Deploy Plan

Standard deploy, no migration, no flag. Takes effect for dev/sandbox reads immediately.
