### PR TITLE
Update Deep Dive model routing

### DIFF
--- a/front/lib/actions/mcp_internal_actions/utils/web_summarization.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/web_summarization.test.ts
@@ -6,7 +6,7 @@ import { GPT_5_6_LUNA_MODEL_ID } from "@app/types/assistant/models/openai";
 import { describe, expect, it } from "vitest";
 
 describe("getModelConfigForWebSummarization", () => {
-  it("uses GPT 5.6 Luna with medium reasoning when OpenAI is available", async () => {
+  it("uses GPT 5.6 Luna with light reasoning when OpenAI is available", async () => {
     const workspace = await WorkspaceFactory.basic({
       whiteListedProviders: ["openai"],
     });
@@ -17,7 +17,7 @@ describe("getModelConfigForWebSummarization", () => {
         providerId: "openai",
         modelId: GPT_5_6_LUNA_MODEL_ID,
       },
-      reasoningEffort: "medium",
+      reasoningEffort: "light",
     });
   });
 

--- a/front/lib/actions/mcp_internal_actions/utils/web_summarization.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/web_summarization.test.ts
@@ -1,0 +1,37 @@
+import { getModelConfigForWebSummarization } from "@app/lib/actions/mcp_internal_actions/utils/web_summarization";
+import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
+import { Authenticator } from "@app/lib/auth";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { GPT_5_6_LUNA_MODEL_ID } from "@app/types/assistant/models/openai";
+import { describe, expect, it } from "vitest";
+
+describe("getModelConfigForWebSummarization", () => {
+  it("uses GPT 5.6 Luna with medium reasoning when OpenAI is available", async () => {
+    const workspace = await WorkspaceFactory.basic({
+      whiteListedProviders: ["openai"],
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    expect(getModelConfigForWebSummarization(auth)).toMatchObject({
+      modelConfiguration: {
+        providerId: "openai",
+        modelId: GPT_5_6_LUNA_MODEL_ID,
+      },
+      reasoningEffort: "medium",
+    });
+  });
+
+  it("falls back to the preferred available small model", async () => {
+    const workspace = await WorkspaceFactory.basic({
+      whiteListedProviders: ["anthropic"],
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const smallModel = getSmallWhitelistedModel(auth);
+
+    expect(smallModel).not.toBeNull();
+    expect(getModelConfigForWebSummarization(auth)).toEqual({
+      modelConfiguration: smallModel,
+      reasoningEffort: smallModel?.defaultReasoningEffort,
+    });
+  });
+});

--- a/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
@@ -109,7 +109,7 @@ export function getModelConfigForWebSummarization(auth: Authenticator): {
   if (luna) {
     return {
       modelConfiguration: luna,
-      reasoningEffort: "medium",
+      reasoningEffort: "light",
     };
   }
 

--- a/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
@@ -2,13 +2,15 @@ import type { AgentLoopRunContext } from "@app/lib/actions/types";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import {
   getSmallWhitelistedModel,
-  getWhitelistedProviders,
+  selectEnabledModel,
 } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
-import { CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
-import { GEMINI_3_5_FLASH_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
-import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import { GPT_5_6_LUNA_MODEL_CONFIG } from "@app/types/assistant/models/openai";
+import type {
+  ModelConfigurationType,
+  ReasoningEffort,
+} from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -36,8 +38,8 @@ export async function summarizeWithLLM({
 }): Promise<Result<string, Error>> {
   const toSummarize = content.slice(0, MAX_CHARACTERS_TO_SUMMARIZE);
 
-  const model = getFastModelConfigForSummarization(auth);
-  if (!model) {
+  const modelConfig = getModelConfigForWebSummarization(auth);
+  if (!modelConfig) {
     return new Err(
       new Error("Failed to find a whitelisted model to generate summary")
     );
@@ -61,9 +63,10 @@ export async function summarizeWithLLM({
   const res = await runMultiActionsAgent(
     auth,
     {
-      providerId: model.providerId,
-      modelId: model.modelId,
+      providerId: modelConfig.modelConfiguration.providerId,
+      modelId: modelConfig.modelConfiguration.modelId,
       functionCall: null, // No function call needed, just text generation
+      reasoningEffort: modelConfig.reasoningEffort,
       temperature: 0.3,
       useCache: false,
     },
@@ -96,18 +99,25 @@ export async function summarizeWithLLM({
   return new Ok(summary);
 }
 
-function getFastModelConfigForSummarization(
-  auth: Authenticator
-): ModelConfigurationType | null {
-  const providers = getWhitelistedProviders(auth);
-
-  if (providers.has("anthropic")) {
-    return CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG;
+export function getModelConfigForWebSummarization(auth: Authenticator): {
+  modelConfiguration: ModelConfigurationType;
+  reasoningEffort: ReasoningEffort;
+} | null {
+  const luna = selectEnabledModel(auth, [GPT_5_6_LUNA_MODEL_CONFIG], {
+    featureFlags: [],
+  });
+  if (luna) {
+    return {
+      modelConfiguration: luna,
+      reasoningEffort: "medium",
+    };
   }
 
-  if (providers.has("google_ai_studio")) {
-    return GEMINI_3_5_FLASH_MODEL_CONFIG;
-  }
-
-  return getSmallWhitelistedModel(auth);
+  const smallModel = getSmallWhitelistedModel(auth);
+  return smallModel
+    ? {
+        modelConfiguration: smallModel,
+        reasoningEffort: smallModel.defaultReasoningEffort,
+      }
+    : null;
 }

--- a/front/lib/api/assistant/call_llm.ts
+++ b/front/lib/api/assistant/call_llm.ts
@@ -5,7 +5,10 @@ import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
 import type { ModelProviderIdType } from "@app/lib/resources/storage/models/workspace";
-import type { ModelIdType } from "@app/types/assistant/models/types";
+import type {
+  ModelIdType,
+  ReasoningEffort,
+} from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { z } from "zod";
@@ -14,6 +17,7 @@ export interface LLMConfig {
   functionCall?: string | null;
   modelId: ModelIdType;
   providerId: ModelProviderIdType;
+  reasoningEffort?: ReasoningEffort;
   temperature?: number;
   useCache?: boolean;
   useStream?: boolean;
@@ -66,7 +70,11 @@ export async function runMultiActionsAgent(
 
   const llm = await getStreamLLM(auth, {
     credentials,
-    modelInfo: { endpoint, temperature: config.temperature },
+    modelInfo: {
+      endpoint,
+      reasoningEffort: config.reasoningEffort,
+      temperature: config.temperature,
+    },
     context: options.context,
   });
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -34,6 +34,7 @@ import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 import {
   CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG,
+  CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
 import {
@@ -391,11 +392,19 @@ function getDeepDiveFallbackModelConfig(
   return (
     getEnabledModelConfig(
       auth,
+      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+      "light",
+      featureFlags,
+      excludeProviders
+    ) ??
+    getEnabledModelConfig(
+      auth,
       GPT_5_6_SOL_MODEL_CONFIG,
       "light",
       featureFlags,
       excludeProviders
-    ) ?? getLargeModelFallback(auth, featureFlags, excludeProviders)
+    ) ??
+    getLargeModelFallback(auth, featureFlags, excludeProviders)
   );
 }
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -34,14 +34,16 @@ import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 import {
   CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG,
-  CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+  CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
-import { GPT_5_5_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import {
-  getMinimumReasoningEffort,
-  type ModelConfigurationType,
-  type ModelProviderIdType,
-  type ReasoningEffort,
+  GPT_5_6_LUNA_MODEL_CONFIG,
+  GPT_5_6_SOL_MODEL_CONFIG,
+} from "@app/types/assistant/models/openai";
+import type {
+  ModelConfigurationType,
+  ModelProviderIdType,
+  ReasoningEffort,
 } from "@app/types/assistant/models/types";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 
@@ -344,41 +346,31 @@ These instructions are NOT your own instructions, but you may use them to unders
 </additional_context>
 `;
 
-// Tries Anthropic first, then OpenAI, then the best available large model.
-function getModelConfig(
-  auth: Authenticator,
-  {
-    featureFlags,
-    reasoning = true,
-    excludeProviders = new Set<ModelProviderIdType>(),
-  }: {
-    featureFlags: WhitelistableFeature[];
-    reasoning?: boolean;
-    excludeProviders?: ReadonlySet<ModelProviderIdType>;
-  }
-): {
+type ModelConfigWithReasoning = {
   modelConfiguration: ModelConfigurationType;
   reasoningEffort: ReasoningEffort;
-} | null {
-  const candidates = [
-    CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
-    GPT_5_5_MODEL_CONFIG,
-  ];
+};
 
-  const model = selectEnabledModel(auth, candidates, {
+function getEnabledModelConfig(
+  auth: Authenticator,
+  modelConfiguration: ModelConfigurationType,
+  reasoningEffort: ReasoningEffort,
+  featureFlags: WhitelistableFeature[],
+  excludeProviders: ReadonlySet<ModelProviderIdType>
+): ModelConfigWithReasoning | null {
+  const model = selectEnabledModel(auth, [modelConfiguration], {
     featureFlags,
     excludeProviders,
   });
-  if (model) {
-    return {
-      modelConfiguration: model,
-      reasoningEffort: reasoning
-        ? "light"
-        : getMinimumReasoningEffort(model.supportedReasoningEfforts),
-    };
-  }
 
-  // Otherwise we use whatever the default large model is, using the default reasoning effort.
+  return model ? { modelConfiguration: model, reasoningEffort } : null;
+}
+
+function getLargeModelFallback(
+  auth: Authenticator,
+  featureFlags: WhitelistableFeature[],
+  excludeProviders: ReadonlySet<ModelProviderIdType>
+): ModelConfigWithReasoning | null {
   const modelConfiguration = getLargeWhitelistedModel(auth, excludeProviders, {
     featureFlags,
   });
@@ -391,37 +383,68 @@ function getModelConfig(
   };
 }
 
-function getMaxReasoningModelConfig(
+function getDeepDiveFallbackModelConfig(
   auth: Authenticator,
   featureFlags: WhitelistableFeature[],
-  excludeProviders: ReadonlySet<ModelProviderIdType> = new Set()
-): {
-  modelConfiguration: ModelConfigurationType;
-  reasoningEffort: ReasoningEffort;
-} | null {
-  if (
-    selectEnabledModel(auth, [GPT_5_5_MODEL_CONFIG], {
+  excludeProviders: ReadonlySet<ModelProviderIdType>
+): ModelConfigWithReasoning | null {
+  return (
+    getEnabledModelConfig(
+      auth,
+      GPT_5_6_SOL_MODEL_CONFIG,
+      "light",
       featureFlags,
-      excludeProviders,
-    })
-  ) {
-    return {
-      modelConfiguration: GPT_5_5_MODEL_CONFIG,
-      reasoningEffort: "high",
-    };
-  }
-  if (
-    selectEnabledModel(auth, [CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG], {
+      excludeProviders
+    ) ?? getLargeModelFallback(auth, featureFlags, excludeProviders)
+  );
+}
+
+function getDustTaskModelConfig(
+  auth: Authenticator,
+  featureFlags: WhitelistableFeature[],
+  excludeProviders: ReadonlySet<ModelProviderIdType>
+): ModelConfigWithReasoning | null {
+  return (
+    getEnabledModelConfig(
+      auth,
+      GPT_5_6_LUNA_MODEL_CONFIG,
+      "high",
       featureFlags,
-      excludeProviders,
-    })
-  ) {
-    return {
-      modelConfiguration: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
-      reasoningEffort: "high",
-    };
-  }
-  return getModelConfig(auth, { featureFlags, excludeProviders });
+      excludeProviders
+    ) ??
+    getEnabledModelConfig(
+      auth,
+      CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
+      "light",
+      featureFlags,
+      excludeProviders
+    ) ??
+    getLargeModelFallback(auth, featureFlags, excludeProviders)
+  );
+}
+
+function getPlanningModelConfig(
+  auth: Authenticator,
+  featureFlags: WhitelistableFeature[],
+  excludeProviders: ReadonlySet<ModelProviderIdType>
+): ModelConfigWithReasoning | null {
+  return (
+    getEnabledModelConfig(
+      auth,
+      GPT_5_6_SOL_MODEL_CONFIG,
+      "high",
+      featureFlags,
+      excludeProviders
+    ) ??
+    getEnabledModelConfig(
+      auth,
+      CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG,
+      "high",
+      featureFlags,
+      excludeProviders
+    ) ??
+    getLargeModelFallback(auth, featureFlags, excludeProviders)
+  );
 }
 
 export function _getDeepDiveGlobalAgent(
@@ -444,19 +467,21 @@ export function _getDeepDiveGlobalAgent(
 ): AgentConfigurationType | null {
   const { run_agent: runAgentMCPServerView } = mcpServerViews;
   const pictureUrl = DUST_AVATAR_URL;
-  const modelConfig = getModelConfig(auth, { featureFlags, excludeProviders });
+  const modelConfig = getDeepDiveFallbackModelConfig(
+    auth,
+    featureFlags,
+    excludeProviders
+  );
 
-  const enterpriseModelConfig =
-    shouldUseOpus(auth) &&
-    selectEnabledModel(auth, [CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG], {
-      featureFlags,
-      excludeProviders,
-    })
-      ? {
-          modelConfiguration: CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG,
-          reasoningEffort: modelConfig?.reasoningEffort ?? ("medium" as const),
-        }
-      : null;
+  const enterpriseModelConfig = shouldUseOpus(auth)
+    ? getEnabledModelConfig(
+        auth,
+        CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG,
+        "light",
+        featureFlags,
+        excludeProviders
+      )
+    : null;
 
   const effectiveModelConfig = enterpriseModelConfig ?? modelConfig;
 
@@ -645,11 +670,11 @@ export function _getDustTaskGlobalAgent(
     canEdit: false,
   };
 
-  const modelConfig = getModelConfig(auth, {
+  const modelConfig = getDustTaskModelConfig(
+    auth,
     featureFlags,
-    reasoning: false,
-    excludeProviders,
-  });
+    excludeProviders
+  );
 
   if (!modelConfig || settings?.status === "disabled_by_admin") {
     return {
@@ -765,7 +790,7 @@ export function _getPlanningAgent(
     canEdit: false,
   };
 
-  const modelConfig = getMaxReasoningModelConfig(
+  const modelConfig = getPlanningModelConfig(
     auth,
     featureFlags,
     excludeProviders

--- a/front/lib/api/assistant/global_agents/global_agents.test.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.test.ts
@@ -1,8 +1,13 @@
 import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_agents";
+import { Authenticator } from "@app/lib/auth";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import { CLAUDE_SONNET_5_MODEL_ID } from "@app/types/assistant/models/anthropic";
+import {
+  CLAUDE_OPUS_5_MODEL_ID,
+  CLAUDE_SONNET_5_MODEL_ID,
+} from "@app/types/assistant/models/anthropic";
 import {
   GPT_5_6_LUNA_MODEL_ID,
   GPT_5_6_SOL_MODEL_ID,
@@ -352,6 +357,90 @@ describe("getGlobalAgents OpenAI Dust agents", () => {
       {
         sId: GLOBAL_AGENTS_SID.DUST_OAI_LUNA_HIGH,
         modelId: GPT_5_6_LUNA_MODEL_ID,
+        reasoningEffort: "high",
+      },
+    ]);
+  });
+});
+
+describe("getGlobalAgents Deep Dive model routing", () => {
+  it("falls back to Sol for Deep Dive while using Sol for planning and Luna high for tasks", async () => {
+    const workspace = await WorkspaceFactory.enterprise({
+      whiteListedProviders: ["openai"],
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const agents = await getGlobalAgents(
+      auth,
+      [
+        GLOBAL_AGENTS_SID.DEEP_DIVE,
+        GLOBAL_AGENTS_SID.DUST_TASK,
+        GLOBAL_AGENTS_SID.DUST_PLANNING,
+      ],
+      "light"
+    );
+
+    expect(
+      agents.map((agent) => ({
+        sId: agent.sId,
+        modelId: agent.model.modelId,
+        reasoningEffort: agent.model.reasoningEffort,
+      }))
+    ).toEqual([
+      {
+        sId: GLOBAL_AGENTS_SID.DEEP_DIVE,
+        modelId: GPT_5_6_SOL_MODEL_ID,
+        reasoningEffort: "light",
+      },
+      {
+        sId: GLOBAL_AGENTS_SID.DUST_TASK,
+        modelId: GPT_5_6_LUNA_MODEL_ID,
+        reasoningEffort: "high",
+      },
+      {
+        sId: GLOBAL_AGENTS_SID.DUST_PLANNING,
+        modelId: GPT_5_6_SOL_MODEL_ID,
+        reasoningEffort: "high",
+      },
+    ]);
+  });
+
+  it("falls back to Sonnet 5 for tasks and Opus 5 for planning", async () => {
+    const workspace = await WorkspaceFactory.enterprise({
+      whiteListedProviders: ["anthropic"],
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const agents = await getGlobalAgents(
+      auth,
+      [
+        GLOBAL_AGENTS_SID.DEEP_DIVE,
+        GLOBAL_AGENTS_SID.DUST_TASK,
+        GLOBAL_AGENTS_SID.DUST_PLANNING,
+      ],
+      "light"
+    );
+
+    expect(
+      agents.map((agent) => ({
+        sId: agent.sId,
+        modelId: agent.model.modelId,
+        reasoningEffort: agent.model.reasoningEffort,
+      }))
+    ).toEqual([
+      {
+        sId: GLOBAL_AGENTS_SID.DEEP_DIVE,
+        modelId: CLAUDE_OPUS_5_MODEL_ID,
+        reasoningEffort: "light",
+      },
+      {
+        sId: GLOBAL_AGENTS_SID.DUST_TASK,
+        modelId: CLAUDE_SONNET_5_MODEL_ID,
+        reasoningEffort: "light",
+      },
+      {
+        sId: GLOBAL_AGENTS_SID.DUST_PLANNING,
+        modelId: CLAUDE_OPUS_5_MODEL_ID,
         reasoningEffort: "high",
       },
     ]);

--- a/front/lib/api/assistant/global_agents/global_agents.test.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.test.ts
@@ -6,6 +6,7 @@ import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import {
   CLAUDE_OPUS_5_MODEL_ID,
+  CLAUDE_SONNET_4_6_MODEL_ID,
   CLAUDE_SONNET_5_MODEL_ID,
 } from "@app/types/assistant/models/anthropic";
 import {
@@ -364,6 +365,25 @@ describe("getGlobalAgents OpenAI Dust agents", () => {
 });
 
 describe("getGlobalAgents Deep Dive model routing", () => {
+  it("keeps Sonnet 4.6 as the Deep Dive primary model", async () => {
+    const workspace = await WorkspaceFactory.basic({
+      whiteListedProviders: ["anthropic", "openai"],
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const agents = await getGlobalAgents(
+      auth,
+      [GLOBAL_AGENTS_SID.DEEP_DIVE],
+      "light"
+    );
+
+    expect(agents).toHaveLength(1);
+    expect(agents[0].model).toMatchObject({
+      modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+      reasoningEffort: "light",
+    });
+  });
+
   it("falls back to Sol for Deep Dive while using Sol for planning and Luna high for tasks", async () => {
     const workspace = await WorkspaceFactory.enterprise({
       whiteListedProviders: ["openai"],


### PR DESCRIPTION
## Description

- Route Deep Dive fallback and planning through GPT-5.6 Sol.
- Route research tasks through GPT-5.6 Luna high and browser summaries through GPT-5.6 Luna low.
- Fall back to Sonnet 5 for tasks and Opus 5 for planning before the normal model fallback.

## Tests

Added focused coverage for OpenAI and Anthropic routing, including browser-summary fallback selection. Tested locally with the two targeted Vitest files.

## Risk

Changes model cost and response behavior for Deep Dive workflows. Safe to roll back by reverting the routing change.

## Deploy Plan

Standard deploy.