### PR TITLE
Avoid resumable uploads for Pod Function payloads

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.test.ts
@@ -26,6 +26,11 @@ vi.mock("@app/lib/file_storage", () => ({
     delete: vi.fn(async (path: string) => {
       gcsStore.delete(path);
     }),
+    uploadBufferToBucket: vi.fn(
+      async ({ buffer, filePath }: { buffer: Buffer; filePath: string }) => {
+        gcsStore.set(filePath, buffer);
+      }
+    ),
   })),
 }));
 

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -313,6 +313,11 @@ describe("SandboxFunctionInvocationResource", () => {
     expect(fileStorageMock.getObject(invocation.gcsPath!)).toBe(
       JSON.stringify({ version: 2, input: { message: "hello" } })
     );
+    expect(fileStorageMock.saveFileCalls).toContainEqual({
+      filePath: invocation.gcsPath,
+      content: expect.any(Buffer),
+      contentType: "application/json",
+    });
 
     const refetched = await SandboxFunctionInvocationResource.fetchById(
       authenticator,

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -610,15 +610,14 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   }
 
   private async writeDataToGcs(): Promise<Result<undefined, Error>> {
-    const writeResult = await withRetry(() =>
-      getPrivateUploadBucket()
-        .file(this.gcsPath)
-        .save(Buffer.from(JSON.stringify(this.data), "utf-8"), {
-          contentType: "application/json",
-        })
-    );
-    if (writeResult.isErr()) {
-      return writeResult;
+    try {
+      await getPrivateUploadBucket().uploadBufferToBucket({
+        buffer: Buffer.from(JSON.stringify(this.data), "utf-8"),
+        contentType: "application/json",
+        filePath: this.gcsPath,
+      });
+    } catch (err) {
+      return new Err(normalizeError(err));
     }
     return new Ok(undefined);
   }

--- a/front/lib/resources/sandbox_function_mcp_action_resource.test.ts
+++ b/front/lib/resources/sandbox_function_mcp_action_resource.test.ts
@@ -35,6 +35,11 @@ vi.mock("@app/lib/file_storage", () => ({
       }
       gcsStore.delete(path);
     }),
+    uploadBufferToBucket: vi.fn(
+      async ({ buffer, filePath }: { buffer: Buffer; filePath: string }) => {
+        gcsStore.set(filePath, buffer);
+      }
+    ),
   })),
 }));
 

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -245,6 +245,12 @@ class FileStorageMock {
       uploadFileToBucket: vi.fn().mockResolvedValue(undefined),
       uploadBufferToBucket: vi.fn(
         (args: { buffer: Buffer; contentType: string; filePath: string }) => {
+          if (this._saveShouldFail(args.filePath)) {
+            return Promise.reject(
+              new Error(`Simulated GCS write failure: ${args.filePath}`)
+            );
+          }
+          this._objectStore.set(args.filePath, args.buffer.toString());
           this._saveFileCalls.push({
             filePath: args.filePath,
             content: args.buffer,


### PR DESCRIPTION
## Description

- Route small Pod Function invocation payloads through the existing non-resumable upload helper.
- Retain transient retry behavior while removing resumable-session setup from the hot path.
- Extend the storage mock and test the persisted content type and path.

## Tests

- Passed all 16 focused invocation resource tests.
- Passed the front typecheck.

## Risk

Pod Function payloads are already buffered before upload, so this changes only the GCS upload mode and retry path.

## Deploy Plan

Standard deploy.
