### PR TITLE
Use the same model picker in the input bar and the agent builder.

### DIFF
--- a/front/components/agent_builder/AgentBuilderSectionContainer.tsx
+++ b/front/components/agent_builder/AgentBuilderSectionContainer.tsx
@@ -18,7 +18,7 @@ export function AgentBuilderSectionContainer({
   return (
     <section className="flex flex-col gap-3">
       <div className="flex flex-col items-start justify-between gap-2 sm:flex-row sm:items-end">
-        <div>
+        <div className="max-w-9/10">
           <div className="flex flex-row items-center gap-2">
             <h2 className="heading-lg text-foreground">{title}</h2>
           </div>

--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -173,7 +173,7 @@ export function AgentBuilderSpacesBlock({
       <div className="flex items-start justify-between">
         <div>
           <h2 className="heading-lg text-foreground">Data and access</h2>
-          <p className="text-sm text-muted-foreground">
+          <p className="text-sm text-muted-foreground max-w-9/10">
             Adding spaces or pods will make the data from each of them available
             to the agent. Only members of all the spaces and pods listed will
             have access to the agent.

--- a/front/components/agent_builder/instructions/AdvancedSettings.tsx
+++ b/front/components/agent_builder/instructions/AdvancedSettings.tsx
@@ -2,15 +2,18 @@ import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuild
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { ModelSelectionSubmenu } from "@app/components/agent_builder/instructions/ModelSelectionSubmenu";
 import { ReasoningEffortSubmenu } from "@app/components/agent_builder/instructions/ReasoningEffortSubmenu";
+import { ModelPicker } from "@app/components/assistant/conversation/input_bar/InputBarModelPicker";
 import { SuspensedCodeEditor } from "@app/components/SuspensedCodeEditor";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useModels } from "@app/lib/swr/models";
 import { isSupportingResponseFormat } from "@app/types/assistant/assistant";
-import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
+import { isModelStreamId } from "@app/types/assistant/models/auto";
+import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import { validateResponseFormat } from "@app/types/assistant/models/utils";
+import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
-  Chip,
   cn,
   Dialog,
   DialogContainer,
@@ -26,9 +29,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   File04,
-  SliderToggle,
 } from "@dust-tt/sparkle";
-import React, { useCallback, useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 import { useController } from "react-hook-form";
 
 function getResponseFormatError(value: string): string | null {
@@ -58,17 +60,111 @@ const RESPONSE_FORMAT_PLACEHOLDER =
   "  }\n" +
   "}";
 
-export function AdvancedSettings() {
+function StructuredResponseFormatDialog({
+  isOpen,
+  onOpenChange,
+}: {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
   const { isDark } = useTheme();
-  const { owner } = useAgentBuilderContext();
-  const { models } = useModels({ owner });
 
-  const [autoModel, otherModels] = useMemo(() => {
-    return [
-      models.find((model) => model.modelId === AUTO_MODEL_ID),
-      models.filter((model) => model.modelId !== AUTO_MODEL_ID),
-    ];
-  }, [models]);
+  const { field: responseFormatField } = useController<
+    AgentBuilderFormData,
+    "generationSettings.responseFormat"
+  >({
+    name: "generationSettings.responseFormat",
+  });
+
+  const [tempResponseFormat, setTempResponseFormat] = React.useState<
+    string | null
+  >(null);
+  const currentValue = tempResponseFormat ?? responseFormatField.value ?? "";
+  const validationError = getResponseFormatError(currentValue);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent size="xl" height="lg">
+        <DialogHeader>
+          <DialogTitle visual={<File04 />}>
+            Structured response format
+          </DialogTitle>
+          <DialogDescription>
+            Specify a JSON schema to get responses in a consistent structure.{" "}
+            <a
+              href="https://docs.dust.tt/docs/structured-output-format"
+              target="_blank"
+              rel="noreferrer"
+              className="underline"
+            >
+              See documentation
+            </a>
+          </DialogDescription>
+        </DialogHeader>
+        <DialogContainer>
+          <SuspensedCodeEditor
+            data-color-mode={isDark ? "dark" : "light"}
+            value={currentValue}
+            placeholder={RESPONSE_FORMAT_PLACEHOLDER}
+            name="responseFormat"
+            onChange={(e) => setTempResponseFormat(e.target.value)}
+            minHeight={400}
+            className={cn(
+              "rounded-lg bg-primary-100",
+              validationError && "border-2 border-red-500 bg-primary-100"
+            )}
+            style={{
+              fontSize: 13,
+              fontFamily:
+                "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
+              overflowY: "auto",
+            }}
+            language="json"
+          />
+          {validationError && (
+            <p className="text-sm text-red-500">{validationError}</p>
+          )}
+        </DialogContainer>
+        <DialogFooter
+          className="pt-2"
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: () => {
+              setTempResponseFormat(null);
+              onOpenChange(false);
+            },
+          }}
+          rightButtonProps={{
+            label: "Save",
+            disabled: !!validationError,
+            onClick: () => {
+              if (tempResponseFormat !== null) {
+                responseFormatField.onChange(tempResponseFormat);
+              }
+              setTempResponseFormat(null);
+              onOpenChange(false);
+            },
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function AdvancedSettingsLegacy({
+  owner,
+  setIsResponseFormatDialogOpen,
+}: {
+  owner: LightWorkspaceType;
+  setIsResponseFormatDialogOpen: (open: boolean) => void;
+}) {
+  const { models: allModels } = useModels({ owner });
+
+  // Filter out the auto models and get the rest
+  const [_, models] = useMemo(() => {
+    return [[], allModels.filter((m) => !isModelStreamId(m.modelId))];
+  }, [allModels]);
 
   const { field: modelSettingsField } = useController<
     AgentBuilderFormData,
@@ -76,51 +172,10 @@ export function AdvancedSettings() {
   >({
     name: "generationSettings.modelSettings",
   });
-  const { field: responseFormatField } = useController<
-    AgentBuilderFormData,
-    "generationSettings.responseFormat"
-  >({
-    name: "generationSettings.responseFormat",
-  });
-  const [isResponseFormatDialogOpen, setIsResponseFormatDialogOpen] =
-    React.useState(false);
-  const [tempResponseFormat, setTempResponseFormat] = React.useState<
-    string | null
-  >(null);
-
-  const [modelSettingsBeforeAuto, setModelSettingsBeforeAuto] = React.useState<
-    AgentBuilderFormData["generationSettings"]["modelSettings"] | null
-  >(null);
-
-  const isAutoModelSelected =
-    modelSettingsField.value?.modelId === AUTO_MODEL_ID || false;
-
-  const handleAutoModelSelection = useCallback(
-    (e: React.MouseEvent<HTMLElement>) => {
-      e.preventDefault();
-      e.stopPropagation();
-
-      if (!isAutoModelSelected) {
-        setModelSettingsBeforeAuto(modelSettingsField.value);
-        modelSettingsField.onChange({ ...autoModel });
-      } else {
-        modelSettingsField.onChange(modelSettingsBeforeAuto ?? null);
-      }
-    },
-    [
-      modelSettingsField,
-      modelSettingsBeforeAuto,
-      autoModel,
-      isAutoModelSelected,
-    ]
-  );
 
   if (!models) {
     return null;
   }
-
-  const currentValue = tempResponseFormat ?? responseFormatField.value ?? "";
-  const validationError = getResponseFormatError(currentValue);
 
   const supportsResponseFormat =
     modelSettingsField.value &&
@@ -133,34 +188,8 @@ export function AdvancedSettings() {
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start">
           <DropdownMenuLabel label="Model selection" />
-          {autoModel && (
-            <DropdownMenuItem onClick={handleAutoModelSelection}>
-              <div className="flex w-full items-center gap-x-2.5">
-                <div className="flex grow flex-col">
-                  <span className="flex items-center gap-2">
-                    Auto
-                    <Chip size="xs" color="highlight" label="Recommended" />
-                  </span>
-                  <span className="whitespace-normal text-xs font-normal text-muted-foreground">
-                    Switches model depending on current availability for
-                    balanced performance.
-                  </span>
-                </div>
-                <SliderToggle
-                  selected={isAutoModelSelected}
-                  onClick={handleAutoModelSelection}
-                />
-              </div>
-            </DropdownMenuItem>
-          )}
-
-          {!isAutoModelSelected && (
-            <>
-              <ModelSelectionSubmenu models={otherModels} />
-              <ReasoningEffortSubmenu models={otherModels} />
-            </>
-          )}
-
+          <ModelSelectionSubmenu models={models} />
+          <ReasoningEffortSubmenu models={models} />
           {supportsResponseFormat && (
             <>
               <DropdownMenuSeparator />
@@ -168,7 +197,6 @@ export function AdvancedSettings() {
                 label="Structured response format"
                 onSelect={() => {
                   setTimeout(() => {
-                    setTempResponseFormat(responseFormatField.value ?? null);
                     setIsResponseFormatDialogOpen(true);
                   }, 0);
                 }}
@@ -177,76 +205,122 @@ export function AdvancedSettings() {
           )}
         </DropdownMenuContent>
       </DropdownMenu>
-
-      <Dialog
-        open={isResponseFormatDialogOpen}
-        onOpenChange={setIsResponseFormatDialogOpen}
-      >
-        <DialogContent size="xl" height="lg">
-          <DialogHeader>
-            <DialogTitle visual={<File04 />}>
-              Structured response format
-            </DialogTitle>
-            <DialogDescription>
-              Specify a JSON schema to get responses in a consistent structure.{" "}
-              <a
-                href="https://docs.dust.tt/docs/structured-output-format"
-                target="_blank"
-                rel="noreferrer"
-                className="underline"
-              >
-                See documentation
-              </a>
-            </DialogDescription>
-          </DialogHeader>
-          <DialogContainer>
-            <SuspensedCodeEditor
-              data-color-mode={isDark ? "dark" : "light"}
-              value={currentValue}
-              placeholder={RESPONSE_FORMAT_PLACEHOLDER}
-              name="responseFormat"
-              onChange={(e) => setTempResponseFormat(e.target.value)}
-              minHeight={400}
-              className={cn(
-                "rounded-lg bg-primary-100",
-                validationError && "border-2 border-red-500 bg-primary-100"
-              )}
-              style={{
-                fontSize: 13,
-                fontFamily:
-                  "ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, Menlo, monospace",
-                overflowY: "auto",
-              }}
-              language="json"
-            />
-            {validationError && (
-              <p className="text-sm text-red-500">{validationError}</p>
-            )}
-          </DialogContainer>
-          <DialogFooter
-            className="pt-2"
-            leftButtonProps={{
-              label: "Cancel",
-              variant: "outline",
-              onClick: () => {
-                setTempResponseFormat(null);
-                setIsResponseFormatDialogOpen(false);
-              },
-            }}
-            rightButtonProps={{
-              label: "Save",
-              disabled: !!validationError,
-              onClick: () => {
-                if (tempResponseFormat !== null) {
-                  responseFormatField.onChange(tempResponseFormat);
-                }
-                setTempResponseFormat(null);
-                setIsResponseFormatDialogOpen(false);
-              },
-            }}
-          />
-        </DialogContent>
-      </Dialog>
     </>
   );
+}
+
+export function AdvancedSettings() {
+  const { owner } = useAgentBuilderContext();
+  const { hasFeature } = useFeatureFlags();
+  const hasModelsPicker = hasFeature("models_picker");
+
+  const [isResponseFormatDialogOpen, setIsResponseFormatDialogOpen] =
+    React.useState(false);
+
+  const { field: generationSettingsField } = useController<
+    AgentBuilderFormData,
+    "generationSettings"
+  >({
+    name: "generationSettings",
+  });
+
+  const [modelSelection, setModelSelection] = React.useState<
+    ModelSelectionType | undefined
+  >(undefined);
+
+  useEffect(() => {
+    const modelId = generationSettingsField.value.modelSettings?.modelId;
+    const providerId = generationSettingsField.value.modelSettings?.providerId;
+    const reasoningEffort =
+      generationSettingsField.value.reasoningEffort ?? undefined;
+    if (!modelId || !providerId) {
+      setModelSelection(undefined);
+    } else if (
+      modelId !== modelSelection?.modelId ||
+      providerId !== modelSelection?.providerId ||
+      reasoningEffort !== modelSelection?.reasoningEffort
+    ) {
+      setModelSelection({
+        modelId,
+        providerId,
+        reasoningEffort,
+      });
+    }
+  }, [
+    generationSettingsField.value.modelSettings?.modelId,
+    generationSettingsField.value.modelSettings?.providerId,
+    generationSettingsField.value.reasoningEffort,
+    modelSelection?.modelId,
+    modelSelection?.providerId,
+    modelSelection?.reasoningEffort,
+  ]);
+
+  const supportsResponseFormat =
+    generationSettingsField.value.modelSettings &&
+    isSupportingResponseFormat(
+      generationSettingsField.value.modelSettings.modelId
+    );
+
+  if (hasModelsPicker) {
+    return (
+      <>
+        <StructuredResponseFormatDialog
+          isOpen={isResponseFormatDialogOpen}
+          onOpenChange={setIsResponseFormatDialogOpen}
+        />
+        <ModelPicker
+          // Set these 2 as we are in the context of the agent builder, not a conversation
+          agentId={null}
+          agentModel={null}
+          // Use what is in the agent builder form
+          lastRequestedModel={modelSelection ?? null}
+          owner={owner}
+          buttonSize="sm"
+          buttonVariant="outline"
+          showLabel={true}
+          side="top"
+          disabled={false}
+          onSelectionChange={(newModelSelection) => {
+            // Keep both in sync to avoid extra re-renders
+            setModelSelection(newModelSelection);
+            generationSettingsField.onChange({
+              ...generationSettingsField.value,
+              reasoningEffort: newModelSelection?.reasoningEffort,
+              modelSettings: {
+                modelId: newModelSelection?.modelId,
+                providerId: newModelSelection?.providerId,
+              },
+            });
+          }}
+        />
+        <Button
+          label="JSON Response"
+          variant="outline"
+          size="sm"
+          disabled={!supportsResponseFormat}
+          tooltip={
+            !supportsResponseFormat
+              ? "Pick a specific model that supports structured response format (JSON schema)"
+              : "Will constrain the model to a specific JSON schema"
+          }
+          onClick={() => {
+            setIsResponseFormatDialogOpen(true);
+          }}
+        />
+      </>
+    );
+  } else {
+    return (
+      <>
+        <StructuredResponseFormatDialog
+          isOpen={isResponseFormatDialogOpen}
+          onOpenChange={setIsResponseFormatDialogOpen}
+        />
+        <AdvancedSettingsLegacy
+          owner={owner}
+          setIsResponseFormatDialogOpen={setIsResponseFormatDialogOpen}
+        />
+      </>
+    );
+  }
 }

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -146,16 +146,10 @@ export const InputBar = React.memo(function InputBar({
     DataSourceViewContentNode[]
   >([]);
 
-  // Latest model-picker selection, kept in a ref so the picker's change events
-  // don't re-render the whole input bar; read at submit time. `undefined` means
+  // Latest model-picker selection. The picker writes into this ref so we can
+  // read it at submit without re-rendering the input bar. `undefined` means
   // no override (run the agent's configured model).
   const modelSelectionRef = useRef<ModelSelectionType | undefined>(undefined);
-  const handleModelSelectionChange = useCallback(
-    (modelSelection: ModelSelectionType | undefined) => {
-      modelSelectionRef.current = modelSelection;
-    },
-    []
-  );
 
   const {
     getAndClearSelectedAgent,
@@ -776,7 +770,7 @@ export const InputBar = React.memo(function InputBar({
             isSelectableSpacesLoading={isSelectableSpacesLoading}
             onSelectedSpaceIdsChange={handleSelectedSpaceIdsChange}
             onMCPServerViewSelect={handleMCPServerViewSelect}
-            onModelSelectionChange={handleModelSelectionChange}
+            modelSelectionRef={modelSelectionRef}
             onMCPServerViewDeselect={handleMCPServerViewDeselect}
             onResetMCPServerViews={handleResetMCPServerViews}
             isAgentBuilder={isAgentBuilder}

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -57,9 +57,9 @@ interface InputBarButtonsProps {
   lastRequestedModel: ModelSelectionType | null;
   onAgentRemove: () => void;
   onMCPServerViewSelect: (serverView: MCPServerViewLightType) => void;
-  onModelSelectionChange?: (
-    modelSelection: ModelSelectionType | undefined
-  ) => void;
+  // Read-at-submit sink for the model picker; prefer over a change callback
+  // when the parent only needs the value at submit time.
+  modelSelectionRef?: React.MutableRefObject<ModelSelectionType | undefined>;
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
   onSkillSelect: (skill: SkillWithoutInstructionsAndToolsType) => void;
@@ -91,7 +91,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
   lastRequestedModel,
   onAgentRemove,
   onMCPServerViewSelect,
-  onModelSelectionChange,
+  modelSelectionRef,
   onNodeSelect,
   onNodeUnselect,
   onSkillSelect,
@@ -258,7 +258,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
       buttonSize={buttonSize}
       side={conversation ? "top" : "bottom"}
       disabled={isInputDisabled}
-      onSelectionChange={onModelSelectionChange}
+      selectionRef={modelSelectionRef}
     />
   );
 

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -230,9 +230,7 @@ export interface InputBarContainerProps {
   onEnterKeyDown: CustomEditorProps["onEnterKeyDown"];
   onMCPServerViewDeselect: (serverView: MCPServerViewLightType) => void;
   onMCPServerViewSelect: (serverView: MCPServerViewLightType) => void;
-  onModelSelectionChange?: (
-    modelSelection: ModelSelectionType | undefined
-  ) => void;
+  modelSelectionRef?: React.MutableRefObject<ModelSelectionType | undefined>;
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
   onResetMCPServerViews: () => void;
@@ -292,7 +290,7 @@ const InputBarContainer = ({
   onNodeUnselect,
   attachedNodes,
   onMCPServerViewSelect,
-  onModelSelectionChange,
+  modelSelectionRef,
   onMCPServerViewDeselect,
   selectedMCPServerViews,
   selectedSpaceIds = EMPTY_SPACE_IDS,
@@ -1770,7 +1768,7 @@ const InputBarContainer = ({
                       lastRequestedModel={lastRequestedModel}
                       onAgentRemove={() => setSelectedSingleAgent(null)}
                       onMCPServerViewSelect={onMCPServerViewSelect}
-                      onModelSelectionChange={onModelSelectionChange}
+                      modelSelectionRef={modelSelectionRef}
                       onNodeSelect={onNodeSelect}
                       onNodeUnselect={onNodeUnselect}
                       onSkillSelect={handleSkillSelect}

--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -40,7 +40,7 @@ import {
   DropdownMenu,
   DropdownMenuTrigger,
 } from "@dust-tt/sparkle";
-import type { ComponentType } from "react";
+import type { ComponentType, MutableRefObject } from "react";
 import { useContext, useEffect, useMemo, useRef, useState } from "react";
 
 const TIER_BUTTON_ICON: Record<ModelTierId, ComponentType> = {
@@ -49,19 +49,13 @@ const TIER_BUTTON_ICON: Record<ModelTierId, ComponentType> = {
   complex: BarFull,
 };
 
-interface InputBarModelPickerProps {
-  agentModel: AgentModelConfigurationType | null;
-  agentId: string | null;
-  lastRequestedModel: ModelSelectionType | null;
-  owner: LightWorkspaceType;
-  buttonSize: "xs" | "sm";
-  // Which side the dropdown opens toward. Mirrors the agent picker: "top" in an
-  // active conversation (input bar pinned to the bottom), "bottom" on the new
-  // conversation screen where there is room below.
-  side?: "top" | "bottom";
-  disabled?: boolean;
-  onSelectionChange?: (modelSelection: ModelSelectionType | undefined) => void;
-}
+type InputBarModelPickerProps = Omit<
+  ModelPickerProps,
+  | "buttonVariant"
+  | "showLabel"
+  | "setStickyModelOverride"
+  | "stickyModelOverride"
+>;
 
 export function InputBarModelPicker({
   agentModel,
@@ -71,14 +65,75 @@ export function InputBarModelPicker({
   buttonSize,
   side = "top",
   disabled,
+  selectionRef,
   onSelectionChange,
 }: InputBarModelPickerProps) {
+  const { stickyModelOverride, setStickyModelOverride } =
+    useContext(InputBarContext);
+
+  return (
+    <ModelPicker
+      agentModel={agentModel}
+      agentId={agentId}
+      lastRequestedModel={lastRequestedModel}
+      owner={owner}
+      buttonVariant={"ghost-secondary"}
+      buttonSize={buttonSize}
+      showLabel={false}
+      side={side}
+      disabled={disabled}
+      selectionRef={selectionRef}
+      onSelectionChange={onSelectionChange}
+      stickyModelOverride={stickyModelOverride}
+      setStickyModelOverride={setStickyModelOverride}
+    />
+  );
+}
+
+interface ModelPickerProps {
+  agentModel: AgentModelConfigurationType | null;
+  agentId: string | null;
+  lastRequestedModel: ModelSelectionType | null;
+  owner: LightWorkspaceType;
+  buttonVariant: "outline" | "ghost-secondary";
+  buttonSize: "xs" | "sm";
+  showLabel: boolean;
+  // Which side the dropdown opens toward. Mirrors the agent picker: "top" in an
+  // active conversation (input bar pinned to the bottom), "bottom" on the new
+  // conversation screen where there is room below.
+  side?: "top" | "bottom";
+  disabled?: boolean;
+  // Read-at-submit sink. The picker writes the current toSend here (including
+  // derived changes like agent switches); never triggers a parent re-render.
+  selectionRef?: MutableRefObject<ModelSelectionType | undefined>;
+  // Fired only on intentional user picks / revert — safe to setState.
+  onSelectionChange?: (modelSelection: ModelSelectionType | undefined) => void;
+  stickyModelOverride?: ModelSelectionType | undefined;
+  setStickyModelOverride?: (
+    modelSelection: ModelSelectionType | undefined
+  ) => void;
+}
+
+export function ModelPicker({
+  agentModel,
+  agentId,
+  lastRequestedModel,
+  owner,
+  buttonVariant,
+  buttonSize,
+  showLabel,
+  side = "top",
+  disabled,
+  selectionRef,
+  onSelectionChange,
+  stickyModelOverride,
+  setStickyModelOverride,
+}: ModelPickerProps) {
   const { hasFeature } = useFeatureFlags();
   const hasModelsPicker = hasFeature("models_picker");
   const { subscription } = useAuth();
   const lockPremiumEfforts = !isCreditPricedPlan(subscription.plan);
-  const { stickyModelOverride, setStickyModelOverride } =
-    useContext(InputBarContext);
+
   const { isDark } = useTheme();
 
   const [isOpen, setIsOpen] = useState(false);
@@ -117,22 +172,20 @@ export function InputBarModelPicker({
     }
     prevAgentIdRef.current = agentId;
     setUserOverride(null);
-    setStickyModelOverride(undefined);
+    setStickyModelOverride?.(undefined);
   }, [agentId, setStickyModelOverride]);
 
   const shown: Selection = userOverride ?? baseSelection;
   const shownModelSelection = shown.toSend;
 
-  const canRevert = !isSameSelection(shown.display, agentDefault.display);
+  // Keep the send-time ref current — including agent switches / sticky
+  // resolution where the user didn't pick anything. Mutating a ref during
+  // render is fine and avoids any parent re-render.
+  if (selectionRef) {
+    selectionRef.current = hasModelsPicker ? shownModelSelection : undefined;
+  }
 
-  // Keep the parent's send-time selection in sync. `onSelectionChange` only
-  // stashes the value in a parent ref, so this triggers no parent re-render.
-  useEffect(() => {
-    if (!hasModelsPicker) {
-      return;
-    }
-    onSelectionChange?.(shownModelSelection);
-  }, [hasModelsPicker, onSelectionChange, shownModelSelection]);
+  const canRevert = !isSameSelection(shown.display, agentDefault.display);
 
   // Concrete, selectable models (meta-models are surfaced as tiers instead).
   const allModels = useMemo<ModelConfigurationType[]>(
@@ -166,12 +219,12 @@ export function InputBarModelPicker({
     if (isSameSelection(selection.display, agentDefault.display)) {
       // Exactly the agent default: keep no override so we defer to the agent's
       // own config (toSend undefined).
-      setUserOverride(agentDefault);
-      setStickyModelOverride(undefined);
-      return;
+      setStickyModelOverride?.(undefined);
+    } else {
+      setStickyModelOverride?.(selection.toSend);
     }
     setUserOverride(selection);
-    setStickyModelOverride(selection.toSend);
+    onSelectionChange?.(selection.toSend);
   };
 
   // Picking a concrete model (or nudging its effort slider) must keep the menu
@@ -227,7 +280,8 @@ export function InputBarModelPicker({
 
   const onRevert = () => {
     setUserOverride(agentDefault);
-    setStickyModelOverride(undefined);
+    setStickyModelOverride?.(undefined);
+    onSelectionChange?.(undefined);
   };
 
   if (!hasModelsPicker) {
@@ -239,7 +293,7 @@ export function InputBarModelPicker({
       ? TIER_BUTTON_ICON[shown.display.tierId]
       : getModelMakerLogo(getModelMaker(shown.display.model), isDark);
 
-  const tooltip =
+  const label =
     shown.display.kind === "tier"
       ? getModelTier(shown.display.tierId).name
       : getModelWithReasoningEffortLabel(shown.display);
@@ -265,10 +319,11 @@ export function InputBarModelPicker({
       <DropdownMenuTrigger asChild>
         <Button
           className="px-2"
-          variant="ghost-secondary"
+          variant={buttonVariant}
           size={buttonSize}
           icon={buttonIcon}
-          tooltip={tooltip}
+          label={showLabel ? label : undefined}
+          tooltip={showLabel ? undefined : label}
           disabled={disabled}
         />
       </DropdownMenuTrigger>

--- a/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
@@ -98,7 +98,10 @@ export function AgentInfoTab({
               icon={getModelProviderLogo(model.providerId, isDark)}
               size="xs"
             />
-            <div>{model.displayName}</div>
+            <div className="whitespace-nowrap mr-2">{model.displayName}</div>
+            <div className="text-sm text-muted-foreground">
+              {model.description}
+            </div>
           </div>
         </div>
       )}

--- a/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
@@ -8,7 +8,7 @@ import { isModelAvailable } from "@app/lib/assistant";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { useAppRouter } from "@app/lib/platform";
-import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
+import { isModelStreamId } from "@app/types/assistant/models/auto";
 import type {
   ModelConfigurationType,
   ModelProviderIdType,
@@ -44,7 +44,7 @@ export function ModelProvidersPageContent({
   // Filter models based on feature flags and build modelProviders dynamically
   const filteredModels = uniqBy(USED_MODEL_CONFIGS, (m) => m.modelId).filter(
     (model) =>
-      model.modelId !== AUTO_MODEL_ID &&
+      !isModelStreamId(model.modelId) &&
       !model.isLegacy &&
       isModelAvailable(model, {
         featureFlags,

--- a/front/components/providers/types.ts
+++ b/front/components/providers/types.ts
@@ -7,7 +7,7 @@ import type { ModelMakerIdType } from "@app/types/assistant/models/types";
 import {
   AnthropicLogo,
   DeepseekLogo,
-  DustLogo,
+  DustLogoSquare,
   FireworksLogo,
   GeminiLogo,
   GrokLogo,
@@ -52,16 +52,16 @@ const MODEL_PROVIDER_LOGOS: ModelProviderLogos = {
     light: GrokLogo,
   },
   noop: {
-    light: DustLogo,
+    light: DustLogoSquare,
   },
   auto: {
-    light: DustLogo,
+    light: DustLogoSquare,
   },
   auto_fast: {
-    light: DustLogo,
+    light: DustLogoSquare,
   },
   auto_complex: {
-    light: DustLogo,
+    light: DustLogoSquare,
   },
 };
 

--- a/front/types/assistant/models/auto.ts
+++ b/front/types/assistant/models/auto.ts
@@ -219,19 +219,19 @@ function makeMetaModelConfig(
 export const AUTO_MODEL_CONFIG: ModelConfigurationType = makeMetaModelConfig(
   AUTO_MODEL_ID,
   {
-    displayName: "Auto",
-    description: "Let's Dust select the best model for the task.",
+    displayName: "Standard",
+    description: "Best for most",
   }
 );
 
 export const AUTO_FAST_MODEL_CONFIG: ModelConfigurationType =
   makeMetaModelConfig(AUTO_FAST_MODEL_ID, {
     displayName: "Fast",
-    description: "Fast models for simple tasks.",
+    description: "Quick, low cost",
   });
 
 export const AUTO_COMPLEX_MODEL_CONFIG: ModelConfigurationType =
   makeMetaModelConfig(AUTO_COMPLEX_MODEL_ID, {
     displayName: "Complex",
-    description: "Powerful models for heavy tasks.",
+    description: "Slower, most capable",
   });


### PR DESCRIPTION
## Description

Extracts a generic `ModelPicker` from `InputBarModelPicker` and wires it into `AdvancedSettings` in the agent builder, gated on the `models_picker` FF. The existing dropdown-based flow is preserved as `AdvancedSettingsLegacy` for workspaces without the flag.

Also refactors the model selection sync in the input bar: the `onModelSelectionChange` callback chain (`InputBar` → `InputBarContainer` → `InputBarButtons`) is replaced by a single `modelSelectionRef` passed directly to `ModelPicker`, which writes to it synchronously during render instead of through a `useEffect`. Renames `AUTO_MODEL_CONFIG` display name from "Auto" to "Standard" and tightens description copy for all meta-model tiers. Switches provider logos for `noop`/`auto`/`auto_fast`/`auto_complex` from `DustLogo` to `DustLogoSquare`.

<img width="932" height="212" alt="file-c38a967ae2651ddc640a3bedbbd6c996" src="https://github.com/user-attachments/assets/462eb641-9f85-4eef-9db9-d19466803c08" />
<img width="362" height="251" alt="file-31deef6d50d79fd9948858fbba4bba05" src="https://github.com/user-attachments/assets/013b022d-fe68-4dfd-b4a0-c35a438990f5" />


## Tests

Tested locally.

## Risk

Low. The agent builder model picker path is FF-gated (`models_picker`). The `modelSelectionRef` refactor is behaviorally equivalent — the value is only read at submit time, never during render. Rollback safe.

## Deploy Plan

Deploy front.
