### PR TITLE
fix(front): delete activation pod recommendations and trigger on pod deletion

### DIFF
--- a/front/lib/resources/activation_recommendation_resource.test.ts
+++ b/front/lib/resources/activation_recommendation_resource.test.ts
@@ -1,16 +1,50 @@
 import { Authenticator } from "@app/lib/auth";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { ActivationRecommendationResource } from "@app/lib/resources/activation_recommendation_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { ModelId } from "@app/types/shared/model_id";
 import { describe, expect, it } from "vitest";
 
-const makeRec = (auth: Authenticator) =>
+const makeRec = (
+  auth: Authenticator,
+  { activationPodId }: { activationPodId?: ModelId } = {}
+) =>
   ActivationRecommendationResource.makeNew(auth, {
     title: "Try the Slack integration",
     content: "Connect your workspace Slack to get started.",
     conversationId: null,
+    activationPodId,
   });
+
+// Creates an ActivationPod for the given space, optionally with its own
+// dedicated (schedule) trigger — a webhook trigger would additionally require
+// a real webhook source view (see `createPodActivationTrigger` in
+// `lib/api/activation/nudge.test.ts`), which these tests don't need.
+async function makeActivationPod(
+  auth: Authenticator,
+  pod: SpaceResource,
+  { withTrigger = true }: { withTrigger?: boolean } = {}
+): Promise<ActivationPodResource> {
+  const trigger = withTrigger
+    ? await TriggerFactory.schedule(auth, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        status: "enabled",
+        configuration: { cron: "0 9 * * 1", timezone: "UTC" },
+      })
+    : null;
+
+  return ActivationPodResource.makeNew(auth, {
+    pod,
+    user: auth.getNonNullableUser(),
+    trigger,
+  });
+}
 
 describe("ActivationRecommendationResource", () => {
   describe("makeNew", () => {
@@ -158,6 +192,124 @@ describe("ActivationRecommendationResource", () => {
 
       expect(rec.userId).toBe(user.id);
       expect(rec.userId).not.toBe(otherAuth.getNonNullableUser().id);
+    });
+  });
+
+  describe("deleteAllForActivationPod", () => {
+    it("deletes recommendations linked to the activation pod", async () => {
+      const { authenticator, globalSpace } = await createResourceTest({
+        role: "admin",
+      });
+      const activationPod = await makeActivationPod(
+        authenticator,
+        globalSpace,
+        { withTrigger: false }
+      );
+      const rec = await makeRec(authenticator, {
+        activationPodId: activationPod.id,
+      });
+
+      await ActivationRecommendationResource.deleteAllForActivationPod(
+        authenticator,
+        activationPod
+      );
+
+      const fetched = await ActivationRecommendationResource.fetchById(
+        authenticator,
+        rec.sId
+      );
+      expect(fetched).toBeNull();
+    });
+
+    it("does not delete recommendations linked to a different activation pod", async () => {
+      const { authenticator, globalSpace, systemSpace } =
+        await createResourceTest({ role: "admin" });
+      const activationPod = await makeActivationPod(
+        authenticator,
+        globalSpace,
+        { withTrigger: false }
+      );
+      const otherActivationPod = await makeActivationPod(
+        authenticator,
+        systemSpace,
+        { withTrigger: false }
+      );
+      const otherRec = await makeRec(authenticator, {
+        activationPodId: otherActivationPod.id,
+      });
+
+      await ActivationRecommendationResource.deleteAllForActivationPod(
+        authenticator,
+        activationPod
+      );
+
+      const fetched = await ActivationRecommendationResource.fetchById(
+        authenticator,
+        otherRec.sId
+      );
+      expect(fetched).not.toBeNull();
+    });
+
+    it("does not delete recommendations that aren't linked to any activation pod", async () => {
+      const { authenticator, globalSpace } = await createResourceTest({
+        role: "admin",
+      });
+      const activationPod = await makeActivationPod(
+        authenticator,
+        globalSpace,
+        { withTrigger: false }
+      );
+      const unlinkedRec = await makeRec(authenticator);
+
+      await ActivationRecommendationResource.deleteAllForActivationPod(
+        authenticator,
+        activationPod
+      );
+
+      const fetched = await ActivationRecommendationResource.fetchById(
+        authenticator,
+        unlinkedRec.sId
+      );
+      expect(fetched).not.toBeNull();
+    });
+
+    it("deletes the pod's dedicated activation trigger", async () => {
+      const { authenticator, globalSpace } = await createResourceTest({
+        role: "admin",
+      });
+      const activationPod = await makeActivationPod(authenticator, globalSpace);
+      const triggerId = activationPod.triggerId;
+      if (triggerId === null) {
+        throw new Error("Expected the activation pod to have a trigger.");
+      }
+
+      await ActivationRecommendationResource.deleteAllForActivationPod(
+        authenticator,
+        activationPod
+      );
+
+      const triggers = await TriggerResource.fetchByModelIds(authenticator, [
+        triggerId,
+      ]);
+      expect(triggers).toHaveLength(0);
+    });
+
+    it("does not throw when the activation pod has no trigger", async () => {
+      const { authenticator, globalSpace } = await createResourceTest({
+        role: "admin",
+      });
+      const activationPod = await makeActivationPod(
+        authenticator,
+        globalSpace,
+        { withTrigger: false }
+      );
+
+      await expect(
+        ActivationRecommendationResource.deleteAllForActivationPod(
+          authenticator,
+          activationPod
+        )
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/front/lib/resources/activation_recommendation_resource.ts
+++ b/front/lib/resources/activation_recommendation_resource.ts
@@ -4,9 +4,11 @@ import {
   type ActivationRecommendationStatus,
 } from "@app/lib/models/activation/activation_recommendation";
 import { ConversationModel } from "@app/lib/models/agent/conversation";
+import type { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -194,21 +196,36 @@ export class ActivationRecommendationResource extends BaseResource<ActivationRec
     }));
   }
 
-  // Detaches all recommendations from a Pod being deleted. Recommendations
-  // are owned by the user, not the pod, so they are kept and only unlinked.
-  static async detachActivationPod(
+  // Deletes everything tied to a Pod's activation record before the record
+  // itself is deleted: its recommendations, and its dedicated activation
+  // trigger. The FK from activation_recommendations to activation_pods is
+  // `onDelete: "RESTRICT"`, so the recommendations must go first or deleting
+  // the activation pod record fails. The trigger only exists to nudge this
+  // Pod's user, so — unlike other triggers scoped to the Pod's space, which
+  // are merely detached and kept running elsewhere — it must be actually
+  // deleted, not just unlinked.
+  static async deleteAllForActivationPod(
     auth: Authenticator,
-    activationPodId: ModelId
+    activationPod: ActivationPodResource
   ): Promise<void> {
-    await this.model.update(
-      { activationPodId: null },
-      {
-        where: {
-          workspaceId: auth.getNonNullableWorkspace().id,
-          activationPodId,
-        },
+    await this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        activationPodId: activationPod.id,
+      },
+    });
+
+    if (activationPod.triggerId !== null) {
+      const [trigger] = await TriggerResource.fetchByModelIds(auth, [
+        activationPod.triggerId,
+      ]);
+      if (trigger) {
+        const deleteTriggerRes = await trigger.delete(auth);
+        if (deleteTriggerRes.isErr()) {
+          throw deleteTriggerRes.error;
+        }
       }
-    );
+    }
   }
 
   async updateFields(fields: {

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -28,6 +28,8 @@ import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
 import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { MembershipInvitationModel } from "@app/lib/models/membership_invitation";
 import { SubscriptionModel } from "@app/lib/models/plan";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
+import { ActivationRecommendationResource } from "@app/lib/resources/activation_recommendation_resource";
 import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { AppResource } from "@app/lib/resources/app_resource";
@@ -256,6 +258,19 @@ export async function scrubSpaceActivity({
       spaceId: space.id,
     },
   });
+
+  // Delete recommendations made in this Pod and the Pod's own dedicated
+  // activation trigger before deleting the activation pod record below. The
+  // FK from activation_recommendations to activation_pods is
+  // `onDelete: "RESTRICT"`, so the recommendations must be removed first or
+  // the destroy below fails.
+  const activationPod = await ActivationPodResource.fetchBySpace(auth, space);
+  if (activationPod) {
+    await ActivationRecommendationResource.deleteAllForActivationPod(
+      auth,
+      activationPod
+    );
+  }
 
   // Delete the activation pod record for this space. The FK to spaces is
   // `onDelete: "RESTRICT"`, so this row must be removed before the space


### PR DESCRIPTION
## Description

When a Pod is permanently deleted, `scrubSpaceActivity` cleaned up the pod's activation nudges and the `ActivationPodModel` record, but left two things behind:

- Recommendations still pointing at the pod via `activationPodId`, which is a `RESTRICT` foreign key — deleting a pod with any recommendation attached would fail with a foreign key violation. `ActivationRecommendationResource.detachActivationPod` existed to null out that link but was never actually called anywhere.
- The pod's own dedicated activation trigger, which was only implicitly cleaned up as part of the pod's webhook source view teardown, with no explicit handling.

This PR replaces `detachActivationPod` with `ActivationRecommendationResource.deleteAllForActivationPod`, which now takes the full `ActivationPodResource` and handles both cleanup steps: it deletes the recommendation rows instead of unlinking them, and deletes the pod's dedicated activation trigger (via `TriggerResource.delete`, which also tears down its Temporal workflow) — all before the pod record is removed.

## Tests

Verified with `tsgo --noEmit` and `biome check` on the changed files; no functional test added.
