### PR TITLE
Add workspace identity to shared Frames

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
@@ -1,7 +1,8 @@
 import {
   type FrameAccess,
-  getConversationFrameUserIdentity,
+  getFrameUserIdentity,
 } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
+import type { ScopedWorkspaceUserIdentity } from "@app/types/assistant/visualization";
 import { describe, expect, it } from "vitest";
 
 const authContext = {
@@ -17,16 +18,18 @@ const authContext = {
 
 function getIdentity(
   workspaceId: string,
-  frameAccess: FrameAccess = "conversation"
+  frameAccess: FrameAccess = "conversation",
+  publicUserIdentity?: ScopedWorkspaceUserIdentity
 ) {
-  return getConversationFrameUserIdentity(
+  return getFrameUserIdentity(
     authContext,
     frameAccess,
-    workspaceId
+    workspaceId,
+    publicUserIdentity
   );
 }
 
-describe("getConversationFrameUserIdentity", () => {
+describe("getFrameUserIdentity", () => {
   it("returns identity for the Frame workspace", () => {
     expect(getIdentity("w_current")).toEqual({
       isAuthenticated: true,
@@ -43,8 +46,26 @@ describe("getConversationFrameUserIdentity", () => {
     });
   });
 
-  it("keeps public Frames unauthenticated", () => {
-    expect(getIdentity("w_current", "public-member")).toEqual({
+  it("returns an explicitly scoped public member identity", () => {
+    expect(
+      getIdentity("w_current", "public-member", {
+        workspaceId: "w_current",
+        user: authContext.user,
+      })
+    ).toEqual({
+      isAuthenticated: true,
+      isWorkspaceMember: true,
+      user: authContext.user,
+    });
+  });
+
+  it("rejects a public identity scoped to another workspace", () => {
+    expect(
+      getIdentity("w_current", "public-member", {
+        workspaceId: "w_other",
+        user: authContext.user,
+      })
+    ).toEqual({
       isAuthenticated: false,
       isWorkspaceMember: false,
       user: null,
@@ -53,7 +74,7 @@ describe("getConversationFrameUserIdentity", () => {
 
   it("does not return identity for a non-member session", () => {
     expect(
-      getConversationFrameUserIdentity(
+      getFrameUserIdentity(
         {
           ...authContext,
           workspace: { ...authContext.workspace, role: "none" },
@@ -61,6 +82,19 @@ describe("getConversationFrameUserIdentity", () => {
         "conversation",
         "w_current"
       )
+    ).toEqual({
+      isAuthenticated: false,
+      isWorkspaceMember: false,
+      user: null,
+    });
+  });
+
+  it("keeps anonymous public Frames unauthenticated", () => {
+    expect(
+      getIdentity("w_current", "public-anonymous", {
+        workspaceId: "w_current",
+        user: authContext.user,
+      })
     ).toEqual({
       isAuthenticated: false,
       isWorkspaceMember: false,

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -22,6 +22,7 @@ import type {
   CallFunctionRequest,
   CommandResultMap,
   EditTextFn,
+  ScopedWorkspaceUserIdentity,
   UserIdentityState,
   VisualizationRPCCommand,
   VisualizationRPCRequest,
@@ -85,36 +86,66 @@ interface WorkspaceAuthIdentity {
   workspace: { role: RoleType; sId: string };
 }
 
-export function getConversationFrameUserIdentity(
+export function getFrameUserIdentity(
   authContext: WorkspaceAuthIdentity | null,
   frameAccess: FrameAccess,
-  workspaceId: string
+  workspaceId: string,
+  publicUserIdentity?: ScopedWorkspaceUserIdentity
 ): UserIdentityState {
-  if (
-    frameAccess !== "conversation" ||
-    !authContext ||
-    authContext.workspace.sId !== workspaceId ||
-    authContext.workspace.role === "none"
-  ) {
-    return {
-      isAuthenticated: false,
-      isWorkspaceMember: false,
-      user: null,
-    };
-  }
+  switch (frameAccess) {
+    case "conversation": {
+      if (
+        !authContext ||
+        authContext.workspace.sId !== workspaceId ||
+        authContext.workspace.role === "none"
+      ) {
+        return {
+          isAuthenticated: false,
+          isWorkspaceMember: false,
+          user: null,
+        };
+      }
 
-  const { user } = authContext;
-  return {
-    isAuthenticated: true,
-    isWorkspaceMember: true,
-    user: {
-      sId: user.sId,
-      firstName: user.firstName,
-      lastName: user.lastName,
-      fullName: user.fullName,
-      image: user.image,
-    },
-  };
+      const { user } = authContext;
+      return {
+        isAuthenticated: true,
+        isWorkspaceMember: true,
+        user: {
+          sId: user.sId,
+          firstName: user.firstName,
+          lastName: user.lastName,
+          fullName: user.fullName,
+          image: user.image,
+        },
+      };
+    }
+    case "public-member":
+      if (publicUserIdentity?.workspaceId === workspaceId) {
+        return {
+          isAuthenticated: true,
+          isWorkspaceMember: true,
+          user: publicUserIdentity.user,
+        };
+      }
+      return {
+        isAuthenticated: false,
+        isWorkspaceMember: false,
+        user: null,
+      };
+    case "public-anonymous":
+      return {
+        isAuthenticated: false,
+        isWorkspaceMember: false,
+        user: null,
+      };
+    default:
+      assertNeverAndIgnore(frameAccess);
+      return {
+        isAuthenticated: false,
+        isWorkspaceMember: false,
+        user: null,
+      };
+  }
 }
 
 const sendResponseToIframe = <T extends VisualizationRPCCommand>(
@@ -581,6 +612,7 @@ interface VisualizationActionIframeProps {
   isEditable?: boolean;
   isInDrawer?: boolean;
   onEditText?: EditTextFn;
+  publicUserIdentity?: ScopedWorkspaceUserIdentity;
   frameAccess?: FrameAccess;
   spaceId?: string;
   visualization: Visualization;
@@ -667,6 +699,7 @@ export const VisualizationActionIframe = forwardRef<
     isEditable = false,
     isInDrawer = false,
     onEditText,
+    publicUserIdentity,
     spaceId,
     visualization,
     workspaceId,
@@ -675,12 +708,13 @@ export const VisualizationActionIframe = forwardRef<
 
   const authContext = useContext(AuthContext);
   const userIdentity = useMemo<UserIdentityState>(() => {
-    return getConversationFrameUserIdentity(
+    return getFrameUserIdentity(
       authContext,
       frameAccess,
-      workspaceId
+      workspaceId,
+      publicUserIdentity
     );
-  }, [authContext, frameAccess, workspaceId]);
+  }, [authContext, frameAccess, publicUserIdentity, workspaceId]);
 
   const isPublic = frameAccess !== "conversation";
 

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.test.ts
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.test.ts
@@ -1,5 +1,48 @@
-import { getPublicFrameUserIdentity } from "@app/components/assistant/conversation/interactive_content/PublicFrameRenderer";
-import { describe, expect, it } from "vitest";
+import {
+  getPublicFrameUserIdentity,
+  PublicFrameRenderer,
+} from "@app/components/assistant/conversation/interactive_content/PublicFrameRenderer";
+import { cleanup, render, screen } from "@testing-library/react";
+import { createElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  isUserLoading: true,
+}));
+
+vi.mock(
+  "@app/components/assistant/conversation/actions/VisualizationActionIframe",
+  () => ({
+    VisualizationActionIframe: () => "frame-iframe",
+  })
+);
+
+vi.mock("@app/lib/cookies", () => ({
+  DUST_HAS_SESSION: "dust-session",
+  hasSessionIndicator: () => true,
+}));
+
+vi.mock("@app/lib/swr/frames", () => ({
+  usePublicFrame: () => ({
+    conversationUrl: null,
+    projectUrl: null,
+    isFrameLoading: false,
+    error: null,
+    accessToken: "token",
+    isAuthenticatedMember: true,
+  }),
+}));
+
+vi.mock("@app/lib/swr/user", () => ({
+  useUser: () => ({
+    user: null,
+    isUserLoading: mocks.isUserLoading,
+  }),
+}));
+
+vi.mock("react-cookie", () => ({
+  useCookies: () => [{ "dust-session": "1" }],
+}));
 
 const user = {
   sId: "usr_123",
@@ -9,6 +52,11 @@ const user = {
   image: null,
   workspaces: [{ sId: "w_current" }],
 };
+
+afterEach(() => {
+  cleanup();
+  mocks.isUserLoading = true;
+});
 
 describe("getPublicFrameUserIdentity", () => {
   it("scopes a server-confirmed member to the Frame workspace", () => {
@@ -32,5 +80,25 @@ describe("getPublicFrameUserIdentity", () => {
     expect(
       getPublicFrameUserIdentity(user, false, "w_current")
     ).toBeUndefined();
+  });
+});
+
+describe("PublicFrameRenderer", () => {
+  it("waits for the member identity request before mounting the Frame", () => {
+    const props = {
+      fileId: "file_123",
+      hideHeader: true,
+      shareToken: "share-token",
+      workspaceId: "w_current",
+      vizUrl: "https://viz.dust.tt",
+    };
+    const { rerender } = render(createElement(PublicFrameRenderer, props));
+
+    expect(screen.queryByText("frame-iframe")).toBeNull();
+
+    mocks.isUserLoading = false;
+    rerender(createElement(PublicFrameRenderer, props));
+
+    expect(screen.getByText("frame-iframe")).not.toBeNull();
   });
 });

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.test.ts
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.test.ts
@@ -1,0 +1,36 @@
+import { getPublicFrameUserIdentity } from "@app/components/assistant/conversation/interactive_content/PublicFrameRenderer";
+import { describe, expect, it } from "vitest";
+
+const user = {
+  sId: "usr_123",
+  firstName: "Ada",
+  lastName: "Lovelace",
+  fullName: "Ada Lovelace",
+  image: null,
+  workspaces: [{ sId: "w_current" }],
+};
+
+describe("getPublicFrameUserIdentity", () => {
+  it("scopes a server-confirmed member to the Frame workspace", () => {
+    expect(getPublicFrameUserIdentity(user, true, "w_current")).toEqual({
+      workspaceId: "w_current",
+      user: {
+        sId: "usr_123",
+        firstName: "Ada",
+        lastName: "Lovelace",
+        fullName: "Ada Lovelace",
+        image: null,
+      },
+    });
+  });
+
+  it("rejects a user who belongs only to another workspace", () => {
+    expect(getPublicFrameUserIdentity(user, true, "w_other")).toBeUndefined();
+  });
+
+  it("rejects a viewer not confirmed as a workspace member", () => {
+    expect(
+      getPublicFrameUserIdentity(user, false, "w_current")
+    ).toBeUndefined();
+  });
+});

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
@@ -5,6 +5,10 @@ import { DUST_HAS_SESSION, hasSessionIndicator } from "@app/lib/cookies";
 import { formatFilenameForDisplay } from "@app/lib/files";
 import { usePublicFrame } from "@app/lib/swr/frames";
 import { useUser } from "@app/lib/swr/user";
+import type {
+  ScopedWorkspaceUserIdentity,
+  WorkspaceUserIdentity,
+} from "@app/types/assistant/visualization";
 import { Spinner } from "@dust-tt/sparkle";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
 import React from "react";
@@ -19,6 +23,35 @@ interface PublicFrameRendererProps {
   shareToken: string;
   workspaceId: string;
   vizUrl: string;
+}
+
+interface PublicFrameViewer extends WorkspaceUserIdentity {
+  workspaces: { sId: string }[];
+}
+
+export function getPublicFrameUserIdentity(
+  user: PublicFrameViewer | null,
+  isAuthenticatedMember: boolean,
+  workspaceId: string
+): ScopedWorkspaceUserIdentity | undefined {
+  if (
+    !isAuthenticatedMember ||
+    !user ||
+    !user.workspaces.some((workspace) => workspace.sId === workspaceId)
+  ) {
+    return undefined;
+  }
+
+  return {
+    workspaceId,
+    user: {
+      sId: user.sId,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      fullName: user.fullName,
+      image: user.image,
+    },
+  };
 }
 
 export function PublicFrameRenderer({
@@ -54,6 +87,11 @@ export function PublicFrameRenderer({
     revalidateIfStale: false,
     disabled: !hasSession,
   });
+  const publicUserIdentity = getPublicFrameUserIdentity(
+    user,
+    isAuthenticatedMember,
+    workspaceId
+  );
 
   if (isFrameLoading) {
     return (
@@ -100,6 +138,7 @@ export function PublicFrameRenderer({
             }}
             key={`viz-${fileId}`}
             frameAccess={access}
+            publicUserIdentity={publicUserIdentity}
             isInDrawer
           />
         </div>

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
@@ -82,10 +82,11 @@ export function PublicFrameRenderer({
   const [cookies] = useCookies([DUST_HAS_SESSION]);
   const hasSession = hasSessionIndicator(cookies[DUST_HAS_SESSION]);
 
-  const { user } = useUser({
+  const { user, isUserLoading } = useUser({
     revalidateOnFocus: false,
     revalidateIfStale: false,
     disabled: !hasSession,
+    redirectOnUnauthenticated: false,
   });
   const publicUserIdentity = getPublicFrameUserIdentity(
     user,
@@ -93,7 +94,10 @@ export function PublicFrameRenderer({
     workspaceId
   );
 
-  if (isFrameLoading) {
+  if (
+    isFrameLoading ||
+    (isAuthenticatedMember && hasSession && isUserLoading)
+  ) {
     return (
       <CenteredState>
         <Spinner size="sm" />

--- a/front/types/assistant/visualization.ts
+++ b/front/types/assistant/visualization.ts
@@ -43,6 +43,11 @@ export type UserIdentityState =
       user: null;
     };
 
+export interface ScopedWorkspaceUserIdentity {
+  workspaceId: string;
+  user: WorkspaceUserIdentity;
+}
+
 const SetContentHeightParamsSchema = z.object({
   height: z.number(),
 });


### PR DESCRIPTION
## Description

Stack 2 of 6. Depends on #29678 and is followed by #29681.

Adds `useUserIdentity()` to shared Frames. Identity requires both the shared-Frame response and `/api/user` to confirm an active member of the exact Frame workspace. Member Frames wait for `/api/user` before mounting, so they cannot observe an initial anonymous state.

## Tests

Added coverage for members, non-members, anonymous viewers, revoked membership, workspace mismatch, exhaustive access handling, and the initial user-loading state.

## Risk

Member-visible Frames now wait for user resolution before mounting. Failed or mismatched identity requests remain unauthenticated. Rollback removes shared-Frame identity without changing public access.

## Deploy Plan

Deploy Front after #29678 has completed its Front and Viz rollout.
