### PR TITLE
[front] Lazily seed the per-user spend-cap counter from ES on read miss

### DIFF
--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -364,6 +364,32 @@ async function fetchConsumedAwuCreditsByUserId({
   return consumedByUserId;
 }
 
+/**
+ * A single user's Elasticsearch-derived AWU consumption for the current billing
+ * cycle — the same figure the members table shows as "Consumed (ES)", scoped to
+ * one user (with the free/paid seat split applied). Used to lazily seed the
+ * per-user spend-cap counter on a Redis miss. Returns 0 when there is no usage
+ * or the analytics read fails.
+ */
+export async function getEsConsumedAwuCreditsForUser(
+  auth: Authenticator,
+  { user }: { user: UserResource }
+): Promise<number> {
+  const workspace = auth.getNonNullableWorkspace();
+  const membership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user,
+      workspace,
+    });
+  const freeSeatUserIds = membership?.seatType === "free" ? [user.sId] : [];
+  const consumedByUserId = await fetchConsumedAwuCreditsByUserId({
+    workspace,
+    userIds: [user.sId],
+    freeSeatUserIds,
+  });
+  return consumedByUserId.get(user.sId) ?? 0;
+}
+
 async function fetchPerUserUsageCreditsForMembersTableUncached({
   workspaceId,
   metronomeCustomerId,

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -6,7 +6,10 @@ import {
   buildAuditLogTarget,
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
-import { getEffectiveSpendCapAwuCreditsForUser } from "@app/lib/api/credits/members_usage";
+import {
+  getEffectiveSpendCapAwuCreditsForUser,
+  getEsConsumedAwuCreditsForUser,
+} from "@app/lib/api/credits/members_usage";
 import { reconcileUser } from "@app/lib/api/metronome/reconcile_credit_state";
 import { getUserForWorkspace } from "@app/lib/api/user";
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
@@ -26,6 +29,7 @@ import {
   addFixedWindowCount,
   type FixedWindowBounds,
   getFixedWindowCount,
+  setFixedWindowCount,
 } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import type {
@@ -366,6 +370,50 @@ async function resolveSpendLimitCycleBounds(
 }
 
 /**
+ * Reads the per-user spend-cap counter, lazily seeding it from Elasticsearch
+ * whenever it reads as 0. A 0 count means the counter is absent — a brand-new
+ * cycle (ES ≈ 0, a harmless no-op), the flag just enabled mid-cycle, or the key
+ * evicted under Redis memory pressure — so nothing has been recorded that a
+ * re-seed could clobber. ES is scoped to the current cycle, so the seeded value
+ * is the correct cycle-to-date total in every case. A non-zero count is already
+ * live (the first recorded delta bumps it above 0), so it's used as-is with no
+ * ES read.
+ *
+ * Re-seeding on a 0 count is idempotent and cheap; `SET` (not `INCRBY`) makes
+ * concurrent first-message seeds converge on the same value instead of doubling.
+ * Recording (`recordUserSpendLimitUsage`) runs post-finalize, after this
+ * send-time seed, so it accrues on top of the seeded value.
+ *
+ * Returns the effective count, or `null` on a Redis read error (caller fails
+ * open). A seed write failure degrades to the ES value rather than throwing.
+ */
+async function readSpendLimitCountWithLazySeed(
+  auth: Authenticator,
+  {
+    user,
+    key,
+    bounds,
+  }: { user: UserResource; key: string; bounds: FixedWindowBounds }
+): Promise<number | null> {
+  const countResult = await getFixedWindowCount({ key, bounds });
+  if (countResult.isErr()) {
+    return null;
+  }
+  if (countResult.value > 0) {
+    return countResult.value;
+  }
+
+  const consumed = Math.max(
+    0,
+    Math.round(await getEsConsumedAwuCreditsForUser(auth, { user }))
+  );
+  if (consumed > 0) {
+    await setFixedWindowCount({ key, bounds, value: consumed, logger });
+  }
+  return consumed;
+}
+
+/**
  * Synchronous, Metronome-independent enforcement of the per-user spend cap, read
  * at message-send time from the Redis fixed-window counter over the current
  * contract billing cycle. The threshold is the user's *effective* cap resolved
@@ -391,23 +439,20 @@ export async function isUserSpendLimitRateCapReached(
     return false;
   }
 
-  const countResult = await getFixedWindowCount({
+  const count = await readSpendLimitCountWithLazySeed(auth, {
+    user,
     key: makeSpendLimitAwuCreditsRateLimitKeyForUser(workspace, user.toJSON()),
     bounds,
   });
-  if (countResult.isErr()) {
+  if (count === null) {
     logger.error(
-      {
-        workspaceId: workspace.sId,
-        userId: user.sId,
-        err: countResult.error,
-      },
+      { workspaceId: workspace.sId, userId: user.sId },
       "[SpendLimitRateCap] Failed to read fixed-window count; allowing message"
     );
     return false;
   }
 
-  return countResult.value >= threshold;
+  return count >= threshold;
 }
 
 /**


### PR DESCRIPTION
## Description

Lazily backfills the per-user spend-cap counter from Elasticsearch on a Redis read miss, so enforcement isn't fooled by a `0` count. Stacked on #29640.

**Why:** the fixed-window counter is *per-cycle* (`label = cycle-<start>`) and self-expires ~60s after the cycle ends, so a read returns `0` whenever the key is absent — a brand-new cycle (correct), the flag just enabled mid-cycle (never populated), or the key evicted under Redis memory pressure. The last two silently **under-enforce** the cap (phantom headroom).

**How:** on the flag-gated enforcement read (`isUserSpendLimitRateCapReached`):
- count **> 0** → already live, use as-is (no ES read).
- count **== 0** → the counter is absent, so nothing has been recorded that a re-seed could clobber. Read the user's ES consumption for the current cycle (`getEsConsumedAwuCreditsForUser`, the single-user form of the "Consumed (ES)" figure) and `SET` the counter to it. ES is scoped to the cycle, so this is the correct cycle-to-date total in every case — it heals eviction / mid-cycle enablement and is a harmless ≈0 no-op at cycle start.

Notes:
- **No "seeded" marker.** Re-seeding on a 0 count is idempotent and safe (a 0 means nothing to clobber), so there's no need to track "already seeded" — the first *recorded* delta bumps the count above 0, which is what actually stops further ES reads. `SET` (not `INCRBY`) makes concurrent first-message seeds converge instead of doubling.
- **Ordering:** the send-time seed runs before the post-finalize recording, so `recordUserSpendLimitUsage` accrues on top of the seeded value.
- **Fail-open:** a counter read error → allow the message; a seed write failure → fall back to the ES value. Nothing here throws on the send path.
- Runs only under `enforce_user_spend_limit_rate_cap`.

**Cost:** one ES read per user per cycle is inherent (the first miss can't distinguish new-cycle from eviction without asking ES). While a user sits at exactly 0 for a cycle (0-cost messages, or bursts before the first recording lands) each enforcement re-reads ES — a cheap, ≈0-result query — which is an acceptable trade for dropping the extra marker key/read.

## Tests

- `tsgo` clean across `front` + `front-api`.
- `front-api` `members-usage` endpoint test still green (the new export doesn't change its output).
- Existing rate-limiter suite unchanged/green.

## Risk

Low, and flag-gated. When `enforce_user_spend_limit_rate_cap` is off, this code doesn't run. The seed only fires on a 0 count and is idempotent (`SET`), so it can't double-count or clobber a live value. Read/seed failures fail open (never block a message). Safe to roll back by revert.

## Deploy Plan

Standard deploy, no migration. No behavior change until `enforce_user_spend_limit_rate_cap` is enabled for a workspace; once enabled, the counter self-seeds from ES on the first message per cycle (and after any eviction), so the poke resync (#29640) becomes a bulk convenience rather than a prerequisite.
