### PR TITLE
Scope Pod Function invocation reads by caller

### DIFF
--- a/front-api/routes/sse/w/[wId]/sandbox-functions/[functionId]/invocations/[invocationId]/events.test.ts
+++ b/front-api/routes/sse/w/[wId]/sandbox-functions/[functionId]/invocations/[invocationId]/events.test.ts
@@ -156,16 +156,7 @@ describe("GET /api/sse/w/[wId]/sandbox-functions/[functionId]/invocations/[invoc
       role: "user",
       workspace,
     });
-    const [memberGroup] = await space.fetchGroupResources(auth, {
-      groupReferences: space.groups.filter((group) => group.isRegularAuto()),
-    });
-    expect(memberGroup).toBeDefined();
-    if (!memberGroup) {
-      return;
-    }
-    const addResult = await memberGroup.dangerouslyAddMember(auth, {
-      user: user.toJSON(),
-    });
+    const addResult = await space.addMembers(auth, { userIds: [user.sId] });
     expect(addResult.isOk()).toBe(true);
 
     const response = await getEvents({

--- a/front-api/routes/sse/w/[wId]/sandbox-functions/[functionId]/invocations/[invocationId]/events.test.ts
+++ b/front-api/routes/sse/w/[wId]/sandbox-functions/[functionId]/invocations/[invocationId]/events.test.ts
@@ -75,7 +75,7 @@ async function setupSandboxFunctionInvocation({
     input: undefined,
   });
 
-  return { workspace, sandboxFunction, invocation };
+  return { workspace, auth, space, sandboxFunction, invocation };
 }
 
 function getEvents({
@@ -143,6 +143,35 @@ describe("GET /api/sse/w/[wId]/sandbox-functions/[functionId]/invocations/[invoc
       workspaceId: workspace.sId,
       functionId: sandboxFunction.sId,
       invocationId: "sfi_unknown",
+    });
+
+    expect(response.status).toBe(404);
+    expect(getSandboxFunctionInvocationEvents).not.toHaveBeenCalled();
+  });
+
+  it("hides another member's invocation from a Pod reader", async () => {
+    const { workspace, auth, space, sandboxFunction, invocation } =
+      await setupSandboxFunctionInvocation();
+    const { user } = await createPrivateApiMockRequest({
+      role: "user",
+      workspace,
+    });
+    const [memberGroup] = await space.fetchGroupResources(auth, {
+      groupReferences: space.groups.filter((group) => group.isRegularAuto()),
+    });
+    expect(memberGroup).toBeDefined();
+    if (!memberGroup) {
+      return;
+    }
+    const addResult = await memberGroup.dangerouslyAddMember(auth, {
+      user: user.toJSON(),
+    });
+    expect(addResult.isOk()).toBe(true);
+
+    const response = await getEvents({
+      workspaceId: workspace.sId,
+      functionId: sandboxFunction.sId,
+      invocationId: invocation.sId,
     });
 
     expect(response.status).toBe(404);

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts
@@ -53,15 +53,8 @@ describe("POST /api/v1/w/[wId]/sandbox/sandbox-functions/result", () => {
     await MembershipFactory.associate(workspace, callbackUser, {
       role: "user",
     });
-    const [memberGroup] = await podSpace.fetchGroupResources(auth, {
-      groupReferences: podSpace.groups.filter((group) => group.isRegularAuto()),
-    });
-    expect(memberGroup).toBeDefined();
-    if (!memberGroup) {
-      return;
-    }
-    const addMemberResult = await memberGroup.dangerouslyAddMember(auth, {
-      user: callbackUser.toJSON(),
+    const addMemberResult = await podSpace.addMembers(auth, {
+      userIds: [callbackUser.sId],
     });
     expect(addMemberResult.isOk()).toBe(true);
     const callbackAuth = await Authenticator.fromUserIdAndWorkspaceId(

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts
@@ -1,8 +1,12 @@
+import { generateSandboxFunctionInvocationToken } from "@app/lib/api/sandbox/access_tokens";
+import { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import {
   createPersistedSandboxFunctionInvocationTokenTestContext,
   createSandboxTokenTestContext,
 } from "@app/tests/utils/SandboxTokenFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -43,8 +47,46 @@ describe("POST /api/v1/w/[wId]/sandbox/sandbox-functions/result", () => {
   });
 
   it("returns success for sandbox function invocation result callbacks", async () => {
-    const { auth, token, workspace, sandboxFunction, invocation } =
+    const { auth, workspace, sandbox, podSpace, sandboxFunction } =
       await createPersistedSandboxFunctionInvocationTokenTestContext();
+    const callbackUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, callbackUser, {
+      role: "user",
+    });
+    const [memberGroup] = await podSpace.fetchGroupResources(auth, {
+      groupReferences: podSpace.groups.filter((group) => group.isRegularAuto()),
+    });
+    expect(memberGroup).toBeDefined();
+    if (!memberGroup) {
+      return;
+    }
+    const addMemberResult = await memberGroup.dangerouslyAddMember(auth, {
+      user: callbackUser.toJSON(),
+    });
+    expect(addMemberResult.isOk()).toBe(true);
+    const callbackAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      callbackUser.sId,
+      workspace.sId
+    );
+    const userlessAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const invocation = await SandboxFunctionInvocationResource.makeNew(
+      userlessAuth,
+      { sandboxFunction, input: undefined }
+    );
+    await expect(
+      SandboxFunctionInvocationResource.fetchById(callbackAuth, {
+        sandboxFunction,
+        invocationId: invocation.sId,
+      })
+    ).resolves.toBeNull();
+    const token = await generateSandboxFunctionInvocationToken(callbackAuth, {
+      sandbox,
+      sandboxFunction,
+      invocationId: invocation.sId,
+      execId: `test-function-exec-${sandbox.sId}`,
+    });
 
     const response = await postSandboxFunctionResult(workspace, token, {
       function: "test_function",

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
@@ -57,6 +57,7 @@ app.post(
     const invocation = await SandboxFunctionInvocationResource.fetchById(auth, {
       sandboxFunction,
       invocationId: sandboxClaims.invocationId,
+      access: "system",
     });
     if (!invocation) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -706,7 +706,7 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations/:invo
     });
   });
 
-  it("rejects validation from a user who did not initiate the invocation", async () => {
+  it("hides validation for another user's invocation", async () => {
     const { workspace, sandboxFunction, invocation, action } =
       await setupBlockedAction({ invocationOwnedByOtherMember: true });
 
@@ -718,14 +718,14 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations/:invo
       body: { approved: "approved" },
     });
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(404);
     expect(await response.json()).toMatchObject({
-      error: { type: "invalid_request_error" },
+      error: { type: "action_not_found" },
     });
     expect(vi.mocked(launchSandboxFunctionToolWorkflow)).not.toHaveBeenCalled();
   });
 
-  it("rejects validation when the invocation has no initiating user", async () => {
+  it("hides validation for a userless invocation", async () => {
     const { workspace, sandboxFunction, invocation, action } =
       await setupBlockedAction({ invocationOwnerless: true });
     expect(invocation.userId).toBeNull();
@@ -738,9 +738,9 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations/:invo
       body: { approved: "approved" },
     });
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(404);
     expect(await response.json()).toMatchObject({
-      error: { type: "invalid_request_error" },
+      error: { type: "action_not_found" },
     });
     expect(vi.mocked(launchSandboxFunctionToolWorkflow)).not.toHaveBeenCalled();
   });
@@ -889,7 +889,7 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations/:invo
     });
   });
 
-  it("rejects authentication resolution from a user who did not initiate the invocation", async () => {
+  it("hides authentication resolution for another user's invocation", async () => {
     const { workspace, sandboxFunction, invocation, action } =
       await setupBlockedAction({
         blockedStatus: "blocked_authentication_required",
@@ -904,14 +904,14 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations/:invo
       body: { outcome: "completed" },
     });
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(404);
     expect(await response.json()).toMatchObject({
-      error: { type: "invalid_request_error" },
+      error: { type: "action_not_found" },
     });
     expect(vi.mocked(launchSandboxFunctionToolWorkflow)).not.toHaveBeenCalled();
   });
 
-  it("rejects authentication resolution when the invocation has no initiating user", async () => {
+  it("hides authentication resolution for a userless invocation", async () => {
     const { workspace, sandboxFunction, invocation, action } =
       await setupBlockedAction({
         blockedStatus: "blocked_authentication_required",
@@ -927,9 +927,9 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations/:invo
       body: { outcome: "completed" },
     });
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(404);
     expect(await response.json()).toMatchObject({
-      error: { type: "invalid_request_error" },
+      error: { type: "action_not_found" },
     });
     expect(vi.mocked(launchSandboxFunctionToolWorkflow)).not.toHaveBeenCalled();
   });

--- a/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
+++ b/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
@@ -182,6 +182,7 @@ export async function createSandboxFunctionMCPAction(
   const invocation = await SandboxFunctionInvocationResource.fetchById(auth, {
     sandboxFunction,
     invocationId,
+    access: "system",
   });
   if (!invocation) {
     return new Err(

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -206,6 +206,101 @@ describe("SandboxFunctionInvocationResource", () => {
     expect(formatted).toContain('"updatedAt":');
   });
 
+  it("shows readers only their invocations while Pod administrators see all", async () => {
+    const { authenticator, workspace, space, sandboxFunction, invocation } =
+      await setupExecutionTest();
+    const reader = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, reader, { role: "user" });
+    const [memberGroup] = await space.fetchGroupResources(authenticator, {
+      groupReferences: space.groups.filter((group) => group.isRegularAuto()),
+    });
+    expect(memberGroup).toBeDefined();
+    if (!memberGroup) {
+      return;
+    }
+    const addResult = await memberGroup.dangerouslyAddMember(authenticator, {
+      user: reader.toJSON(),
+    });
+    expect(addResult.isOk()).toBe(true);
+    const readerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      reader.sId,
+      workspace.sId
+    );
+    const readerInvocation = await SandboxFunctionInvocationResource.makeNew(
+      readerAuth,
+      {
+        sandboxFunction,
+        input: { message: "reader-owned" },
+      }
+    );
+
+    const readerInvocations =
+      await SandboxFunctionInvocationResource.listRecent(readerAuth, {
+        sandboxFunction,
+        limit: 10,
+      });
+    expect(readerInvocations.map(({ sId }) => sId)).toEqual([
+      readerInvocation.sId,
+    ]);
+    await expect(
+      SandboxFunctionInvocationResource.fetchById(readerAuth, {
+        sandboxFunction,
+        invocationId: invocation.sId,
+      })
+    ).resolves.toBeNull();
+
+    const administratorInvocations =
+      await SandboxFunctionInvocationResource.listRecent(authenticator, {
+        sandboxFunction,
+        limit: 10,
+      });
+    expect(administratorInvocations.map(({ sId }) => sId)).toEqual([
+      readerInvocation.sId,
+      invocation.sId,
+    ]);
+  });
+
+  it("hides userless invocations from readers but allows administrator and system reads", async () => {
+    const { authenticator, workspace, sandboxFunction } =
+      await setupExecutionTest();
+    const userlessAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const userlessInvocation = await SandboxFunctionInvocationResource.makeNew(
+      userlessAuth,
+      {
+        sandboxFunction,
+        input: { message: "userless" },
+      }
+    );
+    const reader = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, reader, { role: "user" });
+    const readerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      reader.sId,
+      workspace.sId
+    );
+
+    await expect(
+      SandboxFunctionInvocationResource.fetchById(readerAuth, {
+        sandboxFunction,
+        invocationId: userlessInvocation.sId,
+      })
+    ).resolves.toBeNull();
+    await expect(
+      SandboxFunctionInvocationResource.fetchById(authenticator, {
+        sandboxFunction,
+        invocationId: userlessInvocation.sId,
+      })
+    ).resolves.toMatchObject({ sId: userlessInvocation.sId });
+    await expect(
+      SandboxFunctionInvocationResource.fetchById(userlessAuth, {
+        sandboxFunction,
+        invocationId: userlessInvocation.sId,
+        access: "system",
+      })
+    ).resolves.toMatchObject({ sId: userlessInvocation.sId });
+  });
+
   it("formats an explicit message when a function has no invocations", () => {
     expect(formatSandboxFunctionInvocations("never-called", [])).toBe(
       'No invocations found for pod function "never-called".'

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -211,15 +211,8 @@ describe("SandboxFunctionInvocationResource", () => {
       await setupExecutionTest();
     const reader = await UserFactory.basic();
     await MembershipFactory.associate(workspace, reader, { role: "user" });
-    const [memberGroup] = await space.fetchGroupResources(authenticator, {
-      groupReferences: space.groups.filter((group) => group.isRegularAuto()),
-    });
-    expect(memberGroup).toBeDefined();
-    if (!memberGroup) {
-      return;
-    }
-    const addResult = await memberGroup.dangerouslyAddMember(authenticator, {
-      user: reader.toJSON(),
+    const addResult = await space.addMembers(authenticator, {
+      userIds: [reader.sId],
     });
     expect(addResult.isOk()).toBe(true);
     const readerAuth = await Authenticator.fromUserIdAndWorkspaceId(

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -11,7 +11,10 @@ import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import { SandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
-import { authorizeSandboxFunctionInvocation } from "@app/lib/api/sandbox_functions/workspace_user";
+import {
+  authorizeSandboxFunctionInvocation,
+  getAuthenticatedWorkspaceUser,
+} from "@app/lib/api/sandbox_functions/workspace_user";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -63,6 +66,8 @@ const SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS = 16_384;
 const GCS_CONCURRENCY = 4;
 const SANDBOX_FUNCTION_INVOCATION_DATA_VERSION = 2;
 const POD_USER_IDENTITY_ENV = "DUST_POD_USER_IDENTITY";
+
+type SandboxFunctionInvocationReadAccess = "viewer" | "system";
 
 // `code` is not narrowed to `SandboxFunctionCallErrorCode`: it is forwarded from whatever
 // classified the failure (runner, API error type, front), and a code introduced by a newer deploy
@@ -629,17 +634,42 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     auth: Authenticator,
     {
       sandboxFunction,
+      access = "viewer",
     }: {
       sandboxFunction: SandboxFunctionResource;
+      access?: SandboxFunctionInvocationReadAccess;
     },
     options?: ResourceFindOptions<SandboxFunctionInvocationModel>
   ): Promise<SandboxFunctionInvocationResource[]> {
     const { where, ...rest } = options ?? {};
+    // User-facing reads expose the caller's invocations, or every invocation to a Pod
+    // administrator. Execution and callback paths use the explicit system access after validating
+    // their server-owned invocation token or workflow input.
+    let viewerModelId: ModelId | undefined;
+    switch (access) {
+      case "viewer": {
+        const viewer = await getAuthenticatedWorkspaceUser(auth);
+        if (!viewer) {
+          return [];
+        }
+        viewerModelId = sandboxFunction.space.canAdministrate(auth)
+          ? undefined
+          : viewer.id;
+        break;
+      }
+      case "system":
+        viewerModelId = undefined;
+        break;
+      default:
+        return assertNever(access);
+    }
+
     const invocations = await this.model.findAll({
       where: {
         ...where,
         sandboxFunctionId: sandboxFunction.id,
         workspaceId: auth.getNonNullableWorkspace().id,
+        ...(viewerModelId !== undefined ? { userId: viewerModelId } : {}),
       },
       ...rest,
     });
@@ -661,9 +691,11 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     {
       sandboxFunction,
       invocationId,
+      access = "viewer",
     }: {
       sandboxFunction: SandboxFunctionResource;
       invocationId: string;
+      access?: SandboxFunctionInvocationReadAccess;
     }
   ): Promise<SandboxFunctionInvocationResource | null> {
     if (!isResourceSId("sandbox_function_invocation", invocationId)) {
@@ -677,7 +709,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
 
     const [invocation] = await this.baseFetch(
       auth,
-      { sandboxFunction },
+      { sandboxFunction, access },
       {
         where: {
           id: invocationModelId,

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -332,6 +332,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         id: invocation.id,
         workspaceId: invocation.workspaceId,
       }),
+      access: "system",
     });
   }
 

--- a/front/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed.test.ts
+++ b/front/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed.test.ts
@@ -92,11 +92,13 @@ describe("markSandboxFunctionInvocationFailedActivity", () => {
     const userlessAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const userlessInvocation =
-      await SandboxFunctionInvocationResource.makeNew(userlessAuth, {
+    const userlessInvocation = await SandboxFunctionInvocationResource.makeNew(
+      userlessAuth,
+      {
         sandboxFunction,
         input: { message: "hello" },
-      });
+      }
+    );
     expect(userlessInvocation.userId).toBeNull();
 
     await markSandboxFunctionInvocationFailedActivity(userlessAuth.toJSON(), {

--- a/front/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed.test.ts
+++ b/front/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed.test.ts
@@ -87,6 +87,31 @@ describe("markSandboxFunctionInvocationFailedActivity", () => {
     );
   });
 
+  it("marks a userless invocation as errored", async () => {
+    const { authenticator, workspace, sandboxFunction } = await setup();
+    const userlessAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const userlessInvocation =
+      await SandboxFunctionInvocationResource.makeNew(userlessAuth, {
+        sandboxFunction,
+        input: { message: "hello" },
+      });
+    expect(userlessInvocation.userId).toBeNull();
+
+    await markSandboxFunctionInvocationFailedActivity(userlessAuth.toJSON(), {
+      errorMessage: "The worker died before returning a result.",
+      sandboxFunctionId: sandboxFunction.sId,
+      invocationId: userlessInvocation.sId,
+    });
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: userlessInvocation.sId }
+    );
+    expect(refetched?.status).toBe("errored");
+  });
+
   it("does not overwrite an invocation that already succeeded", async () => {
     const { authenticator, sandboxFunction, invocation } = await setup();
     await invocation.succeed({ ok: true });

--- a/front/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed.ts
+++ b/front/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed.ts
@@ -27,6 +27,7 @@ export async function markSandboxFunctionInvocationFailedActivity(
   const invocation = await SandboxFunctionInvocationResource.fetchById(auth, {
     sandboxFunction,
     invocationId,
+    access: "system",
   });
   if (!invocation) {
     throw new Error(`Pod function invocation not found: ${invocationId}`);

--- a/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.test.ts
+++ b/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.test.ts
@@ -1,10 +1,13 @@
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
+import { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { runSandboxFunctionInvocationActivity } from "@app/temporal/sandbox_functions/activities/run_sandbox_function_invocation";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import { sandboxFunctionContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -24,11 +27,11 @@ vi.mock("@app/lib/api/sandbox_functions/events", async (importOriginal) => {
 const schema: JSONSchema = { type: "object" };
 
 async function setup() {
-  const { authenticator, workspace } = await createResourceTest({
+  const { authenticator: adminAuth, workspace } = await createResourceTest({
     role: "admin",
   });
   const space = await SpaceFactory.project(workspace);
-  const file = await FileFactory.create(authenticator, null, {
+  const file = await FileFactory.create(adminAuth, null, {
     contentType: sandboxFunctionContentType,
     fileName: "function.ts",
     fileSize: 100,
@@ -36,7 +39,7 @@ async function setup() {
     useCase: "project_context",
     useCaseMetadata: { spaceId: space.sId },
   });
-  const sandboxFunction = await SandboxFunctionResource.makeNew(authenticator, {
+  const sandboxFunction = await SandboxFunctionResource.makeNew(adminAuth, {
     space,
     file,
     slug: "run-function",
@@ -44,12 +47,33 @@ async function setup() {
     inputSchema: schema,
     outputSchema: schema,
   });
+  const member = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, member, { role: "user" });
+  const [memberGroup] = await space.fetchGroupResources(adminAuth, {
+    groupReferences: space.groups.filter((group) => group.isRegularAuto()),
+  });
+  if (!memberGroup) {
+    throw new Error("Expected the Pod member group to exist.");
+  }
+  const addMemberResult = await memberGroup.dangerouslyAddMember(adminAuth, {
+    user: member.toJSON(),
+  });
+  if (addMemberResult.isErr()) {
+    throw addMemberResult.error;
+  }
+  const authenticator = await Authenticator.fromUserIdAndWorkspaceId(
+    member.sId,
+    workspace.sId
+  );
+  const userlessAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
   const invocation = await SandboxFunctionInvocationResource.makeNew(
-    authenticator,
+    userlessAuth,
     { sandboxFunction, input: { message: "hello" } }
   );
 
-  return { authenticator, sandboxFunction, invocation };
+  return { adminAuth, authenticator, sandboxFunction, invocation };
 }
 
 beforeEach(() => {
@@ -63,6 +87,12 @@ afterEach(() => {
 describe("runSandboxFunctionInvocationActivity", () => {
   it("executes the existing invocation", async () => {
     const { authenticator, sandboxFunction, invocation } = await setup();
+    await expect(
+      SandboxFunctionInvocationResource.fetchById(authenticator, {
+        sandboxFunction,
+        invocationId: invocation.sId,
+      })
+    ).resolves.toBeNull();
     const executeSpy = vi
       .spyOn(SandboxFunctionInvocationResource.prototype, "execute")
       .mockImplementation(async function (
@@ -81,7 +111,8 @@ describe("runSandboxFunctionInvocationActivity", () => {
   });
 
   it("fails the invocation when execution fails", async () => {
-    const { authenticator, sandboxFunction, invocation } = await setup();
+    const { adminAuth, authenticator, sandboxFunction, invocation } =
+      await setup();
     vi.spyOn(
       SandboxFunctionInvocationResource.prototype,
       "execute"
@@ -95,7 +126,7 @@ describe("runSandboxFunctionInvocationActivity", () => {
     ).rejects.toThrow("sandbox unavailable");
 
     const refetched = await SandboxFunctionInvocationResource.fetchById(
-      authenticator,
+      adminAuth,
       { sandboxFunction, invocationId: invocation.sId }
     );
     expect(refetched?.status).toBe("errored");

--- a/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.test.ts
+++ b/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.test.ts
@@ -49,14 +49,8 @@ async function setup() {
   });
   const member = await UserFactory.basic();
   await MembershipFactory.associate(workspace, member, { role: "user" });
-  const [memberGroup] = await space.fetchGroupResources(adminAuth, {
-    groupReferences: space.groups.filter((group) => group.isRegularAuto()),
-  });
-  if (!memberGroup) {
-    throw new Error("Expected the Pod member group to exist.");
-  }
-  const addMemberResult = await memberGroup.dangerouslyAddMember(adminAuth, {
-    user: member.toJSON(),
+  const addMemberResult = await space.addMembers(adminAuth, {
+    userIds: [member.sId],
   });
   if (addMemberResult.isErr()) {
     throw addMemberResult.error;

--- a/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.ts
+++ b/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.ts
@@ -25,6 +25,7 @@ export async function runSandboxFunctionInvocationActivity(
   const invocation = await SandboxFunctionInvocationResource.fetchById(auth, {
     sandboxFunction,
     invocationId,
+    access: "system",
   });
   if (!invocation) {
     throw new Error(`Pod function invocation not found: ${invocationId}`);


### PR DESCRIPTION
## Description

Stack 6 of 6. Depends on #29684.

Scopes Pod Function invocation reads at the database query boundary.

- `SandboxFunctionInvocationResource.baseFetch` takes an `access` mode, `viewer` by default and `system` opt-in. `viewer` adds a `userId` predicate unless the caller can administrate the Pod space, and returns nothing when there is no active workspace member.
- `fetchById` forwards `access`. `listRecent` stays viewer-only, so a Pod member lists and streams only their own invocations while a Pod administrator still sees every one.
- Five trusted paths opt into `system` after their own boundary check: Temporal execution, its failure compensation, the signed result callback, in-function tool calls, and the action lookup behind them.
- Tool validation and personal-authentication endpoints now answer `404` instead of `403` for an invocation the caller cannot see. The initiating-user check stays, and is what a Pod administrator hits when acting on someone else's invocation.

## Tests

Resource and endpoint coverage for readers, administrators, other users, and userless invocations, including userless Temporal and signed-callback cases that first prove ordinary viewer access is denied.

## Risk

Non-admin readers can no longer discover another user's or a userless invocation. Administrator and trusted system paths keep access. No migration; rolls back with the application.

## Deploy Plan

Standard application deploy after #29684.
