### PR TITLE
Avoid fetching all spaces in multiple places. Optimize when we fetch Pods the uer is a member of.

### DIFF
--- a/front-api/routes/v1/w/[wId]/spaces/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/index.ts
@@ -57,8 +57,9 @@ app.route("/:spaceId", spaceId);
 app.get("/", async (ctx): HandlerResult<GetPublicSpacesResponseBody> => {
   const auth = ctx.get("auth");
 
-  const allSpaces = await SpaceResource.listWorkspaceSpacesAsMember(auth);
-  const spaces = allSpaces.filter((space) => space.kind !== "conversations");
+  const spaces = await SpaceResource.listWorkspaceSpacesAsMember(auth, {
+    kinds: ["system", "global", "regular"],
+  });
 
   return ctx.json({
     spaces: spaces.map((space) => space.toJSON()),

--- a/front/lib/api/assistant/conversation/selected_spaces.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.ts
@@ -67,7 +67,7 @@ export async function listSelectableSpaces(
   }
 
   const [spaces, selectedSpaces] = await Promise.all([
-    SpaceResource.listWorkspaceSpacesAsMember(auth),
+    SpaceResource.listWorkspaceSpacesAsMember(auth, { kinds: ["regular"] }),
     ConversationSelectedSpaceResource.listActiveSpacesByConversation(auth, {
       conversation,
     }),

--- a/front/lib/api/assistant/workspace_capabilities.ts
+++ b/front/lib/api/assistant/workspace_capabilities.ts
@@ -101,8 +101,10 @@ export async function listActiveAgentsUsingNonRegionalModels(
 export async function listAvailableTools(
   auth: Authenticator
 ): Promise<AvailableTool[]> {
-  // Get all spaces the user is member of.
-  const userSpaces = await SpaceResource.listWorkspaceSpacesAsMember(auth);
+  // Get all spaces the user is member of that can provide tools.
+  const userSpaces = await SpaceResource.listWorkspaceSpacesAsMember(auth, {
+    kinds: ["global", "regular"],
+  });
 
   // Fetch all MCP server views from those spaces.
   const mcpServerViews =

--- a/front/lib/api/projects/list.ts
+++ b/front/lib/api/projects/list.ts
@@ -176,7 +176,7 @@ export async function listNonArchivedMemberSpacesWithMetadata(
   nonArchivedSpaces: SpaceResource[];
   metadataMap: Map<number, ProjectMetadataResource>;
 }> {
-  const memberSpaces = await SpaceResource.listWorkspaceSpacesAsMember(auth);
+  const memberSpaces = await SpaceResource.listWorkspacePodsAsMember(auth);
   const metadatas = await ProjectMetadataResource.fetchBySpaceModelIds(
     auth,
     memberSpaces.map((s) => s.id)

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -20,6 +20,7 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
 import type { GroupKind, GroupType } from "@app/types/groups";
 import {
@@ -39,6 +40,7 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { GroupSpaceKind, SpaceKind, SpaceType } from "@app/types/space";
 import assert from "assert";
+import uniq from "lodash/uniq";
 import type {
   Attributes,
   CreationAttributes,
@@ -367,6 +369,43 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       // TODO(projects): we might want to filter early on the groups membership to avoid fetching all spaces and then filtering.
       return spaces.filter((s) => s.isMember(auth));
     });
+  }
+
+  static async listWorkspacePodsAsMember(auth: Authenticator) {
+    // Fast path, lookup to pods spaces, we lookup the vault ids of the pods spaces and fetch the spaces by model ids.
+    const raw = await GroupSpaceModel.findAll({
+      attributes: ["vaultId"],
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        kind: { [Op.in]: ["member", "project_editor"] },
+        groupId: { [Op.in]: auth.groupModelIds() },
+      },
+    });
+
+    const podVaultIds = uniq(raw.map((v) => v.vaultId));
+
+    // Then we fetch the spaces by model ids.
+    const allSpaces = await this.baseFetch(auth, {
+      where: {
+        id: { [Op.in]: podVaultIds },
+        kind: "project",
+      },
+    });
+
+    // To be on the safe side.
+    const filteredSpaces = allSpaces.filter((s) => s.isMember(auth));
+    if (filteredSpaces.length !== allSpaces.length) {
+      logger.error(
+        {
+          spaceNotMember: allSpaces
+            .filter((s) => !s.isMember(auth))
+            .map((s) => s.sId),
+        },
+        "The user is not a member of some pod spaces. Action: check how we get the podVaultIds"
+      );
+    }
+
+    return filteredSpaces;
   }
 
   static async listProjectSpaces(


### PR DESCRIPTION
## Description

Two related query optimizations:

- `SpaceResource.listWorkspaceSpacesAsMember` has an optional `kinds` filter, pushing kind filtering into the DB query rather than post-fetching all spaces. Callers in `selected_spaces.ts` (regular only), `workspace_capabilities.ts` (global + regular), and the public spaces API (system + global + regular) pass the exact kinds they need.
- New `listWorkspacePodsAsMember` fast-path for Pod-only lookups: queries `GroupSpaceModel` for `member`/`project_editor` vault IDs matching the auth's `groupModelIds()`, then fetches only `kind: "project"` spaces from those IDs. Used by `listNonArchivedMemberSpacesWithMetadata`. Includes a safety `isMember` guard with error logging in case of a mismatch.

## Tests

Tested locally. No behavioral change — callers were already filtering to the same kinds in application code.

## Risk

Low. Pure query optimization; no data model or API contract changes. The Pod fast path adds a safety filter with error logging, making any regression observable before it causes incorrect results. Fully rollback-safe.

## Deploy Plan

Deploy front + front-api.
