### PR TITLE
[Skills] Remove default skills second permission check

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -163,7 +163,7 @@ app.patch(
           : null,
       });
       if (resolvedDefaultSkills) {
-        await metadata.setDefaultSkills(auth, resolvedDefaultSkills);
+        await metadata.setDefaultSkills(resolvedDefaultSkills);
       }
       if (!body.archive) {
         void launchOrSignalProjectTodoWorkflow({
@@ -214,7 +214,7 @@ app.patch(
         await metadata.updateDefaultAgentId(body.defaultAgentId);
       }
       if (resolvedDefaultSkills) {
-        await metadata.setDefaultSkills(auth, resolvedDefaultSkills);
+        await metadata.setDefaultSkills(resolvedDefaultSkills);
       }
       if (body.todoGenerationEnabled === true && !priorTodoGenerationEnabled) {
         void launchOrSignalProjectTodoWorkflow({

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -608,7 +608,7 @@ describe("getJITServers", () => {
         projectSpace,
         { description: "d" }
       );
-      await metadata.setDefaultSkills(auth, [
+      await metadata.setDefaultSkills([
         podDefaultSkill,
         enabledPodDefaultSkill,
       ]);

--- a/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
+++ b/front/lib/api/poke/plugins/spaces/join_activation_pod.ts
@@ -65,7 +65,7 @@ async function setPodDefaultSkills(
   const skills = await SkillResource.fetchByIds(auth, skillIds, {
     onlyActive: true,
   });
-  await metadata.setDefaultSkills(auth, skills);
+  await metadata.setDefaultSkills(skills);
 
   return new Ok({ skillNames: skills.map((skill) => skill.name) });
 }

--- a/front/lib/resources/project_metadata_resource.test.ts
+++ b/front/lib/resources/project_metadata_resource.test.ts
@@ -143,11 +143,7 @@ describe("ProjectMetadataResource", () => {
         { description: "d" }
       );
 
-      await metadata.setDefaultSkills(authenticator, [
-        skillA,
-        skillB,
-        globalSkill,
-      ]);
+      await metadata.setDefaultSkills([skillA, skillB, globalSkill]);
 
       const reloaded = await ProjectMetadataResource.fetchBySpace(
         authenticator,
@@ -162,7 +158,7 @@ describe("ProjectMetadataResource", () => {
       );
 
       // Full replacement drops the omitted skills (keep only the global one).
-      await metadata.setDefaultSkills(authenticator, [globalSkill]);
+      await metadata.setDefaultSkills([globalSkill]);
       const afterReplace = await ProjectMetadataResource.fetchBySpace(
         authenticator,
         space
@@ -170,7 +166,7 @@ describe("ProjectMetadataResource", () => {
       expect(afterReplace!.defaultSkillIds).toEqual([globalSkill.sId]);
 
       // Empty set clears everything and stores null.
-      await metadata.setDefaultSkills(authenticator, []);
+      await metadata.setDefaultSkills([]);
       const afterClear = await ProjectMetadataResource.fetchBySpace(
         authenticator,
         space
@@ -179,18 +175,17 @@ describe("ProjectMetadataResource", () => {
       expect(afterClear!.defaultSkillsIds).toBeNull();
     });
 
-    it("drops skills that are not usable in the global space", async () => {
+    it("persists space-scoped skills as is, trusting the caller to have validated access", async () => {
       const { workspace: skillWorkspace, authenticator } =
         await createResourceTest({ role: "admin" });
       const space = await SpaceFactory.project(skillWorkspace);
-      const restrictedSpace = await SpaceFactory.regular(skillWorkspace);
 
       const globalSkill = await SkillFactory.create(authenticator, {
         name: "global",
       });
-      const restrictedSkill = await SkillFactory.create(authenticator, {
-        name: "restricted",
-        requestedSpaceIds: [restrictedSpace.id],
+      const podScopedSkill = await SkillFactory.create(authenticator, {
+        name: "pod-scoped",
+        requestedSpaceIds: [space.id],
       });
 
       const metadata = await ProjectMetadataResource.makeNew(
@@ -199,16 +194,15 @@ describe("ProjectMetadataResource", () => {
         { description: "d" }
       );
 
-      await metadata.setDefaultSkills(authenticator, [
-        globalSkill,
-        restrictedSkill,
-      ]);
+      await metadata.setDefaultSkills([globalSkill, podScopedSkill]);
 
       const reloaded = await ProjectMetadataResource.fetchBySpace(
         authenticator,
         space
       );
-      expect(reloaded!.defaultSkillIds).toEqual([globalSkill.sId]);
+      expect([...reloaded!.defaultSkillIds].sort()).toEqual(
+        [globalSkill.sId, podScopedSkill.sId].sort()
+      );
     });
 
     it("de-duplicates skills", async () => {
@@ -225,7 +219,7 @@ describe("ProjectMetadataResource", () => {
 
       // The (workspace, project, skill) unique index would reject a duplicate;
       // setDefaultSkills de-dupes before inserting.
-      await metadata.setDefaultSkills(authenticator, [skill, skill]);
+      await metadata.setDefaultSkills([skill, skill]);
 
       const reloaded = await ProjectMetadataResource.fetchBySpace(
         authenticator,
@@ -245,7 +239,7 @@ describe("ProjectMetadataResource", () => {
         space,
         { description: "d" }
       );
-      await metadata.setDefaultSkills(authenticator, [skill]);
+      await metadata.setDefaultSkills([skill]);
 
       const result = await metadata.delete(authenticator, {});
       expect(result.isOk()).toBe(true);
@@ -268,7 +262,7 @@ describe("ProjectMetadataResource", () => {
         space,
         { description: "d" }
       );
-      await metadata.setDefaultSkills(authenticator, [skill]);
+      await metadata.setDefaultSkills([skill]);
 
       const result = await skill.delete(authenticator);
       expect(result.isOk()).toBe(true);

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -223,19 +223,13 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
     await this.update({ defaultAgentId }, transaction);
   }
 
+  // Space/availability access is enforced by SkillResource.fetchByIds (baseFetch) both when the
+  // caller resolves the skills passed here and on every subsequent read
   async setDefaultSkills(
-    auth: Authenticator,
     skills: SkillResource[],
     transaction?: Transaction
   ): Promise<void> {
-    const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
-    const globalSpaceSkills = skills.filter((skill) =>
-      skill.requestedSpaceIds.every((id) => id === globalSpace.id)
-    );
-
-    const defaultSkillsIds = [
-      ...new Map(globalSpaceSkills.map((s) => [s.sId, s])).keys(),
-    ];
+    const defaultSkillsIds = [...new Map(skills.map((s) => [s.sId, s])).keys()];
 
     await this.update(
       {

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1947,7 +1947,7 @@ describe("SkillResource", () => {
         space,
         { description: "d" }
       );
-      await metadata.setDefaultSkills(authenticator, [defaultSkill]);
+      await metadata.setDefaultSkills([defaultSkill]);
 
       const agent = await AgentConfigurationFactory.createTestAgent(
         authenticator,
@@ -1982,7 +1982,7 @@ describe("SkillResource", () => {
         space,
         { description: "d" }
       );
-      await metadata.setDefaultSkills(authenticator, [defaultSkill]);
+      await metadata.setDefaultSkills([defaultSkill]);
 
       const agent = await AgentConfigurationFactory.createTestAgent(
         authenticator,
@@ -2016,7 +2016,7 @@ describe("SkillResource", () => {
         space,
         { description: "d" }
       );
-      await metadata.setDefaultSkills(authenticator, [defaultSkill]);
+      await metadata.setDefaultSkills([defaultSkill]);
 
       const agent = await AgentConfigurationFactory.createTestAgent(
         authenticator,
@@ -2055,7 +2055,7 @@ describe("SkillResource", () => {
         space,
         { description: "d" }
       );
-      await metadata.setDefaultSkills(authenticator, [skill]);
+      await metadata.setDefaultSkills([skill]);
 
       const agent = await AgentConfigurationFactory.createTestAgent(
         authenticator,
@@ -2089,7 +2089,7 @@ describe("SkillResource", () => {
         space,
         { description: "d" }
       );
-      await metadata.setDefaultSkills(authenticator, [podDefaultSkill]);
+      await metadata.setDefaultSkills([podDefaultSkill]);
 
       const agentSkill = await SkillFactory.create(authenticator, {
         name: "Z Agent Skill",


### PR DESCRIPTION
## Description
`setDefaultSkills` no longer re-filters skills to the global space, instead it trusts its input, since `SkillResource.fetchByIds (baseFetch)` already enforces space access on both write and read. This fixes pod-scoped skills being silently rejected as defaults, matching the picker/slash command. Drops the now-unused auth param.

Note: temporarily more permissive (users with access to a skill restricted to pod A can use it anywhere) until a follow-up PR reintroduces the correct global-or-this-pod restriction.

## Tests
Local tests. Edited skill_resource and project_metadata tests to reflect the edits.

## Risk
Low risk.

## Deploy Plan
Deploy front.
