### PR TITLE
[front] fix: remove incorrect MCP description note

### DIFF
--- a/front/components/actions/mcp/create/MCPServerViewForm.tsx
+++ b/front/components/actions/mcp/create/MCPServerViewForm.tsx
@@ -34,9 +34,6 @@ export function MCPServerViewForm({ mcpServerView }: MCPServerViewFormProps) {
           message={form.formState.errors.description?.message}
           placeholder={getMcpServerViewDescription(mcpServerView)}
         />
-        <p className="text-xs text-primary-500">
-          This is only for internal reference and is not shown to the model.
-        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Description

The tools sheet in Spaces > Tools incorrectly says the tool's description is not shown to the model, even though the description is included in `constructToolsSection`.
Came to my attention while adding a checkbox here and analyzing the content of our system prompt.

This PR removes the incorrect note.

The one at the bottom here:
<img width="509" height="356" alt="image" src="https://github.com/user-attachments/assets/4ccf958e-94f2-4779-a9e7-0b671e8a9064" />

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
