### PR TITLE
Add threshold to hide pod conversations in inbox.

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -119,6 +119,9 @@ import {
   useState,
 } from "react";
 
+// To avoid overwhelming the user with unread pod conversations, we hide them if there are too many.
+const HIDE_UNREAD_POD_CONVERSATIONS_TRESHOLD = 16;
+
 interface AgentSidebarMenuProps {
   owner: WorkspaceType;
   hideActions?: boolean;
@@ -683,11 +686,19 @@ export function AgentSidebarMenu({
   }, [setSidebarOpen, router, activeConversationId, setShouldFocusInput]);
 
   const { allConversations, spaces } = useMemo(() => {
+    const unreadPodConversations = summary
+      .map(({ unreadConversations }) => unreadConversations)
+      .flat();
+    if (
+      unreadPodConversations.length >= HIDE_UNREAD_POD_CONVERSATIONS_TRESHOLD
+    ) {
+      return {
+        allConversations: conversations,
+        spaces: summary.map(({ space }) => space).flat(),
+      };
+    }
     return {
-      allConversations: [
-        ...conversations,
-        ...summary.map(({ unreadConversations }) => unreadConversations).flat(),
-      ],
+      allConversations: [...conversations, ...unreadPodConversations],
       spaces: summary.map(({ space }) => space).flat(),
     };
   }, [conversations, summary]);


### PR DESCRIPTION
## Description

When a user has ≥ 16 unread pod conversations, `AgentSidebarMenu` now excludes them from the merged `allConversations` list to avoid flooding the inbox sidebar. The `spaces` summary is still computed in both branches so pod section headers remain visible even when the conversations are suppressed.

## Tests

Tested manually — verified inbox rendering with both few and many (≥ 16) unread pod conversations.

## Risk

Low. Front-only change to a single `useMemo` in `AgentSidebarMenu`. The capped path (`conversations` only) is effectively the pre-pod-inbox baseline. Fully safe to rollback.

## Deploy Plan

Deploy front.
