### PR TITLE
Improve Pod Function data flow in Frames

### DIFF
--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -141,12 +141,8 @@ Design the function contract around the Frame interaction, not individual databa
 
 - make reads idempotent and side-effect-free, and return one bounded screen snapshot instead of
   creating waterfalls or N+1 calls;
-- project only fields the Frame renders, apply explicit limits or pagination, and add indexes for
-  columns used by filters and ordering;
 - make mutations return the updated entity or screen snapshot so the Frame can update its cache
   without another function call;
-- do not shell out to \`dsbx tools\` from a hot read path when the same data can be stored or queried
-  directly;
 - keep write operations safe against duplicate interaction, using a stable idempotency key when a
   repeated request would otherwise create duplicate data.
 

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -221,10 +221,9 @@ it with the authoritative mutation result afterward. Roll the optimistic value b
 fails. Only call \`mutate()\` without data when the mutation cannot return the affected state; do not
 make a blocking mutation-then-refetch sequence the default.
 
-Do not call \`callFunction\` from an effect for data that can use these hooks. Do not poll every
-second. Prefer event-driven invalidation; when polling is unavoidable, use an interval of at least
-5–10 seconds, pause while the document is hidden, add jitter/backoff, and never start a new request
-while the previous one is still running.
+Do not poll every second. Prefer event-driven invalidation; when polling is unavoidable, use an
+interval of at least 5–10 seconds, pause while the document is hidden, add jitter/backoff, and never
+start a new request while the previous one is still running.
 
 Call mutation handlers from a button or another supported in-Frame interaction. Do not model this
 as HTML form submission because forms cannot run inside the Frame iframe.

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -135,18 +135,6 @@ tool, so \`fetch()\` calls from inside it only reach domains on the pod's egress
 workspace's \`DST_*\` (plain config) and \`DSEC_*\` (HTTPS secret placeholder) environment variables
 are available under the same substitution rules as the Computer.
 
-#### Performance rules
-
-Design the function contract around the Frame interaction, not individual database tables:
-
-- make reads idempotent and side-effect-free, and return one bounded screen snapshot instead of
-  creating waterfalls or N+1 calls;
-- make mutations return the updated entity or screen snapshot so the Frame can update its cache
-  without another function call;
-- keep write operations safe against duplicate interaction, using a stable idempotency key when a
-  repeated request would otherwise create duplicate data.
-
-
 #### Calling other tools from a function
 
 \`dsbx\` is available inside a function's own process, the same way it is in the conversation's
@@ -185,6 +173,17 @@ A Frame calls published functions through the injected \`@dust/react-hooks\` mod
 \`call\` tool. Always pass the fully qualified \`<podId>/<slug>\` reference reported by
 \`${toolName("get")}\`. Never pass a bare slug or infer the function from the Frame's current Pod.
 This keeps the reference stable if the Frame is moved.
+
+##### Designing functions for a Frame
+
+Design the function contract around the Frame interaction, not individual database tables:
+
+- make reads idempotent and side-effect-free, and return one bounded screen snapshot instead of
+  creating waterfalls or N+1 calls;
+- make mutations return the updated entity or screen snapshot so the Frame can update its cache
+  without another function call;
+- keep write operations safe against duplicate interaction, using a stable idempotency key when a
+  repeated request would otherwise create duplicate data.
 
 Use \`usePodFunction\` for idempotent reads. It caches identical calls, deduplicates calls already
 in flight, and keeps previous data visible while revalidating. Pass \`null\` as the reference to

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -242,9 +242,7 @@ fall back to a generic message for the rest. The ones worth branching on are \`i
 \`invalid_output\` for schema mismatches, \`threw\` when the function threw, \`http_error\` when the
 function's own request failed, \`sandbox_function_not_found\`, and \`not_supported\`.
 
-The existing imperative \`callFunction\` remains available unchanged for explicit calls and also
-takes \`<podId>/<slug>\` or a function id. Pod functions are only reachable from authenticated Pod
-Frames, not from public or shared Frames.`,
+Pod functions are only reachable from authenticated Pod Frames, not from public or shared Frames.`,
   mcpServers: [{ name: SANDBOX_FUNCTIONS_SERVER_NAME }],
   version: 5,
   icon: "PuzzleIcon",

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -220,10 +220,6 @@ it with the authoritative mutation result afterward. Roll the optimistic value b
 fails. Only call \`mutate()\` without data when the mutation cannot return the affected state; do not
 make a blocking mutation-then-refetch sequence the default.
 
-Do not poll every second. Prefer event-driven invalidation; when polling is unavoidable, use an
-interval of at least 5–10 seconds, pause while the document is hidden, add jitter/backoff, and never
-start a new request while the previous one is still running.
-
 Call mutation handlers from a button or another supported in-Frame interaction. Do not model this
 as HTML form submission because forms cannot run inside the Frame iframe.
 
@@ -241,7 +237,8 @@ fall back to a generic message for the rest. The ones worth branching on are \`i
 \`invalid_output\` for schema mismatches, \`threw\` when the function threw, \`http_error\` when the
 function's own request failed, \`sandbox_function_not_found\`, and \`not_supported\`.
 
-Pod functions are only reachable from authenticated Pod Frames, not from public or shared Frames.`,
+Pod functions in shared Frames are available to authenticated members of the Pod's workspace;
+anonymous viewers cannot call them.`,
   mcpServers: [{ name: SANDBOX_FUNCTIONS_SERVER_NAME }],
   version: 5,
   icon: "PuzzleIcon",

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -135,6 +135,21 @@ tool, so \`fetch()\` calls from inside it only reach domains on the pod's egress
 workspace's \`DST_*\` (plain config) and \`DSEC_*\` (HTTPS secret placeholder) environment variables
 are available under the same substitution rules as the Computer.
 
+#### Performance rules
+
+Design the function contract around the Frame interaction, not individual database tables:
+
+- make reads idempotent and side-effect-free, and return one bounded screen snapshot instead of
+  creating waterfalls or N+1 calls;
+- project only fields the Frame renders, apply explicit limits or pagination, and add indexes for
+  columns used by filters and ordering;
+- make mutations return the updated entity or screen snapshot so the Frame can update its cache
+  without another function call;
+- do not shell out to \`dsbx tools\` from a hot read path when the same data can be stored or queried
+  directly;
+- keep write operations safe against duplicate interaction, using a stable idempotency key when a
+  repeated request would otherwise create duplicate data.
+
 
 #### Calling other tools from a function
 
@@ -190,7 +205,8 @@ const { data, error, isLoading, isValidating, mutate } = usePodFunction(
 
 Use \`usePodFunctionMutation\` for writes and other side effects. Mutations only run when
 \`trigger\` is called. They are not deduplicated and do not guess which cached queries they affect.
-Revalidate the affected read explicitly after the mutation succeeds.
+Prefer mutation functions whose output matches the affected read snapshot, then write that result
+to the query cache without revalidating.
 
 \`\`\`tsx
 import { usePodFunction, usePodFunctionMutation } from "@dust/react-hooks"
@@ -199,10 +215,20 @@ const comments = usePodFunction("<podId>/list-comments", { threadId })
 const addComment = usePodFunctionMutation("<podId>/post-comment")
 
 async function handleAddComment(body: string) {
-  await addComment.trigger({ threadId, body })
-  await comments.mutate()
+  const updatedComments = await addComment.trigger({ threadId, body })
+  await comments.mutate(updatedComments, { revalidate: false })
 }
 \`\`\`
+
+For immediate feedback, apply an optimistic cache update before triggering the mutation and replace
+it with the authoritative mutation result afterward. Roll the optimistic value back if the mutation
+fails. Only call \`mutate()\` without data when the mutation cannot return the affected state; do not
+make a blocking mutation-then-refetch sequence the default.
+
+Do not call \`callFunction\` from an effect for data that can use these hooks. Do not poll every
+second. Prefer event-driven invalidation; when polling is unavoidable, use an interval of at least
+5–10 seconds, pause while the document is hidden, add jitter/backoff, and never start a new request
+while the previous one is still running.
 
 Call mutation handlers from a button or another supported in-Frame interaction. Do not model this
 as HTML form submission because forms cannot run inside the Frame iframe.
@@ -225,7 +251,7 @@ The existing imperative \`callFunction\` remains available unchanged for explici
 takes \`<podId>/<slug>\` or a function id. Pod functions are only reachable from authenticated Pod
 Frames, not from public or shared Frames.`,
   mcpServers: [{ name: SANDBOX_FUNCTIONS_SERVER_NAME }],
-  version: 4,
+  version: 5,
   icon: "PuzzleIcon",
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);

--- a/viz/app/lib/pod-function-hooks.test.tsx
+++ b/viz/app/lib/pod-function-hooks.test.tsx
@@ -190,12 +190,8 @@ describe("usePodFunction", () => {
     expect(result.current.mutate).toBe(mutate);
   });
 
-  it("shows cached data while revalidating when a query remounts", async () => {
-    const remountRequest = deferred<unknown>();
-    const callFunction = vi
-      .fn()
-      .mockResolvedValueOnce([{ id: 1 }])
-      .mockReturnValueOnce(remountRequest.promise);
+  it("serves cached data without revalidating when a query remounts immediately", async () => {
+    const callFunction = vi.fn().mockResolvedValue([{ id: 1 }]);
     const { result, rerender } = renderHook(
       ({ slug }: { slug: string | null }) =>
         usePodFunction(slug, { threadId: "thread-1" }),
@@ -210,14 +206,9 @@ describe("usePodFunction", () => {
     rerender({ slug: null });
     rerender({ slug: "vlt_123/list-comments" });
 
-    await waitFor(() => expect(callFunction).toHaveBeenCalledTimes(2));
     expect(result.current.data).toEqual([{ id: 1 }]);
-    expect(result.current.isValidating).toBe(true);
-
-    remountRequest.resolve([{ id: 1 }, { id: 2 }]);
-    await waitFor(() =>
-      expect(result.current.data).toEqual([{ id: 1 }, { id: 2 }])
-    );
+    expect(result.current.isValidating).toBe(false);
+    expect(callFunction).toHaveBeenCalledTimes(1);
   });
 
   it("normalizes function failures without retrying", async () => {
@@ -370,13 +361,12 @@ describe("usePodFunctionMutation", () => {
     expect(callFunction).not.toHaveBeenCalled();
   });
 
-  it("supports explicit query revalidation after a successful write", async () => {
-    const comments = [[{ id: 1 }], [{ id: 1 }, { id: 2 }]];
+  it("updates query data from a mutation result without revalidating", async () => {
     const callFunction = vi.fn(async (functionId: string) => {
       if (functionId.endsWith("/post-comment")) {
-        return { id: 2 };
+        return [{ id: 1 }, { id: 2 }];
       }
-      return comments.shift();
+      return [{ id: 1 }];
     });
     const { result } = renderHook(
       () => ({
@@ -390,12 +380,15 @@ describe("usePodFunctionMutation", () => {
 
     await waitFor(() => expect(result.current.list.data).toEqual([{ id: 1 }]));
     await act(async () => {
-      await result.current.post.trigger({
+      const updatedComments = await result.current.post.trigger({
         threadId: "thread-1",
         body: "Second",
       });
-      await result.current.list.mutate();
+      await result.current.list.mutate(updatedComments, {
+        revalidate: false,
+      });
     });
     expect(result.current.list.data).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(callFunction).toHaveBeenCalledTimes(2);
   });
 });

--- a/viz/app/lib/pod-function-hooks.tsx
+++ b/viz/app/lib/pod-function-hooks.tsx
@@ -13,7 +13,7 @@ import {
   useRef,
   useState,
 } from "react";
-import useSWR, { SWRConfig } from "swr";
+import useSWR, { type KeyedMutator, SWRConfig } from "swr";
 import useSWRMutation from "swr/mutation";
 
 interface PodFunctionContextValue {
@@ -29,7 +29,7 @@ export interface UsePodFunctionResult {
   error: Error | undefined;
   isLoading: boolean;
   isValidating: boolean;
-  mutate: () => Promise<unknown>;
+  mutate: KeyedMutator<unknown>;
 }
 
 export interface UsePodFunctionMutationResult {
@@ -42,6 +42,7 @@ export interface UsePodFunctionMutationResult {
 
 type PodFunctionQueryKey = readonly ["pod-function", string, unknown];
 type PodFunctionMutationKey = readonly ["pod-function-mutation", string];
+const POD_FUNCTION_QUERY_DEDUPING_INTERVAL_MS = 2_000;
 
 const PodFunctionContext = createContext<PodFunctionContextValue | null>(null);
 
@@ -112,7 +113,7 @@ export function usePodFunction(
       }
     },
     {
-      dedupingInterval: 0,
+      dedupingInterval: POD_FUNCTION_QUERY_DEDUPING_INTERVAL_MS,
       errorRetryCount: 0,
       keepPreviousData: true,
       refreshInterval: 0,


### PR DESCRIPTION
## Description

- Let Frame reads cache identical Pod Function calls and deduplicate immediate query remounts.
- Let mutation results update the affected query cache without a blocking refetch.
- Refine agent guidance for Frame-specific function contracts and query/mutation hook usage.
- Document that authenticated workspace members can call Pod Functions from shared Frames while anonymous viewers cannot.

## Tests

- Updated the hook tests for mutation cache updates and remount deduplication.
- Passed all 15 focused hook tests.
- Passed the front typecheck.

## Risk

The hook API change is additive. The two-second deduplication window applies to automatic remounts of an identical query; explicit `mutate()` revalidation remains immediate, and this PR imposes no minimum polling interval. The prompt version is bumped so the refined Frame guidance applies to newly generated Frames.

## Deploy Plan

This PR changes both Front and Viz.

1. Deploy Front so the updated Pod Function skill guidance is available.
2. Deploy Viz so the query deduplication and mutation cache updates are active in Frame runtimes.
3. Smoke-test a Pod Function-backed Frame read and mutation, including an authenticated shared Frame.
