### PR TITLE
core: Fix deny-by-default Clippy lints

### DIFF
--- a/core/bin/sqlite_worker.rs
+++ b/core/bin/sqlite_worker.rs
@@ -129,11 +129,6 @@ impl WorkerState {
 
     async fn await_pending_queries(&self) {
         // TODO: wait for all pending database queries to finish.
-        loop {
-            // if no pending query...
-            break;
-            // tokio::time::sleep(std::time::Duration::from_millis(1024)).await;
-        }
     }
 
     async fn heartbeat(&self) -> Result<()> {

--- a/core/src/data_sources/splitter.rs
+++ b/core/src/data_sources/splitter.rs
@@ -107,7 +107,7 @@ async fn split_text(
                 return Err(e);
             }
         }
-        if current_chunk_size <= 0 {
+        if current_chunk_size == 0 {
             return Err(anyhow!("Could not tokenize the provided document"));
         }
         encoded = encoded[current_chunk_size..].to_vec();

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -1366,7 +1366,7 @@ mod tests {
         // Test case 1: Row with data types that should be perfectly bijective
         let simple_row_data = serde_json::Map::from_iter([
             ("integer_col".to_string(), 42.into()),
-            ("float_col".to_string(), 3.14.into()),
+            ("float_col".to_string(), 3.25.into()),
             ("string_col".to_string(), "hello world".into()),
             ("exponent_like_col".to_string(), "32E0134".into()),
             ("bool_col".to_string(), true.into()),


### PR DESCRIPTION
## Description

  Fix the deny-by-default Clippy errors currently blocking the full Core lint run:

  - Use an equality check for a `usize` zero guard in the data-source splitter.
  - Use a non-constant-like floating-point value in the CSV round-trip test.
  - Remove an immediately-breaking placeholder loop from SQLite worker shutdown. (no-op loop which always exited immediately and only
  triggered Clippy’s never_loop lint)

  All changes preserve existing behavior.

  ## Tests

  - `cargo fmt --check`
  - `cargo test --lib test_csv_round_trip_bijective`
  - `cargo test --lib data_sources::splitter::tests` — 10 passed, 1 existing high-CPU test ignored
  - `cargo test --bin sqlite-worker`
  - `cargo clippy --lib --tests --message-format=short`

  ## Risk

  Low. The production-code changes are semantic no-ops.
  Test data just changes a value that's too close to pi.