### PR TITLE
Users can add a reason when requesting overage

### DIFF
--- a/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
@@ -106,6 +106,32 @@ describe("/api/w/[wId]/credits/upgrade-requests", () => {
       expect(body.request.requester.sId).toBe(user.sId);
     });
 
+    it("stores the reason when provided", async () => {
+      const workspace = await creditPricedWorkspace();
+      await createPrivateApiMockRequest({
+        method: "POST",
+        role: "user",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        upgradeRequestsUrl(workspace.sId),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            reason: "Running a large one-off backfill this week.",
+          }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const { request } = await response.json();
+      expect(request.reason).toBe(
+        "Running a large one-off backfill this week."
+      );
+    });
+
     it("is idempotent — a second request reuses the pending one", async () => {
       const workspace = await creditPricedWorkspace();
       const { membership, response: first } =

--- a/front-api/routes/w/[wId]/credits/upgrade-requests.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.ts
@@ -11,6 +11,7 @@ import type {
   PostUpgradeRequestResponseBody,
 } from "@app/types/api/credits/upgrade_requests";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+import { MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS } from "@app/types/memberships";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
@@ -24,6 +25,14 @@ const ParamsSchema = z.object({
 
 const ResolveBodySchema = z.object({
   status: z.union([z.literal("approved"), z.literal("denied")]),
+});
+
+const CreateUpgradeRequestBodySchema = z.object({
+  reason: z
+    .string()
+    .trim()
+    .max(MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS)
+    .optional(),
 });
 
 function upgradeRequestErrorToApiError(
@@ -79,16 +88,22 @@ app.get(
 
 // Member-initiated: request an upgrade of the current user's spend limit.
 /** @ignoreswagger */
-app.post("/", async (ctx): HandlerResult<PostUpgradeRequestResponseBody> => {
-  const auth = ctx.get("auth");
-  const result = await createUpgradeRequest(auth, {
-    auditContext: getAuditLogContext(auth),
-  });
-  if (result.isErr()) {
-    return apiError(ctx, upgradeRequestErrorToApiError(result.error));
+app.post(
+  "/",
+  validate("json", CreateUpgradeRequestBodySchema),
+  async (ctx): HandlerResult<PostUpgradeRequestResponseBody> => {
+    const auth = ctx.get("auth");
+    const { reason } = ctx.req.valid("json");
+    const result = await createUpgradeRequest(auth, {
+      reason: reason ?? null,
+      auditContext: getAuditLogContext(auth),
+    });
+    if (result.isErr()) {
+      return apiError(ctx, upgradeRequestErrorToApiError(result.error));
+    }
+    return ctx.json({ request: result.value });
   }
-  return ctx.json({ request: result.value });
-});
+);
 
 /** @ignoreswagger */
 app.patch(

--- a/front/admin/audit_log_schemas/membership.upgrade_request_created.json
+++ b/front/admin/audit_log_schemas/membership.upgrade_request_created.json
@@ -9,6 +9,7 @@
     }
   ],
   "metadata": {
-    "request_sid": "string"
+    "request_sid": "string",
+    "reason": "string"
   }
 }

--- a/front/components/credits/UsageUpgradeButton.tsx
+++ b/front/components/credits/UsageUpgradeButton.tsx
@@ -139,7 +139,7 @@ export function UsageUpgradeButton({
             <DialogContainer>
               <div className="flex flex-col gap-4">
                 <p className="text-sm text-muted-foreground">
-                  Your workspace admins will review this request.
+                  Your workspace admins and managers will review this request.
                 </p>
                 <BaseFormFieldSection<HTMLTextAreaElement>
                   fieldName="reason"

--- a/front/components/credits/UsageUpgradeButton.tsx
+++ b/front/components/credits/UsageUpgradeButton.tsx
@@ -1,4 +1,6 @@
+import { BaseFormFieldSection } from "@app/components/shared/BaseFormFieldSection";
 import { useRequestUpgrade } from "@app/lib/swr/upgrade_requests";
+import { MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS } from "@app/types/memberships";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -9,8 +11,18 @@ import {
   DialogHeader,
   DialogTitle,
   Hoverable,
+  TextArea,
 } from "@dust-tt/sparkle";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useState } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { z } from "zod";
+
+const requestUpgradeFormSchema = z.object({
+  reason: z.string().trim().max(MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS),
+});
+
+type RequestUpgradeFormValues = z.infer<typeof requestUpgradeFormSchema>;
 
 type UsageUpgradeButtonVariant = "link" | "button";
 
@@ -34,23 +46,26 @@ export function UsageUpgradeButton({
 }: UsageUpgradeButtonProps) {
   const { doRequestUpgrade } = useRequestUpgrade({ workspaceId: owner.sId });
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [requested, setRequested] = useState(false);
+
+  const form = useForm<RequestUpgradeFormValues>({
+    resolver: zodResolver(requestUpgradeFormSchema),
+    defaultValues: { reason: "" },
+  });
 
   const alreadyRequested = hasPendingUpgradeRequest || requested;
 
-  async function handleConfirm() {
-    setIsSubmitting(true);
-    try {
-      const ok = await doRequestUpgrade();
-      if (ok) {
-        setRequested(true);
-        setIsDialogOpen(false);
-      }
-    } finally {
-      setIsSubmitting(false);
+  const onSubmit = async (values: RequestUpgradeFormValues) => {
+    const trimmedReason = values.reason.trim();
+    const ok = await doRequestUpgrade({
+      reason: trimmedReason.length > 0 ? trimmedReason : undefined,
+    });
+    if (ok) {
+      setRequested(true);
+      setIsDialogOpen(false);
+      form.reset();
     }
-  }
+  };
 
   function renderTrigger() {
     if (isManager) {
@@ -117,30 +132,64 @@ export function UsageUpgradeButton({
         onOpenChange={(open) => !open && setIsDialogOpen(false)}
       >
         <DialogContent size="md">
-          <DialogHeader>
-            <DialogTitle>Request a usage limit upgrade</DialogTitle>
-          </DialogHeader>
-          <DialogContainer>
-            <p className="text-sm text-muted-foreground">
-              Your workspace admins and managers will be notified that you'd
-              like your usage limit increased. They'll review your request and
-              get back to you.
-            </p>
-          </DialogContainer>
-          <DialogFooter
-            leftButtonProps={{
-              label: "Cancel",
-              variant: "outline",
-              onClick: () => setIsDialogOpen(false),
-            }}
-            rightButtonProps={{
-              label: "Send request",
-              variant: "primary",
-              isLoading: isSubmitting,
-              disabled: isSubmitting,
-              onClick: () => void handleConfirm(),
-            }}
-          />
+          <FormProvider {...form}>
+            <DialogHeader>
+              <DialogTitle>Request a usage limit upgrade</DialogTitle>
+            </DialogHeader>
+            <DialogContainer>
+              <div className="flex flex-col gap-4">
+                <p className="text-sm text-muted-foreground">
+                  Your workspace admins will review this request.
+                </p>
+                <BaseFormFieldSection<HTMLTextAreaElement>
+                  fieldName="reason"
+                  title="Help your admin decide"
+                >
+                  {({
+                    registerRef,
+                    registerProps,
+                    onChange,
+                    errorMessage,
+                    fieldState,
+                  }) => {
+                    const showError =
+                      fieldState.isDirty ||
+                      fieldState.isTouched ||
+                      form.formState.isSubmitted;
+
+                    return (
+                      <TextArea
+                        ref={registerRef}
+                        placeholder="e.g. processing a large batch of documents for this quarter's audit"
+                        rows={3}
+                        showErrorLabel={showError}
+                        error={showError ? errorMessage : undefined}
+                        onChange={onChange}
+                        {...registerProps}
+                      />
+                    );
+                  }}
+                </BaseFormFieldSection>
+              </div>
+            </DialogContainer>
+            <DialogFooter
+              leftButtonProps={{
+                label: "Cancel",
+                variant: "outline",
+                onClick: () => setIsDialogOpen(false),
+              }}
+              rightButtonProps={{
+                label: "Send request",
+                variant: "primary",
+                isLoading: form.formState.isSubmitting,
+                disabled: form.formState.isSubmitting,
+                onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
+                  event.preventDefault();
+                  void form.handleSubmit(onSubmit)();
+                },
+              }}
+            />
+          </FormProvider>
         </DialogContent>
       </Dialog>
     </>

--- a/front/components/workspace/UpgradeRequestsTable.tsx
+++ b/front/components/workspace/UpgradeRequestsTable.tsx
@@ -59,11 +59,22 @@ const reasonColumn: ColumnDef<RowData, string> = {
   id: "reason" as const,
   header: "",
   enableSorting: false,
-  cell: () => (
-    <DataTable.CellContent>
-      <span className="text-sm text-muted-foreground">{REASON_LABEL}</span>
-    </DataTable.CellContent>
-  ),
+  cell: (info: Info) => {
+    const { reason } = info.row.original.request;
+    return (
+      <DataTable.CellContent>
+        <span
+          className="line-clamp-2 text-sm text-muted-foreground"
+          title={reason ?? undefined}
+        >
+          {reason || REASON_LABEL}
+        </span>
+      </DataTable.CellContent>
+    );
+  },
+  meta: {
+    className: "max-w-64",
+  },
 };
 
 const requestedColumn: ColumnDef<RowData, string> = {

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -80,6 +80,7 @@ async function notifyManagersAndAdminsOfUpgradeRequest(
       requestId: request.sId,
       requesterName: requester.fullName() ?? requester.name,
       requesterEmail: requester.email ?? null,
+      reason: request.reason,
     });
   } catch (err) {
     logger.error(
@@ -94,7 +95,10 @@ async function notifyManagersAndAdminsOfUpgradeRequest(
 // actually being near/at their limit.
 export async function createUpgradeRequest(
   auth: Authenticator,
-  { auditContext }: { auditContext?: AuditLogContext } = {}
+  {
+    reason,
+    auditContext,
+  }: { reason: string | null; auditContext?: AuditLogContext }
 ): Promise<Result<MembershipUpgradeRequestType, UpgradeRequestError>> {
   const subscription = auth.getNonNullableSubscriptionResource();
   if (
@@ -142,6 +146,7 @@ export async function createUpgradeRequest(
 
   const result = await MembershipUpgradeRequestResource.createPending(auth, {
     user,
+    reason,
   });
   if (result.isErr()) {
     return new Err(
@@ -161,7 +166,10 @@ export async function createUpgradeRequest(
       }),
     ],
     context: auditContext,
-    metadata: { request_sid: request.sId },
+    metadata: {
+      request_sid: request.sId,
+      reason: request.reason ?? "",
+    },
   });
 
   void notifyManagersAndAdminsOfUpgradeRequest(auth, { request });

--- a/front/lib/notifications/workflows/upgrade-request-created.ts
+++ b/front/lib/notifications/workflows/upgrade-request-created.ts
@@ -15,6 +15,7 @@ const UpgradeRequestCreatedPayloadSchema = z.object({
   workspaceName: z.string(),
   requesterName: z.string(),
   requesterEmail: z.string().nullable(),
+  reason: z.string().nullable(),
 });
 
 type UpgradeRequestCreatedPayloadType = z.infer<
@@ -32,6 +33,12 @@ function formatRequester(payload: UpgradeRequestCreatedPayloadType): string {
     : payload.requesterName;
 }
 
+function formatRequestDetails(
+  payload: UpgradeRequestCreatedPayloadType
+): string {
+  return payload.reason ? ` (reason: ${payload.reason})` : "";
+}
+
 export const upgradeRequestCreatedWorkflow = workflow(
   UPGRADE_REQUEST_CREATED_TRIGGER_ID,
   async ({ step, payload, subscriber }) => {
@@ -47,7 +54,10 @@ export const upgradeRequestCreatedWorkflow = workflow(
       async () => {
         // Dedupe by requester (a member could re-request across the window) and
         // keep insertion order so the email lists distinct people once.
-        const requesterByKey = new Map<string, string>();
+        const requesterByKey = new Map<
+          string,
+          { label: string; details: string }
+        >();
         for (const event of events) {
           if (!isUpgradeRequestCreatedPayload(event.payload)) {
             continue;
@@ -55,7 +65,10 @@ export const upgradeRequestCreatedWorkflow = workflow(
           const key =
             event.payload.requesterEmail ?? event.payload.requesterName;
           if (!requesterByKey.has(key)) {
-            requesterByKey.set(key, formatRequester(event.payload));
+            requesterByKey.set(key, {
+              label: formatRequester(event.payload),
+              details: formatRequestDetails(event.payload),
+            });
           }
         }
         const requesters = Array.from(requesterByKey.values());
@@ -64,14 +77,16 @@ export const upgradeRequestCreatedWorkflow = workflow(
         const subject =
           count > 1
             ? `[Dust] ${count} members requested a spend-limit upgrade`
-            : `[Dust] ${requesters[0]} requested a spend-limit upgrade`;
+            : `[Dust] ${requesters[0].label} requested a spend-limit upgrade`;
 
         const intro =
           count > 1
             ? `${count} members have reached their per-user spend limit and are requesting an upgrade:`
-            : `${requesters[0]} has reached their per-user spend limit and is requesting an upgrade.`;
+            : `${requesters[0].label} has reached their per-user spend limit and is requesting an upgrade${requesters[0].details}.`;
         const list =
-          count > 1 ? requesters.map((r) => `• ${r}`).join("\n") : "";
+          count > 1
+            ? requesters.map((r) => `• ${r.label}${r.details}`).join("\n")
+            : "";
         const outro =
           count > 1
             ? `Review the requests and adjust their limits from your workspace usage page.`
@@ -119,6 +134,7 @@ export function notifyUpgradeRequested({
   requestId,
   requesterName,
   requesterEmail,
+  reason,
 }: {
   users: Array<{
     sId: string;
@@ -131,6 +147,7 @@ export function notifyUpgradeRequested({
   requestId: string;
   requesterName: string;
   requesterEmail: string | null;
+  reason: string | null;
 }): void {
   if (users.length === 0) {
     return;
@@ -141,6 +158,7 @@ export function notifyUpgradeRequested({
     workspaceName,
     requesterName,
     requesterEmail,
+    reason,
   };
 
   void getNovuClient()

--- a/front/lib/resources/membership_upgrade_request_resource.ts
+++ b/front/lib/resources/membership_upgrade_request_resource.ts
@@ -69,7 +69,7 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
   // against concurrent duplicates.
   static async createPending(
     auth: Authenticator,
-    { user }: { user: UserResource }
+    { user, reason }: { user: UserResource; reason: string | null }
   ): Promise<Result<MembershipUpgradeRequestResource, Error>> {
     const workspace = auth.getNonNullableWorkspace();
     const row = await withTransaction(async (transaction) => {
@@ -89,6 +89,7 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
           workspaceId: workspace.id,
           userId: user.id,
           status: "pending",
+          reason,
         },
         { transaction }
       );
@@ -249,6 +250,7 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
       status: this.status,
       createdAt: this.createdAt.getTime(),
       resolvedAt: this.resolvedAt ? this.resolvedAt.getTime() : null,
+      reason: this.reason,
       requester: {
         sId: this.requester.sId,
         name: this.requester.fullName() || this.requester.name,

--- a/front/lib/resources/storage/models/membership_upgrade_requests.ts
+++ b/front/lib/resources/storage/models/membership_upgrade_requests.ts
@@ -3,6 +3,7 @@ import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import {
+  MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS,
   MEMBERSHIP_UPGRADE_REQUEST_PENDING_STATUS,
   type MembershipUpgradeRequestStatus,
 } from "@app/types/memberships";
@@ -20,6 +21,9 @@ export class MembershipUpgradeRequestModel extends WorkspaceAwareModel<Membershi
 
   declare status: CreationOptional<MembershipUpgradeRequestStatus>;
   declare resolvedAt: Date | null;
+
+  // Why the member needs the raised limit - Optional
+  declare reason: string | null;
 
   // The member who requested the upgrade.
   declare userId: ForeignKey<UserModel["id"]>;
@@ -49,6 +53,11 @@ MembershipUpgradeRequestModel.init(
     },
     resolvedAt: {
       type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
+    },
+    reason: {
+      type: DataTypes.STRING(MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS),
       allowNull: true,
       defaultValue: null,
     },

--- a/front/lib/swr/upgrade_requests.ts
+++ b/front/lib/swr/upgrade_requests.ts
@@ -28,31 +28,34 @@ export function useRequestUpgrade({ workspaceId }: { workspaceId: string }) {
   const sendNotification = useSendNotification();
   const { mutate } = useSWRWithDefaults(usageStatusUrl(workspaceId), null);
 
-  const doRequestUpgrade = useCallback(async (): Promise<boolean> => {
-    const res = await clientFetch(upgradeRequestsUrl(workspaceId), {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({}),
-    });
-
-    if (!res.ok) {
-      const errorData = await getErrorFromResponse(res);
-      sendNotification({
-        type: "error",
-        title: "Failed to request an upgrade",
-        description: errorData.message,
+  const doRequestUpgrade = useCallback(
+    async ({ reason }: { reason?: string }): Promise<boolean> => {
+      const res = await clientFetch(upgradeRequestsUrl(workspaceId), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reason }),
       });
-      return false;
-    }
 
-    await mutate();
-    sendNotification({
-      type: "success",
-      title: "Upgrade requested",
-      description: "Your workspace admins have been notified.",
-    });
-    return true;
-  }, [workspaceId, sendNotification, mutate]);
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Failed to request an upgrade",
+          description: errorData.message,
+        });
+        return false;
+      }
+
+      await mutate();
+      sendNotification({
+        type: "success",
+        title: "Upgrade requested",
+        description: "Your workspace admins have been notified.",
+      });
+      return true;
+    },
+    [workspaceId, sendNotification, mutate]
+  );
 
   return { doRequestUpgrade };
 }

--- a/front/migrations/pre-deploy/20260727135138_add_reason_to_membership_upgrade_requests.sql
+++ b/front/migrations/pre-deploy/20260727135138_add_reason_to_membership_upgrade_requests.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."membership_upgrade_requests" ADD COLUMN "reason" character varying(1024) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying;

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -300,11 +300,15 @@ export const MEMBERSHIP_UPGRADE_REQUEST_STATUSES = [
 export type MembershipUpgradeRequestStatus =
   (typeof MEMBERSHIP_UPGRADE_REQUEST_STATUSES)[number];
 
+export const MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS = 1024;
+
 export interface MembershipUpgradeRequestType {
   sId: string;
   status: MembershipUpgradeRequestStatus;
   createdAt: number;
   resolvedAt: number | null;
+  // Why the member needs the raised limit - Optional
+  reason: string | null;
   requester: {
     sId: string;
     name: string;

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -307,7 +307,6 @@ export interface MembershipUpgradeRequestType {
   status: MembershipUpgradeRequestStatus;
   createdAt: number;
   resolvedAt: number | null;
-  // Why the member needs the raised limit - Optional
   reason: string | null;
   requester: {
     sId: string;


### PR DESCRIPTION
## Description

This PR lets members add optional context when requesting a usage-limit upgrade. Previously, the request contained no explanation, so admins and managers received only the generic upgrade request.

The upgrade dialog now includes a “Help your admin decide” text area. The reason is trimmed, limited to 1,024 characters, and sent with the existing request. Empty input remains valid and is omitted from the request. The API validates the payload and persists the reason on `membership_upgrade_requests`; existing requests remain compatible because the new database column is nullable.

The reason is returned through the upgrade-request resource, displayed in the admin `UpgradeRequestsTable` with a truncated two-line presentation and the full value available on hover, and included in the admin/manager notification workflow. The `membership.upgrade_request_created` audit event also records the reason. Existing request creation, approval, denial, and idempotency behavior is otherwise unchanged.

## Tests

Added regression coverage in `front-api/routes/w/[wId]/credits/upgrade-requests.test.ts` verifying that a supplied reason is persisted and returned by the request endpoint.

Localy tested

## Risk

This change adds a nullable database column and propagates user-provided text through the API response, admin UI, notifications, and the upgrade-request audit event. The reason is bounded to 1,024 characters and remains optional, preserving compatibility with existing requests and callers that do not provide it.

The WorkOS audit-log schema must be updated before deployment so the new `reason` metadata is accepted. Rollback should account for the already-applied nullable column and registered audit schema; reverting the application code does not require removing either immediately.

## Deploy Plan

1 Apply `front/migrations/pre-deploy/20260727135138_add_reason_to_membership_upgrade_requests.sql` in both regions.
2. Deploy `front`.