### PR TITLE
Add dsbx stdout result delivery and bake it into dust-base 0.8.64

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.40"
+version = "0.1.41"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.40"
+version = "0.1.41"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/src/commands/function/envelope.rs
+++ b/cli/dust-sandbox/src/commands/function/envelope.rs
@@ -37,10 +37,7 @@ pub struct TimingsMs {
 }
 
 impl ResultEnvelope {
-    pub fn stdout_outcome(
-        outcome: serde_json::Value,
-        timings_ms: Option<TimingsMs>,
-    ) -> Self {
+    pub fn stdout_outcome(outcome: serde_json::Value, timings_ms: Option<TimingsMs>) -> Self {
         Self {
             protocol_version: RESULT_PROTOCOL_VERSION,
             delivery: ResultDelivery::Stdout.as_str().to_string(),

--- a/cli/dust-sandbox/src/commands/function/envelope.rs
+++ b/cli/dust-sandbox/src/commands/function/envelope.rs
@@ -1,0 +1,119 @@
+use serde::{Deserialize, Serialize};
+
+pub const RESULT_PROTOCOL_VERSION: u32 = 3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum, Default)]
+#[value(rename_all = "lowercase")]
+pub enum ResultDelivery {
+    #[default]
+    Callback,
+    Stdout,
+}
+
+impl ResultDelivery {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Callback => "callback",
+            Self::Stdout => "stdout",
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ResultEnvelope {
+    pub protocol_version: u32,
+    pub delivery: String,
+    pub outcome: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timings_ms: Option<TimingsMs>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TimingsMs {
+    pub total: u64,
+    pub runner: u64,
+}
+
+impl ResultEnvelope {
+    pub fn stdout_outcome(
+        outcome: serde_json::Value,
+        timings_ms: Option<TimingsMs>,
+    ) -> Self {
+        Self {
+            protocol_version: RESULT_PROTOCOL_VERSION,
+            delivery: ResultDelivery::Stdout.as_str().to_string(),
+            outcome,
+            timings_ms,
+        }
+    }
+
+    pub fn stdout_invocation_failed(message: impl Into<String>) -> Self {
+        Self::stdout_outcome(
+            serde_json::json!({
+                "ok": false,
+                "error": {
+                    "code": "invocation_failed",
+                    "message": message.into(),
+                }
+            }),
+            None,
+        )
+    }
+
+    pub fn write_to_stdout(&self) {
+        println!(
+            "{}",
+            serde_json::to_string(self).expect("ResultEnvelope serializes")
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serializes_the_pinned_v3_shape() {
+        // Cross-language pin with front/lib/api/sandbox_functions/result_envelope.test.ts.
+        let envelope = ResultEnvelope::stdout_outcome(
+            serde_json::json!({ "ok": true, "output": { "hello": "world" } }),
+            Some(TimingsMs {
+                total: 12,
+                runner: 8,
+            }),
+        );
+
+        let json = serde_json::to_value(&envelope).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "protocolVersion": 3,
+                "delivery": "stdout",
+                "outcome": { "ok": true, "output": { "hello": "world" } },
+                "timingsMs": { "total": 12, "runner": 8 },
+            })
+        );
+    }
+
+    #[test]
+    fn serializes_invocation_failed_without_timings() {
+        let envelope = ResultEnvelope::stdout_invocation_failed("boom");
+        let json = serde_json::to_value(&envelope).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "protocolVersion": 3,
+                "delivery": "stdout",
+                "outcome": {
+                    "ok": false,
+                    "error": {
+                        "code": "invocation_failed",
+                        "message": "boom",
+                    }
+                },
+            })
+        );
+    }
+}

--- a/cli/dust-sandbox/src/commands/function/envelope.rs
+++ b/cli/dust-sandbox/src/commands/function/envelope.rs
@@ -82,7 +82,7 @@ mod tests {
             }),
         );
 
-        let json = serde_json::to_value(&envelope).unwrap();
+        let json = serde_json::to_value(&envelope).expect("ResultEnvelope serializes to JSON");
         assert_eq!(
             json,
             serde_json::json!({
@@ -97,7 +97,7 @@ mod tests {
     #[test]
     fn serializes_invocation_failed_without_timings() {
         let envelope = ResultEnvelope::stdout_invocation_failed("boom");
-        let json = serde_json::to_value(&envelope).unwrap();
+        let json = serde_json::to_value(&envelope).expect("ResultEnvelope serializes to JSON");
         assert_eq!(
             json,
             serde_json::json!({

--- a/cli/dust-sandbox/src/commands/function/envelope.rs
+++ b/cli/dust-sandbox/src/commands/function/envelope.rs
@@ -2,28 +2,20 @@ use serde::{Deserialize, Serialize};
 
 pub const RESULT_PROTOCOL_VERSION: u32 = 3;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum, Serialize, Deserialize)]
 #[value(rename_all = "lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum ResultDelivery {
-    #[default]
     Callback,
     Stdout,
 }
 
-impl ResultDelivery {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Callback => "callback",
-            Self::Stdout => "stdout",
-        }
-    }
-}
-
+// Mirrors ResultEnvelopeV3Schema in front/lib/api/sandbox_functions/result_envelope.ts.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ResultEnvelope {
     pub protocol_version: u32,
-    pub delivery: String,
+    pub delivery: ResultDelivery,
     pub outcome: serde_json::Value,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timings_ms: Option<TimingsMs>,
@@ -40,7 +32,7 @@ impl ResultEnvelope {
     pub fn stdout_outcome(outcome: serde_json::Value, timings_ms: Option<TimingsMs>) -> Self {
         Self {
             protocol_version: RESULT_PROTOCOL_VERSION,
-            delivery: ResultDelivery::Stdout.as_str().to_string(),
+            delivery: ResultDelivery::Stdout,
             outcome,
             timings_ms,
         }
@@ -73,7 +65,6 @@ mod tests {
 
     #[test]
     fn serializes_the_pinned_v3_shape() {
-        // Cross-language pin with front/lib/api/sandbox_functions/result_envelope.test.ts.
         let envelope = ResultEnvelope::stdout_outcome(
             serde_json::json!({ "ok": true, "output": { "hello": "world" } }),
             Some(TimingsMs {

--- a/cli/dust-sandbox/src/commands/function/mod.rs
+++ b/cli/dust-sandbox/src/commands/function/mod.rs
@@ -10,10 +10,12 @@ use tokio::io::AsyncReadExt as _;
 use tokio::process::Command;
 
 mod build;
+mod envelope;
 mod get;
 mod run;
 
 pub use build::cmd_function_build;
+pub use envelope::ResultDelivery;
 pub use get::cmd_function_get;
 pub use run::cmd_function_run;
 
@@ -44,6 +46,11 @@ const DEFAULT_FUNCTION_WORKING_DIR: &str = "/home/agent";
 pub enum FunctionCommand {
     /// Execute a function: request envelope JSON on stdin, response JSON on stdout
     Run {
+        /// How to deliver the function result. Default remains the in-sandbox
+        /// HTTP callback; `stdout` returns a protocol v3 envelope on stdout for
+        /// the worker that started the command.
+        #[arg(long, value_enum, default_value_t = ResultDelivery::Callback)]
+        result_delivery: ResultDelivery,
         /// Function name (resolved to a <name>.<ext> bundle in ${DUST_FUNCTIONS_DIR})
         name: String,
     },

--- a/cli/dust-sandbox/src/commands/function/mod.rs
+++ b/cli/dust-sandbox/src/commands/function/mod.rs
@@ -44,7 +44,9 @@ const DEFAULT_FUNCTION_WORKING_DIR: &str = "/home/agent";
 
 #[derive(Subcommand)]
 pub enum FunctionCommand {
-    /// Execute a function: request envelope JSON on stdin, response JSON on stdout
+    /// Execute a function. Request envelope JSON on stdin; deliver the result
+    /// via `--result-delivery` (HTTP callback by default, or a protocol v3
+    /// envelope on stdout).
     Run {
         /// How to deliver the function result. Default remains the in-sandbox
         /// HTTP callback; `stdout` returns a protocol v3 envelope on stdout for

--- a/cli/dust-sandbox/src/commands/function/run.rs
+++ b/cli/dust-sandbox/src/commands/function/run.rs
@@ -30,10 +30,13 @@ pub async fn cmd_function_run(name: &str, result_delivery: ResultDelivery) -> Re
     match result_delivery {
         ResultDelivery::Callback => deliver_callback(name, code, &response).await,
         ResultDelivery::Stdout => {
-            deliver_stdout(&response, TimingsMs {
-                total: started.elapsed().as_millis() as u64,
-                runner: runner_ms,
-            });
+            deliver_stdout(
+                &response,
+                TimingsMs {
+                    total: started.elapsed().as_millis() as u64,
+                    runner: runner_ms,
+                },
+            );
         }
     }
 }

--- a/cli/dust-sandbox/src/commands/function/run.rs
+++ b/cli/dust-sandbox/src/commands/function/run.rs
@@ -19,27 +19,29 @@ const NON_JSON_SNIPPET_MAX_CHARS: usize = 512;
 ///   `DUST_SANDBOX_TOKEN` is set. As a testing/local convenience, when there is
 ///   no sandbox token the API call is skipped and the bare runner response is
 ///   written to dsbx's stdout instead (previous behavior).
-/// - `stdout`: print a protocol v3 envelope on stdout. Exit 0 whenever a
-///   well-formed envelope was written, including for runner `ok:false`, so the
-///   worker keeps structured errors. Never POSTs the callback.
+/// - `stdout`: print a protocol v3 envelope on stdout and exit 0, including for
+///   runner `ok:false` and for failures that keep the function from being
+///   spawned at all, so the worker keeps structured errors. Never POSTs the
+///   callback.
 pub async fn cmd_function_run(name: &str, result_delivery: ResultDelivery) -> Result<()> {
     let started = Instant::now();
-    let (code, captured) = spawn_function("run", name, true, true).await?;
+    let spawned = spawn_function("run", name, true, true).await;
     let runner_ms = started.elapsed().as_millis() as u64;
-    let response = captured.unwrap_or_default();
 
     match result_delivery {
-        ResultDelivery::Callback => deliver_callback(name, code, &response).await,
-        ResultDelivery::Stdout => {
-            deliver_stdout(
-                &response,
-                code,
-                TimingsMs {
-                    total: started.elapsed().as_millis() as u64,
-                    runner: runner_ms,
-                },
-            );
+        // Spawn failures keep propagating: the bare `{error}` line emit_error
+        // printed is the contract here, and the exit code stays non-zero.
+        ResultDelivery::Callback => {
+            let (code, captured) = spawned?;
+            deliver_callback(name, code, &captured.unwrap_or_default()).await
         }
+        ResultDelivery::Stdout => deliver_stdout(
+            spawned,
+            TimingsMs {
+                total: started.elapsed().as_millis() as u64,
+                runner: runner_ms,
+            },
+        ),
     }
 }
 
@@ -74,8 +76,8 @@ async fn deliver_callback(name: &str, code: i32, response: &str) -> Result<()> {
     std::process::exit(0);
 }
 
-fn deliver_stdout(response: &str, runner_exit_code: i32, timings_ms: TimingsMs) -> ! {
-    let (envelope, code) = stdout_result(response, runner_exit_code, timings_ms);
+fn deliver_stdout(spawned: Result<(i32, Option<String>)>, timings_ms: TimingsMs) -> ! {
+    let (envelope, code) = stdout_result(spawned, timings_ms);
     envelope.write_to_stdout();
     std::process::exit(code);
 }
@@ -85,11 +87,20 @@ fn deliver_stdout(response: &str, runner_exit_code: i32, timings_ms: TimingsMs) 
 /// Exit is always 0 when a well-formed envelope is produced so the worker can
 /// classify from `outcome` instead of treating the process as a hard failure.
 fn stdout_result(
-    response: &str,
-    runner_exit_code: i32,
+    spawned: Result<(i32, Option<String>)>,
     timings_ms: TimingsMs,
 ) -> (ResultEnvelope, i32) {
-    let line = last_non_empty_line(response);
+    // The function never ran (bad name, unset functions dir, missing or
+    // ambiguous bundle, spawn/read failure): stdout delivery owes the worker an
+    // envelope all the same. The bare `{error}` line emit_error already printed
+    // stays ahead of it on stdout; the envelope is the last non-empty line.
+    let (runner_exit_code, captured) = match spawned {
+        Ok(spawned) => spawned,
+        Err(err) => return (ResultEnvelope::stdout_invocation_failed(err.to_string()), 0),
+    };
+
+    let response = captured.unwrap_or_default();
+    let line = last_non_empty_line(&response);
     if line.is_empty() {
         return (
             ResultEnvelope::stdout_invocation_failed(format!(
@@ -141,8 +152,7 @@ mod tests {
     #[test]
     fn stdout_result_wraps_valid_json_and_exits_0() {
         let (envelope, code) = stdout_result(
-            "noise\n{\"ok\":true,\"output\":1}\n",
-            0,
+            Ok((0, Some("noise\n{\"ok\":true,\"output\":1}\n".to_string()))),
             TimingsMs {
                 total: 12,
                 runner: 8,
@@ -159,8 +169,7 @@ mod tests {
     #[test]
     fn stdout_result_exits_0_for_empty_and_non_json() {
         let (empty, empty_code) = stdout_result(
-            "",
-            7,
+            Ok((7, Some(String::new()))),
             TimingsMs {
                 total: 1,
                 runner: 1,
@@ -173,17 +182,41 @@ mod tests {
         );
 
         let (bad, bad_code) = stdout_result(
-            "not-json\n",
-            1,
+            Ok((1, Some("not-json\n".to_string()))),
             TimingsMs {
                 total: 1,
                 runner: 1,
             },
         );
         assert_eq!(bad_code, 0);
-        let message = bad.outcome["error"]["message"].as_str().unwrap();
+        let message = bad.outcome["error"]["message"]
+            .as_str()
+            .expect("invocation_failed message is a string");
         assert!(message.contains("runner exit 1"));
         assert!(message.contains("not-json"));
+    }
+
+    #[test]
+    fn stdout_result_envelopes_spawn_failures_and_exits_0() {
+        let (envelope, code) = stdout_result(
+            Err(anyhow!("function not found: greet")),
+            TimingsMs {
+                total: 1,
+                runner: 1,
+            },
+        );
+        assert_eq!(code, 0);
+        assert_eq!(envelope.delivery, ResultDelivery::Stdout);
+        assert_eq!(
+            envelope.outcome,
+            serde_json::json!({
+                "ok": false,
+                "error": {
+                    "code": "invocation_failed",
+                    "message": "function not found: greet",
+                }
+            })
+        );
     }
 
     #[test]

--- a/cli/dust-sandbox/src/commands/function/run.rs
+++ b/cli/dust-sandbox/src/commands/function/run.rs
@@ -1,5 +1,8 @@
+use std::time::Instant;
+
 use anyhow::{anyhow, Result};
 
+use super::envelope::{ResultDelivery, ResultEnvelope, TimingsMs};
 use super::{emit_error, spawn_function};
 use crate::api::DustApiClient;
 
@@ -8,14 +11,34 @@ const SANDBOX_TOKEN_ENV: &str = "DUST_SANDBOX_TOKEN";
 /// Execute a function and deliver its response.
 ///
 /// The request envelope is read from stdin and the function runs unprivileged
-/// (agent uid) when dsbx is invoked as root. The response is then delivered to
-/// the Dust result API. As a testing/local convenience, when there is no sandbox
-/// token (`DUST_SANDBOX_TOKEN` unset/empty) the API call is skipped and the
-/// response is written to dsbx's stdout instead (the previous behavior).
-pub async fn cmd_function_run(name: &str) -> Result<()> {
+/// (agent uid) when dsbx is invoked as root.
+///
+/// Delivery modes:
+/// - `callback` (default): POST the runner response to the Dust result API when
+///   `DUST_SANDBOX_TOKEN` is set. As a testing/local convenience, when there is
+///   no sandbox token the API call is skipped and the bare runner response is
+///   written to dsbx's stdout instead (previous behavior).
+/// - `stdout`: print a protocol v3 envelope on stdout. Exit 0 whenever a
+///   well-formed envelope was written, including for runner `ok:false`, so the
+///   worker keeps structured errors. Never POSTs the callback.
+pub async fn cmd_function_run(name: &str, result_delivery: ResultDelivery) -> Result<()> {
+    let started = Instant::now();
     let (code, captured) = spawn_function("run", name, true, true).await?;
+    let runner_ms = started.elapsed().as_millis() as u64;
     let response = captured.unwrap_or_default();
 
+    match result_delivery {
+        ResultDelivery::Callback => deliver_callback(name, code, &response).await,
+        ResultDelivery::Stdout => {
+            deliver_stdout(&response, TimingsMs {
+                total: started.elapsed().as_millis() as u64,
+                runner: runner_ms,
+            });
+        }
+    }
+}
+
+async fn deliver_callback(name: &str, code: i32, response: &str) -> Result<()> {
     let have_token = std::env::var(SANDBOX_TOKEN_ENV)
         .map(|t| !t.is_empty())
         .unwrap_or(false);
@@ -35,7 +58,7 @@ pub async fn cmd_function_run(name: &str) -> Result<()> {
     // The runner always emits a single JSON line; forward it as structured JSON
     // (fall back to a string if it somehow isn't valid JSON).
     let result: serde_json::Value = serde_json::from_str(response.trim())
-        .unwrap_or_else(|_| serde_json::Value::String(response.clone()));
+        .unwrap_or_else(|_| serde_json::Value::String(response.to_string()));
 
     let client = DustApiClient::from_env()?;
     client
@@ -43,4 +66,28 @@ pub async fn cmd_function_run(name: &str) -> Result<()> {
         .await
         .map_err(emit_error)?;
     std::process::exit(0);
+}
+
+fn deliver_stdout(response: &str, timings_ms: TimingsMs) -> ! {
+    let trimmed = response.trim();
+    if trimmed.is_empty() {
+        ResultEnvelope::stdout_invocation_failed("function produced no output").write_to_stdout();
+        std::process::exit(1);
+    }
+
+    match serde_json::from_str::<serde_json::Value>(trimmed) {
+        Ok(outcome) => {
+            ResultEnvelope::stdout_outcome(outcome, Some(timings_ms)).write_to_stdout();
+            // Exit 0 even when the runner reported ok:false, so the worker keeps
+            // the structured error instead of a generic non-zero exit path.
+            std::process::exit(0);
+        }
+        Err(_) => {
+            ResultEnvelope::stdout_invocation_failed(
+                "function produced non-JSON output that could not be wrapped as a result envelope",
+            )
+            .write_to_stdout();
+            std::process::exit(1);
+        }
+    }
 }

--- a/cli/dust-sandbox/src/commands/function/run.rs
+++ b/cli/dust-sandbox/src/commands/function/run.rs
@@ -7,6 +7,7 @@ use super::{emit_error, spawn_function};
 use crate::api::DustApiClient;
 
 const SANDBOX_TOKEN_ENV: &str = "DUST_SANDBOX_TOKEN";
+const NON_JSON_SNIPPET_MAX_CHARS: usize = 512;
 
 /// Execute a function and deliver its response.
 ///
@@ -23,8 +24,9 @@ const SANDBOX_TOKEN_ENV: &str = "DUST_SANDBOX_TOKEN";
 ///   worker keeps structured errors. Never POSTs the callback.
 pub async fn cmd_function_run(name: &str, result_delivery: ResultDelivery) -> Result<()> {
     let started = Instant::now();
+    let runner_started = Instant::now();
     let (code, captured) = spawn_function("run", name, true, true).await?;
-    let runner_ms = started.elapsed().as_millis() as u64;
+    let runner_ms = runner_started.elapsed().as_millis() as u64;
     let response = captured.unwrap_or_default();
 
     match result_delivery {
@@ -32,6 +34,7 @@ pub async fn cmd_function_run(name: &str, result_delivery: ResultDelivery) -> Re
         ResultDelivery::Stdout => {
             deliver_stdout(
                 &response,
+                code,
                 TimingsMs {
                     total: started.elapsed().as_millis() as u64,
                     runner: runner_ms,
@@ -52,16 +55,17 @@ async fn deliver_callback(name: &str, code: i32, response: &str) -> Result<()> {
         std::process::exit(code);
     }
 
+    let line = last_non_empty_line(response);
     // Sandbox: deliver the response to the Dust result API instead of stdout.
-    if response.trim().is_empty() {
+    if line.is_empty() {
         return Err(emit_error(anyhow!(
             "function produced no output to deliver to the result API"
         )));
     }
-    // The runner always emits a single JSON line; forward it as structured JSON
-    // (fall back to a string if it somehow isn't valid JSON).
-    let result: serde_json::Value = serde_json::from_str(response.trim())
-        .unwrap_or_else(|_| serde_json::Value::String(response.to_string()));
+    // The runner emits a JSON line; take the last non-empty line so incidental
+    // console.log output on the same fd does not poison the callback body.
+    let result: serde_json::Value =
+        serde_json::from_str(line).unwrap_or_else(|_| serde_json::Value::String(line.to_string()));
 
     let client = DustApiClient::from_env()?;
     client
@@ -71,27 +75,121 @@ async fn deliver_callback(name: &str, code: i32, response: &str) -> Result<()> {
     std::process::exit(0);
 }
 
-fn deliver_stdout(response: &str, timings_ms: TimingsMs) -> ! {
-    let trimmed = response.trim();
-    if trimmed.is_empty() {
-        ResultEnvelope::stdout_invocation_failed("function produced no output").write_to_stdout();
-        // Exit 0 after any well-formed envelope so the worker keeps structured errors.
-        std::process::exit(0);
+fn deliver_stdout(response: &str, runner_exit_code: i32, timings_ms: TimingsMs) -> ! {
+    let (envelope, code) = stdout_result(response, runner_exit_code, timings_ms);
+    envelope.write_to_stdout();
+    std::process::exit(code);
+}
+
+/// Build the stdout delivery envelope and process exit code.
+///
+/// Exit is always 0 when a well-formed envelope is produced so the worker can
+/// classify from `outcome` instead of treating the process as a hard failure.
+fn stdout_result(
+    response: &str,
+    runner_exit_code: i32,
+    timings_ms: TimingsMs,
+) -> (ResultEnvelope, i32) {
+    let line = last_non_empty_line(response);
+    if line.is_empty() {
+        return (
+            ResultEnvelope::stdout_invocation_failed(format!(
+                "function produced no output (runner exit {runner_exit_code})"
+            )),
+            0,
+        );
     }
 
-    match serde_json::from_str::<serde_json::Value>(trimmed) {
-        Ok(outcome) => {
-            ResultEnvelope::stdout_outcome(outcome, Some(timings_ms)).write_to_stdout();
-            // Exit 0 even when the runner reported ok:false, so the worker keeps
-            // the structured error instead of a generic non-zero exit path.
-            std::process::exit(0);
-        }
+    match serde_json::from_str::<serde_json::Value>(line) {
+        Ok(outcome) => (ResultEnvelope::stdout_outcome(outcome, Some(timings_ms)), 0),
         Err(_) => {
-            ResultEnvelope::stdout_invocation_failed(
-                "function produced non-JSON output that could not be wrapped as a result envelope",
+            let snippet = truncate_chars(line, NON_JSON_SNIPPET_MAX_CHARS);
+            (
+                ResultEnvelope::stdout_invocation_failed(format!(
+                    "function produced non-JSON output (runner exit {runner_exit_code}): {snippet}"
+                )),
+                0,
             )
-            .write_to_stdout();
-            std::process::exit(0);
         }
+    }
+}
+
+fn last_non_empty_line(response: &str) -> &str {
+    response
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .map(str::trim)
+        .unwrap_or("")
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    let mut out = String::new();
+    for (i, ch) in value.chars().enumerate() {
+        if i >= max_chars {
+            out.push('…');
+            break;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stdout_result_wraps_valid_json_and_exits_0() {
+        let (envelope, code) = stdout_result(
+            "noise\n{\"ok\":true,\"output\":1}\n",
+            0,
+            TimingsMs {
+                total: 12,
+                runner: 8,
+            },
+        );
+        assert_eq!(code, 0);
+        assert_eq!(envelope.delivery, ResultDelivery::Stdout);
+        assert_eq!(
+            envelope.outcome,
+            serde_json::json!({ "ok": true, "output": 1 })
+        );
+    }
+
+    #[test]
+    fn stdout_result_exits_0_for_empty_and_non_json() {
+        let (empty, empty_code) = stdout_result(
+            "",
+            7,
+            TimingsMs {
+                total: 1,
+                runner: 1,
+            },
+        );
+        assert_eq!(empty_code, 0);
+        assert_eq!(
+            empty.outcome["error"]["message"],
+            "function produced no output (runner exit 7)"
+        );
+
+        let (bad, bad_code) = stdout_result(
+            "not-json\n",
+            1,
+            TimingsMs {
+                total: 1,
+                runner: 1,
+            },
+        );
+        assert_eq!(bad_code, 0);
+        let message = bad.outcome["error"]["message"].as_str().unwrap();
+        assert!(message.contains("runner exit 1"));
+        assert!(message.contains("not-json"));
+    }
+
+    #[test]
+    fn last_non_empty_line_skips_trailing_blank_lines() {
+        assert_eq!(last_non_empty_line("a\n\n"), "a");
+        assert_eq!(last_non_empty_line("   \n"), "");
     }
 }

--- a/cli/dust-sandbox/src/commands/function/run.rs
+++ b/cli/dust-sandbox/src/commands/function/run.rs
@@ -75,7 +75,8 @@ fn deliver_stdout(response: &str, timings_ms: TimingsMs) -> ! {
     let trimmed = response.trim();
     if trimmed.is_empty() {
         ResultEnvelope::stdout_invocation_failed("function produced no output").write_to_stdout();
-        std::process::exit(1);
+        // Exit 0 after any well-formed envelope so the worker keeps structured errors.
+        std::process::exit(0);
     }
 
     match serde_json::from_str::<serde_json::Value>(trimmed) {
@@ -90,7 +91,7 @@ fn deliver_stdout(response: &str, timings_ms: TimingsMs) -> ! {
                 "function produced non-JSON output that could not be wrapped as a result envelope",
             )
             .write_to_stdout();
-            std::process::exit(1);
+            std::process::exit(0);
         }
     }
 }

--- a/cli/dust-sandbox/src/commands/function/run.rs
+++ b/cli/dust-sandbox/src/commands/function/run.rs
@@ -24,9 +24,8 @@ const NON_JSON_SNIPPET_MAX_CHARS: usize = 512;
 ///   worker keeps structured errors. Never POSTs the callback.
 pub async fn cmd_function_run(name: &str, result_delivery: ResultDelivery) -> Result<()> {
     let started = Instant::now();
-    let runner_started = Instant::now();
     let (code, captured) = spawn_function("run", name, true, true).await?;
-    let runner_ms = runner_started.elapsed().as_millis() as u64;
+    let runner_ms = started.elapsed().as_millis() as u64;
     let response = captured.unwrap_or_default();
 
     match result_delivery {

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -71,9 +71,10 @@ async fn run() -> anyhow::Result<()> {
         Commands::Healthcheck(args) => commands::cmd_healthcheck(args)?,
         Commands::Env(args) => commands::cmd_env(args)?,
         Commands::Function { command } => match command {
-            commands::function::FunctionCommand::Run { name } => {
-                commands::cmd_function_run(&name).await?
-            }
+            commands::function::FunctionCommand::Run {
+                name,
+                result_delivery,
+            } => commands::cmd_function_run(&name, result_delivery).await?,
             commands::function::FunctionCommand::Get { name } => {
                 commands::cmd_function_get(&name).await?
             }
@@ -185,7 +186,45 @@ mod tests {
         let cli = Cli::try_parse_from(["dsbx", "function", "run", "greet"]).expect("parse");
         match cli.command {
             Commands::Function { command } => match command {
-                commands::function::FunctionCommand::Run { name } => assert_eq!(name, "greet"),
+                commands::function::FunctionCommand::Run {
+                    name,
+                    result_delivery,
+                } => {
+                    assert_eq!(name, "greet");
+                    assert_eq!(
+                        result_delivery,
+                        commands::function::ResultDelivery::Callback
+                    );
+                }
+                _ => panic!("expected run"),
+            },
+            _ => panic!("expected function"),
+        }
+    }
+
+    #[test]
+    fn function_run_parses_stdout_result_delivery() {
+        let cli = Cli::try_parse_from([
+            "dsbx",
+            "function",
+            "run",
+            "--result-delivery",
+            "stdout",
+            "greet",
+        ])
+        .expect("parse");
+        match cli.command {
+            Commands::Function { command } => match command {
+                commands::function::FunctionCommand::Run {
+                    name,
+                    result_delivery,
+                } => {
+                    assert_eq!(name, "greet");
+                    assert_eq!(
+                        result_delivery,
+                        commands::function::ResultDelivery::Stdout
+                    );
+                }
                 _ => panic!("expected run"),
             },
             _ => panic!("expected function"),

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -220,10 +220,7 @@ mod tests {
                     result_delivery,
                 } => {
                     assert_eq!(name, "greet");
-                    assert_eq!(
-                        result_delivery,
-                        commands::function::ResultDelivery::Stdout
-                    );
+                    assert_eq!(result_delivery, commands::function::ResultDelivery::Stdout);
                 }
                 _ => panic!("expected run"),
             },

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.63",
+      tag: "0.8.64",
     });
   });
 
@@ -394,7 +394,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.40/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.41/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -25,8 +25,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.63";
-const DSBX_CLI_VERSION = "0.1.40";
+const DUST_BASE_IMAGE_VERSION = "0.8.64";
+const DSBX_CLI_VERSION = "0.1.41";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
 // list must not silently change this user's UID.


### PR DESCRIPTION
## Description

Add `--result-delivery stdout|callback` to `dsbx function run` (default remains `callback`). Stdout mode prints a protocol v3 result envelope and exits 0 whenever that envelope is well-formed, including runner `ok:false` and dsbx-minted `invocation_failed` cases. Parsing uses the last non-empty stdout line so incidental `console.log` output does not poison the result.

Also bumps dsbx to 0.1.41 and pins it in `dust-base` 0.8.64.

Note: this also changes the existing callback path's parsing from the whole trimmed output to the last non-empty stdout line, so incidental `console.log` output no longer poisons the callback body. When the last line is not valid JSON, the callback now forwards that line as a string rather than the full output.

## Tests

- Envelope serde pin, clap parse, and stdout_result unit tests.
- `cargo test` in `cli/dust-sandbox`.
- Registry tests pin the new image tag and dsbx download URL.

## Risk

The image build curls `dsbx-v0.1.41`, so that GitHub release must exist before or right after merge. Default delivery is still callback, so behavior matches today until the worker opts in.

## Deploy Plan

1. Merge.
2. Dispatch Release dsbx CLI for 0.1.41 if the release is not already up.
3. After the template builds, /poke/kill older dust-base versions.

