### PR TITLE
Fix casing of Zach Friedland's name on marketing team page

### DIFF
--- a/marketing/components/home/content/shared/team.ts
+++ b/marketing/components/home/content/shared/team.ts
@@ -617,7 +617,7 @@ export const PEOPLE: Record<string, TeamMember> = {
     github: "https://github.com/avervaet",
   },
   zachfriedland: {
-    name: "Zach friedland",
+    name: "Zach Friedland",
     title: "AI Deployment Strategist",
     image: "https://ca.slack-edge.com/T050RH73H9P-U0BJPL0TUSE-0be6063e3260-512",
     linkedIn: "https://www.linkedin.com/in/zach-friedland/",


### PR DESCRIPTION
## Summary
- PR #29643 added Zach Friedland to the marketing team page but his name was entered as "Zach friedland" (lowercase surname).
- Fixes the casing to "Zach Friedland".

## Test plan
- [x] Visual diff of `marketing/components/home/content/shared/team.ts` confirms the only change is the name casing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)