### PR TITLE
[FILES] Point audio file fragments at their transcript sibling

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -11053,6 +11053,11 @@
             "nullable": true,
             "description": "Path of this file inside the sandbox conversation mount."
           },
+          "processedPath": {
+            "type": "string",
+            "nullable": true,
+            "description": "Path of the plain-text sibling of this file inside the sandbox conversation mount (e.g. an audio transcript), when it has one."
+          },
           "skipDataSourceIndexing": {
             "type": "boolean",
             "description": "Whether data source indexing was skipped for this file."
@@ -13900,6 +13905,12 @@
             "nullable": true,
             "description": "Path of this file inside the sandbox conversation mount.",
             "example": "conversation/report.csv"
+          },
+          "processedPath": {
+            "type": "string",
+            "nullable": true,
+            "description": "Path of the plain-text sibling of this file inside the sandbox conversation mount (e.g. an audio transcript), when it has one.",
+            "example": "conversation/voice.processed.txt"
           },
           "skipDataSourceIndexing": {
             "type": "boolean",

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -651,6 +651,10 @@
  *           type: string
  *           nullable: true
  *           description: Path of this file inside the sandbox conversation mount.
+ *         processedPath:
+ *           type: string
+ *           nullable: true
+ *           description: Path of the plain-text sibling of this file inside the sandbox conversation mount (e.g. an audio transcript), when it has one.
  *         skipDataSourceIndexing:
  *           type: boolean
  *           description: Whether data source indexing was skipped for this file.

--- a/front-api/routes/v1/w/[wId]/swagger_schemas.ts
+++ b/front-api/routes/v1/w/[wId]/swagger_schemas.ts
@@ -467,6 +467,11 @@
  *           nullable: true
  *           description: Path of this file inside the sandbox conversation mount.
  *           example: conversation/report.csv
+ *         processedPath:
+ *           type: string
+ *           nullable: true
+ *           description: Path of the plain-text sibling of this file inside the sandbox conversation mount (e.g. an audio transcript), when it has one.
+ *           example: conversation/voice.processed.txt
  *         skipDataSourceIndexing:
  *           type: boolean
  *           description: Whether data source indexing was skipped for this file.

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -218,6 +218,7 @@ export function getAttachmentFromFileContentFragment(
     ...baseAttachment,
     fileId,
     path: cf.path ?? null,
+    processedPath: cf.processedPath ?? null,
     source: "user",
     createdAt: cf.created,
   };

--- a/front/lib/resources/content_fragment_resource.test.ts
+++ b/front/lib/resources/content_fragment_resource.test.ts
@@ -29,11 +29,13 @@ function makeFileFragment(
   {
     generatedTables = [],
     path = null,
+    processedPath = null,
     snippet = null,
     skipFileProcessing = false,
   }: {
     generatedTables?: string[];
     path?: string | null;
+    processedPath?: string | null;
     snippet?: string | null;
     skipFileProcessing?: boolean;
   } = {}
@@ -56,6 +58,7 @@ function makeFileFragment(
     expiredReason: null,
     contentFragmentType: "file",
     path,
+    processedPath,
     skipFileProcessing,
     fileId: "fil_abc123",
     snippet,
@@ -314,6 +317,26 @@ describe("renderLightContentFragmentForModel", () => {
       expect(result?.content[0]).toMatchObject({
         type: "text",
         text: `<file name="file" path="conversation-conv123/report_fil_abc123.pdf"/>`,
+      });
+    });
+
+    it("points an audio file at its transcript sibling", async () => {
+      const result = await renderLightContentFragmentForModel(
+        authenticator,
+        makeFileFragment("audio/webm", {
+          path: "conversation-conv123/voice-2026-07-24T11:20:00.714Z.webm",
+          processedPath:
+            "conversation-conv123/voice-2026-07-24T11:20:00.714Z.processed.txt",
+        }),
+        visionModel,
+        { excludeImages: false, useFileSystem: true }
+      );
+      expect(result?.content[0]).toMatchObject({
+        type: "text",
+        text:
+          `<file name="file" ` +
+          `path="conversation-conv123/voice-2026-07-24T11:20:00.714Z.webm" ` +
+          `processedPath="conversation-conv123/voice-2026-07-24T11:20:00.714Z.processed.txt"/>`,
       });
     });
 

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -767,6 +767,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
           contentFragmentType: "file",
           expiredReason: fr.expiredReason,
           path: null,
+          processedPath: null,
           skipDataSourceIndexing: false,
           skipFileProcessing: false,
           fileId: null,
@@ -826,6 +827,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
       let isInProjectContext = false;
       let hidden = true;
       let path: string | null = null;
+      let processedPath: string | null = null;
       let skipDataSourceIndexing = false;
       let skipFileProcessing = false;
 
@@ -847,6 +849,11 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
           conversationId: fileResource.useCaseMetadata?.conversationId,
           mountFilePath: fileResource.mountFilePath,
         });
+        processedPath = getConversationFilePath({
+          workspaceId: workspace.sId,
+          conversationId: fileResource.useCaseMetadata?.conversationId,
+          mountFilePath: fileResource.getTextProcessedMountFilePath(),
+        });
       }
 
       if (source.kind === "project_context") {
@@ -862,6 +869,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
         contentFragmentType: "file",
         expiredReason: null,
         path,
+        processedPath,
         skipDataSourceIndexing,
         skipFileProcessing,
         fileId: fileStringId,
@@ -1185,9 +1193,16 @@ function renderFileOrAttachmentXml(
   if (isNewFileExplorer) {
     const path = "path" in attachment ? attachment.path : null;
     const pathAttr = path ? ` path="${path}"` : "";
+    // Binary originals with a text processed version (audio transcripts) are mounted next to the
+    // original. Point the model at the sibling: no tool of ours can read the original.
+    const processedPath =
+      "processedPath" in attachment ? attachment.processedPath : null;
+    const processedPathAttr = processedPath
+      ? ` processedPath="${processedPath}"`
+      : "";
     return content
-      ? `<file name="${attachment.title}"${pathAttr}>${content}\n</file>`
-      : `<file name="${attachment.title}"${pathAttr}/>`;
+      ? `<file name="${attachment.title}"${pathAttr}${processedPathAttr}>${content}\n</file>`
+      : `<file name="${attachment.title}"${pathAttr}${processedPathAttr}/>`;
   }
 
   return renderAttachmentXml({ attachment, content: content ?? null });

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -18,6 +18,10 @@ import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type {
+  AllSupportedFileContentType,
+  FileUseCaseMetadata,
+} from "@app/types/files";
 import {
   frameContentType,
   isUnverifiableFrameFileRefsShareError,
@@ -616,6 +620,49 @@ describe("FileResource", () => {
         where: { id: file.id, workspaceId: workspace.id },
       });
       expect(row?.mountFilePath).toBeNull();
+    });
+
+    it("should expose the transcript sibling for audio files only", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      const makeConversationFile = async (
+        contentType: AllSupportedFileContentType,
+        fileName: string,
+        useCaseMetadata: FileUseCaseMetadata
+      ) => {
+        const file = await FileFactory.create(auth, null, {
+          contentType,
+          fileName,
+          fileSize: 100,
+          status: "created",
+          useCase: "conversation",
+          useCaseMetadata,
+        });
+        await file.markAsReady(auth);
+        return file;
+      };
+
+      const audio = await makeConversationFile("audio/webm", "voice.webm", {
+        conversationId: "conv-audio",
+      });
+      expect(audio.getTextProcessedMountFilePath()).toBe(
+        `w/${workspace.sId}/conversations/conv-audio/files/voice.processed.txt`
+      );
+
+      // Images process to a resized image, not to text.
+      const image = await makeConversationFile("image/png", "shot.png", {
+        conversationId: "conv-image",
+      });
+      expect(image.getTextProcessedMountFilePath()).toBeNull();
+
+      // Raw-mounted files are never processed, so no sibling is written.
+      const rawAudio = await makeConversationFile("audio/webm", "raw.webm", {
+        conversationId: "conv-raw",
+        skipFileProcessing: true,
+      });
+      expect(rawAudio.getTextProcessedMountFilePath()).toBeNull();
     });
 
     it("should not re-resolve when mountFilePath is already set", async () => {

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -642,7 +642,7 @@ export class FileResource extends BaseResource<FileModel> {
   /**
    * Returns the file version to read for "best available" content.
    */
-  private getContentVersion(): FileVersion {
+  getContentVersion(): FileVersion {
     if (this.useCaseMetadata?.skipFileProcessing === true) {
       return "original";
     }
@@ -668,6 +668,37 @@ export class FileResource extends BaseResource<FileModel> {
       return "processed";
     }
     return "original";
+  }
+
+  /**
+   * Mount path of the processed sibling `copyMountFiles` writes next to the original (e.g.
+   * `voice.processed.txt`), or null when this file has no processed version.
+   */
+  getProcessedMountFilePath(): string | null {
+    const { mountFilePath } = this;
+    if (!mountFilePath || this.getContentVersion() !== "processed") {
+      return null;
+    }
+
+    return makeProcessedMountFileName({
+      mountFilePath,
+      processedContentType: getProcessedContentType(
+        this.contentType,
+        this.useCase
+      ),
+    });
+  }
+
+  /**
+   * Same, restricted to files whose processed version is plain text (audio transcripts, text
+   * extraction). This is the only processed sibling worth pointing an agent at: none of our tools
+   * can read the binary original, while images process to a resized image the agent already sees.
+   */
+  getTextProcessedMountFilePath(): string | null {
+    return getProcessedContentType(this.contentType, this.useCase) ===
+      "text/plain"
+      ? this.getProcessedMountFilePath()
+      : null;
   }
 
   /**
@@ -1294,12 +1325,9 @@ export class FileResource extends BaseResource<FileModel> {
     await bucket.copyFile(srcOriginalPath, mountFilePath);
 
     // Copy processed version only if this file type has real processing.
-    if (this.getContentVersion() === "processed") {
+    const processedMountPath = this.getProcessedMountFilePath();
+    if (processedMountPath) {
       const srcProcessedPath = this.getCloudStoragePath(auth, "processed");
-      const processedMountPath = makeProcessedMountFileName({
-        mountFilePath,
-        processedContentType: getProcessedContentType(this.contentType),
-      });
       await bucket.copyFile(srcProcessedPath, processedMountPath);
     }
   }
@@ -1324,22 +1352,11 @@ export class FileResource extends BaseResource<FileModel> {
     const bucket = getPrivateUploadBucket();
     await bucket.delete(this.mountFilePath, { ignoreNotFound: true });
 
-    if (
-      this.useCaseMetadata?.skipFileProcessing === true ||
-      !hasProcessedVersion(this.contentType, this.useCase)
-    ) {
-      return;
-    }
-
     // Only delete processed mount file if this file type has real processing.
-    const processedMountPath = makeProcessedMountFileName({
-      mountFilePath: this.mountFilePath,
-      processedContentType: getProcessedContentType(
-        this.contentType,
-        this.useCase
-      ),
-    });
-    await bucket.delete(processedMountPath, { ignoreNotFound: true });
+    const processedMountPath = this.getProcessedMountFilePath();
+    if (processedMountPath) {
+      await bucket.delete(processedMountPath, { ignoreNotFound: true });
+    }
   }
 
   static async bulkSetUseCaseMetadata(

--- a/front/types/api/assistant/conversation/attachments.ts
+++ b/front/types/api/assistant/conversation/attachments.ts
@@ -27,6 +27,7 @@ export type BaseConversationAttachmentType = {
 export type FileAttachmentType = BaseConversationAttachmentType & {
   fileId: string;
   path: string | null;
+  processedPath?: string | null;
   source: "agent" | "user" | null;
   createdAt?: number;
   updatedAt?: number;

--- a/front/types/content_fragment.ts
+++ b/front/types/content_fragment.ts
@@ -80,6 +80,7 @@ export type ContentNodeContentFragmentType = BaseContentFragmentType & {
 export type FileContentFragmentType = BaseContentFragmentType & {
   contentFragmentType: "file";
   path?: string | null;
+  processedPath?: string | null;
   skipDataSourceIndexing?: boolean;
   skipFileProcessing?: boolean;
 } & (


### PR DESCRIPTION
## Description

Audio `<file>` tags rendered for the new file explorer now carry a `processedPath` attribute pointing at the mounted `.processed.txt` transcript sibling, since no tool can read the original binary and `files_list` filters `.processed.*` entries out.

## Tests

Added a unit test in `content_fragment_resource.test.ts`; full file suite passes (20 tests).

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`
