### PR TITLE
Gate selected Pod Functions to live user sessions

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.39"
+version = "0.1.40"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.39"
+version = "0.1.40"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/README.md
+++ b/cli/dust-sandbox/README.md
@@ -65,6 +65,9 @@ export const schema = {
 ```
 
 Omitting `userIdentity` keeps the function callable without a user.
+Use `interactive_workspace_user_required` when the function must be called
+directly from a logged-in member's live Dust session, rather than by an agent,
+schedule, or API client acting on that member's behalf.
 
 ### Unprivileged execution
 

--- a/cli/dust-sandbox/functions-runner/fixtures/greet.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/greet.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const schema = {
   description: "Greet a user by name",
-  userIdentity: "workspace_user_required",
+  userIdentity: "interactive_workspace_user_required",
   input: z.object({ name: z.string(), formal: z.boolean().optional() }),
   output: z.object({ greeting: z.string() }),
 };

--- a/cli/dust-sandbox/functions-runner/schema.test.ts
+++ b/cli/dust-sandbox/functions-runner/schema.test.ts
@@ -29,7 +29,7 @@ describe("getFunctionSchema", () => {
     const s = await getFunctionSchema(fx("greet.ts"));
     expect(s.name).toBe("greet");
     expect(s.description).toBe("Greet a user by name");
-    expect(s.userIdentity).toBe("workspace_user_required");
+    expect(s.userIdentity).toBe("interactive_workspace_user_required");
     expect(s.input_schema).toMatchObject({ required: ["name"] });
     expect(s.output_schema).toMatchObject({ required: ["greeting"] });
   });

--- a/cli/dust-sandbox/functions-runner/schema.ts
+++ b/cli/dust-sandbox/functions-runner/schema.ts
@@ -6,7 +6,10 @@ import { z } from "zod";
 export interface FunctionSchema {
   name: string;
   description: string | null;
-  userIdentity: "optional" | "workspace_user_required";
+  userIdentity:
+    | "optional"
+    | "workspace_user_required"
+    | "interactive_workspace_user_required";
   input_schema: Record<string, unknown> | null;
   output_schema: Record<string, unknown> | null;
 }
@@ -17,11 +20,14 @@ function parseUserIdentityPolicy(
   if (value === undefined || value === "optional") {
     return "optional";
   }
-  if (value === "workspace_user_required") {
+  if (
+    value === "workspace_user_required" ||
+    value === "interactive_workspace_user_required"
+  ) {
     return value;
   }
   throw new Error(
-    "`schema.userIdentity` must be `optional` or `workspace_user_required`"
+    "`schema.userIdentity` must be `optional`, `workspace_user_required`, or `interactive_workspace_user_required`"
   );
 }
 

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -16,6 +16,7 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SandboxFunctionMCPActionFactory } from "@app/tests/utils/SandboxFunctionMCPActionFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { SandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
@@ -92,7 +93,7 @@ async function setupSandboxFunction({
 }: {
   addCallerToSpace?: boolean;
   withSandboxFunctionsFeatureFlag?: boolean;
-  userIdentity?: "optional" | "workspace_user_required";
+  userIdentity?: SandboxFunctionUserIdentityPolicy;
 } = {}) {
   const { workspace, auth: adminAuth } = await createPrivateApiMockRequest({
     role: "admin",
@@ -307,6 +308,7 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
         invocation: expect.objectContaining({
           sId: invocation.sId,
           context: { timezone: "Europe/Paris" },
+          origin: "interactive_session",
         }),
       }
     );
@@ -332,6 +334,38 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
 
     expect(response.status).toBe(201);
     expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledOnce();
+  });
+
+  it("allows a workspace member's live session to invoke an interactive function", async () => {
+    const { workspace, sandboxFunction } = await setupSandboxFunction({
+      userIdentity: "interactive_workspace_user_required",
+    });
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+    });
+
+    expect(response.status).toBe(201);
+    expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledOnce();
+  });
+
+  it("records an OAuth invocation as delegated", async () => {
+    const { workspace, sandboxFunction } = await setupSandboxFunction();
+    vi.spyOn(Authenticator.prototype, "authMethod").mockReturnValue("oauth");
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+    });
+
+    expect(response.status).toBe(201);
+    expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        invocation: expect.objectContaining({ origin: "delegated" }),
+      })
+    );
   });
 
   it("returns a typed authentication error when the function rejects the caller", async () => {

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -120,7 +120,10 @@ app.post(
       });
     }
 
-    const invocationResult = await sandboxFunction.invoke(auth, body);
+    const invocationResult = await sandboxFunction.invoke(auth, body, {
+      origin:
+        auth.authMethod() === "session" ? "interactive_session" : "delegated",
+    });
     if (invocationResult.isErr()) {
       if (isSandboxFunctionInvocationError(invocationResult.error)) {
         return apiError(ctx, {

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -46,10 +46,10 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
     description:
       "Publish a pod function from a TypeScript source file in the current pod. The source " +
       "must default-export a `fetch(request: Request): Promise<Response>` handler and export a " +
-      "`schema` with zod `input` and `output`. Set `schema.userIdentity` to `optional` or " +
-      "`workspace_user_required`. It is bundled on the pod sandbox (only `zod` is available to " +
-      "import), and its contract is extracted from the `schema` export. Re-publishing the same " +
-      "slug replaces the previous version.",
+      "`schema` with zod `input` and `output`. Set `schema.userIdentity` to `optional`, " +
+      "`workspace_user_required`, or `interactive_workspace_user_required`. It is bundled on the " +
+      "pod sandbox (only `zod` is available to import), and its contract is extracted from the " +
+      "`schema` export. Re-publishing the same slug replaces the previous version.",
     schema: {
       slug: z
         .string()

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.62",
+      tag: "0.8.63",
     });
   });
 

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -394,7 +394,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.39/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.40/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -25,7 +25,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.62";
+const DUST_BASE_IMAGE_VERSION = "0.8.63";
 const DSBX_CLI_VERSION = "0.1.40";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,7 +26,7 @@ import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
 const DUST_BASE_IMAGE_VERSION = "0.8.62";
-const DSBX_CLI_VERSION = "0.1.39";
+const DSBX_CLI_VERSION = "0.1.40";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
 // list must not silently change this user's UID.

--- a/front/lib/api/sandbox_functions/build_on_sandbox.test.ts
+++ b/front/lib/api/sandbox_functions/build_on_sandbox.test.ts
@@ -18,7 +18,7 @@ const okEnvelope = JSON.stringify({ ok: true });
 const validSchemaFile = JSON.stringify({
   name: "greet",
   description: "Greet someone.",
-  userIdentity: "workspace_user_required",
+  userIdentity: "interactive_workspace_user_required",
   input_schema: { type: "object", properties: { name: { type: "string" } } },
   output_schema: {
     type: "object",
@@ -79,7 +79,9 @@ describe("buildSandboxFunctionOnSandbox", () => {
       return;
     }
     expect(result.value.bundleCode).toBe("export default {/*bundle*/};");
-    expect(result.value.userIdentity).toBe("workspace_user_required");
+    expect(result.value.userIdentity).toBe(
+      "interactive_workspace_user_required"
+    );
     expect(result.value.inputSchema).toEqual({
       type: "object",
       properties: { name: { type: "string" } },

--- a/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
@@ -6,7 +6,10 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import type { SandboxFunctionInvocationEvent } from "@app/types/api/sandbox_functions";
+import type {
+  SandboxFunctionInvocationEvent,
+  SandboxFunctionUserIdentityPolicy,
+} from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -73,7 +76,7 @@ function mockResult(result: unknown, invocationId: string): void {
 async function makeFunction(
   auth: Authenticator,
   space: SpaceResource,
-  userIdentity: "optional" | "workspace_user_required" = "optional"
+  userIdentity: SandboxFunctionUserIdentityPolicy = "optional"
 ): Promise<SandboxFunctionResource> {
   const file = await FileFactory.create(auth, null, {
     contentType: sandboxFunctionContentType,
@@ -138,6 +141,12 @@ describe("callSandboxFunction", () => {
       input: { name: "Soupinou" },
       context: { timezone: "Europe/Paris" },
     });
+    expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledWith(
+      auth,
+      expect.objectContaining({
+        invocation: expect.objectContaining({ origin: "delegated" }),
+      })
+    );
   });
 
   it("returns a typed invocation error", async () => {
@@ -229,6 +238,60 @@ describe("callSandboxFunction", () => {
     });
     expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
     expect(getSandboxFunctionInvocationEvents).not.toHaveBeenCalled();
+  });
+
+  it("rejects delegated calls to an interactive-session-required function", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const space = await SpaceFactory.project(workspace);
+    const fn = await makeFunction(
+      authenticator,
+      space,
+      "interactive_workspace_user_required"
+    );
+    vi.spyOn(authenticator, "authMethod").mockReturnValue("session");
+
+    const result = await callSandboxFunction(authenticator, fn, {
+      name: "Soupinou",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error).toEqual({
+      code: "user_authentication_required",
+      message:
+        "This Pod Function requires a logged-in workspace member in a live Dust session.",
+    });
+    expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
+    expect(getSandboxFunctionInvocationEvents).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-session authenticator even with an interactive origin", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const space = await SpaceFactory.project(workspace);
+    const fn = await makeFunction(
+      authenticator,
+      space,
+      "interactive_workspace_user_required"
+    );
+
+    const result = await fn.invoke(
+      authenticator,
+      { input: { name: "Soupinou" } },
+      { origin: "interactive_session" }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.message).toContain("live Dust session");
+    expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
   });
 
   it("errors when no result event arrives", async () => {

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
@@ -75,7 +75,7 @@ describe("publishSandboxFunction", () => {
     vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
       new Ok({
         bundleCode: "export default {};",
-        userIdentity: "workspace_user_required",
+        userIdentity: "interactive_workspace_user_required",
         inputSchema,
         outputSchema,
       })
@@ -95,7 +95,7 @@ describe("publishSandboxFunction", () => {
     const fn = result.value;
     expect(fn.slug).toBe("greet");
     expect(fn.description).toBe("Greet someone.");
-    expect(fn.userIdentity).toBe("workspace_user_required");
+    expect(fn.userIdentity).toBe("interactive_workspace_user_required");
     expect(fn.inputSchema).toEqual(inputSchema);
     expect(fn.outputSchema).toEqual(outputSchema);
 

--- a/front/lib/api/sandbox_functions/workspace_user.ts
+++ b/front/lib/api/sandbox_functions/workspace_user.ts
@@ -5,8 +5,7 @@ import type {
   SandboxFunctionInvocationOrigin,
   SandboxFunctionUserIdentityPolicy,
 } from "@app/types/api/sandbox_functions";
-import { isSandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 
 type SandboxFunctionAuthorization =
   | { authorized: true; user: UserResource | null }
@@ -39,14 +38,7 @@ export async function authorizeSandboxFunctionInvocation(
   }
 ): Promise<SandboxFunctionAuthorization> {
   const user = await getAuthenticatedWorkspaceUser(auth);
-  const policy: unknown = userIdentity ?? "optional";
-  if (!isSandboxFunctionUserIdentityPolicy(policy)) {
-    return {
-      authorized: false,
-      errorMessage:
-        "This Pod Function uses an unsupported user identity policy.",
-    };
-  }
+  const policy = userIdentity ?? "optional";
   switch (policy) {
     case "optional":
       return { authorized: true, user };
@@ -72,6 +64,13 @@ export async function authorizeSandboxFunctionInvocation(
           };
     }
     default:
-      return assertNever(policy);
+      // The policy is persisted as a plain string, so a revision newer than this one can store a
+      // value it does not know. Deny rather than throw so a mixed-version deploy fails closed.
+      assertNeverAndIgnore(policy);
+      return {
+        authorized: false,
+        errorMessage:
+          "This Pod Function uses an unsupported user identity policy.",
+      };
   }
 }

--- a/front/lib/api/sandbox_functions/workspace_user.ts
+++ b/front/lib/api/sandbox_functions/workspace_user.ts
@@ -1,9 +1,16 @@
 import { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
-import type { SandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
+import type {
+  SandboxFunctionInvocationOrigin,
+  SandboxFunctionUserIdentityPolicy,
+} from "@app/types/api/sandbox_functions";
 import { isSandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+
+type SandboxFunctionAuthorization =
+  | { authorized: true; user: UserResource | null }
+  | { authorized: false; errorMessage: string };
 
 export async function getAuthenticatedWorkspaceUser(
   auth: Authenticator
@@ -25,20 +32,45 @@ export async function authorizeSandboxFunctionInvocation(
   auth: Authenticator,
   {
     userIdentity,
+    origin,
   }: {
     userIdentity: SandboxFunctionUserIdentityPolicy | null;
+    origin: SandboxFunctionInvocationOrigin;
   }
-): Promise<{ authorized: boolean; user: UserResource | null }> {
+): Promise<SandboxFunctionAuthorization> {
   const user = await getAuthenticatedWorkspaceUser(auth);
   const policy: unknown = userIdentity ?? "optional";
   if (!isSandboxFunctionUserIdentityPolicy(policy)) {
-    return { authorized: false, user: null };
+    return {
+      authorized: false,
+      errorMessage:
+        "This Pod Function uses an unsupported user identity policy.",
+    };
   }
   switch (policy) {
     case "optional":
       return { authorized: true, user };
     case "workspace_user_required":
-      return { authorized: user !== null, user };
+      return user
+        ? { authorized: true, user }
+        : {
+            authorized: false,
+            errorMessage:
+              "This Pod Function requires a logged-in user from its workspace.",
+          };
+    case "interactive_workspace_user_required": {
+      const authorized =
+        user !== null &&
+        origin === "interactive_session" &&
+        auth.authMethod() === "session";
+      return authorized
+        ? { authorized: true, user }
+        : {
+            authorized: false,
+            errorMessage:
+              "This Pod Function requires a logged-in workspace member in a live Dust session.",
+          };
+    }
     default:
       return assertNever(policy);
   }

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -15,7 +15,10 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import type { SandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
+import type {
+  SandboxFunctionInvocationOrigin,
+  SandboxFunctionUserIdentityPolicy,
+} from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
 import { Ok } from "@app/types/shared/result";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -69,7 +72,8 @@ beforeEach(() => {
 });
 
 async function setupExecutionTest(
-  userIdentity: SandboxFunctionUserIdentityPolicy = "optional"
+  userIdentity: SandboxFunctionUserIdentityPolicy = "optional",
+  origin: SandboxFunctionInvocationOrigin = "delegated"
 ) {
   const { authenticator, workspace } = await createResourceTest({
     role: "admin",
@@ -106,7 +110,7 @@ async function setupExecutionTest(
   );
   const invocation = await SandboxFunctionInvocationResource.makeNew(
     authenticator,
-    { sandboxFunction, input: { message: "hello" } }
+    { sandboxFunction, input: { message: "hello" }, origin }
   );
 
   return {
@@ -690,6 +694,39 @@ describe("SandboxFunctionInvocationResource", () => {
     expect(executionResult.error.message).toContain(
       "requires a logged-in user"
     );
+    expect(execSpy).not.toHaveBeenCalled();
+  });
+
+  it("executes an interactive invocation whose session origin was persisted", async () => {
+    const { authenticator, sandbox, invocation } = await setupExecutionTest(
+      "interactive_workspace_user_required",
+      "interactive_session"
+    );
+    vi.spyOn(authenticator, "authMethod").mockReturnValue("session");
+    const execSpy = vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout: "hello world\n",
+        stderr: "",
+      })
+    );
+
+    const executionResult = await invocation.execute(authenticator);
+
+    expect(executionResult.isOk()).toBe(true);
+    expect(execSpy).toHaveBeenCalledOnce();
+  });
+
+  it("blocks an interactive function whose invocation origin is delegated", async () => {
+    const { authenticator, sandbox, invocation } = await setupExecutionTest(
+      "interactive_workspace_user_required"
+    );
+    vi.spyOn(authenticator, "authMethod").mockReturnValue("session");
+    const execSpy = vi.spyOn(sandbox, "exec");
+
+    const executionResult = await invocation.execute(authenticator);
+
+    expect(executionResult.isErr()).toBe(true);
     expect(execSpy).not.toHaveBeenCalled();
   });
 

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -38,6 +38,7 @@ import type {
   PostSandboxFunctionInvocationRequestBody,
   SandboxFunctionCallError,
   SandboxFunctionInvocationContext,
+  SandboxFunctionInvocationOrigin,
   SandboxFunctionInvocationStatus,
   SandboxFunctionInvocationType,
 } from "@app/types/api/sandbox_functions";
@@ -340,12 +341,11 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       }
       const authorization = await authorizeSandboxFunctionInvocation(auth, {
         userIdentity: persistedFunction.userIdentity,
+        origin: this.origin ?? "delegated",
       });
       if (!authorization.authorized) {
         return new Err(
-          new SandboxFunctionInvocationError(
-            "This Pod Function requires a logged-in user from its workspace."
-          )
+          new SandboxFunctionInvocationError(authorization.errorMessage)
         );
       }
 
@@ -517,10 +517,12 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       sandboxFunction,
       input,
       context,
+      origin = "delegated",
     }: {
       sandboxFunction: SandboxFunctionResource;
       input: unknown;
       context?: SandboxFunctionInvocationContext;
+      origin?: SandboxFunctionInvocationOrigin;
     },
     transaction?: Transaction
   ): Promise<SandboxFunctionInvocationResource> {
@@ -532,6 +534,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
           // Null when the invocation has no human origin (e.g. public API key runs, slack/email
           // bot messages). Scheduled triggers carry their editor's user, so they are not null.
           userId: auth.user()?.id ?? null,
+          origin,
           status: "created",
           // The final path contains the database-generated invocation sId. This placeholder is
           // replaced in the same transaction before the row becomes visible.
@@ -564,15 +567,18 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     {
       sandboxFunction,
       body,
+      origin = "delegated",
     }: {
       sandboxFunction: SandboxFunctionResource;
       body: PostSandboxFunctionInvocationRequestBody;
+      origin?: SandboxFunctionInvocationOrigin;
     }
   ): Promise<Result<SandboxFunctionInvocationResource, Error>> {
     const invocation = await this.makeNew(auth, {
       sandboxFunction,
       input: body.input,
       context: body.context,
+      origin,
     });
     await publishSandboxFunctionInvocationEvent(
       {

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -23,6 +23,7 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import type {
   PostSandboxFunctionInvocationRequestBody,
+  SandboxFunctionInvocationOrigin,
   SandboxFunctionUserIdentityPolicy,
 } from "@app/types/api/sandbox_functions";
 import { isValidSandboxFunctionSlug } from "@app/types/api/sandbox_functions";
@@ -49,6 +50,8 @@ function userIdentityPolicyStrength(
       return 0;
     case "workspace_user_required":
       return 1;
+    case "interactive_workspace_user_required":
+      return 2;
     default:
       return assertNever(policy);
   }
@@ -405,7 +408,8 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
   async invoke(
     auth: Authenticator,
-    body: PostSandboxFunctionInvocationRequestBody
+    body: PostSandboxFunctionInvocationRequestBody,
+    { origin = "delegated" }: { origin?: SandboxFunctionInvocationOrigin } = {}
   ): Promise<Result<SandboxFunctionInvocationResource, Error>> {
     if (auth.getNonNullableWorkspace().id !== this.workspaceId) {
       return new Err(
@@ -416,18 +420,18 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     }
     const authorization = await authorizeSandboxFunctionInvocation(auth, {
       userIdentity: this.userIdentity,
+      origin,
     });
     if (!authorization.authorized) {
       return new Err(
-        new SandboxFunctionInvocationError(
-          "This Pod Function requires a logged-in user from its workspace."
-        )
+        new SandboxFunctionInvocationError(authorization.errorMessage)
       );
     }
 
     return SandboxFunctionInvocationResource.createAndStartExecution(auth, {
       sandboxFunction: this,
       body,
+      origin,
     });
   }
 

--- a/front/lib/resources/storage/models/sandbox_function.ts
+++ b/front/lib/resources/storage/models/sandbox_function.ts
@@ -9,11 +9,13 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { validateJsonSchema } from "@app/lib/utils/json_schemas";
 import type {
+  SandboxFunctionInvocationOrigin,
   SandboxFunctionInvocationStatus,
   SandboxFunctionUserIdentityPolicy,
 } from "@app/types/api/sandbox_functions";
 import {
   isValidSandboxFunctionSlug,
+  SANDBOX_FUNCTION_INVOCATION_ORIGINS,
   SANDBOX_FUNCTION_INVOCATION_STATUSES,
   SANDBOX_FUNCTION_USER_IDENTITY_POLICIES,
 } from "@app/types/api/sandbox_functions";
@@ -62,6 +64,7 @@ export class SandboxFunctionInvocationModel extends WorkspaceAwareModel<SandboxF
   declare sandboxFunctionId: ForeignKey<SandboxFunctionModel["id"]>;
   // Human who triggered the invocation. Null for non-human origins (API key, scheduled/bot runs).
   declare userId: ForeignKey<UserModel["id"]> | null;
+  declare origin: SandboxFunctionInvocationOrigin | null;
   declare status: SandboxFunctionInvocationStatus;
   declare gcsPath: string;
 
@@ -190,6 +193,13 @@ SandboxFunctionInvocationModel.init(
     userId: {
       type: DataTypes.BIGINT,
       allowNull: true,
+    },
+    origin: {
+      type: DataTypes.STRING(64),
+      allowNull: true,
+      validate: {
+        isIn: [SANDBOX_FUNCTION_INVOCATION_ORIGINS],
+      },
     },
     status: {
       type: DataTypes.STRING(64),

--- a/front/migrations/pre-deploy/20260729142921_add_origin_to_sandbox_function_invocations.sql
+++ b/front/migrations/pre-deploy/20260729142921_add_origin_to_sandbox_function_invocations.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_function_invocations" ADD COLUMN "origin" character varying(64) COLLATE "pg_catalog"."default";

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -23,14 +23,6 @@ export const SANDBOX_FUNCTION_USER_IDENTITY_POLICIES = [
 export type SandboxFunctionUserIdentityPolicy =
   (typeof SANDBOX_FUNCTION_USER_IDENTITY_POLICIES)[number];
 
-export function isSandboxFunctionUserIdentityPolicy(
-  value: unknown
-): value is SandboxFunctionUserIdentityPolicy {
-  return SANDBOX_FUNCTION_USER_IDENTITY_POLICIES.some(
-    (policy) => policy === value
-  );
-}
-
 export const SANDBOX_FUNCTION_INVOCATION_ORIGINS = [
   "interactive_session",
   "delegated",

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -17,6 +17,7 @@ export type SandboxFunctionInvocationStatus =
 export const SANDBOX_FUNCTION_USER_IDENTITY_POLICIES = [
   "optional",
   "workspace_user_required",
+  "interactive_workspace_user_required",
 ] as const;
 
 export type SandboxFunctionUserIdentityPolicy =
@@ -29,6 +30,14 @@ export function isSandboxFunctionUserIdentityPolicy(
     (policy) => policy === value
   );
 }
+
+export const SANDBOX_FUNCTION_INVOCATION_ORIGINS = [
+  "interactive_session",
+  "delegated",
+] as const;
+
+export type SandboxFunctionInvocationOrigin =
+  (typeof SANDBOX_FUNCTION_INVOCATION_ORIGINS)[number];
 
 // Lowercase alphanumeric with single hyphen separators (e.g. `greet`, `send-slack-message`).
 export const SANDBOX_FUNCTION_SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;


### PR DESCRIPTION
## Description

Stack 5 of 6. Depends on #29682 and is followed by #29685.

Adds `interactive_workspace_user_required`. The browser route records `interactive_session` only for session authentication; OAuth, agents, schedules, API calls, and other callers remain delegated. Request and execution checks require an active member of the exact function workspace, the persisted interactive origin, and session authentication.

## Tests

Added coverage for runner schema and publication, browser-session success, delegated and OAuth rejection, persisted origin, and execution-time provenance.

## Risk

Existing invocations with a null origin are treated as delegated. During rollout, #29682 rejects this new policy instead of applying weaker authorization. After application deploy and before `/poke/kill`, old sandboxes cannot build or publish the new policy. Rolling back to #29682 leaves interactive functions unavailable but does not run them.

## Deploy Plan

1. Apply the invocation-origin pre-deploy migration.
2. Release `dsbx` 0.1.40.
3. Build and register `dust-base` 0.8.63.
4. Deploy this application revision.
5. After deploy, recycle older Pod sandboxes with `/poke/kill`.
6. Verify browser-session success and delegated/OAuth rejection.
