### PR TITLE
[front] poke: allow selecting the business plan in Switch contract

### DIFF
--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -8,6 +8,8 @@ import { amountCents } from "@app/lib/metronome/amounts";
 import { isPaygEligibleTier } from "@app/lib/metronome/types";
 import {
   CREDIT_PRICED_BUSINESS_PLAN_CODE,
+  CREDIT_PRICED_ENTERPRISE_DEFAULT_PLAN_CODE,
+  isBusinessPlanPrefix,
   isEnterprisePlanPrefix,
 } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
@@ -323,10 +325,10 @@ export default function SwitchContractDialog({
     }
   }, [resolvedCurrency, selectedPackage, form]);
 
-  // When the operator picks a package, derive (Business) or reset
-  // (Enterprise) the plan code. The full list of ENT_* plans is offered for
-  // enterprise; business maps to a single plan code. Both tiers use the same
-  // operator-chosen start moment.
+  // When the operator picks a package, default the plan code for the tier. The
+  // full list of CP_BUSINESS_* / CP_ENT_* plans is offered for the matching
+  // tier (see business/enterprise plan options), each defaulting to its tier's
+  // canonical plan code. Both tiers use the same operator-chosen start moment.
   useEffect(() => {
     if (selectedTier === "business") {
       form.setValue("planCode", CREDIT_PRICED_BUSINESS_PLAN_CODE);
@@ -334,7 +336,7 @@ export default function SwitchContractDialog({
       form.setValue("paygEnabled", false);
       form.setValue("topUpEnabled", false);
     } else if (selectedTier === "enterprise") {
-      form.setValue("planCode", "");
+      form.setValue("planCode", CREDIT_PRICED_ENTERPRISE_DEFAULT_PLAN_CODE);
     }
     if (selectedTier) {
       form.setValue("startingAt", defaultStartingAtUTC);
@@ -410,6 +412,19 @@ export default function SwitchContractDialog({
         .filter(
           (plan) =>
             isEnterprisePlanPrefix(plan.code) && isCreditPricedPlan(plan)
+        )
+        .map((plan) => ({
+          value: plan.code,
+          display: `${plan.name} (${plan.code})`,
+        })),
+    [plans]
+  );
+
+  const businessPlanOptions = useMemo(
+    () =>
+      plans
+        .filter(
+          (plan) => isBusinessPlanPrefix(plan.code) && isCreditPricedPlan(plan)
         )
         .map((plan) => ({
           value: plan.code,
@@ -842,6 +857,18 @@ export default function SwitchContractDialog({
                           />
                         </>
                       )}
+                      {selectedTier === "business" && (
+                        <>
+                          <Label className="text-sm">Business plan</Label>
+                          <SelectField
+                            control={form.control}
+                            name="planCode"
+                            hideLabel
+                            mountPortalContainer={portalContainer}
+                            options={businessPlanOptions}
+                          />
+                        </>
+                      )}
                       {(selectedTier === "enterprise" ||
                         selectedTier === "business") && (
                         <>
@@ -896,14 +923,6 @@ export default function SwitchContractDialog({
                             )}
                           </div>
                         </>
-                      )}
-                      {selectedTier === "business" && (
-                        <div className="col-span-2 text-sm text-muted-foreground">
-                          Target plan:{" "}
-                          <span className="font-mono">
-                            {form.watch("planCode")}
-                          </span>
-                        </div>
                       )}
                     </div>
                     {selectedTier && (


### PR DESCRIPTION
## Description

In the poke **Switch contract** dialog, the business tier now lets the operator pick a plan from the `CP_BUSINESS_*` plans via a dropdown (defaulting to `CP_BUSINESS_PLAN`), mirroring the existing enterprise plan selector, instead of being locked to a single hard-coded plan code shown as read-only text. Enterprise now defaults its selector to `CP_ENT_DEFAULT_PLAN` rather than an empty value.

## Tests

Manually exercised the dialog: selecting a business package shows the new "Business plan" dropdown defaulting to `CP_BUSINESS_PLAN`; selecting an enterprise package defaults to `CP_ENT_DEFAULT_PLAN`. `tsgo --noEmit` and `biome check` both pass. The server already classifies any `CP_BUSINESS_*` code as the business tier, so no backend change was needed.

## Risk

Low — poke-only UI change on an internal admin dialog; the submitted `planCode` is still validated server-side against the package tier. Safe to roll back by reverting the commit.

## Deploy Plan

Standard front deploy; no migrations or coordinated steps required.