### PR TITLE
fix(marketing): exclude unreleased and legacy models from public credits page

### DIFF
--- a/front-api/routes/marketing/model_credits.test.ts
+++ b/front-api/routes/marketing/model_credits.test.ts
@@ -30,6 +30,8 @@ describe("GET /api/marketing/model-credits", () => {
     expect(modelIds).not.toContain("deepseek-chat");
     expect(modelIds).not.toContain("grok-4.5");
     expect(modelIds).not.toContain("o1");
+    // Gated by featureFlag even though plansWithAdvancedModels is also set.
+    expect(modelIds).not.toContain("claude-opus-4-6");
   });
 
   it("excludes legacy models", async () => {

--- a/front-api/routes/marketing/model_credits.test.ts
+++ b/front-api/routes/marketing/model_credits.test.ts
@@ -18,4 +18,27 @@ describe("GET /api/marketing/model-credits", () => {
     expect(typeof model.inputCreditsPerMTokens).toBe("number");
     expect(typeof model.outputCreditsPerMTokens).toBe("number");
   });
+
+  it("excludes models still gated behind an on-demand feature flag", async () => {
+    const response = await honoApp.request("/api/marketing/model-credits");
+    const body = await response.json();
+    const modelIds = body.models.map(
+      (model: { modelId: string }) => model.modelId
+    );
+
+    // Entirely feature-flagged providers (no GA model yet).
+    expect(modelIds).not.toContain("deepseek-chat");
+    expect(modelIds).not.toContain("grok-4.5");
+    expect(modelIds).not.toContain("o1");
+  });
+
+  it("excludes legacy models", async () => {
+    const response = await honoApp.request("/api/marketing/model-credits");
+    const body = await response.json();
+    const modelIds = body.models.map(
+      (model: { modelId: string }) => model.modelId
+    );
+
+    expect(modelIds).not.toContain("claude-3-opus-20240229");
+  });
 });

--- a/front/lib/api/marketing/model_credits.ts
+++ b/front/lib/api/marketing/model_credits.ts
@@ -2,6 +2,7 @@ import {
   computeTokensCostForUsageInMicroUsd,
   MODEL_PRICING,
 } from "@app/lib/api/assistant/token_pricing";
+import { isModelReleased } from "@app/lib/assistant";
 import { awuFromMicroUsd } from "@app/lib/metronome/events";
 import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
 import {
@@ -41,6 +42,14 @@ export function buildPublicModelCredits(): PublicModelCredit[] {
 
   for (const model of SUPPORTED_MODEL_CONFIGS) {
     if (EXCLUDED_PROVIDER_IDS.has(model.providerId)) {
+      continue;
+    }
+
+    if (model.isLegacy) {
+      continue;
+    }
+
+    if (!isModelReleased(model)) {
       continue;
     }
 

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -346,31 +346,12 @@ describe("isModelReleased", () => {
     expect(isModelReleased(model)).toBe(true);
   });
 
-  it("should return true for a model available to plans with advanced model access", () => {
-    const model = createMockModel({
-      availableIfOneOf: { plansWithAdvancedModels: true },
-    });
-
-    expect(isModelReleased(model)).toBe(true);
-  });
-
-  it("should return false for a model gated solely behind a feature flag", () => {
+  it("should return false for a model gated behind a feature flag", () => {
     const model = createMockModel({
       availableIfOneOf: { featureFlag: "deepseek_feature" },
     });
 
     expect(isModelReleased(model)).toBe(false);
-  });
-
-  it("should return true when both plansWithAdvancedModels and featureFlag are set", () => {
-    const model = createMockModel({
-      availableIfOneOf: {
-        plansWithAdvancedModels: true,
-        featureFlag: "deepseek_feature",
-      },
-    });
-
-    expect(isModelReleased(model)).toBe(true);
   });
 });
 

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -1,5 +1,9 @@
 import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
-import { filterEnabledModels, isModelAvailable } from "@app/lib/assistant";
+import {
+  filterEnabledModels,
+  isModelAvailable,
+  isModelReleased,
+} from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
 import {
   FREE_NO_PLAN_CODE,
@@ -332,6 +336,41 @@ describe("isModelAvailable", () => {
         region: TEST_REGION,
       })
     ).toBe(false);
+  });
+});
+
+describe("isModelReleased", () => {
+  it("should return true for a model with no availability restriction", () => {
+    const model = createMockModel({ availableIfOneOf: undefined });
+
+    expect(isModelReleased(model)).toBe(true);
+  });
+
+  it("should return true for a model available to plans with advanced model access", () => {
+    const model = createMockModel({
+      availableIfOneOf: { plansWithAdvancedModels: true },
+    });
+
+    expect(isModelReleased(model)).toBe(true);
+  });
+
+  it("should return false for a model gated solely behind a feature flag", () => {
+    const model = createMockModel({
+      availableIfOneOf: { featureFlag: "deepseek_feature" },
+    });
+
+    expect(isModelReleased(model)).toBe(false);
+  });
+
+  it("should return true when both plansWithAdvancedModels and featureFlag are set", () => {
+    const model = createMockModel({
+      availableIfOneOf: {
+        plansWithAdvancedModels: true,
+        featureFlag: "deepseek_feature",
+      },
+    });
+
+    expect(isModelReleased(model)).toBe(true);
   });
 });
 

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -18,11 +18,9 @@ export function getAdvancedModels(): ModelConfigurationType[] {
   return SUPPORTED_MODEL_CONFIGS.filter(isAdvancedModel);
 }
 
-// True unless the model is only reachable via an on-demand/dust-only feature flag (not GA).
+// False if the model requires an on-demand/dust-only feature flag (not GA).
 export function isModelReleased(m: ModelConfigurationType): boolean {
-  return (
-    !m.availableIfOneOf || m.availableIfOneOf.plansWithAdvancedModels === true
-  );
+  return !m.availableIfOneOf?.featureFlag;
 }
 
 // Returns true if the model is available to the workspace for build.

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -18,6 +18,13 @@ export function getAdvancedModels(): ModelConfigurationType[] {
   return SUPPORTED_MODEL_CONFIGS.filter(isAdvancedModel);
 }
 
+// True unless the model is only reachable via an on-demand/dust-only feature flag (not GA).
+export function isModelReleased(m: ModelConfigurationType): boolean {
+  return (
+    !m.availableIfOneOf || m.availableIfOneOf.plansWithAdvancedModels === true
+  );
+}
+
 // Returns true if the model is available to the workspace for build.
 export function isModelAvailable(
   m: ModelConfigurationType,


### PR DESCRIPTION
## Description

This follow-up tightens the model list exposed by the public `/home/credits` page through `GET /api/marketing/model-credits`.

Until now, `buildPublicModelCredits()` iterated over `SUPPORTED_MODEL_CONFIGS` and could publish models that were still gated behind an on-demand/Dust-only feature flag, as well as legacy or deprecated models. This exposed unreleased entries such as gated xAI, DeepSeek, OpenAI o1, and Claude Opus models on an unauthenticated marketing page.

This PR adds `isModelReleased()` alongside the existing model-availability helpers. It considers a model released only when it has no `availableIfOneOf.featureFlag`, so a feature flag remains authoritative even when `plansWithAdvancedModels` is also configured. `buildPublicModelCredits()` now excludes both unreleased and `isLegacy` models before applying the existing pricing-entry filter.

The change only affects the public credits response. Existing workspace model availability and the underlying pricing configuration remain unchanged. This is a follow-up to [#29726](https://github.com/dust-tt/dust/pull/29726), which introduced the credits page.

## Tests

- Added unit coverage in `front/lib/assistant.test.ts` for released models and feature-flagged models.
- Added API regression coverage in `front-api/routes/marketing/model_credits.test.ts` for gated and legacy model IDs.
- Ran `npx tsgo --noEmit` on `front/lib/assistant.ts` and `front/lib/api/marketing/model_credits.ts`; no new errors were reported.

## Risk

Low. The change narrows only the unauthenticated marketing response and does not modify model availability for workspaces, pricing values, or stored data. No migration or backfill is involved, and the implementation is reversible with a code revert. The main functional risk is an incorrectly configured release flag causing a model to be omitted from the public page; the API regression tests cover representative gated and legacy models.

## Deploy Plan

- No migration or feature-flag activation is required.
- Deploy marketting
