### PR TITLE
Provision dust-builders into the manual Builders group, not the role

### DIFF
--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -296,14 +296,6 @@ export async function createAndTrackMembership({
     }
   }
 
-  // After the restore above, so the group reflects the new role rather than the pre-revoke
-  // one (builder role deprecation).
-  await GroupResource.syncBuilderGroupMembership({
-    workspace: w,
-    user,
-    isBuilder: role === "builder",
-  });
-
   void ServerSideTracking.trackCreateMembership({
     user: user.toJSON(),
     workspace: w,
@@ -382,12 +374,6 @@ export async function revokeAndTrackMembership(
   });
 
   if (revokeResult.isOk()) {
-    await GroupResource.syncBuilderGroupMembership({
-      workspace,
-      user,
-      isBuilder: false,
-    });
-
     const deleteTriggerResult = await TriggerResource.deleteAllForUser(
       auth,
       user
@@ -461,14 +447,6 @@ export async function revokeAndTrackMembership(
         "[Metronome] Failed to remove seat for revoked member"
       );
     }
-  } else if (revokeResult.error.type === "already_revoked") {
-    // Heal drift from a retried revoke whose first attempt failed after the membership
-    // write but before the group sync.
-    await GroupResource.syncBuilderGroupMembership({
-      workspace,
-      user,
-      isBuilder: false,
-    });
   }
 
   return revokeResult;
@@ -540,16 +518,6 @@ export async function updateMembershipRoleAndTrack({
     allowLastAdminRemoval,
     author,
   });
-
-  // On `already_on_role`, the membership already carries `newRole`: syncing anyway heals
-  // drift from a retried role change whose first attempt failed before the group sync.
-  if (updateRes.isOk() || updateRes.error.type === "already_on_role") {
-    await GroupResource.syncBuilderGroupMembership({
-      workspace,
-      user,
-      isBuilder: newRole === "builder",
-    });
-  }
 
   if (updateRes.isOk()) {
     void ServerSideTracking.trackUpdateMembershipRole({

--- a/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
@@ -17,11 +17,9 @@ function determineExpectedRoleFromGroups(
   provisioningGroupMembers: {
     adminUserIds: Set<ModelId>;
     managerUserIds: Set<ModelId>;
-    builderUserIds: Set<ModelId>;
   }
 ): ActiveRoleType {
-  const { adminUserIds, managerUserIds, builderUserIds } =
-    provisioningGroupMembers;
+  const { adminUserIds, managerUserIds } = provisioningGroupMembers;
 
   if (adminUserIds.has(userModelId)) {
     return "admin";
@@ -29,9 +27,8 @@ function determineExpectedRoleFromGroups(
   if (managerUserIds.has(userModelId)) {
     return "manager";
   }
-  if (builderUserIds.has(userModelId)) {
-    return "builder";
-  }
+  // The `dust-builders` group no longer grants the deprecated builder role; membership is
+  // mirrored into the manual "Builders" group instead (see the sync in `execute`).
   return "user";
 }
 
@@ -40,10 +37,11 @@ export const applyGroupRoles = createPlugin({
     id: "apply-roles-from-groups",
     name: "Apply group roles",
     description:
-      "Force resync roles using dust-admins, dust-managers and dust-builders groups",
+      "Force resync roles from dust-admins and dust-managers, and mirror dust-builders into the Builders group",
     resourceTypes: ["workspaces"],
     warning:
-      "This action will override the existing membership roles based on the dust-admins, dust-managers and dust-builders groups. " +
+      "This action will override the existing membership roles based on the dust-admins and dust-managers groups, " +
+      "and sync the manual Builders group from dust-builders (if it exists). " +
       "Make sure the user is aware of this and does not want to keep the roles assigned manually.",
     args: {},
     requiredRoles: ["engineering"],
@@ -109,6 +107,11 @@ export const applyGroupRoles = createPlugin({
         : []
     );
 
+    // The manual "Builders" group is only reconciled when it already exists; this plugin never
+    // creates it (matching provisioning).
+    const hasManualBuildersGroup =
+      (await GroupResource.fetchManualBuildersGroup(workspace)) !== null;
+
     let updatedCount = 0;
     const errors: string[] = [];
 
@@ -123,7 +126,6 @@ export const applyGroupRoles = createPlugin({
       const expectedRole = determineExpectedRoleFromGroups(user.id, {
         adminUserIds,
         managerUserIds,
-        builderUserIds,
       });
 
       if (currentRole !== expectedRole) {
@@ -139,15 +141,19 @@ export const applyGroupRoles = createPlugin({
             `Failed to update role for user ${user.sId}: ${updateResult.error.type}`
           );
         } else {
-          // Per-changed-member queries, like the role update above: poke-only plugin,
-          // bounded by the number of role changes.
-          await GroupResource.syncBuilderGroupMembership({
-            workspace,
-            user,
-            isBuilder: expectedRole === "builder",
-          });
           updatedCount++;
         }
+      }
+
+      // Mirror `dust-builders` membership into the manual "Builders" group, same as provisioning.
+      // Per-member queries: poke-only plugin, bounded by the number of members.
+      if (hasManualBuildersGroup) {
+        await GroupResource.syncBuilderGroupMembership({
+          workspace,
+          user,
+          isBuilder: builderUserIds.has(user.id),
+          createIfMissing: false,
+        });
       }
     }
 

--- a/front/lib/api/user.test.ts
+++ b/front/lib/api/user.test.ts
@@ -336,12 +336,12 @@ describe("determineUserRoleFromGroups", () => {
     expect(role).toBe("admin");
   });
 
-  it("returns 'builder' when the user is in the dust-builders group", async () => {
+  it("does not grant a role for the dust-builders group (builder deprecated)", async () => {
     await addUserToRoleGroup(BUILDER_GROUP_NAME);
 
     const role = await determineUserRoleFromGroups(workspace, user);
 
-    expect(role).toBe("builder");
+    expect(role).toBe("user");
   });
 
   it("grants 'manager' from the dust-managers group", async () => {
@@ -352,17 +352,16 @@ describe("determineUserRoleFromGroups", () => {
     expect(role).toBe("manager");
   });
 
-  it("prioritizes 'admin' over 'manager' and 'builder'", async () => {
+  it("prioritizes 'admin' over 'manager'", async () => {
     await addUserToRoleGroup(ADMIN_GROUP_NAME);
     await addUserToRoleGroup(MANAGER_GROUP_NAME);
-    await addUserToRoleGroup(BUILDER_GROUP_NAME);
 
     const role = await determineUserRoleFromGroups(workspace, user);
 
     expect(role).toBe("admin");
   });
 
-  it("prioritizes 'manager' over 'builder'", async () => {
+  it("grants 'manager' even when also in the dust-builders group", async () => {
     await addUserToRoleGroup(MANAGER_GROUP_NAME);
     await addUserToRoleGroup(BUILDER_GROUP_NAME);
 

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -2,7 +2,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
 import {
   ADMIN_GROUP_NAME,
-  BUILDER_GROUP_NAME,
   GroupResource,
   MANAGER_GROUP_NAME,
 } from "@app/lib/resources/group_resource";
@@ -303,7 +302,6 @@ export async function determineUserRoleFromGroups(
   });
 
   let atLeastManager = false;
-  let atLeastBuilder = false;
 
   for (const group of userGroups) {
     if (group.name === ADMIN_GROUP_NAME) {
@@ -312,17 +310,12 @@ export async function determineUserRoleFromGroups(
     if (group.name === MANAGER_GROUP_NAME) {
       atLeastManager = true;
     }
-    if (group.name === BUILDER_GROUP_NAME) {
-      atLeastBuilder = true;
-    }
   }
   // If we're here, the user is not in the admin group. Role precedence is
-  // admin > manager > builder > user.
+  // admin > manager > user. The `dust-builders` group no longer grants a role: it is mirrored
+  // into the manual "Builders" group instead (see handleRoleAssignmentForGroup).
   if (atLeastManager) {
     return "manager";
-  }
-  if (atLeastBuilder) {
-    return "builder";
   }
 
   // Did not find any group granting a role, so the user should be a regular user.

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -1022,5 +1022,38 @@ describe("GroupResource", () => {
         await provisionedGroup.getActiveMembers(authenticator);
       expect(provisionedMembers).toEqual([]);
     });
+
+    it("does not create the group when createIfMissing is false", async () => {
+      await GroupResource.syncBuilderGroupMembership({
+        workspace,
+        user,
+        isBuilder: true,
+        createIfMissing: false,
+      });
+
+      const group = await GroupResource.fetchByName(
+        authenticator,
+        MANUAL_BUILDERS_GROUP_NAME
+      );
+      expect(group).toBeNull();
+    });
+
+    it("adds the user to an existing group when createIfMissing is false", async () => {
+      const group = await GroupResource.makeNew({
+        name: MANUAL_BUILDERS_GROUP_NAME,
+        workspaceId: workspace.id,
+        kind: "regular_manual",
+      });
+
+      await GroupResource.syncBuilderGroupMembership({
+        workspace,
+        user,
+        isBuilder: true,
+        createIfMissing: false,
+      });
+
+      const members = await group.getActiveMembers(authenticator);
+      expect(members.map((m) => m.id)).toEqual([user.id]);
+    });
   });
 });

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2634,16 +2634,21 @@ export class GroupResource extends BaseResource<GroupModel> {
     workspace,
     user,
     isBuilder,
+    createIfMissing = true,
   }: {
     workspace: LightWorkspaceType;
     user: UserResource;
     isBuilder: boolean;
+    // When false, the group is never created: if it doesn't exist yet the sync is a no-op. Used
+    // by provisioning, which mirrors `dust-builders` membership into an existing manual group but
+    // must not create one.
+    createIfMissing?: boolean;
   }): Promise<void> {
     const existingGroup =
       await GroupResource.fetchManualBuildersGroup(workspace);
 
-    if (!existingGroup && !isBuilder) {
-      // Nothing to revoke from a group that doesn't exist yet.
+    if (!existingGroup && (!isBuilder || !createIfMissing)) {
+      // Nothing to revoke from a group that doesn't exist yet, and we won't create it.
       return;
     }
 

--- a/front/scripts/unrevoke_membership.ts
+++ b/front/scripts/unrevoke_membership.ts
@@ -1,5 +1,4 @@
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
-import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { ArgumentSpecs } from "@app/scripts/helpers";
@@ -81,22 +80,22 @@ makeScript(
     );
 
     if (execute) {
+      // The `builder` role is deprecated and can no longer be assigned, so restore a
+      // previously-revoked builder as a regular user (builders are now driven by the
+      // `dust-builders` provisioning group / manual "Builders" group instead).
+      const restoredRole =
+        latestMembership.role === "builder" ? "user" : latestMembership.role;
+
       // Use updateMembershipRole with allowTerminated=true to unrevoke
       const result = await MembershipResource.updateMembershipRole({
         user,
         workspace,
-        newRole: latestMembership.role,
+        newRole: restoredRole,
         allowTerminated: true,
         author: "no-author",
       });
 
       if (result.isOk()) {
-        await GroupResource.syncBuilderGroupMembership({
-          workspace,
-          user,
-          isBuilder: result.value.newRole === "builder",
-        });
-
         scriptLogger.info(
           {
             userId: user.sId,

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -215,11 +215,20 @@ async function handleRoleAssignmentForGroup(
     directoryId?: string;
   }
 ) {
-  if (
-    group.name !== ADMIN_GROUP_NAME &&
-    group.name !== MANAGER_GROUP_NAME &&
-    group.name !== BUILDER_GROUP_NAME
-  ) {
+  // The `dust-builders` provisioning group no longer grants the deprecated builder role. Mirror
+  // the membership into the workspace's manual "Builders" group when it exists; if the group has
+  // not been created, ignore it (provisioning never creates it).
+  if (group.name === BUILDER_GROUP_NAME) {
+    await GroupResource.syncBuilderGroupMembership({
+      workspace,
+      user,
+      isBuilder: action === "add",
+      createIfMissing: false,
+    });
+    return;
+  }
+
+  if (group.name !== ADMIN_GROUP_NAME && group.name !== MANAGER_GROUP_NAME) {
     // Not a special group, no role assignment needed.
     return;
   }
@@ -258,12 +267,6 @@ async function handleRoleAssignmentForGroup(
           `Failed to assign ${newRole} role to user ${user.sId}: ${updateResult.error.type}`
         );
       }
-
-      await GroupResource.syncBuilderGroupMembership({
-        workspace,
-        user,
-        isBuilder: newRole === "builder",
-      });
 
       logger.info(
         {
@@ -312,12 +315,6 @@ async function handleRoleAssignmentForGroup(
           `Failed to downgrade user role for ${user.sId}: ${updateResult.error.type}`
         );
       }
-
-      await GroupResource.syncBuilderGroupMembership({
-        workspace,
-        user,
-        isBuilder: newRole === "builder",
-      });
 
       logger.info(
         {


### PR DESCRIPTION
## Description

Makes the deprecated **builder role** fully decoupled from the manual **"Builders" group**: the role is never assigned from group membership, and the manual Builders group is fed **only by provisioning** (the `dust-builders` IdP group) plus manual admin edits.

### Provisioning (WorkOS group sync)
- `determineUserRoleFromGroups` (`front/lib/api/user.ts`) drops the `dust-builders` → `builder` branch. Role precedence is now `admin > manager > user`.
- `handleRoleAssignmentForGroup` (`front/temporal/workos_events_queue/activities.ts`) handles `dust-builders` separately: mirrors the add/remove into the manual "Builders" group via `syncBuilderGroupMembership({ createIfMissing: false })` and returns; the admin/manager path no longer runs the role-driven Builders-group sync.
- `GroupResource.syncBuilderGroupMembership` gains `createIfMissing` (default `true`, so existing callers are unchanged). When `false` and the manual group doesn't exist, the sync is a no-op — provisioning never creates the group.

### Stop syncing the Builders group from the membership role
Now that no product path assigns the builder role, the role-driven Builders-group syncs on membership mutations are dead (they'd only ever strip membership). Removed:
- `front/lib/api/membership.ts`: `createAndTrackMembership`, `updateMembershipRoleAndTrack`, and `revokeAndTrackMembership` (incl. the `already_revoked` heal) no longer touch the Builders group.
- Poke **`applyGroupRoles`**: no longer assigns `builder` from the `dust-builders` group. It resyncs admin/manager roles and mirrors `dust-builders` membership into the manual "Builders" group (if it exists), matching provisioning.
- `unrevoke_membership` script: no group sync; also restores a previously-revoked `builder` as a regular `user`.

### Left as-is (out of scope)
- `KeyResource.syncBuilderGroupMembership` — API-key builder scope is a separate concept (keys, not members).
- One-off backfill migrations (`20260721_backfill_builders_group.ts`) — already run, immutable.

This is the provisioning counterpart to invitation acceptance (#29666, builder→user) and the invitation/role-update API rejection (#29674). With these, no product path assigns the builder role.

## Risks

Risk: low/medium (provisioning + poke resync paths). `dust-builders` now yields `user` role + manual Builders-group membership (when the group exists) instead of the `builder` role. Admin/manager provisioning is unchanged. `syncBuilderGroupMembership`'s other callers are unaffected (default `createIfMissing: true`).

## Verification

- `tsgo --noEmit` clean in `front`; `biome check` clean on changed files.
- `front/lib/api/user.test.ts` (16), `front/lib/resources/group_resource.test.ts` (37), `front/lib/api/membership.test.ts` (6) pass — including updated `determineUserRoleFromGroups` expectations and new `createIfMissing: false` coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)