### PR TITLE
Remove /home/api-pricing page from the marketing site

### DIFF
--- a/marketing/pages/home/api-pricing.tsx
+++ b/marketing/pages/home/api-pricing.tsx
@@ -104,11 +104,8 @@ function buildPricingData(): PricingRow[] {
 }
 
 export async function getStaticProps() {
-  return {
-    props: {
-      gtmTrackingId: process.env.NEXT_PUBLIC_GTM_TRACKING_ID ?? null,
-    },
-  };
+  // Page removed from the site; kept in code in case we bring it back.
+  return { notFound: true };
 }
 
 interface PricingTableProps {


### PR DESCRIPTION
## Description

This PR removes the public `/home/api-pricing` page from the marketing site by returning `notFound: true` from `getStaticProps`. Until now, the route rendered the API pricing page and passed the marketing GTM tracking ID as page props.

The page implementation and its related pricing data remain in the repository for now so the page can be restored if needed. This PR deliberately does not remove the dependent snapshots, synchronization checks, or existing links; those can be cleaned up in a follow-up once the page is confirmed to be permanently retired.

The route change is limited to `/home/api-pricing`; other marketing pages and pricing data are unchanged.

Decision: [Slack thread](https://dust4ai.slack.com/archives/C0BJ3T5SA0L/p1785418888081269?thread_ts=1785402253.400979&cid=C0BJ3T5SA0L)

## Tests

- Ran `npx tsgo --noEmit` for the changed marketing file; no new errors were reported.
- Ran `biome check` on the changed file successfully.
- Confirmed after deployment that `https://dust.tt/home/api-pricing` returns 404.

## Risk

Low and intentional: the public route now returns 404. The main compatibility risk is that existing links to `/home/api-pricing` will lead to a 404 until they are removed or updated in a follow-up. No data, pricing configuration, or other routes are changed, and the behavior can be reverted by restoring the previous `getStaticProps` implementation.

## Deploy Plan

- Deploy the marketing application.
- After deployment, verify that `https://dust.tt/home/api-pricing` returns 404.
- Follow-up cleanup may remove the now-unused page code, marketing snapshots, synchronization check, and existing links once the retirement is confirmed.
