### PR TITLE
[front] Per-workspace flip: enforce space access from group_permissions (#9480)

### DIFF
--- a/front/lib/api/assistant/configuration/yaml_import.test.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.test.ts
@@ -30,6 +30,8 @@ async function createPatchableAgent({
 
   const space = await SpaceFactory.regular(workspace);
   await GroupSpaceFactory.associate(space, globalGroup);
+  await space.writeGroupPermissions(auth);
+  await auth.refresh();
 
   const tag = await TagFactory.create(workspace, { name: "yaml-import-test" });
   const template = await TemplateFactory.published();
@@ -364,6 +366,8 @@ describe("patchAgentConfigurationFromJSON", () => {
 
     const space = await SpaceFactory.regular(workspace);
     await GroupSpaceFactory.associate(space, globalGroup);
+    await space.writeGroupPermissions(authenticator);
+    await authenticator.refresh();
 
     const createResult = await createAgentConfiguration(authenticator, {
       name: "YAML export test agent",

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -946,6 +946,11 @@ describe("createAgentMessages", () => {
       expect(refreshedOpenSpace).not.toBeNull();
       expect(refreshedOpenSpace?.isOpen()).toBe(true);
 
+      // `GroupSpaceFactory.associate` writes only the legacy group_vaults row; materialize the
+      // space's group_permissions (as the mutation paths do) and refresh the stale participant auth.
+      await refreshedOpenSpace!.writeGroupPermissions(adminAuth);
+      await auth.refresh();
+
       // Create a user who can access the space (all users can access open spaces)
       const mentionedUser = await UserFactory.basic();
       await MembershipFactory.associate(workspace, mentionedUser, {

--- a/front/lib/api/assistant/conversation/permissions.test.ts
+++ b/front/lib/api/assistant/conversation/permissions.test.ts
@@ -251,6 +251,8 @@ describe("canAgentBeUsedInProjectConversation", () => {
 
       const otherRestrictedSpace = await SpaceFactory.project(workspace);
 
+      await auth.refresh();
+
       const conversation = await ConversationFactory.create(auth, {
         agentConfigurationId: "test-agent",
         messagesCreatedAt: [],

--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -848,6 +848,10 @@ describe("DustFileSystem.forAgentLoop", () => {
         }
       );
 
+      // Refresh the session auth so its group_permissions snapshot includes the open project
+      // created after it was built.
+      await userSessionAuth.refresh();
+
       const access = await ConversationResource.canAccess(
         userSessionAuth,
         podConversation.sId

--- a/front/lib/api/projects/list.test.ts
+++ b/front/lib/api/projects/list.test.ts
@@ -115,6 +115,7 @@ describe("listPodsForScope", () => {
     });
     expect(betaPodRes.isOk()).toBe(true);
 
+    await adminAuth.refresh();
     const { pods, total } = await listPodsForScope(adminAuth, {
       access: "open",
       q: "alpha",
@@ -145,6 +146,7 @@ describe("listPodsForScope", () => {
     });
     expect(cafePodRes.isOk()).toBe(true);
 
+    await adminAuth.refresh();
     const { pods, total } = await listPodsForScope(adminAuth, {
       access: "open",
       q: "cafe",

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -827,6 +827,9 @@ describe("SkillResource", () => {
         skill1OnlySpace,
         testContext.globalGroup
       );
+      await sharedSpace.writeGroupPermissions(testContext.authenticator);
+      await skill1OnlySpace.writeGroupPermissions(testContext.authenticator);
+      await testContext.authenticator.refresh();
 
       const skill1 = await SkillFactory.create(testContext.authenticator, {
         name: "Skill 1",
@@ -1519,6 +1522,8 @@ describe("SkillResource", () => {
         restrictedSpace,
         testContext.globalGroup
       );
+      await restrictedSpace.writeGroupPermissions(testContext.authenticator);
+      await testContext.authenticator.refresh();
 
       const skill = await SkillFactory.create(testContext.authenticator, {
         name: "Skill With Space To Archive",
@@ -1564,6 +1569,8 @@ describe("SkillResource", () => {
     it("keeps a space on the agent when archiving a skill if another active skill still requires it", async () => {
       const sharedSpace = await SpaceFactory.regular(testContext.workspace);
       await GroupSpaceFactory.associate(sharedSpace, testContext.globalGroup);
+      await sharedSpace.writeGroupPermissions(testContext.authenticator);
+      await testContext.authenticator.refresh();
 
       const skill1 = await SkillFactory.create(testContext.authenticator, {
         name: "Skill 1 Sharing Space",
@@ -1805,6 +1812,8 @@ describe("SkillResource", () => {
     it("should return skills that use any of the given MCP server view IDs", async () => {
       const space = await SpaceFactory.regular(testContext.workspace);
       await GroupSpaceFactory.associate(space, testContext.globalGroup);
+      await space.writeGroupPermissions(testContext.authenticator);
+      await testContext.authenticator.refresh();
 
       const server = await RemoteMCPServerFactory.create(testContext.workspace);
       const serverView = await MCPServerViewFactory.create(
@@ -1854,6 +1863,8 @@ describe("SkillResource", () => {
     it("should return skills that use any of the given data source view IDs", async () => {
       const space = await SpaceFactory.regular(testContext.workspace);
       await GroupSpaceFactory.associate(space, testContext.globalGroup);
+      await space.writeGroupPermissions(testContext.authenticator);
+      await testContext.authenticator.refresh();
 
       const dsv1 = await DataSourceViewFactory.folder(
         testContext.workspace,
@@ -2268,6 +2279,8 @@ describe("SkillResource", () => {
     it("should return attached knowledge from data source configurations", async () => {
       const space = await SpaceFactory.regular(testContext.workspace);
       await GroupSpaceFactory.associate(space, testContext.globalGroup);
+      await space.writeGroupPermissions(testContext.authenticator);
+      await testContext.authenticator.refresh();
 
       const dsv = await DataSourceViewFactory.folder(
         testContext.workspace,

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -17,10 +17,8 @@ import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
-import logger from "@app/logger/logger";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SandboxEnvVarFactory } from "@app/tests/utils/SandboxEnvVarFactory";
@@ -971,6 +969,10 @@ describe("SpaceResource", () => {
             group: projectEditorGroup,
             space: projectSpace,
           });
+
+          // The associations were created directly (not through createSpace/updatePermissions), so
+          // seed the space's group_permissions from them.
+          await projectSpace.writeGroupPermissions(adminAuth, {});
         });
 
         it("should not allow simple members to update space permissions", async () => {
@@ -1435,6 +1437,10 @@ describe("SpaceResource", () => {
             group: provisionedEditorGroup,
             space: projectSpace,
           });
+
+          // The associations were created directly (not through createSpace/updatePermissions), so
+          // seed the space's group_permissions from them.
+          await projectSpace.writeGroupPermissions(adminAuth, {});
         });
 
         it("should not allow simple members to update space permissions", async () => {
@@ -2332,7 +2338,7 @@ describe("SpaceResource cleanup on delete", () => {
   });
 });
 
-describe("SpaceResource group_permissions shadow-compare", () => {
+describe("SpaceResource group_permissions enforcement", () => {
   let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
   let adminAuth: Authenticator;
   let memberUser: UserResource;
@@ -2376,116 +2382,34 @@ describe("SpaceResource group_permissions shadow-compare", () => {
     return space;
   }
 
-  // The two sides shadowCompareSpacePermission compares must agree on every verb: the served ACLs
-  // (roles + `group_vaults` groups) and the governance ACLs (same roles, groups from the table).
-  function expectAclParity(auth: Authenticator, space: SpaceResource): void {
-    const legacyAcls = space.getAccessControlLists(auth);
-    const candidateAcls = space.governanceAcls(auth);
+  it("enforces the table: member can read from the space's group grants", async () => {
+    // `SpaceFactory.regular` writes the space's group_permissions on creation.
+    const space = await setupRestrictedSpaceWithMember();
 
-    for (const permission of ["read", "write", "admin"] as const) {
-      expect({
-        spaceKind: space.kind,
-        permission,
-        granted: auth.hasPermissionForAcls(permission, candidateAcls),
-      }).toEqual({
-        spaceKind: space.kind,
-        permission,
-        granted: auth.hasPermissionForAcls(permission, legacyAcls),
-      });
-    }
-  }
+    const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      memberUser.sId,
+      workspace.sId
+    );
 
-  // Space creation dual-writes the space's grants (#9478), so divergence has to be introduced on
-  // purpose: dropping the rows models a space whose grants were never backfilled.
-  async function clearTableGrants(space: SpaceResource): Promise<void> {
+    // Member group confers read+write; served from the group_permissions table.
+    expect(space.canRead(memberAuth)).toBe(true);
+    expect(space.canWrite(memberAuth)).toBe(true);
+  });
+
+  it("enforces the table: member is denied when the space has no grants", async () => {
+    // Member is in the space's inline group, but with the table cleared access is served from the
+    // (empty) table — denied.
+    const space = await setupRestrictedSpaceWithMember();
     await GroupPermissionResource.deleteAllForResource(adminAuth, {
       resourceType: "space",
       resourceId: space.id,
     });
-  }
-
-  it("logs a mismatch when the table diverges from the group rules", async () => {
-    // The table grants nothing, but the member group still grants read via the code rules.
-    const space = await setupRestrictedSpaceWithMember();
-    await clearTableGrants(space);
-    await FeatureFlagFactory.basic(adminAuth, "group_permissions_shadow");
-
-    const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
-      memberUser.sId,
-      workspace.sId
-    );
-    const warn = vi.spyOn(logger, "warn");
-
-    // Served result is unchanged (legacy: role OR group grants read).
-    expect(space.canRead(memberAuth)).toBe(true);
-
-    await vi.waitFor(() =>
-      expect(warn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          resource: "space",
-          spaceId: space.sId,
-          permission: "read",
-        }),
-        "group_permissions_shadow_mismatch"
-      )
-    );
-  });
-
-  it("reaches parity once the grants are backfilled", async () => {
-    const space = await setupRestrictedSpaceWithMember();
-    await clearTableGrants(space);
-    await space.writeGroupPermissions(adminAuth);
-
-    // Build the auth AFTER the write so its GroupPermissions snapshot includes the grants.
-    const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
-      memberUser.sId,
-      workspace.sId
-    );
-
-    // Legacy: the served ACLs (roles + inline groups). Candidate: the governance ACLs, as
-    // shadowCompareSpacePermission builds them.
-    expectAclParity(memberAuth, space);
-  });
-
-  it("reaches parity on the system, global and conversations spaces", async () => {
-    const spaces = await SpaceResource.listWorkspaceSpaces(adminAuth, {
-      includeConversationsSpace: true,
-    });
-    const defaultSpaces = spaces.filter(
-      (space) => space.isSystem() || space.isGlobal() || space.isConversations()
-    );
-    expect(defaultSpaces.length).toBeGreaterThan(0);
 
     const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
       memberUser.sId,
       workspace.sId
     );
 
-    for (const space of defaultSpaces) {
-      expectAclParity(memberAuth, space);
-      expectAclParity(adminAuth, space);
-    }
-  });
-
-  it("never logs a mismatch while the flag is off", async () => {
-    // Divergent data (the table grants nothing) but the flag is off, so the compare never runs.
-    const space = await setupRestrictedSpaceWithMember();
-    await clearTableGrants(space);
-
-    const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
-      memberUser.sId,
-      workspace.sId
-    );
-    const warn = vi.spyOn(logger, "warn");
-
-    expect(space.canRead(memberAuth)).toBe(true);
-
-    // Flush the fire-and-forget; with the flag off it short-circuits before comparing.
-    await new Promise((resolve) => setImmediate(resolve));
-    await new Promise((resolve) => setImmediate(resolve));
-    expect(warn).not.toHaveBeenCalledWith(
-      expect.anything(),
-      "group_permissions_shadow_mismatch"
-    );
+    expect(space.canRead(memberAuth)).toBe(false);
   });
 });

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -25,7 +25,6 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
-import type { GrantVerb } from "@app/types/group_permissions";
 import type { GroupKind, GroupType } from "@app/types/groups";
 import {
   GLOBAL_SPACE_NAME,
@@ -35,7 +34,6 @@ import {
 } from "@app/types/groups";
 import type {
   AccessControlList,
-  GroupGrant,
   RoleGrant,
 } from "@app/types/resource_permissions";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -1814,23 +1812,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       {
         workspaceId: this.workspaceId,
         roles: this.spaceRoleGrants(),
-        groups: this.legacySpaceGroupGrants(),
-      },
-    ];
-  }
-
-  /**
-   * The space's access-control list built from governance data: the code role rules plus the groups
-   *  held in `group_permissions`. At the flip this becomes the served `getAccessControlLists(auth)`
-   *  and `legacySpaceGroupGrants` is deleted without touching it.
-   *
-   * Until then it is the shadow-compare candidate.
-   */
-  governanceAcls(auth: Authenticator): AccessControlList[] {
-    return [
-      {
-        workspaceId: this.workspaceId,
-        roles: this.spaceRoleGrants(),
+        // Group access is enforced from the group_permissions table (#9480): the caller's grants
+        // on this space. The per-kind role rules above are unchanged. `writeGroupPermissions`
+        // keeps the table in sync from the `group_vaults` associations (see `spaceGroupRoles`).
         groups: auth.getGroupPermissions("space", this.id),
       },
     ];
@@ -1928,65 +1912,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     }));
   }
 
-  // The group grants this space confers, derived from its `group_vaults` associations in code, with
-  // the verbs stated literally as `GroupResource.getAccessControlLists` does. This is the legacy
-  // path: what `getAccessControlLists` serves until the flip.
-  private legacySpaceGroupGrants(): GroupGrant[] {
-    // System space: its groups manage the workspace's connections.
-    if (this.isSystem()) {
-      return this.groups.map((group) => ({
-        id: group.groupId,
-        permissions: ["read", "write"],
-      }));
-    }
-
-    // Global Workspace space and Conversations space: write comes from the role grants.
-    if (this.isGlobal() || this.isConversations()) {
-      return this.groups.map((group) => ({
-        id: group.groupId,
-        permissions: ["read"],
-      }));
-    }
-
-    // Provisioned groups do not carry grants on manually-managed spaces.
-    const groups =
-      this.managementMode === "manual"
-        ? this.groups.filter((group) => !group.isProvisioned())
-        : this.groups;
-
-    // Open regular space: every group only reads; write comes from the role grants.
-    if (this.isRegularAndOpen()) {
-      return groups.map((group) => ({
-        id: group.groupId,
-        permissions: ["read"],
-      }));
-    }
-
-    if (this.isProject()) {
-      return groups.map((group) => {
-        switch (group.groupSpaceKind) {
-          case "project_editor":
-            return {
-              id: group.groupId,
-              permissions: ["admin", "read", "write"],
-            };
-          case "member":
-            return { id: group.groupId, permissions: ["read", "write"] };
-          case "project_viewer":
-            return { id: group.groupId, permissions: ["read"] };
-          default:
-            assertNever(group.groupSpaceKind);
-        }
-      });
-    }
-
-    // Restricted regular space.
-    return groups.map((group) => ({
-      id: group.groupId,
-      permissions: ["read", "write"],
-    }));
-  }
-
   // Writes this space's `group_permissions` rows from the roles its `group_vaults` associations
   // confer (see `spaceGroupRoles`). The space mutation paths call this to keep the table in sync as
   // the source of truth. Idempotent — it clears the space's instance grants then re-inserts the
@@ -2079,46 +2004,15 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   canAdministrate(auth: Authenticator) {
-    const perms = this.getAccessControlLists(auth);
-    this.shadowCompareSpacePermission(auth, perms, "admin");
-    return auth.hasPermissionForAcls("admin", perms);
+    return auth.hasPermission("admin", this);
   }
 
   canWrite(auth: Authenticator) {
-    const perms = this.getAccessControlLists(auth);
-    this.shadowCompareSpacePermission(auth, perms, "write");
-    return auth.hasPermissionForAcls("write", perms);
+    return auth.hasPermission("write", this);
   }
 
   canRead(auth: Authenticator) {
-    const perms = this.getAccessControlLists(auth);
-    this.shadowCompareSpacePermission(auth, perms, "read");
-    return auth.hasPermissionForAcls("read", perms);
-  }
-
-  // Shadow-compare: while the `group_permissions_shadow` flag is on for the workspace, check
-  // whether the governance ACL yields the same decision as the legacy inline-group ACL. Legacy is
-  // the served `getAccessControlLists(auth)` (groups from the `group_vaults` associations); the
-  // candidate is `governanceAcls`, built independently from the table. Delegates the flag lookup +
-  // compare + log to the Authenticator as fire-and-forget — never changes the served result.
-  private shadowCompareSpacePermission(
-    auth: Authenticator,
-    legacyAcls: AccessControlList[],
-    permission: GrantVerb
-  ): void {
-    auth.shadowComparePermission(
-      permission,
-      legacyAcls,
-      this.governanceAcls(auth),
-      {
-        resource: "space",
-        spaceId: this.sId,
-        permission,
-        workspaceId: this.workspaceId,
-        // Null for non-user callers (API keys, internal auth).
-        userId: auth.user()?.sId ?? null,
-      }
-    );
+    return auth.hasPermission("read", this);
   }
 
   canReadOrAdministrate(auth: Authenticator) {

--- a/front/migrations/20260728_backfill_space_group_permissions.ts
+++ b/front/migrations/20260728_backfill_space_group_permissions.ts
@@ -50,7 +50,7 @@ async function backfillWorkspaceSpaceGroupPermissions(
         return;
       }
 
-      // One transaction per space so a space is never left without its grants mid-reconcile.
+      // One transaction per space so a space is never left without its grants mid-write.
       await frontSequelize.transaction(async (transaction) => {
         await space.writeGroupPermissions(auth, { transaction });
       });


### PR DESCRIPTION
## Description

Final step of the space-permissions migration ([#9477](https://github.com/dust-tt/tasks/issues/9477)) — sub-issue [#9480](https://github.com/dust-tt/tasks/issues/9480): **flip space access to the `group_permissions` table**.

Stacked on #29639 (shadow). Once shadow-mode confirmed parity, this makes the table the enforced source of truth for space group access. **No feature flag** — the table is written directly at every mutation site (#29619) and backfilled for existing spaces, so it is authoritative everywhere.

### What it does

- **`SpaceResource.getAccessControlLists(auth)`** now returns a single ACL: the (unchanged) per-kind **role** rules + **`auth.getGroupPermissions("space", id)`** for groups — i.e. group access resolved from the `group_permissions` table instead of the legacy inline `group_vaults`.
- **`canRead` / `canWrite` / `canAdministrate`** collapse to `auth.hasPermission(verb, this)`. No `servedAcls` / `governanceAcls` branching.
- `spaceGroupGrants()` (the `group_vaults`-derived grants) stays — it is what `writeGroupPermissions` keeps the table in sync from — but it no longer feeds enforcement.

### Removed / kept
- **Removed:** the `group_permissions_enforce` flag, the `enforced` bit on `GroupPermissions` (+ `isEnforced` / `isGroupPermissionsEnforced` / the resolve-time preload), `servedAcls`, `governanceAcls`, the space `shadowCompareSpacePermission` wiring, and `reconcileGroupPermissions` (the backfill alias — the migration now calls `writeGroupPermissions` directly).
- **Kept:** `Authenticator.shadowComparePermission` and the `group_permissions_shadow` flag, for reuse on other resources.

### Behavior
Group access to every space is now served from the table. `getGroupPermissions` is caller-scoped; the membership check that the composed ACL relied on was already caller-relative, so the served decision is preserved for a correctly-populated table. Admin access flows through the unchanged role path.

## Risk
Medium — this is the step that changes the *served* decision. Correctness depends on the table being populated (direct writes at all mutation sites + the #29619 backfill). `AccessControlList.workspaceId` still gates the role path.

## Tests
Space checks now assert access via the table; `tsgo` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
