### PR TITLE
[front] Expose spaces to governance-grant permission checks

### DIFF
--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1551,6 +1551,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return [
         {
           workspaceId: this.workspaceId,
+          resourceType: "space",
+          resourceId: this.id,
           roles: [{ role: "admin", permissions: ["admin", "write"] }],
           groups: this.groups.map((group) => ({
             id: group.groupId,
@@ -1565,6 +1567,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return [
         {
           workspaceId: this.workspaceId,
+          resourceType: "space",
+          resourceId: this.id,
           roles: [
             { role: "admin", permissions: ["admin", "read", "write"] },
             // TODO(governance): remove once manager is available for everyone
@@ -1593,6 +1597,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return [
         {
           workspaceId: this.workspaceId,
+          resourceType: "space",
+          resourceId: this.id,
           roles: [
             { role: "admin", permissions: ["admin", "read", "write"] },
             // TODO(governance): remove once manager is available for everyone
@@ -1617,6 +1623,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return [
         {
           workspaceId: this.workspaceId,
+          resourceType: "space",
+          resourceId: this.id,
           roles: [
             { role: "admin", permissions: ["admin"] },
             { role: "manager", permissions: this.isOpen() ? ["read"] : [] }, // Non-restricted projects are visible to all users
@@ -1648,6 +1656,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return [
       {
         workspaceId: this.workspaceId,
+        resourceType: "space",
+        resourceId: this.id,
         roles: [{ role: "admin", permissions: ["admin"] }],
         groups: this.groups.reduce((acc, group) => {
           if (groupFilter(group)) {


### PR DESCRIPTION
Set `resourceType: "space"` + `resourceId` on every branch of
`SpaceResource.requestedPermissions()`, so a caller holding a matching
`group_permissions` grant on the space passes read/write/admin checks via the
governance-grant path added in the parent PR (#29379). Dormant until such grants
are written — first consumer is the space_editors work (dust-tt/tasks#9753).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
