### PR TITLE
Fix newly published pod function visibility

### DIFF
--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -674,7 +674,7 @@ export class GCSFileSystemBackend implements FileSystemBackend {
   ): GCSMountTarget["mountProfile"] {
     switch (mount.kind) {
       case "pod_sandbox_functions":
-        return "workload";
+        return "pod_sandbox_functions";
 
       case "pod_state":
         return "pod_state_replica";

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
@@ -11,11 +11,8 @@ import {
   type RootCommand,
   renderRootCommand,
 } from "@app/lib/api/sandbox/root_command";
-import { Authenticator } from "@app/lib/auth";
-import { SandboxResource } from "@app/lib/resources/sandbox_resource";
-import { SandboxModel } from "@app/lib/resources/storage/models/sandbox";
-import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { setupPlainConversation } from "@app/tests/utils/conversation_test_factories";
+import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
 import { Err, Ok } from "@app/types/shared/result";
 import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -48,54 +45,9 @@ function successfulExec() {
   return new Ok({ exitCode: 0, stdout: "", stderr: "" });
 }
 
-function createTestAuth(): Authenticator {
-  const timestamp = new Date();
-  const workspace = new WorkspaceResource(WorkspaceModel, {
-    id: 1,
-    createdAt: timestamp,
-    updatedAt: timestamp,
-    sId: "workspace-id",
-    name: "Test workspace",
-    description: null,
-    segmentation: null,
-    ssoEnforced: false,
-    regionalModelsOnly: false,
-    workOSOrganizationId: null,
-    whiteListedProviders: null,
-    defaultEmbeddingProvider: null,
-    metadata: null,
-    sharingPolicy: "all_scopes",
-    conversationsRetentionDays: null,
-    metronomeCustomerId: null,
-    poolCreditState: "active",
-    programmaticCreditState: "active",
-  });
-
-  return new Authenticator({
-    workspace,
-    role: "user",
-    groupModelIds: [],
-    authMethod: "internal",
-    subscription: null,
-  });
-}
-
-function createTestSandbox() {
-  const timestamp = new Date();
-  const sandbox = new SandboxResource(SandboxModel, {
-    id: 1,
-    workspaceId: 1,
-    createdAt: timestamp,
-    updatedAt: timestamp,
-    providerId: "provider-id",
-    status: "running",
-    statusChangedAt: timestamp,
-    lastActivityAt: timestamp,
-    lastRuntimeRefreshAt: null,
-    baseImage: "test-image",
-    version: "test-version",
-    killRequestedAt: null,
-  });
+async function createTestSandbox() {
+  const { auth, conversation } = await setupPlainConversation();
+  const sandbox = await SandboxFactory.create(auth, conversation.toJSON());
   const execRoot = vi
     .spyOn(sandbox, "execRoot")
     .mockResolvedValue(successfulExec());
@@ -103,7 +55,7 @@ function createTestSandbox() {
     .spyOn(sandbox, "requestKill")
     .mockResolvedValue(undefined);
 
-  return { sandbox, execRoot, requestKill };
+  return { auth, sandbox, execRoot, requestKill };
 }
 
 function createTestImage(): SandboxImage {
@@ -248,8 +200,7 @@ describe("pod sandbox mount wiring", () => {
       new Ok({ accessToken: "token", expiresInSeconds: 3600 })
     );
     const adapter = createPodSandboxAdapter();
-    const { sandbox, execRoot } = createTestSandbox();
-    const auth = createTestAuth();
+    const { auth, sandbox, execRoot } = await createTestSandbox();
     const image = createTestImage();
 
     const result = await adapter.setup(auth, sandbox, image);
@@ -275,7 +226,6 @@ describe("pod sandbox mount wiring", () => {
 });
 
 describe("GCS credential lifecycle", () => {
-  const auth = createTestAuth();
   const image = createTestImage();
 
   beforeEach(() => {
@@ -286,7 +236,7 @@ describe("GCS credential lifecycle", () => {
   });
 
   test("starts the broker only after firewall setup and fail-closes the deny-check", async () => {
-    const { sandbox, execRoot } = createTestSandbox();
+    const { auth, sandbox, execRoot } = await createTestSandbox();
     const adapter = new GCSSandboxMountAdapter("bucket-x", [workloadTarget()]);
 
     const result = await adapter.setup(auth, sandbox, image);
@@ -305,7 +255,7 @@ describe("GCS credential lifecycle", () => {
   });
 
   test("surfaces a firewall startup failure without polling the broker", async () => {
-    const { sandbox, execRoot } = createTestSandbox();
+    const { auth, sandbox, execRoot } = await createTestSandbox();
     execRoot
       .mockReset()
       .mockResolvedValueOnce(successfulExec())
@@ -332,7 +282,7 @@ describe("GCS credential lifecycle", () => {
   });
 
   test("refreshes the broker firewall before writing tokens", async () => {
-    const { sandbox, execRoot, requestKill } = createTestSandbox();
+    const { auth, sandbox, execRoot, requestKill } = await createTestSandbox();
     const adapter = new GCSSandboxMountAdapter("bucket-x", [workloadTarget()]);
 
     const result = await adapter.refreshCredential(auth, sandbox, image);
@@ -345,7 +295,7 @@ describe("GCS credential lifecycle", () => {
   });
 
   test("requests recreation when the image firewall helper is unavailable", async () => {
-    const { sandbox, execRoot, requestKill } = createTestSandbox();
+    const { auth, sandbox, execRoot, requestKill } = await createTestSandbox();
     execRoot.mockReset().mockResolvedValue(
       new Ok({
         exitCode: 127,
@@ -364,7 +314,7 @@ describe("GCS credential lifecycle", () => {
   });
 
   test("does not recreate a sandbox after a transient firewall exec error", async () => {
-    const { sandbox, execRoot, requestKill } = createTestSandbox();
+    const { auth, sandbox, execRoot, requestKill } = await createTestSandbox();
     execRoot
       .mockReset()
       .mockResolvedValue(new Err(new Error("transient E2B error")));

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
@@ -5,11 +5,17 @@ import {
   type GCSMountTarget,
   GCSSandboxMountAdapter,
 } from "@app/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter";
+import { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
 import { podSandboxOnlyMounts } from "@app/lib/api/sandbox/pod_mounts";
 import {
   type RootCommand,
   renderRootCommand,
 } from "@app/lib/api/sandbox/root_command";
+import { Authenticator } from "@app/lib/auth";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { SandboxModel } from "@app/lib/resources/storage/models/sandbox";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { Err, Ok } from "@app/types/shared/result";
 import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -40,6 +46,68 @@ function workloadTarget(
 
 function successfulExec() {
   return new Ok({ exitCode: 0, stdout: "", stderr: "" });
+}
+
+function createTestAuth(): Authenticator {
+  const timestamp = new Date();
+  const workspace = new WorkspaceResource(WorkspaceModel, {
+    id: 1,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    sId: "workspace-id",
+    name: "Test workspace",
+    description: null,
+    segmentation: null,
+    ssoEnforced: false,
+    regionalModelsOnly: false,
+    workOSOrganizationId: null,
+    whiteListedProviders: null,
+    defaultEmbeddingProvider: null,
+    metadata: null,
+    sharingPolicy: "all_scopes",
+    conversationsRetentionDays: null,
+    metronomeCustomerId: null,
+    poolCreditState: "active",
+    programmaticCreditState: "active",
+  });
+
+  return new Authenticator({
+    workspace,
+    role: "user",
+    groupModelIds: [],
+    authMethod: "internal",
+    subscription: null,
+  });
+}
+
+function createTestSandbox() {
+  const timestamp = new Date();
+  const sandbox = new SandboxResource(SandboxModel, {
+    id: 1,
+    workspaceId: 1,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    providerId: "provider-id",
+    status: "running",
+    statusChangedAt: timestamp,
+    lastActivityAt: timestamp,
+    lastRuntimeRefreshAt: null,
+    baseImage: "test-image",
+    version: "test-version",
+    killRequestedAt: null,
+  });
+  const execRoot = vi
+    .spyOn(sandbox, "execRoot")
+    .mockResolvedValue(successfulExec());
+  const requestKill = vi
+    .spyOn(sandbox, "requestKill")
+    .mockResolvedValue(undefined);
+
+  return { sandbox, execRoot, requestKill };
+}
+
+function createTestImage(): SandboxImage {
+  return SandboxImage.fromDocker("test-image").withCapability("gcsfuse");
 }
 
 function getRootCommandCall(
@@ -180,23 +248,15 @@ describe("pod sandbox mount wiring", () => {
       new Ok({ accessToken: "token", expiresInSeconds: 3600 })
     );
     const adapter = createPodSandboxAdapter();
-    const sandbox = {
-      sId: "sandbox-id",
-      execRoot: vi.fn().mockResolvedValue(successfulExec()),
-      requestKill: vi.fn(),
-    };
-    const auth = {
-      getNonNullableWorkspace: () => ({ sId: "workspace-id" }),
-    } as never;
-    const image = {
-      hasCapability: (capability: string) => capability === "gcsfuse",
-    } as never;
+    const { sandbox, execRoot } = createTestSandbox();
+    const auth = createTestAuth();
+    const image = createTestImage();
 
-    const result = await adapter.setup(auth, sandbox as never, image);
+    const result = await adapter.setup(auth, sandbox, image);
 
     expect(result.isOk()).toBe(true);
-    const commands = sandbox.execRoot.mock.calls.map((_, callIndex) =>
-      getRootCommandCall(sandbox.execRoot, callIndex)
+    const commands = execRoot.mock.calls.map((_, callIndex) =>
+      getRootCommandCall(execRoot, callIndex)
     );
     const podFilesCommand = commands.find(
       (command) =>
@@ -215,12 +275,8 @@ describe("pod sandbox mount wiring", () => {
 });
 
 describe("GCS credential lifecycle", () => {
-  const auth = {
-    getNonNullableWorkspace: () => ({ sId: "workspace-id" }),
-  } as never;
-  const image = {
-    hasCapability: (capability: string) => capability === "gcsfuse",
-  } as never;
+  const auth = createTestAuth();
+  const image = createTestImage();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -230,17 +286,13 @@ describe("GCS credential lifecycle", () => {
   });
 
   test("starts the broker only after firewall setup and fail-closes the deny-check", async () => {
-    const sandbox = {
-      sId: "sandbox-id",
-      execRoot: vi.fn().mockResolvedValue(successfulExec()),
-      requestKill: vi.fn(),
-    };
+    const { sandbox, execRoot } = createTestSandbox();
     const adapter = new GCSSandboxMountAdapter("bucket-x", [workloadTarget()]);
 
-    const result = await adapter.setup(auth, sandbox as never, image);
+    const result = await adapter.setup(auth, sandbox, image);
 
     expect(result.isOk()).toBe(true);
-    const command = getRootCommandCall(sandbox.execRoot, 1);
+    const command = getRootCommandCall(execRoot, 1);
     expect(command).toContain(
       "/usr/local/bin/dust-gcs-token-firewall.sh; firewall_exit=$?"
     );
@@ -253,23 +305,20 @@ describe("GCS credential lifecycle", () => {
   });
 
   test("surfaces a firewall startup failure without polling the broker", async () => {
-    const sandbox = {
-      sId: "sandbox-id",
-      execRoot: vi
-        .fn()
-        .mockResolvedValueOnce(successfulExec())
-        .mockResolvedValueOnce(
-          new Ok({
-            exitCode: 1,
-            stdout: "",
-            stderr: "GCS token firewall setup failed (exit code 1)",
-          })
-        ),
-      requestKill: vi.fn(),
-    };
+    const { sandbox, execRoot } = createTestSandbox();
+    execRoot
+      .mockReset()
+      .mockResolvedValueOnce(successfulExec())
+      .mockResolvedValueOnce(
+        new Ok({
+          exitCode: 1,
+          stdout: "",
+          stderr: "GCS token firewall setup failed (exit code 1)",
+        })
+      );
     const adapter = new GCSSandboxMountAdapter("bucket-x", [workloadTarget()]);
 
-    const result = await adapter.setup(auth, sandbox as never, image);
+    const result = await adapter.setup(auth, sandbox, image);
 
     expect(result.isErr()).toBe(true);
     if (result.isOk()) {
@@ -279,74 +328,52 @@ describe("GCS credential lifecycle", () => {
       "GCS token firewall setup failed (exit code 1)"
     );
     expect(result.error.message).not.toContain("not ready in time");
-    expect(sandbox.execRoot).toHaveBeenCalledTimes(2);
+    expect(execRoot).toHaveBeenCalledTimes(2);
   });
 
   test("refreshes the broker firewall before writing tokens", async () => {
-    const sandbox = {
-      sId: "sandbox-id",
-      execRoot: vi.fn().mockResolvedValue(successfulExec()),
-      requestKill: vi.fn(),
-    };
+    const { sandbox, execRoot, requestKill } = createTestSandbox();
     const adapter = new GCSSandboxMountAdapter("bucket-x", [workloadTarget()]);
 
-    const result = await adapter.refreshCredential(
-      auth,
-      sandbox as never,
-      image
-    );
+    const result = await adapter.refreshCredential(auth, sandbox, image);
 
     expect(result.isOk()).toBe(true);
-    expect(sandbox.execRoot).toHaveBeenCalledTimes(2);
-    const firewallCommand = getRootCommandCall(sandbox.execRoot, 0);
+    expect(execRoot).toHaveBeenCalledTimes(2);
+    const firewallCommand = getRootCommandCall(execRoot, 0);
     expect(firewallCommand).toBe("/usr/local/bin/dust-gcs-token-firewall.sh");
-    expect(sandbox.requestKill).not.toHaveBeenCalled();
+    expect(requestKill).not.toHaveBeenCalled();
   });
 
   test("requests recreation when the image firewall helper is unavailable", async () => {
-    const sandbox = {
-      sId: "sandbox-id",
-      execRoot: vi.fn().mockResolvedValue(
-        new Ok({
-          exitCode: 127,
-          stdout: "",
-          stderr: "helper not found",
-        })
-      ),
-      requestKill: vi.fn().mockResolvedValue(undefined),
-    };
+    const { sandbox, execRoot, requestKill } = createTestSandbox();
+    execRoot.mockReset().mockResolvedValue(
+      new Ok({
+        exitCode: 127,
+        stdout: "",
+        stderr: "helper not found",
+      })
+    );
     const adapter = new GCSSandboxMountAdapter("bucket-x", [workloadTarget()]);
 
-    const result = await adapter.refreshCredential(
-      auth,
-      sandbox as never,
-      image
-    );
+    const result = await adapter.refreshCredential(auth, sandbox, image);
 
     expect(result.isErr()).toBe(true);
-    expect(sandbox.execRoot).toHaveBeenCalledTimes(1);
+    expect(execRoot).toHaveBeenCalledTimes(1);
     expect(mockMintDownscopedGcsToken).not.toHaveBeenCalled();
-    expect(sandbox.requestKill).toHaveBeenCalledTimes(1);
+    expect(requestKill).toHaveBeenCalledTimes(1);
   });
 
   test("does not recreate a sandbox after a transient firewall exec error", async () => {
-    const sandbox = {
-      sId: "sandbox-id",
-      execRoot: vi
-        .fn()
-        .mockResolvedValue(new Err(new Error("transient E2B error"))),
-      requestKill: vi.fn(),
-    };
+    const { sandbox, execRoot, requestKill } = createTestSandbox();
+    execRoot
+      .mockReset()
+      .mockResolvedValue(new Err(new Error("transient E2B error")));
     const adapter = new GCSSandboxMountAdapter("bucket-x", [workloadTarget()]);
 
-    const result = await adapter.refreshCredential(
-      auth,
-      sandbox as never,
-      image
-    );
+    const result = await adapter.refreshCredential(auth, sandbox, image);
 
     expect(result.isErr()).toBe(true);
     expect(mockMintDownscopedGcsToken).not.toHaveBeenCalled();
-    expect(sandbox.requestKill).not.toHaveBeenCalled();
+    expect(requestKill).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
@@ -49,6 +49,30 @@ function getRootCommandCall(
   return renderRootCommand(mock.mock.calls[callIndex][1] as RootCommand);
 }
 
+function createPodSandboxAdapter(): GCSSandboxMountAdapter {
+  const backend = new GCSFileSystemBackend("ws1", "test-private-uploads");
+  const adapter = backend.createSandboxAdapter(
+    [
+      {
+        kind: "pod",
+        id: "spc1",
+        scopedPrefix: "pod-spc1",
+        sandboxMountPoint: "/files/pod-spc1",
+        legacyPrefix: "project",
+        legacySandboxMountPoint: "/files/pod",
+        permissions: { canRead: true, canWrite: true },
+      },
+    ],
+    podSandboxOnlyMounts({ sId: "spc1" })
+  );
+
+  if (!(adapter instanceof GCSSandboxMountAdapter)) {
+    throw new Error("expected a GCSSandboxMountAdapter");
+  }
+
+  return adapter;
+}
+
 describe("buildMountCommand", () => {
   test("workload profile mounts as root with allow_other and permissive modes", () => {
     const command = renderRootCommand(
@@ -67,7 +91,7 @@ describe("buildMountCommand", () => {
     expect(command).toContain("bucket-x /files/pod-spc1");
   });
 
-  test("workload profile adds ro for read-only targets", () => {
+  test("pod function profile disables list caching for newly published functions", () => {
     const command = renderRootCommand(
       buildMountCommand({
         bucket: "bucket-x",
@@ -77,11 +101,13 @@ describe("buildMountCommand", () => {
           sandboxMountPoint: "/sandbox-functions/pods/spc1",
           legacySandboxMountPoint: null,
           readOnly: true,
+          mountProfile: "pod_sandbox_functions",
         }),
       })
     );
 
     expect(command).toContain("-o allow_other,ro");
+    expect(command).toContain("--kernel-list-cache-ttl-secs=0");
     expect(command).toContain("--token-url http://127.0.0.1:987/token/mount-1");
   });
 
@@ -126,25 +152,7 @@ describe("pod sandbox mount wiring", () => {
     // Derived from the ACTUAL wiring (podSandboxOnlyMounts + the backend's
     // prefix mapping) rather than hand-built prefixes, so dropping the state
     // mount from the pod set — or regressing its prefix string — fails here.
-    const backend = new GCSFileSystemBackend("ws1", "test-private-uploads");
-    const adapter = backend.createSandboxAdapter(
-      [
-        {
-          kind: "pod",
-          id: "spc1",
-          scopedPrefix: "pod-spc1",
-          sandboxMountPoint: "/files/pod-spc1",
-          legacyPrefix: "project",
-          legacySandboxMountPoint: "/files/pod",
-          permissions: { canRead: true, canWrite: true },
-        },
-      ],
-      podSandboxOnlyMounts({ sId: "spc1" })
-    );
-
-    if (!(adapter instanceof GCSSandboxMountAdapter)) {
-      throw new Error("expected a GCSSandboxMountAdapter");
-    }
+    const adapter = createPodSandboxAdapter();
 
     // Each mount gets its own 1 + 2-rule CAB. The firewall is the sole caller
     // authorization boundary; if a caller reaches the broker, each token still
@@ -164,6 +172,45 @@ describe("pod sandbox mount wiring", () => {
     expect(conditions).toContain("w/ws1/pods/spc1/files/");
     expect(conditions).toContain("w/ws1/pods/spc1/sandbox-functions/");
     expect(conditions).toContain("w/ws1/pods/spc1/state/");
+  });
+
+  test("the real pod function mount disables directory list caching", async () => {
+    vi.clearAllMocks();
+    mockMintDownscopedGcsToken.mockResolvedValue(
+      new Ok({ accessToken: "token", expiresInSeconds: 3600 })
+    );
+    const adapter = createPodSandboxAdapter();
+    const sandbox = {
+      sId: "sandbox-id",
+      execRoot: vi.fn().mockResolvedValue(successfulExec()),
+      requestKill: vi.fn(),
+    };
+    const auth = {
+      getNonNullableWorkspace: () => ({ sId: "workspace-id" }),
+    } as never;
+    const image = {
+      hasCapability: (capability: string) => capability === "gcsfuse",
+    } as never;
+
+    const result = await adapter.setup(auth, sandbox as never, image);
+
+    expect(result.isOk()).toBe(true);
+    const commands = sandbox.execRoot.mock.calls.map((_, callIndex) =>
+      getRootCommandCall(sandbox.execRoot, callIndex)
+    );
+    const podFilesCommand = commands.find(
+      (command) =>
+        command.includes("/usr/bin/gcsfuse") &&
+        command.includes("/files/pod-spc1")
+    );
+    const podFunctionsCommand = commands.find(
+      (command) =>
+        command.includes("/usr/bin/gcsfuse") &&
+        command.includes("/sandbox-functions/pods/spc1")
+    );
+
+    expect(podFilesCommand).toContain("--kernel-list-cache-ttl-secs=60");
+    expect(podFunctionsCommand).toContain("--kernel-list-cache-ttl-secs=0");
   });
 });
 

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
@@ -71,6 +71,8 @@ function tokenUrl(index: number): string {
  * - "workload": root-mounted with `allow_other` so the unprivileged sandbox
  *   users can access it; permissive file/dir modes; 60s kernel list cache
  *   (read-mostly workloads). All agent-facing mounts.
+ * - "pod_sandbox_functions": same access model as "workload", but without
+ *   kernel list caching so newly published functions are visible immediately.
  * - "pod_state_replica": mounted AS `dust-state` (via runuser) so the FUSE
  *   default — only the mounting user can access the fs — makes it invisible to
  *   every other uid, including the untrusted workload uid 1003 and root. No
@@ -79,7 +81,10 @@ function tokenUrl(index: number): string {
  *   /pod-state layout in the image; targets with this profile are only ever
  *   constructed when a pod sandbox (the sandbox-functions computer) boots.
  */
-export type GCSMountProfile = "workload" | "pod_state_replica";
+export type GCSMountProfile =
+  | "workload"
+  | "pod_sandbox_functions"
+  | "pod_state_replica";
 
 export type GCSMountTarget = {
   /**
@@ -413,7 +418,8 @@ export function buildMountCommand({
   ];
 
   switch (target.mountProfile) {
-    case "workload": {
+    case "workload":
+    case "pod_sandbox_functions": {
       // allow_other lets the unprivileged sandbox user read the root-mounted fs. `ro` is only
       // defense-in-depth: the real write protection is the read-only token scope (see
       // buildAccessBoundaryRules), not this flag.
@@ -421,6 +427,8 @@ export function buildMountCommand({
       if (target.readOnly) {
         mountOptions.push("ro");
       }
+      const kernelListCacheTtlSeconds =
+        target.mountProfile === "pod_sandbox_functions" ? 0 : 60;
 
       const flags = [
         ...commonFlags,
@@ -428,7 +436,7 @@ export function buildMountCommand({
         mountOptions.join(","),
         "--file-mode=666",
         "--dir-mode=777",
-        "--kernel-list-cache-ttl-secs=60",
+        `--kernel-list-cache-ttl-secs=${kernelListCacheTtlSeconds}`,
       ];
 
       return rootCommand.stderrToStdout(

--- a/front/lib/api/sandbox/providers/e2b.test.ts
+++ b/front/lib/api/sandbox/providers/e2b.test.ts
@@ -75,7 +75,7 @@ vi.mock("e2b", () => {
   };
 });
 
-import { CommandExitError } from "e2b";
+import { CommandExitError, NotFoundError } from "e2b";
 
 import { SANDBOX_ROOT_SAFE_PATH } from "../hardening";
 import { rootCommand } from "../root_command";
@@ -433,5 +433,47 @@ describe("E2BSandboxProvider", () => {
     expect(mockHandleKill).toHaveBeenCalledTimes(1);
     expect(mockCloseStdin).not.toHaveBeenCalled();
     expect(mockCommandHandleWait).not.toHaveBeenCalled();
+  });
+
+  it("recovers the command result when the process exits before stdin arrives", async () => {
+    const mockHandleKill = vi.fn().mockResolvedValue(false);
+    mockRun.mockResolvedValueOnce({
+      pid: 123,
+      wait: mockCommandHandleWait,
+      kill: mockHandleKill,
+    });
+    mockSendStdin.mockRejectedValueOnce(
+      new NotFoundError("[not_found] process with pid 123 not found")
+    );
+    mockCommandHandleWait.mockRejectedValueOnce(
+      new CommandExitError({
+        exitCode: 1,
+        stdout: '{"error":"function not found: new-function"}',
+        stderr: "",
+      })
+    );
+
+    const provider = new E2BSandboxProvider({
+      apiKey: "api-key",
+      domain: undefined,
+    });
+
+    const result = await provider.exec(
+      "provider-id",
+      "/opt/bin/dsbx function run new-function",
+      { stdin: "request-json", user: "agent-proxied" },
+      { workspaceId: "workspace-id" }
+    );
+
+    expect(result).toEqual(
+      new Ok({
+        exitCode: 1,
+        stdout: '{"error":"function not found: new-function"}',
+        stderr: "",
+      })
+    );
+    expect(mockCommandHandleWait).toHaveBeenCalledTimes(1);
+    expect(mockHandleKill).not.toHaveBeenCalled();
+    expect(mockCloseStdin).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -139,6 +139,14 @@ async function runWithStdin(
     });
     return await handle.wait();
   } catch (err) {
+    if (err instanceof NotFoundError) {
+      // The process can exit between `run` returning its handle and the stdin
+      // RPC reaching E2B. The handle consumes process events from startup, so
+      // waiting recovers the actual exit code and output instead of replacing
+      // them with a misleading "process with pid ... not found" error.
+      return await handle.wait();
+    }
+
     try {
       await handle.kill();
     } catch {


### PR DESCRIPTION
## Description

New pod functions could be invisible to an already-running sandbox for up to 60 seconds because their GCSFuse mount cached directory listings. Give the function bundle mount its own no-list-cache profile while preserving the existing cache for regular pod files.

Also preserve the command result when a short-lived E2B process exits before the stdin RPC arrives, instead of replacing its output with a misleading process-not-found error. Production logs showed 21 occurrences in seven days, all 2 to 43 seconds after function creation.

## Tests

Added focused regression coverage for the real pod mount wiring and the early E2B process-exit race.

- `NODE_ENV=test npm test -- lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts lib/api/sandbox/providers/e2b.test.ts`
- `NODE_OPTIONS="--max-old-space-size=8192" npx tsgo --noEmit`
- `npx biome check` on the five changed files

## Risk

Low. Only the read-only pod function mount stops caching directory listings. This may add GCS list calls when functions are resolved; regular pod file mounts keep the existing 60-second cache. The E2B fallback is limited to process-not-found responses and waits on the already-started command handle.

## Deploy Plan

Standard front deployment. Monitor pod function invocation failures for `process with pid ... not found` and newly created function lookup errors.