### PR TITLE
fix(core): restrict SQLite worker queries

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -178,7 +178,7 @@ reqwest = { version = "0.12", features = ["json"] }
 ring = "0.17.14"
 rsa = { version = "0.9.4", features = ["pem"] }
 rslock = { version = "0.4.0", default-features = false, features = ["tokio-comp"] }
-rusqlite = { version = "0.31", features = ["bundled", "csvtab"] }
+rusqlite = { version = "0.31", features = ["bundled", "csvtab", "hooks"] }
 rustc-hash = "1.1"
 sentencepiece = { version = "0.11", features = ["static"] }
 serde = { version = "1.0", features = ["rc", "derive"] }

--- a/core/src/sqlite_workers/sqlite_database.rs
+++ b/core/src/sqlite_workers/sqlite_database.rs
@@ -11,7 +11,11 @@ use cloud_storage::Object;
 use futures::future::try_join_all;
 use parking_lot::Mutex;
 use rayon::prelude::*;
-use rusqlite::{Connection, InterruptHandle};
+use rusqlite::{
+    config::DbConfig,
+    hooks::{AuthAction, AuthContext, Authorization},
+    Batch, Connection, InterruptHandle,
+};
 use std::{collections::HashMap, io::Write, sync::Arc};
 use tempfile::NamedTempFile;
 use thiserror::Error;
@@ -98,9 +102,29 @@ impl SqliteDatabase {
             let conn = conn.lock();
             let time_query_start = utils::now();
 
-            let mut stmt = conn
-                .prepare(&query)
+            let mut statements = Batch::new(&conn, &query);
+            let stmt = statements
+                .next()
                 .map_err(|e| SqliteDatabaseError::QueryExecutionError(anyhow::Error::new(e)))?;
+            let mut stmt = stmt.ok_or_else(|| {
+                SqliteDatabaseError::QueryExecutionError(anyhow!("Query must contain a statement"))
+            })?;
+
+            if statements
+                .next()
+                .map_err(|e| SqliteDatabaseError::QueryExecutionError(anyhow::Error::new(e)))?
+                .is_some()
+            {
+                return Err(SqliteDatabaseError::QueryExecutionError(anyhow!(
+                    "Query must contain a single statement"
+                )));
+            }
+
+            if !stmt.readonly() {
+                return Err(SqliteDatabaseError::QueryExecutionError(anyhow!(
+                    "Query must be read-only"
+                )));
+            }
 
             let column_names = stmt
                 .column_names()
@@ -212,7 +236,28 @@ async fn create_in_memory_sqlite_db(
     )
     .await?;
 
+    configure_connection_for_user_queries(&conn.lock())?;
+
     Ok((conn, temporary_files))
+}
+
+fn configure_connection_for_user_queries(conn: &Connection) -> Result<()> {
+    conn.set_db_config(DbConfig::SQLITE_DBCONFIG_DEFENSIVE, true)?;
+    conn.pragma_update(None, "query_only", true)?;
+    conn.authorizer(Some(authorize_user_query));
+    Ok(())
+}
+
+fn authorize_user_query(context: AuthContext<'_>) -> Authorization {
+    match context.action {
+        AuthAction::Select | AuthAction::Read { .. } | AuthAction::Recursive => {
+            Authorization::Allow
+        }
+        AuthAction::Function { function_name } if function_name != "load_extension" => {
+            Authorization::Allow
+        }
+        _ => Authorization::Deny,
+    }
 }
 
 async fn create_in_memory_sqlite_db_with_csv(
@@ -320,4 +365,104 @@ async fn create_in_memory_sqlite_db_with_csv(
     );
 
     Ok(Some(temporary_files))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_database() -> Result<SqliteDatabase> {
+        let conn = Connection::open_in_memory()?;
+        rusqlite::vtab::csvtab::load_module(&conn)?;
+        conn.execute_batch("CREATE TABLE data (value TEXT); INSERT INTO data VALUES ('allowed');")?;
+        configure_connection_for_user_queries(&conn)?;
+
+        let interrupt_handle = conn.get_interrupt_handle();
+        Ok(SqliteDatabase {
+            conn: Some(Arc::new(Mutex::new(conn))),
+            interrupt_handle: Some(Arc::new(tokio::sync::Mutex::new(interrupt_handle))),
+            temporary_files: None,
+        })
+    }
+
+    #[tokio::test]
+    async fn allows_read_only_queries() -> Result<()> {
+        let database = create_test_database()?;
+
+        let result = database
+            .query("SELECT upper(value) AS value FROM data", 1_000)
+            .await?;
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].value["value"], "ALLOWED");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rejects_file_reads_through_csv_virtual_tables() -> Result<()> {
+        let database = create_test_database()?;
+        let mut target_file = NamedTempFile::new()?;
+        target_file.write_all(b"secret")?;
+        let query = format!(
+            "CREATE VIRTUAL TABLE stolen USING csv(filename='{}', header=no)",
+            target_file.path().display()
+        );
+
+        let result = database.query(&query, 1_000).await;
+
+        assert!(matches!(
+            result,
+            Err(SqliteDatabaseError::QueryExecutionError(_))
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rejects_file_writes() -> Result<()> {
+        let database = create_test_database()?;
+        let output_directory = tempfile::tempdir()?;
+        let attached_database_path = output_directory.path().join("attached-database");
+        let vacuum_output_path = output_directory.path().join("vacuum-output");
+
+        let attach_result = database
+            .query(
+                &format!(
+                    "ATTACH DATABASE '{}' AS writable",
+                    attached_database_path.display()
+                ),
+                1_000,
+            )
+            .await;
+        let vacuum_result = database
+            .query(
+                &format!("VACUUM INTO '{}'", vacuum_output_path.display()),
+                1_000,
+            )
+            .await;
+
+        assert!(matches!(
+            attach_result,
+            Err(SqliteDatabaseError::QueryExecutionError(_))
+        ));
+        assert!(matches!(
+            vacuum_result,
+            Err(SqliteDatabaseError::QueryExecutionError(_))
+        ));
+        assert!(!attached_database_path.exists());
+        assert!(!vacuum_output_path.exists());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rejects_multiple_statements() -> Result<()> {
+        let database = create_test_database()?;
+
+        let result = database.query("SELECT 1; SELECT 2", 1_000).await;
+
+        assert!(matches!(
+            result,
+            Err(SqliteDatabaseError::QueryExecutionError(_))
+        ));
+        Ok(())
+    }
 }


### PR DESCRIPTION
  ## Description

Resolve Critical vulnerability by enforcing read-only SQL on the SQLite worker.

  The local Table Query path previously executed model-generated SQL without server-side statement
  authorization, allowing arbitrary file access through SQLite features such as `ATTACH DATABASE`,
  `VACUUM INTO`, and CSV virtual-table creation.

  This change:

  - Accepts exactly one SQL statement per query.
  - Requires the prepared statement to be read-only.
  - Enables SQLite defensive and `query_only` modes after transient tables are initialized.
  - Adds an SQLite authorizer that permits reads and safe functions while denying state-changing operations and `load_extension`.
  - Keeps existing read-only `SELECT` queries and standard SQL functions working.

  ## Tests

  - `cargo fmt --check`
  - `cargo check --lib`
  - `cargo test --lib sqlite_workers::sqlite_database::tests` all 4 passed

  The tests verify that:

  - Read-only queries remain supported.
  - CSV virtual-table file reads are rejected.
  - `ATTACH DATABASE` and `VACUUM INTO` file writes are rejected.
  - Multiple statements are rejected.

  ## Risk

  Low to moderate. 
  Existing single-statement, read-only queries remain supported. Queries that previously relied on multiple statements, pragmas, or state-changing SQLite operations will now be rejected intentionally.

  ## Deploy Plan

Deploy Core and the SQLite workers normally.