### PR TITLE
feat: Admin approval flow for overage requests

### DIFF
--- a/front-api/routes/w/[wId]/credits/upgrade-requests.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.ts
@@ -1,10 +1,11 @@
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
-import type { UpgradeRequestError } from "@app/lib/api/credits/upgrade_requests";
+import type { ResolveUpgradeRequestError } from "@app/lib/api/credits/upgrade_requests";
 import {
   createUpgradeRequest,
   listPendingUpgradeRequests,
   resolveUpgradeRequest,
 } from "@app/lib/api/credits/upgrade_requests";
+import { UserSpendLimitError } from "@app/lib/api/users/spend_limit";
 import type {
   GetUpgradeRequestsResponseBody,
   PatchUpgradeRequestResponseBody,
@@ -17,15 +18,23 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import {
+  spendLimitErrorToApiError,
+  UpdateUserSpendLimitBodySchema,
+} from "@front-api/routes/w/[wId]/members/[uId]/spend_limit";
 import { z } from "zod";
 
 const ParamsSchema = z.object({
   requestId: z.string(),
 });
 
-const ResolveBodySchema = z.object({
-  status: z.union([z.literal("approved"), z.literal("denied")]),
-});
+const ResolveBodySchema = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("denied") }),
+  z.object({
+    status: z.literal("approved"),
+    limit: UpdateUserSpendLimitBodySchema.optional(),
+  }),
+]);
 
 const CreateUpgradeRequestBodySchema = z.object({
   reason: z
@@ -36,8 +45,11 @@ const CreateUpgradeRequestBodySchema = z.object({
 });
 
 function upgradeRequestErrorToApiError(
-  error: UpgradeRequestError
+  error: ResolveUpgradeRequestError
 ): APIErrorWithContentfulStatusCode {
+  if (error instanceof UserSpendLimitError) {
+    return spendLimitErrorToApiError(error);
+  }
   switch (error.type) {
     case "workspace_not_metronome_billed":
       return {
@@ -68,7 +80,7 @@ function upgradeRequestErrorToApiError(
         api_error: { type: "invalid_request_error", message: error.message },
       };
     default:
-      assertNever(error.type);
+      assertNever(error);
   }
 }
 
@@ -114,10 +126,10 @@ app.patch(
   async (ctx): HandlerResult<PatchUpgradeRequestResponseBody> => {
     const auth = ctx.get("auth");
     const { requestId } = ctx.req.valid("param");
-    const { status } = ctx.req.valid("json");
+    const resolution = ctx.req.valid("json");
     const result = await resolveUpgradeRequest(auth, {
       requestId,
-      status,
+      resolution,
       auditContext: getAuditLogContext(auth),
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/credits/upgrade-requests.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.ts
@@ -21,7 +21,7 @@ import { validate } from "@front-api/middlewares/validator";
 import {
   spendLimitErrorToApiError,
   UpdateUserSpendLimitBodySchema,
-} from "@front-api/routes/w/[wId]/members/[uId]/spend_limit";
+} from "@front-api/routes/w/[wId]/user_spend_limit_shared";
 import { z } from "zod";
 
 const ParamsSchema = z.object({

--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -116,6 +116,8 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
       expect(await getResponse.json()).toEqual({
         kind: "limited",
         awuCredits: 1500,
+        expiresAt: null,
+        nextCreditResetAt: null,
       });
     });
 
@@ -251,7 +253,10 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
       );
 
       expect(response.status).toBe(200);
-      expect(await response.json()).toEqual({ kind: "unlimited" });
+      expect(await response.json()).toEqual({
+        kind: "unlimited",
+        nextCreditResetAt: null,
+      });
     });
 
     it("returns limited with the override persisted on the membership", async () => {
@@ -280,6 +285,41 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
       expect(await response.json()).toEqual({
         kind: "limited",
         awuCredits: 2500,
+        expiresAt: null,
+        nextCreditResetAt: null,
+      });
+    });
+
+    it("returns the persisted expiresAt when the override has one", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const targetUser = await UserFactory.basic();
+      const membership = await MembershipFactory.associate(
+        workspace,
+        targetUser,
+        { role: "user" }
+      );
+      const expiresAt = new Date("2026-08-15T00:00:00.000Z");
+      await membership.updatePoolCapOverride({
+        poolCapOverrideAwuCredits: 2500,
+        poolCapOverrideExpiresAt: expiresAt,
+      });
+
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        spendLimitUrl(workspace.sId, targetUser.sId)
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        kind: "limited",
+        awuCredits: 2500,
+        expiresAt: expiresAt.getTime(),
+        nextCreditResetAt: null,
       });
     });
   });

--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
@@ -1,81 +1,25 @@
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import {
   getUserSpendLimit,
-  MAX_USER_SPEND_LIMIT_AWU_CREDITS,
-  MIN_USER_SPEND_LIMIT_AWU_CREDITS,
   setUserSpendLimit,
-  type UserSpendLimitError,
 } from "@app/lib/api/users/spend_limit";
 import type {
   GetUserSpendLimitResponseBody,
   PutUserSpendLimitResponseBody,
 } from "@app/types/api/users/spend_limit";
-import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import {
+  spendLimitErrorToApiError,
+  UpdateUserSpendLimitBodySchema,
+} from "@front-api/routes/w/[wId]/user_spend_limit_shared";
 import { z } from "zod";
-
-export const UpdateUserSpendLimitBodySchema = z.discriminatedUnion("kind", [
-  z.object({ kind: z.literal("unlimited") }),
-  z.object({
-    kind: z.literal("limited"),
-    awuCredits: z
-      .number()
-      .int()
-      .min(MIN_USER_SPEND_LIMIT_AWU_CREDITS)
-      .max(MAX_USER_SPEND_LIMIT_AWU_CREDITS),
-    // Epoch ms at which the override auto-reverts to unlimited.
-    // Omitted/null means it never expires.
-    expiresAt: z
-      .number()
-      .int()
-      .positive()
-      .refine((value) => value > Date.now(), {
-        message: "expiresAt must be in the future.",
-      })
-      .nullish(),
-  }),
-]);
 
 const ParamsSchema = z.object({
   uId: z.string(),
 });
-
-export function spendLimitErrorToApiError(
-  error: UserSpendLimitError
-): APIErrorWithContentfulStatusCode {
-  switch (error.type) {
-    case "user_not_found":
-      return {
-        status_code: 404,
-        api_error: {
-          type: "workspace_user_not_found",
-          message: error.message,
-        },
-      };
-    case "workspace_not_metronome_billed":
-      return {
-        status_code: 403,
-        api_error: {
-          type: "plan_limit_error",
-          message: error.message,
-        },
-      };
-    case "metronome_error":
-      return {
-        status_code: 502,
-        api_error: {
-          type: "internal_server_error",
-          message: "Failed to update spend limit in billing system.",
-        },
-      };
-    default:
-      assertNever(error.type);
-  }
-}
 
 // Mounted at /api/w/:wId/members/:uId/spend_limit.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
@@ -18,7 +18,7 @@ import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
-const UpdateUserSpendLimitBodySchema = z.discriminatedUnion("kind", [
+export const UpdateUserSpendLimitBodySchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("unlimited") }),
   z.object({
     kind: z.literal("limited"),
@@ -27,6 +27,16 @@ const UpdateUserSpendLimitBodySchema = z.discriminatedUnion("kind", [
       .int()
       .min(MIN_USER_SPEND_LIMIT_AWU_CREDITS)
       .max(MAX_USER_SPEND_LIMIT_AWU_CREDITS),
+    // Epoch ms at which the override auto-reverts to unlimited.
+    // Omitted/null means it never expires.
+    expiresAt: z
+      .number()
+      .int()
+      .positive()
+      .refine((value) => value > Date.now(), {
+        message: "expiresAt must be in the future.",
+      })
+      .nullish(),
   }),
 ]);
 
@@ -34,7 +44,7 @@ const ParamsSchema = z.object({
   uId: z.string(),
 });
 
-function spendLimitErrorToApiError(
+export function spendLimitErrorToApiError(
   error: UserSpendLimitError
 ): APIErrorWithContentfulStatusCode {
   switch (error.type) {

--- a/front-api/routes/w/[wId]/user_spend_limit_shared.ts
+++ b/front-api/routes/w/[wId]/user_spend_limit_shared.ts
@@ -1,0 +1,63 @@
+import {
+  MAX_USER_SPEND_LIMIT_AWU_CREDITS,
+  MIN_USER_SPEND_LIMIT_AWU_CREDITS,
+  type UserSpendLimitError,
+} from "@app/lib/api/users/spend_limit";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { z } from "zod";
+
+export const UpdateUserSpendLimitBodySchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("unlimited") }),
+  z.object({
+    kind: z.literal("limited"),
+    awuCredits: z
+      .number()
+      .int()
+      .min(MIN_USER_SPEND_LIMIT_AWU_CREDITS)
+      .max(MAX_USER_SPEND_LIMIT_AWU_CREDITS),
+    // Epoch ms at which the override auto-reverts to unlimited.
+    // Omitted/null means it never expires.
+    expiresAt: z
+      .number()
+      .int()
+      .positive()
+      .refine((value) => value > Date.now(), {
+        message: "expiresAt must be in the future.",
+      })
+      .nullish(),
+  }),
+]);
+
+export function spendLimitErrorToApiError(
+  error: UserSpendLimitError
+): APIErrorWithContentfulStatusCode {
+  switch (error.type) {
+    case "user_not_found":
+      return {
+        status_code: 404,
+        api_error: {
+          type: "workspace_user_not_found",
+          message: error.message,
+        },
+      };
+    case "workspace_not_metronome_billed":
+      return {
+        status_code: 403,
+        api_error: {
+          type: "plan_limit_error",
+          message: error.message,
+        },
+      };
+    case "metronome_error":
+      return {
+        status_code: 502,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to update spend limit in billing system.",
+        },
+      };
+    default:
+      assertNever(error.type);
+  }
+}

--- a/front/admin/audit_log_schemas/member.spend_limit_updated.json
+++ b/front/admin/audit_log_schemas/member.spend_limit_updated.json
@@ -10,6 +10,7 @@
   ],
   "metadata": {
     "kind": "string",
-    "awu_credits": "string"
+    "awu_credits": "string",
+    "expires_at": "string"
   }
 }

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -1230,7 +1230,6 @@ export function UsagePage() {
         }}
         member={editSpendLimitMember}
         owner={owner}
-        forceOverride={pendingApproveRequestId !== null}
         onSavingChange={handleUsagePendingChange}
         upgradeRequestId={pendingApproveRequestId}
       />

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -339,31 +339,58 @@ export function UsagePage() {
     },
     []
   );
-  const handleEditLimitRequest = useCallback(
+  const handleSetCreditAmountRequest = useCallback(
     (request: MembershipUpgradeRequestType) => {
       setPendingApproveRequestId(request.sId);
       setEditSpendLimitMember(memberFromUpgradeRequest(request));
     },
     []
   );
-  const handleApproveOnModalSaved = useCallback(() => {
+  // Shared by approval flows before resolving the request.
+  const resolveRequestApproved = useCallback(
+    async (requestId: string): Promise<void> => {
+      await doResolveUpgradeRequest({
+        requestId,
+        resolution: { status: "approved" },
+      });
+    },
+    [doResolveUpgradeRequest]
+  );
+  const handleApproveOnModalSaved = useCallback(async () => {
     if (!pendingApproveRequestId) {
       return;
     }
     const requestId = pendingApproveRequestId;
-    const request = upgradeRequests.find((r) => r.sId === requestId);
     setRequestResolving(requestId, true);
-    void doResolveUpgradeRequest({
-      requestId,
-      requesterName: request?.requester.name ?? "Member",
-      status: "approved",
-    }).finally(() => setRequestResolving(requestId, false));
-  }, [
-    pendingApproveRequestId,
-    upgradeRequests,
-    doResolveUpgradeRequest,
-    setRequestResolving,
-  ]);
+    try {
+      await resolveRequestApproved(requestId);
+    } finally {
+      setRequestResolving(requestId, false);
+    }
+  }, [pendingApproveRequestId, resolveRequestApproved, setRequestResolving]);
+  const handleAllowUnlimitedSpendRequest = useCallback(
+    async (request: MembershipUpgradeRequestType) => {
+      const confirmed = await confirm({
+        title: "Use workspace default",
+        message: `Remove ${request.requester.name}'s custom spend limit? They'll fall back to their group or workspace default cap.`,
+        validateLabel: "Use workspace default",
+        validateVariant: "primary",
+      });
+      if (!confirmed) {
+        return;
+      }
+      setRequestResolving(request.sId, true);
+      try {
+        await doResolveUpgradeRequest({
+          requestId: request.sId,
+          resolution: { status: "approved", limit: { kind: "unlimited" } },
+        });
+      } finally {
+        setRequestResolving(request.sId, false);
+      }
+    },
+    [confirm, doResolveUpgradeRequest, setRequestResolving]
+  );
   const handleDenyRequest = useCallback(
     async (request: MembershipUpgradeRequestType) => {
       const confirmed = await confirm({
@@ -379,8 +406,7 @@ export function UsagePage() {
       try {
         await doResolveUpgradeRequest({
           requestId: request.sId,
-          requesterName: request.requester.name,
-          status: "denied",
+          resolution: { status: "denied" },
         });
       } finally {
         setRequestResolving(request.sId, false);
@@ -1140,9 +1166,11 @@ export function UsagePage() {
                       requests={filteredUpgradeRequests}
                       isLoading={isUpgradeRequestsLoading}
                       seatPlans={seatPlans}
+                      isEnterprise={isEnterprise}
                       pendingRequestIds={resolvingRequestIds}
                       onUpgradePlan={handleUpgradePlanRequest}
-                      onEditLimit={handleEditLimitRequest}
+                      onAllowUnlimitedSpend={handleAllowUnlimitedSpendRequest}
+                      onSetCreditAmount={handleSetCreditAmountRequest}
                       onDeny={handleDenyRequest}
                     />
                   )}
@@ -1226,8 +1254,9 @@ export function UsagePage() {
         }}
         member={editSpendLimitMember}
         owner={owner}
+        forceOverride={pendingApproveRequestId !== null}
         onSavingChange={handleUsagePendingChange}
-        onSaved={handleApproveOnModalSaved}
+        upgradeRequestId={pendingApproveRequestId}
       />
 
       <BulkEditSpendLimitModal

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -368,29 +368,6 @@ export function UsagePage() {
       setRequestResolving(requestId, false);
     }
   }, [pendingApproveRequestId, resolveRequestApproved, setRequestResolving]);
-  const handleAllowUnlimitedSpendRequest = useCallback(
-    async (request: MembershipUpgradeRequestType) => {
-      const confirmed = await confirm({
-        title: "Use workspace default",
-        message: `Remove ${request.requester.name}'s custom spend limit? They'll fall back to their group or workspace default cap.`,
-        validateLabel: "Use workspace default",
-        validateVariant: "primary",
-      });
-      if (!confirmed) {
-        return;
-      }
-      setRequestResolving(request.sId, true);
-      try {
-        await doResolveUpgradeRequest({
-          requestId: request.sId,
-          resolution: { status: "approved", limit: { kind: "unlimited" } },
-        });
-      } finally {
-        setRequestResolving(request.sId, false);
-      }
-    },
-    [confirm, doResolveUpgradeRequest, setRequestResolving]
-  );
   const handleDenyRequest = useCallback(
     async (request: MembershipUpgradeRequestType) => {
       const confirmed = await confirm({
@@ -1169,7 +1146,6 @@ export function UsagePage() {
                       isEnterprise={isEnterprise}
                       pendingRequestIds={resolvingRequestIds}
                       onUpgradePlan={handleUpgradePlanRequest}
-                      onAllowUnlimitedSpend={handleAllowUnlimitedSpendRequest}
                       onSetCreditAmount={handleSetCreditAmountRequest}
                       onDeny={handleDenyRequest}
                     />

--- a/front/components/workspace/BulkEditSpendLimitModal.tsx
+++ b/front/components/workspace/BulkEditSpendLimitModal.tsx
@@ -150,30 +150,24 @@ function BulkEditSpendLimitForm({
 
           {kind === "override" && (
             <div className="flex flex-col gap-1.5 pl-6">
-              <div className="relative">
-                <Input
-                  id="bulk-spend-credit-limit-input"
-                  type="text"
-                  inputMode="numeric"
-                  pattern="[0-9]*"
-                  placeholder="1,000"
-                  value={
-                    creditsInput !== ""
-                      ? Number(creditsInput).toLocaleString()
-                      : ""
-                  }
-                  onChange={(e) => handleCreditsChange(e.target.value)}
-                  isError={validationMessage !== null}
-                  message={validationMessage ?? undefined}
-                  messageStatus={
-                    validationMessage !== null ? "error" : undefined
-                  }
-                  className="pr-28 text-right"
-                />
-                <span className="copy-sm pointer-events-none absolute right-3 top-0 flex h-9 items-center text-muted-foreground dark:text-muted-foreground-night">
-                  credits/month
-                </span>
-              </div>
+              <Input
+                id="bulk-spend-credit-limit-input"
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                placeholder="1,000"
+                value={
+                  creditsInput !== ""
+                    ? Number(creditsInput).toLocaleString()
+                    : ""
+                }
+                onChange={(e) => handleCreditsChange(e.target.value)}
+                isError={validationMessage !== null}
+                message={validationMessage ?? undefined}
+                messageStatus={validationMessage !== null ? "error" : undefined}
+                className="text-right"
+                suffix="credits/month"
+              />
             </div>
           )}
         </RadioGroup>

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -46,14 +46,13 @@ interface EditSpendLimitModalProps {
   onClose: () => void;
   member: MemberUsageType | null;
   owner: WorkspaceType;
-  // When set, the modal skips the "workspace default vs. custom limit"
-  // choice and opens straight into the custom-limit form.
-  forceOverride?: boolean;
   onSavingChange?: (memberId: string, isSaving: boolean) => void;
   // When set, the modal is resolving this pending upgrade request: the limit
   // is submitted together with the approval in a single call instead of a
   // separate spend-limit update, so the two can't drift apart if one half
-  // fails.
+  // fails. It also skips the "workspace default vs. custom limit" choice and
+  // opens straight into the custom-limit form, since approving an overage
+  // request is meant to fix the overage, not reset the member's cap.
   upgradeRequestId?: string | null;
 }
 
@@ -62,10 +61,10 @@ export function EditSpendLimitModal({
   onClose,
   member,
   owner,
-  forceOverride = false,
   onSavingChange,
   upgradeRequestId = null,
 }: EditSpendLimitModalProps) {
+  const forceOverride = upgradeRequestId !== null;
   // Keep the last non-null member so the dialog can render its content through
   // the exit animation after the parent has cleared `member`.
   const lastMemberRef = useRef<MemberUsageType | null>(null);

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -1,9 +1,19 @@
+import type { SpendLimitOverrideFormValues } from "@app/components/workspace/SpendLimitOverrideFields";
+import {
+  SpendLimitOverrideFields,
+  spendLimitOverrideFormSchema,
+} from "@app/components/workspace/SpendLimitOverrideFields";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import {
   useUpdateUserSpendLimit,
   useUserSpendLimit,
 } from "@app/lib/swr/memberships";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { useResolveUpgradeRequest } from "@app/lib/swr/upgrade_requests";
+import type { UserSpendLimit } from "@app/types/api/users/spend_limit";
+import {
+  assertNever,
+  assertNeverAndIgnore,
+} from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
 import {
   AlertCircle,
@@ -15,15 +25,15 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  Input,
   RadioGroup,
   RadioGroupItem,
   Spinner,
 } from "@dust-tt/sparkle";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useRef, useState } from "react";
+import { useForm } from "react-hook-form";
 
-const MIN_AWU_CREDITS = 0;
-const MAX_AWU_CREDITS = 2_000_000;
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 type SpendLimitKind = "default" | "override";
 
@@ -36,10 +46,15 @@ interface EditSpendLimitModalProps {
   onClose: () => void;
   member: MemberUsageType | null;
   owner: WorkspaceType;
+  // When set, the modal skips the "workspace default vs. custom limit"
+  // choice and opens straight into the custom-limit form.
+  forceOverride?: boolean;
   onSavingChange?: (memberId: string, isSaving: boolean) => void;
-  // Fired once the spend limit has been persisted successfully (not on cancel
-  // or a load error). Used to resolve a linked upgrade request as approved.
-  onSaved?: () => void;
+  // When set, the modal is resolving this pending upgrade request: the limit
+  // is submitted together with the approval in a single call instead of a
+  // separate spend-limit update, so the two can't drift apart if one half
+  // fails.
+  upgradeRequestId?: string | null;
 }
 
 export function EditSpendLimitModal({
@@ -47,8 +62,9 @@ export function EditSpendLimitModal({
   onClose,
   member,
   owner,
+  forceOverride = false,
   onSavingChange,
-  onSaved,
+  upgradeRequestId = null,
 }: EditSpendLimitModalProps) {
   // Keep the last non-null member so the dialog can render its content through
   // the exit animation after the parent has cleared `member`.
@@ -71,18 +87,25 @@ export function EditSpendLimitModal({
   const { doUpdateSpendLimit } = useUpdateUserSpendLimit({
     workspaceId: owner.sId,
   });
+  const { doResolveUpgradeRequest } = useResolveUpgradeRequest({
+    workspaceId: owner.sId,
+  });
 
   const [kind, setKind] = useState<SpendLimitKind>("override");
-  const [creditsInput, setCreditsInput] = useState<string>("");
   const [isSaving, setIsSaving] = useState(false);
-  const [validationMessage, setValidationMessage] = useState<string | null>(
-    null
-  );
+
+  const overrideForm = useForm<SpendLimitOverrideFormValues>({
+    resolver: zodResolver(spendLimitOverrideFormSchema),
+    defaultValues: { creditsInput: "", expiryMode: "never" },
+  });
+
+  // The amount currently persisted
+  const currentAwuCredits =
+    spendLimit?.kind === "limited" ? spendLimit.awuCredits : null;
 
   useEffect(() => {
     if (!isOpen) {
       setIsSaving(false);
-      setValidationMessage(null);
       return;
     }
     if (!spendLimit) {
@@ -91,62 +114,30 @@ export function EditSpendLimitModal({
     switch (spendLimit.kind) {
       case "limited":
         setKind("override");
-        setCreditsInput(String(spendLimit.awuCredits));
+        overrideForm.reset({
+          creditsInput: String(spendLimit.awuCredits),
+          expiryMode:
+            spendLimit.expiresAt === null
+              ? "never"
+              : spendLimit.expiresAt === spendLimit.nextCreditResetAt
+                ? "next_credit_reset"
+                : "one_day",
+        });
         break;
       case "unlimited":
-        setKind("default");
-        setCreditsInput("");
+        setKind(forceOverride ? "override" : "default");
+        overrideForm.reset({ creditsInput: "", expiryMode: "never" });
         break;
       default:
         assertNeverAndIgnore(spendLimit);
     }
-    setValidationMessage(null);
-  }, [isOpen, spendLimit]);
+  }, [isOpen, spendLimit, forceOverride, overrideForm]);
 
   function handleSelectKind(next: SpendLimitKind) {
     setKind(next);
-    setValidationMessage(null);
   }
 
-  function handleCreditsChange(value: string) {
-    // Keep only digits — credits are integers and the API range starts at 0.
-    const cleaned = value.replace(/[^\d]/g, "");
-    setCreditsInput(cleaned);
-    setValidationMessage(null);
-  }
-
-  function validate(): { ok: true; awuCredits: number } | { ok: false } {
-    switch (kind) {
-      case "default":
-        return { ok: true, awuCredits: 0 };
-      case "override": {
-        const parsed = Number(creditsInput);
-        if (!Number.isInteger(parsed) || parsed < MIN_AWU_CREDITS) {
-          setValidationMessage(
-            `Enter a whole number of credits between ${MIN_AWU_CREDITS.toLocaleString("en-US")} and ${MAX_AWU_CREDITS.toLocaleString("en-US")}.`
-          );
-          return { ok: false };
-        }
-        if (parsed > MAX_AWU_CREDITS) {
-          setValidationMessage(
-            `Credits cannot exceed ${MAX_AWU_CREDITS.toLocaleString("en-US")}.`
-          );
-          return { ok: false };
-        }
-        return { ok: true, awuCredits: parsed };
-      }
-      default:
-        assertNeverAndIgnore(kind);
-        return { ok: false };
-    }
-  }
-
-  async function handleValidate() {
-    const result = validate();
-    if (!result.ok) {
-      return;
-    }
-
+  async function submitLimit(limit: UserSpendLimit) {
     if (!displayedMember) {
       return;
     }
@@ -154,27 +145,17 @@ export function EditSpendLimitModal({
     setIsSaving(true);
     onSavingChange?.(displayedMember.sId, true);
     try {
-      let limit:
-        | { kind: "unlimited" }
-        | { kind: "limited"; awuCredits: number };
-      switch (kind) {
-        case "default":
-          limit = { kind: "unlimited" };
-          break;
-        case "override":
-          limit = { kind: "limited", awuCredits: result.awuCredits };
-          break;
-        default:
-          assertNeverAndIgnore(kind);
-          return;
-      }
-      const body = await doUpdateSpendLimit({
-        memberId: displayedMember.sId,
-        memberName: displayedMember.name,
-        limit,
-      });
-      if (body) {
-        onSaved?.();
+      const saved = upgradeRequestId
+        ? await doResolveUpgradeRequest({
+            requestId: upgradeRequestId,
+            resolution: { status: "approved", limit },
+          })
+        : !!(await doUpdateSpendLimit({
+            memberId: displayedMember.sId,
+            memberName: displayedMember.name,
+            limit,
+          }));
+      if (saved) {
         onClose();
       }
     } finally {
@@ -183,13 +164,60 @@ export function EditSpendLimitModal({
     }
   }
 
+  async function handleValidate() {
+    if (!displayedMember) {
+      return;
+    }
+
+    switch (kind) {
+      case "default":
+        await submitLimit({ kind: "unlimited" });
+        return;
+      case "override":
+        await overrideForm.handleSubmit(async (data) => {
+          let expiresAt: number | null;
+          switch (data.expiryMode) {
+            case "never":
+              expiresAt = null;
+              break;
+            case "one_day":
+              expiresAt = Date.now() + ONE_DAY_MS;
+              break;
+            case "next_credit_reset":
+              expiresAt = spendLimit?.nextCreditResetAt ?? null;
+              break;
+            default:
+              assertNever(data.expiryMode);
+          }
+          await submitLimit({
+            kind: "limited",
+            awuCredits: Number(data.creditsInput),
+            expiresAt,
+          });
+        })();
+        return;
+      default:
+        assertNever(kind);
+    }
+  }
+
+  const watchedCreditsInput = overrideForm.watch("creditsInput");
   const validateDisabled =
     isSaving ||
     isSpendLimitLoading ||
-    (kind === "override" && creditsInput.length === 0);
+    (kind === "override" && watchedCreditsInput.length === 0);
   const primaryDisabled = isSpendLimitError
     ? isSaving || isSpendLimitLoading
     : validateDisabled;
+
+  const overrideFields = (
+    <SpendLimitOverrideFields
+      control={overrideForm.control}
+      member={displayedMember}
+      currentAwuCredits={currentAwuCredits}
+      nextCreditResetAt={spendLimit?.nextCreditResetAt ?? null}
+    />
+  );
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
@@ -230,6 +258,8 @@ export function EditSpendLimitModal({
             <div className="flex justify-center py-6">
               <Spinner />
             </div>
+          ) : forceOverride ? (
+            overrideFields
           ) : (
             <RadioGroup
               value={kind}
@@ -251,34 +281,7 @@ export function EditSpendLimitModal({
                 label="Use custom monthly limit"
               />
 
-              {kind === "override" && (
-                <div className="flex flex-col gap-1.5 pl-6">
-                  <div className="relative">
-                    <Input
-                      id="spend-credit-limit-input"
-                      type="text"
-                      inputMode="numeric"
-                      pattern="[0-9]*"
-                      placeholder="1,000"
-                      value={
-                        creditsInput !== ""
-                          ? Number(creditsInput).toLocaleString()
-                          : ""
-                      }
-                      onChange={(e) => handleCreditsChange(e.target.value)}
-                      isError={validationMessage !== null}
-                      message={validationMessage ?? undefined}
-                      messageStatus={
-                        validationMessage !== null ? "error" : undefined
-                      }
-                      className="pr-28 text-right"
-                    />
-                    <span className="copy-sm pointer-events-none absolute right-3 top-0 flex h-9 items-center text-muted-foreground">
-                      credits/month
-                    </span>
-                  </div>
-                </div>
-              )}
+              {kind === "override" && overrideFields}
             </RadioGroup>
           )}
         </DialogContainer>
@@ -294,7 +297,7 @@ export function EditSpendLimitModal({
             disabled: primaryDisabled,
             onClick: isSpendLimitError
               ? () => void mutateSpendLimit()
-              : handleValidate,
+              : () => void handleValidate(),
           }}
         />
       </DialogContent>

--- a/front/components/workspace/ManageUpgradeRequestModal.tsx
+++ b/front/components/workspace/ManageUpgradeRequestModal.tsx
@@ -1,0 +1,129 @@
+import type { MembershipUpgradeRequestType } from "@app/types/memberships";
+import {
+  ArrowUp,
+  Avatar,
+  ChevronRight,
+  Coins02,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  Icon,
+  Infinity,
+  ListItem,
+} from "@dust-tt/sparkle";
+import type { ComponentType } from "react";
+
+interface ManageAction {
+  key: string;
+  icon: ComponentType<{ className?: string }>;
+  label: string;
+  description: string;
+  onClick: () => void;
+}
+
+interface ManageUpgradeRequestModalProps {
+  request: MembershipUpgradeRequestType | null;
+  onClose: () => void;
+  canUpgradePlan: boolean;
+  onUpgradePlan: (request: MembershipUpgradeRequestType) => void;
+  onAllowUnlimitedSpend: (request: MembershipUpgradeRequestType) => void;
+  onSetCreditAmount: (request: MembershipUpgradeRequestType) => void;
+}
+
+export function ManageUpgradeRequestModal({
+  request,
+  onClose,
+  canUpgradePlan,
+  onUpgradePlan,
+  onAllowUnlimitedSpend,
+  onSetCreditAmount,
+}: ManageUpgradeRequestModalProps) {
+  const actions: ManageAction[] = [
+    {
+      key: "allow-unlimited-spend",
+      icon: Infinity,
+      label: "Use workspace default",
+      description:
+        "Remove this member's custom limit; they'll fall back to their group or workspace default cap.",
+      onClick: () => request && onAllowUnlimitedSpend(request),
+    },
+    {
+      key: "set-credit-amount",
+      icon: Coins02,
+      label: "Set credit amount",
+      description: "Choose a specific spend limit for this member.",
+      onClick: () => request && onSetCreditAmount(request),
+    },
+    ...(canUpgradePlan
+      ? [
+          {
+            key: "upgrade-plan",
+            icon: ArrowUp,
+            label: "Upgrade User Plan",
+            description: "Move the member to a seat with more credits.",
+            onClick: () => request && onUpgradePlan(request),
+          },
+        ]
+      : []),
+  ];
+
+  return (
+    <Dialog open={request !== null} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent size="md">
+        <DialogHeader>
+          <div className="flex items-center gap-3">
+            <Avatar
+              visual={request?.requester.image ?? undefined}
+              name={request?.requester.name}
+              size="md"
+              isRounded
+            />
+            <div>
+              <DialogTitle>{request?.requester.name}</DialogTitle>
+              <p className="text-sm text-muted-foreground">
+                {request?.requester.email}
+              </p>
+            </div>
+          </div>
+        </DialogHeader>
+        <DialogContainer>
+          <div className="overflow-hidden rounded-2xl border border-border">
+            {actions.map((action, index) => (
+              <ListItem
+                key={action.key}
+                itemsAlignment="center"
+                hasSeparator={index < actions.length - 1}
+                onClick={() => {
+                  action.onClick();
+                  onClose();
+                }}
+              >
+                <Avatar
+                  icon={action.icon}
+                  size="sm"
+                  isRounded
+                  backgroundColor="bg-highlight-50"
+                />
+                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <span className="heading-sm text-foreground">
+                    {action.label}
+                  </span>
+                  <span className="copy-sm text-muted-foreground">
+                    {action.description}
+                  </span>
+                </div>
+                <Icon
+                  visual={ChevronRight}
+                  size="sm"
+                  className="text-muted-foreground"
+                />
+              </ListItem>
+            ))}
+          </div>
+        </DialogContainer>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/workspace/ManageUpgradeRequestModal.tsx
+++ b/front/components/workspace/ManageUpgradeRequestModal.tsx
@@ -10,7 +10,6 @@ import {
   DialogHeader,
   DialogTitle,
   Icon,
-  Infinity,
   ListItem,
 } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
@@ -28,7 +27,6 @@ interface ManageUpgradeRequestModalProps {
   onClose: () => void;
   canUpgradePlan: boolean;
   onUpgradePlan: (request: MembershipUpgradeRequestType) => void;
-  onAllowUnlimitedSpend: (request: MembershipUpgradeRequestType) => void;
   onSetCreditAmount: (request: MembershipUpgradeRequestType) => void;
 }
 
@@ -37,18 +35,9 @@ export function ManageUpgradeRequestModal({
   onClose,
   canUpgradePlan,
   onUpgradePlan,
-  onAllowUnlimitedSpend,
   onSetCreditAmount,
 }: ManageUpgradeRequestModalProps) {
   const actions: ManageAction[] = [
-    {
-      key: "allow-unlimited-spend",
-      icon: Infinity,
-      label: "Use workspace default",
-      description:
-        "Remove this member's custom limit; they'll fall back to their group or workspace default cap.",
-      onClick: () => request && onAllowUnlimitedSpend(request),
-    },
     {
       key: "set-credit-amount",
       icon: Coins02,

--- a/front/components/workspace/SpendLimitOverrideFields.tsx
+++ b/front/components/workspace/SpendLimitOverrideFields.tsx
@@ -1,0 +1,153 @@
+import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
+import { formatShortDate } from "@app/lib/utils/timestamps";
+import type { SpendLimitExpiryKind } from "@app/types/api/users/spend_limit";
+import { SPEND_LIMIT_EXPIRY_KINDS } from "@app/types/api/users/spend_limit";
+import {
+  ContentMessage,
+  Input,
+  RadioGroup,
+  RadioGroupItem,
+} from "@dust-tt/sparkle";
+import type { Control } from "react-hook-form";
+import { useController } from "react-hook-form";
+import { z } from "zod";
+
+export const MIN_AWU_CREDITS = 0;
+export const MAX_AWU_CREDITS = 2_000_000;
+
+function isSpendLimitExpiryKind(value: string): value is SpendLimitExpiryKind {
+  return (SPEND_LIMIT_EXPIRY_KINDS as readonly string[]).includes(value);
+}
+
+export const spendLimitOverrideFormSchema = z
+  .object({
+    creditsInput: z.string(),
+    expiryMode: z.enum(SPEND_LIMIT_EXPIRY_KINDS),
+  })
+  .superRefine((data, ctx) => {
+    const parsed = Number(data.creditsInput);
+    if (!Number.isInteger(parsed) || parsed < MIN_AWU_CREDITS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["creditsInput"],
+        message: `Enter a whole number of credits between ${MIN_AWU_CREDITS.toLocaleString("en-US")} and ${MAX_AWU_CREDITS.toLocaleString("en-US")}.`,
+      });
+      return;
+    }
+    if (parsed > MAX_AWU_CREDITS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["creditsInput"],
+        message: `Credits cannot exceed ${MAX_AWU_CREDITS.toLocaleString("en-US")}.`,
+      });
+    }
+  });
+
+export type SpendLimitOverrideFormValues = z.infer<
+  typeof spendLimitOverrideFormSchema
+>;
+
+interface SpendLimitOverrideFieldsProps {
+  control: Control<SpendLimitOverrideFormValues>;
+  member: MemberUsageType | null;
+  currentAwuCredits: number | null;
+  nextCreditResetAt: number | null;
+}
+
+export function SpendLimitOverrideFields({
+  control,
+  member,
+  currentAwuCredits,
+  nextCreditResetAt,
+}: SpendLimitOverrideFieldsProps) {
+  const { field: creditsField, fieldState: creditsFieldState } = useController({
+    name: "creditsInput",
+    control,
+  });
+  const { field: expiryField } = useController({ name: "expiryMode", control });
+
+  const parsedCreditsInput = Number(creditsField.value);
+  const showsLoweringWarning =
+    currentAwuCredits !== null &&
+    creditsField.value.length > 0 &&
+    Number.isInteger(parsedCreditsInput) &&
+    parsedCreditsInput < currentAwuCredits;
+
+  return (
+    <div className="flex flex-col gap-1.5 pl-6">
+      <Input
+        id="spend-credit-limit-input"
+        type="text"
+        inputMode="numeric"
+        pattern="[0-9]*"
+        placeholder="1,000"
+        value={
+          creditsField.value !== ""
+            ? Number(creditsField.value).toLocaleString()
+            : ""
+        }
+        onChange={(e) =>
+          // Keep only digits — credits are integers and the API range starts at 0.
+          creditsField.onChange(e.target.value.replace(/[^\d]/g, ""))
+        }
+        isError={creditsFieldState.error !== undefined}
+        message={creditsFieldState.error?.message}
+        messageStatus={creditsFieldState.error ? "error" : undefined}
+        className="text-right"
+        suffix="credits/month"
+      />
+      {member && (
+        <div className="flex flex-col gap-0.5">
+          <p className="text-xs text-muted-foreground">
+            Current allowed overage:&nbsp;
+            {(currentAwuCredits ?? 0).toLocaleString("en-US")} credits
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Current overage consumption:&nbsp;
+            {member.consumedFromPoolAwuCredits.toLocaleString("en-US")}
+            &nbsp;credits
+          </p>
+        </div>
+      )}
+      {showsLoweringWarning && (
+        <ContentMessage
+          size="sm"
+          variant="golden"
+          title="This lowers the member's limit"
+        >
+          <p>Won&apos;t unblock them until usage drops below the new limit.</p>
+        </ContentMessage>
+      )}
+      <div className="flex flex-col gap-1.5 pt-2">
+        <span className="text-sm font-medium">Expires</span>
+        <RadioGroup
+          value={expiryField.value}
+          onValueChange={(v) => {
+            if (isSpendLimitExpiryKind(v)) {
+              expiryField.onChange(v);
+            }
+          }}
+          className="flex flex-col gap-2"
+        >
+          <RadioGroupItem
+            value="one_day"
+            id="spend-limit-expiry-one-day"
+            label="In 1 day"
+          />
+          {nextCreditResetAt && (
+            <RadioGroupItem
+              value="next_credit_reset"
+              id="spend-limit-expiry-next-credit-reset"
+              label={`At next credit refresh (${formatShortDate(nextCreditResetAt, { includeYear: true, timeZone: "UTC" })})`}
+            />
+          )}
+          <RadioGroupItem
+            value="never"
+            id="spend-limit-expiry-never"
+            label="Never"
+          />
+        </RadioGroup>
+      </div>
+    </div>
+  );
+}

--- a/front/components/workspace/UpgradeRequestsTable.tsx
+++ b/front/components/workspace/UpgradeRequestsTable.tsx
@@ -139,7 +139,6 @@ interface UpgradeRequestsTableProps {
   isEnterprise: boolean;
   pendingRequestIds: ReadonlySet<string>;
   onUpgradePlan: (request: MembershipUpgradeRequestType) => void;
-  onAllowUnlimitedSpend: (request: MembershipUpgradeRequestType) => void;
   onSetCreditAmount: (request: MembershipUpgradeRequestType) => void;
   onDeny: (request: MembershipUpgradeRequestType) => void;
 }
@@ -151,7 +150,6 @@ export function UpgradeRequestsTable({
   isEnterprise,
   pendingRequestIds,
   onUpgradePlan,
-  onAllowUnlimitedSpend,
   onSetCreditAmount,
   onDeny,
 }: UpgradeRequestsTableProps) {
@@ -219,7 +217,6 @@ export function UpgradeRequestsTable({
         onClose={() => setManageRequest(null)}
         canUpgradePlan={canUpgradePlan}
         onUpgradePlan={onUpgradePlan}
-        onAllowUnlimitedSpend={onAllowUnlimitedSpend}
         onSetCreditAmount={onSetCreditAmount}
       />
     </>

--- a/front/components/workspace/UpgradeRequestsTable.tsx
+++ b/front/components/workspace/UpgradeRequestsTable.tsx
@@ -1,3 +1,4 @@
+import { ManageUpgradeRequestModal } from "@app/components/workspace/ManageUpgradeRequestModal";
 import { buildMemberNameColumn } from "@app/components/workspace/member_name_column";
 import type { SeatPlanResponseBody } from "@app/lib/api/credits/seat_plan";
 import { timeAgoFrom } from "@app/lib/utils";
@@ -5,16 +6,9 @@ import type {
   MembershipSeatType,
   MembershipUpgradeRequestType,
 } from "@app/types/memberships";
-import {
-  Button,
-  Check,
-  DataTable,
-  LoadingBlock,
-  Spinner,
-  X,
-} from "@dust-tt/sparkle";
+import { Button, DataTable, LoadingBlock, Spinner, X } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 type RowData = {
   sId: string;
@@ -94,14 +88,10 @@ const requestedColumn: ColumnDef<RowData, string> = {
 };
 
 function buildActionsColumn({
-  seatPlans,
-  onUpgradePlan,
-  onEditLimit,
+  onManage,
   onDeny,
 }: {
-  seatPlans: SeatPlanResponseBody;
-  onUpgradePlan: (request: MembershipUpgradeRequestType) => void;
-  onEditLimit: (request: MembershipUpgradeRequestType) => void;
+  onManage: (request: MembershipUpgradeRequestType) => void;
   onDeny: (request: MembershipUpgradeRequestType) => void;
 }): ColumnDef<RowData, string> {
   return {
@@ -118,10 +108,6 @@ function buildActionsColumn({
           </div>
         );
       }
-      // Hide "Upgrade plan" when there is no higher seat tier to move the
-      // requester to: their current seat already grants as many AWU credits as
-      // the richest seat the plan offers.
-      const canUpgradePlan = canUpgrade(request.requester.seatType, seatPlans);
       return (
         <div className="flex w-full items-center justify-end gap-2">
           <Button
@@ -131,26 +117,17 @@ function buildActionsColumn({
             label="Deny"
             onClick={() => onDeny(request)}
           />
-          {canUpgradePlan && (
-            <Button
-              size="sm"
-              variant="highlight-secondary"
-              icon={Check}
-              label="Upgrade plan"
-              onClick={() => onUpgradePlan(request)}
-            />
-          )}
           <Button
             size="sm"
             variant="outline"
-            label="Edit limit"
-            onClick={() => onEditLimit(request)}
+            label="Manage"
+            onClick={() => onManage(request)}
           />
         </div>
       );
     },
     meta: {
-      className: "w-96",
+      className: "w-48",
     },
   };
 }
@@ -159,9 +136,11 @@ interface UpgradeRequestsTableProps {
   requests: MembershipUpgradeRequestType[];
   isLoading: boolean;
   seatPlans: SeatPlanResponseBody;
+  isEnterprise: boolean;
   pendingRequestIds: ReadonlySet<string>;
   onUpgradePlan: (request: MembershipUpgradeRequestType) => void;
-  onEditLimit: (request: MembershipUpgradeRequestType) => void;
+  onAllowUnlimitedSpend: (request: MembershipUpgradeRequestType) => void;
+  onSetCreditAmount: (request: MembershipUpgradeRequestType) => void;
   onDeny: (request: MembershipUpgradeRequestType) => void;
 }
 
@@ -169,11 +148,16 @@ export function UpgradeRequestsTable({
   requests,
   isLoading,
   seatPlans,
+  isEnterprise,
   pendingRequestIds,
   onUpgradePlan,
-  onEditLimit,
+  onAllowUnlimitedSpend,
+  onSetCreditAmount,
   onDeny,
 }: UpgradeRequestsTableProps) {
+  const [manageRequest, setManageRequest] =
+    useState<MembershipUpgradeRequestType | null>(null);
+
   const rows: RowData[] = useMemo(
     () =>
       requests.map((request) => ({
@@ -194,13 +178,11 @@ export function UpgradeRequestsTable({
       reasonColumn,
       requestedColumn,
       buildActionsColumn({
-        seatPlans,
-        onUpgradePlan,
-        onEditLimit,
+        onManage: setManageRequest,
         onDeny,
       }),
     ],
-    [seatPlans, onUpgradePlan, onEditLimit, onDeny]
+    [onDeny]
   );
 
   if (isLoading) {
@@ -223,5 +205,23 @@ export function UpgradeRequestsTable({
     );
   }
 
-  return <DataTable<RowData> data={rows} columns={columns} />;
+  // Hide "Upgrade User Plan" for enterprise workspaces
+  // and whenever there is no higher seat tier to move the requester to
+  const canUpgradePlan =
+    !isEnterprise &&
+    canUpgrade(manageRequest?.requester.seatType ?? null, seatPlans);
+
+  return (
+    <>
+      <DataTable<RowData> data={rows} columns={columns} />
+      <ManageUpgradeRequestModal
+        request={manageRequest}
+        onClose={() => setManageRequest(null)}
+        canUpgradePlan={canUpgradePlan}
+        onUpgradePlan={onUpgradePlan}
+        onAllowUnlimitedSpend={onAllowUnlimitedSpend}
+        onSetCreditAmount={onSetCreditAmount}
+      />
+    </>
+  );
 }

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -45,7 +45,7 @@
   "member.bulk_invited": 3,
   "member.bulk_revoked": 3,
   "member.invited": 6,
-  "member.spend_limit_updated": 3,
+  "member.spend_limit_updated": 4,
   "membership.bulk_role_updated": 1,
   "membership.bulk_seat_updated": 1,
   "membership.created": 2,

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -3,6 +3,8 @@ import {
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
 import { isEligibleForAutoSeatUpgrade } from "@app/lib/api/credits/auto_seat_upgrade";
+import type { UserSpendLimitError } from "@app/lib/api/users/spend_limit";
+import { setUserSpendLimit } from "@app/lib/api/users/spend_limit";
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
@@ -12,10 +14,8 @@ import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usag
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { MembershipUpgradeRequestResource } from "@app/lib/resources/membership_upgrade_request_resource";
 import logger from "@app/logger/logger";
-import type {
-  MembershipUpgradeRequestStatus,
-  MembershipUpgradeRequestType,
-} from "@app/types/memberships";
+import type { UpgradeRequestResolution } from "@app/types/api/credits/upgrade_requests";
+import type { MembershipUpgradeRequestType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -34,6 +34,10 @@ export class UpgradeRequestError extends Error {
     super(message);
   }
 }
+
+export type ResolveUpgradeRequestError =
+  | UpgradeRequestError
+  | UserSpendLimitError;
 
 async function isMemberUpgradeRequestAllowed(
   auth: Authenticator
@@ -234,20 +238,19 @@ export async function listPendingUpgradeRequests(
   return requests.map((r) => r.toJSON());
 }
 
-// Admin-only: record the outcome of a request. The actual spend-limit / seat
-// change is performed by the existing flows; this only marks the request.
+// Admin-only: record the outcome of a request.
 export async function resolveUpgradeRequest(
   auth: Authenticator,
   {
     requestId,
-    status,
+    resolution,
     auditContext,
   }: {
     requestId: string;
-    status: Exclude<MembershipUpgradeRequestStatus, "pending">;
+    resolution: UpgradeRequestResolution;
     auditContext?: AuditLogContext;
   }
-): Promise<Result<MembershipUpgradeRequestType, UpgradeRequestError>> {
+): Promise<Result<MembershipUpgradeRequestType, ResolveUpgradeRequestError>> {
   const request = await MembershipUpgradeRequestResource.fetchById(
     auth,
     requestId
@@ -257,10 +260,51 @@ export async function resolveUpgradeRequest(
       new UpgradeRequestError("request_not_found", "Upgrade request not found.")
     );
   }
+  if (request.status !== "pending") {
+    return new Err(
+      new UpgradeRequestError(
+        "request_not_pending",
+        "Upgrade request is not pending."
+      )
+    );
+  }
 
+  // Apply the spend-limit change first, before flipping the request to
+  // resolved. `setUserSpendLimit` is idempotent (it converges to the
+  // requested limit however many times it's called), so if the process
+  // crashes right after this call, the request is still visible as pending
+  // and the next resolution attempt just re-applies the same limit and
+  // succeeds. Doing this the other way around — resolving first — would
+  // instead risk a crash leaving the request permanently "approved" with the
+  // limit never actually applied.
+  if (resolution.status === "approved" && resolution.limit) {
+    const spendLimitResult = await setUserSpendLimit(auth, {
+      userId: request.requester.sId,
+      limit: resolution.limit,
+      auditContext: auditContext ?? { location: "internal" },
+    });
+    if (spendLimitResult.isErr()) {
+      return new Err(spendLimitResult.error);
+    }
+  }
+
+  // Compare-and-set on `status = 'pending'`: if another admin resolved this
+  // request concurrently between the fetch above and here, this fails rather
+  // than silently overwriting their resolution.
   const resolvedByUser = auth.getNonNullableUser();
-  const result = await request.markAsResolved(auth, { status, resolvedByUser });
+  const result = await request.markAsResolved(auth, {
+    status: resolution.status,
+    resolvedByUser,
+  });
   if (result.isErr()) {
+    logger.error(
+      {
+        requestId: request.sId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        resolutionStatus: resolution.status,
+      },
+      "[UpgradeRequest] Request was resolved concurrently by another admin after its spend limit was applied"
+    );
     return new Err(
       new UpgradeRequestError("request_not_pending", result.error.message)
     );
@@ -277,7 +321,7 @@ export async function resolveUpgradeRequest(
       }),
     ],
     context: auditContext,
-    metadata: { status, request_sid: request.sId },
+    metadata: { status: resolution.status, request_sid: request.sId },
   });
 
   return new Ok(request.toJSON());

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -131,14 +131,39 @@ export async function getUserSpendLimit(
       user,
       workspace,
     });
+
+  const nextCreditResetAt = await resolveNextCreditResetAt(workspace);
+
   if (!membership || membership.poolCapOverrideAwuCredits === null) {
-    return new Ok({ kind: "unlimited" });
+    return new Ok({ kind: "unlimited", nextCreditResetAt });
   }
 
   return new Ok({
     kind: "limited",
     awuCredits: membership.poolCapOverrideAwuCredits,
+    expiresAt: membership.poolCapOverrideExpiresAt?.getTime() ?? null,
+    nextCreditResetAt,
   });
+}
+
+/**
+ * Resolve the workspace's next AWU credit pool reset (the Metronome contract
+ * billing-period boundary), in epoch ms.  Null when there is no active
+ * Metronome contract to derive it from, or on a Metronome outage.
+ */
+async function resolveNextCreditResetAt(
+  workspace: LightWorkspaceType
+): Promise<number | null> {
+  if (!workspace.metronomeCustomerId) {
+    return null;
+  }
+  const periodResult = await getCachedMetronomeCurrentBillingPeriod(
+    workspace.sId
+  );
+  if (periodResult.isErr() || !periodResult.value) {
+    return null;
+  }
+  return periodResult.value.cycleEnd.getTime();
 }
 
 export async function setUserSpendLimit(
@@ -225,6 +250,10 @@ export async function setUserSpendLimit(
   await membership.updatePoolCapOverride({
     poolCapOverrideAwuCredits:
       limit.kind === "limited" ? limit.awuCredits : null,
+    poolCapOverrideExpiresAt:
+      limit.kind === "limited" && limit.expiresAt
+        ? new Date(limit.expiresAt)
+        : null,
   });
 
   const revert = () =>
@@ -359,6 +388,10 @@ export async function setUserSpendLimit(
       kind: limit.kind,
       awu_credits:
         limit.kind === "limited" ? String(limit.awuCredits) : "unlimited",
+      expires_at:
+        limit.kind === "limited" && limit.expiresAt
+          ? new Date(limit.expiresAt).toISOString()
+          : "",
     },
   });
 

--- a/front/lib/resources/membership_upgrade_request_resource.ts
+++ b/front/lib/resources/membership_upgrade_request_resource.ts
@@ -190,8 +190,11 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
     return request ?? null;
   }
 
-  // Mark the request as resolved by an admin. Only a `pending` request can be
-  // resolved; resolving an already-resolved request is rejected.
+  // Mark the request as resolved by an admin. This is a compare-and-set on
+  // `status = 'pending'` (not a plain update-by-id) so that two admins
+  // resolving the same request concurrently can't both succeed: only the
+  // update that observes `pending` at the DB level wins, the other gets back
+  // an error instead of silently overwriting the first resolution.
   async markAsResolved(
     auth: Authenticator,
     {
@@ -203,17 +206,23 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
     },
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
-    if (this.status !== "pending") {
+    const [affectedCount, affectedRows] =
+      await MembershipUpgradeRequestModel.update(
+        {
+          status,
+          resolvedByUserId: resolvedByUser.id,
+          resolvedAt: new Date(),
+        },
+        {
+          where: { id: this.id, status: "pending" },
+          transaction,
+          returning: true,
+        }
+      );
+    if (affectedCount === 0) {
       return new Err(new Error("Request is not pending."));
     }
-    await this.update(
-      {
-        status,
-        resolvedByUserId: resolvedByUser.id,
-        resolvedAt: new Date(),
-      },
-      transaction
-    );
+    Object.assign(this, affectedRows[0].get());
     return new Ok(undefined);
   }
 

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -12,6 +12,7 @@ import type {
 import type {
   GetUserSpendLimitResponseBody,
   PutUserSpendLimitResponseBody,
+  UserSpendLimit,
 } from "@app/types/api/users/spend_limit";
 import { SUPPORTED_CURRENCIES } from "@app/types/currency";
 import type { GroupKind } from "@app/types/groups";
@@ -34,6 +35,7 @@ const SpendLimitResponseSchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("limited"),
     awuCredits: z.number(),
+    expiresAt: z.number().nullable().optional(),
   }),
 ]);
 
@@ -653,7 +655,7 @@ export function useUpdateUserSpendLimit({
     }: {
       memberId: string;
       memberName: string;
-      limit: { kind: "unlimited" } | { kind: "limited"; awuCredits: number };
+      limit: UserSpendLimit;
     }): Promise<PutUserSpendLimitResponseBody | null> => {
       const res = await clientFetch(spendLimitUrl(workspaceId, memberId), {
         method: "PUT",

--- a/front/lib/swr/upgrade_requests.ts
+++ b/front/lib/swr/upgrade_requests.ts
@@ -7,8 +7,11 @@ import {
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
-import type { GetUpgradeRequestsResponseBody } from "@app/types/api/credits/upgrade_requests";
-import type { MembershipUpgradeRequestStatus } from "@app/types/memberships";
+import type {
+  GetUpgradeRequestsResponseBody,
+  PatchUpgradeRequestResponseBody,
+  UpgradeRequestResolution,
+} from "@app/types/api/credits/upgrade_requests";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { useCallback } from "react";
 import type { Fetcher } from "swr";
@@ -101,19 +104,17 @@ export function useResolveUpgradeRequest({
   const doResolveUpgradeRequest = useCallback(
     async ({
       requestId,
-      requesterName,
-      status,
+      resolution,
     }: {
       requestId: string;
-      requesterName: string;
-      status: Exclude<MembershipUpgradeRequestStatus, "pending">;
+      resolution: UpgradeRequestResolution;
     }): Promise<boolean> => {
       const res = await clientFetch(
         `${upgradeRequestsUrl(workspaceId)}/${requestId}`,
         {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ status }),
+          body: JSON.stringify(resolution),
         }
       );
 
@@ -127,17 +128,20 @@ export function useResolveUpgradeRequest({
         return false;
       }
 
+      const body: PatchUpgradeRequestResponseBody = await res.json();
+      const requesterName = body.request.requester.name;
+
       // Resolving always removes the request from the pending list. Only an
       // approval edits the member's seat / limit, so the members-usage surface
       // only needs refreshing on approve.
       await Promise.all([
         mutate(),
-        status === "approved"
+        resolution.status === "approved"
           ? invalidateMembersUsage(workspaceId)
           : Promise.resolve(),
       ]);
 
-      switch (status) {
+      switch (resolution.status) {
         case "approved":
           sendNotification({
             type: "success",
@@ -153,7 +157,7 @@ export function useResolveUpgradeRequest({
           });
           break;
         default:
-          assertNeverAndIgnore(status);
+          assertNeverAndIgnore(resolution);
       }
       return true;
     },

--- a/front/lib/utils/timestamps.ts
+++ b/front/lib/utils/timestamps.ts
@@ -66,12 +66,20 @@ export const formatDurationString = (durationMs: number): string => {
 /**
  * Formats a timestamp to a short date string (e.g., "Jan 15").
  * @param timestamp - The timestamp to format (number or string in milliseconds)
+ * @param options.includeYear - Also include the year (e.g., "Jan 15, 2026")
+ * @param options.timeZone - Pin the formatting to a specific IANA time zone
+ * instead of the browser's local one (e.g., to label a UTC billing boundary)
  * @returns A formatted string like "Jan 15"
  */
-export const formatShortDate = (timestamp: number | string): string => {
+export const formatShortDate = (
+  timestamp: number | string,
+  options?: { includeYear?: boolean; timeZone?: string }
+): string => {
   return new Date(timestamp).toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",
+    ...(options?.includeYear && { year: "numeric" }),
+    ...(options?.timeZone && { timeZone: options.timeZone }),
   });
 };
 

--- a/front/types/api/credits/upgrade_requests.ts
+++ b/front/types/api/credits/upgrade_requests.ts
@@ -1,3 +1,4 @@
+import type { UserSpendLimit } from "@app/types/api/users/spend_limit";
 import type { MembershipUpgradeRequestType } from "@app/types/memberships";
 
 export type GetUpgradeRequestsResponseBody = {
@@ -7,6 +8,10 @@ export type GetUpgradeRequestsResponseBody = {
 export type PostUpgradeRequestResponseBody = {
   request: MembershipUpgradeRequestType;
 };
+
+export type UpgradeRequestResolution =
+  | { status: "denied" }
+  | { status: "approved"; limit?: UserSpendLimit };
 
 export type PatchUpgradeRequestResponseBody = {
   request: MembershipUpgradeRequestType;

--- a/front/types/api/users/spend_limit.ts
+++ b/front/types/api/users/spend_limit.ts
@@ -1,8 +1,27 @@
+export const SPEND_LIMIT_EXPIRY_KINDS = [
+  "never",
+  "one_day",
+  "next_credit_reset",
+] as const;
+
+export type SpendLimitExpiryKind = (typeof SPEND_LIMIT_EXPIRY_KINDS)[number];
+
 export type UserSpendLimit =
   | { kind: "unlimited" }
-  | { kind: "limited"; awuCredits: number };
+  | {
+      kind: "limited";
+      awuCredits: number;
+      // Epoch ms at which the override auto-reverts to unlimited. Omitted/null
+      // means it never expires.
+      expiresAt?: number | null;
+    };
 
-export type GetUserSpendLimitResponse = UserSpendLimit;
+export type GetUserSpendLimitResponse = UserSpendLimit & {
+  // Epoch ms of this workspace's next AWU credit pool reset (Metronome
+  // billing period boundary), if resolvable from an active Metronome
+  // contract.
+  nextCreditResetAt: number | null;
+};
 
 export type GetUserSpendLimitResponseBody = GetUserSpendLimitResponse;
 

--- a/sparkle/src/components/Input.tsx
+++ b/sparkle/src/components/Input.tsx
@@ -100,14 +100,17 @@ const labelVariants = cva("pb-0.5 font-medium text-foreground", {
 });
 
 // Full-height muted box flanking the field for a unit/currency (prefix/suffix).
+// Sized with a min-width rather than a fixed width so short content (`$`, `%`)
+// stays compact while longer content (`credits/month`) can still grow the box
+// instead of overflowing it.
 const slotBoxVariants = cva(
   cn("flex h-full shrink-0 items-center justify-center", "bg-muted"),
   {
     variants: {
       size: {
-        xs: "w-6",
-        sm: "w-8",
-        md: "w-10",
+        xs: "min-w-6 px-1.5",
+        sm: "min-w-8 px-2",
+        md: "min-w-10 px-2.5",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Description

Until now, pending overage requests exposed separate “Upgrade plan” and “Edit limit” actions, which made it difficult for admins to choose the intended approval behavior. This PR replaces that layout with a single **Manage** action offering:

- **Set credit amount**, with a custom monthly limit and expiry.
- **Upgrade User Plan**, when the workspace is not enterprise and a higher seat tier is available.

The custom-limit flow displays the member’s current allowed overage and consumption, warns when the new limit is lower than the current one, and supports expiry presets for **1 day**, **the next credit refresh**, or **Never**. Spend-limit responses now expose the persisted expiry and the next workspace credit reset derived from the cached Metronome billing period. Audit events include the expiry timestamp as well.

Approving a request can now apply the selected spend limit as part of the same API operation. The request is marked resolved first, then the spend-limit change is synchronized. If the downstream sync fails, the request is reverted to `pending`; rollback failures are logged for manual reconciliation. Denials and the existing plan-upgrade flow remain supported.

This PR relies on the spend-limit expiry data model and scheduler work in the related stack: #29921, #29960, and #29961.

<img width="1136" height="371" alt="Admin overage request management actions" src="https://github.com/user-attachments/assets/64a50d9e-3f1b-4a80-82d3-8deab95ce3b7" />

<img width="1154" height="647" alt="Capture d’écran 2026-08-11 à 17 29 46" src="https://github.com/user-attachments/assets/18f9ae71-8c6a-43d0-b50c-125977d0fc63" />

<img width="1135" height="707" alt="Capture d’écran 2026-08-11 à 17 30 19" src="https://github.com/user-attachments/assets/bedb8b3d-9fd1-48db-8422-10985021a09f" />

<img width="1151" height="711" alt="Spend limit expiry options" src="https://github.com/user-attachments/assets/b2ff0702-a11d-4ae9-b13c-5967bb269e4e" />

## Tests

The spend-limit API tests were updated to cover nullable expiry fields and persisted `expiresAt` values.

## Risk

Medium. This changes the admin approval path for overage requests and can directly allow to change an user capped spend. The new limit form validates credit bounds and future expiry dates, and unlimited approval requires confirmation.

The approval flow uses rollback protection to avoid leaving a request resolved when its spend-limit synchronization fails. Expiry behavior also depends on the companion Temporal worker and hourly schedule being deployed; without that scheduler, expiring overrides may not be automatically reverted.

The API changes are additive for spend-limit reads, while the audit schema version is incremented to include `expires_at`. No migration is included in this PR; it expects the existing spend-limit expiry column from the related stack.

## Deploy Plan

- Deploy `front-sse` and `front`.