### PR TITLE
Fix: give proper index for conversation participants

### DIFF
--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -207,6 +207,11 @@ ConversationParticipantModel.init(
         name: "conversation_participants_conversation_id",
         concurrently: true,
       },
+      {
+        fields: ["workspaceId", "conversationId", "actionRequired"],
+        name: "conversation_participants_workspace_conversation_action_idx",
+        concurrently: true,
+      },
     ],
   }
 );

--- a/front/migrations/post-deploy/20260730103134_add_composite_index_to_fix_slow_performance_for_conversation_participants.sql
+++ b/front/migrations/post-deploy/20260730103134_add_composite_index_to_fix_slow_performance_for_conversation_participants.sql
@@ -1,0 +1,7 @@
+SET
+  SESSION statement_timeout = 1200000;
+
+SET
+  SESSION lock_timeout = 3000;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS conversation_participants_workspace_conversation_action_idx ON public.conversation_participants USING btree ("workspaceId", "conversationId", "actionRequired");


### PR DESCRIPTION
## Description

Adds a composite index `(workspaceId, conversationId, actionRequired)` on `conversation_participants` to fix slow query performance on that table. The Sequelize model declares the index with `concurrently: true`; the post-deploy SQL migration runs `CREATE INDEX CONCURRENTLY IF NOT EXISTS` with `statement_timeout = 1200000` and `lock_timeout = 3000` to avoid blocking production.

## Tests

Tested locally — migration runs successfully against the target table.

## Risk

Low. `CREATE INDEX CONCURRENTLY` takes no exclusive lock and is safe to roll back with `DROP INDEX CONCURRENTLY conversation_participants_workspace_conversation_action_idx`. The model change is a no-op until the migration runs.

## Deploy Plan

1. Deploy front (model declaration is a no-op at runtime).
2. Run post-deploy SQL migration: `20260730103134_add_composite_index_to_fix_slow_performance_for_conversation_participants.sql`.
