### PR TITLE
Use GPT-5.6 Sol medium for Deep Dive

### DIFF
--- a/front/lib/actions/mcp_internal_actions/utils/web_summarization.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/web_summarization.test.ts
@@ -1,6 +1,6 @@
 import { getModelConfigForWebSummarization } from "@app/lib/actions/mcp_internal_actions/utils/web_summarization";
 import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
-import { Authenticator } from "@app/lib/auth";
+import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { GPT_5_6_LUNA_MODEL_ID } from "@app/types/assistant/models/openai";
 import { describe, expect, it } from "vitest";
@@ -11,14 +11,17 @@ describe("getModelConfigForWebSummarization", () => {
       whiteListedProviders: ["openai"],
     });
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const featureFlags = await getFeatureFlags(auth);
 
-    expect(getModelConfigForWebSummarization(auth)).toMatchObject({
-      modelConfiguration: {
-        providerId: "openai",
-        modelId: GPT_5_6_LUNA_MODEL_ID,
-      },
-      reasoningEffort: "light",
-    });
+    expect(getModelConfigForWebSummarization(auth, featureFlags)).toMatchObject(
+      {
+        modelConfiguration: {
+          providerId: "openai",
+          modelId: GPT_5_6_LUNA_MODEL_ID,
+        },
+        reasoningEffort: "light",
+      }
+    );
   });
 
   it("falls back to the preferred available small model", async () => {
@@ -26,10 +29,13 @@ describe("getModelConfigForWebSummarization", () => {
       whiteListedProviders: ["anthropic"],
     });
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-    const smallModel = getSmallWhitelistedModel(auth);
+    const featureFlags = await getFeatureFlags(auth);
+    const smallModel = getSmallWhitelistedModel(auth, new Set(), {
+      featureFlags,
+    });
 
     expect(smallModel).not.toBeNull();
-    expect(getModelConfigForWebSummarization(auth)).toEqual({
+    expect(getModelConfigForWebSummarization(auth, featureFlags)).toEqual({
       modelConfiguration: smallModel,
       reasoningEffort: smallModel?.defaultReasoningEffort,
     });

--- a/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
@@ -4,13 +4,14 @@ import {
   getSmallWhitelistedModel,
   selectEnabledModel,
 } from "@app/lib/api/assistant/models";
-import type { Authenticator } from "@app/lib/auth";
+import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import { GPT_5_6_LUNA_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import type {
   ModelConfigurationType,
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -38,7 +39,8 @@ export async function summarizeWithLLM({
 }): Promise<Result<string, Error>> {
   const toSummarize = content.slice(0, MAX_CHARACTERS_TO_SUMMARIZE);
 
-  const modelConfig = getModelConfigForWebSummarization(auth);
+  const featureFlags = await getFeatureFlags(auth);
+  const modelConfig = getModelConfigForWebSummarization(auth, featureFlags);
   if (!modelConfig) {
     return new Err(
       new Error("Failed to find a whitelisted model to generate summary")
@@ -99,12 +101,15 @@ export async function summarizeWithLLM({
   return new Ok(summary);
 }
 
-export function getModelConfigForWebSummarization(auth: Authenticator): {
+export function getModelConfigForWebSummarization(
+  auth: Authenticator,
+  featureFlags: WhitelistableFeature[]
+): {
   modelConfiguration: ModelConfigurationType;
   reasoningEffort: ReasoningEffort;
 } | null {
   const luna = selectEnabledModel(auth, [GPT_5_6_LUNA_MODEL_CONFIG], {
-    featureFlags: [],
+    featureFlags,
   });
   if (luna) {
     return {
@@ -113,7 +118,9 @@ export function getModelConfigForWebSummarization(auth: Authenticator): {
     };
   }
 
-  const smallModel = getSmallWhitelistedModel(auth);
+  const smallModel = getSmallWhitelistedModel(auth, new Set(), {
+    featureFlags,
+  });
   return smallModel
     ? {
         modelConfiguration: smallModel,

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -34,7 +34,6 @@ import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 import {
   CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG,
-  CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
 import {
@@ -384,26 +383,34 @@ function getLargeModelFallback(
   };
 }
 
-function getDeepDiveFallbackModelConfig(
+function getDeepDiveModelConfig(
   auth: Authenticator,
   featureFlags: WhitelistableFeature[],
   excludeProviders: ReadonlySet<ModelProviderIdType>
 ): ModelConfigWithReasoning | null {
+  const primaryModelConfig = getEnabledModelConfig(
+    auth,
+    GPT_5_6_SOL_MODEL_CONFIG,
+    "medium",
+    featureFlags,
+    excludeProviders
+  );
+  if (primaryModelConfig) {
+    return primaryModelConfig;
+  }
+
+  const fallbackModelConfig = getEnabledModelConfig(
+    auth,
+    shouldUseOpus(auth)
+      ? CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG
+      : CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
+    "light",
+    featureFlags,
+    excludeProviders
+  );
+
   return (
-    getEnabledModelConfig(
-      auth,
-      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
-      "light",
-      featureFlags,
-      excludeProviders
-    ) ??
-    getEnabledModelConfig(
-      auth,
-      GPT_5_6_SOL_MODEL_CONFIG,
-      "light",
-      featureFlags,
-      excludeProviders
-    ) ??
+    fallbackModelConfig ??
     getLargeModelFallback(auth, featureFlags, excludeProviders)
   );
 }
@@ -476,23 +483,11 @@ export function _getDeepDiveGlobalAgent(
 ): AgentConfigurationType | null {
   const { run_agent: runAgentMCPServerView } = mcpServerViews;
   const pictureUrl = DUST_AVATAR_URL;
-  const modelConfig = getDeepDiveFallbackModelConfig(
+  const modelConfig = getDeepDiveModelConfig(
     auth,
     featureFlags,
     excludeProviders
   );
-
-  const enterpriseModelConfig = shouldUseOpus(auth)
-    ? getEnabledModelConfig(
-        auth,
-        CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG,
-        "light",
-        featureFlags,
-        excludeProviders
-      )
-    : null;
-
-  const effectiveModelConfig = enterpriseModelConfig ?? modelConfig;
 
   const deepAgent: Omit<
     AgentConfigurationType,
@@ -522,7 +517,7 @@ export function _getDeepDiveGlobalAgent(
     canEdit: false,
   };
 
-  if (settings?.status === "disabled_by_admin" || !effectiveModelConfig) {
+  if (settings?.status === "disabled_by_admin" || !modelConfig) {
     return {
       ...deepAgent,
       status: "disabled_by_admin",
@@ -532,10 +527,10 @@ export function _getDeepDiveGlobalAgent(
   }
 
   const model: AgentModelConfigurationType = {
-    providerId: effectiveModelConfig.modelConfiguration.providerId,
-    modelId: effectiveModelConfig.modelConfiguration.modelId,
+    providerId: modelConfig.modelConfiguration.providerId,
+    modelId: modelConfig.modelConfiguration.modelId,
     temperature: 1.0,
-    reasoningEffort: effectiveModelConfig.reasoningEffort,
+    reasoningEffort: modelConfig.reasoningEffort,
   };
 
   deepAgent.model = model;

--- a/front/lib/api/assistant/global_agents/global_agents.test.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.test.ts
@@ -6,9 +6,9 @@ import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import {
   CLAUDE_OPUS_5_MODEL_ID,
-  CLAUDE_SONNET_4_6_MODEL_ID,
   CLAUDE_SONNET_5_MODEL_ID,
 } from "@app/types/assistant/models/anthropic";
+import { GEMINI_3_1_PRO_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 import {
   GPT_5_6_LUNA_MODEL_ID,
   GPT_5_6_SOL_MODEL_ID,
@@ -365,7 +365,7 @@ describe("getGlobalAgents OpenAI Dust agents", () => {
 });
 
 describe("getGlobalAgents Deep Dive model routing", () => {
-  it("keeps Sonnet 4.6 as the Deep Dive primary model", async () => {
+  it("uses Sol with medium reasoning as the Deep Dive primary model", async () => {
     const workspace = await WorkspaceFactory.basic({
       whiteListedProviders: ["anthropic", "openai"],
     });
@@ -379,12 +379,12 @@ describe("getGlobalAgents Deep Dive model routing", () => {
 
     expect(agents).toHaveLength(1);
     expect(agents[0].model).toMatchObject({
-      modelId: CLAUDE_SONNET_4_6_MODEL_ID,
-      reasoningEffort: "light",
+      modelId: GPT_5_6_SOL_MODEL_ID,
+      reasoningEffort: "medium",
     });
   });
 
-  it("falls back to Sol for Deep Dive while using Sol for planning and Luna high for tasks", async () => {
+  it("uses Sol medium for Deep Dive while using Sol high for planning and Luna high for tasks", async () => {
     const workspace = await WorkspaceFactory.enterprise({
       whiteListedProviders: ["openai"],
     });
@@ -410,7 +410,7 @@ describe("getGlobalAgents Deep Dive model routing", () => {
       {
         sId: GLOBAL_AGENTS_SID.DEEP_DIVE,
         modelId: GPT_5_6_SOL_MODEL_ID,
-        reasoningEffort: "light",
+        reasoningEffort: "medium",
       },
       {
         sId: GLOBAL_AGENTS_SID.DUST_TASK,
@@ -425,7 +425,7 @@ describe("getGlobalAgents Deep Dive model routing", () => {
     ]);
   });
 
-  it("falls back to Sonnet 5 for tasks and Opus 5 for planning", async () => {
+  it("falls back to Opus 5 light for enterprise Deep Dive", async () => {
     const workspace = await WorkspaceFactory.enterprise({
       whiteListedProviders: ["anthropic"],
     });
@@ -464,5 +464,43 @@ describe("getGlobalAgents Deep Dive model routing", () => {
         reasoningEffort: "high",
       },
     ]);
+  });
+
+  it("falls back to Sonnet 5 light for non-enterprise Deep Dive", async () => {
+    const workspace = await WorkspaceFactory.basic({
+      whiteListedProviders: ["anthropic"],
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const agents = await getGlobalAgents(
+      auth,
+      [GLOBAL_AGENTS_SID.DEEP_DIVE],
+      "light"
+    );
+
+    expect(agents).toHaveLength(1);
+    expect(agents[0].model).toMatchObject({
+      modelId: CLAUDE_SONNET_5_MODEL_ID,
+      reasoningEffort: "light",
+    });
+  });
+
+  it("uses the generic large fallback when preferred Deep Dive models are unavailable", async () => {
+    const workspace = await WorkspaceFactory.basic({
+      whiteListedProviders: ["google_ai_studio"],
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const agents = await getGlobalAgents(
+      auth,
+      [GLOBAL_AGENTS_SID.DEEP_DIVE],
+      "light"
+    );
+
+    expect(agents).toHaveLength(1);
+    expect(agents[0].model).toMatchObject({
+      modelId: GEMINI_3_1_PRO_MODEL_ID,
+      reasoningEffort: "light",
+    });
   });
 });


### PR DESCRIPTION
## Description

- Use GPT-5.6 Sol with medium reasoning as the Deep Dive default.
- Fall back to Opus 5 light for Enterprise and Dust workspaces, Sonnet 5 light otherwise, then the generic large model fallback.
- Pass workspace feature flags through browser summary model selection and its small model fallback.

Follow-up to #29668.

## Tests

Added focused coverage for the Deep Dive routing order and browser summary selection. Tested locally with the two targeted Vitest files.

## Risk

Changes model cost and response behavior for Deep Dive. Browser summary behavior is unchanged unless model availability depends on a workspace feature flag.

## Deploy Plan

Standard deploy.
