### PR TITLE
Add flag-gated worker stdout delivery for Pod function results

### DIFF
--- a/front/lib/api/sandbox_functions/result_delivery.test.ts
+++ b/front/lib/api/sandbox_functions/result_delivery.test.ts
@@ -1,0 +1,50 @@
+import { parseStdoutResultEnvelope } from "@app/lib/api/sandbox_functions/result_delivery";
+import { describe, expect, it } from "vitest";
+
+describe("parseStdoutResultEnvelope", () => {
+  it("parses the last non-empty stdout line as a v3 envelope", () => {
+    expect(
+      parseStdoutResultEnvelope(
+        "noise\n" +
+          JSON.stringify({
+            protocolVersion: 3,
+            delivery: "stdout",
+            outcome: { ok: true, output: { hello: "world" } },
+          }) +
+          "\n"
+      )
+    ).toEqual({
+      ok: true,
+      output: { hello: "world" },
+    });
+  });
+
+  it("preserves runner ok:false codes", () => {
+    expect(
+      parseStdoutResultEnvelope(
+        JSON.stringify({
+          protocolVersion: 3,
+          delivery: "stdout",
+          outcome: {
+            ok: false,
+            error: { code: "threw", message: "boom" },
+          },
+        })
+      )
+    ).toEqual({
+      ok: false,
+      error: { code: "threw", message: "boom" },
+    });
+  });
+
+  it("returns invocation_failed for empty or non-JSON stdout", () => {
+    expect(parseStdoutResultEnvelope("")).toMatchObject({
+      ok: false,
+      error: { code: "invocation_failed" },
+    });
+    expect(parseStdoutResultEnvelope("not-json")).toMatchObject({
+      ok: false,
+      error: { code: "invocation_failed" },
+    });
+  });
+});

--- a/front/lib/api/sandbox_functions/result_delivery.ts
+++ b/front/lib/api/sandbox_functions/result_delivery.ts
@@ -1,0 +1,45 @@
+import {
+  type NormalizedSandboxFunctionOutcome,
+  normalizeSandboxFunctionResult,
+} from "@app/lib/api/sandbox_functions/result_envelope";
+
+/**
+ * Parse a protocol v3 (or legacy) result envelope from dsbx stdout.
+ * Uses the last non-empty line, matching other dsbx stdout parsers.
+ * Never throws: malformed output becomes an invocation_failed outcome.
+ */
+export function parseStdoutResultEnvelope(
+  stdout: string
+): NormalizedSandboxFunctionOutcome {
+  const lastLine =
+    stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .at(-1) ?? "";
+
+  if (lastLine.length === 0) {
+    return {
+      ok: false,
+      error: {
+        code: "invocation_failed",
+        message: "Pod function produced no stdout result envelope.",
+      },
+    };
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(lastLine);
+  } catch {
+    return {
+      ok: false,
+      error: {
+        code: "invocation_failed",
+        message: "Pod function stdout was not valid JSON.",
+      },
+    };
+  }
+
+  return normalizeSandboxFunctionResult(json);
+}

--- a/front/lib/api/sandbox_functions/result_envelope.ts
+++ b/front/lib/api/sandbox_functions/result_envelope.ts
@@ -15,7 +15,7 @@ export const SUPPORTED_SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSIONS = [
 // Cap on the rejected-payload snippet included in logs.
 const REJECTED_ENVELOPE_LOG_SNIPPET_MAX_CHARS = 512;
 
-type NormalizedSandboxFunctionOutcome =
+export type NormalizedSandboxFunctionOutcome =
   | { ok: true; output: unknown }
   | { ok: false; error: SandboxFunctionCallError };
 

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -1021,4 +1021,39 @@ describe("SandboxFunctionInvocationResource", () => {
     expect(refetched?.error).toEqual({ code: "threw", message: "boom" });
   });
 
+  it("persists a stdout invocation_failed envelope even when exit code is non-zero", async () => {
+    const { authenticator, sandboxFunction, sandbox, invocation } =
+      await setupExecutionTest();
+    vi.mocked(hasFeatureFlag).mockResolvedValue(true);
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 1,
+        stdout: JSON.stringify({
+          protocolVersion: 3,
+          delivery: "stdout",
+          outcome: {
+            ok: false,
+            error: {
+              code: "invocation_failed",
+              message: "function produced no output",
+            },
+          },
+        }),
+        stderr: "",
+      })
+    );
+
+    const executionResult = await invocation.execute(authenticator);
+    expect(executionResult.isOk()).toBe(true);
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.status).toBe("errored");
+    expect(refetched?.error).toEqual({
+      code: "invocation_failed",
+      message: "function produced no output",
+    });
+  });
 });

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -2,7 +2,7 @@ import { formatSandboxFunctionInvocations } from "@app/lib/api/actions/servers/s
 import { generateSandboxFunctionInvocationToken } from "@app/lib/api/sandbox/access_tokens";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
-import { Authenticator } from "@app/lib/auth";
+import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
@@ -50,6 +50,14 @@ vi.mock("@app/lib/api/sandbox_functions/events", async (importOriginal) => {
   };
 });
 
+vi.mock("@app/lib/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@app/lib/auth")>();
+  return {
+    ...actual,
+    hasFeatureFlag: vi.fn(),
+  };
+});
+
 const inputSchema: JSONSchema = {
   type: "object",
   properties: {
@@ -69,6 +77,7 @@ const outputSchema: JSONSchema = {
 beforeEach(() => {
   vi.clearAllMocks();
   fileStorageMock.reset();
+  vi.mocked(hasFeatureFlag).mockResolvedValue(false);
 });
 
 async function setupExecutionTest(
@@ -948,4 +957,68 @@ describe("SandboxFunctionInvocationResource", () => {
     expect(result.error.message).toContain("exit code 2");
     expect(result.error.message).toContain("boom from stdout");
   });
+
+  it("persists a stdout envelope when the flag is enabled", async () => {
+    const { authenticator, sandboxFunction, sandbox, invocation } =
+      await setupExecutionTest();
+    vi.mocked(hasFeatureFlag).mockResolvedValue(true);
+    const execSpy = vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout:
+          JSON.stringify({
+            protocolVersion: 3,
+            delivery: "stdout",
+            outcome: { ok: true, output: { commentId: "from-stdout" } },
+          }) + "\n",
+        stderr: "",
+      })
+    );
+
+    const executionResult = await invocation.execute(authenticator);
+    expect(executionResult.isOk()).toBe(true);
+
+    const [, command] = execSpy.mock.calls[0]!;
+    expect(command).toBe(
+      "/opt/bin/dsbx function run --result-delivery stdout -- 'add-comment'"
+    );
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.status).toBe("succeeded");
+    expect(refetched?.result).toEqual({ commentId: "from-stdout" });
+  });
+
+  it("persists structured runner errors from stdout envelopes with exit 0", async () => {
+    const { authenticator, sandboxFunction, sandbox, invocation } =
+      await setupExecutionTest();
+    vi.mocked(hasFeatureFlag).mockResolvedValue(true);
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          protocolVersion: 3,
+          delivery: "stdout",
+          outcome: {
+            ok: false,
+            error: { code: "threw", message: "boom" },
+          },
+        }),
+        stderr: "",
+      })
+    );
+
+    const executionResult = await invocation.execute(authenticator);
+    expect(executionResult.isOk()).toBe(true);
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.status).toBe("errored");
+    expect(refetched?.error).toEqual({ code: "threw", message: "boom" });
+  });
+
 });

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -551,6 +551,31 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       if (execResult.isErr()) {
         return execResult;
       }
+
+      if (stdoutResultDelivery) {
+        const { exitCode, stdout } = execResult.value;
+        logger.info(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            sandboxFunctionId: sandboxFunction.sId,
+            invocationId: this.sId,
+            exitCode,
+            stdoutBytes: Buffer.byteLength(stdout, "utf8"),
+            deliveryMode: "stdout",
+          },
+          "Pod function stdout result delivery"
+        );
+        // Persist from the envelope even on non-zero exit: dsbx may still have
+        // written a well-formed invocation_failed envelope the worker should keep.
+        const normalized = parseStdoutResultEnvelope(stdout);
+        if (normalized.ok) {
+          await this.succeed(normalized.output);
+        } else {
+          await this.fail(normalized.error);
+        }
+        return new Ok(undefined);
+      }
+
       if (execResult.value.exitCode !== 0) {
         const { exitCode, stdout, stderr } = execResult.value;
         logger.error(
@@ -579,26 +604,6 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
             }`
           )
         );
-      }
-
-      if (stdoutResultDelivery) {
-        const { stdout } = execResult.value;
-        logger.info(
-          {
-            workspaceId: auth.getNonNullableWorkspace().sId,
-            sandboxFunctionId: sandboxFunction.sId,
-            invocationId: this.sId,
-            stdoutBytes: Buffer.byteLength(stdout, "utf8"),
-            deliveryMode: "stdout",
-          },
-          "Pod function stdout result delivery"
-        );
-        const normalized = parseStdoutResultEnvelope(stdout);
-        if (normalized.ok) {
-          await this.succeed(normalized.output);
-        } else {
-          await this.fail(normalized.error);
-        }
       }
 
       return new Ok(undefined);

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -553,7 +553,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       }
 
       if (stdoutResultDelivery) {
-        const { exitCode, stdout } = execResult.value;
+        const { exitCode, stdout, stderr } = execResult.value;
         logger.info(
           {
             workspaceId: auth.getNonNullableWorkspace().sId,
@@ -568,6 +568,24 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         // Persist from the envelope even on non-zero exit: dsbx may still have
         // written a well-formed invocation_failed envelope the worker should keep.
         const normalized = parseStdoutResultEnvelope(stdout);
+        if (!normalized.ok || exitCode !== 0) {
+          // Mirror the callback path's failure logging: without the raw
+          // stdout/stderr there is no way to diagnose a rejected envelope.
+          logger.error(
+            {
+              workspaceId: auth.getNonNullableWorkspace().sId,
+              spaceId: sandboxFunction.space.sId,
+              sandboxFunctionId: sandboxFunction.sId,
+              slug: sandboxFunction.slug,
+              invocationId: this.sId,
+              exitCode,
+              stdout: truncate(stdout, SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS),
+              stderr: truncate(stderr, SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS),
+              deliveryMode: "stdout",
+            },
+            "Sandbox function invocation failed"
+          );
+        }
         if (normalized.ok) {
           await this.succeed(normalized.output);
         } else {

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -16,11 +16,13 @@ import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import { SandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
+import { parseStdoutResultEnvelope } from "@app/lib/api/sandbox_functions/result_delivery";
 import {
   authorizeSandboxFunctionInvocation,
   getAuthenticatedWorkspaceUser,
 } from "@app/lib/api/sandbox_functions/workspace_user";
 import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
@@ -196,9 +198,15 @@ function dustAPIBaseUrlForSandbox(): string {
     : config.getApiBaseUrl();
 }
 
-function buildSandboxFunctionRunCommand(slug: string): string {
+function buildSandboxFunctionRunCommand(
+  slug: string,
+  { stdoutResultDelivery }: { stdoutResultDelivery: boolean }
+): string {
   // dsbx resolves `function run <slug>` as `${DUST_FUNCTIONS_DIR}/<slug>.ts`, which is the
   // read-only mount of the pod's published bundles.
+  if (stdoutResultDelivery) {
+    return `${DSBX_BIN_PATH} function run --result-delivery stdout -- ${shellEscape(slug)}`;
+  }
   return `${DSBX_BIN_PATH} function run ${shellEscape(slug)}`;
 }
 
@@ -486,15 +494,23 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
 
       await ensureResult.value.sandbox.updateLastActivityAt();
 
+      const sandbox = ensureResult.value.sandbox;
+      const stdoutResultDelivery = await hasFeatureFlag(
+        auth,
+        "sandbox_function_stdout_result"
+      );
+
       const execId = generateExecId();
       const token = await generateSandboxFunctionInvocationToken(auth, {
-        sandbox: ensureResult.value.sandbox,
+        sandbox,
         sandboxFunction,
         invocationId: this.sId,
         execId,
       });
 
-      const command = buildSandboxFunctionRunCommand(sandboxFunction.slug);
+      const command = buildSandboxFunctionRunCommand(sandboxFunction.slug, {
+        stdoutResultDelivery,
+      });
       const inputEnvelope = {
         method: "POST",
         url: `https://dust.local/sandbox-functions/${sandboxFunction.sId}/invocations/${this.sId}`,
@@ -514,7 +530,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         this
       );
 
-      const execResult = await ensureResult.value.sandbox.exec(auth, command, {
+      const execResult = await sandbox.exec(auth, command, {
         workingDirectory: SANDBOX_FUNCTION_WORKING_DIRECTORY,
         envVars: {
           DUST_API_URL: `${dustAPIBaseUrlForSandbox()}/api/v1/w/${auth.getNonNullableWorkspace().sId}`,
@@ -563,6 +579,26 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
             }`
           )
         );
+      }
+
+      if (stdoutResultDelivery) {
+        const { stdout } = execResult.value;
+        logger.info(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            sandboxFunctionId: sandboxFunction.sId,
+            invocationId: this.sId,
+            stdoutBytes: Buffer.byteLength(stdout, "utf8"),
+            deliveryMode: "stdout",
+          },
+          "Pod function stdout result delivery"
+        );
+        const normalized = parseStdoutResultEnvelope(stdout);
+        if (normalized.ok) {
+          await this.succeed(normalized.output);
+        } else {
+          await this.fail(normalized.error);
+        }
       }
 
       return new Ok(undefined);

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -206,6 +206,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable Pod Function invocation endpoints",
     stage: "dust_only",
   },
+  sandbox_function_stdout_result: {
+    description:
+      "Return Pod function results through the worker dsbx stdout channel instead of the in-sandbox HTTP callback",
+    stage: "dust_only",
+  },
   run_tools_from_prompt: {
     description: "Enable /run command to directly call tools without LLM",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -782,6 +782,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "restricted_spaces_in_input_bar"
   | "salesforce_synced_queries"
   | "salesforce_tool"
+  | "sandbox_function_stdout_result"
   | "sandbox_functions"
   | "self_created_slack_app_connector_rollout"
   | "servicenow_tool"


### PR DESCRIPTION
## Description

Behind the `sandbox_function_stdout_result` flag, the worker passes `--result-delivery stdout` to dsbx and persists the protocol v3 envelope itself, including when the process exits non-zero but still wrote a well-formed envelope.

Flag off keeps the existing HTTP callback path.

Stacked on the CAS terminal-transition PR.

## Tests

- Unit tests for stdout envelope parsing.
- Resource tests for success, structured `ok:false`, and non-zero exit with an envelope.

## Risk

Medium while rolling out. Kill switch is the feature flag.

## Deploy Plan

1. Merge after the envelope, CAS, and dsbx/image prerequisites.
2. Enable the flag for a small cohort.
3. Watch stdout size logs and `invocation_failed` rates before widening.