### PR TITLE
fix(front): remove duplicate activation pod deletion block

### DIFF
--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -258,29 +258,17 @@ export async function scrubSpaceActivity({
     },
   });
 
-  // Delete recommendations made in this Pod and the Pod's own dedicated
-  // activation trigger before deleting the activation pod record below. The
-  // FK from activation_recommendations to activation_pods is
-  // `onDelete: "RESTRICT"`, so the recommendations must be removed first or
-  // the destroy below fails.
+  // Delete recommendations made in this Pod before deleting the activation
+  // pod record itself. The FK from activation_recommendations to
+  // activation_pods is `onDelete: "RESTRICT"`, so the recommendations must
+  // be removed first or the destroy below fails. The FK from spaces to
+  // activation_pods is `onDelete: "RESTRICT"` too, so this row must be
+  // removed before the space can be hard-deleted.
   const activationPod = await ActivationPodResource.fetchBySpace(auth, space);
   if (activationPod) {
     await ActivationRecommendationResource.deleteAllForActivationPod(
       auth,
       activationPod
-    );
-  }
-
-  // Delete the activation pod record for this space. The FK to spaces is
-  // `onDelete: "RESTRICT"`, so this row must be removed before the space
-  // can be hard-deleted. Recommendations reference the pod with
-  // `onDelete: "RESTRICT"` too; they are owned by the user so they are
-  // detached, not deleted.
-  const activationPod = await ActivationPodResource.fetchBySpace(auth, space);
-  if (activationPod) {
-    await ActivationRecommendationResource.detachActivationPod(
-      auth,
-      activationPod.id
     );
     const deletePodRes = await activationPod.delete(auth, {});
     if (deletePodRes.isErr()) {


### PR DESCRIPTION
## Description

`scrubSpaceActivity` had two back-to-back blocks fetching `activationPod` for
the same space: the first deleted its recommendations
(`deleteAllForActivationPod`), the second re-fetched the pod and called
`ActivationRecommendationResource.detachActivationPod`, a method that no
longer exists on the resource. This redeclared `activationPod` and broke
`tsgo`. Merged into a single fetch that deletes the recommendations and then
the pod.

## Tests

Verified with `npm run tsgo` (front workspace) — no more errors.

## Risk

## Deploy Plan
