### PR TITLE
Add Memory tab to user settings

### DIFF
--- a/front-api/routes/w/[wId]/me/memory.test.ts
+++ b/front-api/routes/w/[wId]/me/memory.test.ts
@@ -1,13 +1,10 @@
 import { DustFileSystemError } from "@app/lib/api/file_system/dust_file_system";
-import {
-  getUserMemory,
-  MAX_USER_MEMORY_CHARS,
-  setUserMemory,
-} from "@app/lib/api/user_memory";
+import { getUserMemory, setUserMemory } from "@app/lib/api/user_memory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import {
   GetUserMemoryResponseBodySchema,
+  MAX_USER_MEMORY_CONTENT_LENGTH,
   PatchUserMemoryResponseBodySchema,
 } from "@app/types/api/me/memory";
 import { Err, Ok } from "@app/types/shared/result";
@@ -123,7 +120,7 @@ describe("PATCH /api/w/:wId/me/memory", () => {
     const { workspace } = await setup();
 
     const response = await patchMemory(workspace.sId, {
-      content: "a".repeat(MAX_USER_MEMORY_CHARS + 1),
+      content: "a".repeat(MAX_USER_MEMORY_CONTENT_LENGTH + 1),
     });
 
     expect(response.status).toBe(400);

--- a/front-api/routes/w/[wId]/me/memory.ts
+++ b/front-api/routes/w/[wId]/me/memory.ts
@@ -3,7 +3,6 @@ import {
   exceedsUserMemoryLimit,
   getUserMemory,
   isUserMemoryEnabled,
-  MAX_USER_MEMORY_CHARS,
   setUserMemory,
   setUserMemoryEnabled,
 } from "@app/lib/api/user_memory";
@@ -11,6 +10,7 @@ import type {
   GetUserMemoryResponseBody,
   PatchUserMemoryResponseBody,
 } from "@app/types/api/me/memory";
+import { MAX_USER_MEMORY_CONTENT_LENGTH } from "@app/types/api/me/memory";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -79,7 +79,7 @@ app.patch(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Memory content exceeds the ${MAX_USER_MEMORY_CHARS} character limit.`,
+            message: `Memory content exceeds the ${MAX_USER_MEMORY_CONTENT_LENGTH} character limit.`,
           },
         });
       }

--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -1,4 +1,5 @@
 import { UsageUpgradeButton } from "@app/components/credits/UsageUpgradeButton";
+import { MarkdownEditor } from "@app/components/editor/MarkdownEditor";
 import {
   NotificationPreferences,
   useNotificationPreferencesForm,
@@ -17,7 +18,7 @@ import { AwuUsageBar } from "@app/components/workspace/MembersUsageTable";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useIsMac } from "@app/hooks/useKeyboardShortcutLabel";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { useAuth } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { isSubmitMessageKey } from "@app/lib/keymaps";
 import { useAppRouter } from "@app/lib/platform";
 import {
@@ -30,9 +31,14 @@ import {
   usePatchUser,
   usePendingInvitations,
   useUser,
+  useUserMemory,
   useWorkspaceUsageStatus,
 } from "@app/lib/swr/user";
 import { getConversationRoute } from "@app/lib/utils/router";
+import {
+  MAX_USER_MEMORY_CHARS,
+  MAX_USER_MEMORY_CONTENT_LENGTH,
+} from "@app/types/api/me/memory";
 import type { PendingInvitationOption } from "@app/types/membership_invitation";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { WorkspaceType } from "@app/types/user";
@@ -41,6 +47,7 @@ import {
   Avatar,
   BarChart01,
   Bell01,
+  Brain,
   Button,
   ContentMessageInline,
   Dialog,
@@ -63,6 +70,7 @@ import {
   Separator,
   Settings01,
   ShapesPlus,
+  SliderToggle,
   Spinner,
   Stars02,
   Sun,
@@ -87,6 +95,7 @@ type SettingsSection =
   | "usage"
   | "customization"
   | "notifications"
+  | "memory"
   | "tools"
   | "invitations";
 
@@ -427,7 +436,7 @@ function PersonalInfoSection({ owner }: { owner: WorkspaceType }) {
 
   if (isUserLoading) {
     return (
-      <SectionContent title="Personal Informations">
+      <SectionContent title="Personal Information">
         <div className="flex justify-center p-6">
           <Spinner />
         </div>
@@ -437,7 +446,7 @@ function PersonalInfoSection({ owner }: { owner: WorkspaceType }) {
 
   return (
     <SectionContent
-      title="Personal Informations"
+      title="Personal Information"
       footer={
         <Button
           label="Save"
@@ -792,8 +801,108 @@ function InvitationsSection({
   );
 }
 
+// ─── Memory ───────────────────────────────────────────────────────────────────
+
+function MemorySection({ owner }: { owner: WorkspaceType }) {
+  const { content, isMemoryEnabled, isMemoryLoading, setMemory } =
+    useUserMemory({ owner });
+
+  const [draft, setDraft] = useState<string | null>(null);
+  const [enabledDraft, setEnabledDraft] = useState<boolean | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const value = draft ?? content;
+  const enabledValue = enabledDraft ?? isMemoryEnabled;
+
+  const isContentDirty = draft !== null && draft !== content;
+  const isEnabledDirty =
+    enabledDraft !== null && enabledDraft !== isMemoryEnabled;
+  const isDirty = isEnabledDirty || (enabledValue && isContentDirty);
+  // The editor shows the visible-character count; the Save gate uses the raw
+  // markdown length against the server cap so we never submit a rejected body.
+  const isOverLimit = value.length > MAX_USER_MEMORY_CONTENT_LENGTH;
+
+  const handleToggle = () => {
+    setEnabledDraft(!enabledValue);
+  };
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      const update: { content?: string; enabled?: boolean } = {};
+      if (isEnabledDirty) {
+        update.enabled = enabledValue;
+      }
+      if (enabledValue && isContentDirty) {
+        update.content = value;
+      }
+
+      const saved = await setMemory(update);
+      if (saved) {
+        setDraft(null);
+        setEnabledDraft(null);
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <SectionContent
+      title="Memory"
+      footer={
+        <Button
+          label="Save"
+          variant="primary"
+          type="button"
+          onClick={handleSave}
+          disabled={!isDirty || isOverLimit || isSaving}
+        />
+      }
+    >
+      {isMemoryLoading ? (
+        <div className="flex justify-center py-8">
+          <Spinner />
+        </div>
+      ) : (
+        <>
+          <div className="flex items-start justify-between gap-4 rounded-2xl border border-border dark:border-border-dark p-4">
+            <div className="flex flex-col gap-1">
+              <span className="heading-base text-foreground">
+                Enable Memory
+              </span>
+              <span className="copy-sm text-muted-foreground">
+                Dust builds a personal memory from your conversations and uses
+                it to tailor future responses.
+              </span>
+            </div>
+            <SliderToggle selected={enabledValue} onClick={handleToggle} />
+          </div>
+
+          {enabledValue && (
+            <div className="flex flex-col gap-2">
+              <span className="heading-base text-foreground">About you</span>
+              <MarkdownEditor
+                value={value}
+                onChange={(markdown) => setDraft(markdown)}
+                readOnly={isSaving}
+                maxCharacterCount={MAX_USER_MEMORY_CHARS}
+                showCharacterCount
+                editorClassName="min-h-96"
+              />
+            </div>
+          )}
+        </>
+      )}
+    </SectionContent>
+  );
+}
+
 // ─── Root ─────────────────────────────────────────────────────────────────────
 
+// Order only. "Memory" (user_memory feature flag) and "Invitations" (pending
+// invitations) keep their position here and are filtered out below when not
+// applicable.
 const NAV_ITEMS: Array<{
   section: SettingsSection;
   icon: React.ComponentType;
@@ -802,8 +911,10 @@ const NAV_ITEMS: Array<{
   { section: "personal", icon: User01, label: "Personal Information" },
   { section: "usage", icon: BarChart01, label: "Usage" },
   { section: "customization", icon: Settings01, label: "Customization" },
+  { section: "memory", icon: Brain, label: "Memory" },
   { section: "notifications", icon: Bell01, label: "Notifications" },
   { section: "tools", icon: ShapesPlus, label: "Tools and Triggers" },
+  { section: "invitations", icon: Mail01, label: "Invitations" },
 ];
 
 export function UserSettingsPopover({
@@ -814,21 +925,28 @@ export function UserSettingsPopover({
   const [activeSection, setActiveSection] =
     useState<SettingsSection>("personal");
 
+  const { hasFeature } = useFeatureFlags();
+  const hasUserMemory = hasFeature("user_memory");
+
   // Only fetch while the popover is open: it is always mounted in the user menu.
   const { pendingInvitations, isPendingInvitationsLoading } =
     usePendingInvitations({ workspaceId: owner.sId, disabled: !open });
   const hasPendingInvitations = pendingInvitations.length > 0;
 
-  // The "Invitations" item only appears when the user has pending invitations.
-  const navItems = useMemo<typeof NAV_ITEMS>(
+  // "Memory" is gated on the user_memory feature flag; "Invitations" only
+  // appears when the user has pending invitations.
+  const navItems = useMemo(
     () =>
-      hasPendingInvitations
-        ? [
-            ...NAV_ITEMS,
-            { section: "invitations", icon: Mail01, label: "Invitations" },
-          ]
-        : NAV_ITEMS,
-    [hasPendingInvitations]
+      NAV_ITEMS.filter((item) => {
+        if (item.section === "memory") {
+          return hasUserMemory;
+        }
+        if (item.section === "invitations") {
+          return hasPendingInvitations;
+        }
+        return true;
+      }),
+    [hasUserMemory, hasPendingInvitations]
   );
 
   useEffect(() => {
@@ -910,6 +1028,7 @@ export function UserSettingsPopover({
             {activeSection === "notifications" && (
               <NotificationsSection owner={owner} />
             )}
+            {activeSection === "memory" && <MemorySection owner={owner} />}
             {activeSection === "tools" && <ToolsSection owner={owner} />}
             {activeSection === "invitations" && (
               <InvitationsSection

--- a/front/lib/api/actions/servers/user_memory/tools/index.ts
+++ b/front/lib/api/actions/servers/user_memory/tools/index.ts
@@ -10,11 +10,11 @@ import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { getUpdatedContentAndOccurrences } from "@app/lib/api/files/utils";
 import {
   exceedsUserMemoryLimit,
-  MAX_USER_MEMORY_CHARS,
   MEMORY_CONTENT_TYPE,
   userMemoryPath,
 } from "@app/lib/api/user_memory";
 import type { Authenticator } from "@app/lib/auth";
+import { MAX_USER_MEMORY_CONTENT_LENGTH } from "@app/types/api/me/memory";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -131,7 +131,7 @@ const handlers: ToolHandlers<typeof USER_MEMORY_TOOLS_METADATA> = {
     if (exceedsUserMemoryLimit(nextContent)) {
       return new Err(
         new MCPError(
-          `Memory would exceed the ${MAX_USER_MEMORY_CHARS} character limit. Shorten the content first.`,
+          `Memory would exceed the ${MAX_USER_MEMORY_CONTENT_LENGTH} character limit. Shorten the content first.`,
           { tracked: false }
         )
       );

--- a/front/lib/api/user_memory.ts
+++ b/front/lib/api/user_memory.ts
@@ -2,20 +2,20 @@ import type { DustFileSystemError } from "@app/lib/api/file_system/dust_file_sys
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { userScopedPath } from "@app/lib/api/file_system/types";
 import type { Authenticator } from "@app/lib/auth";
+import { MAX_USER_MEMORY_CONTENT_LENGTH } from "@app/types/api/me/memory";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 
 const MEMORY_FILE_NAME = "MEMORY.md";
 
 export const MEMORY_CONTENT_TYPE = "text/markdown";
-export const MAX_USER_MEMORY_CHARS = 2_000;
 
 export function userMemoryPath(userId: string): string {
   return userScopedPath(userId, MEMORY_FILE_NAME);
 }
 
 export function exceedsUserMemoryLimit(content: string): boolean {
-  return content.length > MAX_USER_MEMORY_CHARS;
+  return content.length > MAX_USER_MEMORY_CONTENT_LENGTH;
 }
 
 export async function getUserMemory(

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -11,6 +11,7 @@ import {
 } from "@app/lib/swr/swr";
 import type { EmailProviderType } from "@app/lib/utils/email_provider_detection";
 import type { GetPendingInvitationsResponseBody } from "@app/types/api/invitation";
+import type { GetUserMemoryResponseBody } from "@app/types/api/me/memory";
 import type { GetSlackNotificationResponseBody } from "@app/types/api/me/slack_notifications";
 import type {
   GetUserMetadataResponseBody,
@@ -19,7 +20,7 @@ import type {
 import type { FavoritePlatform } from "@app/types/favorite_platforms";
 import type { JobType } from "@app/types/job_type";
 import type { LightWorkspaceType } from "@app/types/user";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import type { Fetcher, SWRConfiguration } from "swr";
 
 export function useUser(
@@ -234,6 +235,61 @@ export function usePendingInvitations({
     isPendingInvitationsLoading: !error && !data && !disabled,
     isPendingInvitationsError: error,
     mutatePendingInvitations: mutate,
+  };
+}
+
+export function useUserMemory({
+  owner,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const sendNotification = useSendNotification();
+  const memoryFetcher: Fetcher<GetUserMemoryResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/me/memory`,
+    memoryFetcher,
+    { disabled }
+  );
+
+  const setMemory = useCallback(
+    async (update: {
+      content?: string;
+      enabled?: boolean;
+    }): Promise<boolean> => {
+      const res = await clientFetch(`/api/w/${owner.sId}/me/memory`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(update),
+      });
+
+      if (res.ok) {
+        sendNotification({ type: "success", title: "Memory saved." });
+        await mutate();
+        return true;
+      }
+
+      const errorData = await getErrorFromResponse(res);
+      sendNotification({
+        type: "error",
+        title: "Error saving memory",
+        description: errorData.message,
+      });
+      return false;
+    },
+    [owner.sId, sendNotification, mutate]
+  );
+
+  return {
+    content: data?.content ?? "",
+    isMemoryEnabled: data?.enabled ?? false,
+    isMemoryLoading: !error && !data && !disabled,
+    isMemoryError: error,
+    mutateMemory: mutate,
+    setMemory,
   };
 }
 

--- a/front/types/api/me/memory.ts
+++ b/front/types/api/me/memory.ts
@@ -1,5 +1,15 @@
 import { z } from "zod";
 
+// User-facing limit, counted as visible characters (markdown formatting syntax
+// does not count against it).
+export const MAX_USER_MEMORY_CHARS = 2_000;
+
+// Server-side cap on the raw stored markdown. Formatting syntax (**bold**,
+// headings, ...) inflates the raw length beyond the visible character count, so
+// this ceiling is slightly higher to avoid rejecting formatted memories that
+// are under the visible limit.
+export const MAX_USER_MEMORY_CONTENT_LENGTH = 2 * MAX_USER_MEMORY_CHARS;
+
 export const GetUserMemoryResponseBodySchema = z.object({
   content: z.string(),
   enabled: z.boolean(),


### PR DESCRIPTION
## Description

Add a feature-flag-gated Memory tab in the user settings popover with a toggle to enable personal memory and an editable `MEMORY.md` with a character counter and Save button. Toggling is a pending change confirmed via Save. Moved MAX_USER_MEMORY_CHARS to a client-safe module.

Toggle off:
<img width="919" height="683" alt="Screenshot 2026-07-29 at 16 00 19" src="https://github.com/user-attachments/assets/8f09c8e2-b9c4-4297-832e-068eeca70d3e" />

Toggle on: 
<img width="905" height="673" alt="Screenshot 2026-07-29 at 16 01 04" src="https://github.com/user-attachments/assets/9099068e-2a34-4dbe-99c3-b5fa76b38f45" />


## Tests

Tested locally 

## Risk

Low gated behind ff 

## Deploy Plan

Deploy front