### PR TITLE
Notion connector: unstuck notionDrainDocumentUpsertQueueWorkflow with continueAsNew

### DIFF
--- a/connectors/src/connectors/notion/temporal/workflows/index.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/index.ts
@@ -252,9 +252,11 @@ export async function notionDrainDocumentUpsertQueueWorkflow({
     await sleep(5000);
   }
 
-  throw new Error(
-    `Timeout (1 hour) waiting for upsert queue to drain for connector ${connectorId}`
-  );
+  // Could not drain in 1H, something is off
+  // Keep waiting in another workflow
+  await continueAsNew<typeof notionDrainDocumentUpsertQueueWorkflow>({
+    connectorId,
+  });
 }
 
 export async function notionUpdateAllParentsFieldsWorkflow({


### PR DESCRIPTION
## Description

Drain could not finish in 1h because the upsert queue was disable.
The workflows are now stuck on the last step, which keep throwing.
We should continue as new the workflow so we can handle situations where the queue is disabled.

## Tests

not tested

## Risk

may not see other issues caused by not being able to drain in 1h
Maybe not deterministic error, but as far as I understand no 

## Deploy Plan

deploy connector 
