### PR TITLE
[front] Add cost.billable_awu to agent message analytics

### DIFF
--- a/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
+++ b/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
@@ -103,6 +103,9 @@
         },
         "tool_awu": {
           "type": "integer"
+        },
+        "billable_awu": {
+          "type": "integer"
         }
       }
     },

--- a/front/lib/analytics/migrations/20260729_add_billable_awu_to_agent_message_analytics_2.http
+++ b/front/lib/analytics/migrations/20260729_add_billable_awu_to_agent_message_analytics_2.http
@@ -1,0 +1,13 @@
+PUT /front.agent_message_analytics_2/_mapping
+{
+  "properties": {
+    "cost": {
+      "type": "object",
+      "properties": {
+        "billable_awu": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/front/lib/analytics/migrations/20260729_backfill_billable_awu_to_agent_message_analytics_2.http
+++ b/front/lib/analytics/migrations/20260729_backfill_billable_awu_to_agent_message_analytics_2.http
@@ -1,0 +1,35 @@
+POST /front.agent_message_analytics_2/_update_by_query?wait_for_completion=false&slices=auto&scroll_size=5000&requests_per_second=10000
+{
+  "conflicts": "proceed",
+  "script": {
+    "lang": "painless",
+    "source": "if (ctx._source.cost == null) { return; } int full = ctx._source.cost.full_awu != null ? (int) ctx._source.cost.full_awu : 0; boolean tracked = ctx._source.status != null && params.tracked_statuses.contains(ctx._source.status); ctx._source.cost.billable_awu = tracked ? full : 0;",
+    "params": {
+      "tracked_statuses": [
+        "created",
+        "succeeded",
+        "cancelled",
+        "interrupted",
+        "gracefully_stopped"
+      ]
+    }
+  },
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "exists": {
+            "field": "cost.full_awu"
+          }
+        }
+      ],
+      "must_not": [
+        {
+          "exists": {
+            "field": "cost.billable_awu"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/front/scripts/backfill_billable_awu_from_db_for_failed_messages.ts
+++ b/front/scripts/backfill_billable_awu_from_db_for_failed_messages.ts
@@ -1,0 +1,163 @@
+import { ANALYTICS_ALIAS_NAME, withEs } from "@app/lib/api/elasticsearch";
+import {
+  AgentMessageModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { makeScript } from "@app/scripts/helpers";
+
+// Pass 2 of the `cost.billable_awu` backfill (pass 1 is the ES-internal
+// `20260729_backfill_billable_awu_...http`, which sets billable_awu = full_awu
+// for tracked statuses and 0 for `failed`). This pass recovers the billable
+// portion of `failed` messages: a message that ended `failed` but did real work
+// in a non-error execution (interrupt/resume) has a DB `costCredits` that already
+// excludes the errored terminal execution and is ceiled per execution — the exact
+// billable amount. We copy that into `cost.billable_awu` for the failed ES docs.
+// Docs whose message has no DB `costCredits` (never populated / message purged)
+// keep the 0 that pass 1 wrote, which matches the pre-existing reconciliation
+// (failed messages were excluded), so there is no regression.
+//
+// New writes already set billable_awu from costCredits, so this only touches
+// historical `failed` docs. ES `_id` comes straight from the search hits, so we
+// don't recompute the hashed document id.
+
+interface FailedDocHit {
+  _id: string;
+  message_id: string;
+  version: number;
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      demandOption: false,
+      description: "Restrict to a single workspace sId (defaults to all).",
+    },
+    batchSize: { type: "number", default: 1000 },
+  },
+  async ({ workspaceId, batchSize, execute }, logger) => {
+    let workspaceModelId: number | null = null;
+    let workspaceSId: string | null = null;
+    if (workspaceId) {
+      const workspace = await WorkspaceResource.fetchById(workspaceId);
+      if (!workspace) {
+        logger.error({ workspaceId }, "Workspace not found.");
+        return;
+      }
+      workspaceModelId = workspace.id;
+      workspaceSId = workspace.sId;
+    }
+
+    let searchAfter: (string | number)[] | undefined = undefined;
+    let scanned = 0;
+    let updated = 0;
+
+    for (;;) {
+      // Read a page of `failed` docs (tie-break on message_id for a stable
+      // search_after cursor). Scoped to the workspace when provided.
+      const filter: Record<string, unknown>[] = [
+        { term: { status: "failed" } },
+      ];
+      if (workspaceSId) {
+        filter.push({ term: { workspace_id: workspaceSId } });
+      }
+
+      const pageRes = await withEs(async (client) =>
+        client.search<{
+          message_id: string;
+          version: string;
+          cost?: { billable_awu?: number };
+        }>({
+          index: ANALYTICS_ALIAS_NAME,
+          size: batchSize,
+          sort: [{ timestamp: "asc" }, { message_id: "asc" }],
+          ...(searchAfter ? { search_after: searchAfter } : {}),
+          query: { bool: { filter } },
+          _source: ["message_id", "version"],
+        })
+      );
+      if (pageRes.isErr()) {
+        logger.error({ err: pageRes.error }, "ES search failed.");
+        return;
+      }
+
+      const hits = pageRes.value.hits.hits;
+      if (hits.length === 0) {
+        break;
+      }
+      searchAfter = hits[hits.length - 1].sort as (string | number)[];
+      scanned += hits.length;
+
+      const docs: FailedDocHit[] = hits
+        .filter((h) => h._id && h._source?.message_id != null)
+        .map((h) => ({
+          _id: h._id as string,
+          message_id: h._source!.message_id,
+          version: Number(h._source!.version ?? 0),
+        }));
+
+      // Look up DB costCredits for this page's messages in one query, keyed by
+      // `${sId}:${version}` since a message sId can have multiple versions.
+      const messageRows = await MessageModel.findAll({
+        where: {
+          sId: docs.map((d) => d.message_id),
+          ...(workspaceModelId ? { workspaceId: workspaceModelId } : {}),
+        },
+        include: [
+          { model: AgentMessageModel, as: "agentMessage", required: true },
+        ],
+      });
+      const costBySIdVersion = new Map<string, number>();
+      for (const row of messageRows) {
+        const costCredits = row.agentMessage?.costCredits;
+        if (costCredits != null && costCredits > 0) {
+          costBySIdVersion.set(`${row.sId}:${row.version}`, costCredits);
+        }
+      }
+
+      const bulkOps: object[] = [];
+      for (const doc of docs) {
+        const costCredits = costBySIdVersion.get(
+          `${doc.message_id}:${doc.version}`
+        );
+        if (costCredits === undefined) {
+          continue;
+        }
+        bulkOps.push(
+          { update: { _id: doc._id, _index: ANALYTICS_ALIAS_NAME } },
+          { doc: { cost: { billable_awu: costCredits } } }
+        );
+      }
+
+      if (bulkOps.length > 0) {
+        if (execute) {
+          const bulkRes = await withEs(async (client) =>
+            client.bulk({ operations: bulkOps, refresh: false })
+          );
+          if (bulkRes.isErr()) {
+            logger.error({ err: bulkRes.error }, "ES bulk update failed.");
+            return;
+          }
+          if (bulkRes.value.errors) {
+            logger.error(
+              { firstItem: bulkRes.value.items?.[0] },
+              "ES bulk update reported item errors."
+            );
+            return;
+          }
+        }
+        updated += bulkOps.length / 2;
+      }
+
+      logger.info({ scanned, updated, execute }, "Progress");
+    }
+
+    logger.info(
+      { scanned, updated, execute },
+      execute
+        ? "Backfill complete."
+        : "Dry run complete (use --execute to apply)."
+    );
+  }
+);

--- a/front/scripts/dev/seed_programmatic_usage.ts
+++ b/front/scripts/dev/seed_programmatic_usage.ts
@@ -115,6 +115,7 @@ async function seedProgrammaticUsage(
         full_awu: awuFromMicroUsd(costMicroUsd),
         llm_awu: awuFromMicroUsd(costMicroUsd),
         tool_awu: 0,
+        billable_awu: awuFromMicroUsd(costMicroUsd),
       },
       context_origin: "api",
       latency_ms: randomInt(LATENCY_MS_RANGE.min, LATENCY_MS_RANGE.max),

--- a/front/scripts/seed/factories/seedAnalytics.ts
+++ b/front/scripts/seed/factories/seedAnalytics.ts
@@ -138,6 +138,7 @@ export async function seedAnalytics(
         full_awu: 0,
         llm_awu: 0,
         tool_awu: 0,
+        billable_awu: 0,
       },
       context_origin: "web",
       latency_ms: agentMessage.modelInteractionDurationMs ?? 0,

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -65,6 +65,7 @@ import type {
 } from "@app/types/assistant/analytics";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
+import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 import { sha256 } from "@app/types/shared/utils/encryption";
 import type { WhereOptions } from "sequelize";
@@ -240,10 +241,18 @@ export async function storeAgentAnalytics(
     contextOrigin
   );
   const toolAwu = toolsUsed.reduce((sum, tool) => sum + tool.cost_awu, 0);
+
+  const isBillable = AGENT_MESSAGE_STATUSES_TO_TRACK.includes(
+    agentAgentMessageRow.status
+  );
+
   const cost = {
     full_awu: llmAwu + toolAwu,
     llm_awu: llmAwu,
     tool_awu: toolAwu,
+    billable_awu: isBillable
+      ? llmAwu + toolAwu
+      : (agentAgentMessageRow.costCredits ?? 0),
   };
 
   // TODO: replace with a recursive research of ancestor messages

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -36,6 +36,7 @@ export interface AgentMessageAnalyticsCost {
   full_awu: number;
   llm_awu: number;
   tool_awu: number;
+  billable_awu: number;
 }
 
 export interface AgentMessageAnalyticsFeedback {


### PR DESCRIPTION
## Description

ES analytics under-counts consumed credits relative to Metronome because it drops
failed-terminal messages **whole**, discarding the legitimate work of their non-error
executions.

The billing policy (matching Metronome) is per **execution**: a message can run across
multiple agent-loop executions (interrupt/resume); every non-error execution is billed,
and only the terminal errored execution is not. The message table (`costCredits`) and the
rate-limiter counters already implement this — `computeAndStoreAgentMessageCredits`
recomputes the message total, gates on the terminal status (errors are terminal, so their
cost is never folded in), ceils per execution, and records the delta. But the ES
reconciliation read sums `cost.full_awu` (the gross recompute) filtered by
`status ∈ AGENT_MESSAGE_STATUSES_TO_TRACK`, so a `failed`-terminal message is excluded
entirely — even the work of an earlier non-error execution.

Evidence (prod, workspace `YFqbaksbN0`): message `l7G4uvGoCV` ran two executions of the
same agent-loop workflow — run 1 (`finalizeSuccessful`, paused with the message still
`created`) did ~20 steps and was correctly billed 265 AWU in Metronome; run 2
(`finalizeCreditStopped`) committed `failed`. Metronome (per execution) kept run 1; ES
dropped the whole message. That gap (`l7G4uvGoCV` + a second failed message) is the entire
ES-vs-Metronome divergence that cycle (ES 3712 vs Metronome 4199).

**This PR** adds a per-execution billable field to the `agent_message_analytics` index and
starts writing it; it does **not** change any read yet.

- `cost.billable_awu` = the message's persisted `costCredits`, which already excludes the
  errored terminal execution and is ceiled per execution — so ES, the message table, and
  the rate-limiter counters are all anchored on the same value. Equals `full_awu` for
  non-failed messages; smaller for failed multi-execution messages (only the non-error runs
  count); `0` for a single-execution failure.
- `cost.full_awu` is unchanged (gross recompute) for dashboards / exports / message counts.
- The free/paid seat split (`is_free_seat`) is orthogonal and untouched.

Reads (`fetchConsumedAwuCreditsByUserId` → members "Consumed (ES)", poke, and the spend-cap
seed `getEsConsumedAwuCreditsForUser`) are repointed to `billable_awu` in the **stacked
follow-up #29734**, which must merge only after the backfill below has run — otherwise the
cap would read a half-populated field.

## Changes

- `types/assistant/analytics.ts`: `billable_awu: number` on `AgentMessageAnalyticsCost`.
- `lib/analytics/indices/agent_message_analytics_2.mappings.json`: `cost.billable_awu` (integer).
- `lib/analytics/migrations/20260729_add_billable_awu_…http`: `PUT /_mapping` to add the field
  to the live v2 index.
- `temporal/analytics_queue/activities.ts`: write `cost.billable_awu = costCredits ?? 0`.
- `lib/analytics/migrations/20260729_backfill_billable_awu_…http`: backfill pass 1.
- `scripts/backfill_billable_awu_from_db_for_failed_messages.ts`: backfill pass 2.
- Seed factories updated to populate the new field.

## Tests

- `npx tsgo --noEmit` clean; `biome check` clean.
- No new automated test (index mapping + Temporal indexing; verified against the prod
  reconciliation above). New writes set the field; existing reads are unchanged, so this
  deploy is behavior-neutral until the backfill + #29734.

## Risk

Low for this PR in isolation: it only adds a mapping field and writes it; nothing reads it
yet. `full_awu` and all existing aggregations are untouched, so dashboards/exports/counts
are unaffected. The behavioral change lands with #29734, gated on the backfill.

## Deploy Plan

1. Merge & deploy this PR (new docs start carrying `billable_awu`).
2. Apply the mapping: run `20260729_add_billable_awu_to_agent_message_analytics_2.http`.
3. Backfill pass 1 (ES-internal, no DB): run
   `20260729_backfill_billable_awu_to_agent_message_analytics_2.http`
   (`billable_awu = full_awu` for tracked statuses, `0` for `failed`) — reproduces today's
   numbers, covers the deep ES history.
4. Backfill pass 2 (DB, failed docs only): run
   `npx tsx front/scripts/backfill_billable_awu_from_db_for_failed_messages.ts --execute`
   to recover the non-error work (`run1`) of failed multi-execution messages from DB
   `costCredits`. Dry-run first (omit `--execute`).
5. Once the backfill is confirmed, mark #29734 ready and merge to switch the reads.

Stacked follow-up: #29734.
