### PR TITLE
[sparkle] fix: keep checkbox entirely filled during animation

### DIFF
--- a/sparkle/src/components/Checkbox.tsx
+++ b/sparkle/src/components/Checkbox.tsx
@@ -9,6 +9,7 @@ import { Tooltip } from "./Tooltip";
 export const checkboxStyles = cva(
   cn(
     "h-4 w-4 rounded-md relative shrink-0 peer border transition duration-100 ease-out motion-reduce:transition-none",
+    // transition-none removes interpolation but not the transform itself.
     "active:scale-95 motion-reduce:active:scale-100",
     "border-border-form bg-background",
     "data-[state=checked]:border-border-form-active",

--- a/sparkle/src/components/Checkbox.tsx
+++ b/sparkle/src/components/Checkbox.tsx
@@ -9,7 +9,7 @@ import { Tooltip } from "./Tooltip";
 export const checkboxStyles = cva(
   cn(
     "h-4 w-4 rounded-md relative shrink-0 peer border transition duration-100 ease-out motion-reduce:transition-none",
-    "active:scale-95",
+    "active:scale-95 motion-reduce:active:scale-100",
     "border-border-form bg-background",
     "data-[state=checked]:border-border-form-active",
     "data-[state=indeterminate]:border-border-form-active",
@@ -19,16 +19,12 @@ export const checkboxStyles = cva(
   )
 );
 
-// The checked state renders a dark rounded square that fills the box's inner
-// content area; the "ring" is the box's own border showing through.
-// Concentric corners: inner radius = outer radius (rounded-md, 6px) minus the
-// 1px border the fill sits inside.
+// Keep the fill mounted and full-sized so checked controls stay still on mount
+// and the border never separates from the fill during the icon animation.
 export const checkboxIndicatorStyles = cva(
   cn(
-    "absolute inset-0 flex items-center justify-center rounded-[5px]",
-    // Quick pop-in on check; unchecking unmounts instantly, which is fine —
-    // exits may be faster than entrances, and this is a high-frequency control.
-    "animate-in fade-in-0 zoom-in-90 duration-150 ease-enter motion-reduce:animate-none"
+    "group/checkbox-indicator absolute inset-0 flex items-center justify-center rounded-[5px] opacity-0",
+    "data-[state=checked]:opacity-100 data-[state=indeterminate]:opacity-100"
   ),
   {
     variants: {
@@ -39,6 +35,20 @@ export const checkboxIndicatorStyles = cva(
     },
     defaultVariants: {
       isMutedAfterCheck: false,
+    },
+  }
+);
+
+export const checkboxIconStyles = cva(
+  "absolute h-3 w-3 scale-90 text-background opacity-0 transition-[opacity,transform] duration-150 ease-enter motion-reduce:transition-none",
+  {
+    variants: {
+      state: {
+        checked:
+          "group-data-[state=checked]/checkbox-indicator:scale-100 group-data-[state=checked]/checkbox-indicator:opacity-100",
+        indeterminate:
+          "group-data-[state=indeterminate]/checkbox-indicator:scale-100 group-data-[state=indeterminate]/checkbox-indicator:opacity-100",
+      },
     },
   }
 );
@@ -68,13 +78,11 @@ const Checkbox = React.forwardRef<
       {...props}
     >
       <CheckboxPrimitive.Indicator
+        forceMount
         className={checkboxIndicatorStyles({ isMutedAfterCheck })}
       >
-        {checked === "partial" ? (
-          <Minus className="h-3 w-3 text-background" />
-        ) : (
-          <Check className="h-3 w-3 text-background" />
-        )}
+        <Check className={checkboxIconStyles({ state: "checked" })} />
+        <Minus className={checkboxIconStyles({ state: "indeterminate" })} />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   );

--- a/sparkle/src/components/Checkbox.tsx
+++ b/sparkle/src/components/Checkbox.tsx
@@ -19,6 +19,10 @@ export const checkboxStyles = cva(
   )
 );
 
+// The checked state renders a dark rounded square that fills the box's inner
+// content area; the "ring" is the box's own border showing through.
+// Concentric corners: inner radius = outer radius (rounded-md, 6px) minus the
+// 1px border the fill sits inside.
 // Keep the fill mounted and full-sized so checked controls stay still on mount
 // and the border never separates from the fill during the icon animation.
 export const checkboxIndicatorStyles = cva(

--- a/sparkle/src/components/Checkbox.tsx
+++ b/sparkle/src/components/Checkbox.tsx
@@ -9,7 +9,7 @@ import { Tooltip } from "./Tooltip";
 export const checkboxStyles = cva(
   cn(
     "h-4 w-4 rounded-md relative shrink-0 peer border transition duration-100 ease-out motion-reduce:transition-none",
-    // transition-none removes interpolation but not the transform itself.
+    // Disabling the transition would make the press scale instantaneous, so disable the scale too.
     "active:scale-95 motion-reduce:active:scale-100",
     "border-border-form bg-background",
     "data-[state=checked]:border-border-form-active",

--- a/sparkle/src/components/OptionCard.tsx
+++ b/sparkle/src/components/OptionCard.tsx
@@ -1,5 +1,6 @@
 import { Card } from "@sparkle/components/Card";
 import {
+  checkboxIconStyles,
   checkboxIndicatorStyles,
   checkboxStyles,
 } from "@sparkle/components/Checkbox";
@@ -156,13 +157,15 @@ export function OptionCard(props: OptionCardProps) {
       {selectionIndicator === "checkbox" && (
         <div
           aria-hidden="true"
+          data-state={selected ? "checked" : "unchecked"}
           className={cn(checkboxStyles(), "pointer-events-none shrink-0")}
         >
-          {selected && (
-            <div className={checkboxIndicatorStyles()}>
-              <Check className="h-3 w-3 text-background" />
-            </div>
-          )}
+          <div
+            data-state={selected ? "checked" : "unchecked"}
+            className={checkboxIndicatorStyles()}
+          >
+            <Check className={checkboxIconStyles({ state: "checked" })} />
+          </div>
         </div>
       )}
     </Card>

--- a/sparkle/src/stories/Checkbox.stories.tsx
+++ b/sparkle/src/stories/Checkbox.stories.tsx
@@ -141,8 +141,16 @@ export const Interactive: Story = {
   tags: ["ai-generated", "needs-work"],
   play: async ({ canvas, userEvent }) => {
     const checkbox = canvas.getByRole("checkbox");
+    const indicator = checkbox.querySelector('[data-state="unchecked"]');
+
     await expect(checkbox).toHaveAttribute("aria-checked", "false");
+    await expect(indicator).not.toBeNull();
+
     await userEvent.click(checkbox);
+
     await expect(checkbox).toHaveAttribute("aria-checked", "true");
+    await expect(checkbox.querySelector('[data-state="checked"]')).toBe(
+      indicator
+    );
   },
 };


### PR DESCRIPTION
## Description

Checking a checkbox briefly left an empty gap between its border and the fill during the animation.

This PR fixes that by keeping the indicator mounted and full-sized, then animate only the check or partial-state icon from the indicator state. This also prevents the animation from replaying when a selected control mounts again.

The general approach is to not render conditionally and always render everything to make sure animations happen smoothly.

Struggling a bit to capture a gif, can be checked out using the preview.

## Tests

- Updated the story.

## Risk

- Low.

## Deploy Plan

- Deploy front.
