### PR TITLE
[TRIGGERS] Fix schedule generation for workspaces without OpenAI whitelisted

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
@@ -57,13 +57,17 @@ app.post(
       ].includes(r.error.message)
         ? r.error.message
         : GENERIC_ERROR_MESSAGE;
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: cleanMessage,
+      return apiError(
+        ctx,
+        {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: cleanMessage,
+          },
         },
-      });
+        r.error
+      );
     }
 
     return ctx.json(scheduleConfigToResponse(r.value));

--- a/front/lib/api/assistant/configuration/triggers/cron_timezone.ts
+++ b/front/lib/api/assistant/configuration/triggers/cron_timezone.ts
@@ -1,5 +1,9 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import {
+  getSmallWhitelistedModel,
+  getWhitelistedProviders,
+} from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import { GPT_5_4_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import type { ScheduleConfig } from "@app/types/assistant/triggers";
@@ -63,7 +67,10 @@ export async function getCronTimezoneGeneration(
 ): Promise<Result<ScheduleConfig, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
-  const model = GPT_5_4_MINI_MODEL_CONFIG;
+  const providers = getWhitelistedProviders(auth);
+  const model = providers.has("openai")
+    ? GPT_5_4_MINI_MODEL_CONFIG
+    : getSmallWhitelistedModel(auth);
   if (!model) {
     return new Err(
       new Error("Failed to find a whitelisted model to generate cron rule")


### PR DESCRIPTION
## Description

`getCronTimezoneGeneration` hardcoded an OpenAI model, so `text_as_cron_rule` returned "Unable to generate a schedule" on every request for workspaces that don't whitelist `openai` — no endpoint was reachable and the LLM was never called. Falls back to `getSmallWhitelistedModel(auth)`, and passes the underlying error to `apiError` so the real cause is logged instead of the sanitized user-facing message.

## Tests

Not tested end-to-end. Root cause confirmed by checking `whiteListedProviders` on the three workspaces hitting this in Datadog; type-check passes.

## Risk

Low. OpenAI workspaces keep GPT-5.4-mini, so only currently-broken workspaces change behavior.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`
