### PR TITLE
Pause goals when continuation is unsafe

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -1688,6 +1688,43 @@ describe("postUserMessage", () => {
       branchId: null,
     });
     expect(continuedGoal?.turnCount).toBe(2);
+
+    vi.mocked(launchAgentLoopWorkflow).mockRejectedValueOnce(
+      new Error("Temporal unavailable")
+    );
+    const failedRecoveryOutcome = await continueActiveGoal(auth, {
+      agentMessageId: firstAgentMessage.sId,
+      agentMessageVersion: firstAgentMessage.version,
+      conversationId: conversation.sId,
+      conversationTitle: conversation.title,
+      conversationBranchId: null,
+      userMessageId: result.value.userMessage.sId,
+      userMessageVersion: result.value.userMessage.version,
+      userMessageOrigin: "web",
+    });
+    expect(failedRecoveryOutcome).toBe("paused");
+    const failedGoal = await ConversationGoalResource.fetchLatest(auth, {
+      conversation: conversationResource,
+      branchId: null,
+    });
+    expect(failedGoal?.toJSON()).toMatchObject({
+      status: "paused",
+      reason: "continuation_failed",
+    });
+    if (!failedGoal) {
+      throw new Error("Failed goal not found");
+    }
+    expect(
+      (
+        await AgentMessageModel.findOne({
+          where: {
+            id: failedGoal.currentAgentMessageId,
+            workspaceId: workspace.id,
+          },
+        })
+      )?.status
+    ).toBe("failed");
+
     expect(
       await UserMessageModel.count({
         where: {
@@ -1697,6 +1734,50 @@ describe("postUserMessage", () => {
         },
       })
     ).toBe(1);
+  });
+
+  it("pauses an active goal before accepting user steering", async () => {
+    await FeatureFlagFactory.basic(auth, "goal_mode");
+    const user = auth.getNonNullableUser().toJSON();
+    const context = {
+      username: user.username,
+      timezone: "UTC",
+      fullName: user.fullName,
+      email: user.email,
+      profilePictureUrl: user.image,
+      origin: "web" as const,
+    };
+    const started = await postUserMessage(auth, {
+      conversationResource,
+      content: "Ship Goal Mode",
+      mentions: [{ configurationId: agentConfig1.sId }],
+      context,
+      skipToolsValidation: false,
+      goal: { objective: "Ship Goal Mode" },
+    });
+    expect(started.isOk()).toBe(true);
+    if (started.isErr()) {
+      return;
+    }
+
+    const steered = await postUserMessage(auth, {
+      conversationResource,
+      content: "Change direction",
+      mentions: [{ configurationId: agentConfig1.sId }],
+      context,
+      skipToolsValidation: false,
+    });
+    expect(steered.isOk()).toBe(true);
+    expect(
+      (
+        await ConversationGoalResource.fetchLatest(auth, {
+          conversation: conversationResource,
+        })
+      )?.toJSON()
+    ).toMatchObject({
+      status: "paused",
+      reason: "user_interrupted",
+    });
   });
 
   it("rejects goal metadata when Goal Mode is not enabled", async () => {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -541,7 +541,7 @@ export async function postUserMessage(
     modelSelection,
     goal,
     continuationGoal,
-    awaitWorkflowLaunch,
+    deferAgentLoopWorkflow,
   }: {
     conversationResource: ConversationResource;
     branchId?: string | null;
@@ -555,7 +555,7 @@ export async function postUserMessage(
     modelSelection?: ModelSelectionType;
     goal?: GoalCreation;
     continuationGoal?: ConversationGoalResource;
-    awaitWorkflowLaunch?: boolean;
+    deferAgentLoopWorkflow?: boolean;
   }
 ): Promise<
   Result<
@@ -878,6 +878,17 @@ export async function postUserMessage(
     // connection pool, resulting in a deadlock.
     await getConversationRankVersionLock(auth, conversation, t);
 
+    if (
+      continuationGoal &&
+      !(await continuationGoal.lockForContinuation(auth, {
+        conversation: conversationResource,
+        branchId: conversation.branchId,
+        transaction: t,
+      }))
+    ) {
+      return { continuationConflict: true as const };
+    }
+
     let nextMessageRank: number | undefined;
 
     // We will do best effort to create a branch, but there a several conditions that we will not create a branch.
@@ -963,6 +974,18 @@ export async function postUserMessage(
           }
         }
       }
+    }
+
+    if (
+      !goal &&
+      context.origin !== "goal_continuation" &&
+      featureFlags.includes("goal_mode")
+    ) {
+      await ConversationGoalResource.pauseActiveForUserMessage(auth, {
+        conversation: conversationResource,
+        branchId: conversation.branchId,
+        transaction: t,
+      });
     }
 
     if (goal) {
@@ -1158,6 +1181,16 @@ export async function postUserMessage(
     });
   }
 
+  if ("continuationConflict" in transactionResult) {
+    return new Err({
+      status_code: 409,
+      api_error: {
+        type: "invalid_request_error",
+        message: "This goal continuation was already claimed by another turn.",
+      },
+    });
+  }
+
   const { userMessage, agentMessages } = transactionResult;
 
   // If a user is mentioned, we want to make sure the conversation has a title.
@@ -1219,20 +1252,21 @@ export async function postUserMessage(
   }
 
   // Run agent loop workflows after the transaction commits, to ensure messages are persisted.
-  if (agentMessages.length > 0) {
-    await runAgentLoopWorkflow({
-      auth,
-      agentMessages,
-      conversation,
-      userMessage,
-      awaitLaunch: awaitWorkflowLaunch,
-    });
-  } else if (runningAgentMessage && userMessage.visibility === "pending") {
-    // Pending path: signal the running agent loop to gracefully stop.
-    await gracefullyStopAgentLoop(auth, {
-      messageIds: [runningAgentMessage.sId],
-      conversationId: conversation.sId,
-    });
+  if (!deferAgentLoopWorkflow) {
+    if (agentMessages.length > 0) {
+      await runAgentLoopWorkflow({
+        auth,
+        agentMessages,
+        conversation,
+        userMessage,
+      });
+    } else if (runningAgentMessage && userMessage.visibility === "pending") {
+      // Pending path: signal the running agent loop to gracefully stop.
+      await gracefullyStopAgentLoop(auth, {
+        messageIds: [runningAgentMessage.sId],
+        conversationId: conversation.sId,
+      });
+    }
   }
 
   await Promise.all([

--- a/front/lib/api/assistant/goal_mode.ts
+++ b/front/lib/api/assistant/goal_mode.ts
@@ -2,20 +2,79 @@ import { postUserMessage } from "@app/lib/api/assistant/conversation";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { ConversationGoalResource } from "@app/lib/resources/conversation_goal_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import type { GoalType } from "@app/types/assistant/goal";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 export type GoalContinuationOutcome =
   | "continued"
   | "already_processed"
   | "inactive"
+  | "newer_message"
   | "not_succeeded"
   | "paused";
 
 const GOAL_CONTINUATION_MESSAGE =
   "Continue working toward the active goal. Review the conversation and prior progress, then take the next concrete steps. Do not repeat completed work. Use update_goal only when the full goal is complete and verified, or when a genuine blocker prevents further progress.";
+
+async function pauseFailedGoalTurn(
+  auth: Authenticator,
+  {
+    conversation,
+    goal,
+  }: {
+    conversation: ConversationResource;
+    goal: ConversationGoalResource;
+  }
+): Promise<boolean> {
+  const applied = await goal.failCurrentTurn(auth, {
+    conversation,
+    reason: "continuation_failed",
+  });
+  if (applied) {
+    await ConversationResource.setIsRunningAgentLoop(auth, {
+      conversation: conversation.toJSON(),
+      isRunningAgentLoop: false,
+    });
+  }
+  return applied;
+}
+
+async function launchGoalTurn(
+  auth: Authenticator,
+  {
+    conversation,
+    goal,
+    agentLoopArgs,
+  }: {
+    conversation: ConversationResource;
+    goal: ConversationGoalResource;
+    agentLoopArgs: AgentLoopArgs;
+  }
+): Promise<GoalContinuationOutcome> {
+  await ConversationResource.setIsRunningAgentLoop(auth, {
+    conversation: conversation.toJSON(),
+    isRunningAgentLoop: true,
+  });
+  try {
+    await launchAgentLoopWorkflow({ auth, agentLoopArgs, startStep: 0 });
+    return "continued";
+  } catch (error) {
+    await pauseFailedGoalTurn(auth, { conversation, goal });
+    logger.error(
+      {
+        error: normalizeError(error),
+        conversationId: conversation.sId,
+        goalId: goal.sId,
+      },
+      "Failed to launch a goal turn"
+    );
+    return "paused";
+  }
+}
 
 async function ensureCurrentGoalTurn(
   auth: Authenticator,
@@ -39,23 +98,17 @@ async function ensureCurrentGoalTurn(
     case "already_succeeded":
       return "continued";
     case "unavailable":
+      await pauseFailedGoalTurn(auth, { conversation, goal: activeGoal });
       return "paused";
     case "restart":
-      break;
+      return launchGoalTurn(auth, {
+        conversation,
+        goal: activeGoal,
+        agentLoopArgs: recovery.agentLoopArgs,
+      });
     default:
       return assertNever(recovery);
   }
-
-  await ConversationResource.setIsRunningAgentLoop(auth, {
-    conversation: conversation.toJSON(),
-    isRunningAgentLoop: true,
-  });
-  await launchAgentLoopWorkflow({
-    auth,
-    agentLoopArgs: recovery.agentLoopArgs,
-    startStep: 0,
-  });
-  return "continued";
 }
 
 export async function startActiveGoalTurn(
@@ -96,19 +149,55 @@ export async function startActiveGoalTurn(
     skipDustAutoMention: true,
     doNotAssociateUser: true,
     continuationGoal: activeGoal,
-    awaitWorkflowLaunch: true,
+    deferAgentLoopWorkflow: true,
   });
-  if (result.isOk() && result.value.agentMessages.length === 1) {
-    return "continued";
-  }
   const latest = await ConversationGoalResource.fetchLatest(auth, {
     conversation,
     branchId: goal.branchId,
   });
-  return latest?.sId === goal.sId &&
+  if (
+    result.isOk() &&
+    result.value.agentMessages.length === 1 &&
+    latest?.sId === goal.sId &&
+    latest.status === "active" &&
     latest.currentAgentMessageId !== expectedCurrentAgentMessageModelId
-    ? "continued"
-    : "inactive";
+  ) {
+    const agentMessage = result.value.agentMessages[0];
+    return launchGoalTurn(auth, {
+      conversation,
+      goal: latest,
+      agentLoopArgs: {
+        agentMessageId: agentMessage.sId,
+        agentMessageVersion: agentMessage.version,
+        conversationId: conversation.sId,
+        conversationBranchId: goal.branchId,
+        conversationTitle: conversation.title,
+        userMessageId: result.value.userMessage.sId,
+        userMessageVersion: result.value.userMessage.version,
+        userMessageOrigin: result.value.userMessage.context.origin,
+      },
+    });
+  }
+  if (
+    latest?.sId === goal.sId &&
+    latest.status === "active" &&
+    latest.currentAgentMessageId !== expectedCurrentAgentMessageModelId
+  ) {
+    return "continued";
+  }
+
+  logger.error(
+    {
+      conversationId: conversation.sId,
+      goalId: goal.sId,
+      errorType: result.isErr()
+        ? result.error.api_error.type
+        : "missing_agent_message",
+    },
+    "Failed to create the next goal turn"
+  );
+  await pauseFailedGoalTurn(auth, { conversation, goal: activeGoal });
+  return "paused";
 }
 
 export async function continueActiveGoal(
@@ -129,6 +218,7 @@ export async function continueActiveGoal(
     case "inactive":
     case "not_succeeded":
     case "already_processed":
+    case "newer_message":
       return decision.type;
     case "turn_limit_reached":
       return "paused";
@@ -145,7 +235,13 @@ export async function continueActiveGoal(
     agentLoopArgs.conversationId
   );
   if (!conversation) {
-    return "inactive";
+    await ConversationGoalResource.pauseForAgentMessage(auth, {
+      conversationId: agentLoopArgs.conversationId,
+      conversationBranchId: agentLoopArgs.conversationBranchId,
+      agentMessageId: agentLoopArgs.agentMessageId,
+      reason: "conversation_unavailable",
+    });
+    return "paused";
   }
   return decision.type === "ensure_current"
     ? ensureCurrentGoalTurn(auth, { conversation, goal: decision.goal })

--- a/front/lib/resources/conversation_goal_resource.test.ts
+++ b/front/lib/resources/conversation_goal_resource.test.ts
@@ -152,4 +152,93 @@ describe("ConversationGoalResource", () => {
       )?.turnCount
     ).toBe(1);
   });
+
+  it("pauses instead of continuing behind newer user input", async () => {
+    const { message } = await createAgentMessage("succeeded");
+    await createGoal(message.sId);
+    await ConversationFactory.createUserMessageWithRank({
+      auth,
+      workspace,
+      conversationId: conversation.id,
+      rank: 2,
+      content: "Follow this new direction",
+    });
+
+    expect(
+      await ConversationGoalResource.claimContinuation(auth, {
+        conversationId: conversation.sId,
+        conversationBranchId: null,
+        agentMessageId: message.sId,
+      })
+    ).toEqual({ type: "newer_message" });
+    expect(
+      (
+        await ConversationGoalResource.fetchLatest(auth, {
+          conversation: conversationResource,
+        })
+      )?.toJSON()
+    ).toMatchObject({
+      status: "paused",
+      reason: "user_interrupted",
+    });
+
+    expect(
+      await ConversationGoalResource.claimContinuation(auth, {
+        conversationId: conversation.sId,
+        conversationBranchId: null,
+        agentMessageId: message.sId,
+      })
+    ).toEqual({ type: "inactive" });
+  });
+
+  it("ignores a delayed failure from an older goal turn", async () => {
+    const first = await createAgentMessage("succeeded");
+    const goal = await createGoal(first.message.sId);
+    await ConversationGoalResource.claimContinuation(auth, {
+      conversationId: conversation.sId,
+      conversationBranchId: null,
+      agentMessageId: first.message.sId,
+    });
+    const second = await createAgentMessage("created", 2);
+
+    await withTransaction(async (transaction) => {
+      expect(
+        await goal.setCurrentAgentMessage(auth, {
+          conversation: conversationResource,
+          branchId: null,
+          agentMessageId: second.message.sId,
+          agentConfigurationId: agent.sId,
+          transaction,
+        })
+      ).toBe(true);
+    });
+
+    await ConversationGoalResource.pauseForAgentMessage(auth, {
+      conversationId: conversation.sId,
+      conversationBranchId: null,
+      agentMessageId: first.message.sId,
+      reason: "delayed_old_turn_failure",
+    });
+    expect(
+      (
+        await ConversationGoalResource.fetchLatest(auth, {
+          conversation: conversationResource,
+        })
+      )?.status
+    ).toBe("active");
+
+    await ConversationGoalResource.pauseForAgentMessage(auth, {
+      conversationId: conversation.sId,
+      conversationBranchId: null,
+      agentMessageId: second.message.sId,
+      reason: "current_turn_failure",
+    });
+    expect(
+      (
+        await ConversationGoalResource.fetchLatest(auth, {
+          conversation: conversationResource,
+        })
+      )?.status
+    ).toBe("paused");
+  });
 });

--- a/front/lib/resources/conversation_goal_resource.ts
+++ b/front/lib/resources/conversation_goal_resource.ts
@@ -34,6 +34,7 @@ export type GoalContinuationDecision =
       type:
         | "already_processed"
         | "inactive"
+        | "newer_message"
         | "not_succeeded"
         | "turn_limit_reached";
     };
@@ -311,6 +312,8 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
         status === "complete" ? "completed" : "blocked";
       if (
         goal.agentConfigurationId !== agentLoopData.agentConfiguration.sId ||
+        goal.agentConfigurationId !==
+          agentLoopData.agentMessage.configuration.sId ||
         goal.currentAgentMessageId !==
           agentLoopData.agentMessage.agentMessageId ||
         goal.lastAgentMessageId === goal.currentAgentMessageId
@@ -331,7 +334,11 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
           terminalAt: new Date(),
         },
         {
-          where: { id: goal.id, workspaceId: goal.workspaceId },
+          where: {
+            id: goal.id,
+            workspaceId: goal.workspaceId,
+            status: "active",
+          },
           returning: true,
           transaction,
         }
@@ -391,6 +398,9 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
           workspaceId: auth.getNonNullableWorkspace().id,
           conversationId: conversation.id,
           sId: agentMessageId,
+          branchId: conversationBranchId
+            ? getResourceIdFromSId(conversationBranchId)
+            : null,
         },
         include: [
           {
@@ -423,6 +433,32 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
       ) {
         return { type: "inactive" };
       }
+
+      const newerMessage = await MessageModel.findOne({
+        attributes: ["id"],
+        where: {
+          workspaceId: goalRow.workspaceId,
+          conversationId: goalRow.conversationId,
+          branchId: conversationBranchId
+            ? getResourceIdFromSId(conversationBranchId)
+            : null,
+          rank: { [Op.gt]: message.rank },
+          visibility: { [Op.not]: "deleted" },
+        },
+        transaction,
+      });
+      if (newerMessage) {
+        await goalRow.update(
+          {
+            status: "paused",
+            reason: "user_interrupted",
+            lastAgentMessageId: message.agentMessage.id,
+          },
+          { transaction }
+        );
+        return { type: "newer_message" };
+      }
+
       if (goalRow.turnCount >= goalRow.maxTurns) {
         await goalRow.update(
           {
@@ -446,6 +482,190 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
         type: "continue",
         goal: new this(this.model, goalRow.get()).toJSON(),
       };
+    });
+  }
+
+  static async pauseActiveForUserMessage(
+    auth: Authenticator,
+    {
+      conversation,
+      branchId,
+      transaction,
+    }: {
+      conversation: ConversationResource;
+      branchId: string | null;
+      transaction: Transaction;
+    }
+  ): Promise<boolean> {
+    const row = await this.model.findOne({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId: conversation.id,
+        branchId: branchId ? getResourceIdFromSId(branchId) : null,
+      },
+      order: [
+        ["createdAt", "DESC"],
+        ["id", "DESC"],
+      ],
+      transaction,
+      lock: transaction.LOCK.UPDATE,
+    });
+    if (!row || row.status !== "active") {
+      return false;
+    }
+    await row.update(
+      { status: "paused", reason: "user_interrupted" },
+      { transaction }
+    );
+    return true;
+  }
+
+  async lockForContinuation(
+    auth: Authenticator,
+    {
+      conversation,
+      branchId,
+      transaction,
+    }: {
+      conversation: ConversationResource;
+      branchId: string | null;
+      transaction: Transaction;
+    }
+  ): Promise<boolean> {
+    const branchModelId = branchId ? getResourceIdFromSId(branchId) : null;
+    if (branchId && !branchModelId) {
+      return false;
+    }
+    const row = await this.model.findOne({
+      where: {
+        id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId: conversation.id,
+        branchId: branchModelId,
+        currentAgentMessageId: this.currentAgentMessageId,
+        lastAgentMessageId: this.currentAgentMessageId,
+        status: "active",
+      },
+      transaction,
+      lock: transaction.LOCK.UPDATE,
+    });
+    return row !== null;
+  }
+
+  static async pauseForAgentMessage(
+    auth: Authenticator,
+    {
+      conversationId,
+      conversationBranchId,
+      agentMessageId,
+      reason,
+    }: {
+      conversationId: string;
+      conversationBranchId: string | null;
+      agentMessageId: string;
+      reason: string;
+    }
+  ): Promise<boolean> {
+    const conversation = await ConversationModel.findOne({
+      attributes: ["id"],
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        sId: conversationId,
+      },
+    });
+    if (!conversation) {
+      return false;
+    }
+
+    return withTransaction(async (transaction) => {
+      const goal = await this.model.findOne({
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          conversationId: conversation.id,
+          branchId: conversationBranchId
+            ? getResourceIdFromSId(conversationBranchId)
+            : null,
+          status: "active",
+        },
+        order: [
+          ["createdAt", "DESC"],
+          ["id", "DESC"],
+        ],
+        transaction,
+        lock: transaction.LOCK.UPDATE,
+      });
+      if (!goal) {
+        return false;
+      }
+
+      const message = await MessageModel.findOne({
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          conversationId: conversation.id,
+          sId: agentMessageId,
+          branchId: conversationBranchId
+            ? getResourceIdFromSId(conversationBranchId)
+            : null,
+        },
+        include: [
+          {
+            model: AgentMessageModel,
+            as: "agentMessage",
+            required: true,
+          },
+        ],
+        transaction,
+      });
+      if (
+        !message?.agentMessage ||
+        goal.currentAgentMessageId !== message.agentMessage.id
+      ) {
+        return false;
+      }
+      await goal.update({ status: "paused", reason }, { transaction });
+      return true;
+    });
+  }
+
+  async failCurrentTurn(
+    auth: Authenticator,
+    {
+      conversation,
+      reason,
+    }: {
+      conversation: ConversationResource;
+      reason: string;
+    }
+  ): Promise<boolean> {
+    return withTransaction(async (transaction) => {
+      const goal = await this.model.findOne({
+        where: {
+          id: this.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+          conversationId: conversation.id,
+          branchId: this.branchId,
+          currentAgentMessageId: this.currentAgentMessageId,
+          status: "active",
+        },
+        transaction,
+        lock: transaction.LOCK.UPDATE,
+      });
+      if (!goal) {
+        return false;
+      }
+      await AgentMessageModel.update(
+        { status: "failed", completedAt: new Date() },
+        {
+          where: {
+            id: goal.currentAgentMessageId,
+            workspaceId: goal.workspaceId,
+            status: "created",
+          },
+          transaction,
+        }
+      );
+      await goal.update({ status: "paused", reason }, { transaction });
+      return true;
     });
   }
 

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -4,7 +4,12 @@ import {
   sendEmailReplyOnError,
 } from "@app/lib/api/assistant/email/email_reply";
 import { continueActiveGoal } from "@app/lib/api/assistant/goal_mode";
-import { Authenticator, type AuthenticatorType } from "@app/lib/auth";
+import {
+  Authenticator,
+  type AuthenticatorType,
+  hasFeatureFlag,
+} from "@app/lib/auth";
+import { ConversationGoalResource } from "@app/lib/resources/conversation_goal_resource";
 import { launchAgentMessageAnalytics } from "@app/temporal/agent_loop/activities/analytics";
 import {
   creditsExhaustedMessage,
@@ -26,6 +31,22 @@ import {
 } from "@app/temporal/agent_loop/activities/usage_tracking";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 
+async function pauseActiveGoal(
+  auth: Authenticator,
+  agentLoopArgs: AgentLoopArgs,
+  reason: string
+): Promise<void> {
+  if (!(await hasFeatureFlag(auth, "goal_mode"))) {
+    return;
+  }
+  await ConversationGoalResource.pauseForAgentMessage(auth, {
+    conversationId: agentLoopArgs.conversationId,
+    conversationBranchId: agentLoopArgs.conversationBranchId,
+    agentMessageId: agentLoopArgs.agentMessageId,
+    reason,
+  });
+}
+
 export async function finalizeSuccessfulAgentLoopActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
@@ -44,6 +65,7 @@ export async function finalizeSuccessfulAgentLoopActivity(
   if (
     goalOutcome === "continued" ||
     goalOutcome === "already_processed" ||
+    goalOutcome === "newer_message" ||
     goalOutcome === "not_succeeded"
   ) {
     return;
@@ -70,6 +92,7 @@ export async function finalizeGracefullyStoppedAgentLoopActivity(
   await finalizeGracefulStop(authType, agentLoopArgs);
 
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
+  await pauseActiveGoal(auth, agentLoopArgs, "agent_loop_stopped");
 
   await Promise.all([
     snapshotAgentMessageSkills(auth, agentLoopArgs),
@@ -97,6 +120,7 @@ export async function finalizeInterruptedAgentLoopActivity(
   await finalizeInterruption(authType, agentLoopArgs);
 
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
+  await pauseActiveGoal(auth, agentLoopArgs, "user_interrupted");
 
   await Promise.all([
     snapshotAgentMessageSkills(auth, agentLoopArgs),
@@ -116,6 +140,7 @@ export async function finalizeCancelledAgentLoopActivity(
   await finalizeCancellation(authType, agentLoopArgs);
 
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
+  await pauseActiveGoal(auth, agentLoopArgs, "agent_loop_cancelled");
 
   await Promise.all([
     snapshotAgentMessageSkills(auth, agentLoopArgs),
@@ -138,6 +163,7 @@ export async function finalizeCreditStoppedAgentLoopActivity(
   await finalizeCreditStop(authType, agentLoopArgs);
 
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
+  await pauseActiveGoal(auth, agentLoopArgs, "credits_exhausted");
 
   await Promise.all([
     snapshotAgentMessageSkills(auth, agentLoopArgs),
@@ -159,6 +185,7 @@ export async function finalizeErroredAgentLoopActivity(
   await notifyWorkflowError(authType, agentLoopArgs, error);
 
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
+  await pauseActiveGoal(auth, agentLoopArgs, "agent_loop_error");
 
   await Promise.all([
     snapshotAgentMessageSkills(auth, agentLoopArgs),


### PR DESCRIPTION
## Description

Pause an active goal when newer user input wins the continuation race, a terminal agent-loop outcome prevents continuation, or workflow creation and recovery fail. User messages and continuation claims serialize on the same goal row. Exact current-turn checks keep delayed failures from affecting a newer turn, and feature-flag checks keep the terminal hot paths inert when Goal Mode is off.

Stacked on #29702.

## Tests

Covered serialized user steering, newer-message fallback detection, stale terminal failures, atomic failed-turn cleanup, workflow relaunch failure, and the existing continuation recovery journey.

## Risk

Failures intentionally leave a visible paused goal for explicit recovery. The next stack PR adds pause, resume, and cancel controls.

## Deploy Plan

Merge after #29702. Keep `goal_mode` disabled until #29708 is deployed so paused goals have explicit recovery controls.