### PR TITLE
Add user memory API and per-user toggle

### DIFF
--- a/front-api/routes/w/[wId]/me/index.ts
+++ b/front-api/routes/w/[wId]/me/index.ts
@@ -1,6 +1,7 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
 
 import approvals from "./approvals";
+import memory from "./memory";
 import pendingInvitations from "./pending-invitations";
 import slackNotifications from "./slack-notifications";
 import triggers from "./triggers";
@@ -9,6 +10,7 @@ import triggers from "./triggers";
 const app = workspaceApp();
 
 app.route("/approvals", approvals);
+app.route("/memory", memory);
 app.route("/pending-invitations", pendingInvitations);
 app.route("/slack-notifications", slackNotifications);
 app.route("/triggers", triggers);

--- a/front-api/routes/w/[wId]/me/memory.test.ts
+++ b/front-api/routes/w/[wId]/me/memory.test.ts
@@ -1,0 +1,185 @@
+import { DustFileSystemError } from "@app/lib/api/file_system/dust_file_system";
+import {
+  getUserMemory,
+  MAX_USER_MEMORY_CHARS,
+  setUserMemory,
+} from "@app/lib/api/user_memory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import {
+  GetUserMemoryResponseBodySchema,
+  PatchUserMemoryResponseBodySchema,
+} from "@app/types/api/me/memory";
+import { Err, Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+const ApiErrorSchema = z.object({
+  error: z.object({
+    type: z.string(),
+  }),
+});
+
+// The content is read/written through GCS via DustFileSystem.forUser, so mock
+// those two functions. The enabled flag lives in user metadata and runs for
+// real against the test DB.
+vi.mock(import("@app/lib/api/user_memory"), async (orig) => {
+  const mod = await orig();
+  return {
+    ...mod,
+    getUserMemory: vi.fn(),
+    setUserMemory: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.mocked(getUserMemory).mockResolvedValue(new Ok(""));
+  vi.mocked(setUserMemory).mockResolvedValue(new Ok(undefined));
+});
+
+function getMemory(wId: string) {
+  return honoApp.request(`/api/w/${wId}/me/memory`);
+}
+
+function patchMemory(wId: string, body: Record<string, unknown>) {
+  return honoApp.request(`/api/w/${wId}/me/memory`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function setup() {
+  const res = await createPrivateApiMockRequest();
+  await FeatureFlagFactory.basic(res.auth, "user_memory");
+  return res;
+}
+
+describe("feature flag gating", () => {
+  it("returns 403 when user_memory is disabled", async () => {
+    const { workspace } = await createPrivateApiMockRequest();
+
+    const response = await getMemory(workspace.sId);
+
+    expect(response.status).toBe(403);
+    const data = ApiErrorSchema.parse(await response.json());
+    expect(data.error.type).toBe("feature_flag_not_found");
+  });
+});
+
+describe("GET /api/w/:wId/me/memory", () => {
+  it("returns the user's memory content and enabled flag", async () => {
+    vi.mocked(getUserMemory).mockResolvedValue(new Ok("remember this"));
+    const { workspace } = await setup();
+
+    const response = await getMemory(workspace.sId);
+
+    expect(response.status).toBe(200);
+    const data = GetUserMemoryResponseBodySchema.parse(await response.json());
+    expect(data.content).toBe("remember this");
+    expect(data.enabled).toBe(true);
+  });
+
+  it("returns empty content when memory does not exist yet", async () => {
+    const { workspace } = await setup();
+
+    const response = await getMemory(workspace.sId);
+
+    expect(response.status).toBe(200);
+    const data = GetUserMemoryResponseBodySchema.parse(await response.json());
+    expect(data.content).toBe("");
+  });
+
+  it("maps a filesystem error to a 500", async () => {
+    vi.mocked(getUserMemory).mockResolvedValue(
+      new Err(new DustFileSystemError("internal", "boom"))
+    );
+    const { workspace } = await setup();
+
+    const response = await getMemory(workspace.sId);
+
+    expect(response.status).toBe(500);
+    const data = ApiErrorSchema.parse(await response.json());
+    expect(data.error.type).toBe("internal_server_error");
+  });
+});
+
+describe("PATCH /api/w/:wId/me/memory", () => {
+  it("saves the provided content", async () => {
+    const { workspace } = await setup();
+
+    const response = await patchMemory(workspace.sId, {
+      content: "new memory",
+    });
+
+    expect(response.status).toBe(200);
+    const data = PatchUserMemoryResponseBodySchema.parse(await response.json());
+    expect(data.content).toBe("new memory");
+    expect(setUserMemory).toHaveBeenCalledWith(expect.anything(), "new memory");
+  });
+
+  it("returns 400 when content exceeds the size limit", async () => {
+    const { workspace } = await setup();
+
+    const response = await patchMemory(workspace.sId, {
+      content: "a".repeat(MAX_USER_MEMORY_CHARS + 1),
+    });
+
+    expect(response.status).toBe(400);
+    const data = ApiErrorSchema.parse(await response.json());
+    expect(data.error.type).toBe("invalid_request_error");
+    expect(setUserMemory).not.toHaveBeenCalled();
+  });
+
+  it("updates the enabled flag without touching content", async () => {
+    const { workspace } = await setup();
+
+    const response = await patchMemory(workspace.sId, { enabled: false });
+
+    expect(response.status).toBe(200);
+    const data = PatchUserMemoryResponseBodySchema.parse(await response.json());
+    expect(data.enabled).toBe(false);
+    expect(setUserMemory).not.toHaveBeenCalled();
+
+    const getResponse = await getMemory(workspace.sId);
+    const getData = GetUserMemoryResponseBodySchema.parse(
+      await getResponse.json()
+    );
+    expect(getData.enabled).toBe(false);
+  });
+
+  it("re-enables memory", async () => {
+    const { workspace } = await setup();
+
+    await patchMemory(workspace.sId, { enabled: false });
+    await patchMemory(workspace.sId, { enabled: true });
+
+    const getResponse = await getMemory(workspace.sId);
+    const getData = GetUserMemoryResponseBodySchema.parse(
+      await getResponse.json()
+    );
+    expect(getData.enabled).toBe(true);
+  });
+
+  it("returns 400 for a non-boolean enabled value", async () => {
+    const { workspace } = await setup();
+
+    const response = await patchMemory(workspace.sId, { enabled: "yes" });
+
+    expect(response.status).toBe(400);
+    const data = ApiErrorSchema.parse(await response.json());
+    expect(data.error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 400 when neither content nor enabled is provided", async () => {
+    const { workspace } = await setup();
+
+    const response = await patchMemory(workspace.sId, {});
+
+    expect(response.status).toBe(400);
+    const data = ApiErrorSchema.parse(await response.json());
+    expect(data.error.type).toBe("invalid_request_error");
+    expect(setUserMemory).not.toHaveBeenCalled();
+  });
+});

--- a/front-api/routes/w/[wId]/me/memory.ts
+++ b/front-api/routes/w/[wId]/me/memory.ts
@@ -1,0 +1,115 @@
+import type { DustFileSystemError } from "@app/lib/api/file_system/dust_file_system";
+import {
+  exceedsUserMemoryLimit,
+  getUserMemory,
+  isUserMemoryEnabled,
+  MAX_USER_MEMORY_CHARS,
+  setUserMemory,
+  setUserMemoryEnabled,
+} from "@app/lib/api/user_memory";
+import type {
+  GetUserMemoryResponseBody,
+  PatchUserMemoryResponseBody,
+} from "@app/types/api/me/memory";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
+import type { Context } from "hono";
+import { z } from "zod";
+
+const PatchMemoryBodySchema = z
+  .object({
+    content: z.string().optional(),
+    enabled: z.boolean().optional(),
+  })
+  .refine((body) => body.content !== undefined || body.enabled !== undefined, {
+    message: "At least one field must be provided",
+  });
+
+// The path is internally built and always valid, so no client-side filesystem
+// error (not_found, invalid_path, already_exists, ...) is reachable here: the
+// only outcomes are `unauthorized` (403) or a genuine GCS/internal failure (500).
+function fileSystemApiError(ctx: Context, error: DustFileSystemError) {
+  if (error.code === "unauthorized") {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: { type: "workspace_auth_error", message: error.message },
+    });
+  }
+  return apiError(ctx, {
+    status_code: 500,
+    api_error: { type: "internal_server_error", message: error.message },
+  });
+}
+
+// Mounted at /api/w/:wId/me/memory. Always scoped to the authenticated user's
+// own memory (via DustFileSystem.forUser). `enabled` is a field of the memory
+// resource rather than a sub-resource with its own path.
+const app = workspaceApp();
+
+app.use(withFeatureFlag("user_memory"));
+
+/** @ignoreswagger */
+app.get("/", async (ctx): HandlerResult<GetUserMemoryResponseBody> => {
+  const auth = ctx.get("auth");
+
+  const result = await getUserMemory(auth);
+  if (result.isErr()) {
+    return fileSystemApiError(ctx, result.error);
+  }
+
+  const enabled = await isUserMemoryEnabled(auth);
+
+  return ctx.json({ content: result.value, enabled });
+});
+
+/** @ignoreswagger */
+app.patch(
+  "/",
+  validate("json", PatchMemoryBodySchema),
+  async (ctx): HandlerResult<PatchUserMemoryResponseBody> => {
+    const auth = ctx.get("auth");
+    const { content: contentInput, enabled: enabledInput } =
+      ctx.req.valid("json");
+
+    if (contentInput !== undefined) {
+      if (exceedsUserMemoryLimit(contentInput)) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Memory content exceeds the ${MAX_USER_MEMORY_CHARS} character limit.`,
+          },
+        });
+      }
+
+      const result = await setUserMemory(auth, contentInput);
+      if (result.isErr()) {
+        return fileSystemApiError(ctx, result.error);
+      }
+    }
+
+    let content = contentInput;
+    if (content === undefined) {
+      const result = await getUserMemory(auth);
+      if (result.isErr()) {
+        return fileSystemApiError(ctx, result.error);
+      }
+      content = result.value;
+    }
+
+    if (enabledInput !== undefined) {
+      await setUserMemoryEnabled(auth, enabledInput);
+    }
+
+    let enabled = enabledInput;
+    if (enabled === undefined) {
+      enabled = await isUserMemoryEnabled(auth);
+    }
+
+    return ctx.json({ content, enabled });
+  }
+);
+
+export default app;

--- a/front/lib/api/actions/servers/user_memory/tools/index.ts
+++ b/front/lib/api/actions/servers/user_memory/tools/index.ts
@@ -7,17 +7,16 @@ import {
   USER_MEMORY_TOOLS_METADATA,
 } from "@app/lib/api/actions/servers/user_memory/metadata";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
-import { SCOPED_PREFIX_USER } from "@app/lib/api/file_system/types";
 import { getUpdatedContentAndOccurrences } from "@app/lib/api/files/utils";
+import {
+  exceedsUserMemoryLimit,
+  MAX_USER_MEMORY_CHARS,
+  MEMORY_CONTENT_TYPE,
+  userMemoryPath,
+} from "@app/lib/api/user_memory";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-
-const MEMORY_CONTENT_TYPE = "text/markdown";
-
-function userMemoryPath(userId: string): string {
-  return `${SCOPED_PREFIX_USER}${userId}/MEMORY.md`;
-}
 
 async function openUserMemory(
   auth: Authenticator
@@ -127,6 +126,15 @@ const handlers: ToolHandlers<typeof USER_MEMORY_TOOLS_METADATA> = {
       }
 
       nextContent = updatedContent;
+    }
+
+    if (exceedsUserMemoryLimit(nextContent)) {
+      return new Err(
+        new MCPError(
+          `Memory would exceed the ${MAX_USER_MEMORY_CHARS} character limit. Shorten the content first.`,
+          { tracked: false }
+        )
+      );
     }
 
     const writeResult = await fs.write(path, nextContent, MEMORY_CONTENT_TYPE);

--- a/front/lib/api/file_system/types.ts
+++ b/front/lib/api/file_system/types.ts
@@ -117,3 +117,7 @@ export function conversationScopedPath({
 export function podScopedPath(spaceId: string, rel: string): string {
   return `${SCOPED_PREFIX_POD}${spaceId}/${rel}`;
 }
+
+export function userScopedPath(userId: string, rel: string): string {
+  return `${SCOPED_PREFIX_USER}${userId}/${rel}`;
+}

--- a/front/lib/api/user_memory.ts
+++ b/front/lib/api/user_memory.ts
@@ -1,0 +1,76 @@
+import type { DustFileSystemError } from "@app/lib/api/file_system/dust_file_system";
+import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import { userScopedPath } from "@app/lib/api/file_system/types";
+import type { Authenticator } from "@app/lib/auth";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+
+const MEMORY_FILE_NAME = "MEMORY.md";
+
+export const MEMORY_CONTENT_TYPE = "text/markdown";
+export const MAX_USER_MEMORY_CHARS = 2_000;
+
+export function userMemoryPath(userId: string): string {
+  return userScopedPath(userId, MEMORY_FILE_NAME);
+}
+
+export function exceedsUserMemoryLimit(content: string): boolean {
+  return content.length > MAX_USER_MEMORY_CHARS;
+}
+
+export async function getUserMemory(
+  auth: Authenticator
+): Promise<Result<string, DustFileSystemError>> {
+  const fsResult = await DustFileSystem.forUser(auth);
+  if (fsResult.isErr()) {
+    return fsResult;
+  }
+
+  // Having a user is guaranteed by DustFileSystem.forUser, so we can safely call getNonNullableUser here.
+  const user = auth.getNonNullableUser();
+  const readResult = await fsResult.value.readBuffer(userMemoryPath(user.sId));
+  if (readResult.isErr()) {
+    return readResult;
+  }
+
+  return new Ok(readResult.value?.toString("utf-8") ?? "");
+}
+
+export async function setUserMemory(
+  auth: Authenticator,
+  content: string
+): Promise<Result<undefined, DustFileSystemError>> {
+  const fsResult = await DustFileSystem.forUser(auth);
+  if (fsResult.isErr()) {
+    return fsResult;
+  }
+
+  const user = auth.getNonNullableUser();
+  const writeResult = await fsResult.value.write(
+    userMemoryPath(user.sId),
+    content,
+    MEMORY_CONTENT_TYPE
+  );
+  if (writeResult.isErr()) {
+    return writeResult;
+  }
+
+  return new Ok(undefined);
+}
+
+export async function isUserMemoryEnabled(
+  auth: Authenticator
+): Promise<boolean> {
+  const user = auth.user();
+  if (!user) {
+    return false;
+  }
+  return user.isMemoryEnabled(auth);
+}
+
+export async function setUserMemoryEnabled(
+  auth: Authenticator,
+  enabled: boolean
+): Promise<void> {
+  await auth.getNonNullableUser().setMemoryEnabled(auth, enabled);
+}

--- a/front/lib/resources/skill/code_defined/system/user_memory.ts
+++ b/front/lib/resources/skill/code_defined/system/user_memory.ts
@@ -4,6 +4,7 @@ import {
   USER_MEMORY_READ_TOOL_NAME,
   USER_MEMORY_SERVER_NAME,
 } from "@app/lib/api/actions/servers/user_memory/metadata";
+import { isUserMemoryEnabled } from "@app/lib/api/user_memory";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import type { SystemSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
@@ -50,7 +51,11 @@ export const userMemorySkill = {
   icon: "ActionLightbulbIcon",
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);
-    return !flags.includes("user_memory");
+    if (!flags.includes("user_memory")) {
+      return true;
+    }
+    const enabled = await isUserMemoryEnabled(auth);
+    return !enabled;
   },
   getAutoEnabledOrEquippedForAgentLoop: () => "enabled",
 } as const satisfies SystemSkillDefinition;

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -65,6 +65,7 @@ export interface DeleteUserApprovalsResponseBody {
 
 const USER_METADATA_COMMA_SEPARATOR = ",";
 const USER_METADATA_COMMA_REPLACEMENT = "DUST_COMMA";
+const USER_MEMORY_ENABLED_METADATA_KEY = "userMemoryEnabled";
 const TOOLS_VALIDATION_WILDCARD = "*";
 const USER_SEARCH_DB_BATCH_SIZE = 1000;
 
@@ -719,6 +720,22 @@ export class UserResource extends BaseResource<UserModel> {
     }
 
     await metadata.update({ value });
+  }
+
+  async isMemoryEnabled(auth: Authenticator): Promise<boolean> {
+    const metadata = await this.getMetadata(
+      USER_MEMORY_ENABLED_METADATA_KEY,
+      auth.getNonNullableWorkspace().id
+    );
+    return metadata?.value !== "false";
+  }
+
+  async setMemoryEnabled(auth: Authenticator, enabled: boolean): Promise<void> {
+    await this.setMetadata(
+      USER_MEMORY_ENABLED_METADATA_KEY,
+      enabled ? "true" : "false",
+      auth.getNonNullableWorkspace().id
+    );
   }
 
   async deleteMetadata(where: WhereOptions<UserMetadataModel>) {

--- a/front/types/api/me/memory.ts
+++ b/front/types/api/me/memory.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const GetUserMemoryResponseBodySchema = z.object({
+  content: z.string(),
+  enabled: z.boolean(),
+});
+export type GetUserMemoryResponseBody = z.infer<
+  typeof GetUserMemoryResponseBodySchema
+>;
+
+export const PatchUserMemoryResponseBodySchema = z.object({
+  content: z.string(),
+  enabled: z.boolean(),
+});
+export type PatchUserMemoryResponseBody = z.infer<
+  typeof PatchUserMemoryResponseBodySchema
+>;


### PR DESCRIPTION
## Description

Add GET/POST endpoints for a user's MEMORY.md and a per-user enable toggle (stored in user metadata, on by default), and gate the user_memory system skill on that toggle.

MEMORY.md is capped at 2K chars. 

## Tests

Tested locally 

## Risk

Low

## Deploy Plan

Deploy front 