### PR TITLE
Stop assigning the builder role from Poke plugins

### DIFF
--- a/front/components/members/RolesDropDown.tsx
+++ b/front/components/members/RolesDropDown.tsx
@@ -6,7 +6,7 @@ import {
 } from "@app/components/members/Roles";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import type { ActiveRoleType } from "@app/types/user";
-import { ACTIVE_ROLES, isAdmin } from "@app/types/user";
+import { ASSIGNABLE_ROLES, isAdmin } from "@app/types/user";
 import {
   Button,
   ChevronDown,
@@ -34,11 +34,7 @@ export function RoleDropDown({
   // `builder` is deprecated: display it as a regular member.
   const displayedRole = normalizeDisplayRole(selectedRole);
 
-  const availableRoles = ACTIVE_ROLES.filter((role) => {
-    // `builder` is deprecated and can no longer be assigned.
-    if (role === "builder") {
-      return false;
-    }
+  const availableRoles = ASSIGNABLE_ROLES.filter((role) => {
     // `admin` can only be assigned by those allowed to manage the admin role
     // (matches the server-side escalation guard).
     if (role === "admin" && !canManageAdminRole) {

--- a/front/components/poke/members/MembersBulkActions.tsx
+++ b/front/components/poke/members/MembersBulkActions.tsx
@@ -5,7 +5,7 @@ import { useAppRouter } from "@app/lib/platform";
 import type { MembershipSeatType } from "@app/types/memberships";
 import { MEMBERSHIP_SEAT_TYPES } from "@app/types/memberships";
 import type { ActiveRoleType, WorkspaceType } from "@app/types/user";
-import { ACTIVE_ROLES } from "@app/types/user";
+import { ASSIGNABLE_ROLES } from "@app/types/user";
 import {
   Button,
   DropdownMenu,
@@ -115,7 +115,7 @@ export function MembersBulkActions({
           />
         </DropdownMenuTrigger>
         <DropdownMenuContent>
-          {ACTIVE_ROLES.map((role) => (
+          {ASSIGNABLE_ROLES.map((role) => (
             <DropdownMenuItem key={role} onClick={() => onSetRole(role)}>
               {role}
             </DropdownMenuItem>

--- a/front/components/poke/members/columns.tsx
+++ b/front/components/poke/members/columns.tsx
@@ -6,7 +6,7 @@ import type {
 } from "@app/types/memberships";
 import { MEMBERSHIP_SEAT_TYPES } from "@app/types/memberships";
 import type { ActiveRoleType, RoleType } from "@app/types/user";
-import { ACTIVE_ROLES } from "@app/types/user";
+import { ASSIGNABLE_ROLES } from "@app/types/user";
 import { IconButton, Trash01 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
@@ -147,7 +147,14 @@ export function makeColumnsForMembers({
                 revoked
               </option>
             )}
-            {ACTIVE_ROLES.map((role) => (
+            {member.role === "builder" && (
+              // `builder` is deprecated and no longer assignable, but legacy
+              // builders still need to display their current role.
+              <option value="builder" disabled>
+                builder
+              </option>
+            )}
+            {ASSIGNABLE_ROLES.map((role) => (
               <option key={role} value={role}>
                 {role}
               </option>

--- a/front/lib/api/poke/plugins/workspaces/batch_update_members.ts
+++ b/front/lib/api/poke/plugins/workspaces/batch_update_members.ts
@@ -23,7 +23,7 @@ import {
 } from "@app/types/memberships";
 import { mapToEnumValues } from "@app/types/poke/plugins";
 import { Err, Ok } from "@app/types/shared/result";
-import { ACTIVE_ROLES, isActiveRoleType } from "@app/types/user";
+import { ASSIGNABLE_ROLES, isActiveRoleType } from "@app/types/user";
 
 // One email per line; trim, lowercase and dedupe.
 function parseEmails(raw: string): string[] {
@@ -76,7 +76,9 @@ export const batchUpdateMembersPlugin = createPlugin({
         label: "Role",
         description:
           "The role to assign (used when the action is 'Update role').",
-        values: mapToEnumValues(ACTIVE_ROLES, (role) => ({
+        // The deprecated `builder` role can no longer be assigned; it is granted only through the
+        // `dust-builders` provisioning group.
+        values: mapToEnumValues(ASSIGNABLE_ROLES, (role) => ({
           label: role,
           value: role,
         })),
@@ -229,7 +231,7 @@ export const batchUpdateMembersPlugin = createPlugin({
 
       case "update_role": {
         const role = args.role[0];
-        if (!role || !isActiveRoleType(role)) {
+        if (!role || !isActiveRoleType(role) || role === "builder") {
           return new Err(new Error("Please select a role."));
         }
 

--- a/front/lib/api/poke/plugins/workspaces/batch_update_members.ts
+++ b/front/lib/api/poke/plugins/workspaces/batch_update_members.ts
@@ -23,7 +23,7 @@ import {
 } from "@app/types/memberships";
 import { mapToEnumValues } from "@app/types/poke/plugins";
 import { Err, Ok } from "@app/types/shared/result";
-import { ASSIGNABLE_ROLES, isActiveRoleType } from "@app/types/user";
+import { ASSIGNABLE_ROLES, isAssignableRoleType } from "@app/types/user";
 
 // One email per line; trim, lowercase and dedupe.
 function parseEmails(raw: string): string[] {
@@ -76,8 +76,6 @@ export const batchUpdateMembersPlugin = createPlugin({
         label: "Role",
         description:
           "The role to assign (used when the action is 'Update role').",
-        // The deprecated `builder` role can no longer be assigned; it is granted only through the
-        // `dust-builders` provisioning group.
         values: mapToEnumValues(ASSIGNABLE_ROLES, (role) => ({
           label: role,
           value: role,
@@ -231,7 +229,7 @@ export const batchUpdateMembersPlugin = createPlugin({
 
       case "update_role": {
         const role = args.role[0];
-        if (!role || !isActiveRoleType(role) || role === "builder") {
+        if (!role || !isAssignableRoleType(role)) {
           return new Err(new Error("Please select a role."));
         }
 

--- a/front/lib/api/poke/plugins/workspaces/invite_user.ts
+++ b/front/lib/api/poke/plugins/workspaces/invite_user.ts
@@ -5,11 +5,10 @@ import {
 import { handleMembershipInvitations } from "@app/lib/api/invitation";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { isEmailValid } from "@app/lib/utils";
-import { isMembershipRoleType } from "@app/types/memberships";
 import { mapToEnumValues } from "@app/types/poke/plugins";
 import { Err, Ok } from "@app/types/shared/result";
 import { pluralize } from "@app/types/shared/utils/string_utils";
-import { ASSIGNABLE_ROLES } from "@app/types/user";
+import { ASSIGNABLE_ROLES, isAssignableRoleType } from "@app/types/user";
 
 export const inviteUser = createPlugin({
   manifest: {
@@ -28,8 +27,6 @@ export const inviteUser = createPlugin({
         type: "enum",
         label: "Role",
         description: "Role of the user to invite",
-        // The deprecated `builder` role can no longer be assigned; it is granted only through the
-        // `dust-builders` provisioning group.
         values: mapToEnumValues(ASSIGNABLE_ROLES, (role) => ({
           label: role,
           value: role,
@@ -81,10 +78,8 @@ export const inviteUser = createPlugin({
       );
     }
 
-    // The deprecated `builder` role can no longer be assigned; it is granted only through the
-    // `dust-builders` provisioning group.
     const role = args.role[0];
-    if (!role || !isMembershipRoleType(role) || role === "builder") {
+    if (!role || !isAssignableRoleType(role)) {
       return new Err(new Error("Please select a valid role."));
     }
 

--- a/front/lib/api/poke/plugins/workspaces/invite_user.ts
+++ b/front/lib/api/poke/plugins/workspaces/invite_user.ts
@@ -5,11 +5,11 @@ import {
 import { handleMembershipInvitations } from "@app/lib/api/invitation";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { isEmailValid } from "@app/lib/utils";
-import type { MembershipRoleType } from "@app/types/memberships";
-import { MEMBERSHIP_ROLE_TYPES } from "@app/types/memberships";
+import { isMembershipRoleType } from "@app/types/memberships";
 import { mapToEnumValues } from "@app/types/poke/plugins";
 import { Err, Ok } from "@app/types/shared/result";
 import { pluralize } from "@app/types/shared/utils/string_utils";
+import { ASSIGNABLE_ROLES } from "@app/types/user";
 
 export const inviteUser = createPlugin({
   manifest: {
@@ -28,7 +28,9 @@ export const inviteUser = createPlugin({
         type: "enum",
         label: "Role",
         description: "Role of the user to invite",
-        values: mapToEnumValues(MEMBERSHIP_ROLE_TYPES, (role) => ({
+        // The deprecated `builder` role can no longer be assigned; it is granted only through the
+        // `dust-builders` provisioning group.
+        values: mapToEnumValues(ASSIGNABLE_ROLES, (role) => ({
           label: role,
           value: role,
         })),
@@ -79,15 +81,19 @@ export const inviteUser = createPlugin({
       );
     }
 
+    // The deprecated `builder` role can no longer be assigned; it is granted only through the
+    // `dust-builders` provisioning group.
+    const role = args.role[0];
+    if (!role || !isMembershipRoleType(role) || role === "builder") {
+      return new Err(new Error("Please select a valid role."));
+    }
+
     const invitationRes = await handleMembershipInvitations(auth, {
       owner: auth.getNonNullableWorkspace(),
       user: auth.getNonNullableUser().toJSON(),
       subscription,
       force: args.force,
-      invitationRequests: emails.map((email) => ({
-        email,
-        role: args.role[0] as MembershipRoleType,
-      })),
+      invitationRequests: emails.map((email) => ({ email, role })),
     });
 
     if (invitationRes.isErr()) {

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -16,8 +16,6 @@ export type WorkspaceSegmentationType = "interesting" | null;
 
 export const ROLES = ["admin", "manager", "builder", "user", "none"] as const;
 export const ACTIVE_ROLES = ["admin", "manager", "builder", "user"] as const;
-// Roles that can be explicitly assigned (invitations, role updates). Excludes the deprecated
-// `builder` role, which is granted only through the `dust-builders` provisioning group.
 export const ASSIGNABLE_ROLES = ["admin", "manager", "user"] as const;
 export const ANONYMOUS_USER_IMAGE_URL = "/static/humanavatar/anonymous.png";
 
@@ -45,6 +43,12 @@ export type ActiveRoleType = z.infer<typeof ActiveRoleSchema>;
 
 export function isActiveRoleType(role: string): role is ActiveRoleType {
   return ACTIVE_ROLES.includes(role as ActiveRoleType);
+}
+
+export type AssignableRoleType = (typeof ASSIGNABLE_ROLES)[number];
+
+export function isAssignableRoleType(role: string): role is AssignableRoleType {
+  return ASSIGNABLE_ROLES.includes(role as AssignableRoleType);
 }
 
 // Roles that can be assigned through the API (invitations, membership role updates). The

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -16,6 +16,9 @@ export type WorkspaceSegmentationType = "interesting" | null;
 
 export const ROLES = ["admin", "manager", "builder", "user", "none"] as const;
 export const ACTIVE_ROLES = ["admin", "manager", "builder", "user"] as const;
+// Roles that can be explicitly assigned (invitations, role updates). Excludes the deprecated
+// `builder` role, which is granted only through the `dust-builders` provisioning group.
+export const ASSIGNABLE_ROLES = ["admin", "manager", "user"] as const;
 export const ANONYMOUS_USER_IMAGE_URL = "/static/humanavatar/anonymous.png";
 
 export const MANAGER_ROLE_NAME = "manager";


### PR DESCRIPTION
## Description

Closes the last paths that could produce a builder membership: two Poke super-admin plugins still let an operator assign the deprecated `builder` role.

- **`batch_update_members`** ("Update role" action) exposed `builder` in its role dropdown (built from `ACTIVE_ROLES`) and passed it straight to `updateMembershipRoleAndTrack` — a real builder membership.
- **`invite_user`** exposed `builder` (from `MEMBERSHIP_ROLE_TYPES`) and created a builder invitation.

Both now:
- Build the role dropdown from a new `ASSIGNABLE_ROLES` tuple (`admin`/`manager`/`user`) in `front/types/user.ts`.
- Reject `builder` server-side in the handler (defense-in-depth beyond the dropdown).

`invite_user` also drops a non-type-safe `as MembershipRoleType` cast in favor of an `isMembershipRoleType` guard.

The `builder` role is now granted only through the `dust-builders` provisioning group (which feeds the manual "Builders" group, per the provisioning PR).

### Context

This is the Poke counterpart to the earlier steps — invitation acceptance downgrade (#29666), invitation/member role-update API rejection (#29674), and provisioning/`applyGroupRoles` (#29675). With this, no product or admin path assigns the builder role. (Dev/seed scripts and pre-existing DB memberships are unaffected; API-key builder *scope* is a separate concept, untouched.)

## Risks

Risk: low. Poke-only UI/validation change; `builder` was already hidden from the end-user product surfaces.

## Verification

- `tsgo --noEmit` clean in `front`; `biome check` clean on changed files.
- No tests exist for these poke plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)