### PR TITLE
Fix unhandled API error in datasource handleSearch

### DIFF
--- a/front/lib/api/search.ts
+++ b/front/lib/api/search.ts
@@ -135,9 +135,16 @@ export async function handleSearch(
     spacesToSearch
   );
 
-  // If we don't have any data source views, we return an empty result without
-  // failing, allowing the caller to still use other search sources
-  if (!allDatasourceViews.length) {
+  const filteredDatasourceViews = dataSourceViewIdsBySpaceId
+    ? allDatasourceViews.filter((dsv) =>
+        dataSourceViewIdsBySpaceId[dsv.space.sId]?.includes(dsv.sId)
+      )
+    : allDatasourceViews;
+
+  // If we don't have any data source views (none in the workspace,
+  // or none after filtering), we return an empty result without
+  // failing, allowing the caller to still use other search sources.
+  if (!filteredDatasourceViews.length) {
     return new Ok({
       nodes: [],
       resultsCount: 0,
@@ -145,12 +152,6 @@ export async function handleSearch(
       nextPageCursor: null,
     });
   }
-
-  const filteredDatasourceViews = dataSourceViewIdsBySpaceId
-    ? allDatasourceViews.filter((dsv) =>
-        dataSourceViewIdsBySpaceId[dsv.space.sId]?.includes(dsv.sId)
-      )
-    : allDatasourceViews;
 
   const excludedNodeMimeTypes = [
     ...(nodeIds || searchSourceUrls ? [] : NON_SEARCHABLE_NODES_MIME_TYPES),


### PR DESCRIPTION
## Description

We have this unhandled API error on `/api/w/:wId/search`

```
  Error: Must have at least one datasource
      at getSearchFilterFromDataSourceViews (/app/front/lib/search.ts:121:11)
      at handleSearch (/app/front/lib/api/search.ts:162:27)
```

This fix prevent sending empty datasource view array to getSearchFilterFromDataSourceViews which throws.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
