### PR TITLE
Add terminal image pruning to conversation window state

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.test.ts
@@ -2,9 +2,17 @@ import {
   CheckpointedConversationWindowState,
   MINIMUM_PRUNING_BATCH_TOKENS,
 } from "@app/lib/api/assistant/conversation_rendering/checkpointed_window_state";
-import type { InteractionWithTokens } from "@app/lib/api/assistant/conversation_rendering/pruning";
+import {
+  IMAGE_CONTENT_TOKEN_COUNT,
+  type InteractionWithTokens,
+} from "@app/lib/api/assistant/conversation_rendering/pruning";
 import type { ModelMessageTypeMultiActions } from "@app/types/assistant/generation";
+import { isImageContent } from "@app/types/assistant/generation";
 import { describe, expect, it } from "vitest";
+
+const DEFAULT_MESSAGE_TOKEN_COUNT = 10;
+const PRUNABLE_TOOL_RESULT_TOKEN_COUNT = 11_000;
+const LOW_PRUNING_BUDGET = 15_000;
 
 function withTokens<T extends ModelMessageTypeMultiActions>(
   message: T,
@@ -24,7 +32,24 @@ function userMessage(name: string, tokenCount: number) {
   );
 }
 
-function assistantMessage(name: string, tokenCount = 10) {
+function userImageMessage(name: string, imageUrls: string[]) {
+  return withTokens(
+    {
+      role: "user" as const,
+      name,
+      content: imageUrls.map((url) => ({
+        type: "image_url" as const,
+        image_url: { url },
+      })),
+    },
+    imageUrls.length * IMAGE_CONTENT_TOKEN_COUNT + DEFAULT_MESSAGE_TOKEN_COUNT
+  );
+}
+
+function assistantMessage(
+  name: string,
+  tokenCount = DEFAULT_MESSAGE_TOKEN_COUNT
+) {
   return withTokens(
     {
       role: "assistant" as const,
@@ -43,6 +68,23 @@ function functionMessage(name: string, tokenCount: number) {
       name,
       function_call_id: `${name}_call`,
       content: `${name}_result`,
+    },
+    tokenCount
+  );
+}
+
+function functionImageMessage(name: string, tokenCount: number) {
+  return withTokens(
+    {
+      role: "function" as const,
+      name,
+      function_call_id: `${name}_call`,
+      content: [
+        {
+          type: "image_url" as const,
+          image_url: { url: `${name}_image` },
+        },
+      ],
     },
     tokenCount
   );
@@ -68,14 +110,17 @@ function isPruned(content: unknown): boolean {
 function makeState({
   pruningBudget = 30_000,
   budgetForInteractions = 100_000,
+  maxImages,
 }: {
   pruningBudget?: number;
   budgetForInteractions?: number;
+  maxImages?: number;
 } = {}) {
   return CheckpointedConversationWindowState.empty({
     pruningBudget,
     budgetForInteractions,
     logDetails: {},
+    maxImages,
   });
 }
 
@@ -136,17 +181,125 @@ describe("CheckpointedConversationWindowState", () => {
     expect(state.renderedInteractions()).toHaveLength(2);
   });
 
+  it("rejects messages appended after the state has been fitted", () => {
+    const state = makeState();
+    state.append(
+      interaction([userMessage("first", DEFAULT_MESSAGE_TOKEN_COUNT)])
+    );
+    state.fit();
+
+    expect(() =>
+      state.append(
+        interaction([userMessage("second", DEFAULT_MESSAGE_TOKEN_COUNT)])
+      )
+    ).toThrow("Cannot append to a fitted conversation window state.");
+  });
+
+  it("prunes the oldest images and retains the newest images", () => {
+    const state = makeState({ maxImages: 1 });
+    const input = userImageMessage("user", ["old_image", "new_image"]);
+
+    state.append(interaction([input]));
+
+    const result = state.fit();
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+
+    const [message] = result.value.interactions[0].messages;
+    expect(message.role).toBe("user");
+    if (message.role !== "user") {
+      return;
+    }
+    expect(message.content).toEqual([
+      { type: "image_url", image_url: { url: "new_image" } },
+    ]);
+    expect(result.value.stats.totalTokensAfterPruning).toBe(
+      input.tokenCount - IMAGE_CONTENT_TOKEN_COUNT
+    );
+    expect(result.value.prunedContext).toBe(false);
+    expect(input.content.filter(isImageContent)).toHaveLength(2);
+  });
+
+  it("keeps image-only messages valid when every image is pruned", () => {
+    const state = makeState({ maxImages: 1 });
+    const oldMessage = userImageMessage("old", ["old_image"]);
+
+    state.append(interaction([oldMessage]));
+    state.append(interaction([userImageMessage("new", ["new_image"])]));
+
+    const result = state.fit();
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+
+    const messages = result.value.interactions.flatMap((item) => item.messages);
+    expect(messages[0].role).toBe("user");
+    if (messages[0].role !== "user") {
+      return;
+    }
+    expect(messages[0].content).toEqual([
+      {
+        type: "text",
+        text: expect.stringContaining("model input image limit"),
+      },
+    ]);
+    expect(result.value.prunedContext).toBe(false);
+    expect(oldMessage.content).toEqual([
+      { type: "image_url", image_url: { url: "old_image" } },
+    ]);
+  });
+
+  it("counts only images surviving tool-result pruning", () => {
+    const state = makeState({
+      pruningBudget: LOW_PRUNING_BUDGET,
+      maxImages: 1,
+    });
+
+    state.append(
+      interaction([
+        userImageMessage("user", ["user_image"]),
+        assistantMessage("call_first"),
+        functionImageMessage("first", PRUNABLE_TOOL_RESULT_TOKEN_COUNT),
+        assistantMessage("call_second"),
+        functionImageMessage("second", PRUNABLE_TOOL_RESULT_TOKEN_COUNT),
+        assistantMessage("answer"),
+      ])
+    );
+    state.append(interaction([userMessage("follow_up", 10)]));
+
+    const result = state.fit();
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+
+    expect(
+      toolResults(state).every((message) => isPruned(message.content))
+    ).toBe(true);
+    const firstMessage = result.value.interactions[0].messages[0];
+    expect(firstMessage.role).toBe("user");
+    if (firstMessage.role !== "user") {
+      return;
+    }
+    expect(firstMessage.content).toEqual([
+      { type: "image_url", image_url: { url: "user_image" } },
+    ]);
+  });
+
   it("prunes consumed results in a buffered checkpoint and protects the pending batch", () => {
     const state = makeState();
     const input = interaction([
       userMessage("question", 10),
       assistantMessage("call_first"),
-      functionMessage("first", 11_000),
+      functionMessage("first", PRUNABLE_TOOL_RESULT_TOKEN_COUNT),
       assistantMessage("call_second"),
-      functionMessage("second", 11_000),
+      functionMessage("second", PRUNABLE_TOOL_RESULT_TOKEN_COUNT),
       assistantMessage("call_parallel"),
-      functionMessage("pending_first", 11_000),
-      functionMessage("pending_second", 11_000),
+      functionMessage("pending_first", PRUNABLE_TOOL_RESULT_TOKEN_COUNT),
+      functionMessage("pending_second", PRUNABLE_TOOL_RESULT_TOKEN_COUNT),
     ]);
 
     state.append(input);
@@ -182,11 +335,11 @@ describe("CheckpointedConversationWindowState", () => {
       interaction([
         userMessage("first_question", 10),
         assistantMessage("call_first"),
-        functionMessage("first", 11_000),
+        functionMessage("first", PRUNABLE_TOOL_RESULT_TOKEN_COUNT),
         assistantMessage("call_second"),
-        functionMessage("second", 11_000),
+        functionMessage("second", PRUNABLE_TOOL_RESULT_TOKEN_COUNT),
         assistantMessage("call_third"),
-        functionMessage("third", 11_000),
+        functionMessage("third", PRUNABLE_TOOL_RESULT_TOKEN_COUNT),
       ])
     );
     state.append(interaction([userMessage("follow_up", 10)]));
@@ -203,7 +356,7 @@ describe("CheckpointedConversationWindowState", () => {
   });
 
   it("waits for a full checkpoint of reclaimable results before moving the frontier", () => {
-    const state = makeState({ pruningBudget: 15_000 });
+    const state = makeState({ pruningBudget: LOW_PRUNING_BUDGET });
 
     state.append(
       interaction([
@@ -294,11 +447,11 @@ describe("CheckpointedConversationWindowState", () => {
     const prefix = interaction([
       userMessage("question", 10),
       assistantMessage("call_first"),
-      functionMessage("first", 11_000),
+      functionMessage("first", PRUNABLE_TOOL_RESULT_TOKEN_COUNT),
       assistantMessage("call_second"),
-      functionMessage("second", 11_000),
+      functionMessage("second", PRUNABLE_TOOL_RESULT_TOKEN_COUNT),
       assistantMessage("call_third"),
-      functionMessage("third", 11_000),
+      functionMessage("third", PRUNABLE_TOOL_RESULT_TOKEN_COUNT),
     ]);
     const prefixState = makeState();
     prefixState.append(prefix);

--- a/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.test.ts
@@ -218,6 +218,7 @@ describe("CheckpointedConversationWindowState", () => {
     expect(result.value.stats.totalTokensAfterPruning).toBe(
       input.tokenCount - IMAGE_CONTENT_TOKEN_COUNT
     );
+    expect(result.value.stats.prunedImageCount).toBe(1);
     expect(result.value.prunedContext).toBe(false);
     expect(input.content.filter(isImageContent)).toHaveLength(2);
   });

--- a/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.ts
+++ b/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.ts
@@ -80,6 +80,7 @@ function pruneImagesBeyondLimit(
       imageMessage = message;
       content = message.content;
       break;
+
     case "function":
       if (!Array.isArray(message.content)) {
         return {
@@ -92,6 +93,7 @@ function pruneImagesBeyondLimit(
       imageMessage = message;
       content = message.content;
       break;
+
     case "assistant":
     case "compaction":
       return {
@@ -100,6 +102,7 @@ function pruneImagesBeyondLimit(
         retainedImageCount: 0,
         tokenSavings: 0,
       };
+
     default:
       return assertNever(message);
   }
@@ -183,6 +186,7 @@ export class CheckpointedConversationWindowState {
   private retainedTokens = 0;
   private totalTokensBefore = 0;
   private prunedTokens = 0;
+  private prunedImageCount = 0;
   private fitted = false;
 
   private pendingToolResults: PendingToolResult[] = [];
@@ -324,6 +328,7 @@ export class CheckpointedConversationWindowState {
           node.message = result.message;
           this.retainedTokens -= result.tokenSavings;
           this.prunedTokens += result.tokenSavings;
+          this.prunedImageCount += result.prunedImageCount;
         }
         imagesToKeep -= result.retainedImageCount;
       }
@@ -400,6 +405,7 @@ export class CheckpointedConversationWindowState {
       totalTokensAfterPruning,
       pruningBudget: this.options.pruningBudget,
       budgetForInteractions: this.options.budgetForInteractions,
+      prunedImageCount: this.prunedImageCount,
     };
   }
 }

--- a/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.ts
+++ b/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.ts
@@ -4,6 +4,7 @@ import type {
 } from "@app/lib/api/assistant/conversation_rendering/pruning";
 import {
   getToolResultTokenSavings,
+  IMAGE_CONTENT_TOKEN_COUNT,
   PRUNING_CHECKPOINT_TOKENS,
   pruneToolResultMessage,
 } from "@app/lib/api/assistant/conversation_rendering/pruning";
@@ -12,8 +13,17 @@ import type {
   ConversationWindowResult,
 } from "@app/lib/api/assistant/conversation_rendering/window_types";
 import logger from "@app/logger/logger";
+import type { Content } from "@app/types/assistant/generation";
+import { isImageContent } from "@app/types/assistant/generation";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+const PRUNED_IMAGE_PLACEHOLDER =
+  "<dust_system>" +
+  "This image is no longer available (pruned to respect the model input image limit)." +
+  "</dust_system>";
+const PRUNED_IMAGE_PLACEHOLDER_TOKENS = 24;
 
 type RegularMessageNode = {
   kind: "message";
@@ -45,7 +55,98 @@ type WindowInteraction = {
   messages: WindowMessageNode[];
 };
 
+type ImageBearingMessage = Extract<
+  MessageWithTokens,
+  { role: "user" | "content_fragment" | "function" }
+>;
+
 export const MINIMUM_PRUNING_BATCH_TOKENS = 5_000;
+
+function pruneImagesBeyondLimit(
+  message: MessageWithTokens,
+  imagesToKeep: number
+): {
+  message: MessageWithTokens;
+  prunedImageCount: number;
+  retainedImageCount: number;
+  tokenSavings: number;
+} {
+  let imageMessage: ImageBearingMessage;
+  let content: Content[];
+
+  switch (message.role) {
+    case "user":
+    case "content_fragment":
+      imageMessage = message;
+      content = message.content;
+      break;
+    case "function":
+      if (!Array.isArray(message.content)) {
+        return {
+          message,
+          prunedImageCount: 0,
+          retainedImageCount: 0,
+          tokenSavings: 0,
+        };
+      }
+      imageMessage = message;
+      content = message.content;
+      break;
+    case "assistant":
+    case "compaction":
+      return {
+        message,
+        prunedImageCount: 0,
+        retainedImageCount: 0,
+        tokenSavings: 0,
+      };
+    default:
+      return assertNever(message);
+  }
+
+  let prunedImageCount = 0;
+  let retainedImageCount = 0;
+  const retainedContentReversed: Content[] = [];
+  for (let index = content.length - 1; index >= 0; index--) {
+    const item = content[index];
+    if (!isImageContent(item) || retainedImageCount < imagesToKeep) {
+      retainedContentReversed.push(item);
+      if (isImageContent(item)) {
+        retainedImageCount += 1;
+      }
+    } else {
+      prunedImageCount += 1;
+    }
+  }
+
+  if (prunedImageCount === 0) {
+    return {
+      message,
+      prunedImageCount: 0,
+      retainedImageCount,
+      tokenSavings: 0,
+    };
+  }
+
+  const retainedContent = retainedContentReversed.reverse();
+  const addedPlaceholder = retainedContent.length === 0;
+  const tokenSavings =
+    prunedImageCount * IMAGE_CONTENT_TOKEN_COUNT -
+    (addedPlaceholder ? PRUNED_IMAGE_PLACEHOLDER_TOKENS : 0);
+
+  return {
+    message: {
+      ...imageMessage,
+      content: addedPlaceholder
+        ? [{ type: "text", text: PRUNED_IMAGE_PLACEHOLDER }]
+        : retainedContent,
+      tokenCount: imageMessage.tokenCount - tokenSavings,
+    },
+    prunedImageCount,
+    retainedImageCount,
+    tokenSavings,
+  };
+}
 
 function makeWindowMessageNode(message: MessageWithTokens): WindowMessageNode {
   if (message.role === "function") {
@@ -73,12 +174,16 @@ function makeWindowMessageNode(message: MessageWithTokens): WindowMessageNode {
  * If tool-result pruning cannot keep the complete interaction history below the nominal budget,
  * the window keeps serving it and reports the excess through logs and metrics. The provider limit
  * remains the final boundary. The latest unconsumed result batch always remains intact.
+ *
+ * When configured, an image limit is applied after tool-result pruning. The newest images are
+ * retained and the oldest overflow is removed, including when token-based pruning did not run.
  */
 export class CheckpointedConversationWindowState {
   private interactions: WindowInteraction[] = [];
   private retainedTokens = 0;
   private totalTokensBefore = 0;
   private prunedTokens = 0;
+  private fitted = false;
 
   private pendingToolResults: PendingToolResult[] = [];
   private eligibleToolResults: EligibleToolResult[] = [];
@@ -90,6 +195,7 @@ export class CheckpointedConversationWindowState {
       pruningBudget: number;
       budgetForInteractions: number;
       logDetails: Record<string, unknown>;
+      maxImages?: number;
     }
   ) {}
 
@@ -97,11 +203,17 @@ export class CheckpointedConversationWindowState {
     pruningBudget: number;
     budgetForInteractions: number;
     logDetails: Record<string, unknown>;
+    maxImages?: number;
   }): CheckpointedConversationWindowState {
     return new CheckpointedConversationWindowState(options);
   }
 
   append(interaction: InteractionWithTokens): void {
+    // fit() applies terminal rewrites, so cached pruning savings must not be reused afterward.
+    if (this.fitted) {
+      throw new Error("Cannot append to a fitted conversation window state.");
+    }
+
     if (interaction.messages.length === 0) {
       return;
     }
@@ -143,6 +255,7 @@ export class CheckpointedConversationWindowState {
   }
 
   fit(): Result<ConversationWindowResult, Error> {
+    this.fitted = true;
     const { budgetForInteractions, logDetails } = this.options;
 
     if (this.interactions.length === 0) {
@@ -152,6 +265,8 @@ export class CheckpointedConversationWindowState {
         stats: this.stats(),
       });
     }
+
+    this.applyImageLimit();
 
     if (this.retainedTokens > budgetForInteractions) {
       logger.warn(
@@ -182,6 +297,37 @@ export class CheckpointedConversationWindowState {
     return latestInteraction.messages.some(
       (node) => node.kind === "tool_result" && node.pruned
     );
+  }
+
+  private applyImageLimit(): void {
+    const { maxImages } = this.options;
+    if (maxImages === undefined) {
+      return;
+    }
+
+    let imagesToKeep = maxImages;
+    for (
+      let interactionIndex = this.interactions.length - 1;
+      interactionIndex >= 0;
+      interactionIndex--
+    ) {
+      const interaction = this.interactions[interactionIndex];
+      for (
+        let messageIndex = interaction.messages.length - 1;
+        messageIndex >= 0;
+        messageIndex--
+      ) {
+        const node = interaction.messages[messageIndex];
+        const result = pruneImagesBeyondLimit(node.message, imagesToKeep);
+
+        if (result.prunedImageCount > 0) {
+          node.message = result.message;
+          this.retainedTokens -= result.tokenSavings;
+          this.prunedTokens += result.tokenSavings;
+        }
+        imagesToKeep -= result.retainedImageCount;
+      }
+    }
   }
 
   private isModelInputCheckpoint(

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -10,7 +10,10 @@ import type {
   InteractionWithTokens,
   MessageWithTokens,
 } from "@app/lib/api/assistant/conversation_rendering/pruning";
-import { sumInteractionTokens } from "@app/lib/api/assistant/conversation_rendering/pruning";
+import {
+  IMAGE_CONTENT_TOKEN_COUNT,
+  sumInteractionTokens,
+} from "@app/lib/api/assistant/conversation_rendering/pruning";
 import type { ConversationWindowResult } from "@app/lib/api/assistant/conversation_rendering/window_types";
 import type { EnabledSkill } from "@app/lib/api/assistant/skills_rendering";
 import { getTextContentFromMessage } from "@app/lib/api/assistant/utils";
@@ -36,8 +39,6 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
-// Fixed number of tokens assumed for image contents
-const IMAGE_CONTENT_TOKEN_COUNT = 3100;
 export const TOOL_DEFINITIONS_COUNT_ADJUSTMENT_FACTOR = 0.7;
 export const TOKENS_MARGIN = 1024;
 

--- a/front/lib/api/assistant/conversation_rendering/instrumentation.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/instrumentation.test.ts
@@ -9,6 +9,7 @@ function statsWhereNothingHappened(): ConversationPruningStats {
     totalTokensAfterPruning: 50_000,
     pruningBudget: 100_000,
     budgetForInteractions: 160_000,
+    prunedImageCount: 0,
   };
 }
 

--- a/front/lib/api/assistant/conversation_rendering/pruning.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.ts
@@ -8,6 +8,9 @@ const PRUNED_TOOL_RESULT_PLACEHOLDER =
   "</dust_system>";
 const PRUNED_TOOL_RESULT_TOKENS = 24;
 
+// Fixed number of tokens assumed for image contents.
+export const IMAGE_CONTENT_TOKEN_COUNT = 3_100;
+
 // Pruning advances through history in batches of this size, not message by message. Every move
 // of the pruning frontier invalidates the provider cache from that point on. Moving it for a
 // handful of tokens costs more than it saves, so it only moves once a batch has accumulated.

--- a/front/lib/api/assistant/conversation_rendering/window_types.ts
+++ b/front/lib/api/assistant/conversation_rendering/window_types.ts
@@ -5,6 +5,7 @@ export type ConversationPruningStats = {
   totalTokensAfterPruning: number;
   pruningBudget: number;
   budgetForInteractions: number;
+  prunedImageCount: number;
 };
 
 export type ConversationWindowResult = {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Some providers, such as Anthropic, limit the number of input images. This adds an optional image cap to `CheckpointedConversationWindowState`, pruning the oldest images during the terminal `fit()` pass while preserving token accounting and valid message contents.

It also makes `fit()` explicitly terminal to prevent later appends from using stale pruning state.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
