### PR TITLE
[front] poke: classify any CP_BUSINESS_* plan as the business tier

### DIFF
--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -43,8 +43,7 @@ import {
 } from "@app/lib/metronome/types";
 import { resolveCurrencyFromStripe } from "@app/lib/plans/billing_currency";
 import {
-  CREDIT_PRICED_BUSINESS_LEGACY_LARGE_PLAN_CODE,
-  CREDIT_PRICED_BUSINESS_PLAN_CODE,
+  isBusinessPlanPrefix,
   isEnterprisePlanPrefix,
   isProPlanPrefix,
   PRO_PLAN_SEAT_39_CODE,
@@ -107,11 +106,7 @@ function classifyPlanCode(planCode: string): MetronomePackageTier {
   if (isEnterprisePlanPrefix(planCode)) {
     return "enterprise";
   }
-  if (
-    planCode === CREDIT_PRICED_BUSINESS_PLAN_CODE ||
-    planCode === CREDIT_PRICED_BUSINESS_LEGACY_LARGE_PLAN_CODE ||
-    planCode === PRO_PLAN_SEAT_39_CODE
-  ) {
+  if (isBusinessPlanPrefix(planCode) || planCode === PRO_PLAN_SEAT_39_CODE) {
     return "business";
   }
   if (isProPlanPrefix(planCode)) {


### PR DESCRIPTION
## Description

Follow-up to #29741. The Switch contract dialog now offers every `CP_BUSINESS_*` plan, but the server-side `classifyPlanCode` only recognized the two canonical business codes — so selecting a plan like `CP_BUSINESS_SWEEP` was classified as `"free"` and rejected with `Plan CP_BUSINESS_SWEEP (tier "free") does not match the selected Metronome package (tier "business")`. This matches on the `CP_BUSINESS_` prefix instead, mirroring the enterprise branch and the dialog's own plan filter.

## Tests

`tsgo --noEmit` and `biome check` pass. Manually confirmed a business package + `CP_BUSINESS_SWEEP` no longer trips the tier-mismatch guard.

## Risk

Low — widens business-tier classification to all `CP_BUSINESS_*` codes on the internal poke switch-contract path; `PRO_PLAN_SEAT_39` still classifies as business. Safe to roll back by reverting.

## Deploy Plan

Standard front deploy; no migrations or coordinated steps required.