### PR TITLE
Prioritize awake sandboxes in the sandbox reaper, sleep idle ones faster

### DIFF
--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -540,9 +540,12 @@ describe("SandboxResource.dangerouslyGetKillRequestedSandboxes", () => {
       agentConfigurationId,
       messagesCreatedAt: [new Date()],
     });
+    const olderActivityAt = new Date(Date.now() - 60 * 60 * 1000);
+    const recentActivityAt = new Date();
     const older = await SandboxFactory.create(authenticator, conversation, {
       status: "sleeping",
       killRequestedAt: new Date(),
+      lastActivityAt: olderActivityAt,
     });
     const recent = await SandboxFactory.create(
       authenticator,
@@ -550,17 +553,8 @@ describe("SandboxResource.dangerouslyGetKillRequestedSandboxes", () => {
       {
         status: "sleeping",
         killRequestedAt: new Date(),
+        lastActivityAt: recentActivityAt,
       }
-    );
-    const olderActivityAt = new Date(Date.now() - 60 * 60 * 1000);
-    const recentActivityAt = new Date();
-    await SandboxModel.update(
-      { lastActivityAt: olderActivityAt } as Partial<SandboxModel>,
-      { where: { id: older.id } }
-    );
-    await SandboxModel.update(
-      { lastActivityAt: recentActivityAt } as Partial<SandboxModel>,
-      { where: { id: recent.id } }
     );
 
     const firstPage =

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -497,6 +497,92 @@ describe("SandboxResource.dangerouslyGetKillRequestedSandboxes", () => {
     expect(secondPage).toHaveLength(1);
     expect(secondPage[0]?.id).not.toBe(firstSandbox.id);
   });
+
+  it("filters by statuses when provided", async () => {
+    const secondConversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId,
+      messagesCreatedAt: [new Date()],
+    });
+    const runningSandbox = await SandboxFactory.create(
+      authenticator,
+      conversation,
+      {
+        status: "running",
+        killRequestedAt: new Date(),
+      }
+    );
+    const sleepingSandbox = await SandboxFactory.create(
+      authenticator,
+      secondConversation,
+      {
+        status: "sleeping",
+        killRequestedAt: new Date(),
+      }
+    );
+
+    const awakeRows =
+      await SandboxResource.dangerouslyGetKillRequestedSandboxes({
+        limit: 10,
+        statuses: ["running", "pending_approval"],
+      });
+    expect(awakeRows.map((r) => r.id)).toEqual([runningSandbox.id]);
+
+    const sleepingRows =
+      await SandboxResource.dangerouslyGetKillRequestedSandboxes({
+        limit: 10,
+        statuses: ["sleeping"],
+      });
+    expect(sleepingRows.map((r) => r.id)).toEqual([sleepingSandbox.id]);
+  });
+
+  it("orders by lastActivityAt descending and paginates when requested", async () => {
+    const secondConversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId,
+      messagesCreatedAt: [new Date()],
+    });
+    const older = await SandboxFactory.create(authenticator, conversation, {
+      status: "sleeping",
+      killRequestedAt: new Date(),
+    });
+    const recent = await SandboxFactory.create(
+      authenticator,
+      secondConversation,
+      {
+        status: "sleeping",
+        killRequestedAt: new Date(),
+      }
+    );
+    const olderActivityAt = new Date(Date.now() - 60 * 60 * 1000);
+    const recentActivityAt = new Date();
+    await SandboxModel.update(
+      { lastActivityAt: olderActivityAt } as Partial<SandboxModel>,
+      { where: { id: older.id } }
+    );
+    await SandboxModel.update(
+      { lastActivityAt: recentActivityAt } as Partial<SandboxModel>,
+      { where: { id: recent.id } }
+    );
+
+    const firstPage =
+      await SandboxResource.dangerouslyGetKillRequestedSandboxes({
+        limit: 1,
+        statuses: ["sleeping"],
+        order: "lastActivityAtDesc",
+      });
+    expect(firstPage.map((r) => r.id)).toEqual([recent.id]);
+
+    const secondPage =
+      await SandboxResource.dangerouslyGetKillRequestedSandboxes({
+        limit: 1,
+        statuses: ["sleeping"],
+        order: "lastActivityAtDesc",
+        after: {
+          sandboxModelId: recent.id,
+          timestamp: recentActivityAt,
+        },
+      });
+    expect(secondPage.map((r) => r.id)).toEqual([older.id]);
+  });
 });
 
 describe("SandboxResource.dangerouslyRequestKillForBaseImage", () => {

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -963,8 +963,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    *
    * `statuses` narrows the sweep: the reaper prioritizes awake sandboxes
    * (running / pending_approval) and sweeps sleeping ones separately, most
-   * recently active first (`lastActivityAtDesc`), since those are the most
-   * likely to be woken by a returning user.
+   * recently active first (`lastActivityAtDesc`). Recently active sleepers
+   * are the most likely to be woken by a returning user, so destroying them
+   * first runs their pre-destroy flush before the user hits the lazy
+   * recreate path.
    *
    * WORKSPACE_ISOLATION_BYPASS: The reaper operates across all workspaces.
    */

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -79,6 +79,10 @@ export type SandboxTimestampCursor = {
   timestamp: Date;
 };
 
+export type KillRequestedSandboxesOrder =
+  | "killRequestedAtAsc"
+  | "lastActivityAtDesc";
+
 export type SandboxDeleteOwner = SandboxLifecycleOwner & {
   deleteSandbox: (
     sandbox: SandboxResource,
@@ -957,30 +961,53 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    * kill-requester workflow marks rows; the reaper (and the bash path) is
    * responsible for actually destroying them.
    *
+   * `statuses` narrows the sweep: the reaper prioritizes awake sandboxes
+   * (running / pending_approval) and sweeps sleeping ones separately, most
+   * recently active first (`lastActivityAtDesc`), since those are the most
+   * likely to be woken by a returning user.
+   *
    * WORKSPACE_ISOLATION_BYPASS: The reaper operates across all workspaces.
    */
   static async dangerouslyGetKillRequestedSandboxes(opts: {
     limit: number;
     after?: SandboxTimestampCursor;
+    statuses?: SandboxStatus[];
+    order?: KillRequestedSandboxesOrder;
   }): Promise<SandboxResource[]> {
+    const order = opts.order ?? "killRequestedAtAsc";
     const rows = await this.model.findAll({
       // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
       dangerouslyBypassWorkspaceIsolationSecurity: true,
       where: {
         killRequestedAt: { [Op.ne]: null },
-        status: { [Op.ne]: "deleted" },
+        status: opts.statuses
+          ? { [Op.in]: opts.statuses }
+          : { [Op.ne]: "deleted" },
         ...(opts.after && {
-          [Op.and]: where(
-            fn("ROW", col("killRequestedAt"), col("id")),
-            Op.gt,
-            fn("ROW", opts.after.timestamp, opts.after.sandboxModelId)
-          ),
+          [Op.and]:
+            order === "lastActivityAtDesc"
+              ? where(
+                  fn("ROW", col("lastActivityAt"), col("id")),
+                  Op.lt,
+                  fn("ROW", opts.after.timestamp, opts.after.sandboxModelId)
+                )
+              : where(
+                  fn("ROW", col("killRequestedAt"), col("id")),
+                  Op.gt,
+                  fn("ROW", opts.after.timestamp, opts.after.sandboxModelId)
+                ),
         }),
       },
-      order: [
-        ["killRequestedAt", "ASC"],
-        ["id", "ASC"],
-      ],
+      order:
+        order === "lastActivityAtDesc"
+          ? [
+              ["lastActivityAt", "DESC"],
+              ["id", "DESC"],
+            ]
+          : [
+              ["killRequestedAt", "ASC"],
+              ["id", "ASC"],
+            ],
       limit: opts.limit,
     });
 

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -963,10 +963,9 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    *
    * `statuses` narrows the sweep: the reaper prioritizes awake sandboxes
    * (running / pending_approval) and sweeps sleeping ones separately, most
-   * recently active first (`lastActivityAtDesc`). Recently active sleepers
-   * are the most likely to be woken by a returning user, so destroying them
-   * first runs their pre-destroy flush before the user hits the lazy
-   * recreate path.
+   * recently active first (`lastActivityAtDesc`). Sleepers are already
+   * flushed from pause time; destroying recently active ones first takes
+   * the provider destroy off the user's lazy recreate path.
    *
    * WORKSPACE_ISOLATION_BYPASS: The reaper operates across all workspaces.
    */

--- a/front/lib/resources/storage/models/sandbox.ts
+++ b/front/lib/resources/storage/models/sandbox.ts
@@ -92,6 +92,16 @@ SandboxModel.init(
         },
       },
       {
+        // Low-priority reaper sweep: kill-requested sleeping sandboxes are
+        // destroyed most-recently-active first.
+        fields: ["lastActivityAt", "id"],
+        name: "sandboxes_reaper_kill_requested_sleeping_idx",
+        where: {
+          killRequestedAt: { [Op.ne]: null },
+          status: "sleeping",
+        },
+      },
+      {
         fields: ["status", "lastActivityAt", "id"],
         name: "sandboxes_reaper_stale_idx",
         where: { killRequestedAt: { [Op.is]: null } },

--- a/front/migrations/pre-deploy/20260730131801_add_sandbox_reaper_kill_requested_sleeping_index.sql
+++ b/front/migrations/pre-deploy/20260730131801_add_sandbox_reaper_kill_requested_sleeping_index.sql
@@ -1,0 +1,7 @@
+/*
+Statement 0
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY sandboxes_reaper_kill_requested_sleeping_idx ON public.sandboxes USING btree ("lastActivityAt", id) WHERE (("killRequestedAt" IS NOT NULL) AND ((status)::text = 'sleeping'::text));

--- a/front/temporal/sandbox_reaper/activities.test.ts
+++ b/front/temporal/sandbox_reaper/activities.test.ts
@@ -209,4 +209,59 @@ describe("reapSandboxPhaseActivity", () => {
     const sandbox = await PodSandboxAdapter.fetchSandbox(authenticator, pod);
     expect(sandbox?.status).toBe("deleted");
   });
+
+  it("defers kill-requested sleeping sandboxes to the low-priority phase", async () => {
+    mockGetSandboxImage.mockReturnValue(
+      new Ok({
+        toCreateConfig: () => ({
+          imageId: { imageName: "test-image", tag: "0.0.1" },
+          envVars: {},
+          network: { egress: "restricted" },
+          resources: { cpu: 1, memoryMB: 512 },
+        }),
+      })
+    );
+    mockGetSandboxProvider.mockReturnValue({
+      create: vi.fn().mockResolvedValue(new Ok({ providerId: "pod-provider" })),
+      destroy: mockProviderDestroy.mockResolvedValue(new Ok(undefined)),
+    });
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace);
+    const podSandboxResult = await PodSandboxAdapter.ensureSandboxActive(
+      authenticator,
+      pod
+    );
+    if (podSandboxResult.isErr()) {
+      throw podSandboxResult.error;
+    }
+    await podSandboxResult.value.sandbox.updateStatus("sleeping");
+    await podSandboxResult.value.sandbox.requestKill();
+
+    const awakeResult = await reapSandboxPhaseActivity({
+      cursor: null,
+      phase: "kill_requested",
+    });
+    expect(awakeResult.processedCount).toBe(0);
+    expect(mockProviderDestroy).not.toHaveBeenCalled();
+
+    const result = await reapSandboxPhaseActivity({
+      cursor: null,
+      phase: "kill_requested_sleeping",
+    });
+
+    expect(result).toEqual({
+      failedCount: 0,
+      nextCursor: null,
+      processedCount: 1,
+      skippedCount: 0,
+      succeededCount: 1,
+    });
+    expect(mockProviderDestroy).toHaveBeenCalledWith("pod-provider", {
+      workspaceId: workspace.sId,
+    });
+    const sandbox = await PodSandboxAdapter.fetchSandbox(authenticator, pod);
+    expect(sandbox?.status).toBe("deleted");
+  });
 });

--- a/front/temporal/sandbox_reaper/activities.test.ts
+++ b/front/temporal/sandbox_reaper/activities.test.ts
@@ -210,7 +210,7 @@ describe("reapSandboxPhaseActivity", () => {
     expect(sandbox?.status).toBe("deleted");
   });
 
-  it("defers kill-requested sleeping sandboxes to the low-priority phase", async () => {
+  it("skips kill-requested sleeping sandboxes in the awake kill phase", async () => {
     mockGetSandboxImage.mockReturnValue(
       new Ok({
         toCreateConfig: () => ({

--- a/front/temporal/sandbox_reaper/activities.ts
+++ b/front/temporal/sandbox_reaper/activities.ts
@@ -553,6 +553,11 @@ export async function reapSandboxPhaseActivity({
  * Compatibility activity for sandbox reaper workflows started before the
  * phase-pagination patch. Keep its no-argument input and boolean output until
  * every pre-patch workflow execution has closed.
+ *
+ * Note: the "kill_requested" phase is awake-only now, so pre-patch executions
+ * replaying through this activity skip sleeping kill-requested rows. That is
+ * fine: the next scheduled (post-patch) execution sweeps them via the
+ * "kill_requested_sleeping" phase.
  */
 export async function reapStaleSandboxesActivity(): Promise<boolean> {
   const phases: ReaperPhase[] = [

--- a/front/temporal/sandbox_reaper/activities.ts
+++ b/front/temporal/sandbox_reaper/activities.ts
@@ -26,6 +26,7 @@ const REAPER_CONCURRENCY = 16;
 
 export type ReaperPhase =
   | "kill_requested"
+  | "kill_requested_sleeping"
   | "running"
   | "pending_approval"
   | "sleeping";
@@ -462,10 +463,13 @@ export async function reapSandboxPhaseActivity({
 
   switch (phase) {
     case "kill_requested": {
+      // Awake kill-requested sandboxes consume cluster capacity, so they are
+      // destroyed ahead of sleeping ones.
       const sandboxes =
         await SandboxResource.dangerouslyGetKillRequestedSandboxes({
           limit: BATCH_SIZE,
           after,
+          statuses: ["running", "pending_approval"],
         });
       return processReaperBatch(
         phase,
@@ -473,6 +477,26 @@ export async function reapSandboxPhaseActivity({
         (auth, owner) => owner.dangerouslyDestroySandboxIfKillRequested(auth),
         getKillRequestedAt,
         "Reaper: failed to destroy kill-requested sandbox — continuing."
+      );
+    }
+    case "kill_requested_sleeping": {
+      // Sleeping kill-requested sandboxes are pure storage cleanup: they are
+      // destroyed lazily on user access (ensureActive recreates them), so the
+      // reaper sweeps them last, most recently active first — those are the
+      // most likely to be woken soon.
+      const sandboxes =
+        await SandboxResource.dangerouslyGetKillRequestedSandboxes({
+          limit: BATCH_SIZE,
+          after,
+          statuses: ["sleeping"],
+          order: "lastActivityAtDesc",
+        });
+      return processReaperBatch(
+        phase,
+        sandboxes,
+        (auth, owner) => owner.dangerouslyDestroySandboxIfKillRequested(auth),
+        (sandbox) => sandbox.lastActivityAt,
+        "Reaper: failed to destroy kill-requested sleeping sandbox — continuing."
       );
     }
     case "running": {

--- a/front/temporal/sandbox_reaper/activities.ts
+++ b/front/temporal/sandbox_reaper/activities.ts
@@ -480,16 +480,14 @@ export async function reapSandboxPhaseActivity({
       );
     }
     case "kill_requested_sleeping": {
-      // Sleeping kill-requested sandboxes are pure cleanup: when a user
-      // returns, ensureActive destroys and recreates them on the spot, so the
-      // reaper sweeps them last.
+      // Sleeping kill-requested sandboxes free no concurrency (already
+      // paused) and were flushed at pause time — runPreSleepCheck no-ops
+      // here. Destroying them in the reaper still helps: ensureActive would
+      // otherwise pay the provider destroy on the user's recreate path.
       //
       // Most recently active first: those are the most likely to be woken by
-      // a returning user, and destroying them proactively runs the
-      // pre-destroy flush (which pushes filesystem state to the replica the
-      // recreated sandbox mounts) in the background. If the reaper gets there
-      // first, the user's recreate mounts an already-flushed replica and the
-      // flush never sits on the request critical path.
+      // a returning user, so the background destroy lands before they hit
+      // ensureActive.
       const sandboxes =
         await SandboxResource.dangerouslyGetKillRequestedSandboxes({
           limit: BATCH_SIZE,

--- a/front/temporal/sandbox_reaper/activities.ts
+++ b/front/temporal/sandbox_reaper/activities.ts
@@ -480,10 +480,16 @@ export async function reapSandboxPhaseActivity({
       );
     }
     case "kill_requested_sleeping": {
-      // Sleeping kill-requested sandboxes are pure storage cleanup: they are
-      // destroyed lazily on user access (ensureActive recreates them), so the
-      // reaper sweeps them last, most recently active first — those are the
-      // most likely to be woken soon.
+      // Sleeping kill-requested sandboxes are pure cleanup: when a user
+      // returns, ensureActive destroys and recreates them on the spot, so the
+      // reaper sweeps them last.
+      //
+      // Most recently active first: those are the most likely to be woken by
+      // a returning user, and destroying them proactively runs the
+      // pre-destroy flush (which pushes filesystem state to the replica the
+      // recreated sandbox mounts) in the background. If the reaper gets there
+      // first, the user's recreate mounts an already-flushed replica and the
+      // flush never sits on the request critical path.
       const sandboxes =
         await SandboxResource.dangerouslyGetKillRequestedSandboxes({
           limit: BATCH_SIZE,

--- a/front/temporal/sandbox_reaper/config.ts
+++ b/front/temporal/sandbox_reaper/config.ts
@@ -11,13 +11,13 @@ const ONE_MINUTE_MS = 60 * 1_000;
 const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
 const ONE_DAY_MS = 24 * ONE_HOUR_MS;
 
-/** Sleep sandboxes that have been inactive for this long. Default: 10 min. */
+/** Sleep sandboxes that have been inactive for this long. Default: 5 min. */
 const sleepThresholdEnv = EnvironmentConfig.getOptionalEnvVariable(
   "SANDBOX_SLEEP_THRESHOLD_MS"
 );
 export const SLEEP_THRESHOLD_MS = sleepThresholdEnv
   ? Number(sleepThresholdEnv)
-  : 10 * ONE_MINUTE_MS;
+  : 5 * ONE_MINUTE_MS;
 
 /** Transition pending_approval sandboxes to sleeping after this long. Default: 30 min. */
 const pendingApprovalThresholdEnv = EnvironmentConfig.getOptionalEnvVariable(

--- a/front/temporal/sandbox_reaper/workflows.ts
+++ b/front/temporal/sandbox_reaper/workflows.ts
@@ -14,14 +14,28 @@ const { reapSandboxPhaseActivity, reapStaleSandboxesActivity } =
     },
   });
 
-const REAPER_PHASES = [
+// Legacy phase order, kept for replay of pre-patch executions.
+const REAPER_PHASES_V1 = [
   "kill_requested",
   "running",
   "pending_approval",
   "sleeping",
 ] satisfies ReaperPhase[];
 
-const MAX_BATCHES_PER_PHASE = 100;
+// Priority order: pausing stale awake sandboxes and destroying awake
+// kill-requested sandboxes directly cap cluster concurrency, so they run
+// first. Kill-requested sleeping sandboxes are pure storage cleanup (they are
+// destroyed lazily on user access) and are swept last, when higher-priority
+// phases leave room in the run.
+const REAPER_PHASES_V2 = [
+  "running",
+  "pending_approval",
+  "kill_requested",
+  "sleeping",
+  "kill_requested_sleeping",
+] satisfies ReaperPhase[];
+
+const MAX_BATCHES_PER_PHASE = 200;
 
 export async function sandboxReaperWorkflow(): Promise<void> {
   // Patch lifecycle for phase pagination:
@@ -37,7 +51,16 @@ export async function sandboxReaperWorkflow(): Promise<void> {
     return;
   }
 
-  for (const phase of REAPER_PHASES) {
+  // Patch lifecycle for prioritized phases:
+  // 1. Now: pre-patch executions replay the legacy phase order.
+  // 2. After 2026-08-14: replace patched() with deprecatePatch() and remove
+  //    REAPER_PHASES_V1.
+  // 3. After 2026-08-28: remove deprecatePatch() and the patch marker.
+  const phases = patched("sandbox-reaper-prioritized-phases")
+    ? REAPER_PHASES_V2
+    : REAPER_PHASES_V1;
+
+  for (const phase of phases) {
     let cursor: ReaperCursor | null = null;
     let processedBatches = 0;
 

--- a/front/temporal/sandbox_reaper/workflows.ts
+++ b/front/temporal/sandbox_reaper/workflows.ts
@@ -22,17 +22,20 @@ const REAPER_PHASES_V1 = [
   "sleeping",
 ] satisfies ReaperPhase[];
 
-// Priority order: pausing stale awake sandboxes and destroying awake
-// kill-requested sandboxes directly cap cluster concurrency, so they run
-// first. Kill-requested sleeping sandboxes are pure storage cleanup (they are
-// destroyed lazily on user access) and are swept last, when higher-priority
-// phases leave room in the run.
+// Priority order: concurrency-freeing work first, then storage cleanup.
+// Awake kill-requested sandboxes burn E2B capacity and sit on the user
+// recreate path, so they are destroyed first. Stale running sandboxes are
+// paused next (same concurrency win, non-destructive). pending_approval is
+// cheap DB-only bookkeeping (already paused). Kill-requested sleepers are
+// storage/rollout cleanup ahead of cold sleeping destroy — they free no
+// concurrency, but taking the provider destroy off ensureActive is hotter
+// than 4-day-stale sleepers.
 const REAPER_PHASES_V2 = [
+  "kill_requested",
   "running",
   "pending_approval",
-  "kill_requested",
-  "sleeping",
   "kill_requested_sleeping",
+  "sleeping",
 ] satisfies ReaperPhase[];
 
 const MAX_BATCHES_PER_PHASE = 200;

--- a/front/temporal/sandbox_reaper/workflows.ts
+++ b/front/temporal/sandbox_reaper/workflows.ts
@@ -51,11 +51,10 @@ export async function sandboxReaperWorkflow(): Promise<void> {
     return;
   }
 
-  // Patch lifecycle for prioritized phases:
-  // 1. Now: pre-patch executions replay the legacy phase order.
-  // 2. After 2026-08-14: replace patched() with deprecatePatch() and remove
-  //    REAPER_PHASES_V1.
-  // 3. After 2026-08-28: remove deprecatePatch() and the patch marker.
+  // Patch for prioritized phases: pre-patch executions replay the legacy phase
+  // order. After deploy, pause the schedule, terminate any open
+  // sandboxReaperWorkflow, wait for the worker rollout to finish, then remove
+  // REAPER_PHASES_V1 and this patched() call immediately.
   const phases = patched("sandbox-reaper-prioritized-phases")
     ? REAPER_PHASES_V2
     : REAPER_PHASES_V1;

--- a/front/tests/utils/SandboxFactory.ts
+++ b/front/tests/utils/SandboxFactory.ts
@@ -15,6 +15,7 @@ export class SandboxFactory {
     opts?: {
       status?: SandboxStatus;
       statusChangedAt?: Date | null;
+      lastActivityAt?: Date;
       baseImage?: string;
       version?: string;
       killRequestedAt?: Date | null;
@@ -43,6 +44,13 @@ export class SandboxFactory {
     if (opts?.killRequestedAt !== undefined) {
       await SandboxModel.update(
         { killRequestedAt: opts.killRequestedAt } as Partial<SandboxModel>,
+        { where: { id: sandbox.id } }
+      );
+    }
+
+    if (opts?.lastActivityAt !== undefined) {
+      await SandboxModel.update(
+        { lastActivityAt: opts.lastActivityAt } as Partial<SandboxModel>,
         { where: { id: sandbox.id } }
       );
     }


### PR DESCRIPTION
## Description

Yesterday's sandbox image rollout spiked EU E2B cluster concurrency: the kill-requester marked the whole old-version fleet (~30k sandboxes, mostly sleeping), the kill sweep saturated every reaper run, and the pause sweep starved, leaving idle running sandboxes stacked up.

Changes:
- Split the kill_requested phase in two: awake sandboxes (running / pending_approval) are destroyed first, sleeping ones are swept last, most recently active first (they are the likeliest to be woken by a returning user). Sleeping kills are best-effort cleanup only: `ensureActive` already destroys and recreates kill-requested sandboxes lazily on access.
- Reorder phases so pausing stale running sandboxes runs before any kill sweep. Later phases only get batches when earlier ones leave room, so sleeping kills effectively run when the reaper is idle.
- Double `MAX_BATCHES_PER_PHASE` to 200. The 100-batch cap (12.8k kills per 5-min run) was the bottleneck when draining rollout backlogs.
- Lower the default sleep threshold from 10 to 5 min to cut the idle tail of each session (still env-overridable).
- Add a partial index on `(lastActivityAt, id)` for kill-requested sleeping sandboxes to back the new sweep (pre-deploy migration).

The workflow phase reorder is behind a Temporal patch (`sandbox-reaper-prioritized-phases`) so in-flight executions replay deterministically.

## Tests

Added resource tests for the status filter and the lastActivityAt-desc pagination, and a reaper test that sleeping kill-requested sandboxes are skipped by the awake phase and destroyed by the low-priority phase.

## Risk

Low. Rollout-day backlog drains slower for sleeping sandboxes by design (they linger as paused snapshots longer, storage cost only). Reaper behavior for awake sandboxes is unchanged apart from ordering. Migration is a concurrent partial index, no locking. Rollback is a revert; the new phase name is only read by new workflow executions.

## Deploy Plan

Pre-deploy migration must run before the code ships (standard). Temporal patch cleanup comments reference follow-up dates.