### PR TITLE
[front] enh: add dialog to warn before restricting MCP tools used by agents

### DIFF
--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -18,7 +18,6 @@ import { getSensitivityLabelProviderForServerId } from "@app/lib/actions/mcp_int
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
-import { LinkWrapper } from "@app/lib/platform";
 import {
   useMCPServer,
   useMCPServers,
@@ -170,13 +169,14 @@ export function MCPServerDetails({
           <ul className="list-disc space-y-1 pl-5">
             {affectedAgents.map((agent) => (
               <li key={agent.sId}>
-                <LinkWrapper
+                <a
                   href={getAgentBuilderRoute(owner.sId, agent.sId)}
                   target="_blank"
+                  rel="noopener noreferrer"
                   className="underline underline-offset-2"
                 >
                   {agent.name}
-                </LinkWrapper>
+                </a>
               </li>
             ))}
           </ul>

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -170,7 +170,9 @@ export function MCPServerDetails({
               <div key={agent.sId} className="flex items-center gap-2">
                 <Avatar size="xs" visual={agent.pictureUrl} />
                 <div className="flex min-w-0 items-center gap-1">
-                  <span className="truncate">{agent.name}</span>
+                  <span className="truncate text-sm font-medium text-foreground">
+                    {agent.name}
+                  </span>
                   <a
                     href={getAgentBuilderRoute(owner.sId, agent.sId)}
                     target="_blank"

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -164,7 +164,7 @@ export function MCPServerDetails({
       message: (
         <div className="space-y-2">
           <p>
-            Saving this change will remove the tool from the following agents:
+            Saving will remove the tool from the following agents:
           </p>
           <ul className="list-disc space-y-1 pl-5">
             {affectedAgents.map((agent) => (

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -18,6 +18,7 @@ import { getSensitivityLabelProviderForServerId } from "@app/lib/actions/mcp_int
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
+import { LinkWrapper } from "@app/lib/platform";
 import {
   useMCPServer,
   useMCPServers,
@@ -25,6 +26,7 @@ import {
   useMutateMCPServersViewsForAdmin,
 } from "@app/lib/swr/mcp_servers";
 import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
+import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import datadogLogger from "@app/logger/datadogLogger";
 import type { WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
@@ -167,7 +169,15 @@ export function MCPServerDetails({
           </p>
           <ul className="list-disc space-y-1 pl-5">
             {affectedAgents.map((agent) => (
-              <li key={agent.sId}>{agent.name}</li>
+              <li key={agent.sId}>
+                <LinkWrapper
+                  href={getAgentBuilderRoute(owner.sId, agent.sId)}
+                  target="_blank"
+                  className="underline underline-offset-2"
+                >
+                  {agent.name}
+                </LinkWrapper>
+              </li>
             ))}
           </ul>
           <p>Skills using this tool will not be affected.</p>

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -29,6 +29,7 @@ import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import datadogLogger from "@app/logger/datadogLogger";
 import type { WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
+import { Avatar } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useContext, useMemo } from "react";
 import { useForm } from "react-hook-form";
@@ -163,23 +164,21 @@ export function MCPServerDetails({
       title: "Remove this tool from agents?",
       message: (
         <div className="space-y-2">
-          <p>
-            Saving will remove the tool from the following agents:
-          </p>
-          <ul className="list-disc space-y-1 pl-5">
+          <p>Saving will remove the tool from the following agents:</p>
+          <div className="space-y-1">
             {affectedAgents.map((agent) => (
-              <li key={agent.sId}>
-                <a
-                  href={getAgentBuilderRoute(owner.sId, agent.sId)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline underline-offset-2"
-                >
-                  {agent.name}
-                </a>
-              </li>
+              <a
+                key={agent.sId}
+                href={getAgentBuilderRoute(owner.sId, agent.sId)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2 underline-offset-2 hover:underline"
+              >
+                <Avatar size="xs" visual={agent.pictureUrl} />
+                <span>{agent.name}</span>
+              </a>
             ))}
-          </ul>
+          </div>
           <p>Skills using this tool will not be affected.</p>
         </div>
       ),

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -21,6 +21,7 @@ import { clientFetch } from "@app/lib/egress/client";
 import {
   useMCPServer,
   useMCPServers,
+  useMCPServersUsage,
   useMutateMCPServersViewsForAdmin,
 } from "@app/lib/swr/mcp_servers";
 import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
@@ -93,6 +94,10 @@ export function MCPServerDetails({
     // cached response. SWR still fetches normally if the cache is unexpectedly empty.
     revalidateIfStale: false,
   });
+  const { usage, mutate: mutateMCPServersUsage } = useMCPServersUsage({
+    owner,
+    disabled: !isOpen || readOnly,
+  });
 
   // Collect all effective view names from other servers (excluding the current one).
   const existingViewNames = useMemo(
@@ -140,6 +145,38 @@ export function MCPServerDetails({
         )
       : undefined,
   });
+
+  const confirmSkillsRestrictionChange = async (
+    isRestrictedToSkills: boolean
+  ): Promise<boolean> => {
+    if (!isRestrictedToSkills || !mcpServerView) {
+      return true;
+    }
+
+    const affectedAgents = usage?.[mcpServerView.server.sId]?.agents ?? [];
+    if (affectedAgents.length === 0) {
+      return true;
+    }
+
+    return confirm({
+      title: "Remove this tool from agents?",
+      message: (
+        <div className="space-y-2">
+          <p>
+            Saving this change will remove the tool from the following agents:
+          </p>
+          <ul className="list-disc space-y-1 pl-5">
+            {affectedAgents.map((agent) => (
+              <li key={agent.sId}>{agent.name}</li>
+            ))}
+          </ul>
+          <p>Skills using this tool will not be affected.</p>
+        </div>
+      ),
+      validateLabel: "Continue",
+      validateVariant: "warning",
+    });
+  };
 
   const applyToolChanges = async (
     toolChanges: Array<{
@@ -381,6 +418,7 @@ export function MCPServerDetails({
           // Revalidate caches.
           await mutateMCPServersViewsForAdmin();
           await mutateMCPServer();
+          await mutateMCPServersUsage();
 
           sendNotification({
             type: "success",
@@ -466,6 +504,7 @@ export function MCPServerDetails({
         spaces={spaces}
         readOnly={readOnly}
         sensitivityLabelsController={sensitivityLabelsController}
+        confirmSkillsRestrictionChange={confirmSkillsRestrictionChange}
       />
     </FormProvider>
   );

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -29,7 +29,7 @@ import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import datadogLogger from "@app/logger/datadogLogger";
 import type { WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
-import { Avatar, Icon, LinkExternal01 } from "@dust-tt/sparkle";
+import { Avatar, buttonVariants, Icon, LinkExternal01 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useContext, useMemo } from "react";
 import { useForm } from "react-hook-form";
@@ -163,30 +163,39 @@ export function MCPServerDetails({
     return confirm({
       title: "Remove this tool from agents?",
       message: (
-        <div className="space-y-2">
-          <p>Saving will remove the tool from the following agents:</p>
-          <div className="space-y-1">
+        <div className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            Saving will remove the tool from the following agents:
+          </p>
+          <div className="divide-y divide-separator overflow-hidden rounded-xl border border-separator bg-background">
             {affectedAgents.map((agent) => (
-              <div key={agent.sId} className="flex items-center gap-2">
+              <div
+                key={agent.sId}
+                className="flex items-center gap-3 px-3 py-2.5"
+              >
                 <Avatar size="xs" visual={agent.pictureUrl} />
-                <div className="flex min-w-0 items-center gap-1">
-                  <span className="truncate text-sm font-medium text-foreground">
-                    {agent.name}
-                  </span>
-                  <a
-                    href={getAgentBuilderRoute(owner.sId, agent.sId)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label={`Open ${agent.name} in Agent Builder`}
-                    className="shrink-0 text-muted-foreground hover:text-foreground"
-                  >
-                    <Icon visual={LinkExternal01} size="xs" />
-                  </a>
-                </div>
+                <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+                  {agent.name}
+                </span>
+                <a
+                  href={getAgentBuilderRoute(owner.sId, agent.sId)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`Open ${agent.name} in Agent Builder`}
+                  className={buttonVariants({
+                    variant: "ghost-secondary",
+                    size: "xs",
+                    isIconOnly: true,
+                  })}
+                >
+                  <Icon visual={LinkExternal01} size="xs" />
+                </a>
               </div>
             ))}
           </div>
-          <p>Skills using this tool will not be affected.</p>
+          <p className="text-sm text-muted-foreground">
+            Skills using this tool will not be affected.
+          </p>
         </div>
       ),
       validateLabel: "Continue",

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -29,7 +29,7 @@ import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import datadogLogger from "@app/logger/datadogLogger";
 import type { WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
-import { Avatar } from "@dust-tt/sparkle";
+import { Avatar, Icon, LinkExternal01 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useContext, useMemo } from "react";
 import { useForm } from "react-hook-form";
@@ -167,16 +167,19 @@ export function MCPServerDetails({
           <p>Saving will remove the tool from the following agents:</p>
           <div className="space-y-1">
             {affectedAgents.map((agent) => (
-              <a
-                key={agent.sId}
-                href={getAgentBuilderRoute(owner.sId, agent.sId)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-2 underline-offset-2 hover:underline"
-              >
+              <div key={agent.sId} className="flex items-center gap-2">
                 <Avatar size="xs" visual={agent.pictureUrl} />
-                <span>{agent.name}</span>
-              </a>
+                <span className="truncate">{agent.name}</span>
+                <a
+                  href={getAgentBuilderRoute(owner.sId, agent.sId)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`Open ${agent.name} in Agent Builder`}
+                  className="shrink-0 text-muted-foreground hover:text-foreground"
+                >
+                  <Icon visual={LinkExternal01} size="xs" />
+                </a>
+              </div>
             ))}
           </div>
           <p>Skills using this tool will not be affected.</p>

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -169,16 +169,18 @@ export function MCPServerDetails({
             {affectedAgents.map((agent) => (
               <div key={agent.sId} className="flex items-center gap-2">
                 <Avatar size="xs" visual={agent.pictureUrl} />
-                <span className="truncate">{agent.name}</span>
-                <a
-                  href={getAgentBuilderRoute(owner.sId, agent.sId)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label={`Open ${agent.name} in Agent Builder`}
-                  className="shrink-0 text-muted-foreground hover:text-foreground"
-                >
-                  <Icon visual={LinkExternal01} size="xs" />
-                </a>
+                <div className="flex min-w-0 items-center gap-1">
+                  <span className="truncate">{agent.name}</span>
+                  <a
+                    href={getAgentBuilderRoute(owner.sId, agent.sId)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={`Open ${agent.name} in Agent Builder`}
+                    className="shrink-0 text-muted-foreground hover:text-foreground"
+                  >
+                    <Icon visual={LinkExternal01} size="xs" />
+                  </a>
+                </div>
               </div>
             ))}
           </div>

--- a/front/components/actions/mcp/MCPServerDetailsInfo.tsx
+++ b/front/components/actions/mcp/MCPServerDetailsInfo.tsx
@@ -24,6 +24,9 @@ type MCPServerDetailsInfoProps = {
   owner: LightWorkspaceType;
   readOnly?: boolean;
   sensitivityLabelsController?: SensitivityLabelsController;
+  confirmSkillsRestrictionChange?: (
+    isRestrictedToSkills: boolean
+  ) => Promise<boolean>;
 };
 
 export function MCPServerDetailsInfo({
@@ -31,6 +34,7 @@ export function MCPServerDetailsInfo({
   owner,
   readOnly = false,
   sensitivityLabelsController,
+  confirmSkillsRestrictionChange,
 }: MCPServerDetailsInfoProps) {
   const editedAt = useMemo(() => {
     const d = new Date(0);
@@ -82,7 +86,10 @@ export function MCPServerDetailsInfo({
         </div>
       )}
       <Separator />
-      <MCPServerViewForm mcpServerView={mcpServerView} />
+      <MCPServerViewForm
+        mcpServerView={mcpServerView}
+        confirmSkillsRestrictionChange={confirmSkillsRestrictionChange}
+      />
       <Separator />
       {mcpServerView.server.authorization && (
         <MCPServerSettings

--- a/front/components/actions/mcp/MCPServerDetailsSheet.tsx
+++ b/front/components/actions/mcp/MCPServerDetailsSheet.tsx
@@ -46,6 +46,9 @@ interface MCPServerDetailsSheetProps {
   spaces: SpaceType[];
   readOnly?: boolean;
   sensitivityLabelsController?: SensitivityLabelsController;
+  confirmSkillsRestrictionChange: (
+    isRestrictedToSkills: boolean
+  ) => Promise<boolean>;
 }
 
 export function MCPServerDetailsSheet({
@@ -58,6 +61,7 @@ export function MCPServerDetailsSheet({
   spaces,
   readOnly = false,
   sensitivityLabelsController,
+  confirmSkillsRestrictionChange,
 }: MCPServerDetailsSheetProps) {
   const [selectedTab, setSelectedTab] = useState<TabType>("info");
   const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
@@ -207,6 +211,9 @@ export function MCPServerDetailsSheet({
                         owner={owner}
                         sensitivityLabelsController={
                           sensitivityLabelsController
+                        }
+                        confirmSkillsRestrictionChange={
+                          confirmSkillsRestrictionChange
                         }
                       />
                     </div>

--- a/front/components/actions/mcp/create/MCPServerViewForm.tsx
+++ b/front/components/actions/mcp/create/MCPServerViewForm.tsx
@@ -6,14 +6,34 @@ import { useController, useFormContext } from "react-hook-form";
 
 interface MCPServerViewFormProps {
   mcpServerView: MCPServerViewType;
+  confirmSkillsRestrictionChange?: (
+    isRestrictedToSkills: boolean
+  ) => Promise<boolean>;
 }
 
-export function MCPServerViewForm({ mcpServerView }: MCPServerViewFormProps) {
+export function MCPServerViewForm({
+  mcpServerView,
+  confirmSkillsRestrictionChange,
+}: MCPServerViewFormProps) {
   const form = useFormContext<MCPServerFormValues>();
   const { field: isRestrictedToSkillsField } = useController({
     name: "isRestrictedToSkills",
     control: form.control,
   });
+
+  const handleSkillsRestrictionChange = async (
+    isRestrictedToSkills: boolean
+  ) => {
+    if (confirmSkillsRestrictionChange) {
+      const confirmed =
+        await confirmSkillsRestrictionChange(isRestrictedToSkills);
+      if (!confirmed) {
+        return;
+      }
+    }
+
+    isRestrictedToSkillsField.onChange(isRestrictedToSkills);
+  };
 
   return (
     <div className="space-y-5 text-foreground">
@@ -45,7 +65,7 @@ export function MCPServerViewForm({ mcpServerView }: MCPServerViewFormProps) {
         description="Use this when the tool should always be accompanied by workspace context or safety rules from a skill."
         checked={isRestrictedToSkillsField.value}
         onCheckedChange={(checked) => {
-          isRestrictedToSkillsField.onChange(checked === true);
+          void handleSkillsRestrictionChange(checked === true);
         }}
       />
     </div>


### PR DESCRIPTION
## Overall goal

Some MCP tools rely on skill instructions for workspace-specific guidance, safety rules, or shortcuts that avoid unnecessary runtime research and credit spend. Exposing the raw tool directly lets agents bypass that context. The overall goal here is to let admins keep an MCP server available only through skills.

Closes https://github.com/dust-tt/tasks/issues/9792

## Description

https://github.com/dust-tt/dust/pull/29597 added a checkbox in the UI to restrict access to a tool to skills (i.e. you can't add it to an agent nor add it directly to a convo from the input bar).
The back-end drops existing agent relations in this case.
This PR adds a confirmation dialog to mention that some agents will be affected, if any, and lists them

<img width="424" height="305" alt="image" src="https://github.com/user-attachments/assets/47cd1f75-818d-4f01-9ad6-f98cf6ae8e87" />

## Tests

- Tested locally.

## Risk

- Low, affects the MCP settings confirmation flow.

## Deploy Plan

- Deploy front.
