### PR TITLE
[SCRUB] Cap the free-plan downgrade cron so it stops wedging on large backlogs

### DIFF
--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -698,7 +698,11 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     return res !== null;
   }
 
-  static async internalFetchWorkspacesWithFreeEndedSubscriptions(): Promise<{
+  static async internalFetchWorkspacesWithFreeEndedSubscriptions({
+    limit,
+  }: {
+    limit?: number;
+  } = {}): Promise<{
     workspaces: LightWorkspaceType[];
   }> {
     const freeEndedSubscriptions = await SubscriptionModel.findAll({
@@ -710,6 +714,9 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
         },
       },
       include: [WorkspaceModel],
+      // Oldest expiry first, so a capped run drains the backlog deterministically.
+      order: [["endDate", "ASC"]],
+      limit,
     });
 
     const workspaces = freeEndedSubscriptions.map((s) =>

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -41,6 +41,7 @@ import { CustomerioServerSideTracking } from "@app/lib/tracking/customerio/serve
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
+import { MAX_WORKSPACES_TO_DOWNGRADE_PER_RUN } from "@app/temporal/scrub_workspace/config";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -419,7 +420,9 @@ export async function endSubscriptionFreeEndedWorkspacesActivity(): Promise<{
   workspaceIds: string[];
 }> {
   const { workspaces } =
-    await SubscriptionResource.internalFetchWorkspacesWithFreeEndedSubscriptions();
+    await SubscriptionResource.internalFetchWorkspacesWithFreeEndedSubscriptions(
+      { limit: MAX_WORKSPACES_TO_DOWNGRADE_PER_RUN }
+    );
 
   await concurrentExecutor(
     workspaces,

--- a/front/temporal/scrub_workspace/client.ts
+++ b/front/temporal/scrub_workspace/client.ts
@@ -151,7 +151,9 @@ export async function launchDowngradeFreeEndedWorkspacesWorkflow(): Promise<
     workflowId: DOWNGRADE_FREE_ENDED_WORKSPACES_WORKFLOW_ID,
     signal: runScrubFreeEndedWorkspacesSignal,
     signalArgs: undefined,
-    cronSchedule: "0 18 * * 1-5", // Every weekday at 6pm.
+    // Scrub children email on start, so this is also the send window: weekday
+    // 15:00-17:00 UTC is EU afternoon and US morning year-round, DST included.
+    cronSchedule: "0 15-17 * * 1-5",
   });
 
   return new Ok(undefined);

--- a/front/temporal/scrub_workspace/config.ts
+++ b/front/temporal/scrub_workspace/config.ts
@@ -4,6 +4,10 @@ export const QUEUE_NAME = `scrub-workspace-queue-v${QUEUE_VERSION}`;
 export const DOWNGRADE_FREE_ENDED_WORKSPACES_WORKFLOW_ID =
   "downgrade-and-scrub-free-ended-workspaces";
 
+// One scrub child per workspace, and Temporal caps pending children at 1000 per
+// run — going over wedges the cron. Backlog drains over successive runs.
+export const MAX_WORKSPACES_TO_DOWNGRADE_PER_RUN = 500;
+
 export const LAST_EMAIL_BEFORE_SCRUB_IN_DAYS = 3;
 export const WORKSPACE_DEFAULT_RETENTION_DAYS = 30;
 export const WORKSPACE_RETENTION_MIN_DAYS = 7;


### PR DESCRIPTION
## Description

The downgrade cron starts one scrub child per expired workspace, so it hit Temporal's 1000-pending-children cap on Apr 27, wedged, and was terminated on May 2 — 40,701 expired free plans are still active. Now capped at 500 workspaces per run (oldest expiry first), 3 runs per weekday at 15:00-17:00 UTC (scrub children email on start, so that doubles as the send window).

## Tests

No.

## Risk

Relaunching drains the 40,701 backlog at ~1,500/weekday, each workspace getting a data-deletion email and a scrub 30 days later. Rate is tunable via `MAX_WORKSPACES_TO_DOWNGRADE_PER_RUN`.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`
- The cron is terminated and won't restart on its own — relaunch from Prodbox (US only):
  ```
  cd /dust/front
  npx tsx temporal/scrub_workspace/admin/cli.ts launch-workflow-to-downgrade-free-ended-workspaces
  ```
  It fires a run immediately, so the first 500 emails go out on the spot.
