### PR TITLE
Centralize Pod function result normalization and make terminal transitions idempotent

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts
@@ -203,4 +203,100 @@ describe("POST /api/v1/w/[wId]/sandbox/sandbox-functions/result", () => {
     });
     expect(publishSandboxFunctionInvocationEvent).not.toHaveBeenCalled();
   });
+
+  it("accepts protocol v3 success envelopes", async () => {
+    const { auth, token, workspace, sandboxFunction, invocation } =
+      await createPersistedSandboxFunctionInvocationTokenTestContext();
+
+    const response = await postSandboxFunctionResult(workspace, token, {
+      result: {
+        protocolVersion: 3,
+        delivery: "callback",
+        outcome: { ok: true, output: { hello: "v3" } },
+        timingsMs: { total: 10, runner: 4 },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const refetchedInvocation =
+      await SandboxFunctionInvocationResource.fetchById(auth, {
+        sandboxFunction,
+        invocationId: invocation.sId,
+      });
+    expect(refetchedInvocation?.status).toBe("succeeded");
+    expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledWith(
+      {
+        type: "sandbox_function_invocation_result",
+        created: expect.any(Number),
+        invocationId: invocation.sId,
+        functionId: sandboxFunction.sId,
+        result: { hello: "v3" },
+      },
+      { invocationId: invocation.sId }
+    );
+  });
+
+  it("publishes protocol v3 runner errors as invocation errors", async () => {
+    const { auth, token, workspace, sandboxFunction, invocation } =
+      await createPersistedSandboxFunctionInvocationTokenTestContext();
+
+    const response = await postSandboxFunctionResult(workspace, token, {
+      result: {
+        protocolVersion: 3,
+        delivery: "stdout",
+        outcome: {
+          ok: false,
+          error: {
+            code: "threw",
+            message: "boom",
+          },
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const refetchedInvocation =
+      await SandboxFunctionInvocationResource.fetchById(auth, {
+        sandboxFunction,
+        invocationId: invocation.sId,
+      });
+    expect(refetchedInvocation?.status).toBe("errored");
+    expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledWith(
+      {
+        type: "sandbox_function_invocation_error",
+        created: expect.any(Number),
+        invocationId: invocation.sId,
+        functionId: sandboxFunction.sId,
+        error: {
+          code: "threw",
+          message: "boom",
+        },
+      },
+      { invocationId: invocation.sId }
+    );
+  });
+
+  it("treats a second callback for an already-succeeded invocation as a no-op", async () => {
+    const { auth, token, workspace, sandboxFunction, invocation } =
+      await createPersistedSandboxFunctionInvocationTokenTestContext();
+
+    const first = await postSandboxFunctionResult(workspace, token, {
+      result: { ok: true, output: { hello: "first" } },
+    });
+    expect(first.status).toBe(200);
+
+    const second = await postSandboxFunctionResult(workspace, token, {
+      result: { ok: true, output: { hello: "second" } },
+    });
+    expect(second.status).toBe(200);
+
+    const refetchedInvocation =
+      await SandboxFunctionInvocationResource.fetchById(auth, {
+        sandboxFunction,
+        invocationId: invocation.sId,
+      });
+    expect(refetchedInvocation?.status).toBe("succeeded");
+    expect(refetchedInvocation?.result).toEqual({ hello: "first" });
+    expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledTimes(1);
+  });
 });

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
@@ -2,7 +2,6 @@ import { isSandboxFunctionInvocationTokenPayload } from "@app/lib/api/sandbox/ac
 import { normalizeSandboxFunctionResult } from "@app/lib/api/sandbox_functions/result_envelope";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
-import logger from "@app/logger/logger";
 import { sandboxApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -70,17 +69,6 @@ app.post(
     }
 
     const normalized = normalizeSandboxFunctionResult(result);
-    if (normalized.timingsMs) {
-      logger.info(
-        {
-          invocationId: invocation.sId,
-          functionId: sandboxFunction.sId,
-          timingsMs: normalized.timingsMs,
-        },
-        "Pod function result timings"
-      );
-    }
-
     if (normalized.ok) {
       await invocation.succeed(normalized.output);
     } else {

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
@@ -1,120 +1,14 @@
 import { isSandboxFunctionInvocationTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import { normalizeSandboxFunctionResult } from "@app/lib/api/sandbox_functions/result_envelope";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
-import type { SandboxFunctionCallError } from "@app/types/api/sandbox_functions";
-import { SANDBOX_FUNCTION_RUNNER_ERROR_CODES } from "@app/types/api/sandbox_functions";
+import logger from "@app/logger/logger";
 import { sandboxApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { SuccessResponseBody } from "@front-api/routes/types";
 import { z } from "zod";
-
-type JsonValue = null | boolean | number | string | object;
-const DefinedJsonValueSchema = z.custom<JsonValue>((v) => v !== undefined);
-const SandboxFunctionRunnerOutputSchema = z.discriminatedUnion("ok", [
-  z.object({ ok: z.literal(true), output: DefinedJsonValueSchema }).strict(),
-  z
-    .object({
-      ok: z.literal(false),
-      error: z
-        .object({
-          code: z.enum(SANDBOX_FUNCTION_RUNNER_ERROR_CODES),
-          message: z.string(),
-          status: z.number().int().optional(),
-        })
-        .strict(),
-    })
-    .strict(),
-]);
-
-const LegacySandboxFunctionRunnerOutputSchema = z.discriminatedUnion("ok", [
-  z
-    .object({
-      ok: z.literal(true),
-      response: z
-        .object({
-          status: z.number().int(),
-          headers: z.record(z.string(), z.string()),
-          body: z.string().nullable(),
-          encoding: z.enum(["utf8", "base64"]),
-        })
-        .strict(),
-    })
-    .strict(),
-  z
-    .object({
-      ok: z.literal(false),
-      error: z
-        .object({
-          kind: z.enum(["bad_input", "import_failed", "threw", "bad_return"]),
-          message: z.string(),
-          stack: z.string().optional(),
-        })
-        .strict(),
-    })
-    .strict(),
-]);
-
-type NormalizedRunnerOutput =
-  | { ok: true; output: unknown }
-  | { ok: false; error: SandboxFunctionCallError };
-
-function normalizeRunnerOutput(result: unknown): NormalizedRunnerOutput {
-  const current = SandboxFunctionRunnerOutputSchema.safeParse(result);
-  if (current.success) {
-    return current.data;
-  }
-
-  const legacy = LegacySandboxFunctionRunnerOutputSchema.safeParse(result);
-  if (!legacy.success) {
-    return {
-      ok: false,
-      error: {
-        code: "invocation_failed",
-        message: "Sandbox function returned an invalid result envelope.",
-      },
-    };
-  }
-
-  if (!legacy.data.ok) {
-    return {
-      ok: false,
-      error: {
-        code: legacy.data.error.kind,
-        message: legacy.data.error.message,
-      },
-    };
-  }
-
-  const { response } = legacy.data;
-  const body =
-    response.body === null
-      ? ""
-      : Buffer.from(response.body, response.encoding).toString("utf8");
-  if (response.status < 200 || response.status >= 300) {
-    return {
-      ok: false,
-      error: {
-        code: "http_error",
-        message: `Function returned HTTP ${response.status}${body ? `: ${body}` : "."}`,
-        status: response.status,
-      },
-    };
-  }
-
-  try {
-    return { ok: true, output: JSON.parse(body) };
-  } catch {
-    return {
-      ok: false,
-      error: {
-        code: "invalid_output",
-        message: "Function response body is not valid JSON.",
-      },
-    };
-  }
-}
 
 const PostSandboxFunctionResultRequestBodySchema = z
   .object({
@@ -175,7 +69,18 @@ app.post(
       });
     }
 
-    const normalized = normalizeRunnerOutput(result);
+    const normalized = normalizeSandboxFunctionResult(result);
+    if (normalized.timingsMs) {
+      logger.info(
+        {
+          invocationId: invocation.sId,
+          functionId: sandboxFunction.sId,
+          timingsMs: normalized.timingsMs,
+        },
+        "Pod function result timings"
+      );
+    }
+
     if (normalized.ok) {
       await invocation.succeed(normalized.output);
     } else {

--- a/front/lib/api/sandbox_functions/result_envelope.test.ts
+++ b/front/lib/api/sandbox_functions/result_envelope.test.ts
@@ -91,6 +91,35 @@ describe("normalizeSandboxFunctionResult", () => {
     });
   });
 
+  it("drops timingsMs with unbounded or invalid keys", () => {
+    const tooManyKeys = Object.fromEntries(
+      Array.from({ length: 33 }, (_, i) => [`phase${i}`, i])
+    );
+    expect(
+      normalizeSandboxFunctionResult({
+        protocolVersion: 3,
+        delivery: "stdout",
+        outcome: { ok: true, output: 1 },
+        timingsMs: tooManyKeys,
+      })
+    ).toEqual({
+      ok: true,
+      output: 1,
+    });
+
+    expect(
+      normalizeSandboxFunctionResult({
+        protocolVersion: 3,
+        delivery: "spool",
+        outcome: { ok: true, output: 1 },
+        timingsMs: { "bad-key!": 1 },
+      })
+    ).toEqual({
+      ok: true,
+      output: 1,
+    });
+  });
+
   it("accepts the current runner success and failure envelopes", () => {
     expect(
       normalizeSandboxFunctionResult({ ok: true, output: { hello: "world" } })

--- a/front/lib/api/sandbox_functions/result_envelope.test.ts
+++ b/front/lib/api/sandbox_functions/result_envelope.test.ts
@@ -1,0 +1,176 @@
+import {
+  normalizeSandboxFunctionResult,
+  SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSION,
+} from "@app/lib/api/sandbox_functions/result_envelope";
+import { describe, expect, it } from "vitest";
+
+describe("normalizeSandboxFunctionResult", () => {
+  it("accepts a protocol v3 success envelope", () => {
+    // Cross-language pin for the Rust ResultEnvelope serde shape added with
+    // `--result-delivery stdout` (Workstream 1 CLI PR). Keep the literal stable.
+    const envelope = {
+      protocolVersion: SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSION,
+      delivery: "stdout",
+      outcome: { ok: true, output: { hello: "world" } },
+      timingsMs: { total: 12, runner: 8, importBundle: 3 },
+      futureField: "ignored",
+    };
+
+    expect(normalizeSandboxFunctionResult(envelope)).toEqual({
+      ok: true,
+      output: { hello: "world" },
+      timingsMs: { total: 12, runner: 8, importBundle: 3 },
+    });
+  });
+
+  it("preserves the runner error code from a protocol v3 failure envelope", () => {
+    expect(
+      normalizeSandboxFunctionResult({
+        protocolVersion: 3,
+        delivery: "callback",
+        outcome: {
+          ok: false,
+          error: {
+            code: "invalid_output",
+            message: "Function output does not match schema.output.",
+          },
+        },
+      })
+    ).toEqual({
+      ok: false,
+      error: {
+        code: "invalid_output",
+        message: "Function output does not match schema.output.",
+      },
+    });
+  });
+
+  it("fails a protocol v3 envelope with a malformed outcome", () => {
+    expect(
+      normalizeSandboxFunctionResult({
+        protocolVersion: 3,
+        delivery: "stdout",
+        outcome: { ok: true },
+      })
+    ).toEqual({
+      ok: false,
+      error: {
+        code: "invocation_failed",
+        message: "Sandbox function returned an invalid result envelope.",
+      },
+    });
+  });
+
+  it("rejects an unsupported protocol version without falling through to legacy parsers", () => {
+    expect(
+      normalizeSandboxFunctionResult({
+        protocolVersion: 4,
+        delivery: "stdout",
+        outcome: { ok: true, output: { hello: "world" } },
+      })
+    ).toEqual({
+      ok: false,
+      error: {
+        code: "invocation_failed",
+        message: "Unsupported Pod function result protocol version 4.",
+      },
+    });
+  });
+
+  it("drops invalid timingsMs without failing the outcome", () => {
+    expect(
+      normalizeSandboxFunctionResult({
+        protocolVersion: 3,
+        delivery: "stdout",
+        outcome: { ok: true, output: 1 },
+        timingsMs: { total: -1 },
+      })
+    ).toEqual({
+      ok: true,
+      output: 1,
+    });
+  });
+
+  it("accepts the current runner success and failure envelopes", () => {
+    expect(
+      normalizeSandboxFunctionResult({ ok: true, output: { hello: "world" } })
+    ).toEqual({ ok: true, output: { hello: "world" } });
+
+    expect(
+      normalizeSandboxFunctionResult({
+        ok: false,
+        error: {
+          code: "http_error",
+          message: "Function returned HTTP 502.",
+          status: 502,
+        },
+      })
+    ).toEqual({
+      ok: false,
+      error: {
+        code: "http_error",
+        message: "Function returned HTTP 502.",
+        status: 502,
+      },
+    });
+  });
+
+  it("normalizes successful callbacks from the previous runner image", () => {
+    expect(
+      normalizeSandboxFunctionResult({
+        ok: true,
+        response: {
+          status: 200,
+          headers: { "content-type": "application/json" },
+          body: Buffer.from(JSON.stringify({ hello: "legacy" })).toString(
+            "base64"
+          ),
+          encoding: "base64",
+        },
+      })
+    ).toEqual({ ok: true, output: { hello: "legacy" } });
+  });
+
+  it("normalizes non-2xx and threw errors from the previous runner image", () => {
+    expect(
+      normalizeSandboxFunctionResult({
+        ok: true,
+        response: {
+          status: 500,
+          headers: {},
+          body: Buffer.from("boom").toString("base64"),
+          encoding: "base64",
+        },
+      })
+    ).toEqual({
+      ok: false,
+      error: {
+        code: "http_error",
+        message: "Function returned HTTP 500: boom",
+        status: 500,
+      },
+    });
+
+    expect(
+      normalizeSandboxFunctionResult({
+        ok: false,
+        error: { kind: "threw", message: "boom" },
+      })
+    ).toEqual({
+      ok: false,
+      error: { code: "threw", message: "boom" },
+    });
+  });
+
+  it("fails malformed envelopes with the stable invalid-envelope message", () => {
+    for (const result of [null, {}, { ok: true }]) {
+      expect(normalizeSandboxFunctionResult(result)).toEqual({
+        ok: false,
+        error: {
+          code: "invocation_failed",
+          message: "Sandbox function returned an invalid result envelope.",
+        },
+      });
+    }
+  });
+});

--- a/front/lib/api/sandbox_functions/result_envelope.ts
+++ b/front/lib/api/sandbox_functions/result_envelope.ts
@@ -1,0 +1,195 @@
+import type { SandboxFunctionCallError } from "@app/types/api/sandbox_functions";
+import { SANDBOX_FUNCTION_RUNNER_ERROR_CODES } from "@app/types/api/sandbox_functions";
+import { z } from "zod";
+
+export const SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSION = 3;
+
+export type SandboxFunctionResultDelivery = "stdout" | "callback";
+
+// Phase names are owned by the runner/CLI and grow over time (Workstream 6). Keep this a
+// bounded record of non-negative millisecond values rather than a closed field list.
+export type SandboxFunctionResultTimingsMs = Record<string, number>;
+
+export type NormalizedSandboxFunctionOutcome =
+  | { ok: true; output: unknown; timingsMs?: SandboxFunctionResultTimingsMs }
+  | {
+      ok: false;
+      error: SandboxFunctionCallError;
+      timingsMs?: SandboxFunctionResultTimingsMs;
+    };
+
+type JsonValue = null | boolean | number | string | object;
+const DefinedJsonValueSchema = z.custom<JsonValue>((v) => v !== undefined);
+
+const SandboxFunctionRunnerOutputSchema = z.discriminatedUnion("ok", [
+  z.object({ ok: z.literal(true), output: DefinedJsonValueSchema }).strict(),
+  z
+    .object({
+      ok: z.literal(false),
+      error: z
+        .object({
+          code: z.enum(SANDBOX_FUNCTION_RUNNER_ERROR_CODES),
+          message: z.string(),
+          status: z.number().int().optional(),
+        })
+        .strict(),
+    })
+    .strict(),
+]);
+
+const LegacySandboxFunctionRunnerOutputSchema = z.discriminatedUnion("ok", [
+  z
+    .object({
+      ok: z.literal(true),
+      response: z
+        .object({
+          status: z.number().int(),
+          headers: z.record(z.string(), z.string()),
+          body: z.string().nullable(),
+          encoding: z.enum(["utf8", "base64"]),
+        })
+        .strict(),
+    })
+    .strict(),
+  z
+    .object({
+      ok: z.literal(false),
+      error: z
+        .object({
+          kind: z.enum(["bad_input", "import_failed", "threw", "bad_return"]),
+          message: z.string(),
+          stack: z.string().optional(),
+        })
+        .strict(),
+    })
+    .strict(),
+]);
+
+// One hour ceiling: runner phase timings above this are discarded as implausible rather than
+// failing the whole envelope.
+const MAX_TIMING_MS = 60 * 60 * 1000;
+
+const TimingsMsSchema = z.record(
+  z.string(),
+  z.number().finite().nonnegative().max(MAX_TIMING_MS)
+);
+
+// Deliberately not `.strict()`: the wrapper is a forward-compatibility seam, so a field added by
+// a newer dsbx must not fail the parse. Inner outcome schemas stay `.strict()`.
+const ResultEnvelopeV3Schema = z.object({
+  protocolVersion: z.literal(SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSION),
+  delivery: z.enum(["stdout", "callback"]),
+  outcome: z.unknown(),
+  timingsMs: z.unknown().optional(),
+});
+
+const ProtocolVersionProbeSchema = z.object({
+  protocolVersion: z.number().int(),
+});
+
+function invalidResultEnvelope(): NormalizedSandboxFunctionOutcome {
+  return {
+    ok: false,
+    error: {
+      code: "invocation_failed",
+      message: "Sandbox function returned an invalid result envelope.",
+    },
+  };
+}
+
+function parseTimingsMs(
+  value: unknown
+): SandboxFunctionResultTimingsMs | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = TimingsMsSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
+}
+
+function normalizeRunnerOutcome(
+  result: unknown
+): NormalizedSandboxFunctionOutcome {
+  const current = SandboxFunctionRunnerOutputSchema.safeParse(result);
+  if (current.success) {
+    return current.data;
+  }
+
+  const legacy = LegacySandboxFunctionRunnerOutputSchema.safeParse(result);
+  if (!legacy.success) {
+    return invalidResultEnvelope();
+  }
+
+  if (!legacy.data.ok) {
+    return {
+      ok: false,
+      error: {
+        code: legacy.data.error.kind,
+        message: legacy.data.error.message,
+      },
+    };
+  }
+
+  const { response } = legacy.data;
+  const body =
+    response.body === null
+      ? ""
+      : Buffer.from(response.body, response.encoding).toString("utf8");
+  if (response.status < 200 || response.status >= 300) {
+    return {
+      ok: false,
+      error: {
+        code: "http_error",
+        message: `Function returned HTTP ${response.status}${body ? `: ${body}` : "."}`,
+        status: response.status,
+      },
+    };
+  }
+
+  try {
+    return { ok: true, output: JSON.parse(body) };
+  } catch {
+    return {
+      ok: false,
+      error: {
+        code: "invalid_output",
+        message: "Function response body is not valid JSON.",
+      },
+    };
+  }
+}
+
+/**
+ * Normalize a Pod function result payload from either the HTTP callback body or a future
+ * worker-owned stdout envelope into one classified outcome.
+ */
+export function normalizeSandboxFunctionResult(
+  result: unknown
+): NormalizedSandboxFunctionOutcome {
+  const versionProbe = ProtocolVersionProbeSchema.safeParse(result);
+  if (versionProbe.success) {
+    if (
+      versionProbe.data.protocolVersion !==
+      SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSION
+    ) {
+      return {
+        ok: false,
+        error: {
+          code: "invocation_failed",
+          message: `Unsupported Pod function result protocol version ${versionProbe.data.protocolVersion}.`,
+        },
+      };
+    }
+
+    const v3 = ResultEnvelopeV3Schema.safeParse(result);
+    if (!v3.success) {
+      return invalidResultEnvelope();
+    }
+
+    const outcome = normalizeRunnerOutcome(v3.data.outcome);
+    const timingsMs = parseTimingsMs(v3.data.timingsMs);
+    return timingsMs === undefined ? outcome : { ...outcome, timingsMs };
+  }
+
+  return normalizeRunnerOutcome(result);
+}

--- a/front/lib/api/sandbox_functions/result_envelope.ts
+++ b/front/lib/api/sandbox_functions/result_envelope.ts
@@ -4,19 +4,16 @@ import { z } from "zod";
 
 export const SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSION = 3;
 
-export type SandboxFunctionResultDelivery = "stdout" | "callback";
-
 // Phase names are owned by the runner/CLI and grow over time (Workstream 6). Keep this a
 // bounded record of non-negative millisecond values rather than a closed field list.
 export type SandboxFunctionResultTimingsMs = Record<string, number>;
 
-export type NormalizedSandboxFunctionOutcome =
-  | { ok: true; output: unknown; timingsMs?: SandboxFunctionResultTimingsMs }
-  | {
-      ok: false;
-      error: SandboxFunctionCallError;
-      timingsMs?: SandboxFunctionResultTimingsMs;
-    };
+export type NormalizedSandboxFunctionOutcome = {
+  timingsMs?: SandboxFunctionResultTimingsMs;
+} & (
+  | { ok: true; output: unknown }
+  | { ok: false; error: SandboxFunctionCallError }
+);
 
 type JsonValue = null | boolean | number | string | object;
 const DefinedJsonValueSchema = z.custom<JsonValue>((v) => v !== undefined);
@@ -68,17 +65,25 @@ const LegacySandboxFunctionRunnerOutputSchema = z.discriminatedUnion("ok", [
 // One hour ceiling: runner phase timings above this are discarded as implausible rather than
 // failing the whole envelope.
 const MAX_TIMING_MS = 60 * 60 * 1000;
+const MAX_TIMING_KEYS = 32;
+const TIMING_KEY_REGEX = /^[a-zA-Z][a-zA-Z0-9_]{0,63}$/;
 
-const TimingsMsSchema = z.record(
-  z.string(),
-  z.number().finite().nonnegative().max(MAX_TIMING_MS)
-);
+const TimingsMsSchema = z
+  .record(
+    z.string().regex(TIMING_KEY_REGEX),
+    z.number().finite().nonnegative().max(MAX_TIMING_MS)
+  )
+  .refine((value) => Object.keys(value).length <= MAX_TIMING_KEYS, {
+    message: `timingsMs may contain at most ${MAX_TIMING_KEYS} keys`,
+  });
 
 // Deliberately not `.strict()`: the wrapper is a forward-compatibility seam, so a field added by
 // a newer dsbx must not fail the parse. Inner outcome schemas stay `.strict()`.
+// `delivery` is accepted as an opaque string until a consumer reads it; closing it to an enum
+// would break a future dsbx that adds a mode (e.g. spool) before front knows about it.
 const ResultEnvelopeV3Schema = z.object({
   protocolVersion: z.literal(SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSION),
-  delivery: z.enum(["stdout", "callback"]),
+  delivery: z.string().min(1),
   outcome: z.unknown(),
   timingsMs: z.unknown().optional(),
 });

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -451,6 +451,31 @@ describe("SandboxFunctionInvocationResource", () => {
     expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledTimes(1);
   });
 
+  it("releases a won succeed claim when the terminal blob write fails", async () => {
+    const { authenticator, sandboxFunction, invocation } =
+      await setupExecutionTest();
+    fileStorageMock.setFileSaveFails(
+      (filePath) => filePath === invocation.gcsPath
+    );
+
+    await expect(
+      invocation.succeed({ commentId: "comment-1" })
+    ).rejects.toThrow();
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.status).toBe("created");
+    expect(publishSandboxFunctionInvocationEvent).not.toHaveBeenCalled();
+
+    fileStorageMock.setFileSaveFails(() => false);
+    expect(
+      await refetched!.fail(new Error("recoverable after gcs failure"))
+    ).toBe(true);
+    expect(refetched!.status).toBe("errored");
+  });
+
   it("migrates a v1 blob, which recorded the message only", async () => {
     const { authenticator, sandboxFunction, invocation } =
       await setupExecutionTest();

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -392,6 +392,65 @@ describe("SandboxFunctionInvocationResource", () => {
     });
   });
 
+  it("makes succeed a compare-and-set so a second delivery is a no-op", async () => {
+    const { authenticator, sandboxFunction, invocation } =
+      await setupExecutionTest();
+    const result = { commentId: "comment-1" };
+
+    expect(await invocation.succeed(result)).toBe(true);
+    expect(await invocation.succeed({ commentId: "comment-2" })).toBe(false);
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.status).toBe("succeeded");
+    expect(refetched?.result).toEqual(result);
+    expect(fileStorageMock.getObject(invocation.gcsPath!)).toContain(
+      '"commentId":"comment-1"'
+    );
+    expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects fail after succeed without overwriting the result", async () => {
+    const { authenticator, sandboxFunction, invocation } =
+      await setupExecutionTest();
+    const result = { commentId: "comment-1" };
+
+    expect(await invocation.succeed(result)).toBe(true);
+    expect(await invocation.fail(new Error("late failure"))).toBe(false);
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.status).toBe("succeeded");
+    expect(refetched?.result).toEqual(result);
+    expect(refetched?.error).toBeUndefined();
+    expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects markCreatedAsErrored after succeed", async () => {
+    const { authenticator, sandboxFunction, invocation } =
+      await setupExecutionTest();
+
+    expect(await invocation.succeed({ commentId: "comment-1" })).toBe(true);
+    expect(
+      await invocation.markCreatedAsErrored({
+        code: "invocation_failed",
+        message: "activity timed out",
+      })
+    ).toBe(false);
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.status).toBe("succeeded");
+    expect(refetched?.result).toEqual({ commentId: "comment-1" });
+    expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledTimes(1);
+  });
+
   it("migrates a v1 blob, which recorded the message only", async () => {
     const { authenticator, sandboxFunction, invocation } =
       await setupExecutionTest();

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -282,6 +282,15 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       }
     );
     if (affectedCount === 0) {
+      logger.info(
+        {
+          workspaceModelId: this.workspaceId,
+          sandboxFunctionId: this.sandboxFunction.sId,
+          invocationId: this.sId,
+          attemptedStatus: status,
+        },
+        "Skipping terminal transition for an already-terminal Pod function invocation"
+      );
       return false;
     }
     const row = rows[0];
@@ -289,6 +298,40 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       Object.assign(this, row.get());
     }
     return true;
+  }
+
+  // Give the claim back if terminal blob persistence fails, so a later fail()/
+  // markCreatedAsErrored() path can still record the outcome.
+  private async releaseTerminalStatus(
+    from: Extract<SandboxFunctionInvocationStatus, "succeeded" | "errored">
+  ): Promise<void> {
+    const [affectedCount, rows] = await this.model.update(
+      { status: "created" },
+      {
+        where: {
+          id: this.id,
+          workspaceId: this.workspaceId,
+          status: from,
+        },
+        returning: true,
+      }
+    );
+    if (affectedCount === 0) {
+      logger.error(
+        {
+          workspaceModelId: this.workspaceId,
+          sandboxFunctionId: this.sandboxFunction.sId,
+          invocationId: this.sId,
+          fromStatus: from,
+        },
+        "Failed to release Pod function terminal claim after blob write failure"
+      );
+      return;
+    }
+    const row = rows[0];
+    if (row) {
+      Object.assign(this, row.get());
+    }
   }
 
   async fail(error: Error | SandboxFunctionCallError): Promise<boolean> {
@@ -299,14 +342,6 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
 
     const claimed = await this.claimTerminalStatus("errored");
     if (!claimed) {
-      logger.info(
-        {
-          workspaceId: this.workspaceId,
-          sandboxFunctionId: this.sandboxFunction.sId,
-          invocationId: this.sId,
-        },
-        "Skipping fail for an already-terminal Pod function invocation"
-      );
       return false;
     }
 
@@ -319,7 +354,12 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       // record of a failure the stream classified precisely.
       error: callError,
     };
-    await this.writeDataToGcs();
+    try {
+      await this.writeDataToGcs();
+    } catch (err) {
+      await this.releaseTerminalStatus("errored");
+      throw err;
+    }
     await publishSandboxFunctionInvocationEvent(
       {
         type: "sandbox_function_invocation_error",
@@ -336,14 +376,6 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   async succeed(result: unknown): Promise<boolean> {
     const claimed = await this.claimTerminalStatus("succeeded");
     if (!claimed) {
-      logger.info(
-        {
-          workspaceId: this.workspaceId,
-          sandboxFunctionId: this.sandboxFunction.sId,
-          invocationId: this.sId,
-        },
-        "Skipping succeed for an already-terminal Pod function invocation"
-      );
       return false;
     }
 
@@ -353,7 +385,12 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       context: this.context,
       result,
     };
-    await this.writeDataToGcs();
+    try {
+      await this.writeDataToGcs();
+    } catch (err) {
+      await this.releaseTerminalStatus("succeeded");
+      throw err;
+    }
     await publishSandboxFunctionInvocationEvent(
       {
         type: "sandbox_function_invocation_result",

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -263,11 +263,53 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     return this.data.error;
   }
 
-  async fail(error: Error | SandboxFunctionCallError): Promise<void> {
+  // Compare-and-set: only the caller that flips `created` owns the outcome. Guards the
+  // double-delivery window (worker stdout + late HTTP callback) without a lock.
+  // BaseResource.update() only keys on `id`, so the predicate goes on the model here
+  // (cf. ConversationForkResource.markFileCopied).
+  private async claimTerminalStatus(
+    status: Extract<SandboxFunctionInvocationStatus, "succeeded" | "errored">
+  ): Promise<boolean> {
+    const [affectedCount, rows] = await this.model.update(
+      { status },
+      {
+        where: {
+          id: this.id,
+          workspaceId: this.workspaceId,
+          status: "created",
+        },
+        returning: true,
+      }
+    );
+    if (affectedCount === 0) {
+      return false;
+    }
+    const row = rows[0];
+    if (row) {
+      Object.assign(this, row.get());
+    }
+    return true;
+  }
+
+  async fail(error: Error | SandboxFunctionCallError): Promise<boolean> {
     const callError: SandboxFunctionCallError =
       error instanceof Error
         ? { code: "invocation_failed", message: error.message }
         : error;
+
+    const claimed = await this.claimTerminalStatus("errored");
+    if (!claimed) {
+      logger.info(
+        {
+          workspaceId: this.workspaceId,
+          sandboxFunctionId: this.sandboxFunction.sId,
+          invocationId: this.sId,
+        },
+        "Skipping fail for an already-terminal Pod function invocation"
+      );
+      return false;
+    }
+
     this.data = {
       version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
       input: this.input,
@@ -278,7 +320,6 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       error: callError,
     };
     await this.writeDataToGcs();
-    await this.update({ status: "errored" });
     await publishSandboxFunctionInvocationEvent(
       {
         type: "sandbox_function_invocation_error",
@@ -289,9 +330,23 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       },
       { invocationId: this.sId }
     );
+    return true;
   }
 
-  async succeed(result: unknown): Promise<void> {
+  async succeed(result: unknown): Promise<boolean> {
+    const claimed = await this.claimTerminalStatus("succeeded");
+    if (!claimed) {
+      logger.info(
+        {
+          workspaceId: this.workspaceId,
+          sandboxFunctionId: this.sandboxFunction.sId,
+          invocationId: this.sId,
+        },
+        "Skipping succeed for an already-terminal Pod function invocation"
+      );
+      return false;
+    }
+
     this.data = {
       version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
       input: this.input,
@@ -299,7 +354,6 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       result,
     };
     await this.writeDataToGcs();
-    await this.update({ status: "succeeded" });
     await publishSandboxFunctionInvocationEvent(
       {
         type: "sandbox_function_invocation_result",
@@ -310,6 +364,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       },
       { invocationId: this.sId }
     );
+    return true;
   }
 
   async execute(auth: Authenticator): Promise<Result<undefined, Error>> {
@@ -587,10 +642,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   async markCreatedAsErrored(
     error: SandboxFunctionCallError
   ): Promise<boolean> {
-    if (this.status !== "created") {
+    const claimed = await this.claimTerminalStatus("errored");
+    if (!claimed) {
       return false;
     }
-    await this.update({ status: "errored" });
 
     // Do not overwrite the invocation blob here. This path only records that
     // execution failed before the runner could return a structured result.


### PR DESCRIPTION
## Description

Workstream 1, PR 1 of the Pod function latency program. No delivery-path behavior change yet.

- Move runner-envelope normalization out of the callback route into `front/lib/api/sandbox_functions/result_envelope.ts` so the worker can reuse it when reading stdout.
- Accept protocol v3 envelopes (`protocolVersion` / `delivery` / `outcome` / `timingsMs`) alongside the current runner and legacy HTTP shapes. Unknown `protocolVersion` values fail closed with an explicit message.
- Make `succeed` / `fail` / `markCreatedAsErrored` compare-and-set on status `created`, so exactly one deliverer owns an invocation outcome (also fixes a retried callback overwriting the blob today).
- If terminal blob persistence fails after a won claim, release the claim so a later fail path can still record the outcome.

Callback delivery, CLI, and sandbox image are unchanged.

## Tests

- Added unit coverage for v2/v3/legacy envelope normalization and bounded timingsMs keys.
- Extended resource tests for lost terminal claims and GCS write failure releasing the claim.
- Extended callback route tests for v3 envelopes and duplicate callbacks.
- Ran the related front, front-api, and Temporal activity suites locally.

## Risk

Low. Parser accepts a new envelope shape but nothing emits it yet. Rollback is a revert.

## Deploy Plan

Standard deploy.