### PR TITLE
[front-api] Pin lru-memoizer to v3 so cache TTLs are honored

### DIFF
--- a/front-api/package.json
+++ b/front-api/package.json
@@ -29,6 +29,7 @@
     "@novu/framework": "^2.11.1",
     "openai": "^6.46.0",
     "umzug": "3.8.3",
+    "lru-memoizer": "^3.0.0",
     "@hono/mcp": "^0.3.0",
     "@hono/node-server": "^1.19.10",
     "@hono/zod-validator": "^0.7.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -571,6 +571,7 @@
         "@novu/framework": "^2.11.1",
         "hono": "^4.12.15",
         "jsonwebtoken": "^9.0.0",
+        "lru-memoizer": "^3.0.0",
         "openai": "^6.46.0",
         "swagger-jsdoc": "^6.2.8",
         "umzug": "3.8.3",
@@ -751,6 +752,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "front-api/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "front-api/node_modules/lru-memoizer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-3.0.0.tgz",
+      "integrity": "sha512-m83w/cYXLdUIboKSPxzPAGfYnk+vqeDYXuoSrQRw1q+yVEd8IXhvMufN8Q5TIPe7e2jyX4SRNrDJI2Skw1yznQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "^11.0.1"
       }
     },
     "front-api/node_modules/openai": {


### PR DESCRIPTION
## Description

Feature flag changes did not reach `front-api` Pods. Only the Pod that ran the Poke toggle picked them up. Other Pods stayed stale indefinitely.

Root cause, step by step:

1. `front/lib/auth.ts` caches feature flags with `lru-memoizer`. It passes `ttl: 3000`.
2. `front-api` bundles `front`'s source but keeps dependencies external (`front-api/esbuild.shared.ts`). So `lru-memoizer` is resolved by Node when the server starts, and resolution starts from the bundle at `/app/front-api/dist/server.js` — not from `front/lib`, where the import is written.
3. Node looks for a `node_modules` folder next to that file, then in each parent folder, up to the filesystem root:
   - `/app/front-api/dist/node_modules` — does not exist
   - `/app/front-api/node_modules` — before this PR, no `lru-memoizer` here
   - `/app/node_modules` — **match**
4. That root copy is `lru-memoizer@2.3.0`, which depends on `lru-cache@6.0.0`. Nothing declares it at the root. npm hoists transitive dependencies into the top-level `node_modules`, and this one arrives through `front` → `jwks-rsa@3.2.2`, which asks for the range `lru-memoizer@^2.2.0` and gets `2.3.0` installed for it (see `npm explain lru-memoizer`).
5. `front` itself declares `^3.0.0`, so two versions are needed and only one can hold the hoisted root slot. npm gave it to `2.3.0` and pushed `3.0.0` down into `front/node_modules`. Node never looks there from the bundle, because `/app/front` is not a parent of `/app/front-api/dist`.
6. The `NODE_PATH=/app/front/node_modules` set in `dockerfiles/front.Dockerfile` does not help either. `NODE_PATH` is only consulted **after** the walk-up fails. Here the walk-up succeeds at `/app/node_modules`, so `NODE_PATH` is never reached.
7. In `lru-cache@6` the expiry option is named `maxAge`. `ttl` did not exist until `lru-cache@7`. Unknown options are ignored, so `maxAge` stayed `0`, which means never expire.
8. Result: every cached flag entry was immortal. The 3s TTL never applied. Only an explicit `del` refreshed an entry, and the Poke plugin does that on the single Pod that served the toggle.

Reference documentation for the resolution rules above:

- [Node — Loading from `node_modules` folders](https://nodejs.org/api/modules.html#loading-from-node_modules-folders): the parent-directory walk-up.
- [Node — All together](https://nodejs.org/api/modules.html#all-together): the full resolution algorithm in pseudo-code, including `NODE_MODULES_PATHS`.
- [Node — Loading from the global folders](https://nodejs.org/api/modules.html#loading-from-the-global-folders): why `NODE_PATH` is only a fallback.
- [npm — `node_modules` folder layout](https://docs.npmjs.com/cli/v10/configuring-npm/folders#node-modules): why a version conflict is installed nested instead of hoisted.
- [esbuild — `packages`](https://esbuild.github.io/api/#packages): what marking dependencies external means.

The fix is one dependency declaration in `front-api/package.json`.

This does not change anything for `jwks-rsa`. npm installs both versions side by side rather than replacing one with the other:

- `jwks-rsa` asks for the range `^2.2.0`, which means `>=2.2.0 <3.0.0`. npm installs `2.3.0` to satisfy it, the newest published 2.x. That copy stays at the repository root, which is where `jwks-rsa`'s own walk-up finds it. The caret excludes `3.0.0`, so `jwks-rsa` can never pick up v3 on its own.
- `front-api` now asks for `^3.0.0`, which npm satisfies with `3.0.0`. Two different versions cannot share one folder, so npm installs a second copy at `front-api/node_modules/lru-memoizer`.

Each consumer gets the copy closest to itself. Verified on the installed tree:

```
jwks-rsa resolves:           2.3.0   ./node_modules/lru-memoizer/
front-api bundle resolves:   3.0.0   ./front-api/node_modules/lru-memoizer/
front resolves:              3.0.0   ./front/node_modules/lru-memoizer/
```

So `jwks-rsa` keeps the version it expects, and `front-api` gets the one `front` was written against. Nothing is shared between them.

Why not fix this at the root instead:

- A root `overrides` entry would force `jwks-rsa` onto v3 as well. It declares `^2.2.0` and passes `maxAge` (`node_modules/jwks-rsa/src/wrappers/cache.js`), which v3 ignores. Its JWKS signing-key cache would then never expire, so a rotated key would never be picked up. That is this same bug, moved into key caching.
- A root `dependencies` entry would work, but the root currently has no runtime dependencies at all, and anything hoisted there is shared by all ten workspaces. It would also stay exposed to future hoisting changes, while a declaration inside `front-api` always wins its own walk-up.

Notes:

- This is the pattern already used for `openai` in this workspace (the lockfile has `front-api/node_modules/openai`).
- The workers image was never affected. It runs from `/app/front/dist`, so its walk-up finds `/app/front/node_modules` first.
- Two other caches were hit by the same bug and are fixed by this change: the global feature flags cache (60s) and `isDeepDiveDisabledByAdmin` (3s).

## Tests

This is a dependency-only change, so the test is which version each workspace resolves:

```bash
npm ls lru-memoizer -w front
npm ls lru-memoizer -w front-api
```

**Before**

```
$ npm ls lru-memoizer -w front
dust-monorepo@1.0.0 /path/to/dust
└─┬ @dust-tt/front@0.1.0 -> ./front
  ├─┬ jwks-rsa@3.2.2
  │ └── lru-memoizer@2.3.0
  └── lru-memoizer@3.0.0

$ npm ls lru-memoizer -w front-api
dust-monorepo@1.0.0 /path/to/dust
└── (empty)
```

`front-api` declared nothing. At runtime Node therefore walked up to the hoisted root copy, `2.3.0`, which depends on `lru-cache@6`. That version ignores `ttl`, so nothing ever expired.

**Now**

```
$ npm ls lru-memoizer -w front
dust-monorepo@1.0.0 /path/to/dust
└─┬ @dust-tt/front@0.1.0 -> ./front
  ├─┬ jwks-rsa@3.2.2
  │ └── lru-memoizer@2.3.0
  └── lru-memoizer@3.0.0

$ npm ls lru-memoizer -w front-api
dust-monorepo@1.0.0 /path/to/dust
└─┬ @dust-tt/front-api@0.1.0 -> ./front-api
  └── lru-memoizer@3.0.0
```

`front-api` now resolves `3.0.0`, which depends on `lru-cache@11`. That version honors `ttl`, so entries expire after 3s as intended.

`front` is unchanged. `jwks-rsa` keeps `2.3.0`.

Also confirmed the effect directly: a cache built with `ttl: 300` and read again after 1s re-loads when resolved from `front-api`. Before this change it served the first value forever.

Unit tests cannot catch this class of bug. Vitest runs under `front`'s resolution, where `ttl` always worked.

## Risk

Low for correctness. Dependency-only change, no source change, and `3.0.0` is the version `front` already declares and runs its tests against.

One behaviour change to be aware of: the TTL now actually applies in `front-api`. The flag caches were effectively permanent before, so this restores database reads that had accidentally stopped happening. Expect up to one `feature_flags` query per active workspace per Pod every 3 seconds, plus one `global_feature_flags` query per Pod every 60 seconds. Both queries are small and indexed. This matches what the workers image has been doing all along.

Rollback is a plain revert. No migration and no data change.

## Deploy Plan

1. Merge. CI runs `npm ci`, which installs `front-api/node_modules/lru-memoizer@3.0.0`.
2. Deploy the `front-api` image as usual. No ordering constraint and no coordination with other services.
3. Verify resolution inside a Pod:
   ```bash
   cd /app/front-api && node -e 'console.log(require.resolve("lru-memoizer"))'
   ```
   Expect a path under `/app/front-api/node_modules`. A path under `/app/node_modules` means the fix did not take.
4. Verify behaviour: toggle a flag for a test workspace in Poke, then poll `/api/w/:wId/auth-context`. All Pods should agree within about 3 seconds.
5. Watch `front-api` database query volume for a few minutes. The increase should be small.

Run `npm ci` locally before the next `npm run dev` in `front-api`.
