### PR TITLE
Add dbt and Snowflake CLIs to sandbox base image

### DIFF
--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.60",
+      tag: "0.8.61",
     });
   });
 
@@ -399,6 +399,28 @@ describe("sandbox image registry", () => {
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"
         ),
+      ])
+    );
+  });
+
+  test("installs the pinned dbt Cloud CLI release to /opt/bin", () => {
+    const operations = getDustBaseImageOperations();
+    const runCommands = getRunCommands(operations);
+    const image = getDustBaseImage();
+    const installCommand = runCommands.find((command) =>
+      command.includes("dbt-labs/dbt-cli/releases/download")
+    );
+
+    expect(installCommand).toBeDefined();
+    expect(installCommand).toContain(
+      "https://github.com/dbt-labs/dbt-cli/releases/download/v0.40.18/dbt_0.40.18_linux_amd64.tar.gz"
+    );
+    expect(installCommand).toContain(
+      "chown root:root /opt/bin/dbt && chmod 755 /opt/bin/dbt"
+    );
+    expect(image.tools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "dbt", version: "0.40.18" }),
       ])
     );
   });

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -425,6 +425,31 @@ describe("sandbox image registry", () => {
     );
   });
 
+  test("installs the pinned Snowflake CLI release to /opt/bin", () => {
+    const operations = getDustBaseImageOperations();
+    const runCommands = getRunCommands(operations);
+    const image = getDustBaseImage();
+    const installCommand = runCommands.find((command) =>
+      command.includes("sfc-repo.snowflakecomputing.com/snowflake-cli")
+    );
+
+    expect(installCommand).toBeDefined();
+    expect(installCommand).toContain(
+      "https://sfc-repo.snowflakecomputing.com/snowflake-cli/linux_x86_64/3.23.0/snowflake-cli-3.23.0.x86_64.deb"
+    );
+    expect(installCommand).toContain(
+      "bb1a3e645c171f43dac44965daa4047c256424bf47c954fef8b2a00d38e84775  /tmp/snowflake-cli.deb"
+    );
+    expect(installCommand).toContain(
+      "ln -sf /usr/lib/snowflake/snowflake-cli/snow /opt/bin/snow"
+    );
+    expect(image.tools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "snow", version: "3.23.0" }),
+      ])
+    );
+  });
+
   test("installs the pinned litestream release to /opt/bin", () => {
     const runCommands = getRunCommands(getDustBaseImageOperations());
     const installCommand = runCommands.find((command) =>

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -39,6 +39,11 @@ const APPLY_PATCH_VERSION = "0.1.0";
 const BUN_VERSION = "1.3.14";
 // dbt Cloud CLI (closed-source; github.com/dbt-labs/dbt-cli). Invoked as `dbt`.
 const DBT_CLI_VERSION = "0.40.18";
+// Snowflake CLI (github.com/snowflakedb/snowflake-cli). Invoked as `snow`.
+// Linux x86_64 .deb from https://sfc-repo.snowflakecomputing.com/snowflake-cli/
+const SNOWFLAKE_CLI_VERSION = "3.23.0";
+const SNOWFLAKE_CLI_DEB_SHA256 =
+  "bb1a3e645c171f43dac44965daa4047c256424bf47c954fef8b2a00d38e84775";
 // LibreOffice "Fresh" PPA. The Ubuntu 24.04 base ships LibreOffice 24.2, whose
 // PDF layout engine places text differently from a current desktop LibreOffice
 // (26.x). Since the pptx QA reads word positions off the soffice-rendered PDF to
@@ -517,6 +522,22 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
     version: DBT_CLI_VERSION,
     description:
       "dbt Cloud CLI for running dbt commands against a dbt platform project",
+    runtime: "system",
+  })
+  .runCmd(
+    `curl -fsSL https://sfc-repo.snowflakecomputing.com/snowflake-cli/linux_x86_64/${SNOWFLAKE_CLI_VERSION}/snowflake-cli-${SNOWFLAKE_CLI_VERSION}.x86_64.deb -o /tmp/snowflake-cli.deb && ` +
+      `echo "${SNOWFLAKE_CLI_DEB_SHA256}  /tmp/snowflake-cli.deb" | sha256sum -c - && ` +
+      "apt-get install -y /tmp/snowflake-cli.deb && " +
+      "ln -sf /usr/lib/snowflake/snowflake-cli/snow /opt/bin/snow && " +
+      "chown -h root:root /opt/bin/snow && " +
+      "rm -f /tmp/snowflake-cli.deb",
+    { user: "root" }
+  )
+  .registerTool({
+    name: "snow",
+    version: SNOWFLAKE_CLI_VERSION,
+    description:
+      "Snowflake CLI for managing Snowflake accounts, objects, and apps",
     runtime: "system",
   })
   .runCmd(

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -25,7 +25,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.60";
+const DUST_BASE_IMAGE_VERSION = "0.8.61";
 const DSBX_CLI_VERSION = "0.1.38";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
@@ -37,6 +37,8 @@ const APPLY_PATCH_VERSION = "0.1.0";
 // Modern x86_64 build (requires AVX2). Switch to the baseline variant if a
 // future sandbox CPU lacks it.
 const BUN_VERSION = "1.3.14";
+// dbt Cloud CLI (closed-source; github.com/dbt-labs/dbt-cli). Invoked as `dbt`.
+const DBT_CLI_VERSION = "0.40.18";
 // LibreOffice "Fresh" PPA. The Ubuntu 24.04 base ships LibreOffice 24.2, whose
 // PDF layout engine places text differently from a current desktop LibreOffice
 // (26.x). Since the pptx QA reads word positions off the soffice-rendered PDF to
@@ -499,6 +501,23 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
     name: "bun",
     description: "Fast JavaScript/TypeScript runtime and package manager",
     runtime: "node",
+  })
+  .runCmd(
+    `curl -fsSL https://github.com/dbt-labs/dbt-cli/releases/download/v${DBT_CLI_VERSION}/dbt_${DBT_CLI_VERSION}_linux_amd64.tar.gz -o /tmp/dbt.tar.gz && ` +
+      `curl -fsSL https://github.com/dbt-labs/dbt-cli/releases/download/v${DBT_CLI_VERSION}/dbt_checksums.txt -o /tmp/dbt-checksums.txt && ` +
+      `grep "dbt_${DBT_CLI_VERSION}_linux_amd64.tar.gz" /tmp/dbt-checksums.txt | awk '{print $1 "  /tmp/dbt.tar.gz"}' | sha256sum -c - && ` +
+      "tar -xzf /tmp/dbt.tar.gz -C /tmp dbt && " +
+      "rm /tmp/dbt.tar.gz /tmp/dbt-checksums.txt && " +
+      "mv /tmp/dbt /opt/bin/dbt && " +
+      "chown root:root /opt/bin/dbt && chmod 755 /opt/bin/dbt",
+    { user: "root" }
+  )
+  .registerTool({
+    name: "dbt",
+    version: DBT_CLI_VERSION,
+    description:
+      "dbt Cloud CLI for running dbt commands against a dbt platform project",
+    runtime: "system",
   })
   .runCmd(
     `curl -fsSL https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/litestream-${LITESTREAM_VERSION}-linux-x86_64.tar.gz -o /tmp/litestream.tar.gz && ` +


### PR DESCRIPTION
## Description

Adds pinned dbt Cloud CLI (`dbt` 0.40.18) and Snowflake CLI (`snow` 3.23.0) to the default sandbox base image, and bumps `dust-base` to `0.8.61`.

Both install with checksum verification: dbt from GitHub releases into `/opt/bin`, Snowflake from Snowflake's linux x86_64 .deb (also linked at `/opt/bin/snow`).

## Tests

Ran `registry.test.ts` locally.

## Risk

Low. New binaries only; existing sandboxes keep the old image until killed. Needs a new image build before the bumped tag is usable.

## Deploy Plan

1. Release/build the new `dust-base:0.8.61` sandbox image (required before or with front deploy).
2. Deploy front with this change.
3. After deploy, open `/poke/kill` and kill older `dust-base` versions so conversations pick up the new image.