### PR TITLE
Expose the invocation user to Pod Functions

### DIFF
--- a/cli/dust-sandbox/pod/bun.lock
+++ b/cli/dust-sandbox/pod/bun.lock
@@ -6,6 +6,7 @@
       "name": "@dust/pod",
       "dependencies": {
         "drizzle-orm": "0.45.2",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -22,5 +23,7 @@
     "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "prisma": "*", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "prisma", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
   }
 }

--- a/cli/dust-sandbox/pod/identity.test.ts
+++ b/cli/dust-sandbox/pod/identity.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  currentUser,
+  POD_USER_IDENTITY_ENV,
+  POD_WORKSPACE_ID_ENV,
+  PodUserIdentityError,
+} from "@dust/pod";
+
+const identity = {
+  workspaceId: "w_current",
+  user: {
+    sId: "usr_123",
+    firstName: "Ada",
+    lastName: "Lovelace",
+    fullName: "Ada Lovelace",
+    image: null,
+  },
+};
+
+afterEach(() => {
+  delete process.env[POD_USER_IDENTITY_ENV];
+  delete process.env[POD_WORKSPACE_ID_ENV];
+});
+
+describe("currentUser", () => {
+  test("returns the user scoped to the current workspace", () => {
+    process.env[POD_WORKSPACE_ID_ENV] = "w_current";
+    process.env[POD_USER_IDENTITY_ENV] = JSON.stringify(identity);
+
+    expect(currentUser()).toEqual(identity.user);
+  });
+
+  test("returns null for a userless invocation", () => {
+    process.env[POD_WORKSPACE_ID_ENV] = "w_current";
+    process.env[POD_USER_IDENTITY_ENV] = "";
+
+    expect(currentUser()).toBeNull();
+  });
+
+  test("rejects identity from another workspace", () => {
+    process.env[POD_WORKSPACE_ID_ENV] = "w_other";
+    process.env[POD_USER_IDENTITY_ENV] = JSON.stringify(identity);
+
+    expect(() => currentUser()).toThrow(PodUserIdentityError);
+    expect(() => currentUser()).toThrow(/does not match/);
+  });
+
+  test("rejects malformed identity", () => {
+    process.env[POD_WORKSPACE_ID_ENV] = "w_current";
+    process.env[POD_USER_IDENTITY_ENV] = JSON.stringify({
+      workspaceId: "w_current",
+      user: { sId: "usr_123" },
+    });
+
+    expect(() => currentUser()).toThrow(PodUserIdentityError);
+  });
+});

--- a/cli/dust-sandbox/pod/identity.ts
+++ b/cli/dust-sandbox/pod/identity.ts
@@ -1,0 +1,94 @@
+export const POD_USER_IDENTITY_ENV = "DUST_POD_USER_IDENTITY";
+export const POD_WORKSPACE_ID_ENV = "WORKSPACE_ID";
+
+export interface WorkspaceUserIdentity {
+  readonly sId: string;
+  readonly firstName: string;
+  readonly lastName: string | null;
+  readonly fullName: string;
+  readonly image: string | null;
+}
+
+interface WorkspaceUserIdentityEnvelope {
+  workspaceId: string;
+  user: WorkspaceUserIdentity;
+}
+
+export class PodUserIdentityError extends Error {
+  override readonly name = "PodUserIdentityError";
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isWorkspaceUserIdentity(
+  value: unknown
+): value is WorkspaceUserIdentity {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "sId" in value &&
+    typeof value.sId === "string" &&
+    "firstName" in value &&
+    typeof value.firstName === "string" &&
+    "lastName" in value &&
+    isNullableString(value.lastName) &&
+    "fullName" in value &&
+    typeof value.fullName === "string" &&
+    "image" in value &&
+    isNullableString(value.image)
+  );
+}
+
+function isWorkspaceUserIdentityEnvelope(
+  value: unknown
+): value is WorkspaceUserIdentityEnvelope {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "workspaceId" in value &&
+    typeof value.workspaceId === "string" &&
+    "user" in value &&
+    isWorkspaceUserIdentity(value.user)
+  );
+}
+
+/**
+ * Return the user attributed to this function invocation.
+ *
+ * The identity is always scoped to the workspace owning the current Pod.
+ * Userless invocations return null.
+ */
+export function currentUser(): WorkspaceUserIdentity | null {
+  const rawIdentity = process.env[POD_USER_IDENTITY_ENV];
+  if (!rawIdentity) {
+    return null;
+  }
+
+  let value: unknown;
+  try {
+    value = JSON.parse(rawIdentity);
+  } catch {
+    throw new PodUserIdentityError("The Pod user identity is invalid.");
+  }
+
+  if (!isWorkspaceUserIdentityEnvelope(value)) {
+    throw new PodUserIdentityError("The Pod user identity is invalid.");
+  }
+
+  const workspaceId = process.env[POD_WORKSPACE_ID_ENV];
+  if (!workspaceId || value.workspaceId !== workspaceId) {
+    throw new PodUserIdentityError(
+      "The Pod user identity does not match the current workspace."
+    );
+  }
+
+  return Object.freeze({
+    sId: value.user.sId,
+    firstName: value.user.firstName,
+    lastName: value.user.lastName,
+    fullName: value.user.fullName,
+    image: value.user.image,
+  });
+}

--- a/cli/dust-sandbox/pod/identity.ts
+++ b/cli/dust-sandbox/pod/identity.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 export const POD_USER_IDENTITY_ENV = "DUST_POD_USER_IDENTITY";
 export const POD_WORKSPACE_ID_ENV = "WORKSPACE_ID";
 
@@ -14,44 +16,19 @@ interface WorkspaceUserIdentityEnvelope {
   user: WorkspaceUserIdentity;
 }
 
+const workspaceUserIdentityEnvelopeSchema = z.object({
+  workspaceId: z.string(),
+  user: z.object({
+    sId: z.string(),
+    firstName: z.string(),
+    lastName: z.string().nullable(),
+    fullName: z.string(),
+    image: z.string().nullable(),
+  }),
+});
+
 export class PodUserIdentityError extends Error {
   override readonly name = "PodUserIdentityError";
-}
-
-function isNullableString(value: unknown): value is string | null {
-  return value === null || typeof value === "string";
-}
-
-function isWorkspaceUserIdentity(
-  value: unknown
-): value is WorkspaceUserIdentity {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "sId" in value &&
-    typeof value.sId === "string" &&
-    "firstName" in value &&
-    typeof value.firstName === "string" &&
-    "lastName" in value &&
-    isNullableString(value.lastName) &&
-    "fullName" in value &&
-    typeof value.fullName === "string" &&
-    "image" in value &&
-    isNullableString(value.image)
-  );
-}
-
-function isWorkspaceUserIdentityEnvelope(
-  value: unknown
-): value is WorkspaceUserIdentityEnvelope {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "workspaceId" in value &&
-    typeof value.workspaceId === "string" &&
-    "user" in value &&
-    isWorkspaceUserIdentity(value.user)
-  );
 }
 
 /**
@@ -66,16 +43,18 @@ export function currentUser(): WorkspaceUserIdentity | null {
     return null;
   }
 
-  let value: unknown;
+  let parsedJson: unknown;
   try {
-    value = JSON.parse(rawIdentity);
+    parsedJson = JSON.parse(rawIdentity);
   } catch {
     throw new PodUserIdentityError("The Pod user identity is invalid.");
   }
-
-  if (!isWorkspaceUserIdentityEnvelope(value)) {
+  const parsedIdentity =
+    workspaceUserIdentityEnvelopeSchema.safeParse(parsedJson);
+  if (!parsedIdentity.success) {
     throw new PodUserIdentityError("The Pod user identity is invalid.");
   }
+  const value: WorkspaceUserIdentityEnvelope = parsedIdentity.data;
 
   const workspaceId = process.env[POD_WORKSPACE_ID_ENV];
   if (!workspaceId || value.workspaceId !== workspaceId) {

--- a/cli/dust-sandbox/pod/index.ts
+++ b/cli/dust-sandbox/pod/index.ts
@@ -3,5 +3,7 @@
  *
  * Surfaces:
  * - `db(name)`: the pod's SQLite state databases, through Drizzle (./db.ts).
+ * - `currentUser()`: the workspace-scoped user attributed to this invocation.
  */
 export * from "./db.ts";
+export * from "./identity.ts";

--- a/cli/dust-sandbox/pod/package.json
+++ b/cli/dust-sandbox/pod/package.json
@@ -10,6 +10,9 @@
     "test": "bun test",
     "build": "bun build index.ts --bundle --target=bun --packages=external --outfile dist/index.js"
   },
-  "dependencies": { "drizzle-orm": "0.45.2" },
+  "dependencies": {
+    "drizzle-orm": "0.45.2",
+    "zod": "^4.4.3"
+  },
   "devDependencies": { "@types/bun": "latest" }
 }

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.59",
+      tag: "0.8.60",
     });
   });
 

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -25,7 +25,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.59";
+const DUST_BASE_IMAGE_VERSION = "0.8.60";
 const DSBX_CLI_VERSION = "0.1.38";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that

--- a/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
@@ -163,6 +163,21 @@ describe("callSandboxFunction", () => {
     });
   });
 
+  it("fails closed on a policy introduced by a newer application version", async () => {
+    const { auth, fn } = await setup();
+    Object.assign(fn, { authentication: "future_policy" });
+
+    const result = await callSandboxFunction(auth, fn, { name: "x" });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("invocation_failed");
+    expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
+    expect(getSandboxFunctionInvocationEvents).not.toHaveBeenCalled();
+  });
+
   it("errors when no result event arrives", async () => {
     const { auth, fn } = await setup();
     vi.mocked(getSandboxFunctionInvocationEvents).mockReturnValue(

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -4,13 +4,16 @@ import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import { sandboxFunctionContentType } from "@app/types/files";
 import { Ok } from "@app/types/shared/result";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -103,6 +106,7 @@ async function setupExecutionTest() {
 
   return {
     authenticator,
+    workspace,
     space,
     sandboxFunction,
     sandbox,
@@ -564,6 +568,56 @@ describe("SandboxFunctionInvocationResource", () => {
     );
 
     const executionResult = await invocation.execute(userlessAuth);
+    if (executionResult.isErr()) {
+      throw executionResult.error;
+    }
+
+    expect(execSpy.mock.calls[0]?.[2]?.envVars).toMatchObject({
+      DUST_POD_USER_IDENTITY: "",
+    });
+  });
+
+  it("clears user identity when the executor differs from the invocation user", async () => {
+    const { workspace, sandbox, invocation } = await setupExecutionTest();
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+    const otherUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      workspace.sId
+    );
+    const execSpy = vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout: "hello world\n",
+        stderr: "",
+      })
+    );
+
+    const executionResult = await invocation.execute(otherUserAuth);
+    if (executionResult.isErr()) {
+      throw executionResult.error;
+    }
+
+    expect(execSpy.mock.calls[0]?.[2]?.envVars).toMatchObject({
+      DUST_POD_USER_IDENTITY: "",
+    });
+  });
+
+  it("clears user identity when the invocation user is no longer a member", async () => {
+    const { authenticator, sandbox, invocation } = await setupExecutionTest();
+    vi.spyOn(
+      MembershipResource,
+      "getActiveRoleForUserInWorkspace"
+    ).mockResolvedValueOnce("none");
+    const execSpy = vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout: "hello world\n",
+        stderr: "",
+      })
+    );
+
+    const executionResult = await invocation.execute(authenticator);
     if (executionResult.isErr()) {
       throw executionResult.error;
     }

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -8,6 +8,7 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { SandboxFunctionModel } from "@app/lib/resources/storage/models/sandbox_function";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -625,6 +626,26 @@ describe("SandboxFunctionInvocationResource", () => {
     expect(execSpy.mock.calls[0]?.[2]?.envVars).toMatchObject({
       DUST_POD_USER_IDENTITY: "",
     });
+  });
+
+  it("fails closed when a newer application persisted an unknown policy", async () => {
+    const { authenticator, sandbox, sandboxFunction, invocation } =
+      await setupExecutionTest();
+    await SandboxFunctionModel.update(
+      { authentication: "future_policy" },
+      {
+        where: {
+          id: sandboxFunction.id,
+          workspaceId: sandboxFunction.workspaceId,
+        },
+      }
+    );
+    const execSpy = vi.spyOn(sandbox, "exec");
+
+    const executionResult = await invocation.execute(authenticator);
+
+    expect(executionResult.isErr()).toBe(true);
+    expect(execSpy).not.toHaveBeenCalled();
   });
 
   it("surfaces the runner stderr when the invocation exits non-zero", async () => {

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -500,6 +500,15 @@ describe("SandboxFunctionInvocationResource", () => {
       DUST_POD_DATABASE_MAX_SIZE_BYTES: "1073741824",
       DUST_SANDBOX_TOKEN: "sbt-function-token",
     });
+    expect(
+      JSON.parse(opts?.envVars?.DUST_POD_USER_IDENTITY ?? "")
+    ).toMatchObject({
+      workspaceId: authenticator.getNonNullableWorkspace().sId,
+      user: {
+        sId: authenticator.getNonNullableUser().sId,
+        fullName: authenticator.getNonNullableUser().fullName(),
+      },
+    });
     expect(opts?.user).toBe("agent-proxied");
     expect(opts?.workingDirectory).toBe("/home/agent");
     expect(typeof opts?.stdin).toBe("string");
@@ -539,6 +548,29 @@ describe("SandboxFunctionInvocationResource", () => {
     expect(ensurePodSandboxReady).not.toHaveBeenCalled();
     expect(generateSandboxFunctionInvocationToken).not.toHaveBeenCalled();
     expect(execSpy).not.toHaveBeenCalled();
+  });
+
+  it("clears user identity for a userless invocation", async () => {
+    const { authenticator, sandbox, invocation } = await setupExecutionTest();
+    const userlessAuth = await Authenticator.internalAdminForWorkspace(
+      authenticator.getNonNullableWorkspace().sId
+    );
+    const execSpy = vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout: "hello world\n",
+        stderr: "",
+      })
+    );
+
+    const executionResult = await invocation.execute(userlessAuth);
+    if (executionResult.isErr()) {
+      throw executionResult.error;
+    }
+
+    expect(execSpy.mock.calls[0]?.[2]?.envVars).toMatchObject({
+      DUST_POD_USER_IDENTITY: "",
+    });
   });
 
   it("surfaces the runner stderr when the invocation exits non-zero", async () => {

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -16,7 +16,10 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
-import { SandboxFunctionInvocationModel } from "@app/lib/resources/storage/models/sandbox_function";
+import {
+  SandboxFunctionInvocationModel,
+  SandboxFunctionModel,
+} from "@app/lib/resources/storage/models/sandbox_function";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import {
@@ -325,6 +328,20 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
 
     try {
       const { sandboxFunction } = this;
+      const persistedFunction = await SandboxFunctionModel.findOne({
+        where: {
+          id: this.sandboxFunctionId,
+          workspaceId: this.workspaceId,
+        },
+      });
+      if (!persistedFunction || persistedFunction.authentication !== null) {
+        return new Err(
+          new Error(
+            "This Pod Function cannot execute with an unsupported authentication policy."
+          )
+        );
+      }
+
       const ensureResult = await ensurePodSandboxReady(
         auth,
         sandboxFunction.space

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -10,9 +10,10 @@ import {
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
-import type { Authenticator } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxFunctionInvocationModel } from "@app/lib/resources/storage/models/sandbox_function";
@@ -55,6 +56,7 @@ const SANDBOX_FUNCTION_ERROR_DETAIL_MAX_CHARS = 2_048;
 const SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS = 16_384;
 const GCS_CONCURRENCY = 4;
 const SANDBOX_FUNCTION_INVOCATION_DATA_VERSION = 2;
+const POD_USER_IDENTITY_ENV = "DUST_POD_USER_IDENTITY";
 
 // `code` is not narrowed to `SandboxFunctionCallErrorCode`: it is forwarded from whatever
 // classified the failure (runner, API error type, front), and a code introduced by a newer deploy
@@ -164,6 +166,40 @@ function buildSandboxFunctionRunCommand(slug: string): string {
   // dsbx resolves `function run <slug>` as `${DUST_FUNCTIONS_DIR}/<slug>.ts`, which is the
   // read-only mount of the pod's published bundles.
   return `${DSBX_BIN_PATH} function run ${shellEscape(slug)}`;
+}
+
+async function getSandboxFunctionUserIdentity(
+  auth: Authenticator,
+  invocation: SandboxFunctionInvocationResource
+) {
+  const workspace = auth.getNonNullableWorkspace();
+  const user = auth.user();
+  if (
+    !user ||
+    invocation.workspaceId !== workspace.id ||
+    invocation.userId !== user.id
+  ) {
+    return null;
+  }
+
+  const role = await MembershipResource.getActiveRoleForUserInWorkspace({
+    user,
+    workspace,
+  });
+  if (!Authenticator.isMember(role)) {
+    return null;
+  }
+
+  return {
+    workspaceId: workspace.sId,
+    user: {
+      sId: user.sId,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      fullName: user.fullName(),
+      image: user.imageUrl,
+    },
+  };
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -321,6 +357,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
           : { body: JSON.stringify(this.input) }),
         encoding: "utf8",
       };
+      const userIdentity = await getSandboxFunctionUserIdentity(auth, this);
 
       const execResult = await ensureResult.value.sandbox.exec(auth, command, {
         workingDirectory: SANDBOX_FUNCTION_WORKING_DIRECTORY,
@@ -331,6 +368,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
           ),
           ...podDatabaseExecEnvVars(),
           DUST_SANDBOX_TOKEN: token,
+          // Set this for every invocation so userless calls cannot inherit a sandbox-level value.
+          [POD_USER_IDENTITY_ENV]: userIdentity
+            ? JSON.stringify(userIdentity)
+            : "",
         },
         stdin: JSON.stringify(inputEnvelope),
         timeoutMs: SANDBOX_FUNCTION_EXEC_TIMEOUT_MS,

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -346,6 +346,14 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     auth: Authenticator,
     body: PostSandboxFunctionInvocationRequestBody
   ): Promise<Result<SandboxFunctionInvocationResource, Error>> {
+    if (this.authentication !== null) {
+      return new Err(
+        new Error(
+          "This Pod Function uses an authentication policy unsupported by this application version."
+        )
+      );
+    }
+
     return SandboxFunctionInvocationResource.createAndStartExecution(auth, {
       sandboxFunction: this,
       body,

--- a/front/lib/resources/storage/models/sandbox_function.ts
+++ b/front/lib/resources/storage/models/sandbox_function.ts
@@ -43,6 +43,9 @@ export class SandboxFunctionModel extends WorkspaceAwareModel<SandboxFunctionMod
   declare fileId: ForeignKey<FileModel["id"]>;
   declare slug: string;
   declare description: string;
+  // Non-null policies are introduced by the next deploy. This predecessor
+  // recognizes the column only so mixed-version instances can fail closed.
+  declare authentication: string | null;
   declare inputSchema: JSONSchema;
   declare outputSchema: JSONSchema;
 
@@ -94,6 +97,10 @@ SandboxFunctionModel.init(
     description: {
       type: DataTypes.STRING(255),
       allowNull: false,
+    },
+    authentication: {
+      type: DataTypes.STRING(64),
+      allowNull: true,
     },
     inputSchema: {
       type: DataTypes.JSONB,

--- a/front/migrations/pre-deploy/20260729142338_add_authentication_to_sandbox_functions.sql
+++ b/front/migrations/pre-deploy/20260729142338_add_authentication_to_sandbox_functions.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_functions" ADD COLUMN "authentication" character varying(64) COLLATE "pg_catalog"."default";


### PR DESCRIPTION
## Description

Stack 3 of 6. Depends on #29679 and is followed by #29682.

Adds `currentUser()` to `@dust/pod`. Front derives the payload from the invocation owner and a fresh active membership in the exact function workspace. The runtime validates the payload with Zod and rejects a mismatched workspace. This PR also introduces the nullable authentication-policy column used by later slices; this version denies every non-null policy at request and execution time.

## Tests

Added coverage for authenticated, userless, revoked, malformed, and cross-workspace identities, reserved execution payloads, future-policy rejection, and the sandbox image registry.

## Risk

Malformed or cross-workspace injected payloads now throw `PodUserIdentityError`; userless and revoked invocations return `null`. Once later PRs persist policies, this PR is the rollback floor because older versions could run them without enforcement.

## Deploy Plan

1. Apply the pre-deploy migration.
2. Build and register `dust-base` 0.8.60.
3. Deploy this application revision everywhere.
4. After deploy, recycle pre-0.8.60 Pod sandboxes with `/poke/kill`.
5. Smoke-test authenticated, revoked, and userless `currentUser()` calls.

Do not deploy #29682 until this revision is live everywhere.
