### PR TITLE
Recover interrupted goal handoffs

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -1680,8 +1680,8 @@ describe("postUserMessage", () => {
       userMessageVersion: result.value.userMessage.version,
       userMessageOrigin: "web",
     });
-    expect(retryOutcome).toBe("already_processed");
-    expect(launchAgentLoopWorkflow).toHaveBeenCalledTimes(2);
+    expect(retryOutcome).toBe("continued");
+    expect(launchAgentLoopWorkflow).toHaveBeenCalledTimes(3);
 
     const continuedGoal = await ConversationGoalResource.fetchLatest(auth, {
       conversation: conversationResource,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -540,7 +540,7 @@ export async function postUserMessage(
     doNotAssociateUser,
     modelSelection,
     goal,
-    continuationGoalId,
+    continuationGoal,
     awaitWorkflowLaunch,
   }: {
     conversationResource: ConversationResource;
@@ -554,7 +554,7 @@ export async function postUserMessage(
     skipDustAutoMention?: boolean;
     modelSelection?: ModelSelectionType;
     goal?: GoalCreation;
-    continuationGoalId?: string;
+    continuationGoal?: ConversationGoalResource;
     awaitWorkflowLaunch?: boolean;
   }
 ): Promise<
@@ -1115,18 +1115,23 @@ export async function postUserMessage(
         );
       }
 
-      if (continuationGoalId) {
+      if (continuationGoal) {
         const agentMessage = agentMessages[0];
-        if (!agentMessage || agentMessages.length !== 1) {
+        if (
+          !agentMessage ||
+          agentMessages.length !== 1 ||
+          !(await continuationGoal.setCurrentAgentMessage(auth, {
+            conversation: conversationResource,
+            branchId: conversation.branchId,
+            agentMessageId: agentMessage.sId,
+            agentConfigurationId: agentMessage.configuration.sId,
+            transaction: t,
+          }))
+        ) {
           throw new Error(
-            "Goal Mode invariant violated: expected one continuation agent message."
+            "Goal Mode invariant violated: failed to associate the continuation agent message."
           );
         }
-        await ConversationGoalResource.setCurrentAgentMessage(auth, {
-          goalId: continuationGoalId,
-          agentMessageModelId: agentMessage.agentMessageId,
-          transaction: t,
-        });
       }
 
       const userMessage = {

--- a/front/lib/api/assistant/goal_mode.ts
+++ b/front/lib/api/assistant/goal_mode.ts
@@ -2,6 +2,7 @@ import { postUserMessage } from "@app/lib/api/assistant/conversation";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { ConversationGoalResource } from "@app/lib/resources/conversation_goal_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import type { GoalType } from "@app/types/assistant/goal";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -16,6 +17,47 @@ export type GoalContinuationOutcome =
 const GOAL_CONTINUATION_MESSAGE =
   "Continue working toward the active goal. Review the conversation and prior progress, then take the next concrete steps. Do not repeat completed work. Use update_goal only when the full goal is complete and verified, or when a genuine blocker prevents further progress.";
 
+async function ensureCurrentGoalTurn(
+  auth: Authenticator,
+  {
+    conversation,
+    goal,
+  }: {
+    conversation: ConversationResource;
+    goal: GoalType;
+  }
+): Promise<GoalContinuationOutcome> {
+  const activeGoal = await ConversationGoalResource.fetchLatest(auth, {
+    conversation,
+    branchId: goal.branchId,
+  });
+  if (activeGoal?.sId !== goal.sId || activeGoal.status !== "active") {
+    return "paused";
+  }
+  const recovery = await activeGoal.fetchTurnRecovery(auth, { conversation });
+  switch (recovery.type) {
+    case "already_succeeded":
+      return "continued";
+    case "unavailable":
+      return "paused";
+    case "restart":
+      break;
+    default:
+      return assertNever(recovery);
+  }
+
+  await ConversationResource.setIsRunningAgentLoop(auth, {
+    conversation: conversation.toJSON(),
+    isRunningAgentLoop: true,
+  });
+  await launchAgentLoopWorkflow({
+    auth,
+    agentLoopArgs: recovery.agentLoopArgs,
+    startStep: 0,
+  });
+  return "continued";
+}
+
 export async function startActiveGoalTurn(
   auth: Authenticator,
   {
@@ -26,6 +68,14 @@ export async function startActiveGoalTurn(
     goal: GoalType;
   }
 ): Promise<GoalContinuationOutcome> {
+  const activeGoal = await ConversationGoalResource.fetchLatest(auth, {
+    conversation,
+    branchId: goal.branchId,
+  });
+  if (activeGoal?.sId !== goal.sId || activeGoal.status !== "active") {
+    return "paused";
+  }
+  const expectedCurrentAgentMessageModelId = activeGoal.currentAgentMessageId;
   const user = auth.getNonNullableUser();
   const result = await postUserMessage(auth, {
     conversationResource: conversation,
@@ -45,10 +95,18 @@ export async function startActiveGoalTurn(
     skipToolsValidation: false,
     skipDustAutoMention: true,
     doNotAssociateUser: true,
-    continuationGoalId: goal.sId,
+    continuationGoal: activeGoal,
     awaitWorkflowLaunch: true,
   });
-  return result.isOk() && result.value.agentMessages.length === 1
+  if (result.isOk() && result.value.agentMessages.length === 1) {
+    return "continued";
+  }
+  const latest = await ConversationGoalResource.fetchLatest(auth, {
+    conversation,
+    branchId: goal.branchId,
+  });
+  return latest?.sId === goal.sId &&
+    latest.currentAgentMessageId !== expectedCurrentAgentMessageModelId
     ? "continued"
     : "inactive";
 }
@@ -74,6 +132,8 @@ export async function continueActiveGoal(
       return decision.type;
     case "turn_limit_reached":
       return "paused";
+    case "ensure_current":
+      break;
     case "continue":
       break;
     default:
@@ -84,7 +144,10 @@ export async function continueActiveGoal(
     auth,
     agentLoopArgs.conversationId
   );
-  return conversation
-    ? startActiveGoalTurn(auth, { conversation, goal: decision.goal })
-    : "inactive";
+  if (!conversation) {
+    return "inactive";
+  }
+  return decision.type === "ensure_current"
+    ? ensureCurrentGoalTurn(auth, { conversation, goal: decision.goal })
+    : startActiveGoalTurn(auth, { conversation, goal: decision.goal });
 }

--- a/front/lib/resources/conversation_goal_resource.test.ts
+++ b/front/lib/resources/conversation_goal_resource.test.ts
@@ -1,0 +1,155 @@
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationGoalResource } from "@app/lib/resources/conversation_goal_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import type { WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("ConversationGoalResource", () => {
+  let auth: Authenticator;
+  let workspace: WorkspaceType;
+  let conversation: ConversationType;
+  let conversationResource: ConversationResource;
+  let agent: LightAgentConfigurationType;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({ role: "builder" });
+    auth = setup.authenticator;
+    workspace = auth.getNonNullableWorkspace();
+    agent = await AgentConfigurationFactory.createTestAgent(auth);
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+    const resource = await ConversationResource.fetchById(
+      auth,
+      conversation.sId
+    );
+    if (!resource) {
+      throw new Error("Conversation not found");
+    }
+    conversationResource = resource;
+  });
+
+  async function createAgentMessage(status: "created" | "succeeded", rank = 1) {
+    const message = await ConversationFactory.createAgentMessageWithRank({
+      workspace,
+      conversationId: conversation.id,
+      rank,
+      agentConfigurationId: agent.sId,
+    });
+    const agentMessageModelId = message.agentMessageId;
+    if (agentMessageModelId === null) {
+      throw new Error("Agent message not found");
+    }
+    if (status === "succeeded") {
+      await ConversationFactory.setAgentMessageStatus({
+        workspace,
+        agentMessageModelId,
+        status,
+      });
+    }
+    return { message, agentMessageModelId };
+  }
+
+  async function createGoal(currentAgentMessageId: string) {
+    return withTransaction((transaction) =>
+      ConversationGoalResource.makeNew(
+        auth,
+        {
+          objective: "Ship and verify Goal Mode",
+          conversation: conversationResource,
+          branchId: null,
+          agentConfigurationId: agent.sId,
+          currentAgentMessageId,
+          maxTurns: 25,
+        },
+        transaction
+      )
+    );
+  }
+
+  it("recovers an abandoned continuation claim", async () => {
+    const { message } = await createAgentMessage("succeeded");
+    const goal = await createGoal(message.sId);
+
+    expect(
+      await ConversationGoalResource.claimContinuation(auth, {
+        conversationId: conversation.sId,
+        conversationBranchId: null,
+        agentMessageId: message.sId,
+      })
+    ).toMatchObject({ type: "continue", goal: { turnCount: 2 } });
+    expect(
+      await ConversationGoalResource.claimContinuation(auth, {
+        conversationId: conversation.sId,
+        conversationBranchId: null,
+        agentMessageId: message.sId,
+      })
+    ).toMatchObject({ type: "continue", goal: { turnCount: 2 } });
+
+    const next = await createAgentMessage("created", 2);
+    await withTransaction(async (transaction) => {
+      expect(
+        await goal.setCurrentAgentMessage(auth, {
+          conversation: conversationResource,
+          branchId: null,
+          agentMessageId: next.message.sId,
+          agentConfigurationId: agent.sId,
+          transaction,
+        })
+      ).toBe(true);
+    });
+    await withTransaction(async (transaction) => {
+      expect(
+        await goal.setCurrentAgentMessage(auth, {
+          conversation: conversationResource,
+          branchId: null,
+          agentMessageId: next.message.sId,
+          agentConfigurationId: agent.sId,
+          transaction,
+        })
+      ).toBe(false);
+    });
+    expect(
+      (
+        await ConversationGoalResource.fetchLatest(auth, {
+          conversation: conversationResource,
+        })
+      )?.currentAgentMessageId
+    ).toBe(next.agentMessageModelId);
+
+    expect(
+      await ConversationGoalResource.claimContinuation(auth, {
+        conversationId: conversation.sId,
+        conversationBranchId: null,
+        agentMessageId: message.sId,
+      })
+    ).toMatchObject({ type: "ensure_current", goal: { turnCount: 2 } });
+  });
+
+  it("does not claim an unfinished agent turn", async () => {
+    const { message } = await createAgentMessage("created");
+    await createGoal(message.sId);
+
+    expect(
+      await ConversationGoalResource.claimContinuation(auth, {
+        conversationId: conversation.sId,
+        conversationBranchId: null,
+        agentMessageId: message.sId,
+      })
+    ).toEqual({ type: "not_succeeded" });
+    expect(
+      (
+        await ConversationGoalResource.fetchLatest(auth, {
+          conversation: conversationResource,
+        })
+      )?.turnCount
+    ).toBe(1);
+  });
+});

--- a/front/lib/resources/conversation_goal_resource.ts
+++ b/front/lib/resources/conversation_goal_resource.ts
@@ -3,6 +3,7 @@ import {
   AgentMessageModel,
   ConversationModel,
   MessageModel,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import {
   ConversationGoalModel,
@@ -15,7 +16,10 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import { withTransaction } from "@app/lib/utils/sql_utils";
-import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
+import type {
+  AgentLoopArgs,
+  AgentLoopExecutionData,
+} from "@app/types/assistant/agent_run";
 import type { GoalStatus, GoalType } from "@app/types/assistant/goal";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok, type Result } from "@app/types/shared/result";
@@ -25,7 +29,7 @@ import { Op } from "sequelize";
 export const DEFAULT_GOAL_MAX_TURNS = 25;
 
 export type GoalContinuationDecision =
-  | { type: "continue"; goal: GoalType }
+  | { type: "continue" | "ensure_current"; goal: GoalType }
   | {
       type:
         | "already_processed"
@@ -33,6 +37,11 @@ export type GoalContinuationDecision =
         | "not_succeeded"
         | "turn_limit_reached";
     };
+
+export type GoalTurnRecovery =
+  | { type: "already_succeeded" }
+  | { type: "restart"; agentLoopArgs: AgentLoopArgs }
+  | { type: "unavailable" };
 
 export class GoalTransitionError extends Error {
   constructor(
@@ -396,7 +405,16 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
         return { type: "not_succeeded" };
       }
       if (goalRow.lastAgentMessageId === message.agentMessage.id) {
-        return { type: "already_processed" };
+        if (goalRow.currentAgentMessageId === message.agentMessage.id) {
+          return {
+            type: "continue",
+            goal: new this(this.model, goalRow.get()).toJSON(),
+          };
+        }
+        return {
+          type: "ensure_current",
+          goal: new this(this.model, goalRow.get()).toJSON(),
+        };
       }
       if (
         goalRow.currentAgentMessageId !== message.agentMessage.id ||
@@ -431,33 +449,136 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
     });
   }
 
-  static async setCurrentAgentMessage(
+  async fetchTurnRecovery(
     auth: Authenticator,
     {
-      goalId,
-      agentMessageModelId,
+      conversation,
+    }: {
+      conversation: ConversationResource;
+    }
+  ): Promise<GoalTurnRecovery> {
+    if (
+      this.workspaceId !== auth.getNonNullableWorkspace().id ||
+      this.conversationId !== conversation.id ||
+      this.status !== "active"
+    ) {
+      return { type: "unavailable" };
+    }
+    const agentMessage = await MessageModel.findOne({
+      where: {
+        workspaceId: this.workspaceId,
+        conversationId: conversation.id,
+        branchId: this.branchId,
+        agentMessageId: this.currentAgentMessageId,
+      },
+      include: [
+        {
+          model: AgentMessageModel,
+          as: "agentMessage",
+          required: true,
+          where: { agentConfigurationId: this.agentConfigurationId },
+        },
+      ],
+    });
+    if (agentMessage?.agentMessage?.status === "succeeded") {
+      return { type: "already_succeeded" };
+    }
+    if (
+      agentMessage?.agentMessage?.status !== "created" ||
+      !agentMessage.parentId
+    ) {
+      return { type: "unavailable" };
+    }
+    const userMessage = await MessageModel.findOne({
+      where: {
+        id: agentMessage.parentId,
+        workspaceId: this.workspaceId,
+        conversationId: conversation.id,
+        branchId: this.branchId,
+      },
+      include: [
+        {
+          model: UserMessageModel,
+          as: "userMessage",
+          required: true,
+        },
+      ],
+    });
+    if (!userMessage?.userMessage) {
+      return { type: "unavailable" };
+    }
+    return {
+      type: "restart",
+      agentLoopArgs: {
+        agentMessageId: agentMessage.sId,
+        agentMessageVersion: agentMessage.version,
+        conversationId: conversation.sId,
+        conversationBranchId: this.toJSON().branchId,
+        conversationTitle: conversation.title,
+        userMessageId: userMessage.sId,
+        userMessageVersion: userMessage.version,
+        userMessageOrigin: userMessage.userMessage.userContextOrigin,
+      },
+    };
+  }
+
+  async setCurrentAgentMessage(
+    auth: Authenticator,
+    {
+      conversation,
+      branchId,
+      agentMessageId,
+      agentConfigurationId,
       transaction,
     }: {
-      goalId: string;
-      agentMessageModelId: ModelId;
+      conversation: ConversationResource;
+      branchId: string | null;
+      agentMessageId: string;
+      agentConfigurationId: string;
       transaction: Transaction;
     }
-  ): Promise<void> {
-    const goalModelId = getResourceIdFromSId(goalId);
-    if (!goalModelId) {
-      throw new Error("Invalid goal identifier");
+  ): Promise<boolean> {
+    const branchModelId = branchId ? getResourceIdFromSId(branchId) : null;
+    if (branchId && !branchModelId) {
+      return false;
     }
-    await this.model.update(
-      { currentAgentMessageId: agentMessageModelId },
+    const message = await MessageModel.findOne({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId: conversation.id,
+        branchId: branchModelId,
+        sId: agentMessageId,
+      },
+      include: [
+        {
+          model: AgentMessageModel,
+          as: "agentMessage",
+          required: true,
+          where: { agentConfigurationId },
+        },
+      ],
+      transaction,
+    });
+    if (!message?.agentMessage) {
+      return false;
+    }
+    const [updated] = await this.model.update(
+      { currentAgentMessageId: message.agentMessage.id },
       {
         where: {
-          id: goalModelId,
+          id: this.id,
           workspaceId: auth.getNonNullableWorkspace().id,
+          conversationId: conversation.id,
+          branchId: branchModelId,
+          agentConfigurationId,
+          currentAgentMessageId: this.currentAgentMessageId,
+          lastAgentMessageId: this.currentAgentMessageId,
           status: "active",
         },
         transaction,
       }
     );
+    return updated === 1;
   }
 
   async delete(


### PR DESCRIPTION
## Description

Make automatic goal continuation recoverable across two interruption windows: after a turn is claimed but before its next message exists, and after the message exists but before its workflow launches. The Goal Resource owns current-turn recovery and the transaction-local compare-and-set, so API code neither queries Sequelize directly nor exposes numeric model IDs.

Stacked on #29701.

## Tests

Covered abandoned-claim retry, successful and stale compare-and-set handoffs, existing-turn recovery, and unfinished-turn rejection.

## Risk

This slice recovers incomplete handoffs. #29706 pauses goals when launches or turns fail, and #29708 adds user recovery controls. Keep the feature flag disabled until those successors are deployed.

## Deploy Plan

Merge after #29701. Do not enable `goal_mode` until #29706, #29708, and the remaining stack are deployed.