### PR TITLE
[front] enh: add link to skill in `enable_skill` action details

### DIFF
--- a/front/components/actions/ActionDetailsWrapper.tsx
+++ b/front/components/actions/ActionDetailsWrapper.tsx
@@ -184,6 +184,7 @@ export function ActionDetailsWrapper({
         >
           {actionName}
         </span>
+        {headerAction}
         {hasDuration && (
           <DurationLabel
             durationMs={displayedDurationMs}
@@ -191,7 +192,6 @@ export function ActionDetailsWrapper({
             size="sm"
           />
         )}
-        {headerAction}
       </div>
       {children}
     </>

--- a/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
@@ -77,6 +77,19 @@ export function MCPSkillEnableActionDetails({
     >
       {showSidebarDetails && (
         <div className="dd-privacy-mask flex flex-col gap-4 py-4 pl-6">
+          {outputItems.length > 0 && (
+            <div>
+              <span className="font-medium text-foreground">Output</span>
+              <div className="my-2 flex flex-col gap-2">
+                {outputItems.map((o, index) => (
+                  <ContentMessage key={index} variant="primary" size="lg">
+                    {getOutputText(o) ?? ""}
+                  </ContentMessage>
+                ))}
+              </div>
+            </div>
+          )}
+
           {hasDescription && (
             <div>
               <span className="font-medium text-foreground">Description</span>
@@ -90,19 +103,6 @@ export function MCPSkillEnableActionDetails({
                     isLastMessage={false}
                   />
                 </ContentMessage>
-              </div>
-            </div>
-          )}
-
-          {outputItems.length > 0 && (
-            <div>
-              <span className="font-medium text-foreground">Output</span>
-              <div className="my-2 flex flex-col gap-2">
-                {outputItems.map((o, index) => (
-                  <ContentMessage key={index} variant="primary" size="lg">
-                    {getOutputText(o) ?? ""}
-                  </ContentMessage>
-                ))}
               </div>
             </div>
           )}

--- a/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
@@ -11,7 +11,12 @@ import { getEnableSkillIdFromOutputBlock } from "@app/lib/api/actions/servers/sk
 import { SKILL_ICON } from "@app/lib/skill";
 import { useSkill } from "@app/lib/swr/skill_configurations";
 import { getManageSkillsRoute } from "@app/lib/utils/router";
-import { Button, ContentMessage, Spinner } from "@dust-tt/sparkle";
+import {
+  ContentMessage,
+  IconButton,
+  LinkExternal01,
+  Spinner,
+} from "@dust-tt/sparkle";
 
 export function MCPSkillEnableActionDetails({
   owner,
@@ -59,11 +64,11 @@ export function MCPSkillEnableActionDetails({
       actionName={actionName}
       headerAction={
         displayContext !== "conversation" && enabledSkillId ? (
-          <Button
+          <IconButton
             href={getManageSkillsRoute(owner.sId, enabledSkillId)}
-            label="View skill"
+            icon={LinkExternal01}
             size="xs"
-            variant="outline"
+            tooltip="View skill"
           />
         ) : undefined
       }

--- a/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
@@ -15,6 +15,7 @@ import {
   ContentMessage,
   IconButton,
   LinkExternal01,
+  Markdown,
   Spinner,
 } from "@dust-tt/sparkle";
 
@@ -77,12 +78,15 @@ export function MCPSkillEnableActionDetails({
       {showSidebarDetails && (
         <div className="dd-privacy-mask flex flex-col gap-4 py-4 pl-6">
           {hasDescription && (
-            <div>
-              <span className="font-medium text-foreground">Description</span>
-              <div className="my-2 text-sm text-muted-foreground">
-                {description}
-              </div>
-            </div>
+            <ContentMessage title="Description" variant="primary" size="lg">
+              <Markdown
+                content={description}
+                isStreaming={false}
+                forcedTextSize="text-sm"
+                textColor="text-muted-foreground"
+                isLastMessage={false}
+              />
+            </ContentMessage>
           )}
 
           {outputItems.length > 0 && (

--- a/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
@@ -78,15 +78,20 @@ export function MCPSkillEnableActionDetails({
       {showSidebarDetails && (
         <div className="dd-privacy-mask flex flex-col gap-4 py-4 pl-6">
           {hasDescription && (
-            <ContentMessage title="Description" variant="primary" size="lg">
-              <Markdown
-                content={description}
-                isStreaming={false}
-                forcedTextSize="text-sm"
-                textColor="text-muted-foreground"
-                isLastMessage={false}
-              />
-            </ContentMessage>
+            <div>
+              <span className="font-medium text-foreground">Description</span>
+              <div className="my-2">
+                <ContentMessage variant="primary" size="lg">
+                  <Markdown
+                    content={description}
+                    isStreaming={false}
+                    forcedTextSize="text-sm"
+                    textColor="text-muted-foreground"
+                    isLastMessage={false}
+                  />
+                </ContentMessage>
+              </div>
+            </div>
           )}
 
           {outputItems.length > 0 && (

--- a/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
@@ -10,7 +10,8 @@ import { isSkillEnableInputType } from "@app/lib/actions/mcp_internal_actions/ty
 import { getEnableSkillIdFromOutputBlock } from "@app/lib/api/actions/servers/skill_management/rendering";
 import { SKILL_ICON } from "@app/lib/skill";
 import { useSkill } from "@app/lib/swr/skill_configurations";
-import { ContentMessage, Spinner } from "@dust-tt/sparkle";
+import { getManageSkillsRoute } from "@app/lib/utils/router";
+import { Button, ContentMessage, Spinner } from "@dust-tt/sparkle";
 
 export function MCPSkillEnableActionDetails({
   owner,
@@ -42,22 +43,43 @@ export function MCPSkillEnableActionDetails({
     disabled: !shouldFetchSkill,
   });
 
+  const description = skill?.userFacingDescription.trim() ?? "";
+  const hasDescription = description.length > 0;
   const instructions = skill?.instructions ?? "";
   const hasInstructions = instructions.trim().length > 0;
   const showInstructionsSection =
     shouldFetchSkill && (isSkillLoading || isSkillError || hasInstructions);
   const showSidebarDetails =
     displayContext !== "conversation" &&
-    (showInstructionsSection || outputItems.length > 0);
+    (hasDescription || showInstructionsSection || outputItems.length > 0);
 
   return (
     <ActionDetailsWrapper
       displayContext={displayContext}
       actionName={actionName}
+      headerAction={
+        displayContext !== "conversation" && enabledSkillId ? (
+          <Button
+            href={getManageSkillsRoute(owner.sId, enabledSkillId)}
+            label="View skill"
+            size="xs"
+            variant="outline"
+          />
+        ) : undefined
+      }
       visual={SKILL_ICON}
     >
       {showSidebarDetails && (
         <div className="dd-privacy-mask flex flex-col gap-4 py-4 pl-6">
+          {hasDescription && (
+            <div>
+              <span className="font-medium text-foreground">Description</span>
+              <div className="my-2 text-sm text-muted-foreground">
+                {description}
+              </div>
+            </div>
+          )}
+
           {outputItems.length > 0 && (
             <div>
               <span className="font-medium text-foreground">Output</span>


### PR DESCRIPTION
## Description

There is currently no direct way to go inspect a skill that was just enabled from the conversation.

This PR adds a button that redirects to the skill from the  `enable_skill` MCP action details.
Also adds the description.

<img width="882" height="558" alt="image" src="https://github.com/user-attachments/assets/5edf5f1d-2a49-4d62-8f87-9e4754bc2f13" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
