### PR TITLE
[DOCS] Fix broken docs.dust.tt links with stray /update/ prefix

### DIFF
--- a/front/components/agent_builder/triggers/webhook/WebhookEditionSheet.tsx
+++ b/front/components/agent_builder/triggers/webhook/WebhookEditionSheet.tsx
@@ -120,7 +120,7 @@ function WebhookEditionExecutionLimit({
         quota.
         <br /> (
         <LinkWrapper
-          href="https://docs.dust.tt/update/docs/rate-limiting#/"
+          href="https://docs.dust.tt/docs/rate-limiting#/"
           target="_blank"
           rel="noreferrer"
           className="underline"

--- a/front/lib/api/actions/servers/gong/metadata.ts
+++ b/front/lib/api/actions/servers/gong/metadata.ts
@@ -85,7 +85,7 @@ export const GONG_SERVER = {
       supported_use_cases: ["personal_actions", "platform_actions"] as const,
     },
     icon: "GongLogo",
-    documentationUrl: "https://docs.dust.tt/update/docs/gong-mcp",
+    documentationUrl: "https://docs.dust.tt/docs/gong-mcp",
   },
   tools: GONG_TOOLS_METADATA,
 } as const satisfies ServerMetadata;


### PR DESCRIPTION
## Description

Removes a stray `/update/` prefix from two `docs.dust.tt` links (Gong MCP server metadata and the webhook rate-limiting link) that were 404ing after the Mintlify migration.

## Tests

Not needed. Both destination URLs return 200 on docs.dust.tt.

## Risk

None.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`