### PR TITLE
[front] reset search input in group dropdown and fix label 

### DIFF
--- a/front/components/pages/workspace/governance/GroupSelector.tsx
+++ b/front/components/pages/workspace/governance/GroupSelector.tsx
@@ -37,7 +37,13 @@ export const GroupSelector = ({
   const selectedGroupIds = selectedGroups.map((g) => g.sId);
   return (
     <div className="flex items-center gap-2 flex-wrap">
-      <DropdownMenu>
+      <DropdownMenu
+        onOpenChange={(open) => {
+          if (open) {
+            setGroupSearch("");
+          }
+        }}
+      >
         <DropdownMenuTrigger asChild>
           <Button
             variant="outline"

--- a/front/components/skills/SkillsBatchEdit.tsx
+++ b/front/components/skills/SkillsBatchEdit.tsx
@@ -25,10 +25,10 @@ export type BatchAvailabilityAction = {
 
 const BATCH_AVAILABILITY_ACTIONS: BatchAvailabilityAction[] = [
   {
-    label: "Editor only",
+    label: "Editors only",
     availability: "editors",
     getDialogTitle: (count) =>
-      `Make ${count} skill${pluralize(count)} editor only`,
+      `Make ${count} skill${pluralize(count)} editors only`,
     dialogDescription: (count) =>
       count === 1
         ? "Non-editors won’t see this skill as an option in the builder. Agents and skills that already use it won’t lose access."

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -48,7 +48,7 @@ export const SKILL_AVAILABILITY_DISPLAY: Record<
   SkillAvailability,
   { label: string; color: "primary" | "success" | "highlight" }
 > = {
-  editors: { label: "Editor only", color: "primary" },
+  editors: { label: "Editors only", color: "primary" },
   workspace_users: { label: "Workspace members", color: "success" },
   users_and_agents: { label: "Auto-discoverable", color: "highlight" },
 };


### PR DESCRIPTION
## Description
This PR is to reset the search input bar of group dropdown in admin governance page + fix label for editors only
 
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
