### PR TITLE
[Admin Governance] Resolve skill attachment ownership

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -8510,7 +8510,7 @@
     "/api/w/{wId}/files/{fileId}": {
       "get": {
         "summary": "Get or download a file",
-        "description": "View or download a file. Use query parameters `version` (original, processed, public) and `action` (view, download).",
+        "description": "View or download a file. Skill attachments require read access to their associated skill. Use query parameters `version` (original, processed, public) and `action` (view, download).",
         "tags": [
           "Private Files"
         ],

--- a/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
@@ -105,6 +105,45 @@ describe("GET /api/w/:wId/files/:fileId", () => {
     });
   });
 
+  it("should return 404 when user cannot read an attached skill", async () => {
+    const { auth, user, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    const skill = await SkillFactory.create(auth, {
+      requestedSpaceIds: [restrictedSpace.id],
+    });
+    const file = await FileFactory.create(auth, user, {
+      contentType: "text/plain",
+      fileName: "restricted.txt",
+      fileSize: 1024,
+      status: "ready",
+      useCase: "skill_attachment",
+    });
+    await skill.updateSkill(auth, {
+      agentFacingDescription: skill.agentFacingDescription,
+      attachedKnowledge: [],
+      fileAttachments: [file],
+      icon: skill.icon,
+      instructions: skill.instructions,
+      mcpServerViews: [],
+      name: skill.name,
+      requestedSpaceIds: skill.requestedSpaceIds,
+      userFacingDescription: skill.userFacingDescription,
+    });
+
+    const response = await honoApp.request(fileUrl(workspace, file.sId));
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "file_not_found",
+        message: "File not found.",
+      },
+    });
+  });
+
   it("should redirect to signed URL for download action", async () => {
     const { auth, user, workspace } = await createPrivateApiMockRequest({
       method: "GET",

--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -77,7 +77,7 @@ const app = createHono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
  * /api/w/{wId}/files/{fileId}:
  *   get:
  *     summary: Get or download a file
- *     description: View or download a file. Use query parameters `version` (original, processed, public) and `action` (view, download).
+ *     description: View or download a file. Skill attachments require read access to their associated skill. Use query parameters `version` (original, processed, public) and `action` (view, download).
  *     tags:
  *       - Private Files
  *     parameters:
@@ -211,6 +211,16 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const accessCheck = await checkFileAccess(ctx, file);
   if (accessCheck) {
     return accessCheck;
+  }
+
+  if (
+    file.useCase === "skill_attachment" &&
+    !(await canReadSkillFile(auth, file))
+  ) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: { type: "file_not_found", message: "File not found." },
+    });
   }
 
   const action = getSecureFileAction(ctx.req.query("action"), file);
@@ -507,6 +517,14 @@ async function canWriteSkillFile(
   auth: Authenticator,
   file: FileResource
 ): Promise<boolean> {
+  const { isReferenced, skills } = await SkillResource.fetchFileSkills(
+    auth,
+    file
+  );
+  if (isReferenced) {
+    return skills.some((skill) => skill.canWrite(auth));
+  }
+
   const skillId = file.useCaseMetadata?.skillId;
   if (skillId) {
     const skill = await SkillResource.fetchById(auth, skillId);
@@ -515,6 +533,24 @@ async function canWriteSkillFile(
 
   const isFileAuthor = file.userId === auth.user()?.id;
   return isFileAuthor && (await auth.hasWorkspacePermission("create", "skill"));
+}
+
+async function canReadSkillFile(
+  auth: Authenticator,
+  file: FileResource
+): Promise<boolean> {
+  const { isReferenced, skills } = await SkillResource.fetchFileSkills(
+    auth,
+    file
+  );
+  if (isReferenced) {
+    return skills.length > 0;
+  }
+
+  const skillId = file.useCaseMetadata?.skillId;
+  return skillId
+    ? (await SkillResource.fetchById(auth, skillId)) !== null
+    : false;
 }
 
 async function getSpaceForFile(

--- a/front-api/routes/w/[wId]/skills/[sId]/files/[fileId]/content.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/files/[fileId]/content.test.ts
@@ -34,25 +34,50 @@ describe("GET /api/w/:wId/skills/:sId/files/:fileId/content", () => {
     expect(response.headers.get("Content-Type")).toBe("text/x-python");
   });
 
-  it("streams skill attachment content for a readable skill", async () => {
-    const { auth, workspace, user } = await createPrivateApiMockRequest({
+  it("streams historical attachment content for a readable skill", async () => {
+    const {
+      auth: editorAuth,
+      workspace,
+      user,
+    } = await createPrivateApiMockRequest({
       method: "GET",
       role: "user",
     });
-    const skill = await SkillFactory.create(auth, {
-      addCurrentUserAsEditor: false,
-    });
+    const skill = await SkillFactory.create(editorAuth);
 
-    expect(skill.canWrite(auth)).toBe(false);
-
-    const file = await FileFactory.create(auth, user, {
+    const file = await FileFactory.create(editorAuth, user, {
       contentType: "text/yaml",
       fileName: "config.yaml",
       fileSize: 11,
       status: "ready",
       useCase: "skill_attachment",
-      useCaseMetadata: { skillId: skill.sId },
     });
+    const skillUpdate = {
+      agentFacingDescription: skill.agentFacingDescription,
+      attachedKnowledge: [],
+      icon: skill.icon,
+      instructions: skill.instructions,
+      mcpServerViews: [],
+      name: skill.name,
+      requestedSpaceIds: skill.requestedSpaceIds,
+      userFacingDescription: skill.userFacingDescription,
+    };
+    await skill.updateSkill(editorAuth, {
+      ...skillUpdate,
+      fileAttachments: [file],
+    });
+    await skill.updateSkill(editorAuth, {
+      ...skillUpdate,
+      fileAttachments: [],
+    });
+
+    const { auth: readerAuth } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+      workspace,
+    });
+
+    expect(skill.canWrite(readerAuth)).toBe(false);
 
     const response = await get(workspace, skill.sId, file.sId);
 

--- a/front-api/routes/w/[wId]/skills/[sId]/files/[fileId]/content.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/files/[fileId]/content.ts
@@ -28,11 +28,21 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
   }
 
   const file = await FileResource.fetchById(auth, fileId);
-  if (
-    !file ||
-    file.useCase !== "skill_attachment" ||
-    file.useCaseMetadata?.skillId !== sId
-  ) {
+  if (!file || file.useCase !== "skill_attachment") {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: { type: "file_not_found", message: "File not found." },
+    });
+  }
+
+  const { isReferenced, skills } = await SkillResource.fetchFileSkills(
+    auth,
+    file
+  );
+  const belongsToSkill =
+    skills.some((referencedSkill) => referencedSkill.id === skill.id) ||
+    (!isReferenced && file.useCaseMetadata?.skillId === sId);
+  if (!belongsToSkill) {
     return apiError(ctx, {
       status_code: 404,
       api_error: { type: "file_not_found", message: "File not found." },

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -954,11 +954,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       where,
     });
 
-    const skillIds = uniq(
+    const skillModelIds = uniq(
       versions.map((version) => version.skillConfigurationId)
     );
-    const skills = await this.fetchByModelIds(auth, skillIds);
-    return { isReferenced: skillIds.length > 0, skills };
+    const skills = await this.fetchByModelIds(auth, skillModelIds);
+    return { isReferenced: skillModelIds.length > 0, skills };
   }
 
   static async fetchById(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -922,6 +922,45 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
   }
 
+  static async fetchFileSkills(
+    auth: Authenticator,
+    file: FileResource
+  ): Promise<{ isReferenced: boolean; skills: SkillResource[] }> {
+    const workspace = auth.getNonNullableWorkspace();
+    // The unique workspace/file index bounds this lookup to one attachment.
+    const attachment = await SkillFileAttachmentModel.findOne({
+      attributes: ["skillConfigurationId"],
+      where: {
+        fileId: file.id,
+        workspaceId: workspace.id,
+      },
+    });
+
+    if (attachment) {
+      const skills = await this.fetchByModelIds(auth, [
+        attachment.skillConfigurationId,
+      ]);
+      return { isReferenced: true, skills };
+    }
+
+    // This fallback is only used for detached files. The workspace-leading index bounds the scan.
+    const where: WhereOptions<SkillVersionModel> = {
+      fileAttachmentIds: { [Op.contains]: [file.id] },
+      workspaceId: workspace.id,
+    };
+    const versions = await SkillVersionModel.findAll({
+      attributes: ["skillConfigurationId"],
+      group: ["skillConfigurationId"],
+      where,
+    });
+
+    const skillIds = uniq(
+      versions.map((version) => version.skillConfigurationId)
+    );
+    const skills = await this.fetchByModelIds(auth, skillIds);
+    return { isReferenced: skillIds.length > 0, skills };
+  }
+
   static async fetchById(
     auth: Authenticator,
     sId: string


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/29651.

Second PR in a three-PR stack. Once a file is attached, its optional upload metadata is not a safe source of ownership. File access now resolves the live attachment or skill version history first, applies the associated skill permissions, and only falls back to upload metadata for files that have never been referenced.

This protects generic file downloads and skill file content reads, including detached files retained in version history.

Next: https://github.com/dust-tt/dust/pull/29670

## Risks

Blast radius: Reads and uploads of skill attachment files through private endpoints.
Risk: standard

## Deploy Plan

- deploy front

## Tests

- [x] Private file endpoint tests (20)
- [x] Skill attachment content endpoint tests (5)
