### PR TITLE
Add manual goal pause controls

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -6683,6 +6683,10 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": [
+                    "goal",
+                    "canManage"
+                  ],
                   "properties": {
                     "goal": {
                       "type": "object",
@@ -6692,6 +6696,9 @@
                           "$ref": "#/components/schemas/PrivateGoal"
                         }
                       ]
+                    },
+                    "canManage": {
+                      "type": "boolean"
                     }
                   }
                 }
@@ -6700,6 +6707,94 @@
           },
           "403": {
             "description": "Goal Mode is not enabled for the workspace."
+          }
+        }
+      },
+      "patch": {
+        "summary": "Pause a conversation goal",
+        "description": "Pause automatic continuation for the latest active Goal Mode goal on a conversation branch.",
+        "tags": [
+          "Private Conversations"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "action"
+                ],
+                "properties": {
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "pause"
+                    ]
+                  },
+                  "branchId": {
+                    "type": "string",
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated goal.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "goal",
+                    "canManage"
+                  ],
+                  "properties": {
+                    "goal": {
+                      "$ref": "#/components/schemas/PrivateGoal"
+                    },
+                    "canManage": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Goal Mode is disabled or the caller does not own the goal."
+          },
+          "404": {
+            "description": "Conversation, branch, or goal not found."
+          },
+          "409": {
+            "description": "Invalid or conflicting goal transition."
           }
         }
       }

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/goal.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/goal.test.ts
@@ -10,7 +10,12 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { honoApp } from "@front-api/app";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/temporal/agent_loop/client", () => ({
+  launchAgentLoopWorkflow: vi.fn(),
+  launchCompactionWorkflow: vi.fn(),
+}));
 
 async function setupTest(enableGoalMode: boolean) {
   const { workspace, auth, user } = await createPrivateApiMockRequest({
@@ -39,6 +44,21 @@ function getGoal(
   );
 }
 
+function patchGoal(
+  workspaceId: string,
+  conversationId: string,
+  branchId?: string
+) {
+  return honoApp.request(
+    `/api/w/${workspaceId}/assistant/conversations/${conversationId}/goal`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "pause", branchId }),
+    }
+  );
+}
+
 describe("conversation goal API", () => {
   it("is gated by the Goal Mode feature flag", async () => {
     const { workspace, conversation } = await setupTest(false);
@@ -46,7 +66,7 @@ describe("conversation goal API", () => {
     expect(response.status).toBe(403);
   });
 
-  it("returns the latest goal", async () => {
+  it("returns and updates the latest goal", async () => {
     const { workspace, conversation, agent, auth } = await setupTest(true);
     const message = await ConversationFactory.createAgentMessageWithRank({
       workspace,
@@ -78,10 +98,28 @@ describe("conversation goal API", () => {
 
     const response = await getGoal(workspace.sId, conversation.sId);
     expect(response.status).toBe(200);
-    expect((await response.json()).goal).toMatchObject({
-      objective: "Finish the release",
-      status: "active",
+    expect(await response.json()).toMatchObject({
+      canManage: true,
+      goal: {
+        objective: "Finish the release",
+        status: "active",
+      },
     });
+
+    const paused = await patchGoal(workspace.sId, conversation.sId);
+    expect(paused.status).toBe(200);
+    expect((await paused.json()).goal).toMatchObject({
+      status: "paused",
+      reason: "paused_by_user",
+    });
+
+    await createPrivateApiMockRequest({
+      role: "admin",
+      workspace,
+    });
+    const nonOwnerView = await getGoal(workspace.sId, conversation.sId);
+    expect((await nonOwnerView.json()).canManage).toBe(false);
+    expect((await patchGoal(workspace.sId, conversation.sId)).status).toBe(403);
   });
 
   it("returns a branch goal and rejects a branch from another conversation", async () => {
@@ -130,6 +168,9 @@ describe("conversation goal API", () => {
     const response = await getGoal(workspace.sId, conversation.sId, branch.sId);
     expect(response.status).toBe(200);
     expect((await response.json()).goal.objective).toBe("Finish the branch");
+    const paused = await patchGoal(workspace.sId, conversation.sId, branch.sId);
+    expect(paused.status).toBe(200);
+    expect((await paused.json()).goal.status).toBe("paused");
 
     const otherConversation = await ConversationFactory.create(auth, {
       agentConfigurationId: agent.sId,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/goal.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/goal.ts
@@ -1,11 +1,18 @@
-import { hasFeatureFlag } from "@app/lib/auth";
+import { pauseGoalByUser } from "@app/lib/api/assistant/goal_mode";
+import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
-import { ConversationGoalResource } from "@app/lib/resources/conversation_goal_resource";
+import {
+  ConversationGoalResource,
+  type GoalTransitionError,
+} from "@app/lib/resources/conversation_goal_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import {
   type GetConversationGoalResponseBody,
   GoalBranchSchema,
+  PatchConversationGoalRequestBodySchema,
+  type PatchConversationGoalResponseBody,
 } from "@app/types/api/assistant/goal";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -17,6 +24,54 @@ const ParamsSchema = z.object({
 });
 
 const app = workspaceApp();
+
+async function isValidBranch(
+  auth: Authenticator,
+  conversation: ConversationResource,
+  branchId: string | null
+): Promise<boolean> {
+  if (!branchId) {
+    return true;
+  }
+  const branch = await ConversationBranchResource.fetchById(auth, branchId);
+  return branch?.conversationId === conversation.id;
+}
+
+function apiErrorForTransition(
+  ctx: Parameters<typeof apiError>[0],
+  error: GoalTransitionError
+) {
+  switch (error.type) {
+    case "goal_not_found":
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "invalid_request_error",
+          message: "No goal exists for this conversation branch.",
+        },
+      });
+    case "forbidden":
+    case "wrong_agent":
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "Only the user who created this goal can update it.",
+        },
+      });
+    case "goal_conflict":
+    case "invalid_transition":
+      return apiError(ctx, {
+        status_code: 409,
+        api_error: {
+          type: "invalid_request_error",
+          message: "This goal cannot perform the requested transition.",
+        },
+      });
+    default:
+      return assertNever(error.type);
+  }
+}
 
 /**
  * @swagger
@@ -51,14 +106,68 @@ const app = workspaceApp();
  *           application/json:
  *             schema:
  *               type: object
+ *               required: [goal, canManage]
  *               properties:
  *                 goal:
  *                   type: object
  *                   nullable: true
  *                   allOf:
  *                     - $ref: '#/components/schemas/PrivateGoal'
+ *                 canManage:
+ *                   type: boolean
  *       403:
  *         description: Goal Mode is not enabled for the workspace.
+ *   patch:
+ *     summary: Pause a conversation goal
+ *     description: Pause automatic continuation for the latest active Goal Mode goal on a conversation branch.
+ *     tags:
+ *       - Private Conversations
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [action]
+ *             properties:
+ *               action:
+ *                 type: string
+ *                 enum: [pause]
+ *               branchId:
+ *                 type: string
+ *                 nullable: true
+ *     responses:
+ *       200:
+ *         description: Updated goal.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required: [goal, canManage]
+ *               properties:
+ *                 goal:
+ *                   $ref: '#/components/schemas/PrivateGoal'
+ *                 canManage:
+ *                   type: boolean
+ *       403:
+ *         description: Goal Mode is disabled or the caller does not own the goal.
+ *       404:
+ *         description: Conversation, branch, or goal not found.
+ *       409:
+ *         description: Invalid or conflicting goal transition.
  */
 app.get(
   "/",
@@ -79,13 +188,7 @@ app.get(
     }
 
     const conversation = await ConversationResource.fetchById(auth, cId);
-    const branch = branchId
-      ? await ConversationBranchResource.fetchById(auth, branchId)
-      : null;
-    if (
-      !conversation ||
-      (branchId && (!branch || branch.conversationId !== conversation.id))
-    ) {
+    if (!conversation || !(await isValidBranch(auth, conversation, branchId))) {
       return apiError(ctx, {
         status_code: 404,
         api_error: {
@@ -99,7 +202,53 @@ app.get(
       conversation,
       branchId,
     });
-    return ctx.json({ goal: goal?.toJSON() ?? null });
+    return ctx.json({
+      goal: goal?.toJSON() ?? null,
+      canManage: goal !== null && goal.createdByUserId === auth.user()?.id,
+    });
+  }
+);
+
+app.patch(
+  "/",
+  validate("param", ParamsSchema),
+  validate("json", PatchConversationGoalRequestBodySchema),
+  async (ctx): HandlerResult<PatchConversationGoalResponseBody> => {
+    const auth = ctx.get("auth");
+    const { cId } = ctx.req.valid("param");
+    const { branchId: requestedBranchId } = ctx.req.valid("json");
+    const branchId = requestedBranchId ?? null;
+
+    if (!(await hasFeatureFlag(auth, "goal_mode"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Goal Mode is not enabled for this workspace.",
+        },
+      });
+    }
+
+    const conversation = await ConversationResource.fetchById(auth, cId);
+    if (!conversation || !(await isValidBranch(auth, conversation, branchId))) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: "Conversation or branch not found.",
+        },
+      });
+    }
+
+    const result = await pauseGoalByUser(auth, {
+      conversation,
+      branchId,
+    });
+    if (result.isErr()) {
+      return apiErrorForTransition(ctx, result.error);
+    }
+
+    return ctx.json({ goal: result.value.toJSON(), canManage: true });
   }
 );
 

--- a/front/components/assistant/conversation/goal_mode/GoalCard.tsx
+++ b/front/components/assistant/conversation/goal_mode/GoalCard.tsx
@@ -1,8 +1,13 @@
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useConversationGoal } from "@app/lib/swr/conversation_goals";
 import type { GoalType } from "@app/types/assistant/goal";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
-import { ContentMessageInline, Target04 } from "@dust-tt/sparkle";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import {
+  ContentMessageAction,
+  ContentMessageInline,
+  PauseCircle,
+  Target04,
+} from "@dust-tt/sparkle";
 import React from "react";
 
 interface GoalCardProps {
@@ -23,8 +28,7 @@ function getStatusLabel(goal: GoalType): string | null {
     case "cancelled":
       return null;
     default:
-      assertNeverAndIgnore(goal.status);
-      return null;
+      return assertNever(goal.status);
   }
 }
 
@@ -34,8 +38,9 @@ export const GoalCard = React.memo(function GoalCard({
   workspaceId,
 }: GoalCardProps) {
   const { hasFeature } = useFeatureFlags();
-  const { goal } = useConversationGoal({
-    conversationId: hasFeature("goal_mode") ? conversationId : null,
+  const isGoalModeEnabled = hasFeature("goal_mode");
+  const { goal, canManage, isPausing, pauseGoal } = useConversationGoal({
+    conversationId: isGoalModeEnabled ? conversationId : null,
     workspaceId,
     branchId,
   });
@@ -43,6 +48,8 @@ export const GoalCard = React.memo(function GoalCard({
   if (!goal || !statusLabel) {
     return null;
   }
+
+  const isRunning = goal.status === "active";
 
   return (
     <ContentMessageInline
@@ -56,6 +63,17 @@ export const GoalCard = React.memo(function GoalCard({
           {goal.reason ? `${statusLabel} · ${goal.reason}` : statusLabel}
         </span>
       </div>
+      {canManage && isRunning && (
+        <ContentMessageAction
+          icon={PauseCircle}
+          variant="ghost"
+          size="xs"
+          tooltip="Pause future goal turns"
+          isLoading={isPausing}
+          disabled={isPausing}
+          onClick={() => void pauseGoal()}
+        />
+      )}
     </ContentMessageInline>
   );
 });

--- a/front/lib/api/actions/servers/goal_mode/tools/index.ts
+++ b/front/lib/api/actions/servers/goal_mode/tools/index.ts
@@ -50,6 +50,10 @@ const handlers: ToolHandlers<typeof GOAL_MODE_TOOLS_METADATA> = {
               "The goal changed concurrently. Re-read the goal state before retrying."
             )
           );
+        case "forbidden":
+          return new Err(
+            new MCPError("Only the user who created this goal can manage it.")
+          );
         default:
           return assertNever(result.error.type);
       }

--- a/front/lib/api/assistant/goal_mode.ts
+++ b/front/lib/api/assistant/goal_mode.ts
@@ -1,11 +1,15 @@
 import { postUserMessage } from "@app/lib/api/assistant/conversation";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
-import { ConversationGoalResource } from "@app/lib/resources/conversation_goal_resource";
+import {
+  ConversationGoalResource,
+  type GoalTransitionError,
+} from "@app/lib/resources/conversation_goal_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import type { GoalType } from "@app/types/assistant/goal";
+import type { Result } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
@@ -246,4 +250,20 @@ export async function continueActiveGoal(
   return decision.type === "ensure_current"
     ? ensureCurrentGoalTurn(auth, { conversation, goal: decision.goal })
     : startActiveGoalTurn(auth, { conversation, goal: decision.goal });
+}
+
+export function pauseGoalByUser(
+  auth: Authenticator,
+  {
+    conversation,
+    branchId,
+  }: {
+    conversation: ConversationResource;
+    branchId: string | null;
+  }
+): Promise<Result<ConversationGoalResource, GoalTransitionError>> {
+  return ConversationGoalResource.pauseByUser(auth, {
+    conversation,
+    branchId,
+  });
 }

--- a/front/lib/resources/conversation_goal_resource.ts
+++ b/front/lib/resources/conversation_goal_resource.ts
@@ -49,6 +49,7 @@ export class GoalTransitionError extends Error {
     readonly type:
       | "goal_not_found"
       | "goal_conflict"
+      | "forbidden"
       | "invalid_transition"
       | "wrong_agent"
   ) {
@@ -624,6 +625,68 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
       }
       await goal.update({ status: "paused", reason }, { transaction });
       return true;
+    });
+  }
+
+  static async pauseByUser(
+    auth: Authenticator,
+    {
+      conversation,
+      branchId,
+    }: {
+      conversation: ConversationResource;
+      branchId: string | null;
+    }
+  ): Promise<Result<ConversationGoalResource, GoalTransitionError>> {
+    return withTransaction(async (transaction) => {
+      const row = await this.model.findOne({
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          conversationId: conversation.id,
+          branchId: branchId ? getResourceIdFromSId(branchId) : null,
+        },
+        order: [
+          ["createdAt", "DESC"],
+          ["id", "DESC"],
+        ],
+        transaction,
+        lock: transaction.LOCK.UPDATE,
+      });
+      if (!row) {
+        return new Err(new GoalTransitionError("goal_not_found"));
+      }
+
+      const goal = new this(this.model, row.get());
+      if (goal.createdByUserId !== auth.getNonNullableUser().id) {
+        return new Err(new GoalTransitionError("forbidden"));
+      }
+
+      if (goal.status === "paused") {
+        return new Ok(goal);
+      }
+      if (goal.status !== "active") {
+        return new Err(new GoalTransitionError("invalid_transition"));
+      }
+
+      const [, rows] = await this.model.update(
+        {
+          status: "paused",
+          reason: "paused_by_user",
+        },
+        {
+          where: {
+            id: goal.id,
+            workspaceId: goal.workspaceId,
+            status: goal.status,
+          },
+          returning: true,
+          transaction,
+        }
+      );
+      const updated = rows[0];
+      return updated
+        ? new Ok(new this(this.model, updated.get()))
+        : new Err(new GoalTransitionError("goal_conflict"));
     });
   }
 

--- a/front/lib/swr/conversation_goals.ts
+++ b/front/lib/swr/conversation_goals.ts
@@ -1,5 +1,14 @@
-import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import {
+  getErrorFromResponse,
+  useFetcher,
+  useSWRWithDefaults,
+} from "@app/lib/swr/swr";
 import type { GetConversationGoalResponseBody } from "@app/types/api/assistant/goal";
+import { PatchConversationGoalResponseBodySchema } from "@app/types/api/assistant/goal";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { useCallback, useState } from "react";
 import type { Fetcher } from "swr";
 
 export function conversationGoalKey({
@@ -26,17 +35,69 @@ export function useConversationGoal({
 }) {
   const { fetcher } = useFetcher();
   const goalFetcher: Fetcher<GetConversationGoalResponseBody> = fetcher;
+  const sendNotification = useSendNotification();
+  const [isPausing, setIsPausing] = useState(false);
   const key = conversationId
     ? conversationGoalKey({ workspaceId, conversationId, branchId })
     : null;
-  const { data, error } = useSWRWithDefaults(key, goalFetcher, {
+  const { data, error, mutate } = useSWRWithDefaults(key, goalFetcher, {
     refreshInterval: (latest) =>
       latest?.goal?.status === "active" ? 2_000 : 0,
   });
 
+  const pauseGoal = useCallback(async (): Promise<boolean> => {
+    if (!key) {
+      return false;
+    }
+
+    setIsPausing(true);
+    try {
+      const response = await clientFetch(key, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "pause", branchId }),
+      });
+      if (!response.ok) {
+        const apiError = await getErrorFromResponse(response);
+        sendNotification({
+          type: "error",
+          title: "Failed to update goal",
+          description: apiError.message,
+        });
+        return false;
+      }
+
+      const updated = PatchConversationGoalResponseBodySchema.safeParse(
+        await response.json()
+      );
+      if (!updated.success) {
+        sendNotification({
+          type: "error",
+          title: "Failed to update goal",
+          description: "The server returned an invalid response.",
+        });
+        return false;
+      }
+      await mutate(updated.data, { revalidate: false });
+      return true;
+    } catch (error) {
+      sendNotification({
+        type: "error",
+        title: "Failed to update goal",
+        description: normalizeError(error).message,
+      });
+      return false;
+    } finally {
+      setIsPausing(false);
+    }
+  }, [branchId, key, mutate, sendNotification]);
+
   return {
     goal: data?.goal ?? null,
+    canManage: data?.canManage ?? false,
     isGoalLoading: conversationId !== null && !data && !error,
     isGoalError: error,
+    isPausing,
+    pauseGoal,
   };
 }

--- a/front/types/api/assistant/goal.ts
+++ b/front/types/api/assistant/goal.ts
@@ -1,10 +1,26 @@
-import type { GoalType } from "@app/types/assistant/goal";
+import { GoalSchema } from "@app/types/assistant/goal";
 import { z } from "zod";
 
 export const GoalBranchSchema = z.object({
   branchId: z.string().nullable().optional(),
 });
 
-export type GetConversationGoalResponseBody = {
-  goal: GoalType | null;
-};
+export const GetConversationGoalResponseBodySchema = z.object({
+  goal: GoalSchema.nullable(),
+  canManage: z.boolean(),
+});
+export type GetConversationGoalResponseBody = z.infer<
+  typeof GetConversationGoalResponseBodySchema
+>;
+
+export const PatchConversationGoalRequestBodySchema = GoalBranchSchema.extend({
+  action: z.literal("pause"),
+});
+
+export const PatchConversationGoalResponseBodySchema = z.object({
+  goal: GoalSchema,
+  canManage: z.boolean(),
+});
+export type PatchConversationGoalResponseBody = z.infer<
+  typeof PatchConversationGoalResponseBodySchema
+>;

--- a/front/types/assistant/goal.ts
+++ b/front/types/assistant/goal.ts
@@ -32,3 +32,17 @@ export type GoalType = {
   updatedAt: number;
   terminalAt: number | null;
 };
+
+export const GoalSchema: z.ZodType<GoalType> = z.object({
+  sId: z.string(),
+  objective: z.string(),
+  status: GoalStatusSchema,
+  agentConfigurationId: z.string(),
+  branchId: z.string().nullable(),
+  turnCount: z.number(),
+  maxTurns: z.number(),
+  reason: z.string().nullable(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  terminalAt: z.number().nullable(),
+});


### PR DESCRIPTION
## Description

Add an owner-only pause transition for Goal Mode. The conversation card shows the current goal to every conversation reader but only renders the pause control for its creator. Pausing stops future automatic goal turns; it does not interrupt an agent turn that is already running. The branch-scoped SWR hook validates responses and reports both API and transport failures.

Stacked on #29706.

## Tests

Covered the feature flag gate, root and branch pause journeys, owner visibility, non-owner rejection, branch isolation, both TypeScript projects, and strict Swagger generation.

## Risk

A paused goal remains paused until a later user action. The next stack PR adds explicit resume and cancel controls.

## Deploy Plan

Merge after #29706. Keep `goal_mode` disabled until #29709 is deployed so users have the complete recovery controls.