### PR TITLE
Prevent assigning the deprecated builder role via the API

### DIFF
--- a/front-api/routes/w/[wId]/invitations/index.test.ts
+++ b/front-api/routes/w/[wId]/invitations/index.test.ts
@@ -158,7 +158,7 @@ describe("POST /api/w/:wId/invitations", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify([
         { email: "new-user@example.com", role: "user" },
-        { email: "new-builder@example.com", role: "builder" },
+        { email: "new-manager@example.com", role: "manager" },
       ]),
     });
 
@@ -166,6 +166,23 @@ describe("POST /api/w/:wId/invitations", () => {
     const data = await response.json();
     expect(data).toHaveLength(2);
     expect(data.every((r: { success: boolean }) => r.success)).toBe(true);
+  });
+
+  it("rejects an invitation with the deprecated builder role", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    const response = await honoApp.request(invitationsUrl(workspace.sId), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify([
+        { email: "new-builder@example.com", role: "builder" },
+      ]),
+    });
+
+    expect(response.status).toBe(400);
   });
 
   it("creates invitations for multiple new emails in a single request", async () => {
@@ -179,7 +196,7 @@ describe("POST /api/w/:wId/invitations", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify([
         { email: "new-user-1@example.com", role: "user" },
-        { email: "new-user-2@example.com", role: "builder" },
+        { email: "new-user-2@example.com", role: "manager" },
         { email: "new-user-3@example.com", role: "admin" },
       ]),
     });
@@ -198,7 +215,7 @@ describe("POST /api/w/:wId/invitations", () => {
 
     const byEmail = new Map(invitations.map((i) => [i.inviteEmail, i]));
     expect(byEmail.get("new-user-1@example.com")?.initialRole).toBe("user");
-    expect(byEmail.get("new-user-2@example.com")?.initialRole).toBe("builder");
+    expect(byEmail.get("new-user-2@example.com")?.initialRole).toBe("manager");
     expect(byEmail.get("new-user-3@example.com")?.initialRole).toBe("admin");
 
     expect(sgSendMock).toHaveBeenCalledTimes(3);

--- a/front-api/routes/w/[wId]/members/[uId]/index.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/index.test.ts
@@ -34,7 +34,7 @@ describe("POST /api/w/:wId/members/:uId", () => {
       );
     });
 
-    it("should return 400 when sole admin tries to change own role to builder", async () => {
+    it("should return 400 when sole admin tries to change own role to user", async () => {
       const { workspace, user } = await createPrivateApiMockRequest({
         method: "POST",
         role: "admin",
@@ -45,7 +45,7 @@ describe("POST /api/w/:wId/members/:uId", () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ role: "builder" }),
+          body: JSON.stringify({ role: "user" }),
         }
       );
 
@@ -120,14 +120,39 @@ describe("POST /api/w/:wId/members/:uId", () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ role: "builder" }),
+          body: JSON.stringify({ role: "manager" }),
         }
       );
 
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.member).toBeDefined();
-      expect(data.member.workspaces[0].role).toBe("builder");
+      expect(data.member.workspaces[0].role).toBe("manager");
+    });
+
+    it("should return 400 when assigning the deprecated builder role", async () => {
+      const { workspace } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+      });
+
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+      });
+
+      const response = await honoApp.request(
+        memberUrl(workspace.sId, targetUser.sId),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ role: "builder" }),
+        }
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.type).toBe("invalid_request_error");
     });
 
     it("should return 400 when sole admin tries to revoke themselves", async () => {
@@ -383,14 +408,14 @@ describe("POST /api/w/:wId/members/:uId", () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ role: "builder" }),
+          body: JSON.stringify({ role: "manager" }),
         }
       );
 
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.member).toBeDefined();
-      expect(data.member.workspaces[0].role).toBe("builder");
+      expect(data.member.workspaces[0].role).toBe("manager");
     });
   });
 
@@ -531,7 +556,7 @@ describe("POST /api/w/:wId/members/:uId", () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ role: "builder" }),
+          body: JSON.stringify({ role: "manager" }),
         }
       );
 

--- a/front-api/routes/w/[wId]/members/[uId]/index.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/index.ts
@@ -16,8 +16,8 @@ import type {
   GetMemberResponseBody,
   PostMemberResponseBody,
 } from "@app/types/api/user";
-import { isMembershipRoleType } from "@app/types/memberships";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { AssignableRoleSchema } from "@app/types/user";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -197,17 +197,20 @@ app.post(
         }
       }
     } else {
-      const role = body.role;
-      if (!isMembershipRoleType(role)) {
+      // The deprecated `builder` role can no longer be assigned; it is granted only through the
+      // `dust-builders` provisioning group.
+      const roleParse = AssignableRoleSchema.safeParse(body.role);
+      if (!roleParse.success) {
         return apiError(ctx, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
             message:
-              "The request body is invalid, expects { role: 'admin' | 'manager' | 'builder' | 'user' }.",
+              "The request body is invalid, expects { role: 'admin' | 'manager' | 'user' }.",
           },
         });
       }
+      const role = roleParse.data;
 
       // Check if this is an admin trying to change their own role and they are the sole admin
       const currentUser = auth.user();
@@ -299,7 +302,6 @@ app.post(
     switch (body.role) {
       case "admin":
       case "manager":
-      case "builder":
       case "user":
         w.role = body.role;
         break;

--- a/front/types/api/invitation.ts
+++ b/front/types/api/invitation.ts
@@ -3,7 +3,7 @@ import type {
   PendingInvitationOption,
 } from "@app/types/membership_invitation";
 import { MEMBERSHIP_SEAT_TYPES } from "@app/types/memberships";
-import { ActiveRoleSchema } from "@app/types/user";
+import { AssignableRoleSchema } from "@app/types/user";
 import { z } from "zod";
 
 export type GetWorkspaceInvitationsResponseBody = {
@@ -21,7 +21,7 @@ export type GetPendingInvitationsResponseBody = {
 export const PostInvitationRequestBodySchema = z.array(
   z.object({
     email: z.string(),
-    role: ActiveRoleSchema,
+    role: AssignableRoleSchema,
     seatType: z.enum(MEMBERSHIP_SEAT_TYPES).nullish(),
   })
 );
@@ -42,5 +42,5 @@ export type PostMemberInvitationsResponseBody = {
 
 export const PostMemberInvitationBodySchema = z.object({
   status: z.enum(["revoked", "pending"]),
-  initialRole: ActiveRoleSchema,
+  initialRole: AssignableRoleSchema,
 });

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -44,6 +44,18 @@ export function isActiveRoleType(role: string): role is ActiveRoleType {
   return ACTIVE_ROLES.includes(role as ActiveRoleType);
 }
 
+// Roles that can be assigned through the API (invitations, membership role updates). The
+// deprecated `builder` role is rejected here — it is granted only through the `dust-builders`
+// provisioning group — while remaining a valid role value elsewhere (existing memberships, role
+// display, and legacy/pending invitations).
+export function isAssignableRole(role: RoleType): boolean {
+  return role !== "builder" && role !== "none";
+}
+
+export const AssignableRoleSchema = ActiveRoleSchema.refine(isAssignableRole, {
+  message: "The 'builder' role can no longer be assigned.",
+});
+
 export type WorkspaceSharingPolicy =
   | "workspace_only"
   | "workspace_and_emails"


### PR DESCRIPTION
## Description

The `builder` role is deprecated and, going forward, is meant to be granted **only** through the `dust-builders` provisioning group (`determineUserRoleFromGroups`). Two private API endpoints still accepted `builder` server-side even though the UI role dropdown no longer offers it:

- **Invitation create** — `POST /api/w/:wId/invitations` (and invitation update `POST /api/w/:wId/invitations/:iId`).
- **Membership role update** — `POST /api/w/:wId/members/:uId`.

This closes both paths. `types/user.ts` gains `AssignableRoleSchema` — a runtime refinement over `ActiveRoleSchema` that rejects `builder` (and `none`) while **keeping `builder` a valid role value everywhere else** (existing memberships, role display, and legacy/pending invitations that are read, resent, or downgraded). It is wired into:
- `PostInvitationRequestBodySchema` and `PostMemberInvitationBodySchema` (invitations).
- The member role-update handler, replacing the `isMembershipRoleType` check.

Requests carrying `role: "builder"` now get a `400 invalid_request_error`.

### Why a runtime refinement instead of narrowing the type

`builder` must remain representable in TypeScript: legacy/pending invitations and existing memberships can be `builder`, and the frontend carries `ActiveRoleType` to display and resend them. Narrowing the wire type to exclude `builder` would break those read/resend paths. The refinement rejects `builder` at the validation boundary without changing the inferred type.

### Scope

Provisioning (`dust-builders` → `builder`) is unaffected — it does not go through these endpoint schemas. Poke's super-admin invite form (`InviteMemberFormSchema`) is intentionally left alone. API-key `role` scopes are a separate concept and untouched.

Together with #29666 (invitation *acceptance* downgrades builder→user), assignment of `builder` through the product APIs is now closed; provisioning is the sole path.

## Risks

Risk: low. Stricter validation on a private API; the UI already stopped offering `builder`, so no current client sends it. `builder` remains fully readable/displayable.

## Verification

- `tsgo --noEmit` clean in `front` and `front-api`.
- `biome check` clean on changed files.
- `front-api` `invitations/index.test.ts` (10), `invitations/[iId]/index.test.ts` (part of 9), `members/[uId]/index.test.ts` (25) — all pass, including new 400-rejection tests on both endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)