### PR TITLE
Accept protocol v3 Pod function result envelopes

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts
@@ -203,4 +203,76 @@ describe("POST /api/v1/w/[wId]/sandbox/sandbox-functions/result", () => {
     });
     expect(publishSandboxFunctionInvocationEvent).not.toHaveBeenCalled();
   });
+
+  it("accepts protocol v3 success envelopes", async () => {
+    const { auth, token, workspace, sandboxFunction, invocation } =
+      await createPersistedSandboxFunctionInvocationTokenTestContext();
+
+    const response = await postSandboxFunctionResult(workspace, token, {
+      result: {
+        protocolVersion: 3,
+        delivery: "callback",
+        outcome: { ok: true, output: { hello: "v3" } },
+        timingsMs: { total: 10, runner: 4 },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const refetchedInvocation =
+      await SandboxFunctionInvocationResource.fetchById(auth, {
+        sandboxFunction,
+        invocationId: invocation.sId,
+      });
+    expect(refetchedInvocation?.status).toBe("succeeded");
+    expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledWith(
+      {
+        type: "sandbox_function_invocation_result",
+        created: expect.any(Number),
+        invocationId: invocation.sId,
+        functionId: sandboxFunction.sId,
+        result: { hello: "v3" },
+      },
+      { invocationId: invocation.sId }
+    );
+  });
+
+  it("publishes protocol v3 runner errors as invocation errors", async () => {
+    const { auth, token, workspace, sandboxFunction, invocation } =
+      await createPersistedSandboxFunctionInvocationTokenTestContext();
+
+    const response = await postSandboxFunctionResult(workspace, token, {
+      result: {
+        protocolVersion: 3,
+        delivery: "stdout",
+        outcome: {
+          ok: false,
+          error: {
+            code: "threw",
+            message: "boom",
+          },
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const refetchedInvocation =
+      await SandboxFunctionInvocationResource.fetchById(auth, {
+        sandboxFunction,
+        invocationId: invocation.sId,
+      });
+    expect(refetchedInvocation?.status).toBe("errored");
+    expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledWith(
+      {
+        type: "sandbox_function_invocation_error",
+        created: expect.any(Number),
+        invocationId: invocation.sId,
+        functionId: sandboxFunction.sId,
+        error: {
+          code: "threw",
+          message: "boom",
+        },
+      },
+      { invocationId: invocation.sId }
+    );
+  });
 });

--- a/front/lib/api/sandbox_functions/result_envelope.test.ts
+++ b/front/lib/api/sandbox_functions/result_envelope.test.ts
@@ -1,0 +1,214 @@
+import {
+  normalizeSandboxFunctionResult,
+  SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSION,
+} from "@app/lib/api/sandbox_functions/result_envelope";
+import { describe, expect, it } from "vitest";
+
+describe("normalizeSandboxFunctionResult", () => {
+  it("accepts a protocol v3 success envelope", () => {
+    // Keep the literal stable: bumping SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSION
+    // must fail this pin until the wire shape and dsbx emitter move together.
+    const envelope = {
+      protocolVersion: 3,
+      delivery: "stdout",
+      outcome: { ok: true, output: { hello: "world" } },
+      timingsMs: { total: 12, runner: 8, importBundle: 3 },
+      futureField: "ignored",
+    };
+
+    expect(SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSION).toBe(3);
+    expect(normalizeSandboxFunctionResult(envelope)).toEqual({
+      ok: true,
+      output: { hello: "world" },
+    });
+  });
+
+  it("preserves the runner error code from a protocol v3 failure envelope", () => {
+    expect(
+      normalizeSandboxFunctionResult({
+        protocolVersion: 3,
+        delivery: "callback",
+        outcome: {
+          ok: false,
+          error: {
+            code: "invalid_output",
+            message: "Function output does not match schema.output.",
+          },
+        },
+      })
+    ).toEqual({
+      ok: false,
+      error: {
+        code: "invalid_output",
+        message: "Function output does not match schema.output.",
+      },
+    });
+  });
+
+  it("accepts dsbx-minted invocation_failed codes in a protocol v3 outcome", () => {
+    expect(
+      normalizeSandboxFunctionResult({
+        protocolVersion: 3,
+        delivery: "stdout",
+        outcome: {
+          ok: false,
+          error: {
+            code: "invocation_failed",
+            message: "function produced no output",
+          },
+        },
+      })
+    ).toEqual({
+      ok: false,
+      error: {
+        code: "invocation_failed",
+        message: "function produced no output",
+      },
+    });
+  });
+
+  it("fails a protocol v3 envelope with a malformed outcome", () => {
+    expect(
+      normalizeSandboxFunctionResult({
+        protocolVersion: 3,
+        delivery: "stdout",
+        outcome: { ok: true },
+      })
+    ).toEqual({
+      ok: false,
+      error: {
+        code: "invocation_failed",
+        message: "Sandbox function returned an invalid result envelope.",
+      },
+    });
+  });
+
+  it("rejects an unsupported protocol version without falling through to legacy parsers", () => {
+    expect(
+      normalizeSandboxFunctionResult({
+        protocolVersion: 4,
+        delivery: "stdout",
+        outcome: { ok: true, output: { hello: "world" } },
+      })
+    ).toEqual({
+      ok: false,
+      error: {
+        code: "invocation_failed",
+        message: "Unsupported Pod function result protocol version 4.",
+      },
+    });
+  });
+
+  it("rejects a non-integer protocol version without falling through to legacy parsers", () => {
+    expect(
+      normalizeSandboxFunctionResult({
+        protocolVersion: 3.5,
+        delivery: "stdout",
+        outcome: { ok: true, output: 1 },
+      })
+    ).toEqual({
+      ok: false,
+      error: {
+        code: "invocation_failed",
+        message: "Sandbox function returned an invalid result envelope.",
+      },
+    });
+  });
+
+  it("ignores timingsMs until a consumer reads it", () => {
+    expect(
+      normalizeSandboxFunctionResult({
+        protocolVersion: 3,
+        delivery: "stdout",
+        outcome: { ok: true, output: 1 },
+        timingsMs: { total: -1, "bad-key!": 1 },
+      })
+    ).toEqual({
+      ok: true,
+      output: 1,
+    });
+  });
+
+  it("accepts the current runner success and failure envelopes", () => {
+    expect(
+      normalizeSandboxFunctionResult({ ok: true, output: { hello: "world" } })
+    ).toEqual({ ok: true, output: { hello: "world" } });
+
+    expect(
+      normalizeSandboxFunctionResult({
+        ok: false,
+        error: {
+          code: "http_error",
+          message: "Function returned HTTP 502.",
+          status: 502,
+        },
+      })
+    ).toEqual({
+      ok: false,
+      error: {
+        code: "http_error",
+        message: "Function returned HTTP 502.",
+        status: 502,
+      },
+    });
+  });
+
+  it("normalizes successful callbacks from the previous runner image", () => {
+    expect(
+      normalizeSandboxFunctionResult({
+        ok: true,
+        response: {
+          status: 200,
+          headers: { "content-type": "application/json" },
+          body: Buffer.from(JSON.stringify({ hello: "legacy" })).toString(
+            "base64"
+          ),
+          encoding: "base64",
+        },
+      })
+    ).toEqual({ ok: true, output: { hello: "legacy" } });
+  });
+
+  it("normalizes non-2xx and threw errors from the previous runner image", () => {
+    expect(
+      normalizeSandboxFunctionResult({
+        ok: true,
+        response: {
+          status: 500,
+          headers: {},
+          body: Buffer.from("boom").toString("base64"),
+          encoding: "base64",
+        },
+      })
+    ).toEqual({
+      ok: false,
+      error: {
+        code: "http_error",
+        message: "Function returned HTTP 500: boom",
+        status: 500,
+      },
+    });
+
+    expect(
+      normalizeSandboxFunctionResult({
+        ok: false,
+        error: { kind: "threw", message: "boom" },
+      })
+    ).toEqual({
+      ok: false,
+      error: { code: "threw", message: "boom" },
+    });
+  });
+
+  it("fails malformed envelopes with the stable invalid-envelope message", () => {
+    for (const result of [null, {}, { ok: true }]) {
+      expect(normalizeSandboxFunctionResult(result)).toEqual({
+        ok: false,
+        error: {
+          code: "invocation_failed",
+          message: "Sandbox function returned an invalid result envelope.",
+        },
+      });
+    }
+  });
+});

--- a/front/lib/api/sandbox_functions/result_envelope.ts
+++ b/front/lib/api/sandbox_functions/result_envelope.ts
@@ -1,6 +1,19 @@
+import logger from "@app/logger/logger";
 import type { SandboxFunctionCallError } from "@app/types/api/sandbox_functions";
 import { SANDBOX_FUNCTION_RUNNER_ERROR_CODES } from "@app/types/api/sandbox_functions";
 import { z } from "zod";
+
+// Current wire version dsbx emits. Parsing accepts the supported set below so a future bump
+// does not instantly fail long-lived baked pod images still on an older version.
+export const SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSION = 3;
+
+export const SUPPORTED_SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSIONS = [
+  SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSION,
+] as const;
+
+export type NormalizedSandboxFunctionOutcome =
+  | { ok: true; output: unknown }
+  | { ok: false; error: SandboxFunctionCallError };
 
 type JsonValue = null | boolean | number | string | object;
 const DefinedJsonValueSchema = z.custom<JsonValue>((v) => v !== undefined);
@@ -12,7 +25,12 @@ const SandboxFunctionRunnerOutputSchema = z.discriminatedUnion("ok", [
       ok: z.literal(false),
       error: z
         .object({
-          code: z.enum(SANDBOX_FUNCTION_RUNNER_ERROR_CODES),
+          // Accept runner codes and front/dsbx-minted codes (e.g. invocation_failed).
+          // Stored paths already treat code as an opaque string for the same reason.
+          code: z.union([
+            z.enum(SANDBOX_FUNCTION_RUNNER_ERROR_CODES),
+            z.enum(["invocation_failed", "transport_error", "not_supported"]),
+          ]),
           message: z.string(),
           status: z.number().int().optional(),
         })
@@ -49,15 +67,36 @@ const LegacySandboxFunctionRunnerOutputSchema = z.discriminatedUnion("ok", [
     .strict(),
 ]);
 
-export type NormalizedSandboxFunctionOutcome =
-  | { ok: true; output: unknown }
-  | { ok: false; error: SandboxFunctionCallError };
+// Mirrors ResultEnvelope in cli/dust-sandbox/src/commands/function/envelope.rs.
+// Deliberately not `.strict()`: the wrapper is a forward-compatibility seam, so a field added by
+// a newer dsbx must not fail the parse. Inner outcome schemas stay `.strict()`.
+// `delivery` is optional and opaque until a consumer reads it.
+const ResultEnvelopeV3Schema = z.object({
+  protocolVersion: z.literal(SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSION),
+  delivery: z.string().min(1).optional(),
+  outcome: z.unknown(),
+  timingsMs: z.unknown().optional(),
+});
 
-/**
- * Normalize a Pod function result payload from the HTTP callback body into one
- * classified outcome. Lifted from the callback route with no behavior change.
- */
-export function normalizeSandboxFunctionResult(
+const ProtocolVersionProbeSchema = z.object({
+  protocolVersion: z.number(),
+});
+
+function invalidResultEnvelope(
+  reason: string,
+  details?: Record<string, unknown>
+): NormalizedSandboxFunctionOutcome {
+  logger.warn({ reason, ...details }, "Rejected Pod function result envelope");
+  return {
+    ok: false,
+    error: {
+      code: "invocation_failed",
+      message: "Sandbox function returned an invalid result envelope.",
+    },
+  };
+}
+
+function normalizeRunnerOutcome(
   result: unknown
 ): NormalizedSandboxFunctionOutcome {
   const current = SandboxFunctionRunnerOutputSchema.safeParse(result);
@@ -67,13 +106,7 @@ export function normalizeSandboxFunctionResult(
 
   const legacy = LegacySandboxFunctionRunnerOutputSchema.safeParse(result);
   if (!legacy.success) {
-    return {
-      ok: false,
-      error: {
-        code: "invocation_failed",
-        message: "Sandbox function returned an invalid result envelope.",
-      },
-    };
+    return invalidResultEnvelope("unrecognized_runner_outcome");
   }
 
   if (!legacy.data.ok) {
@@ -113,4 +146,52 @@ export function normalizeSandboxFunctionResult(
       },
     };
   }
+}
+
+function isSupportedProtocolVersion(version: number): boolean {
+  return (
+    Number.isInteger(version) &&
+    (
+      SUPPORTED_SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSIONS as readonly number[]
+    ).includes(version)
+  );
+}
+
+/**
+ * Normalize a Pod function result payload from either the HTTP callback body or a
+ * worker-owned stdout envelope into one classified outcome.
+ */
+export function normalizeSandboxFunctionResult(
+  result: unknown
+): NormalizedSandboxFunctionOutcome {
+  const versionProbe = ProtocolVersionProbeSchema.safeParse(result);
+  if (versionProbe.success) {
+    const { protocolVersion } = versionProbe.data;
+    if (!Number.isInteger(protocolVersion)) {
+      return invalidResultEnvelope("non_integer_protocol_version", {
+        protocolVersion,
+      });
+    }
+    if (!isSupportedProtocolVersion(protocolVersion)) {
+      return {
+        ok: false,
+        error: {
+          code: "invocation_failed",
+          message: `Unsupported Pod function result protocol version ${protocolVersion}.`,
+        },
+      };
+    }
+
+    const v3 = ResultEnvelopeV3Schema.safeParse(result);
+    if (!v3.success) {
+      return invalidResultEnvelope("malformed_v3_envelope", {
+        protocolVersion,
+      });
+    }
+
+    // timingsMs is accepted on the wire for forward compatibility but not consumed yet.
+    return normalizeRunnerOutcome(v3.data.outcome);
+  }
+
+  return normalizeRunnerOutcome(result);
 }

--- a/front/lib/api/sandbox_functions/result_envelope.ts
+++ b/front/lib/api/sandbox_functions/result_envelope.ts
@@ -182,6 +182,10 @@ export function normalizeSandboxFunctionResult(
       });
     }
     if (!isSupportedProtocolVersion(protocolVersion)) {
+      logger.warn(
+        { reason: "unsupported_protocol_version", protocolVersion },
+        "Rejected Pod function result envelope"
+      );
       return {
         ok: false,
         error: {

--- a/front/lib/api/sandbox_functions/result_envelope.ts
+++ b/front/lib/api/sandbox_functions/result_envelope.ts
@@ -1,6 +1,7 @@
 import logger from "@app/logger/logger";
 import type { SandboxFunctionCallError } from "@app/types/api/sandbox_functions";
 import { SANDBOX_FUNCTION_RUNNER_ERROR_CODES } from "@app/types/api/sandbox_functions";
+import { truncate } from "@app/types/shared/utils/string_utils";
 import { z } from "zod";
 
 // Current wire version dsbx emits. Parsing accepts the supported set below so a future bump
@@ -10,6 +11,9 @@ export const SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSION = 3;
 export const SUPPORTED_SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSIONS = [
   SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSION,
 ] as const;
+
+// Cap on the rejected-payload snippet included in logs.
+const REJECTED_ENVELOPE_LOG_SNIPPET_MAX_CHARS = 512;
 
 export type NormalizedSandboxFunctionOutcome =
   | { ok: true; output: unknown }
@@ -106,7 +110,12 @@ function normalizeRunnerOutcome(
 
   const legacy = LegacySandboxFunctionRunnerOutputSchema.safeParse(result);
   if (!legacy.success) {
-    return invalidResultEnvelope("unrecognized_runner_outcome");
+    return invalidResultEnvelope("unrecognized_runner_outcome", {
+      resultSnippet: truncate(
+        JSON.stringify(result) ?? "undefined",
+        REJECTED_ENVELOPE_LOG_SNIPPET_MAX_CHARS
+      ),
+    });
   }
 
   if (!legacy.data.ok) {
@@ -186,6 +195,10 @@ export function normalizeSandboxFunctionResult(
     if (!v3.success) {
       return invalidResultEnvelope("malformed_v3_envelope", {
         protocolVersion,
+        resultSnippet: truncate(
+          JSON.stringify(result) ?? "undefined",
+          REJECTED_ENVELOPE_LOG_SNIPPET_MAX_CHARS
+        ),
       });
     }
 


### PR DESCRIPTION
## Description

Accept protocol v3 result envelopes (`protocolVersion` / optional `delivery` / `outcome` / optional `timingsMs`) on top of the relocated normalizer, alongside the current and legacy runner shapes.

Also accepts front/dsbx-minted error codes such as `invocation_failed`, fails closed on unsupported protocol versions via an append-only supported set, and logs rejected envelopes. `timingsMs` is accepted on the wire but not consumed yet.

Stacked on the pure extraction PR.

## Tests

- Unit coverage for legacy, current, and v3 envelopes (including dsbx-minted `invocation_failed`).
- Route tests for v3 success and error callbacks.

## Risk

Low. Additive acceptance of a shape nothing emits in production yet. Rollback is a revert. When a later protocol version is introduced, keep older versions in the supported set until baked images rotate off them.

## Deploy Plan

Standard deploy. Merge after the extraction PR.