### PR TITLE
[front] fix batch edit skill availability mutate

### DIFF
--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -184,16 +184,19 @@ export function useSkillsWithRelations({
     queryParams.set("bypassEditorVisibility", "true");
   }
 
-  const { data, isLoading, mutate } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/skills?${queryParams.toString()}`,
-    skillsFetcher,
-    { disabled }
-  );
+  const { data, isLoading, mutate, mutateRegardlessOfQueryParams } =
+    useSWRWithDefaults(
+      `/api/w/${owner.sId}/skills?${queryParams.toString()}`,
+      skillsFetcher,
+      { disabled }
+    );
 
   return {
     skillsWithRelations: data?.skills ?? emptyArray(),
     isSkillsWithRelationsLoading: isLoading,
     mutateSkillsWithRelations: mutate,
+    mutateSkillsWithRelationsRegardlessOfQueryParams:
+      mutateRegardlessOfQueryParams,
   };
 }
 
@@ -205,12 +208,13 @@ export function useUpdateSkillsAvailability({
   const { fetcher } = useFetcher();
   const sendNotification = useSendNotification();
 
-  const { mutateSkillsWithRelations: mutateActiveSkills } =
-    useSkillsWithRelations({
-      owner,
-      status: "active",
-      disabled: true,
-    });
+  const {
+    mutateSkillsWithRelationsRegardlessOfQueryParams: mutateActiveSkills,
+  } = useSkillsWithRelations({
+    owner,
+    status: "active",
+    disabled: true,
+  });
 
   const doUpdateAvailability = async (
     skillIds: string[],


### PR DESCRIPTION
## Description
This PR is to refetch skills list after batch editing.  Here is what Claude says:

Before: after a batch availability edit, we refreshed only one hardcoded cache key (status=active). But the list on screen often uses a different key (e.g. admin's bypassEditorVisibility toggle, or availability filters), so its cache never updated → stale.

Fix: instead of refreshing one key, refresh all skills-list caches for the workspace (match any /skills key regardless of query params). Now the visible list always updates.


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
