### PR TITLE
[connectors] perf: Probe workspace availability with /exists instead of listing spaces

### DIFF
--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -269,16 +269,18 @@ const _webhookSlackAPIHandler = async (
                   logger
                 );
 
-                // Make a simple API call to check if workspace is accessible
-                const spacesRes = await dustAPI.getSpaces();
-                if (spacesRes.isErr()) {
+                // Probe the workspace: /exists does no work beyond
+                // authentication and returns an error when the workspace is
+                // gone, relocated or in maintenance.
+                const existsRes = await dustAPI.exists();
+                if (existsRes.isErr()) {
                   logger.info(
                     {
                       connectorId: connector.id,
                       slackTeamId: teamId,
                       slackChannelId: channel,
                       workspaceId: dataSourceConfig.workspaceId,
-                      error: spacesRes.error.message,
+                      error: existsRes.error.message,
                     },
                     "Skipping webhook: workspace is unavailable (likely in maintenance)"
                   );

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -64,22 +64,22 @@ export async function autoReadChannel(
     logger
   );
 
-  // Make a simple API call to check if workspace is accessible
-  // If workspace is in maintenance, the API will return 503
-  const spacesRes = await dustAPI.getSpaces();
-  if (spacesRes.isErr()) {
+  // Probe the workspace: /exists does no work beyond authentication and
+  // returns an error when the workspace is gone, relocated or in maintenance.
+  const existsRes = await dustAPI.exists();
+  if (existsRes.isErr()) {
     logger.info(
       {
         connectorId: connector.id,
         teamId,
         workspaceId: dataSourceConfig.workspaceId,
-        error: spacesRes.error.message,
+        error: existsRes.error.message,
       },
       "Skipping auto-read channel: workspace API call failed (likely in maintenance)"
     );
     return new Err(
       new Error(
-        `Cannot auto-read channel: workspace is unavailable (${spacesRes.error.message})`
+        `Cannot auto-read channel: workspace is unavailable (${existsRes.error.message})`
       )
     );
   }

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1746,7 +1746,10 @@ async function isAgentAccessingRestrictedSpace(
 
     const agentSpaceIds = agent.requestedSpaceIds.flat();
 
-    const spacesRes = await dustAPI.getSpaces();
+    // Only regular spaces can be restricted in this listing: the endpoint
+    // never returns project spaces, and global and system spaces are never
+    // flagged as restricted.
+    const spacesRes = await dustAPI.getSpaces({ kinds: ["regular"] });
     if (spacesRes.isErr()) {
       logger.error(
         { error: spacesRes.error, agentId },


### PR DESCRIPTION


## Description

Replace the simple call to get spaces by a /exists on workspace

Context is in the base PR

## Tests

N/A

## Risk

Low

## Deploy Plan

Deploy connectors