### PR TITLE
[connectors] enh: Add the Slack webhook event workflow and activity

### DIFF
--- a/connectors/src/api/webhooks/slack/created_channel.ts
+++ b/connectors/src/api/webhooks/slack/created_channel.ts
@@ -12,7 +12,9 @@ interface ChannelCreatedEventPayload {
   name: string;
 }
 
-type ChannelCreatedEvent = SlackWebhookEvent<ChannelCreatedEventPayload>;
+type ChannelCreatedEvent = SlackWebhookEvent<ChannelCreatedEventPayload> & {
+  channel: ChannelCreatedEventPayload;
+};
 
 export function isChannelCreatedEvent(
   event: unknown
@@ -32,26 +34,22 @@ export function isChannelCreatedEvent(
 }
 
 export interface OnChannelCreationInterface {
-  event: ChannelCreatedEvent;
+  channelId: string;
+  contextTeamId: string;
   logger: Logger;
   provider?: Extract<ConnectorProvider, "slack_bot" | "slack">;
 }
 
 export async function onChannelCreation({
-  event,
+  channelId,
+  contextTeamId,
   logger,
   provider = "slack",
 }: OnChannelCreationInterface): Promise<Result<void, Error>> {
-  const { channel } = event;
-  if (!channel) {
-    return new Err(
-      new Error("Missing channel in request body for message event")
-    );
-  }
   const autoReadRes = await autoReadChannel(
-    channel.context_team_id,
+    contextTeamId,
     logger,
-    channel.id,
+    channelId,
     provider
   );
   if (autoReadRes.isErr()) {

--- a/connectors/src/api/webhooks/slack/deprecated_bot.ts
+++ b/connectors/src/api/webhooks/slack/deprecated_bot.ts
@@ -5,7 +5,6 @@ import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 import { removeNulls } from "@connectors/types/shared/utils/general";
 import type { WebClient } from "@slack/web-api";
-import type { Request, Response } from "express";
 import type { Logger } from "pino";
 
 async function sendSlackMessage(
@@ -40,22 +39,28 @@ async function makeSlackDeprecatedBotErrorMessage(
 ) {
   const slackClient = await getSlackClient(slackBotConnector.id);
 
-  const slackBotUserId = await getBotUserIdResponse(
+  const slackBotUserIdRes = await getBotUserIdResponse(
     slackClient,
     slackBotConnector.id
   );
+  if (slackBotUserIdRes.isErr()) {
+    throw slackBotUserIdRes.error;
+  }
 
-  return `Oops! That's the deprecated version of Dust. Mention <@${slackBotUserId}> instead!`;
+  return `Oops! That's the deprecated version of Dust. Mention <@${slackBotUserIdRes.value}> instead!`;
 }
 
-export async function handleDeprecatedChatBot(
-  req: Request,
-  res: Response,
-  logger: Logger
-) {
-  const { event, team_id: slackTeamId } = req.body;
-  const { channel: slackChannel, ts: slackMessageTs } = event;
-
+export async function handleDeprecatedChatBot({
+  logger,
+  slackChannel,
+  slackMessageTs,
+  slackTeamId,
+}: {
+  logger: Logger;
+  slackChannel: string;
+  slackMessageTs: string;
+  slackTeamId: string;
+}) {
   const localLogger = logger.child({
     action: "handleDeprecatedChatBot",
     slackChannel,
@@ -67,11 +72,10 @@ export async function handleDeprecatedChatBot(
     slackTeamId,
     "slack"
   );
-  // If there are no slack configurations, return 200.
   if (slackConfigurations.length === 0) {
     localLogger.info("No deprecated Slack configurations found.", slackTeamId);
 
-    return res.status(200).send();
+    return;
   }
 
   const connectors = removeNulls(
@@ -91,16 +95,20 @@ export async function handleDeprecatedChatBot(
     (c) => c.connectorId === slackBotConnector?.id
   );
 
-  // We need to answer 200 quickly to Slack, otherwise they will retry the HTTP request.
-  res.status(200).send();
-
   if (!deprecatedSlackConnector) {
     localLogger.info("No deprecated Slack connector found.");
     return;
   }
+  if (deprecatedSlackConnector.isPaused()) {
+    localLogger.info(
+      { connectorId: deprecatedSlackConnector.id },
+      "Deprecated Slack connector is paused."
+    );
+    return;
+  }
 
   const deprecatedSlackClient = await getSlackClient(
-    deprecatedSlackConnector?.id
+    deprecatedSlackConnector.id
   );
 
   // Case 1: Slack bot connector is not installed.

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -4,6 +4,7 @@ import {
 } from "@connectors/api/webhooks/slack/created_channel";
 import { handleDeprecatedChatBot } from "@connectors/api/webhooks/slack/deprecated_bot";
 import type {
+  SlackWebhookEvent,
   SlackWebhookReqBody,
   SlackWebhookResBody,
 } from "@connectors/api/webhooks/slack/utils";
@@ -29,6 +30,7 @@ import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import { SlackChannelModel } from "@connectors/lib/models/slack";
+import type { Logger } from "@connectors/logger/logger";
 import mainLogger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -37,6 +39,29 @@ import { INTERNAL_MIME_TYPES } from "@connectors/types";
 import { DustAPI, removeNulls } from "@dust-tt/client";
 import { JSON } from "@jsonjoy.com/util/lib/json-brand";
 import type { Request, Response } from "express";
+
+// Answers Slack before doing the Slack API work, otherwise they retry the HTTP
+// request. `handleDeprecatedChatBot` used to own that response.
+async function notifyDeprecatedBot(
+  res: Response<SlackWebhookResBody>,
+  event: SlackWebhookEvent,
+  teamId: string,
+  logger: Logger
+) {
+  res.status(200).send();
+
+  if (!event.channel || !event.ts) {
+    logger.info("Ignoring event without a channel or a timestamp");
+    return;
+  }
+
+  await handleDeprecatedChatBot({
+    logger,
+    slackChannel: event.channel,
+    slackMessageTs: event.ts,
+    slackTeamId: teamId,
+  });
+}
 
 const _webhookSlackAPIHandler = async (
   req: Request<
@@ -108,7 +133,7 @@ const _webhookSlackAPIHandler = async (
     try {
       switch (event.type) {
         case "app_mention": {
-          await handleDeprecatedChatBot(req, res, logger);
+          await notifyDeprecatedBot(res, event, teamId, logger);
           break;
         }
         /**
@@ -177,7 +202,7 @@ const _webhookSlackAPIHandler = async (
               return res.status(200).send();
             }
             // Message from an actual user (a human)
-            await handleDeprecatedChatBot(req, res, logger);
+            await notifyDeprecatedBot(res, event, teamId, logger);
             break;
           } else if (
             event.channel_type === "channel" ||
@@ -499,7 +524,8 @@ const _webhookSlackAPIHandler = async (
         case "channel_created": {
           if (isChannelCreatedEvent(event)) {
             const onChannelCreationRes = await onChannelCreation({
-              event,
+              channelId: event.channel.id,
+              contextTeamId: event.channel.context_team_id,
               logger,
               provider: "slack",
             });

--- a/connectors/src/api/webhooks/webhook_slack_bot.ts
+++ b/connectors/src/api/webhooks/webhook_slack_bot.ts
@@ -238,7 +238,8 @@ const _webhookSlackBotAPIHandler = async (
         case "channel_created": {
           if (isChannelCreatedEvent(event)) {
             const onChannelCreationRes = await onChannelCreation({
-              event,
+              channelId: event.channel.id,
+              contextTeamId: event.channel.context_team_id,
               logger,
               provider: "slack_bot",
             });

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -1593,3 +1593,6 @@ export async function autoReadChannelActivity(
 
   return true;
 }
+
+// Registered here so the Slack worker picks it up with the other activities.
+export { processSlackWebhookEventActivity } from "@connectors/connectors/slack/temporal/webhook_activities";

--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -8,11 +8,15 @@ import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
 import { normalizeError } from "@connectors/types";
 import { Err, Ok, removeNulls } from "@dust-tt/client";
+import { WorkflowExecutionAlreadyStartedError } from "@temporalio/common";
 
 import { getWeekStart } from "../lib/utils";
 import { QUEUE_NAME } from "./config";
 import { newWebhookSignal, syncChannelSignal } from "./signals";
-import type { JoinChannelUseCaseType } from "./workflows";
+import type {
+  JoinChannelUseCaseType,
+  SlackWebhookEventPayload,
+} from "./workflows";
 import {
   joinChannelWorkflow,
   joinChannelWorkflowId,
@@ -20,6 +24,8 @@ import {
   migrateChannelsFromLegacyBotToNewBotWorkflowId,
   slackGarbageCollectorWorkflow,
   slackGarbageCollectorWorkflowId,
+  slackWebhookEventWorkflow,
+  slackWebhookEventWorkflowId,
   syncOneMessageDebounced,
   syncOneMessageDebouncedWorkflowId,
   syncOneThreadDebounced,
@@ -29,6 +35,45 @@ import {
 } from "./workflows";
 
 const logger = mainLogger.child({ provider: "slack" });
+
+/**
+ * Starts one workflow per Slack webhook event. Start-only on purpose: this runs
+ * at Slack webhook rate, so it must never touch the database or the Slack API.
+ * Everything the event needs is resolved workflow side.
+ */
+export async function launchSlackWebhookEventWorkflow(
+  teamId: string,
+  eventId: string,
+  event: SlackWebhookEventPayload
+) {
+  const client = await getTemporalClient();
+
+  const workflowId = slackWebhookEventWorkflowId(eventId);
+  try {
+    await client.workflow.start(slackWebhookEventWorkflow, {
+      args: [teamId, event],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+    });
+
+    return new Ok(workflowId);
+  } catch (e) {
+    if (e instanceof WorkflowExecutionAlreadyStartedError) {
+      // Slack redelivered an event we are already handling.
+      logger.info(
+        { teamId, eventType: event.type, workflowId },
+        "Slack webhook event already queued"
+      );
+      return new Ok(workflowId);
+    }
+
+    logger.error(
+      { error: e, teamId, eventType: event.type, workflowId },
+      "Failed launchSlackWebhookEventWorkflow"
+    );
+    return new Err(normalizeError(e));
+  }
+}
 
 export async function launchSlackSyncWorkflow(
   connectorId: ModelId,
@@ -281,6 +326,16 @@ export async function launchSlackGarbageCollectWorkflow(connectorId: ModelId) {
     );
     return new Ok(workflowId);
   } catch (e) {
+    if (e instanceof WorkflowExecutionAlreadyStartedError) {
+      // A collection is already running for that connector, which is what the
+      // caller wants.
+      logger.info(
+        { connectorId, workflowId },
+        "slackGarbageCollector workflow already running."
+      );
+      return new Ok(workflowId);
+    }
+
     logger.error(
       {
         workflowId,

--- a/connectors/src/connectors/slack/temporal/webhook_activities.ts
+++ b/connectors/src/connectors/slack/temporal/webhook_activities.ts
@@ -1,0 +1,562 @@
+import { onChannelCreation } from "@connectors/api/webhooks/slack/created_channel";
+import { handleDeprecatedChatBot } from "@connectors/api/webhooks/slack/deprecated_bot";
+import { getBotUserIdResponse } from "@connectors/connectors/slack/lib/bot_user_helpers";
+import { updateSlackChannelInConnectorsDb } from "@connectors/connectors/slack/lib/channels";
+import {
+  getSlackClient,
+  reportSlackUsage,
+  withSlackErrorHandling,
+} from "@connectors/connectors/slack/lib/slack_client";
+import {
+  getSlackChannelSourceUrl,
+  slackChannelInternalIdFromSlackChannelId,
+} from "@connectors/connectors/slack/lib/utils";
+import {
+  launchSlackGarbageCollectWorkflow,
+  launchSlackSyncOneMessageWorkflow,
+  launchSlackSyncOneThreadWorkflow,
+} from "@connectors/connectors/slack/temporal/client";
+import type { SlackWebhookEventPayload } from "@connectors/connectors/slack/temporal/workflows";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { getDustAPI } from "@connectors/lib/api/dust_api";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
+import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
+import { SlackChannelModel } from "@connectors/lib/models/slack";
+import type { Logger } from "@connectors/logger/logger";
+import mainLogger from "@connectors/logger/logger";
+import { statsDClient } from "@connectors/logger/withlogging";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
+import { INTERNAL_MIME_TYPES, normalizeError } from "@connectors/types";
+import { removeNulls } from "@dust-tt/client";
+import { Op } from "sequelize";
+
+interface SyncTarget {
+  connector: ConnectorResource;
+  slackConfiguration: SlackConfigurationResource;
+}
+
+/**
+ * Resolves the connectors that may sync a channel: the channel must be
+ * selected, readable and not skipped, and the workspace must be up.
+ */
+async function listSyncableConnectors(
+  slackConfigurations: SlackConfigurationResource[],
+  channelId: string,
+  logger: Logger
+): Promise<SyncTarget[]> {
+  const connectors = await ConnectorResource.fetchByIds(
+    "slack",
+    slackConfigurations.map((c) => c.connectorId)
+  );
+
+  const slackChannels = await SlackChannelModel.findAll({
+    where: {
+      connectorId: { [Op.in]: connectors.map((c) => c.id) },
+      slackChannelId: channelId,
+    },
+  });
+  const channelByConnectorId = new Map(
+    slackChannels.map((c) => [c.connectorId, c])
+  );
+  const configurationByConnectorId = new Map(
+    slackConfigurations.map((c) => [c.connectorId, c])
+  );
+
+  const candidates: SyncTarget[] = [];
+  for (const connector of connectors) {
+    const slackConfiguration = configurationByConnectorId.get(connector.id);
+    if (!slackConfiguration) {
+      continue;
+    }
+
+    // Slack keeps pushing events at a paused connector, so dropping them here
+    // is what stops the churn once its token has been revoked.
+    if (connector.isPaused()) {
+      logger.info(
+        { connectorId: connector.id, slackChannelId: channelId },
+        "Ignoring messages because connector is paused"
+      );
+      continue;
+    }
+
+    const slackChannel = channelByConnectorId.get(connector.id);
+    if (!slackChannel) {
+      logger.info(
+        { connectorId: connector.id, slackChannelId: channelId },
+        "Ignoring messages because channel is not yet in DB"
+      );
+      continue;
+    }
+    if (slackChannel.skipReason) {
+      logger.info(
+        {
+          connectorId: connector.id,
+          slackChannelId: channelId,
+          skipReason: slackChannel.skipReason,
+        },
+        `Ignoring messages because channel is skipped: ${slackChannel.skipReason}`
+      );
+      continue;
+    }
+    if (!["read", "read_write"].includes(slackChannel.permission)) {
+      logger.info(
+        {
+          connectorId: connector.id,
+          slackChannelId: channelId,
+          permission: slackChannel.permission,
+        },
+        "Ignoring messages because channel permission is not read or read_write"
+      );
+      continue;
+    }
+
+    candidates.push({ connector, slackConfiguration });
+  }
+
+  return removeNulls(
+    await concurrentExecutor(
+      candidates,
+      async (candidate) => {
+        // /exists does no work beyond authentication and errors when the
+        // workspace is gone, relocated or in maintenance.
+        const existsRes = await getDustAPI(
+          dataSourceConfigFromConnector(candidate.connector)
+        ).exists();
+        if (existsRes.isErr()) {
+          logger.info(
+            {
+              connectorId: candidate.connector.id,
+              slackChannelId: channelId,
+              workspaceId: candidate.connector.workspaceId,
+              error: existsRes.error.message,
+            },
+            "Ignoring messages because workspace is unavailable (likely in maintenance)"
+          );
+          return null;
+        }
+        return candidate;
+      },
+      { concurrency: 4 }
+    )
+  );
+}
+
+async function applyChannelRename(
+  { connector, slackConfiguration }: SyncTarget,
+  { channelId, channelName }: { channelId: string; channelName: string }
+) {
+  await upsertDataSourceFolder({
+    dataSourceConfig: dataSourceConfigFromConnector(connector),
+    folderId: slackChannelInternalIdFromSlackChannelId(channelId),
+    parents: [slackChannelInternalIdFromSlackChannelId(channelId)],
+    parentId: null,
+    title: `#${channelName}`,
+    mimeType: INTERNAL_MIME_TYPES.SLACK.CHANNEL,
+    sourceUrl: getSlackChannelSourceUrl(channelId, slackConfiguration),
+    providerVisibility: "public",
+  });
+
+  await updateSlackChannelInConnectorsDb({
+    slackChannelId: channelId,
+    slackChannelName: channelName,
+    connectorId: connector.id,
+  });
+}
+
+/**
+ * Syncs a message posted in a channel or a group. A target that fails is
+ * logged and dropped: Slack has already been answered, and the other targets
+ * still have to run.
+ */
+async function syncChannelMessage(
+  event: SlackWebhookEventPayload,
+  slackConfigurations: SlackConfigurationResource[],
+  logger: Logger
+) {
+  const { channelId, threadTs } = event;
+  if (!channelId) {
+    logger.info("Ignoring channel message without a channel");
+    return;
+  }
+
+  const channelName =
+    event.subtype === "channel_name" ? event.channelName : undefined;
+  // A deleted message carries its own timestamp: we re-sync the thread it
+  // belonged to, or the week it was posted in.
+  const messageTs =
+    event.subtype === "message_deleted" ? event.deletedTs : event.ts;
+
+  if (event.subtype === "channel_name" && !channelName) {
+    logger.info(
+      { slackChannelId: channelId },
+      "Ignoring channel_name event without a new name"
+    );
+    return;
+  }
+  if (!channelName && !threadTs && !messageTs) {
+    logger.info(
+      { slackChannelId: channelId },
+      "Ignoring message event without 'thread_ts' or message 'ts'"
+    );
+    return;
+  }
+
+  const targets = await listSyncableConnectors(
+    slackConfigurations,
+    channelId,
+    logger
+  );
+
+  // A target that fails does not stop the others, but it does fail the
+  // activity: dropping the event would mean never syncing that thread.
+  const errors: Error[] = [];
+
+  for (const target of targets) {
+    const { connector } = target;
+
+    if (channelName) {
+      await applyChannelRename(target, { channelId, channelName });
+      logger.info(
+        {
+          connectorId: connector.id,
+          slackChannelId: channelId,
+          newName: channelName,
+        },
+        "Successfully processed Slack channel rename"
+      );
+    } else if (threadTs) {
+      const res = await launchSlackSyncOneThreadWorkflow(
+        connector.id,
+        channelId,
+        threadTs
+      );
+      if (res.isErr()) {
+        logger.error(
+          {
+            err: res.error,
+            connectorId: connector.id,
+            slackChannelId: channelId,
+            threadTs,
+          },
+          "Failed to launch Slack thread sync"
+        );
+        errors.push(res.error);
+      }
+    } else if (messageTs) {
+      const res = await launchSlackSyncOneMessageWorkflow(
+        connector.id,
+        channelId,
+        messageTs
+      );
+      if (res.isErr()) {
+        logger.error(
+          {
+            err: res.error,
+            connectorId: connector.id,
+            slackChannelId: channelId,
+            messageTs,
+          },
+          "Failed to launch Slack messages sync"
+        );
+        errors.push(res.error);
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Failed to launch Slack sync for ${errors.length} connector(s): ` +
+        errors.map((e) => e.message).join(", ")
+    );
+  }
+}
+
+async function handleAppMention(
+  event: SlackWebhookEventPayload,
+  teamId: string,
+  logger: Logger
+) {
+  if (!event.channelId || !event.ts) {
+    logger.info("Ignoring app_mention without a channel or a timestamp");
+    return;
+  }
+
+  await handleDeprecatedChatBot({
+    logger,
+    slackChannel: event.channelId,
+    slackMessageTs: event.ts,
+    slackTeamId: teamId,
+  });
+}
+
+/**
+ * Resolves the connector running the bot for a Slack team, its client and its
+ * bot user id. Returns null when the team has no enabled bot or when its
+ * connector is paused.
+ */
+async function resolveActiveBot(teamId: string, logger: Logger) {
+  const slackConfig = await SlackConfigurationResource.fetchByActiveBot(teamId);
+  if (!slackConfig) {
+    return null;
+  }
+
+  const connector = await ConnectorResource.fetchById(slackConfig.connectorId);
+  if (!connector) {
+    return null;
+  }
+  if (connector.isPaused()) {
+    logger.info(
+      { connectorId: connector.id },
+      "Ignoring event because the bot connector is paused"
+    );
+    return null;
+  }
+
+  const slackClient = await getSlackClient(connector.id);
+  const botUserIdRes = await getBotUserIdResponse(slackClient, connector.id);
+  if (botUserIdRes.isErr()) {
+    throw botUserIdRes.error;
+  }
+
+  return { botUserId: botUserIdRes.value, connector, slackClient };
+}
+
+async function handleDirectMessage(
+  event: SlackWebhookEventPayload,
+  teamId: string,
+  logger: Logger
+) {
+  if (
+    event.subtype === "message_changed" ||
+    event.subtype === "message_deleted"
+  ) {
+    // Ignore message_changed and message_deleted events in private messages.
+    return;
+  }
+  if (!event.channelId || !event.ts) {
+    logger.info("Ignoring direct message without a channel or a timestamp");
+    return;
+  }
+
+  const bot = await resolveActiveBot(teamId, logger);
+  if (!bot) {
+    logger.info(
+      "Ignoring direct message: no usable Slack configuration with an enabled bot"
+    );
+    return;
+  }
+
+  if (event.userId === bot.botUserId) {
+    // Message sent from the bot itself.
+    return;
+  }
+
+  await handleDeprecatedChatBot({
+    logger,
+    slackChannel: event.channelId,
+    slackMessageTs: event.ts,
+    slackTeamId: teamId,
+  });
+}
+
+async function joinCreatedChannel(
+  event: SlackWebhookEventPayload,
+  logger: Logger
+) {
+  if (!event.channelId || !event.contextTeamId) {
+    logger.info("Ignoring channel_created event without a channel");
+    return;
+  }
+
+  const res = await onChannelCreation({
+    channelId: event.channelId,
+    contextTeamId: event.contextTeamId,
+    logger,
+    provider: "slack",
+  });
+  if (res.isErr()) {
+    throw res.error;
+  }
+}
+
+async function announceBotJoinedPrivateChannel(
+  event: SlackWebhookEventPayload,
+  teamId: string,
+  logger: Logger
+) {
+  const { channelId } = event;
+  if (!channelId) {
+    logger.info("Ignoring member_joined_channel event without a channel");
+    return;
+  }
+
+  const bot = await resolveActiveBot(teamId, logger);
+  if (!bot) {
+    logger.info(
+      "Ignoring member_joined_channel event: no usable Slack configuration with an enabled bot"
+    );
+    return;
+  }
+
+  // If the bot is not the one joining the channel, ignore.
+  if (event.userId !== bot.botUserId) {
+    return;
+  }
+
+  const { connector, slackClient } = bot;
+
+  reportSlackUsage({
+    connectorId: connector.id,
+    method: "conversations.info",
+    channelId,
+  });
+  const channelInfo = await withSlackErrorHandling(() =>
+    slackClient.conversations.info({ channel: channelId })
+  );
+
+  if (channelInfo?.channel?.is_private) {
+    reportSlackUsage({
+      connectorId: connector.id,
+      method: "chat.postMessage",
+      channelId,
+    });
+    await withSlackErrorHandling(() =>
+      slackClient.chat.postMessage({
+        channel: channelId,
+        text: "You can now talk to Dust in this channel. ⚠️ If private channel synchronization has been allowed on your Dust workspace, admins will now be able to synchronize data from this channel.",
+      })
+    );
+  }
+}
+
+async function garbageCollectChannels(
+  slackConfigurations: SlackConfigurationResource[],
+  logger: Logger
+) {
+  const errors: Error[] = [];
+
+  for (const slackConfiguration of slackConfigurations) {
+    const res = await launchSlackGarbageCollectWorkflow(
+      slackConfiguration.connectorId
+    );
+    if (res.isErr()) {
+      logger.error(
+        { err: res.error, connectorId: slackConfiguration.connectorId },
+        "Failed to launch Slack garbage collection"
+      );
+      errors.push(res.error);
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Failed to launch Slack garbage collection for ${errors.length} connector(s): ` +
+        errors.map((e) => e.message).join(", ")
+    );
+  }
+}
+
+async function dispatchEvent(
+  event: SlackWebhookEventPayload,
+  teamId: string,
+  slackConfigurations: SlackConfigurationResource[],
+  logger: Logger
+) {
+  switch (event.type) {
+    case "app_mention":
+      return handleAppMention(event, teamId, logger);
+
+    case "message":
+      // Slack routes direct messages and channel messages through the same
+      // event type.
+      if (event.channelType === "im") {
+        return handleDirectMessage(event, teamId, logger);
+      }
+      if (event.channelType === "channel" || event.channelType === "group") {
+        return syncChannelMessage(event, slackConfigurations, logger);
+      }
+      return;
+
+    case "channel_created":
+      return joinCreatedChannel(event, logger);
+
+    case "member_joined_channel":
+      return announceBotJoinedPrivateChannel(event, teamId, logger);
+
+    case "channel_left":
+    case "channel_deleted":
+      return garbageCollectChannels(slackConfigurations, logger);
+
+    // The rename itself comes as a `message` event with the `channel_name`
+    // subtype, handled above.
+    case "channel_rename":
+      return;
+
+    default:
+      logger.info(
+        { eventType: event.type },
+        "Webhook event type not supported"
+      );
+      return;
+  }
+}
+
+/**
+ * Processes one Slack webhook event. The webhook handler does no work at all,
+ * so everything happens here: resolving the connectors, validating the channel
+ * and dispatching the sync.
+ *
+ * A failing event is retried a bounded number of times (see the retry policy on
+ * `slackWebhookEventWorkflow`) and then dropped: Slack was answered 200 and
+ * never retries, so nothing else would ever pick the event up. Replaying is
+ * safe because the handlers are idempotent: syncs are launched under
+ * deterministic workflow ids, and the Slack messages the bot posts are the last
+ * thing a handler does.
+ */
+export async function processSlackWebhookEventActivity({
+  event,
+  teamId,
+}: {
+  event: SlackWebhookEventPayload;
+  teamId: string;
+}) {
+  const logger = mainLogger.child({
+    connectorType: "slack",
+    slackTeamId: teamId,
+    eventType: event.type,
+  });
+
+  // Mirrors slack_webhook.events_queued.count emitted by the webhook handler.
+  // A queued event that never shows up here means the workflow is wedged, which
+  // nothing else would notice: Slack was answered 200 and never retries.
+  statsDClient.increment("slack_webhook.events_processed.count", 1, [
+    `event_type:${event.type}`,
+  ]);
+
+  const slackConfigurations = await SlackConfigurationResource.listForTeamId(
+    teamId,
+    "slack"
+  );
+  if (slackConfigurations.length === 0) {
+    logger.info(
+      "Dropping Slack webhook event: no Slack configuration for team"
+    );
+    return;
+  }
+
+  try {
+    await dispatchEvent(event, teamId, slackConfigurations, logger);
+  } catch (e) {
+    logger.error(
+      { err: normalizeError(e) },
+      "Failed to process Slack webhook event"
+    );
+    // Counts attempts, not events: a retried event lands here once per attempt.
+    statsDClient.increment("slack_webhook.event_errors.count", 1, [
+      `event_type:${event.type}`,
+    ]);
+
+    throw e;
+  }
+}

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -21,6 +21,29 @@ const JOIN_CHANNEL_USE_CASES = [
 ] as const;
 export type JoinChannelUseCaseType = (typeof JOIN_CHANNEL_USE_CASES)[number];
 
+/**
+ * Projection of a Slack webhook event, built by the webhook handler and carried
+ * to `slackWebhookEventWorkflow`. Only the fields the handlers read are kept:
+ * message text, blocks and attachments never leave the webhook.
+ */
+export interface SlackWebhookEventPayload {
+  type: string;
+  subtype?: "message_changed" | "message_deleted" | "channel_name";
+  channelType?: "channel" | "group" | "im" | "mpim";
+  // Always an id: `channel_created` carries an object that the webhook handler
+  // flattens.
+  channelId?: string;
+  // New channel name, on the `channel_name` message subtype.
+  channelName?: string;
+  // Team the channel belongs to, on `channel_created`. Differs from the webhook
+  // team id on shared channels.
+  contextTeamId?: string;
+  userId?: string;
+  ts?: string;
+  threadTs?: string;
+  deletedTs?: string;
+}
+
 // Dynamic activity creation with fresh routing evaluation (enables retry queue switching).
 function getSlackActivities() {
   const {
@@ -61,6 +84,22 @@ function getSlackActivities() {
       startToCloseTimeout: "60 minutes",
     });
 
+  // Bounded on purpose: this workflow carries no connector id, so the activity
+  // interceptor cannot pause a connector that keeps failing, and Slack keeps
+  // pushing events at us regardless. Retries buy us transient failures, not a
+  // recovery from a broken connector.
+  const { processSlackWebhookEventActivity } = proxyActivities<
+    typeof activities
+  >({
+    startToCloseTimeout: "10 minutes",
+    retry: {
+      initialInterval: "5s",
+      maximumInterval: "60s",
+      backoffCoefficient: 2,
+      maximumAttempts: 4,
+    },
+  });
+
   return {
     attemptChannelJoinActivity,
     autoReadChannelActivity,
@@ -69,6 +108,7 @@ function getSlackActivities() {
     getChannel,
     getChannelsToGarbageCollect,
     migrateChannelsFromLegacyBotToNewBotActivity,
+    processSlackWebhookEventActivity,
     reportInitialSyncProgressActivity,
     saveSuccessSyncActivity,
     syncChannel,
@@ -189,6 +229,23 @@ export async function syncOneChannel(
   if (updateSyncStatus) {
     await getSlackActivities().saveSuccessSyncActivity(connectorId);
   }
+}
+
+/**
+ * Entry point for a Slack webhook event: one workflow per event, so the webhook
+ * handler never touches the database. Resolving the connectors, validating the
+ * channel and dispatching the sync all happen in the activity. Coalescing is
+ * not this workflow's job — the sync workflows it dispatches to are already
+ * debounced per thread and per channel week.
+ */
+export async function slackWebhookEventWorkflow(
+  teamId: string,
+  event: SlackWebhookEventPayload
+) {
+  await getSlackActivities().processSlackWebhookEventActivity({
+    teamId,
+    event,
+  });
 }
 
 export async function syncOneThreadDebounced(
@@ -366,6 +423,15 @@ export function syncOneChanneWorkflowlId(
   channelId: string
 ) {
   return `slack-syncOneChannel-${connectorId}-${channelId}`;
+}
+
+/**
+ * Keyed on Slack's own event id, which makes a redelivery of the same event a
+ * no-op instead of a duplicate: Slack retries an event it believes we failed to
+ * acknowledge, and some handlers post messages to Slack.
+ */
+export function slackWebhookEventWorkflowId(eventId: string) {
+  return `slack-webhookEvent-${eventId}`;
 }
 
 export function syncOneThreadDebouncedWorkflowId(


### PR DESCRIPTION
## Description

First PR of two: 

1. (this PR) Put all the content of slack webhook handler into a temporal workflow resisting the urge to refacto and just make the switch case cleaner
2. remove the "simple calls" in the webhook handler and defer all the heavy DB duty into the brand new temporal workflow to have a controllable back-pressure.

## Tests

Added some tests
Tested locally (on the top branch)

## Risks

Standard : moving a lot of logic, and potentially putting some load on the slack workers (sending a lot of signals) - will need monitoring
Blast radius : slack bot and slack connector

## Plan

- Deploy connectors
Note this branch is a no-op, incident risk is triggered by the next one