### PR TITLE
Only update keys lastUpdatedAt once per hour

### DIFF
--- a/front/lib/resources/key_resource.test.ts
+++ b/front/lib/resources/key_resource.test.ts
@@ -77,7 +77,11 @@ vi.mock("@app/lib/utils/cache", () => ({
 
 import type { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
-import { KeyResource } from "@app/lib/resources/key_resource";
+import {
+  KeyResource,
+  MARK_AS_USED_MIN_INTERVAL_MS,
+} from "@app/lib/resources/key_resource";
+import { KeyModel } from "@app/lib/resources/storage/models/keys";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -287,5 +291,71 @@ describe("KeyResource.keyCacheKeyResolver", () => {
     expect(KeyResource.keyCacheKeyResolver("secret-a")).toBe(
       "key:secret:6d0bd572a4f30536d6ad11b514678cb41703fdef30d395f4ecb207a6d2bd2fd3"
     );
+  });
+});
+
+describe("KeyResource.markAsUsed", () => {
+  let globalGroup: GroupResource;
+
+  beforeEach(async () => {
+    inMemoryCache.clear();
+    const testSetup = await createResourceTest({ role: "admin" });
+    globalGroup = testSetup.globalGroup;
+  });
+
+  it("writes lastUsedAt when it has never been set", async () => {
+    const key = await KeyFactory.regular(globalGroup);
+    expect(key.lastUsedAt).toBeNull();
+
+    await key.markAsUsed();
+
+    expect(key.lastUsedAt).not.toBeNull();
+  });
+
+  it("skips the DB write when lastUsedAt is within the throttle window", async () => {
+    const key = await KeyFactory.regular(globalGroup);
+    await key.markAsUsed();
+    const firstLastUsedAt = key.lastUsedAt;
+
+    const updateSpy = vi.spyOn(KeyModel, "update");
+    await key.markAsUsed();
+
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(key.lastUsedAt).toEqual(firstLastUsedAt);
+    updateSpy.mockRestore();
+  });
+
+  it("writes again when lastUsedAt is older than the throttle window", async () => {
+    const key = await KeyFactory.regular(globalGroup);
+    const staleDate = new Date(Date.now() - MARK_AS_USED_MIN_INTERVAL_MS - 1);
+    await KeyModel.update(
+      { lastUsedAt: staleDate },
+      { where: { id: key.id, workspaceId: key.workspaceId } }
+    );
+
+    const reloaded = await KeyResource.fetchBySecret(key.secret);
+    expect(reloaded).not.toBeNull();
+
+    await reloaded!.markAsUsed();
+
+    expect(reloaded!.lastUsedAt).not.toBeNull();
+    expect(reloaded!.lastUsedAt!.getTime()).toBeGreaterThan(
+      staleDate.getTime()
+    );
+  });
+
+  it("invalidates the secret cache so subsequent fetches see the new lastUsedAt", async () => {
+    const key = await KeyFactory.regular(globalGroup);
+    await KeyResource.fetchBySecret(key.secret); // populate cache with null lastUsedAt
+
+    await key.markAsUsed();
+
+    const fetched = await KeyResource.fetchBySecret(key.secret);
+    expect(fetched?.lastUsedAt).not.toBeNull();
+
+    const updateSpy = vi.spyOn(KeyModel, "update");
+    await fetched!.markAsUsed();
+    expect(updateSpy).not.toHaveBeenCalled();
+    updateSpy.mockRestore();
   });
 });

--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -53,6 +53,10 @@ export interface KeyAuthType {
 export const DEFAULT_SYSTEM_KEY_NAME = "DustSystemKey";
 export const SECRET_KEY_PREFIX = "sk-";
 
+// "Last used" is only shown coarsely in the UI; skip DB writes within this window
+// to avoid row-lock contention on hot API keys.
+export const MARK_AS_USED_MIN_INTERVAL_MS = 60 * 60 * 1000;
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface KeyResource extends ReadonlyAttributesType<KeyModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -267,14 +271,16 @@ export class KeyResource extends BaseResource<KeyModel> {
   }
 
   async markAsUsed() {
-    return this.model.update(
-      { lastUsedAt: new Date() },
-      {
-        where: {
-          id: this.id,
-        },
-      }
-    );
+    if (
+      this.lastUsedAt &&
+      Date.now() - this.lastUsedAt.getTime() < MARK_AS_USED_MIN_INTERVAL_MS
+    ) {
+      return;
+    }
+
+    // Use `this.update` (not `model.update`) so the instance and Redis secret
+    // cache stay consistent — otherwise every cached hit would keep writing.
+    return this.update({ lastUsedAt: new Date() });
   }
 
   async setIsDisabled() {


### PR DESCRIPTION
## Description

`KeyResource.markAsUsed()` was issuing a DB write on every authenticated API request, causing row-lock contention on hot keys. Throttle writes to at most once per hour via `MARK_AS_USED_MIN_INTERVAL_MS = 3_600_000`. Also switches from `this.model.update` to `this.update` so the in-memory instance and Redis secret cache stay consistent after a write — previously, every cached hit would still trigger a write on the next request.

## Tests

Added 4 unit tests in `key_resource.test.ts`: first write (null → set), skip within the throttle window, write again after the window expires, and cache invalidation so subsequent fetches see the updated `lastUsedAt`.

## Risk

Low. `lastUsedAt` is a coarse "last seen" display field — skipping sub-hour updates has no functional impact. Rollback: revert to unconditional `this.model.update` in `markAsUsed`.

## Deploy Plan

Deploy front.
