### PR TITLE
Downgrade builder invitations to user on acceptance

### DIFF
--- a/front/lib/api/signup.test.ts
+++ b/front/lib/api/signup.test.ts
@@ -1,0 +1,146 @@
+import * as workosAudit from "@app/lib/api/audit/workos_audit";
+import { handleMembershipInvite } from "@app/lib/api/signup";
+import type { CachedContract } from "@app/lib/metronome/plan_type";
+import * as planType from "@app/lib/metronome/plan_type";
+import * as seatTypes from "@app/lib/metronome/seat_types";
+import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { MembershipInvitationFactory } from "@app/tests/utils/MembershipInvitationFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { MembershipSeatType } from "@app/types/memberships";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/plan_type", async () => {
+  const actual = await vi.importActual<typeof planType>(
+    "@app/lib/metronome/plan_type"
+  );
+  return { ...actual, getActiveContract: vi.fn() };
+});
+
+vi.mock("@app/lib/metronome/seat_types", async () => {
+  const actual = await vi.importActual<typeof seatTypes>(
+    "@app/lib/metronome/seat_types"
+  );
+  return { ...actual, getProductSeatTypes: vi.fn() };
+});
+
+vi.mock("@app/lib/api/audit/workos_audit", async () => {
+  const actual = await vi.importActual<typeof workosAudit>(
+    "@app/lib/api/audit/workos_audit"
+  );
+  return { ...actual, emitAuditLogEventDirect: vi.fn() };
+});
+
+vi.mock("@app/temporal/usage_queue/client", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/temporal/usage_queue/client")
+  >("@app/temporal/usage_queue/client");
+  return {
+    ...actual,
+    launchMetronomeSeatCountSyncWorkflow: vi.fn(),
+    launchUpdateUsageWorkflow: vi.fn(),
+  };
+});
+
+import {
+  launchMetronomeSeatCountSyncWorkflow,
+  launchUpdateUsageWorkflow,
+} from "@app/temporal/usage_queue/client";
+
+function setupEntitledSeats(seatTypeList: MembershipSeatType[]): void {
+  const contract = {
+    subscriptions: seatTypeList.map((seatType) => ({
+      subscription_rate: {
+        product: { id: `${seatType}-product`, name: seatType },
+      },
+    })),
+    recurring_credits: [],
+    overrides: seatTypeList.map((seatType) => ({
+      entitled: true,
+      product: { id: `${seatType}-product` },
+    })),
+  } as unknown as CachedContract;
+
+  const catalog = new Map<string, MembershipSeatType>(
+    seatTypeList.map((seatType) => [`${seatType}-product`, seatType])
+  );
+
+  vi.mocked(planType.getActiveContract).mockResolvedValue(contract);
+  vi.mocked(seatTypes.getProductSeatTypes).mockResolvedValue(catalog);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  vi.mocked(workosAudit.emitAuditLogEventDirect).mockResolvedValue(undefined);
+  vi.mocked(launchUpdateUsageWorkflow).mockResolvedValue(new Ok(undefined));
+  vi.mocked(launchMetronomeSeatCountSyncWorkflow).mockResolvedValue(
+    new Ok(undefined)
+  );
+  setupEntitledSeats(["free", "pro"]);
+});
+
+describe("handleMembershipInvite", () => {
+  it("downgrades a builder invitation to a user membership", async () => {
+    const workspace = await WorkspaceFactory.creditPricedFree();
+    const user = await UserFactory.basic();
+    await MembershipInvitationFactory.create(workspace, {
+      inviteEmail: user.email,
+      initialRole: "builder",
+    });
+    // Re-fetch so the invitation carries its workspace association.
+    const membershipInvite =
+      await MembershipInvitationResource.getPendingForEmailAndWorkspace({
+        email: user.email,
+        workspace: renderLightWorkspaceType({ workspace }),
+      });
+    expect(membershipInvite).not.toBeNull();
+
+    const result = await handleMembershipInvite({
+      user,
+      membershipInvite: membershipInvite!,
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    const membership =
+      await MembershipResource.getLatestMembershipOfUserInWorkspace({
+        user,
+        workspace: renderLightWorkspaceType({ workspace }),
+      });
+    expect(membership?.role).toBe("user");
+  });
+
+  it("preserves a non-builder invitation role", async () => {
+    const workspace = await WorkspaceFactory.creditPricedFree();
+    const user = await UserFactory.basic();
+    await MembershipInvitationFactory.create(workspace, {
+      inviteEmail: user.email,
+      initialRole: "admin",
+    });
+    // Re-fetch so the invitation carries its workspace association.
+    const membershipInvite =
+      await MembershipInvitationResource.getPendingForEmailAndWorkspace({
+        email: user.email,
+        workspace: renderLightWorkspaceType({ workspace }),
+      });
+    expect(membershipInvite).not.toBeNull();
+
+    const result = await handleMembershipInvite({
+      user,
+      membershipInvite: membershipInvite!,
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    const membership =
+      await MembershipResource.getLatestMembershipOfUserInWorkspace({
+        user,
+        workspace: renderLightWorkspaceType({ workspace }),
+      });
+    expect(membership?.role).toBe("admin");
+  });
+});

--- a/front/lib/api/signup.ts
+++ b/front/lib/api/signup.ts
@@ -19,7 +19,16 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import type { LightWorkspaceType } from "@app/types/user";
+import type { ActiveRoleType, LightWorkspaceType } from "@app/types/user";
+
+// The `builder` role is deprecated: it can only be granted through the `dust-builders` provisioning
+// group, never through invitations. Any pending or legacy `builder` invitation resolves to a
+// regular `user` membership when accepted.
+function membershipRoleForInvitation(
+  initialRole: ActiveRoleType
+): ActiveRoleType {
+  return initialRole === "builder" ? "user" : initialRole;
+}
 
 // `membershipInvite` flow: we know we can add the user to the associated `workspaceId` as all the
 // checks (decoding the JWT) have been run before. Simply create the membership if it does not
@@ -85,7 +94,7 @@ export async function handleMembershipInvite({
     const updateRes = await updateMembershipRoleAndTrack({
       user,
       workspace: lightWorkspace,
-      newRole: membershipInvite.initialRole,
+      newRole: membershipRoleForInvitation(membershipInvite.initialRole),
       allowTerminated: true,
       author: "no-author",
     });
@@ -104,7 +113,7 @@ export async function handleMembershipInvite({
     await createAndTrackMembership({
       workspace: lightWorkspace,
       user,
-      role: membershipInvite.initialRole,
+      role: membershipRoleForInvitation(membershipInvite.initialRole),
       origin: "invited",
       requestedSeatType: membershipInvite.seatType,
     });
@@ -161,7 +170,9 @@ export async function handleEnterpriseSignUpFlow(
     await createAndTrackMembership({
       workspace: lightWorkspace,
       user,
-      role: pendingMembershipInvitation?.initialRole ?? "user",
+      role: membershipRoleForInvitation(
+        pendingMembershipInvitation?.initialRole ?? "user"
+      ),
       origin: pendingMembershipInvitation ? "invited" : "auto-joined",
       requestedSeatType: pendingMembershipInvitation?.seatType ?? null,
     });


### PR DESCRIPTION
## Description

The `builder` role is deprecated and, going forward, is meant to be granted **only** through the `dust-builders` provisioning group (`determineUserRoleFromGroups`). Invitations should no longer confer it.

`front/lib/api/signup.ts` now maps `builder` → `user` at the invitation-acceptance chokepoint, so any pending or legacy `builder` invitation resolves to a regular `user` membership when accepted — in both `handleMembershipInvite` (standard flow) and `handleEnterpriseSignUpFlow` (enterprise flow). The mapping is confined to the acceptance path, so the `dust-builders` provisioning group still grants `builder`.

Adds `front/lib/api/signup.test.ts` covering the builder→user downgrade and the non-builder passthrough.

### Note: is provisioning the only path now?

Not fully. After this PR, the paths that can still produce a `builder` membership are:
- **`dust-builders` provisioning group** — the intended path (unchanged).
- **Invitation create API** (`PostInvitationRequestBodySchema` accepts `ActiveRoleSchema`) and **member role-update API** (`members/[uId]` validates via `isMembershipRoleType`) still accept `builder` server-side, even though the UI role dropdown no longer offers it.

Tightening those two API schemas would be a natural follow-up if we want provisioning to be the *sole* path. This PR only closes the invitation-acceptance path.

## Risks

Risk: low. Behavior change affects only the deprecated `builder` role on invitation acceptance.

## Verification

- `tsgo --noEmit` clean in `front`.
- `npm run format:changed` clean.
- `front/lib/api/signup.test.ts` — 2 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)