### PR TITLE
Add the agent message consumption attribution data model

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -23,6 +23,7 @@ import {
   GlobalAgentSettingsModel,
 } from "@app/lib/models/agent/agent";
 import { AgentDataRetentionModel } from "@app/lib/models/agent/agent_data_retention";
+import { AgentMessageConsumptionItemModel } from "@app/lib/models/agent/agent_message_consumption_item";
 import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import { AgentSuggestionModel } from "@app/lib/models/agent/agent_suggestion";
@@ -239,6 +240,7 @@ export function loadAllModels() {
     AgentStepContentModel,
     AgentMCPActionModel,
     AgentMCPActionOutputItemModel,
+    AgentMessageConsumptionItemModel,
     AgentStepContentToolExecutionModel,
     AgentChildAgentConfigurationModel,
     FeatureFlagModel,

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -2,6 +2,7 @@ import { hardDeleteDataSource } from "@app/lib/api/data_sources";
 import { deleteOwnerPolicy } from "@app/lib/api/sandbox/egress_policy";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { AgentMessageConsumptionItemModel } from "@app/lib/models/agent/agent_message_consumption_item";
 import { AgentSuggestionModel } from "@app/lib/models/agent/agent_suggestion";
 import {
   AgentMessageFeedbackModel,
@@ -228,6 +229,13 @@ export async function destroyConversation(
       const contentFragmentIds = removeNulls(
         messagesChunk.map((m) => m.contentFragmentId)
       );
+
+      await AgentMessageConsumptionItemModel.destroy({
+        where: {
+          workspaceId: owner.id,
+          agentMessageId: agentMessageIds,
+        },
+      });
 
       await destroyActionsRelatedResources(auth, agentMessageIds);
 

--- a/front/lib/models/agent/agent_message_consumption_item.ts
+++ b/front/lib/models/agent/agent_message_consumption_item.ts
@@ -183,11 +183,6 @@ AgentMessageConsumptionItemModel.init(
       },
       {
         concurrently: true,
-        fields: ["workspaceId", "conversationId", "agentMessageId"],
-        name: "agent_message_consumption_items_conversation_message",
-      },
-      {
-        concurrently: true,
         fields: ["conversationId"],
       },
       {
@@ -238,23 +233,5 @@ AgentMessageModel.hasMany(AgentMessageConsumptionItemModel, {
 });
 AgentMessageConsumptionItemModel.belongsTo(AgentMessageModel, {
   foreignKey: { name: "agentMessageId", allowNull: false },
-  onDelete: "RESTRICT",
-});
-
-RunUsageModel.hasMany(AgentMessageConsumptionItemModel, {
-  foreignKey: { name: "runUsageId", allowNull: true },
-  onDelete: "RESTRICT",
-});
-AgentMessageConsumptionItemModel.belongsTo(RunUsageModel, {
-  foreignKey: { name: "runUsageId", allowNull: true },
-  onDelete: "RESTRICT",
-});
-
-AgentMCPActionModel.hasMany(AgentMessageConsumptionItemModel, {
-  foreignKey: { name: "agentMCPActionId", allowNull: true },
-  onDelete: "RESTRICT",
-});
-AgentMessageConsumptionItemModel.belongsTo(AgentMCPActionModel, {
-  foreignKey: { name: "agentMCPActionId", allowNull: true },
   onDelete: "RESTRICT",
 });

--- a/front/lib/models/agent/agent_message_consumption_item.ts
+++ b/front/lib/models/agent/agent_message_consumption_item.ts
@@ -1,0 +1,254 @@
+import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
+import {
+  AgentMessageModel,
+  ConversationModel,
+} from "@app/lib/models/agent/conversation";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
+import { RunUsageModel } from "@app/lib/resources/storage/models/runs";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import {
+  AGENT_MESSAGE_CONSUMPTION_ITEM_TYPES,
+  type AgentMessageConsumptionItemType,
+} from "@app/types/assistant/agent_message_consumption";
+import type { CreationOptional, ForeignKey } from "sequelize";
+import { Op } from "sequelize";
+
+function validateConsumptionItemShape(
+  this: AgentMessageConsumptionItemModel
+): void {
+  const isTool = this.itemType === "tool";
+
+  if (isTool && this.agentMCPActionId === null) {
+    throw new Error("Tool attribution items require an agent MCP action");
+  }
+  if (!isTool && this.runUsageId === null) {
+    throw new Error("Non-tool attribution items require a run usage");
+  }
+  if (!isTool && this.agentMCPActionId !== null) {
+    throw new Error("Only tool attribution items may reference an action");
+  }
+  if (!isTool && this.directCreditAmountMicro !== null) {
+    throw new Error("Only tool attribution items may contain direct credits");
+  }
+  if (
+    this.directCreditAmountMicro !== null &&
+    this.grossAttributedCreditAmountMicro < this.directCreditAmountMicro
+  ) {
+    throw new Error("Gross attributed credits cannot be below direct credits");
+  }
+
+  switch (this.itemType) {
+    case "system":
+    case "input":
+      if (this.outputTokensCount !== null) {
+        throw new Error(`${this.itemType} items cannot contain output tokens`);
+      }
+      break;
+    case "output":
+    case "reasoning":
+      if (this.inputTokensCount !== null) {
+        throw new Error(`${this.itemType} items cannot contain input tokens`);
+      }
+      break;
+    case "tool":
+      break;
+  }
+}
+
+export class AgentMessageConsumptionItemModel extends WorkspaceAwareModel<AgentMessageConsumptionItemModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare conversationId: ForeignKey<ConversationModel["id"]>;
+  declare agentMessageId: ForeignKey<AgentMessageModel["id"]>;
+  declare runUsageId: ForeignKey<RunUsageModel["id"]> | null;
+  declare agentMCPActionId: ForeignKey<AgentMCPActionModel["id"]> | null;
+  declare itemKey: string;
+  declare itemType: AgentMessageConsumptionItemType;
+  declare attributionVersion: number;
+  declare inputTokensCount: number | null;
+  declare outputTokensCount: number | null;
+  declare grossAttributedCreditAmountMicro: number;
+  declare directCreditAmountMicro: number | null;
+  declare completedAt: Date | null;
+}
+
+AgentMessageConsumptionItemModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    conversationId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      references: {
+        model: ConversationModel,
+        key: "id",
+      },
+    },
+    agentMessageId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      references: {
+        model: AgentMessageModel,
+        key: "id",
+      },
+    },
+    runUsageId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+      references: {
+        model: RunUsageModel,
+        key: "id",
+      },
+    },
+    agentMCPActionId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+      references: {
+        model: AgentMCPActionModel,
+        key: "id",
+      },
+    },
+    itemKey: {
+      type: DataTypes.STRING(256),
+      allowNull: false,
+    },
+    itemType: {
+      type: DataTypes.STRING(32),
+      allowNull: false,
+      validate: {
+        isIn: [AGENT_MESSAGE_CONSUMPTION_ITEM_TYPES],
+      },
+    },
+    attributionVersion: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      validate: { min: 1 },
+    },
+    inputTokensCount: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      validate: { min: 0 },
+    },
+    outputTokensCount: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      validate: { min: 0 },
+    },
+    grossAttributedCreditAmountMicro: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      validate: { min: 0 },
+    },
+    directCreditAmountMicro: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+      validate: { min: 0 },
+    },
+    completedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+  },
+  {
+    sequelize: frontSequelize,
+    modelName: "agent_message_consumption_item",
+    tableName: "agent_message_consumption_items",
+    indexes: [
+      {
+        unique: true,
+        concurrently: true,
+        fields: [
+          "workspaceId",
+          "agentMessageId",
+          "attributionVersion",
+          "itemKey",
+        ],
+        name: "agent_message_consumption_items_message_version_key",
+      },
+      {
+        concurrently: true,
+        fields: ["workspaceId", "conversationId", "agentMessageId"],
+        name: "agent_message_consumption_items_conversation_message",
+      },
+      {
+        concurrently: true,
+        fields: ["conversationId"],
+      },
+      {
+        concurrently: true,
+        fields: ["agentMessageId"],
+      },
+      {
+        concurrently: true,
+        fields: ["runUsageId"],
+      },
+      {
+        concurrently: true,
+        fields: ["agentMCPActionId"],
+      },
+      {
+        unique: true,
+        concurrently: true,
+        fields: ["workspaceId", "attributionVersion", "agentMCPActionId"],
+        where: { agentMCPActionId: { [Op.ne]: null } },
+        name: "agent_message_consumption_items_unique_action",
+      },
+      {
+        unique: true,
+        concurrently: true,
+        fields: ["workspaceId", "attributionVersion", "runUsageId", "itemType"],
+        where: { agentMCPActionId: null },
+        name: "agent_message_consumption_items_unique_run_item_type",
+      },
+    ],
+    validate: {
+      validConsumptionItemShape: validateConsumptionItemShape,
+    },
+  }
+);
+
+ConversationModel.hasMany(AgentMessageConsumptionItemModel, {
+  foreignKey: { name: "conversationId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+AgentMessageConsumptionItemModel.belongsTo(ConversationModel, {
+  foreignKey: { name: "conversationId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+
+AgentMessageModel.hasMany(AgentMessageConsumptionItemModel, {
+  foreignKey: { name: "agentMessageId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+AgentMessageConsumptionItemModel.belongsTo(AgentMessageModel, {
+  foreignKey: { name: "agentMessageId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+
+RunUsageModel.hasMany(AgentMessageConsumptionItemModel, {
+  foreignKey: { name: "runUsageId", allowNull: true },
+  onDelete: "RESTRICT",
+});
+AgentMessageConsumptionItemModel.belongsTo(RunUsageModel, {
+  foreignKey: { name: "runUsageId", allowNull: true },
+  onDelete: "RESTRICT",
+});
+
+AgentMCPActionModel.hasMany(AgentMessageConsumptionItemModel, {
+  foreignKey: { name: "agentMCPActionId", allowNull: true },
+  onDelete: "RESTRICT",
+});
+AgentMessageConsumptionItemModel.belongsTo(AgentMCPActionModel, {
+  foreignKey: { name: "agentMCPActionId", allowNull: true },
+  onDelete: "RESTRICT",
+});

--- a/front/lib/models/agent/agent_message_consumption_item.ts
+++ b/front/lib/models/agent/agent_message_consumption_item.ts
@@ -11,7 +11,7 @@ import {
   AGENT_MESSAGE_CONSUMPTION_ITEM_TYPES,
   type AgentMessageConsumptionItemType,
 } from "@app/types/assistant/agent_message_consumption";
-import { assertNever } from "@dust-tt/client";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { CreationOptional, ForeignKey } from "sequelize";
 import { Op } from "sequelize";
 

--- a/front/lib/models/agent/agent_message_consumption_item.ts
+++ b/front/lib/models/agent/agent_message_consumption_item.ts
@@ -11,6 +11,7 @@ import {
   AGENT_MESSAGE_CONSUMPTION_ITEM_TYPES,
   type AgentMessageConsumptionItemType,
 } from "@app/types/assistant/agent_message_consumption";
+import { assertNever } from "@dust-tt/client";
 import type { CreationOptional, ForeignKey } from "sequelize";
 import { Op } from "sequelize";
 
@@ -45,14 +46,19 @@ function validateConsumptionItemShape(
         throw new Error(`${this.itemType} items cannot contain output tokens`);
       }
       break;
+
     case "output":
     case "reasoning":
       if (this.inputTokensCount !== null) {
         throw new Error(`${this.itemType} items cannot contain input tokens`);
       }
       break;
+
     case "tool":
       break;
+
+    default:
+      assertNever(this.itemType);
   }
 }
 

--- a/front/lib/models/agent/agent_message_consumption_item.ts
+++ b/front/lib/models/agent/agent_message_consumption_item.ts
@@ -1,16 +1,15 @@
-import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import {
   AgentMessageModel,
   ConversationModel,
 } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
-import { RunUsageModel } from "@app/lib/resources/storage/models/runs";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import {
   AGENT_MESSAGE_CONSUMPTION_ITEM_TYPES,
   type AgentMessageConsumptionItemType,
 } from "@app/types/assistant/agent_message_consumption";
+import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { CreationOptional, ForeignKey } from "sequelize";
 import { Op } from "sequelize";
@@ -68,8 +67,8 @@ export class AgentMessageConsumptionItemModel extends WorkspaceAwareModel<AgentM
 
   declare conversationId: ForeignKey<ConversationModel["id"]>;
   declare agentMessageId: ForeignKey<AgentMessageModel["id"]>;
-  declare runUsageId: ForeignKey<RunUsageModel["id"]> | null;
-  declare agentMCPActionId: ForeignKey<AgentMCPActionModel["id"]> | null;
+  declare runUsageId: ModelId | null;
+  declare agentMCPActionId: ModelId | null;
   declare itemKey: string;
   declare itemType: AgentMessageConsumptionItemType;
   declare attributionVersion: number;
@@ -111,18 +110,10 @@ AgentMessageConsumptionItemModel.init(
     runUsageId: {
       type: DataTypes.BIGINT,
       allowNull: true,
-      references: {
-        model: RunUsageModel,
-        key: "id",
-      },
     },
     agentMCPActionId: {
       type: DataTypes.BIGINT,
       allowNull: true,
-      references: {
-        model: AgentMCPActionModel,
-        key: "id",
-      },
     },
     itemKey: {
       type: DataTypes.STRING(256),
@@ -188,14 +179,6 @@ AgentMessageConsumptionItemModel.init(
       {
         concurrently: true,
         fields: ["agentMessageId"],
-      },
-      {
-        concurrently: true,
-        fields: ["runUsageId"],
-      },
-      {
-        concurrently: true,
-        fields: ["agentMCPActionId"],
       },
       {
         unique: true,

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -3,6 +3,7 @@ import { loadAllModels } from "@app/admin/db";
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
+import { AgentMessageConsumptionItemModel } from "@app/lib/models/agent/agent_message_consumption_item";
 import {
   AgentMessageModel,
   ConversationModel,
@@ -757,6 +758,7 @@ describe("destroyConversation", () => {
   });
 
   it("should delete MCP actions with a missing step content link", async () => {
+    mockDeleteOwnerPolicy.mockResolvedValue(new Ok(undefined));
     const conversationType = await ConversationFactory.create(auth, {
       agentConfigurationId,
       messagesCreatedAt: [new Date()],
@@ -806,7 +808,7 @@ describe("destroyConversation", () => {
       mcpServerName: "test_server",
     };
 
-    await AgentMCPActionModel.create({
+    const action = await AgentMCPActionModel.create({
       workspaceId: auth.getNonNullableWorkspace().id,
       agentMessageId,
       mcpServerConfigurationId: generateRandomModelSId(),
@@ -823,11 +825,35 @@ describe("destroyConversation", () => {
       },
     });
 
+    await AgentMessageConsumptionItemModel.create({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      conversationId: conversation.id,
+      agentMessageId,
+      runUsageId: null,
+      agentMCPActionId: action.id,
+      itemKey: `tool-action:${action.id}`,
+      itemType: "tool",
+      attributionVersion: 1,
+      inputTokensCount: null,
+      outputTokensCount: null,
+      grossAttributedCreditAmountMicro: 0,
+      directCreditAmountMicro: null,
+      completedAt: null,
+    });
+
     const result = await destroyConversation(auth, { conversation });
 
     expect(result.isOk()).toBe(true);
     await expect(
       AgentMCPActionModel.count({
+        where: {
+          agentMessageId,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+      })
+    ).resolves.toBe(0);
+    await expect(
+      AgentMessageConsumptionItemModel.count({
         where: {
           agentMessageId,
           workspaceId: auth.getNonNullableWorkspace().id,
@@ -7171,6 +7197,7 @@ describe("ConversationResource.listConversationsInSpacePaginated", () => {
 });
 
 const KNOWN_CONVERSATION_RELATED_MODELS = [
+  "agent_message_consumption_item",
   "agent_message_skills",
   "agent_message_feedback",
   "agent_step_content_tool_execution",

--- a/front/migrations/pre-deploy/20260728223702_add_agent_message_consumption_items.sql
+++ b/front/migrations/pre-deploy/20260728223702_add_agent_message_consumption_items.sql
@@ -51,10 +51,6 @@ CREATE UNIQUE INDEX CONCURRENTLY agent_message_consumption_items_message_version
 
 SET SESSION statement_timeout = 1200000;
 SET SESSION lock_timeout = 3000;
-CREATE INDEX CONCURRENTLY agent_message_consumption_items_conversation_message ON public.agent_message_consumption_items USING btree ("workspaceId", "conversationId", "agentMessageId");
-
-SET SESSION statement_timeout = 1200000;
-SET SESSION lock_timeout = 3000;
 CREATE INDEX CONCURRENTLY agent_message_consumption_items_conversation_id ON public.agent_message_consumption_items USING btree ("conversationId");
 
 SET SESSION statement_timeout = 1200000;
@@ -104,19 +100,3 @@ ALTER TABLE "public"."agent_message_consumption_items" ADD CONSTRAINT "agent_mes
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
 ALTER TABLE "public"."agent_message_consumption_items" VALIDATE CONSTRAINT "agent_message_consumption_items_agentMessageId_fkey";
-
-SET SESSION statement_timeout = 3000;
-SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."agent_message_consumption_items" ADD CONSTRAINT "agent_message_consumption_items_runUsageId_fkey" FOREIGN KEY ("runUsageId") REFERENCES run_usages(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
-
-SET SESSION statement_timeout = 3000;
-SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."agent_message_consumption_items" VALIDATE CONSTRAINT "agent_message_consumption_items_runUsageId_fkey";
-
-SET SESSION statement_timeout = 3000;
-SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."agent_message_consumption_items" ADD CONSTRAINT "agent_message_consumption_items_agentMCPActionId_fkey" FOREIGN KEY ("agentMCPActionId") REFERENCES agent_mcp_actions(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
-
-SET SESSION statement_timeout = 3000;
-SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."agent_message_consumption_items" VALIDATE CONSTRAINT "agent_message_consumption_items_agentMCPActionId_fkey";

--- a/front/migrations/pre-deploy/20260728223702_add_agent_message_consumption_items.sql
+++ b/front/migrations/pre-deploy/20260728223702_add_agent_message_consumption_items.sql
@@ -1,0 +1,122 @@
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE SEQUENCE "public"."agent_message_consumption_items_id_seq"
+	AS bigint
+	INCREMENT BY 1
+	MINVALUE 1 MAXVALUE 9223372036854775807
+	START WITH 1 CACHE 1 NO CYCLE
+;
+
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE TABLE "public"."agent_message_consumption_items" (
+	"id" bigint DEFAULT nextval('agent_message_consumption_items_id_seq'::regclass) NOT NULL,
+	"workspaceId" bigint NOT NULL,
+	"conversationId" bigint NOT NULL,
+	"agentMessageId" bigint NOT NULL,
+	"runUsageId" bigint,
+	"agentMCPActionId" bigint,
+	"itemKey" character varying(256) COLLATE "pg_catalog"."default" NOT NULL,
+	"itemType" character varying(32) COLLATE "pg_catalog"."default" NOT NULL,
+	"attributionVersion" integer NOT NULL,
+	"inputTokensCount" integer,
+	"outputTokensCount" integer,
+	"grossAttributedCreditAmountMicro" bigint NOT NULL,
+	"directCreditAmountMicro" bigint,
+	"completedAt" timestamp with time zone,
+	"createdAt" timestamp with time zone NOT NULL,
+	"updatedAt" timestamp with time zone NOT NULL,
+	CONSTRAINT "agent_message_consumption_items_type_check" CHECK ("itemType" IN ('system', 'input', 'output', 'reasoning', 'tool')),
+	CONSTRAINT "agent_message_consumption_items_version_check" CHECK ("attributionVersion" >= 1),
+	CONSTRAINT "agent_message_consumption_items_input_tokens_check" CHECK ("inputTokensCount" IS NULL OR "inputTokensCount" >= 0),
+	CONSTRAINT "agent_message_consumption_items_output_tokens_check" CHECK ("outputTokensCount" IS NULL OR "outputTokensCount" >= 0),
+	CONSTRAINT "agent_message_consumption_items_gross_credits_check" CHECK ("grossAttributedCreditAmountMicro" >= 0),
+	CONSTRAINT "agent_message_consumption_items_direct_credits_check" CHECK ("directCreditAmountMicro" IS NULL OR "directCreditAmountMicro" >= 0),
+	CONSTRAINT "agent_message_consumption_items_reference_shape_check" CHECK (("itemType" = 'tool' AND "agentMCPActionId" IS NOT NULL) OR ("itemType" <> 'tool' AND "runUsageId" IS NOT NULL AND "agentMCPActionId" IS NULL)),
+	CONSTRAINT "agent_message_consumption_items_direct_shape_check" CHECK ("directCreditAmountMicro" IS NULL OR ("itemType" = 'tool' AND "grossAttributedCreditAmountMicro" >= "directCreditAmountMicro")),
+	CONSTRAINT "agent_message_consumption_items_token_shape_check" CHECK (("itemType" IN ('system', 'input') AND "outputTokensCount" IS NULL) OR ("itemType" IN ('output', 'reasoning') AND "inputTokensCount" IS NULL) OR "itemType" = 'tool')
+);
+
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY agent_message_consumption_items_pkey ON public.agent_message_consumption_items USING btree (id);
+
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_message_consumption_items" ADD CONSTRAINT "agent_message_consumption_items_pkey" PRIMARY KEY USING INDEX "agent_message_consumption_items_pkey";
+
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY agent_message_consumption_items_message_version_key ON public.agent_message_consumption_items USING btree ("workspaceId", "agentMessageId", "attributionVersion", "itemKey");
+
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY agent_message_consumption_items_conversation_message ON public.agent_message_consumption_items USING btree ("workspaceId", "conversationId", "agentMessageId");
+
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY agent_message_consumption_items_conversation_id ON public.agent_message_consumption_items USING btree ("conversationId");
+
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY agent_message_consumption_items_agent_message_id ON public.agent_message_consumption_items USING btree ("agentMessageId");
+
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY agent_message_consumption_items_run_usage_id ON public.agent_message_consumption_items USING btree ("runUsageId");
+
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY agent_message_consumption_items_agent_m_c_p_action_id ON public.agent_message_consumption_items USING btree ("agentMCPActionId");
+
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY agent_message_consumption_items_unique_action ON public.agent_message_consumption_items USING btree ("workspaceId", "attributionVersion", "agentMCPActionId") WHERE "agentMCPActionId" IS NOT NULL;
+
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY agent_message_consumption_items_unique_run_item_type ON public.agent_message_consumption_items USING btree ("workspaceId", "attributionVersion", "runUsageId", "itemType") WHERE "agentMCPActionId" IS NULL;
+
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER SEQUENCE "public"."agent_message_consumption_items_id_seq" OWNED BY "public"."agent_message_consumption_items"."id";
+
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_message_consumption_items" ADD CONSTRAINT "agent_message_consumption_items_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES workspaces(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_message_consumption_items" VALIDATE CONSTRAINT "agent_message_consumption_items_workspaceId_fkey";
+
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_message_consumption_items" ADD CONSTRAINT "agent_message_consumption_items_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES conversations(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_message_consumption_items" VALIDATE CONSTRAINT "agent_message_consumption_items_conversationId_fkey";
+
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_message_consumption_items" ADD CONSTRAINT "agent_message_consumption_items_agentMessageId_fkey" FOREIGN KEY ("agentMessageId") REFERENCES agent_messages(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_message_consumption_items" VALIDATE CONSTRAINT "agent_message_consumption_items_agentMessageId_fkey";
+
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_message_consumption_items" ADD CONSTRAINT "agent_message_consumption_items_runUsageId_fkey" FOREIGN KEY ("runUsageId") REFERENCES run_usages(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_message_consumption_items" VALIDATE CONSTRAINT "agent_message_consumption_items_runUsageId_fkey";
+
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_message_consumption_items" ADD CONSTRAINT "agent_message_consumption_items_agentMCPActionId_fkey" FOREIGN KEY ("agentMCPActionId") REFERENCES agent_mcp_actions(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_message_consumption_items" VALIDATE CONSTRAINT "agent_message_consumption_items_agentMCPActionId_fkey";

--- a/front/migrations/pre-deploy/20260728223702_add_agent_message_consumption_items.sql
+++ b/front/migrations/pre-deploy/20260728223702_add_agent_message_consumption_items.sql
@@ -25,16 +25,7 @@ CREATE TABLE "public"."agent_message_consumption_items" (
 	"directCreditAmountMicro" bigint,
 	"completedAt" timestamp with time zone,
 	"createdAt" timestamp with time zone NOT NULL,
-	"updatedAt" timestamp with time zone NOT NULL,
-	CONSTRAINT "agent_message_consumption_items_type_check" CHECK ("itemType" IN ('system', 'input', 'output', 'reasoning', 'tool')),
-	CONSTRAINT "agent_message_consumption_items_version_check" CHECK ("attributionVersion" >= 1),
-	CONSTRAINT "agent_message_consumption_items_input_tokens_check" CHECK ("inputTokensCount" IS NULL OR "inputTokensCount" >= 0),
-	CONSTRAINT "agent_message_consumption_items_output_tokens_check" CHECK ("outputTokensCount" IS NULL OR "outputTokensCount" >= 0),
-	CONSTRAINT "agent_message_consumption_items_gross_credits_check" CHECK ("grossAttributedCreditAmountMicro" >= 0),
-	CONSTRAINT "agent_message_consumption_items_direct_credits_check" CHECK ("directCreditAmountMicro" IS NULL OR "directCreditAmountMicro" >= 0),
-	CONSTRAINT "agent_message_consumption_items_reference_shape_check" CHECK (("itemType" = 'tool' AND "agentMCPActionId" IS NOT NULL) OR ("itemType" <> 'tool' AND "runUsageId" IS NOT NULL AND "agentMCPActionId" IS NULL)),
-	CONSTRAINT "agent_message_consumption_items_direct_shape_check" CHECK ("directCreditAmountMicro" IS NULL OR ("itemType" = 'tool' AND "grossAttributedCreditAmountMicro" >= "directCreditAmountMicro")),
-	CONSTRAINT "agent_message_consumption_items_token_shape_check" CHECK (("itemType" IN ('system', 'input') AND "outputTokensCount" IS NULL) OR ("itemType" IN ('output', 'reasoning') AND "inputTokensCount" IS NULL) OR "itemType" = 'tool')
+	"updatedAt" timestamp with time zone NOT NULL
 );
 
 SET SESSION statement_timeout = 1200000;
@@ -56,14 +47,6 @@ CREATE INDEX CONCURRENTLY agent_message_consumption_items_conversation_id ON pub
 SET SESSION statement_timeout = 1200000;
 SET SESSION lock_timeout = 3000;
 CREATE INDEX CONCURRENTLY agent_message_consumption_items_agent_message_id ON public.agent_message_consumption_items USING btree ("agentMessageId");
-
-SET SESSION statement_timeout = 1200000;
-SET SESSION lock_timeout = 3000;
-CREATE INDEX CONCURRENTLY agent_message_consumption_items_run_usage_id ON public.agent_message_consumption_items USING btree ("runUsageId");
-
-SET SESSION statement_timeout = 1200000;
-SET SESSION lock_timeout = 3000;
-CREATE INDEX CONCURRENTLY agent_message_consumption_items_agent_m_c_p_action_id ON public.agent_message_consumption_items USING btree ("agentMCPActionId");
 
 SET SESSION statement_timeout = 1200000;
 SET SESSION lock_timeout = 3000;

--- a/front/types/assistant/agent_message_consumption.ts
+++ b/front/types/assistant/agent_message_consumption.ts
@@ -1,0 +1,10 @@
+export const AGENT_MESSAGE_CONSUMPTION_ITEM_TYPES = [
+  "system",
+  "input",
+  "output",
+  "reasoning",
+  "tool",
+] as const;
+
+export type AgentMessageConsumptionItemType =
+  (typeof AGENT_MESSAGE_CONSUMPTION_ITEM_TYPES)[number];


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR introduces the PG data model for agent message consumption attribution. The broader design is
documented in the design [document](https://app.notion.com/p/dust-tt/Design-Doc-Credits-Observability-3aa28599d94180799f56c88dbd9983c4).

Dust already stores the authoritative billed value on `AgentMessage.costCredits`. That value remains the source of truth for billing, limits, Metronome events, fair-use accounting, and customer-facing totals. Consumption attribution is a separate explanatory layer that describes which recognizable parts of an execution contributed to that bill.

This PR deliberately contains only the DB schema. It does not materialize attribution, plumbing comes in a wave of follow up PRs.

## Intended write lifecycle

A tool attribution row must be created as soon as the model-emitted action exists, before the tool is executed.

>[!IMPORTANT]
> This ordering is important for tools that require approval. When the model emits such a tool call, the agent workflow creates the `AgentMCPAction`, marks the conversation as requiring action, and terminates the current workflow execution. The tool result does not exist yet, and execution may resume much later in a new workflow after the user approves or denies the action.

The first attribution pass will therefore create a pending tool row linked to both the emitting `RunUsage`, when available, and the `AgentMCPAction`. At that point, the row can capture the estimated model-output footprint of emitting the tool name and parameters. The row remains incomplete through `completedAt = NULL`.

When the tool eventually runs, a later attribution pass finds the same deterministic row and enriches it with the estimated input footprint of the result produced by the tool, the exact direct tool credit charge when one exists, and the final gross attributed credit amount. It then sets `completedAt`.

If the user denies the action, the same row can be completed without a tool-result footprint or direct execution charge. If execution is cancelled or evidence remains unavailable, the row stays incomplete. Readers can then return the exact billed total while withholding an incomplete detailed explanation.

A tool attribution row is created once and identified deterministically. Later Temporal executions may complete that same row as new evidence becomes available, but they never replace it or create another row for the same tool action. Once completed, the row is immutable.

## Data ownership

- `AgentMessage` continues to own the exact number of credits billed for the message.
- `RunUsage` continues to own provider-reported model usage, including provider and model identity, prompt tokens,
completion tokens, reasoning tokens, cache usage, batch status, and the model cost calculated from those facts.
- `AgentMCPAction` continues to own tool identity, execution status, configuration, and action provenance.
- `AgentMessageConsumptionItem` owns only the versioned semantic attribution of that existing usage to recognizable
work.

The new table intentionally does not copy provider identity, model identity, tool identity, tool arguments, tool results, prompts, or rendered model requests. Those facts remain available through their owning records.

## Item semantics

Each row represents one semantic contribution to an agent message. Supported item types are `system`, `input`, `output`, `reasoning`, and `tool`.

An `input` row represents model-input work assigned to general request and conversation processing. A system row is reserved for attribution versions that separately measure system instructions and tool definitions. First iteration is expected to fold those two elements into `input`.

An `output` row represents ordinary assistant `output`. A `reasoning` row represents `reasoning` tokens when the provider reports them separately.

A `tool` row represents one bill-relevant tool execution and is linked to exactly one `AgentMCPAction`. It combines all recognizable contributions associated with that execution into one product-level item.

On a `tool` row, `outputTokensCount` means the estimated model-output footprint used to emit the tool name and its parameters. **It does not mean the result returned by the tool.**

On a `tool` row, `inputTokensCount` means the estimated model-input footprint of the result produced by the tool execution. **It does not mean the tool parameters**.

This distinction follows the model boundary. Parameters are generated by the model and therefore belong to its output side. Tool results become potential model context and therefore belong to the input side.

A tool result footprint may exist even when no later model request consumes the result. It explains the compound footprint produced by that action. Later model calls independently record the input that was actually rendered for them.

## Credit fields and cache effects

`grossAttributedCreditAmountMicro` stores the estimated token footprint converted to credits without applying
cache effects. Materializing this value ensures PG reads and future Elasticsearch rebuilds do not need to rerun historical token pricing.

For tool rows, the gross amount includes both attributed model work and the exact direct execution charge when one exists.

`directCreditAmountMicro` stores that direct tool charge separately. This preserves the historical amount actually used when billing the message and lets analytics distinguish direct execution credits from attributed model work.

The attribution table does not store cache adjustments. Cache effectiveness is a message-level explanation derived by comparing the sum of gross attributed credits with the authoritative `AgentMessage.costCredits`. Attribution remains cache-naive, while the billed value reflects the actual cache behavior.

Missing evidence is represented by `NULL`, not zero. Zero means the contribution was measured and found to be empty. `NULL` means it was not observed or cannot yet be established.

## Idempotency and concurrency

`itemKey` provides deterministic identity within an agent message and attribution version. Future materializers
will use keys shaped as `run-usage:{runUsageId}:input`, `run-usage:{runUsageId}:output`, `run-usage:
{runUsageId}:reasoning`, and `tool-action:{agentMCPActionId}`.

The unique message, version, and item-key index makes repeated materialization safe across Temporal retries.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] Apply SQL migration
- [ ] Deploy front
