### PR TITLE
Bake dsbx 0.1.39 into dust-base 0.8.62

### DIFF
--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.61",
+      tag: "0.8.62",
     });
   });
 
@@ -394,7 +394,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.38/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.39/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -25,8 +25,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.61";
-const DSBX_CLI_VERSION = "0.1.38";
+const DUST_BASE_IMAGE_VERSION = "0.8.62";
+const DSBX_CLI_VERSION = "0.1.39";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
 // list must not silently change this user's UID.


### PR DESCRIPTION
## Description

Workstream 1, PR D. Pin `DSBX_CLI_VERSION` to 0.1.39 and `DUST_BASE_IMAGE_VERSION` to 0.8.62 so new Pod sandboxes get the stdout-capable CLI.

Merge only after `dsbx-v0.1.39` exists on GitHub Releases (dispatch Release dsbx CLI after the CLI PR merges).

## Tests

Registry tests pin the new image tag and dsbx download URL. Image build + security check on deploy is the real e2e.

## Risk

Medium for image rollout. New binary still defaults to callback. Rollback: recreate sandboxes on the previous dust-base tag.

## Deploy Plan

1. Confirm the dsbx-v0.1.39 release exists.
2. Merge (needs sandbox-image-ack).
3. After template build, /poke/kill older dust-base versions.