### PR TITLE
[front] fix: Dedupe conversation mark-as-read PATCHes

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.test.ts
@@ -182,6 +182,36 @@ describe("GET /api/w/:wId/assistant/conversations/:cId", () => {
     expect(response.status).toBe(404);
     expect((await response.json()).error.type).toBe("conversation_not_found");
   });
+
+  it("hydrates read state on the returned conversation", async () => {
+    const { workspace, auth, globalSpace } = await createPrivateApiMockRequest({
+      role: "user",
+      method: "GET",
+    });
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      requestedSpaceIds: [globalSpace.id],
+      messagesCreatedAt: [new Date()],
+    });
+
+    const unreadResponse = await getConversation(workspace, conversation.sId);
+    expect(unreadResponse.status).toBe(200);
+    const unreadBody = await unreadResponse.json();
+    expect(unreadBody.conversation.unread).toBe(true);
+    expect(unreadBody.conversation.lastReadMs).toBeNull();
+
+    const patchResponse = await patchConversation(workspace, conversation.sId, {
+      read: true,
+    });
+    expect(patchResponse.status).toBe(200);
+
+    const readResponse = await getConversation(workspace, conversation.sId);
+    expect(readResponse.status).toBe(200);
+    const readBody = await readResponse.json();
+    expect(readBody.conversation.unread).toBe(false);
+    expect(readBody.conversation.lastReadMs).toEqual(expect.any(Number));
+  });
 });
 
 describe("PATCH /api/w/:wId/assistant/conversations/:cId", () => {
@@ -230,5 +260,85 @@ describe("PATCH /api/w/:wId/assistant/conversations/:cId", () => {
     });
 
     expect(response.status).toBe(400);
+  });
+
+  it("marks an unread conversation as read", async () => {
+    const { workspace, auth, globalSpace } = await createPrivateApiMockRequest({
+      role: "user",
+      method: "PATCH",
+    });
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      requestedSpaceIds: [globalSpace.id],
+      messagesCreatedAt: [new Date()],
+    });
+
+    const before =
+      await ConversationResource.fetchConversationWithParticipantState(
+        auth,
+        conversation.sId
+      );
+    assert(before.isOk(), "Expected conversation to be fetched");
+    expect(before.value.unread).toBe(true);
+
+    const response = await patchConversation(workspace, conversation.sId, {
+      read: true,
+    });
+    expect(response.status).toBe(200);
+
+    const after =
+      await ConversationResource.fetchConversationWithParticipantState(
+        auth,
+        conversation.sId
+      );
+    assert(after.isOk(), "Expected conversation to be fetched");
+    expect(after.value.unread).toBe(false);
+    expect(after.value.lastReadMs).not.toBeNull();
+  });
+
+  it("skips the lastReadAt write when the conversation is already read", async () => {
+    const { workspace, auth, globalSpace } = await createPrivateApiMockRequest({
+      role: "user",
+      method: "PATCH",
+    });
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      requestedSpaceIds: [globalSpace.id],
+      messagesCreatedAt: [new Date()],
+    });
+
+    const firstResponse = await patchConversation(workspace, conversation.sId, {
+      read: true,
+    });
+    expect(firstResponse.status).toBe(200);
+
+    const firstState =
+      await ConversationResource.fetchConversationWithParticipantState(
+        auth,
+        conversation.sId
+      );
+    assert(firstState.isOk(), "Expected conversation to be fetched");
+    const firstLastReadMs = firstState.value.lastReadMs;
+    expect(firstLastReadMs).not.toBeNull();
+
+    // Ensure a second write would produce a different lastReadAt.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const secondResponse = await patchConversation(
+      workspace,
+      conversation.sId,
+      { read: true }
+    );
+    expect(secondResponse.status).toBe(200);
+
+    const secondState =
+      await ConversationResource.fetchConversationWithParticipantState(
+        auth,
+        conversation.sId
+      );
+    assert(secondState.isOk(), "Expected conversation to be fetched");
+    expect(secondState.value.lastReadMs).toBe(firstLastReadMs);
   });
 });

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -200,9 +200,13 @@ app.get(
     const auth = ctx.get("auth");
     const { cId } = ctx.req.valid("param");
 
-    const conversation = await ConversationResource.fetchById(auth, cId, {
-      includeForkingData: true,
-    });
+    // Read state must be hydrated: without it the serialized conversation always
+    // reports `unread: true` / `lastReadMs: null`.
+    const conversation = await ConversationResource.fetchByIdWithReadState(
+      auth,
+      cId,
+      { includeForkingData: true }
+    );
 
     if (!conversation) {
       // Distinguish between "not found" and "access restricted" for the UI.
@@ -286,9 +290,14 @@ app.patch(
 
     if ("read" in data) {
       if (data.read) {
-        await ConversationResource.markAsReadForAuthUser(auth, {
-          conversation,
-        });
+        // Clients re-send this on many triggers: skip the write when the conversation is
+        // already read up to its latest activity. This also preserves future-dated
+        // `lastReadAt` stamps (see markAsReadForAuthUser) instead of clobbering them.
+        if (conversation.unread) {
+          await ConversationResource.markAsReadForAuthUser(auth, {
+            conversation,
+          });
+        }
 
         // A stale `actionRequired` flag (e.g. left behind by a manual tool approval whose
         // message got interrupted before blocked actions were resolved on termination) would

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -35,6 +35,7 @@ import {
   makeInitialMessageStreamState,
 } from "@app/components/assistant/conversation/types";
 import {
+  requestConversationMarkAsRead,
   useConversation,
   useConversationContextUsage,
   useConversationFeedbacks,
@@ -92,7 +93,6 @@ import {
   VirtuosoMessageList,
   VirtuosoMessageListLicense,
 } from "@virtuoso.dev/message-list";
-import debounce from "lodash/debounce";
 import type { MutableRefObject } from "react";
 import {
   useCallback,
@@ -387,7 +387,7 @@ export const ConversationViewer = ({
     disabled: !conversation?.spaceId,
   });
 
-  const { markAsRead } = useConversationMarkAsRead({
+  useConversationMarkAsRead({
     conversation,
     workspaceId: owner.sId,
   });
@@ -729,11 +729,6 @@ export const ConversationViewer = ({
 
   // Hooks related to conversation events streaming.
 
-  const debouncedMarkAsRead = useMemo(
-    () => debounce(markAsRead, 2000),
-    [markAsRead]
-  );
-
   const eventIds = useRef<string[]>([]);
 
   // Only conversation related events are handled here.
@@ -804,7 +799,11 @@ export const ConversationViewer = ({
                   { revalidate: false }
                 );
               }
-              void debouncedMarkAsRead(conversationId);
+              requestConversationMarkAsRead({
+                workspaceId: owner.sId,
+                conversationId,
+                activityAtMs: event.created,
+              });
 
               if (userMessage.contentFragments.length > 0) {
                 void mutateConversationAttachments();
@@ -900,7 +899,11 @@ export const ConversationViewer = ({
             break;
 
           case "conversation_title":
-            void debouncedMarkAsRead(conversationId);
+            requestConversationMarkAsRead({
+              workspaceId: owner.sId,
+              conversationId,
+              activityAtMs: event.created,
+            });
             void mutateConversation(
               (current) => {
                 if (current) {
@@ -935,9 +938,11 @@ export const ConversationViewer = ({
             }
             break;
           case "agent_message_done":
-            // Mark as read and do not mutate the list of convos in the sidebar to avoid useless network request.
-            // Debounce the call as we might receive multiple events for the same conversation (as we replay the events).
-            void debouncedMarkAsRead(event.conversationId);
+            requestConversationMarkAsRead({
+              workspaceId: owner.sId,
+              conversationId: event.conversationId,
+              activityAtMs: event.created,
+            });
 
             // Re-fetch context usage after the agent finishes so the indicator is up-to-date.
             void mutateContextUsage();
@@ -1106,7 +1111,6 @@ export const ConversationViewer = ({
     [
       conversation?.forkingData?.forkedFrom?.fileCopyStatus,
       conversationId,
-      debouncedMarkAsRead,
       mutateContextUsage,
       mutateConversation,
       mutateConversationAttachments,

--- a/front/hooks/conversations/index.ts
+++ b/front/hooks/conversations/index.ts
@@ -8,7 +8,10 @@ export { useConversationBranchActions } from "./useConversationBranchActions";
 export { useConversationContextUsage } from "./useConversationContextUsage";
 export { useConversationFeedbacks } from "./useConversationFeedbacks";
 export { useConversationFileContent } from "./useConversationFileContent";
-export { useConversationMarkAsRead } from "./useConversationMarkAsRead";
+export {
+  requestConversationMarkAsRead,
+  useConversationMarkAsRead,
+} from "./useConversationMarkAsRead";
 export {
   useConversationMessage,
   useConversationMessageAction,

--- a/front/hooks/conversations/useConversationMarkAsRead.ts
+++ b/front/hooks/conversations/useConversationMarkAsRead.ts
@@ -6,11 +6,180 @@ import type {
   ConversationListItemType,
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
-import { isPodConversation } from "@app/types/assistant/conversation";
-import { useCallback, useEffect } from "react";
+import { useEffect } from "react";
+
+import { useConversation } from "./useConversation";
 import { useConversations } from "./useConversations";
 
-const DELAY_BEFORE_MARKING_AS_READ = 2000;
+const DELAY_BEFORE_MARKING_AS_READ_MS = 2000;
+
+// Mark-as-read requests are debounced and deduplicated at module level: the components
+// that trigger them (ConversationViewer, its SSE handlers) mount and unmount constantly,
+// so per-instance timers and dedup state would reset mid-burst and re-send the same
+// PATCH many times over.
+
+type PendingMark = {
+  workspaceId: string;
+  // Highest activity timestamp this mark must cover.
+  activityAtMs: number;
+  // null while parked because the tab is hidden.
+  timeoutId: ReturnType<typeof setTimeout> | null;
+};
+
+const pendingByConversationId = new Map<string, PendingMark>();
+
+// Highest activity timestamp already covered, either by a successful PATCH or by the
+// server-reported `lastReadAt` observed on fetched conversations.
+const coveredUpToMsByConversationId = new Map<string, number>();
+
+function recordConversationReadUpTo(
+  conversationId: string,
+  readUpToMs: number
+): void {
+  coveredUpToMsByConversationId.set(
+    conversationId,
+    Math.max(coveredUpToMsByConversationId.get(conversationId) ?? 0, readUpToMs)
+  );
+}
+
+// Conversations this session can no longer access (403/404): a stale tab would
+// otherwise retry them forever.
+const inaccessibleConversationIds = new Set<string>();
+
+type MarkedAsReadListener = (conversationId: string) => void;
+const markedAsReadListeners = new Set<MarkedAsReadListener>();
+
+function subscribeToConversationMarkedAsRead(
+  listener: MarkedAsReadListener
+): () => void {
+  markedAsReadListeners.add(listener);
+  return () => {
+    markedAsReadListeners.delete(listener);
+  };
+}
+
+let isVisibilityListenerRegistered = false;
+
+// Marks parked while the tab was hidden resume when it becomes visible again.
+function registerVisibilityListenerOnce(): void {
+  if (isVisibilityListenerRegistered) {
+    return;
+  }
+  isVisibilityListenerRegistered = true;
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState !== "visible") {
+      return;
+    }
+    for (const [conversationId, pending] of pendingByConversationId) {
+      if (pending.timeoutId === null) {
+        pending.timeoutId = setTimeout(
+          () => void markAsRead(conversationId),
+          DELAY_BEFORE_MARKING_AS_READ_MS
+        );
+      }
+    }
+  });
+}
+
+export function requestConversationMarkAsRead({
+  workspaceId,
+  conversationId,
+  activityAtMs = Date.now(),
+}: {
+  workspaceId: string;
+  conversationId: string;
+  // Timestamp of the activity that must end up covered by `lastReadAt`. Requests whose
+  // activity a previous mark already covers are dropped.
+  activityAtMs?: number;
+}): void {
+  if (inaccessibleConversationIds.has(conversationId)) {
+    return;
+  }
+
+  const pending = pendingByConversationId.get(conversationId);
+  if (pending) {
+    pending.activityAtMs = Math.max(pending.activityAtMs, activityAtMs);
+    if (pending.timeoutId !== null) {
+      clearTimeout(pending.timeoutId);
+      pending.timeoutId = setTimeout(
+        () => void markAsRead(conversationId),
+        DELAY_BEFORE_MARKING_AS_READ_MS
+      );
+    }
+    return;
+  }
+
+  if (
+    activityAtMs <= (coveredUpToMsByConversationId.get(conversationId) ?? 0)
+  ) {
+    return;
+  }
+
+  registerVisibilityListenerOnce();
+  pendingByConversationId.set(conversationId, {
+    workspaceId,
+    activityAtMs,
+    timeoutId: setTimeout(
+      () => void markAsRead(conversationId),
+      DELAY_BEFORE_MARKING_AS_READ_MS
+    ),
+  });
+}
+
+async function markAsRead(conversationId: string): Promise<void> {
+  const pending = pendingByConversationId.get(conversationId);
+  if (!pending) {
+    return;
+  }
+
+  // A hidden tab is not reading anything: park until it is visible again.
+  if (document.visibilityState === "hidden") {
+    pending.timeoutId = null;
+    return;
+  }
+
+  pendingByConversationId.delete(conversationId);
+
+  // Re-check at flush time: the conversation data (and its `lastReadAt` seed) may have
+  // arrived after this mark was scheduled.
+  if (
+    pending.activityAtMs <=
+    (coveredUpToMsByConversationId.get(conversationId) ?? 0)
+  ) {
+    return;
+  }
+
+  try {
+    const response = await clientFetch(
+      `/api/w/${pending.workspaceId}/assistant/conversations/${conversationId}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          read: true,
+        } satisfies PatchConversationsRequestBody),
+      }
+    );
+
+    if (!response.ok) {
+      if (response.status === 403 || response.status === 404) {
+        inaccessibleConversationIds.add(conversationId);
+      }
+      throw new Error("Failed to mark conversation as read");
+    }
+
+    recordConversationReadUpTo(conversationId, pending.activityAtMs);
+
+    for (const listener of markedAsReadListeners) {
+      listener(conversationId);
+    }
+  } catch (error) {
+    // Dropped on purpose: the next activity or view schedules a new mark.
+    logger.error({ err: error }, "Error marking conversation as read:");
+  }
+}
 
 export function useConversationMarkAsRead({
   conversation,
@@ -18,7 +187,7 @@ export function useConversationMarkAsRead({
 }: {
   conversation?: ConversationWithoutContentType;
   workspaceId: string;
-}) {
+}): void {
   const { mutateConversations } = useConversations({
     workspaceId,
     options: { disabled: true },
@@ -31,101 +200,104 @@ export function useConversationMarkAsRead({
     },
   });
 
-  const markAsRead = useCallback(
-    async (
-      conversationId: string,
-      options?: {
-        mutateList?: boolean;
-        mutateSpaceConversationsSummary?: boolean;
-      }
-    ): Promise<void> => {
-      try {
-        const response = await clientFetch(
-          `/api/w/${workspaceId}/assistant/conversations/${conversationId}`,
-          {
-            method: "PATCH",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              read: true,
-            } satisfies PatchConversationsRequestBody),
-          }
-        );
+  // We only need the mutator, to reflect the read state on the open conversation.
+  const { mutateConversation } = useConversation({
+    conversationId: conversation?.sId ?? null,
+    workspaceId,
+    options: { disabled: true },
+  });
 
-        if (!response.ok) {
-          throw new Error("Failed to mark conversation as read");
+  const conversationSId = conversation?.sId;
+
+  // Depending on the conversation value is deliberate: activity landing while the user
+  // views the conversation produces a new object with `unread: true` and a newer
+  // `updated`, which must schedule a new mark. Identity churn without new activity is
+  // deduplicated on `updated` by the module-level scheduler above.
+  useEffect(() => {
+    if (!conversation?.sId) {
+      return;
+    }
+    // Server truth: everything up to `lastReadAt` is already read. Seeding lets the
+    // scheduler drop replayed SSE events for activity the user has already seen.
+    if (conversation.lastReadMs !== null) {
+      recordConversationReadUpTo(conversation.sId, conversation.lastReadMs);
+    }
+    if (conversation.unread) {
+      requestConversationMarkAsRead({
+        workspaceId,
+        conversationId: conversation.sId,
+        activityAtMs: conversation.updated,
+      });
+    }
+  }, [workspaceId, conversation]);
+
+  // Reflect successful marks in the SWR caches while mounted.
+  useEffect(() => {
+    return subscribeToConversationMarkedAsRead((conversationId) => {
+      void mutateConversations(
+        (prevState: ConversationListItemType[] | undefined) =>
+          prevState?.map((c) =>
+            c.sId === conversationId
+              ? { ...c, unread: false, isRunningAgentLoop: false }
+              : c
+          ),
+        { revalidate: false }
+      );
+
+      void mutateSpaceSummary((prevState) => {
+        if (!prevState) {
+          return prevState;
         }
-        if (options?.mutateList) {
-          void mutateConversations(
-            (prevState: ConversationListItemType[] | undefined) =>
-              prevState?.map((c) =>
-                c.sId === conversationId
-                  ? { ...c, unread: false, isRunningAgentLoop: false }
-                  : c
+        const containsConversation = prevState.summary.some(
+          (spaceSummary) =>
+            spaceSummary.unreadConversations.some(
+              ({ sId }) => sId === conversationId
+            ) ||
+            spaceSummary.nonParticipantUnreadConversations.some(
+              ({ sId }) => sId === conversationId
+            )
+        );
+        if (!containsConversation) {
+          return prevState;
+        }
+        return {
+          ...prevState,
+          summary: prevState.summary.map((spaceSummary) => ({
+            ...spaceSummary,
+            unreadConversations: spaceSummary.unreadConversations.filter(
+              ({ sId }) => sId !== conversationId
+            ),
+            nonParticipantUnreadConversations:
+              spaceSummary.nonParticipantUnreadConversations.filter(
+                ({ sId }) => sId !== conversationId
               ),
-            { revalidate: false }
-          );
-        }
-        if (options?.mutateSpaceConversationsSummary) {
-          void mutateSpaceSummary((prevState) => {
-            if (!prevState) {
-              return prevState;
+          })),
+        };
+      });
+
+      if (conversationId === conversationSId) {
+        void mutateConversation(
+          (current) => {
+            if (!current) {
+              return current;
             }
             return {
-              ...prevState,
-              summary: prevState.summary.map((spaceSummary) => {
-                if (spaceSummary.space.sId === conversation?.spaceId) {
-                  return {
-                    ...spaceSummary,
-                    unreadConversations:
-                      spaceSummary.unreadConversations.filter(
-                        ({ sId }) => sId !== conversationId
-                      ) ?? [],
-                    nonParticipantUnreadConversations:
-                      spaceSummary.nonParticipantUnreadConversations.filter(
-                        ({ sId }) => sId !== conversationId
-                      ) ?? [],
-                  };
-                }
-                return spaceSummary;
-              }),
+              ...current,
+              conversation: {
+                ...current.conversation,
+                lastReadMs: Date.now(),
+                unread: false,
+              },
             };
-          });
-        }
-      } catch (error) {
-        logger.error({ err: error }, "Error marking conversation as read:");
+          },
+          { revalidate: false }
+        );
       }
-    },
-    [
-      workspaceId,
-      mutateConversations,
-      mutateSpaceSummary,
-      conversation?.spaceId,
-    ]
-  );
-
-  useEffect(() => {
-    let timeout: NodeJS.Timeout | null = null;
-    if (conversation?.sId && conversation?.unread) {
-      timeout = setTimeout(
-        () =>
-          markAsRead(conversation.sId, {
-            mutateList: !isPodConversation(conversation),
-            mutateSpaceConversationsSummary: isPodConversation(conversation),
-          }),
-        DELAY_BEFORE_MARKING_AS_READ
-      );
-    }
-
-    return () => {
-      if (timeout) {
-        clearTimeout(timeout);
-      }
-    };
-  }, [markAsRead, conversation]);
-
-  return {
-    markAsRead,
-  };
+    });
+  }, [
+    mutateConversations,
+    mutateSpaceSummary,
+    mutateConversation,
+    conversationSId,
+  ]);
 }

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1320,10 +1320,24 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return res.length > 0 ? res[0] : null;
   }
 
-  static async fetchByIdsWithReadState(auth: Authenticator, sIds: string[]) {
-    const conversations = await this.fetchByIds(auth, sIds);
+  static async fetchByIdsWithReadState(
+    auth: Authenticator,
+    sIds: string[],
+    options?: FetchConversationOptions
+  ) {
+    const conversations = await this.fetchByIds(auth, sIds, options);
     await this.enrichWithReadState(auth, conversations);
     return conversations;
+  }
+
+  static async fetchByIdWithReadState(
+    auth: Authenticator,
+    sId: string,
+    options?: FetchConversationOptions
+  ): Promise<ConversationResource | null> {
+    const res = await this.fetchByIdsWithReadState(auth, [sId], options);
+
+    return res.length > 0 ? res[0] : null;
   }
 
   /**


### PR DESCRIPTION
## Description

We PATCH `{read: true}` on conversations ~6x more often than we even GET them, same user, same conversation, sometimes 300ms apart. Went 8-10x worse on July 28 when pod conversations landed in the inbox (nudges all day × always-open tabs).

Three compounding issues:

- every trigger has its own 2s debounce (open-conversation effect + 3 SSE handlers), and all that state lives in hooks that mount/unmount constantly, so nothing ever coalesces
- the conversation detail GET never hydrates read state: every conversation is served `unread: true` / `lastReadMs: null`, so we re-mark already-read conversations on every open/revalidation
- the endpoint upserts lastReadAt unconditionally

This PR:

- moves debounce + dedup to module level, above the mount/unmount churn: every trigger funnels into `requestConversationMarkAsRead`, each request carries the activity timestamp it must cover (`conversation.updated` from the effect, `event.created` from SSE all server clock), anything already covered is dropped. Hidden tabs park the mark until visible again, 403/404 blacklists the conversation (zombie tabs were PATCHing a 404 forever)
- hydrates `unread` / `lastReadMs` on the detail GET (`fetchByIdWithReadState`), which also feeds the dedup floor
- skips the lastReadAt write when the conversation is already read up to its latest activity

The effect firing on the conversation value stays: it's the intended "new activity while viewing → mark read" behavior, the global dedup just makes the churn free.

## Tests

- Added endpoint tests (read-state hydration, write skip)
- Tested locally
- Front-edged

## Risk

Low - same triggers as before, one shared pipe. Worst case a conversation stays bold in the sidebar until the next activity/revalidation.

## Plan

Deploy front
