### PR TITLE
fix(front): isolate per-workspace failures in governance capabilities backfill

### DIFF
--- a/front/migrations/20260721_backfill_governance_capabilities.ts
+++ b/front/migrations/20260721_backfill_governance_capabilities.ts
@@ -6,11 +6,14 @@ import {
 import { Authenticator } from "@app/lib/auth";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import type { CapabilityKey } from "@app/types/group_permissions";
 import { capabilityKey } from "@app/types/group_permissions";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
 
 interface SeederCounts {
   seededEverybody: number;
@@ -69,117 +72,141 @@ makeScript(
         newCounts(),
       ])
     );
+    // A single workspace throwing must not abort the whole fleet: `runOnAllWorkspaces` runs the
+    // worker under `concurrentExecutor`, whose `Promise.all` would reject on the first throw and
+    // kill the run mid-fleet. Writes are committed per-capability, so a partial run leaves every
+    // workspace past the failure untouched and each rerun rediscovers them. Isolate failures per
+    // workspace, count them, and keep going so the backfill converges in one pass.
+    let failedWorkspaces = 0;
 
     await runOnAllWorkspaces(
       async (workspace) => {
-        const auth = await Authenticator.internalAdminForWorkspace(
-          workspace.sId
-        );
-
-        const states = await GroupPermissionResource.getCapabilitiesState(
-          auth,
-          CAPABILITY_SEEDERS.map((seeder) => seeder.capability)
-        );
-        // Fetched once per workspace (not per capability) for the "is this recognizably our own
-        // seeded output" check below.
-        const buildersGroup = await GroupResource.fetchManualBuildersGroup(
-          auth.getNonNullableWorkspace()
-        );
-
-        for (const seeder of CAPABILITY_SEEDERS) {
-          const key = capabilityKey(seeder.capability);
-          const counts = countsByCapability.get(key);
-          if (!counts) {
-            throw new Error(`Missing counters for capability ${key}.`);
-          }
-
-          const target = await seeder.resolveTarget(auth);
-          const effectiveTarget = await resolveEffectiveTarget(auth, target);
-
-          const current = states.get(key);
-
-          if (effectiveTarget === "admins_only") {
-            if (!current || current.scope === "admins_only") {
-              // Already the default state; nothing to do.
-              counts.alreadyAdminsOnly++;
-              continue;
-            }
-
-            // Legacy state no longer grants this capability (e.g. the flag got enabled, or the
-            // Builders group disappeared, since an earlier run) — actively revert, unlike the
-            // "everyone"/"builders" branch below, which preserves any existing configuration.
-            logger.info(
-              {
-                workspaceId: workspace.sId,
-                capability: key,
-                previousScope: current?.scope,
-              },
-              execute
-                ? "Reverting to admins_only."
-                : "Would revert to admins_only."
-            );
-            if (execute) {
-              await GroupPermissionResource.disable(auth, seeder.capability);
-            }
-            counts.seededAdminsOnly++;
-            continue;
-          }
-
-          if (effectiveTarget === "builders") {
-            const isRecognizedBuildersState =
-              current &&
-              current.scope === "groups" &&
-              !!buildersGroup &&
-              current.groups.length === 1 &&
-              current.groups[0].id === buildersGroup.id;
-
-            if (isRecognizedBuildersState) {
-              counts.alreadyBuilders++;
-              continue;
-            }
-          }
-
-          if (effectiveTarget === "everyone") {
-            if (current && current.scope === "everyone") {
-              counts.alreadyEverybody++;
-              continue;
-            }
-          }
-
-          const outcome = await applyCapabilityTarget(
-            auth,
-            seeder.capability,
-            target,
-            { dryRun: !execute }
+        try {
+          await backfillWorkspace(
+            workspace,
+            countsByCapability,
+            execute,
+            logger
           );
-
-          logger.info(
-            { workspaceId: workspace.sId, capability: key, target, outcome },
-            execute ? "Applied." : "Would apply."
+        } catch (err) {
+          failedWorkspaces++;
+          logger.error(
+            { workspaceId: workspace.sId, err: normalizeError(err) },
+            "Failed to backfill governance capabilities; continuing."
           );
-
-          switch (outcome) {
-            case "seeded_everybody":
-              counts.seededEverybody++;
-              break;
-            case "seeded_builders":
-              counts.seededBuilders++;
-              break;
-            case "skipped_admins_only":
-            case "skipped_no_builders_group":
-              // Does not happen, handled in effectiveTarget === "admins_only"
-              break;
-            default:
-              assertNeverAndIgnore(outcome);
-          }
         }
       },
       { wId, concurrency: WORKSPACE_CONCURRENCY }
     );
 
     logger.info(
-      Object.fromEntries(countsByCapability),
+      { ...Object.fromEntries(countsByCapability), failedWorkspaces },
       execute ? "Backfill completed." : "Dry run completed."
     );
   }
 );
+
+async function backfillWorkspace(
+  workspace: LightWorkspaceType,
+  countsByCapability: Map<CapabilityKey, SeederCounts>,
+  execute: boolean,
+  logger: Logger
+): Promise<void> {
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  const states = await GroupPermissionResource.getCapabilitiesState(
+    auth,
+    CAPABILITY_SEEDERS.map((seeder) => seeder.capability)
+  );
+  // Fetched once per workspace (not per capability) for the "is this recognizably our own
+  // seeded output" check below.
+  const buildersGroup = await GroupResource.fetchManualBuildersGroup(
+    auth.getNonNullableWorkspace()
+  );
+
+  for (const seeder of CAPABILITY_SEEDERS) {
+    const key = capabilityKey(seeder.capability);
+    const counts = countsByCapability.get(key);
+    if (!counts) {
+      throw new Error(`Missing counters for capability ${key}.`);
+    }
+
+    const target = await seeder.resolveTarget(auth);
+    const effectiveTarget = await resolveEffectiveTarget(auth, target);
+
+    const current = states.get(key);
+
+    if (effectiveTarget === "admins_only") {
+      if (!current || current.scope === "admins_only") {
+        // Already the default state; nothing to do.
+        counts.alreadyAdminsOnly++;
+        continue;
+      }
+
+      // Legacy state no longer grants this capability (e.g. the flag got enabled, or the
+      // Builders group disappeared, since an earlier run) — actively revert, unlike the
+      // "everyone"/"builders" branch below, which preserves any existing configuration.
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          capability: key,
+          previousScope: current?.scope,
+        },
+        execute ? "Reverting to admins_only." : "Would revert to admins_only."
+      );
+      if (execute) {
+        await GroupPermissionResource.disable(auth, seeder.capability);
+      }
+      counts.seededAdminsOnly++;
+      continue;
+    }
+
+    if (effectiveTarget === "builders") {
+      const isRecognizedBuildersState =
+        current &&
+        current.scope === "groups" &&
+        !!buildersGroup &&
+        current.groups.length === 1 &&
+        current.groups[0].id === buildersGroup.id;
+
+      if (isRecognizedBuildersState) {
+        counts.alreadyBuilders++;
+        continue;
+      }
+    }
+
+    if (effectiveTarget === "everyone") {
+      if (current && current.scope === "everyone") {
+        counts.alreadyEverybody++;
+        continue;
+      }
+    }
+
+    const outcome = await applyCapabilityTarget(
+      auth,
+      seeder.capability,
+      target,
+      { dryRun: !execute }
+    );
+
+    logger.info(
+      { workspaceId: workspace.sId, capability: key, target, outcome },
+      execute ? "Applied." : "Would apply."
+    );
+
+    switch (outcome) {
+      case "seeded_everybody":
+        counts.seededEverybody++;
+        break;
+      case "seeded_builders":
+        counts.seededBuilders++;
+        break;
+      case "skipped_admins_only":
+      case "skipped_no_builders_group":
+        // Does not happen, handled in effectiveTarget === "admins_only"
+        break;
+      default:
+        assertNeverAndIgnore(outcome);
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Running `migrations/20260721_backfill_governance_capabilities.ts` repeatedly kept "finding new workspaces to handle" — the backfill never converged.

The root cause is in the loop, not the state logic (which is idempotent). The per-workspace worker runs under `concurrentExecutor` with **no per-workspace error isolation**:

```ts
while ((work = queue.shift())) {
  const result = await iterator(work.item, work.index); // throws -> worker rejects
}
await Promise.all([...workers]); // first rejection rejects everything
```

So any single workspace that throws — a missing global group (`assert` in `getCapabilitiesState`), the resolve→apply builders-group race (`assert(buildersGroup, "Builders group disappeared…")`), or a transient DB error / connection-pool pressure under concurrency 4 — rejects the shared `Promise.all`, which propagates up through `runOnAllWorkspaces` and hits `makeScript`'s `.catch(() => process.exit(1))`, killing the whole run mid-fleet.

Each capability write commits in its own transaction (no outer transaction over the run), so a partial run leaves every workspace **past the failure point** untouched. On the next run those show up again as unprocessed work, the run makes a bit more progress, then aborts again at the next failure — hence "new workspaces" on every run.

## Fix

Extract the worker body into `backfillWorkspace(...)` and wrap the call in a `try/catch`: failures are logged (with `workspaceId`, per our logging convention) and counted in a new `failedWorkspaces` counter surfaced in the final summary. One bad workspace can no longer abort the fleet, so the backfill converges in a single pass.

Pure error-handling change — the per-workspace / per-capability logic is unchanged (the large diff is the body being extracted and reindented).

## Test plan
- [x] `npx tsgo --noEmit` clean
- [x] `npm run format:changed` clean
- [ ] Dry run on a workspace subset, then `--execute`, confirming a rerun reports only `already*` states and `failedWorkspaces: 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)