### PR TITLE
Drop workspace_id from sandbox StatsD tags

### DIFF
--- a/front/lib/api/sandbox/db.ts
+++ b/front/lib/api/sandbox/db.ts
@@ -450,7 +450,7 @@ export async function ensurePodStateHealthOnSleep(
       if (refreshResult.error instanceof SandboxNotFoundError) {
         return new Ok(undefined);
       }
-      recordPodStateHealth("failure", ctx);
+      recordPodStateHealth("failure");
       childLogger.error(
         { err: refreshResult.error },
         "Pod state pre-sleep: GCS credential refresh failed — not pausing"
@@ -467,7 +467,7 @@ export async function ensurePodStateHealthOnSleep(
     if (livenessResult.error instanceof SandboxNotFoundError) {
       return new Ok(undefined);
     }
-    recordPodStateHealth("failure", ctx);
+    recordPodStateHealth("failure");
     childLogger.error(
       { err: livenessResult.error },
       "Pod state pre-sleep: replica mount is not a live FUSE mount — not pausing"
@@ -484,7 +484,7 @@ export async function ensurePodStateHealthOnSleep(
     if (namesResult.error instanceof SandboxNotFoundError) {
       return new Ok(undefined);
     }
-    recordPodStateHealth("failure", ctx);
+    recordPodStateHealth("failure");
     childLogger.error(
       { err: namesResult.error },
       "Pod state pre-sleep: database enumeration failed — not pausing"
@@ -506,7 +506,7 @@ export async function ensurePodStateHealthOnSleep(
     if (daemonResult.error instanceof SandboxNotFoundError) {
       return new Ok(undefined);
     }
-    recordPodStateHealth("failure", ctx);
+    recordPodStateHealth("failure");
     childLogger.error(
       { err: daemonResult.error },
       "Pod state pre-sleep: litestream daemon is not active — not pausing"
@@ -542,7 +542,7 @@ export async function ensurePodStateHealthOnSleep(
       if (failure instanceof SandboxNotFoundError) {
         return new Ok(undefined);
       }
-      recordPodStateHealth("failure", ctx);
+      recordPodStateHealth("failure");
       childLogger.error(
         { err: failure, database: name },
         "Pod state pre-sleep: litestream sync failed — restarting daemon, not pausing"
@@ -560,7 +560,7 @@ export async function ensurePodStateHealthOnSleep(
     }
   }
 
-  recordPodStateHealth("success", ctx);
+  recordPodStateHealth("success");
 
   return new Ok(undefined);
 }

--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -6,12 +6,8 @@ import tracer from "@app/logger/tracer";
 // Intentionally NOT tagged by workspace_id: region (+ operation/status) is
 // what matters for aggregates, and workspace_id multiplies cardinality past
 // Datadog custom-metric limits. Per-workspace drill-down stays in APM traces.
-interface MetricContext {
-  region?: string;
-}
-
-function buildTags(ctx?: MetricContext): string[] {
-  return [`region:${ctx?.region ?? regionConfig.getCurrentRegion()}`];
+function regionTag(): string {
+  return `region:${regionConfig.getCurrentRegion()}`;
 }
 
 // Semantic phases of the "zero to first executed command" startup path, in
@@ -89,30 +85,26 @@ export function recordSandboxStartupTotal(
   status: "success" | "error"
 ): void {
   getStatsDClient().distribution("sandbox.startup.total.duration", durationMs, [
-    ...buildTags({ region }),
+    `region:${region ?? regionConfig.getCurrentRegion()}`,
     `cold:${cold}`,
     `status:${status}`,
   ]);
 }
 
 export function recordLifecycleOperation(
-  operation: "create" | "wake" | "sleep" | "destroy",
-  ctx?: MetricContext
+  operation: "create" | "wake" | "sleep" | "destroy"
 ): void {
-  getStatsDClient().increment(
-    `sandbox.lifecycle.${operation}`,
-    1,
-    buildTags(ctx)
-  );
+  getStatsDClient().increment(`sandbox.lifecycle.${operation}`, 1, [
+    regionTag(),
+  ]);
 }
 
 export function recordStateDuration(
   previousStatus: SandboxStatus,
-  durationMs: number,
-  ctx?: MetricContext
+  durationMs: number
 ): void {
   getStatsDClient().distribution("sandbox.lifecycle.duration", durationMs, [
-    ...buildTags(ctx),
+    regionTag(),
     `status:${previousStatus}`,
   ]);
 }
@@ -131,12 +123,9 @@ export function recordToolDuration(
 // Health of the pod-state pre-sleep flush: a success/failure counter. Datadog
 // monitors page on the failure count; the stable logger.error message next to
 // each failing call site carries the cause.
-export function recordPodStateHealth(
-  status: "success" | "failure",
-  ctx?: MetricContext
-): void {
+export function recordPodStateHealth(status: "success" | "failure"): void {
   getStatsDClient().increment("sandbox.pod_state.health", 1, [
-    ...buildTags(ctx),
+    regionTag(),
     `status:${status}`,
   ]);
 }

--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -3,16 +3,15 @@ import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import tracer from "@app/logger/tracer";
 
+// Intentionally NOT tagged by workspace_id: region (+ operation/status) is
+// what matters for aggregates, and workspace_id multiplies cardinality past
+// Datadog custom-metric limits. Per-workspace drill-down stays in APM traces.
 interface MetricContext {
-  workspaceId: string;
   region?: string;
 }
 
-function buildTags(ctx: MetricContext): string[] {
-  return [
-    `workspace_id:${ctx.workspaceId}`,
-    `region:${ctx.region ?? regionConfig.getCurrentRegion()}`,
-  ];
+function buildTags(ctx?: MetricContext): string[] {
+  return [`region:${ctx?.region ?? regionConfig.getCurrentRegion()}`];
 }
 
 // Semantic phases of the "zero to first executed command" startup path, in
@@ -81,22 +80,16 @@ export function traceSandboxStartupPhase<T>(
   });
 }
 
-// The single net-new aggregate metric: the headline "0 -> first command" wall
-// time for one sandbox readiness run, split cold (fresh create path) vs warm
-// (wake/reuse). This is NOT covered by sandbox.tools.duration, whose timer
-// starts only once setup is already done and times the user command alone.
-//
-// Intentionally NOT tagged by workspace_id: the cold/warm split per region is
-// what matters for latency, and workspace_id would multiply cardinality on a
-// per-readiness-run distribution. Per-workspace drill-down stays available
-// via APM traces.
+// Headline "0 -> first command" wall time for one sandbox readiness run,
+// split cold (fresh create) vs warm (wake/reuse). Not covered by
+// sandbox.tools.duration, which starts only once setup is done.
 export function recordSandboxStartupTotal(
   durationMs: number,
   { region, cold }: { region?: string; cold: boolean },
   status: "success" | "error"
 ): void {
   getStatsDClient().distribution("sandbox.startup.total.duration", durationMs, [
-    `region:${region ?? regionConfig.getCurrentRegion()}`,
+    ...buildTags({ region }),
     `cold:${cold}`,
     `status:${status}`,
   ]);
@@ -104,7 +97,7 @@ export function recordSandboxStartupTotal(
 
 export function recordLifecycleOperation(
   operation: "create" | "wake" | "sleep" | "destroy",
-  ctx: MetricContext
+  ctx?: MetricContext
 ): void {
   getStatsDClient().increment(
     `sandbox.lifecycle.${operation}`,
@@ -116,7 +109,7 @@ export function recordLifecycleOperation(
 export function recordStateDuration(
   previousStatus: SandboxStatus,
   durationMs: number,
-  ctx: MetricContext
+  ctx?: MetricContext
 ): void {
   getStatsDClient().distribution("sandbox.lifecycle.duration", durationMs, [
     ...buildTags(ctx),
@@ -140,7 +133,7 @@ export function recordToolDuration(
 // each failing call site carries the cause.
 export function recordPodStateHealth(
   status: "success" | "failure",
-  ctx: MetricContext
+  ctx?: MetricContext
 ): void {
   getStatsDClient().increment("sandbox.pod_state.health", 1, [
     ...buildTags(ctx),

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -102,19 +102,15 @@ describe("SandboxResource.updateStatus", () => {
       statusChangedAt: new Date(Date.now() - 60_000),
     });
 
-    const ctx = { workspaceId: authenticator.getNonNullableWorkspace().sId };
-    await sandbox.updateStatus("sleeping", { ctx });
+    await sandbox.updateStatus("sleeping");
 
     expect(mockDistribution).toHaveBeenCalledWith(
       "sandbox.lifecycle.duration",
       expect.any(Number),
-      expect.arrayContaining([
+      [
         expect.stringMatching(/^region:/),
         "status:running",
-      ])
-    );
-    expect(mockDistribution.mock.calls[0][2]).not.toEqual(
-      expect.arrayContaining([expect.stringMatching(/^workspace_id:/)])
+      ]
     );
 
     const durationArg = mockDistribution.mock.calls[0][1];
@@ -128,8 +124,7 @@ describe("SandboxResource.updateStatus", () => {
       statusChangedAt: null,
     });
 
-    const ctx = { workspaceId: authenticator.getNonNullableWorkspace().sId };
-    await sandbox.updateStatus("sleeping", { ctx });
+    await sandbox.updateStatus("sleeping");
 
     expect(mockDistribution).not.toHaveBeenCalled();
   });
@@ -141,8 +136,7 @@ describe("SandboxResource.updateStatus", () => {
     });
 
     const originalStatusChangedAt = sandbox.statusChangedAt;
-    const ctx = { workspaceId: authenticator.getNonNullableWorkspace().sId };
-    await sandbox.updateStatus("running", { ctx });
+    await sandbox.updateStatus("running");
 
     expect(mockDistribution).not.toHaveBeenCalled();
 
@@ -162,9 +156,8 @@ describe("SandboxResource.updateStatus", () => {
       statusChangedAt: originalTime,
     });
 
-    const ctx = { workspaceId: authenticator.getNonNullableWorkspace().sId };
     const beforeTransition = Date.now();
-    await sandbox.updateStatus("sleeping", { ctx });
+    await sandbox.updateStatus("sleeping");
     const afterTransition = Date.now();
 
     const reloaded = await ConversationSandboxAdapter.fetchSandbox(

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -109,9 +109,12 @@ describe("SandboxResource.updateStatus", () => {
       "sandbox.lifecycle.duration",
       expect.any(Number),
       expect.arrayContaining([
-        `workspace_id:${ctx.workspaceId}`,
+        expect.stringMatching(/^region:/),
         "status:running",
       ])
+    );
+    expect(mockDistribution.mock.calls[0][2]).not.toEqual(
+      expect.arrayContaining([expect.stringMatching(/^workspace_id:/)])
     );
 
     const durationArg = mockDistribution.mock.calls[0][1];

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -107,10 +107,7 @@ describe("SandboxResource.updateStatus", () => {
     expect(mockDistribution).toHaveBeenCalledWith(
       "sandbox.lifecycle.duration",
       expect.any(Number),
-      [
-        expect.stringMatching(/^region:/),
-        "status:running",
-      ]
+      [expect.stringMatching(/^region:/), "status:running"]
     );
 
     const durationArg = mockDistribution.mock.calls[0][1];

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -217,9 +217,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
 
     const sandbox = await withTransaction(createSandbox, transaction);
 
-    recordLifecycleOperation("create", {
-      workspaceId: auth.getNonNullableWorkspace().sId,
-    });
+    recordLifecycleOperation("create");
 
     return new this(this.model, sandbox.get());
   }

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -132,13 +132,12 @@ export class SandboxResource extends BaseResource<SandboxModel> {
 
   private static async finalizeDestroyed(
     sandbox: SandboxResource,
-    ctx: { workspaceId: string },
     opts: { recordLifecycle: boolean }
   ): Promise<void> {
-    await sandbox.updateStatus("deleted", { ctx });
+    await sandbox.updateStatus("deleted");
     SandboxResource.deleteEgressPolicyAfterDestroy(sandbox);
     if (opts.recordLifecycle) {
-      recordLifecycleOperation("destroy", ctx);
+      recordLifecycleOperation("destroy");
     }
   }
 
@@ -282,7 +281,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   async updateStatus(
     newStatus: SandboxStatus,
     opts?: {
-      ctx?: { workspaceId: string };
       transaction?: Transaction;
     }
   ): Promise<void> {
@@ -292,9 +290,9 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       return;
     }
 
-    if (opts?.ctx && this.statusChangedAt) {
+    if (this.statusChangedAt) {
       const durationMs = Date.now() - this.statusChangedAt.getTime();
-      recordStateDuration(previousStatus, durationMs, opts.ctx);
+      recordStateDuration(previousStatus, durationMs);
     }
 
     await this.update(
@@ -495,7 +493,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     );
 
     return this.withLifecycleLock(owner.lockKey, async (provider) => {
-      const ctx = { workspaceId: auth.getNonNullableWorkspace().sId };
       const tracingOpts = { workspaceId: auth.getNonNullableWorkspace().sId };
       const existing = await owner.fetchSandbox();
 
@@ -691,13 +688,13 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         await existing.updateLastRuntimeRefreshAt(null);
       }
 
-      await existing.updateStatus("running", { ctx });
+      await existing.updateStatus("running");
       await existing.updateLastActivityAt();
 
       if (wokeFromSleep) {
-        recordLifecycleOperation("wake", ctx);
+        recordLifecycleOperation("wake");
       } else if (freshlyCreated) {
-        recordLifecycleOperation("create", ctx);
+        recordLifecycleOperation("create");
       }
 
       return new Ok({ sandbox: existing, freshlyCreated, wokeFromSleep });
@@ -724,7 +721,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         return new Ok(undefined);
       }
 
-      const ctx = { workspaceId: auth.getNonNullableWorkspace().sId };
       const tracingOpts = { workspaceId: auth.getNonNullableWorkspace().sId };
 
       const checkResult = await this.runPreSleepCheck(
@@ -748,14 +744,14 @@ export class SandboxResource extends BaseResource<SandboxModel> {
             { sandbox: sandbox.toLogJSON() },
             "Sandbox not found at provider during sleep — marking deleted."
           );
-          await sandbox.updateStatus("deleted", { ctx });
+          await sandbox.updateStatus("deleted");
           return new Ok(undefined);
         }
         return result;
       }
 
-      await sandbox.updateStatus("sleeping", { ctx });
-      recordLifecycleOperation("sleep", ctx);
+      await sandbox.updateStatus("sleeping");
+      recordLifecycleOperation("sleep");
       logger.info({ sandbox: sandbox.toLogJSON() }, "Sandbox put to sleep.");
       return new Ok(undefined);
     });
@@ -779,7 +775,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         return new Ok(undefined);
       }
 
-      const ctx = { workspaceId: auth.getNonNullableWorkspace().sId };
+      const tracingOpts = { workspaceId: auth.getNonNullableWorkspace().sId };
 
       // The health check runs BEFORE the pending_approval DB flip on purpose:
       // a failure then leaves DB=running + SDK=running (nothing happened),
@@ -809,9 +805,9 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       // failure leaves DB=pending_approval + SDK=running, which is the
       // recoverable shape: ensureActive's pending_approval branch will wake
       // the (still-running) sandbox on the next call, idempotently.
-      await sandbox.updateStatus("pending_approval", { ctx });
+      await sandbox.updateStatus("pending_approval");
 
-      const sleepResult = await provider.sleep(sandbox.providerId, ctx);
+      const sleepResult = await provider.sleep(sandbox.providerId, tracingOpts);
       if (sleepResult.isErr()) {
         logger.error(
           {
@@ -846,8 +842,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         return new Ok(undefined);
       }
 
-      const ctx = { workspaceId: auth.getNonNullableWorkspace().sId };
-      await sandbox.updateStatus("sleeping", { ctx });
+      await sandbox.updateStatus("sleeping");
       logger.info(
         { sandbox: sandbox.toLogJSON() },
         "Pending-approval sandbox transitioned to sleeping."
@@ -871,7 +866,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         return new Ok(undefined);
       }
 
-      const ctx = { workspaceId: auth.getNonNullableWorkspace().sId };
       const tracingOpts = { workspaceId: auth.getNonNullableWorkspace().sId };
 
       const result = await provider.destroy(sandbox.providerId, tracingOpts);
@@ -881,7 +875,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
             { sandbox: sandbox.toLogJSON() },
             "Sandbox not found at provider during destroy — marking deleted."
           );
-          await SandboxResource.finalizeDestroyed(sandbox, ctx, {
+          await SandboxResource.finalizeDestroyed(sandbox, {
             recordLifecycle: false,
           });
           return new Ok(undefined);
@@ -889,7 +883,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         return result;
       }
 
-      await SandboxResource.finalizeDestroyed(sandbox, ctx, {
+      await SandboxResource.finalizeDestroyed(sandbox, {
         recordLifecycle: true,
       });
 
@@ -1017,7 +1011,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         return new Ok(undefined);
       }
 
-      const ctx = { workspaceId: auth.getNonNullableWorkspace().sId };
       const tracingOpts = { workspaceId: auth.getNonNullableWorkspace().sId };
 
       // Pre-destroy flush: kill-requested destroys (image rollouts) would
@@ -1046,7 +1039,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
             { sandbox: sandbox.toLogJSON() },
             "Kill-requested sandbox not found at provider — marking deleted."
           );
-          await SandboxResource.finalizeDestroyed(sandbox, ctx, {
+          await SandboxResource.finalizeDestroyed(sandbox, {
             recordLifecycle: false,
           });
           return new Ok(undefined);
@@ -1054,7 +1047,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         return result;
       }
 
-      await SandboxResource.finalizeDestroyed(sandbox, ctx, {
+      await SandboxResource.finalizeDestroyed(sandbox, {
         recordLifecycle: true,
       });
 


### PR DESCRIPTION
## Description

`sandbox.lifecycle.duration` tripped the high-cardinality custom metric monitor (~11k series). Root cause was tagging every sample with `workspace_id`.

Stop emitting `workspace_id` on sandbox StatsD metrics (region + status/operation only). Per-workspace drill-down stays in APM traces.

## Tests

Updated `sandbox_resource.test.ts` and ran it locally.

## Risk

Low. Dashboards/monitors that grouped these metrics by `workspace_id` will lose that dimension. No such monitors found.

## Deploy Plan

Standard deploy. Old high-cardinality series age out on their own.

Made with [Cursor](https://cursor.com)