### PR TITLE
Extract Pod function result normalization from the callback route

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
@@ -1,120 +1,13 @@
 import { isSandboxFunctionInvocationTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import { normalizeSandboxFunctionResult } from "@app/lib/api/sandbox_functions/result_envelope";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
-import type { SandboxFunctionCallError } from "@app/types/api/sandbox_functions";
-import { SANDBOX_FUNCTION_RUNNER_ERROR_CODES } from "@app/types/api/sandbox_functions";
 import { sandboxApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { SuccessResponseBody } from "@front-api/routes/types";
 import { z } from "zod";
-
-type JsonValue = null | boolean | number | string | object;
-const DefinedJsonValueSchema = z.custom<JsonValue>((v) => v !== undefined);
-const SandboxFunctionRunnerOutputSchema = z.discriminatedUnion("ok", [
-  z.object({ ok: z.literal(true), output: DefinedJsonValueSchema }).strict(),
-  z
-    .object({
-      ok: z.literal(false),
-      error: z
-        .object({
-          code: z.enum(SANDBOX_FUNCTION_RUNNER_ERROR_CODES),
-          message: z.string(),
-          status: z.number().int().optional(),
-        })
-        .strict(),
-    })
-    .strict(),
-]);
-
-const LegacySandboxFunctionRunnerOutputSchema = z.discriminatedUnion("ok", [
-  z
-    .object({
-      ok: z.literal(true),
-      response: z
-        .object({
-          status: z.number().int(),
-          headers: z.record(z.string(), z.string()),
-          body: z.string().nullable(),
-          encoding: z.enum(["utf8", "base64"]),
-        })
-        .strict(),
-    })
-    .strict(),
-  z
-    .object({
-      ok: z.literal(false),
-      error: z
-        .object({
-          kind: z.enum(["bad_input", "import_failed", "threw", "bad_return"]),
-          message: z.string(),
-          stack: z.string().optional(),
-        })
-        .strict(),
-    })
-    .strict(),
-]);
-
-type NormalizedRunnerOutput =
-  | { ok: true; output: unknown }
-  | { ok: false; error: SandboxFunctionCallError };
-
-function normalizeRunnerOutput(result: unknown): NormalizedRunnerOutput {
-  const current = SandboxFunctionRunnerOutputSchema.safeParse(result);
-  if (current.success) {
-    return current.data;
-  }
-
-  const legacy = LegacySandboxFunctionRunnerOutputSchema.safeParse(result);
-  if (!legacy.success) {
-    return {
-      ok: false,
-      error: {
-        code: "invocation_failed",
-        message: "Sandbox function returned an invalid result envelope.",
-      },
-    };
-  }
-
-  if (!legacy.data.ok) {
-    return {
-      ok: false,
-      error: {
-        code: legacy.data.error.kind,
-        message: legacy.data.error.message,
-      },
-    };
-  }
-
-  const { response } = legacy.data;
-  const body =
-    response.body === null
-      ? ""
-      : Buffer.from(response.body, response.encoding).toString("utf8");
-  if (response.status < 200 || response.status >= 300) {
-    return {
-      ok: false,
-      error: {
-        code: "http_error",
-        message: `Function returned HTTP ${response.status}${body ? `: ${body}` : "."}`,
-        status: response.status,
-      },
-    };
-  }
-
-  try {
-    return { ok: true, output: JSON.parse(body) };
-  } catch {
-    return {
-      ok: false,
-      error: {
-        code: "invalid_output",
-        message: "Function response body is not valid JSON.",
-      },
-    };
-  }
-}
 
 const PostSandboxFunctionResultRequestBodySchema = z
   .object({
@@ -175,7 +68,7 @@ app.post(
       });
     }
 
-    const normalized = normalizeRunnerOutput(result);
+    const normalized = normalizeSandboxFunctionResult(result);
     if (normalized.ok) {
       await invocation.succeed(normalized.output);
     } else {

--- a/front/lib/api/sandbox_functions/result_envelope.ts
+++ b/front/lib/api/sandbox_functions/result_envelope.ts
@@ -1,0 +1,116 @@
+import type { SandboxFunctionCallError } from "@app/types/api/sandbox_functions";
+import { SANDBOX_FUNCTION_RUNNER_ERROR_CODES } from "@app/types/api/sandbox_functions";
+import { z } from "zod";
+
+type JsonValue = null | boolean | number | string | object;
+const DefinedJsonValueSchema = z.custom<JsonValue>((v) => v !== undefined);
+
+const SandboxFunctionRunnerOutputSchema = z.discriminatedUnion("ok", [
+  z.object({ ok: z.literal(true), output: DefinedJsonValueSchema }).strict(),
+  z
+    .object({
+      ok: z.literal(false),
+      error: z
+        .object({
+          code: z.enum(SANDBOX_FUNCTION_RUNNER_ERROR_CODES),
+          message: z.string(),
+          status: z.number().int().optional(),
+        })
+        .strict(),
+    })
+    .strict(),
+]);
+
+const LegacySandboxFunctionRunnerOutputSchema = z.discriminatedUnion("ok", [
+  z
+    .object({
+      ok: z.literal(true),
+      response: z
+        .object({
+          status: z.number().int(),
+          headers: z.record(z.string(), z.string()),
+          body: z.string().nullable(),
+          encoding: z.enum(["utf8", "base64"]),
+        })
+        .strict(),
+    })
+    .strict(),
+  z
+    .object({
+      ok: z.literal(false),
+      error: z
+        .object({
+          kind: z.enum(["bad_input", "import_failed", "threw", "bad_return"]),
+          message: z.string(),
+          stack: z.string().optional(),
+        })
+        .strict(),
+    })
+    .strict(),
+]);
+
+export type NormalizedSandboxFunctionOutcome =
+  | { ok: true; output: unknown }
+  | { ok: false; error: SandboxFunctionCallError };
+
+/**
+ * Normalize a Pod function result payload from the HTTP callback body into one
+ * classified outcome. Lifted from the callback route with no behavior change.
+ */
+export function normalizeSandboxFunctionResult(
+  result: unknown
+): NormalizedSandboxFunctionOutcome {
+  const current = SandboxFunctionRunnerOutputSchema.safeParse(result);
+  if (current.success) {
+    return current.data;
+  }
+
+  const legacy = LegacySandboxFunctionRunnerOutputSchema.safeParse(result);
+  if (!legacy.success) {
+    return {
+      ok: false,
+      error: {
+        code: "invocation_failed",
+        message: "Sandbox function returned an invalid result envelope.",
+      },
+    };
+  }
+
+  if (!legacy.data.ok) {
+    return {
+      ok: false,
+      error: {
+        code: legacy.data.error.kind,
+        message: legacy.data.error.message,
+      },
+    };
+  }
+
+  const { response } = legacy.data;
+  const body =
+    response.body === null
+      ? ""
+      : Buffer.from(response.body, response.encoding).toString("utf8");
+  if (response.status < 200 || response.status >= 300) {
+    return {
+      ok: false,
+      error: {
+        code: "http_error",
+        message: `Function returned HTTP ${response.status}${body ? `: ${body}` : "."}`,
+        status: response.status,
+      },
+    };
+  }
+
+  try {
+    return { ok: true, output: JSON.parse(body) };
+  } catch {
+    return {
+      ok: false,
+      error: {
+        code: "invalid_output",
+        message: "Function response body is not valid JSON.",
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Description

Move the existing runner and legacy result parsers out of the callback route into `front/lib/api/sandbox_functions/result_envelope.ts`. Behavior is unchanged: same schemas, same messages, same succeed/fail outcomes.

## Tests

Existing callback route tests cover the moved parsers.

## Risk

Low. Pure relocation. Rollback is a revert.

## Deploy Plan

Standard deploy.