### PR TITLE
Add agent message consumption item resource

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -2,7 +2,6 @@ import { hardDeleteDataSource } from "@app/lib/api/data_sources";
 import { deleteOwnerPolicy } from "@app/lib/api/sandbox/egress_policy";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
-import { AgentMessageConsumptionItemModel } from "@app/lib/models/agent/agent_message_consumption_item";
 import { AgentSuggestionModel } from "@app/lib/models/agent/agent_suggestion";
 import {
   AgentMessageFeedbackModel,
@@ -19,6 +18,7 @@ import {
   ConversationSkillModel,
 } from "@app/lib/models/skill/conversation_skill";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { getContentFragmentBaseCloudStorageForWorkspace } from "@app/lib/resources/content_fragment_resource";
 import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
@@ -230,12 +230,12 @@ export async function destroyConversation(
         messagesChunk.map((m) => m.contentFragmentId)
       );
 
-      await AgentMessageConsumptionItemModel.destroy({
-        where: {
-          workspaceId: owner.id,
-          agentMessageId: agentMessageIds,
-        },
-      });
+      await AgentMessageConsumptionItemResource.deleteByAgentMessageModelIds(
+        auth,
+        {
+          agentMessageModelIds: agentMessageIds,
+        }
+      );
 
       await destroyActionsRelatedResources(auth, agentMessageIds);
 

--- a/front/lib/models/agent/agent_message_consumption_item.ts
+++ b/front/lib/models/agent/agent_message_consumption_item.ts
@@ -31,6 +31,9 @@ function validateConsumptionItemShape(
   if (!isTool && this.directCreditAmountMicro !== null) {
     throw new Error("Only tool attribution items may contain direct credits");
   }
+  if (!isTool && this.completedAt === null) {
+    throw new Error("Only tool attribution items may be pending");
+  }
   if (
     this.directCreditAmountMicro !== null &&
     this.grossAttributedCreditAmountMicro < this.directCreditAmountMicro

--- a/front/lib/models/agent/agent_message_consumption_item.ts
+++ b/front/lib/models/agent/agent_message_consumption_item.ts
@@ -35,6 +35,15 @@ function validateConsumptionItemShape(
     throw new Error("Only tool attribution items may be pending");
   }
   if (
+    isTool &&
+    this.completedAt === null &&
+    (this.inputTokensCount !== null || this.directCreditAmountMicro !== null)
+  ) {
+    throw new Error(
+      "Pending tool attribution items cannot contain result or direct credit evidence"
+    );
+  }
+  if (
     this.directCreditAmountMicro !== null &&
     this.grossAttributedCreditAmountMicro < this.directCreditAmountMicro
   ) {

--- a/front/lib/resources/agent_message_consumption_item_resource.test.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.test.ts
@@ -72,105 +72,90 @@ async function setupMessageWithEvidence(
 }
 
 describe("AgentMessageConsumptionItemResource", () => {
-  it("creates pending facts idempotently and derives their identities", async () => {
+  it("records completed facts idempotently without rewriting them", async () => {
     const { authenticator: auth, workspace } = await createResourceTest({});
     const context = await setupMessageWithEvidence(auth, workspace);
-    const sources = [
+    const records = [
       {
         itemType: "input" as const,
         runUsageModelId: context.runUsageModelId,
+        inputTokensCount: 100,
+        grossAttributedCreditAmountMicro: 300_000,
+        state: "completed" as const,
       },
       {
         itemType: "tool" as const,
         runUsageModelId: context.runUsageModelId,
         agentMCPActionModelId: context.action.id,
+        inputTokensCount: 40,
+        outputTokensCount: 12,
+        grossAttributedCreditAmountMicro: 2_000_000,
+        directCreditAmountMicro: 1_000_000,
+        state: "completed" as const,
       },
     ];
 
-    await AgentMessageConsumptionItemResource.createPendingItems(auth, {
-      ...context,
-      attributionVersion: 1,
-      sources,
-    });
-    await AgentMessageConsumptionItemResource.createPendingItems(auth, {
-      ...context,
-      attributionVersion: 1,
-      sources,
-    });
+    const initialItems = await AgentMessageConsumptionItemResource.recordItems(
+      auth,
+      {
+        ...context,
+        attributionVersion: 1,
+        records,
+      }
+    );
+    const retriedItems = await AgentMessageConsumptionItemResource.recordItems(
+      auth,
+      {
+        ...context,
+        attributionVersion: 1,
+        records,
+      }
+    );
 
-    const items =
-      await AgentMessageConsumptionItemResource.listByAgentMessageModelId(
-        auth,
-        {
-          agentMessageModelId: context.agentMessageModelId,
-          attributionVersion: 1,
-        }
-      );
-    expect(items).toHaveLength(2);
-    expect(items).toEqual(
+    expect(initialItems).toHaveLength(2);
+    expect(retriedItems).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           itemKey: `run-usage:${context.runUsageModelId}:input`,
           itemType: "input",
-          completedAt: null,
+          inputTokensCount: 100,
         }),
         expect.objectContaining({
           itemKey: `tool-action:${context.action.id}`,
           itemType: "tool",
-          completedAt: null,
+          inputTokensCount: 40,
+          outputTokensCount: 12,
+          directCreditAmountMicro: 1_000_000,
         }),
       ])
     );
-
-    await expect(
-      AgentMessageConsumptionItemResource.setEvidence(auth, {
-        agentMessageModelId: context.agentMessageModelId,
-        attributionVersion: 1,
-        evidence: {
-          itemType: "input",
-          runUsageModelId: context.runUsageModelId,
-          inputTokensCount: 100,
-          grossAttributedCreditAmountMicro: 300_000,
-          state: "completed",
-        },
-      })
-    ).resolves.toMatchObject({
-      inputTokensCount: 100,
-      outputTokensCount: null,
-      directCreditAmountMicro: null,
-    });
+    expect(retriedItems.every((item) => item.completedAt !== null)).toBe(true);
+    expect(retriedItems.map((item) => item.updatedAt)).toEqual(
+      initialItems.map((item) => item.updatedAt)
+    );
   });
 
-  it("enriches a pending fact and makes completed evidence immutable", async () => {
+  it("completes an approval-spanning fact and makes it immutable", async () => {
     const { authenticator: auth, workspace } = await createResourceTest({});
     const context = await setupMessageWithEvidence(auth, workspace);
-    await AgentMessageConsumptionItemResource.createPendingItems(auth, {
-      ...context,
-      attributionVersion: 1,
-      sources: [
-        {
-          itemType: "tool",
-          runUsageModelId: context.runUsageModelId,
-          agentMCPActionModelId: context.action.id,
-        },
-      ],
-    });
-
-    const pending = await AgentMessageConsumptionItemResource.setEvidence(
+    const [pending] = await AgentMessageConsumptionItemResource.recordItems(
       auth,
       {
+        ...context,
         agentMessageModelId: context.agentMessageModelId,
         attributionVersion: 1,
-        evidence: {
-          itemType: "tool",
-          runUsageModelId: context.runUsageModelId,
-          agentMCPActionModelId: context.action.id,
-          inputTokensCount: null,
-          outputTokensCount: 12,
-          grossAttributedCreditAmountMicro: 400_000,
-          directCreditAmountMicro: null,
-          state: "pending",
-        },
+        records: [
+          {
+            itemType: "tool",
+            runUsageModelId: context.runUsageModelId,
+            agentMCPActionModelId: context.action.id,
+            inputTokensCount: null,
+            outputTokensCount: 12,
+            grossAttributedCreditAmountMicro: 400_000,
+            directCreditAmountMicro: null,
+            state: "pending",
+          },
+        ],
       }
     );
     expect(pending).toMatchObject({
@@ -180,7 +165,7 @@ describe("AgentMessageConsumptionItemResource", () => {
       completedAt: null,
     });
 
-    const finalEvidence = {
+    const finalRecord = {
       itemType: "tool" as const,
       runUsageModelId: context.runUsageModelId,
       agentMCPActionModelId: context.action.id,
@@ -190,12 +175,13 @@ describe("AgentMessageConsumptionItemResource", () => {
       directCreditAmountMicro: 1_000_000,
       state: "completed" as const,
     };
-    const completed = await AgentMessageConsumptionItemResource.setEvidence(
+    const [completed] = await AgentMessageConsumptionItemResource.recordItems(
       auth,
       {
+        ...context,
         agentMessageModelId: context.agentMessageModelId,
         attributionVersion: 1,
-        evidence: finalEvidence,
+        records: [finalRecord],
       }
     );
     expect(completed).toMatchObject({
@@ -207,21 +193,18 @@ describe("AgentMessageConsumptionItemResource", () => {
     expect(completed.completedAt).not.toBeNull();
 
     await expect(
-      AgentMessageConsumptionItemResource.setEvidence(auth, {
-        agentMessageModelId: context.agentMessageModelId,
+      AgentMessageConsumptionItemResource.recordItems(auth, {
+        ...context,
         attributionVersion: 1,
-        evidence: finalEvidence,
+        records: [finalRecord],
       })
-    ).resolves.toMatchObject({ id: completed.id });
+    ).resolves.toEqual([expect.objectContaining({ id: completed.id })]);
 
     await expect(
-      AgentMessageConsumptionItemResource.setEvidence(auth, {
-        agentMessageModelId: context.agentMessageModelId,
+      AgentMessageConsumptionItemResource.recordItems(auth, {
+        ...context,
         attributionVersion: 1,
-        evidence: {
-          ...finalEvidence,
-          inputTokensCount: 41,
-        },
+        records: [{ ...finalRecord, inputTokensCount: 41 }],
       })
     ).rejects.toThrow("Completed consumption item");
   });
@@ -232,15 +215,20 @@ describe("AgentMessageConsumptionItemResource", () => {
     const foreign = await setupMessageWithEvidence(auth, workspace);
 
     await expect(
-      AgentMessageConsumptionItemResource.createPendingItems(auth, {
+      AgentMessageConsumptionItemResource.recordItems(auth, {
         conversationModelId: owner.conversationModelId,
         agentMessageModelId: owner.agentMessageModelId,
         attributionVersion: 1,
-        sources: [
+        records: [
           {
             itemType: "tool",
             runUsageModelId: owner.runUsageModelId,
             agentMCPActionModelId: foreign.action.id,
+            inputTokensCount: null,
+            outputTokensCount: 12,
+            grossAttributedCreditAmountMicro: 400_000,
+            directCreditAmountMicro: null,
+            state: "pending",
           },
         ],
       })
@@ -249,14 +237,17 @@ describe("AgentMessageConsumptionItemResource", () => {
     );
 
     await expect(
-      AgentMessageConsumptionItemResource.createPendingItems(auth, {
+      AgentMessageConsumptionItemResource.recordItems(auth, {
         conversationModelId: owner.conversationModelId,
         agentMessageModelId: owner.agentMessageModelId,
         attributionVersion: 1,
-        sources: [
+        records: [
           {
             itemType: "input",
             runUsageModelId: foreign.runUsageModelId,
+            inputTokensCount: 100,
+            grossAttributedCreditAmountMicro: 300_000,
+            state: "completed",
           },
         ],
       })
@@ -276,14 +267,19 @@ describe("AgentMessageConsumptionItemResource", () => {
       runUsageModelId: ModelId;
       action: AgentMCPActionResource;
     }) {
-      await AgentMessageConsumptionItemResource.createPendingItems(auth, {
+      await AgentMessageConsumptionItemResource.recordItems(auth, {
         ...context,
         attributionVersion: 1,
-        sources: [
+        records: [
           {
             itemType: "tool",
             runUsageModelId: context.runUsageModelId,
             agentMCPActionModelId: context.action.id,
+            inputTokensCount: null,
+            outputTokensCount: 12,
+            grossAttributedCreditAmountMicro: 400_000,
+            directCreditAmountMicro: null,
+            state: "pending",
           },
         ],
       });

--- a/front/lib/resources/agent_message_consumption_item_resource.test.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.test.ts
@@ -1,0 +1,314 @@
+import type { Authenticator } from "@app/lib/auth";
+import { AgentMessageModel } from "@app/lib/models/agent/conversation";
+import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
+import { RunResource } from "@app/lib/resources/run_resource";
+import { RunUsageModel } from "@app/lib/resources/storage/models/runs";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { LightWorkspaceType } from "@app/types/user";
+import { describe, expect, it } from "vitest";
+
+async function setupMessageWithEvidence(
+  auth: Authenticator,
+  workspace: LightWorkspaceType
+) {
+  const agentConfiguration = await AgentConfigurationFactory.createTestAgent(
+    auth,
+    { name: `Consumption ${generateRandomModelSId()}` }
+  );
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: agentConfiguration.sId,
+    messagesCreatedAt: [],
+  });
+  const { agentMessage } = await ConversationFactory.createAgentMessage(auth, {
+    workspace,
+    conversation,
+    agentConfig: agentConfiguration,
+  });
+
+  const dustRunId = generateRandomModelSId();
+  const run = await RunResource.makeNew({
+    appId: null,
+    dustRunId,
+    runType: "deploy",
+    useWorkspaceCredentials: false,
+    workspaceId: workspace.id,
+  });
+  const runUsage = await RunUsageModel.create({
+    workspaceId: workspace.id,
+    runId: run.id,
+    providerId: "openai",
+    modelId: "gpt-5-mini",
+    promptTokens: 100,
+    completionTokens: 20,
+    reasoningTokens: null,
+    cachedTokens: null,
+    cacheCreationTokens: null,
+    costMicroUsd: 10,
+    isBatch: false,
+  });
+  await AgentMessageModel.update(
+    { runIds: [dustRunId] },
+    { where: { id: agentMessage.agentMessageId, workspaceId: workspace.id } }
+  );
+
+  const { action } = await AgentMCPActionFactory.create(auth, {
+    workspace,
+    conversationModelId: conversation.id,
+    agentMessageModelId: agentMessage.agentMessageId,
+  });
+
+  return {
+    conversationModelId: conversation.id,
+    agentMessageModelId: agentMessage.agentMessageId,
+    runUsageModelId: runUsage.id,
+    action,
+  };
+}
+
+describe("AgentMessageConsumptionItemResource", () => {
+  it("creates pending facts idempotently and derives their identities", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const context = await setupMessageWithEvidence(auth, workspace);
+    const sources = [
+      {
+        itemType: "input" as const,
+        runUsageModelId: context.runUsageModelId,
+      },
+      {
+        itemType: "tool" as const,
+        runUsageModelId: context.runUsageModelId,
+        agentMCPActionModelId: context.action.id,
+      },
+    ];
+
+    await AgentMessageConsumptionItemResource.createPendingItems(auth, {
+      ...context,
+      attributionVersion: 1,
+      sources,
+    });
+    await AgentMessageConsumptionItemResource.createPendingItems(auth, {
+      ...context,
+      attributionVersion: 1,
+      sources,
+    });
+
+    const items =
+      await AgentMessageConsumptionItemResource.listByAgentMessageModelId(
+        auth,
+        {
+          agentMessageModelId: context.agentMessageModelId,
+          attributionVersion: 1,
+        }
+      );
+    expect(items).toHaveLength(2);
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          itemKey: `run-usage:${context.runUsageModelId}:input`,
+          itemType: "input",
+          completedAt: null,
+        }),
+        expect.objectContaining({
+          itemKey: `tool-action:${context.action.id}`,
+          itemType: "tool",
+          completedAt: null,
+        }),
+      ])
+    );
+
+    await expect(
+      AgentMessageConsumptionItemResource.setEvidence(auth, {
+        agentMessageModelId: context.agentMessageModelId,
+        attributionVersion: 1,
+        evidence: {
+          itemType: "input",
+          runUsageModelId: context.runUsageModelId,
+          inputTokensCount: 100,
+          grossAttributedCreditAmountMicro: 300_000,
+          state: "completed",
+        },
+      })
+    ).resolves.toMatchObject({
+      inputTokensCount: 100,
+      outputTokensCount: null,
+      directCreditAmountMicro: null,
+    });
+  });
+
+  it("enriches a pending fact and makes completed evidence immutable", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const context = await setupMessageWithEvidence(auth, workspace);
+    await AgentMessageConsumptionItemResource.createPendingItems(auth, {
+      ...context,
+      attributionVersion: 1,
+      sources: [
+        {
+          itemType: "tool",
+          runUsageModelId: context.runUsageModelId,
+          agentMCPActionModelId: context.action.id,
+        },
+      ],
+    });
+
+    const pending = await AgentMessageConsumptionItemResource.setEvidence(
+      auth,
+      {
+        agentMessageModelId: context.agentMessageModelId,
+        attributionVersion: 1,
+        evidence: {
+          itemType: "tool",
+          runUsageModelId: context.runUsageModelId,
+          agentMCPActionModelId: context.action.id,
+          inputTokensCount: null,
+          outputTokensCount: 12,
+          grossAttributedCreditAmountMicro: 400_000,
+          directCreditAmountMicro: null,
+          state: "pending",
+        },
+      }
+    );
+    expect(pending).toMatchObject({
+      inputTokensCount: null,
+      outputTokensCount: 12,
+      grossAttributedCreditAmountMicro: 400_000,
+      completedAt: null,
+    });
+
+    const finalEvidence = {
+      itemType: "tool" as const,
+      runUsageModelId: context.runUsageModelId,
+      agentMCPActionModelId: context.action.id,
+      inputTokensCount: 40,
+      outputTokensCount: 12,
+      grossAttributedCreditAmountMicro: 2_000_000,
+      directCreditAmountMicro: 1_000_000,
+      state: "completed" as const,
+    };
+    const completed = await AgentMessageConsumptionItemResource.setEvidence(
+      auth,
+      {
+        agentMessageModelId: context.agentMessageModelId,
+        attributionVersion: 1,
+        evidence: finalEvidence,
+      }
+    );
+    expect(completed).toMatchObject({
+      inputTokensCount: 40,
+      outputTokensCount: 12,
+      grossAttributedCreditAmountMicro: 2_000_000,
+      directCreditAmountMicro: 1_000_000,
+    });
+    expect(completed.completedAt).not.toBeNull();
+
+    await expect(
+      AgentMessageConsumptionItemResource.setEvidence(auth, {
+        agentMessageModelId: context.agentMessageModelId,
+        attributionVersion: 1,
+        evidence: finalEvidence,
+      })
+    ).resolves.toMatchObject({ id: completed.id });
+
+    await expect(
+      AgentMessageConsumptionItemResource.setEvidence(auth, {
+        agentMessageModelId: context.agentMessageModelId,
+        attributionVersion: 1,
+        evidence: {
+          ...finalEvidence,
+          inputTokensCount: 41,
+        },
+      })
+    ).rejects.toThrow("Completed consumption item");
+  });
+
+  it("rejects evidence sources owned by another agent message", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const owner = await setupMessageWithEvidence(auth, workspace);
+    const foreign = await setupMessageWithEvidence(auth, workspace);
+
+    await expect(
+      AgentMessageConsumptionItemResource.createPendingItems(auth, {
+        conversationModelId: owner.conversationModelId,
+        agentMessageModelId: owner.agentMessageModelId,
+        attributionVersion: 1,
+        sources: [
+          {
+            itemType: "tool",
+            runUsageModelId: owner.runUsageModelId,
+            agentMCPActionModelId: foreign.action.id,
+          },
+        ],
+      })
+    ).rejects.toThrow(
+      "Consumption item action does not belong to the agent message"
+    );
+
+    await expect(
+      AgentMessageConsumptionItemResource.createPendingItems(auth, {
+        conversationModelId: owner.conversationModelId,
+        agentMessageModelId: owner.agentMessageModelId,
+        attributionVersion: 1,
+        sources: [
+          {
+            itemType: "input",
+            runUsageModelId: foreign.runUsageModelId,
+          },
+        ],
+      })
+    ).rejects.toThrow(
+      "Consumption item run usage does not belong to the agent message"
+    );
+  });
+
+  it("deletes facts only for the requested owning messages", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const first = await setupMessageWithEvidence(auth, workspace);
+    const second = await setupMessageWithEvidence(auth, workspace);
+
+    async function createToolFact(context: {
+      conversationModelId: ModelId;
+      agentMessageModelId: ModelId;
+      runUsageModelId: ModelId;
+      action: AgentMCPActionResource;
+    }) {
+      await AgentMessageConsumptionItemResource.createPendingItems(auth, {
+        ...context,
+        attributionVersion: 1,
+        sources: [
+          {
+            itemType: "tool",
+            runUsageModelId: context.runUsageModelId,
+            agentMCPActionModelId: context.action.id,
+          },
+        ],
+      });
+    }
+    await createToolFact(first);
+    await createToolFact(second);
+
+    await AgentMessageConsumptionItemResource.deleteByAgentMessageModelIds(
+      auth,
+      {
+        agentMessageModelIds: [first.agentMessageModelId],
+      }
+    );
+
+    await expect(
+      AgentMessageConsumptionItemResource.listByAgentMessageModelId(auth, {
+        agentMessageModelId: first.agentMessageModelId,
+        attributionVersion: 1,
+      })
+    ).resolves.toHaveLength(0);
+    await expect(
+      AgentMessageConsumptionItemResource.listByAgentMessageModelId(auth, {
+        agentMessageModelId: second.agentMessageModelId,
+        attributionVersion: 1,
+      })
+    ).resolves.toHaveLength(1);
+  });
+});

--- a/front/lib/resources/agent_message_consumption_item_resource.test.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.test.ts
@@ -72,7 +72,7 @@ async function setupMessageWithEvidence(
 }
 
 describe("AgentMessageConsumptionItemResource", () => {
-  it("records completed facts idempotently without rewriting them", async () => {
+  it("keeps the first completed facts when insertion is retried", async () => {
     const { authenticator: auth, workspace } = await createResourceTest({});
     const context = await setupMessageWithEvidence(auth, workspace);
     const records = [
@@ -95,25 +95,30 @@ describe("AgentMessageConsumptionItemResource", () => {
       },
     ];
 
-    const initialItems = await AgentMessageConsumptionItemResource.recordItems(
-      auth,
-      {
-        ...context,
-        attributionVersion: 1,
-        records,
-      }
-    );
-    const retriedItems = await AgentMessageConsumptionItemResource.recordItems(
-      auth,
-      {
-        ...context,
-        attributionVersion: 1,
-        records,
-      }
-    );
+    await AgentMessageConsumptionItemResource.insertItemsIdempotently(auth, {
+      ...context,
+      attributionVersion: 1,
+      records,
+    });
+    await AgentMessageConsumptionItemResource.insertItemsIdempotently(auth, {
+      ...context,
+      attributionVersion: 1,
+      records: [
+        { ...records[0], inputTokensCount: 101 },
+        { ...records[1], inputTokensCount: 41 },
+      ],
+    });
 
-    expect(initialItems).toHaveLength(2);
-    expect(retriedItems).toEqual(
+    const items =
+      await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
+        auth,
+        {
+          agentMessageModelIds: [context.agentMessageModelId],
+          attributionVersion: 1,
+        }
+      );
+    expect(items).toHaveLength(2);
+    expect(items).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           itemKey: `run-usage:${context.runUsageModelId}:input`,
@@ -129,35 +134,37 @@ describe("AgentMessageConsumptionItemResource", () => {
         }),
       ])
     );
-    expect(retriedItems.every((item) => item.completedAt !== null)).toBe(true);
-    expect(retriedItems.map((item) => item.updatedAt)).toEqual(
-      initialItems.map((item) => item.updatedAt)
-    );
+    expect(items.every((item) => item.completedAt !== null)).toBe(true);
   });
 
-  it("completes an approval-spanning fact and makes it immutable", async () => {
+  it("completes an approval-spanning fact without rewriting completed evidence", async () => {
     const { authenticator: auth, workspace } = await createResourceTest({});
     const context = await setupMessageWithEvidence(auth, workspace);
-    const [pending] = await AgentMessageConsumptionItemResource.recordItems(
-      auth,
-      {
-        ...context,
-        agentMessageModelId: context.agentMessageModelId,
-        attributionVersion: 1,
-        records: [
-          {
-            itemType: "tool",
-            runUsageModelId: context.runUsageModelId,
-            agentMCPActionModelId: context.action.id,
-            inputTokensCount: null,
-            outputTokensCount: 12,
-            grossAttributedCreditAmountMicro: 400_000,
-            directCreditAmountMicro: null,
-            state: "pending",
-          },
-        ],
-      }
-    );
+    await AgentMessageConsumptionItemResource.insertItemsIdempotently(auth, {
+      ...context,
+      agentMessageModelId: context.agentMessageModelId,
+      attributionVersion: 1,
+      records: [
+        {
+          itemType: "tool",
+          runUsageModelId: context.runUsageModelId,
+          agentMCPActionModelId: context.action.id,
+          inputTokensCount: null,
+          outputTokensCount: 12,
+          grossAttributedCreditAmountMicro: 400_000,
+          directCreditAmountMicro: null,
+          state: "pending",
+        },
+      ],
+    });
+    const [pending] =
+      await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
+        auth,
+        {
+          agentMessageModelIds: [context.agentMessageModelId],
+          attributionVersion: 1,
+        }
+      );
     expect(pending).toMatchObject({
       inputTokensCount: null,
       outputTokensCount: 12,
@@ -175,15 +182,19 @@ describe("AgentMessageConsumptionItemResource", () => {
       directCreditAmountMicro: 1_000_000,
       state: "completed" as const,
     };
-    const [completed] = await AgentMessageConsumptionItemResource.recordItems(
-      auth,
-      {
-        ...context,
-        agentMessageModelId: context.agentMessageModelId,
-        attributionVersion: 1,
-        records: [finalRecord],
-      }
-    );
+    await AgentMessageConsumptionItemResource.completeItemsIdempotently(auth, {
+      ...context,
+      attributionVersion: 1,
+      records: [finalRecord],
+    });
+    const [completed] =
+      await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
+        auth,
+        {
+          agentMessageModelIds: [context.agentMessageModelId],
+          attributionVersion: 1,
+        }
+      );
     expect(completed).toMatchObject({
       inputTokensCount: 40,
       outputTokensCount: 12,
@@ -192,68 +203,75 @@ describe("AgentMessageConsumptionItemResource", () => {
     });
     expect(completed.completedAt).not.toBeNull();
 
-    await expect(
-      AgentMessageConsumptionItemResource.recordItems(auth, {
-        ...context,
-        attributionVersion: 1,
-        records: [finalRecord],
-      })
-    ).resolves.toEqual([expect.objectContaining({ id: completed.id })]);
+    await AgentMessageConsumptionItemResource.completeItemsIdempotently(auth, {
+      ...context,
+      attributionVersion: 1,
+      records: [{ ...finalRecord, inputTokensCount: 41 }],
+    });
+    await AgentMessageConsumptionItemResource.insertItemsIdempotently(auth, {
+      ...context,
+      attributionVersion: 1,
+      records: [
+        {
+          ...finalRecord,
+          inputTokensCount: null,
+          grossAttributedCreditAmountMicro: 400_000,
+          directCreditAmountMicro: null,
+          state: "pending",
+        },
+      ],
+    });
 
-    await expect(
-      AgentMessageConsumptionItemResource.recordItems(auth, {
-        ...context,
-        attributionVersion: 1,
-        records: [{ ...finalRecord, inputTokensCount: 41 }],
-      })
-    ).rejects.toThrow("Completed consumption item");
+    const [unchanged] =
+      await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
+        auth,
+        {
+          agentMessageModelIds: [context.agentMessageModelId],
+          attributionVersion: 1,
+        }
+      );
+    expect(unchanged).toMatchObject({
+      id: completed.id,
+      inputTokensCount: 40,
+      grossAttributedCreditAmountMicro: 2_000_000,
+      directCreditAmountMicro: 1_000_000,
+    });
   });
 
-  it("rejects evidence sources owned by another agent message", async () => {
+  it("inserts a completed fact when no pending row exists", async () => {
     const { authenticator: auth, workspace } = await createResourceTest({});
-    const owner = await setupMessageWithEvidence(auth, workspace);
-    const foreign = await setupMessageWithEvidence(auth, workspace);
+    const context = await setupMessageWithEvidence(auth, workspace);
+
+    await AgentMessageConsumptionItemResource.completeItemsIdempotently(auth, {
+      ...context,
+      attributionVersion: 1,
+      records: [
+        {
+          itemType: "tool",
+          runUsageModelId: context.runUsageModelId,
+          agentMCPActionModelId: context.action.id,
+          inputTokensCount: 40,
+          outputTokensCount: 12,
+          grossAttributedCreditAmountMicro: 2_000_000,
+          directCreditAmountMicro: 1_000_000,
+          state: "completed",
+        },
+      ],
+    });
 
     await expect(
-      AgentMessageConsumptionItemResource.recordItems(auth, {
-        conversationModelId: owner.conversationModelId,
-        agentMessageModelId: owner.agentMessageModelId,
+      AgentMessageConsumptionItemResource.listByAgentMessageModelIds(auth, {
+        agentMessageModelIds: [context.agentMessageModelId],
         attributionVersion: 1,
-        records: [
-          {
-            itemType: "tool",
-            runUsageModelId: owner.runUsageModelId,
-            agentMCPActionModelId: foreign.action.id,
-            inputTokensCount: null,
-            outputTokensCount: 12,
-            grossAttributedCreditAmountMicro: 400_000,
-            directCreditAmountMicro: null,
-            state: "pending",
-          },
-        ],
       })
-    ).rejects.toThrow(
-      "Consumption item action does not belong to the agent message"
-    );
-
-    await expect(
-      AgentMessageConsumptionItemResource.recordItems(auth, {
-        conversationModelId: owner.conversationModelId,
-        agentMessageModelId: owner.agentMessageModelId,
-        attributionVersion: 1,
-        records: [
-          {
-            itemType: "input",
-            runUsageModelId: foreign.runUsageModelId,
-            inputTokensCount: 100,
-            grossAttributedCreditAmountMicro: 300_000,
-            state: "completed",
-          },
-        ],
-      })
-    ).rejects.toThrow(
-      "Consumption item run usage does not belong to the agent message"
-    );
+    ).resolves.toEqual([
+      expect.objectContaining({
+        itemKey: `tool-action:${context.action.id}`,
+        inputTokensCount: 40,
+        outputTokensCount: 12,
+        completedAt: expect.any(Date),
+      }),
+    ]);
   });
 
   it("deletes facts only for the requested owning messages", async () => {
@@ -267,7 +285,7 @@ describe("AgentMessageConsumptionItemResource", () => {
       runUsageModelId: ModelId;
       action: AgentMCPActionResource;
     }) {
-      await AgentMessageConsumptionItemResource.recordItems(auth, {
+      await AgentMessageConsumptionItemResource.insertItemsIdempotently(auth, {
         ...context,
         attributionVersion: 1,
         records: [
@@ -295,14 +313,14 @@ describe("AgentMessageConsumptionItemResource", () => {
     );
 
     await expect(
-      AgentMessageConsumptionItemResource.listByAgentMessageModelId(auth, {
-        agentMessageModelId: first.agentMessageModelId,
+      AgentMessageConsumptionItemResource.listByAgentMessageModelIds(auth, {
+        agentMessageModelIds: [first.agentMessageModelId],
         attributionVersion: 1,
       })
     ).resolves.toHaveLength(0);
     await expect(
-      AgentMessageConsumptionItemResource.listByAgentMessageModelId(auth, {
-        agentMessageModelId: second.agentMessageModelId,
+      AgentMessageConsumptionItemResource.listByAgentMessageModelIds(auth, {
+        agentMessageModelIds: [second.agentMessageModelId],
         attributionVersion: 1,
       })
     ).resolves.toHaveLength(1);

--- a/front/lib/resources/agent_message_consumption_item_resource.test.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.test.ts
@@ -1,7 +1,9 @@
 import type { Authenticator } from "@app/lib/auth";
+import { AgentMessageConsumptionItemModel } from "@app/lib/models/agent/agent_message_consumption_item";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { RunUsageModel } from "@app/lib/resources/storage/models/runs";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -62,9 +64,16 @@ async function setupMessageWithEvidence(
     conversationModelId: conversation.id,
     agentMessageModelId: agentMessage.agentMessageId,
   });
+  const conversationResource = await ConversationResource.fetchById(
+    auth,
+    conversation.sId
+  );
+  if (!conversationResource) {
+    throw new Error("Conversation not found");
+  }
 
   return {
-    conversationModelId: conversation.id,
+    conversation: conversationResource,
     agentMessageModelId: agentMessage.agentMessageId,
     runUsageModelId: runUsage.id,
     action,
@@ -72,6 +81,31 @@ async function setupMessageWithEvidence(
 }
 
 describe("AgentMessageConsumptionItemResource", () => {
+  it("rejects pending non-tool items", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const context = await setupMessageWithEvidence(auth, workspace);
+
+    const item = AgentMessageConsumptionItemModel.build({
+      workspaceId: workspace.id,
+      conversationId: context.conversation.id,
+      agentMessageId: context.agentMessageModelId,
+      runUsageId: context.runUsageModelId,
+      agentMCPActionId: null,
+      itemKey: `run-usage:${context.runUsageModelId}:input`,
+      itemType: "input",
+      attributionVersion: 1,
+      inputTokensCount: 100,
+      outputTokensCount: null,
+      grossAttributedCreditAmountMicro: 300_000,
+      directCreditAmountMicro: null,
+      completedAt: null,
+    });
+
+    await expect(item.validate()).rejects.toThrow(
+      "Only tool attribution items may be pending"
+    );
+  });
+
   it("keeps the first completed facts when insertion is retried", async () => {
     const { authenticator: auth, workspace } = await createResourceTest({});
     const context = await setupMessageWithEvidence(auth, workspace);
@@ -81,33 +115,39 @@ describe("AgentMessageConsumptionItemResource", () => {
         runUsageModelId: context.runUsageModelId,
         inputTokensCount: 100,
         grossAttributedCreditAmountMicro: 300_000,
-        state: "completed" as const,
       },
       {
         itemType: "tool" as const,
         runUsageModelId: context.runUsageModelId,
-        agentMCPActionModelId: context.action.id,
+        action: context.action,
         inputTokensCount: 40,
         outputTokensCount: 12,
         grossAttributedCreditAmountMicro: 2_000_000,
         directCreditAmountMicro: 1_000_000,
-        state: "completed" as const,
       },
     ];
 
-    await AgentMessageConsumptionItemResource.insertItemsIdempotently(auth, {
-      ...context,
-      attributionVersion: 1,
-      records,
-    });
-    await AgentMessageConsumptionItemResource.insertItemsIdempotently(auth, {
-      ...context,
-      attributionVersion: 1,
-      records: [
-        { ...records[0], inputTokensCount: 101 },
-        { ...records[1], inputTokensCount: 41 },
-      ],
-    });
+    await AgentMessageConsumptionItemResource.insertCompletedItemsIdempotently(
+      auth,
+      {
+        conversation: context.conversation,
+        agentMessageModelId: context.agentMessageModelId,
+        attributionVersion: 1,
+        records,
+      }
+    );
+    await AgentMessageConsumptionItemResource.insertCompletedItemsIdempotently(
+      auth,
+      {
+        conversation: context.conversation,
+        agentMessageModelId: context.agentMessageModelId,
+        attributionVersion: 1,
+        records: [
+          { ...records[0], inputTokensCount: 101 },
+          { ...records[1], inputTokensCount: 41 },
+        ],
+      }
+    );
 
     const items =
       await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
@@ -117,147 +157,77 @@ describe("AgentMessageConsumptionItemResource", () => {
           attributionVersion: 1,
         }
       );
-    expect(items).toHaveLength(2);
     expect(items).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           itemKey: `run-usage:${context.runUsageModelId}:input`,
-          itemType: "input",
           inputTokensCount: 100,
         }),
         expect.objectContaining({
           itemKey: `tool-action:${context.action.id}`,
-          itemType: "tool",
           inputTokensCount: 40,
           outputTokensCount: 12,
           directCreditAmountMicro: 1_000_000,
         }),
       ])
     );
+    expect(items).toHaveLength(2);
     expect(items.every((item) => item.completedAt !== null)).toBe(true);
   });
 
-  it("completes an approval-spanning fact without rewriting completed evidence", async () => {
+  it("completes an approval-spanning tool once", async () => {
     const { authenticator: auth, workspace } = await createResourceTest({});
     const context = await setupMessageWithEvidence(auth, workspace);
-    await AgentMessageConsumptionItemResource.insertItemsIdempotently(auth, {
-      ...context,
-      agentMessageModelId: context.agentMessageModelId,
-      attributionVersion: 1,
-      records: [
-        {
-          itemType: "tool",
-          runUsageModelId: context.runUsageModelId,
-          agentMCPActionModelId: context.action.id,
-          inputTokensCount: null,
+
+    await AgentMessageConsumptionItemResource.insertPendingToolItemIdempotently(
+      auth,
+      {
+        conversation: context.conversation,
+        attributionVersion: 1,
+        item: {
+          action: context.action,
+          runUsageModelId: null,
           outputTokensCount: 12,
           grossAttributedCreditAmountMicro: 400_000,
-          directCreditAmountMicro: null,
-          state: "pending",
         },
-      ],
-    });
-    const [pending] =
-      await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
-        auth,
-        {
-          agentMessageModelIds: [context.agentMessageModelId],
-          attributionVersion: 1,
-        }
-      );
-    expect(pending).toMatchObject({
-      inputTokensCount: null,
-      outputTokensCount: 12,
-      grossAttributedCreditAmountMicro: 400_000,
-      completedAt: null,
-    });
+      }
+    );
 
-    const finalRecord = {
-      itemType: "tool" as const,
+    const completedItem = {
+      action: context.action,
       runUsageModelId: context.runUsageModelId,
-      agentMCPActionModelId: context.action.id,
       inputTokensCount: 40,
       outputTokensCount: 12,
       grossAttributedCreditAmountMicro: 2_000_000,
       directCreditAmountMicro: 1_000_000,
-      state: "completed" as const,
     };
-    await AgentMessageConsumptionItemResource.completeItemsIdempotently(auth, {
-      ...context,
-      attributionVersion: 1,
-      records: [finalRecord],
-    });
-    const [completed] =
-      await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
-        auth,
-        {
-          agentMessageModelIds: [context.agentMessageModelId],
-          attributionVersion: 1,
-        }
-      );
-    expect(completed).toMatchObject({
-      inputTokensCount: 40,
-      outputTokensCount: 12,
-      grossAttributedCreditAmountMicro: 2_000_000,
-      directCreditAmountMicro: 1_000_000,
-    });
-    expect(completed.completedAt).not.toBeNull();
-
-    await AgentMessageConsumptionItemResource.completeItemsIdempotently(auth, {
-      ...context,
-      attributionVersion: 1,
-      records: [{ ...finalRecord, inputTokensCount: 41 }],
-    });
-    await AgentMessageConsumptionItemResource.insertItemsIdempotently(auth, {
-      ...context,
-      attributionVersion: 1,
-      records: [
-        {
-          ...finalRecord,
-          inputTokensCount: null,
-          grossAttributedCreditAmountMicro: 400_000,
-          directCreditAmountMicro: null,
-          state: "pending",
-        },
-      ],
-    });
-
-    const [unchanged] =
-      await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
-        auth,
-        {
-          agentMessageModelIds: [context.agentMessageModelId],
-          attributionVersion: 1,
-        }
-      );
-    expect(unchanged).toMatchObject({
-      id: completed.id,
-      inputTokensCount: 40,
-      grossAttributedCreditAmountMicro: 2_000_000,
-      directCreditAmountMicro: 1_000_000,
-    });
-  });
-
-  it("inserts a completed fact when no pending row exists", async () => {
-    const { authenticator: auth, workspace } = await createResourceTest({});
-    const context = await setupMessageWithEvidence(auth, workspace);
-
-    await AgentMessageConsumptionItemResource.completeItemsIdempotently(auth, {
-      ...context,
-      attributionVersion: 1,
-      records: [
-        {
-          itemType: "tool",
+    await AgentMessageConsumptionItemResource.completePendingToolItemIdempotently(
+      auth,
+      {
+        attributionVersion: 1,
+        item: completedItem,
+      }
+    );
+    await AgentMessageConsumptionItemResource.completePendingToolItemIdempotently(
+      auth,
+      {
+        attributionVersion: 1,
+        item: { ...completedItem, inputTokensCount: 41 },
+      }
+    );
+    await AgentMessageConsumptionItemResource.insertPendingToolItemIdempotently(
+      auth,
+      {
+        conversation: context.conversation,
+        attributionVersion: 1,
+        item: {
+          action: context.action,
           runUsageModelId: context.runUsageModelId,
-          agentMCPActionModelId: context.action.id,
-          inputTokensCount: 40,
           outputTokensCount: 12,
-          grossAttributedCreditAmountMicro: 2_000_000,
-          directCreditAmountMicro: 1_000_000,
-          state: "completed",
+          grossAttributedCreditAmountMicro: 400_000,
         },
-      ],
-    });
+      }
+    );
 
     await expect(
       AgentMessageConsumptionItemResource.listByAgentMessageModelIds(auth, {
@@ -267,11 +237,41 @@ describe("AgentMessageConsumptionItemResource", () => {
     ).resolves.toEqual([
       expect.objectContaining({
         itemKey: `tool-action:${context.action.id}`,
+        runUsageId: context.runUsageModelId,
         inputTokensCount: 40,
         outputTokensCount: 12,
+        grossAttributedCreditAmountMicro: 2_000_000,
+        directCreditAmountMicro: 1_000_000,
         completedAt: expect.any(Date),
       }),
     ]);
+  });
+
+  it("does not create a tool fact when no pending fact exists", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const context = await setupMessageWithEvidence(auth, workspace);
+
+    await AgentMessageConsumptionItemResource.completePendingToolItemIdempotently(
+      auth,
+      {
+        attributionVersion: 1,
+        item: {
+          action: context.action,
+          runUsageModelId: context.runUsageModelId,
+          inputTokensCount: 40,
+          outputTokensCount: 12,
+          grossAttributedCreditAmountMicro: 2_000_000,
+          directCreditAmountMicro: 1_000_000,
+        },
+      }
+    );
+
+    await expect(
+      AgentMessageConsumptionItemResource.listByAgentMessageModelIds(auth, {
+        agentMessageModelIds: [context.agentMessageModelId],
+        attributionVersion: 1,
+      })
+    ).resolves.toHaveLength(0);
   });
 
   it("deletes facts only for the requested owning messages", async () => {
@@ -280,36 +280,31 @@ describe("AgentMessageConsumptionItemResource", () => {
     const second = await setupMessageWithEvidence(auth, workspace);
 
     async function createToolFact(context: {
-      conversationModelId: ModelId;
+      conversation: ConversationResource;
       agentMessageModelId: ModelId;
       runUsageModelId: ModelId;
       action: AgentMCPActionResource;
     }) {
-      await AgentMessageConsumptionItemResource.insertItemsIdempotently(auth, {
-        ...context,
-        attributionVersion: 1,
-        records: [
-          {
-            itemType: "tool",
+      await AgentMessageConsumptionItemResource.insertPendingToolItemIdempotently(
+        auth,
+        {
+          conversation: context.conversation,
+          attributionVersion: 1,
+          item: {
+            action: context.action,
             runUsageModelId: context.runUsageModelId,
-            agentMCPActionModelId: context.action.id,
-            inputTokensCount: null,
             outputTokensCount: 12,
             grossAttributedCreditAmountMicro: 400_000,
-            directCreditAmountMicro: null,
-            state: "pending",
           },
-        ],
-      });
+        }
+      );
     }
     await createToolFact(first);
     await createToolFact(second);
 
     await AgentMessageConsumptionItemResource.deleteByAgentMessageModelIds(
       auth,
-      {
-        agentMessageModelIds: [first.agentMessageModelId],
-      }
+      { agentMessageModelIds: [first.agentMessageModelId] }
     );
 
     await expect(

--- a/front/lib/resources/agent_message_consumption_item_resource.test.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.test.ts
@@ -1,16 +1,14 @@
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMessageConsumptionItemModel } from "@app/lib/models/agent/agent_message_consumption_item";
-import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { RunResource } from "@app/lib/resources/run_resource";
-import { RunUsageModel } from "@app/lib/resources/storage/models/runs";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { RunFactory } from "@app/tests/utils/RunFactory";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { LightWorkspaceType } from "@app/types/user";
 import { describe, expect, it } from "vitest";
@@ -27,37 +25,13 @@ async function setupMessageWithEvidence(
     agentConfigurationId: agentConfiguration.sId,
     messagesCreatedAt: [],
   });
+  const { run, runUsageModelId } = await RunFactory.createWithUsage(auth);
   const { agentMessage } = await ConversationFactory.createAgentMessage(auth, {
     workspace,
     conversation,
     agentConfig: agentConfiguration,
+    runIds: [run.dustRunId],
   });
-
-  const dustRunId = generateRandomModelSId();
-  const run = await RunResource.makeNew({
-    appId: null,
-    dustRunId,
-    runType: "deploy",
-    useWorkspaceCredentials: false,
-    workspaceId: workspace.id,
-  });
-  const runUsage = await RunUsageModel.create({
-    workspaceId: workspace.id,
-    runId: run.id,
-    providerId: "openai",
-    modelId: "gpt-5-mini",
-    promptTokens: 100,
-    completionTokens: 20,
-    reasoningTokens: null,
-    cachedTokens: null,
-    cacheCreationTokens: null,
-    costMicroUsd: 10,
-    isBatch: false,
-  });
-  await AgentMessageModel.update(
-    { runIds: [dustRunId] },
-    { where: { id: agentMessage.agentMessageId, workspaceId: workspace.id } }
-  );
 
   const { action } = await AgentMCPActionFactory.create(auth, {
     workspace,
@@ -75,13 +49,13 @@ async function setupMessageWithEvidence(
   return {
     conversation: conversationResource,
     agentMessageModelId: agentMessage.agentMessageId,
-    runUsageModelId: runUsage.id,
+    runUsageModelId,
     action,
   };
 }
 
 describe("AgentMessageConsumptionItemResource", () => {
-  it("rejects pending non-tool items", async () => {
+  it("keeps pending state exclusive to incomplete tools", async () => {
     const { authenticator: auth, workspace } = await createResourceTest({});
     const context = await setupMessageWithEvidence(auth, workspace);
 
@@ -103,6 +77,25 @@ describe("AgentMessageConsumptionItemResource", () => {
 
     await expect(item.validate()).rejects.toThrow(
       "Only tool attribution items may be pending"
+    );
+
+    const pendingToolWithResult = AgentMessageConsumptionItemModel.build({
+      workspaceId: workspace.id,
+      conversationId: context.conversation.id,
+      agentMessageId: context.agentMessageModelId,
+      runUsageId: context.runUsageModelId,
+      agentMCPActionId: context.action.id,
+      itemKey: `tool-action:${context.action.id}`,
+      itemType: "tool",
+      attributionVersion: 1,
+      inputTokensCount: 40,
+      outputTokensCount: 12,
+      grossAttributedCreditAmountMicro: 300_000,
+      directCreditAmountMicro: null,
+      completedAt: null,
+    });
+    await expect(pendingToolWithResult.validate()).rejects.toThrow(
+      "Pending tool attribution items cannot contain result or direct credit evidence"
     );
   });
 
@@ -186,7 +179,7 @@ describe("AgentMessageConsumptionItemResource", () => {
         attributionVersion: 1,
         item: {
           action: context.action,
-          runUsageModelId: null,
+          runUsageModelId: context.runUsageModelId,
           outputTokensCount: 12,
           grossAttributedCreditAmountMicro: 400_000,
         },
@@ -195,9 +188,7 @@ describe("AgentMessageConsumptionItemResource", () => {
 
     const completedItem = {
       action: context.action,
-      runUsageModelId: context.runUsageModelId,
       inputTokensCount: 40,
-      outputTokensCount: 12,
       grossAttributedCreditAmountMicro: 2_000_000,
       directCreditAmountMicro: 1_000_000,
     };
@@ -257,9 +248,7 @@ describe("AgentMessageConsumptionItemResource", () => {
         attributionVersion: 1,
         item: {
           action: context.action,
-          runUsageModelId: context.runUsageModelId,
           inputTokensCount: 40,
-          outputTokensCount: 12,
           grossAttributedCreditAmountMicro: 2_000_000,
           directCreditAmountMicro: 1_000_000,
         },
@@ -279,12 +268,12 @@ describe("AgentMessageConsumptionItemResource", () => {
     const first = await setupMessageWithEvidence(auth, workspace);
     const second = await setupMessageWithEvidence(auth, workspace);
 
-    async function createToolFact(context: {
+    const createToolFact = async (context: {
       conversation: ConversationResource;
       agentMessageModelId: ModelId;
       runUsageModelId: ModelId;
       action: AgentMCPActionResource;
-    }) {
+    }) => {
       await AgentMessageConsumptionItemResource.insertPendingToolItemIdempotently(
         auth,
         {
@@ -298,7 +287,7 @@ describe("AgentMessageConsumptionItemResource", () => {
           },
         }
       );
-    }
+    };
     await createToolFact(first);
     await createToolFact(second);
 

--- a/front/lib/resources/agent_message_consumption_item_resource.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.ts
@@ -1,46 +1,45 @@
 import type { Authenticator } from "@app/lib/auth";
-import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentMessageConsumptionItemModel } from "@app/lib/models/agent/agent_message_consumption_item";
-import {
-  AgentMessageModel,
-  ConversationModel,
-} from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import {
-  RunModel,
-  RunUsageModel,
-} from "@app/lib/resources/storage/models/runs";
+import { frontSequelize } from "@app/lib/resources/storage";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
-import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type { Attributes, Transaction } from "sequelize";
-import { Op } from "sequelize";
+import type { Attributes, CreationAttributes, Transaction } from "sequelize";
+import { Op, QueryTypes } from "sequelize";
 
-interface ConsumptionItemEvidenceBase {
+type ConsumptionItemState = "pending" | "completed";
+
+interface ConsumptionItemEvidenceBase<
+  TState extends ConsumptionItemState = ConsumptionItemState,
+> {
   grossAttributedCreditAmountMicro: number;
-  state: "pending" | "completed";
+  state: TState;
 }
 
-export type AgentMessageConsumptionItemRecord =
-  | (ConsumptionItemEvidenceBase & {
+export type AgentMessageConsumptionItemRecord<
+  TState extends ConsumptionItemState = ConsumptionItemState,
+> =
+  | (ConsumptionItemEvidenceBase<TState> & {
       itemType: "system" | "input";
       runUsageModelId: ModelId;
       inputTokensCount: number | null;
     })
-  | (ConsumptionItemEvidenceBase & {
+  | (ConsumptionItemEvidenceBase<TState> & {
       itemType: "output" | "reasoning";
       runUsageModelId: ModelId;
       outputTokensCount: number | null;
     })
-  | (ConsumptionItemEvidenceBase & {
+  | (ConsumptionItemEvidenceBase<TState> & {
       itemType: "tool";
       runUsageModelId: ModelId | null;
       agentMCPActionModelId: ModelId;
+      /** Estimated tokens in the result returned by this tool execution */
       inputTokensCount: number | null;
+      /** Estimated tokens in the model output that emitted the tool name and arguments */
       outputTokensCount: number | null;
       directCreditAmountMicro: number | null;
     });
@@ -52,6 +51,27 @@ type ConsumptionItemEvidenceAttributes = Pick<
   | "grossAttributedCreditAmountMicro"
   | "directCreditAmountMicro"
 >;
+
+type ConsumptionItemCreationAttributes =
+  CreationAttributes<AgentMessageConsumptionItemModel>;
+
+const UPSERT_COLUMNS = [
+  "workspaceId",
+  "conversationId",
+  "agentMessageId",
+  "runUsageId",
+  "agentMCPActionId",
+  "itemKey",
+  "itemType",
+  "attributionVersion",
+  "inputTokensCount",
+  "outputTokensCount",
+  "grossAttributedCreditAmountMicro",
+  "directCreditAmountMicro",
+  "completedAt",
+  "createdAt",
+  "updatedAt",
+] as const satisfies ReadonlyArray<keyof ConsumptionItemCreationAttributes>;
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface AgentMessageConsumptionItemResource
@@ -123,274 +143,183 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
     }
   }
 
-  private static hasSameSource(
-    item: AgentMessageConsumptionItemModel,
-    record: AgentMessageConsumptionItemRecord
-  ): boolean {
-    switch (record.itemType) {
-      case "system":
-      case "input":
-      case "output":
-      case "reasoning":
-        return (
-          item.itemType === record.itemType &&
-          item.runUsageId === record.runUsageModelId &&
-          item.agentMCPActionId === null
-        );
-
-      case "tool":
-        return (
-          item.itemType === "tool" &&
-          item.runUsageId === record.runUsageModelId &&
-          item.agentMCPActionId === record.agentMCPActionModelId
-        );
-
-      default:
-        return assertNever(record);
-    }
-  }
-
-  private static hasSameEvidence(
-    item: AgentMessageConsumptionItemModel,
-    evidence: ConsumptionItemEvidenceAttributes
-  ): boolean {
-    return (
-      item.inputTokensCount === evidence.inputTokensCount &&
-      item.outputTokensCount === evidence.outputTokensCount &&
-      item.grossAttributedCreditAmountMicro ===
-        evidence.grossAttributedCreditAmountMicro &&
-      item.directCreditAmountMicro === evidence.directCreditAmountMicro
-    );
-  }
-
-  private static async validateOwnership(
-    auth: Authenticator,
-    {
-      conversationModelId,
-      agentMessageModelId,
-      records,
-      transaction,
-    }: {
-      conversationModelId: ModelId;
-      agentMessageModelId: ModelId;
-      records: AgentMessageConsumptionItemRecord[];
-      transaction?: Transaction;
-    }
-  ): Promise<void> {
-    const workspaceModelId = auth.getNonNullableWorkspace().id;
-    const [conversation, agentMessage] = await Promise.all([
-      ConversationModel.findOne({
-        where: { id: conversationModelId, workspaceId: workspaceModelId },
-        transaction,
-      }),
-      AgentMessageModel.findOne({
-        where: { id: agentMessageModelId, workspaceId: workspaceModelId },
-        transaction,
-      }),
-    ]);
-
-    if (!conversation || !agentMessage) {
-      throw new Error("Consumption item owner was not found in the workspace");
-    }
-    if (agentMessage.conversationId !== conversation.id) {
-      throw new Error(
-        "Consumption item conversation does not own the agent message"
-      );
-    }
-
-    const runUsageModelIds = [
-      ...new Set(
-        records.flatMap((record) =>
-          record.runUsageModelId === null ? [] : [record.runUsageModelId]
-        )
-      ),
-    ];
-    if (runUsageModelIds.length > 0) {
-      const runUsages = await RunUsageModel.findAll({
-        where: {
-          id: { [Op.in]: runUsageModelIds },
-          workspaceId: workspaceModelId,
-        },
-        transaction,
-      });
-      const runs = await RunModel.findAll({
-        where: {
-          id: { [Op.in]: runUsages.map((usage) => usage.runId) },
-          workspaceId: workspaceModelId,
-        },
-        transaction,
-      });
-      const runByModelId = new Map(runs.map((run) => [run.id, run]));
-      const messageRunIds = new Set(agentMessage.runIds ?? []);
-      if (
-        runUsages.length !== runUsageModelIds.length ||
-        runUsages.some((usage) => {
-          const run = runByModelId.get(usage.runId);
-          return !run || !messageRunIds.has(run.dustRunId);
-        })
-      ) {
-        throw new Error(
-          "Consumption item run usage does not belong to the agent message"
-        );
-      }
-    }
-
-    const actionModelIds = [
-      ...new Set(
-        records.flatMap((record) =>
-          record.itemType === "tool" ? [record.agentMCPActionModelId] : []
-        )
-      ),
-    ];
-    if (actionModelIds.length > 0) {
-      const actions = await AgentMCPActionModel.findAll({
-        where: {
-          id: { [Op.in]: actionModelIds },
-          workspaceId: workspaceModelId,
-          agentMessageId: agentMessageModelId,
-        },
-        transaction,
-      });
-      if (actions.length !== actionModelIds.length) {
-        throw new Error(
-          "Consumption item action does not belong to the agent message"
-        );
-      }
-    }
-  }
-
-  static async recordItems(
-    auth: Authenticator,
-    {
-      conversationModelId,
-      agentMessageModelId,
-      attributionVersion,
-      records,
-      transaction,
-    }: {
-      conversationModelId: ModelId;
-      agentMessageModelId: ModelId;
-      attributionVersion: number;
-      records: AgentMessageConsumptionItemRecord[];
-      transaction?: Transaction;
-    }
-  ): Promise<AgentMessageConsumptionItemResource[]> {
-    if (records.length === 0) {
-      return [];
-    }
-
+  private static assertUniqueItemKeys(
+    records: AgentMessageConsumptionItemRecord[]
+  ): void {
     const itemKeys = records.map((record) => this.itemKey(record));
     if (new Set(itemKeys).size !== itemKeys.length) {
       throw new Error("Consumption items contain duplicate identities");
     }
-
-    await this.validateOwnership(auth, {
-      conversationModelId,
-      agentMessageModelId,
-      records,
-      transaction,
-    });
-
-    return withTransaction(async (currentTransaction) => {
-      const workspaceModelId = auth.getNonNullableWorkspace().id;
-      const completedAt = new Date();
-      await this.model.bulkCreate(
-        records.map((record) => {
-          const attributes = this.evidenceAttributes(record);
-          return {
-            ...attributes,
-            workspaceId: workspaceModelId,
-            conversationId: conversationModelId,
-            agentMessageId: agentMessageModelId,
-            runUsageId: record.runUsageModelId,
-            agentMCPActionId:
-              record.itemType === "tool" ? record.agentMCPActionModelId : null,
-            itemKey: this.itemKey(record),
-            itemType: record.itemType,
-            attributionVersion,
-            completedAt: record.state === "completed" ? completedAt : null,
-          };
-        }),
-        {
-          ignoreDuplicates: true,
-          transaction: currentTransaction,
-          validate: true,
-        }
-      );
-
-      const items = await this.model.findAll({
-        where: {
-          workspaceId: workspaceModelId,
-          agentMessageId: agentMessageModelId,
-          attributionVersion,
-          itemKey: { [Op.in]: itemKeys },
-        },
-        lock: currentTransaction.LOCK.UPDATE,
-        order: [["id", "ASC"]],
-        transaction: currentTransaction,
-      });
-      const itemByKey = new Map(items.map((item) => [item.itemKey, item]));
-
-      for (const record of records) {
-        const itemKey = this.itemKey(record);
-        const item = itemByKey.get(itemKey);
-        if (
-          !item ||
-          item.conversationId !== conversationModelId ||
-          !this.hasSameSource(item, record)
-        ) {
-          throw new Error(`Conflicting consumption item identity ${itemKey}`);
-        }
-        const attributes = this.evidenceAttributes(record);
-        if (item.completedAt !== null) {
-          if (
-            record.state === "completed" &&
-            !this.hasSameEvidence(item, attributes)
-          ) {
-            throw new Error(
-              `Completed consumption item ${itemKey} is immutable`
-            );
-          }
-          continue;
-        }
-
-        if (
-          record.state === "pending" &&
-          this.hasSameEvidence(item, attributes)
-        ) {
-          continue;
-        }
-
-        item.set({
-          ...attributes,
-          completedAt: record.state === "completed" ? completedAt : null,
-        });
-        await item.save({ transaction: currentTransaction });
-      }
-
-      return items.map((item) => new this(this.model, item.get()));
-    }, transaction);
   }
 
-  static async listByAgentMessageModelId(
+  private static creationAttributes(
+    workspaceModelId: ModelId,
+    {
+      conversationModelId,
+      agentMessageModelId,
+      attributionVersion,
+      record,
+      now,
+    }: {
+      conversationModelId: ModelId;
+      agentMessageModelId: ModelId;
+      attributionVersion: number;
+      record: AgentMessageConsumptionItemRecord;
+      now: Date;
+    }
+  ): ConsumptionItemCreationAttributes {
+    return {
+      ...this.evidenceAttributes(record),
+      workspaceId: workspaceModelId,
+      conversationId: conversationModelId,
+      agentMessageId: agentMessageModelId,
+      runUsageId: record.runUsageModelId,
+      agentMCPActionId:
+        record.itemType === "tool" ? record.agentMCPActionModelId : null,
+      itemKey: this.itemKey(record),
+      itemType: record.itemType,
+      attributionVersion,
+      completedAt: record.state === "completed" ? now : null,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  /**
+   * Inserts initial attribution facts without changing an existing identity
+   * Normal executions insert completed facts while approval stops insert pending facts
+   */
+  static async insertItemsIdempotently(
     auth: Authenticator,
     {
+      conversationModelId,
       agentMessageModelId,
+      attributionVersion,
+      records,
+      transaction,
+    }: {
+      conversationModelId: ModelId;
+      agentMessageModelId: ModelId;
+      attributionVersion: number;
+      records: AgentMessageConsumptionItemRecord[];
+      transaction?: Transaction;
+    }
+  ): Promise<void> {
+    if (records.length === 0) {
+      return;
+    }
+
+    this.assertUniqueItemKeys(records);
+    const now = new Date();
+    await this.model.bulkCreate(
+      records.map((record) =>
+        this.creationAttributes(auth.getNonNullableWorkspace().id, {
+          conversationModelId,
+          agentMessageModelId,
+          attributionVersion,
+          record,
+          now,
+        })
+      ),
+      { ignoreDuplicates: true, transaction, validate: true }
+    );
+  }
+
+  /**
+   * Completes approval-spanning facts
+   * A missing pending fact is inserted and an already completed fact stays immutable
+   */
+  static async completeItemsIdempotently(
+    auth: Authenticator,
+    {
+      conversationModelId,
+      agentMessageModelId,
+      attributionVersion,
+      records,
+      transaction,
+    }: {
+      conversationModelId: ModelId;
+      agentMessageModelId: ModelId;
+      attributionVersion: number;
+      records: AgentMessageConsumptionItemRecord<"completed">[];
+      transaction?: Transaction;
+    }
+  ): Promise<void> {
+    if (records.length === 0) {
+      return;
+    }
+
+    this.assertUniqueItemKeys(records);
+    const now = new Date();
+    const attributes = records.map((record) =>
+      this.creationAttributes(auth.getNonNullableWorkspace().id, {
+        conversationModelId,
+        agentMessageModelId,
+        attributionVersion,
+        record,
+        now,
+      })
+    );
+    for (const itemAttributes of attributes) {
+      await this.model.build(itemAttributes).validate();
+    }
+
+    const bind = attributes.flatMap((itemAttributes) =>
+      UPSERT_COLUMNS.map((column) => itemAttributes[column])
+    );
+    const valueTuples = attributes.map((_, rowIndex) => {
+      const firstParameterIndex = rowIndex * UPSERT_COLUMNS.length + 1;
+      return `(${UPSERT_COLUMNS.map(
+        (__, columnIndex) => `$${firstParameterIndex + columnIndex}`
+      ).join(", ")})`;
+    });
+    const quotedColumns = UPSERT_COLUMNS.map((column) => `"${column}"`).join(
+      ", "
+    );
+
+    // biome-ignore lint/plugin/noRawSql: Conditional upsert prevents pending completion races
+    await frontSequelize.query(
+      `INSERT INTO "agent_message_consumption_items" (${quotedColumns})
+       VALUES ${valueTuples.join(", ")}
+       ON CONFLICT ("workspaceId", "agentMessageId", "attributionVersion", "itemKey")
+       DO UPDATE SET
+         "inputTokensCount" = EXCLUDED."inputTokensCount",
+         "outputTokensCount" = EXCLUDED."outputTokensCount",
+         "grossAttributedCreditAmountMicro" = EXCLUDED."grossAttributedCreditAmountMicro",
+         "directCreditAmountMicro" = EXCLUDED."directCreditAmountMicro",
+         "completedAt" = EXCLUDED."completedAt",
+         "updatedAt" = EXCLUDED."updatedAt"
+       WHERE "agent_message_consumption_items"."completedAt" IS NULL`,
+      { bind, type: QueryTypes.INSERT, transaction }
+    );
+  }
+
+  static async listByAgentMessageModelIds(
+    auth: Authenticator,
+    {
+      agentMessageModelIds,
       attributionVersion,
       transaction,
     }: {
-      agentMessageModelId: ModelId;
+      agentMessageModelIds: ModelId[];
       attributionVersion: number;
       transaction?: Transaction;
     }
   ): Promise<AgentMessageConsumptionItemResource[]> {
+    if (agentMessageModelIds.length === 0) {
+      return [];
+    }
+
     const items = await this.model.findAll({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
-        agentMessageId: agentMessageModelId,
+        agentMessageId: { [Op.in]: agentMessageModelIds },
         attributionVersion,
       },
-      order: [["id", "ASC"]],
+      order: [
+        ["agentMessageId", "ASC"],
+        ["id", "ASC"],
+      ],
       transaction,
     });
 

--- a/front/lib/resources/agent_message_consumption_item_resource.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.ts
@@ -9,25 +9,13 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import assert from "assert";
 import type { Attributes, CreationAttributes, Transaction } from "sequelize";
 import { Op } from "sequelize";
 
 interface ConsumptionItemEvidenceBase {
   grossAttributedCreditAmountMicro: number;
 }
-
-export type CompletedAgentMessageConsumptionItem =
-  | (ConsumptionItemEvidenceBase & {
-      itemType: "system" | "input";
-      runUsageModelId: ModelId;
-      inputTokensCount: number | null;
-    })
-  | (ConsumptionItemEvidenceBase & {
-      itemType: "output" | "reasoning";
-      runUsageModelId: ModelId;
-      outputTokensCount: number | null;
-    })
-  | CompletedToolConsumptionItem;
 
 export type CompletedToolConsumptionItem = ConsumptionItemEvidenceBase & {
   itemType: "tool";
@@ -53,6 +41,19 @@ export type PendingToolConsumptionItem = ConsumptionItemEvidenceBase & {
   /** Estimated tokens in the model output that emitted the tool name and arguments */
   outputTokensCount: number | null;
 };
+
+export type CompletedAgentMessageConsumptionItem =
+  | (ConsumptionItemEvidenceBase & {
+      itemType: "system" | "input";
+      runUsageModelId: ModelId;
+      inputTokensCount: number | null;
+    })
+  | (ConsumptionItemEvidenceBase & {
+      itemType: "output" | "reasoning";
+      runUsageModelId: ModelId;
+      outputTokensCount: number | null;
+    })
+  | CompletedToolConsumptionItem;
 
 type ConsumptionItemEvidenceAttributes = Pick<
   Attributes<AgentMessageConsumptionItemModel>,
@@ -139,9 +140,11 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
     records: CompletedAgentMessageConsumptionItem[]
   ): void {
     const itemKeys = records.map((record) => this.itemKey(record));
-    if (new Set(itemKeys).size !== itemKeys.length) {
-      throw new Error("Consumption items contain duplicate identities");
-    }
+    const uniqueItemKeys = new Set(itemKeys);
+    assert(
+      uniqueItemKeys.size === itemKeys.length,
+      "Consumption items contain duplicate identities"
+    );
   }
 
   private static creationAttributes(
@@ -197,14 +200,14 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
     }
 
     this.assertUniqueItemKeys(records);
-    for (const record of records) {
-      if (
-        record.itemType === "tool" &&
-        record.action.agentMessageId !== agentMessageModelId
-      ) {
-        throw new Error("Tool consumption item has a different owner");
-      }
-    }
+    assert(
+      records.every(
+        (record) =>
+          record.itemType !== "tool" ||
+          record.action.agentMessageId === agentMessageModelId
+      ),
+      "Tool consumption items must have the same agent message ID as the owning agent message"
+    );
 
     const now = new Date();
     await this.model.bulkCreate(

--- a/front/lib/resources/agent_message_consumption_item_resource.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.ts
@@ -1,7 +1,8 @@
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMessageConsumptionItemModel } from "@app/lib/models/agent/agent_message_consumption_item";
+import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import { frontSequelize } from "@app/lib/resources/storage";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -9,40 +10,45 @@ import type { Result } from "@app/types/shared/result";
 import { Err } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { Attributes, CreationAttributes, Transaction } from "sequelize";
-import { Op, QueryTypes } from "sequelize";
+import { Op } from "sequelize";
 
-type ConsumptionItemState = "pending" | "completed";
-
-interface ConsumptionItemEvidenceBase<
-  TState extends ConsumptionItemState = ConsumptionItemState,
-> {
+interface ConsumptionItemEvidenceBase {
   grossAttributedCreditAmountMicro: number;
-  state: TState;
 }
 
-export type AgentMessageConsumptionItemRecord<
-  TState extends ConsumptionItemState = ConsumptionItemState,
-> =
-  | (ConsumptionItemEvidenceBase<TState> & {
+export type CompletedAgentMessageConsumptionItem =
+  | (ConsumptionItemEvidenceBase & {
       itemType: "system" | "input";
       runUsageModelId: ModelId;
       inputTokensCount: number | null;
     })
-  | (ConsumptionItemEvidenceBase<TState> & {
+  | (ConsumptionItemEvidenceBase & {
       itemType: "output" | "reasoning";
       runUsageModelId: ModelId;
       outputTokensCount: number | null;
     })
-  | (ConsumptionItemEvidenceBase<TState> & {
-      itemType: "tool";
-      runUsageModelId: ModelId | null;
-      agentMCPActionModelId: ModelId;
-      /** Estimated tokens in the result returned by this tool execution */
-      inputTokensCount: number | null;
-      /** Estimated tokens in the model output that emitted the tool name and arguments */
-      outputTokensCount: number | null;
-      directCreditAmountMicro: number | null;
-    });
+  | CompletedToolConsumptionItem;
+
+export type CompletedToolConsumptionItem = CompletedToolConsumptionEvidence & {
+  itemType: "tool";
+};
+
+export type CompletedToolConsumptionEvidence = ConsumptionItemEvidenceBase & {
+  runUsageModelId: ModelId | null;
+  action: AgentMCPActionResource;
+  /** Estimated tokens in the result returned by this tool execution */
+  inputTokensCount: number | null;
+  /** Estimated tokens in the model output that emitted the tool name and arguments */
+  outputTokensCount: number | null;
+  directCreditAmountMicro: number | null;
+};
+
+export type PendingToolConsumptionItem = ConsumptionItemEvidenceBase & {
+  action: AgentMCPActionResource;
+  runUsageModelId: ModelId | null;
+  /** Estimated tokens in the model output that emitted the tool name and arguments */
+  outputTokensCount: number | null;
+};
 
 type ConsumptionItemEvidenceAttributes = Pick<
   Attributes<AgentMessageConsumptionItemModel>,
@@ -54,24 +60,6 @@ type ConsumptionItemEvidenceAttributes = Pick<
 
 type ConsumptionItemCreationAttributes =
   CreationAttributes<AgentMessageConsumptionItemModel>;
-
-const UPSERT_COLUMNS = [
-  "workspaceId",
-  "conversationId",
-  "agentMessageId",
-  "runUsageId",
-  "agentMCPActionId",
-  "itemKey",
-  "itemType",
-  "attributionVersion",
-  "inputTokensCount",
-  "outputTokensCount",
-  "grossAttributedCreditAmountMicro",
-  "directCreditAmountMicro",
-  "completedAt",
-  "createdAt",
-  "updatedAt",
-] as const satisfies ReadonlyArray<keyof ConsumptionItemCreationAttributes>;
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface AgentMessageConsumptionItemResource
@@ -89,7 +77,7 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
     super(model, blob);
   }
 
-  private static itemKey(record: AgentMessageConsumptionItemRecord): string {
+  private static itemKey(record: CompletedAgentMessageConsumptionItem): string {
     switch (record.itemType) {
       case "system":
       case "input":
@@ -98,7 +86,7 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
         return `run-usage:${record.runUsageModelId}:${record.itemType}`;
 
       case "tool":
-        return `tool-action:${record.agentMCPActionModelId}`;
+        return `tool-action:${record.action.id}`;
 
       default:
         return assertNever(record);
@@ -106,7 +94,7 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
   }
 
   private static evidenceAttributes(
-    record: AgentMessageConsumptionItemRecord
+    record: CompletedAgentMessageConsumptionItem
   ): ConsumptionItemEvidenceAttributes {
     switch (record.itemType) {
       case "system":
@@ -144,7 +132,7 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
   }
 
   private static assertUniqueItemKeys(
-    records: AgentMessageConsumptionItemRecord[]
+    records: CompletedAgentMessageConsumptionItem[]
   ): void {
     const itemKeys = records.map((record) => this.itemKey(record));
     if (new Set(itemKeys).size !== itemKeys.length) {
@@ -164,7 +152,7 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
       conversationModelId: ModelId;
       agentMessageModelId: ModelId;
       attributionVersion: number;
-      record: AgentMessageConsumptionItemRecord;
+      record: CompletedAgentMessageConsumptionItem;
       now: Date;
     }
   ): ConsumptionItemCreationAttributes {
@@ -174,34 +162,29 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
       conversationId: conversationModelId,
       agentMessageId: agentMessageModelId,
       runUsageId: record.runUsageModelId,
-      agentMCPActionId:
-        record.itemType === "tool" ? record.agentMCPActionModelId : null,
+      agentMCPActionId: record.itemType === "tool" ? record.action.id : null,
       itemKey: this.itemKey(record),
       itemType: record.itemType,
       attributionVersion,
-      completedAt: record.state === "completed" ? now : null,
+      completedAt: now,
       createdAt: now,
       updatedAt: now,
     };
   }
 
-  /**
-   * Inserts initial attribution facts without changing an existing identity
-   * Normal executions insert completed facts while approval stops insert pending facts
-   */
-  static async insertItemsIdempotently(
+  static async insertCompletedItemsIdempotently(
     auth: Authenticator,
     {
-      conversationModelId,
+      conversation,
       agentMessageModelId,
       attributionVersion,
       records,
       transaction,
     }: {
-      conversationModelId: ModelId;
+      conversation: ConversationResource;
       agentMessageModelId: ModelId;
       attributionVersion: number;
-      records: AgentMessageConsumptionItemRecord[];
+      records: CompletedAgentMessageConsumptionItem[];
       transaction?: Transaction;
     }
   ): Promise<void> {
@@ -210,87 +193,113 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
     }
 
     this.assertUniqueItemKeys(records);
+    for (const record of records) {
+      if (
+        record.itemType === "tool" &&
+        record.action.agentMessageId !== agentMessageModelId
+      ) {
+        throw new Error("Tool consumption item has a different owner");
+      }
+    }
+
     const now = new Date();
     await this.model.bulkCreate(
       records.map((record) =>
         this.creationAttributes(auth.getNonNullableWorkspace().id, {
-          conversationModelId,
+          conversationModelId: conversation.id,
           agentMessageModelId,
           attributionVersion,
           record,
           now,
         })
       ),
-      { ignoreDuplicates: true, transaction, validate: true }
+      {
+        ignoreDuplicates: true,
+        returning: false,
+        transaction,
+        validate: true,
+      }
     );
   }
 
-  /**
-   * Completes approval-spanning facts
-   * A missing pending fact is inserted and an already completed fact stays immutable
-   */
-  static async completeItemsIdempotently(
+  static async insertPendingToolItemIdempotently(
     auth: Authenticator,
     {
-      conversationModelId,
-      agentMessageModelId,
+      conversation,
       attributionVersion,
-      records,
+      item,
       transaction,
     }: {
-      conversationModelId: ModelId;
-      agentMessageModelId: ModelId;
+      conversation: ConversationResource;
       attributionVersion: number;
-      records: AgentMessageConsumptionItemRecord<"completed">[];
+      item: PendingToolConsumptionItem;
       transaction?: Transaction;
     }
   ): Promise<void> {
-    if (records.length === 0) {
-      return;
-    }
-
-    this.assertUniqueItemKeys(records);
     const now = new Date();
-    const attributes = records.map((record) =>
-      this.creationAttributes(auth.getNonNullableWorkspace().id, {
-        conversationModelId,
-        agentMessageModelId,
-        attributionVersion,
-        record,
-        now,
-      })
+    await this.model.bulkCreate(
+      [
+        {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          conversationId: conversation.id,
+          agentMessageId: item.action.agentMessageId,
+          runUsageId: item.runUsageModelId,
+          agentMCPActionId: item.action.id,
+          itemKey: `tool-action:${item.action.id}`,
+          itemType: "tool",
+          attributionVersion,
+          inputTokensCount: null,
+          outputTokensCount: item.outputTokensCount,
+          grossAttributedCreditAmountMicro:
+            item.grossAttributedCreditAmountMicro,
+          directCreditAmountMicro: null,
+          completedAt: null,
+          createdAt: now,
+          updatedAt: now,
+        },
+      ],
+      {
+        ignoreDuplicates: true,
+        returning: false,
+        transaction,
+        validate: true,
+      }
     );
-    for (const itemAttributes of attributes) {
-      await this.model.build(itemAttributes).validate();
+  }
+
+  static async completePendingToolItemIdempotently(
+    auth: Authenticator,
+    {
+      attributionVersion,
+      item,
+      transaction,
+    }: {
+      attributionVersion: number;
+      item: CompletedToolConsumptionEvidence;
+      transaction?: Transaction;
     }
-
-    const bind = attributes.flatMap((itemAttributes) =>
-      UPSERT_COLUMNS.map((column) => itemAttributes[column])
-    );
-    const valueTuples = attributes.map((_, rowIndex) => {
-      const firstParameterIndex = rowIndex * UPSERT_COLUMNS.length + 1;
-      return `(${UPSERT_COLUMNS.map(
-        (__, columnIndex) => `$${firstParameterIndex + columnIndex}`
-      ).join(", ")})`;
-    });
-    const quotedColumns = UPSERT_COLUMNS.map((column) => `"${column}"`).join(
-      ", "
-    );
-
-    // biome-ignore lint/plugin/noRawSql: Conditional upsert prevents pending completion races
-    await frontSequelize.query(
-      `INSERT INTO "agent_message_consumption_items" (${quotedColumns})
-       VALUES ${valueTuples.join(", ")}
-       ON CONFLICT ("workspaceId", "agentMessageId", "attributionVersion", "itemKey")
-       DO UPDATE SET
-         "inputTokensCount" = EXCLUDED."inputTokensCount",
-         "outputTokensCount" = EXCLUDED."outputTokensCount",
-         "grossAttributedCreditAmountMicro" = EXCLUDED."grossAttributedCreditAmountMicro",
-         "directCreditAmountMicro" = EXCLUDED."directCreditAmountMicro",
-         "completedAt" = EXCLUDED."completedAt",
-         "updatedAt" = EXCLUDED."updatedAt"
-       WHERE "agent_message_consumption_items"."completedAt" IS NULL`,
-      { bind, type: QueryTypes.INSERT, transaction }
+  ): Promise<void> {
+    await this.model.update(
+      {
+        itemType: "tool",
+        agentMCPActionId: item.action.id,
+        runUsageId: item.runUsageModelId,
+        inputTokensCount: item.inputTokensCount,
+        outputTokensCount: item.outputTokensCount,
+        grossAttributedCreditAmountMicro: item.grossAttributedCreditAmountMicro,
+        directCreditAmountMicro: item.directCreditAmountMicro,
+        completedAt: new Date(),
+      },
+      {
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          agentMCPActionId: item.action.id,
+          attributionVersion,
+          itemType: "tool",
+          completedAt: { [Op.is]: null },
+        },
+        transaction,
+      }
     );
   }
 

--- a/front/lib/resources/agent_message_consumption_item_resource.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.ts
@@ -1,0 +1,468 @@
+import type { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
+import { AgentMessageConsumptionItemModel } from "@app/lib/models/agent/agent_message_consumption_item";
+import {
+  AgentMessageModel,
+  ConversationModel,
+} from "@app/lib/models/agent/conversation";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import {
+  RunModel,
+  RunUsageModel,
+} from "@app/lib/resources/storage/models/runs";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import type { AgentMessageConsumptionItemType } from "@app/types/assistant/agent_message_consumption";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Err } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { Attributes, Transaction } from "sequelize";
+import { Op } from "sequelize";
+
+type NonToolConsumptionItemType = Exclude<
+  AgentMessageConsumptionItemType,
+  "tool"
+>;
+
+export type AgentMessageConsumptionItemSource =
+  | {
+      itemType: NonToolConsumptionItemType;
+      runUsageModelId: ModelId;
+    }
+  | {
+      itemType: "tool";
+      runUsageModelId: ModelId | null;
+      agentMCPActionModelId: ModelId;
+    };
+
+interface ConsumptionItemEvidenceBase {
+  grossAttributedCreditAmountMicro: number;
+  state: "pending" | "completed";
+}
+
+export type AgentMessageConsumptionItemEvidence =
+  | (ConsumptionItemEvidenceBase & {
+      itemType: "system" | "input";
+      runUsageModelId: ModelId;
+      inputTokensCount: number | null;
+    })
+  | (ConsumptionItemEvidenceBase & {
+      itemType: "output" | "reasoning";
+      runUsageModelId: ModelId;
+      outputTokensCount: number | null;
+    })
+  | (ConsumptionItemEvidenceBase & {
+      itemType: "tool";
+      runUsageModelId: ModelId | null;
+      agentMCPActionModelId: ModelId;
+      inputTokensCount: number | null;
+      outputTokensCount: number | null;
+      directCreditAmountMicro: number | null;
+    });
+
+type ConsumptionItemEvidenceAttributes = Pick<
+  Attributes<AgentMessageConsumptionItemModel>,
+  | "inputTokensCount"
+  | "outputTokensCount"
+  | "grossAttributedCreditAmountMicro"
+  | "directCreditAmountMicro"
+>;
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface AgentMessageConsumptionItemResource
+  extends ReadonlyAttributesType<AgentMessageConsumptionItemModel> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessageConsumptionItemModel> {
+  static model: ModelStaticWorkspaceAware<AgentMessageConsumptionItemModel> =
+    AgentMessageConsumptionItemModel;
+
+  constructor(
+    model: ModelStaticWorkspaceAware<AgentMessageConsumptionItemModel>,
+    blob: Attributes<AgentMessageConsumptionItemModel>
+  ) {
+    super(model, blob);
+  }
+
+  private static itemKey(source: AgentMessageConsumptionItemSource): string {
+    switch (source.itemType) {
+      case "system":
+      case "input":
+      case "output":
+      case "reasoning":
+        return `run-usage:${source.runUsageModelId}:${source.itemType}`;
+
+      case "tool":
+        return `tool-action:${source.agentMCPActionModelId}`;
+
+      default:
+        return assertNever(source);
+    }
+  }
+
+  private static evidenceAttributes(
+    evidence: AgentMessageConsumptionItemEvidence
+  ): ConsumptionItemEvidenceAttributes {
+    switch (evidence.itemType) {
+      case "system":
+      case "input":
+        return {
+          inputTokensCount: evidence.inputTokensCount,
+          outputTokensCount: null,
+          grossAttributedCreditAmountMicro:
+            evidence.grossAttributedCreditAmountMicro,
+          directCreditAmountMicro: null,
+        };
+
+      case "output":
+      case "reasoning":
+        return {
+          inputTokensCount: null,
+          outputTokensCount: evidence.outputTokensCount,
+          grossAttributedCreditAmountMicro:
+            evidence.grossAttributedCreditAmountMicro,
+          directCreditAmountMicro: null,
+        };
+
+      case "tool":
+        return {
+          inputTokensCount: evidence.inputTokensCount,
+          outputTokensCount: evidence.outputTokensCount,
+          grossAttributedCreditAmountMicro:
+            evidence.grossAttributedCreditAmountMicro,
+          directCreditAmountMicro: evidence.directCreditAmountMicro,
+        };
+
+      default:
+        return assertNever(evidence);
+    }
+  }
+
+  private static hasSameSource(
+    item: AgentMessageConsumptionItemModel,
+    source: AgentMessageConsumptionItemSource
+  ): boolean {
+    switch (source.itemType) {
+      case "system":
+      case "input":
+      case "output":
+      case "reasoning":
+        return (
+          item.itemType === source.itemType &&
+          item.runUsageId === source.runUsageModelId &&
+          item.agentMCPActionId === null
+        );
+
+      case "tool":
+        return (
+          item.itemType === "tool" &&
+          item.runUsageId === source.runUsageModelId &&
+          item.agentMCPActionId === source.agentMCPActionModelId
+        );
+
+      default:
+        return assertNever(source);
+    }
+  }
+
+  private static hasSameEvidence(
+    item: AgentMessageConsumptionItemModel,
+    evidence: ConsumptionItemEvidenceAttributes
+  ): boolean {
+    return (
+      item.inputTokensCount === evidence.inputTokensCount &&
+      item.outputTokensCount === evidence.outputTokensCount &&
+      item.grossAttributedCreditAmountMicro ===
+        evidence.grossAttributedCreditAmountMicro &&
+      item.directCreditAmountMicro === evidence.directCreditAmountMicro
+    );
+  }
+
+  private static async validateOwnership(
+    auth: Authenticator,
+    {
+      conversationModelId,
+      agentMessageModelId,
+      sources,
+      transaction,
+    }: {
+      conversationModelId: ModelId;
+      agentMessageModelId: ModelId;
+      sources: AgentMessageConsumptionItemSource[];
+      transaction: Transaction;
+    }
+  ): Promise<void> {
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
+    const [conversation, agentMessage] = await Promise.all([
+      ConversationModel.findOne({
+        where: { id: conversationModelId, workspaceId: workspaceModelId },
+        transaction,
+      }),
+      AgentMessageModel.findOne({
+        where: { id: agentMessageModelId, workspaceId: workspaceModelId },
+        transaction,
+      }),
+    ]);
+
+    if (!conversation || !agentMessage) {
+      throw new Error("Consumption item owner was not found in the workspace");
+    }
+    if (agentMessage.conversationId !== conversation.id) {
+      throw new Error(
+        "Consumption item conversation does not own the agent message"
+      );
+    }
+
+    const runUsageModelIds = [
+      ...new Set(
+        sources.flatMap((source) =>
+          source.runUsageModelId === null ? [] : [source.runUsageModelId]
+        )
+      ),
+    ];
+    if (runUsageModelIds.length > 0) {
+      const runUsages = await RunUsageModel.findAll({
+        where: {
+          id: { [Op.in]: runUsageModelIds },
+          workspaceId: workspaceModelId,
+        },
+        transaction,
+      });
+      const runs = await RunModel.findAll({
+        where: {
+          id: { [Op.in]: runUsages.map((usage) => usage.runId) },
+          workspaceId: workspaceModelId,
+        },
+        transaction,
+      });
+      const runByModelId = new Map(runs.map((run) => [run.id, run]));
+      const messageRunIds = new Set(agentMessage.runIds ?? []);
+      if (
+        runUsages.length !== runUsageModelIds.length ||
+        runUsages.some((usage) => {
+          const run = runByModelId.get(usage.runId);
+          return !run || !messageRunIds.has(run.dustRunId);
+        })
+      ) {
+        throw new Error(
+          "Consumption item run usage does not belong to the agent message"
+        );
+      }
+    }
+
+    const actionModelIds = [
+      ...new Set(
+        sources.flatMap((source) =>
+          source.itemType === "tool" ? [source.agentMCPActionModelId] : []
+        )
+      ),
+    ];
+    if (actionModelIds.length > 0) {
+      const actions = await AgentMCPActionModel.findAll({
+        where: {
+          id: { [Op.in]: actionModelIds },
+          workspaceId: workspaceModelId,
+          agentMessageId: agentMessageModelId,
+        },
+        transaction,
+      });
+      if (actions.length !== actionModelIds.length) {
+        throw new Error(
+          "Consumption item action does not belong to the agent message"
+        );
+      }
+    }
+  }
+
+  static async createPendingItems(
+    auth: Authenticator,
+    {
+      conversationModelId,
+      agentMessageModelId,
+      attributionVersion,
+      sources,
+      transaction,
+    }: {
+      conversationModelId: ModelId;
+      agentMessageModelId: ModelId;
+      attributionVersion: number;
+      sources: AgentMessageConsumptionItemSource[];
+      transaction?: Transaction;
+    }
+  ): Promise<AgentMessageConsumptionItemResource[]> {
+    if (sources.length === 0) {
+      return [];
+    }
+
+    return withTransaction(async (currentTransaction) => {
+      await this.validateOwnership(auth, {
+        conversationModelId,
+        agentMessageModelId,
+        sources,
+        transaction: currentTransaction,
+      });
+
+      const workspaceModelId = auth.getNonNullableWorkspace().id;
+      await this.model.bulkCreate(
+        sources.map((source) => ({
+          workspaceId: workspaceModelId,
+          conversationId: conversationModelId,
+          agentMessageId: agentMessageModelId,
+          runUsageId: source.runUsageModelId,
+          agentMCPActionId:
+            source.itemType === "tool" ? source.agentMCPActionModelId : null,
+          itemKey: this.itemKey(source),
+          itemType: source.itemType,
+          attributionVersion,
+          inputTokensCount: null,
+          outputTokensCount: null,
+          grossAttributedCreditAmountMicro: 0,
+          directCreditAmountMicro: null,
+          completedAt: null,
+        })),
+        {
+          ignoreDuplicates: true,
+          transaction: currentTransaction,
+          validate: true,
+        }
+      );
+
+      const items = await this.model.findAll({
+        where: {
+          workspaceId: workspaceModelId,
+          agentMessageId: agentMessageModelId,
+          attributionVersion,
+          itemKey: { [Op.in]: sources.map((source) => this.itemKey(source)) },
+        },
+        order: [["id", "ASC"]],
+        transaction: currentTransaction,
+      });
+      const itemByKey = new Map(items.map((item) => [item.itemKey, item]));
+
+      for (const source of sources) {
+        const item = itemByKey.get(this.itemKey(source));
+        if (
+          !item ||
+          item.conversationId !== conversationModelId ||
+          !this.hasSameSource(item, source)
+        ) {
+          throw new Error(
+            `Conflicting consumption item identity ${this.itemKey(source)}`
+          );
+        }
+      }
+
+      return items.map((item) => new this(this.model, item.get()));
+    }, transaction);
+  }
+
+  static async setEvidence(
+    auth: Authenticator,
+    {
+      agentMessageModelId,
+      attributionVersion,
+      evidence,
+      transaction,
+    }: {
+      agentMessageModelId: ModelId;
+      attributionVersion: number;
+      evidence: AgentMessageConsumptionItemEvidence;
+      transaction?: Transaction;
+    }
+  ): Promise<AgentMessageConsumptionItemResource> {
+    return withTransaction(async (currentTransaction) => {
+      const workspaceModelId = auth.getNonNullableWorkspace().id;
+      const itemKey = this.itemKey(evidence);
+      const item = await this.model.findOne({
+        where: {
+          workspaceId: workspaceModelId,
+          agentMessageId: agentMessageModelId,
+          attributionVersion,
+          itemKey,
+        },
+        lock: currentTransaction.LOCK.UPDATE,
+        transaction: currentTransaction,
+      });
+      if (!item || !this.hasSameSource(item, evidence)) {
+        throw new Error(`Consumption item ${itemKey} was not initialized`);
+      }
+
+      const attributes = this.evidenceAttributes(evidence);
+      if (item.completedAt !== null) {
+        if (
+          evidence.state === "completed" &&
+          !this.hasSameEvidence(item, attributes)
+        ) {
+          throw new Error(`Completed consumption item ${itemKey} is immutable`);
+        }
+        return new this(this.model, item.get());
+      }
+
+      item.set({
+        ...attributes,
+        completedAt: evidence.state === "completed" ? new Date() : null,
+      });
+      await item.save({ transaction: currentTransaction });
+
+      return new this(this.model, item.get());
+    }, transaction);
+  }
+
+  static async listByAgentMessageModelId(
+    auth: Authenticator,
+    {
+      agentMessageModelId,
+      attributionVersion,
+      transaction,
+    }: {
+      agentMessageModelId: ModelId;
+      attributionVersion: number;
+      transaction?: Transaction;
+    }
+  ): Promise<AgentMessageConsumptionItemResource[]> {
+    const items = await this.model.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        agentMessageId: agentMessageModelId,
+        attributionVersion,
+      },
+      order: [["id", "ASC"]],
+      transaction,
+    });
+
+    return items.map((item) => new this(this.model, item.get()));
+  }
+
+  static async deleteByAgentMessageModelIds(
+    auth: Authenticator,
+    {
+      agentMessageModelIds,
+      transaction,
+    }: {
+      agentMessageModelIds: ModelId[];
+      transaction?: Transaction;
+    }
+  ): Promise<number> {
+    if (agentMessageModelIds.length === 0) {
+      return 0;
+    }
+
+    return this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        agentMessageId: { [Op.in]: agentMessageModelIds },
+      },
+      transaction,
+    });
+  }
+
+  async delete(): Promise<Result<undefined, Error>> {
+    return new Err(
+      new Error(
+        "Consumption items can only be deleted with their owning agent message"
+      )
+    );
+  }
+}

--- a/front/lib/resources/agent_message_consumption_item_resource.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.ts
@@ -174,7 +174,7 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
       conversationModelId: ModelId;
       agentMessageModelId: ModelId;
       records: AgentMessageConsumptionItemRecord[];
-      transaction: Transaction;
+      transaction?: Transaction;
     }
   ): Promise<void> {
     const workspaceModelId = auth.getNonNullableWorkspace().id;
@@ -279,19 +279,19 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
       return [];
     }
 
+    const itemKeys = records.map((record) => this.itemKey(record));
+    if (new Set(itemKeys).size !== itemKeys.length) {
+      throw new Error("Consumption items contain duplicate identities");
+    }
+
+    await this.validateOwnership(auth, {
+      conversationModelId,
+      agentMessageModelId,
+      records,
+      transaction,
+    });
+
     return withTransaction(async (currentTransaction) => {
-      const itemKeys = records.map((record) => this.itemKey(record));
-      if (new Set(itemKeys).size !== itemKeys.length) {
-        throw new Error("Consumption items contain duplicate identities");
-      }
-
-      await this.validateOwnership(auth, {
-        conversationModelId,
-        agentMessageModelId,
-        records,
-        transaction: currentTransaction,
-      });
-
       const workspaceModelId = auth.getNonNullableWorkspace().id;
       const completedAt = new Date();
       await this.model.bulkCreate(

--- a/front/lib/resources/agent_message_consumption_item_resource.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.ts
@@ -13,7 +13,6 @@ import {
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { withTransaction } from "@app/lib/utils/sql_utils";
-import type { AgentMessageConsumptionItemType } from "@app/types/assistant/agent_message_consumption";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err } from "@app/types/shared/result";
@@ -21,28 +20,12 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { Attributes, Transaction } from "sequelize";
 import { Op } from "sequelize";
 
-type NonToolConsumptionItemType = Exclude<
-  AgentMessageConsumptionItemType,
-  "tool"
->;
-
-export type AgentMessageConsumptionItemSource =
-  | {
-      itemType: NonToolConsumptionItemType;
-      runUsageModelId: ModelId;
-    }
-  | {
-      itemType: "tool";
-      runUsageModelId: ModelId | null;
-      agentMCPActionModelId: ModelId;
-    };
-
 interface ConsumptionItemEvidenceBase {
   grossAttributedCreditAmountMicro: number;
   state: "pending" | "completed";
 }
 
-export type AgentMessageConsumptionItemEvidence =
+export type AgentMessageConsumptionItemRecord =
   | (ConsumptionItemEvidenceBase & {
       itemType: "system" | "input";
       runUsageModelId: ModelId;
@@ -86,33 +69,33 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
     super(model, blob);
   }
 
-  private static itemKey(source: AgentMessageConsumptionItemSource): string {
-    switch (source.itemType) {
+  private static itemKey(record: AgentMessageConsumptionItemRecord): string {
+    switch (record.itemType) {
       case "system":
       case "input":
       case "output":
       case "reasoning":
-        return `run-usage:${source.runUsageModelId}:${source.itemType}`;
+        return `run-usage:${record.runUsageModelId}:${record.itemType}`;
 
       case "tool":
-        return `tool-action:${source.agentMCPActionModelId}`;
+        return `tool-action:${record.agentMCPActionModelId}`;
 
       default:
-        return assertNever(source);
+        return assertNever(record);
     }
   }
 
   private static evidenceAttributes(
-    evidence: AgentMessageConsumptionItemEvidence
+    record: AgentMessageConsumptionItemRecord
   ): ConsumptionItemEvidenceAttributes {
-    switch (evidence.itemType) {
+    switch (record.itemType) {
       case "system":
       case "input":
         return {
-          inputTokensCount: evidence.inputTokensCount,
+          inputTokensCount: record.inputTokensCount,
           outputTokensCount: null,
           grossAttributedCreditAmountMicro:
-            evidence.grossAttributedCreditAmountMicro,
+            record.grossAttributedCreditAmountMicro,
           directCreditAmountMicro: null,
         };
 
@@ -120,50 +103,50 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
       case "reasoning":
         return {
           inputTokensCount: null,
-          outputTokensCount: evidence.outputTokensCount,
+          outputTokensCount: record.outputTokensCount,
           grossAttributedCreditAmountMicro:
-            evidence.grossAttributedCreditAmountMicro,
+            record.grossAttributedCreditAmountMicro,
           directCreditAmountMicro: null,
         };
 
       case "tool":
         return {
-          inputTokensCount: evidence.inputTokensCount,
-          outputTokensCount: evidence.outputTokensCount,
+          inputTokensCount: record.inputTokensCount,
+          outputTokensCount: record.outputTokensCount,
           grossAttributedCreditAmountMicro:
-            evidence.grossAttributedCreditAmountMicro,
-          directCreditAmountMicro: evidence.directCreditAmountMicro,
+            record.grossAttributedCreditAmountMicro,
+          directCreditAmountMicro: record.directCreditAmountMicro,
         };
 
       default:
-        return assertNever(evidence);
+        return assertNever(record);
     }
   }
 
   private static hasSameSource(
     item: AgentMessageConsumptionItemModel,
-    source: AgentMessageConsumptionItemSource
+    record: AgentMessageConsumptionItemRecord
   ): boolean {
-    switch (source.itemType) {
+    switch (record.itemType) {
       case "system":
       case "input":
       case "output":
       case "reasoning":
         return (
-          item.itemType === source.itemType &&
-          item.runUsageId === source.runUsageModelId &&
+          item.itemType === record.itemType &&
+          item.runUsageId === record.runUsageModelId &&
           item.agentMCPActionId === null
         );
 
       case "tool":
         return (
           item.itemType === "tool" &&
-          item.runUsageId === source.runUsageModelId &&
-          item.agentMCPActionId === source.agentMCPActionModelId
+          item.runUsageId === record.runUsageModelId &&
+          item.agentMCPActionId === record.agentMCPActionModelId
         );
 
       default:
-        return assertNever(source);
+        return assertNever(record);
     }
   }
 
@@ -185,12 +168,12 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
     {
       conversationModelId,
       agentMessageModelId,
-      sources,
+      records,
       transaction,
     }: {
       conversationModelId: ModelId;
       agentMessageModelId: ModelId;
-      sources: AgentMessageConsumptionItemSource[];
+      records: AgentMessageConsumptionItemRecord[];
       transaction: Transaction;
     }
   ): Promise<void> {
@@ -217,8 +200,8 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
 
     const runUsageModelIds = [
       ...new Set(
-        sources.flatMap((source) =>
-          source.runUsageModelId === null ? [] : [source.runUsageModelId]
+        records.flatMap((record) =>
+          record.runUsageModelId === null ? [] : [record.runUsageModelId]
         )
       ),
     ];
@@ -254,8 +237,8 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
 
     const actionModelIds = [
       ...new Set(
-        sources.flatMap((source) =>
-          source.itemType === "tool" ? [source.agentMCPActionModelId] : []
+        records.flatMap((record) =>
+          record.itemType === "tool" ? [record.agentMCPActionModelId] : []
         )
       ),
     ];
@@ -276,52 +259,58 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
     }
   }
 
-  static async createPendingItems(
+  static async recordItems(
     auth: Authenticator,
     {
       conversationModelId,
       agentMessageModelId,
       attributionVersion,
-      sources,
+      records,
       transaction,
     }: {
       conversationModelId: ModelId;
       agentMessageModelId: ModelId;
       attributionVersion: number;
-      sources: AgentMessageConsumptionItemSource[];
+      records: AgentMessageConsumptionItemRecord[];
       transaction?: Transaction;
     }
   ): Promise<AgentMessageConsumptionItemResource[]> {
-    if (sources.length === 0) {
+    if (records.length === 0) {
       return [];
     }
 
     return withTransaction(async (currentTransaction) => {
+      const itemKeys = records.map((record) => this.itemKey(record));
+      if (new Set(itemKeys).size !== itemKeys.length) {
+        throw new Error("Consumption items contain duplicate identities");
+      }
+
       await this.validateOwnership(auth, {
         conversationModelId,
         agentMessageModelId,
-        sources,
+        records,
         transaction: currentTransaction,
       });
 
       const workspaceModelId = auth.getNonNullableWorkspace().id;
+      const completedAt = new Date();
       await this.model.bulkCreate(
-        sources.map((source) => ({
-          workspaceId: workspaceModelId,
-          conversationId: conversationModelId,
-          agentMessageId: agentMessageModelId,
-          runUsageId: source.runUsageModelId,
-          agentMCPActionId:
-            source.itemType === "tool" ? source.agentMCPActionModelId : null,
-          itemKey: this.itemKey(source),
-          itemType: source.itemType,
-          attributionVersion,
-          inputTokensCount: null,
-          outputTokensCount: null,
-          grossAttributedCreditAmountMicro: 0,
-          directCreditAmountMicro: null,
-          completedAt: null,
-        })),
+        records.map((record) => {
+          const attributes = this.evidenceAttributes(record);
+          return {
+            ...attributes,
+            workspaceId: workspaceModelId,
+            conversationId: conversationModelId,
+            agentMessageId: agentMessageModelId,
+            runUsageId: record.runUsageModelId,
+            agentMCPActionId:
+              record.itemType === "tool" ? record.agentMCPActionModelId : null,
+            itemKey: this.itemKey(record),
+            itemType: record.itemType,
+            attributionVersion,
+            completedAt: record.state === "completed" ? completedAt : null,
+          };
+        }),
         {
           ignoreDuplicates: true,
           transaction: currentTransaction,
@@ -334,79 +323,52 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
           workspaceId: workspaceModelId,
           agentMessageId: agentMessageModelId,
           attributionVersion,
-          itemKey: { [Op.in]: sources.map((source) => this.itemKey(source)) },
+          itemKey: { [Op.in]: itemKeys },
         },
+        lock: currentTransaction.LOCK.UPDATE,
         order: [["id", "ASC"]],
         transaction: currentTransaction,
       });
       const itemByKey = new Map(items.map((item) => [item.itemKey, item]));
 
-      for (const source of sources) {
-        const item = itemByKey.get(this.itemKey(source));
+      for (const record of records) {
+        const itemKey = this.itemKey(record);
+        const item = itemByKey.get(itemKey);
         if (
           !item ||
           item.conversationId !== conversationModelId ||
-          !this.hasSameSource(item, source)
+          !this.hasSameSource(item, record)
         ) {
-          throw new Error(
-            `Conflicting consumption item identity ${this.itemKey(source)}`
-          );
+          throw new Error(`Conflicting consumption item identity ${itemKey}`);
         }
+        const attributes = this.evidenceAttributes(record);
+        if (item.completedAt !== null) {
+          if (
+            record.state === "completed" &&
+            !this.hasSameEvidence(item, attributes)
+          ) {
+            throw new Error(
+              `Completed consumption item ${itemKey} is immutable`
+            );
+          }
+          continue;
+        }
+
+        if (
+          record.state === "pending" &&
+          this.hasSameEvidence(item, attributes)
+        ) {
+          continue;
+        }
+
+        item.set({
+          ...attributes,
+          completedAt: record.state === "completed" ? completedAt : null,
+        });
+        await item.save({ transaction: currentTransaction });
       }
 
       return items.map((item) => new this(this.model, item.get()));
-    }, transaction);
-  }
-
-  static async setEvidence(
-    auth: Authenticator,
-    {
-      agentMessageModelId,
-      attributionVersion,
-      evidence,
-      transaction,
-    }: {
-      agentMessageModelId: ModelId;
-      attributionVersion: number;
-      evidence: AgentMessageConsumptionItemEvidence;
-      transaction?: Transaction;
-    }
-  ): Promise<AgentMessageConsumptionItemResource> {
-    return withTransaction(async (currentTransaction) => {
-      const workspaceModelId = auth.getNonNullableWorkspace().id;
-      const itemKey = this.itemKey(evidence);
-      const item = await this.model.findOne({
-        where: {
-          workspaceId: workspaceModelId,
-          agentMessageId: agentMessageModelId,
-          attributionVersion,
-          itemKey,
-        },
-        lock: currentTransaction.LOCK.UPDATE,
-        transaction: currentTransaction,
-      });
-      if (!item || !this.hasSameSource(item, evidence)) {
-        throw new Error(`Consumption item ${itemKey} was not initialized`);
-      }
-
-      const attributes = this.evidenceAttributes(evidence);
-      if (item.completedAt !== null) {
-        if (
-          evidence.state === "completed" &&
-          !this.hasSameEvidence(item, attributes)
-        ) {
-          throw new Error(`Completed consumption item ${itemKey} is immutable`);
-        }
-        return new this(this.model, item.get());
-      }
-
-      item.set({
-        ...attributes,
-        completedAt: evidence.state === "completed" ? new Date() : null,
-      });
-      await item.save({ transaction: currentTransaction });
-
-      return new this(this.model, item.get());
     }, transaction);
   }
 

--- a/front/lib/resources/agent_message_consumption_item_resource.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.ts
@@ -29,17 +29,21 @@ export type CompletedAgentMessageConsumptionItem =
     })
   | CompletedToolConsumptionItem;
 
-export type CompletedToolConsumptionItem = CompletedToolConsumptionEvidence & {
+export type CompletedToolConsumptionItem = ConsumptionItemEvidenceBase & {
   itemType: "tool";
-};
-
-export type CompletedToolConsumptionEvidence = ConsumptionItemEvidenceBase & {
   runUsageModelId: ModelId | null;
   action: AgentMCPActionResource;
   /** Estimated tokens in the result returned by this tool execution */
   inputTokensCount: number | null;
   /** Estimated tokens in the model output that emitted the tool name and arguments */
   outputTokensCount: number | null;
+  directCreditAmountMicro: number | null;
+};
+
+export type PendingToolConsumptionCompletion = ConsumptionItemEvidenceBase & {
+  action: AgentMCPActionResource;
+  /** Estimated tokens in the result returned by this tool execution */
+  inputTokensCount: number | null;
   directCreditAmountMicro: number | null;
 };
 
@@ -275,7 +279,7 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
       transaction,
     }: {
       attributionVersion: number;
-      item: CompletedToolConsumptionEvidence;
+      item: PendingToolConsumptionCompletion;
       transaction?: Transaction;
     }
   ): Promise<void> {
@@ -283,9 +287,7 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
       {
         itemType: "tool",
         agentMCPActionId: item.action.id,
-        runUsageId: item.runUsageModelId,
         inputTokensCount: item.inputTokensCount,
-        outputTokensCount: item.outputTokensCount,
         grossAttributedCreditAmountMicro: item.grossAttributedCreditAmountMicro,
         directCreditAmountMicro: item.directCreditAmountMicro,
         completedAt: new Date(),

--- a/front/lib/resources/agent_message_consumption_item_resource.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.ts
@@ -13,9 +13,9 @@ import assert from "assert";
 import type { Attributes, CreationAttributes, Transaction } from "sequelize";
 import { Op } from "sequelize";
 
-interface ConsumptionItemEvidenceBase {
+type ConsumptionItemEvidenceBase = {
   grossAttributedCreditAmountMicro: number;
-}
+};
 
 export type CompletedToolConsumptionItem = ConsumptionItemEvidenceBase & {
   itemType: "tool";
@@ -42,17 +42,21 @@ export type PendingToolConsumptionItem = ConsumptionItemEvidenceBase & {
   outputTokensCount: number | null;
 };
 
+type CompletedRunInputConsumptionItem = ConsumptionItemEvidenceBase & {
+  itemType: "system" | "input";
+  runUsageModelId: ModelId;
+  inputTokensCount: number | null;
+};
+
+type CompletedRunOutputConsumptionItem = ConsumptionItemEvidenceBase & {
+  itemType: "output" | "reasoning";
+  runUsageModelId: ModelId;
+  outputTokensCount: number | null;
+};
+
 export type CompletedAgentMessageConsumptionItem =
-  | (ConsumptionItemEvidenceBase & {
-      itemType: "system" | "input";
-      runUsageModelId: ModelId;
-      inputTokensCount: number | null;
-    })
-  | (ConsumptionItemEvidenceBase & {
-      itemType: "output" | "reasoning";
-      runUsageModelId: ModelId;
-      outputTokensCount: number | null;
-    })
+  | CompletedRunInputConsumptionItem
+  | CompletedRunOutputConsumptionItem
   | CompletedToolConsumptionItem;
 
 type ConsumptionItemEvidenceAttributes = Pick<
@@ -148,7 +152,7 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
   }
 
   private static creationAttributes(
-    workspaceModelId: ModelId,
+    auth: Authenticator,
     {
       conversationModelId,
       agentMessageModelId,
@@ -165,7 +169,7 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
   ): ConsumptionItemCreationAttributes {
     return {
       ...this.evidenceAttributes(record),
-      workspaceId: workspaceModelId,
+      workspaceId: auth.getNonNullableWorkspace().id,
       conversationId: conversationModelId,
       agentMessageId: agentMessageModelId,
       runUsageId: record.runUsageModelId,
@@ -174,8 +178,6 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
       itemType: record.itemType,
       attributionVersion,
       completedAt: now,
-      createdAt: now,
-      updatedAt: now,
     };
   }
 
@@ -212,7 +214,7 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
     const now = new Date();
     await this.model.bulkCreate(
       records.map((record) =>
-        this.creationAttributes(auth.getNonNullableWorkspace().id, {
+        this.creationAttributes(auth, {
           conversationModelId: conversation.id,
           agentMessageModelId,
           attributionVersion,
@@ -224,6 +226,7 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
         ignoreDuplicates: true,
         returning: false,
         transaction,
+        // Sequelize disables validation by default for bulkCreate.
         validate: true,
       }
     );
@@ -269,6 +272,7 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
         ignoreDuplicates: true,
         returning: false,
         transaction,
+        // Sequelize disables validation by default for bulkCreate.
         validate: true,
       }
     );

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -3,6 +3,7 @@ import { loadAllModels } from "@app/admin/db";
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
+import { AgentMessageConsumptionItemModel } from "@app/lib/models/agent/agent_message_consumption_item";
 import {
   AgentMessageModel,
   ConversationModel,
@@ -825,22 +826,20 @@ describe("destroyConversation", () => {
       },
     });
 
-    await AgentMessageConsumptionItemResource.insertItemsIdempotently(auth, {
-      conversationModelId: conversation.id,
-      agentMessageModelId: agentMessageId,
+    await AgentMessageConsumptionItemModel.create({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      conversationId: conversation.id,
+      agentMessageId,
+      runUsageId: null,
+      agentMCPActionId: action.id,
+      itemKey: `tool-action:${action.id}`,
+      itemType: "tool",
       attributionVersion: 1,
-      records: [
-        {
-          itemType: "tool",
-          runUsageModelId: null,
-          agentMCPActionModelId: action.id,
-          inputTokensCount: null,
-          outputTokensCount: null,
-          grossAttributedCreditAmountMicro: 0,
-          directCreditAmountMicro: null,
-          state: "pending",
-        },
-      ],
+      inputTokensCount: null,
+      outputTokensCount: null,
+      grossAttributedCreditAmountMicro: 0,
+      directCreditAmountMicro: null,
+      completedAt: null,
     });
 
     const result = await destroyConversation(auth, { conversation });

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -825,15 +825,20 @@ describe("destroyConversation", () => {
       },
     });
 
-    await AgentMessageConsumptionItemResource.createPendingItems(auth, {
+    await AgentMessageConsumptionItemResource.recordItems(auth, {
       conversationModelId: conversation.id,
       agentMessageModelId: agentMessageId,
       attributionVersion: 1,
-      sources: [
+      records: [
         {
           itemType: "tool",
           runUsageModelId: null,
           agentMCPActionModelId: action.id,
+          inputTokensCount: null,
+          outputTokensCount: null,
+          grossAttributedCreditAmountMicro: 0,
+          directCreditAmountMicro: null,
+          state: "pending",
         },
       ],
     });

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -3,7 +3,6 @@ import { loadAllModels } from "@app/admin/db";
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
-import { AgentMessageConsumptionItemModel } from "@app/lib/models/agent/agent_message_consumption_item";
 import {
   AgentMessageModel,
   ConversationModel,
@@ -14,6 +13,7 @@ import {
 } from "@app/lib/models/agent/conversation";
 import { ConversationSelectedSpaceModel } from "@app/lib/models/agent/conversation_selected_space";
 import { getReinforcedSkillsMetadata } from "@app/lib/reinforcement/types";
+import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -825,20 +825,17 @@ describe("destroyConversation", () => {
       },
     });
 
-    await AgentMessageConsumptionItemModel.create({
-      workspaceId: auth.getNonNullableWorkspace().id,
-      conversationId: conversation.id,
-      agentMessageId,
-      runUsageId: null,
-      agentMCPActionId: action.id,
-      itemKey: `tool-action:${action.id}`,
-      itemType: "tool",
+    await AgentMessageConsumptionItemResource.createPendingItems(auth, {
+      conversationModelId: conversation.id,
+      agentMessageModelId: agentMessageId,
       attributionVersion: 1,
-      inputTokensCount: null,
-      outputTokensCount: null,
-      grossAttributedCreditAmountMicro: 0,
-      directCreditAmountMicro: null,
-      completedAt: null,
+      sources: [
+        {
+          itemType: "tool",
+          runUsageModelId: null,
+          agentMCPActionModelId: action.id,
+        },
+      ],
     });
 
     const result = await destroyConversation(auth, { conversation });
@@ -853,13 +850,11 @@ describe("destroyConversation", () => {
       })
     ).resolves.toBe(0);
     await expect(
-      AgentMessageConsumptionItemModel.count({
-        where: {
-          agentMessageId,
-          workspaceId: auth.getNonNullableWorkspace().id,
-        },
+      AgentMessageConsumptionItemResource.listByAgentMessageModelId(auth, {
+        agentMessageModelId: agentMessageId,
+        attributionVersion: 1,
       })
-    ).resolves.toBe(0);
+    ).resolves.toHaveLength(0);
   });
 
   it("should delete selected spaces before deleting a conversation", async () => {

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -825,7 +825,7 @@ describe("destroyConversation", () => {
       },
     });
 
-    await AgentMessageConsumptionItemResource.recordItems(auth, {
+    await AgentMessageConsumptionItemResource.insertItemsIdempotently(auth, {
       conversationModelId: conversation.id,
       agentMessageModelId: agentMessageId,
       attributionVersion: 1,
@@ -855,8 +855,8 @@ describe("destroyConversation", () => {
       })
     ).resolves.toBe(0);
     await expect(
-      AgentMessageConsumptionItemResource.listByAgentMessageModelId(auth, {
-        agentMessageModelId: agentMessageId,
+      AgentMessageConsumptionItemResource.listByAgentMessageModelIds(auth, {
+        agentMessageModelIds: [agentMessageId],
         attributionVersion: 1,
       })
     ).resolves.toHaveLength(0);

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -436,6 +436,7 @@ export class ConversationFactory {
       conversation,
       agentConfig,
       mcpAction,
+      runIds = null,
     }: {
       workspace: WorkspaceType;
       conversation:
@@ -446,6 +447,7 @@ export class ConversationFactory {
       mcpAction?: {
         toolConfiguration: LightServerSideMCPToolConfigurationType;
       };
+      runIds?: string[] | null;
     }
   ): Promise<{
     messageRow: MessageModel;
@@ -459,6 +461,7 @@ export class ConversationFactory {
       conversationId: conversation.id,
       workspaceId: workspace.id,
       skipToolsValidation: false,
+      runIds,
     });
 
     const messageRow = await MessageModel.create({

--- a/front/tests/utils/RunFactory.ts
+++ b/front/tests/utils/RunFactory.ts
@@ -1,0 +1,51 @@
+import type { Authenticator } from "@app/lib/auth";
+import { RunResource } from "@app/lib/resources/run_resource";
+import { RunUsageModel } from "@app/lib/resources/storage/models/runs";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { GPT_5_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
+import type { ModelIdType } from "@app/types/assistant/models/types";
+
+export class RunFactory {
+  static async createWithUsage(
+    auth: Authenticator,
+    {
+      inputTokens = 100,
+      outputTokens = 20,
+      reasoningTokens,
+      modelId = GPT_5_MINI_MODEL_CONFIG.modelId,
+    }: {
+      inputTokens?: number;
+      outputTokens?: number;
+      reasoningTokens?: number;
+      modelId?: ModelIdType;
+    } = {}
+  ) {
+    const workspace = auth.getNonNullableWorkspace();
+    const run = await RunResource.makeNew({
+      appId: null,
+      dustRunId: generateRandomModelSId(),
+      runType: "deploy",
+      useWorkspaceCredentials: false,
+      workspaceId: workspace.id,
+    });
+    await run.recordTokenUsage(
+      auth,
+      {
+        inputTokens,
+        totalOutputTokens: outputTokens,
+        reasoningTokens,
+        totalTokens: inputTokens + outputTokens,
+      },
+      modelId
+    );
+
+    const runUsage = await RunUsageModel.findOne({
+      where: { runId: run.id, workspaceId: workspace.id },
+    });
+    if (!runUsage) {
+      throw new Error("Run usage not found after recording token usage");
+    }
+
+    return { run, runUsageModelId: runUsage.id };
+  }
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds the resource used to persist and read agent message consumption items introduced by the preceding data
model PR https://github.com/dust-tt/dust/pull/29664. It intentionally contains no materializer or call sites.

Completed items are inserted idempotently in bulk. Tools spanning approval or another resumable interruption may
first be inserted as pending, then completed with their result footprint, direct charge, final gross attribution,
and completion timestamp. Completion cannot rewrite the emitting run or the tool-call output footprint captured when
the row was created.

Only tool items may be `pending`. Deterministic identities make retries no-ops and preserve the first completed facts.
The resource also provides version-scoped message reads and explicit deletion with the owning agent message.

The PR does not calculate billing, pricing, or token attribution.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
