### PR TITLE
Gong connector: treat 'Company is inactive' error as invalid credentials error to stop the connector

### DIFF
--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -250,6 +250,9 @@ const RETRY_AFTER_CEILING_SECONDS = 3600;
 const GONG_INVALID_CREDENTIALS_MESSAGES = [
   "Validate credentials failed. Please check your credentials and try again.",
   "Your access token has been revoked. Please generate a new access token.",
+  // Returned when the customer's Gong instance is deactivated (e.g. subscription ended); no
+  // credentials can work until the customer reactivates their Gong account.
+  "Company is inactive",
 ];
 
 export function clampRetryAfterSeconds(


### PR DESCRIPTION
## Description

We have a connector failing in loop with
```
Error: Gong API responded with status: 401 on /calls/transcript
```
Due to a 401 `Company is inactive`

We should no retry in that case so I have added this error to the GONG_INVALID_CREDENTIALS_MESSAGES to pause the connector with an `oauth_token_revoked` error.

## Tests

not tested

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy connector
