### PR TITLE
[front] perf: create auto-allowed MCP actions in running status

### DIFF
--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -82,8 +82,9 @@ export async function* runToolWithStreaming(
         }),
   });
 
-  // Sandbox function actions are created in running status.
-  if (isAgentLoopRunContext(runContext)) {
+  // Sandbox function actions and auto-allowed agent-loop actions are created in running
+  // status; only approved or resumed actions still carry a pre-run status to transition.
+  if (isAgentLoopRunContext(runContext) && status !== "running") {
     await runContext.action.updateStatus("running");
   }
   const startDate = performance.now();

--- a/front/lib/api/sandbox/create_child_action.test.ts
+++ b/front/lib/api/sandbox/create_child_action.test.ts
@@ -272,7 +272,7 @@ describe("createSandboxChildAction", () => {
       auth,
       result.value.actionId
     );
-    expect(child?.status).toBe("ready_allowed_implicitly");
+    expect(child?.status).toBe("running");
     // The child configuration must carry the same function-call name as direct
     // calls so approval checks and recordings share one key.
     expect(child?.toolConfiguration.name).toBe(directCallToolName);
@@ -294,7 +294,7 @@ describe("createSandboxChildAction", () => {
       auth,
       result.value.actionId
     );
-    expect(child?.status).toBe("ready_allowed_implicitly");
+    expect(child?.status).toBe("running");
     expect(vi.mocked(launchSandboxChildToolWorkflow)).toHaveBeenCalledTimes(1);
   });
 
@@ -389,7 +389,7 @@ describe("createSandboxChildAction", () => {
       auth,
       result.value.actionId
     );
-    expect(child?.status).toBe("ready_allowed_implicitly");
+    expect(child?.status).toBe("running");
     expect(child?.toolConfiguration.name).toBe(disambiguatedKey);
   });
 

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -223,12 +223,18 @@ export async function createSandboxChildAction(
     },
   });
 
+  // Auto-allowed child actions are launched right after creation: persist them as
+  // "running" directly (like sandbox function actions) instead of rewriting the row at
+  // execution start.
+  const persistedStatus =
+    status === "ready_allowed_implicitly" ? "running" : status;
+
   const action = await createMCPAction(auth, {
     actionConfiguration: fullToolConfiguration,
     agentMessage,
     augmentedInputs: rawInputs,
     conversation,
-    status,
+    status: persistedStatus,
     stepContent: parentAction.stepContent,
     stepContext: {
       ...parentAction.stepContext,

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -35,6 +35,14 @@ type CreateToolActionsResult = {
   actionBlobs: ActionBlob[];
 };
 
+type PreparedToolAction = {
+  actionConfiguration: MCPToolConfigurationType;
+  rawInputs: Record<string, unknown>;
+  status: "ready_allowed_implicitly" | "blocked_validation_required";
+  stepContent: AgentStepContentResource;
+  stepContext: StepContext;
+};
+
 export async function createToolActionsActivity(
   auth: Authenticator,
   {
@@ -62,22 +70,64 @@ export async function createToolActionsActivity(
     "isLastBlockingEventForStep"
   >[] = [];
 
+  const stepContents = await AgentStepContentResource.fetchByModelIds(
+    auth,
+    actions.map(
+      ({ functionCallId }) => functionCallStepContentIds[functionCallId]
+    )
+  );
+  const stepContentsById = new Map(stepContents.map((sc) => [sc.id, sc]));
+
+  // Execution statuses are resolved for the whole step upfront: whether any tool of the
+  // step awaits approval decides the status the other tools are persisted with below.
+  const preparedActions: PreparedToolAction[] = [];
   for (const [
     index,
     { action: actionConfiguration, functionCallId },
   ] of actions.entries()) {
     const stepContentId = functionCallStepContentIds[functionCallId];
+    const stepContent = stepContentsById.get(stepContentId);
+    assert(
+      stepContent,
+      `Step content not found for stepContentId: ${stepContentId}`
+    );
+    assert(
+      stepContent.isFunctionCallContent(),
+      `Expected step content to be a function call, got: ${stepContent.value.type}`
+    );
 
-    const result = await createActionForTool(auth, {
+    const rawInputs = JSON.parse(stepContent.value.value.arguments);
+    const { status } = await getExecutionStatusFromConfig(auth, {
       actionConfiguration,
+      skipToolsValidation: agentMessage.skipToolsValidation,
+      context: {
+        toolInputs: rawInputs,
+      },
+    });
+
+    preparedActions.push({
+      actionConfiguration,
+      rawInputs,
+      status,
+      stepContent,
+      stepContext: stepContexts[index],
+    });
+  }
+
+  const stepRequiresApproval = preparedActions.some(
+    ({ status }) => status === "blocked_validation_required"
+  );
+
+  for (const preparedAction of preparedActions) {
+    const result = await createActionForTool(auth, {
+      ...preparedAction,
       agentConfiguration,
       model: modelInfo.endpoint.modelConfig,
       agentMessage,
       conversation,
-      stepContentId,
-      stepContext: stepContexts[index],
       step,
       runIds,
+      stepRequiresApproval,
     });
 
     if (result) {
@@ -116,18 +166,19 @@ async function createActionForTool(
     model,
     agentMessage,
     conversation,
-    stepContentId,
+    rawInputs,
+    status,
+    stepContent,
     stepContext,
+    stepRequiresApproval,
     step,
     runIds,
-  }: {
-    actionConfiguration: MCPToolConfigurationType;
+  }: PreparedToolAction & {
     agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
     model: ModelConfigurationType;
     agentMessage: AgentLoopExecutionData["agentMessage"];
     conversation: ConversationWithoutContentType;
-    stepContentId: ModelId;
-    stepContext: StepContext;
+    stepRequiresApproval: boolean;
     step: number;
     runIds: string[];
   }
@@ -138,37 +189,13 @@ async function createActionForTool(
     "isLastBlockingEventForStep"
   >;
 } | void> {
-  // First, get the step content and parse inputs - we need this for medium stake checks
-  const stepContent = await AgentStepContentResource.fetchByModelIdWithAuth(
-    auth,
-    stepContentId
-  );
-  assert(
-    stepContent,
-    `Step content not found for stepContentId: ${stepContentId}`
-  );
-
-  assert(
-    stepContent.isFunctionCallContent(),
-    `Expected step content to be a function call, got: ${stepContent.value.type}`
-  );
-
-  const rawInputs = JSON.parse(stepContent.value.value.arguments);
-  const { status } = await getExecutionStatusFromConfig(auth, {
-    actionConfiguration,
-    skipToolsValidation: agentMessage.skipToolsValidation,
-    context: {
-      toolInputs: rawInputs,
-    },
-  });
-
   const validateToolInputsResult = validateToolInputs(rawInputs);
   if (validateToolInputsResult.isErr()) {
     logger.error(
       {
         conversationId: conversation.sId,
         agentMessageId: agentMessage.sId,
-        stepContentId,
+        stepContentId: stepContent.id,
         modelId: model.modelId,
         providerId: model.providerId,
         error: validateToolInputsResult.error,
@@ -203,6 +230,14 @@ async function createActionForTool(
     rawInputs,
   });
 
+  // The workflow runs the step's tools right after creation unless one of them awaits
+  // approval: auto-allowed tools are persisted as "running" directly (like sandbox
+  // function actions) instead of being rewritten to it at execution start.
+  const persistedStatus =
+    status === "ready_allowed_implicitly" && !stepRequiresApproval
+      ? "running"
+      : status;
+
   // Create the action object in the database and yield an event for the generation of the params.
   // We store the action here as the params have been generated, if an error occurs later on,
   // the error will be stored on the parent agent message.
@@ -211,7 +246,7 @@ async function createActionForTool(
     agentMessage,
     augmentedInputs,
     conversation,
-    status,
+    status: persistedStatus,
     stepContent,
     stepContext,
   });
@@ -269,7 +304,7 @@ async function createActionForTool(
   return {
     actionBlob: {
       actionId: action.id,
-      actionStatus: status,
+      actionStatus: persistedStatus,
       needsApproval: status === "blocked_validation_required",
       retryPolicy: getRetryPolicyFromToolConfiguration(actionConfiguration),
     },

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -19,8 +19,6 @@ import logger from "@app/logger/logger";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
 import type { AgentActionsEvent } from "@app/types/assistant/agent";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
-import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { ModelId } from "@app/types/shared/model_id";
 import assert from "assert";
 
@@ -61,8 +59,7 @@ export async function createToolActionsActivity(
     runIds: string[];
   }
 ): Promise<CreateToolActionsResult> {
-  const { agentConfiguration, modelInfo, agentMessage, conversation } =
-    runAgentData;
+  const { agentMessage, conversation } = runAgentData;
 
   const actionBlobs: ActionBlob[] = [];
   const approvalEvents: Omit<
@@ -120,11 +117,8 @@ export async function createToolActionsActivity(
 
   for (const preparedAction of preparedActions) {
     const result = await createActionForTool(auth, {
-      ...preparedAction,
-      agentConfiguration,
-      model: modelInfo.endpoint.modelConfig,
-      agentMessage,
-      conversation,
+      preparedAction,
+      runAgentData,
       step,
       runIds,
       stepRequiresApproval,
@@ -161,23 +155,14 @@ export async function createToolActionsActivity(
 async function createActionForTool(
   auth: Authenticator,
   {
-    actionConfiguration,
-    agentConfiguration,
-    model,
-    agentMessage,
-    conversation,
-    rawInputs,
-    status,
-    stepContent,
-    stepContext,
+    preparedAction,
+    runAgentData,
     stepRequiresApproval,
     step,
     runIds,
-  }: PreparedToolAction & {
-    agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
-    model: ModelConfigurationType;
-    agentMessage: AgentLoopExecutionData["agentMessage"];
-    conversation: ConversationWithoutContentType;
+  }: {
+    preparedAction: PreparedToolAction;
+    runAgentData: AgentLoopExecutionData;
     stepRequiresApproval: boolean;
     step: number;
     runIds: string[];
@@ -189,6 +174,12 @@ async function createActionForTool(
     "isLastBlockingEventForStep"
   >;
 } | void> {
+  const { actionConfiguration, rawInputs, status, stepContent, stepContext } =
+    preparedAction;
+  const { agentConfiguration, modelInfo, agentMessage, conversation } =
+    runAgentData;
+  const model = modelInfo.endpoint.modelConfig;
+
   const validateToolInputsResult = validateToolInputs(rawInputs);
   if (validateToolInputsResult.isErr()) {
     logger.error(


### PR DESCRIPTION
## Description

The PR removes one of the two UPDATEs every auto-approved tool execution used to make. Here is the before and after.

Before. An agent-loop tool touched agent_mcp_actions three times:

1. createToolActionsActivity INSERTs the row with the status computed from the tool's permission: ready_allowed_implicitly for anything auto-approved.
2. runToolActivity starts executing and the first thing runToolWithStreaming did was an unconditional updateStatus("running") for every agent-loop action. That is UPDATE 1.
3. When the tool finishes, markAsSucceeded / markAsErrored writes the final status plus executionDurationMs. That is UPDATE 2

That is ~2 updates per insert, which is exactly what you can find in pg_stat_user_tables (I reset the stats this morning).

The insight is that the ready_allowed_implicitly → running transition carries no information. Nothing ever observes the difference: the workflow goes straight from the create activity to the run activity, resume logic (getExistingActionsAndBlobs) only asks "is it final?" and "is it blocked_validation_required?", and both values answer those questions identically. So:

- At creation time we already know the tool will start executing immediately (its status is auto-allowed, and the workflow only pauses a step when some tool in it needs approval). In that case the row is INSERTed with status: "running" directly. This is the same pattern sandbox function actions already used, per the old comment in run_tool.ts.
- The write in runToolWithStreaming becomes conditional: if (isAgentLoopRunContext(runContext) && status !== "running"). For rows born as running the condition is false and UPDATE 1 never happens. It still fires for the cases where the persisted status genuinely differs at execution start: user-approved tools (ready_allowed_explicitly), tools resumed after auth or a user answer, and the carve-out below.
- UPDATE 2 stays. The outcome is only known at the end, and the row must exist during execution (output items FK to it, the MCP progress token is the action id), so insert-at-completion is not an option (I'm sad ☹️)

## Tests

Tested locally 
front-edging

## Risk

Low
Blast radius: Agent. loop

## Plan

- [ ] Deploy front