### PR TITLE
Add goal resume and cancel controls

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -6711,8 +6711,8 @@
         }
       },
       "patch": {
-        "summary": "Pause a conversation goal",
-        "description": "Pause automatic continuation for the latest active Goal Mode goal on a conversation branch.",
+        "summary": "Update a conversation goal",
+        "description": "Pause, resume, or cancel the latest Goal Mode goal on a conversation branch. Cancel prevents future goal turns but does not interrupt a turn that is already running.",
         "tags": [
           "Private Conversations"
         ],
@@ -6752,7 +6752,9 @@
                   "action": {
                     "type": "string",
                     "enum": [
-                      "pause"
+                      "pause",
+                      "resume",
+                      "cancel"
                     ]
                   },
                   "branchId": {
@@ -12225,7 +12227,11 @@
               "wakeup",
               "zapier",
               "zendesk",
-              "onboarding_conversation"
+              "onboarding_conversation",
+              "reinforced_skill_notification",
+              "reinforcement",
+              "branch_anchor",
+              "goal_continuation"
             ]
           },
           "selectedSpaceIds": {

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -1284,7 +1284,7 @@
  *           type: string
  *         origin:
  *           type: string
- *           enum: [web, project_kickoff, extension, agent_sidekick, api, cli, cli_programmatic, email, excel, gsheet, make, n8n, powerpoint, raycast, slack, slack_workflow, teams, transcript, triggered_programmatic, triggered, wakeup, zapier, zendesk, onboarding_conversation]
+ *           enum: [web, project_kickoff, extension, agent_sidekick, api, cli, cli_programmatic, email, excel, gsheet, make, n8n, powerpoint, raycast, slack, slack_workflow, teams, transcript, triggered_programmatic, triggered, wakeup, zapier, zendesk, onboarding_conversation, reinforced_skill_notification, reinforcement, branch_anchor, goal_continuation]
  *         selectedSpaceIds:
  *           type: array
  *           items:

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/goal.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/goal.test.ts
@@ -5,12 +5,14 @@ import {
 } from "@app/lib/resources/conversation_goal_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import type { GoalUserAction } from "@app/types/assistant/goal";
 import { honoApp } from "@front-api/app";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/temporal/agent_loop/client", () => ({
   launchAgentLoopWorkflow: vi.fn(),
@@ -47,6 +49,7 @@ function getGoal(
 function patchGoal(
   workspaceId: string,
   conversationId: string,
+  action: GoalUserAction,
   branchId?: string
 ) {
   return honoApp.request(
@@ -54,12 +57,16 @@ function patchGoal(
     {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ action: "pause", branchId }),
+      body: JSON.stringify({ action, branchId }),
     }
   );
 }
 
 describe("conversation goal API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("is gated by the Goal Mode feature flag", async () => {
     const { workspace, conversation } = await setupTest(false);
     const response = await getGoal(workspace.sId, conversation.sId);
@@ -74,6 +81,10 @@ describe("conversation goal API", () => {
       rank: 0,
       agentConfigurationId: agent.sId,
     });
+    const agentMessageModelId = message.agentMessageId;
+    if (agentMessageModelId === null) {
+      throw new Error("Agent message not found");
+    }
     const conversationResource = await ConversationResource.fetchById(
       auth,
       conversation.sId
@@ -106,11 +117,70 @@ describe("conversation goal API", () => {
       },
     });
 
-    const paused = await patchGoal(workspace.sId, conversation.sId);
+    const paused = await patchGoal(workspace.sId, conversation.sId, "pause");
     expect(paused.status).toBe(200);
     expect((await paused.json()).goal).toMatchObject({
       status: "paused",
       reason: "paused_by_user",
+    });
+
+    const runningAgentSpy = vi
+      .spyOn(ConversationResource.prototype, "getRunningAgentMessage")
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        sId: message.sId,
+        rank: message.rank,
+        agentMessageId: agentMessageModelId,
+        agentConfigurationId: agent.sId,
+      });
+    const racedResume = await patchGoal(
+      workspace.sId,
+      conversation.sId,
+      "resume"
+    );
+    runningAgentSpy.mockRestore();
+    expect(racedResume.status).toBe(409);
+    expect(
+      await ConversationGoalResource.fetchLatest(auth, {
+        conversation: conversationResource,
+      })
+    ).toMatchObject({ status: "paused", turnCount: 1 });
+
+    await ConversationFactory.setAgentMessageStatus({
+      workspace,
+      agentMessageModelId,
+      status: "succeeded",
+    });
+    const resumed = await patchGoal(workspace.sId, conversation.sId, "resume");
+    expect(resumed.status).toBe(200);
+    expect((await resumed.json()).goal).toMatchObject({
+      status: "active",
+      turnCount: 2,
+    });
+    const resumedGoal = await ConversationGoalResource.fetchLatest(auth, {
+      conversation: conversationResource,
+    });
+    expect(resumedGoal?.currentAgentMessageId).not.toBe(agentMessageModelId);
+    expect(launchAgentLoopWorkflow).toHaveBeenCalledOnce();
+
+    vi.mocked(launchAgentLoopWorkflow).mockClear();
+    const retriedResume = await patchGoal(
+      workspace.sId,
+      conversation.sId,
+      "resume"
+    );
+    expect(retriedResume.status).toBe(200);
+    expect(launchAgentLoopWorkflow).toHaveBeenCalledOnce();
+
+    const cancelled = await patchGoal(
+      workspace.sId,
+      conversation.sId,
+      "cancel"
+    );
+    expect(cancelled.status).toBe(200);
+    expect((await cancelled.json()).goal).toMatchObject({
+      status: "cancelled",
+      reason: "cancelled_by_user",
     });
 
     await createPrivateApiMockRequest({
@@ -119,7 +189,9 @@ describe("conversation goal API", () => {
     });
     const nonOwnerView = await getGoal(workspace.sId, conversation.sId);
     expect((await nonOwnerView.json()).canManage).toBe(false);
-    expect((await patchGoal(workspace.sId, conversation.sId)).status).toBe(403);
+    expect(
+      (await patchGoal(workspace.sId, conversation.sId, "cancel")).status
+    ).toBe(403);
   });
 
   it("returns a branch goal and rejects a branch from another conversation", async () => {
@@ -168,7 +240,12 @@ describe("conversation goal API", () => {
     const response = await getGoal(workspace.sId, conversation.sId, branch.sId);
     expect(response.status).toBe(200);
     expect((await response.json()).goal.objective).toBe("Finish the branch");
-    const paused = await patchGoal(workspace.sId, conversation.sId, branch.sId);
+    const paused = await patchGoal(
+      workspace.sId,
+      conversation.sId,
+      "pause",
+      branch.sId
+    );
     expect(paused.status).toBe(200);
     expect((await paused.json()).goal.status).toBe("paused");
 

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/goal.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/goal.ts
@@ -1,4 +1,4 @@
-import { pauseGoalByUser } from "@app/lib/api/assistant/goal_mode";
+import { updateGoalFromUser } from "@app/lib/api/assistant/goal_mode";
 import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import {
@@ -68,6 +68,15 @@ function apiErrorForTransition(
           message: "This goal cannot perform the requested transition.",
         },
       });
+    case "agent_turn_in_progress":
+      return apiError(ctx, {
+        status_code: 409,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "Wait for the current agent turn to finish before resuming this goal.",
+        },
+      });
     default:
       return assertNever(error.type);
   }
@@ -118,8 +127,8 @@ function apiErrorForTransition(
  *       403:
  *         description: Goal Mode is not enabled for the workspace.
  *   patch:
- *     summary: Pause a conversation goal
- *     description: Pause automatic continuation for the latest active Goal Mode goal on a conversation branch.
+ *     summary: Update a conversation goal
+ *     description: Pause, resume, or cancel the latest Goal Mode goal on a conversation branch. Cancel prevents future goal turns but does not interrupt a turn that is already running.
  *     tags:
  *       - Private Conversations
  *     parameters:
@@ -145,7 +154,7 @@ function apiErrorForTransition(
  *             properties:
  *               action:
  *                 type: string
- *                 enum: [pause]
+ *                 enum: [pause, resume, cancel]
  *               branchId:
  *                 type: string
  *                 nullable: true
@@ -216,7 +225,7 @@ app.patch(
   async (ctx): HandlerResult<PatchConversationGoalResponseBody> => {
     const auth = ctx.get("auth");
     const { cId } = ctx.req.valid("param");
-    const { branchId: requestedBranchId } = ctx.req.valid("json");
+    const { action, branchId: requestedBranchId } = ctx.req.valid("json");
     const branchId = requestedBranchId ?? null;
 
     if (!(await hasFeatureFlag(auth, "goal_mode"))) {
@@ -240,9 +249,10 @@ app.patch(
       });
     }
 
-    const result = await pauseGoalByUser(auth, {
+    const result = await updateGoalFromUser(auth, {
       conversation,
       branchId,
+      action,
     });
     if (result.isErr()) {
       return apiErrorForTransition(ctx, result.error);

--- a/front/components/assistant/conversation/goal_mode/GoalCard.tsx
+++ b/front/components/assistant/conversation/goal_mode/GoalCard.tsx
@@ -1,12 +1,14 @@
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useConversationGoal } from "@app/lib/swr/conversation_goals";
 import type { GoalType } from "@app/types/assistant/goal";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
   ContentMessageAction,
   ContentMessageInline,
   PauseCircle,
+  Play,
   Target04,
+  Trash04,
 } from "@dust-tt/sparkle";
 import React from "react";
 
@@ -28,7 +30,8 @@ function getStatusLabel(goal: GoalType): string | null {
     case "cancelled":
       return null;
     default:
-      return assertNever(goal.status);
+      assertNeverAndIgnore(goal.status);
+      return null;
   }
 }
 
@@ -39,7 +42,7 @@ export const GoalCard = React.memo(function GoalCard({
 }: GoalCardProps) {
   const { hasFeature } = useFeatureFlags();
   const isGoalModeEnabled = hasFeature("goal_mode");
-  const { goal, canManage, isPausing, pauseGoal } = useConversationGoal({
+  const { goal, canManage, pendingAction, updateGoal } = useConversationGoal({
     conversationId: isGoalModeEnabled ? conversationId : null,
     workspaceId,
     branchId,
@@ -50,6 +53,8 @@ export const GoalCard = React.memo(function GoalCard({
   }
 
   const isRunning = goal.status === "active";
+  const canResume =
+    isRunning || goal.status === "paused" || goal.status === "blocked";
 
   return (
     <ContentMessageInline
@@ -69,9 +74,31 @@ export const GoalCard = React.memo(function GoalCard({
           variant="ghost"
           size="xs"
           tooltip="Pause future goal turns"
-          isLoading={isPausing}
-          disabled={isPausing}
-          onClick={() => void pauseGoal()}
+          isLoading={pendingAction === "pause"}
+          disabled={pendingAction !== null}
+          onClick={() => void updateGoal("pause")}
+        />
+      )}
+      {canManage && canResume && (
+        <ContentMessageAction
+          icon={Play}
+          variant="ghost"
+          size="xs"
+          tooltip={isRunning ? "Retry current goal turn" : "Resume goal"}
+          isLoading={pendingAction === "resume"}
+          disabled={pendingAction !== null}
+          onClick={() => void updateGoal("resume")}
+        />
+      )}
+      {canManage && (
+        <ContentMessageAction
+          icon={Trash04}
+          variant="ghost"
+          size="xs"
+          tooltip="Cancel future goal turns"
+          isLoading={pendingAction === "cancel"}
+          disabled={pendingAction !== null}
+          onClick={() => void updateGoal("cancel")}
         />
       )}
     </ContentMessageInline>

--- a/front/lib/api/actions/servers/goal_mode/tools/index.ts
+++ b/front/lib/api/actions/servers/goal_mode/tools/index.ts
@@ -54,6 +54,10 @@ const handlers: ToolHandlers<typeof GOAL_MODE_TOOLS_METADATA> = {
           return new Err(
             new MCPError("Only the user who created this goal can manage it.")
           );
+        case "agent_turn_in_progress":
+          return new Err(
+            new MCPError("The current goal turn is still running.")
+          );
         default:
           return assertNever(result.error.type);
       }

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -1779,7 +1779,38 @@ describe("postUserMessage", () => {
       reason: "user_interrupted",
     });
   });
-
+  it("steers an auto-mentioned message when a resumed turn wins the lock", async () => {
+    await FeatureFlagFactory.basic(auth, "goal_mode");
+    const user = auth.getNonNullableUser().toJSON();
+    const runningAgentSpy = vi
+      .spyOn(ConversationResource.prototype, "getRunningAgentMessage")
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        sId: "agent-message-resumed",
+        rank: 0,
+        agentMessageId: 1,
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      });
+    const result = await postUserMessage(auth, {
+      conversationResource,
+      content: "Continue from here",
+      mentions: [],
+      context: {
+        username: user.username,
+        timezone: "UTC",
+        fullName: user.fullName,
+        email: user.email,
+        profilePictureUrl: user.image,
+        origin: "web",
+      },
+      skipToolsValidation: false,
+    });
+    runningAgentSpy.mockRestore();
+    expect(result).toMatchObject({
+      value: { userMessage: { visibility: "pending" }, agentMessages: [] },
+    });
+    expect(launchAgentLoopWorkflow).not.toHaveBeenCalled();
+  });
   it("rejects goal metadata when Goal Mode is not enabled", async () => {
     const user = auth.getNonNullableUser().toJSON();
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -181,6 +181,8 @@ import { col } from "sequelize";
 
 // Rate limit for programmatic usage: 1 message per this amount of dollars per minute.
 const PROGRAMMATIC_RATE_LIMIT_DOLLARS_PER_MESSAGE = 3;
+export const GOAL_RESUME_AGENT_RUNNING_MESSAGE =
+  "Wait for the current agent turn to finish before resuming this goal.";
 
 // Concurrency limits for pool-credit workspaces based on pool credit state.
 // Prevents close-to-0 attacks where many requests are sent simultaneously
@@ -541,6 +543,7 @@ export async function postUserMessage(
     modelSelection,
     goal,
     continuationGoal,
+    resumeGoal,
     deferAgentLoopWorkflow,
   }: {
     conversationResource: ConversationResource;
@@ -555,6 +558,7 @@ export async function postUserMessage(
     modelSelection?: ModelSelectionType;
     goal?: GoalCreation;
     continuationGoal?: ConversationGoalResource;
+    resumeGoal?: boolean;
     deferAgentLoopWorkflow?: boolean;
   }
 ): Promise<
@@ -635,8 +639,8 @@ export async function postUserMessage(
     }
   }
 
-  // Snapshot user-explicit agent mentions before any auto-injection. Steering and
-  // visibility decisions downstream depend on user intent, not on server-injected mentions.
+  // Snapshot user-explicit agent mentions before any auto-injection. Agent
+  // switching validation depends on user intent, not server-injected mentions.
   const explicitAgentMentions = mentions.filter(isAgentMention);
 
   // Auto-inject @dust for mention-less web/extension messages in single-user conversations.
@@ -878,14 +882,37 @@ export async function postUserMessage(
     // connection pool, resulting in a deadlock.
     await getConversationRankVersionLock(auth, conversation, t);
 
-    if (
-      continuationGoal &&
-      !(await continuationGoal.lockForContinuation(auth, {
-        conversation: conversationResource,
-        branchId: conversation.branchId,
-        transaction: t,
-      }))
-    ) {
+    if (resumeGoal) {
+      const lockedRunningAgentMessage =
+        await conversationResource.getRunningAgentMessage(auth, {
+          branchId: conversation.branchId,
+          transaction: t,
+        });
+      if (lockedRunningAgentMessage) {
+        return { continuationInFlight: true as const };
+      }
+    }
+
+    if (continuationGoal) {
+      const continuationLock = resumeGoal
+        ? await continuationGoal.lockForResume(auth, {
+            conversation: conversationResource,
+            branchId: conversation.branchId,
+            transaction: t,
+          })
+        : await continuationGoal.lockForContinuation(auth, {
+            conversation: conversationResource,
+            branchId: conversation.branchId,
+            transaction: t,
+          });
+      if (
+        typeof continuationLock === "boolean"
+          ? !continuationLock
+          : continuationLock.isErr()
+      ) {
+        return { continuationConflict: true as const };
+      }
+    } else if (resumeGoal) {
       return { continuationConflict: true as const };
     }
 
@@ -1028,21 +1055,14 @@ export async function postUserMessage(
       authMethod: auth.authMethod(),
     };
 
-    // Re-read the agent message status inside the critical section of the advisory lock. Between
-    // the initial check and acquiring the lock, the agent loop may have finalized — if so, clear
-    // runningAgentMessage so we fall through to the normal flow.
-    if (runningAgentMessage) {
-      const agentMessageRow = await AgentMessageModel.findOne({
-        where: {
-          id: runningAgentMessage.agentMessageId,
-          workspaceId: owner.id,
-        },
-        transaction: t,
-      });
-
-      if (agentMessageRow?.status !== "created") {
-        runningAgentMessage = undefined;
-      }
+    // Re-read under the message lock when steering or Goal Mode can start a
+    // competing turn. This closes the gap between the preflight and the lock.
+    if (runningAgentMessage || featureFlags.includes("goal_mode")) {
+      runningAgentMessage =
+        (await conversationResource.getRunningAgentMessage(auth, {
+          branchId: conversation.branchId,
+          transaction: t,
+        })) ?? undefined;
     }
 
     // We set the visibility of the user message to "pending" if steering is enabled, we have a
@@ -1050,7 +1070,11 @@ export async function postUserMessage(
     // over we don't attempt steering as the intent is to start a new agentic loop and stop the
     // parent one ASAP.
     const visibility: MessageVisibility =
-      runningAgentMessage && explicitAgentMentions.length > 0 && !isHandover
+      runningAgentMessage &&
+      (explicitAgentMentions.length > 0 ||
+        (featureFlags.includes("goal_mode") &&
+          mentions.some(isAgentMention))) &&
+      !isHandover
         ? "pending"
         : "visible";
 
@@ -1187,6 +1211,16 @@ export async function postUserMessage(
       api_error: {
         type: "invalid_request_error",
         message: "This goal continuation was already claimed by another turn.",
+      },
+    });
+  }
+
+  if ("continuationInFlight" in transactionResult) {
+    return new Err({
+      status_code: 409,
+      api_error: {
+        type: "invalid_request_error",
+        message: GOAL_RESUME_AGENT_RUNNING_MESSAGE,
       },
     });
   }

--- a/front/lib/api/assistant/goal_mode.ts
+++ b/front/lib/api/assistant/goal_mode.ts
@@ -1,15 +1,18 @@
-import { postUserMessage } from "@app/lib/api/assistant/conversation";
+import {
+  GOAL_RESUME_AGENT_RUNNING_MESSAGE,
+  postUserMessage,
+} from "@app/lib/api/assistant/conversation";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import {
   ConversationGoalResource,
-  type GoalTransitionError,
+  GoalTransitionError,
 } from "@app/lib/resources/conversation_goal_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
-import type { GoalType } from "@app/types/assistant/goal";
-import type { Result } from "@app/types/shared/result";
+import type { GoalType, GoalUserAction } from "@app/types/assistant/goal";
+import { Err, Ok, type Result } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
@@ -19,6 +22,7 @@ export type GoalContinuationOutcome =
   | "inactive"
   | "newer_message"
   | "not_succeeded"
+  | "agent_turn_in_progress"
   | "paused";
 
 const GOAL_CONTINUATION_MESSAGE =
@@ -120,16 +124,23 @@ export async function startActiveGoalTurn(
   {
     conversation,
     goal,
+    resumeGoal = false,
   }: {
     conversation: ConversationResource;
     goal: GoalType;
+    resumeGoal?: boolean;
   }
 ): Promise<GoalContinuationOutcome> {
   const activeGoal = await ConversationGoalResource.fetchLatest(auth, {
     conversation,
     branchId: goal.branchId,
   });
-  if (activeGoal?.sId !== goal.sId || activeGoal.status !== "active") {
+  if (
+    activeGoal?.sId !== goal.sId ||
+    (resumeGoal
+      ? activeGoal.status !== "paused" && activeGoal.status !== "blocked"
+      : activeGoal.status !== "active")
+  ) {
     return "paused";
   }
   const expectedCurrentAgentMessageModelId = activeGoal.currentAgentMessageId;
@@ -153,12 +164,20 @@ export async function startActiveGoalTurn(
     skipDustAutoMention: true,
     doNotAssociateUser: true,
     continuationGoal: activeGoal,
+    resumeGoal,
     deferAgentLoopWorkflow: true,
   });
   const latest = await ConversationGoalResource.fetchLatest(auth, {
     conversation,
     branchId: goal.branchId,
   });
+  if (
+    resumeGoal &&
+    result.isErr() &&
+    result.error.api_error.message === GOAL_RESUME_AGENT_RUNNING_MESSAGE
+  ) {
+    return "agent_turn_in_progress";
+  }
   if (
     result.isOk() &&
     result.value.agentMessages.length === 1 &&
@@ -252,18 +271,77 @@ export async function continueActiveGoal(
     : startActiveGoalTurn(auth, { conversation, goal: decision.goal });
 }
 
-export function pauseGoalByUser(
+export async function updateGoalFromUser(
   auth: Authenticator,
   {
     conversation,
     branchId,
+    action,
   }: {
     conversation: ConversationResource;
     branchId: string | null;
+    action: GoalUserAction;
   }
 ): Promise<Result<ConversationGoalResource, GoalTransitionError>> {
-  return ConversationGoalResource.pauseByUser(auth, {
+  if (action === "resume") {
+    const goal = await ConversationGoalResource.fetchLatest(auth, {
+      conversation,
+      branchId,
+    });
+    if (!goal) {
+      return new Err(new GoalTransitionError("goal_not_found"));
+    }
+    if (goal.createdByUserId !== auth.getNonNullableUser().id) {
+      return new Err(new GoalTransitionError("forbidden"));
+    }
+
+    let outcome: GoalContinuationOutcome;
+    switch (goal.status) {
+      case "paused":
+      case "blocked":
+        outcome = await startActiveGoalTurn(auth, {
+          conversation,
+          goal: goal.toJSON(),
+          resumeGoal: true,
+        });
+        break;
+      case "active":
+        outcome =
+          goal.lastAgentMessageId === goal.currentAgentMessageId
+            ? await startActiveGoalTurn(auth, {
+                conversation,
+                goal: goal.toJSON(),
+              })
+            : await ensureCurrentGoalTurn(auth, {
+                conversation,
+                goal: goal.toJSON(),
+              });
+        break;
+      case "completed":
+      case "cancelled":
+        return new Err(new GoalTransitionError("invalid_transition"));
+      default:
+        return assertNever(goal.status);
+    }
+    if (outcome === "agent_turn_in_progress") {
+      return new Err(new GoalTransitionError("agent_turn_in_progress"));
+    }
+    return new Ok(
+      (await ConversationGoalResource.fetchLatest(auth, {
+        conversation,
+        branchId,
+      })) ?? goal
+    );
+  }
+
+  const transition = await ConversationGoalResource.transitionByUser(auth, {
     conversation,
     branchId,
+    action,
   });
+  if (transition.isErr()) {
+    return transition;
+  }
+
+  return transition;
 }

--- a/front/lib/resources/conversation_goal_resource.test.ts
+++ b/front/lib/resources/conversation_goal_resource.test.ts
@@ -1,5 +1,9 @@
 import type { Authenticator } from "@app/lib/auth";
-import { ConversationGoalResource } from "@app/lib/resources/conversation_goal_resource";
+import { ConversationGoalModel } from "@app/lib/models/agent/conversation_goal";
+import {
+  ConversationGoalResource,
+  DEFAULT_GOAL_MAX_TURNS,
+} from "@app/lib/resources/conversation_goal_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -57,7 +61,10 @@ describe("ConversationGoalResource", () => {
     return { message, agentMessageModelId };
   }
 
-  async function createGoal(currentAgentMessageId: string) {
+  async function createGoal(
+    currentAgentMessageId: string,
+    maxTurns = DEFAULT_GOAL_MAX_TURNS
+  ) {
     return withTransaction((transaction) =>
       ConversationGoalResource.makeNew(
         auth,
@@ -67,7 +74,7 @@ describe("ConversationGoalResource", () => {
           branchId: null,
           agentConfigurationId: agent.sId,
           currentAgentMessageId,
-          maxTurns: 25,
+          maxTurns,
         },
         transaction
       )
@@ -188,7 +195,91 @@ describe("ConversationGoalResource", () => {
         conversationBranchId: null,
         agentMessageId: message.sId,
       })
-    ).toEqual({ type: "inactive" });
+    ).toEqual({ type: "already_processed" });
+  });
+
+  it.each([
+    "turn_limit_reached",
+    "paused_by_user",
+    "blocked",
+  ] as const)("extends the safety budget when resuming from %s", async (reason) => {
+    const { message } = await createAgentMessage("succeeded");
+    const goal = await createGoal(message.sId, 1);
+
+    if (reason === "turn_limit_reached") {
+      expect(
+        await ConversationGoalResource.claimContinuation(auth, {
+          conversationId: conversation.sId,
+          conversationBranchId: null,
+          agentMessageId: message.sId,
+        })
+      ).toEqual({ type: "turn_limit_reached" });
+    } else if (reason === "paused_by_user") {
+      expect(
+        (
+          await ConversationGoalResource.transitionByUser(auth, {
+            conversation: conversationResource,
+            branchId: null,
+            action: "pause",
+          })
+        ).isOk()
+      ).toBe(true);
+    } else {
+      await ConversationGoalModel.update(
+        { status: "blocked", reason, terminalAt: new Date() },
+        { where: { id: goal.id } }
+      );
+      expect(
+        await ConversationGoalResource.fetchUnfinished(auth, {
+          conversationModelId: conversation.id,
+          branchId: null,
+        })
+      ).toMatchObject({ id: goal.id, status: "blocked" });
+    }
+
+    const resumed = await withTransaction((transaction) =>
+      goal.lockForResume(auth, {
+        conversation: conversationResource,
+        branchId: null,
+        transaction,
+      })
+    );
+    expect(resumed.isOk()).toBe(true);
+    if (resumed.isOk()) {
+      expect(resumed.value).toMatchObject({
+        status: "active",
+        turnCount: 2,
+        maxTurns: 1 + DEFAULT_GOAL_MAX_TURNS,
+      });
+    }
+  });
+
+  it("does not double-count a failed continuation retry", async () => {
+    const { message } = await createAgentMessage("succeeded");
+    const goal = await createGoal(message.sId);
+    await ConversationGoalResource.claimContinuation(auth, {
+      conversationId: conversation.sId,
+      conversationBranchId: null,
+      agentMessageId: message.sId,
+    });
+    await ConversationGoalResource.pauseForAgentMessage(auth, {
+      conversationId: conversation.sId,
+      conversationBranchId: null,
+      agentMessageId: message.sId,
+      reason: "continuation_failed",
+    });
+
+    const resumed = await withTransaction((transaction) =>
+      goal.lockForResume(auth, {
+        conversation: conversationResource,
+        branchId: null,
+        transaction,
+      })
+    );
+    expect(resumed.isOk()).toBe(true);
+    if (resumed.isOk()) {
+      expect(resumed.value.turnCount).toBe(2);
+    }
   });
 
   it("ignores a delayed failure from an older goal turn", async () => {

--- a/front/lib/resources/conversation_goal_resource.ts
+++ b/front/lib/resources/conversation_goal_resource.ts
@@ -20,9 +20,14 @@ import type {
   AgentLoopArgs,
   AgentLoopExecutionData,
 } from "@app/types/assistant/agent_run";
-import type { GoalStatus, GoalType } from "@app/types/assistant/goal";
+import type {
+  GoalStatus,
+  GoalType,
+  GoalUserAction,
+} from "@app/types/assistant/goal";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok, type Result } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { Attributes, Transaction } from "sequelize";
 import { Op } from "sequelize";
 
@@ -50,6 +55,7 @@ export class GoalTransitionError extends Error {
       | "goal_not_found"
       | "goal_conflict"
       | "forbidden"
+      | "agent_turn_in_progress"
       | "invalid_transition"
       | "wrong_agent"
   ) {
@@ -390,7 +396,7 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
         transaction,
         lock: transaction.LOCK.UPDATE,
       });
-      if (!goalRow || goalRow.status !== "active") {
+      if (!goalRow) {
         return { type: "inactive" };
       }
 
@@ -416,23 +422,50 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
         return { type: "not_succeeded" };
       }
       if (goalRow.lastAgentMessageId === message.agentMessage.id) {
-        if (goalRow.currentAgentMessageId === message.agentMessage.id) {
+        if (
+          goalRow.status === "active" &&
+          goalRow.currentAgentMessageId === message.agentMessage.id
+        ) {
           return {
             type: "continue",
             goal: new this(this.model, goalRow.get()).toJSON(),
           };
         }
-        return {
-          type: "ensure_current",
-          goal: new this(this.model, goalRow.get()).toJSON(),
-        };
+        return goalRow.status === "active"
+          ? {
+              type: "ensure_current",
+              goal: new this(this.model, goalRow.get()).toJSON(),
+            }
+          : { type: "already_processed" };
+      }
+      if (goalRow.status !== "active") {
+        return { type: "inactive" };
       }
       if (
-        goalRow.currentAgentMessageId !== message.agentMessage.id ||
         goalRow.agentConfigurationId !==
-          message.agentMessage.agentConfigurationId
+        message.agentMessage.agentConfigurationId
       ) {
         return { type: "inactive" };
+      }
+      if (goalRow.currentAgentMessageId !== message.agentMessage.id) {
+        const currentMessage = await MessageModel.findOne({
+          attributes: ["rank"],
+          where: {
+            workspaceId: goalRow.workspaceId,
+            conversationId: goalRow.conversationId,
+            agentMessageId: goalRow.currentAgentMessageId,
+            branchId: conversationBranchId
+              ? getResourceIdFromSId(conversationBranchId)
+              : null,
+          },
+          transaction,
+        });
+        return currentMessage && message.rank < currentMessage.rank
+          ? {
+              type: "ensure_current",
+              goal: new this(this.model, goalRow.get()).toJSON(),
+            }
+          : { type: "inactive" };
       }
 
       const newerMessage = await MessageModel.findOne({
@@ -553,6 +586,59 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
     return row !== null;
   }
 
+  async lockForResume(
+    auth: Authenticator,
+    {
+      conversation,
+      branchId,
+      transaction,
+    }: {
+      conversation: ConversationResource;
+      branchId: string | null;
+      transaction: Transaction;
+    }
+  ): Promise<Result<ConversationGoalResource, GoalTransitionError>> {
+    const row = await this.model.findOne({
+      where: {
+        id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId: conversation.id,
+        branchId: branchId ? getResourceIdFromSId(branchId) : null,
+      },
+      transaction,
+      lock: transaction.LOCK.UPDATE,
+    });
+    if (!row) {
+      return new Err(new GoalTransitionError("goal_not_found"));
+    }
+    if (row.createdByUserId !== auth.getNonNullableUser().id) {
+      return new Err(new GoalTransitionError("forbidden"));
+    }
+    if (row.status !== "paused" && row.status !== "blocked") {
+      return new Err(new GoalTransitionError("invalid_transition"));
+    }
+
+    const retryingAllocatedTurn = row.reason === "continuation_failed";
+    const turnCount = retryingAllocatedTurn ? row.turnCount : row.turnCount + 1;
+    await row.update(
+      {
+        status: "active",
+        reason: null,
+        terminalAt: null,
+        lastAgentMessageId: row.currentAgentMessageId,
+        turnCount,
+        maxTurns:
+          !retryingAllocatedTurn && turnCount > row.maxTurns
+            ? row.maxTurns + DEFAULT_GOAL_MAX_TURNS
+            : row.maxTurns,
+      },
+      { transaction }
+    );
+    return new Ok(
+      new ConversationGoalResource(ConversationGoalResource.model, row.get())
+    );
+  }
+
   static async pauseForAgentMessage(
     auth: Authenticator,
     {
@@ -628,14 +714,16 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
     });
   }
 
-  static async pauseByUser(
+  static async transitionByUser(
     auth: Authenticator,
     {
       conversation,
       branchId,
+      action,
     }: {
       conversation: ConversationResource;
       branchId: string | null;
+      action: GoalUserAction;
     }
   ): Promise<Result<ConversationGoalResource, GoalTransitionError>> {
     return withTransaction(async (transaction) => {
@@ -661,17 +749,44 @@ export class ConversationGoalResource extends BaseResource<ConversationGoalModel
         return new Err(new GoalTransitionError("forbidden"));
       }
 
-      if (goal.status === "paused") {
+      if (
+        (action === "pause" && goal.status === "paused") ||
+        (action === "cancel" && goal.status === "cancelled")
+      ) {
         return new Ok(goal);
       }
-      if (goal.status !== "active") {
-        return new Err(new GoalTransitionError("invalid_transition"));
+
+      let status: GoalStatus;
+      let reason: string | null;
+      let terminalAt: Date | null;
+      switch (action) {
+        case "pause":
+          if (goal.status !== "active") {
+            return new Err(new GoalTransitionError("invalid_transition"));
+          }
+          status = "paused";
+          reason = "paused_by_user";
+          terminalAt = null;
+          break;
+        case "resume":
+          return new Err(new GoalTransitionError("invalid_transition"));
+        case "cancel":
+          if (goal.status === "completed") {
+            return new Err(new GoalTransitionError("invalid_transition"));
+          }
+          status = "cancelled";
+          reason = "cancelled_by_user";
+          terminalAt = new Date();
+          break;
+        default:
+          return assertNever(action);
       }
 
       const [, rows] = await this.model.update(
         {
-          status: "paused",
-          reason: "paused_by_user",
+          status,
+          reason,
+          terminalAt,
         },
         {
           where: {

--- a/front/lib/swr/conversation_goals.ts
+++ b/front/lib/swr/conversation_goals.ts
@@ -7,6 +7,7 @@ import {
 } from "@app/lib/swr/swr";
 import type { GetConversationGoalResponseBody } from "@app/types/api/assistant/goal";
 import { PatchConversationGoalResponseBodySchema } from "@app/types/api/assistant/goal";
+import type { GoalUserAction } from "@app/types/assistant/goal";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { useCallback, useState } from "react";
 import type { Fetcher } from "swr";
@@ -36,7 +37,9 @@ export function useConversationGoal({
   const { fetcher } = useFetcher();
   const goalFetcher: Fetcher<GetConversationGoalResponseBody> = fetcher;
   const sendNotification = useSendNotification();
-  const [isPausing, setIsPausing] = useState(false);
+  const [pendingAction, setPendingAction] = useState<GoalUserAction | null>(
+    null
+  );
   const key = conversationId
     ? conversationGoalKey({ workspaceId, conversationId, branchId })
     : null;
@@ -45,59 +48,62 @@ export function useConversationGoal({
       latest?.goal?.status === "active" ? 2_000 : 0,
   });
 
-  const pauseGoal = useCallback(async (): Promise<boolean> => {
-    if (!key) {
-      return false;
-    }
-
-    setIsPausing(true);
-    try {
-      const response = await clientFetch(key, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ action: "pause", branchId }),
-      });
-      if (!response.ok) {
-        const apiError = await getErrorFromResponse(response);
-        sendNotification({
-          type: "error",
-          title: "Failed to update goal",
-          description: apiError.message,
-        });
+  const updateGoal = useCallback(
+    async (action: GoalUserAction): Promise<boolean> => {
+      if (!key) {
         return false;
       }
 
-      const updated = PatchConversationGoalResponseBodySchema.safeParse(
-        await response.json()
-      );
-      if (!updated.success) {
+      setPendingAction(action);
+      try {
+        const response = await clientFetch(key, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action, branchId }),
+        });
+        if (!response.ok) {
+          const apiError = await getErrorFromResponse(response);
+          sendNotification({
+            type: "error",
+            title: "Failed to update goal",
+            description: apiError.message,
+          });
+          return false;
+        }
+
+        const updated = PatchConversationGoalResponseBodySchema.safeParse(
+          await response.json()
+        );
+        if (!updated.success) {
+          sendNotification({
+            type: "error",
+            title: "Failed to update goal",
+            description: "The server returned an invalid response.",
+          });
+          return false;
+        }
+        await mutate(updated.data, { revalidate: false });
+        return true;
+      } catch (error) {
         sendNotification({
           type: "error",
           title: "Failed to update goal",
-          description: "The server returned an invalid response.",
+          description: normalizeError(error).message,
         });
         return false;
+      } finally {
+        setPendingAction(null);
       }
-      await mutate(updated.data, { revalidate: false });
-      return true;
-    } catch (error) {
-      sendNotification({
-        type: "error",
-        title: "Failed to update goal",
-        description: normalizeError(error).message,
-      });
-      return false;
-    } finally {
-      setIsPausing(false);
-    }
-  }, [branchId, key, mutate, sendNotification]);
+    },
+    [branchId, key, mutate, sendNotification]
+  );
 
   return {
     goal: data?.goal ?? null,
     canManage: data?.canManage ?? false,
     isGoalLoading: conversationId !== null && !data && !error,
     isGoalError: error,
-    isPausing,
-    pauseGoal,
+    pendingAction,
+    updateGoal,
   };
 }

--- a/front/types/api/assistant/goal.ts
+++ b/front/types/api/assistant/goal.ts
@@ -1,4 +1,4 @@
-import { GoalSchema } from "@app/types/assistant/goal";
+import { GoalSchema, GoalUserActionSchema } from "@app/types/assistant/goal";
 import { z } from "zod";
 
 export const GoalBranchSchema = z.object({
@@ -14,7 +14,7 @@ export type GetConversationGoalResponseBody = z.infer<
 >;
 
 export const PatchConversationGoalRequestBodySchema = GoalBranchSchema.extend({
-  action: z.literal("pause"),
+  action: GoalUserActionSchema,
 });
 
 export const PatchConversationGoalResponseBodySchema = z.object({

--- a/front/types/assistant/goal.ts
+++ b/front/types/assistant/goal.ts
@@ -11,6 +11,9 @@ export const GOAL_STATUSES = [
 export const GoalStatusSchema = z.enum(GOAL_STATUSES);
 export type GoalStatus = z.infer<typeof GoalStatusSchema>;
 
+export const GoalUserActionSchema = z.enum(["pause", "resume", "cancel"]);
+export type GoalUserAction = z.infer<typeof GoalUserActionSchema>;
+
 export const GoalCreationSchema = z.object({
   objective: z.string().trim().min(1).max(4_000),
 });


### PR DESCRIPTION
## Description

Add owner-only Resume and Cancel controls to the Goal Mode status card. Resume atomically reactivates the goal and creates the next continuation under the conversation message lock, rejects a concurrent agent turn, and can retry an active turn whose workflow handoff was interrupted. Resuming from any exhausted user pause or blocked state extends the safety budget, while failed handoff retries do not double-count a turn. Cancel prevents future goal turns without interrupting a turn that is already running.

Stacked on #29708.

## Tests

- Resource tests cover budget extension from turn-limit, user-paused, and blocked states, the blocked unfinished-goal invariant, failed-handoff accounting, and delayed callbacks.
- API tests cover the in-lock agent-turn race, atomic resume into a new turn, current-message advancement, workflow launch and retry, cancellation, ownership, branch routing, and the feature flag.
- The full conversation suite, SWR tests, and focused resource and route tests pass.
- Front and front-api TypeScript checks pass.
- Strict Swagger generation and annotation lint pass.

## Risk

Resume creates a real continuation user message and starts its agent workflow. Cancellation is deliberately non-interrupting: a running turn may finish, but it cannot schedule another goal turn afterward.

## Deploy Plan

Merge after #29708. Keep the `goal_mode` feature flag disabled broadly until this PR is deployed, then enable it only for selected workspaces.