### PR TITLE
Add IF NOT EXISTS

### DIFF
--- a/front/migrations/post-deploy/20260727091303_add_conditional_index_on_agent_step_content_for_text_only_content.sql
+++ b/front/migrations/post-deploy/20260727091303_add_conditional_index_on_agent_step_content_for_text_only_content.sql
@@ -1,3 +1,3 @@
 SET SESSION statement_timeout = 1200000;
 SET SESSION lock_timeout = 3000;
-CREATE INDEX CONCURRENTLY agent_step_contents_workspace_id_text_content_idx ON public.agent_step_contents USING btree ("workspaceId", "agentMessageId") WHERE ((type)::text = 'text_content'::text);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS agent_step_contents_workspace_id_text_content_idx ON public.agent_step_contents USING btree ("workspaceId", "agentMessageId") WHERE ((type)::text = 'text_content'::text);


### PR DESCRIPTION
## Description

Added `IF NOT EXISTS` to the `CREATE INDEX CONCURRENTLY` statement in `20260727091303_add_conditional_index_on_agent_step_content_for_text_only_content.sql`. Makes the migration idempotent — if the index `agent_step_contents_workspace_id_text_content_idx` was already created by a previous run, the migration no longer fails with a duplicate-index error.

## Tests

Verified SQL syntax manually. No application logic changed.

## Risk

Low. `IF NOT EXISTS` is a standard Postgres modifier; the index creation behavior is identical when the index doesn't exist, and silently no-ops when it does. Safe to re-run.

## Deploy Plan

Run the post-deploy SQL migration against the `front` DB.
