### PR TITLE
Require workspace users for selected Pod Functions

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.38"
+version = "0.1.39"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.38"
+version = "0.1.39"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/README.md
+++ b/cli/dust-sandbox/README.md
@@ -51,8 +51,20 @@ Functions are self-contained Bun bundles in `$DUST_FUNCTIONS_DIR`, named
 
 - `dsbx function run <name>` — request envelope JSON on stdin → parsed output or error envelope
   on stdout (`{ok, response}` / `{ok:false, error}`).
-- `dsbx function get <name>` — prints `{name, description, input_schema,
-  output_schema}` (JSON Schema).
+- `dsbx function get <name>` — prints `{name, description, authentication,
+  input_schema, output_schema}` (JSON Schema).
+
+Functions may require a current member of their Pod's workspace:
+
+```ts
+export const schema = {
+  authentication: "workspace_user_required",
+  input: z.object({}),
+  output: z.object({}),
+};
+```
+
+Omitting `authentication` keeps the function callable without a user.
 
 ### Unprivileged execution
 

--- a/cli/dust-sandbox/README.md
+++ b/cli/dust-sandbox/README.md
@@ -51,20 +51,20 @@ Functions are self-contained Bun bundles in `$DUST_FUNCTIONS_DIR`, named
 
 - `dsbx function run <name>` — request envelope JSON on stdin → parsed output or error envelope
   on stdout (`{ok, response}` / `{ok:false, error}`).
-- `dsbx function get <name>` — prints `{name, description, authentication,
+- `dsbx function get <name>` — prints `{name, description, userIdentity,
   input_schema, output_schema}` (JSON Schema).
 
 Functions may require a current member of their Pod's workspace:
 
 ```ts
 export const schema = {
-  authentication: "workspace_user_required",
+  userIdentity: "workspace_user_required",
   input: z.object({}),
   output: z.object({}),
 };
 ```
 
-Omitting `authentication` keeps the function callable without a user.
+Omitting `userIdentity` keeps the function callable without a user.
 
 ### Unprivileged execution
 

--- a/cli/dust-sandbox/functions-runner/fixtures/greet.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/greet.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const schema = {
   description: "Greet a user by name",
+  authentication: "workspace_user_required",
   input: z.object({ name: z.string(), formal: z.boolean().optional() }),
   output: z.object({ greeting: z.string() }),
 };

--- a/cli/dust-sandbox/functions-runner/fixtures/greet.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/greet.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const schema = {
   description: "Greet a user by name",
-  authentication: "workspace_user_required",
+  userIdentity: "workspace_user_required",
   input: z.object({ name: z.string(), formal: z.boolean().optional() }),
   output: z.object({ greeting: z.string() }),
 };

--- a/cli/dust-sandbox/functions-runner/fixtures/invalid-authentication.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/invalid-authentication.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const schema = {
+  authentication: "logged_in",
+  input: z.object({}),
+  output: z.object({}),
+};

--- a/cli/dust-sandbox/functions-runner/fixtures/invalid-user-identity.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/invalid-user-identity.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const schema = {
-  authentication: "logged_in",
+  userIdentity: "logged_in",
   input: z.object({}),
   output: z.object({}),
 };

--- a/cli/dust-sandbox/functions-runner/schema.test.ts
+++ b/cli/dust-sandbox/functions-runner/schema.test.ts
@@ -29,14 +29,14 @@ describe("getFunctionSchema", () => {
     const s = await getFunctionSchema(fx("greet.ts"));
     expect(s.name).toBe("greet");
     expect(s.description).toBe("Greet a user by name");
-    expect(s.authentication).toBe("workspace_user_required");
+    expect(s.userIdentity).toBe("workspace_user_required");
     expect(s.input_schema).toMatchObject({ required: ["name"] });
     expect(s.output_schema).toMatchObject({ required: ["greeting"] });
   });
 
   test("nulls a malformed (non-Zod) schema field", async () => {
     const s = await getFunctionSchema(fx("bad-schema.ts"));
-    expect(s.authentication).toBe("optional");
+    expect(s.userIdentity).toBe("optional");
     expect(s.input_schema).toBeNull();
     expect(s.output_schema).toBeNull();
   });
@@ -51,9 +51,9 @@ describe("getFunctionSchema", () => {
     await expect(getFunctionSchema(fx("nope.ts"))).rejects.toThrow();
   });
 
-  test("rejects an unknown authentication policy", async () => {
+  test("rejects an unknown user identity policy", async () => {
     await expect(
-      getFunctionSchema(fx("invalid-authentication.ts"))
-    ).rejects.toThrow(/schema.authentication/);
+      getFunctionSchema(fx("invalid-user-identity.ts"))
+    ).rejects.toThrow(/schema.userIdentity/);
   });
 });

--- a/cli/dust-sandbox/functions-runner/schema.test.ts
+++ b/cli/dust-sandbox/functions-runner/schema.test.ts
@@ -29,12 +29,14 @@ describe("getFunctionSchema", () => {
     const s = await getFunctionSchema(fx("greet.ts"));
     expect(s.name).toBe("greet");
     expect(s.description).toBe("Greet a user by name");
+    expect(s.authentication).toBe("workspace_user_required");
     expect(s.input_schema).toMatchObject({ required: ["name"] });
     expect(s.output_schema).toMatchObject({ required: ["greeting"] });
   });
 
   test("nulls a malformed (non-Zod) schema field", async () => {
     const s = await getFunctionSchema(fx("bad-schema.ts"));
+    expect(s.authentication).toBe("optional");
     expect(s.input_schema).toBeNull();
     expect(s.output_schema).toBeNull();
   });
@@ -47,5 +49,11 @@ describe("getFunctionSchema", () => {
 
   test("throws when the file cannot be imported", async () => {
     await expect(getFunctionSchema(fx("nope.ts"))).rejects.toThrow();
+  });
+
+  test("rejects an unknown authentication policy", async () => {
+    await expect(
+      getFunctionSchema(fx("invalid-authentication.ts"))
+    ).rejects.toThrow(/schema.authentication/);
   });
 });

--- a/cli/dust-sandbox/functions-runner/schema.ts
+++ b/cli/dust-sandbox/functions-runner/schema.ts
@@ -6,8 +6,23 @@ import { z } from "zod";
 export interface FunctionSchema {
   name: string;
   description: string | null;
+  authentication: "optional" | "workspace_user_required";
   input_schema: Record<string, unknown> | null;
   output_schema: Record<string, unknown> | null;
+}
+
+function parseAuthenticationPolicy(
+  value: unknown
+): FunctionSchema["authentication"] {
+  if (value === undefined || value === "optional") {
+    return "optional";
+  }
+  if (value === "workspace_user_required") {
+    return value;
+  }
+  throw new Error(
+    "`schema.authentication` must be `optional` or `workspace_user_required`"
+  );
 }
 
 export function toJsonSchema(value: unknown): Record<string, unknown> | null {
@@ -23,7 +38,12 @@ export async function getFunctionSchema(
 ): Promise<FunctionSchema> {
   const mod = await import(handlerPath);
   const schema = mod.schema as
-    | { description?: unknown; input?: unknown; output?: unknown }
+    | {
+        description?: unknown;
+        authentication?: unknown;
+        input?: unknown;
+        output?: unknown;
+      }
     | undefined;
   if (schema === undefined) {
     throw new Error("function declares no `schema` export");
@@ -32,6 +52,7 @@ export async function getFunctionSchema(
     name: basename(handlerPath, extname(handlerPath)),
     description:
       typeof schema.description === "string" ? schema.description : null,
+    authentication: parseAuthenticationPolicy(schema.authentication),
     input_schema: toJsonSchema(schema.input),
     output_schema: toJsonSchema(schema.output),
   };

--- a/cli/dust-sandbox/functions-runner/schema.ts
+++ b/cli/dust-sandbox/functions-runner/schema.ts
@@ -6,14 +6,14 @@ import { z } from "zod";
 export interface FunctionSchema {
   name: string;
   description: string | null;
-  authentication: "optional" | "workspace_user_required";
+  userIdentity: "optional" | "workspace_user_required";
   input_schema: Record<string, unknown> | null;
   output_schema: Record<string, unknown> | null;
 }
 
-function parseAuthenticationPolicy(
+function parseUserIdentityPolicy(
   value: unknown
-): FunctionSchema["authentication"] {
+): FunctionSchema["userIdentity"] {
   if (value === undefined || value === "optional") {
     return "optional";
   }
@@ -21,7 +21,7 @@ function parseAuthenticationPolicy(
     return value;
   }
   throw new Error(
-    "`schema.authentication` must be `optional` or `workspace_user_required`"
+    "`schema.userIdentity` must be `optional` or `workspace_user_required`"
   );
 }
 
@@ -40,7 +40,7 @@ export async function getFunctionSchema(
   const schema = mod.schema as
     | {
         description?: unknown;
-        authentication?: unknown;
+        userIdentity?: unknown;
         input?: unknown;
         output?: unknown;
       }
@@ -52,7 +52,7 @@ export async function getFunctionSchema(
     name: basename(handlerPath, extname(handlerPath)),
     description:
       typeof schema.description === "string" ? schema.description : null,
-    authentication: parseAuthenticationPolicy(schema.authentication),
+    userIdentity: parseUserIdentityPolicy(schema.userIdentity),
     input_schema: toJsonSchema(schema.input),
     output_schema: toJsonSchema(schema.output),
   };

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -88,11 +88,11 @@ afterEach(() => {
 async function setupSandboxFunction({
   addCallerToSpace = true,
   withSandboxFunctionsFeatureFlag = true,
-  authentication = "optional",
+  userIdentity = "optional",
 }: {
   addCallerToSpace?: boolean;
   withSandboxFunctionsFeatureFlag?: boolean;
-  authentication?: "optional" | "workspace_user_required";
+  userIdentity?: "optional" | "workspace_user_required";
 } = {}) {
   const { workspace, auth: adminAuth } = await createPrivateApiMockRequest({
     role: "admin",
@@ -115,7 +115,7 @@ async function setupSandboxFunction({
     file,
     slug: "run-function",
     description: "Run the function.",
-    authentication,
+    userIdentity,
     inputSchema,
     outputSchema,
   });
@@ -322,7 +322,7 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
 
   it("allows a workspace member to invoke a workspace-user-required function", async () => {
     const { workspace, sandboxFunction } = await setupSandboxFunction({
-      authentication: "workspace_user_required",
+      userIdentity: "workspace_user_required",
     });
 
     const response = await postInvocation({

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -1,5 +1,6 @@
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
+import { SandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
 import { Authenticator } from "@app/lib/auth";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
@@ -87,9 +88,11 @@ afterEach(() => {
 async function setupSandboxFunction({
   addCallerToSpace = true,
   withSandboxFunctionsFeatureFlag = true,
+  authentication = "optional",
 }: {
   addCallerToSpace?: boolean;
   withSandboxFunctionsFeatureFlag?: boolean;
+  authentication?: "optional" | "workspace_user_required";
 } = {}) {
   const { workspace, auth: adminAuth } = await createPrivateApiMockRequest({
     role: "admin",
@@ -112,6 +115,7 @@ async function setupSandboxFunction({
     file,
     slug: "run-function",
     description: "Run the function.",
+    authentication,
     inputSchema,
     outputSchema,
   });
@@ -314,6 +318,45 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
       },
       { invocationId: invocation.sId }
     );
+  });
+
+  it("allows a workspace member to invoke a workspace-user-required function", async () => {
+    const { workspace, sandboxFunction } = await setupSandboxFunction({
+      authentication: "workspace_user_required",
+    });
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+    });
+
+    expect(response.status).toBe(201);
+    expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledOnce();
+  });
+
+  it("returns a typed authentication error when the function rejects the caller", async () => {
+    const { workspace, sandboxFunction } = await setupSandboxFunction();
+    vi.spyOn(SandboxFunctionResource.prototype, "invoke").mockResolvedValueOnce(
+      new Err(
+        new SandboxFunctionInvocationError(
+          "This Pod Function requires a logged-in user from its workspace."
+        )
+      )
+    );
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toMatchObject({
+      error: {
+        type: "user_authentication_required",
+        message:
+          "This Pod Function requires a logged-in user from its workspace.",
+      },
+    });
   });
 
   it("creates an invocation by pod id and function slug", async () => {

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -1,4 +1,5 @@
 import { MCP_VALIDATION_OUTPUTS } from "@app/lib/actions/constants";
+import { isSandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
 import { resolveSandboxFunctionActionAuthentication } from "@app/lib/api/sandbox_functions/resolve_authentication";
 import { validateSandboxFunctionAction } from "@app/lib/api/sandbox_functions/validate_action";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
@@ -121,6 +122,15 @@ app.post(
 
     const invocationResult = await sandboxFunction.invoke(auth, body);
     if (invocationResult.isErr()) {
+      if (isSandboxFunctionInvocationError(invocationResult.error)) {
+        return apiError(ctx, {
+          status_code: 401,
+          api_error: {
+            type: invocationResult.error.code,
+            message: invocationResult.error.message,
+          },
+        });
+      }
       return apiError(
         ctx,
         {

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -26,7 +26,7 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
   {
     name: "get",
     description:
-      "Get a pod function's input and output JSON schemas by its slug.",
+      "Get a pod function's authentication policy and input and output JSON schemas by its slug.",
     schema: {
       slug: z
         .string()
@@ -46,9 +46,10 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
     description:
       "Publish a pod function from a TypeScript source file in the current pod. The source " +
       "must default-export a `fetch(request: Request): Promise<Response>` handler and export a " +
-      "`schema` with zod `input` and `output`. It is bundled on the pod sandbox (only `zod` is " +
-      "available to import) and its input and output JSON schemas are extracted from the `schema` " +
-      "export. Re-publishing the same slug replaces the previous version.",
+      "`schema` with zod `input` and `output`. Set `schema.authentication` to `optional` or " +
+      "`workspace_user_required`. It is bundled on the pod sandbox (only `zod` is available to " +
+      "import), and its contract is extracted from the `schema` export. Re-publishing the same " +
+      "slug replaces the previous version.",
     schema: {
       slug: z
         .string()

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -26,7 +26,7 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
   {
     name: "get",
     description:
-      "Get a pod function's authentication policy and input and output JSON schemas by its slug.",
+      "Get a pod function's user identity policy and input and output JSON schemas by its slug.",
     schema: {
       slug: z
         .string()
@@ -46,7 +46,7 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
     description:
       "Publish a pod function from a TypeScript source file in the current pod. The source " +
       "must default-export a `fetch(request: Request): Promise<Response>` handler and export a " +
-      "`schema` with zod `input` and `output`. Set `schema.authentication` to `optional` or " +
+      "`schema` with zod `input` and `output`. Set `schema.userIdentity` to `optional` or " +
       "`workspace_user_required`. It is bundled on the pod sandbox (only `zod` is available to " +
       "import), and its contract is extracted from the `schema` export. Re-publishing the same " +
       "slug replaces the previous version.",

--- a/front/lib/api/actions/servers/sandbox_functions/tools/get.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/get.test.ts
@@ -59,7 +59,7 @@ describe("formatSandboxFunction", () => {
     const out = formatSandboxFunction(fn);
 
     expect(out).toContain("greet: Greet a user by name.");
-    expect(out).toContain("authentication: optional");
+    expect(out).toContain("userIdentity: optional");
     expect(out).toContain(`input: ${JSON.stringify(fn.inputSchema)}`);
     expect(out).toContain(`output: ${JSON.stringify(fn.outputSchema)}`);
   });

--- a/front/lib/api/actions/servers/sandbox_functions/tools/get.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/get.test.ts
@@ -59,6 +59,7 @@ describe("formatSandboxFunction", () => {
     const out = formatSandboxFunction(fn);
 
     expect(out).toContain("greet: Greet a user by name.");
+    expect(out).toContain("authentication: optional");
     expect(out).toContain(`input: ${JSON.stringify(fn.inputSchema)}`);
     expect(out).toContain(`output: ${JSON.stringify(fn.outputSchema)}`);
   });

--- a/front/lib/api/actions/servers/sandbox_functions/tools/get.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/get.ts
@@ -10,6 +10,7 @@ import { Err, Ok } from "@app/types/shared/result";
 export function formatSandboxFunction(fn: SandboxFunctionResource): string {
   return [
     `${fn.slug}: ${fn.description}`,
+    `authentication: ${fn.authentication ?? "optional"}`,
     `input: ${JSON.stringify(fn.inputSchema)}`,
     `output: ${JSON.stringify(fn.outputSchema)}`,
   ].join("\n");

--- a/front/lib/api/actions/servers/sandbox_functions/tools/get.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/get.ts
@@ -10,7 +10,7 @@ import { Err, Ok } from "@app/types/shared/result";
 export function formatSandboxFunction(fn: SandboxFunctionResource): string {
   return [
     `${fn.slug}: ${fn.description}`,
-    `authentication: ${fn.authentication ?? "optional"}`,
+    `userIdentity: ${fn.userIdentity ?? "optional"}`,
     `input: ${JSON.stringify(fn.inputSchema)}`,
     `output: ${JSON.stringify(fn.outputSchema)}`,
   ].join("\n");

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -394,7 +394,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.38/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.39/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.61",
+      tag: "0.8.62",
     });
   });
 

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,7 +26,7 @@ import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
 const DUST_BASE_IMAGE_VERSION = "0.8.61";
-const DSBX_CLI_VERSION = "0.1.38";
+const DSBX_CLI_VERSION = "0.1.39";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
 // list must not silently change this user's UID.

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -25,7 +25,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.61";
+const DUST_BASE_IMAGE_VERSION = "0.8.62";
 const DSBX_CLI_VERSION = "0.1.39";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that

--- a/front/lib/api/sandbox_functions/build_on_sandbox.test.ts
+++ b/front/lib/api/sandbox_functions/build_on_sandbox.test.ts
@@ -184,6 +184,7 @@ describe("buildSandboxFunctionOnSandbox", () => {
             JSON.stringify({
               name: "greet",
               description: null,
+              authentication: "optional",
               input_schema: null,
               output_schema: { type: "object" },
             })
@@ -203,7 +204,7 @@ describe("buildSandboxFunctionOnSandbox", () => {
     expect(result.error.code).toBe("invalid_contract");
   });
 
-  it("defaults functions built by an older sandbox image to optional authentication", async () => {
+  it("rejects an older sandbox image that omits authentication", async () => {
     const { authenticator, sandbox, space } = await setup();
     vi.spyOn(sandbox, "exec").mockResolvedValue(
       new Ok({ exitCode: 0, stdout: okEnvelope, stderr: "" })
@@ -228,11 +229,11 @@ describe("buildSandboxFunctionOnSandbox", () => {
       srcSandboxPath: SRC,
     });
 
-    expect(result.isOk()).toBe(true);
-    if (result.isErr()) {
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
       return;
     }
-    expect(result.value.authentication).toBe("optional");
+    expect(result.error.code).toBe("schema_extraction_failed");
   });
 
   it("returns an internal error when the exec itself fails", async () => {

--- a/front/lib/api/sandbox_functions/build_on_sandbox.test.ts
+++ b/front/lib/api/sandbox_functions/build_on_sandbox.test.ts
@@ -18,6 +18,7 @@ const okEnvelope = JSON.stringify({ ok: true });
 const validSchemaFile = JSON.stringify({
   name: "greet",
   description: "Greet someone.",
+  authentication: "workspace_user_required",
   input_schema: { type: "object", properties: { name: { type: "string" } } },
   output_schema: {
     type: "object",
@@ -78,6 +79,7 @@ describe("buildSandboxFunctionOnSandbox", () => {
       return;
     }
     expect(result.value.bundleCode).toBe("export default {/*bundle*/};");
+    expect(result.value.authentication).toBe("workspace_user_required");
     expect(result.value.inputSchema).toEqual({
       type: "object",
       properties: { name: { type: "string" } },
@@ -199,6 +201,38 @@ describe("buildSandboxFunctionOnSandbox", () => {
       return;
     }
     expect(result.error.code).toBe("invalid_contract");
+  });
+
+  it("defaults functions built by an older sandbox image to optional authentication", async () => {
+    const { authenticator, sandbox, space } = await setup();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({ exitCode: 0, stdout: okEnvelope, stderr: "" })
+    );
+    vi.spyOn(sandbox, "readFile")
+      .mockResolvedValueOnce(new Ok(Buffer.from("bundle")))
+      .mockResolvedValueOnce(
+        new Ok(
+          Buffer.from(
+            JSON.stringify({
+              name: "greet",
+              description: null,
+              input_schema: { type: "object" },
+              output_schema: { type: "object" },
+            })
+          )
+        )
+      );
+
+    const result = await buildSandboxFunctionOnSandbox(authenticator, {
+      space,
+      srcSandboxPath: SRC,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value.authentication).toBe("optional");
   });
 
   it("returns an internal error when the exec itself fails", async () => {

--- a/front/lib/api/sandbox_functions/build_on_sandbox.test.ts
+++ b/front/lib/api/sandbox_functions/build_on_sandbox.test.ts
@@ -18,7 +18,7 @@ const okEnvelope = JSON.stringify({ ok: true });
 const validSchemaFile = JSON.stringify({
   name: "greet",
   description: "Greet someone.",
-  authentication: "workspace_user_required",
+  userIdentity: "workspace_user_required",
   input_schema: { type: "object", properties: { name: { type: "string" } } },
   output_schema: {
     type: "object",
@@ -79,7 +79,7 @@ describe("buildSandboxFunctionOnSandbox", () => {
       return;
     }
     expect(result.value.bundleCode).toBe("export default {/*bundle*/};");
-    expect(result.value.authentication).toBe("workspace_user_required");
+    expect(result.value.userIdentity).toBe("workspace_user_required");
     expect(result.value.inputSchema).toEqual({
       type: "object",
       properties: { name: { type: "string" } },
@@ -184,7 +184,7 @@ describe("buildSandboxFunctionOnSandbox", () => {
             JSON.stringify({
               name: "greet",
               description: null,
-              authentication: "optional",
+              userIdentity: "optional",
               input_schema: null,
               output_schema: { type: "object" },
             })
@@ -204,7 +204,7 @@ describe("buildSandboxFunctionOnSandbox", () => {
     expect(result.error.code).toBe("invalid_contract");
   });
 
-  it("rejects an older sandbox image that omits authentication", async () => {
+  it("rejects an older sandbox image that omits user identity", async () => {
     const { authenticator, sandbox, space } = await setup();
     vi.spyOn(sandbox, "exec").mockResolvedValue(
       new Ok({ exitCode: 0, stdout: okEnvelope, stderr: "" })

--- a/front/lib/api/sandbox_functions/build_on_sandbox.ts
+++ b/front/lib/api/sandbox_functions/build_on_sandbox.ts
@@ -47,10 +47,7 @@ const jsonSchemaValue = z.custom<JSONSchema>(
 const functionSchemaFileSchema = z.object({
   name: z.string(),
   description: z.string().nullable(),
-  // Old sandbox images omit this field during a rolling deploy.
-  authentication: z
-    .enum(SANDBOX_FUNCTION_AUTHENTICATION_POLICIES)
-    .default("optional"),
+  authentication: z.enum(SANDBOX_FUNCTION_AUTHENTICATION_POLICIES),
   input_schema: jsonSchemaValue.nullable(),
   output_schema: jsonSchemaValue.nullable(),
 });

--- a/front/lib/api/sandbox_functions/build_on_sandbox.ts
+++ b/front/lib/api/sandbox_functions/build_on_sandbox.ts
@@ -7,8 +7,8 @@ import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import type { Authenticator } from "@app/lib/auth";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import {
-  SANDBOX_FUNCTION_AUTHENTICATION_POLICIES,
-  type SandboxFunctionAuthenticationPolicy,
+  SANDBOX_FUNCTION_USER_IDENTITY_POLICIES,
+  type SandboxFunctionUserIdentityPolicy,
 } from "@app/types/api/sandbox_functions";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -23,7 +23,7 @@ const BUILD_EXEC_TIMEOUT_MS = 2 * 60 * 1000;
 
 export interface SandboxFunctionBuildResult {
   bundleCode: string;
-  authentication: SandboxFunctionAuthenticationPolicy;
+  userIdentity: SandboxFunctionUserIdentityPolicy;
   inputSchema: JSONSchema;
   outputSchema: JSONSchema;
 }
@@ -47,7 +47,7 @@ const jsonSchemaValue = z.custom<JSONSchema>(
 const functionSchemaFileSchema = z.object({
   name: z.string(),
   description: z.string().nullable(),
-  authentication: z.enum(SANDBOX_FUNCTION_AUTHENTICATION_POLICIES),
+  userIdentity: z.enum(SANDBOX_FUNCTION_USER_IDENTITY_POLICIES),
   input_schema: jsonSchemaValue.nullable(),
   output_schema: jsonSchemaValue.nullable(),
 });
@@ -212,7 +212,7 @@ function parseSchemaFile(
   }
 
   const {
-    authentication,
+    userIdentity,
     input_schema: inputSchema,
     output_schema: outputSchema,
   } = parsed.data;
@@ -225,5 +225,5 @@ function parseSchemaFile(
     );
   }
 
-  return new Ok({ bundleCode, authentication, inputSchema, outputSchema });
+  return new Ok({ bundleCode, userIdentity, inputSchema, outputSchema });
 }

--- a/front/lib/api/sandbox_functions/build_on_sandbox.ts
+++ b/front/lib/api/sandbox_functions/build_on_sandbox.ts
@@ -6,6 +6,10 @@ import type { SandboxFunctionErrorCode } from "@app/lib/api/sandbox_functions/er
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import type { Authenticator } from "@app/lib/auth";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import {
+  SANDBOX_FUNCTION_AUTHENTICATION_POLICIES,
+  type SandboxFunctionAuthenticationPolicy,
+} from "@app/types/api/sandbox_functions";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -19,6 +23,7 @@ const BUILD_EXEC_TIMEOUT_MS = 2 * 60 * 1000;
 
 export interface SandboxFunctionBuildResult {
   bundleCode: string;
+  authentication: SandboxFunctionAuthenticationPolicy;
   inputSchema: JSONSchema;
   outputSchema: JSONSchema;
 }
@@ -42,6 +47,10 @@ const jsonSchemaValue = z.custom<JSONSchema>(
 const functionSchemaFileSchema = z.object({
   name: z.string(),
   description: z.string().nullable(),
+  // Old sandbox images omit this field during a rolling deploy.
+  authentication: z
+    .enum(SANDBOX_FUNCTION_AUTHENTICATION_POLICIES)
+    .default("optional"),
   input_schema: jsonSchemaValue.nullable(),
   output_schema: jsonSchemaValue.nullable(),
 });
@@ -205,8 +214,11 @@ function parseSchemaFile(
     );
   }
 
-  const { input_schema: inputSchema, output_schema: outputSchema } =
-    parsed.data;
+  const {
+    authentication,
+    input_schema: inputSchema,
+    output_schema: outputSchema,
+  } = parsed.data;
   if (inputSchema === null || outputSchema === null) {
     return new Err(
       new SandboxFunctionError(
@@ -216,5 +228,5 @@ function parseSchemaFile(
     );
   }
 
-  return new Ok({ bundleCode, inputSchema, outputSchema });
+  return new Ok({ bundleCode, authentication, inputSchema, outputSchema });
 }

--- a/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
@@ -1,6 +1,6 @@
 import { callSandboxFunction } from "@app/lib/api/sandbox_functions/call_sandbox_function";
 import type { SandboxFunctionInvocationStreamEvent } from "@app/lib/api/sandbox_functions/events";
-import type { Authenticator } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
@@ -72,7 +72,8 @@ function mockResult(result: unknown, invocationId: string): void {
 
 async function makeFunction(
   auth: Authenticator,
-  space: SpaceResource
+  space: SpaceResource,
+  authentication: "optional" | "workspace_user_required" = "optional"
 ): Promise<SandboxFunctionResource> {
   const file = await FileFactory.create(auth, null, {
     contentType: sandboxFunctionContentType,
@@ -87,6 +88,7 @@ async function makeFunction(
     file,
     slug: "greet",
     description: "Greet a user by name.",
+    authentication,
     inputSchema,
     outputSchema,
   });
@@ -174,6 +176,37 @@ describe("callSandboxFunction", () => {
       return;
     }
     expect(result.error.code).toBe("invocation_failed");
+    expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
+    expect(getSandboxFunctionInvocationEvents).not.toHaveBeenCalled();
+  });
+
+  it("rejects a workspace-user-required function without creating an invocation", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const space = await SpaceFactory.project(workspace);
+    const fn = await makeFunction(
+      authenticator,
+      space,
+      "workspace_user_required"
+    );
+    const userlessAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+
+    const result = await callSandboxFunction(userlessAuth, fn, {
+      name: "Soupinou",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error).toEqual({
+      code: "user_authentication_required",
+      message:
+        "This Pod Function requires a logged-in user from its workspace.",
+    });
     expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
     expect(getSandboxFunctionInvocationEvents).not.toHaveBeenCalled();
   });

--- a/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
@@ -211,6 +211,23 @@ describe("callSandboxFunction", () => {
     expect(getSandboxFunctionInvocationEvents).not.toHaveBeenCalled();
   });
 
+  it("rejects an authentication policy unknown to this application version", async () => {
+    const { auth, fn } = await setup();
+    Object.assign(fn, { authentication: "newer_required_policy" });
+
+    const result = await callSandboxFunction(auth, fn, {
+      name: "Soupinou",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("user_authentication_required");
+    expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
+    expect(getSandboxFunctionInvocationEvents).not.toHaveBeenCalled();
+  });
+
   it("errors when no result event arrives", async () => {
     const { auth, fn } = await setup();
     vi.mocked(getSandboxFunctionInvocationEvents).mockReturnValue(

--- a/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
@@ -175,7 +175,7 @@ describe("callSandboxFunction", () => {
     if (result.isOk()) {
       return;
     }
-    expect(result.error.code).toBe("invocation_failed");
+    expect(result.error.code).toBe("user_authentication_required");
     expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
     expect(getSandboxFunctionInvocationEvents).not.toHaveBeenCalled();
   });
@@ -207,23 +207,6 @@ describe("callSandboxFunction", () => {
       message:
         "This Pod Function requires a logged-in user from its workspace.",
     });
-    expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
-    expect(getSandboxFunctionInvocationEvents).not.toHaveBeenCalled();
-  });
-
-  it("rejects an authentication policy unknown to this application version", async () => {
-    const { auth, fn } = await setup();
-    Object.assign(fn, { authentication: "newer_required_policy" });
-
-    const result = await callSandboxFunction(auth, fn, {
-      name: "Soupinou",
-    });
-
-    expect(result.isErr()).toBe(true);
-    if (result.isOk()) {
-      return;
-    }
-    expect(result.error.code).toBe("user_authentication_required");
     expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
     expect(getSandboxFunctionInvocationEvents).not.toHaveBeenCalled();
   });

--- a/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
@@ -73,7 +73,7 @@ function mockResult(result: unknown, invocationId: string): void {
 async function makeFunction(
   auth: Authenticator,
   space: SpaceResource,
-  authentication: "optional" | "workspace_user_required" = "optional"
+  userIdentity: "optional" | "workspace_user_required" = "optional"
 ): Promise<SandboxFunctionResource> {
   const file = await FileFactory.create(auth, null, {
     contentType: sandboxFunctionContentType,
@@ -88,7 +88,7 @@ async function makeFunction(
     file,
     slug: "greet",
     description: "Greet a user by name.",
-    authentication,
+    userIdentity,
     inputSchema,
     outputSchema,
   });
@@ -167,7 +167,7 @@ describe("callSandboxFunction", () => {
 
   it("fails closed on a policy introduced by a newer application version", async () => {
     const { auth, fn } = await setup();
-    Object.assign(fn, { authentication: "future_policy" });
+    Object.assign(fn, { userIdentity: "future_policy" });
 
     const result = await callSandboxFunction(auth, fn, { name: "x" });
 

--- a/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
@@ -180,6 +180,26 @@ describe("callSandboxFunction", () => {
     expect(getSandboxFunctionInvocationEvents).not.toHaveBeenCalled();
   });
 
+  it("rejects an authenticator from another workspace", async () => {
+    const { fn } = await setup();
+    const { authenticator: otherWorkspaceAuth } = await createResourceTest({
+      role: "admin",
+    });
+
+    const result = await fn.invoke(otherWorkspaceAuth, {
+      input: { name: "Soupinou" },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.message).toBe(
+      "This Pod Function belongs to another workspace."
+    );
+    expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
+  });
+
   it("rejects a workspace-user-required function without creating an invocation", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",

--- a/front/lib/api/sandbox_functions/call_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.ts
@@ -1,3 +1,4 @@
+import { isSandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
 import { getSandboxFunctionInvocationEvents } from "@app/lib/api/sandbox_functions/events";
 import type { Authenticator } from "@app/lib/auth";
 import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
@@ -26,6 +27,12 @@ export async function callSandboxFunction(
     context,
   });
   if (invocationResult.isErr()) {
+    if (isSandboxFunctionInvocationError(invocationResult.error)) {
+      return new Err({
+        code: invocationResult.error.code,
+        message: invocationResult.error.message,
+      });
+    }
     return new Err({
       code: "invocation_failed",
       message: invocationResult.error.message,

--- a/front/lib/api/sandbox_functions/errors.ts
+++ b/front/lib/api/sandbox_functions/errors.ts
@@ -18,3 +18,18 @@ export class SandboxFunctionError extends Error {
     this.name = "SandboxFunctionError";
   }
 }
+
+export class SandboxFunctionInvocationError extends Error {
+  readonly code = "user_authentication_required";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "SandboxFunctionInvocationError";
+  }
+}
+
+export function isSandboxFunctionInvocationError(
+  error: Error
+): error is SandboxFunctionInvocationError {
+  return error instanceof SandboxFunctionInvocationError;
+}

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
@@ -27,6 +27,13 @@ vi.mock(
   }
 );
 
+vi.mock("@app/lib/lock", () => ({
+  executeWithLock: async (
+    _lockName: string,
+    callback: () => Promise<unknown>
+  ) => callback(),
+}));
+
 const inputSchema: JSONSchema = {
   type: "object",
   properties: { name: { type: "string" } },

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
@@ -66,7 +66,12 @@ describe("publishSandboxFunction", () => {
   it("publishes a new function with one bundle file under the dedicated prefix", async () => {
     const { workspace, space, auth } = await setupPod();
     vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
-      new Ok({ bundleCode: "export default {};", inputSchema, outputSchema })
+      new Ok({
+        bundleCode: "export default {};",
+        authentication: "workspace_user_required",
+        inputSchema,
+        outputSchema,
+      })
     );
 
     const result = await publishSandboxFunction(auth, {
@@ -83,6 +88,7 @@ describe("publishSandboxFunction", () => {
     const fn = result.value;
     expect(fn.slug).toBe("greet");
     expect(fn.description).toBe("Greet someone.");
+    expect(fn.authentication).toBe("workspace_user_required");
     expect(fn.inputSchema).toEqual(inputSchema);
     expect(fn.outputSchema).toEqual(outputSchema);
 
@@ -114,7 +120,12 @@ describe("publishSandboxFunction", () => {
     const { workspace, space, auth } = await setupPod();
 
     vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
-      new Ok({ bundleCode: "v1", inputSchema, outputSchema })
+      new Ok({
+        bundleCode: "v1",
+        authentication: "workspace_user_required",
+        inputSchema,
+        outputSchema,
+      })
     );
     const first = await publishSandboxFunction(auth, {
       space,
@@ -138,7 +149,12 @@ describe("publishSandboxFunction", () => {
       required: ["text"],
     };
     vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
-      new Ok({ bundleCode: "v2", inputSchema, outputSchema: newOutputSchema })
+      new Ok({
+        bundleCode: "v2",
+        authentication: "optional",
+        inputSchema,
+        outputSchema: newOutputSchema,
+      })
     );
     const second = await publishSandboxFunction(auth, {
       space,
@@ -153,6 +169,7 @@ describe("publishSandboxFunction", () => {
 
     expect(second.value.id).toBe(first.value.id);
     expect(second.value.description).toBe("v2");
+    expect(second.value.authentication).toBe("optional");
     expect(second.value.outputSchema).toEqual(newOutputSchema);
     // The bundle file is reused in place, not replaced: same row, canonical mount path retained, and
     // its version bumped by the re-upload.

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
@@ -75,7 +75,7 @@ describe("publishSandboxFunction", () => {
     vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
       new Ok({
         bundleCode: "export default {};",
-        authentication: "workspace_user_required",
+        userIdentity: "workspace_user_required",
         inputSchema,
         outputSchema,
       })
@@ -95,7 +95,7 @@ describe("publishSandboxFunction", () => {
     const fn = result.value;
     expect(fn.slug).toBe("greet");
     expect(fn.description).toBe("Greet someone.");
-    expect(fn.authentication).toBe("workspace_user_required");
+    expect(fn.userIdentity).toBe("workspace_user_required");
     expect(fn.inputSchema).toEqual(inputSchema);
     expect(fn.outputSchema).toEqual(outputSchema);
 
@@ -129,7 +129,7 @@ describe("publishSandboxFunction", () => {
     vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
       new Ok({
         bundleCode: "v1",
-        authentication: "workspace_user_required",
+        userIdentity: "workspace_user_required",
         inputSchema,
         outputSchema,
       })
@@ -158,7 +158,7 @@ describe("publishSandboxFunction", () => {
     vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
       new Ok({
         bundleCode: "v2",
-        authentication: "optional",
+        userIdentity: "optional",
         inputSchema,
         outputSchema: newOutputSchema,
       })
@@ -176,7 +176,7 @@ describe("publishSandboxFunction", () => {
 
     expect(second.value.id).toBe(first.value.id);
     expect(second.value.description).toBe("v2");
-    expect(second.value.authentication).toBe("optional");
+    expect(second.value.userIdentity).toBe("optional");
     expect(second.value.outputSchema).toEqual(newOutputSchema);
     // The bundle file is reused in place, not replaced: same row, canonical mount path retained, and
     // its version bumped by the re-upload.

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.ts
@@ -55,7 +55,7 @@ export async function publishSandboxFunction(
   if (buildResult.isErr()) {
     return buildResult;
   }
-  const { bundleCode, authentication, inputSchema, outputSchema } =
+  const { bundleCode, userIdentity, inputSchema, outputSchema } =
     buildResult.value;
 
   // Re-publish overwrites the existing bundle in place so its mount path (<prefix>/<slug>.ts) stays
@@ -69,7 +69,7 @@ export async function publishSandboxFunction(
     const updateResult = await existing.updateContent(auth, {
       bundleCode,
       description,
-      authentication,
+      userIdentity,
       inputSchema,
       outputSchema,
     });
@@ -92,7 +92,7 @@ export async function publishSandboxFunction(
     file: fileResult.value,
     slug,
     description,
-    authentication,
+    userIdentity,
     inputSchema,
     outputSchema,
   });

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.ts
@@ -55,7 +55,8 @@ export async function publishSandboxFunction(
   if (buildResult.isErr()) {
     return buildResult;
   }
-  const { bundleCode, inputSchema, outputSchema } = buildResult.value;
+  const { bundleCode, authentication, inputSchema, outputSchema } =
+    buildResult.value;
 
   // Re-publish overwrites the existing bundle in place so its mount path (<prefix>/<slug>.ts) stays
   // stable; only a first publish creates the backing file.
@@ -68,6 +69,7 @@ export async function publishSandboxFunction(
     const updateResult = await existing.updateContent(auth, {
       bundleCode,
       description,
+      authentication,
       inputSchema,
       outputSchema,
     });
@@ -90,6 +92,7 @@ export async function publishSandboxFunction(
     file: fileResult.value,
     slug,
     description,
+    authentication,
     inputSchema,
     outputSchema,
   });

--- a/front/lib/api/sandbox_functions/workspace_user.ts
+++ b/front/lib/api/sandbox_functions/workspace_user.ts
@@ -24,16 +24,10 @@ export async function authorizeSandboxFunctionInvocation(
   auth: Authenticator,
   {
     authentication,
-    workspaceModelId,
   }: {
     authentication: SandboxFunctionAuthenticationPolicy | null;
-    workspaceModelId: number;
   }
 ): Promise<{ authorized: boolean; user: UserResource | null }> {
-  if (auth.getNonNullableWorkspace().id !== workspaceModelId) {
-    return { authorized: false, user: null };
-  }
-
   const user = await getAuthenticatedWorkspaceUser(auth);
   const policy = authentication ?? "optional";
   switch (policy) {

--- a/front/lib/api/sandbox_functions/workspace_user.ts
+++ b/front/lib/api/sandbox_functions/workspace_user.ts
@@ -2,7 +2,8 @@ import { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import type { SandboxFunctionAuthenticationPolicy } from "@app/types/api/sandbox_functions";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { isSandboxFunctionAuthenticationPolicy } from "@app/types/api/sandbox_functions";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export async function getAuthenticatedWorkspaceUser(
   auth: Authenticator
@@ -29,14 +30,16 @@ export async function authorizeSandboxFunctionInvocation(
   }
 ): Promise<{ authorized: boolean; user: UserResource | null }> {
   const user = await getAuthenticatedWorkspaceUser(auth);
-  const policy = authentication ?? "optional";
+  const policy: unknown = authentication ?? "optional";
+  if (!isSandboxFunctionAuthenticationPolicy(policy)) {
+    return { authorized: false, user: null };
+  }
   switch (policy) {
     case "optional":
       return { authorized: true, user };
     case "workspace_user_required":
       return { authorized: user !== null, user };
     default:
-      assertNeverAndIgnore(policy);
-      return { authorized: false, user: null };
+      return assertNever(policy);
   }
 }

--- a/front/lib/api/sandbox_functions/workspace_user.ts
+++ b/front/lib/api/sandbox_functions/workspace_user.ts
@@ -24,13 +24,13 @@ export async function authorizeSandboxFunctionInvocation(
   auth: Authenticator,
   {
     authentication,
-    workspaceId,
+    workspaceModelId,
   }: {
     authentication: SandboxFunctionAuthenticationPolicy | null;
-    workspaceId: number;
+    workspaceModelId: number;
   }
 ): Promise<{ authorized: boolean; user: UserResource | null }> {
-  if (auth.getNonNullableWorkspace().id !== workspaceId) {
+  if (auth.getNonNullableWorkspace().id !== workspaceModelId) {
     return { authorized: false, user: null };
   }
 

--- a/front/lib/api/sandbox_functions/workspace_user.ts
+++ b/front/lib/api/sandbox_functions/workspace_user.ts
@@ -1,0 +1,19 @@
+import { Authenticator } from "@app/lib/auth";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+
+export async function getAuthenticatedWorkspaceUser(
+  auth: Authenticator
+): Promise<UserResource | null> {
+  const user = auth.user();
+  if (!user) {
+    return null;
+  }
+
+  const role = await MembershipResource.getActiveRoleForUserInWorkspace({
+    user,
+    workspace: auth.getNonNullableWorkspace(),
+  });
+
+  return Authenticator.isMember(role) ? user : null;
+}

--- a/front/lib/api/sandbox_functions/workspace_user.ts
+++ b/front/lib/api/sandbox_functions/workspace_user.ts
@@ -1,6 +1,8 @@
 import { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import type { SandboxFunctionAuthenticationPolicy } from "@app/types/api/sandbox_functions";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 
 export async function getAuthenticatedWorkspaceUser(
   auth: Authenticator
@@ -16,4 +18,31 @@ export async function getAuthenticatedWorkspaceUser(
   });
 
   return Authenticator.isMember(role) ? user : null;
+}
+
+export async function authorizeSandboxFunctionInvocation(
+  auth: Authenticator,
+  {
+    authentication,
+    workspaceId,
+  }: {
+    authentication: SandboxFunctionAuthenticationPolicy | null;
+    workspaceId: number;
+  }
+): Promise<{ authorized: boolean; user: UserResource | null }> {
+  if (auth.getNonNullableWorkspace().id !== workspaceId) {
+    return { authorized: false, user: null };
+  }
+
+  const user = await getAuthenticatedWorkspaceUser(auth);
+  const policy = authentication ?? "optional";
+  switch (policy) {
+    case "optional":
+      return { authorized: true, user };
+    case "workspace_user_required":
+      return { authorized: user !== null, user };
+    default:
+      assertNeverAndIgnore(policy);
+      return { authorized: false, user: null };
+  }
 }

--- a/front/lib/api/sandbox_functions/workspace_user.ts
+++ b/front/lib/api/sandbox_functions/workspace_user.ts
@@ -1,8 +1,8 @@
 import { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
-import type { SandboxFunctionAuthenticationPolicy } from "@app/types/api/sandbox_functions";
-import { isSandboxFunctionAuthenticationPolicy } from "@app/types/api/sandbox_functions";
+import type { SandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
+import { isSandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export async function getAuthenticatedWorkspaceUser(
@@ -24,14 +24,14 @@ export async function getAuthenticatedWorkspaceUser(
 export async function authorizeSandboxFunctionInvocation(
   auth: Authenticator,
   {
-    authentication,
+    userIdentity,
   }: {
-    authentication: SandboxFunctionAuthenticationPolicy | null;
+    userIdentity: SandboxFunctionUserIdentityPolicy | null;
   }
 ): Promise<{ authorized: boolean; user: UserResource | null }> {
   const user = await getAuthenticatedWorkspaceUser(auth);
-  const policy: unknown = authentication ?? "optional";
-  if (!isSandboxFunctionAuthenticationPolicy(policy)) {
+  const policy: unknown = userIdentity ?? "optional";
+  if (!isSandboxFunctionUserIdentityPolicy(policy)) {
     return { authorized: false, user: null };
   }
   switch (policy) {

--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -5,16 +5,16 @@ import tracer from "@app/logger/tracer";
 // Returns the lock value if the lock is acquired, that can be used to unlock, otherwise undefined.
 export async function distributedLock(
   redisCli: RedisClientType,
-  key: string
+  key: string,
+  lockTtlMs: number = 5_000
 ): Promise<string | undefined> {
   const lockKey = `lock:${key}`;
   const lockValue = `${Date.now()}-${Math.random()}`;
-  const lockTimeout = 5000; // 5 seconds timeout
 
   // Try to acquire the lock using SET with NX and PX options
   const result = await redisCli.set(lockKey, lockValue, {
     NX: true,
-    PX: lockTimeout,
+    PX: lockTtlMs,
   });
 
   if (result !== "OK") {
@@ -58,7 +58,10 @@ export const executeWithLock = async <T>(
   // `lock.acquire` APM span with this resource, so contention/wait time is
   // visible separately from the time spent holding the lock. Off by default so
   // existing callers are unchanged and we don't span every lock app-wide.
-  { traceAcquireResource }: { traceAcquireResource?: string } = {}
+  {
+    lockTtlMs = 5_000,
+    traceAcquireResource,
+  }: { lockTtlMs?: number; traceAcquireResource?: string } = {}
 ): Promise<T> => {
   const client = await getRedisStreamClient({ origin: "lock" });
 
@@ -67,7 +70,7 @@ export const executeWithLock = async <T>(
     let acquired: string | undefined;
     while (Date.now() - startMs < timeoutMs) {
       // Try to acquire the lock
-      acquired = await distributedLock(client, lockName);
+      acquired = await distributedLock(client, lockName, lockTtlMs);
       if (acquired) {
         break;
       }

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -8,7 +8,7 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
-import { SandboxFunctionModel } from "@app/lib/resources/storage/models/sandbox_function";
+import { frontSequelize } from "@app/lib/resources/storage";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -635,16 +635,12 @@ describe("SandboxFunctionInvocationResource", () => {
   it("fails closed when a newer application persisted an unknown policy", async () => {
     const { authenticator, sandbox, sandboxFunction, invocation } =
       await setupExecutionTest();
-    await SandboxFunctionModel.update(
+    await frontSequelize.getQueryInterface().bulkUpdate(
+      "sandbox_functions",
+      { authentication: "future_policy" },
       {
-        authentication: "future_policy" as SandboxFunctionAuthenticationPolicy,
-      },
-      {
-        validate: false,
-        where: {
-          id: sandboxFunction.id,
-          workspaceId: sandboxFunction.workspaceId,
-        },
+        id: sandboxFunction.id,
+        workspaceId: sandboxFunction.workspaceId,
       }
     );
 
@@ -653,6 +649,25 @@ describe("SandboxFunctionInvocationResource", () => {
     const executionResult = await invocation.execute(authenticator);
 
     expect(executionResult.isErr()).toBe(true);
+    expect(execSpy).not.toHaveBeenCalled();
+  });
+
+  it("blocks execution with an authenticator from another workspace", async () => {
+    const { sandbox, invocation } = await setupExecutionTest();
+    const { authenticator: otherWorkspaceAuth } = await createResourceTest({
+      role: "admin",
+    });
+    const execSpy = vi.spyOn(sandbox, "exec");
+
+    const executionResult = await invocation.execute(otherWorkspaceAuth);
+
+    expect(executionResult.isErr()).toBe(true);
+    if (executionResult.isOk()) {
+      return;
+    }
+    expect(executionResult.error.message).toBe(
+      "This Pod Function belongs to another workspace."
+    );
     expect(execSpy).not.toHaveBeenCalled();
   });
 

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -15,7 +15,7 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import type { SandboxFunctionAuthenticationPolicy } from "@app/types/api/sandbox_functions";
+import type { SandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
 import { Ok } from "@app/types/shared/result";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -69,7 +69,7 @@ beforeEach(() => {
 });
 
 async function setupExecutionTest(
-  authentication: SandboxFunctionAuthenticationPolicy = "optional"
+  userIdentity: SandboxFunctionUserIdentityPolicy = "optional"
 ) {
   const { authenticator, workspace } = await createResourceTest({
     role: "admin",
@@ -88,7 +88,7 @@ async function setupExecutionTest(
     file,
     slug: "add-comment",
     description: "Add a comment.",
-    authentication,
+    userIdentity,
     inputSchema,
     outputSchema,
   });
@@ -637,7 +637,7 @@ describe("SandboxFunctionInvocationResource", () => {
       await setupExecutionTest();
     await frontSequelize.getQueryInterface().bulkUpdate(
       "sandbox_functions",
-      { authentication: "future_policy" },
+      { userIdentity: "future_policy" },
       {
         id: sandboxFunction.id,
         workspaceId: sandboxFunction.workspaceId,

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -636,8 +636,11 @@ describe("SandboxFunctionInvocationResource", () => {
     const { authenticator, sandbox, sandboxFunction, invocation } =
       await setupExecutionTest();
     await SandboxFunctionModel.update(
-      { authentication: "future_policy" },
       {
+        authentication: "future_policy" as SandboxFunctionAuthenticationPolicy,
+      },
+      {
+        validate: false,
         where: {
           id: sandboxFunction.id,
           workspaceId: sandboxFunction.workspaceId,

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -15,6 +15,7 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { SandboxFunctionAuthenticationPolicy } from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
 import { Ok } from "@app/types/shared/result";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -67,7 +68,9 @@ beforeEach(() => {
   fileStorageMock.reset();
 });
 
-async function setupExecutionTest() {
+async function setupExecutionTest(
+  authentication: SandboxFunctionAuthenticationPolicy = "optional"
+) {
   const { authenticator, workspace } = await createResourceTest({
     role: "admin",
   });
@@ -85,6 +88,7 @@ async function setupExecutionTest() {
     file,
     slug: "add-comment",
     description: "Add a comment.",
+    authentication,
     inputSchema,
     outputSchema,
   });
@@ -640,11 +644,34 @@ describe("SandboxFunctionInvocationResource", () => {
         },
       }
     );
+
     const execSpy = vi.spyOn(sandbox, "exec");
 
     const executionResult = await invocation.execute(authenticator);
 
     expect(executionResult.isErr()).toBe(true);
+    expect(execSpy).not.toHaveBeenCalled();
+  });
+
+  it("blocks a required invocation when membership is revoked before execution", async () => {
+    const { authenticator, sandbox, invocation } = await setupExecutionTest(
+      "workspace_user_required"
+    );
+    vi.spyOn(
+      MembershipResource,
+      "getActiveRoleForUserInWorkspace"
+    ).mockResolvedValueOnce("none");
+    const execSpy = vi.spyOn(sandbox, "exec");
+
+    const executionResult = await invocation.execute(authenticator);
+
+    expect(executionResult.isErr()).toBe(true);
+    if (executionResult.isOk()) {
+      return;
+    }
+    expect(executionResult.error.message).toContain(
+      "requires a logged-in user"
+    );
     expect(execSpy).not.toHaveBeenCalled();
   });
 

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -333,7 +333,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       }
       const authorization = await authorizeSandboxFunctionInvocation(auth, {
         authentication: persistedFunction.authentication,
-        workspaceId: this.workspaceId,
+        workspaceModelId: this.workspaceId,
       });
       if (!authorization.authorized) {
         return new Err(

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -339,7 +339,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         return new Err(new Error("The Pod Function no longer exists."));
       }
       const authorization = await authorizeSandboxFunctionInvocation(auth, {
-        authentication: persistedFunction.authentication,
+        userIdentity: persistedFunction.userIdentity,
       });
       if (!authorization.authorized) {
         return new Err(

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -10,10 +10,10 @@ import {
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
-import { Authenticator } from "@app/lib/auth";
+import { getAuthenticatedWorkspaceUser } from "@app/lib/api/sandbox_functions/workspace_user";
+import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import {
@@ -176,20 +176,12 @@ async function getSandboxFunctionUserIdentity(
   invocation: SandboxFunctionInvocationResource
 ) {
   const workspace = auth.getNonNullableWorkspace();
-  const user = auth.user();
+  const user = await getAuthenticatedWorkspaceUser(auth);
   if (
     !user ||
     invocation.workspaceId !== workspace.id ||
     invocation.userId !== user.id
   ) {
-    return null;
-  }
-
-  const role = await MembershipResource.getActiveRoleForUserInWorkspace({
-    user,
-    workspace,
-  });
-  if (!Authenticator.isMember(role)) {
     return null;
   }
 

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -322,6 +322,13 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
 
     try {
       const { sandboxFunction } = this;
+      if (auth.getNonNullableWorkspace().id !== this.workspaceId) {
+        return new Err(
+          new SandboxFunctionInvocationError(
+            "This Pod Function belongs to another workspace."
+          )
+        );
+      }
       const persistedFunction = await SandboxFunctionModel.findOne({
         where: {
           id: this.sandboxFunctionId,
@@ -333,7 +340,6 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       }
       const authorization = await authorizeSandboxFunctionInvocation(auth, {
         authentication: persistedFunction.authentication,
-        workspaceModelId: this.workspaceId,
       });
       if (!authorization.authorized) {
         return new Err(

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -9,8 +9,9 @@ import {
 } from "@app/lib/api/sandbox/access_tokens";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
+import { SandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
-import { getAuthenticatedWorkspaceUser } from "@app/lib/api/sandbox_functions/workspace_user";
+import { authorizeSandboxFunctionInvocation } from "@app/lib/api/sandbox_functions/workspace_user";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -28,6 +29,7 @@ import {
   makeSId,
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import type { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor, withRetry } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
@@ -171,12 +173,12 @@ function buildSandboxFunctionRunCommand(slug: string): string {
   return `${DSBX_BIN_PATH} function run ${shellEscape(slug)}`;
 }
 
-async function getSandboxFunctionUserIdentity(
+function getSandboxFunctionUserIdentity(
   auth: Authenticator,
+  user: UserResource | null,
   invocation: SandboxFunctionInvocationResource
 ) {
   const workspace = auth.getNonNullableWorkspace();
-  const user = await getAuthenticatedWorkspaceUser(auth);
   if (
     !user ||
     invocation.workspaceId !== workspace.id ||
@@ -326,10 +328,17 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
           workspaceId: this.workspaceId,
         },
       });
-      if (!persistedFunction || persistedFunction.authentication !== null) {
+      if (!persistedFunction) {
+        return new Err(new Error("The Pod Function no longer exists."));
+      }
+      const authorization = await authorizeSandboxFunctionInvocation(auth, {
+        authentication: persistedFunction.authentication,
+        workspaceId: this.workspaceId,
+      });
+      if (!authorization.authorized) {
         return new Err(
-          new Error(
-            "This Pod Function cannot execute with an unsupported authentication policy."
+          new SandboxFunctionInvocationError(
+            "This Pod Function requires a logged-in user from its workspace."
           )
         );
       }
@@ -366,7 +375,11 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
           : { body: JSON.stringify(this.input) }),
         encoding: "utf8",
       };
-      const userIdentity = await getSandboxFunctionUserIdentity(auth, this);
+      const userIdentity = getSandboxFunctionUserIdentity(
+        auth,
+        authorization.user,
+        this
+      );
 
       const execResult = await ensureResult.value.sandbox.exec(auth, command, {
         workingDirectory: SANDBOX_FUNCTION_WORKING_DIRECTORY,

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -13,7 +13,7 @@ import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { sandboxFunctionContentType } from "@app/types/files";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const inputSchema: JSONSchema = {
   type: "object",
@@ -433,6 +433,59 @@ describe("SandboxFunctionResource", () => {
     expect(fetched?.fileId).toBe(firstFile.id);
     expect(fetched?.description).toBe("Second.");
     expect(fetched?.outputSchema).toEqual(newOutputSchema);
+  });
+
+  it("locks re-publish and persists a stricter policy before replacing the bundle", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const space = await SpaceFactory.project(workspace);
+    const file = await FileFactory.create(authenticator, null, {
+      contentType: sandboxFunctionContentType,
+      fileName: "greet.ts",
+      fileSize: 100,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: space.sId },
+    });
+    const sandboxFunction = await SandboxFunctionResource.makeNew(
+      authenticator,
+      {
+        space,
+        file,
+        slug: "greet",
+        description: "First.",
+        authentication: "optional",
+        inputSchema,
+        outputSchema,
+      }
+    );
+    const lockSpy = vi.spyOn(SandboxFunctionModel, "findOne");
+    vi.spyOn(sandboxFunction.file, "uploadContent").mockRejectedValueOnce(
+      new Error("upload failed")
+    );
+
+    const result = await sandboxFunction.updateContent(authenticator, {
+      bundleCode: "v2",
+      description: "Second.",
+      authentication: "workspace_user_required",
+      inputSchema,
+      outputSchema,
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(lockSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lock: expect.anything(),
+        transaction: expect.anything(),
+      })
+    );
+    const fetched = await SandboxFunctionResource.fetchById(
+      authenticator,
+      sandboxFunction.sId
+    );
+    expect(fetched?.authentication).toBe("workspace_user_required");
+    expect(fetched?.description).toBe("First.");
   });
 
   it("deletes all sandbox functions for a space", async () => {

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -495,7 +495,6 @@ describe("SandboxFunctionResource", () => {
       sandboxFunction.sId
     );
     expect(fetched?.userIdentity).toBe("workspace_user_required");
-    expect(fetched?.legacyAuthentication).toBe("workspace_user_required");
     expect(fetched?.description).toBe("First.");
   });
 

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -466,7 +466,7 @@ describe("SandboxFunctionResource", () => {
         file,
         slug: "greet",
         description: "First.",
-        authentication: "optional",
+        userIdentity: "optional",
         inputSchema,
         outputSchema,
       }
@@ -478,7 +478,7 @@ describe("SandboxFunctionResource", () => {
     const result = await sandboxFunction.updateContent(authenticator, {
       bundleCode: "v2",
       description: "Second.",
-      authentication: "workspace_user_required",
+      userIdentity: "workspace_user_required",
       inputSchema,
       outputSchema,
     });
@@ -494,7 +494,8 @@ describe("SandboxFunctionResource", () => {
       authenticator,
       sandboxFunction.sId
     );
-    expect(fetched?.authentication).toBe("workspace_user_required");
+    expect(fetched?.userIdentity).toBe("workspace_user_required");
+    expect(fetched?.legacyAuthentication).toBe("workspace_user_required");
     expect(fetched?.description).toBe("First.");
   });
 

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -15,6 +15,16 @@ import { sandboxFunctionContentType } from "@app/types/files";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const executeWithLockMock = vi.hoisted(() =>
+  vi.fn(async (_lockName: string, callback: () => Promise<unknown>) =>
+    callback()
+  )
+);
+
+vi.mock("@app/lib/lock", () => ({
+  executeWithLock: executeWithLockMock,
+}));
+
 const inputSchema: JSONSchema = {
   type: "object",
   properties: {
@@ -32,6 +42,7 @@ const outputSchema: JSONSchema = {
 };
 
 beforeEach(() => {
+  vi.clearAllMocks();
   fileStorageMock.reset();
 });
 
@@ -460,7 +471,6 @@ describe("SandboxFunctionResource", () => {
         outputSchema,
       }
     );
-    const lockSpy = vi.spyOn(SandboxFunctionModel, "findOne");
     vi.spyOn(sandboxFunction.file, "uploadContent").mockRejectedValueOnce(
       new Error("upload failed")
     );
@@ -474,11 +484,11 @@ describe("SandboxFunctionResource", () => {
     });
 
     expect(result.isErr()).toBe(true);
-    expect(lockSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        lock: expect.anything(),
-        transaction: expect.anything(),
-      })
+    expect(executeWithLockMock).toHaveBeenCalledWith(
+      `sandbox_function:publish:${sandboxFunction.sId}`,
+      expect.any(Function),
+      30_000,
+      { lockTtlMs: 300_000 }
     );
     const fetched = await SandboxFunctionResource.fetchById(
       authenticator,

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -1,4 +1,6 @@
 import type { PokePodFunction } from "@app/lib/api/poke/projects";
+import { SandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
+import { getAuthenticatedWorkspaceUser } from "@app/lib/api/sandbox_functions/workspace_user";
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -18,7 +20,10 @@ import {
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { UserResource } from "@app/lib/resources/user_resource";
-import type { PostSandboxFunctionInvocationRequestBody } from "@app/types/api/sandbox_functions";
+import type {
+  PostSandboxFunctionInvocationRequestBody,
+  SandboxFunctionAuthenticationPolicy,
+} from "@app/types/api/sandbox_functions";
 import { isValidSandboxFunctionSlug } from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -75,6 +80,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       file,
       slug,
       description,
+      authentication = "optional",
       inputSchema,
       outputSchema,
     }: {
@@ -82,6 +88,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       file: FileResource;
       slug: string;
       description: string;
+      authentication?: SandboxFunctionAuthenticationPolicy;
       inputSchema: JSONSchema;
       outputSchema: JSONSchema;
     },
@@ -120,6 +127,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         fileId: file.id,
         slug,
         description,
+        authentication,
         inputSchema,
         outputSchema,
       },
@@ -140,18 +148,25 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     {
       bundleCode,
       description,
+      authentication = this.authentication ?? "optional",
       inputSchema,
       outputSchema,
     }: {
       bundleCode: string;
       description: string;
+      authentication?: SandboxFunctionAuthenticationPolicy;
       inputSchema: JSONSchema;
       outputSchema: JSONSchema;
     }
   ): Promise<Result<undefined, Error>> {
     try {
       await this.file.uploadContent(auth, bundleCode);
-      await this.update({ description, inputSchema, outputSchema });
+      await this.update({
+        description,
+        authentication,
+        inputSchema,
+        outputSchema,
+      });
     } catch (error) {
       return new Err(normalizeError(error));
     }
@@ -346,10 +361,15 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     auth: Authenticator,
     body: PostSandboxFunctionInvocationRequestBody
   ): Promise<Result<SandboxFunctionInvocationResource, Error>> {
-    if (this.authentication !== null) {
+    const authentication = this.authentication ?? "optional";
+    if (
+      authentication === "workspace_user_required" &&
+      (this.workspaceId !== auth.getNonNullableWorkspace().id ||
+        !(await getAuthenticatedWorkspaceUser(auth)))
+    ) {
       return new Err(
-        new Error(
-          "This Pod Function uses an authentication policy unsupported by this application version."
+        new SandboxFunctionInvocationError(
+          "This Pod Function requires a logged-in user from its workspace."
         )
       );
     }

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -408,9 +408,15 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     auth: Authenticator,
     body: PostSandboxFunctionInvocationRequestBody
   ): Promise<Result<SandboxFunctionInvocationResource, Error>> {
+    if (auth.getNonNullableWorkspace().id !== this.workspaceId) {
+      return new Err(
+        new SandboxFunctionInvocationError(
+          "This Pod Function belongs to another workspace."
+        )
+      );
+    }
     const authorization = await authorizeSandboxFunctionInvocation(auth, {
       authentication: this.authentication,
-      workspaceModelId: this.workspaceId,
     });
     if (!authorization.authorized) {
       return new Err(

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -29,7 +29,7 @@ import { isValidSandboxFunctionSlug } from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok, type Result } from "@app/types/shared/result";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -50,8 +50,7 @@ function authenticationPolicyStrength(
     case "workspace_user_required":
       return 1;
     default:
-      assertNeverAndIgnore(authentication);
-      return Number.MAX_SAFE_INTEGER;
+      return assertNever(authentication);
   }
 }
 

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -2,6 +2,7 @@ import type { PokePodFunction } from "@app/lib/api/poke/projects";
 import { SandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
 import { authorizeSandboxFunctionInvocation } from "@app/lib/api/sandbox_functions/workspace_user";
 import type { Authenticator } from "@app/lib/auth";
+import { executeWithLock } from "@app/lib/lock";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
@@ -20,7 +21,6 @@ import {
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { UserResource } from "@app/lib/resources/user_resource";
-import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
   PostSandboxFunctionInvocationRequestBody,
   SandboxFunctionAuthenticationPolicy,
@@ -38,6 +38,8 @@ import type { Attributes, Transaction } from "sequelize";
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface SandboxFunctionResource
   extends ReadonlyAttributesType<SandboxFunctionModel> {}
+
+const SANDBOX_FUNCTION_PUBLISH_LOCK_TTL_MS = 5 * 60_000;
 
 function authenticationPolicyStrength(
   authentication: SandboxFunctionAuthenticationPolicy
@@ -176,47 +178,44 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     }
   ): Promise<Result<undefined, Error>> {
     try {
-      return await withTransaction(async (transaction) => {
-        const lockedFunction = await this.model.findOne({
-          where: {
-            id: this.id,
-            workspaceId: auth.getNonNullableWorkspace().id,
-          },
-          transaction,
-          lock: transaction.LOCK.UPDATE,
-        });
-        if (!lockedFunction) {
-          return new Err(new Error("The Pod Function no longer exists."));
-        }
+      return await executeWithLock(
+        `sandbox_function:publish:${this.sId}`,
+        async () => {
+          const currentFunction = await this.model.findOne({
+            where: {
+              id: this.id,
+              workspaceId: auth.getNonNullableWorkspace().id,
+            },
+          });
+          if (!currentFunction) {
+            return new Err(new Error("The Pod Function no longer exists."));
+          }
 
-        try {
           const currentAuthentication =
-            lockedFunction.authentication ?? "optional";
+            currentFunction.authentication ?? "optional";
           if (
             authenticationPolicyStrength(authentication) >
             authenticationPolicyStrength(currentAuthentication)
           ) {
-            await this.update({ authentication }, transaction);
+            // Commit a stricter policy before exposing its bundle. If the
+            // upload fails, the old bundle remains callable only under the
+            // stricter policy.
+            await this.update({ authentication });
           }
 
           await this.file.uploadContent(auth, bundleCode);
-          await this.update(
-            {
-              description,
-              authentication,
-              inputSchema,
-              outputSchema,
-            },
-            transaction
-          );
-        } catch (error) {
-          // Resolving with Err commits any restrictive policy written before
-          // the bundle upload, keeping a partial re-publish fail-closed.
-          return new Err(normalizeError(error));
-        }
+          await this.update({
+            description,
+            authentication,
+            inputSchema,
+            outputSchema,
+          });
 
-        return new Ok(undefined);
-      });
+          return new Ok(undefined);
+        },
+        30_000,
+        { lockTtlMs: SANDBOX_FUNCTION_PUBLISH_LOCK_TTL_MS }
+      );
     } catch (error) {
       return new Err(normalizeError(error));
     }
@@ -411,7 +410,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
   ): Promise<Result<SandboxFunctionInvocationResource, Error>> {
     const authorization = await authorizeSandboxFunctionInvocation(auth, {
       authentication: this.authentication,
-      workspaceId: this.workspaceId,
+      workspaceModelId: this.workspaceId,
     });
     if (!authorization.authorized) {
       return new Err(

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -23,7 +23,7 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import type {
   PostSandboxFunctionInvocationRequestBody,
-  SandboxFunctionAuthenticationPolicy,
+  SandboxFunctionUserIdentityPolicy,
 } from "@app/types/api/sandbox_functions";
 import { isValidSandboxFunctionSlug } from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
@@ -41,16 +41,16 @@ export interface SandboxFunctionResource
 
 const SANDBOX_FUNCTION_PUBLISH_LOCK_TTL_MS = 5 * 60_000;
 
-function authenticationPolicyStrength(
-  authentication: SandboxFunctionAuthenticationPolicy
+function userIdentityPolicyStrength(
+  policy: SandboxFunctionUserIdentityPolicy
 ): number {
-  switch (authentication) {
+  switch (policy) {
     case "optional":
       return 0;
     case "workspace_user_required":
       return 1;
     default:
-      return assertNever(authentication);
+      return assertNever(policy);
   }
 }
 
@@ -97,7 +97,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       file,
       slug,
       description,
-      authentication = "optional",
+      userIdentity = "optional",
       inputSchema,
       outputSchema,
     }: {
@@ -105,7 +105,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       file: FileResource;
       slug: string;
       description: string;
-      authentication?: SandboxFunctionAuthenticationPolicy;
+      userIdentity?: SandboxFunctionUserIdentityPolicy;
       inputSchema: JSONSchema;
       outputSchema: JSONSchema;
     },
@@ -144,7 +144,8 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         fileId: file.id,
         slug,
         description,
-        authentication,
+        legacyAuthentication: userIdentity,
+        userIdentity,
         inputSchema,
         outputSchema,
       },
@@ -165,13 +166,13 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     {
       bundleCode,
       description,
-      authentication = this.authentication ?? "optional",
+      userIdentity = this.userIdentity ?? "optional",
       inputSchema,
       outputSchema,
     }: {
       bundleCode: string;
       description: string;
-      authentication?: SandboxFunctionAuthenticationPolicy;
+      userIdentity?: SandboxFunctionUserIdentityPolicy;
       inputSchema: JSONSchema;
       outputSchema: JSONSchema;
     }
@@ -190,22 +191,26 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
             return new Err(new Error("The Pod Function no longer exists."));
           }
 
-          const currentAuthentication =
-            currentFunction.authentication ?? "optional";
+          const currentUserIdentity =
+            currentFunction.userIdentity ?? "optional";
           if (
-            authenticationPolicyStrength(authentication) >
-            authenticationPolicyStrength(currentAuthentication)
+            userIdentityPolicyStrength(userIdentity) >
+            userIdentityPolicyStrength(currentUserIdentity)
           ) {
             // Commit a stricter policy before exposing its bundle. If the
             // upload fails, the old bundle remains callable only under the
             // stricter policy.
-            await this.update({ authentication });
+            await this.update({
+              legacyAuthentication: userIdentity,
+              userIdentity,
+            });
           }
 
           await this.file.uploadContent(auth, bundleCode);
           await this.update({
             description,
-            authentication,
+            legacyAuthentication: userIdentity,
+            userIdentity,
             inputSchema,
             outputSchema,
           });
@@ -415,7 +420,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       );
     }
     const authorization = await authorizeSandboxFunctionInvocation(auth, {
-      authentication: this.authentication,
+      userIdentity: this.userIdentity,
     });
     if (!authorization.authorized) {
       return new Err(

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -1,6 +1,6 @@
 import type { PokePodFunction } from "@app/lib/api/poke/projects";
 import { SandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
-import { getAuthenticatedWorkspaceUser } from "@app/lib/api/sandbox_functions/workspace_user";
+import { authorizeSandboxFunctionInvocation } from "@app/lib/api/sandbox_functions/workspace_user";
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -20,6 +20,7 @@ import {
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
   PostSandboxFunctionInvocationRequestBody,
   SandboxFunctionAuthenticationPolicy,
@@ -28,6 +29,7 @@ import { isValidSandboxFunctionSlug } from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok, type Result } from "@app/types/shared/result";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -36,6 +38,20 @@ import type { Attributes, Transaction } from "sequelize";
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface SandboxFunctionResource
   extends ReadonlyAttributesType<SandboxFunctionModel> {}
+
+function authenticationPolicyStrength(
+  authentication: SandboxFunctionAuthenticationPolicy
+): number {
+  switch (authentication) {
+    case "optional":
+      return 0;
+    case "workspace_user_required":
+      return 1;
+    default:
+      assertNeverAndIgnore(authentication);
+      return Number.MAX_SAFE_INTEGER;
+  }
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> {
@@ -160,18 +176,50 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     }
   ): Promise<Result<undefined, Error>> {
     try {
-      await this.file.uploadContent(auth, bundleCode);
-      await this.update({
-        description,
-        authentication,
-        inputSchema,
-        outputSchema,
+      return await withTransaction(async (transaction) => {
+        const lockedFunction = await this.model.findOne({
+          where: {
+            id: this.id,
+            workspaceId: auth.getNonNullableWorkspace().id,
+          },
+          transaction,
+          lock: transaction.LOCK.UPDATE,
+        });
+        if (!lockedFunction) {
+          return new Err(new Error("The Pod Function no longer exists."));
+        }
+
+        try {
+          const currentAuthentication =
+            lockedFunction.authentication ?? "optional";
+          if (
+            authenticationPolicyStrength(authentication) >
+            authenticationPolicyStrength(currentAuthentication)
+          ) {
+            await this.update({ authentication }, transaction);
+          }
+
+          await this.file.uploadContent(auth, bundleCode);
+          await this.update(
+            {
+              description,
+              authentication,
+              inputSchema,
+              outputSchema,
+            },
+            transaction
+          );
+        } catch (error) {
+          // Resolving with Err commits any restrictive policy written before
+          // the bundle upload, keeping a partial re-publish fail-closed.
+          return new Err(normalizeError(error));
+        }
+
+        return new Ok(undefined);
       });
     } catch (error) {
       return new Err(normalizeError(error));
     }
-
-    return new Ok(undefined);
   }
 
   private static async baseFetch(
@@ -361,12 +409,11 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     auth: Authenticator,
     body: PostSandboxFunctionInvocationRequestBody
   ): Promise<Result<SandboxFunctionInvocationResource, Error>> {
-    const authentication = this.authentication ?? "optional";
-    if (
-      authentication === "workspace_user_required" &&
-      (this.workspaceId !== auth.getNonNullableWorkspace().id ||
-        !(await getAuthenticatedWorkspaceUser(auth)))
-    ) {
+    const authorization = await authorizeSandboxFunctionInvocation(auth, {
+      authentication: this.authentication,
+      workspaceId: this.workspaceId,
+    });
+    if (!authorization.authorized) {
       return new Err(
         new SandboxFunctionInvocationError(
           "This Pod Function requires a logged-in user from its workspace."

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -144,7 +144,6 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         fileId: file.id,
         slug,
         description,
-        legacyAuthentication: userIdentity,
         userIdentity,
         inputSchema,
         outputSchema,
@@ -200,16 +199,12 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
             // Commit a stricter policy before exposing its bundle. If the
             // upload fails, the old bundle remains callable only under the
             // stricter policy.
-            await this.update({
-              legacyAuthentication: userIdentity,
-              userIdentity,
-            });
+            await this.update({ userIdentity });
           }
 
           await this.file.uploadContent(auth, bundleCode);
           await this.update({
             description,
-            legacyAuthentication: userIdentity,
             userIdentity,
             inputSchema,
             outputSchema,

--- a/front/lib/resources/storage/models/sandbox_function.ts
+++ b/front/lib/resources/storage/models/sandbox_function.ts
@@ -9,13 +9,13 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { validateJsonSchema } from "@app/lib/utils/json_schemas";
 import type {
-  SandboxFunctionAuthenticationPolicy,
   SandboxFunctionInvocationStatus,
+  SandboxFunctionUserIdentityPolicy,
 } from "@app/types/api/sandbox_functions";
 import {
   isValidSandboxFunctionSlug,
-  SANDBOX_FUNCTION_AUTHENTICATION_POLICIES,
   SANDBOX_FUNCTION_INVOCATION_STATUSES,
+  SANDBOX_FUNCTION_USER_IDENTITY_POLICIES,
 } from "@app/types/api/sandbox_functions";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
@@ -47,7 +47,8 @@ export class SandboxFunctionModel extends WorkspaceAwareModel<SandboxFunctionMod
   declare fileId: ForeignKey<FileModel["id"]>;
   declare slug: string;
   declare description: string;
-  declare authentication: SandboxFunctionAuthenticationPolicy | null;
+  declare legacyAuthentication: string | null;
+  declare userIdentity: SandboxFunctionUserIdentityPolicy | null;
   declare inputSchema: JSONSchema;
   declare outputSchema: JSONSchema;
 
@@ -100,11 +101,16 @@ SandboxFunctionModel.init(
       type: DataTypes.STRING(255),
       allowNull: false,
     },
-    authentication: {
+    legacyAuthentication: {
+      field: "authentication",
+      type: DataTypes.STRING(64),
+      allowNull: true,
+    },
+    userIdentity: {
       type: DataTypes.STRING(64),
       allowNull: true,
       validate: {
-        isIn: [SANDBOX_FUNCTION_AUTHENTICATION_POLICIES],
+        isIn: [SANDBOX_FUNCTION_USER_IDENTITY_POLICIES],
       },
     },
     inputSchema: {

--- a/front/lib/resources/storage/models/sandbox_function.ts
+++ b/front/lib/resources/storage/models/sandbox_function.ts
@@ -47,7 +47,6 @@ export class SandboxFunctionModel extends WorkspaceAwareModel<SandboxFunctionMod
   declare fileId: ForeignKey<FileModel["id"]>;
   declare slug: string;
   declare description: string;
-  declare legacyAuthentication: string | null;
   declare userIdentity: SandboxFunctionUserIdentityPolicy | null;
   declare inputSchema: JSONSchema;
   declare outputSchema: JSONSchema;
@@ -100,11 +99,6 @@ SandboxFunctionModel.init(
     description: {
       type: DataTypes.STRING(255),
       allowNull: false,
-    },
-    legacyAuthentication: {
-      field: "authentication",
-      type: DataTypes.STRING(64),
-      allowNull: true,
     },
     userIdentity: {
       type: DataTypes.STRING(64),

--- a/front/lib/resources/storage/models/sandbox_function.ts
+++ b/front/lib/resources/storage/models/sandbox_function.ts
@@ -8,9 +8,13 @@ import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { validateJsonSchema } from "@app/lib/utils/json_schemas";
-import type { SandboxFunctionInvocationStatus } from "@app/types/api/sandbox_functions";
+import type {
+  SandboxFunctionAuthenticationPolicy,
+  SandboxFunctionInvocationStatus,
+} from "@app/types/api/sandbox_functions";
 import {
   isValidSandboxFunctionSlug,
+  SANDBOX_FUNCTION_AUTHENTICATION_POLICIES,
   SANDBOX_FUNCTION_INVOCATION_STATUSES,
 } from "@app/types/api/sandbox_functions";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -43,9 +47,7 @@ export class SandboxFunctionModel extends WorkspaceAwareModel<SandboxFunctionMod
   declare fileId: ForeignKey<FileModel["id"]>;
   declare slug: string;
   declare description: string;
-  // Non-null policies are introduced by the next deploy. This predecessor
-  // recognizes the column only so mixed-version instances can fail closed.
-  declare authentication: string | null;
+  declare authentication: SandboxFunctionAuthenticationPolicy | null;
   declare inputSchema: JSONSchema;
   declare outputSchema: JSONSchema;
 
@@ -101,6 +103,9 @@ SandboxFunctionModel.init(
     authentication: {
       type: DataTypes.STRING(64),
       allowNull: true,
+      validate: {
+        isIn: [SANDBOX_FUNCTION_AUTHENTICATION_POLICIES],
+      },
     },
     inputSchema: {
       type: DataTypes.JSONB,

--- a/front/migrations/post-deploy/20260730140944_drop_authentication_from_sandbox_functions.sql
+++ b/front/migrations/post-deploy/20260730140944_drop_authentication_from_sandbox_functions.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_functions" DROP COLUMN "authentication";

--- a/front/migrations/pre-deploy/20260730140943_add_user_identity_to_sandbox_functions.sql
+++ b/front/migrations/pre-deploy/20260730140943_add_user_identity_to_sandbox_functions.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_functions" ADD COLUMN "userIdentity" character varying(64) COLLATE "pg_catalog"."default";

--- a/front/migrations/pre-deploy/20260730140943_rename_authentication_to_user_identity.sql
+++ b/front/migrations/pre-deploy/20260730140943_rename_authentication_to_user_identity.sql
@@ -3,9 +3,4 @@ Statement 0
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."sandbox_functions" ADD COLUMN "userIdentity" character varying(64) COLLATE "pg_catalog"."default";
-
-SET SESSION statement_timeout = 1200000;
-UPDATE "public"."sandbox_functions"
-SET "userIdentity" = "authentication"
-WHERE "authentication" IS NOT NULL;
+ALTER TABLE "public"."sandbox_functions" RENAME COLUMN "authentication" TO "userIdentity";

--- a/front/migrations/pre-deploy/20260730140943_rename_authentication_to_user_identity.sql
+++ b/front/migrations/pre-deploy/20260730140943_rename_authentication_to_user_identity.sql
@@ -1,0 +1,11 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_functions" ADD COLUMN "userIdentity" character varying(64) COLLATE "pg_catalog"."default";
+
+SET SESSION statement_timeout = 1200000;
+UPDATE "public"."sandbox_functions"
+SET "userIdentity" = "authentication"
+WHERE "authentication" IS NOT NULL;

--- a/front/migrations/pre-deploy/20260730140943_rename_authentication_to_user_identity.sql
+++ b/front/migrations/pre-deploy/20260730140943_rename_authentication_to_user_identity.sql
@@ -1,6 +1,0 @@
-/*
-Statement 0
-*/
-SET SESSION statement_timeout = 3000;
-SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."sandbox_functions" RENAME COLUMN "authentication" TO "userIdentity";

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -22,6 +22,14 @@ export const SANDBOX_FUNCTION_AUTHENTICATION_POLICIES = [
 export type SandboxFunctionAuthenticationPolicy =
   (typeof SANDBOX_FUNCTION_AUTHENTICATION_POLICIES)[number];
 
+export function isSandboxFunctionAuthenticationPolicy(
+  value: unknown
+): value is SandboxFunctionAuthenticationPolicy {
+  return SANDBOX_FUNCTION_AUTHENTICATION_POLICIES.some(
+    (policy) => policy === value
+  );
+}
+
 // Lowercase alphanumeric with single hyphen separators (e.g. `greet`, `send-slack-message`).
 export const SANDBOX_FUNCTION_SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -14,6 +14,14 @@ export const SANDBOX_FUNCTION_INVOCATION_STATUSES = [
 export type SandboxFunctionInvocationStatus =
   (typeof SANDBOX_FUNCTION_INVOCATION_STATUSES)[number];
 
+export const SANDBOX_FUNCTION_AUTHENTICATION_POLICIES = [
+  "optional",
+  "workspace_user_required",
+] as const;
+
+export type SandboxFunctionAuthenticationPolicy =
+  (typeof SANDBOX_FUNCTION_AUTHENTICATION_POLICIES)[number];
+
 // Lowercase alphanumeric with single hyphen separators (e.g. `greet`, `send-slack-message`).
 export const SANDBOX_FUNCTION_SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -14,18 +14,18 @@ export const SANDBOX_FUNCTION_INVOCATION_STATUSES = [
 export type SandboxFunctionInvocationStatus =
   (typeof SANDBOX_FUNCTION_INVOCATION_STATUSES)[number];
 
-export const SANDBOX_FUNCTION_AUTHENTICATION_POLICIES = [
+export const SANDBOX_FUNCTION_USER_IDENTITY_POLICIES = [
   "optional",
   "workspace_user_required",
 ] as const;
 
-export type SandboxFunctionAuthenticationPolicy =
-  (typeof SANDBOX_FUNCTION_AUTHENTICATION_POLICIES)[number];
+export type SandboxFunctionUserIdentityPolicy =
+  (typeof SANDBOX_FUNCTION_USER_IDENTITY_POLICIES)[number];
 
-export function isSandboxFunctionAuthenticationPolicy(
+export function isSandboxFunctionUserIdentityPolicy(
   value: unknown
-): value is SandboxFunctionAuthenticationPolicy {
-  return SANDBOX_FUNCTION_AUTHENTICATION_POLICIES.some(
+): value is SandboxFunctionUserIdentityPolicy {
+  return SANDBOX_FUNCTION_USER_IDENTITY_POLICIES.some(
     (policy) => policy === value
   );
 }


### PR DESCRIPTION
## Description

Stack 4 of 6. Depends on #29681 and is followed by #29684.

Adds `schema.userIdentity: "workspace_user_required"` to Pod Functions. Authorization checks the exact function workspace and a fresh active membership at request and execution time. Unknown policies and old runner output fail closed.

The persisted policy moves from `authentication` to `userIdentity` through an expand/contract migration: pre-deploy adds the new column, the application only uses the new column, and post-deploy removes the unused old column. No copy or dual-write is needed because Pod Function identity policies are not in use yet.

Re-publication uses a distributed lock and commits stricter policy before bundle upload, preventing a strict bundle from being exposed under a weaker policy.

## Tests

Added runner-schema, build, publish, re-publication failure, lock, direct-call, execution, and endpoint coverage for member, userless, revoked, cross-workspace, old-runner, and unknown-policy cases.

## Risk

Apply the pre-deploy migration before application deployment and the post-deploy migration only after every application instance is on this revision. After the post-deploy migration, rolling back below this PR is unsupported.

Publishing from an old sandbox is rejected until old sandboxes are recycled. A failed upload can leave the previous bundle under a stricter policy, which is intentional.

During the rolling deploy, instances still on the previous revision ignore `userIdentity`
entirely: a strict function published through a new instance is invocable without a user via a
not-yet-updated instance or worker, and a publish routed to a not-yet-updated instance
silently persists no policy. Do not publish Pod Functions during the rollout; after all
instances are updated, re-verify (and re-publish if needed) any function published during the
window.

## Deploy Plan

Start only after #29681 is live everywhere.

1. Release `dsbx` 0.1.39.
2. Build and register `dust-base` 0.8.62.
3. Apply `20260730140943_add_user_identity_to_sandbox_functions.sql` as a pre-deploy migration.
4. Deploy this application revision.
5. Once all application instances are updated, apply `20260730140944_drop_authentication_from_sandbox_functions.sql` as a post-deploy migration.
6. Recycle older Pod sandboxes with `/poke/kill`.
7. Verify publish, member invocation, userless rejection, and re-publication.

