### PR TITLE
[front] Soft-delete webhook source views and their triggers when deleting a space

### DIFF
--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -155,6 +155,36 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
         { concurrency: 4 }
       );
 
+      const webhookSourceViews = await WebhookSourcesViewResource.listBySpace(
+        auth,
+        space
+      );
+      for (const webhookSourceView of webhookSourceViews) {
+        // Delete triggers referencing this webhook source view first.
+        const triggers = await TriggerResource.listByWebhookSourceViewId(
+          auth,
+          webhookSourceView.id
+        );
+        await concurrentExecutor(
+          triggers,
+          async (trigger) => {
+            const res = await trigger.delete(auth, { transaction: t });
+            if (res.isErr()) {
+              throw res.error;
+            }
+          },
+          { concurrency: 4 }
+        );
+
+        const res = await webhookSourceView.delete(auth, {
+          hardDelete: false,
+          transaction: t,
+        });
+        if (res.isErr()) {
+          throw res.error;
+        }
+      }
+
       // Get MCP server views and data source views from the space being deleted.
       const mcpServerViews = await MCPServerViewResource.listBySpace(
         auth,


### PR DESCRIPTION
## Summary

- When `softDeleteSpaceAndLaunchScrubWorkflow` is called, webhook source views belonging to that space are now soft-deleted along with their associated triggers. Previously, they were orphaned, causing errors in our base resource fetcher
- Triggers are deleted first to avoid FK constraint violations, mirroring the existing pattern used for other resource types in the same function.

## Testing
1. deleted pod
2. Called base resource fetcher and confirmed no errors

## Risk

Low, this likely should have already been in place

## Deploy
1. Deploy front

