### PR TITLE
[sparkle] Increase contrast on ButtonsSwitch container

### DIFF
--- a/sparkle/src/components/ButtonsSwitch.tsx
+++ b/sparkle/src/components/ButtonsSwitch.tsx
@@ -31,7 +31,7 @@ const useButtonsSwitch = () => {
 const listStyles = cva(
   cn(
     "inline-flex items-center gap-1",
-    "box-border bg-muted border border-border"
+    "box-border bg-background border border-border-dark"
   ),
   {
     variants: {


### PR DESCRIPTION
## Summary
- The `ButtonsSwitchList` track used `bg-muted`/`border-border`, both nearly white in light mode, which gave almost no visual contrast against the page and made the pill hard to see.
- The track background is now `bg-background` (pure white, lighter than before) with a one-step-darker `border-border-dark` stroke, while the buttons themselves are unchanged.

## Test plan
- [x] Verified in Storybook (`Actions/ButtonsSwitch` — Default, Controlled, Sizes stories) in light theme
- [x] Verified dark theme is unaffected (uses its own dark: overrides already)