### PR TITLE
Remove dead buildersOnly member-search plumbing

### DIFF
--- a/front-api/routes/w/[wId]/members/search.test.ts
+++ b/front-api/routes/w/[wId]/members/search.test.ts
@@ -260,41 +260,6 @@ describe("GET /api/w/:wId/members/search", () => {
     expect(data.members[0].email).toBeDefined();
   });
 
-  it("allows non-admin users to filter with buildersOnly", async () => {
-    const { workspace } = await setup("builder");
-
-    const users = await Promise.all([
-      UserFactory.basic(),
-      UserFactory.basic(),
-      UserFactory.basic(),
-    ]);
-
-    await Promise.all([
-      MembershipFactory.associate(workspace, users[0], { role: "admin" }),
-      MembershipFactory.associate(workspace, users[1], { role: "builder" }),
-      MembershipFactory.associate(workspace, users[2], { role: "user" }),
-    ]);
-
-    const response = await honoApp.request(
-      searchUrl(workspace.sId, {
-        buildersOnly: "true",
-        offset: "0",
-        limit: "25",
-      })
-    );
-
-    expect(response.status).toBe(200);
-    const data = await response.json();
-    // The caller (builder) + users[0] (admin) + users[1] (builder) = 3.
-    expect(data.total).toBe(3);
-    expect(data.members).toHaveLength(3);
-    // Non-admin receives minimal essential user data plus workspace info.
-    for (const member of data.members) {
-      expect(member.workspace).toBeDefined();
-      expect(member.email).toBeDefined();
-    }
-  });
-
   it("paginates correctly for non-admin users", async () => {
     const { workspace } = await setup("user");
 
@@ -323,40 +288,6 @@ describe("GET /api/w/:wId/members/search", () => {
     for (const member of data.members) {
       expect(member.workspace).toBeDefined();
       expect(member.email).toBeDefined();
-    }
-  });
-
-  it("filters to only builders and admins when buildersOnly=true", async () => {
-    const { workspace } = await setup();
-
-    const users = await Promise.all([
-      UserFactory.basic(),
-      UserFactory.basic(),
-      UserFactory.basic(),
-      UserFactory.basic(),
-    ]);
-
-    await Promise.all([
-      MembershipFactory.associate(workspace, users[0], { role: "admin" }),
-      MembershipFactory.associate(workspace, users[1], { role: "builder" }),
-      MembershipFactory.associate(workspace, users[2], { role: "user" }),
-      MembershipFactory.associate(workspace, users[3], { role: "user" }),
-    ]);
-
-    const response = await honoApp.request(
-      searchUrl(workspace.sId, {
-        buildersOnly: "true",
-        offset: "0",
-        limit: "25",
-      })
-    );
-
-    expect(response.status).toBe(200);
-    const data = await response.json();
-    expect(data.total).toBe(3);
-    expect(data.members).toHaveLength(3);
-    for (const member of data.members) {
-      expect(["admin", "builder"]).toContain(member.workspace.role);
     }
   });
 });

--- a/front-api/routes/w/[wId]/members/search.ts
+++ b/front-api/routes/w/[wId]/members/search.ts
@@ -20,6 +20,8 @@ const SearchMembersQuerySchema = z.object({
   searchTerm: z.string().optional(),
   searchEmails: z.string().optional(),
   groupKind: z.enum(GROUP_KINDS).exclude(["system"]).optional(),
+  // Deprecated: the builder-role filter was removed; accepted but ignored to
+  // avoid breaking clients that still send it. Remove once no client does.
   buildersOnly: z
     .string()
     .transform((v) => v === "true")
@@ -58,7 +60,6 @@ app.get(
         searchTerm: query.searchTerm,
         searchEmails: emails,
         groupKind: query.groupKind,
-        buildersOnly: query.buildersOnly,
       },
       query
     );

--- a/front/components/assistant/conversation/space/ManageUsersPanel.tsx
+++ b/front/components/assistant/conversation/space/ManageUsersPanel.tsx
@@ -39,7 +39,6 @@ interface EditorsOnlyMode extends BaseManageUsersPanelProps {
   editors: SearchMemberType[];
   onEditorsChange: (editors: SearchMemberType[]) => void;
   title?: string;
-  buildersOnly?: boolean;
 }
 
 type ManageUsersPanelProps = SpaceMembersMode | EditorsOnlyMode;
@@ -50,8 +49,6 @@ export function ManageUsersPanel(props: ManageUsersPanelProps) {
   const [isSaving, setIsSaving] = useState(false);
   const sendNotification = useSendNotification();
   const doUpdateSpace = useUpdateSpace({ owner });
-
-  const buildersOnly = mode === "editors-only" ? props.buildersOnly : undefined;
 
   const [currentMembers, setCurrentMembers] = useState<Set<string>>(new Set());
   const [currentEditors, setCurrentEditors] = useState<Set<string>>(new Set());
@@ -225,7 +222,6 @@ export function ManageUsersPanel(props: ManageUsersPanelProps) {
             selectedMemberIds={currentMembers}
             onSelectionChange={handleSelectionChange}
             extraColumns={editorColumn}
-            buildersOnly={buildersOnly}
             initialMembers={initialMembers}
           />
         </SheetContainer>

--- a/front/components/members/MemberSelectionTable.tsx
+++ b/front/components/members/MemberSelectionTable.tsx
@@ -62,7 +62,6 @@ interface MemberSelectionTableProps {
   selectedMemberIds: Set<string>;
   onSelectionChange: (ids: Set<string>, users: SearchMemberType[]) => void;
   extraColumns?: ColumnDef<MemberRowData>[];
-  buildersOnly?: boolean;
   initialMembers?: SearchMemberType[];
 }
 
@@ -71,7 +70,6 @@ export function MemberSelectionTable({
   selectedMemberIds,
   onSelectionChange,
   extraColumns,
-  buildersOnly,
   initialMembers,
 }: MemberSelectionTableProps) {
   const [searchText, setSearchText] = useState("");
@@ -90,7 +88,6 @@ export function MemberSelectionTable({
     searchTerm: searchText,
     pageIndex: pagination.pageIndex,
     pageSize: pagination.pageSize,
-    buildersOnly,
     disabled: !searchText,
   });
 

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -44,7 +44,7 @@ import type {
   WorkspaceSegmentationType,
   WorkspaceType,
 } from "@app/types/user";
-import { ACTIVE_ROLES, isBuilder } from "@app/types/user";
+import { ACTIVE_ROLES } from "@app/types/user";
 import type { WorkspaceDomain } from "@app/types/workspace";
 import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
@@ -303,7 +303,6 @@ export async function searchMembers(
     searchTerm?: string;
     searchEmails?: string[];
     groupKind?: Exclude<GroupKind, "system">;
-    buildersOnly?: boolean;
   },
   paginationParams: SearchMembersPaginationParams
 ): Promise<{ members: UserTypeWithWorkspace[]; total: number }> {
@@ -384,14 +383,9 @@ export async function searchMembers(
     { concurrency: 5 }
   );
 
-  let filteredUsers = usersWithWorkspace;
-  if (options.buildersOnly) {
-    filteredUsers = usersWithWorkspace.filter((u) => isBuilder(u.workspace));
-  }
-
   return {
-    members: filteredUsers,
-    total: options.buildersOnly ? filteredUsers.length : total,
+    members: usersWithWorkspace,
+    total,
   };
 }
 

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -128,7 +128,6 @@ export function useSearchMembers<
   pageIndex,
   pageSize,
   groupKind,
-  buildersOnly,
   disabled,
 }: {
   workspaceId: string;
@@ -136,7 +135,6 @@ export function useSearchMembers<
   pageIndex: number;
   pageSize: number;
   groupKind?: Exclude<GroupKind, "system">;
-  buildersOnly?: boolean;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
@@ -163,10 +161,6 @@ export function useSearchMembers<
 
   if (groupKind && isGroupKind(groupKind)) {
     searchParams.set("groupKind", groupKind);
-  }
-
-  if (buildersOnly) {
-    searchParams.set("buildersOnly", "true");
   }
 
   const { data, error, mutate, mutateRegardlessOfQueryParams } =


### PR DESCRIPTION
## Description

Follow-up to #29637 (now merged), which explicitly deferred this to the "builder-deprecation cleanup series":

> `buildersOnly` plumbing in `ManageUsersPanel`/`MemberSelectionTable` no longer has callers; left for the builder-deprecation cleanup series.

Now that #29637 dropped the `admin_governance` feature flag, nothing sets `buildersOnly` on the member search anymore — the only caller (`SkillEditorsSheet` via `buildersOnly={!hasFeature("admin_governance")}`) is now always `false`.

This removes the dead plumbing:
- `searchMembers` (`front/lib/api/workspace.ts`) no longer accepts or filters on `buildersOnly` (drops the now-unused `isBuilder` import).
- `useSearchMembers` (swr) and `MemberSelectionTable`/`ManageUsersPanel` no longer thread it through.
- Drops the two functional tests that exercised the removed filter.

The private `/api/w/:wId/members/search` route **keeps `buildersOnly` in its query schema, marked deprecated**, so any client still sending it is not broken — the value is accepted and simply ignored. It can be dropped from the schema once no client sends it.

Note: fully removing the `builder` role is a larger multi-PR effort — the `isBuilder()` write-access checks still depend on the not-yet-merged `space.globalWrite` capability, and `builder` is still stored on existing memberships. This PR is only the dead-plumbing cleanup step.

## Risks

Blast radius: the member/editor search used in the editor/member pickers.
Risk: low. No API breaking change — the deprecated `buildersOnly` param is still accepted (ignored).

## Verification

- `tsgo --noEmit` clean in both `front` and `front-api`.
- `npm run format:changed` clean.
- `front-api` `members/search.test.ts` — 9 remaining tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)