### PR TITLE
[front] Repoint credit reads to cost.billable_awu

### DIFF
--- a/front/lib/api/analytics/agents_export.ts
+++ b/front/lib/api/analytics/agents_export.ts
@@ -3,7 +3,6 @@ import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
-import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
@@ -14,9 +13,7 @@ type TopAgentExportBucket = {
   doc_count: number;
   unique_users?: estypes.AggregationsCardinalityAggregate;
   unique_conversations?: estypes.AggregationsCardinalityAggregate;
-  credits?: estypes.AggregationsFilterAggregate & {
-    total?: estypes.AggregationsSumAggregate;
-  };
+  credits?: estypes.AggregationsSumAggregate;
 };
 
 type TopAgentsExportAggs = {
@@ -102,13 +99,10 @@ export async function fetchAgentExportRows(
             unique_conversations: {
               cardinality: { field: "conversation_id" },
             },
-            // Credits mirror the billed scope (failed messages carry a cost in
-            // the index but are never billed), while the count metrics above
-            // stay inclusive of all activity.
-            credits: {
-              filter: { terms: { status: AGENT_MESSAGE_STATUSES_TO_TRACK } },
-              aggs: { total: { sum: { field: "cost.full_awu" } } },
-            },
+            // Billed credits per execution via `cost.billable_awu` (0 for the
+            // non-billable errored-terminal part), so no status filter is needed;
+            // the count metrics above stay inclusive of all activity.
+            credits: { sum: { field: "cost.billable_awu" } },
           },
         },
       },
@@ -131,7 +125,7 @@ export async function fetchAgentExportRows(
         messages: b.doc_count,
         distinctUsersReached: Math.round(b.unique_users?.value ?? 0),
         distinctConversations: Math.round(b.unique_conversations?.value ?? 0),
-        credits: Math.round(b.credits?.total?.value ?? 0),
+        credits: Math.round(b.credits?.value ?? 0),
       },
     ])
   );

--- a/front/lib/api/analytics/messages_export.ts
+++ b/front/lib/api/analytics/messages_export.ts
@@ -205,7 +205,7 @@ export async function fetchMessageExportRows({
       modelId: doc.model?.model_id ?? "",
       modelProviderId: doc.model?.provider_id ?? "",
       modelResolutionMethod: doc.model?.resolution_method ?? "",
-      credits: Math.round(doc.cost?.full_awu ?? 0),
+      credits: Math.round(doc.cost?.billable_awu ?? 0),
     };
   });
 

--- a/front/lib/api/analytics/users_export.ts
+++ b/front/lib/api/analytics/users_export.ts
@@ -2,7 +2,6 @@ import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { getUserGroupMemberships } from "@app/lib/workspace_usage";
-import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
@@ -15,9 +14,7 @@ type TopUserExportBucket = {
   doc_count: number;
   last_message?: estypes.AggregationsMaxAggregate;
   active_days?: estypes.AggregationsDateHistogramAggregate;
-  credits?: estypes.AggregationsFilterAggregate & {
-    total?: estypes.AggregationsSumAggregate;
-  };
+  credits?: estypes.AggregationsSumAggregate;
 };
 
 type TopUsersExportAggs = {
@@ -79,13 +76,10 @@ export async function fetchUserExportRows({
                 time_zone: timezone,
               },
             },
-            // Credits mirror the billed scope (failed messages carry a cost in
-            // the index but are never billed), while the count metrics above
-            // stay inclusive of all activity.
-            credits: {
-              filter: { terms: { status: AGENT_MESSAGE_STATUSES_TO_TRACK } },
-              aggs: { total: { sum: { field: "cost.full_awu" } } },
-            },
+            // Billed credits per execution via `cost.billable_awu` (0 for the
+            // non-billable errored-terminal part), so no status filter is needed;
+            // the count metrics above stay inclusive of all activity.
+            credits: { sum: { field: "cost.billable_awu" } },
           },
         },
       },
@@ -116,7 +110,7 @@ export async function fetchUserExportRows({
           activeDaysCount: Array.isArray(activeDaysBuckets)
             ? activeDaysBuckets.filter((d) => d.doc_count > 0).length
             : 0,
-          credits: Math.round(b.credits?.total?.value ?? 0),
+          credits: Math.round(b.credits?.value ?? 0),
         },
       ] as const;
     })

--- a/front/lib/api/assistant/observability/agent_credits.ts
+++ b/front/lib/api/assistant/observability/agent_credits.ts
@@ -66,7 +66,7 @@ type AgentCreditAggs = {
   by_agent?: estypes.AggregationsMultiBucketAggregateBase<AgentBucket>;
 };
 
-// Per-agent AWU credits (cost.full_awu) over the last `days`: the agent's
+// Per-agent billed AWU credits (cost.billable_awu) over the last `days`: the agent's
 // current model and description, its message count, its top 3 users (by cost)
 // and top 3 skills (by execution count — skills carry no per-skill cost).
 // Ranked by credits desc.
@@ -114,7 +114,7 @@ export async function fetchAgentCreditBreakdown(
           ...(includeAgentIds ? { include: includeAgentIds } : {}),
         },
         aggs: {
-          credits: { sum: { field: "cost.full_awu" } },
+          credits: { sum: { field: "cost.billable_awu" } },
           top_users: {
             terms: {
               field: "user_id",
@@ -122,7 +122,7 @@ export async function fetchAgentCreditBreakdown(
               exclude: ["unknown"],
               order: { user_credits: "desc" },
             },
-            aggs: { user_credits: { sum: { field: "cost.full_awu" } } },
+            aggs: { user_credits: { sum: { field: "cost.billable_awu" } } },
           },
           top_skills: {
             nested: { path: "skills_used" },

--- a/front/lib/api/assistant/observability/credit_usage.ts
+++ b/front/lib/api/assistant/observability/credit_usage.ts
@@ -107,7 +107,7 @@ type CreditUsageTypeAggs = {
 };
 
 const creditSubAggs = {
-  total_cost: { sum: { field: "cost.full_awu" } },
+  total_cost: { sum: { field: "cost.billable_awu" } },
 } satisfies Record<string, estypes.AggregationsAggregationContainer>;
 
 function totalCreditsFromSlice(slice: CreditSlice): number {
@@ -255,10 +255,10 @@ function buildCreditDateHistogram({
   };
 }
 
-// Sums the per-message AWU credits (cost.full_awu) precomputed at index time
-// with the billing pipeline's conversion. Still an estimate vs the billed
+// Sums the per-message billed AWU credits (cost.billable_awu) precomputed at index
+// time with the billing pipeline's conversion. Still an estimate vs the billed
 // figure on the usage page (indexing lag, docs indexed before the cost fields
-// shipped). Groups are ranked exactly by cost.full_awu inside ES.
+// shipped). Groups are ranked exactly by cost.billable_awu inside ES.
 export async function fetchCreditUsage(
   auth: Authenticator,
   {
@@ -357,7 +357,7 @@ type TopConversationsAggs = {
   by_conversation?: estypes.AggregationsMultiBucketAggregateBase<GroupBucket>;
 };
 
-// Conversations ranked by summed per-message AWU credits (cost.full_awu) over
+// Conversations ranked by summed per-message billed AWU credits (cost.billable_awu) over
 // the window. Same source and scope as fetchCreditUsage; scope to a user via
 // `userIds` so the ranking only counts that user's messages. Conversations
 // that can no longer be fetched (deleted, or the caller lost access) are

--- a/front/lib/api/assistant/observability/overview.ts
+++ b/front/lib/api/assistant/observability/overview.ts
@@ -3,7 +3,6 @@ import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentCostStats } from "@app/types/api/assistant/observability/overview";
-import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
@@ -135,10 +134,11 @@ export async function fetchAgentCostStats(
     bool: {
       filter: [
         baseQuery,
-        // Mirror the billed scope: failed messages carry a non-zero
-        // `cost.full_awu` in the index but are never billed by Metronome.
-        { terms: { status: AGENT_MESSAGE_STATUSES_TO_TRACK } },
-        { range: { "cost.full_awu": { gt: 0 } } },
+        // Billed cost per execution: `cost.billable_awu` is already 0 for the
+        // non-billable (errored terminal) part, so no status filter is needed and
+        // failed multi-execution messages still contribute their non-error work.
+        // `> 0` keeps this to messages that actually incurred billed cost.
+        { range: { "cost.billable_awu": { gt: 0 } } },
       ],
     },
   };
@@ -148,10 +148,10 @@ export async function fetchAgentCostStats(
       by_agent: {
         terms: { field: "agent_id", size: agentIds.length },
         aggs: {
-          total_cost: { sum: { field: "cost.full_awu" } },
-          avg_cost: { avg: { field: "cost.full_awu" } },
+          total_cost: { sum: { field: "cost.billable_awu" } },
+          avg_cost: { avg: { field: "cost.billable_awu" } },
           median_cost: {
-            percentiles: { field: "cost.full_awu", percents: [50] },
+            percentiles: { field: "cost.billable_awu", percents: [50] },
           },
         },
       },

--- a/front/lib/api/assistant/observability/user_credits.ts
+++ b/front/lib/api/assistant/observability/user_credits.ts
@@ -46,7 +46,7 @@ type UserCreditAggs = {
   by_user?: estypes.AggregationsMultiBucketAggregateBase<UserBucket>;
 };
 
-// Per-user AWU credits (cost.full_awu) over the last `days`: message count,
+// Per-user billed AWU credits (cost.billable_awu) over the last `days`: message count,
 // credits, and the user's top 3 agents (with each agent's current model and
 // description). Ranked by credits desc. Non-free scope and the programmatic
 // "unknown" user (no attributable person) are excluded to keep this a
@@ -90,14 +90,14 @@ export async function fetchUserCreditBreakdown(
           ...(includeUserIds ? { include: includeUserIds } : {}),
         },
         aggs: {
-          credits: { sum: { field: "cost.full_awu" } },
+          credits: { sum: { field: "cost.billable_awu" } },
           top_agents: {
             terms: {
               field: "agent_id",
               size: 3,
               order: { agent_credits: "desc" },
             },
-            aggs: { agent_credits: { sum: { field: "cost.full_awu" } } },
+            aggs: { agent_credits: { sum: { field: "cost.billable_awu" } } },
           },
         },
       },

--- a/front/lib/api/assistant/observability/utils.ts
+++ b/front/lib/api/assistant/observability/utils.ts
@@ -1,7 +1,6 @@
 import { contextOriginFilter } from "@app/lib/api/assistant/observability/context_origin";
 import type { Authenticator } from "@app/lib/auth";
 import { FREE_ORIGINS } from "@app/lib/metronome/events";
-import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
 
@@ -152,14 +151,14 @@ export function buildAgentAnalyticsBaseQuery({
   };
 }
 
-// Workspace query scoped to the window, with free origins excluded and only the
-// billed message statuses kept, to mirror the non-free billed scope. Metronome
-// only emits usage events and credits for AGENT_MESSAGE_STATUSES_TO_TRACK (see
-// usage_queue activities and credit_cost), so failed messages carry a non-zero
-// `cost.full_awu` in the index but are never billed; without the status filter
-// the credit totals over-count failed runs and diverge from Metronome. Shared by
-// the credit fetchers (timeseries, breakdown, per-user and per-agent tables) so
-// the scope stays identical across them. `extraFilters` / `extraMustNot` carry
+// Workspace query scoped to the window, with free origins excluded. No status
+// filter: credit sums use `cost.billable_awu`, which already encodes the billed
+// amount per execution (a failed-terminal message contributes only its non-error
+// executions' work, 0 when the only/last execution errored), so it matches
+// Metronome without excluding `failed` docs — and, unlike a status filter, it
+// keeps the non-error work of failed multi-execution messages. Shared by the
+// credit fetchers (timeseries, breakdown, per-user and per-agent tables) so the
+// scope stays identical across them. `extraFilters` / `extraMustNot` carry
 // per-caller constraints (e.g. requiring an agent_id, or excluding the
 // programmatic "unknown" user).
 export function buildCreditsScopeQuery(
@@ -201,11 +200,7 @@ export function buildCreditsScopeQuery(
   });
   return {
     bool: {
-      filter: [
-        baseQuery,
-        { terms: { status: AGENT_MESSAGE_STATUSES_TO_TRACK } },
-        ...extraFilters,
-      ],
+      filter: [baseQuery, ...extraFilters],
       must_not: [
         { terms: { context_origin: [...FREE_ORIGINS] } },
         ...extraMustNot,

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -56,7 +56,6 @@ import {
   setFixedWindowCount,
 } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
-import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
 import type {
   MembershipSeatType,
@@ -242,7 +241,7 @@ async function fetchCreditsResetAt(
 }
 
 // Per-user consumed AWU credits for the current billing cycle, summed from the
-// analytics index (`cost.full_awu`, precomputed at index time) by Elasticsearch.
+// analytics index (`cost.billable_awu`, precomputed at index time) by Elasticsearch.
 // This replaces the per-user Metronome usage scan that previously dominated the
 // members-table load.
 //
@@ -253,9 +252,12 @@ async function fetchCreditsResetAt(
 // drops the user's pre-upgrade free usage (its docs stay `is_free_seat: true`),
 // while paid→paid changes (pro→max) keep counting (all `is_free_seat: false`).
 //
-// Filtered to the billed message statuses so the consumed total matches Metronome
-// (failed messages are indexed with a cost but never billed). Returns an empty
-// map on any failure so the table still renders (the consumed column shows 0).
+// Sums `cost.billable_awu` (= the message's `costCredits`), which already encodes
+// the billing policy per execution: every non-error execution counts, the errored
+// terminal execution does not — so failed-terminal messages contribute their
+// non-error work (0 when the only/last execution errored). This matches Metronome
+// without a status filter. Returns an empty map on any failure so the table still
+// renders (the consumed column shows 0).
 async function fetchConsumedAwuCreditsByUserId({
   workspace,
   userIds,
@@ -292,13 +294,9 @@ async function fetchConsumedAwuCreditsByUserId({
         filter: [
           { term: { workspace_id: workspace.sId } },
           { terms: { user_id: userIds } },
-          // Mirror the billing-side filter: Metronome only emits usage events
-          // and credits for these statuses (see usage_queue activities and
-          // credit_cost), so failed messages carry a non-zero `cost.full_awu`
-          // in the index but are never billed. Without this filter the consumed
-          // total over-counts failed runs (e.g. failed triggers) and diverges
-          // from Metronome.
-          { terms: { status: AGENT_MESSAGE_STATUSES_TO_TRACK } },
+          // No status filter: `cost.billable_awu` is already 0 for the non-billable
+          // (errored terminal execution) part, so failed-terminal messages
+          // contribute only their non-error work — matching Metronome per execution.
           {
             range: {
               timestamp: {
@@ -329,11 +327,11 @@ async function fetchConsumedAwuCreditsByUserId({
               filter: {
                 bool: { must_not: [{ term: { is_free_seat: true } }] },
               },
-              aggs: { credits: { sum: { field: "cost.full_awu" } } },
+              aggs: { credits: { sum: { field: "cost.billable_awu" } } },
             },
             free_credits: {
               filter: { term: { is_free_seat: true } },
-              aggs: { credits: { sum: { field: "cost.full_awu" } } },
+              aggs: { credits: { sum: { field: "cost.billable_awu" } } },
             },
           },
         },


### PR DESCRIPTION
## Description

⚠️ **Draft — do NOT merge until the `cost.billable_awu` backfill from #29733 has run in prod.**
Merging before the backfill makes these reads sum a half-populated field and under-count
consumption (and under-enforce the spend cap).

Stacked on #29733 (which adds and populates `cost.billable_awu`). This PR repoints **every
billing-intent credit surface** from `sum(cost.full_awu)` + a `status ∈ AGENT_MESSAGE_STATUSES_TO_TRACK`
filter to `sum(cost.billable_awu)` (dropping the status filter), so "consumed / billed credits"
everywhere equals what Metronome bills per execution — **including the non-error work of failed
multi-execution messages**, which the status filter previously dropped whole (the `l7G4uvGoCV`
gap from #29733).

Since `billable_awu == full_awu` for non-failed messages, **non-failed totals are unchanged**;
only failed-terminal messages now contribute their billed portion (the non-error executions' work,
or 0 when the only/last execution errored).

## Reads switched

- **Spend cap + members "Consumed (ES)" + poke** — `fetchConsumedAwuCreditsByUserId` (and the
  spend-cap seed `getEsConsumedAwuCreditsForUser`). Correctness-critical.
- **Observability credit dashboards** — `buildCreditsScopeQuery` (shared by credit_usage
  timeseries/breakdown/tables, user_credits, agent_credits) drops its status filter; `overview`
  agent cost stats (`> 0` gate + sum/avg/median) switch to `billable_awu`.
- **Exports** — `users_export` / `agents_export` per-entity credit totals; `messages_export`
  per-message `credits` column.

Left on `full_awu` intentionally: the per-message cost **breakdown** in `credit_cost.ts`
(`totalAwu = llmAwu + toolAwu` must hold — it's a gross component breakdown, not a billed figure).

## Behavior note (message counts)

Dropping the shared status filter in `buildCreditsScopeQuery` also makes the credit dashboards'
message **counts** (`doc_count`) include failed messages (previously excluded). Credit *values*
are unaffected (failed docs carry only their billed portion). Export and overview counts are
**unchanged** — their status filter was local to the credit sub-agg, or they have no count metric.
If you want the dashboard counts to stay failed-excluded, say so and I'll wrap the count in a
status-filtered sub-agg; I left it inclusive since "what happened" is the more natural count.

## Tests

- `npx tsgo --noEmit` clean; `biome check` clean.
- Equivalence by construction with #29733: `billable_awu == full_awu` for non-failed docs, so all
  non-failed aggregates are identical; failed-terminal docs now contribute their billed portion.

## Deploy Plan

1. Land & deploy #29733; run its backfill (passes 1 and 2) in prod.
2. Confirm `billable_awu` is populated (spot-check members "Consumed (ES)" vs Metronome).
3. Mark this PR ready, merge, deploy.

Stacked on: #29733.
