### PR TITLE
Fix: unread conversations in pod summary are enriched with the next wake up (so they show up in the correct section)

### DIFF
--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -3431,6 +3431,65 @@ describe("listSpaceUnreadConversationsForUser", () => {
     expect(allConversationIds).toContain(conversationIds[0]);
     expect(allConversationIds).not.toContain(subConversation.sId);
   });
+
+  it("hydrates nextWakeupAt on unread space conversations", async () => {
+    vi.spyOn(
+      wakeUpTemporalClient,
+      "launchOrScheduleWakeUpTemporalWorkflow"
+    ).mockResolvedValue(new Ok(undefined));
+
+    const agentConfiguration =
+      await AgentConfigurationFactory.createTestAgent(adminAuth);
+    const conversationResource = await ConversationResource.fetchById(
+      userAuth,
+      conversationIds[0]
+    );
+    assert(conversationResource, "Conversation not found");
+    const conversation = conversationResource.toJSON();
+
+    const scheduledFireAt = new Date("2030-01-01T12:00:00.000Z");
+    const cancelledFireAt = new Date("2029-01-01T12:00:00.000Z");
+
+    const cancelledWakeUpResult = await WakeUpResource.makeNew(
+      adminAuth,
+      {
+        scheduleType: "one_shot",
+        fireAt: cancelledFireAt,
+        cronExpression: null,
+        cronTimezone: null,
+        reason: "Cancelled wake-up",
+      },
+      conversation,
+      agentConfiguration
+    );
+    assert(cancelledWakeUpResult.isOk(), "Failed to create cancelled wake-up.");
+    await cancelledWakeUpResult.value.markCancelled(adminAuth);
+
+    const scheduledWakeUpResult = await WakeUpResource.makeNew(
+      adminAuth,
+      {
+        scheduleType: "one_shot",
+        fireAt: scheduledFireAt,
+        cronExpression: null,
+        cronTimezone: null,
+        reason: "Scheduled wake-up",
+      },
+      conversation,
+      agentConfiguration
+    );
+    assert(scheduledWakeUpResult.isOk(), "Failed to create scheduled wake-up.");
+
+    const userConversations =
+      await ConversationResource.listSpaceUnreadConversationsAndActivityForUser(
+        userAuth,
+        spaceModelIds
+      );
+    const item = userConversations.unreadConversations.find(
+      (c) => c.sId === conversationIds[0]
+    );
+
+    expect(item?.toJSON().nextWakeupAt).toBe(scheduledFireAt.getTime());
+  });
 });
 
 describe("Space Handling", () => {

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -166,6 +166,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   // User-specific fields (populated when conversations are listed for a user).
   private userParticipation?: UserParticipation;
   private userLastReadAt: Date | null = null;
+  private nextWakeupAt: number | null = null;
   private _forkingData?: ConversationForkingDataType;
 
   constructor(
@@ -1343,6 +1344,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       return new Map();
     }
     await this.enrichWithParticipationAndReadState(auth, conversations);
+    await this.enrichWithNextWakeupAt(auth, conversations);
     return new Map(conversations.map((c) => [c.sId, c.toListItem()]));
   }
 
@@ -1940,17 +1942,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const result = await this.fetchPrivateConversationsPaginated(auth, {
       pagination,
     });
-    const nextWakeupAtByConversationId =
-      await this.fetchNextWakeupAtByConversationId(
-        auth,
-        result.conversations.map((c) => c.id)
-      );
+    await this.enrichWithNextWakeupAt(auth, result.conversations);
 
     return {
-      conversations: result.conversations.map((c) => ({
-        ...c.toListItem(),
-        nextWakeupAt: nextWakeupAtByConversationId.get(c.id) ?? null,
-      })),
+      conversations: result.conversations.map((c) => c.toListItem()),
       hasMore: result.hasMore,
       lastValue: result.lastValue,
     };
@@ -1961,18 +1956,18 @@ export class ConversationResource extends BaseResource<ConversationModel> {
    * depends on `ConversationResource` to reuse the established conversation ES reindexing path.
    * This is all to avoid import cycles.
    */
-  private static async fetchNextWakeupAtByConversationId(
+  private static async enrichWithNextWakeupAt(
     auth: Authenticator,
-    conversationIds: ModelId[]
-  ): Promise<Map<ModelId, number>> {
-    if (conversationIds.length === 0) {
-      return new Map();
+    conversations: ConversationResource[]
+  ): Promise<void> {
+    if (conversations.length === 0) {
+      return;
     }
 
     const wakeUps = await WakeUpModel.findAll({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
-        conversationId: { [Op.in]: conversationIds },
+        conversationId: { [Op.in]: conversations.map((c) => c.id) },
         status: ACTIVE_WAKE_UP_STATUSES,
       },
       order: [
@@ -2015,7 +2010,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       }
     }
 
-    return nextWakeupAtByConversationId;
+    for (const conversation of conversations) {
+      conversation.nextWakeupAt =
+        nextWakeupAtByConversationId.get(conversation.id) ?? null;
+    }
   }
 
   static async listSpaceUnreadConversationsAndActivityForUser(
@@ -2082,6 +2080,12 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         !participantConversationIds.has(c.id) &&
         (c.userLastReadAt === null || c.updatedAt > c.userLastReadAt)
     );
+
+    // Hydrate next wake-up only for conversations returned to the summary (sidebar inbox).
+    await this.enrichWithNextWakeupAt(auth, [
+      ...unreadConversations,
+      ...nonParticipantUnreadConversations,
+    ]);
 
     const lastUserActivityBySpace = new Map<number, Date>();
 
@@ -5176,7 +5180,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       hasError: this.hasError,
       lastReadMs: this.userLastReadAt?.getTime() ?? null,
       metadata: this.metadata ?? {},
-      nextWakeupAt: null,
+      nextWakeupAt: this.nextWakeupAt,
       requestedSpaceIds: this.getRequestedSpaceIdsFromModel(),
       sId: this.sId,
       spaceId: this.space?.sId ?? null,


### PR DESCRIPTION
## Description

`listSpaceUnreadConversationsAndActivityForUser` was never calling `enrichWithNextWakeupAt`, so `nextWakeupAt` was always `null` on conversations returned in the pod sidebar summary. As a result, conversations with an active scheduled wake-up were missing from the "Triggered" section and landing in the wrong inbox bucket.

Fix: call `enrichWithNextWakeupAt` on `unreadConversations` + `nonParticipantUnreadConversations` before building the summary. Also refactors `fetchNextWakeupAtByConversationId` → `enrichWithNextWakeupAt` to mutate instances directly (storing `nextWakeupAt` as an instance field), so `toListItem()` can read it instead of hardcoding `null`.

## Tests

Added a unit test in `conversation_resource.test.ts` that creates both a cancelled and a scheduled `WakeUpResource` for an unread conversation, then asserts `listSpaceUnreadConversationsAndActivityForUser` returns the correct `nextWakeupAt` timestamp (and ignores the cancelled one).

## Risk

Low. Pure bug fix — adds one `WakeUpModel.findAll` query in a path that was already missing it (the same query already ran in the private conversations path). No schema changes, no API contract changes. Safe to rollback.

## Deploy Plan

Deploy front.
