### PR TITLE
Make Pod function terminal transitions compare-and-set idempotent

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts
@@ -310,4 +310,28 @@ describe("POST /api/v1/w/[wId]/sandbox/sandbox-functions/result", () => {
       { invocationId: invocation.sId }
     );
   });
+
+  it("treats a second callback for an already-succeeded invocation as a no-op", async () => {
+    const { auth, token, workspace, sandboxFunction, invocation } =
+      await createPersistedSandboxFunctionInvocationTokenTestContext();
+
+    const first = await postSandboxFunctionResult(workspace, token, {
+      result: { ok: true, output: { hello: "first" } },
+    });
+    expect(first.status).toBe(200);
+
+    const second = await postSandboxFunctionResult(workspace, token, {
+      result: { ok: true, output: { hello: "second" } },
+    });
+    expect(second.status).toBe(200);
+
+    const refetchedInvocation =
+      await SandboxFunctionInvocationResource.fetchById(auth, {
+        sandboxFunction,
+        invocationId: invocation.sId,
+      });
+    expect(refetchedInvocation?.status).toBe("succeeded");
+    expect(refetchedInvocation?.result).toEqual({ hello: "first" });
+    expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledTimes(1);
+  });
 });

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -488,6 +488,90 @@ describe("SandboxFunctionInvocationResource", () => {
     });
   });
 
+  it("makes succeed a compare-and-set so a second delivery is a no-op", async () => {
+    const { authenticator, sandboxFunction, invocation } =
+      await setupExecutionTest();
+    const result = { commentId: "comment-1" };
+
+    expect(await invocation.succeed(result)).toBe(true);
+    expect(await invocation.succeed({ commentId: "comment-2" })).toBe(false);
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.status).toBe("succeeded");
+    expect(refetched?.result).toEqual(result);
+    expect(fileStorageMock.getObject(invocation.gcsPath!)).toContain(
+      '"commentId":"comment-1"'
+    );
+    expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects fail after succeed without overwriting the result", async () => {
+    const { authenticator, sandboxFunction, invocation } =
+      await setupExecutionTest();
+    const result = { commentId: "comment-1" };
+
+    expect(await invocation.succeed(result)).toBe(true);
+    expect(await invocation.fail(new Error("late failure"))).toBe(false);
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.status).toBe("succeeded");
+    expect(refetched?.result).toEqual(result);
+    expect(refetched?.error).toBeUndefined();
+    expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects markCreatedAsErrored after succeed", async () => {
+    const { authenticator, sandboxFunction, invocation } =
+      await setupExecutionTest();
+
+    expect(await invocation.succeed({ commentId: "comment-1" })).toBe(true);
+    expect(
+      await invocation.markCreatedAsErrored({
+        code: "invocation_failed",
+        message: "activity timed out",
+      })
+    ).toBe(false);
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.status).toBe("succeeded");
+    expect(refetched?.result).toEqual({ commentId: "comment-1" });
+    expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases a won succeed claim when the terminal blob write fails", async () => {
+    const { authenticator, sandboxFunction, invocation } =
+      await setupExecutionTest();
+    fileStorageMock.setFileSaveFails(
+      (filePath) => filePath === invocation.gcsPath
+    );
+
+    await expect(
+      invocation.succeed({ commentId: "comment-1" })
+    ).rejects.toThrow();
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.status).toBe("created");
+    expect(publishSandboxFunctionInvocationEvent).not.toHaveBeenCalled();
+
+    fileStorageMock.setFileSaveFails(() => false);
+    expect(
+      await refetched!.fail(new Error("recoverable after gcs failure"))
+    ).toBe(true);
+    expect(refetched!.status).toBe("errored");
+  });
+
   it("migrates a v1 blob, which recorded the message only", async () => {
     const { authenticator, sandboxFunction, invocation } =
       await setupExecutionTest();

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -286,34 +286,28 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     return this.data.error;
   }
 
-  // Compare-and-set: only the caller that flips `created` owns the outcome. Guards the
-  // double-delivery window (worker stdout + late HTTP callback) without a lock.
-  // BaseResource.update() only keys on `id`, so the predicate goes on the model here
-  // (cf. ConversationForkResource.markFileCopied).
-  private async claimTerminalStatus(
-    status: Extract<SandboxFunctionInvocationStatus, "succeeded" | "errored">
-  ): Promise<boolean> {
+  // WHERE-guarded compare-and-swap on status. Same pattern as
+  // SandboxFunctionMCPActionResource.updateStatusFromExpected: BaseResource.update()
+  // only keys on `id`, so the expected-status predicate goes on the model here.
+  private async casStatus({
+    from,
+    to,
+  }: {
+    from: SandboxFunctionInvocationStatus;
+    to: SandboxFunctionInvocationStatus;
+  }): Promise<boolean> {
     const [affectedCount, rows] = await this.model.update(
-      { status },
+      { status: to },
       {
         where: {
           id: this.id,
           workspaceId: this.workspaceId,
-          status: "created",
+          status: from,
         },
         returning: true,
       }
     );
     if (affectedCount === 0) {
-      logger.info(
-        {
-          workspaceModelId: this.workspaceId,
-          sandboxFunctionId: this.sandboxFunction.sId,
-          invocationId: this.sId,
-          attemptedStatus: status,
-        },
-        "Skipping terminal transition for an already-terminal Pod function invocation"
-      );
       return false;
     }
     const row = rows[0];
@@ -325,21 +319,11 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
 
   // Give the claim back if terminal blob persistence fails, so a later fail()/
   // markCreatedAsErrored() path can still record the outcome.
-  private async releaseTerminalStatus(
-    from: Extract<SandboxFunctionInvocationStatus, "succeeded" | "errored">
+  private async releaseTerminalClaim(
+    from: Exclude<SandboxFunctionInvocationStatus, "created">
   ): Promise<void> {
-    const [affectedCount, rows] = await this.model.update(
-      { status: "created" },
-      {
-        where: {
-          id: this.id,
-          workspaceId: this.workspaceId,
-          status: from,
-        },
-        returning: true,
-      }
-    );
-    if (affectedCount === 0) {
+    const released = await this.casStatus({ from, to: "created" });
+    if (!released) {
       logger.error(
         {
           workspaceModelId: this.workspaceId,
@@ -349,11 +333,6 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         },
         "Failed to release Pod function terminal claim after blob write failure"
       );
-      return;
-    }
-    const row = rows[0];
-    if (row) {
-      Object.assign(this, row.get());
     }
   }
 
@@ -363,8 +342,23 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         ? { code: "invocation_failed", message: error.message }
         : error;
 
-    const claimed = await this.claimTerminalStatus("errored");
+    // Only the caller that flips `created` owns the outcome. Guards the
+    // double-delivery window (worker stdout + late HTTP callback).
+    const claimed = await this.casStatus({
+      from: "created",
+      to: "errored",
+    });
     if (!claimed) {
+      logger.warn(
+        {
+          workspaceModelId: this.workspaceId,
+          sandboxFunctionId: this.sandboxFunction.sId,
+          invocationId: this.sId,
+          attemptedStatus: "errored",
+          attemptedError: callError,
+        },
+        "Skipping terminal transition for an already-terminal Pod function invocation"
+      );
       return false;
     }
 
@@ -377,11 +371,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       // record of a failure the stream classified precisely.
       error: callError,
     };
-    try {
-      await this.writeDataToGcs();
-    } catch (err) {
-      await this.releaseTerminalStatus("errored");
-      throw err;
+    const writeResult = await this.writeDataToGcs();
+    if (writeResult.isErr()) {
+      await this.releaseTerminalClaim("errored");
+      throw writeResult.error;
     }
     await publishSandboxFunctionInvocationEvent(
       {
@@ -397,8 +390,24 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   }
 
   async succeed(result: unknown): Promise<boolean> {
-    const claimed = await this.claimTerminalStatus("succeeded");
+    const claimed = await this.casStatus({
+      from: "created",
+      to: "succeeded",
+    });
     if (!claimed) {
+      logger.warn(
+        {
+          workspaceModelId: this.workspaceId,
+          sandboxFunctionId: this.sandboxFunction.sId,
+          invocationId: this.sId,
+          attemptedStatus: "succeeded",
+          attemptedResult: truncate(
+            JSON.stringify(result),
+            SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS
+          ),
+        },
+        "Skipping terminal transition for an already-terminal Pod function invocation"
+      );
       return false;
     }
 
@@ -408,11 +417,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       context: this.context,
       result,
     };
-    try {
-      await this.writeDataToGcs();
-    } catch (err) {
-      await this.releaseTerminalStatus("succeeded");
-      throw err;
+    const writeResult = await this.writeDataToGcs();
+    if (writeResult.isErr()) {
+      await this.releaseTerminalClaim("succeeded");
+      throw writeResult.error;
     }
     await publishSandboxFunctionInvocationEvent(
       {
@@ -426,7 +434,6 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     );
     return true;
   }
-
   async execute(auth: Authenticator): Promise<Result<undefined, Error>> {
     if (this.status !== "created") {
       logger.info(
@@ -602,7 +609,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     this.data = migrateStoredInvocationData(storedResult.value);
   }
 
-  private async writeDataToGcs(): Promise<void> {
+  private async writeDataToGcs(): Promise<Result<undefined, Error>> {
     const writeResult = await withRetry(() =>
       getPrivateUploadBucket()
         .file(this.gcsPath)
@@ -611,8 +618,9 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         })
     );
     if (writeResult.isErr()) {
-      throw writeResult.error;
+      return writeResult;
     }
+    return new Ok(undefined);
   }
 
   private static async deleteDataFromGcs(gcsPaths: string[]): Promise<void> {
@@ -678,7 +686,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       return resource;
     }, transaction);
 
-    await resource.writeDataToGcs();
+    const writeResult = await resource.writeDataToGcs();
+    if (writeResult.isErr()) {
+      throw writeResult.error;
+    }
     return resource;
   }
 
@@ -724,8 +735,21 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   async markCreatedAsErrored(
     error: SandboxFunctionCallError
   ): Promise<boolean> {
-    const claimed = await this.claimTerminalStatus("errored");
+    const claimed = await this.casStatus({
+      from: "created",
+      to: "errored",
+    });
     if (!claimed) {
+      logger.warn(
+        {
+          workspaceModelId: this.workspaceId,
+          sandboxFunctionId: this.sandboxFunction.sId,
+          invocationId: this.sId,
+          attemptedStatus: "errored",
+          attemptedError: error,
+        },
+        "Skipping terminal transition for an already-terminal Pod function invocation"
+      );
       return false;
     }
 

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -286,11 +286,88 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     return this.data.error;
   }
 
-  async fail(error: Error | SandboxFunctionCallError): Promise<void> {
+  // Compare-and-set: only the caller that flips `created` owns the outcome. Guards the
+  // double-delivery window (worker stdout + late HTTP callback) without a lock.
+  // BaseResource.update() only keys on `id`, so the predicate goes on the model here
+  // (cf. ConversationForkResource.markFileCopied).
+  private async claimTerminalStatus(
+    status: Extract<SandboxFunctionInvocationStatus, "succeeded" | "errored">
+  ): Promise<boolean> {
+    const [affectedCount, rows] = await this.model.update(
+      { status },
+      {
+        where: {
+          id: this.id,
+          workspaceId: this.workspaceId,
+          status: "created",
+        },
+        returning: true,
+      }
+    );
+    if (affectedCount === 0) {
+      logger.info(
+        {
+          workspaceModelId: this.workspaceId,
+          sandboxFunctionId: this.sandboxFunction.sId,
+          invocationId: this.sId,
+          attemptedStatus: status,
+        },
+        "Skipping terminal transition for an already-terminal Pod function invocation"
+      );
+      return false;
+    }
+    const row = rows[0];
+    if (row) {
+      Object.assign(this, row.get());
+    }
+    return true;
+  }
+
+  // Give the claim back if terminal blob persistence fails, so a later fail()/
+  // markCreatedAsErrored() path can still record the outcome.
+  private async releaseTerminalStatus(
+    from: Extract<SandboxFunctionInvocationStatus, "succeeded" | "errored">
+  ): Promise<void> {
+    const [affectedCount, rows] = await this.model.update(
+      { status: "created" },
+      {
+        where: {
+          id: this.id,
+          workspaceId: this.workspaceId,
+          status: from,
+        },
+        returning: true,
+      }
+    );
+    if (affectedCount === 0) {
+      logger.error(
+        {
+          workspaceModelId: this.workspaceId,
+          sandboxFunctionId: this.sandboxFunction.sId,
+          invocationId: this.sId,
+          fromStatus: from,
+        },
+        "Failed to release Pod function terminal claim after blob write failure"
+      );
+      return;
+    }
+    const row = rows[0];
+    if (row) {
+      Object.assign(this, row.get());
+    }
+  }
+
+  async fail(error: Error | SandboxFunctionCallError): Promise<boolean> {
     const callError: SandboxFunctionCallError =
       error instanceof Error
         ? { code: "invocation_failed", message: error.message }
         : error;
+
+    const claimed = await this.claimTerminalStatus("errored");
+    if (!claimed) {
+      return false;
+    }
+
     this.data = {
       version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
       input: this.input,
@@ -300,8 +377,12 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       // record of a failure the stream classified precisely.
       error: callError,
     };
-    await this.writeDataToGcs();
-    await this.update({ status: "errored" });
+    try {
+      await this.writeDataToGcs();
+    } catch (err) {
+      await this.releaseTerminalStatus("errored");
+      throw err;
+    }
     await publishSandboxFunctionInvocationEvent(
       {
         type: "sandbox_function_invocation_error",
@@ -312,17 +393,27 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       },
       { invocationId: this.sId }
     );
+    return true;
   }
 
-  async succeed(result: unknown): Promise<void> {
+  async succeed(result: unknown): Promise<boolean> {
+    const claimed = await this.claimTerminalStatus("succeeded");
+    if (!claimed) {
+      return false;
+    }
+
     this.data = {
       version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
       input: this.input,
       context: this.context,
       result,
     };
-    await this.writeDataToGcs();
-    await this.update({ status: "succeeded" });
+    try {
+      await this.writeDataToGcs();
+    } catch (err) {
+      await this.releaseTerminalStatus("succeeded");
+      throw err;
+    }
     await publishSandboxFunctionInvocationEvent(
       {
         type: "sandbox_function_invocation_result",
@@ -333,6 +424,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       },
       { invocationId: this.sId }
     );
+    return true;
   }
 
   async execute(auth: Authenticator): Promise<Result<undefined, Error>> {
@@ -632,10 +724,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   async markCreatedAsErrored(
     error: SandboxFunctionCallError
   ): Promise<boolean> {
-    if (this.status !== "created") {
+    const claimed = await this.claimTerminalStatus("errored");
+    if (!claimed) {
       return false;
     }
-    await this.update({ status: "errored" });
 
     // Do not overwrite the invocation blob here. This path only records that
     // execution failed before the runner could return a structured result.


### PR DESCRIPTION
## Description

Make `succeed` / `fail` / `markCreatedAsErrored` compare-and-set on status `created`, so only one deliverer can take an invocation terminal. If the terminal GCS write fails after a won claim, release the claim so a later fail path can still record the outcome.

Also covers a duplicate HTTP callback: the second POST is a no-op.

Stacked on the shared result-envelope PR.

## Tests

- Resource tests for lost claims and GCS write failure releasing the claim.
- Route test that a second successful callback does not overwrite the first result.

## Risk

Low for callers: `succeed`/`fail` now return `boolean` and existing callers ignore it. Behavioural notes: the row can briefly look terminal before its GCS blob exists, and a failed terminal write resurrects the row to `created`. Rollback is a revert.

## Deploy Plan

Standard deploy. Merge after the envelope PR.