### PR TITLE
Opt: cache for agent_step_contents

### DIFF
--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -439,7 +439,6 @@ export async function batchRenderAgentMessages<V extends RenderMessageVariant>(
     async () =>
       AgentStepContentResource.fetchByAgentMessages(auth, {
         agentMessageIds,
-        latestVersionsOnly: true,
         textContentOnly,
       }),
     async () =>

--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -51,6 +51,7 @@ export const REDIS_CACHE_CONCURRENCY = 32;
 
 export type RedisUsageTagsType =
   | "agent_recent_authors"
+  | "agent_step_content_cache"
   | "agent_usage"
   | "assistant_generation"
   | "cache_diagnostics"

--- a/front/lib/reinforcement/tool_execution.ts
+++ b/front/lib/reinforcement/tool_execution.ts
@@ -45,7 +45,7 @@ async function fetchStepContentByCallId(
 > {
   const stepContents = await AgentStepContentResource.fetchByAgentMessages(
     auth,
-    { agentMessageIds: [agentMessageModelId], latestVersionsOnly: true }
+    { agentMessageIds: [agentMessageModelId] }
   );
 
   const functionCallStepContents = stepContents.filter(

--- a/front/lib/resources/agent_step_content/cache.ts
+++ b/front/lib/resources/agent_step_content/cache.ts
@@ -1,0 +1,254 @@
+import { getRedisCacheClient } from "@app/lib/api/redis";
+import logger from "@app/logger/logger";
+import type { AgentContentItemType } from "@app/types/assistant/agent_message_content";
+import type { ModelId } from "@app/types/shared/model_id";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import groupBy from "lodash/groupBy";
+
+export const AGENT_STEP_CONTENT_CACHE_TTL_MS = 15 * 60 * 1000;
+
+// Bump the `:v1` suffix any time the cached value shape changes, so stale entries
+// from previous formats are orphaned instead of mis-parsed.
+export function agentStepContentCacheKey({
+  workspaceId,
+  agentMessageId,
+}: {
+  workspaceId: ModelId;
+  agentMessageId: ModelId;
+}): string {
+  return `agent_step_contents:w:${workspaceId}:am:${agentMessageId}:v1`;
+}
+
+export function agentStepContentHashField({
+  step,
+  index,
+}: {
+  step: number;
+  index: number;
+}): string {
+  return `${step}:${index}`;
+}
+
+export type CachedAgentStepContent = {
+  id: ModelId;
+  workspaceId: ModelId;
+  agentMessageId: ModelId;
+  step: number;
+  index: number;
+  version: number;
+  type: AgentContentItemType["type"];
+  value: AgentContentItemType;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AgentStepContentCacheMetadata = {
+  id: ModelId;
+  agentMessageId: ModelId;
+  step: number;
+  index: number;
+  version: number;
+  type: AgentContentItemType["type"];
+};
+
+/**
+ * Write-through warm after create (or after a cache-miss PG fetch). Best-effort:
+ * failures are logged and ignored so Redis never blocks the agent loop.
+ */
+export async function warmAgentStepContentCache(
+  content: CachedAgentStepContent
+): Promise<void> {
+  try {
+    const redis = await getRedisCacheClient({
+      origin: "agent_step_content_cache",
+    });
+    const key = agentStepContentCacheKey({
+      workspaceId: content.workspaceId,
+      agentMessageId: content.agentMessageId,
+    });
+    const field = agentStepContentHashField({
+      step: content.step,
+      index: content.index,
+    });
+
+    const multi = redis.multi();
+    multi.hSet(key, field, JSON.stringify(content));
+    multi.pExpire(key, AGENT_STEP_CONTENT_CACHE_TTL_MS);
+    await multi.exec();
+  } catch (err) {
+    logger.warn(
+      {
+        err: normalizeError(err),
+        agentMessageId: content.agentMessageId,
+        step: content.step,
+        index: content.index,
+      },
+      "Failed to warm agent step content cache"
+    );
+  }
+}
+
+export async function warmAgentStepContentCacheMany(
+  contents: CachedAgentStepContent[]
+): Promise<void> {
+  await Promise.all(contents.map((c) => warmAgentStepContentCache(c)));
+}
+
+function isCachedAgentStepContent(
+  value: unknown
+): value is CachedAgentStepContent {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === "number" &&
+    typeof v.workspaceId === "number" &&
+    typeof v.agentMessageId === "number" &&
+    typeof v.step === "number" &&
+    typeof v.index === "number" &&
+    typeof v.version === "number" &&
+    typeof v.type === "string" &&
+    v.value !== null &&
+    typeof v.value === "object" &&
+    typeof v.createdAt === "string" &&
+    typeof v.updatedAt === "string"
+  );
+}
+
+/**
+ * Given latest-version metadata from PG (no `value` column), try to hydrate
+ * full rows from the per-agentMessage Redis Hash. A message is a hit only when
+ * every expected `(step, index)` field is present and matches `id` + `version`.
+ *
+ * Returns null if Redis itself fails — caller should treat all ids as misses.
+ */
+export async function tryHydrateAgentStepContentsFromCache({
+  workspaceId,
+  agentMessageIds,
+  latestMetadata,
+}: {
+  workspaceId: ModelId;
+  agentMessageIds: ModelId[];
+  latestMetadata: AgentStepContentCacheMetadata[];
+}): Promise<{
+  hitsByAgentMessageId: Map<ModelId, CachedAgentStepContent[]>;
+  missAgentMessageIds: ModelId[];
+} | null> {
+  const uniqueIds = [...new Set(agentMessageIds)];
+  if (uniqueIds.length === 0) {
+    return { hitsByAgentMessageId: new Map(), missAgentMessageIds: [] };
+  }
+
+  const expectedByMessage = groupBy(latestMetadata, (m) => m.agentMessageId);
+
+  try {
+    const redis = await getRedisCacheClient({
+      origin: "agent_step_content_cache",
+    });
+
+    const multi = redis.multi();
+    for (const agentMessageId of uniqueIds) {
+      multi.hGetAll(agentStepContentCacheKey({ workspaceId, agentMessageId }));
+    }
+    const results = await multi.exec();
+
+    const hitsByAgentMessageId = new Map<ModelId, CachedAgentStepContent[]>();
+    const missAgentMessageIds: ModelId[] = [];
+
+    for (let i = 0; i < uniqueIds.length; i++) {
+      const agentMessageId = uniqueIds[i];
+      const expected = expectedByMessage[agentMessageId] ?? [];
+      const hash = results[i] as Record<string, string> | null | undefined;
+
+      if (expected.length === 0) {
+        hitsByAgentMessageId.set(agentMessageId, []);
+        continue;
+      }
+
+      if (!hash || Object.keys(hash).length === 0) {
+        missAgentMessageIds.push(agentMessageId);
+        continue;
+      }
+
+      const hydrated: CachedAgentStepContent[] = [];
+      let complete = true;
+
+      for (const meta of expected) {
+        const field = agentStepContentHashField({
+          step: meta.step,
+          index: meta.index,
+        });
+        const raw = hash[field];
+        if (!raw) {
+          complete = false;
+          break;
+        }
+
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(raw);
+        } catch {
+          complete = false;
+          break;
+        }
+
+        if (
+          !isCachedAgentStepContent(parsed) ||
+          parsed.id !== meta.id ||
+          parsed.version !== meta.version ||
+          parsed.agentMessageId !== meta.agentMessageId
+        ) {
+          complete = false;
+          break;
+        }
+
+        hydrated.push(parsed);
+      }
+
+      if (complete) {
+        hitsByAgentMessageId.set(agentMessageId, hydrated);
+      } else {
+        missAgentMessageIds.push(agentMessageId);
+      }
+    }
+
+    return { hitsByAgentMessageId, missAgentMessageIds };
+  } catch (err) {
+    logger.warn(
+      {
+        err: normalizeError(err),
+        workspaceId,
+        agentMessageCount: uniqueIds.length,
+      },
+      "Failed to read agent step content cache; falling back to Postgres"
+    );
+    return null;
+  }
+}
+
+export function toCachedAgentStepContent(blob: {
+  id: ModelId;
+  workspaceId: ModelId;
+  agentMessageId: ModelId;
+  step: number;
+  index: number;
+  version: number;
+  type: AgentContentItemType["type"];
+  value: AgentContentItemType;
+  createdAt: Date;
+  updatedAt: Date;
+}): CachedAgentStepContent {
+  return {
+    id: blob.id,
+    workspaceId: blob.workspaceId,
+    agentMessageId: blob.agentMessageId,
+    step: blob.step,
+    index: blob.index,
+    version: blob.version,
+    type: blob.type,
+    value: blob.value,
+    createdAt: blob.createdAt.toISOString(),
+    updatedAt: blob.updatedAt.toISOString(),
+  };
+}

--- a/front/lib/resources/agent_step_content_resource.test.ts
+++ b/front/lib/resources/agent_step_content_resource.test.ts
@@ -1,6 +1,12 @@
+import { getRedisCacheClient } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
+import {
+  AGENT_STEP_CONTENT_CACHE_TTL_MS,
+  agentStepContentCacheKey,
+  agentStepContentHashField,
+} from "@app/lib/resources/agent_step_content/cache";
 import {
   AgentStepContentResource,
   FETCH_BY_AGENT_MESSAGES_CHUNK_SIZE,
@@ -9,7 +15,7 @@ import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFa
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { AgentTextContentType } from "@app/types/assistant/agent_message_content";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 function makeTextContent(value: string): AgentTextContentType {
   return {
@@ -102,7 +108,6 @@ describe("AgentStepContentResource.fetchByAgentMessages", () => {
       authenticator,
       {
         agentMessageIds: agentMessages.map((message) => message.id),
-        latestVersionsOnly: true,
       }
     );
 
@@ -116,5 +121,169 @@ describe("AgentStepContentResource.fetchByAgentMessages", () => {
     );
     expect(latestVersion?.version).toBe(1);
     expect(latestVersion?.value).toEqual(makeTextContent("new version"));
+  });
+});
+
+describe("AgentStepContentResource Redis cache", () => {
+  let authenticator: Authenticator;
+  let workspaceId: number;
+  let agentMessage: AgentMessageModel;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    authenticator = setup.authenticator;
+    workspaceId = setup.workspace.id;
+
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      {
+        name: "Step Content Cache Agent",
+      }
+    );
+    const [message] = await createAgentMessages(authenticator, {
+      count: 1,
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+    });
+    agentMessage = message;
+  });
+
+  it("warms Redis on createNewVersion and serves fetchByAgentMessages from cache", async () => {
+    const created = await AgentStepContentResource.createNewVersion({
+      workspaceId,
+      agentMessageId: agentMessage.id,
+      step: 0,
+      index: 0,
+      type: "text_content",
+      value: makeTextContent("from create"),
+    });
+
+    const redis = await getRedisCacheClient({
+      origin: "agent_step_content_cache",
+    });
+    const key = agentStepContentCacheKey({
+      workspaceId,
+      agentMessageId: agentMessage.id,
+    });
+    const field = agentStepContentHashField({ step: 0, index: 0 });
+
+    // Inspect the hash written by createNewVersion.
+    const hash = await redis.hGetAll(key);
+    expect(hash[field]).toBeDefined();
+    expect(JSON.parse(hash[field]).id).toBe(created.id);
+    expect(JSON.parse(hash[field]).value).toEqual(
+      makeTextContent("from create")
+    );
+
+    // Spy on full-row PG fetch: cache hit should skip loading `value` from PG.
+    const findAllSpy = vi.spyOn(AgentStepContentModel, "findAll");
+
+    const fetched = await AgentStepContentResource.fetchByAgentMessages(
+      authenticator,
+      { agentMessageIds: [agentMessage.id] }
+    );
+
+    expect(fetched).toHaveLength(1);
+    expect(fetched[0].id).toBe(created.id);
+    expect(fetched[0].value).toEqual(makeTextContent("from create"));
+
+    // Metadata query excludes `value`; no subsequent full-row findAll.
+    const findAllCalls = findAllSpy.mock.calls;
+    expect(findAllCalls.length).toBeGreaterThanOrEqual(1);
+    for (const [options] of findAllCalls) {
+      const attrs = options?.attributes;
+      expect(attrs).toBeDefined();
+      if (Array.isArray(attrs)) {
+        expect(attrs).not.toContain("value");
+      }
+    }
+
+    findAllSpy.mockRestore();
+  });
+
+  it("falls back to Postgres when the Redis hash is incomplete", async () => {
+    const created = await AgentStepContentResource.createNewVersion({
+      workspaceId,
+      agentMessageId: agentMessage.id,
+      step: 0,
+      index: 0,
+      type: "text_content",
+      value: makeTextContent("cached"),
+    });
+
+    // Second row inserted without warming Redis (bulkCreate bypasses createNewVersion).
+    await AgentStepContentModel.create({
+      workspaceId,
+      agentMessageId: agentMessage.id,
+      step: 0,
+      index: 1,
+      version: 0,
+      type: "text_content",
+      value: makeTextContent("only in pg"),
+    });
+
+    const fetched = await AgentStepContentResource.fetchByAgentMessages(
+      authenticator,
+      { agentMessageIds: [agentMessage.id] }
+    );
+
+    expect(fetched).toHaveLength(2);
+    expect(
+      fetched.map((c) => (c.value as AgentTextContentType).value).toSorted()
+    ).toEqual(["cached", "only in pg"]);
+    expect(fetched.map((c) => c.id).includes(created.id)).toBe(true);
+  });
+
+  it("overwrites the hash field when creating a new version of the same step/index", async () => {
+    await AgentStepContentResource.createNewVersion({
+      workspaceId,
+      agentMessageId: agentMessage.id,
+      step: 0,
+      index: 0,
+      type: "text_content",
+      value: makeTextContent("v0"),
+    });
+
+    const v1 = await AgentStepContentResource.createNewVersion({
+      workspaceId,
+      agentMessageId: agentMessage.id,
+      step: 0,
+      index: 0,
+      type: "text_content",
+      value: makeTextContent("v1"),
+    });
+
+    const fetched = await AgentStepContentResource.fetchByAgentMessages(
+      authenticator,
+      { agentMessageIds: [agentMessage.id] }
+    );
+
+    expect(fetched).toHaveLength(1);
+    expect(fetched[0].id).toBe(v1.id);
+    expect(fetched[0].version).toBe(1);
+    expect(fetched[0].value).toEqual(makeTextContent("v1"));
+  });
+
+  it("refreshes TTL on warm", async () => {
+    await AgentStepContentResource.createNewVersion({
+      workspaceId,
+      agentMessageId: agentMessage.id,
+      step: 0,
+      index: 0,
+      type: "text_content",
+      value: makeTextContent("ttl"),
+    });
+
+    const redis = await getRedisCacheClient({
+      origin: "agent_step_content_cache",
+    });
+    // multi().pExpire is invoked during warm; assert the mock was used with the TTL.
+    expect(redis.pExpire).toHaveBeenCalledWith(
+      agentStepContentCacheKey({
+        workspaceId,
+        agentMessageId: agentMessage.id,
+      }),
+      AGENT_STEP_CONTENT_CACHE_TTL_MS
+    );
   });
 });

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -3,12 +3,20 @@ import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
+import {
+  type CachedAgentStepContent,
+  toCachedAgentStepContent,
+  tryHydrateAgentStepContentsFromCache,
+  warmAgentStepContentCache,
+  warmAgentStepContentCacheMany,
+} from "@app/lib/resources/agent_step_content/cache";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import type {
   AgentFunctionCallContentType,
@@ -30,6 +38,18 @@ export const FETCH_BY_AGENT_MESSAGES_CHUNK_SIZE = 512;
 // to bump up FETCH_BY_AGENT_MESSAGES_CHUNK_SIZE
 // value = max peak concurrency - 1
 const FETCH_BY_AGENT_MESSAGES_CONCURRENCY = 4;
+
+const METADATA_ATTRIBUTES = [
+  "id",
+  "createdAt",
+  "updatedAt",
+  "workspaceId",
+  "agentMessageId",
+  "step",
+  "index",
+  "version",
+  "type",
+] as const;
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -143,33 +163,50 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
   }
 
   /**
-   * Helper to filter latest versions from fetched content
+   * Helper to filter latest versions from fetched content.
+   * Contents must already be ordered by version DESC within each group.
    */
-  private static filterLatestVersions(
-    contents: AgentStepContentModel[],
-    groupByFields: string[]
-  ): AgentStepContentModel[] {
+  private static filterLatestVersions<
+    T extends {
+      agentMessageId: ModelId;
+      step: number;
+      index: number;
+    },
+  >(contents: T[], groupByFields: (keyof T)[]): T[] {
     const grouped = groupBy(contents, (content) =>
-      groupByFields
-        .map((field) => content[field as keyof AgentStepContentModel])
-        .join("-")
+      groupByFields.map((field) => content[field]).join("-")
     );
 
     // For each group, keep only the first item (already sorted by version DESC)
     return Object.values(grouped).map((group) => group[0]);
   }
 
-  static async fetchByAgentMessages(
+  private static fromCached(
+    cached: CachedAgentStepContent
+  ): AgentStepContentResource {
+    return new AgentStepContentResource(this.model, {
+      id: cached.id,
+      workspaceId: cached.workspaceId,
+      agentMessageId: cached.agentMessageId,
+      step: cached.step,
+      index: cached.index,
+      version: cached.version,
+      type: cached.type,
+      value: cached.value,
+      createdAt: new Date(cached.createdAt),
+      updatedAt: new Date(cached.updatedAt),
+    });
+  }
+
+  private static async fetchByAgentMessagesFromPostgres(
     auth: Authenticator,
     {
       agentMessageIds,
       transaction,
-      latestVersionsOnly = false,
       textContentOnly = false,
     }: {
       agentMessageIds: ModelId[];
       transaction?: Transaction;
-      latestVersionsOnly?: boolean;
       textContentOnly?: boolean;
     }
   ): Promise<AgentStepContentResource[]> {
@@ -183,7 +220,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
 
     const batchResults = await concurrentExecutor(
       chunks,
-      async (chunk) =>
+      async (idsChunk) =>
         this.model.findAll({
           where: {
             workspaceId: owner.id,
@@ -198,7 +235,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
             ["version", "DESC"],
           ],
           bind: {
-            agentMessageIds: chunk,
+            agentMessageIds: idsChunk,
           },
           transaction,
         }),
@@ -209,16 +246,174 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
 
     let contents = batchResults.flat();
 
-    if (latestVersionsOnly) {
-      contents = this.filterLatestVersions(contents, [
-        "agentMessageId",
-        "step",
-        "index",
-      ]);
-    }
+    // We only care about the latest version of the step content for each agent message, step, and index.
+    contents = this.filterLatestVersions(contents, [
+      "agentMessageId",
+      "step",
+      "index",
+    ]);
 
     return contents.map(
       (content) => new AgentStepContentResource(this.model, content.get())
+    );
+  }
+
+  /**
+   * Cheap metadata-only fetch (no TOAST de-toast of `value`) used to check
+   * Redis Hash completeness before hydrating from cache.
+   */
+  private static async fetchLatestMetadataByAgentMessages(
+    auth: Authenticator,
+    {
+      agentMessageIds,
+      textContentOnly = false,
+    }: {
+      agentMessageIds: ModelId[];
+      textContentOnly?: boolean;
+    }
+  ): Promise<
+    Array<{
+      id: ModelId;
+      agentMessageId: ModelId;
+      step: number;
+      index: number;
+      version: number;
+      type: AgentStepContentModel["type"];
+    }>
+  > {
+    const owner = auth.getNonNullableWorkspace();
+    const chunks = chunk(agentMessageIds, FETCH_BY_AGENT_MESSAGES_CHUNK_SIZE);
+
+    const batchResults = await concurrentExecutor(
+      chunks,
+      async (idsChunk) =>
+        this.model.findAll({
+          attributes: [...METADATA_ATTRIBUTES],
+          where: {
+            workspaceId: owner.id,
+            ...(textContentOnly ? { type: "text_content" } : {}),
+            agentMessageId: {
+              [Op.any]: Sequelize.literal("$agentMessageIds::bigint[]"),
+            },
+          },
+          order: [
+            ["step", "ASC"],
+            ["index", "ASC"],
+            ["version", "DESC"],
+          ],
+          bind: {
+            agentMessageIds: idsChunk,
+          },
+        }),
+      { concurrency: FETCH_BY_AGENT_MESSAGES_CONCURRENCY }
+    );
+
+    return this.filterLatestVersions(batchResults.flat(), [
+      "agentMessageId",
+      "step",
+      "index",
+    ]).map((row) => ({
+      id: row.id,
+      agentMessageId: row.agentMessageId,
+      step: row.step,
+      index: row.index,
+      version: row.version,
+      type: row.type,
+    }));
+  }
+
+  static async fetchByAgentMessages(
+    auth: Authenticator,
+    {
+      agentMessageIds,
+      transaction,
+      textContentOnly = false,
+    }: {
+      agentMessageIds: ModelId[];
+      transaction?: Transaction;
+      textContentOnly?: boolean;
+    }
+  ): Promise<AgentStepContentResource[]> {
+    if (agentMessageIds.length === 0) {
+      return [];
+    }
+
+    // Skip cache inside a transaction: Redis is not transactional with PG, and
+    // callers may be reading uncommitted rows.
+    if (transaction) {
+      return this.fetchByAgentMessagesFromPostgres(auth, {
+        agentMessageIds,
+        transaction,
+        textContentOnly,
+      });
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+
+    const latestMetadata = await this.fetchLatestMetadataByAgentMessages(auth, {
+      agentMessageIds,
+      textContentOnly,
+    });
+
+    const cacheResult = await tryHydrateAgentStepContentsFromCache({
+      workspaceId: owner.id,
+      agentMessageIds,
+      latestMetadata,
+    });
+
+    if (!cacheResult) {
+      getStatsDClient().increment(
+        "agent_step_content.fetch.count",
+        agentMessageIds.length,
+        ["source:postgres", "cache:error"]
+      );
+      return this.fetchByAgentMessagesFromPostgres(auth, {
+        agentMessageIds,
+        textContentOnly,
+      });
+    }
+
+    const { hitsByAgentMessageId, missAgentMessageIds } = cacheResult;
+
+    getStatsDClient().increment(
+      "agent_step_content.fetch.count",
+      hitsByAgentMessageId.size,
+      ["source:cache"]
+    );
+    getStatsDClient().increment(
+      "agent_step_content.fetch.count",
+      missAgentMessageIds.length,
+      ["source:postgres"]
+    );
+
+    const hitResources = [...hitsByAgentMessageId.values()].flatMap((cached) =>
+      cached.map((c) => this.fromCached(c))
+    );
+
+    if (missAgentMessageIds.length === 0) {
+      return hitResources.toSorted(
+        (a, b) =>
+          a.agentMessageId - b.agentMessageId ||
+          a.step - b.step ||
+          a.index - b.index
+      );
+    }
+
+    const missResources = await this.fetchByAgentMessagesFromPostgres(auth, {
+      agentMessageIds: missAgentMessageIds,
+      textContentOnly,
+    });
+
+    // Re-warm so the next fetch within the TTL can skip TOAST.
+    void warmAgentStepContentCacheMany(
+      missResources.map((r) => toCachedAgentStepContent(r))
+    );
+
+    return [...hitResources, ...missResources].toSorted(
+      (a, b) =>
+        a.agentMessageId - b.agentMessageId ||
+        a.step - b.step ||
+        a.index - b.index
     );
   }
 
@@ -311,7 +506,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     CreationAttributes<AgentStepContentModel>,
     "version"
   >): Promise<AgentStepContentResource> {
-    return withTransaction(async (transaction: Transaction) => {
+    const resource = await withTransaction(async (transaction: Transaction) => {
       const existingContent = await this.model.findAll({
         where: {
           agentMessageId,
@@ -341,6 +536,11 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
         transaction
       );
     });
+
+    // Warm after commit so readers never see uncommitted rows in Redis.
+    await warmAgentStepContentCache(toCachedAgentStepContent(resource));
+
+    return resource;
   }
 
   get sId(): string {

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -501,7 +501,6 @@ async function withContentView(
     auth,
     {
       agentMessageIds: [agentMessage.agentMessageId],
-      latestVersionsOnly: true,
     }
   );
   const contents = stepContents.map((sc) => ({

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -11,11 +11,58 @@ import { afterEach, beforeEach, vi } from "vitest";
 
 // Mock Redis - must be at module level.
 // runOnRedis uses a shared in-memory store so that set/get/del/ttl persist across calls
-// (needed for OTP challenge generate → validate flows). runOnRedisCache stays stateless.
+// (needed for OTP challenge generate → validate flows).
+// getRedisCacheClient uses a shared Hash-aware store so warm → fetch round-trips work.
 const redisStore = new Map<string, { value: string; expiresAtMs: number }>();
+const redisHashStore = new Map<string, Map<string, string>>();
+
+function attachHashCommands(
+  client: Record<string, unknown>,
+  hashStore: Map<string, Map<string, string>>
+) {
+  const hSet = vi.fn(async (key: string, field: string, value: string) => {
+    let hash = hashStore.get(key);
+    if (!hash) {
+      hash = new Map();
+      hashStore.set(key, hash);
+    }
+    hash.set(field, value);
+    return 1;
+  });
+  const hGetAll = vi.fn(async (key: string) => {
+    const hash = hashStore.get(key);
+    if (!hash) {
+      return {};
+    }
+    return Object.fromEntries(hash);
+  });
+  const pExpire = vi.fn(async (_key: string, _ms: number) => true);
+
+  const multi = vi.fn(() => {
+    const ops: Array<() => Promise<unknown>> = [];
+    const multiClient = {
+      hSet: (key: string, field: string, value: string) => {
+        ops.push(() => hSet(key, field, value));
+        return multiClient;
+      },
+      hGetAll: (key: string) => {
+        ops.push(() => hGetAll(key));
+        return multiClient;
+      },
+      pExpire: (key: string, ms: number) => {
+        ops.push(() => pExpire(key, ms));
+        return multiClient;
+      },
+      exec: async () => Promise.all(ops.map((op) => op())),
+    };
+    return multiClient;
+  });
+
+  Object.assign(client, { hSet, hGetAll, pExpire, multi });
+}
 
 function createStatefulMockRedisClient() {
-  return {
+  const client: Record<string, unknown> = {
     get: vi.fn(async (key: string) => {
       const entry = redisStore.get(key);
       if (!entry) {
@@ -33,6 +80,7 @@ function createStatefulMockRedisClient() {
     }),
     del: vi.fn(async (key: string) => {
       redisStore.delete(key);
+      redisHashStore.delete(key);
     }),
     ttl: vi.fn(async (key: string) => {
       const entry = redisStore.get(key);
@@ -46,7 +94,6 @@ function createStatefulMockRedisClient() {
     expire: vi.fn(),
     zRange: vi.fn(),
     zCount: vi.fn().mockResolvedValue(0),
-    hGetAll: vi.fn().mockResolvedValue([]),
     hGet: vi.fn(),
     quit: vi.fn().mockResolvedValue(undefined),
     on: vi.fn(),
@@ -70,33 +117,42 @@ function createStatefulMockRedisClient() {
       return 1;
     }),
   };
+  attachHashCommands(client, redisHashStore);
+  return client;
 }
 
-const createMockRedisClient = () => ({
-  get: vi.fn(),
-  set: vi.fn(),
-  del: vi.fn(),
-  ttl: vi.fn(),
-  zAdd: vi.fn(),
-  expire: vi.fn(),
-  zRange: vi.fn(),
-  zCount: vi.fn().mockResolvedValue(0),
-  hGetAll: vi.fn().mockResolvedValue([]),
-  hGet: vi.fn(),
-  quit: vi.fn().mockResolvedValue(undefined),
-  on: vi.fn(),
-  xAdd: vi.fn().mockResolvedValue("0-0"),
-  xRead: vi.fn().mockResolvedValue(null),
-  xDel: vi.fn().mockResolvedValue(1),
-  publish: vi.fn().mockResolvedValue(1),
-  subscribe: vi.fn().mockResolvedValue(undefined),
-  unsubscribe: vi.fn().mockResolvedValue(undefined),
-  ping: vi.fn().mockResolvedValue("PONG"),
-  eval: vi.fn().mockResolvedValue(1),
-});
+const createMockRedisClient = () => {
+  const client: Record<string, unknown> = {
+    get: vi.fn(),
+    set: vi.fn(),
+    del: vi.fn(),
+    ttl: vi.fn(),
+    zAdd: vi.fn(),
+    expire: vi.fn(),
+    zRange: vi.fn(),
+    zCount: vi.fn().mockResolvedValue(0),
+    hGet: vi.fn(),
+    quit: vi.fn().mockResolvedValue(undefined),
+    on: vi.fn(),
+    xAdd: vi.fn().mockResolvedValue("0-0"),
+    xRead: vi.fn().mockResolvedValue(null),
+    xDel: vi.fn().mockResolvedValue(1),
+    publish: vi.fn().mockResolvedValue(1),
+    subscribe: vi.fn().mockResolvedValue(undefined),
+    unsubscribe: vi.fn().mockResolvedValue(undefined),
+    ping: vi.fn().mockResolvedValue("PONG"),
+    eval: vi.fn().mockResolvedValue(1),
+  };
+  // Stateless clients get an isolated hash store (fresh per client instance).
+  attachHashCommands(client, new Map());
+  return client;
+};
 
 // runOnRedis: shared stateful client (persists across calls within a test).
 const statefulRedisClient = createStatefulMockRedisClient();
+// getRedisCacheClient: shared Hash-aware client so warm → fetch round-trips work.
+const sharedCacheRedisClient = createStatefulMockRedisClient();
+
 const mockRunOnRedisImpl = async (
   opts: unknown,
   fn: (
@@ -106,7 +162,7 @@ const mockRunOnRedisImpl = async (
   return fn(statefulRedisClient);
 };
 
-// runOnRedisCache: stateless (fresh client per call).
+// runOnRedisCache: fresh client per call (isolated hash store).
 const mockRunOnRedisCacheImpl = async (
   opts: unknown,
   fn: (client: ReturnType<typeof createMockRedisClient>) => Promise<unknown>
@@ -116,11 +172,9 @@ const mockRunOnRedisCacheImpl = async (
 };
 
 vi.mock("@app/lib/api/redis", () => ({
-  getRedisStreamClient: vi
-    .fn()
-    .mockResolvedValue(createStatefulMockRedisClient()),
+  getRedisStreamClient: vi.fn().mockResolvedValue(statefulRedisClient),
   createRedisStreamClient: vi.fn().mockResolvedValue(createMockRedisClient()),
-  getRedisCacheClient: vi.fn().mockResolvedValue(createMockRedisClient()),
+  getRedisCacheClient: vi.fn().mockResolvedValue(sharedCacheRedisClient),
   runOnRedis: vi.fn().mockImplementation(mockRunOnRedisImpl),
   runOnRedisCache: vi.fn().mockImplementation(mockRunOnRedisCacheImpl),
   closeRedisClients: vi.fn().mockResolvedValue(undefined),
@@ -228,6 +282,7 @@ beforeEach(async (c) => {
   vi.clearAllMocks();
   fileStorageMock.reset();
   redisStore.clear();
+  redisHashStore.clear();
 
   const namespace = createNamespace("test-namespace");
 


### PR DESCRIPTION
## Description

`AgentStepContentResource.fetchByAgentMessages` now uses a Redis Hash cache to avoid reading the `value` TOAST column from Postgres on repeated fetches. On cache hit, we run only a cheap metadata-only PG query (no `value`) and hydrate the full rows from Redis. On miss, we fall back to the full PG fetch and re-warm the cache. Redis failures are best-effort: logged and silently fall through to Postgres.

- New `front/lib/resources/agent_step_content/cache.ts`: cache key, hash-field scheme, `warmAgentStepContentCache`, `tryHydrateAgentStepContentsFromCache`.
- `fetchByAgentMessages` split into `fetchLatestMetadataByAgentMessages` (metadata only) + `fetchByAgentMessagesFromPostgres` (full rows), with the cache layer sitting in between.
- `latestVersionsOnly` parameter removed — latest-version filtering is now always applied.
- Cache bypassed inside a transaction (Redis is not transactional with PG).
- `agent_step_content.fetch.count` StatsD metric tagged `source:cache|postgres|cache:error`.

## Tests

Added 4 Redis cache integration tests in `agent_step_content_resource.test.ts`: cache warm on `createNewVersion`, PG fallback when the hash is incomplete, version overwrite on same `step/index`, and TTL refresh assertion. Tested locally.

## Risk

Low. Cache is entirely best-effort — any Redis error falls back to Postgres transparently. No DB migration. Transaction-bound callers are unaffected (cache is skipped). The `latestVersionsOnly` removal is safe: filtering is now always on, matching previous behavior at all call sites.

## Deploy Plan

Deploy front.
