### PR TITLE
Continue active goals after successful turns

### DIFF
--- a/front/lib/api/actions/servers/run_agent/conversation.ts
+++ b/front/lib/api/actions/servers/run_agent/conversation.ts
@@ -282,7 +282,9 @@ export async function getOrCreateConversation(
       fullName: `@${mainAgent.name}`,
       email: null,
       profilePictureUrl: mainAgent.pictureUrl,
-      origin: parentOrigin,
+      // Goal continuation is an internal-only origin that is not part of the
+      // public client contract used to create sub-agent conversations.
+      origin: parentOrigin === "goal_continuation" ? "web" : parentOrigin,
       selectedMCPServerViewIds: toolsetsToAdd,
     },
     agenticMessageData: {

--- a/front/lib/api/analytics/source_labels.ts
+++ b/front/lib/api/analytics/source_labels.ts
@@ -2,7 +2,7 @@ import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 
 export type AnalyticsVisibleOrigin = Exclude<
   UserMessageOrigin,
-  "reinforced_skill_notification" | "branch_anchor"
+  "reinforced_skill_notification" | "branch_anchor" | "goal_continuation"
 >;
 
 export const SOURCE_ORIGIN_LABELS: Record<AnalyticsVisibleOrigin, string> = {

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -1651,15 +1651,11 @@ describe("postUserMessage", () => {
     expect(launchAgentLoopWorkflow).toHaveBeenCalledTimes(1);
 
     const firstAgentMessage = result.value.agentMessages[0];
-    await AgentMessageModel.update(
-      { status: "succeeded" },
-      {
-        where: {
-          id: firstAgentMessage.agentMessageId,
-          workspaceId: workspace.id,
-        },
-      }
-    );
+    await ConversationFactory.setAgentMessageStatus({
+      workspace,
+      agentMessageModelId: firstAgentMessage.agentMessageId,
+      status: "succeeded",
+    });
 
     const outcome = await continueActiveGoal(auth, {
       agentMessageId: firstAgentMessage.sId,

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -15,6 +15,7 @@ import {
   getConversation,
   getLightConversation,
 } from "@app/lib/api/assistant/conversation/fetch";
+import { continueActiveGoal } from "@app/lib/api/assistant/goal_mode";
 import { gracefullyStopAgentLoop } from "@app/lib/api/assistant/pubsub";
 import { publishAgentMessagesEvents } from "@app/lib/api/assistant/streaming/events";
 import * as attachmentsModule from "@app/lib/api/files/attachments";
@@ -1648,6 +1649,58 @@ describe("postUserMessage", () => {
     });
     expect(result.value.agentMessages).toHaveLength(1);
     expect(launchAgentLoopWorkflow).toHaveBeenCalledTimes(1);
+
+    const firstAgentMessage = result.value.agentMessages[0];
+    await AgentMessageModel.update(
+      { status: "succeeded" },
+      {
+        where: {
+          id: firstAgentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      }
+    );
+
+    const outcome = await continueActiveGoal(auth, {
+      agentMessageId: firstAgentMessage.sId,
+      agentMessageVersion: firstAgentMessage.version,
+      conversationId: conversation.sId,
+      conversationTitle: conversation.title,
+      conversationBranchId: null,
+      userMessageId: result.value.userMessage.sId,
+      userMessageVersion: result.value.userMessage.version,
+      userMessageOrigin: "web",
+    });
+    expect(outcome).toBe("continued");
+    expect(launchAgentLoopWorkflow).toHaveBeenCalledTimes(2);
+
+    const retryOutcome = await continueActiveGoal(auth, {
+      agentMessageId: firstAgentMessage.sId,
+      agentMessageVersion: firstAgentMessage.version,
+      conversationId: conversation.sId,
+      conversationTitle: conversation.title,
+      conversationBranchId: null,
+      userMessageId: result.value.userMessage.sId,
+      userMessageVersion: result.value.userMessage.version,
+      userMessageOrigin: "web",
+    });
+    expect(retryOutcome).toBe("already_processed");
+    expect(launchAgentLoopWorkflow).toHaveBeenCalledTimes(2);
+
+    const continuedGoal = await ConversationGoalResource.fetchLatest(auth, {
+      conversation: conversationResource,
+      branchId: null,
+    });
+    expect(continuedGoal?.turnCount).toBe(2);
+    expect(
+      await UserMessageModel.count({
+        where: {
+          conversationId: conversation.id,
+          workspaceId: workspace.id,
+          userContextOrigin: "goal_continuation",
+        },
+      })
+    ).toBe(1);
   });
 
   it("rejects goal metadata when Goal Mode is not enabled", async () => {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -515,6 +515,7 @@ export function isUserMessageContextValid(
     case "reinforced_skill_notification":
     case "reinforcement":
     case "branch_anchor":
+    case "goal_continuation":
     case "web":
       return false;
     default:
@@ -539,6 +540,8 @@ export async function postUserMessage(
     doNotAssociateUser,
     modelSelection,
     goal,
+    continuationGoalId,
+    awaitWorkflowLaunch,
   }: {
     conversationResource: ConversationResource;
     branchId?: string | null;
@@ -551,6 +554,8 @@ export async function postUserMessage(
     skipDustAutoMention?: boolean;
     modelSelection?: ModelSelectionType;
     goal?: GoalCreation;
+    continuationGoalId?: string;
+    awaitWorkflowLaunch?: boolean;
   }
 ): Promise<
   Result<
@@ -1110,6 +1115,20 @@ export async function postUserMessage(
         );
       }
 
+      if (continuationGoalId) {
+        const agentMessage = agentMessages[0];
+        if (!agentMessage || agentMessages.length !== 1) {
+          throw new Error(
+            "Goal Mode invariant violated: expected one continuation agent message."
+          );
+        }
+        await ConversationGoalResource.setCurrentAgentMessage(auth, {
+          goalId: continuationGoalId,
+          agentMessageModelId: agentMessage.agentMessageId,
+          transaction: t,
+        });
+      }
+
       const userMessage = {
         ...userMessageWithoutMentions,
         richMentions: richMentions,
@@ -1142,10 +1161,12 @@ export async function postUserMessage(
     await ensureConversationTitle(auth, { conversation });
   }
 
-  await triggerConversationUnreadNotifications(auth, {
-    conversationId: conversation.sId,
-    messageId: userMessage.sId,
-  });
+  if (context.origin !== "goal_continuation") {
+    await triggerConversationUnreadNotifications(auth, {
+      conversationId: conversation.sId,
+      messageId: userMessage.sId,
+    });
+  }
 
   void ServerSideTracking.trackUserMessage({
     userMessage,
@@ -1199,6 +1220,7 @@ export async function postUserMessage(
       agentMessages,
       conversation,
       userMessage,
+      awaitLaunch: awaitWorkflowLaunch,
     });
   } else if (runningAgentMessage && userMessage.visibility === "pending") {
     // Pending path: signal the running agent loop to gracefully stop.

--- a/front/lib/api/assistant/conversation/agent_loop.ts
+++ b/front/lib/api/assistant/conversation/agent_loop.ts
@@ -18,11 +18,15 @@ export const runAgentLoopWorkflow = async ({
   agentMessages,
   conversation,
   userMessage,
+  awaitLaunch = false,
 }: {
   auth: Authenticator;
   agentMessages: AgentMessageType[];
   conversation: ConversationWithoutContentType;
   userMessage: UserMessageTypeWithoutMentions;
+  // Durable callers such as Goal Mode wait until the deterministic Temporal
+  // workflow has been started before acknowledging the handoff.
+  awaitLaunch?: boolean;
 }) => {
   await concurrentExecutor(
     agentMessages,
@@ -42,7 +46,7 @@ export const runAgentLoopWorkflow = async ({
         isRunningAgentLoop: true,
       });
 
-      void launchAgentLoopWorkflow({
+      const launch = launchAgentLoopWorkflow({
         auth,
         agentLoopArgs: {
           agentMessageId: agentMessage.sId,
@@ -56,6 +60,11 @@ export const runAgentLoopWorkflow = async ({
         },
         startStep: 0,
       });
+      if (awaitLaunch) {
+        await launch;
+      } else {
+        void launch;
+      }
     },
     { concurrency: MAX_CONCURRENT_AGENT_EXECUTIONS_PER_USER_MESSAGE }
   );

--- a/front/lib/api/assistant/goal_mode.ts
+++ b/front/lib/api/assistant/goal_mode.ts
@@ -1,0 +1,87 @@
+import { postUserMessage } from "@app/lib/api/assistant/conversation";
+import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { ConversationGoalResource } from "@app/lib/resources/conversation_goal_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+import type { GoalType } from "@app/types/assistant/goal";
+
+export type GoalContinuationOutcome =
+  | "continued"
+  | "already_processed"
+  | "inactive"
+  | "not_succeeded"
+  | "paused";
+
+const GOAL_CONTINUATION_MESSAGE =
+  "Continue working toward the active goal. Review the conversation and prior progress, then take the next concrete steps. Do not repeat completed work. Use update_goal only when the full goal is complete and verified, or when a genuine blocker prevents further progress.";
+
+export async function startActiveGoalTurn(
+  auth: Authenticator,
+  {
+    conversation,
+    goal,
+  }: {
+    conversation: ConversationResource;
+    goal: GoalType;
+  }
+): Promise<GoalContinuationOutcome> {
+  const user = auth.getNonNullableUser();
+  const result = await postUserMessage(auth, {
+    conversationResource: conversation,
+    branchId: goal.branchId,
+    content: GOAL_CONTINUATION_MESSAGE,
+    mentions: [{ configurationId: goal.agentConfigurationId }],
+    context: {
+      timezone: "Etc/UTC",
+      username: user.username,
+      fullName: user.fullName(),
+      email: user.email,
+      profilePictureUrl: user.imageUrl,
+      origin: "goal_continuation",
+      clientSideMCPServerIds: [],
+      selectedSpaceIds: [],
+    },
+    skipToolsValidation: false,
+    skipDustAutoMention: true,
+    doNotAssociateUser: true,
+    continuationGoalId: goal.sId,
+    awaitWorkflowLaunch: true,
+  });
+  return result.isOk() && result.value.agentMessages.length === 1
+    ? "continued"
+    : "inactive";
+}
+
+export async function continueActiveGoal(
+  auth: Authenticator,
+  agentLoopArgs: AgentLoopArgs
+): Promise<GoalContinuationOutcome> {
+  const featureFlags = await getFeatureFlags(auth);
+  if (!featureFlags.includes("goal_mode")) {
+    return "inactive";
+  }
+
+  const decision = await ConversationGoalResource.claimContinuation(auth, {
+    conversationId: agentLoopArgs.conversationId,
+    conversationBranchId: agentLoopArgs.conversationBranchId,
+    agentMessageId: agentLoopArgs.agentMessageId,
+  });
+  switch (decision.type) {
+    case "inactive":
+    case "not_succeeded":
+    case "already_processed":
+      return decision.type;
+    case "turn_limit_reached":
+      return "paused";
+    case "continue":
+      break;
+  }
+
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    agentLoopArgs.conversationId
+  );
+  return conversation
+    ? startActiveGoalTurn(auth, { conversation, goal: decision.goal })
+    : "inactive";
+}

--- a/front/lib/api/assistant/goal_mode.ts
+++ b/front/lib/api/assistant/goal_mode.ts
@@ -4,6 +4,7 @@ import { ConversationGoalResource } from "@app/lib/resources/conversation_goal_r
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import type { GoalType } from "@app/types/assistant/goal";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type GoalContinuationOutcome =
   | "continued"
@@ -75,6 +76,8 @@ export async function continueActiveGoal(
       return "paused";
     case "continue":
       break;
+    default:
+      return assertNever(decision);
   }
 
   const conversation = await ConversationResource.fetchById(

--- a/front/lib/api/programmatic_usage/common.ts
+++ b/front/lib/api/programmatic_usage/common.ts
@@ -39,6 +39,7 @@ export const USAGE_ORIGINS_CLASSIFICATION: Record<
   reinforced_skill_notification: "user",
   reinforcement: "programmatic",
   branch_anchor: "user",
+  goal_continuation: "user",
 };
 
 export const USER_USAGE_ORIGINS = Object.keys(

--- a/front/lib/api/v1/backward_compatibility.ts
+++ b/front/lib/api/v1/backward_compatibility.ts
@@ -126,7 +126,18 @@ export function addBackwardCompatibleConversationFields(
       } else if (
         isArrayOf<MessageType, UserMessageType>(c, isUserMessageType)
       ) {
-        return c.map((m) => m);
+        return c.map((m) => ({
+          ...m,
+          context: {
+            ...m.context,
+            // Synthetic Goal Mode turns are internal. Keep the existing public
+            // SDK origin union stable when serializing a conversation.
+            origin:
+              m.context.origin === "goal_continuation"
+                ? ("web" as const)
+                : m.context.origin,
+          },
+        }));
       } else if (
         isArrayOf<MessageType, ContentFragmentType>(c, isContentFragmentType)
       ) {

--- a/front/lib/notifications/workflows/conversation-unread.test.ts
+++ b/front/lib/notifications/workflows/conversation-unread.test.ts
@@ -97,6 +97,7 @@ describe("conversation-unread workflow business logic", () => {
     reinforced_skill_notification: false,
     reinforcement: false,
     branch_anchor: false,
+    goal_continuation: false,
   };
   describe("shouldSendNotificationForAgentAnswer", () => {
     it.each(

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -65,6 +65,7 @@ export const shouldSendNotificationForAgentAnswer = (
     case "reinforced_skill_notification":
     case "reinforcement":
     case "branch_anchor":
+    case "goal_continuation":
       // Internal bootstrap conversations shouldn't trigger unread notifications.
       return false;
     case "api":

--- a/front/lib/resources/conversation_goal_resource.ts
+++ b/front/lib/resources/conversation_goal_resource.ts
@@ -1,6 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMessageModel,
+  ConversationModel,
   MessageModel,
 } from "@app/lib/models/agent/conversation";
 import {
@@ -22,6 +23,16 @@ import type { Attributes, Transaction } from "sequelize";
 import { Op } from "sequelize";
 
 export const DEFAULT_GOAL_MAX_TURNS = 25;
+
+export type GoalContinuationDecision =
+  | { type: "continue"; goal: GoalType }
+  | {
+      type:
+        | "already_processed"
+        | "inactive"
+        | "not_succeeded"
+        | "turn_limit_reached";
+    };
 
 export class GoalTransitionError extends Error {
   constructor(
@@ -321,6 +332,132 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
         ? new Ok(new this(this.model, updated.get()))
         : new Err(new GoalTransitionError("goal_conflict"));
     });
+  }
+
+  static async claimContinuation(
+    auth: Authenticator,
+    {
+      conversationId,
+      conversationBranchId,
+      agentMessageId,
+    }: {
+      conversationId: string;
+      conversationBranchId: string | null;
+      agentMessageId: string;
+    }
+  ): Promise<GoalContinuationDecision> {
+    const conversation = await ConversationModel.findOne({
+      attributes: ["id"],
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        sId: conversationId,
+      },
+    });
+    if (!conversation) {
+      return { type: "inactive" };
+    }
+
+    return withTransaction(async (transaction) => {
+      const goalRow = await this.model.findOne({
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          conversationId: conversation.id,
+          branchId: conversationBranchId
+            ? getResourceIdFromSId(conversationBranchId)
+            : null,
+        },
+        order: [
+          ["createdAt", "DESC"],
+          ["id", "DESC"],
+        ],
+        transaction,
+        lock: transaction.LOCK.UPDATE,
+      });
+      if (!goalRow || goalRow.status !== "active") {
+        return { type: "inactive" };
+      }
+
+      const message = await MessageModel.findOne({
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          conversationId: conversation.id,
+          sId: agentMessageId,
+        },
+        include: [
+          {
+            model: AgentMessageModel,
+            as: "agentMessage",
+            required: true,
+          },
+        ],
+        transaction,
+      });
+      if (message?.agentMessage?.status !== "succeeded") {
+        return { type: "not_succeeded" };
+      }
+      if (goalRow.lastAgentMessageId === message.agentMessage.id) {
+        return { type: "already_processed" };
+      }
+      if (
+        goalRow.currentAgentMessageId !== message.agentMessage.id ||
+        goalRow.agentConfigurationId !==
+          message.agentMessage.agentConfigurationId
+      ) {
+        return { type: "inactive" };
+      }
+      if (goalRow.turnCount >= goalRow.maxTurns) {
+        await goalRow.update(
+          {
+            status: "paused",
+            reason: "turn_limit_reached",
+            lastAgentMessageId: message.agentMessage.id,
+          },
+          { transaction }
+        );
+        return { type: "turn_limit_reached" };
+      }
+
+      await goalRow.update(
+        {
+          lastAgentMessageId: message.agentMessage.id,
+          turnCount: goalRow.turnCount + 1,
+        },
+        { transaction }
+      );
+      return {
+        type: "continue",
+        goal: new this(this.model, goalRow.get()).toJSON(),
+      };
+    });
+  }
+
+  static async setCurrentAgentMessage(
+    auth: Authenticator,
+    {
+      goalId,
+      agentMessageModelId,
+      transaction,
+    }: {
+      goalId: string;
+      agentMessageModelId: ModelId;
+      transaction: Transaction;
+    }
+  ): Promise<void> {
+    const goalModelId = getResourceIdFromSId(goalId);
+    if (!goalModelId) {
+      throw new Error("Invalid goal identifier");
+    }
+    await this.model.update(
+      { currentAgentMessageId: agentMessageModelId },
+      {
+        where: {
+          id: goalModelId,
+          workspaceId: auth.getNonNullableWorkspace().id,
+          status: "active",
+        },
+        transaction,
+      }
+    );
   }
 
   async delete(

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -3,6 +3,7 @@ import {
   sendEmailReplyOnCompletion,
   sendEmailReplyOnError,
 } from "@app/lib/api/assistant/email/email_reply";
+import { continueActiveGoal } from "@app/lib/api/assistant/goal_mode";
 import { Authenticator, type AuthenticatorType } from "@app/lib/auth";
 import { launchAgentMessageAnalytics } from "@app/temporal/agent_loop/activities/analytics";
 import {
@@ -37,6 +38,18 @@ export async function finalizeSuccessfulAgentLoopActivity(
     launchTrackProgrammaticUsage(auth, agentLoopArgs),
     launchEmitMetronomeUsageEvents(auth, agentLoopArgs),
     computeAndStoreAgentMessageCredits(auth, agentLoopArgs),
+  ]);
+
+  const goalOutcome = await continueActiveGoal(auth, agentLoopArgs);
+  if (
+    goalOutcome === "continued" ||
+    goalOutcome === "already_processed" ||
+    goalOutcome === "not_succeeded"
+  ) {
+    return;
+  }
+
+  await Promise.all([
     conversationUnreadNotification(auth, agentLoopArgs),
     activationNewConversationNotification(auth, agentLoopArgs),
     handleMentions(auth, agentLoopArgs),

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -127,13 +127,16 @@ export type UserMessageOrigin =
   | "reinforcement"
   // Internal anchor user message inserted at the start of an empty conversation so
   // a branch can be created before any user-visible message exists.
-  | "branch_anchor";
+  | "branch_anchor"
+  // Internal model-visible turn inserted while an active Goal Mode goal continues.
+  | "goal_continuation";
 
 export const HIDDEN_MESSAGE_ORIGINS: UserMessageOrigin[] = [
   "onboarding_conversation",
   "project_kickoff",
   "reinforced_skill_notification",
   "branch_anchor",
+  "goal_continuation",
   "wakeup",
 ];
 

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -401,6 +401,7 @@ const USER_MESSAGE_ORIGINS = [
   "reinforced_skill_notification",
   "reinforcement",
   "branch_anchor",
+  "goal_continuation",
 ] as const;
 
 const UserMessageOriginEnumSchema = z.enum(USER_MESSAGE_ORIGINS);


### PR DESCRIPTION
## Description

After a successful turn, atomically claim the active goal and start one hidden continuation turn unless the agent already completed or blocked it. Synthetic turns stay hidden, user-billed, and notification-free.

Stacked on #29700.

## Tests

Covered continuation creation, duplicate finalization, hidden-message persistence, exhaustive decision handling, and answer-notification suppression.

## Risk

This slice intentionally handles only the happy path. #29702 adds abandoned-claim and workflow-launch recovery, so `goal_mode` must remain disabled until that successor is deployed.

## Deploy Plan

Merge after #29700. Do not enable `goal_mode` until #29702 and the remaining recovery stack are deployed.