### PR TITLE
refactor: align client MCP tool definitions with internal ones

### DIFF
--- a/extension/shared/tools/index.ts
+++ b/extension/shared/tools/index.ts
@@ -1,5 +1,6 @@
 import {
   buildTools,
+  type MCPToolHandlerExtra,
   type ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 
@@ -39,7 +40,10 @@ export function registerAllTools(
   captureService: CaptureService | null,
   workspaceId: string
 ): void {
-  const handlers: ToolHandlers<typeof CHROME_TOOLS_METADATA, []> = {
+  const handlers: ToolHandlers<
+    typeof CHROME_TOOLS_METADATA,
+    MCPToolHandlerExtra
+  > = {
     [ATTACH_TABS_TEXT_TOOL_NAME]: (params) =>
       attachTabsTextTool({ ...params, captureService }),
     [TAKE_SCREENSHOT_OR_ATTACH_FILE_TOOL_NAME]: (params) =>
@@ -75,8 +79,8 @@ export function registerAllTools(
           },
         },
       },
-      async (params) => {
-        const result = await tool.handler(params);
+      async (params, extra) => {
+        const result = await tool.handler(params, extra);
         if (result.isErr()) {
           return {
             isError: true,

--- a/extension/shared/tools/index.ts
+++ b/extension/shared/tools/index.ts
@@ -1,6 +1,6 @@
 import {
-  buildClientTools,
-  type ClientToolHandlers,
+  buildTools,
+  type ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 
 import type { CaptureService } from "@extension/shared/services/capture";
@@ -39,7 +39,7 @@ export function registerAllTools(
   captureService: CaptureService | null,
   workspaceId: string
 ): void {
-  const handlers: ClientToolHandlers<typeof CHROME_TOOLS_METADATA> = {
+  const handlers: ToolHandlers<typeof CHROME_TOOLS_METADATA, []> = {
     [ATTACH_TABS_TEXT_TOOL_NAME]: (params) =>
       attachTabsTextTool({ ...params, captureService }),
     [TAKE_SCREENSHOT_OR_ATTACH_FILE_TOOL_NAME]: (params) =>
@@ -57,7 +57,7 @@ export function registerAllTools(
     [INTERACT_WITH_PAGE_TOOL_NAME]: (params) => interactWithPageTool(params),
   };
 
-  const tools = buildClientTools(CHROME_TOOLS_METADATA, handlers);
+  const tools = buildTools(CHROME_TOOLS_METADATA, handlers);
 
   for (const tool of tools) {
     server.registerTool(

--- a/extension/shared/tools/index.ts
+++ b/extension/shared/tools/index.ts
@@ -1,5 +1,6 @@
 import {
   buildTools,
+  type MCPToolHandlerExtra,
   type ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 
@@ -39,7 +40,10 @@ export function registerAllTools(
   captureService: CaptureService | null,
   workspaceId: string
 ): void {
-  const handlers = {
+  const handlers: ToolHandlers<
+    typeof CHROME_TOOLS_METADATA,
+    MCPToolHandlerExtra
+  > = {
     [ATTACH_TABS_TEXT_TOOL_NAME]: (params) =>
       attachTabsTextTool({ ...params, captureService }),
     [TAKE_SCREENSHOT_OR_ATTACH_FILE_TOOL_NAME]: (params) =>
@@ -55,7 +59,7 @@ export function registerAllTools(
     [OPEN_BROWSER_TAB_TOOL_NAME]: (params) => openBrowserTab(params),
     [RELOAD_BROWSER_TAB_TOOL_NAME]: (params) => reloadBrowserTabTool(params),
     [INTERACT_WITH_PAGE_TOOL_NAME]: (params) => interactWithPageTool(params),
-  } satisfies ToolHandlers<typeof CHROME_TOOLS_METADATA>;
+  };
 
   const tools = buildTools(CHROME_TOOLS_METADATA, handlers);
 
@@ -75,8 +79,8 @@ export function registerAllTools(
           },
         },
       },
-      async (params) => {
-        const result = await tool.handler(params);
+      async (params, extra) => {
+        const result = await tool.handler(params, extra);
         if (result.isErr()) {
           return {
             isError: true,

--- a/extension/shared/tools/index.ts
+++ b/extension/shared/tools/index.ts
@@ -1,6 +1,5 @@
 import {
   buildTools,
-  type MCPToolHandlerExtra,
   type ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 
@@ -40,10 +39,7 @@ export function registerAllTools(
   captureService: CaptureService | null,
   workspaceId: string
 ): void {
-  const handlers: ToolHandlers<
-    typeof CHROME_TOOLS_METADATA,
-    MCPToolHandlerExtra
-  > = {
+  const handlers = {
     [ATTACH_TABS_TEXT_TOOL_NAME]: (params) =>
       attachTabsTextTool({ ...params, captureService }),
     [TAKE_SCREENSHOT_OR_ATTACH_FILE_TOOL_NAME]: (params) =>
@@ -59,7 +55,7 @@ export function registerAllTools(
     [OPEN_BROWSER_TAB_TOOL_NAME]: (params) => openBrowserTab(params),
     [RELOAD_BROWSER_TAB_TOOL_NAME]: (params) => reloadBrowserTabTool(params),
     [INTERACT_WITH_PAGE_TOOL_NAME]: (params) => interactWithPageTool(params),
-  };
+  } satisfies ToolHandlers<typeof CHROME_TOOLS_METADATA>;
 
   const tools = buildTools(CHROME_TOOLS_METADATA, handlers);
 
@@ -79,8 +75,8 @@ export function registerAllTools(
           },
         },
       },
-      async (params, extra) => {
-        const result = await tool.handler(params, extra);
+      async (params) => {
+        const result = await tool.handler(params);
         if (result.isErr()) {
           return {
             isError: true,

--- a/extension/shared/tools/index.ts
+++ b/extension/shared/tools/index.ts
@@ -1,7 +1,6 @@
 import {
   buildTools,
-  type MCPToolHandlerExtra,
-  type ToolHandlers,
+  type ClientToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 
 import type { CaptureService } from "@extension/shared/services/capture";
@@ -40,10 +39,7 @@ export function registerAllTools(
   captureService: CaptureService | null,
   workspaceId: string
 ): void {
-  const handlers: ToolHandlers<
-    typeof CHROME_TOOLS_METADATA,
-    MCPToolHandlerExtra
-  > = {
+  const handlers: ClientToolHandlers<typeof CHROME_TOOLS_METADATA> = {
     [ATTACH_TABS_TEXT_TOOL_NAME]: (params) =>
       attachTabsTextTool({ ...params, captureService }),
     [TAKE_SCREENSHOT_OR_ATTACH_FILE_TOOL_NAME]: (params) =>

--- a/extension/shared/tools/metadata.ts
+++ b/extension/shared/tools/metadata.ts
@@ -213,7 +213,7 @@ type_text automatically focuses the element before typing.
 delete_text automatically focuses the element before deleting the text.
 For the above reasons in most cases you do NOT need to click an element before calling type_text or delete_text.
 Avoid unnecessary actions.`,
-    schema: z.object({
+    schema: {
       action: z
         .enum(["get_elements", "click_element", "type_text", "delete_text"])
         .describe("Action to perform."),
@@ -239,7 +239,7 @@ Avoid unnecessary actions.`,
         .describe(
           "A human-readable description of the interaction being performed. Describe the tab, the element, and the action clearly, e.g. 'Click the Submit button on the Login tab' or 'Type \"hello\" into the search input on the Google tab'."
         ),
-    }).shape,
+    },
     argumentsRequiringApproval: ["tabId"],
     stake: "medium",
     displayLabels: {

--- a/extension/shared/tools/metadata.ts
+++ b/extension/shared/tools/metadata.ts
@@ -1,4 +1,3 @@
-import { createClientToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { z } from "zod";
 
@@ -41,8 +40,9 @@ export function getBrowserMCPServerInstructions({
   );
 }
 
-export const CHROME_TOOLS_METADATA = createClientToolsRecord({
-  [ATTACH_TABS_TEXT_TOOL_NAME]: {
+export const CHROME_TOOLS_METADATA = [
+  {
+    name: ATTACH_TABS_TEXT_TOOL_NAME,
     description:
       "Extracts the title, URL, and text content of a browser tab. " +
       "Use this to read and understand the specific content the user is viewing, including ordinary HTML pages, rendered emails or threads, search results, filtered lists, and other visible browser state. " +
@@ -67,7 +67,8 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [TAKE_SCREENSHOT_OR_ATTACH_FILE_TOOL_NAME]: {
+  {
+    name: TAKE_SCREENSHOT_OR_ATTACH_FILE_TOOL_NAME,
     description:
       "Captures or attaches visual or file content from a browser tab. " +
       "For PDF pages, uploads the file and returns the full extracted text so you can read it. " +
@@ -93,7 +94,8 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [LIST_BROWSER_TABS_TOOL_NAME]: {
+  {
+    name: LIST_BROWSER_TABS_TOOL_NAME,
     description:
       "Lists all open tabs in the current browser window with their tab ID, title, URL, and whether they are active. " +
       "The active tab (what the user is currently looking at) is marked with an asterisk (*). " +
@@ -108,7 +110,8 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [SWITCH_TO_BROWSER_TAB_TOOL_NAME]: {
+  {
+    name: SWITCH_TO_BROWSER_TAB_TOOL_NAME,
     description:
       "Switches to the specified browser tab, making it the active tab. " +
       `Use ${LIST_BROWSER_TABS_TOOL_NAME} to discover tab IDs.`,
@@ -123,7 +126,8 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [CLOSE_BROWSER_TAB_TOOL_NAME]: {
+  {
+    name: CLOSE_BROWSER_TAB_TOOL_NAME,
     description: `Closes the specified browser tab. Use ${LIST_BROWSER_TABS_TOOL_NAME} to discover tab IDs.`,
     schema: {
       tabId: z.number().describe("The tab ID to close."),
@@ -136,7 +140,8 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [OPEN_BROWSER_TAB_TOOL_NAME]: {
+  {
+    name: OPEN_BROWSER_TAB_TOOL_NAME,
     description: "Opens a new browser tab with the specified URL.",
     schema: {
       url: z.string().url().describe("The URL to open in a new tab."),
@@ -149,7 +154,8 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [MOVE_BROWSER_TAB_TOOL_NAME]: {
+  {
+    name: MOVE_BROWSER_TAB_TOOL_NAME,
     description:
       "Moves a browser tab to a new position (index) in the tab bar. " +
       `Use ${LIST_BROWSER_TABS_TOOL_NAME} to discover tab IDs and current order.`,
@@ -169,7 +175,8 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [RELOAD_BROWSER_TAB_TOOL_NAME]: {
+  {
+    name: RELOAD_BROWSER_TAB_TOOL_NAME,
     description:
       "Reloads the specified browser tab. Useful after server-side actions that modify page content. " +
       `Use ${LIST_BROWSER_TABS_TOOL_NAME} to discover tab IDs.`,
@@ -184,7 +191,8 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
     toolCostCategory: "basic",
     freeUsage: true,
   },
-  [INTERACT_WITH_PAGE_TOOL_NAME]: {
+  {
+    name: INTERACT_WITH_PAGE_TOOL_NAME,
     description: `Interact with a browser tab of the user's browser window.
 
 Available actions:
@@ -241,4 +249,4 @@ Avoid unnecessary actions.`,
     toolCostCategory: "basic",
     freeUsage: true,
   },
-});
+] as const;

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -32,14 +32,14 @@ export type ToolHandlers<
   ToolsList extends readonly ToolMeta[],
   // Keep tool names as a separate generic so that generic consumers don't widen them to strings.
   ToolNames extends string = ToolsList[number]["name"],
-  HandlerExtra = ToolHandlerExtra,
+  THandlerExtra = ToolHandlerExtra,
 > = {
   [ToolName in ToolNames]: (
     // Type the params with the type inferred from the zod schema (z.ZodObject because it's a zod shape, not a schema).
     params: z.infer<
       z.ZodObject<Extract<ToolsList[number], { name: ToolName }>["schema"]>
     >,
-    extra: HandlerExtra
+    extra: THandlerExtra
   ) => Promise<ToolHandlerResult>;
 };
 
@@ -51,7 +51,7 @@ export type ClientToolHandlers<
 export interface ToolDefinition<
   TName extends string = string,
   TSchema extends ZodRawShape = ZodRawShape,
-  HandlerExtra = ToolHandlerExtra,
+  THandlerExtra = ToolHandlerExtra,
 > {
   name: TName;
   enableAlerting?: boolean;
@@ -69,7 +69,7 @@ export interface ToolDefinition<
   >;
   handler(
     params: z.infer<z.ZodObject<TSchema>>,
-    extra: HandlerExtra
+    extra: THandlerExtra
   ): Promise<ToolHandlerResult>;
 }
 
@@ -82,11 +82,11 @@ export function buildTools<
   const TName extends string,
   const T extends readonly ToolMeta<TName>[],
   // Internal tools always receive auth and runContext, while client-side tools do not.
-  HandlerExtra = ToolHandlerExtra,
+  THandlerExtra = ToolHandlerExtra,
 >(
   metadata: T,
-  handlers: ToolHandlers<T, TName, HandlerExtra>
-): ToolDefinition<TName, ZodRawShape, HandlerExtra>[] {
+  handlers: ToolHandlers<T, TName, THandlerExtra>
+): ToolDefinition<TName, ZodRawShape, THandlerExtra>[] {
   return metadata.map((tool) => ({
     ...tool,
     handler: handlers[tool.name],

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -30,9 +30,9 @@ export type ToolHandlerResult = Result<CallToolResult["content"], MCPError>;
 
 export type ToolHandlers<
   ToolsList extends readonly ToolMeta[],
-  HandlerExtra = ToolHandlerExtra,
   // Keep tool names as a separate generic so that generic consumers don't widen them to strings.
   ToolNames extends string = ToolsList[number]["name"],
+  HandlerExtra = ToolHandlerExtra,
 > = {
   [ToolName in ToolNames]: (
     // Type the params with the type inferred from the zod schema (z.ZodObject because it's a zod shape, not a schema).
@@ -46,7 +46,7 @@ export type ToolHandlers<
 export type ClientToolHandlers<
   ToolsList extends readonly ToolMeta[],
   ToolNames extends string = ToolsList[number]["name"],
-> = ToolHandlers<ToolsList, MCPToolHandlerExtra, ToolNames>;
+> = ToolHandlers<ToolsList, ToolNames, MCPToolHandlerExtra>;
 
 export interface ToolDefinition<
   TName extends string = string,
@@ -85,7 +85,7 @@ export function buildTools<
   HandlerExtra = ToolHandlerExtra,
 >(
   metadata: T,
-  handlers: ToolHandlers<T, HandlerExtra, TName>
+  handlers: ToolHandlers<T, TName, HandlerExtra>
 ): ToolDefinition<TName, ZodRawShape, HandlerExtra>[] {
   return metadata.map((tool) => ({
     ...tool,

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -76,6 +76,7 @@ export type ToolMeta<
 export function buildTools<
   const TName extends string,
   const T extends readonly ToolMeta<TName>[],
+  // Internal tools always receive auth and runContext, while client-side tools do not.
   HandlerExtra = ToolHandlerExtra,
 >(
   metadata: T,

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -78,14 +78,13 @@ export type ToolMeta<
   TSchema extends ZodRawShape = ZodRawShape,
 > = Omit<ToolDefinition<TName, TSchema>, "handler">;
 
+// Type that ties the values in `argumentsRequiringApproval` with the actual parameter names in the schema.
 type ValidToolMetadata<T extends readonly ToolMeta[]> = {
-  [K in Extract<keyof T, `${number}`>]: T[K] extends ToolMeta
-    ? {
-        argumentsRequiringApproval?: ReadonlyArray<
-          Extract<keyof z.infer<z.ZodObject<T[K]["schema"]>>, string>
-        >;
-      }
-    : T[K];
+  [K in keyof T]: {
+    argumentsRequiringApproval?: ReadonlyArray<
+      Extract<keyof z.infer<z.ZodObject<T[K]["schema"]>>, string>
+    >;
+  };
 };
 
 export function buildTools<
@@ -94,7 +93,7 @@ export function buildTools<
   // Internal tools always receive auth and runContext, while client-side tools do not.
   THandlerExtra = ToolHandlerExtra,
 >(
-  metadata: T & ValidToolMetadata<NoInfer<T>>,
+  metadata: T & ValidToolMetadata<T>,
   handlers: ToolHandlers<T, TName, THandlerExtra>
 ): ToolDefinition<TName, ZodRawShape, THandlerExtra>[] {
   return metadata.map((tool) => ({

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -78,13 +78,23 @@ export type ToolMeta<
   TSchema extends ZodRawShape = ZodRawShape,
 > = Omit<ToolDefinition<TName, TSchema>, "handler">;
 
+type ValidToolMetadata<T extends readonly ToolMeta[]> = {
+  [K in Extract<keyof T, `${number}`>]: T[K] extends ToolMeta
+    ? {
+        argumentsRequiringApproval?: ReadonlyArray<
+          Extract<keyof z.infer<z.ZodObject<T[K]["schema"]>>, string>
+        >;
+      }
+    : T[K];
+};
+
 export function buildTools<
   const TName extends string,
   const T extends readonly ToolMeta<TName>[],
   // Internal tools always receive auth and runContext, while client-side tools do not.
   THandlerExtra = ToolHandlerExtra,
 >(
-  metadata: T,
+  metadata: T & ValidToolMetadata<NoInfer<T>>,
   handlers: ToolHandlers<T, TName, THandlerExtra>
 ): ToolDefinition<TName, ZodRawShape, THandlerExtra>[] {
   return metadata.map((tool) => ({

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -16,10 +16,12 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 import type { ZodRawShape, z } from "zod";
 
-export type ToolHandlerExtra = RequestHandlerExtra<
+export type MCPToolHandlerExtra = RequestHandlerExtra<
   ServerRequest,
   ServerNotification
-> & {
+>;
+
+export type ToolHandlerExtra = MCPToolHandlerExtra & {
   auth: Authenticator;
   runContext: ToolRunContext;
 };
@@ -28,6 +30,7 @@ export type ToolHandlerResult = Result<CallToolResult["content"], MCPError>;
 
 export type ToolHandlers<
   ToolsList extends readonly ToolMeta[],
+  HandlerExtra = ToolHandlerExtra,
   // Keep tool names as a separate generic so that generic consumers don't widen them to strings.
   ToolNames extends string = ToolsList[number]["name"],
 > = {
@@ -36,25 +39,14 @@ export type ToolHandlers<
     params: z.infer<
       z.ZodObject<Extract<ToolsList[number], { name: ToolName }>["schema"]>
     >,
-    extra: ToolHandlerExtra
-  ) => Promise<ToolHandlerResult>;
-};
-
-// Client-side handlers do not receive the auth and runContext available to internal tools.
-type ToolHandlersWithoutExtra<
-  ToolsList extends readonly ToolMeta[],
-  ToolNames extends string = ToolsList[number]["name"],
-> = {
-  [ToolName in ToolNames]: (
-    params: z.infer<
-      z.ZodObject<Extract<ToolsList[number], { name: ToolName }>["schema"]>
-    >
+    extra: HandlerExtra
   ) => Promise<ToolHandlerResult>;
 };
 
 export interface ToolDefinition<
   TName extends string = string,
   TSchema extends ZodRawShape = ZodRawShape,
+  HandlerExtra = ToolHandlerExtra,
 > {
   name: TName;
   enableAlerting?: boolean;
@@ -72,16 +64,9 @@ export interface ToolDefinition<
   >;
   handler(
     params: z.infer<z.ZodObject<TSchema>>,
-    extra: ToolHandlerExtra
+    extra: HandlerExtra
   ): Promise<ToolHandlerResult>;
 }
-
-type ToolDefinitionWithoutExtra<
-  TName extends string = string,
-  TSchema extends ZodRawShape = ZodRawShape,
-> = Omit<ToolDefinition<TName, TSchema>, "handler"> & {
-  handler(params: z.infer<z.ZodObject<TSchema>>): Promise<ToolHandlerResult>;
-};
 
 export type ToolMeta<
   TName extends string = string,
@@ -91,21 +76,12 @@ export type ToolMeta<
 export function buildTools<
   const TName extends string,
   const T extends readonly ToolMeta<TName>[],
+  // Internal tools always receive auth and runContext, while client-side tools do not.
+  HandlerExtra = ToolHandlerExtra,
 >(
   metadata: T,
-  handlers: ToolHandlersWithoutExtra<T, TName>
-): ToolDefinitionWithoutExtra<TName>[];
-export function buildTools<
-  const TName extends string,
-  const T extends readonly ToolMeta<TName>[],
->(metadata: T, handlers: ToolHandlers<T, TName>): ToolDefinition<TName>[];
-export function buildTools<
-  const TName extends string,
-  const T extends readonly ToolMeta<TName>[],
->(
-  metadata: T,
-  handlers: ToolHandlersWithoutExtra<T, TName> | ToolHandlers<T, TName>
-) {
+  handlers: ToolHandlers<T, HandlerExtra, TName>
+): ToolDefinition<TName, ZodRawShape, HandlerExtra>[] {
   return metadata.map((tool) => ({
     ...tool,
     handler: handlers[tool.name],

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -16,12 +16,10 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 import type { ZodRawShape, z } from "zod";
 
-export type MCPToolHandlerExtra = RequestHandlerExtra<
+export type ToolHandlerExtra = RequestHandlerExtra<
   ServerRequest,
   ServerNotification
->;
-
-export type ToolHandlerExtra = MCPToolHandlerExtra & {
+> & {
   auth: Authenticator;
   runContext: ToolRunContext;
 };
@@ -30,7 +28,6 @@ export type ToolHandlerResult = Result<CallToolResult["content"], MCPError>;
 
 export type ToolHandlers<
   ToolsList extends readonly ToolMeta[],
-  HandlerExtra = ToolHandlerExtra,
   // Keep tool names as a separate generic so that generic consumers don't widen them to strings.
   ToolNames extends string = ToolsList[number]["name"],
 > = {
@@ -39,14 +36,25 @@ export type ToolHandlers<
     params: z.infer<
       z.ZodObject<Extract<ToolsList[number], { name: ToolName }>["schema"]>
     >,
-    extra: HandlerExtra
+    extra: ToolHandlerExtra
+  ) => Promise<ToolHandlerResult>;
+};
+
+// Client-side handlers do not receive the auth and runContext available to internal tools.
+type ToolHandlersWithoutExtra<
+  ToolsList extends readonly ToolMeta[],
+  ToolNames extends string = ToolsList[number]["name"],
+> = {
+  [ToolName in ToolNames]: (
+    params: z.infer<
+      z.ZodObject<Extract<ToolsList[number], { name: ToolName }>["schema"]>
+    >
   ) => Promise<ToolHandlerResult>;
 };
 
 export interface ToolDefinition<
   TName extends string = string,
   TSchema extends ZodRawShape = ZodRawShape,
-  HandlerExtra = ToolHandlerExtra,
 > {
   name: TName;
   enableAlerting?: boolean;
@@ -64,9 +72,16 @@ export interface ToolDefinition<
   >;
   handler(
     params: z.infer<z.ZodObject<TSchema>>,
-    extra: HandlerExtra
+    extra: ToolHandlerExtra
   ): Promise<ToolHandlerResult>;
 }
+
+type ToolDefinitionWithoutExtra<
+  TName extends string = string,
+  TSchema extends ZodRawShape = ZodRawShape,
+> = Omit<ToolDefinition<TName, TSchema>, "handler"> & {
+  handler(params: z.infer<z.ZodObject<TSchema>>): Promise<ToolHandlerResult>;
+};
 
 export type ToolMeta<
   TName extends string = string,
@@ -76,12 +91,21 @@ export type ToolMeta<
 export function buildTools<
   const TName extends string,
   const T extends readonly ToolMeta<TName>[],
-  // Internal tools always receive auth and runContext, while client-side tools do not.
-  HandlerExtra = ToolHandlerExtra,
 >(
   metadata: T,
-  handlers: ToolHandlers<T, HandlerExtra, TName>
-): ToolDefinition<TName, ZodRawShape, HandlerExtra>[] {
+  handlers: ToolHandlersWithoutExtra<T, TName>
+): ToolDefinitionWithoutExtra<TName>[];
+export function buildTools<
+  const TName extends string,
+  const T extends readonly ToolMeta<TName>[],
+>(metadata: T, handlers: ToolHandlers<T, TName>): ToolDefinition<TName>[];
+export function buildTools<
+  const TName extends string,
+  const T extends readonly ToolMeta<TName>[],
+>(
+  metadata: T,
+  handlers: ToolHandlersWithoutExtra<T, TName> | ToolHandlers<T, TName>
+) {
   return metadata.map((tool) => ({
     ...tool,
     handler: handlers[tool.name],

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -16,12 +16,12 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 import type { ZodRawShape, z } from "zod";
 
-export type MCPToolHandlerExtra = RequestHandlerExtra<
+export type BaseToolHandlerExtra = RequestHandlerExtra<
   ServerRequest,
   ServerNotification
 >;
 
-export type ToolHandlerExtra = MCPToolHandlerExtra & {
+export type ToolHandlerExtra = BaseToolHandlerExtra & {
   auth: Authenticator;
   runContext: ToolRunContext;
 };
@@ -46,7 +46,7 @@ export type ToolHandlers<
 export type ClientToolHandlers<
   ToolsList extends readonly ToolMeta[],
   ToolNames extends string = ToolsList[number]["name"],
-> = ToolHandlers<ToolsList, ToolNames, MCPToolHandlerExtra>;
+> = ToolHandlers<ToolsList, ToolNames, BaseToolHandlerExtra>;
 
 export interface ToolDefinition<
   TName extends string = string,

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -16,10 +16,12 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 import type { ZodRawShape, z } from "zod";
 
-export type ToolHandlerExtra = RequestHandlerExtra<
+export type MCPToolHandlerExtra = RequestHandlerExtra<
   ServerRequest,
   ServerNotification
-> & {
+>;
+
+export type ToolHandlerExtra = MCPToolHandlerExtra & {
   auth: Authenticator;
   runContext: ToolRunContext;
 };
@@ -28,7 +30,7 @@ export type ToolHandlerResult = Result<CallToolResult["content"], MCPError>;
 
 export type ToolHandlers<
   ToolsList extends readonly ToolMeta[],
-  HandlerExtraArgs extends unknown[] = [extra: ToolHandlerExtra],
+  HandlerExtra = ToolHandlerExtra,
   // Keep tool names as a separate generic so that generic consumers don't widen them to strings.
   ToolNames extends string = ToolsList[number]["name"],
 > = {
@@ -37,14 +39,14 @@ export type ToolHandlers<
     params: z.infer<
       z.ZodObject<Extract<ToolsList[number], { name: ToolName }>["schema"]>
     >,
-    ...extra: HandlerExtraArgs
+    extra: HandlerExtra
   ) => Promise<ToolHandlerResult>;
 };
 
 export interface ToolDefinition<
   TName extends string = string,
   TSchema extends ZodRawShape = ZodRawShape,
-  HandlerExtraArgs extends unknown[] = [extra: ToolHandlerExtra],
+  HandlerExtra = ToolHandlerExtra,
 > {
   name: TName;
   enableAlerting?: boolean;
@@ -62,7 +64,7 @@ export interface ToolDefinition<
   >;
   handler(
     params: z.infer<z.ZodObject<TSchema>>,
-    ...extra: HandlerExtraArgs
+    extra: HandlerExtra
   ): Promise<ToolHandlerResult>;
 }
 
@@ -74,11 +76,11 @@ export type ToolMeta<
 export function buildTools<
   const TName extends string,
   const T extends readonly ToolMeta<TName>[],
-  HandlerExtraArgs extends unknown[] = [extra: ToolHandlerExtra],
+  HandlerExtra = ToolHandlerExtra,
 >(
   metadata: T,
-  handlers: ToolHandlers<T, HandlerExtraArgs, TName>
-): ToolDefinition<TName, ZodRawShape, HandlerExtraArgs>[] {
+  handlers: ToolHandlers<T, HandlerExtra, TName>
+): ToolDefinition<TName, ZodRawShape, HandlerExtra>[] {
   return metadata.map((tool) => ({
     ...tool,
     handler: handlers[tool.name],

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -28,6 +28,7 @@ export type ToolHandlerResult = Result<CallToolResult["content"], MCPError>;
 
 export type ToolHandlers<
   ToolsList extends readonly ToolMeta[],
+  HandlerExtraArgs extends unknown[] = [extra: ToolHandlerExtra],
   // Keep tool names as a separate generic so that generic consumers don't widen them to strings.
   ToolNames extends string = ToolsList[number]["name"],
 > = {
@@ -36,21 +37,14 @@ export type ToolHandlers<
     params: z.infer<
       z.ZodObject<Extract<ToolsList[number], { name: ToolName }>["schema"]>
     >,
-    extra: ToolHandlerExtra
-  ) => Promise<ToolHandlerResult>;
-};
-
-export type ClientToolHandlers<
-  T extends Record<string, { schema: ZodRawShape }>,
-> = {
-  [K in keyof T]: (
-    params: z.infer<z.ZodObject<T[K]["schema"]>>
+    ...extra: HandlerExtraArgs
   ) => Promise<ToolHandlerResult>;
 };
 
 export interface ToolDefinition<
   TName extends string = string,
   TSchema extends ZodRawShape = ZodRawShape,
+  HandlerExtraArgs extends unknown[] = [extra: ToolHandlerExtra],
 > {
   name: TName;
   enableAlerting?: boolean;
@@ -63,30 +57,13 @@ export interface ToolDefinition<
   displayLabels: ToolDisplayLabels;
   toolCostCategory: ToolCostCategory;
   freeUsage: boolean;
-  handler(
-    params: z.infer<z.ZodObject<TSchema>>,
-    extra: ToolHandlerExtra
-  ): Promise<ToolHandlerResult>;
-}
-
-interface ClientToolDefinition<
-  TName extends string = string,
-  TSchema extends ZodRawShape = ZodRawShape,
-> {
-  name: TName;
-  enableAlerting?: boolean;
-  description: string;
-  schema: TSchema;
-  stake: MCPToolStakeLevelType;
-  displayLabels: ToolDisplayLabels;
-  toolCostCategory: ToolCostCategory;
-  freeUsage: boolean;
-  argumentsRequiringApproval?: Array<
+  argumentsRequiringApproval?: ReadonlyArray<
     Extract<keyof z.infer<z.ZodObject<TSchema>>, string>
   >;
-  handler: (
-    params: z.infer<z.ZodObject<TSchema>>
-  ) => Promise<ToolHandlerResult>;
+  handler(
+    params: z.infer<z.ZodObject<TSchema>>,
+    ...extra: HandlerExtraArgs
+  ): Promise<ToolHandlerResult>;
 }
 
 export type ToolMeta<
@@ -94,43 +71,14 @@ export type ToolMeta<
   TSchema extends ZodRawShape = ZodRawShape,
 > = Omit<ToolDefinition<TName, TSchema>, "handler">;
 
-export type ClientToolMeta<
-  TName extends string = string,
-  TSchema extends ZodRawShape = ZodRawShape,
-> = Omit<ClientToolDefinition<TName, TSchema>, "handler">;
-
-export function createClientToolsRecord<
-  T extends {
-    [K in keyof T]: T[K] extends { schema: infer S extends ZodRawShape }
-      ? Omit<ClientToolMeta<string, S>, "name">
-      : Omit<ClientToolMeta, "name">;
-  },
->(tools: T): { [K in keyof T]: T[K] & { name: K } } {
-  return Object.fromEntries(
-    Object.entries(tools).map(([key, value]) => [
-      key,
-      { ...(value as object), name: key },
-    ])
-  ) as { [K in keyof T]: T[K] & { name: K } };
-}
-
-export function buildClientTools<T extends Record<string, ClientToolMeta>>(
-  metadata: T,
-  handlers: ClientToolHandlers<T>
-): ClientToolDefinition[] {
-  return (Object.keys(metadata) as (keyof T & string)[]).map(
-    (key) =>
-      ({
-        ...metadata[key],
-        handler: handlers[key],
-      }) as unknown as ClientToolDefinition
-  );
-}
-
 export function buildTools<
   const TName extends string,
   const T extends readonly ToolMeta<TName>[],
->(metadata: T, handlers: ToolHandlers<T, TName>): ToolDefinition[] {
+  HandlerExtraArgs extends unknown[] = [extra: ToolHandlerExtra],
+>(
+  metadata: T,
+  handlers: ToolHandlers<T, HandlerExtraArgs, TName>
+): ToolDefinition<TName, ZodRawShape, HandlerExtraArgs>[] {
   return metadata.map((tool) => ({
     ...tool,
     handler: handlers[tool.name],

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -43,6 +43,11 @@ export type ToolHandlers<
   ) => Promise<ToolHandlerResult>;
 };
 
+export type ClientToolHandlers<
+  ToolsList extends readonly ToolMeta[],
+  ToolNames extends string = ToolsList[number]["name"],
+> = ToolHandlers<ToolsList, MCPToolHandlerExtra, ToolNames>;
+
 export interface ToolDefinition<
   TName extends string = string,
   TSchema extends ZodRawShape = ZodRawShape,


### PR DESCRIPTION
## Description

Follow-up on [#29115](https://github.com/dust-tt/dust/pull/29115), which moved internal MCP tool metadata from helper-built records to explicit arrays and the shared `ToolHandlers` / `buildTools` pattern.

Client tools still used the old pattern with `createClientToolsRecord` and quite a few specific (almost duplicated) types and heplers.

The only difference between internal and client is that internal tool handlers are always passed an auth and a context.

This does not require re-publishing the extension. No expected behavior change and has almost no runtime change. The changes in front are only typing.

## Tests

- Covered by existing tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.

