### PR TITLE
Start goals from the conversation input

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -7552,6 +7552,19 @@
                   "content": {
                     "type": "string"
                   },
+                  "goal": {
+                    "type": "object",
+                    "description": "Optional Goal Mode request. When present, the objective is created atomically with this message.",
+                    "required": [
+                      "objective"
+                    ],
+                    "properties": {
+                      "objective": {
+                        "type": "string",
+                        "maxLength": 4000
+                      }
+                    }
+                  },
                   "mentions": {
                     "type": "array",
                     "items": {
@@ -8185,6 +8198,19 @@
                     "properties": {
                       "content": {
                         "type": "string"
+                      },
+                      "goal": {
+                        "type": "object",
+                        "description": "Optional Goal Mode request. When present, the objective is created atomically with this message.",
+                        "required": [
+                          "objective"
+                        ],
+                        "properties": {
+                          "objective": {
+                            "type": "string",
+                            "maxLength": 4000
+                          }
+                        }
                       },
                       "mentions": {
                         "type": "array",

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
@@ -1,6 +1,8 @@
+import { ConversationGoalResource } from "@app/lib/resources/conversation_goal_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
@@ -8,18 +10,26 @@ import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
 import { assert, describe, expect, it, vi } from "vitest";
 
+vi.mock("@app/temporal/agent_loop/client", () => ({
+  launchAgentLoopWorkflow: vi.fn(),
+  launchCompactionWorkflow: vi.fn(),
+}));
+
 vi.mock("@app/lib/api/programmatic_usage/tracking", () => ({
   isProgrammaticUsage: () => false,
   checkProgrammaticUsageLimits: vi.fn(),
 }));
 
-async function setupTest(role: MembershipRoleType = "admin") {
+async function setupTest(
+  role: MembershipRoleType = "admin",
+  messagesCreatedAt = [new Date()]
+) {
   const { workspace, auth, globalSpace, user } =
     await createPrivateApiMockRequest({ role, method: "POST" });
 
   const conversation = await ConversationFactory.create(auth, {
     agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-    messagesCreatedAt: [new Date()],
+    messagesCreatedAt,
   });
 
   return { auth, conversation, globalSpace, user, workspace };
@@ -47,6 +57,40 @@ function getTools(workspace: { sId: string }, conversationId: string) {
 }
 
 describe("POST /api/w/:wId/assistant/conversations/:cId/messages", () => {
+  it("creates a goal with the first agent turn", async () => {
+    const { workspace, conversation, auth, user } = await setupTest(
+      "admin",
+      []
+    );
+    await FeatureFlagFactory.basic(auth, "goal_mode");
+
+    const response = await postMessage(workspace, conversation.sId, {
+      content: "Ship Goal Mode",
+      mentions: [{ configurationId: GLOBAL_AGENTS_SID.DUST }],
+      context: {
+        timezone: "Europe/Paris",
+        profilePictureUrl: user.imageUrl ?? null,
+      },
+      skipToolsValidation: true,
+      goal: { objective: "Ship Goal Mode" },
+    });
+
+    expect(response.status).toBe(200);
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversation.sId
+    );
+    assert(conversationResource);
+    const goal = await ConversationGoalResource.fetchLatest(auth, {
+      conversation: conversationResource,
+      branchId: null,
+    });
+    expect(goal?.toJSON()).toMatchObject({
+      objective: "Ship Goal Mode",
+      status: "active",
+    });
+  });
+
   it("enables MCP server views when selectedMCPServerViewIds are provided", async () => {
     const { workspace, conversation, auth, globalSpace, user } =
       await setupTest("admin");

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -125,6 +125,14 @@ const app = workspaceApp();
  *             properties:
  *               content:
  *                 type: string
+ *               goal:
+ *                 type: object
+ *                 description: Optional Goal Mode request. When present, the objective is created atomically with this message.
+ *                 required: [objective]
+ *                 properties:
+ *                   objective:
+ *                     type: string
+ *                     maxLength: 4000
  *               mentions:
  *                 type: array
  *                 items:
@@ -266,8 +274,14 @@ app.post(
     const user = auth.getNonNullableUser();
     const { cId: conversationId } = ctx.req.valid("param");
 
-    const { content, context, mentions, skipToolsValidation, modelSelection } =
-      ctx.req.valid("json");
+    const {
+      content,
+      context,
+      goal,
+      mentions,
+      skipToolsValidation,
+      modelSelection,
+    } = ctx.req.valid("json");
 
     if (context.clientSideMCPServerIds) {
       const hasServerAccess = await concurrentExecutor(
@@ -398,6 +412,7 @@ app.post(
       },
       skipToolsValidation: skipToolsValidation ?? false,
       modelSelection,
+      goal,
     });
 
     if (messageRes.isErr()) {

--- a/front-api/routes/w/[wId]/assistant/conversations/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/index.test.ts
@@ -16,9 +16,12 @@ vi.mock("@app/lib/api/assistant/conversation/content_fragment", () => ({
 }));
 
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
+import { ConversationGoalResource } from "@app/lib/resources/conversation_goal_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
@@ -28,7 +31,7 @@ describe("POST /api/w/:wId/assistant/conversations", () => {
     vi.clearAllMocks();
   });
 
-  it("creates a conversation with content fragments when private conversation URLs are enabled", async () => {
+  it("creates a conversation with content fragments and an active goal", async () => {
     const { workspace, auth, globalSpace } = await createPrivateApiMockRequest({
       method: "POST",
       role: "admin",
@@ -46,6 +49,7 @@ describe("POST /api/w/:wId/assistant/conversations", () => {
         description: "Route behavior test agent",
       }
     );
+    await FeatureFlagFactory.basic(auth, "goal_mode");
 
     const dataSourceView = await DataSourceViewFactory.folder(
       workspace,
@@ -89,6 +93,7 @@ describe("POST /api/w/:wId/assistant/conversations", () => {
           timezone: "Europe/Paris",
           profilePictureUrl: null,
         },
+        goal: { objective: "Finish the route test" },
       },
     };
 
@@ -131,5 +136,18 @@ describe("POST /api/w/:wId/assistant/conversations", () => {
         (item: { type: string }) => item.type === "agent_message"
       )
     ).toBe(true);
+
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      responseData.conversation.sId
+    );
+    expect(conversation).not.toBeNull();
+    if (conversation) {
+      const goal = await ConversationGoalResource.fetchLatest(auth, {
+        conversation,
+        branchId: null,
+      });
+      expect(goal?.objective).toBe("Finish the route test");
+    }
   });
 });

--- a/front-api/routes/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/index.ts
@@ -137,6 +137,14 @@ const app = workspaceApp();
  *                 properties:
  *                   content:
  *                     type: string
+ *                   goal:
+ *                     type: object
+ *                     description: Optional Goal Mode request. When present, the objective is created atomically with this message.
+ *                     required: [objective]
+ *                     properties:
+ *                       objective:
+ *                         type: string
+ *                         maxLength: 4000
  *                   mentions:
  *                     type: array
  *                     items:
@@ -459,6 +467,7 @@ app.post(
         },
         skipToolsValidation: skipToolsValidation ?? false,
         modelSelection: message.modelSelection,
+        goal: message.goal,
       });
       if (messageRes.isErr()) {
         return apiError(ctx, messageRes.error);

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -11,18 +11,16 @@ import { useConversationSidePanelContext } from "@app/components/assistant/conve
 import { ConversationViewer } from "@app/components/assistant/conversation/ConversationViewer";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
+import type { InputBarSubmit } from "@app/components/assistant/conversation/input_bar/types";
 import type { VirtuosoMessageListContext } from "@app/components/assistant/conversation/types";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { useAuth } from "@app/lib/auth/AuthContext";
-import type { DustError } from "@app/lib/error";
 import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
 import { toRichAgentMentionType } from "@app/types/assistant/mentions";
-import type { ContentFragmentsType } from "@app/types/content_fragment";
 import type { ConversationSidePanelType } from "@app/types/conversation_side_panel";
-import type { Result } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import { Spinner } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef } from "react";
@@ -67,11 +65,7 @@ interface PreviewContentProps {
   owner: WorkspaceType;
   currentPanel: ConversationSidePanelType;
   resetConversation: () => void;
-  createConversation: (
-    input: string,
-    mentions: RichMention[],
-    contentFragments: ContentFragmentsType
-  ) => Promise<Result<undefined, DustError>>;
+  createConversation: InputBarSubmit;
   draftAgent: LightAgentConfigurationType | null;
   isSavingDraftAgent: boolean;
   isTrialPlan: boolean;

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -1,16 +1,13 @@
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { submitAgentBuilderForm } from "@app/components/agent_builder/submitAgentBuilderForm";
+import type { InputBarSubmit } from "@app/components/assistant/conversation/input_bar/types";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useAuth } from "@app/lib/auth/AuthContext";
-import type { DustError } from "@app/lib/error";
 import { useFetcher } from "@app/lib/swr/swr";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationType } from "@app/types/assistant/conversation";
-import type { RichMention } from "@app/types/assistant/mentions";
-import type { ContentFragmentsType } from "@app/types/content_fragment";
-import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import isEqual from "lodash/isEqual";
 import { useCallback, useRef, useState } from "react";
@@ -122,12 +119,8 @@ export function useDraftConversation({
     user,
   });
 
-  const createConversation = useCallback(
-    async (
-      input: string,
-      mentions: RichMention[],
-      contentFragments: ContentFragmentsType
-    ): Promise<Result<undefined, DustError>> => {
+  const createConversation = useCallback<InputBarSubmit>(
+    async (input, mentions, contentFragments, { goal }) => {
       try {
         // Ensure we have a current draft agent before submitting
         const currentAgent = await getDraftAgent();
@@ -161,6 +154,7 @@ export function useDraftConversation({
           configurationId: mention.id,
         })),
         contentFragments,
+        goal,
       };
 
       const result = await createConversationWithMessage({

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -14,6 +14,7 @@ import type { FeedbackSelectorBaseProps } from "@app/components/assistant/conver
 import { FeedbackSelector } from "@app/components/assistant/conversation/FeedbackSelector";
 import { useGenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { getModelWithReasoningEffortLabel } from "@app/components/assistant/conversation/input_bar/modelPickerUtils";
+import type { InputBarSubmit } from "@app/components/assistant/conversation/input_bar/types";
 import type {
   AgentMessageStateWithControlEvent,
   AgentMessageWithStreaming,
@@ -63,7 +64,6 @@ import { CONTEXT_WINDOW_DOC_URL } from "@app/lib/api/assistant/errors";
 import config from "@app/lib/api/config";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
-import type { DustError } from "@app/lib/error";
 import { FILE_ID_PATTERN } from "@app/lib/files";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { getFilePreviewDirectivePaths } from "@app/lib/markdown/file_preview";
@@ -79,20 +79,15 @@ import {
   isGlobalAgentWithFeedback,
 } from "@app/types/assistant/assistant";
 import { isLightAgentMessageType } from "@app/types/assistant/conversation";
-import type {
-  RichAgentMention,
-  RichMention,
-} from "@app/types/assistant/mentions";
+import type { RichAgentMention } from "@app/types/assistant/mentions";
 import {
   isAgentMention,
   toRichAgentMentionType,
 } from "@app/types/assistant/mentions";
-import type { ContentFragmentsType } from "@app/types/content_fragment";
 import {
   isInteractiveContentType,
   isSupportedImageContentType,
 } from "@app/types/files";
-import type { Result } from "@app/types/shared/result";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type {
   LightWorkspaceType,
@@ -229,11 +224,7 @@ interface AgentMessageProps {
   triggeringUser: UserType | null;
   isOnboardingConversation: boolean;
   onCompletionStatusClick?: (messageId: string, actionId?: string) => void;
-  handleSubmit: (
-    input: string,
-    mentions: RichMention[],
-    contentFragments: ContentFragmentsType
-  ) => Promise<Result<undefined, DustError>>;
+  handleSubmit: InputBarSubmit;
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
   isAutoScrollEnabledRef: MutableRefObject<boolean>;
@@ -1035,10 +1026,15 @@ export function AgentMessage({
             description: "",
           };
 
-      const result = await handleSubmit(reply, [mention], {
-        uploaded: [],
-        contentNodes: [],
-      });
+      const result = await handleSubmit(
+        reply,
+        [mention],
+        {
+          uploaded: [],
+          contentNodes: [],
+        },
+        {}
+      );
 
       if (result.isErr()) {
         sendNotification({

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -8,6 +8,7 @@ import { AgentBrowserContainer } from "@app/components/assistant/conversation/Ag
 import { ConversationViewer } from "@app/components/assistant/conversation/ConversationViewer";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import type { InputBarSubmit } from "@app/components/assistant/conversation/input_bar/types";
 import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
 import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
 import { useConversations } from "@app/hooks/conversations";
@@ -16,7 +17,6 @@ import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversati
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { getRandomGreetingForName } from "@app/lib/client/greetings";
-import type { DustError } from "@app/lib/error";
 import { useAppRouter } from "@app/lib/platform";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { useWorkspaceUsageStatus } from "@app/lib/swr/user";
@@ -26,15 +26,11 @@ import type {
   ConversationListItemType,
   SubmitMessageError,
 } from "@app/types/assistant/conversation";
-import type { RichMention } from "@app/types/assistant/mentions";
 import {
   toMentionType,
   toRichAgentMentionType,
 } from "@app/types/assistant/mentions";
-import type { ModelSelectionType } from "@app/types/assistant/models/types";
-import type { ContentFragmentsType } from "@app/types/content_fragment";
 import type { SubscriptionType } from "@app/types/plan";
-import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { UserType, WorkspaceType } from "@app/types/user";
@@ -129,15 +125,13 @@ export function ConversationContainerVirtuoso({
     [sendNotification]
   );
 
-  const handleConversationCreation = useCallback(
+  const handleConversationCreation = useCallback<InputBarSubmit>(
     async (
-      input: string,
-      mentions: RichMention[],
-      contentFragments: ContentFragmentsType,
-      selectedMCPServerViewIds?: string[],
-      selectedSpaceIds?: string[],
-      modelSelection?: ModelSelectionType
-    ): Promise<Result<undefined, DustError>> => {
+      input,
+      mentions,
+      contentFragments,
+      { selectedMCPServerViewIds, selectedSpaceIds, modelSelection, goal }
+    ) => {
       if (isSubmitting) {
         return new Err({
           code: "internal_error",
@@ -188,12 +182,10 @@ export function ConversationContainerVirtuoso({
           selectedSpaceIds,
           richMentions: mentions,
           modelSelection,
+          goal,
         },
-        // Navigate as soon as the conversation exists; the first message is posted
-        // in the background by useCreateConversationWithMessage. Background-post
-        // failures (e.g. no seat, credits) are surfaced through `onError` so the
-        // same blocking popup shows even though the conversation already exists.
-        deferMessage: true,
+        // Keep goal creation atomic with its first message.
+        deferMessage: !goal,
         onError: handleSubmitMessageError,
       });
 

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -12,6 +12,7 @@ import {
   InputBarContext,
   type PendingConversationMessage,
 } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import type { InputBarSubmit } from "@app/components/assistant/conversation/input_bar/types";
 import {
   createPlaceholderAgentMessage,
   createPlaceholderUserMessage,
@@ -54,7 +55,6 @@ import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/cit
 import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
 import type { ConversationEvents } from "@app/lib/api/assistant/streaming/types";
 import { getUpdatedParticipantsFromEvent } from "@app/lib/client/conversation/event_handlers";
-import type { DustError } from "@app/lib/error";
 import {
   AgentMessageCompletedEvent,
   CompactionCompletedEvent,
@@ -72,15 +72,11 @@ import {
   isLightAgentMessageType,
   isUserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
-import type { RichMention } from "@app/types/assistant/mentions";
 import {
   isRichAgentMention,
   toMentionType,
 } from "@app/types/assistant/mentions";
-import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import { isActiveWakeUp } from "@app/types/assistant/wakeups";
-import type { ContentFragmentsType } from "@app/types/content_fragment";
-import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import { cn } from "@dust-tt/sparkle";
@@ -1137,15 +1133,13 @@ export const ConversationViewer = ({
       initialListData.length > 0,
   });
 
-  const handleSubmit = useCallback(
+  const handleSubmit = useCallback<InputBarSubmit>(
     async (
-      input: string,
-      mentions: RichMention[],
-      contentFragments: ContentFragmentsType,
-      _selectedMCPServerViewIds?: string[],
-      selectedSpaceIds?: string[],
-      modelSelection?: ModelSelectionType
-    ): Promise<Result<undefined, DustError>> => {
+      input,
+      mentions,
+      contentFragments,
+      { selectedSpaceIds, modelSelection, goal }
+    ) => {
       if (!virtuosoMessageListRef?.current) {
         return new Err({
           code: "internal_error",
@@ -1175,6 +1169,7 @@ export const ConversationViewer = ({
           selectedSpaceIds,
           skipToolsValidation: agentBuilderContext?.skipToolsValidation,
           modelSelection,
+          goal,
         };
 
         const lastMessageRank = Math.max(

--- a/front/components/assistant/conversation/goal_mode/utils.test.ts
+++ b/front/components/assistant/conversation/goal_mode/utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { parseGoalCommand } from "./utils";
+
+describe("parseGoalCommand", () => {
+  it("extracts the objective and removes the slash command", () => {
+    expect(parseGoalCommand("/goal Ship and verify the feature", true)).toEqual(
+      {
+        input: "Ship and verify the feature",
+        goal: { objective: "Ship and verify the feature" },
+      }
+    );
+  });
+
+  it("supports multiline objectives", () => {
+    expect(parseGoalCommand("/goal Build it\nThen test it", true)).toEqual({
+      input: "Build it\nThen test it",
+      goal: { objective: "Build it\nThen test it" },
+    });
+  });
+
+  it("leaves messages unchanged when the flag is disabled", () => {
+    expect(parseGoalCommand("/goal Do the work", false)).toEqual({
+      input: "/goal Do the work",
+      goal: undefined,
+    });
+  });
+
+  it("does not treat an empty command as a goal", () => {
+    expect(parseGoalCommand("/goal ", true)).toEqual({
+      input: "/goal ",
+      goal: undefined,
+    });
+  });
+});

--- a/front/components/assistant/conversation/goal_mode/utils.ts
+++ b/front/components/assistant/conversation/goal_mode/utils.ts
@@ -1,0 +1,26 @@
+import type { GoalCreation } from "@app/types/assistant/goal";
+
+export type ParsedGoalCommand = {
+  input: string;
+  goal: GoalCreation | undefined;
+};
+
+export function parseGoalCommand(
+  markdown: string,
+  isGoalModeEnabled: boolean
+): ParsedGoalCommand {
+  if (!isGoalModeEnabled) {
+    return { input: markdown, goal: undefined };
+  }
+
+  const match = markdown.match(/^\/goal\s+([\s\S]*\S)\s*$/i);
+  if (!match) {
+    return { input: markdown, goal: undefined };
+  }
+
+  const objective = match[1].trim();
+  return {
+    input: objective,
+    goal: { objective },
+  };
+}

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -14,6 +14,7 @@ import {
   INPUT_BAR_COMPACT_MORPH_TRANSITION_CLASSES,
   INPUT_BAR_COMPACT_PILL_CLASSES,
 } from "@app/components/assistant/conversation/input_bar/inputBarCompactStyles";
+import type { InputBarSubmit } from "@app/components/assistant/conversation/input_bar/types";
 import { useConversationDrafts } from "@app/components/assistant/conversation/input_bar/useConversationDrafts";
 import { PlanCard } from "@app/components/assistant/conversation/plan_mode/PlanCard";
 import {
@@ -23,7 +24,6 @@ import {
 import { RUNNING_AGENT_SWITCH_BLOCK_MESSAGE } from "@app/lib/api/assistant/errors";
 import type { MCPServerViewLightType } from "@app/lib/api/mcp";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
-import type { DustError } from "@app/lib/error";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import {
   useAddConversationSelectedSpaces,
@@ -40,13 +40,10 @@ import type {
   ConversationWithoutContentType,
   SelectableConversationSpaceType,
 } from "@app/types/assistant/conversation";
-import type { GoalCreation } from "@app/types/assistant/goal";
 import type { RichMention } from "@app/types/assistant/mentions";
 import type { ModelSelectionType } from "@app/types/assistant/models/types";
-import type { ContentFragmentsType } from "@app/types/content_fragment";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import { isEqualNode } from "@app/types/data_source_view";
-import type { Result } from "@app/types/shared/result";
 import type { SpaceType } from "@app/types/space";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import uniqBy from "lodash/uniqBy";
@@ -78,15 +75,7 @@ function sameStringSet(a: string[], b: string[]) {
 interface InputBarProps {
   owner: WorkspaceType;
   user: UserType | null;
-  onSubmit: (
-    input: string,
-    mentions: RichMention[],
-    contentFragments: ContentFragmentsType,
-    selectedMCPServerViewIds?: string[],
-    selectedSpaceIds?: string[],
-    modelSelection?: ModelSelectionType,
-    goal?: GoalCreation
-  ) => Promise<Result<undefined, DustError>>;
+  onSubmit: InputBarSubmit;
   draftKey: string;
   conversation?: ConversationWithoutContentType;
   space?: SpaceType;
@@ -594,12 +583,15 @@ export const InputBar = React.memo(function InputBar({
             }),
             contentNodes: attachedNodes,
           },
-          // Only send the selectedMCPServerViewIds if we are creating a new conversation.
-          // Once the conversation is created, the selectedMCPServerViewIds will be updated in the conversationTools hook.
-          selectedMCPServerViews.map((sv) => sv.sId),
-          selectedSpaceIds,
-          modelSelectionRef.current,
-          goal
+          {
+            // Once created, server views are synced by the conversation tools hook.
+            selectedMCPServerViewIds: selectedMCPServerViews.map(
+              (serverView) => serverView.sId
+            ),
+            selectedSpaceIds,
+            modelSelection: modelSelectionRef.current,
+            goal,
+          }
         );
 
         if (r.isOk()) {
@@ -633,12 +625,11 @@ export const InputBar = React.memo(function InputBar({
             }),
             contentNodes: attachedNodes,
           },
-          // Existing conversation: MCP server views are synced via the
-          // conversationTools hook.
-          undefined,
-          selectedSpaceIds,
-          modelSelectionRef.current,
-          goal
+          {
+            selectedSpaceIds,
+            modelSelection: modelSelectionRef.current,
+            goal,
+          }
         );
 
         // Execute these operations in parallel with the submission.

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -1,6 +1,7 @@
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import { useFileDrop } from "@app/components/assistant/conversation/FileUploaderContext";
 import { useGenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
+import { parseGoalCommand } from "@app/components/assistant/conversation/goal_mode/utils";
 import { InputBarAttachments } from "@app/components/assistant/conversation/input_bar/InputBarAttachments";
 import type { InputBarContainerProps } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
 import InputBarContainer, {
@@ -39,6 +40,7 @@ import type {
   ConversationWithoutContentType,
   SelectableConversationSpaceType,
 } from "@app/types/assistant/conversation";
+import type { GoalCreation } from "@app/types/assistant/goal";
 import type { RichMention } from "@app/types/assistant/mentions";
 import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
@@ -82,7 +84,8 @@ interface InputBarProps {
     contentFragments: ContentFragmentsType,
     selectedMCPServerViewIds?: string[],
     selectedSpaceIds?: string[],
-    modelSelection?: ModelSelectionType
+    modelSelection?: ModelSelectionType,
+    goal?: GoalCreation
   ) => Promise<Result<undefined, DustError>>;
   draftKey: string;
   conversation?: ConversationWithoutContentType;
@@ -141,6 +144,7 @@ export const InputBar = React.memo(function InputBar({
   const [isLocalSubmitting, setIsLocalSubmitting] = useState(isSubmitting);
   const [isShaking, setIsShaking] = useState(false);
   const { featureFlags } = useFeatureFlags();
+  const isGoalModeEnabled = featureFlags.includes("goal_mode");
 
   const [attachedNodes, setAttachedNodes] = useState<
     DataSourceViewContentNode[]
@@ -533,6 +537,7 @@ export const InputBar = React.memo(function InputBar({
     onBeforeSubmit?.();
 
     const { mentions: rawMentions, markdown } = markdownAndMentions;
+    const { input, goal } = parseGoalCommand(markdown, isGoalModeEnabled);
     const shouldInjectSelectedAgent =
       selectedSingleAgent &&
       !rawMentions.some((m) => m.id === selectedSingleAgent.id);
@@ -563,7 +568,8 @@ export const InputBar = React.memo(function InputBar({
         attachment_count: attachedNodes.length + uploadedFiles.length,
         tool_count: selectedMCPServerViews.length,
         tool_names: selectedMCPServerViews.map((t) => t.server.name).join(","),
-        message_length: markdown.length,
+        message_length: input.length,
+        is_goal_mode: Boolean(goal),
       },
     });
 
@@ -575,7 +581,7 @@ export const InputBar = React.memo(function InputBar({
 
       try {
         const r = await onSubmit(
-          markdown,
+          input,
           mentions,
           {
             uploaded: fileUploaderService.getFileBlobs().map((cf) => {
@@ -592,7 +598,8 @@ export const InputBar = React.memo(function InputBar({
           // Once the conversation is created, the selectedMCPServerViewIds will be updated in the conversationTools hook.
           selectedMCPServerViews.map((sv) => sv.sId),
           selectedSpaceIds,
-          modelSelectionRef.current
+          modelSelectionRef.current,
+          goal
         );
 
         if (r.isOk()) {
@@ -613,7 +620,7 @@ export const InputBar = React.memo(function InputBar({
 
       try {
         const submitPromise = onSubmit(
-          markdown,
+          input,
           mentions,
           {
             uploaded: fileUploaderService.getFileBlobs().map((cf) => {
@@ -630,7 +637,8 @@ export const InputBar = React.memo(function InputBar({
           // conversationTools hook.
           undefined,
           selectedSpaceIds,
-          modelSelectionRef.current
+          modelSelectionRef.current,
+          goal
         );
 
         // Execute these operations in parallel with the submission.

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -328,6 +328,8 @@ const InputBarContainer = ({
     null
   );
   const { subscription } = useAuth();
+  const { hasFeature } = useFeatureFlags();
+  const isGoalModeEnabled = hasFeature("goal_mode");
   const isMobile = useIsMobile();
   const { selectedSingleAgent, setSelectedSingleAgent, isLoadingGoTemplate } =
     useContext(InputBarContext);
@@ -406,6 +408,7 @@ const InputBarContainer = ({
   slashCommandsRef.current = getAvailableInputBarSlashCommands({
     hasAttachment: actions.includes("attachment"),
     hasConversation: Boolean(conversation?.sId),
+    hasGoalMode: isGoalModeEnabled,
   });
   const onSelectRef = useRef<((item: SlashCommand) => void) | undefined>(
     undefined
@@ -682,6 +685,9 @@ const InputBarContainer = ({
           }
         })();
         break;
+      case "goal":
+        editorRef.current?.chain().focus().insertContent("/goal ").run();
+        break;
       default:
         assertNeverAndIgnore(command.id);
     }
@@ -945,7 +951,6 @@ const InputBarContainer = ({
     });
   }, [attachedNodes]);
 
-  const { hasFeature } = useFeatureFlags();
   const isLiveStt = hasFeature("live_speech_to_text");
 
   const voiceTranscriberService = useVoiceTranscriberService({

--- a/front/components/assistant/conversation/input_bar/types.ts
+++ b/front/components/assistant/conversation/input_bar/types.ts
@@ -1,0 +1,20 @@
+import type { DustError } from "@app/lib/error";
+import type { GoalCreation } from "@app/types/assistant/goal";
+import type { RichMention } from "@app/types/assistant/mentions";
+import type { ModelSelectionType } from "@app/types/assistant/models/types";
+import type { ContentFragmentsType } from "@app/types/content_fragment";
+import type { Result } from "@app/types/shared/result";
+
+export type InputBarSubmitOptions = {
+  selectedMCPServerViewIds?: string[];
+  selectedSpaceIds?: string[];
+  modelSelection?: ModelSelectionType;
+  goal?: GoalCreation;
+};
+
+export type InputBarSubmit = (
+  input: string,
+  mentions: RichMention[],
+  contentFragments: ContentFragmentsType,
+  options: InputBarSubmitOptions
+) => Promise<Result<undefined, DustError>>;

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -1,10 +1,10 @@
 import type { WorkspaceLimit } from "@app/components/app/ReachedLimitPopup";
 import type { InputBarContainerProps } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
+import type { InputBarSubmit } from "@app/components/assistant/conversation/input_bar/types";
 import type { AgentLoopToolNotificationEvent } from "@app/lib/actions/mcp";
 import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
-import type { DustError } from "@app/lib/error";
 import type { AgentMCPActionType } from "@app/types/actions";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
@@ -26,10 +26,7 @@ import {
   isUserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
 
-import type { RichMention } from "@app/types/assistant/mentions";
-import type { ContentFragmentsType } from "@app/types/content_fragment";
 import type { ModelId } from "@app/types/shared/model_id";
-import type { Result } from "@app/types/shared/result";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import type { MutableRefObject } from "react";
@@ -115,11 +112,7 @@ export type VirtuosoMessageListContext = {
   owner: LightWorkspaceType;
   user: UserType;
   isOnboardingConversation: boolean;
-  handleSubmit: (
-    input: string,
-    mentions: RichMention[],
-    contentFragments: ContentFragmentsType
-  ) => Promise<Result<undefined, DustError>>;
+  handleSubmit: InputBarSubmit;
   draftKey: string;
   conversation?: ConversationWithoutContentType;
   agentBuilderContext?: {

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.test.ts
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.test.ts
@@ -15,6 +15,7 @@ import {
 const ALL_COMMANDS = getAvailableInputBarSlashCommands({
   hasAttachment: true,
   hasConversation: true,
+  hasGoalMode: true,
 });
 
 function getInputBarSlashCommandItemId(item: SlashCommand): string {
@@ -31,6 +32,7 @@ describe("getAvailableInputBarSlashCommands", () => {
       getAvailableInputBarSlashCommands({
         hasAttachment: true,
         hasConversation: false,
+        hasGoalMode: false,
       }).map((command) => command.id)
     ).toEqual(["upload-file"]);
   });
@@ -40,8 +42,19 @@ describe("getAvailableInputBarSlashCommands", () => {
       getAvailableInputBarSlashCommands({
         hasAttachment: true,
         hasConversation: true,
+        hasGoalMode: false,
       }).map((command) => command.id)
     ).toEqual(["upload-file", "compact"]);
+  });
+
+  it("includes goal only when Goal Mode is enabled", () => {
+    expect(
+      getAvailableInputBarSlashCommands({
+        hasAttachment: false,
+        hasConversation: false,
+        hasGoalMode: true,
+      }).map((command) => command.id)
+    ).toEqual(["goal"]);
   });
 });
 
@@ -64,6 +77,7 @@ describe("buildInputBarSlashCommandItems", () => {
     });
 
     expect(result.map(getInputBarSlashCommandItemId)).toEqual([
+      "goal",
       "compact",
       "upload-file",
       "attach-knowledge",
@@ -77,7 +91,7 @@ describe("buildInputBarSlashCommandItems", () => {
         includeAttachKnowledge: false,
         query: "",
       }).map(getInputBarSlashCommandItemId)
-    ).toEqual(["compact", "upload-file"]);
+    ).toEqual(["goal", "compact", "upload-file"]);
 
     expect(
       buildInputBarSlashCommandItems({

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes.ts
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes.ts
@@ -1,20 +1,22 @@
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
-import { Minimize01, UploadCloud02 } from "@dust-tt/sparkle";
+import { Minimize01, Target04, UploadCloud02 } from "@dust-tt/sparkle";
 import type React from "react";
 
 export type InputBarSlashCommandId =
   | "attach-knowledge"
   | "compact"
+  | "goal"
   | "upload-file";
 
 /** Run commands backed by `INPUT_BAR_SLASH_COMMANDS` (icon, label, handler via `onSelectRef`). */
 export type InputBarRunCommandId = Extract<
   InputBarSlashCommandId,
-  "compact" | "upload-file"
+  "compact" | "goal" | "upload-file"
 >;
 
 /** Reorder this list to change display order in the `/` menu. */
 export const INPUT_BAR_SLASH_COMMAND_ORDER: InputBarSlashCommandId[] = [
+  "goal",
   "compact",
   "upload-file",
   "attach-knowledge",
@@ -30,6 +32,12 @@ export interface InputBarSlashCommand {
 }
 
 export const INPUT_BAR_SLASH_COMMANDS: InputBarSlashCommand[] = [
+  {
+    description: "Keep working autonomously until an objective is complete",
+    icon: Target04,
+    id: "goal",
+    label: "Goal",
+  },
   {
     description: "Upload a file from your device",
     icon: UploadCloud02,
@@ -47,9 +55,11 @@ export const INPUT_BAR_SLASH_COMMANDS: InputBarSlashCommand[] = [
 export function getAvailableInputBarSlashCommands({
   hasAttachment,
   hasConversation,
+  hasGoalMode,
 }: {
   hasAttachment: boolean;
   hasConversation: boolean;
+  hasGoalMode: boolean;
 }): InputBarSlashCommand[] {
   return INPUT_BAR_SLASH_COMMANDS.filter((command) => {
     if (command.id === "upload-file") {
@@ -58,6 +68,10 @@ export function getAvailableInputBarSlashCommands({
 
     if (command.id === "compact") {
       return hasConversation;
+    }
+
+    if (command.id === "goal") {
+      return hasGoalMode;
     }
 
     return true;

--- a/front/components/pod/PodPageContent.tsx
+++ b/front/components/pod/PodPageContent.tsx
@@ -1,3 +1,4 @@
+import type { InputBarSubmit } from "@app/components/assistant/conversation/input_bar/types";
 import type { TaskOwnerFilter } from "@app/components/assistant/conversation/space/conversations/project_tasks/projectTasksListScope";
 import { ManageUsersPanel } from "@app/components/assistant/conversation/space/ManageUsersPanel";
 import { PodConversationsTab } from "@app/components/pod/conversation/PodConversationsTab";
@@ -13,15 +14,10 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import type { PodUiScopedPreferences } from "@app/hooks/useScopedUIPreferences";
 import type { PodTab } from "@app/hooks/useSpaceProjectTabs";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
-import type { DustError } from "@app/lib/error";
 import { useAppRouter } from "@app/lib/platform";
 import type { useSpaceInfo } from "@app/lib/swr/spaces";
 import { getConversationRoute } from "@app/lib/utils/router";
-import type { RichMention } from "@app/types/assistant/mentions";
 import { toMentionType } from "@app/types/assistant/mentions";
-import type { ModelSelectionType } from "@app/types/assistant/models/types";
-import type { ContentFragmentsType } from "@app/types/content_fragment";
-import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { TabsContent } from "@dust-tt/sparkle";
 import { useCallback, useState } from "react";
@@ -94,15 +90,13 @@ export function PodPageContent({
     });
   };
 
-  const handleConversationCreation = useCallback(
+  const handleConversationCreation = useCallback<InputBarSubmit>(
     async (
-      input: string,
-      mentions: RichMention[],
-      contentFragments: ContentFragmentsType,
-      selectedMCPServerViewIds?: string[],
-      _selectedSpaceIds?: string[],
-      modelSelection?: ModelSelectionType
-    ): Promise<Result<undefined, DustError>> => {
+      input,
+      mentions,
+      contentFragments,
+      { selectedMCPServerViewIds, modelSelection, goal }
+    ) => {
       if (isSubmitting) {
         return new Err({
           code: "internal_error",
@@ -122,11 +116,10 @@ export function PodPageContent({
           selectedMCPServerViewIds,
           richMentions: mentions,
           modelSelection,
+          goal,
         },
         spaceId: podInfo.sId,
-        // Navigate as soon as the conversation exists; the first message is posted
-        // in the background by useCreateConversationWithMessage.
-        deferMessage: true,
+        deferMessage: !goal,
       });
 
       setIsSubmitting(false);

--- a/front/components/pod/conversation/PodConversationsTab.tsx
+++ b/front/components/pod/conversation/PodConversationsTab.tsx
@@ -1,5 +1,6 @@
 import { ActivationNextSteps } from "@app/components/assistant/conversation/ActivationNextSteps";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
+import type { InputBarSubmit } from "@app/components/assistant/conversation/input_bar/types";
 import { getGroupConversationsByDate } from "@app/components/assistant/conversation/utils";
 import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
@@ -21,10 +22,6 @@ import type { PodConversationListItemType } from "@app/types/api/assistant/conve
 import type { GetSpaceResponseBody } from "@app/types/api/spaces";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { getConversationDisplayTitle } from "@app/types/assistant/conversation";
-import type { RichMention } from "@app/types/assistant/mentions";
-import type { ModelSelectionType } from "@app/types/assistant/models/types";
-import type { ContentFragmentsType } from "@app/types/content_fragment";
-import type { Result } from "@app/types/shared/result";
 import {
   resolveDefaultAgentId,
   type UserType,
@@ -67,14 +64,7 @@ interface PodConversationsTabProps {
   isPodEmpty: boolean;
   conversationFilter: PodConversationListFilter;
   onConversationFilterChange: (filter: PodConversationListFilter) => void;
-  onSubmit: (
-    input: string,
-    mentions: RichMention[],
-    contentFragments: ContentFragmentsType,
-    selectedMCPServerViewIds?: string[],
-    selectedSpaceIds?: string[],
-    modelSelection?: ModelSelectionType
-  ) => Promise<Result<undefined, any>>;
+  onSubmit: InputBarSubmit;
   onNavigateToTasks: () => void;
 }
 

--- a/front/hooks/useCreateConversationWithMessage.ts
+++ b/front/hooks/useCreateConversationWithMessage.ts
@@ -21,6 +21,7 @@ import type {
   ConversationVisibility,
   SubmitMessageError,
 } from "@app/types/assistant/conversation";
+import type { GoalCreation } from "@app/types/assistant/goal";
 import type { MentionType, RichMention } from "@app/types/assistant/mentions";
 import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
@@ -68,6 +69,7 @@ export function useCreateConversationWithMessage({
         richMentions?: RichMention[];
         // Optional per-message model override from the input-bar model picker.
         modelSelection?: ModelSelectionType;
+        goal?: GoalCreation;
       };
       visibility?: ConversationVisibility;
       title?: string;
@@ -102,6 +104,7 @@ export function useCreateConversationWithMessage({
         origin: messageOrigin,
         richMentions,
         modelSelection,
+        goal,
       } = messageData;
       const origin = messageOrigin ?? contextOrigin;
       const selectedSpaceIds =
@@ -159,6 +162,7 @@ export function useCreateConversationWithMessage({
             skipToolsValidation,
             profilePictureUrl: user.image,
             modelSelection,
+            goal,
             onError:
               onError ??
               ((err) => {
@@ -197,6 +201,7 @@ export function useCreateConversationWithMessage({
           },
           mentions,
           modelSelection,
+          goal,
         },
         contentFragments: [
           ...contentFragments.uploaded.map((cf) => ({
@@ -276,6 +281,7 @@ async function postFirstMessageInBackground({
   skipToolsValidation,
   profilePictureUrl,
   modelSelection,
+  goal,
   onError,
 }: {
   workspaceId: string;
@@ -290,6 +296,7 @@ async function postFirstMessageInBackground({
   skipToolsValidation: boolean;
   profilePictureUrl: string | null;
   modelSelection?: ModelSelectionType;
+  goal?: GoalCreation;
   onError?: (err: SubmitMessageError) => void;
 }): Promise<void> {
   const timezone =
@@ -366,6 +373,7 @@ async function postFirstMessageInBackground({
           mentions,
           skipToolsValidation,
           modelSelection,
+          goal,
         }),
       }
     );

--- a/front/hooks/useSubmitMessage.ts
+++ b/front/hooks/useSubmitMessage.ts
@@ -6,6 +6,7 @@ import type {
   ClientMessageOrigin,
   SubmitMessageError,
 } from "@app/types/assistant/conversation";
+import type { GoalCreation } from "@app/types/assistant/goal";
 import type { MentionType } from "@app/types/assistant/mentions";
 import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
@@ -40,6 +41,7 @@ export function useSubmitMessage({
       origin?: ClientMessageOrigin;
       skipToolsValidation?: boolean;
       modelSelection?: ModelSelectionType;
+      goal?: GoalCreation;
     }): Promise<Result<PostMessagesResponseBody, SubmitMessageError>> => {
       if (!conversationId) {
         return new Err({
@@ -58,6 +60,7 @@ export function useSubmitMessage({
         origin: messageOrigin,
         skipToolsValidation,
         modelSelection,
+        goal,
       } = messageData;
       const origin = messageOrigin ?? contextOrigin;
 
@@ -136,6 +139,7 @@ export function useSubmitMessage({
             mentions,
             skipToolsValidation,
             modelSelection,
+            goal,
           }),
         }
       );

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -34,6 +34,7 @@ import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -89,6 +90,7 @@ vi.mock("@app/lib/api/assistant/conversation/content_fragment", () => ({
 import { runOnRedis } from "@app/lib/api/redis";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
+import { ConversationGoalResource } from "@app/lib/resources/conversation_goal_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { GroupSpaceViewerResource } from "@app/lib/resources/group_space_viewer_resource";
@@ -1606,6 +1608,79 @@ describe("postUserMessage", () => {
     );
 
     vi.clearAllMocks();
+  });
+
+  it("creates an active goal atomically with its first agent turn", async () => {
+    await FeatureFlagFactory.basic(auth, "goal_mode");
+    const user = auth.getNonNullableUser().toJSON();
+
+    const result = await postUserMessage(auth, {
+      conversationResource,
+      content: "Ship and verify Goal Mode",
+      mentions: [{ configurationId: agentConfig1.sId }],
+      context: {
+        username: user.username,
+        timezone: "UTC",
+        fullName: user.fullName,
+        email: user.email,
+        profilePictureUrl: user.image,
+        origin: "web",
+      },
+      skipToolsValidation: false,
+      goal: { objective: "Ship and verify Goal Mode" },
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+
+    const goal = await ConversationGoalResource.fetchLatest(auth, {
+      conversation: conversationResource,
+      branchId: null,
+    });
+    expect(goal?.toJSON()).toMatchObject({
+      objective: "Ship and verify Goal Mode",
+      status: "active",
+      agentConfigurationId: agentConfig1.sId,
+      turnCount: 1,
+      maxTurns: 25,
+    });
+    expect(result.value.agentMessages).toHaveLength(1);
+    expect(launchAgentLoopWorkflow).toHaveBeenCalledTimes(1);
+
+  });
+
+  it("rejects goal metadata when Goal Mode is not enabled", async () => {
+    const user = auth.getNonNullableUser().toJSON();
+
+    const result = await postUserMessage(auth, {
+      conversationResource,
+      content: "Try to start a goal",
+      mentions: [{ configurationId: agentConfig1.sId }],
+      context: {
+        username: user.username,
+        timezone: "UTC",
+        fullName: user.fullName,
+        email: user.email,
+        profilePictureUrl: user.image,
+        origin: "web",
+      },
+      skipToolsValidation: false,
+      goal: { objective: "Try to start a goal" },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.status_code).toBe(403);
+      expect(result.error.api_error.type).toBe("invalid_request_error");
+    }
+    expect(
+      await ConversationGoalResource.fetchLatest(auth, {
+        conversation: conversationResource,
+        branchId: null,
+      })
+    ).toBeNull();
   });
 
   it("should reject programmatic messages when programmatic credits are exhausted", async () => {

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -1648,7 +1648,6 @@ describe("postUserMessage", () => {
     });
     expect(result.value.agentMessages).toHaveLength(1);
     expect(launchAgentLoopWorkflow).toHaveBeenCalledTimes(1);
-
   });
 
   it("rejects goal metadata when Goal Mode is not enabled", async () => {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -97,6 +97,10 @@ import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_reso
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import {
+  ConversationGoalResource,
+  DEFAULT_GOAL_MAX_TURNS,
+} from "@app/lib/resources/conversation_goal_resource";
+import {
   ConversationResource,
   type RunningAgentMessageContext,
 } from "@app/lib/resources/conversation_resource";
@@ -152,6 +156,7 @@ import {
   isUserMessageType,
   UNRESUMABLE_AGENT_MESSAGE_STATUSES,
 } from "@app/types/assistant/conversation";
+import type { GoalCreation } from "@app/types/assistant/goal";
 import type { MentionType } from "@app/types/assistant/mentions";
 import {
   isAgentMention,
@@ -533,6 +538,7 @@ export async function postUserMessage(
     skipDustAutoMention,
     doNotAssociateUser,
     modelSelection,
+    goal,
   }: {
     conversationResource: ConversationResource;
     branchId?: string | null;
@@ -544,6 +550,7 @@ export async function postUserMessage(
     doNotAssociateUser?: boolean;
     skipDustAutoMention?: boolean;
     modelSelection?: ModelSelectionType;
+    goal?: GoalCreation;
   }
 ): Promise<
   Result<
@@ -576,6 +583,25 @@ export async function postUserMessage(
 
   const featureFlags = await getFeatureFlags(auth);
   const isPartOfPod = isPodConversation(conversation);
+
+  if (goal && !featureFlags.includes("goal_mode")) {
+    return new Err({
+      status_code: 403,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Goal Mode is not enabled for this workspace.",
+      },
+    });
+  }
+  if (goal && !user) {
+    return new Err({
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Goal Mode requires an authenticated user.",
+      },
+    });
+  }
 
   if (isPartOfPod) {
     // Check if the user is a member of the space.
@@ -685,6 +711,17 @@ export async function postUserMessage(
   let runningAgentMessage: RunningAgentMessageContext | undefined =
     runningAgentContext ?? undefined;
 
+  if (goal && runningAgentMessage) {
+    return new Err({
+      status_code: 409,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "A goal cannot be started while another agent turn is still running.",
+      },
+    });
+  }
+
   // Steering invariants: enforce single agent loop per conversation.
   if (explicitAgentMentions.length > 1) {
     return new Err({
@@ -743,6 +780,16 @@ export async function postUserMessage(
 
   let agentConfigurations = removeNulls(results[0]);
   let shouldCreateBranch = false;
+
+  if (goal && agentConfigurations.length !== 1) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Goal Mode requires exactly one agent.",
+      },
+    });
+  }
 
   // Retired global agents can't be invoked (new conversations or new messages).
   // The internal `run_agent` path is exempt: some hidden sub-agents are retired.
@@ -820,7 +867,7 @@ export async function postUserMessage(
   }
 
   // In one big transaction create all Message, UserMessage, AgentMessage and Mention rows.
-  const { userMessage, agentMessages } = await withTransaction(async (t) => {
+  const transactionResult = await withTransaction(async (t) => {
     // Since we are getting a transaction level lock, we can't execute any other SQL query outside of
     // this transaction, otherwise this other query will be competing for a connection in the database
     // connection pool, resulting in a deadlock.
@@ -910,6 +957,20 @@ export async function postUserMessage(
             nextMessageRank = previousMessage.rank + 1;
           }
         }
+      }
+    }
+
+    if (goal) {
+      const existingGoal = await ConversationGoalResource.fetchUnfinished(
+        auth,
+        {
+          conversationModelId: conversation.id,
+          branchId: conversation.branchId,
+          transaction: t,
+        }
+      );
+      if (existingGoal) {
+        return { goalConflict: true as const };
       }
     }
 
@@ -1028,6 +1089,30 @@ export async function postUserMessage(
 
       richMentions.push(...agentRichMentions);
 
+      if (goal) {
+        const agentMessage = agentMessages[0];
+        if (!agentMessage || !user) {
+          throw new Error(
+            "Goal Mode invariant violated: expected one agent message and an authenticated user."
+          );
+        }
+        await ConversationGoalResource.makeNew(
+          auth,
+          {
+            objective: goal.objective,
+            conversationId: conversation.id,
+            branchId: conversation.branchId
+              ? getResourceIdFromSId(conversation.branchId)
+              : null,
+            createdByUserId: user.id,
+            agentConfigurationId: agentMessage.configuration.sId,
+            currentAgentMessageId: agentMessage.agentMessageId,
+            maxTurns: DEFAULT_GOAL_MAX_TURNS,
+          },
+          t
+        );
+      }
+
       const userMessage = {
         ...userMessageWithoutMentions,
         richMentions: richMentions,
@@ -1040,6 +1125,19 @@ export async function postUserMessage(
       };
     }
   });
+
+  if ("goalConflict" in transactionResult) {
+    return new Err({
+      status_code: 409,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "An unfinished goal already exists for this conversation branch.",
+      },
+    });
+  }
+
+  const { userMessage, agentMessages } = transactionResult;
 
   // If a user is mentioned, we want to make sure the conversation has a title.
   // This ensures that mentioned users receive a notification with a conversation title.

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1100,13 +1100,10 @@ export async function postUserMessage(
           auth,
           {
             objective: goal.objective,
-            conversationId: conversation.id,
-            branchId: conversation.branchId
-              ? getResourceIdFromSId(conversation.branchId)
-              : null,
-            createdByUserId: user.id,
+            conversation: conversationResource,
+            branchId: conversation.branchId,
             agentConfigurationId: agentMessage.configuration.sId,
-            currentAgentMessageId: agentMessage.agentMessageId,
+            currentAgentMessageId: agentMessage.sId,
             maxTurns: DEFAULT_GOAL_MAX_TURNS,
           },
           t

--- a/front/lib/resources/conversation_goal_resource.ts
+++ b/front/lib/resources/conversation_goal_resource.ts
@@ -3,7 +3,10 @@ import {
   AgentMessageModel,
   MessageModel,
 } from "@app/lib/models/agent/conversation";
-import { ConversationGoalModel } from "@app/lib/models/agent/conversation_goal";
+import {
+  ConversationGoalModel,
+  UNFINISHED_GOAL_STATUSES,
+} from "@app/lib/models/agent/conversation_goal";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -218,15 +221,15 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
         workspaceId: auth.getNonNullableWorkspace().id,
         conversationId: conversationModelId,
         branchId: branchId ? getResourceIdFromSId(branchId) : null,
-        status: { [Op.in]: ["active", "paused"] },
+        status: { [Op.in]: UNFINISHED_GOAL_STATUSES },
       },
       order: [
         ["createdAt", "DESC"],
         ["id", "DESC"],
       ],
       transaction,
-     });
-     return row ? new this(this.model, row.get()) : null;
+    });
+    return row ? new this(this.model, row.get()) : null;
   }
 
   static async fetchActiveForAgentLoop(

--- a/front/lib/resources/conversation_goal_resource.ts
+++ b/front/lib/resources/conversation_goal_resource.ts
@@ -16,6 +16,9 @@ import type { GoalStatus, GoalType } from "@app/types/assistant/goal";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import type { Attributes, Transaction } from "sequelize";
+import { Op } from "sequelize";
+
+export const DEFAULT_GOAL_MAX_TURNS = 25;
 
 export class GoalTransitionError extends Error {
   constructor(
@@ -196,6 +199,34 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
         conversationId: conversationModelId,
       },
     });
+  }
+
+  static async fetchUnfinished(
+    auth: Authenticator,
+    {
+      conversationModelId,
+      branchId,
+      transaction,
+    }: {
+      conversationModelId: ModelId;
+      branchId: string | null;
+      transaction?: Transaction;
+    }
+  ): Promise<ConversationGoalResource | null> {
+    const row = await this.model.findOne({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId: conversationModelId,
+        branchId: branchId ? getResourceIdFromSId(branchId) : null,
+        status: { [Op.in]: ["active", "paused"] },
+      },
+      order: [
+        ["createdAt", "DESC"],
+        ["id", "DESC"],
+      ],
+      transaction,
+     });
+     return row ? new this(this.model, row.get()) : null;
   }
 
   static async fetchActiveForAgentLoop(

--- a/front/types/api/assistant.ts
+++ b/front/types/api/assistant.ts
@@ -1,6 +1,7 @@
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import { INTERNAL_MIME_TYPES_VALUES } from "@dust-tt/client";
 import { z } from "zod";
+import { GoalCreationSchema } from "../assistant/goal";
 import { ModelSelectionSchema } from "../assistant/models/types";
 import type { SupportedNonImageContentType } from "../files";
 import { getSupportedNonImageMimeTypes } from "../files";
@@ -24,6 +25,7 @@ const UserMessageOriginSchema = z.enum([
 
 export const MessageBaseSchema = z.object({
   content: z.string(),
+  goal: GoalCreationSchema.optional(),
   mentions: z.array(z.union([AgentMentionSchema, UserMentionSchema])),
   context: z.object({
     timezone: z.string(),

--- a/front/types/assistant/goal.ts
+++ b/front/types/assistant/goal.ts
@@ -11,6 +11,11 @@ export const GOAL_STATUSES = [
 export const GoalStatusSchema = z.enum(GOAL_STATUSES);
 export type GoalStatus = z.infer<typeof GoalStatusSchema>;
 
+export const GoalCreationSchema = z.object({
+  objective: z.string().trim().min(1).max(4_000),
+});
+export type GoalCreation = z.infer<typeof GoalCreationSchema>;
+
 export type GoalType = {
   sId: string;
   objective: string;


### PR DESCRIPTION
## Description

Add the feature-gated `/goal` command and persist its objective atomically with the first agent turn. Goal Mode requires exactly one agent and rejects requests while another turn is running. A shared submit options object carries the goal through home, existing conversations, agent preview, and Pods without positional-argument drops.

Stacked on #29696.

## Tests

- Covers slash parsing and feature-gated command availability.
- Verifies atomic goal creation and disabled-flag rejection in the domain path.
- Exercises goal creation through both existing-conversation and new-conversation HTTP routes.
- Type-checks every supported conversation submission surface against the shared callback contract.

## Risk

Until #29701 lands, an unfinished goal remains active after its first agent response but is not automatically resumed. The user can continue it manually, and the goal does not expire after one turn.

## Deploy Plan

Merge after #29696. Keep `goal_mode` disabled until the complete stack is deployed.