### PR TITLE
Hide internal skills from capability pickers

### DIFF
--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -321,6 +321,25 @@ describe("GET /api/w/:wId/skills", () => {
     expect(customOnlySIds).toContain(customSkill.sId);
   });
 
+  it("excludes internal runtime skills from user-selectable results", async () => {
+    const { workspace, auth } = await setupTest();
+    await FeatureFlagFactory.basic(auth, "goal_mode");
+
+    const allSkillIds = (await (await getSkills(workspace)).json()).skills.map(
+      (skill: SkillWithoutInstructionsAndToolsType) => skill.sId
+    );
+    expect(allSkillIds).toContain("goal_mode");
+
+    const response = await getSkills(workspace, {
+      userSelectableOnly: "true",
+    });
+    expect(response.status).toBe(200);
+    const selectableSkillIds = (await response.json()).skills.map(
+      (skill: SkillWithoutInstructionsAndToolsType) => skill.sId
+    );
+    expect(selectableSkillIds).not.toContain("goal_mode");
+  });
+
   it("should return suggested skills when status=suggested", async () => {
     const { workspace, user } = await setupTest();
 

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -132,6 +132,7 @@ app.get(
     const status = ctx.req.query("status");
     const globalSpaceOnly = ctx.req.query("globalSpaceOnly");
     const onlyCustom = ctx.req.query("onlyCustom");
+    const userSelectableOnly = ctx.req.query("userSelectableOnly") === "true";
     // @deprecated Use availability instead. Kept while old clients still send it.
     const isDefault = ctx.req.query("isDefault");
     const bypassEditorVisibility =
@@ -193,9 +194,12 @@ app.get(
 
     // Skills with editors-only availability (unpublished) are only listed for members of
     // their editor group.
+    const visibleSkills = userSelectableOnly
+      ? allSkills.filter((skill) => skill.isUserSelectable)
+      : allSkills;
     const skills = bypassEditorVisibility
-      ? allSkills
-      : allSkills.filter(
+      ? visibleSkills
+      : visibleSkills.filter(
           (skill) => skill.availability !== "editors" || skill.canWrite(auth)
         );
 

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -258,6 +258,7 @@ export function CapabilitiesPicker({
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
+    userSelectableOnly: true,
     swrOptions: CAPABILITIES_SWR_OPTIONS,
   });
 

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.test.ts
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.test.ts
@@ -10,6 +10,7 @@ import {
   getAvailableInputBarSlashCommands,
   INPUT_BAR_SLASH_COMMANDS,
   type InputBarSlashCommand,
+  isInputBarSlashCommandArgumentQuery,
 } from "./InputBarSlashSuggestionTypes";
 
 const ALL_COMMANDS = getAvailableInputBarSlashCommands({
@@ -55,6 +56,35 @@ describe("getAvailableInputBarSlashCommands", () => {
         hasGoalMode: true,
       }).map((command) => command.id)
     ).toEqual(["goal"]);
+  });
+});
+
+describe("isInputBarSlashCommandArgumentQuery", () => {
+  it("identifies text after an argument-taking command", () => {
+    expect(
+      isInputBarSlashCommandArgumentQuery({
+        commands: ALL_COMMANDS,
+        query: "goal Ship and verify the feature",
+      })
+    ).toBe(true);
+  });
+
+  it("keeps suggestions open until the command argument starts", () => {
+    expect(
+      isInputBarSlashCommandArgumentQuery({
+        commands: ALL_COMMANDS,
+        query: "goal",
+      })
+    ).toBe(false);
+  });
+
+  it("keeps multi-word capability searches open", () => {
+    expect(
+      isInputBarSlashCommandArgumentQuery({
+        commands: ALL_COMMANDS,
+        query: "create a",
+      })
+    ).toBe(false);
   });
 });
 

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
@@ -1,5 +1,8 @@
 import { InputBarSlashSuggestionDropdown } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown";
-import type { InputBarSlashCommand } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
+import {
+  isInputBarSlashCommandArgumentQuery,
+  type InputBarSlashCommand,
+} from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
 import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
 import { createSlashSuggestionExtension } from "@app/components/editor/extensions/shared/slash_suggestion/SlashSuggestionExtension";
 import {
@@ -75,8 +78,13 @@ export const InputBarSlashSuggestionExtension = createSlashSuggestionExtension<
     (editor.isFocused || isActive) &&
     storage.dismissedTriggerStart !== range.from &&
     isAllowedSlashQuery(state, range),
-  shouldShow: ({ transaction }) =>
-    !transaction.getMeta("paste") && transaction.getMeta("uiEvent") !== "paste",
+  shouldShow: ({ options, query, transaction }) =>
+    !transaction.getMeta("paste") &&
+    transaction.getMeta("uiEvent") !== "paste" &&
+    !isInputBarSlashCommandArgumentQuery({
+      commands: options.slashCommandsRef.current ?? [],
+      query,
+    }),
   items: () => [],
   command: ({ editor, range, props, options, storage }) => {
     storage.dismissedTriggerStart = null;

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes.ts
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes.ts
@@ -25,6 +25,7 @@ export const INPUT_BAR_SLASH_COMMAND_ORDER: InputBarSlashCommandId[] = [
 // Static command offered by the input bar `/` dropdown, as opposed to workspace capabilities
 // (skills and tools) which are fetched.
 export interface InputBarSlashCommand {
+  acceptsArguments?: boolean;
   description: string;
   icon: React.ComponentType;
   id: InputBarRunCommandId;
@@ -33,6 +34,7 @@ export interface InputBarSlashCommand {
 
 export const INPUT_BAR_SLASH_COMMANDS: InputBarSlashCommand[] = [
   {
+    acceptsArguments: true,
     description: "Keep working autonomously until an objective is complete",
     icon: Target04,
     id: "goal",
@@ -76,6 +78,20 @@ export function getAvailableInputBarSlashCommands({
 
     return true;
   });
+}
+
+export function isInputBarSlashCommandArgumentQuery({
+  commands,
+  query,
+}: {
+  commands: InputBarSlashCommand[];
+  query: string;
+}) {
+  const commandName = query.match(/^(\S+)\s/)?.[1]?.toLowerCase();
+
+  return commands.some(
+    (command) => command.acceptsArguments && command.id === commandName
+  );
 }
 
 export type InputBarSlashCommandSkill = SkillWithoutInstructionsAndToolsType;

--- a/front/components/editor/extensions/shared/slash_suggestion/SlashSuggestionExtension.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/SlashSuggestionExtension.ts
@@ -31,8 +31,10 @@ export interface SlashSuggestionShouldShowContext<
 > {
   editor: Editor;
   options: Options;
+  query: string;
   range: Range;
   storage: Storage;
+  text: string;
   transaction: Transaction;
 }
 
@@ -186,11 +188,13 @@ export function createSlashSuggestionExtension<
             ),
           ...(shouldShow
             ? {
-                shouldShow: ({ editor, range, transaction }) =>
+                shouldShow: ({ editor, query, range, text, transaction }) =>
                   Boolean(
                     shouldShow({
                       editor,
+                      query,
                       range,
+                      text,
                       transaction,
                       options: extensionOptions,
                       storage: extensionStorage,

--- a/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
@@ -76,6 +76,7 @@ export function useInputBarSlashCommandCapabilities({
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
+    userSelectableOnly: true,
     swrOptions: CAPABILITIES_SWR_OPTIONS,
   });
   // The JIT views endpoint only returns views whose tools can be enabled directly in a
@@ -128,6 +129,7 @@ export function useSkillBuilderSlashCommandCapabilities({
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
+    userSelectableOnly: true,
   });
   const { serverViews, isLoading: isServerViewsLoading } =
     useMCPServerViewsFromSpaces(owner, spaces);

--- a/front/components/editor/input_bar/useCustomEditor.test.ts
+++ b/front/components/editor/input_bar/useCustomEditor.test.ts
@@ -2,6 +2,7 @@ import {
   InputBarSlashSuggestionExtension,
   inputBarSlashSuggestionPluginKey,
 } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension";
+import { INPUT_BAR_SLASH_COMMANDS } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
 import { buildEditorExtensions } from "@app/components/editor/input_bar/useCustomEditor";
 import type { WorkspaceType } from "@app/types/user";
 import { Editor } from "@tiptap/react";
@@ -35,7 +36,7 @@ describe("buildEditorExtensions", () => {
           onNodeSelectRef: { current: undefined },
           onSelectRef: { current: undefined },
           selectedMCPServerViewIdsRef: { current: new Set<string>() },
-          slashCommandsRef: { current: [] },
+          slashCommandsRef: { current: INPUT_BAR_SLASH_COMMANDS },
           includeAttachKnowledgeRef: { current: false },
           spaceIdRef: { current: null },
         }),
@@ -243,6 +244,24 @@ describe("buildEditorExtensions", () => {
         .setMeta("uiEvent", "paste")
     );
 
+    expect(
+      inputBarSlashSuggestionPluginKey.getState(editor.state)?.active
+    ).toBe(false);
+  });
+
+  it("closes slash suggestions when goal arguments start", () => {
+    editor.destroy();
+    editor = createSlashSuggestionEditor();
+    editor.isFocused = true;
+    editor.storage.inputBarSlashSuggestion.hasBeenFocused = true;
+
+    editor.commands.insertContent("/goal");
+    expect(
+      inputBarSlashSuggestionPluginKey.getState(editor.state)?.active
+    ).toBe(true);
+
+    editor.commands.insertContent(" Ship and verify the feature");
+    expect(editor.getText()).toBe("/goal Ship and verify the feature");
     expect(
       inputBarSlashSuggestionPluginKey.getState(editor.state)?.active
     ).toBe(false);

--- a/front/lib/resources/skill/code_defined/global_registry.ts
+++ b/front/lib/resources/skill/code_defined/global_registry.ts
@@ -55,6 +55,10 @@ export class GlobalSkillsRegistry {
     });
   }
 
+  static isUserSelectable(sId: string): boolean {
+    return this.getByIdInternal(sId)?.isUserSelectable ?? true;
+  }
+
   static doesSkillInheritAgentConfigurationDataSources(sId: string): boolean {
     return (
       this.getByIdInternal(sId)?.inheritAgentConfigurationDataSources ?? false

--- a/front/lib/resources/skill/code_defined/shared.ts
+++ b/front/lib/resources/skill/code_defined/shared.ts
@@ -38,6 +38,9 @@ interface BaseSkillDefinition<
   // Defaults to false: code-defined skill instructions are hidden by default and
   // opted in per skill (e.g. docs/pptx/xlsx). System skills stay hidden.
   readonly exposeInstructions?: boolean;
+  // Defaults to true. Internal runtime skills can opt out of capability pickers
+  // while remaining available for contextual auto-enablement.
+  readonly isUserSelectable?: boolean;
   readonly isRestricted?: (auth: Authenticator) => Promise<boolean>;
   // Optional callback to auto-add a code-defined skill for an agent loop
   // (subject to isRestricted), without adding it to the agent configuration.

--- a/front/lib/resources/skill/code_defined/system/goal_mode.ts
+++ b/front/lib/resources/skill/code_defined/system/goal_mode.ts
@@ -41,6 +41,7 @@ You are running in Goal Mode. The user has deliberately asked you to keep workin
   mcpServers: [{ name: GOAL_MODE_SERVER_NAME }],
   version: 1,
   icon: "ActionCheckCircleIcon",
+  isUserSelectable: false,
   isRestricted: async (auth: Authenticator) => {
     const featureFlags = await getFeatureFlags(auth);
     return !featureFlags.includes("goal_mode");

--- a/front/lib/resources/skill/code_defined/system_registry.ts
+++ b/front/lib/resources/skill/code_defined/system_registry.ts
@@ -45,6 +45,10 @@ export class SystemSkillsRegistry {
     return this.getByIdInternal(sId) !== undefined;
   }
 
+  static isUserSelectable(sId: string): boolean {
+    return this.getByIdInternal(sId)?.isUserSelectable ?? true;
+  }
+
   static doesSkillInheritAgentConfigurationDataSources(sId: string): boolean {
     return (
       this.getByIdInternal(sId)?.inheritAgentConfigurationDataSources ?? false

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -389,6 +389,16 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     return SystemSkillsRegistry.isSystemSkill(this.sId);
   }
 
+  get isUserSelectable(): boolean {
+    if (!this.globalSId) {
+      return true;
+    }
+
+    return this.isSystemSkill
+      ? SystemSkillsRegistry.isUserSelectable(this.globalSId)
+      : GlobalSkillsRegistry.isUserSelectable(this.globalSId);
+  }
+
   get inheritsAgentConfigurationDataSources(): boolean {
     if (!this.globalSId) {
       return false;

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -101,6 +101,7 @@ export function useSkills({
   status,
   globalSpaceOnly,
   availability,
+  userSelectableOnly,
   bypassEditorVisibility,
   swrOptions,
 }: {
@@ -109,6 +110,7 @@ export function useSkills({
   status?: SkillStatus;
   globalSpaceOnly?: boolean;
   availability?: SkillAvailability | SkillAvailability[];
+  userSelectableOnly?: boolean;
   // Admin-only: bypass the editor-visibility rule and also list unpublished
   // (editors-only) skills the caller does not edit.
   bypassEditorVisibility?: boolean;
@@ -135,6 +137,9 @@ export function useSkills({
     for (const value of availabilities) {
       queryParams.append("availability", value);
     }
+  }
+  if (userSelectableOnly) {
+    queryParams.set("userSelectableOnly", "true");
   }
   if (bypassEditorVisibility) {
     queryParams.set("bypassEditorVisibility", "true");


### PR DESCRIPTION
## Description

Mark Goal Mode as an internal, non-user-selectable system skill and request only user-selectable skills from conversation and slash capability pickers. The `/goal` command remains discoverable, and an active goal continues to auto-enable the Goal Mode instructions and tool at runtime.

Treat argument-taking slash commands explicitly: after `/goal` is selected and its trailing space is inserted, the slash suggestion session closes instead of filtering capabilities with the goal objective.

Stacked on #29709.

## Tests

- Goal Mode system-skill tests verify contextual auto-enablement.
- Skills API tests verify Goal Mode remains fetchable normally but is omitted from user-selectable results.
- Slash suggestion unit and plugin-level tests verify `/goal` is suggested, closes when arguments start, and does not change multi-word capability search.
- Front and front-api TypeScript checks pass.
- Visual verification shows one Goal command, no Goal Mode capability entry, and no suggestion popover while editing `/goal Ship and verify the feature`.

## Risk

Low. The new API query parameter is optional and backward compatible. Existing skill lists are unchanged unless a caller explicitly requests user-selectable skills only. Argument handling is opt-in metadata on the Goal command, so other slash searches keep their current behavior.

## Deploy Plan

Merge after #29709. Keep the existing `goal_mode` feature flag rollout.