### PR TITLE
Let agents finish active goals

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -750,6 +750,12 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "toolCostCategory": "advanced",
     },
   },
+  "goal_mode": {
+    "update_goal": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+  },
   "gong": {
     "get_call": {
       "freeUsage": false,
@@ -2836,6 +2842,9 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_thread": "never_ask",
     "send_mail": "high",
     "set_message_labels": "low",
+  },
+  "goal_mode": {
+    "update_goal": "never_ask",
   },
   "gong": {
     "get_call": "never_ask",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -34,6 +34,7 @@ import { FRESHSERVICE_SERVER } from "@app/lib/api/actions/servers/freshservice/m
 import { FRONT_SERVER } from "@app/lib/api/actions/servers/front/metadata";
 import { GITHUB_SERVER } from "@app/lib/api/actions/servers/github/metadata";
 import { GMAIL_SERVER } from "@app/lib/api/actions/servers/gmail/metadata";
+import { GOAL_MODE_SERVER } from "@app/lib/api/actions/servers/goal_mode/metadata";
 import { GONG_SERVER } from "@app/lib/api/actions/servers/gong/metadata";
 import { GOOGLE_CALENDAR_SERVER } from "@app/lib/api/actions/servers/google_calendar/metadata";
 import { GOOGLE_DRIVE_SERVER } from "@app/lib/api/actions/servers/google_drive/metadata";
@@ -238,6 +239,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "ask_user_question",
   "wakeups",
   "plan_mode",
+  "goal_mode",
   "workspace_analytics",
   "activation_recommendations",
 ] as const;
@@ -1165,6 +1167,17 @@ export const INTERNAL_MCP_SERVERS = ensureUniqueToolNames({
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     metadata: PLAN_MODE_SERVER,
+  },
+  goal_mode: {
+    id: 1044,
+    availability: "auto_hidden_builder",
+    allowMultipleInstances: false,
+    isRestricted: ({ featureFlags }) => !featureFlags.includes("goal_mode"),
+    isPreview: true,
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    metadata: GOAL_MODE_SERVER,
   },
   files: {
     id: 1033,

--- a/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
+++ b/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
@@ -38,7 +38,8 @@
     { "name": "user_analytics", "id": 1039 },
     { "name": "activation_recommendations", "id": 1040 },
     { "name": "agent_templates", "id": 1041 },
-    { "name": "user_memory", "id": 1043 }
+    { "name": "user_memory", "id": 1043 },
+    { "name": "goal_mode", "id": 1044 }
   ],
   "manual": [
     { "name": "github", "id": 1 },

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -29,6 +29,7 @@ import { default as freshserviceServer } from "@app/lib/api/actions/servers/fres
 import { default as frontServer } from "@app/lib/api/actions/servers/front";
 import { default as githubServer } from "@app/lib/api/actions/servers/github";
 import { default as gmailServer } from "@app/lib/api/actions/servers/gmail";
+import { default as goalModeServer } from "@app/lib/api/actions/servers/goal_mode";
 import { default as gongServer } from "@app/lib/api/actions/servers/gong";
 import { default as calendarServer } from "@app/lib/api/actions/servers/google_calendar";
 import { default as driveServer } from "@app/lib/api/actions/servers/google_drive";
@@ -286,6 +287,8 @@ export async function getInternalMCPServer(
       return wakeupsServer(auth, toolContext);
     case "plan_mode":
       return planModeServer(auth, toolContext);
+    case "goal_mode":
+      return goalModeServer(auth, toolContext);
     case "workday":
       return workdayServer(auth, toolContext);
     case "user_analytics":

--- a/front/lib/api/actions/servers/goal_mode/index.ts
+++ b/front/lib/api/actions/servers/goal_mode/index.ts
@@ -1,0 +1,24 @@
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { ToolContext } from "@app/lib/actions/types";
+import { GOAL_MODE_SERVER_NAME } from "@app/lib/api/actions/servers/goal_mode/metadata";
+import { TOOLS } from "@app/lib/api/actions/servers/goal_mode/tools";
+import type { Authenticator } from "@app/lib/auth";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+function createServer(
+  auth: Authenticator,
+  toolContext?: ToolContext
+): McpServer {
+  const server = makeInternalMCPServer(GOAL_MODE_SERVER_NAME);
+
+  for (const tool of TOOLS) {
+    registerTool(auth, toolContext, server, tool, {
+      monitoringName: GOAL_MODE_SERVER_NAME,
+    });
+  }
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/actions/servers/goal_mode/metadata.ts
+++ b/front/lib/api/actions/servers/goal_mode/metadata.ts
@@ -1,0 +1,54 @@
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { z } from "zod";
+
+export const GOAL_MODE_SERVER_NAME = "goal_mode" as const;
+export const UPDATE_GOAL_TOOL_NAME = "update_goal" as const;
+
+export const GOAL_MODE_TOOLS_METADATA = [
+  {
+    name: UPDATE_GOAL_TOOL_NAME,
+    description:
+      "Update the active goal to a terminal status. Use `complete` only when the entire objective " +
+      "has been achieved and appropriately verified; incomplete, partial, or merely promising work " +
+      "must remain active. Use `blocked` only for a genuine impasse after exhausting safe in-scope " +
+      "alternatives and when progress requires user input or an external state change. Do not call " +
+      "this tool just because a turn is ending: omitting it causes Goal Mode to start another turn. " +
+      "After a successful call, provide one concise final summary to the user and do not start new work.",
+    schema: {
+      status: z
+        .enum(["complete", "blocked"])
+        .describe(
+          "`complete` when the full objective is achieved and verified; `blocked` only at a genuine impasse."
+        ),
+      reason: z
+        .string()
+        .trim()
+        .min(1)
+        .max(1_000)
+        .optional()
+        .describe(
+          "For `blocked`, briefly state the specific dependency or user decision required. Optional for `complete`."
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Updating goal",
+      done: "Goal updated",
+    },
+    toolCostCategory: "basic",
+    freeUsage: true,
+  },
+] as const;
+
+export const GOAL_MODE_SERVER = {
+  serverInfo: {
+    name: GOAL_MODE_SERVER_NAME,
+    version: "1.0.0",
+    description:
+      "Update the lifecycle of the active autonomous goal. The goal remains active across agent turns until this server records completion or a genuine blocker.",
+    icon: "ActionCheckCircleIcon" as const,
+    authorization: null,
+    documentationUrl: null,
+  },
+  tools: GOAL_MODE_TOOLS_METADATA,
+} as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/goal_mode/tools/index.ts
+++ b/front/lib/api/actions/servers/goal_mode/tools/index.ts
@@ -1,0 +1,63 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
+import { GOAL_MODE_TOOLS_METADATA } from "@app/lib/api/actions/servers/goal_mode/metadata";
+import { ConversationGoalResource } from "@app/lib/resources/conversation_goal_resource";
+import { Err, Ok } from "@app/types/shared/result";
+import assert from "assert";
+
+const handlers: ToolHandlers<typeof GOAL_MODE_TOOLS_METADATA> = {
+  update_goal: async ({ status, reason }, { auth, runContext }) => {
+    assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+
+    const result = await ConversationGoalResource.updateFromAgent(auth, {
+      agentLoopData: {
+        agentConfiguration: runContext.agentConfiguration,
+        agentMessage: runContext.agentMessage,
+        conversation: runContext.conversation,
+        modelInfo: runContext.modelInfo,
+        userMessage: runContext.userMessage,
+      },
+      status,
+      reason,
+    });
+    if (result.isErr()) {
+      switch (result.error.type) {
+        case "goal_not_found":
+          return new Err(new MCPError("No goal exists for this branch."));
+        case "invalid_transition":
+          return new Err(
+            new MCPError(
+              "The goal is no longer active. It may have been paused, cancelled, or completed."
+            )
+          );
+        case "wrong_agent":
+        case "forbidden":
+          return new Err(
+            new MCPError(
+              "Only the root agent assigned to the active goal can update it."
+            )
+          );
+        case "goal_conflict":
+          return new Err(
+            new MCPError(
+              "The goal changed concurrently. Re-read the goal state before retrying."
+            )
+          );
+      }
+    }
+
+    return new Ok([
+      {
+        type: "text",
+        text:
+          result.value.status === "completed"
+            ? "Goal marked complete. Give the user one concise final summary of the outcome and verification."
+            : "Goal marked blocked. Give the user one concise final summary naming the blocker and what is needed to resume.",
+      },
+    ]);
+  },
+};
+
+export const TOOLS = buildTools(GOAL_MODE_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/goal_mode/tools/index.ts
+++ b/front/lib/api/actions/servers/goal_mode/tools/index.ts
@@ -5,11 +5,17 @@ import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import { GOAL_MODE_TOOLS_METADATA } from "@app/lib/api/actions/servers/goal_mode/metadata";
 import { ConversationGoalResource } from "@app/lib/resources/conversation_goal_resource";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import assert from "assert";
 
 const handlers: ToolHandlers<typeof GOAL_MODE_TOOLS_METADATA> = {
   update_goal: async ({ status, reason }, { auth, runContext }) => {
     assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+    if (status === "blocked" && !reason) {
+      return new Err(
+        new MCPError("A blocked goal requires a concrete blocker in `reason`.")
+      );
+    }
 
     const result = await ConversationGoalResource.updateFromAgent(auth, {
       agentLoopData: {
@@ -33,7 +39,6 @@ const handlers: ToolHandlers<typeof GOAL_MODE_TOOLS_METADATA> = {
             )
           );
         case "wrong_agent":
-        case "forbidden":
           return new Err(
             new MCPError(
               "Only the root agent assigned to the active goal can update it."
@@ -45,6 +50,8 @@ const handlers: ToolHandlers<typeof GOAL_MODE_TOOLS_METADATA> = {
               "The goal changed concurrently. Re-read the goal state before retrying."
             )
           );
+        default:
+          return assertNever(result.error.type);
       }
     }
 

--- a/front/lib/resources/conversation_goal_resource.ts
+++ b/front/lib/resources/conversation_goal_resource.ts
@@ -88,14 +88,14 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
     {
       objective,
       conversation,
-      branchId,
+      branchId = null,
       agentConfigurationId,
       currentAgentMessageId,
       maxTurns,
     }: {
       objective: string;
       conversation: ConversationResource;
-      branchId: string | null;
+      branchId?: string | null;
       agentConfigurationId: string;
       currentAgentMessageId: string;
       maxTurns: number;

--- a/front/lib/resources/conversation_goal_resource.ts
+++ b/front/lib/resources/conversation_goal_resource.ts
@@ -5,13 +5,29 @@ import {
 } from "@app/lib/models/agent/conversation";
 import { ConversationGoalModel } from "@app/lib/models/agent/conversation_goal";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
-import { makeSId } from "@app/lib/resources/string_ids";
+import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
+import type { GoalStatus, GoalType } from "@app/types/assistant/goal";
 import type { ModelId } from "@app/types/shared/model_id";
-import { Ok, type Result } from "@app/types/shared/result";
+import { Err, Ok, type Result } from "@app/types/shared/result";
 import type { Attributes, Transaction } from "sequelize";
+
+export class GoalTransitionError extends Error {
+  constructor(
+    readonly type:
+      | "goal_not_found"
+      | "goal_conflict"
+      | "invalid_transition"
+      | "wrong_agent"
+  ) {
+    super(type);
+  }
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface ConversationGoalResource
@@ -46,17 +62,40 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
     });
   }
 
+  toJSON(): GoalType {
+    return {
+      sId: this.sId,
+      objective: this.objective,
+      status: this.status,
+      agentConfigurationId: this.agentConfigurationId,
+      branchId: this.branchId
+        ? ConversationBranchResource.modelIdToSId({
+            id: this.branchId,
+            workspaceId: this.workspaceId,
+          })
+        : null,
+      turnCount: this.turnCount,
+      maxTurns: this.maxTurns,
+      reason: this.reason,
+      createdAt: this.createdAt.getTime(),
+      updatedAt: this.updatedAt.getTime(),
+      terminalAt: this.terminalAt?.getTime() ?? null,
+    };
+  }
+
   static async makeNew(
     auth: Authenticator,
     {
       objective,
       conversation,
+      branchId,
       agentConfigurationId,
       currentAgentMessageId,
       maxTurns,
     }: {
       objective: string;
       conversation: ConversationResource;
+      branchId: string | null;
       agentConfigurationId: string;
       currentAgentMessageId: string;
       maxTurns: number;
@@ -64,11 +103,28 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
     transaction: Transaction
   ): Promise<ConversationGoalResource> {
     const workspace = auth.getNonNullableWorkspace();
+    let branchModelId: ModelId | null = null;
+    if (branchId) {
+      const branch = await ConversationBranchResource.fetchById(
+        auth,
+        branchId,
+        transaction
+      );
+      if (
+        !branch ||
+        branch.conversationId !== conversation.id ||
+        !branch.canWrite(auth)
+      ) {
+        throw new Error("Invalid conversation branch for goal.");
+      }
+      branchModelId = branch.id;
+    }
+
     const message = await MessageModel.findOne({
       where: {
         workspaceId: workspace.id,
         conversationId: conversation.id,
-        branchId: null,
+        branchId: branchModelId,
         sId: currentAgentMessageId,
       },
       include: [
@@ -82,7 +138,7 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
       transaction,
     });
     if (!message?.agentMessage) {
-      throw new Error("Invalid root agent message for conversation goal.");
+      throw new Error("Invalid agent message for conversation goal.");
     }
 
     const row = await this.model.create(
@@ -90,7 +146,7 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
         workspaceId: workspace.id,
         objective,
         conversationId: conversation.id,
-        branchId: null,
+        branchId: branchModelId,
         createdByUserId: auth.getNonNullableUser().id,
         agentConfigurationId,
         currentAgentMessageId: message.agentMessage.id,
@@ -110,15 +166,17 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
     auth: Authenticator,
     {
       conversation,
+      branchId = null,
     }: {
       conversation: ConversationResource;
+      branchId?: string | null;
     }
   ): Promise<ConversationGoalResource | null> {
     const row = await this.model.findOne({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         conversationId: conversation.id,
-        branchId: null,
+        branchId: branchId ? getResourceIdFromSId(branchId) : null,
       },
       order: [
         ["createdAt", "DESC"],
@@ -137,6 +195,97 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
         workspaceId: auth.getNonNullableWorkspace().id,
         conversationId: conversationModelId,
       },
+    });
+  }
+
+  static async fetchActiveForAgentLoop(
+    auth: Authenticator,
+    agentLoopData: AgentLoopExecutionData
+  ): Promise<ConversationGoalResource | null> {
+    const row = await this.model.findOne({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId: agentLoopData.conversation.id,
+        branchId: agentLoopData.conversation.branchId
+          ? getResourceIdFromSId(agentLoopData.conversation.branchId)
+          : null,
+        status: "active",
+        agentConfigurationId: agentLoopData.agentConfiguration.sId,
+        currentAgentMessageId: agentLoopData.agentMessage.agentMessageId,
+      },
+    });
+    if (!row || row.lastAgentMessageId === row.currentAgentMessageId) {
+      return null;
+    }
+    return new this(this.model, row.get());
+  }
+
+  static async updateFromAgent(
+    auth: Authenticator,
+    {
+      agentLoopData,
+      status,
+      reason,
+    }: {
+      agentLoopData: AgentLoopExecutionData;
+      status: "complete" | "blocked";
+      reason?: string;
+    }
+  ): Promise<Result<ConversationGoalResource, GoalTransitionError>> {
+    return withTransaction(async (transaction) => {
+      const row = await this.model.findOne({
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          conversationId: agentLoopData.conversation.id,
+          branchId: agentLoopData.conversation.branchId
+            ? getResourceIdFromSId(agentLoopData.conversation.branchId)
+            : null,
+        },
+        order: [
+          ["createdAt", "DESC"],
+          ["id", "DESC"],
+        ],
+        transaction,
+        lock: transaction.LOCK.UPDATE,
+      });
+      if (!row) {
+        return new Err(new GoalTransitionError("goal_not_found"));
+      }
+
+      const goal = new this(this.model, row.get());
+      const targetStatus: GoalStatus =
+        status === "complete" ? "completed" : "blocked";
+      if (
+        goal.agentConfigurationId !== agentLoopData.agentConfiguration.sId ||
+        goal.currentAgentMessageId !==
+          agentLoopData.agentMessage.agentMessageId ||
+        goal.lastAgentMessageId === goal.currentAgentMessageId
+      ) {
+        return new Err(new GoalTransitionError("wrong_agent"));
+      }
+      if (goal.status === targetStatus) {
+        return new Ok(goal);
+      }
+      if (goal.status !== "active") {
+        return new Err(new GoalTransitionError("invalid_transition"));
+      }
+
+      const [, rows] = await this.model.update(
+        {
+          status: targetStatus,
+          reason: reason ?? null,
+          terminalAt: new Date(),
+        },
+        {
+          where: { id: goal.id, workspaceId: goal.workspaceId },
+          returning: true,
+          transaction,
+        }
+      );
+      const updated = rows[0];
+      return updated
+        ? new Ok(new this(this.model, updated.get()))
+        : new Err(new GoalTransitionError("goal_conflict"));
     });
   }
 

--- a/front/lib/resources/skill/code_defined/shared.ts
+++ b/front/lib/resources/skill/code_defined/shared.ts
@@ -45,7 +45,9 @@ interface BaseSkillDefinition<
   readonly getAutoEnabledOrEquippedForAgentLoop?: (params: {
     agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
     conversation: ConversationWithoutContentType;
-  }) => T | undefined;
+    agentLoopData?: AgentLoopExecutionData;
+    auth: Authenticator;
+  }) => T | undefined | Promise<T | undefined>;
   // Optional callback to hide a skill from a given agent loop (both from equipped and enabled).
   readonly isDisabledForAgentLoop?: (
     agentLoopData: AgentLoopExecutionData

--- a/front/lib/resources/skill/code_defined/system/goal_mode.test.ts
+++ b/front/lib/resources/skill/code_defined/system/goal_mode.test.ts
@@ -1,4 +1,8 @@
+import { UPDATE_GOAL_TOOL_NAME } from "@app/lib/api/actions/servers/goal_mode/metadata";
+import { TOOLS } from "@app/lib/api/actions/servers/goal_mode/tools";
+import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import { ConversationGoalResource } from "@app/lib/resources/conversation_goal_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { goalModeSkill } from "@app/lib/resources/skill/code_defined/system/goal_mode";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -41,34 +45,66 @@ describe("goalModeSkill", () => {
     if (!userMessage || !agentMessage) {
       throw new Error("Expected one user and agent message");
     }
+    const conversationResource = await ConversationResource.fetchById(
+      setup.authenticator,
+      conversation.sId
+    );
+    if (!conversationResource) {
+      throw new Error("Expected conversation resource");
+    }
+    const { model, ...agentConfiguration } = agent;
+    const branch = await ConversationBranchResource.makeNew(
+      setup.authenticator,
+      {
+        state: "open",
+        previousMessageId: agentMessage.id,
+        conversationId: conversation.id,
+        userId: setup.user.id,
+      }
+    );
+    const branchTurn = await ConversationFactory.createAgentMessage(
+      setup.authenticator,
+      {
+        workspace: setup.workspace,
+        conversation,
+        agentConfig: agent,
+        branchId: branch.id,
+      }
+    );
+    const branchAgentMessage = branchTurn.agentMessage;
 
     await withTransaction((transaction) =>
       ConversationGoalResource.makeNew(
         setup.authenticator,
         {
           objective: "Complete the release",
-          conversationId: conversation.id,
-          branchId: null,
-          createdByUserId: setup.user.id,
+          conversation: conversationResource,
+          branchId: branch.sId,
           agentConfigurationId: agent.sId,
-          currentAgentMessageId: agentMessage.agentMessageId,
+          currentAgentMessageId: branchAgentMessage.sId,
           maxTurns: 25,
         },
         transaction
       )
     );
 
-    const { model, ...agentConfiguration } = agent;
     const agentLoopData = {
       agentConfiguration,
       modelInfo: {
         endpoint: getTestStreamEndpoint(model.modelId),
         ...model,
       },
-      agentMessage,
-      conversation,
+      agentMessage: branchAgentMessage,
+      conversation: { ...conversation, branchId: branch.sId },
       userMessage,
     };
+
+    expect(
+      await ConversationGoalResource.fetchLatest(setup.authenticator, {
+        conversation: conversationResource,
+        branchId: null,
+      })
+    ).toBeNull();
 
     expect(
       await goalModeSkill.getAutoEnabledOrEquippedForAgentLoop({
@@ -86,9 +122,20 @@ describe("goalModeSkill", () => {
         agentLoopData,
       }
     );
-    expect(instructions).toContain("<active_goal>\nComplete the release");
-    expect(instructions).toContain("This is turn 1 of at most 25");
+    expect(instructions).not.toContain("Complete the release");
     expect(instructions).toContain("update_goal");
+
+    const updateGoalTool = TOOLS.find(
+      (tool) => tool.name === UPDATE_GOAL_TOOL_NAME
+    );
+    if (!updateGoalTool) {
+      throw new Error("Expected update_goal tool");
+    }
+    const blocked = await updateGoalTool.handler({ status: "blocked" }, {
+      auth: setup.authenticator,
+      runContext: { contextType: "agent_loop", ...agentLoopData },
+    } as unknown as Parameters<typeof updateGoalTool.handler>[1]);
+    expect(blocked.isErr()).toBe(true);
 
     const completed = await ConversationGoalResource.updateFromAgent(
       setup.authenticator,
@@ -100,21 +147,11 @@ describe("goalModeSkill", () => {
     );
     expect(completed.isOk()).toBe(true);
     if (completed.isOk()) {
-      expect(completed.value).toMatchObject({
+      expect(completed.value.toJSON()).toMatchObject({
         status: "completed",
         reason: "Release checks passed",
       });
     }
-    expect(
-      (
-        await ConversationGoalResource.updateFromAgent(setup.authenticator, {
-          agentLoopData,
-          status: "complete",
-          reason: "Release checks passed",
-        })
-      ).isOk()
-    ).toBe(true);
-
     expect(
       await goalModeSkill.getAutoEnabledOrEquippedForAgentLoop({
         agentConfiguration,

--- a/front/lib/resources/skill/code_defined/system/goal_mode.test.ts
+++ b/front/lib/resources/skill/code_defined/system/goal_mode.test.ts
@@ -1,0 +1,127 @@
+import { ConversationGoalResource } from "@app/lib/resources/conversation_goal_resource";
+import { goalModeSkill } from "@app/lib/resources/skill/code_defined/system/goal_mode";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { getTestStreamEndpoint } from "@app/tests/utils/models";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("goalModeSkill", () => {
+  let setup: Awaited<ReturnType<typeof createResourceTest>>;
+
+  beforeEach(async () => {
+    setup = await createResourceTest({ role: "builder" });
+  });
+
+  it("is restricted until the Goal Mode feature flag is enabled", async () => {
+    expect(await goalModeSkill.isRestricted(setup.authenticator)).toBe(true);
+
+    await FeatureFlagFactory.basic(setup.authenticator, "goal_mode");
+
+    expect(await goalModeSkill.isRestricted(setup.authenticator)).toBe(false);
+  });
+
+  it("auto-enables only for the active goal agent and exposes goal instructions", async () => {
+    await FeatureFlagFactory.basic(setup.authenticator, "goal_mode");
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      setup.authenticator
+    );
+    const conversation = await ConversationFactory.create(setup.authenticator, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    const userMessage = conversation.content
+      .flat()
+      .find((message) => message.type === "user_message");
+    const agentMessage = conversation.content
+      .flat()
+      .find((message) => message.type === "agent_message");
+    if (!userMessage || !agentMessage) {
+      throw new Error("Expected one user and agent message");
+    }
+
+    await withTransaction((transaction) =>
+      ConversationGoalResource.makeNew(
+        setup.authenticator,
+        {
+          objective: "Complete the release",
+          conversationId: conversation.id,
+          branchId: null,
+          createdByUserId: setup.user.id,
+          agentConfigurationId: agent.sId,
+          currentAgentMessageId: agentMessage.agentMessageId,
+          maxTurns: 25,
+        },
+        transaction
+      )
+    );
+
+    const { model, ...agentConfiguration } = agent;
+    const agentLoopData = {
+      agentConfiguration,
+      modelInfo: {
+        endpoint: getTestStreamEndpoint(model.modelId),
+        ...model,
+      },
+      agentMessage,
+      conversation,
+      userMessage,
+    };
+
+    expect(
+      await goalModeSkill.getAutoEnabledOrEquippedForAgentLoop({
+        agentConfiguration,
+        conversation,
+        agentLoopData,
+        auth: setup.authenticator,
+      })
+    ).toBe("enabled");
+
+    const instructions = await goalModeSkill.fetchInstructions(
+      setup.authenticator,
+      {
+        spaceIds: [],
+        agentLoopData,
+      }
+    );
+    expect(instructions).toContain("<active_goal>\nComplete the release");
+    expect(instructions).toContain("This is turn 1 of at most 25");
+    expect(instructions).toContain("update_goal");
+
+    const completed = await ConversationGoalResource.updateFromAgent(
+      setup.authenticator,
+      {
+        agentLoopData,
+        status: "complete",
+        reason: "Release checks passed",
+      }
+    );
+    expect(completed.isOk()).toBe(true);
+    if (completed.isOk()) {
+      expect(completed.value).toMatchObject({
+        status: "completed",
+        reason: "Release checks passed",
+      });
+    }
+    expect(
+      (
+        await ConversationGoalResource.updateFromAgent(setup.authenticator, {
+          agentLoopData,
+          status: "complete",
+          reason: "Release checks passed",
+        })
+      ).isOk()
+    ).toBe(true);
+
+    expect(
+      await goalModeSkill.getAutoEnabledOrEquippedForAgentLoop({
+        agentConfiguration,
+        conversation,
+        agentLoopData,
+        auth: setup.authenticator,
+      })
+    ).toBeUndefined();
+  });
+});

--- a/front/lib/resources/skill/code_defined/system/goal_mode.ts
+++ b/front/lib/resources/skill/code_defined/system/goal_mode.ts
@@ -1,0 +1,64 @@
+import {
+  GOAL_MODE_SERVER_NAME,
+  UPDATE_GOAL_TOOL_NAME,
+} from "@app/lib/api/actions/servers/goal_mode/metadata";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { ConversationGoalResource } from "@app/lib/resources/conversation_goal_resource";
+import type { SystemSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+
+export const goalModeSkill = {
+  sId: "goal_mode",
+  kind: "system",
+  name: "Goal Mode",
+  userFacingDescription:
+    "Keep an agent working across autonomous turns until it explicitly completes or blocks the goal.",
+  agentFacingDescription:
+    "Persist across turns until the active user goal is fully achieved or genuinely blocked.",
+  fetchInstructions: async (auth, { agentLoopData }) => {
+    if (!agentLoopData) {
+      return "";
+    }
+    const goal = await ConversationGoalResource.fetchActiveForAgentLoop(
+      auth,
+      agentLoopData
+    );
+    if (!goal) {
+      return "";
+    }
+
+    return `
+You are running in Goal Mode. The user has deliberately asked you to keep working across autonomous turns until the goal is fully achieved.
+
+<active_goal>
+${goal.objective}
+</active_goal>
+
+This is turn ${goal.turnCount} of at most ${goal.maxTurns}.
+
+- Work concretely toward the whole active goal. Inspect prior progress before acting, avoid repeating completed work, and verify material results.
+- An ordinary final response does not end Goal Mode. If you do not call \`${UPDATE_GOAL_TOOL_NAME}\`, the runtime will start another turn so you can continue.
+- Call \`${UPDATE_GOAL_TOOL_NAME}\` with \`status: "complete"\` only when every part of the objective is achieved and the relevant verification is finished. Partial progress, a plausible plan, or running out of work for this turn is not completion.
+- Call \`${UPDATE_GOAL_TOOL_NAME}\` with \`status: "blocked"\` only at a genuine impasse after exhausting safe in-scope alternatives, where progress requires user input, new authority, or an external-state change. Include the concrete blocker in \`reason\`.
+- Do not pause, cancel, replace, or silently reinterpret the goal. Those lifecycle controls belong to the user and runtime.
+- When calling \`${UPDATE_GOAL_TOOL_NAME}\`, make it your last tool call. After it succeeds, give the user one concise final summary of the outcome and verification, or of the blocker and what is needed to resume.
+`;
+  },
+  mcpServers: [{ name: GOAL_MODE_SERVER_NAME }],
+  version: 1,
+  icon: "ActionCheckCircleIcon",
+  isRestricted: async (auth: Authenticator) => {
+    const featureFlags = await getFeatureFlags(auth);
+    return !featureFlags.includes("goal_mode");
+  },
+  getAutoEnabledOrEquippedForAgentLoop: async ({ agentLoopData, auth }) => {
+    if (!agentLoopData) {
+      return undefined;
+    }
+    const goal = await ConversationGoalResource.fetchActiveForAgentLoop(
+      auth,
+      agentLoopData
+    );
+    return goal ? "enabled" : undefined;
+  },
+} as const satisfies SystemSkillDefinition;

--- a/front/lib/resources/skill/code_defined/system/goal_mode.ts
+++ b/front/lib/resources/skill/code_defined/system/goal_mode.ts
@@ -30,12 +30,6 @@ export const goalModeSkill = {
     return `
 You are running in Goal Mode. The user has deliberately asked you to keep working across autonomous turns until the goal is fully achieved.
 
-<active_goal>
-${goal.objective}
-</active_goal>
-
-This is turn ${goal.turnCount} of at most ${goal.maxTurns}.
-
 - Work concretely toward the whole active goal. Inspect prior progress before acting, avoid repeating completed work, and verify material results.
 - An ordinary final response does not end Goal Mode. If you do not call \`${UPDATE_GOAL_TOOL_NAME}\`, the runtime will start another turn so you can continue.
 - Call \`${UPDATE_GOAL_TOOL_NAME}\` with \`status: "complete"\` only when every part of the objective is achieved and the relevant verification is finished. Partial progress, a plausible plan, or running out of work for this turn is not completion.

--- a/front/lib/resources/skill/code_defined/system/index.ts
+++ b/front/lib/resources/skill/code_defined/system/index.ts
@@ -2,6 +2,7 @@ import { ensureUniqueSIds } from "@app/lib/resources/skill/code_defined/shared";
 import { discoverKnowledgeSkill } from "@app/lib/resources/skill/code_defined/system/discover_knowledge";
 import { discoverSkillsSkill } from "@app/lib/resources/skill/code_defined/system/discover_skills";
 import { discoverToolsSkill } from "@app/lib/resources/skill/code_defined/system/discover_tools";
+import { goalModeSkill } from "@app/lib/resources/skill/code_defined/system/goal_mode";
 import { planModeSkill } from "@app/lib/resources/skill/code_defined/system/plan_mode";
 import { userMemorySkill } from "@app/lib/resources/skill/code_defined/system/user_memory";
 
@@ -9,6 +10,7 @@ export const SYSTEM_SKILLS_ARRAY = ensureUniqueSIds([
   discoverKnowledgeSkill,
   discoverSkillsSkill,
   discoverToolsSkill,
+  goalModeSkill,
   planModeSkill,
   userMemorySkill,
 ] as const);

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1801,9 +1801,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       ...(await GlobalSkillsRegistry.findAll(auth)),
     ]) {
       switch (
-        def.getAutoEnabledOrEquippedForAgentLoop?.({
+        await def.getAutoEnabledOrEquippedForAgentLoop?.({
           agentConfiguration,
           conversation,
+          agentLoopData,
+          auth,
         })
       ) {
         case "enabled":

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -436,6 +436,7 @@ export class ConversationFactory {
       conversation,
       agentConfig,
       mcpAction,
+      branchId,
     }: {
       workspace: WorkspaceType;
       conversation:
@@ -446,6 +447,7 @@ export class ConversationFactory {
       mcpAction?: {
         toolConfiguration: LightServerSideMCPToolConfigurationType;
       };
+      branchId?: ModelId;
     }
   ): Promise<{
     messageRow: MessageModel;
@@ -468,6 +470,7 @@ export class ConversationFactory {
       parentId: null,
       agentMessageId: agentMessageRow.id,
       workspaceId: workspace.id,
+      branchId,
     });
 
     const agentMessage: AgentMessageType = {

--- a/front/types/assistant/goal.ts
+++ b/front/types/assistant/goal.ts
@@ -10,3 +10,17 @@ export const GOAL_STATUSES = [
 
 export const GoalStatusSchema = z.enum(GOAL_STATUSES);
 export type GoalStatus = z.infer<typeof GoalStatusSchema>;
+
+export type GoalType = {
+  sId: string;
+  objective: string;
+  status: GoalStatus;
+  agentConfigurationId: string;
+  branchId: string | null;
+  turnCount: number;
+  maxTurns: number;
+  reason: string | null;
+  createdAt: number;
+  updatedAt: number;
+  terminalAt: number | null;
+};

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -237,6 +237,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable the Plan Mode skill: agents maintain a live plan.md for genuinely multi-step tasks, with an optional human-approval checkpoint.",
     stage: "dust_only",
   },
+  goal_mode: {
+    description:
+      "Enable Goal Mode: agents keep running autonomous turns until they explicitly complete or block a user-defined goal.",
+    stage: "dust_only",
+  },
   allow_old_notion_mcp: {
     description:
       "Allow individual workspaces to keep using the old internal Notion MCP server alongside the official one",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -773,6 +773,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "reinforced_agents"
   | "self_improvement_beta_tester"
   | "legacy_billing"
+  | "goal_mode"
   | "plan_mode"
   | "pod_default_agent"
   | "pod_default_skills"


### PR DESCRIPTION
## Description

Register the branch-aware Goal Mode system skill and `update_goal` tool. The skill contributes a stable cached policy only while the exact root agent turn owns an active goal. The tool can complete that goal or mark it blocked with a required concrete reason.

Stacked on #29694.

## Tests

- Covers feature-flag restriction and branch-scoped auto-enablement.
- Exercises blocked-reason validation and goal completion.
- Verifies the system prompt does not interpolate goal-specific state.
- Updates and validates the MCP availability metadata snapshots.

## Risk

The skill is restricted by `goal_mode`, and no user-facing path creates goals yet. The stable prompt text avoids invalidating the one-hour system-prompt cache on every goal or turn.

## Deploy Plan

Merge after #29694, then standard deploy with `goal_mode` disabled.