### PR TITLE
[front] Make billable_awu pass-2 backfill per-workspace

### DIFF
--- a/front/scripts/backfill_billable_awu_from_db_for_failed_messages.ts
+++ b/front/scripts/backfill_billable_awu_from_db_for_failed_messages.ts
@@ -3,8 +3,12 @@ import {
   AgentMessageModel,
   MessageModel,
 } from "@app/lib/models/agent/conversation";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { makeScript } from "@app/scripts/helpers";
+import type { Logger } from "@app/logger/logger";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Op } from "sequelize";
+
+import { makeScript } from "./helpers";
+import { runOnAllWorkspaces } from "./workspace_helpers";
 
 // Pass 2 of the `cost.billable_awu` backfill (pass 1 is the ES-internal
 // `20260729_backfill_billable_awu_...http`, which sets billable_awu = full_awu
@@ -12,149 +16,148 @@ import { makeScript } from "@app/scripts/helpers";
 // portion of `failed` messages: a message that ended `failed` but did real work
 // in a non-error execution (interrupt/resume) has a DB `costCredits` that already
 // excludes the errored terminal execution and is ceiled per execution — the exact
-// billable amount. We copy that into `cost.billable_awu` for the failed ES docs.
-// Docs whose message has no DB `costCredits` (never populated / message purged)
-// keep the 0 that pass 1 wrote, which matches the pre-existing reconciliation
-// (failed messages were excluded), so there is no regression.
+// billable amount. We copy that into `cost.billable_awu`.
 //
-// New writes already set billable_awu from costCredits, so this only touches
-// historical `failed` docs. ES `_id` comes straight from the search hits, so we
-// don't recompute the hashed document id.
+// Runs per workspace (runOnAllWorkspaces); every DB query is scoped by
+// `workspaceId` (indexed), so there is no unbounded cross-workspace scan. Within a
+// workspace, the failed-with-costCredits set is small, and we update only those ES
+// docs. Failed messages with no/zero `costCredits` keep the 0 pass 1 wrote — no
+// regression.
 
-interface FailedDocHit {
-  _id: string;
-  message_id: string;
-  version: number;
+async function backfillWorkspace(
+  workspace: LightWorkspaceType,
+  execute: boolean,
+  logger: Logger
+): Promise<{ updated: number; missingInEs: number }> {
+  // Scoped to this workspace (workspaceId is indexed): the failed multi-execution
+  // messages whose billed amount (costCredits) must land in ES `billable_awu`.
+  const agentMessages = await AgentMessageModel.findAll({
+    where: {
+      workspaceId: workspace.id,
+      status: "failed",
+      costCredits: { [Op.gt]: 0 },
+    },
+    attributes: ["id", "costCredits"],
+  });
+  if (agentMessages.length === 0) {
+    return { updated: 0, missingInEs: 0 };
+  }
+
+  const costByAgentMessageModelId = new Map(
+    agentMessages.map((am) => [am.id, am.costCredits])
+  );
+
+  // The ES doc id uses the Message sId/version; fetch the Message rows pointing at
+  // these AgentMessages (also scoped by workspaceId).
+  const messages = await MessageModel.findAll({
+    where: {
+      workspaceId: workspace.id,
+      agentMessageId: agentMessages.map((am) => am.id),
+    },
+    attributes: ["sId", "version", "agentMessageId"],
+  });
+
+  const bulkOps: object[] = [];
+  for (const message of messages) {
+    const costCredits = message.agentMessageId
+      ? costByAgentMessageModelId.get(message.agentMessageId)
+      : undefined;
+    if (costCredits == null) {
+      continue;
+    }
+    const docId = `${workspace.sId}_${message.sId}_${message.version}`;
+    bulkOps.push(
+      { update: { _id: docId, _index: ANALYTICS_ALIAS_NAME } },
+      { doc: { cost: { billable_awu: costCredits } } }
+    );
+  }
+
+  const candidates = bulkOps.length / 2;
+  if (candidates === 0) {
+    return { updated: 0, missingInEs: 0 };
+  }
+
+  if (!execute) {
+    logger.info(
+      { workspaceId: workspace.sId, wouldUpdate: candidates },
+      "[DRY RUN] would set billable_awu for failed messages"
+    );
+    return { updated: candidates, missingInEs: 0 };
+  }
+
+  const bulkRes = await withEs(async (client) =>
+    client.bulk({ operations: bulkOps, refresh: false })
+  );
+  if (bulkRes.isErr()) {
+    logger.error(
+      { workspaceId: workspace.sId, err: bulkRes.error },
+      "ES bulk update failed."
+    );
+    return { updated: 0, missingInEs: 0 };
+  }
+
+  // A message may have no analytics doc (never indexed); tolerate 404
+  // (document_missing) per item but log anything else.
+  let updated = 0;
+  let missingInEs = 0;
+  if (bulkRes.value.errors) {
+    for (const item of bulkRes.value.items ?? []) {
+      const status = item.update?.status;
+      if (status === undefined || status < 300) {
+        updated += 1;
+      } else if (status === 404) {
+        missingInEs += 1;
+      } else {
+        logger.error(
+          { workspaceId: workspace.sId, item: item.update },
+          "ES bulk update item failed (non-404)."
+        );
+      }
+    }
+  } else {
+    updated = candidates;
+  }
+
+  logger.info(
+    { workspaceId: workspace.sId, updated, missingInEs },
+    "Set billable_awu for failed messages"
+  );
+  return { updated, missingInEs };
 }
 
 makeScript(
   {
     workspaceId: {
       type: "string",
-      demandOption: false,
-      description: "Restrict to a single workspace sId (defaults to all).",
+      required: false,
+      description: "Single workspace sId to process (all if omitted).",
     },
-    batchSize: { type: "number", default: 1000 },
+    fromWorkspaceId: {
+      type: "number",
+      required: false,
+      description: "Resume from this workspace model id.",
+    },
+    concurrency: { type: "number", default: 8 },
   },
-  async ({ workspaceId, batchSize, execute }, logger) => {
-    let workspaceModelId: number | null = null;
-    let workspaceSId: string | null = null;
-    if (workspaceId) {
-      const workspace = await WorkspaceResource.fetchById(workspaceId);
-      if (!workspace) {
-        logger.error({ workspaceId }, "Workspace not found.");
-        return;
-      }
-      workspaceModelId = workspace.id;
-      workspaceSId = workspace.sId;
-    }
+  async ({ workspaceId, fromWorkspaceId, concurrency, execute }, logger) => {
+    let totalUpdated = 0;
+    let totalMissingInEs = 0;
 
-    let searchAfter: (string | number)[] | undefined = undefined;
-    let scanned = 0;
-    let updated = 0;
-
-    for (;;) {
-      // Read a page of `failed` docs (tie-break on message_id for a stable
-      // search_after cursor). Scoped to the workspace when provided.
-      const filter: Record<string, unknown>[] = [
-        { term: { status: "failed" } },
-      ];
-      if (workspaceSId) {
-        filter.push({ term: { workspace_id: workspaceSId } });
-      }
-
-      const pageRes = await withEs(async (client) =>
-        client.search<{
-          message_id: string;
-          version: string;
-          cost?: { billable_awu?: number };
-        }>({
-          index: ANALYTICS_ALIAS_NAME,
-          size: batchSize,
-          sort: [{ timestamp: "asc" }, { message_id: "asc" }],
-          ...(searchAfter ? { search_after: searchAfter } : {}),
-          query: { bool: { filter } },
-          _source: ["message_id", "version"],
-        })
-      );
-      if (pageRes.isErr()) {
-        logger.error({ err: pageRes.error }, "ES search failed.");
-        return;
-      }
-
-      const hits = pageRes.value.hits.hits;
-      if (hits.length === 0) {
-        break;
-      }
-      searchAfter = hits[hits.length - 1].sort as (string | number)[];
-      scanned += hits.length;
-
-      const docs: FailedDocHit[] = hits
-        .filter((h) => h._id && h._source?.message_id != null)
-        .map((h) => ({
-          _id: h._id as string,
-          message_id: h._source!.message_id,
-          version: Number(h._source!.version ?? 0),
-        }));
-
-      // Look up DB costCredits for this page's messages in one query, keyed by
-      // `${sId}:${version}` since a message sId can have multiple versions.
-      const messageRows = await MessageModel.findAll({
-        where: {
-          sId: docs.map((d) => d.message_id),
-          ...(workspaceModelId ? { workspaceId: workspaceModelId } : {}),
-        },
-        include: [
-          { model: AgentMessageModel, as: "agentMessage", required: true },
-        ],
-      });
-      const costBySIdVersion = new Map<string, number>();
-      for (const row of messageRows) {
-        const costCredits = row.agentMessage?.costCredits;
-        if (costCredits != null && costCredits > 0) {
-          costBySIdVersion.set(`${row.sId}:${row.version}`, costCredits);
-        }
-      }
-
-      const bulkOps: object[] = [];
-      for (const doc of docs) {
-        const costCredits = costBySIdVersion.get(
-          `${doc.message_id}:${doc.version}`
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        const { updated, missingInEs } = await backfillWorkspace(
+          workspace,
+          execute,
+          logger
         );
-        if (costCredits === undefined) {
-          continue;
-        }
-        bulkOps.push(
-          { update: { _id: doc._id, _index: ANALYTICS_ALIAS_NAME } },
-          { doc: { cost: { billable_awu: costCredits } } }
-        );
-      }
-
-      if (bulkOps.length > 0) {
-        if (execute) {
-          const bulkRes = await withEs(async (client) =>
-            client.bulk({ operations: bulkOps, refresh: false })
-          );
-          if (bulkRes.isErr()) {
-            logger.error({ err: bulkRes.error }, "ES bulk update failed.");
-            return;
-          }
-          if (bulkRes.value.errors) {
-            logger.error(
-              { firstItem: bulkRes.value.items?.[0] },
-              "ES bulk update reported item errors."
-            );
-            return;
-          }
-        }
-        updated += bulkOps.length / 2;
-      }
-
-      logger.info({ scanned, updated, execute }, "Progress");
-    }
+        totalUpdated += updated;
+        totalMissingInEs += missingInEs;
+      },
+      { concurrency, wId: workspaceId, fromWorkspaceId }
+    );
 
     logger.info(
-      { scanned, updated, execute },
+      { totalUpdated, totalMissingInEs, execute },
       execute
         ? "Backfill complete."
         : "Dry run complete (use --execute to apply)."


### PR DESCRIPTION
## Description

Pass-2 of the `cost.billable_awu` backfill: recover `billable_awu` for **failed
multi-execution** messages (which did billable work in a non-error execution — the DB
`costCredits`). Pass 1 (ES-internal `.http`) already ran in prod; #29733 is merged.

The first cut scanned cross-workspace with an unindexed filter and **DB-timed-out**. This
is a standard `runOnAllWorkspaces` script instead:

- iterate **per workspace**; **every DB query is scoped by `workspaceId`** (indexed) — no
  unbounded cross-workspace scan.
- per workspace: fetch the `failed` AgentMessages with `costCredits > 0` (tiny set), then
  their Message rows, and bulk-update only those ES docs by their deterministic id
  `${workspaceSId}_${messageSId}_${version}`.
- tolerates `404`/document-missing (messages never indexed).

Failed messages with no/zero `costCredits` keep the `0` pass 1 wrote — no regression.

## Usage

Dry-run by default; `--execute` to apply.

```
npx tsx scripts/backfill_billable_awu_from_db_for_failed_messages.ts            # dry run, all workspaces
npx tsx scripts/backfill_billable_awu_from_db_for_failed_messages.ts --execute  # apply
# options: --workspaceId <sId>  --fromWorkspaceId <modelId>  --concurrency <n>
```

## Tests

- `npx tsgo --noEmit` clean; `biome` clean.
- Idempotent (re-running sets the same values); `--fromWorkspaceId` resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
