### PR TITLE
Drop blobs whose space could not be resolved

### DIFF
--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -124,7 +124,7 @@ export abstract class ResourceWithSpace<
         .map((b) => {
           const space = spaces.find((space) => space.id === b.vaultId);
           if (!space) {
-            throw new Error("Unreachable: space not found.");
+            return null;
           }
 
           // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -160,6 +160,8 @@ export abstract class ResourceWithSpace<
             includedResults
           );
         })
+        // Drop blobs whose space could not be resolved (skipped above).
+        .filter((cls): cls is T => cls !== null)
         // Filter out resources that the user cannot fetch.
         .filter((cls) => cls.canFetch(auth))
     );


### PR DESCRIPTION
## Summary

- In `ResourceWithSpace`, when mapping blobs to resources, a space lookup failure previously threw an `Unreachable` error
- Changed to return `null` and filter out such blobs instead, so a missing space is treated as a soft-skip rather than a crash

## Testing

- Existing tests cover the `ResourceWithSpace` mapping path
- Behavior change: blobs with an unresolvable space are silently dropped rather than causing an unhandled error

## Risk

Low — narrows error surface by converting a hard throw into a graceful skip.