### PR TITLE
Refactor Frame runtime access boundary

### DIFF
--- a/front/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe.test.ts
+++ b/front/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe.test.ts
@@ -1,0 +1,42 @@
+import { getAuthenticatedFrameUserIdentity } from "@app/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe";
+import { describe, expect, it } from "vitest";
+
+const authContext = {
+  workspace: { role: "user" as const, sId: "w_current" },
+  user: {
+    sId: "usr_123",
+    firstName: "Ada",
+    lastName: "Lovelace",
+    fullName: "Ada Lovelace",
+    image: null,
+  },
+};
+
+describe("getAuthenticatedFrameUserIdentity", () => {
+  it("scopes the authenticated user to the Frame workspace", () => {
+    expect(getAuthenticatedFrameUserIdentity(authContext, "w_current")).toEqual(
+      {
+        workspaceId: "w_current",
+        user: authContext.user,
+      }
+    );
+  });
+
+  it("rejects an auth context for another workspace", () => {
+    expect(
+      getAuthenticatedFrameUserIdentity(authContext, "w_other")
+    ).toBeUndefined();
+  });
+
+  it("rejects a non-member auth context", () => {
+    expect(
+      getAuthenticatedFrameUserIdentity(
+        {
+          ...authContext,
+          workspace: { ...authContext.workspace, role: "none" },
+        },
+        "w_current"
+      )
+    ).toBeUndefined();
+  });
+});

--- a/front/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe.test.ts
+++ b/front/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe.test.ts
@@ -22,13 +22,13 @@ describe("getAuthenticatedFrameUserIdentity", () => {
     );
   });
 
-  it("rejects an auth context for another workspace", () => {
+  it("returns no identity for an auth context from another workspace", () => {
     expect(
       getAuthenticatedFrameUserIdentity(authContext, "w_other")
     ).toBeUndefined();
   });
 
-  it("rejects a non-member auth context", () => {
+  it("returns no identity for a non-member auth context", () => {
     expect(
       getAuthenticatedFrameUserIdentity(
         {

--- a/front/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe.tsx
@@ -1,0 +1,65 @@
+import {
+  VisualizationActionIframe,
+  type VisualizationActionIframeProps,
+} from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
+import { AuthContext } from "@app/lib/auth/AuthContext";
+import type {
+  ScopedWorkspaceUserIdentity,
+  WorkspaceUserIdentity,
+} from "@app/types/assistant/visualization";
+import type { RoleType } from "@app/types/user";
+import { forwardRef, useContext } from "react";
+
+interface WorkspaceAuthIdentity {
+  user: WorkspaceUserIdentity;
+  workspace: { role: RoleType; sId: string };
+}
+
+export function getAuthenticatedFrameUserIdentity(
+  authContext: WorkspaceAuthIdentity | null,
+  workspaceId: string
+): ScopedWorkspaceUserIdentity | undefined {
+  if (
+    !authContext ||
+    authContext.workspace.sId !== workspaceId ||
+    authContext.workspace.role === "none"
+  ) {
+    return undefined;
+  }
+
+  return {
+    workspaceId,
+    user: {
+      sId: authContext.user.sId,
+      firstName: authContext.user.firstName,
+      lastName: authContext.user.lastName,
+      fullName: authContext.user.fullName,
+      image: authContext.user.image,
+    },
+  };
+}
+
+type AuthenticatedVisualizationActionIframeProps = Omit<
+  VisualizationActionIframeProps,
+  "canInvokeFunctions" | "scopedUserIdentity"
+>;
+
+export const AuthenticatedVisualizationActionIframe = forwardRef<
+  HTMLIFrameElement,
+  AuthenticatedVisualizationActionIframeProps
+>(function AuthenticatedVisualizationActionIframe(props, ref) {
+  const authContext = useContext(AuthContext);
+  const scopedUserIdentity = getAuthenticatedFrameUserIdentity(
+    authContext,
+    props.workspaceId
+  );
+
+  return (
+    <VisualizationActionIframe
+      {...props}
+      ref={ref}
+      canInvokeFunctions={scopedUserIdentity !== undefined}
+      scopedUserIdentity={scopedUserIdentity}
+    />
+  );
+});

--- a/front/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe.tsx
@@ -39,10 +39,11 @@ export function getAuthenticatedFrameUserIdentity(
   };
 }
 
-type AuthenticatedVisualizationActionIframeProps = Omit<
-  VisualizationActionIframeProps,
-  "canInvokeFunctions" | "scopedUserIdentity"
->;
+interface AuthenticatedVisualizationActionIframeProps
+  extends Omit<
+    VisualizationActionIframeProps,
+    "canInvokeFunctions" | "scopedUserIdentity"
+  > {}
 
 export const AuthenticatedVisualizationActionIframe = forwardRef<
   HTMLIFrameElement,

--- a/front/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe.tsx
@@ -7,12 +7,12 @@ import type {
   ScopedWorkspaceUserIdentity,
   WorkspaceUserIdentity,
 } from "@app/types/assistant/visualization";
-import type { RoleType } from "@app/types/user";
+import type { LightWorkspaceType } from "@app/types/user";
 import { forwardRef, useContext } from "react";
 
 interface WorkspaceAuthIdentity {
   user: WorkspaceUserIdentity;
-  workspace: { role: RoleType; sId: string };
+  workspace: Pick<LightWorkspaceType, "role" | "sId">;
 }
 
 export function getAuthenticatedFrameUserIdentity(

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
@@ -1,101 +1,39 @@
-import {
-  type FrameAccess,
-  getFrameUserIdentity,
-} from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
+import { getFrameUserIdentity } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
 import type { ScopedWorkspaceUserIdentity } from "@app/types/assistant/visualization";
 import { describe, expect, it } from "vitest";
 
-const authContext = {
-  workspace: { role: "user" as const, sId: "w_current" },
-  user: {
-    sId: "usr_123",
-    firstName: "Ada",
-    lastName: "Lovelace",
-    fullName: "Ada Lovelace",
-    image: null,
-  },
+const user = {
+  sId: "usr_123",
+  firstName: "Ada",
+  lastName: "Lovelace",
+  fullName: "Ada Lovelace",
+  image: null,
 };
 
-function getIdentity(
-  workspaceId: string,
-  frameAccess: FrameAccess = "conversation",
-  publicUserIdentity?: ScopedWorkspaceUserIdentity
-) {
-  return getFrameUserIdentity(
-    authContext,
-    frameAccess,
-    workspaceId,
-    publicUserIdentity
-  );
-}
+const scopedUserIdentity: ScopedWorkspaceUserIdentity = {
+  workspaceId: "w_current",
+  user,
+};
 
 describe("getFrameUserIdentity", () => {
-  it("returns identity for the Frame workspace", () => {
-    expect(getIdentity("w_current")).toEqual({
+  it("returns an identity scoped to the Frame workspace", () => {
+    expect(getFrameUserIdentity("w_current", scopedUserIdentity)).toEqual({
       isAuthenticated: true,
       isWorkspaceMember: true,
-      user: authContext.user,
+      user,
     });
   });
 
   it("does not return identity for another workspace", () => {
-    expect(getIdentity("w_other")).toEqual({
+    expect(getFrameUserIdentity("w_other", scopedUserIdentity)).toEqual({
       isAuthenticated: false,
       isWorkspaceMember: false,
       user: null,
     });
   });
 
-  it("returns an explicitly scoped public member identity", () => {
-    expect(
-      getIdentity("w_current", "public-member", {
-        workspaceId: "w_current",
-        user: authContext.user,
-      })
-    ).toEqual({
-      isAuthenticated: true,
-      isWorkspaceMember: true,
-      user: authContext.user,
-    });
-  });
-
-  it("rejects a public identity scoped to another workspace", () => {
-    expect(
-      getIdentity("w_current", "public-member", {
-        workspaceId: "w_other",
-        user: authContext.user,
-      })
-    ).toEqual({
-      isAuthenticated: false,
-      isWorkspaceMember: false,
-      user: null,
-    });
-  });
-
-  it("does not return identity for a non-member session", () => {
-    expect(
-      getFrameUserIdentity(
-        {
-          ...authContext,
-          workspace: { ...authContext.workspace, role: "none" },
-        },
-        "conversation",
-        "w_current"
-      )
-    ).toEqual({
-      isAuthenticated: false,
-      isWorkspaceMember: false,
-      user: null,
-    });
-  });
-
-  it("keeps anonymous public Frames unauthenticated", () => {
-    expect(
-      getIdentity("w_current", "public-anonymous", {
-        workspaceId: "w_current",
-        user: authContext.user,
-      })
-    ).toEqual({
+  it("keeps a missing identity unauthenticated", () => {
+    expect(getFrameUserIdentity("w_current")).toEqual({
       isAuthenticated: false,
       isWorkspaceMember: false,
       user: null,

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
@@ -1,4 +1,4 @@
-import { getFrameUserIdentity } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
+import { getFrameRuntimeAccess } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
 import type { ScopedWorkspaceUserIdentity } from "@app/types/assistant/visualization";
 import { describe, expect, it } from "vitest";
 
@@ -15,28 +15,41 @@ const scopedUserIdentity: ScopedWorkspaceUserIdentity = {
   user,
 };
 
-describe("getFrameUserIdentity", () => {
-  it("returns an identity scoped to the Frame workspace", () => {
-    expect(getFrameUserIdentity("w_current", scopedUserIdentity)).toEqual({
-      isAuthenticated: true,
-      isWorkspaceMember: true,
-      user,
+describe("getFrameRuntimeAccess", () => {
+  it("enables access with an identity scoped to the Frame workspace", () => {
+    expect(
+      getFrameRuntimeAccess("w_current", true, scopedUserIdentity)
+    ).toEqual({
+      canInvokeFunctions: true,
+      userIdentity: {
+        isAuthenticated: true,
+        isWorkspaceMember: true,
+        user,
+      },
     });
   });
 
-  it("does not return identity for another workspace", () => {
-    expect(getFrameUserIdentity("w_other", scopedUserIdentity)).toEqual({
-      isAuthenticated: false,
-      isWorkspaceMember: false,
-      user: null,
+  it("fails closed for an identity from another workspace", () => {
+    expect(getFrameRuntimeAccess("w_other", true, scopedUserIdentity)).toEqual({
+      canInvokeFunctions: false,
+      userIdentity: {
+        isAuthenticated: false,
+        isWorkspaceMember: false,
+        user: null,
+      },
     });
   });
 
-  it("keeps a missing identity unauthenticated", () => {
-    expect(getFrameUserIdentity("w_current")).toEqual({
-      isAuthenticated: false,
-      isWorkspaceMember: false,
-      user: null,
+  it("keeps function calls disabled when the caller capability is false", () => {
+    expect(
+      getFrameRuntimeAccess("w_current", false, scopedUserIdentity)
+    ).toEqual({
+      canInvokeFunctions: false,
+      userIdentity: {
+        isAuthenticated: true,
+        isWorkspaceMember: true,
+        user,
+      },
     });
   });
 });

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -7,7 +7,6 @@ import type {
   SandboxFunctionMCPApproveExecutionEvent,
   SandboxFunctionToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
-import { AuthContext } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import datadogLogger from "@app/logger/datadogLogger";
@@ -35,7 +34,6 @@ import {
   assertNeverAndIgnore,
 } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import type { RoleType } from "@app/types/user";
 import {
   AlertCircle,
   Button,
@@ -55,7 +53,6 @@ import type { SetStateAction } from "react";
 import {
   forwardRef,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -79,73 +76,23 @@ type ProtectedVisualization = BaseVisualization & {
 
 export type Visualization = PublicVisualization | ProtectedVisualization;
 
-export type FrameAccess = "conversation" | "public-anonymous" | "public-member";
-
-interface WorkspaceAuthIdentity {
-  user: NonNullable<UserIdentityState["user"]>;
-  workspace: { role: RoleType; sId: string };
-}
-
 export function getFrameUserIdentity(
-  authContext: WorkspaceAuthIdentity | null,
-  frameAccess: FrameAccess,
   workspaceId: string,
-  publicUserIdentity?: ScopedWorkspaceUserIdentity
+  scopedUserIdentity?: ScopedWorkspaceUserIdentity
 ): UserIdentityState {
-  switch (frameAccess) {
-    case "conversation": {
-      if (
-        !authContext ||
-        authContext.workspace.sId !== workspaceId ||
-        authContext.workspace.role === "none"
-      ) {
-        return {
-          isAuthenticated: false,
-          isWorkspaceMember: false,
-          user: null,
-        };
-      }
-
-      const { user } = authContext;
-      return {
-        isAuthenticated: true,
-        isWorkspaceMember: true,
-        user: {
-          sId: user.sId,
-          firstName: user.firstName,
-          lastName: user.lastName,
-          fullName: user.fullName,
-          image: user.image,
-        },
-      };
-    }
-    case "public-member":
-      if (publicUserIdentity?.workspaceId === workspaceId) {
-        return {
-          isAuthenticated: true,
-          isWorkspaceMember: true,
-          user: publicUserIdentity.user,
-        };
-      }
-      return {
-        isAuthenticated: false,
-        isWorkspaceMember: false,
-        user: null,
-      };
-    case "public-anonymous":
-      return {
-        isAuthenticated: false,
-        isWorkspaceMember: false,
-        user: null,
-      };
-    default:
-      assertNeverAndIgnore(frameAccess);
-      return {
-        isAuthenticated: false,
-        isWorkspaceMember: false,
-        user: null,
-      };
+  if (scopedUserIdentity?.workspaceId === workspaceId) {
+    return {
+      isAuthenticated: true,
+      isWorkspaceMember: true,
+      user: scopedUserIdentity.user,
+    };
   }
+
+  return {
+    isAuthenticated: false,
+    isWorkspaceMember: false,
+    user: null,
+  };
 }
 
 const sendResponseToIframe = <T extends VisualizationRPCCommand>(
@@ -606,14 +553,14 @@ export function CodeDrawer({
   );
 }
 
-interface VisualizationActionIframeProps {
+export interface VisualizationActionIframeProps {
   agentConfigurationId: string | null;
+  canInvokeFunctions: boolean;
   conversationId: string | null;
   isEditable?: boolean;
   isInDrawer?: boolean;
   onEditText?: EditTextFn;
-  publicUserIdentity?: ScopedWorkspaceUserIdentity;
-  frameAccess?: FrameAccess;
+  scopedUserIdentity?: ScopedWorkspaceUserIdentity;
   spaceId?: string;
   visualization: Visualization;
   vizUrl: string;
@@ -695,28 +642,22 @@ export const VisualizationActionIframe = forwardRef<
 
   const {
     agentConfigurationId,
+    canInvokeFunctions,
     conversationId,
     isEditable = false,
     isInDrawer = false,
     onEditText,
-    publicUserIdentity,
+    scopedUserIdentity,
     spaceId,
     visualization,
     workspaceId,
-    frameAccess = "conversation",
   } = props;
 
-  const authContext = useContext(AuthContext);
   const userIdentity = useMemo<UserIdentityState>(() => {
-    return getFrameUserIdentity(
-      authContext,
-      frameAccess,
-      workspaceId,
-      publicUserIdentity
-    );
-  }, [authContext, frameAccess, publicUserIdentity, workspaceId]);
+    return getFrameUserIdentity(workspaceId, scopedUserIdentity);
+  }, [scopedUserIdentity, workspaceId]);
 
-  const isPublic = frameAccess !== "conversation";
+  const isPublic = visualization.accessToken !== undefined;
 
   const getFileBlob = useCallback(
     async (fileId: string) => {
@@ -768,10 +709,10 @@ export const VisualizationActionIframe = forwardRef<
       Result<SandboxFunctionInvocationType, SandboxFunctionCallError>
     > => {
       try {
-        if (frameAccess === "public-anonymous") {
+        if (!canInvokeFunctions) {
           return new Err({
             code: "not_supported",
-            message: "Pod functions are not supported in shared frames.",
+            message: "Function calls are not available in this Frame.",
           });
         }
 
@@ -817,7 +758,7 @@ export const VisualizationActionIframe = forwardRef<
         });
       }
     },
-    [frameAccess, workspaceId]
+    [canInvokeFunctions, workspaceId]
   );
 
   useVisualizationDataHandler({

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -76,22 +76,30 @@ type ProtectedVisualization = BaseVisualization & {
 
 export type Visualization = PublicVisualization | ProtectedVisualization;
 
-export function getFrameUserIdentity(
+export function getFrameRuntimeAccess(
   workspaceId: string,
+  canInvokeFunctions: boolean,
   scopedUserIdentity?: ScopedWorkspaceUserIdentity
-): UserIdentityState {
-  if (scopedUserIdentity?.workspaceId === workspaceId) {
-    return {
-      isAuthenticated: true,
-      isWorkspaceMember: true,
-      user: scopedUserIdentity.user,
-    };
-  }
+): {
+  canInvokeFunctions: boolean;
+  userIdentity: UserIdentityState;
+} {
+  const userIdentity: UserIdentityState =
+    scopedUserIdentity?.workspaceId === workspaceId
+      ? {
+          isAuthenticated: true,
+          isWorkspaceMember: true,
+          user: scopedUserIdentity.user,
+        }
+      : {
+          isAuthenticated: false,
+          isWorkspaceMember: false,
+          user: null,
+        };
 
   return {
-    isAuthenticated: false,
-    isWorkspaceMember: false,
-    user: null,
+    canInvokeFunctions: canInvokeFunctions && userIdentity.isWorkspaceMember,
+    userIdentity,
   };
 }
 
@@ -653,9 +661,13 @@ export const VisualizationActionIframe = forwardRef<
     workspaceId,
   } = props;
 
-  const userIdentity = useMemo<UserIdentityState>(() => {
-    return getFrameUserIdentity(workspaceId, scopedUserIdentity);
-  }, [scopedUserIdentity, workspaceId]);
+  const runtimeAccess = useMemo(() => {
+    return getFrameRuntimeAccess(
+      workspaceId,
+      canInvokeFunctions,
+      scopedUserIdentity
+    );
+  }, [canInvokeFunctions, scopedUserIdentity, workspaceId]);
 
   const isPublic = visualization.accessToken !== undefined;
 
@@ -709,7 +721,7 @@ export const VisualizationActionIframe = forwardRef<
       Result<SandboxFunctionInvocationType, SandboxFunctionCallError>
     > => {
       try {
-        if (!canInvokeFunctions) {
+        if (!runtimeAccess.canInvokeFunctions) {
           return new Err({
             code: "not_supported",
             message: "Function calls are not available in this Frame.",
@@ -758,7 +770,7 @@ export const VisualizationActionIframe = forwardRef<
         });
       }
     },
-    [canInvokeFunctions, workspaceId]
+    [runtimeAccess.canInvokeFunctions, workspaceId]
   );
 
   useVisualizationDataHandler({
@@ -771,7 +783,7 @@ export const VisualizationActionIframe = forwardRef<
     setErrorMessage,
     visualization,
     vizIframeRef,
-    userIdentity,
+    userIdentity: runtimeAccess.userIdentity,
     waitForSandboxFunctionInvocationResult,
     workspaceId,
   });

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -1,4 +1,4 @@
-import { VisualizationActionIframe } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
+import { AuthenticatedVisualizationActionIframe } from "@app/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { ConversationSidePanelHeader } from "@app/components/assistant/conversation/ConversationSidePanelHeader";
 import { DEFAULT_RIGHT_PANEL_SIZE } from "@app/components/assistant/conversation/constant";
@@ -429,7 +429,7 @@ export function FrameRenderer({
           </div>
         ) : (
           <div className="h-full">
-            <VisualizationActionIframe
+            <AuthenticatedVisualizationActionIframe
               agentConfigurationId={
                 fileMetadata?.useCaseMetadata
                   .lastEditedByAgentConfigurationId ?? ""

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.test.ts
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.test.ts
@@ -2,18 +2,31 @@ import {
   getPublicFrameUserIdentity,
   PublicFrameRenderer,
 } from "@app/components/assistant/conversation/interactive_content/PublicFrameRenderer";
+import type { ScopedWorkspaceUserIdentity } from "@app/types/assistant/visualization";
 import { cleanup, render, screen } from "@testing-library/react";
 import { createElement } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  iframeProps: null as {
+    canInvokeFunctions: boolean;
+    scopedUserIdentity?: ScopedWorkspaceUserIdentity;
+  } | null,
+  isAuthenticatedMember: true,
   isUserLoading: true,
+  user: null as typeof user | null,
 }));
 
 vi.mock(
   "@app/components/assistant/conversation/actions/VisualizationActionIframe",
   () => ({
-    VisualizationActionIframe: () => "frame-iframe",
+    VisualizationActionIframe: (props: {
+      canInvokeFunctions: boolean;
+      scopedUserIdentity?: ScopedWorkspaceUserIdentity;
+    }) => {
+      mocks.iframeProps = props;
+      return "frame-iframe";
+    },
   })
 );
 
@@ -29,13 +42,13 @@ vi.mock("@app/lib/swr/frames", () => ({
     isFrameLoading: false,
     error: null,
     accessToken: "token",
-    isAuthenticatedMember: true,
+    isAuthenticatedMember: mocks.isAuthenticatedMember,
   }),
 }));
 
 vi.mock("@app/lib/swr/user", () => ({
   useUser: () => ({
-    user: null,
+    user: mocks.user,
     isUserLoading: mocks.isUserLoading,
   }),
 }));
@@ -55,7 +68,10 @@ const user = {
 
 afterEach(() => {
   cleanup();
+  mocks.iframeProps = null;
+  mocks.isAuthenticatedMember = true;
   mocks.isUserLoading = true;
+  mocks.user = null;
 });
 
 describe("getPublicFrameUserIdentity", () => {
@@ -100,5 +116,48 @@ describe("PublicFrameRenderer", () => {
     rerender(createElement(PublicFrameRenderer, props));
 
     expect(screen.getByText("frame-iframe")).not.toBeNull();
+  });
+
+  it("enables function calls with the matching member identity", () => {
+    mocks.isUserLoading = false;
+    mocks.user = user;
+
+    render(
+      createElement(PublicFrameRenderer, {
+        fileId: "file_123",
+        hideHeader: true,
+        shareToken: "share-token",
+        workspaceId: "w_current",
+        vizUrl: "https://viz.dust.tt",
+      })
+    );
+
+    expect(mocks.iframeProps).toMatchObject({
+      canInvokeFunctions: true,
+      scopedUserIdentity: {
+        workspaceId: "w_current",
+        user: expect.objectContaining({ sId: "usr_123" }),
+      },
+    });
+  });
+
+  it("disables function calls without a member identity", () => {
+    mocks.isAuthenticatedMember = false;
+    mocks.isUserLoading = false;
+
+    render(
+      createElement(PublicFrameRenderer, {
+        fileId: "file_123",
+        hideHeader: true,
+        shareToken: "share-token",
+        workspaceId: "w_current",
+        vizUrl: "https://viz.dust.tt",
+      })
+    );
+
+    expect(mocks.iframeProps).toMatchObject({
+      canInvokeFunctions: false,
+      scopedUserIdentity: undefined,
+    });
   });
 });

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
@@ -75,10 +75,6 @@ export function PublicFrameRenderer({
     shareToken,
   });
 
-  // Members can call functions on shared frames; anonymous viewers cannot.
-  // Real authorization still happens server-side on invocation.
-  const access = isAuthenticatedMember ? "public-member" : "public-anonymous";
-
   const [cookies] = useCookies([DUST_HAS_SESSION]);
   const hasSession = hasSessionIndicator(cookies[DUST_HAS_SESSION]);
 
@@ -141,8 +137,8 @@ export function PublicFrameRenderer({
               identifier: `viz-${fileId}`,
             }}
             key={`viz-${fileId}`}
-            frameAccess={access}
-            publicUserIdentity={publicUserIdentity}
+            canInvokeFunctions={publicUserIdentity !== undefined}
+            scopedUserIdentity={publicUserIdentity}
             isInDrawer
           />
         </div>

--- a/front/components/markdown/VisualizationBlock.tsx
+++ b/front/components/markdown/VisualizationBlock.tsx
@@ -1,4 +1,4 @@
-import { VisualizationActionIframe } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
+import { AuthenticatedVisualizationActionIframe } from "@app/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe";
 import type { LightWorkspaceType } from "@app/types/user";
 import { MarkdownContentContext } from "@dust-tt/sparkle";
 import { useContext, useMemo } from "react";
@@ -61,7 +61,7 @@ export function getVisualizationPlugin(
   const customRenderer = {
     visualization: (code: string, complete: boolean, lineStart: number) => {
       return (
-        <VisualizationActionIframe
+        <AuthenticatedVisualizationActionIframe
           workspaceId={owner.sId}
           vizUrl={vizUrl}
           visualization={{

--- a/front/components/pod/conversation/PodPinnedBanner.tsx
+++ b/front/components/pod/conversation/PodPinnedBanner.tsx
@@ -1,4 +1,4 @@
-import { VisualizationActionIframe } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
+import { AuthenticatedVisualizationActionIframe } from "@app/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe";
 import { usePinPodBanner } from "@app/hooks/usePinPodBanner";
 import { useScopedPodUiPreferences } from "@app/hooks/useScopedUIPreferences";
 import { useAuth } from "@app/lib/auth/AuthContext";
@@ -45,7 +45,7 @@ function PodPinnedBannerFrame({
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   return (
-    <VisualizationActionIframe
+    <AuthenticatedVisualizationActionIframe
       agentConfigurationId={null}
       workspaceId={owner.sId}
       vizUrl={vizUrl}

--- a/front/components/pod/files/PodFrameSheet.tsx
+++ b/front/components/pod/files/PodFrameSheet.tsx
@@ -1,4 +1,4 @@
-import { VisualizationActionIframe } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
+import { AuthenticatedVisualizationActionIframe } from "@app/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe";
 import { ExportContentDropdown } from "@app/components/assistant/conversation/interactive_content/ExportContentDropdown";
 import { ShareFrameSheet } from "@app/components/assistant/conversation/interactive_content/frame/ShareFrameSheet";
 import { PinPodBannerButton } from "@app/components/pod/files/PinPodBannerButton";
@@ -98,7 +98,7 @@ export function PodFrameSheet({
           ) : (
             fileId &&
             vizUrl && (
-              <VisualizationActionIframe
+              <AuthenticatedVisualizationActionIframe
                 agentConfigurationId={
                   fileMetadata?.useCaseMetadata
                     .lastEditedByAgentConfigurationId ?? null


### PR DESCRIPTION
## Description

- keep `VisualizationActionIframe` independent of conversation, public member, and public anonymous locations
- pass workspace-scoped identity and function invocation capability as generic runtime inputs
- add an authenticated app adapter that fails closed when its auth context does not match the Frame workspace
- preserve public viewer identity and invocation behavior while keeping its access policy in `PublicFrameRenderer`

Follow-up to [post-merge feedback on #29679](https://github.com/dust-tt/dust/pull/29679#discussion_r3677890144).

## Tests

- `npm test -- components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe.test.ts components/assistant/conversation/actions/VisualizationActionIframe.test.ts components/assistant/conversation/interactive_content/PublicFrameRenderer.test.ts`
- `npx tsgo --noEmit`

## Risk

Low. This is a frontend boundary refactor with focused coverage for authenticated, anonymous, and cross-workspace behavior. The server remains authoritative for function invocation authorization.

## Deploy Plan

Deploy front.
