### PR TITLE
[front] perf: skip identical runKey rewrites on runs

### DIFF
--- a/front/lib/resources/run_resource.test.ts
+++ b/front/lib/resources/run_resource.test.ts
@@ -95,3 +95,41 @@ describe("RunResource.setUsageTypeForRuns", () => {
     expect(usages[0]?.usageType).toBe("free");
   });
 });
+
+describe("RunResource.setRunKeyForDustRunIds", () => {
+  it("tags untagged runs, skips already-tagged rows, and overwrites a different key", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const dustRunId = generateRandomModelSId();
+    await RunResource.makeNew({
+      appId: null,
+      dustRunId,
+      runType: "agent_loop",
+      useWorkspaceCredentials: false,
+      workspaceId: workspace.id,
+    });
+
+    await RunResource.setRunKeyForDustRunIds(auth, {
+      dustRunIds: [dustRunId],
+      runKey: "key-a",
+    });
+    const tagged = await RunResource.fetchByDustRunId(auth, { dustRunId });
+    expect(tagged?.runKey).toBe("key-a");
+
+    // Re-tagging with the same key must not rewrite the row. The sleep keeps
+    // millisecond-precision updatedAt from masking a rewrite.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await RunResource.setRunKeyForDustRunIds(auth, {
+      dustRunIds: [dustRunId],
+      runKey: "key-a",
+    });
+    const retagged = await RunResource.fetchByDustRunId(auth, { dustRunId });
+    expect(retagged?.updatedAt.getTime()).toBe(tagged?.updatedAt.getTime());
+
+    await RunResource.setRunKeyForDustRunIds(auth, {
+      dustRunIds: [dustRunId],
+      runKey: "key-b",
+    });
+    const overwritten = await RunResource.fetchByDustRunId(auth, { dustRunId });
+    expect(overwritten?.runKey).toBe("key-b");
+  });
+});

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -210,6 +210,9 @@ export class RunResource extends BaseResource<RunModel> {
         where: {
           dustRunId: { [Op.in]: dustRunIds },
           workspaceId: auth.getNonNullableWorkspace().id,
+          // The finalize and analytics paths both tag with the same deterministic key:
+          // skip rows already tagged so repeat tagging does not rewrite identical rows.
+          [Op.or]: [{ runKey: null }, { runKey: { [Op.ne]: runKey } }],
         },
       }
     );


### PR DESCRIPTION
## Description

- Runs is one of our biggest table, and it is updated x2 the rate of inserts, which for an "almost-append-only" table is quite pathological. 
- This PR transform the bespoke idempotent `setRunKeyForDustRunIds` from "we will alway update the same row with runKey" to "we will update the same row with runKey only once". Which is more idempotent imo.

## Test 

Existing

## Risk

Low - inclined to say None, we only update if runKey changes instead of always updating, so unless we have some logic based on updatedAt ... could not find any

## Plan


Deploy front