### PR TITLE
Return Pod Function results to the worker

### DIFF
--- a/cli/dust-sandbox/src/commands/function/run.rs
+++ b/cli/dust-sandbox/src/commands/function/run.rs
@@ -4,14 +4,18 @@ use super::{emit_error, spawn_function};
 use crate::api::DustApiClient;
 
 const SANDBOX_TOKEN_ENV: &str = "DUST_SANDBOX_TOKEN";
+const RESULT_TRANSPORT_ENV: &str = "DUST_SANDBOX_FUNCTION_RESULT_TRANSPORT";
+const STDOUT_RESULT_TRANSPORT: &str = "stdout";
+
+fn should_return_result_via_stdout(have_token: bool, configured_transport: Option<&str>) -> bool {
+    !have_token || configured_transport == Some(STDOUT_RESULT_TRANSPORT)
+}
 
 /// Execute a function and deliver its response.
 ///
 /// The request envelope is read from stdin and the function runs unprivileged
-/// (agent uid) when dsbx is invoked as root. The response is then delivered to
-/// the Dust result API. As a testing/local convenience, when there is no sandbox
-/// token (`DUST_SANDBOX_TOKEN` unset/empty) the API call is skipped and the
-/// response is written to dsbx's stdout instead (the previous behavior).
+/// (agent uid) when dsbx is invoked as root. New callers request the response
+/// on stdout. The result API remains the default for older front deployments.
 pub async fn cmd_function_run(name: &str) -> Result<()> {
     let (code, captured) = spawn_function("run", name, true, true).await?;
     let response = captured.unwrap_or_default();
@@ -19,9 +23,9 @@ pub async fn cmd_function_run(name: &str) -> Result<()> {
     let have_token = std::env::var(SANDBOX_TOKEN_ENV)
         .map(|t| !t.is_empty())
         .unwrap_or(false);
+    let configured_transport = std::env::var(RESULT_TRANSPORT_ENV).ok();
 
-    // No sandbox token: local/testing — emit the response on stdout, as before.
-    if !have_token {
+    if should_return_result_via_stdout(have_token, configured_transport.as_deref()) {
         print!("{response}");
         std::process::exit(code);
     }
@@ -43,4 +47,24 @@ pub async fn cmd_function_run(name: &str) -> Result<()> {
         .await
         .map_err(emit_error)?;
     std::process::exit(0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_return_result_via_stdout;
+
+    #[test]
+    fn returns_results_on_stdout_for_local_calls() {
+        assert!(should_return_result_via_stdout(false, None));
+    }
+
+    #[test]
+    fn returns_results_on_stdout_when_front_requests_it() {
+        assert!(should_return_result_via_stdout(true, Some("stdout")));
+    }
+
+    #[test]
+    fn preserves_the_callback_for_older_front_deployments() {
+        assert!(!should_return_result_via_stdout(true, None));
+    }
 }

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
@@ -1,120 +1,13 @@
 import { isSandboxFunctionInvocationTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import { normalizeSandboxFunctionRunnerOutput } from "@app/lib/api/sandbox_functions/runner_output";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
-import type { SandboxFunctionCallError } from "@app/types/api/sandbox_functions";
-import { SANDBOX_FUNCTION_RUNNER_ERROR_CODES } from "@app/types/api/sandbox_functions";
 import { sandboxApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { SuccessResponseBody } from "@front-api/routes/types";
 import { z } from "zod";
-
-type JsonValue = null | boolean | number | string | object;
-const DefinedJsonValueSchema = z.custom<JsonValue>((v) => v !== undefined);
-const SandboxFunctionRunnerOutputSchema = z.discriminatedUnion("ok", [
-  z.object({ ok: z.literal(true), output: DefinedJsonValueSchema }).strict(),
-  z
-    .object({
-      ok: z.literal(false),
-      error: z
-        .object({
-          code: z.enum(SANDBOX_FUNCTION_RUNNER_ERROR_CODES),
-          message: z.string(),
-          status: z.number().int().optional(),
-        })
-        .strict(),
-    })
-    .strict(),
-]);
-
-const LegacySandboxFunctionRunnerOutputSchema = z.discriminatedUnion("ok", [
-  z
-    .object({
-      ok: z.literal(true),
-      response: z
-        .object({
-          status: z.number().int(),
-          headers: z.record(z.string(), z.string()),
-          body: z.string().nullable(),
-          encoding: z.enum(["utf8", "base64"]),
-        })
-        .strict(),
-    })
-    .strict(),
-  z
-    .object({
-      ok: z.literal(false),
-      error: z
-        .object({
-          kind: z.enum(["bad_input", "import_failed", "threw", "bad_return"]),
-          message: z.string(),
-          stack: z.string().optional(),
-        })
-        .strict(),
-    })
-    .strict(),
-]);
-
-type NormalizedRunnerOutput =
-  | { ok: true; output: unknown }
-  | { ok: false; error: SandboxFunctionCallError };
-
-function normalizeRunnerOutput(result: unknown): NormalizedRunnerOutput {
-  const current = SandboxFunctionRunnerOutputSchema.safeParse(result);
-  if (current.success) {
-    return current.data;
-  }
-
-  const legacy = LegacySandboxFunctionRunnerOutputSchema.safeParse(result);
-  if (!legacy.success) {
-    return {
-      ok: false,
-      error: {
-        code: "invocation_failed",
-        message: "Sandbox function returned an invalid result envelope.",
-      },
-    };
-  }
-
-  if (!legacy.data.ok) {
-    return {
-      ok: false,
-      error: {
-        code: legacy.data.error.kind,
-        message: legacy.data.error.message,
-      },
-    };
-  }
-
-  const { response } = legacy.data;
-  const body =
-    response.body === null
-      ? ""
-      : Buffer.from(response.body, response.encoding).toString("utf8");
-  if (response.status < 200 || response.status >= 300) {
-    return {
-      ok: false,
-      error: {
-        code: "http_error",
-        message: `Function returned HTTP ${response.status}${body ? `: ${body}` : "."}`,
-        status: response.status,
-      },
-    };
-  }
-
-  try {
-    return { ok: true, output: JSON.parse(body) };
-  } catch {
-    return {
-      ok: false,
-      error: {
-        code: "invalid_output",
-        message: "Function response body is not valid JSON.",
-      },
-    };
-  }
-}
 
 const PostSandboxFunctionResultRequestBodySchema = z
   .object({
@@ -175,7 +68,7 @@ app.post(
       });
     }
 
-    const normalized = normalizeRunnerOutput(result);
+    const normalized = normalizeSandboxFunctionRunnerOutput(result);
     if (normalized.ok) {
       await invocation.succeed(normalized.output);
     } else {

--- a/front/lib/api/sandbox_functions/runner_output.ts
+++ b/front/lib/api/sandbox_functions/runner_output.ts
@@ -1,0 +1,129 @@
+import type { SandboxFunctionCallError } from "@app/types/api/sandbox_functions";
+import { SANDBOX_FUNCTION_RUNNER_ERROR_CODES } from "@app/types/api/sandbox_functions";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
+import { z } from "zod";
+
+type JsonValue = null | boolean | number | string | object;
+const DefinedJsonValueSchema = z.custom<JsonValue>(
+  (value) => value !== undefined
+);
+const SandboxFunctionRunnerOutputSchema = z.discriminatedUnion("ok", [
+  z.object({ ok: z.literal(true), output: DefinedJsonValueSchema }).strict(),
+  z
+    .object({
+      ok: z.literal(false),
+      error: z
+        .object({
+          code: z.enum(SANDBOX_FUNCTION_RUNNER_ERROR_CODES),
+          message: z.string(),
+          status: z.number().int().optional(),
+        })
+        .strict(),
+    })
+    .strict(),
+]);
+
+const LegacySandboxFunctionRunnerOutputSchema = z.discriminatedUnion("ok", [
+  z
+    .object({
+      ok: z.literal(true),
+      response: z
+        .object({
+          status: z.number().int(),
+          headers: z.record(z.string(), z.string()),
+          body: z.string().nullable(),
+          encoding: z.enum(["utf8", "base64"]),
+        })
+        .strict(),
+    })
+    .strict(),
+  z
+    .object({
+      ok: z.literal(false),
+      error: z
+        .object({
+          kind: z.enum(["bad_input", "import_failed", "threw", "bad_return"]),
+          message: z.string(),
+          stack: z.string().optional(),
+        })
+        .strict(),
+    })
+    .strict(),
+]);
+
+export type NormalizedSandboxFunctionRunnerOutput =
+  | { ok: true; output: unknown }
+  | { ok: false; error: SandboxFunctionCallError };
+
+export function parseSandboxFunctionRunnerOutput(
+  result: unknown
+): Result<NormalizedSandboxFunctionRunnerOutput, Error> {
+  const current = SandboxFunctionRunnerOutputSchema.safeParse(result);
+  if (current.success) {
+    return new Ok(current.data);
+  }
+
+  const legacy = LegacySandboxFunctionRunnerOutputSchema.safeParse(result);
+  if (!legacy.success) {
+    return new Err(
+      new Error("Sandbox function returned an invalid result envelope.")
+    );
+  }
+
+  if (!legacy.data.ok) {
+    return new Ok({
+      ok: false,
+      error: {
+        code: legacy.data.error.kind,
+        message: legacy.data.error.message,
+      },
+    });
+  }
+
+  const { response } = legacy.data;
+  const body =
+    response.body === null
+      ? ""
+      : Buffer.from(response.body, response.encoding).toString("utf8");
+  if (response.status < 200 || response.status >= 300) {
+    return new Ok({
+      ok: false,
+      error: {
+        code: "http_error",
+        message: `Function returned HTTP ${response.status}${body ? `: ${body}` : "."}`,
+        status: response.status,
+      },
+    });
+  }
+
+  const parsedBody = safeParseJSON(body);
+  if (parsedBody.isErr()) {
+    return new Ok({
+      ok: false,
+      error: {
+        code: "invalid_output",
+        message: "Function response body is not valid JSON.",
+      },
+    });
+  }
+
+  return new Ok({ ok: true, output: parsedBody.value });
+}
+
+export function normalizeSandboxFunctionRunnerOutput(
+  result: unknown
+): NormalizedSandboxFunctionRunnerOutput {
+  const parsed = parseSandboxFunctionRunnerOutput(result);
+  if (parsed.isOk()) {
+    return parsed.value;
+  }
+
+  return {
+    ok: false,
+    error: {
+      code: "invocation_failed",
+      message: parsed.error.message,
+    },
+  };
+}

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -450,7 +450,10 @@ describe("SandboxFunctionInvocationResource", () => {
     const execSpy = vi.spyOn(sandbox, "exec").mockResolvedValue(
       new Ok({
         exitCode: 0,
-        stdout: "hello world\n",
+        stdout: `${JSON.stringify({
+          ok: true,
+          output: { commentId: "comment-1" },
+        })}\n`,
         stderr: "",
       })
     );
@@ -472,7 +475,8 @@ describe("SandboxFunctionInvocationResource", () => {
         sandboxFunction,
         invocationId: invocation.sId,
       });
-    expect(refetchedInvocation?.status).toBe("created");
+    expect(refetchedInvocation?.status).toBe("succeeded");
+    expect(refetchedInvocation?.result).toEqual({ commentId: "comment-1" });
     expect(updateLastActivityAtSpy).toHaveBeenCalledOnce();
     expect(ensurePodSandboxReady).toHaveBeenCalledWith(authenticator, space);
     expect(generateSandboxFunctionInvocationToken).toHaveBeenCalledWith(
@@ -499,6 +503,7 @@ describe("SandboxFunctionInvocationResource", () => {
       DUST_POD_DATABASES_DIR: "/pod-state/databases",
       DUST_POD_DATABASE_MAX_SIZE_BYTES: "1073741824",
       DUST_SANDBOX_TOKEN: "sbt-function-token",
+      DUST_SANDBOX_FUNCTION_RESULT_TRANSPORT: "stdout",
     });
     expect(opts?.user).toBe("agent-proxied");
     expect(opts?.workingDirectory).toBe("/home/agent");
@@ -517,6 +522,64 @@ describe("SandboxFunctionInvocationResource", () => {
       },
       body: JSON.stringify({ message: "hello" }),
       encoding: "utf8",
+    });
+  });
+
+  it("persists a structured runner error returned on stdout", async () => {
+    const { authenticator, sandboxFunction, sandbox, invocation } =
+      await setupExecutionTest();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 1,
+        stdout: `${JSON.stringify({
+          ok: false,
+          error: {
+            code: "invalid_output",
+            message: "Output did not match the schema.",
+          },
+        })}\n`,
+        stderr: "",
+      })
+    );
+
+    const result = await invocation.execute(authenticator);
+
+    expect(result.isOk()).toBe(true);
+    const refetchedInvocation =
+      await SandboxFunctionInvocationResource.fetchById(authenticator, {
+        sandboxFunction,
+        invocationId: invocation.sId,
+      });
+    expect(refetchedInvocation?.status).toBe("errored");
+    expect(refetchedInvocation?.error).toEqual({
+      code: "invalid_output",
+      message: "Output did not match the schema.",
+    });
+  });
+
+  it("accepts a terminal callback from an older dsbx image", async () => {
+    const { authenticator, sandboxFunction, sandbox, invocation } =
+      await setupExecutionTest();
+    vi.spyOn(sandbox, "exec").mockImplementation(async () => {
+      await invocation.succeed({ commentId: "callback-result" });
+      return new Ok({
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+      });
+    });
+
+    const result = await invocation.execute(authenticator);
+
+    expect(result.isOk()).toBe(true);
+    const refetchedInvocation =
+      await SandboxFunctionInvocationResource.fetchById(authenticator, {
+        sandboxFunction,
+        invocationId: invocation.sId,
+      });
+    expect(refetchedInvocation?.status).toBe("succeeded");
+    expect(refetchedInvocation?.result).toEqual({
+      commentId: "callback-result",
     });
   });
 

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -10,6 +10,7 @@ import {
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
+import { parseSandboxFunctionRunnerOutput } from "@app/lib/api/sandbox_functions/runner_output";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -49,6 +50,7 @@ import { fromError } from "zod-validation-error";
 const SANDBOX_FUNCTION_WORKING_DIRECTORY = "/home/agent";
 const SANDBOX_FUNCTION_EXEC_TIMEOUT_MS = 2 * 60 * 1000;
 const DSBX_BIN_PATH = "/opt/bin/dsbx";
+const SANDBOX_FUNCTION_RESULT_TRANSPORT = "stdout";
 // Caps on runner output surfaced on failure: a small head for the error forwarded to the agent,
 // a larger one for the log fields.
 const SANDBOX_FUNCTION_ERROR_DETAIL_MAX_CHARS = 2_048;
@@ -318,6 +320,8 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
           ),
           ...podDatabaseExecEnvVars(),
           DUST_SANDBOX_TOKEN: token,
+          DUST_SANDBOX_FUNCTION_RESULT_TRANSPORT:
+            SANDBOX_FUNCTION_RESULT_TRANSPORT,
         },
         stdin: JSON.stringify(inputEnvelope),
         timeoutMs: SANDBOX_FUNCTION_EXEC_TIMEOUT_MS,
@@ -326,8 +330,24 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       if (execResult.isErr()) {
         return execResult;
       }
+
+      const { exitCode, stdout, stderr } = execResult.value;
+      const parsedStdout = safeParseJSON(stdout.trim());
+      if (parsedStdout.isOk()) {
+        const runnerOutput = parseSandboxFunctionRunnerOutput(
+          parsedStdout.value
+        );
+        if (runnerOutput.isOk()) {
+          if (runnerOutput.value.ok) {
+            await this.succeed(runnerOutput.value.output);
+          } else {
+            await this.fail(runnerOutput.value.error);
+          }
+          return new Ok(undefined);
+        }
+      }
+
       if (execResult.value.exitCode !== 0) {
-        const { exitCode, stdout, stderr } = execResult.value;
         logger.error(
           {
             workspaceId: auth.getNonNullableWorkspace().sId,
@@ -356,10 +376,35 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         );
       }
 
+      // Older dsbx images ignore the result-transport setting and complete
+      // through the callback endpoint. The callback finishes before dsbx
+      // exits, so a terminal database status proves that path completed.
+      const persistedStatus = await this.fetchPersistedStatus();
+      if (persistedStatus === "succeeded" || persistedStatus === "errored") {
+        return new Ok(undefined);
+      }
+
+      const error = {
+        code: "invocation_failed" as const,
+        message: "Sandbox function returned an invalid result envelope.",
+      };
+      await this.fail(error);
       return new Ok(undefined);
     } catch (error) {
       return new Err(normalizeError(error));
     }
+  }
+
+  private async fetchPersistedStatus(): Promise<SandboxFunctionInvocationStatus | null> {
+    const invocation = await SandboxFunctionInvocationResource.model.findOne({
+      attributes: ["status"],
+      where: {
+        id: this.id,
+        workspaceId: this.workspaceId,
+      },
+    });
+
+    return invocation?.status ?? null;
   }
 
   static modelIdToSId({


### PR DESCRIPTION
## Description

- Return structured Pod Function results on stdout to the owning worker.
- Parse and persist the result in the worker without an extra HTTP callback.
- Keep the callback endpoint and add rollout compatibility for old workers and old runner images.
- Share result-envelope parsing between direct results and the callback route.

## Tests

- Passed 18 focused invocation resource tests and 6 result endpoint tests.
- Passed front and front API typechecks and the Swagger annotation lint.
- Passed all 265 Rust tests.

## Risk

The new stdout transport is enabled only when the front worker sets its environment flag. New runners still use the callback with old workers, and new workers accept callback completion from old runners.

## Deploy Plan

The front worker and runner image can roll in either order because both mixed-version paths are covered. Keep the callback endpoint until old runner images have drained.
