### PR TITLE
Admin history view for resolved upgrade requests

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -18,6 +18,7 @@ import { MembersSelectionBanner } from "@app/components/workspace/MembersSelecti
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import { getSeatIconColorClass } from "@app/components/workspace/seat_styles";
 import { TopUpsHistoryTable } from "@app/components/workspace/TopUpsHistoryTable";
+import { UpgradeRequestsHistoryTable } from "@app/components/workspace/UpgradeRequestsHistoryTable";
 import { UpgradeRequestsTable } from "@app/components/workspace/UpgradeRequestsTable";
 import { LockedSection } from "@app/components/workspace/usage/LockedSection";
 import { ModelTiersSettingsCard } from "@app/components/workspace/usage/ModelTiersSettingsCard";
@@ -71,8 +72,10 @@ import {
   useWorkspaceAllowedModelTiers,
 } from "@app/lib/swr/model_tiers";
 import {
+  UPGRADE_REQUESTS_HISTORY_PAGE_SIZE,
   useResolveUpgradeRequest,
   useUpgradeRequests,
+  useUpgradeRequestsHistory,
 } from "@app/lib/swr/upgrade_requests";
 import { useUsageSettings } from "@app/lib/swr/usage_settings";
 import {
@@ -261,11 +264,26 @@ export function UsagePage() {
   );
   const isWorkspaceAdmin = isAdmin(owner);
   const modelsPickerEnabled = hasFeature("models_picker") && isWorkspaceAdmin;
-  const [membersTab, setMembersTab] = useState<"members" | "requests">(
-    "members"
-  );
-  const { upgradeRequests, isUpgradeRequestsLoading } = useUpgradeRequests({
+  const [membersTab, setMembersTab] = useState<
+    "members" | "requests" | "history"
+  >("members");
+  const { upgradeRequests, isUpgradeRequestsLoading, isUpgradeRequestsError } =
+    useUpgradeRequests({
+      workspaceId: owner.sId,
+    });
+  const [historyPagination, setHistoryPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: UPGRADE_REQUESTS_HISTORY_PAGE_SIZE,
+  });
+  const {
+    upgradeRequestsHistory,
+    totalUpgradeRequestsHistoryCount,
+    isUpgradeRequestsHistoryLoading,
+    isUpgradeRequestsHistoryError,
+  } = useUpgradeRequestsHistory({
     workspaceId: owner.sId,
+    pageIndex: historyPagination.pageIndex,
+    disabled: membersTab !== "history",
   });
 
   const filteredUpgradeRequests = useMemo(() => {
@@ -1113,9 +1131,13 @@ export function UsagePage() {
                   <ButtonsSwitchList
                     size="xs"
                     defaultValue="members"
-                    onValueChange={(v: string) =>
-                      setMembersTab(v === "requests" ? "requests" : "members")
-                    }
+                    onValueChange={(v: string) => {
+                      if (v === "requests" || v === "history") {
+                        setMembersTab(v);
+                      } else {
+                        setMembersTab("members");
+                      }
+                    }}
                   >
                     <ButtonsSwitch value="members" label="Members" />
                     <ButtonsSwitch
@@ -1128,6 +1150,7 @@ export function UsagePage() {
                           : undefined
                       }
                     />
+                    <ButtonsSwitch value="history" label="History" />
                   </ButtonsSwitchList>
                   {membersTab === "members" && (
                     <div className="flex flex-row items-center gap-2">
@@ -1144,21 +1167,33 @@ export function UsagePage() {
                   )}
                 </div>
                 <div className="flex flex-col gap-2 pt-2">
-                  {membersTab === "members" ? (
+                  {membersTab === "members" && (
                     <>
                       {selectionBanner}
                       {membersTable}
                     </>
-                  ) : (
+                  )}
+                  {membersTab === "requests" && (
                     <UpgradeRequestsTable
                       requests={filteredUpgradeRequests}
                       isLoading={isUpgradeRequestsLoading}
+                      isError={isUpgradeRequestsError}
                       seatPlans={seatPlans}
                       isEnterprise={isEnterprise}
                       pendingRequestIds={resolvingRequestIds}
                       onUpgradePlan={handleUpgradePlanRequest}
                       onSetCreditAmount={handleSetCreditAmountRequest}
                       onDeny={handleDenyRequest}
+                    />
+                  )}
+                  {membersTab === "history" && (
+                    <UpgradeRequestsHistoryTable
+                      requests={upgradeRequestsHistory}
+                      isLoading={isUpgradeRequestsHistoryLoading}
+                      isError={isUpgradeRequestsHistoryError}
+                      totalRowCount={totalUpgradeRequestsHistoryCount}
+                      pagination={historyPagination}
+                      setPagination={setHistoryPagination}
                     />
                   )}
                 </div>

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -52,7 +52,9 @@ interface EditSpendLimitModalProps {
   // separate spend-limit update, so the two can't drift apart if one half
   // fails. It also skips the "workspace default vs. custom limit" choice and
   // opens straight into the custom-limit form, since approving an overage
-  // request is meant to fix the overage, not reset the member's cap.
+  // request is meant to fix the overage, not reset the member's cap. The
+  // combined resolution also records the granted amount/expiry on the
+  // request for the admin history view (see `setUserSpendLimit`).
   upgradeRequestId?: string | null;
 }
 
@@ -192,6 +194,7 @@ export function EditSpendLimitModal({
             kind: "limited",
             awuCredits: Number(data.creditsInput),
             expiresAt,
+            expiryKind: data.expiryMode,
           });
         })();
         return;

--- a/front/components/workspace/UpgradeRequestsHistoryTable.tsx
+++ b/front/components/workspace/UpgradeRequestsHistoryTable.tsx
@@ -1,0 +1,398 @@
+import { seatTypeDisplayName } from "@app/components/workspace/billing/seatTypeUtils";
+import { buildMemberNameColumn } from "@app/components/workspace/member_name_column";
+import { getSeatIconColorClass } from "@app/components/workspace/seat_styles";
+import type { SpendLimitExpiryKind } from "@app/types/api/users/spend_limit";
+import type { MembershipUpgradeRequestType } from "@app/types/memberships";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
+import {
+  AlertCircle,
+  Avatar,
+  ChevronRight,
+  Chip,
+  ContentMessage,
+  DataTable,
+  Icon,
+  LoadingBlock,
+  Popover,
+  Tooltip,
+} from "@dust-tt/sparkle";
+import type {
+  CellContext,
+  ColumnDef,
+  PaginationState,
+} from "@tanstack/react-table";
+import { useMemo } from "react";
+
+type RowData = {
+  sId: string;
+  name: string;
+  email: string | null;
+  image: string | null;
+  createdAt: number;
+  request: MembershipUpgradeRequestType;
+  // Rows are not clickable, but DataTable's row type requires at least one
+  // of its optional fields to be present.
+  onClick?: () => void;
+};
+
+type Info = CellContext<RowData, string>;
+
+const nameColumn = buildMemberNameColumn<RowData>("User");
+
+const REASON_LABEL = "Reached credit limit";
+
+function formatDate(epochMs: number): string {
+  return new Date(epochMs).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function durationLabel(expiryKind: SpendLimitExpiryKind | null): string | null {
+  if (expiryKind === null) {
+    return null;
+  }
+  switch (expiryKind) {
+    case "one_day":
+      return "1 day";
+    case "next_credit_reset":
+      return "Until next billing";
+    case "never":
+      return "Forever";
+    default:
+      assertNeverAndIgnore(expiryKind);
+      return null;
+  }
+}
+
+const issuedColumn: ColumnDef<RowData, string> = {
+  id: "issued" as const,
+  header: "Requested",
+  accessorFn: (row) => row.createdAt.toString(),
+  cell: (info: Info) => (
+    <DataTable.CellContent>
+      <span className="text-sm text-muted-foreground">
+        {formatDate(info.row.original.createdAt)}
+      </span>
+    </DataTable.CellContent>
+  ),
+  meta: {
+    className: "w-28",
+  },
+};
+
+// The pool-cap override or seat upgrade this request actually resulted in, if
+// any.
+const grantedColumn: ColumnDef<RowData, string> = {
+  id: "granted" as const,
+  header: "Granted",
+  enableSorting: false,
+  cell: (info: Info) => {
+    const {
+      status,
+      grantedAwuCredits,
+      grantedUnlimitedSpend,
+      grantedSeatType,
+    } = info.row.original.request;
+
+    if (status !== "approved") {
+      return (
+        <DataTable.CellContent>
+          <span className="text-sm text-muted-foreground">—</span>
+        </DataTable.CellContent>
+      );
+    }
+
+    if (grantedSeatType) {
+      return (
+        <DataTable.CellContent>
+          <span
+            className={`text-sm font-medium ${getSeatIconColorClass(grantedSeatType)}`}
+          >
+            Upgraded to {seatTypeDisplayName(grantedSeatType)}
+          </span>
+        </DataTable.CellContent>
+      );
+    }
+
+    if (grantedUnlimitedSpend) {
+      return (
+        <DataTable.CellContent>
+          <span className="text-sm">Unlimited spend</span>
+        </DataTable.CellContent>
+      );
+    }
+
+    if (grantedAwuCredits !== null) {
+      return (
+        <DataTable.CellContent>
+          <span className="text-sm">
+            {grantedAwuCredits.toLocaleString("en-US")} credits
+          </span>
+        </DataTable.CellContent>
+      );
+    }
+
+    return (
+      <DataTable.CellContent>
+        <span className="text-sm text-muted-foreground">—</span>
+      </DataTable.CellContent>
+    );
+  },
+  meta: {
+    className: "w-36",
+  },
+};
+
+// When the grant reverts, if ever. only a credit-amount grant
+// can carry the admin's duration choice.
+const untilColumn: ColumnDef<RowData, string> = {
+  id: "until" as const,
+  header: "For",
+  enableSorting: false,
+  cell: (info: Info) => {
+    const {
+      status,
+      grantedAwuCredits,
+      grantedExpiryKind,
+      grantedUnlimitedSpend,
+      grantedSeatType,
+    } = info.row.original.request;
+
+    const hasGrant =
+      grantedAwuCredits !== null || grantedUnlimitedSpend || grantedSeatType;
+    if (status !== "approved" || !hasGrant) {
+      return (
+        <DataTable.CellContent>
+          <span className="text-sm text-muted-foreground">—</span>
+        </DataTable.CellContent>
+      );
+    }
+
+    const label =
+      grantedSeatType || grantedUnlimitedSpend
+        ? "Forever"
+        : (durationLabel(grantedExpiryKind) ?? "—");
+
+    return (
+      <DataTable.CellContent>
+        <span className="text-sm text-muted-foreground">{label}</span>
+      </DataTable.CellContent>
+    );
+  },
+  meta: {
+    className: "w-28",
+  },
+};
+
+function ReasonCell({ reason }: { reason: string | null }) {
+  if (!reason) {
+    return (
+      <span className="text-sm text-muted-foreground">{REASON_LABEL}</span>
+    );
+  }
+
+  return (
+    <Popover
+      popoverTriggerAsChild
+      trigger={
+        <button
+          type="button"
+          className="flex flex-col items-start gap-0.5 text-left"
+        >
+          <span className="line-clamp-2 text-sm text-muted-foreground">
+            {reason}
+          </span>
+          <span className="flex items-center gap-0.5 text-xs font-medium text-highlight">
+            Show more
+            <Icon visual={ChevronRight} size="xs" />
+          </span>
+        </button>
+      }
+      content={
+        <p className="whitespace-pre-wrap text-sm text-foreground">{reason}</p>
+      }
+    />
+  );
+}
+
+const reasonColumn: ColumnDef<RowData, string> = {
+  id: "reason" as const,
+  header: "Reason",
+  enableSorting: false,
+  cell: (info: Info) => (
+    <DataTable.CellContent>
+      <ReasonCell reason={info.row.original.request.reason} />
+    </DataTable.CellContent>
+  ),
+  meta: {
+    className: "max-w-64",
+  },
+};
+
+const statusColumn: ColumnDef<RowData, string> = {
+  id: "status" as const,
+  header: "Decision",
+  enableSorting: false,
+  cell: (info: Info) => {
+    const { status } = info.row.original.request;
+    return (
+      <DataTable.CellContent>
+        {status === "approved" ? (
+          <Chip size="xs" color="success" label="Approved" />
+        ) : (
+          <Chip size="xs" color="warning" label="Denied" />
+        )}
+      </DataTable.CellContent>
+    );
+  },
+  meta: {
+    className: "w-28",
+  },
+};
+
+const resolvedAtColumn: ColumnDef<RowData, string> = {
+  id: "resolvedAt" as const,
+  header: "Resolved",
+  accessorFn: (row) => (row.request.resolvedAt ?? row.createdAt).toString(),
+  cell: (info: Info) => {
+    const { resolvedAt } = info.row.original.request;
+    return (
+      <DataTable.CellContent>
+        <span className="text-sm text-muted-foreground">
+          {resolvedAt ? formatDate(resolvedAt) : "—"}
+        </span>
+      </DataTable.CellContent>
+    );
+  },
+  meta: {
+    className: "w-28",
+  },
+};
+
+// Logo-only (avatar, no name) to save space — the name is available on hover.
+const resolvedByColumn: ColumnDef<RowData, string> = {
+  id: "resolvedBy" as const,
+  header: "Resolved by",
+  enableSorting: false,
+  cell: (info: Info) => {
+    const { resolvedBy } = info.row.original.request;
+    if (!resolvedBy) {
+      return (
+        <DataTable.CellContent>
+          <span className="text-sm text-muted-foreground">—</span>
+        </DataTable.CellContent>
+      );
+    }
+    return (
+      <DataTable.CellContent>
+        <Tooltip
+          tooltipTriggerAsChild
+          label={resolvedBy.name}
+          trigger={
+            <Avatar
+              visual={resolvedBy.image ?? ANONYMOUS_USER_IMAGE_URL}
+              name={resolvedBy.name}
+              size="sm"
+              isRounded
+            />
+          }
+        />
+      </DataTable.CellContent>
+    );
+  },
+  meta: {
+    className: "w-16",
+  },
+};
+
+interface UpgradeRequestsHistoryTableProps {
+  requests: MembershipUpgradeRequestType[];
+  isLoading: boolean;
+  isError: boolean;
+  totalRowCount: number;
+  pagination: PaginationState;
+  setPagination: (pagination: PaginationState) => void;
+}
+
+export function UpgradeRequestsHistoryTable({
+  requests,
+  isLoading,
+  isError,
+  totalRowCount,
+  pagination,
+  setPagination,
+}: UpgradeRequestsHistoryTableProps) {
+  const rows: RowData[] = useMemo(
+    () =>
+      requests.map((request) => ({
+        sId: request.sId,
+        name: request.requester.name,
+        email: request.requester.email,
+        image: request.requester.image,
+        createdAt: request.createdAt,
+        request,
+      })),
+    [requests]
+  );
+
+  const columns = useMemo(
+    () => [
+      nameColumn,
+      issuedColumn,
+      grantedColumn,
+      untilColumn,
+      reasonColumn,
+      statusColumn,
+      resolvedAtColumn,
+      resolvedByColumn,
+    ],
+    []
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex w-full flex-col space-y-2">
+        <LoadingBlock className="h-8 w-full rounded-xl" />
+        <LoadingBlock className="h-8 w-full rounded-xl" />
+        <LoadingBlock className="h-8 w-full rounded-xl" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <ContentMessage
+        title="Failed to load upgrade request history"
+        icon={AlertCircle}
+        variant="warning"
+      >
+        An error occurred while loading the upgrade request history. Please
+        refresh the page or contact support if the issue persists.
+      </ContentMessage>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="flex w-full justify-center py-8">
+        <span className="text-sm text-muted-foreground">
+          No resolved upgrade requests yet.
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <DataTable<RowData>
+      data={rows}
+      columns={columns}
+      pagination={pagination}
+      setPagination={setPagination}
+      totalRowCount={totalRowCount}
+    />
+  );
+}

--- a/front/components/workspace/UpgradeRequestsTable.tsx
+++ b/front/components/workspace/UpgradeRequestsTable.tsx
@@ -6,7 +6,15 @@ import type {
   MembershipSeatType,
   MembershipUpgradeRequestType,
 } from "@app/types/memberships";
-import { Button, DataTable, LoadingBlock, Spinner, X } from "@dust-tt/sparkle";
+import {
+  AlertCircle,
+  Button,
+  ContentMessage,
+  DataTable,
+  LoadingBlock,
+  Spinner,
+  X,
+} from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 
@@ -135,6 +143,7 @@ function buildActionsColumn({
 interface UpgradeRequestsTableProps {
   requests: MembershipUpgradeRequestType[];
   isLoading: boolean;
+  isError: boolean;
   seatPlans: SeatPlanResponseBody;
   isEnterprise: boolean;
   pendingRequestIds: ReadonlySet<string>;
@@ -146,6 +155,7 @@ interface UpgradeRequestsTableProps {
 export function UpgradeRequestsTable({
   requests,
   isLoading,
+  isError,
   seatPlans,
   isEnterprise,
   pendingRequestIds,
@@ -190,6 +200,19 @@ export function UpgradeRequestsTable({
         <LoadingBlock className="h-8 w-full rounded-xl" />
         <LoadingBlock className="h-8 w-full rounded-xl" />
       </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <ContentMessage
+        title="Failed to load upgrade requests"
+        icon={AlertCircle}
+        variant="warning"
+      >
+        An error occurred while loading pending upgrade requests. Please refresh
+        the page or contact support if the issue persists.
+      </ContentMessage>
     );
   }
 

--- a/front/components/workspace/member_name_column.tsx
+++ b/front/components/workspace/member_name_column.tsx
@@ -9,13 +9,12 @@ interface MemberNameRow {
   image: string | null;
 }
 
-export function buildMemberNameColumn<TRow extends MemberNameRow>(): ColumnDef<
-  TRow,
-  string
-> {
+export function buildMemberNameColumn<TRow extends MemberNameRow>(
+  header = "Name"
+): ColumnDef<TRow, string> {
   return {
     id: "name" as const,
-    header: "Name",
+    header,
     enableSorting: true,
     accessorFn: (row) => row.name,
     cell: (info: CellContext<TRow, string>) => (

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -652,15 +652,19 @@ export function useUpdateUserSpendLimit({
       memberId,
       memberName,
       limit,
+      requestId,
     }: {
       memberId: string;
       memberName: string;
       limit: UserSpendLimit;
+      // Set when this save resolves a specific upgrade request — see
+      // `setUserSpendLimit`.
+      requestId?: string | null;
     }): Promise<PutUserSpendLimitResponseBody | null> => {
       const res = await clientFetch(spendLimitUrl(workspaceId, memberId), {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(limit),
+        body: JSON.stringify({ ...limit, requestId: requestId ?? undefined }),
       });
 
       if (!res.ok) {

--- a/front/lib/swr/upgrade_requests.ts
+++ b/front/lib/swr/upgrade_requests.ts
@@ -93,6 +93,43 @@ export function useUpgradeRequests({
   };
 }
 
+// Server-enforced page size for the History tab — must match
+// `RESOLVED_UPGRADE_REQUESTS_HISTORY_PAGE_SIZE` in
+// `@app/lib/api/credits/upgrade_requests`.
+export const UPGRADE_REQUESTS_HISTORY_PAGE_SIZE = 100;
+
+// Admin-only: resolved (approved/denied) upgrade requests, for the History
+// tab. Disabled until that tab is visible.
+export function useUpgradeRequestsHistory({
+  workspaceId,
+  pageIndex,
+  disabled,
+}: {
+  workspaceId: string;
+  pageIndex: number;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const upgradeRequestsHistoryFetcher: Fetcher<GetUpgradeRequestsResponseBody> =
+    fetcher;
+
+  const offset = pageIndex * UPGRADE_REQUESTS_HISTORY_PAGE_SIZE;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `${upgradeRequestsUrl(workspaceId)}?status=resolved&offset=${offset}`,
+    upgradeRequestsHistoryFetcher,
+    { disabled, keepPreviousData: true }
+  );
+
+  return {
+    upgradeRequestsHistory: data?.requests ?? emptyArray(),
+    totalUpgradeRequestsHistoryCount: data?.total ?? 0,
+    isUpgradeRequestsHistoryLoading: !error && !data && !disabled,
+    isUpgradeRequestsHistoryError: !!error,
+    mutateUpgradeRequestsHistory: mutate,
+  };
+}
+
 export function useResolveUpgradeRequest({
   workspaceId,
 }: {


### PR DESCRIPTION
## Description

Until now, resolved upgrade requests disappeared from the workspace Usage page, so admins could not review what was requested, what was granted, or who made the decision. This PR adds a **History** tab next to Members and Requests for browsing resolved upgrade requests.

The history table displays the requester, request and resolution dates, the effective grant, grant duration, reason, decision, and resolving admin. Grants are rendered as a credit amount, “Unlimited spend”, or the selected seat upgrade, with seat colors matching the seat picker. Long reasons are clamped in the table and can be expanded in a popover. Empty and loading states are included.

History is loaded through the resolved-requests API only when the tab is active and is paginated in pages of 100 items, with the server-provided total used by the table pagination controls. The spend-limit modal now forwards the selected expiry preset so the history view can show the requested duration. Existing Members and pending Requests tabs remain unchanged.

Screenshots:

![Upgrade request history](https://github.com/user-attachments/assets/9f9b8a22-f2b6-4a5f-a96d-efd8dc196b8a)

![Upgrade request history details](https://github.com/user-attachments/assets/940a414e-589e-4d0b-b430-cf9fd21e8350)

It depends on [#29960](https://github.com/dust-tt/dust/pull/29960) for the schema and [#29961](https://github.com/dust-tt/dust/pull/29961) for the resource and API behavior.

## Tests

- Local testing

## Risk

This adds a new user-facing tab and history query without changing the existing Members or pending Requests flows. The main dependency risk is frontend/backend version skew: the history tab relies on the resolved-request response fields and pagination contract from [#29961](https://github.com/dust-tt/dust/pull/29961). Older records with unset grant snapshots are rendered conservatively as unavailable rather than inferred. The history request is disabled outside the active tab to avoid unnecessary polling or fetches.

## Deploy Plan

Deploy the schema migration from [#29960](https://github.com/dust-tt/dust/pull/29960) and the API/resource changes from [#29961](https://github.com/dust-tt/dust/pull/29961) before deploying this frontend change. No additional migration, backfill, feature flag, or manual rollout step is included in this PR.