### PR TITLE
Add workspace user identity to conversation Frames

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
@@ -1,0 +1,50 @@
+import {
+  type FrameAccess,
+  getConversationFrameUserIdentity,
+} from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
+import { describe, expect, it } from "vitest";
+
+const authContext = {
+  workspace: { sId: "w_current" },
+  user: {
+    sId: "usr_123",
+    firstName: "Ada",
+    lastName: "Lovelace",
+    fullName: "Ada Lovelace",
+    image: null,
+  },
+};
+
+function getIdentity(
+  workspaceId: string,
+  frameAccess: FrameAccess = "conversation"
+) {
+  return getConversationFrameUserIdentity(
+    authContext,
+    frameAccess,
+    workspaceId
+  );
+}
+
+describe("getConversationFrameUserIdentity", () => {
+  it("returns identity for the Frame workspace", () => {
+    expect(getIdentity("w_current")).toEqual({
+      isAuthenticated: true,
+      user: authContext.user,
+    });
+  });
+
+  it("does not return identity for another workspace", () => {
+    expect(getIdentity("w_other")).toEqual({
+      isAuthenticated: false,
+      user: null,
+    });
+  });
+
+  it("keeps public Frames unauthenticated", () => {
+    expect(getIdentity("w_current", "public-member")).toEqual({
+      isAuthenticated: false,
+      user: null,
+    });
+  });
+});

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
@@ -5,7 +5,7 @@ import {
 import { describe, expect, it } from "vitest";
 
 const authContext = {
-  workspace: { sId: "w_current" },
+  workspace: { role: "user" as const, sId: "w_current" },
   user: {
     sId: "usr_123",
     firstName: "Ada",
@@ -30,6 +30,7 @@ describe("getConversationFrameUserIdentity", () => {
   it("returns identity for the Frame workspace", () => {
     expect(getIdentity("w_current")).toEqual({
       isAuthenticated: true,
+      isWorkspaceMember: true,
       user: authContext.user,
     });
   });
@@ -37,6 +38,7 @@ describe("getConversationFrameUserIdentity", () => {
   it("does not return identity for another workspace", () => {
     expect(getIdentity("w_other")).toEqual({
       isAuthenticated: false,
+      isWorkspaceMember: false,
       user: null,
     });
   });
@@ -44,6 +46,24 @@ describe("getConversationFrameUserIdentity", () => {
   it("keeps public Frames unauthenticated", () => {
     expect(getIdentity("w_current", "public-member")).toEqual({
       isAuthenticated: false,
+      isWorkspaceMember: false,
+      user: null,
+    });
+  });
+
+  it("does not return identity for a non-member session", () => {
+    expect(
+      getConversationFrameUserIdentity(
+        {
+          ...authContext,
+          workspace: { ...authContext.workspace, role: "none" },
+        },
+        "conversation",
+        "w_current"
+      )
+    ).toEqual({
+      isAuthenticated: false,
+      isWorkspaceMember: false,
       user: null,
     });
   });

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -7,6 +7,7 @@ import type {
   SandboxFunctionMCPApproveExecutionEvent,
   SandboxFunctionToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
+import { AuthContext } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import datadogLogger from "@app/logger/datadogLogger";
@@ -21,6 +22,7 @@ import type {
   CallFunctionRequest,
   CommandResultMap,
   EditTextFn,
+  UserIdentityState,
   VisualizationRPCCommand,
   VisualizationRPCRequest,
 } from "@app/types/assistant/visualization";
@@ -51,6 +53,7 @@ import type { SetStateAction } from "react";
 import {
   forwardRef,
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -75,6 +78,37 @@ type ProtectedVisualization = BaseVisualization & {
 export type Visualization = PublicVisualization | ProtectedVisualization;
 
 export type FrameAccess = "conversation" | "public-anonymous" | "public-member";
+
+interface WorkspaceAuthIdentity {
+  user: NonNullable<UserIdentityState["user"]>;
+  workspace: { sId: string };
+}
+
+export function getConversationFrameUserIdentity(
+  authContext: WorkspaceAuthIdentity | null,
+  frameAccess: FrameAccess,
+  workspaceId: string
+): UserIdentityState {
+  if (
+    frameAccess !== "conversation" ||
+    !authContext ||
+    authContext.workspace.sId !== workspaceId
+  ) {
+    return { isAuthenticated: false, user: null };
+  }
+
+  const { user } = authContext;
+  return {
+    isAuthenticated: true,
+    user: {
+      sId: user.sId,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      fullName: user.fullName,
+      image: user.image,
+    },
+  };
+}
 
 const sendResponseToIframe = <T extends VisualizationRPCCommand>(
   request: { command: T } & VisualizationRPCRequest,
@@ -311,6 +345,7 @@ function useVisualizationDataHandler({
   setErrorMessage,
   visualization,
   vizIframeRef,
+  userIdentity,
   waitForSandboxFunctionInvocationResult,
   workspaceId,
 }: {
@@ -326,6 +361,7 @@ function useVisualizationDataHandler({
   setErrorMessage: (v: SetStateAction<string | null>) => void;
   visualization: Visualization;
   vizIframeRef: React.MutableRefObject<HTMLIFrameElement | null>;
+  userIdentity: UserIdentityState;
   waitForSandboxFunctionInvocationResult: (params: {
     functionId: string;
     invocationId: string;
@@ -417,6 +453,10 @@ function useVisualizationDataHandler({
           break;
         }
 
+        case "getUserIdentity":
+          sendResponseToIframe(data, userIdentity, event.source);
+          break;
+
         case "getFile":
           const fileBlob = await getFileBlob(data.params.fileId);
 
@@ -491,6 +531,7 @@ function useVisualizationDataHandler({
     setCodeDrawerOpened,
     visualization.identifier,
     vizIframeRef,
+    userIdentity,
     sendNotification,
     waitForSandboxFunctionInvocationResult,
     workspaceId,
@@ -625,6 +666,15 @@ export const VisualizationActionIframe = forwardRef<
     frameAccess = "conversation",
   } = props;
 
+  const authContext = useContext(AuthContext);
+  const userIdentity = useMemo<UserIdentityState>(() => {
+    return getConversationFrameUserIdentity(
+      authContext,
+      frameAccess,
+      workspaceId
+    );
+  }, [authContext, frameAccess, workspaceId]);
+
   const isPublic = frameAccess !== "conversation";
 
   const getFileBlob = useCallback(
@@ -739,6 +789,7 @@ export const VisualizationActionIframe = forwardRef<
     setErrorMessage,
     visualization,
     vizIframeRef,
+    userIdentity,
     waitForSandboxFunctionInvocationResult,
     workspaceId,
   });

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -34,6 +34,7 @@ import {
   assertNeverAndIgnore,
 } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { RoleType } from "@app/types/user";
 import {
   AlertCircle,
   Button,
@@ -81,7 +82,7 @@ export type FrameAccess = "conversation" | "public-anonymous" | "public-member";
 
 interface WorkspaceAuthIdentity {
   user: NonNullable<UserIdentityState["user"]>;
-  workspace: { sId: string };
+  workspace: { role: RoleType; sId: string };
 }
 
 export function getConversationFrameUserIdentity(
@@ -92,14 +93,20 @@ export function getConversationFrameUserIdentity(
   if (
     frameAccess !== "conversation" ||
     !authContext ||
-    authContext.workspace.sId !== workspaceId
+    authContext.workspace.sId !== workspaceId ||
+    authContext.workspace.role === "none"
   ) {
-    return { isAuthenticated: false, user: null };
+    return {
+      isAuthenticated: false,
+      isWorkspaceMember: false,
+      user: null,
+    };
   }
 
   const { user } = authContext;
   return {
     isAuthenticated: true,
+    isWorkspaceMember: true,
     user: {
       sId: user.sId,
       firstName: user.firstName,

--- a/front/types/assistant/visualization.ts
+++ b/front/types/assistant/visualization.ts
@@ -34,10 +34,12 @@ export interface WorkspaceUserIdentity {
 export type UserIdentityState =
   | {
       isAuthenticated: true;
+      isWorkspaceMember: true;
       user: WorkspaceUserIdentity;
     }
   | {
       isAuthenticated: false;
+      isWorkspaceMember: false;
       user: null;
     };
 

--- a/front/types/assistant/visualization.ts
+++ b/front/types/assistant/visualization.ts
@@ -23,6 +23,24 @@ const CallFunctionParamsSchema = z.object({
 
 type CallFunctionParams = z.infer<typeof CallFunctionParamsSchema>;
 
+export interface WorkspaceUserIdentity {
+  sId: string;
+  firstName: string;
+  lastName: string | null;
+  fullName: string;
+  image: string | null;
+}
+
+export type UserIdentityState =
+  | {
+      isAuthenticated: true;
+      user: WorkspaceUserIdentity;
+    }
+  | {
+      isAuthenticated: false;
+      user: null;
+    };
+
 const SetContentHeightParamsSchema = z.object({
   height: z.number(),
 });
@@ -55,6 +73,11 @@ const GetFileRequestSchema = VisualizationRPCRequestBaseSchema.extend({
 const CallFunctionRequestSchema = VisualizationRPCRequestBaseSchema.extend({
   command: z.literal("callFunction"),
   params: CallFunctionParamsSchema,
+});
+
+const GetUserIdentityRequestSchema = VisualizationRPCRequestBaseSchema.extend({
+  command: z.literal("getUserIdentity"),
+  params: z.null(),
 });
 
 const GetCodeToExecuteRequestSchema = VisualizationRPCRequestBaseSchema.extend({
@@ -105,6 +128,7 @@ const EditTextRequestSchema = VisualizationRPCRequestBaseSchema.extend({
 
 const VisualizationRPCRequestSchema = z.union([
   CallFunctionRequestSchema,
+  GetUserIdentityRequestSchema,
   GetFileRequestSchema,
   GetCodeToExecuteRequestSchema,
   SetContentHeightRequestSchema,
@@ -124,6 +148,7 @@ export type VisualizationRPCCommand = VisualizationRPCRequest["command"];
 // Define a mapped type for backward compatibility.
 export type VisualizationRPCRequestMap = {
   callFunction: CallFunctionParams;
+  getUserIdentity: null;
   getFile: GetFileParams;
   getCodeToExecute: null;
   setContentHeight: SetContentHeightParams;
@@ -136,6 +161,7 @@ export type VisualizationRPCRequestMap = {
 // Command results.
 export interface CommandResultMap {
   callFunction: unknown;
+  getUserIdentity: UserIdentityState;
   getCodeToExecute: { code: string };
   getFile: { fileBlob: Blob | null };
   downloadFileRequest: { blob: Blob; filename?: string };

--- a/viz/app/components/VisualizationWrapper.test.ts
+++ b/viz/app/components/VisualizationWrapper.test.ts
@@ -1,9 +1,16 @@
 // @vitest-environment jsdom
 
-import { makeSendCrossDocumentMessage } from "@viz/app/components/VisualizationWrapper";
-import { describe, expect, it, vi } from "vitest";
+import {
+  makeSendCrossDocumentMessage,
+  USER_IDENTITY_RPC_TIMEOUT_MS,
+} from "@viz/app/components/VisualizationWrapper";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const ALLOWED_ORIGIN = "https://app.dust.tt";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 function hasMessageUniqueId(
   value: unknown
@@ -29,6 +36,7 @@ describe("makeSendCrossDocumentMessage", () => {
             messageUniqueId: message.messageUniqueId,
             result: {
               isAuthenticated: true,
+              isWorkspaceMember: true,
               user: {
                 sId: "usr_123",
                 firstName: "Ada",
@@ -48,6 +56,7 @@ describe("makeSendCrossDocumentMessage", () => {
 
     await expect(sendMessage("getUserIdentity", null)).resolves.toMatchObject({
       isAuthenticated: true,
+      isWorkspaceMember: true,
       user: { sId: "usr_123" },
     });
   });
@@ -78,6 +87,27 @@ describe("makeSendCrossDocumentMessage", () => {
         input: { name: "Dust" },
       })
     ).resolves.toEqual({ greeting: "Hello" });
+  });
+
+  it("fails closed when an older Frame host does not answer identity requests", async () => {
+    vi.useFakeTimers();
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+    vi.spyOn(window, "postMessage").mockImplementation(() => undefined);
+    const sendMessage = makeSendCrossDocumentMessage({
+      identifier: "frame",
+      allowedOrigins: [ALLOWED_ORIGIN],
+    });
+
+    const expectation = expect(
+      sendMessage("getUserIdentity", null)
+    ).rejects.toThrow("Frame host did not provide user identity.");
+    await vi.advanceTimersByTimeAsync(USER_IDENTITY_RPC_TIMEOUT_MS);
+
+    await expectation;
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "message",
+      expect.any(Function)
+    );
   });
 
   it("rejects with the structured error sent by the parent", async () => {

--- a/viz/app/components/VisualizationWrapper.test.ts
+++ b/viz/app/components/VisualizationWrapper.test.ts
@@ -17,6 +17,41 @@ function hasMessageUniqueId(
 }
 
 describe("makeSendCrossDocumentMessage", () => {
+  it("returns the workspace-scoped identity from the parent", async () => {
+    vi.spyOn(window, "postMessage").mockImplementation((message) => {
+      if (!hasMessageUniqueId(message)) {
+        throw new Error("RPC request has no message id.");
+      }
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: ALLOWED_ORIGIN,
+          data: {
+            messageUniqueId: message.messageUniqueId,
+            result: {
+              isAuthenticated: true,
+              user: {
+                sId: "usr_123",
+                firstName: "Ada",
+                lastName: "Lovelace",
+                fullName: "Ada Lovelace",
+                image: null,
+              },
+            },
+          },
+        })
+      );
+    });
+    const sendMessage = makeSendCrossDocumentMessage({
+      identifier: "frame",
+      allowedOrigins: [ALLOWED_ORIGIN],
+    });
+
+    await expect(sendMessage("getUserIdentity", null)).resolves.toMatchObject({
+      isAuthenticated: true,
+      user: { sId: "usr_123" },
+    });
+  });
+
   it("returns a direct callFunction result from the parent", async () => {
     vi.spyOn(window, "postMessage").mockImplementation((message) => {
       if (!hasMessageUniqueId(message)) {

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -9,6 +9,7 @@ import {
   PodFunctionHooksProvider,
   usePodFunction,
   usePodFunctionMutation,
+  useUserIdentity,
 } from "@viz/app/lib/pod-function-hooks";
 import { transformEditableText } from "@viz/app/lib/transformEditableText";
 import type {
@@ -475,6 +476,7 @@ export function VisualizationWrapper({
             useFile: (fileId: string) => useFile(fileId, api.data),
             usePodFunction,
             usePodFunctionMutation,
+            useUserIdentity,
           },
         };
 

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -678,6 +678,8 @@ function isOriginAllowed(origin: string, allowedOrigins: string[]): boolean {
   });
 }
 
+export const USER_IDENTITY_RPC_TIMEOUT_MS = 5_000;
+
 export function makeSendCrossDocumentMessage({
   identifier,
   allowedOrigins,
@@ -691,6 +693,14 @@ export function makeSendCrossDocumentMessage({
   ) => {
     return new Promise<CommandResultMap[T]>((resolve, reject) => {
       const messageUniqueId = Math.random().toString();
+      let timeoutId: number | null = null;
+
+      const cleanup = () => {
+        window.removeEventListener("message", listener);
+        if (timeoutId !== null) {
+          window.clearTimeout(timeoutId);
+        }
+      };
 
       const listener = (event: MessageEvent) => {
         if (!isOriginAllowed(event.origin, allowedOrigins)) {
@@ -702,15 +712,21 @@ export function makeSendCrossDocumentMessage({
         }
 
         if (event.data.messageUniqueId === messageUniqueId) {
+          cleanup();
           if (event.data.error) {
             reject(event.data.error);
           } else {
             resolve(event.data.result);
           }
-          window.removeEventListener("message", listener);
         }
       };
       window.addEventListener("message", listener);
+      if (command === "getUserIdentity") {
+        timeoutId = window.setTimeout(() => {
+          cleanup();
+          reject(new Error("Frame host did not provide user identity."));
+        }, USER_IDENTITY_RPC_TIMEOUT_MS);
+      }
       window.parent?.postMessage(
         {
           command,

--- a/viz/app/lib/data-apis/cache-data-api.ts
+++ b/viz/app/lib/data-apis/cache-data-api.ts
@@ -1,5 +1,6 @@
 import { SandboxFunctionCallError } from "@viz/app/lib/data-apis/sandbox-function-call-error";
 import type { VisualizationDataAPI } from "@viz/app/lib/visualization-api";
+import type { UserIdentityState } from "@viz/app/types";
 
 export interface PreFetchedFile {
   data: string; // base64
@@ -47,6 +48,10 @@ export class CacheDataAPI implements VisualizationDataAPI {
       code: "not_supported",
       message: `Sandbox function ${functionId} is not supported in public frames.`,
     });
+  }
+
+  async getUserIdentity(): Promise<UserIdentityState> {
+    return { isAuthenticated: false, user: null };
   }
 
   async fetchFile(fileId: string): Promise<File | null> {

--- a/viz/app/lib/data-apis/cache-data-api.ts
+++ b/viz/app/lib/data-apis/cache-data-api.ts
@@ -51,7 +51,11 @@ export class CacheDataAPI implements VisualizationDataAPI {
   }
 
   async getUserIdentity(): Promise<UserIdentityState> {
-    return { isAuthenticated: false, user: null };
+    return {
+      isAuthenticated: false,
+      isWorkspaceMember: false,
+      user: null,
+    };
   }
 
   async fetchFile(fileId: string): Promise<File | null> {

--- a/viz/app/lib/data-apis/hybrid-data-api.ts
+++ b/viz/app/lib/data-apis/hybrid-data-api.ts
@@ -16,6 +16,10 @@ export class HybridDataAPI implements VisualizationDataAPI {
     return this.rpc.callFunction(functionId, input);
   }
 
+  async getUserIdentity() {
+    return this.rpc.getUserIdentity();
+  }
+
   async fetchFile(fileId: string): Promise<File | null> {
     return this.cache.fetchFile(fileId);
   }

--- a/viz/app/lib/data-apis/rpc-data-api.test.ts
+++ b/viz/app/lib/data-apis/rpc-data-api.test.ts
@@ -7,6 +7,7 @@ describe("sandbox function data APIs", () => {
   it("loads workspace-scoped identity over RPC", async () => {
     const sendMessage = vi.fn().mockResolvedValue({
       isAuthenticated: true,
+      isWorkspaceMember: true,
       user: {
         sId: "usr_123",
         firstName: "Ada",
@@ -19,6 +20,7 @@ describe("sandbox function data APIs", () => {
 
     await expect(api.getUserIdentity()).resolves.toMatchObject({
       isAuthenticated: true,
+      isWorkspaceMember: true,
       user: { sId: "usr_123" },
     });
     expect(sendMessage).toHaveBeenCalledWith("getUserIdentity", null);
@@ -29,6 +31,7 @@ describe("sandbox function data APIs", () => {
 
     await expect(api.getUserIdentity()).resolves.toEqual({
       isAuthenticated: false,
+      isWorkspaceMember: false,
       user: null,
     });
   });

--- a/viz/app/lib/data-apis/rpc-data-api.test.ts
+++ b/viz/app/lib/data-apis/rpc-data-api.test.ts
@@ -1,9 +1,38 @@
 import { CacheDataAPI } from "@viz/app/lib/data-apis/cache-data-api";
 import { RPCDataAPI } from "@viz/app/lib/data-apis/rpc-data-api";
 import { SandboxFunctionCallError } from "@viz/app/lib/data-apis/sandbox-function-call-error";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 describe("sandbox function data APIs", () => {
+  it("loads workspace-scoped identity over RPC", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({
+      isAuthenticated: true,
+      user: {
+        sId: "usr_123",
+        firstName: "Ada",
+        lastName: "Lovelace",
+        fullName: "Ada Lovelace",
+        image: null,
+      },
+    });
+    const api = new RPCDataAPI(sendMessage);
+
+    await expect(api.getUserIdentity()).resolves.toMatchObject({
+      isAuthenticated: true,
+      user: { sId: "usr_123" },
+    });
+    expect(sendMessage).toHaveBeenCalledWith("getUserIdentity", null);
+  });
+
+  it("returns no identity from the public cache", async () => {
+    const api = new CacheDataAPI();
+
+    await expect(api.getUserIdentity()).resolves.toEqual({
+      isAuthenticated: false,
+      user: null,
+    });
+  });
+
   it("rejects RPC calls with a typed sandbox function error", async () => {
     const api = new RPCDataAPI(async () => {
       throw {

--- a/viz/app/lib/data-apis/rpc-data-api.ts
+++ b/viz/app/lib/data-apis/rpc-data-api.ts
@@ -36,6 +36,10 @@ export class RPCDataAPI implements VisualizationDataAPI {
     }
   }
 
+  async getUserIdentity() {
+    return this.sendMessage("getUserIdentity", null);
+  }
+
   async fetchFile(fileId: string): Promise<File | null> {
     try {
       console.log(">> RPCDataAPI: Fetching file via RPC", fileId);

--- a/viz/app/lib/pod-function-hooks.test.tsx
+++ b/viz/app/lib/pod-function-hooks.test.tsx
@@ -5,6 +5,7 @@ import {
   PodFunctionHooksProvider,
   usePodFunction,
   usePodFunctionMutation,
+  useUserIdentity,
 } from "@viz/app/lib/pod-function-hooks";
 import type { VisualizationDataAPI } from "@viz/app/lib/visualization-api";
 import { createElement, type PropsWithChildren } from "react";
@@ -28,6 +29,9 @@ function makeDataAPI(
     callFunction,
     fetchCode: vi.fn(),
     fetchFile: vi.fn(),
+    getUserIdentity: vi
+      .fn()
+      .mockResolvedValue({ isAuthenticated: false, user: null }),
   };
 }
 
@@ -36,6 +40,56 @@ function makeWrapper(dataAPI: VisualizationDataAPI) {
     return createElement(PodFunctionHooksProvider, { dataAPI }, children);
   };
 }
+
+describe("useUserIdentity", () => {
+  it("returns the user authenticated in the Frame workspace", async () => {
+    const dataAPI = makeDataAPI(vi.fn());
+    dataAPI.getUserIdentity = vi.fn().mockResolvedValue({
+      isAuthenticated: true,
+      user: {
+        sId: "usr_123",
+        firstName: "Ada",
+        lastName: "Lovelace",
+        fullName: "Ada Lovelace",
+        image: null,
+      },
+    });
+
+    const { result } = renderHook(() => useUserIdentity(), {
+      wrapper: makeWrapper(dataAPI),
+    });
+
+    expect(result.current).toMatchObject({
+      isAuthenticated: false,
+      isLoading: true,
+      user: null,
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current).toMatchObject({
+      isAuthenticated: true,
+      user: { sId: "usr_123", fullName: "Ada Lovelace" },
+    });
+  });
+
+  it("fails closed when identity cannot be loaded", async () => {
+    const dataAPI = makeDataAPI(vi.fn());
+    dataAPI.getUserIdentity = vi
+      .fn()
+      .mockRejectedValue(new Error("Frame host unavailable"));
+
+    const { result } = renderHook(() => useUserIdentity(), {
+      wrapper: makeWrapper(dataAPI),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current).toMatchObject({
+      isAuthenticated: false,
+      user: null,
+      error: new Error("Frame host unavailable"),
+    });
+  });
+});
 
 describe("usePodFunction", () => {
   it("calls a qualified slug and returns the direct function output", async () => {

--- a/viz/app/lib/pod-function-hooks.test.tsx
+++ b/viz/app/lib/pod-function-hooks.test.tsx
@@ -29,9 +29,11 @@ function makeDataAPI(
     callFunction,
     fetchCode: vi.fn(),
     fetchFile: vi.fn(),
-    getUserIdentity: vi
-      .fn()
-      .mockResolvedValue({ isAuthenticated: false, user: null }),
+    getUserIdentity: vi.fn().mockResolvedValue({
+      isAuthenticated: false,
+      isWorkspaceMember: false,
+      user: null,
+    }),
   };
 }
 
@@ -46,6 +48,7 @@ describe("useUserIdentity", () => {
     const dataAPI = makeDataAPI(vi.fn());
     dataAPI.getUserIdentity = vi.fn().mockResolvedValue({
       isAuthenticated: true,
+      isWorkspaceMember: true,
       user: {
         sId: "usr_123",
         firstName: "Ada",
@@ -61,6 +64,7 @@ describe("useUserIdentity", () => {
 
     expect(result.current).toMatchObject({
       isAuthenticated: false,
+      isWorkspaceMember: false,
       isLoading: true,
       user: null,
     });
@@ -68,6 +72,7 @@ describe("useUserIdentity", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current).toMatchObject({
       isAuthenticated: true,
+      isWorkspaceMember: true,
       user: { sId: "usr_123", fullName: "Ada Lovelace" },
     });
   });
@@ -85,6 +90,7 @@ describe("useUserIdentity", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current).toMatchObject({
       isAuthenticated: false,
+      isWorkspaceMember: false,
       user: null,
       error: new Error("Frame host unavailable"),
     });

--- a/viz/app/lib/pod-function-hooks.tsx
+++ b/viz/app/lib/pod-function-hooks.tsx
@@ -157,6 +157,7 @@ export function useUserIdentity(): UseUserIdentityResult {
     return {
       error: result.error,
       isAuthenticated: false,
+      isWorkspaceMember: false,
       isLoading: !result.error,
       user: null,
     };

--- a/viz/app/lib/pod-function-hooks.tsx
+++ b/viz/app/lib/pod-function-hooks.tsx
@@ -2,6 +2,7 @@
 
 import { normalizeSandboxFunctionCallError } from "@viz/app/lib/data-apis/sandbox-function-call-error";
 import type { VisualizationDataAPI } from "@viz/app/lib/visualization-api";
+import type { UserIdentityState } from "@viz/app/types";
 import {
   createContext,
   createElement,
@@ -39,6 +40,11 @@ export interface UsePodFunctionMutationResult {
   reset: () => void;
   trigger: (input: unknown) => Promise<unknown>;
 }
+
+export type UseUserIdentityResult = UserIdentityState & {
+  error: Error | undefined;
+  isLoading: boolean;
+};
 
 type PodFunctionQueryKey = readonly ["pod-function", string, unknown];
 type PodFunctionMutationKey = readonly ["pod-function-mutation", string];
@@ -130,6 +136,36 @@ export function usePodFunction(
     isLoading: key !== null && result.isLoading,
     isValidating: key !== null && result.isValidating,
     mutate,
+  };
+}
+
+export function useUserIdentity(): UseUserIdentityResult {
+  const { dataAPI } = usePodFunctionContext();
+  const result = useSWR<UserIdentityState, Error>(
+    "workspace-user-identity",
+    () => dataAPI.getUserIdentity(),
+    {
+      errorRetryCount: 0,
+      revalidateIfStale: false,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      shouldRetryOnError: false,
+    }
+  );
+
+  if (!result.data) {
+    return {
+      error: result.error,
+      isAuthenticated: false,
+      isLoading: !result.error,
+      user: null,
+    };
+  }
+
+  return {
+    ...result.data,
+    error: result.error,
+    isLoading: false,
   };
 }
 

--- a/viz/app/lib/visualization-api.ts
+++ b/viz/app/lib/visualization-api.ts
@@ -1,3 +1,4 @@
+import type { UserIdentityState } from "@viz/app/types";
 import type {
   SupportedEventType,
   SupportedMessage,
@@ -12,6 +13,11 @@ export interface VisualizationDataAPI {
    * Call a sandbox function.
    */
   callFunction(functionId: string, input?: unknown): Promise<unknown>;
+
+  /**
+   * Return the user authenticated in the workspace owning this Frame.
+   */
+  getUserIdentity(): Promise<UserIdentityState>;
 
   /**
    * Fetch a file by ID.

--- a/viz/app/types.ts
+++ b/viz/app/types.ts
@@ -11,6 +11,24 @@ interface CallFunctionParams {
   input?: unknown;
 }
 
+export interface WorkspaceUserIdentity {
+  sId: string;
+  firstName: string;
+  lastName: string | null;
+  fullName: string;
+  image: string | null;
+}
+
+export type UserIdentityState =
+  | {
+      isAuthenticated: true;
+      user: WorkspaceUserIdentity;
+    }
+  | {
+      isAuthenticated: false;
+      user: null;
+    };
+
 interface SetContentHeightParams {
   height: number;
 }
@@ -38,6 +56,7 @@ interface EditTextParams {
 // Define a mapped type to extend the base with specific parameters.
 export type VisualizationRPCRequestMap = {
   callFunction: CallFunctionParams;
+  getUserIdentity: null;
   getFile: GetFileParams;
   getCodeToExecute: null;
   setContentHeight: SetContentHeightParams;
@@ -54,6 +73,7 @@ export type VisualizationRPCCommand = keyof VisualizationRPCRequestMap;
 
 export interface CommandResultMap {
   callFunction: unknown;
+  getUserIdentity: UserIdentityState;
   getCodeToExecute: { code: string };
   getFile: { fileBlob: Blob | null };
   downloadFileRequest: { blob: Blob; filename?: string };

--- a/viz/app/types.ts
+++ b/viz/app/types.ts
@@ -22,10 +22,12 @@ export interface WorkspaceUserIdentity {
 export type UserIdentityState =
   | {
       isAuthenticated: true;
+      isWorkspaceMember: true;
       user: WorkspaceUserIdentity;
     }
   | {
       isAuthenticated: false;
+      isWorkspaceMember: false;
       user: null;
     };
 


### PR DESCRIPTION
## Description

Stack 1 of 6, followed by #29679.

Adds `useUserIdentity()` to conversation Frames through the existing RPC channel. The host returns a sanitized user only for conversation access, an active role, and an exact workspace match. Older hosts fail closed after an identity-only five-second timeout.

## Tests

Added hook and RPC coverage for active, revoked, anonymous, and cross-workspace callers, plus cache lifecycle and old-host timeout cleanup.

## Risk

The RPC is additive. A temporary Front/Viz version mismatch returns no identity after the timeout, so rollback is safe.

## Deploy Plan

1. Deploy Front so the Frame host serves the identity RPC.
2. Deploy Viz so Frame code receives `useUserIdentity()`.
3. Smoke-test authenticated and anonymous conversation Frames.
