### PR TITLE
Show conversations from pods in inbox, separate triggers.

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -10,9 +10,10 @@ import { renderPodsList } from "@app/components/assistant/conversation/sidebar/P
 import { PodsBrowsePopover } from "@app/components/assistant/conversation/sidebar/PodsBrowsePopover";
 import { SidebarSearch } from "@app/components/assistant/conversation/sidebar/SidebarSearch";
 import {
-  filterTriggeredConversations,
+  filterReadTriggeredConversations,
   getGroupConversationsByDate,
   getGroupConversationsByUnreadAndActionRequired,
+  groupUnreadConversations,
 } from "@app/components/assistant/conversation/utils";
 import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { ImportSkillsDialog } from "@app/components/skills/import/ImportSkillsDialog";
@@ -59,7 +60,8 @@ import {
   type ConversationListItemType,
   getConversationDisplayTitle,
 } from "@app/types/assistant/conversation";
-import type { PodType, SpaceType } from "@app/types/space";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { PodListItemType, PodType, SpaceType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
 import {
   ArrowRight,
@@ -680,18 +682,30 @@ export function AgentSidebarMenu({
     }
   }, [setSidebarOpen, router, activeConversationId, setShouldFocusInput]);
 
+  const { allConversations, spaces } = useMemo(() => {
+    return {
+      allConversations: [
+        ...conversations,
+        ...summary.map(({ unreadConversations }) => unreadConversations).flat(),
+      ],
+      spaces: summary.map(({ space }) => space).flat(),
+    };
+  }, [conversations, summary]);
+
   const hasTriggeredConversations = useMemo(
     () =>
-      conversations.some((c: ConversationListItemType) => c.triggerId !== null),
-    [conversations]
+      allConversations.some(
+        (c: ConversationListItemType) => c.triggerId !== null
+      ),
+    [allConversations]
   );
 
   const filteredConversations = useMemo(() => {
-    return filterTriggeredConversations(
-      conversations,
+    return filterReadTriggeredConversations(
+      allConversations,
       hideTriggeredConversations
     );
-  }, [conversations, hideTriggeredConversations]);
+  }, [allConversations, hideTriggeredConversations]);
 
   const isSearchActive = titleFilter.trim().length > 0;
 
@@ -833,6 +847,7 @@ export function AgentSidebarMenu({
     return (
       <NavigationListWithInbox
         conversations={filteredConversations}
+        pods={spaces}
         titleFilter={sidebarTitleFilter}
         isMultiSelect={isMultiSelect}
         selectedConversations={selectedConversations}
@@ -1210,6 +1225,7 @@ export function AgentSidebarMenu({
 interface UnreadConversationsSectionProps {
   label: string;
   conversations: ConversationListItemType[];
+  pods: PodListItemType[];
   isMultiSelect: boolean;
   isMarkingAllAsRead: boolean;
   onMarkAllAsRead: (conversationIds: string[]) => void;
@@ -1237,6 +1253,7 @@ const GRID_STYLE = { display: "grid" } as const;
 function UnreadConversationsSection({
   label,
   conversations,
+  pods,
   isMultiSelect,
   isMarkingAllAsRead,
   titleFilter,
@@ -1246,6 +1263,16 @@ function UnreadConversationsSection({
   activeConversationId,
   owner,
 }: UnreadConversationsSectionProps) {
+  const conversationGroups = useMemo(
+    () => groupUnreadConversations(conversations, pods),
+    [conversations, pods]
+  );
+
+  const podById = useMemo(
+    () => new Map(pods.map((pod) => [pod.sId, pod])),
+    [pods]
+  );
+
   const totalCount = conversations.length;
 
   const shouldShowMarkAllAsReadButton =
@@ -1261,7 +1288,7 @@ function UnreadConversationsSection({
           <Button
             size="xmini"
             variant="ghost-secondary"
-            label="Mark as read"
+            label="Mark all as read"
             onClick={() => onMarkAllAsRead(conversations.map((c) => c.sId))}
             isLoading={isMarkingAllAsRead}
             hasLighterFont
@@ -1272,28 +1299,84 @@ function UnreadConversationsSection({
       actionOnHover={false}
     >
       <AnimatePresence initial={false}>
-        {conversations.map((conversation) => (
-          <motion.div
-            key={conversation.sId}
-            style={GRID_STYLE}
-            animate={GRID_ANIMATE}
-            exit={GRID_EXIT}
-            transition={{ ease: "easeOut", duration: 0.1 }}
-          >
-            <div className="overflow-hidden">
-              <ConversationListItem
-                key={conversation.sId}
-                conversation={conversation}
-                isMultiSelect={isMultiSelect}
-                selectedConversations={selectedConversations}
-                toggleConversationSelection={toggleConversationSelection}
-                activeConversationId={activeConversationId}
-                owner={owner}
-                showStatusDot={false}
-              />
-            </div>
-          </motion.div>
-        ))}
+        {conversationGroups.flatMap((group) => {
+          switch (group.type) {
+            case "non_pod":
+              return group.conversations.map((conversation) => (
+                <motion.div
+                  key={conversation.sId}
+                  style={GRID_STYLE}
+                  animate={GRID_ANIMATE}
+                  exit={GRID_EXIT}
+                  transition={{ ease: "easeOut", duration: 0.1 }}
+                >
+                  <div className="overflow-hidden">
+                    <ConversationListItem
+                      conversation={conversation}
+                      isMultiSelect={isMultiSelect}
+                      selectedConversations={selectedConversations}
+                      toggleConversationSelection={toggleConversationSelection}
+                      activeConversationId={activeConversationId}
+                      owner={owner}
+                      showStatusDot={false}
+                    />
+                  </div>
+                </motion.div>
+              ));
+            case "pod": {
+              const pod = podById.get(group.spaceId);
+              return [
+                <NavigationListLabel
+                  key={`pod-label-${group.spaceId}`}
+                  className="bg-background"
+                  label={group.podName}
+                  icon={pod ? getSpaceIcon(pod) : undefined}
+                  isSticky
+                  action={
+                    shouldShowMarkAllAsReadButton ? (
+                      <Button
+                        size="xmini"
+                        variant="ghost-secondary"
+                        label="Mark as read"
+                        onClick={() =>
+                          onMarkAllAsRead(group.conversations.map((c) => c.sId))
+                        }
+                        isLoading={isMarkingAllAsRead}
+                        hasLighterFont
+                        className="hover:bg-hover active:bg-selected"
+                      />
+                    ) : null
+                  }
+                />,
+                ...group.conversations.map((conversation) => (
+                  <motion.div
+                    key={conversation.sId}
+                    style={GRID_STYLE}
+                    animate={GRID_ANIMATE}
+                    exit={GRID_EXIT}
+                    transition={{ ease: "easeOut", duration: 0.1 }}
+                  >
+                    <div className="overflow-hidden">
+                      <ConversationListItem
+                        conversation={conversation}
+                        isMultiSelect={isMultiSelect}
+                        selectedConversations={selectedConversations}
+                        toggleConversationSelection={
+                          toggleConversationSelection
+                        }
+                        activeConversationId={activeConversationId}
+                        owner={owner}
+                        showStatusDot={false}
+                      />
+                    </div>
+                  </motion.div>
+                )),
+              ];
+            }
+            default:
+              assertNever(group);
+          }
+        })}
       </AnimatePresence>
     </NavigationListCollapsibleSection>
   );
@@ -1482,6 +1565,7 @@ const ConversationListItem = memo(
 
 interface NavigationListWithInboxProps {
   conversations: ConversationListItemType[];
+  pods: PodListItemType[];
   titleFilter: string;
   isMultiSelect: boolean;
   selectedConversations: ConversationListItemType[];
@@ -1503,6 +1587,7 @@ interface NavigationListWithInboxProps {
 
 function NavigationListWithInbox({
   conversations,
+  pods,
   titleFilter,
   isMultiSelect,
   selectedConversations,
@@ -1530,6 +1615,7 @@ function NavigationListWithInbox({
     readConversations,
     inboxConversations,
     skillSuggestionConversations,
+    triggeredConversations,
   } = useMemo(() => {
     return getGroupConversationsByUnreadAndActionRequired(
       conversations,
@@ -1583,6 +1669,31 @@ function NavigationListWithInbox({
     >
       <div className="flex flex-col gap-4">
         <AnimatePresence initial={false}>
+          {triggeredConversations.length > 0 && (
+            <motion.div
+              key="triggered"
+              style={GRID_STYLE}
+              animate={GRID_ANIMATE}
+              exit={GRID_EXIT}
+              transition={{ duration: 0.2, ease: "easeOut" }}
+            >
+              <div className="overflow-hidden">
+                <UnreadConversationsSection
+                  label="Auto"
+                  conversations={triggeredConversations}
+                  pods={pods}
+                  isMultiSelect={isMultiSelect}
+                  isMarkingAllAsRead={isMarkingAllAsRead}
+                  titleFilter={titleFilter}
+                  onMarkAllAsRead={markAllAsRead}
+                  selectedConversations={selectedConversations}
+                  toggleConversationSelection={toggleConversationSelection}
+                  activeConversationId={activeConversationId}
+                  owner={owner}
+                />
+              </div>
+            </motion.div>
+          )}
           {skillSuggestionConversations.length > 0 && (
             <motion.div
               key="skill-suggestions"
@@ -1595,6 +1706,7 @@ function NavigationListWithInbox({
                 <UnreadConversationsSection
                   label="Skill suggestions"
                   conversations={skillSuggestionConversations}
+                  pods={pods}
                   isMultiSelect={isMultiSelect}
                   isMarkingAllAsRead={isMarkingAllAsRead}
                   titleFilter={titleFilter}
@@ -1619,6 +1731,7 @@ function NavigationListWithInbox({
                 <UnreadConversationsSection
                   label="Inbox"
                   conversations={inboxConversations}
+                  pods={pods}
                   isMultiSelect={isMultiSelect}
                   isMarkingAllAsRead={isMarkingAllAsRead}
                   titleFilter={titleFilter}

--- a/front/components/assistant/conversation/utils.ts
+++ b/front/components/assistant/conversation/utils.ts
@@ -12,10 +12,12 @@ import type {
 } from "@app/types/assistant/conversation";
 import {
   getConversationDisplayTitle,
+  isPodConversation,
   isReinforcedSkillNotificationMetadata,
 } from "@app/types/assistant/conversation";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import { truncate } from "@app/types/shared/utils/string_utils";
+import type { PodListItemType } from "@app/types/space";
 import moment from "moment";
 import type { VirtuosoMessage } from "./types";
 
@@ -68,6 +70,11 @@ export function getGroupConversationsByUnreadAndActionRequired(
           if (conversation.unread || conversation.actionRequired) {
             if (isReinforcedSkillConversation(conversation)) {
               acc.skillSuggestionConversations.push(conversation);
+            } else if (
+              conversation.triggerId !== null ||
+              conversation.nextWakeupAt !== null
+            ) {
+              acc.triggeredConversations.push(conversation);
             } else {
               acc.inboxConversations.push(conversation);
             }
@@ -81,10 +88,12 @@ export function getGroupConversationsByUnreadAndActionRequired(
           readConversations: [],
           inboxConversations: [],
           skillSuggestionConversations: [],
+          triggeredConversations: [],
         } as {
           readConversations: ConversationListItemType[];
           inboxConversations: ConversationListItemType[];
           skillSuggestionConversations: ConversationListItemType[];
+          triggeredConversations: ConversationListItemType[];
         }
       )
   );
@@ -140,7 +149,7 @@ export function getGroupConversationsByDate<
   return groups;
 }
 
-export function filterTriggeredConversations(
+export function filterReadTriggeredConversations(
   conversations: ConversationListItemType[],
   hideTriggered: boolean
 ): ConversationListItemType[] {
@@ -151,6 +160,82 @@ export function filterTriggeredConversations(
   return conversations.filter(
     (c) => c.triggerId === null || c.unread || c.actionRequired
   );
+}
+
+/**
+ * Group unread conversations for the sidebar inbox sections:
+ * 1. Non-pod conversations first
+ * 2. Pod conversations grouped by pod name
+ * 3. Within each group, by updatedAt descending
+ */
+export type UnreadConversationGroup =
+  | {
+      type: "non_pod";
+      conversations: ConversationListItemType[];
+    }
+  | {
+      type: "pod";
+      spaceId: string;
+      podName: string;
+      conversations: ConversationListItemType[];
+    };
+
+export function groupUnreadConversations(
+  conversations: ConversationListItemType[],
+  pods: PodListItemType[]
+): UnreadConversationGroup[] {
+  const podNameById = new Map(pods.map((pod) => [pod.sId, pod.name]));
+
+  const sorted = conversations.toSorted((a, b) => {
+    const aIsPod = isPodConversation(a);
+    const bIsPod = isPodConversation(b);
+
+    if (aIsPod !== bIsPod) {
+      return aIsPod ? 1 : -1;
+    }
+
+    if (aIsPod && bIsPod) {
+      const aName = podNameById.get(a.spaceId) ?? "";
+      const bName = podNameById.get(b.spaceId) ?? "";
+      const nameCmp = aName.localeCompare(bName);
+      if (nameCmp !== 0) {
+        return nameCmp;
+      }
+    }
+
+    return b.updated - a.updated;
+  });
+
+  const groups: UnreadConversationGroup[] = [];
+
+  for (const conversation of sorted) {
+    if (!isPodConversation(conversation)) {
+      const lastGroup = groups[groups.length - 1];
+      if (lastGroup?.type === "non_pod") {
+        lastGroup.conversations.push(conversation);
+      } else {
+        groups.push({ type: "non_pod", conversations: [conversation] });
+      }
+      continue;
+    }
+
+    const lastGroup = groups[groups.length - 1];
+    if (
+      lastGroup?.type === "pod" &&
+      lastGroup.spaceId === conversation.spaceId
+    ) {
+      lastGroup.conversations.push(conversation);
+    } else {
+      groups.push({
+        type: "pod",
+        spaceId: conversation.spaceId,
+        podName: podNameById.get(conversation.spaceId) ?? "",
+        conversations: [conversation],
+      });
+    }
+  }
+
+  return groups;
 }
 
 export function findFirstUnreadMessageIndex(

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -109,7 +109,6 @@ const NavigationListItem = React.forwardRef<
 
     const shouldShowStatusDot = status !== "idle";
     const counterValue = count && count > 0 ? count : undefined;
-    const shouldHideStatusIndicators = Boolean(moreMenu && selected);
 
     return (
       <div
@@ -181,7 +180,7 @@ const NavigationListItem = React.forwardRef<
                 {suffix}
               </div>
             )}
-            {counterValue !== undefined && !shouldHideStatusIndicators && (
+            {counterValue !== undefined && (
               <Counter
                 value={counterValue}
                 size="xs"
@@ -193,7 +192,7 @@ const NavigationListItem = React.forwardRef<
                 )}
               />
             )}
-            {shouldShowStatusDot && !shouldHideStatusIndicators && (
+            {shouldShowStatusDot && (
               <div
                 className={cn(
                   "heading-xs flex flex-shrink-0 items-center justify-center rounded-full",
@@ -249,6 +248,7 @@ NavigationListItemAction.displayName = "NavigationListItemAction";
 interface NavigationListLabelProps
   extends React.HTMLAttributes<HTMLDivElement> {
   label: string;
+  icon?: React.ComponentType;
   action?: React.ReactNode;
   isSticky?: boolean;
 }
@@ -256,7 +256,7 @@ interface NavigationListLabelProps
 const NavigationListLabel = React.forwardRef<
   HTMLDivElement,
   NavigationListLabelProps
->(({ className, label, isSticky, action, ...props }, ref) => (
+>(({ className, label, icon, isSticky, action, ...props }, ref) => (
   <div
     ref={ref}
     className={cn(
@@ -270,6 +270,7 @@ const NavigationListLabel = React.forwardRef<
     {...props}
   >
     <div className="flex items-center gap-1 overflow-hidden text-ellipsis">
+      {icon && <Icon visual={icon} size="xs" />}
       <span className="overflow-hidden text-ellipsis">{label}</span>
     </div>
     {action}


### PR DESCRIPTION
## Description

Two related inbox improvements:

- **Pod conversations in inbox**: unread conversations from pods now appear alongside direct conversations in the Triggered / Skill Suggestions / Inbox sections. `AgentSidebarMenu` merges `conversations` and pod `summary.unreadConversations` into `allConversations`, then `groupUnreadConversations` in `utils.ts` sorts them — non-pod first, then pod conversations grouped by pod name with sticky `NavigationListLabel` headers (pod icon via `getSpaceIcon`).
- **Separate "Triggered" section**: conversations with `triggerId !== null || nextWakeupAt !== null` are now routed into a dedicated "Triggered" bucket in `getGroupConversationsByUnreadAndActionRequired`, appearing above Skill Suggestions and Inbox instead of being mixed into Inbox.

Also includes: `filterTriggeredConversations` → `filterReadTriggeredConversations` rename for clarity, `NavigationListLabel` gains an optional `icon` prop, removal of `shouldHideStatusIndicators` (counter/dot was incorrectly hidden when a selected nav item had a `moreMenu`), and "Mark as read" → "Mark all as read" label fix.

Before
<img width="345" height="705" alt="image" src="https://github.com/user-attachments/assets/366c367a-6918-4c3d-a067-0d81191a884e" />

After
<img width="345" height="837" alt="image" src="https://github.com/user-attachments/assets/bb097d69-35e4-4ccd-a59a-df5bb4f753e0" />


## Tests

Tested locally in the sidebar with pod conversations and triggered conversations active.

## Risk

Low. Pure frontend rendering logic; no API or data model changes. The `groupUnreadConversations` sort is additive — worst case a pod conversation shows up in the wrong bucket if `isPodConversation` returns an unexpected value, but that's contained to the inbox view.

## Deploy Plan

Deploy `front`.
