### PR TITLE
[Admin Governance] Fix skill attachment file edit permissions

### DIFF
--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -26,6 +26,7 @@ const ParamsSchema = z.object({
   fileId: z.string(),
 });
 
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import editText from "./edit-text";
 import exportApp from "./export";
 import metadata from "./metadata";
@@ -268,6 +269,20 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
         message: "You cannot edit files in that space.",
       },
     });
+  } else if (file.useCase === "skill_attachment") {
+    const skillResource = await SkillResource.fetchById(
+      auth,
+      file.useCaseMetadata?.skillId ?? ""
+    );
+    if (!skillResource || !skillResource.canWrite(auth)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "Only skill editors can modify files attached to a skill.",
+        },
+      });
+    }
     // TODO(governance) - auth.isBuilder to be replaced with auth.isManager
   } else if (!auth.isBuilder() && file.useCase !== "conversation") {
     return apiError(ctx, {


### PR DESCRIPTION
Description
---
Fixes issue reported [here](https://dust4ai.slack.com/archives/C05DP58UKR7/p1785309266382139) where skill attachment files couldn't be edited by skill editors due to a legacy builders gating. Now, only skill editors can modify files attached to a skill.

Risk
---
Low

Deploy
---
front