### PR TITLE
feat(marketing): add standalone credits pricing page

### DIFF
--- a/front-api/routes/marketing/index.ts
+++ b/front-api/routes/marketing/index.ts
@@ -2,11 +2,13 @@ import { createHono } from "@front-api/lib/hono";
 
 import academy from "./academy";
 import integrations from "./integrations";
+import modelCredits from "./model_credits";
 
 // Mounted under /api/marketing.
 const app = createHono();
 
 app.route("/academy", academy);
 app.route("/integrations", integrations);
+app.route("/model-credits", modelCredits);
 
 export default app;

--- a/front-api/routes/marketing/model_credits.test.ts
+++ b/front-api/routes/marketing/model_credits.test.ts
@@ -1,0 +1,21 @@
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+describe("GET /api/marketing/model-credits", () => {
+  it("returns the public model credits table", async () => {
+    const response = await honoApp.request("/api/marketing/model-credits");
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(Array.isArray(body.models)).toBe(true);
+    expect(body.models.length).toBeGreaterThan(0);
+
+    const [model] = body.models;
+    expect(typeof model.modelId).toBe("string");
+    expect(typeof model.displayName).toBe("string");
+    expect(typeof model.modelMaker).toBe("string");
+    expect(typeof model.modelMakerDisplayName).toBe("string");
+    expect(typeof model.inputCreditsPerMTokens).toBe("number");
+    expect(typeof model.outputCreditsPerMTokens).toBe("number");
+  });
+});

--- a/front-api/routes/marketing/model_credits.ts
+++ b/front-api/routes/marketing/model_credits.ts
@@ -1,0 +1,15 @@
+import { buildPublicModelCredits } from "@app/lib/api/marketing/model_credits";
+import { unauthedApp } from "@front-api/middlewares/ctx";
+
+// Mounted at /api/marketing/model-credits. No auth — public metadata
+// consumed by the marketing site's credits pricing page.
+const app = unauthedApp();
+
+const models = buildPublicModelCredits();
+
+/** @ignoreswagger */
+app.get("/", (ctx) => {
+  return ctx.json({ models });
+});
+
+export default app;

--- a/front/lib/api/marketing/model_credits.ts
+++ b/front/lib/api/marketing/model_credits.ts
@@ -1,0 +1,80 @@
+import {
+  computeTokensCostForUsageInMicroUsd,
+  MODEL_PRICING,
+} from "@app/lib/api/assistant/token_pricing";
+import { awuFromMicroUsd } from "@app/lib/metronome/events";
+import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
+import {
+  getModelMaker,
+  getModelMakerDisplayName,
+} from "@app/types/assistant/models/providers";
+import type { ModelMakerIdType } from "@app/types/assistant/models/types";
+
+export interface PublicModelCredit {
+  modelId: string;
+  displayName: string;
+  modelMaker: ModelMakerIdType;
+  modelMakerDisplayName: string;
+  inputCreditsPerMTokens: number;
+  outputCreditsPerMTokens: number;
+}
+
+const ONE_MILLION_TOKENS = 1_000_000;
+
+// Some models (e.g. Grok 4.5) have a higher-priced long-context tier past a
+// prompt token threshold. Pricing a single token keeps every model on its
+// base tier, so the displayed rate is the flat per-million-token price
+// rather than the blended rate of one huge long-context request.
+const SINGLE_TOKEN = 1;
+
+// Provider ids that are internal routing/no-op concepts rather than actual,
+// separately priced models — not relevant on a public per-model credits page.
+const EXCLUDED_PROVIDER_IDS = new Set([
+  "noop",
+  "auto",
+  "auto_fast",
+  "auto_complex",
+]);
+
+export function buildPublicModelCredits(): PublicModelCredit[] {
+  const rows: PublicModelCredit[] = [];
+
+  for (const model of SUPPORTED_MODEL_CONFIGS) {
+    if (EXCLUDED_PROVIDER_IDS.has(model.providerId)) {
+      continue;
+    }
+
+    // Skip models without an explicit pricing entry rather than silently
+    // falling back to computeTokensCostForUsageInMicroUsd's default pricing.
+    if (!(model.modelId in MODEL_PRICING)) {
+      continue;
+    }
+
+    const inputCostMicroUsd =
+      computeTokensCostForUsageInMicroUsd({
+        modelId: model.modelId,
+        promptTokens: SINGLE_TOKEN,
+        completionTokens: 0,
+        cachedTokens: null,
+      }) * ONE_MILLION_TOKENS;
+    const outputCostMicroUsd =
+      computeTokensCostForUsageInMicroUsd({
+        modelId: model.modelId,
+        promptTokens: 0,
+        completionTokens: SINGLE_TOKEN,
+        cachedTokens: null,
+      }) * ONE_MILLION_TOKENS;
+
+    const modelMaker = getModelMaker(model);
+    rows.push({
+      modelId: model.modelId,
+      displayName: model.displayName,
+      modelMaker,
+      modelMakerDisplayName: getModelMakerDisplayName(modelMaker),
+      inputCreditsPerMTokens: awuFromMicroUsd(inputCostMicroUsd),
+      outputCreditsPerMTokens: awuFromMicroUsd(outputCostMicroUsd),
+    });
+  }
+
+  return rows;
+}

--- a/marketing/lib/api/model_credits.ts
+++ b/marketing/lib/api/model_credits.ts
@@ -1,0 +1,42 @@
+import config from "@marketing/lib/api/config";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const modelCreditSchema = z.object({
+  modelId: z.string(),
+  displayName: z.string(),
+  // Plain string at the wire boundary — front may introduce a new model
+  // maker before this app's logo mapping is updated. Unknown makers fall
+  // back to a generic rendering instead of crashing the page.
+  modelMaker: z.string(),
+  modelMakerDisplayName: z.string(),
+  inputCreditsPerMTokens: z.number(),
+  outputCreditsPerMTokens: z.number(),
+});
+
+export type PublicModelCredit = z.infer<typeof modelCreditSchema>;
+
+const modelCreditsResponseSchema = z.object({
+  models: z.array(modelCreditSchema),
+});
+
+export async function fetchPublicModelCredits(): Promise<PublicModelCredit[]> {
+  const res = await fetch(
+    `${config.getApiBaseUrl()}/api/marketing/model-credits`
+  );
+
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch marketing model credits: ${res.status} ${res.statusText}`
+    );
+  }
+
+  const parsed = modelCreditsResponseSchema.safeParse(await res.json());
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid marketing model credits response: ${fromError(parsed.error)}`
+    );
+  }
+
+  return parsed.data.models;
+}

--- a/marketing/next.config.js
+++ b/marketing/next.config.js
@@ -283,6 +283,11 @@ const config = {
         permanent: true,
       },
       {
+        source: "/credits",
+        destination: "/home/credits",
+        permanent: true,
+      },
+      {
         source: "/security",
         destination: "/home/security",
         permanent: true,

--- a/marketing/pages/home/credits.tsx
+++ b/marketing/pages/home/credits.tsx
@@ -24,23 +24,24 @@ import {
   m,
   MotionConfig,
 } from "framer-motion";
-import type { GetStaticProps } from "next";
+import type { GetServerSideProps } from "next";
 import { useRouter } from "next/router";
 import type React from "react";
 import type { ReactElement } from "react";
 import { useState } from "react";
-
-// Model credits data changes only when a new model is added or its pricing
-// changes, so a build-once page would go stale for days between deploys.
-// Revalidate periodically instead of on every request.
-const MODEL_CREDITS_REVALIDATE_SECONDS = 60 * 60;
 
 interface CreditsPageProps {
   gtmTrackingId: string | null;
   providerSections: ProviderSection[];
 }
 
-export const getStaticProps: GetStaticProps<CreditsPageProps> = async () => {
+// Server-rendered (like /integrations) rather than statically generated:
+// a build-time getStaticProps would call the live API at `next build` time,
+// which fails whenever this page ships before the API endpoint it depends
+// on has been deployed.
+export const getServerSideProps: GetServerSideProps<
+  CreditsPageProps
+> = async () => {
   const models = await fetchPublicModelCredits();
 
   return {
@@ -48,7 +49,6 @@ export const getStaticProps: GetStaticProps<CreditsPageProps> = async () => {
       gtmTrackingId: process.env.NEXT_PUBLIC_GTM_TRACKING_ID ?? null,
       providerSections: groupByModelMaker(models),
     },
-    revalidate: MODEL_CREDITS_REVALIDATE_SECONDS,
   };
 };
 

--- a/marketing/pages/home/credits.tsx
+++ b/marketing/pages/home/credits.tsx
@@ -1,0 +1,415 @@
+// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
+import type { LandingLayoutProps } from "@marketing/components/home/LandingLayout";
+import LandingLayout from "@marketing/components/home/LandingLayout";
+import { PageMetadata } from "@marketing/components/home/PageMetadata";
+import { classNames } from "@marketing/lib/utils";
+import {
+  AnthropicLogo,
+  ChevronDown,
+  cn,
+  DeepseekLogo,
+  GeminiLogo,
+  GrokLogo,
+  MistralLogo,
+  MoonshotLogo,
+  OpenaiLogo,
+  ZaiLogo,
+} from "@dust-tt/sparkle";
+import { AnimatePresence, MotionConfig, motion } from "framer-motion";
+import { useRouter } from "next/router";
+import type React from "react";
+import type { ReactElement } from "react";
+import { useState } from "react";
+
+export async function getStaticProps() {
+  return {
+    props: {
+      gtmTrackingId: process.env.NEXT_PUBLIC_GTM_TRACKING_ID ?? null,
+    },
+  };
+}
+
+// ---------- Types ----------
+
+interface ModelCreditRow {
+  model: string;
+  inputCreditsPerMTokens: string;
+  outputCreditsPerMTokens: string;
+}
+
+interface ProviderSection {
+  provider: string;
+  Logo: React.ComponentType<{ className?: string }>;
+  rows: ModelCreditRow[];
+}
+
+// ---------- Data ----------
+
+const PROVIDER_SECTIONS: ProviderSection[] = [
+  {
+    provider: "OpenAI",
+    Logo: OpenaiLogo,
+    rows: [
+      {
+        model: "GPT 5",
+        inputCreditsPerMTokens: "148",
+        outputCreditsPerMTokens: "1,177",
+      },
+      {
+        model: "GPT 5.1",
+        inputCreditsPerMTokens: "148",
+        outputCreditsPerMTokens: "1,177",
+      },
+      {
+        model: "GPT 5.2",
+        inputCreditsPerMTokens: "206",
+        outputCreditsPerMTokens: "1,648",
+      },
+      {
+        model: "GPT 5.4",
+        inputCreditsPerMTokens: "295",
+        outputCreditsPerMTokens: "1,765",
+      },
+      {
+        model: "GPT 5.5",
+        inputCreditsPerMTokens: "589",
+        outputCreditsPerMTokens: "3,530",
+      },
+      {
+        model: "GPT 5.6 Luna",
+        inputCreditsPerMTokens: "118",
+        outputCreditsPerMTokens: "706",
+      },
+      {
+        model: "GPT 5.6 Sol",
+        inputCreditsPerMTokens: "589",
+        outputCreditsPerMTokens: "3,530",
+      },
+      {
+        model: "GPT 5.6 Terra",
+        inputCreditsPerMTokens: "295",
+        outputCreditsPerMTokens: "1,765",
+      },
+      {
+        model: "GPT-5 Mini",
+        inputCreditsPerMTokens: "30",
+        outputCreditsPerMTokens: "236",
+      },
+      {
+        model: "GPT-5 Nano",
+        inputCreditsPerMTokens: "6",
+        outputCreditsPerMTokens: "48",
+      },
+      {
+        model: "GPT-5.4 Mini",
+        inputCreditsPerMTokens: "89",
+        outputCreditsPerMTokens: "530",
+      },
+      {
+        model: "GPT-5.4 Nano",
+        inputCreditsPerMTokens: "24",
+        outputCreditsPerMTokens: "148",
+      },
+    ],
+  },
+  {
+    provider: "Anthropic",
+    Logo: AnthropicLogo,
+    rows: [
+      {
+        model: "Claude 4.5 Haiku",
+        inputCreditsPerMTokens: "118",
+        outputCreditsPerMTokens: "589",
+      },
+      {
+        model: "Claude Fable 5",
+        inputCreditsPerMTokens: "1,177",
+        outputCreditsPerMTokens: "5,883",
+      },
+      {
+        model: "Claude Opus 4.6",
+        inputCreditsPerMTokens: "589",
+        outputCreditsPerMTokens: "2,942",
+      },
+      {
+        model: "Claude Opus 4.7",
+        inputCreditsPerMTokens: "589",
+        outputCreditsPerMTokens: "2,942",
+      },
+      {
+        model: "Claude Opus 4.8",
+        inputCreditsPerMTokens: "589",
+        outputCreditsPerMTokens: "2,942",
+      },
+      {
+        model: "Claude Opus 5",
+        inputCreditsPerMTokens: "589",
+        outputCreditsPerMTokens: "2,942",
+      },
+      {
+        model: "Claude Sonnet 4.6",
+        inputCreditsPerMTokens: "353",
+        outputCreditsPerMTokens: "1,765",
+      },
+      {
+        model: "Claude Sonnet 5",
+        inputCreditsPerMTokens: "236",
+        outputCreditsPerMTokens: "1,177",
+      },
+    ],
+  },
+  {
+    provider: "DeepSeek",
+    Logo: DeepseekLogo,
+    rows: [
+      {
+        model: "DeepSeek V4 Pro, Fireworks",
+        inputCreditsPerMTokens: "205",
+        outputCreditsPerMTokens: "410",
+      },
+    ],
+  },
+  {
+    provider: "Z.ai",
+    Logo: ZaiLogo,
+    rows: [
+      {
+        model: "GLM-5.2, Fireworks",
+        inputCreditsPerMTokens: "165",
+        outputCreditsPerMTokens: "518",
+      },
+    ],
+  },
+  {
+    provider: "Moonshot AI",
+    Logo: MoonshotLogo,
+    rows: [
+      {
+        model: "Kimi K2.5, Fireworks",
+        inputCreditsPerMTokens: "71",
+        outputCreditsPerMTokens: "353",
+      },
+      {
+        model: "Kimi K2.6, Fireworks",
+        inputCreditsPerMTokens: "112",
+        outputCreditsPerMTokens: "471",
+      },
+    ],
+  },
+  {
+    provider: "Google",
+    Logo: GeminiLogo,
+    rows: [
+      {
+        model: "Gemini 3.1 Flash Lite",
+        inputCreditsPerMTokens: "30",
+        outputCreditsPerMTokens: "177",
+      },
+      {
+        model: "Gemini 3.1 Pro",
+        inputCreditsPerMTokens: "471",
+        outputCreditsPerMTokens: "2,118",
+      },
+      {
+        model: "Gemini 3.5 Flash",
+        inputCreditsPerMTokens: "177",
+        outputCreditsPerMTokens: "1,059",
+      },
+    ],
+  },
+  {
+    provider: "Mistral",
+    Logo: MistralLogo,
+    rows: [
+      {
+        model: "Mistral Codestral",
+        inputCreditsPerMTokens: "106",
+        outputCreditsPerMTokens: "330",
+      },
+      {
+        model: "Mistral Large",
+        inputCreditsPerMTokens: "236",
+        outputCreditsPerMTokens: "706",
+      },
+      {
+        model: "Mistral Medium 3.5",
+        inputCreditsPerMTokens: "177",
+        outputCreditsPerMTokens: "883",
+      },
+      {
+        model: "Mistral Small",
+        inputCreditsPerMTokens: "106",
+        outputCreditsPerMTokens: "330",
+      },
+    ],
+  },
+  {
+    provider: "xAI",
+    Logo: GrokLogo,
+    rows: [
+      {
+        model: "Grok 4.5",
+        inputCreditsPerMTokens: "236",
+        outputCreditsPerMTokens: "706",
+      },
+    ],
+  },
+];
+
+// ---------- Subcomponents ----------
+
+function Hero() {
+  return (
+    <section className="-mx-6 flex flex-col items-center px-4 pt-6 text-center md:mx-0 md:px-0 md:pt-10 lg:pt-14">
+      <h1
+        className={classNames(
+          "heading-5xl md:heading-6xl lg:heading-7xl",
+          "mb-5 max-w-3xl text-balance text-foreground"
+        )}
+      >
+        Dust credits
+      </h1>
+      <p className="copy-lg mb-9 max-w-2xl text-balance text-muted-foreground">
+        These are intelligence credits only, excluding separate action credits.
+        The figures are rounded up per model and execution, matching the
+        codebase conversion logic.
+      </p>
+    </section>
+  );
+}
+
+function ModelCreditsTable() {
+  const [openSections, setOpenSections] = useState<Record<string, boolean>>(
+    () => Object.fromEntries(PROVIDER_SECTIONS.map((s) => [s.provider, true]))
+  );
+
+  const toggleSection = (provider: string) => {
+    setOpenSections((prev) => ({
+      ...prev,
+      [provider]: !(prev[provider] ?? true),
+    }));
+  };
+
+  return (
+    <section className="-mx-6 px-3 py-8 md:mx-0 md:px-0 md:py-12">
+      <table className="mx-auto w-full max-w-3xl border-separate border-spacing-0">
+        {/* top-16 matches the ScrollingHeader scrolled height (h-16). */}
+        <thead className="sticky top-16 z-10">
+          <tr className="grid grid-cols-2 bg-background md:table-row">
+            <th className="hidden border-b border-border bg-background px-2 py-4 text-left align-bottom md:table-cell md:py-5">
+              <span className="heading-lg text-foreground">Model</span>
+            </th>
+            <th className="block border-b border-border bg-background px-3 py-4 text-center align-bottom md:table-cell md:w-[240px] md:px-5 md:py-5">
+              <span className="heading-sm text-foreground">
+                Input credits / 1M tokens
+              </span>
+            </th>
+            <th className="block border-b border-border bg-background px-3 py-4 text-center align-bottom md:table-cell md:w-[240px] md:px-5 md:py-5">
+              <span className="heading-sm text-foreground">
+                Output credits / 1M tokens
+              </span>
+            </th>
+          </tr>
+        </thead>
+        {PROVIDER_SECTIONS.map((section) => {
+          const isOpen = openSections[section.provider] ?? true;
+          const Logo = section.Logo;
+          return (
+            <tbody
+              key={section.provider}
+              // Row-dim on hover, gated to hover-capable devices to avoid
+              // sticky hover on touch.
+              className="motion-safe:[&_tr[data-row=model]]:transition-opacity motion-safe:[&_tr[data-row=model]]:duration-200 [@media(hover:hover)]:[&:has(tr[data-row=model]:hover)_tr[data-row=model]:not(:hover)]:opacity-40"
+            >
+              <tr className="grid grid-cols-1 md:table-row">
+                <th
+                  colSpan={3}
+                  scope="colgroup"
+                  className="block border-t border-border p-0 text-left md:table-cell"
+                >
+                  <button
+                    type="button"
+                    onClick={() => toggleSection(section.provider)}
+                    aria-expanded={isOpen}
+                    className="group flex w-full items-center justify-between gap-2 px-2 py-6 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+                  >
+                    <span className="flex items-center gap-3">
+                      <Logo className="h-6 w-6 flex-shrink-0" />
+                      <span className="heading-2xl font-semibold text-foreground">
+                        {section.provider}
+                      </span>
+                    </span>
+                    <ChevronDown
+                      className={cn(
+                        "h-5 w-5 text-muted-foreground transition-transform duration-200",
+                        !isOpen && "-rotate-90"
+                      )}
+                    />
+                  </button>
+                </th>
+              </tr>
+              <AnimatePresence initial={false}>
+                {isOpen &&
+                  section.rows.map((row, idx) => (
+                    <motion.tr
+                      key={`${section.provider}:${row.model}`}
+                      data-row="model"
+                      className={cn(
+                        "grid grid-cols-2 md:table-row",
+                        idx % 2 === 1 && "bg-muted/40"
+                      )}
+                      initial={{ y: -4 }}
+                      animate={{ y: 0 }}
+                      transition={{
+                        duration: 0.18,
+                        ease: [0.215, 0.61, 0.355, 1],
+                      }}
+                    >
+                      <td className="col-span-2 block px-2 pb-1.5 pt-3.5 align-middle md:table-cell md:py-3.5 md:pb-3.5">
+                        <span className="copy-sm block max-w-[560px] font-medium text-foreground">
+                          {row.model}
+                        </span>
+                      </td>
+                      <td className="block px-2 pb-3.5 pt-1.5 text-center align-middle tabular-nums md:table-cell md:w-[240px] md:px-5 md:py-3.5 md:pt-3.5">
+                        <span className="copy-sm text-foreground">
+                          {row.inputCreditsPerMTokens}
+                        </span>
+                      </td>
+                      <td className="block px-2 pb-3.5 pt-1.5 text-center align-middle tabular-nums md:table-cell md:w-[240px] md:px-5 md:py-3.5 md:pt-3.5">
+                        <span className="copy-sm text-foreground">
+                          {row.outputCreditsPerMTokens}
+                        </span>
+                      </td>
+                    </motion.tr>
+                  ))}
+              </AnimatePresence>
+            </tbody>
+          );
+        })}
+      </table>
+    </section>
+  );
+}
+
+// ---------- Page ----------
+
+// biome-ignore lint/plugin/nextjsPageComponentNaming: matches pricing page pattern
+export default function Credits() {
+  const router = useRouter();
+
+  return (
+    <MotionConfig reducedMotion="user">
+      <PageMetadata
+        title="Dust Credits: Model Credit Consumption"
+        description="Intelligence credit consumption per model on Dust, in credits per million input and output tokens."
+        pathname={router.asPath}
+      />
+      <Hero />
+      <ModelCreditsTable />
+    </MotionConfig>
+  );
+}
+
+Credits.getLayout = (page: ReactElement, pageProps: LandingLayoutProps) => {
+  return <LandingLayout pageProps={pageProps}>{page}</LandingLayout>;
+};

--- a/marketing/pages/home/credits.tsx
+++ b/marketing/pages/home/credits.tsx
@@ -2,7 +2,8 @@
 import type { LandingLayoutProps } from "@marketing/components/home/LandingLayout";
 import LandingLayout from "@marketing/components/home/LandingLayout";
 import { PageMetadata } from "@marketing/components/home/PageMetadata";
-import { classNames } from "@marketing/lib/utils";
+import type { PublicModelCredit } from "@marketing/lib/api/model_credits";
+import { fetchPublicModelCredits } from "@marketing/lib/api/model_credits";
 import {
   AnthropicLogo,
   ChevronDown,
@@ -10,251 +11,96 @@ import {
   DeepseekLogo,
   GeminiLogo,
   GrokLogo,
+  MinimaxLogo,
   MistralLogo,
   MoonshotLogo,
   OpenaiLogo,
   ZaiLogo,
 } from "@dust-tt/sparkle";
-import { AnimatePresence, MotionConfig, motion } from "framer-motion";
+import {
+  AnimatePresence,
+  domAnimation,
+  LazyMotion,
+  m,
+  MotionConfig,
+} from "framer-motion";
+import type { GetStaticProps } from "next";
 import { useRouter } from "next/router";
 import type React from "react";
 import type { ReactElement } from "react";
 import { useState } from "react";
 
-export async function getStaticProps() {
+// Model credits data changes only when a new model is added or its pricing
+// changes, so a build-once page would go stale for days between deploys.
+// Revalidate periodically instead of on every request.
+const MODEL_CREDITS_REVALIDATE_SECONDS = 60 * 60;
+
+interface CreditsPageProps {
+  gtmTrackingId: string | null;
+  providerSections: ProviderSection[];
+}
+
+export const getStaticProps: GetStaticProps<CreditsPageProps> = async () => {
+  const models = await fetchPublicModelCredits();
+
   return {
     props: {
       gtmTrackingId: process.env.NEXT_PUBLIC_GTM_TRACKING_ID ?? null,
+      providerSections: groupByModelMaker(models),
     },
+    revalidate: MODEL_CREDITS_REVALIDATE_SECONDS,
   };
-}
+};
 
 // ---------- Types ----------
 
-interface ModelCreditRow {
-  model: string;
-  inputCreditsPerMTokens: string;
-  outputCreditsPerMTokens: string;
-}
-
 interface ProviderSection {
   provider: string;
-  Logo: React.ComponentType<{ className?: string }>;
-  rows: ModelCreditRow[];
+  modelMaker: string;
+  rows: PublicModelCredit[];
 }
 
 // ---------- Data ----------
 
-const PROVIDER_SECTIONS: ProviderSection[] = [
-  {
-    provider: "OpenAI",
-    Logo: OpenaiLogo,
-    rows: [
-      {
-        model: "GPT 5",
-        inputCreditsPerMTokens: "148",
-        outputCreditsPerMTokens: "1,177",
-      },
-      {
-        model: "GPT 5.1",
-        inputCreditsPerMTokens: "148",
-        outputCreditsPerMTokens: "1,177",
-      },
-      {
-        model: "GPT 5.2",
-        inputCreditsPerMTokens: "206",
-        outputCreditsPerMTokens: "1,648",
-      },
-      {
-        model: "GPT 5.4",
-        inputCreditsPerMTokens: "295",
-        outputCreditsPerMTokens: "1,765",
-      },
-      {
-        model: "GPT 5.5",
-        inputCreditsPerMTokens: "589",
-        outputCreditsPerMTokens: "3,530",
-      },
-      {
-        model: "GPT 5.6 Luna",
-        inputCreditsPerMTokens: "118",
-        outputCreditsPerMTokens: "706",
-      },
-      {
-        model: "GPT 5.6 Sol",
-        inputCreditsPerMTokens: "589",
-        outputCreditsPerMTokens: "3,530",
-      },
-      {
-        model: "GPT 5.6 Terra",
-        inputCreditsPerMTokens: "295",
-        outputCreditsPerMTokens: "1,765",
-      },
-      {
-        model: "GPT-5 Mini",
-        inputCreditsPerMTokens: "30",
-        outputCreditsPerMTokens: "236",
-      },
-      {
-        model: "GPT-5 Nano",
-        inputCreditsPerMTokens: "6",
-        outputCreditsPerMTokens: "48",
-      },
-      {
-        model: "GPT-5.4 Mini",
-        inputCreditsPerMTokens: "89",
-        outputCreditsPerMTokens: "530",
-      },
-      {
-        model: "GPT-5.4 Nano",
-        inputCreditsPerMTokens: "24",
-        outputCreditsPerMTokens: "148",
-      },
-    ],
-  },
-  {
-    provider: "Anthropic",
-    Logo: AnthropicLogo,
-    rows: [
-      {
-        model: "Claude 4.5 Haiku",
-        inputCreditsPerMTokens: "118",
-        outputCreditsPerMTokens: "589",
-      },
-      {
-        model: "Claude Fable 5",
-        inputCreditsPerMTokens: "1,177",
-        outputCreditsPerMTokens: "5,883",
-      },
-      {
-        model: "Claude Opus 4.6",
-        inputCreditsPerMTokens: "589",
-        outputCreditsPerMTokens: "2,942",
-      },
-      {
-        model: "Claude Opus 4.7",
-        inputCreditsPerMTokens: "589",
-        outputCreditsPerMTokens: "2,942",
-      },
-      {
-        model: "Claude Opus 4.8",
-        inputCreditsPerMTokens: "589",
-        outputCreditsPerMTokens: "2,942",
-      },
-      {
-        model: "Claude Opus 5",
-        inputCreditsPerMTokens: "589",
-        outputCreditsPerMTokens: "2,942",
-      },
-      {
-        model: "Claude Sonnet 4.6",
-        inputCreditsPerMTokens: "353",
-        outputCreditsPerMTokens: "1,765",
-      },
-      {
-        model: "Claude Sonnet 5",
-        inputCreditsPerMTokens: "236",
-        outputCreditsPerMTokens: "1,177",
-      },
-    ],
-  },
-  {
-    provider: "DeepSeek",
-    Logo: DeepseekLogo,
-    rows: [
-      {
-        model: "DeepSeek V4 Pro, Fireworks",
-        inputCreditsPerMTokens: "205",
-        outputCreditsPerMTokens: "410",
-      },
-    ],
-  },
-  {
-    provider: "Z.ai",
-    Logo: ZaiLogo,
-    rows: [
-      {
-        model: "GLM-5.2, Fireworks",
-        inputCreditsPerMTokens: "165",
-        outputCreditsPerMTokens: "518",
-      },
-    ],
-  },
-  {
-    provider: "Moonshot AI",
-    Logo: MoonshotLogo,
-    rows: [
-      {
-        model: "Kimi K2.5, Fireworks",
-        inputCreditsPerMTokens: "71",
-        outputCreditsPerMTokens: "353",
-      },
-      {
-        model: "Kimi K2.6, Fireworks",
-        inputCreditsPerMTokens: "112",
-        outputCreditsPerMTokens: "471",
-      },
-    ],
-  },
-  {
-    provider: "Google",
-    Logo: GeminiLogo,
-    rows: [
-      {
-        model: "Gemini 3.1 Flash Lite",
-        inputCreditsPerMTokens: "30",
-        outputCreditsPerMTokens: "177",
-      },
-      {
-        model: "Gemini 3.1 Pro",
-        inputCreditsPerMTokens: "471",
-        outputCreditsPerMTokens: "2,118",
-      },
-      {
-        model: "Gemini 3.5 Flash",
-        inputCreditsPerMTokens: "177",
-        outputCreditsPerMTokens: "1,059",
-      },
-    ],
-  },
-  {
-    provider: "Mistral",
-    Logo: MistralLogo,
-    rows: [
-      {
-        model: "Mistral Codestral",
-        inputCreditsPerMTokens: "106",
-        outputCreditsPerMTokens: "330",
-      },
-      {
-        model: "Mistral Large",
-        inputCreditsPerMTokens: "236",
-        outputCreditsPerMTokens: "706",
-      },
-      {
-        model: "Mistral Medium 3.5",
-        inputCreditsPerMTokens: "177",
-        outputCreditsPerMTokens: "883",
-      },
-      {
-        model: "Mistral Small",
-        inputCreditsPerMTokens: "106",
-        outputCreditsPerMTokens: "330",
-      },
-    ],
-  },
-  {
-    provider: "xAI",
-    Logo: GrokLogo,
-    rows: [
-      {
-        model: "Grok 4.5",
-        inputCreditsPerMTokens: "236",
-        outputCreditsPerMTokens: "706",
-      },
-    ],
-  },
-];
+const LOGO_BY_MODEL_MAKER: Record<
+  string,
+  React.ComponentType<{ className?: string }>
+> = {
+  openai: OpenaiLogo,
+  anthropic: AnthropicLogo,
+  mistral: MistralLogo,
+  google_ai_studio: GeminiLogo,
+  deepseek: DeepseekLogo,
+  xai: GrokLogo,
+  zai: ZaiLogo,
+  moonshot: MoonshotLogo,
+  minimax: MinimaxLogo,
+};
+
+function groupByModelMaker(models: PublicModelCredit[]): ProviderSection[] {
+  const sectionByMaker = new Map<string, ProviderSection>();
+
+  for (const model of models) {
+    let section = sectionByMaker.get(model.modelMaker);
+    if (!section) {
+      section = {
+        provider: model.modelMakerDisplayName,
+        modelMaker: model.modelMaker,
+        rows: [],
+      };
+      sectionByMaker.set(model.modelMaker, section);
+    }
+    section.rows.push(model);
+  }
+
+  const sections = Array.from(sectionByMaker.values());
+  for (const section of sections) {
+    section.rows.sort((a, b) => a.displayName.localeCompare(b.displayName));
+  }
+  sections.sort((a, b) => a.provider.localeCompare(b.provider));
+
+  return sections;
+}
 
 // ---------- Subcomponents ----------
 
@@ -262,7 +108,7 @@ function Hero() {
   return (
     <section className="-mx-6 flex flex-col items-center px-4 pt-6 text-center md:mx-0 md:px-0 md:pt-10 lg:pt-14">
       <h1
-        className={classNames(
+        className={cn(
           "heading-5xl md:heading-6xl lg:heading-7xl",
           "mb-5 max-w-3xl text-balance text-foreground"
         )}
@@ -278,9 +124,13 @@ function Hero() {
   );
 }
 
-function ModelCreditsTable() {
+interface ModelCreditsTableProps {
+  providerSections: ProviderSection[];
+}
+
+function ModelCreditsTable({ providerSections }: ModelCreditsTableProps) {
   const [openSections, setOpenSections] = useState<Record<string, boolean>>(
-    () => Object.fromEntries(PROVIDER_SECTIONS.map((s) => [s.provider, true]))
+    () => Object.fromEntries(providerSections.map((s) => [s.provider, true]))
   );
 
   const toggleSection = (provider: string) => {
@@ -311,9 +161,9 @@ function ModelCreditsTable() {
             </th>
           </tr>
         </thead>
-        {PROVIDER_SECTIONS.map((section) => {
+        {providerSections.map((section) => {
           const isOpen = openSections[section.provider] ?? true;
-          const Logo = section.Logo;
+          const Logo = LOGO_BY_MODEL_MAKER[section.modelMaker] ?? null;
           return (
             <tbody
               key={section.provider}
@@ -334,7 +184,7 @@ function ModelCreditsTable() {
                     className="group flex w-full items-center justify-between gap-2 px-2 py-6 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
                   >
                     <span className="flex items-center gap-3">
-                      <Logo className="h-6 w-6 flex-shrink-0" />
+                      {Logo && <Logo className="h-6 w-6 flex-shrink-0" />}
                       <span className="heading-2xl font-semibold text-foreground">
                         {section.provider}
                       </span>
@@ -351,8 +201,8 @@ function ModelCreditsTable() {
               <AnimatePresence initial={false}>
                 {isOpen &&
                   section.rows.map((row, idx) => (
-                    <motion.tr
-                      key={`${section.provider}:${row.model}`}
+                    <m.tr
+                      key={`${section.provider}:${row.modelId}`}
                       data-row="model"
                       className={cn(
                         "grid grid-cols-2 md:table-row",
@@ -367,20 +217,20 @@ function ModelCreditsTable() {
                     >
                       <td className="col-span-2 block px-2 pb-1.5 pt-3.5 align-middle md:table-cell md:py-3.5 md:pb-3.5">
                         <span className="copy-sm block max-w-[560px] font-medium text-foreground">
-                          {row.model}
+                          {row.displayName}
                         </span>
                       </td>
                       <td className="block px-2 pb-3.5 pt-1.5 text-center align-middle tabular-nums md:table-cell md:w-[240px] md:px-5 md:py-3.5 md:pt-3.5">
                         <span className="copy-sm text-foreground">
-                          {row.inputCreditsPerMTokens}
+                          {row.inputCreditsPerMTokens.toLocaleString("en-US")}
                         </span>
                       </td>
                       <td className="block px-2 pb-3.5 pt-1.5 text-center align-middle tabular-nums md:table-cell md:w-[240px] md:px-5 md:py-3.5 md:pt-3.5">
                         <span className="copy-sm text-foreground">
-                          {row.outputCreditsPerMTokens}
+                          {row.outputCreditsPerMTokens.toLocaleString("en-US")}
                         </span>
                       </td>
-                    </motion.tr>
+                    </m.tr>
                   ))}
               </AnimatePresence>
             </tbody>
@@ -394,19 +244,21 @@ function ModelCreditsTable() {
 // ---------- Page ----------
 
 // biome-ignore lint/plugin/nextjsPageComponentNaming: matches pricing page pattern
-export default function Credits() {
+export default function Credits({ providerSections }: CreditsPageProps) {
   const router = useRouter();
 
   return (
-    <MotionConfig reducedMotion="user">
-      <PageMetadata
-        title="Dust Credits: Model Credit Consumption"
-        description="Intelligence credit consumption per model on Dust, in credits per million input and output tokens."
-        pathname={router.asPath}
-      />
-      <Hero />
-      <ModelCreditsTable />
-    </MotionConfig>
+    <LazyMotion features={domAnimation}>
+      <MotionConfig reducedMotion="user">
+        <PageMetadata
+          title="Dust Credits: Model Credit Consumption"
+          description="Intelligence credit consumption per model on Dust, in credits per million input and output tokens."
+          pathname={router.asPath}
+        />
+        <Hero />
+        <ModelCreditsTable providerSections={providerSections} />
+      </MotionConfig>
+    </LazyMotion>
   );
 }
 


### PR DESCRIPTION
## Description

Adds a new standalone `/credits` marketing page (`/home/credits`) listing intelligence credit consumption per model, grouped in collapsible provider sections with logos (OpenAI, Anthropic, Google, Mistral, xAI, DeepSeek, Z.ai, Moonshot AI). A permanent redirect from `/credits` → `/home/credits` is added in `next.config.js`. The page is not yet linked in the navigation.

## Tests

Manual: navigate to `/credits` and verify the redirect works, sections are collapsible, all provider logos render, and the disclaimer is visible.

## Risk

Low — new page only, no existing functionality changed.

## Deploy Plan

1. Deploy front 
2. Deploy marketing.