### PR TITLE
Drop sandbox reaper Temporal dual-path patches

### DIFF
--- a/front/temporal/sandbox_reaper/activities.ts
+++ b/front/temporal/sandbox_reaper/activities.ts
@@ -552,31 +552,3 @@ export async function reapSandboxPhaseActivity({
       return assertNever(phase);
   }
 }
-
-/**
- * Compatibility activity for sandbox reaper workflows started before the
- * phase-pagination patch. Keep its no-argument input and boolean output until
- * every pre-patch workflow execution has closed.
- *
- * Note: the "kill_requested" phase is awake-only now, so pre-patch executions
- * replaying through this activity skip sleeping kill-requested rows. That is
- * fine: the next scheduled (post-patch) execution sweeps them via the
- * "kill_requested_sleeping" phase.
- */
-export async function reapStaleSandboxesActivity(): Promise<boolean> {
-  const phases: ReaperPhase[] = [
-    "kill_requested",
-    "running",
-    "pending_approval",
-    "sleeping",
-  ];
-  let hasMore = false;
-
-  for (const phase of phases) {
-    const result = await reapSandboxPhaseActivity({ cursor: null, phase });
-    hasMore ||=
-      result.processedCount >= BATCH_SIZE && result.succeededCount > 0;
-  }
-
-  return hasMore;
-}

--- a/front/temporal/sandbox_reaper/workflows.ts
+++ b/front/temporal/sandbox_reaper/workflows.ts
@@ -3,16 +3,15 @@ import type {
   ReaperCursor,
   ReaperPhase,
 } from "@app/temporal/sandbox_reaper/activities";
-import { log, patched, proxyActivities } from "@temporalio/workflow";
+import { log, proxyActivities } from "@temporalio/workflow";
 
-const { reapSandboxPhaseActivity, reapStaleSandboxesActivity } =
-  proxyActivities<typeof activities>({
-    startToCloseTimeout: "10 minutes",
-    heartbeatTimeout: "1 minute",
-    retry: {
-      maximumAttempts: 3,
-    },
-  });
+const { reapSandboxPhaseActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "10 minutes",
+  heartbeatTimeout: "1 minute",
+  retry: {
+    maximumAttempts: 3,
+  },
+});
 
 // Priority order: concurrency-freeing work first, then storage cleanup.
 // Awake kill-requested sandboxes burn E2B capacity and sit on the user
@@ -33,19 +32,6 @@ const REAPER_PHASES = [
 const MAX_BATCHES_PER_PHASE = 200;
 
 export async function sandboxReaperWorkflow(): Promise<void> {
-  // Patch lifecycle for phase pagination:
-  // 1. Now: pre-patch executions retain the no-argument boolean activity.
-  // 2. After 2026-08-07: replace patched() with deprecatePatch() and remove the
-  //    compatibility branch and activity.
-  // 3. After 2026-08-21: remove deprecatePatch() and the patch marker.
-  if (!patched("sandbox-reaper-phase-pagination")) {
-    let hasMore = true;
-    while (hasMore) {
-      hasMore = await reapStaleSandboxesActivity();
-    }
-    return;
-  }
-
   for (const phase of REAPER_PHASES) {
     let cursor: ReaperCursor | null = null;
     let processedBatches = 0;

--- a/front/temporal/sandbox_reaper/workflows.ts
+++ b/front/temporal/sandbox_reaper/workflows.ts
@@ -14,23 +14,15 @@ const { reapSandboxPhaseActivity, reapStaleSandboxesActivity } =
     },
   });
 
-// Legacy phase order, kept for replay of pre-patch executions.
-const REAPER_PHASES_V1 = [
-  "kill_requested",
-  "running",
-  "pending_approval",
-  "sleeping",
-] satisfies ReaperPhase[];
-
 // Priority order: concurrency-freeing work first, then storage cleanup.
 // Awake kill-requested sandboxes burn E2B capacity and sit on the user
 // recreate path, so they are destroyed first. Stale running sandboxes are
 // paused next (same concurrency win, non-destructive). pending_approval is
 // cheap DB-only bookkeeping (already paused). Kill-requested sleepers are
-// storage/rollout cleanup ahead of cold sleeping destroy — they free no
+// storage/rollout cleanup ahead of cold sleeping destroy - they free no
 // concurrency, but taking the provider destroy off ensureActive is hotter
 // than 4-day-stale sleepers.
-const REAPER_PHASES_V2 = [
+const REAPER_PHASES = [
   "kill_requested",
   "running",
   "pending_approval",
@@ -54,15 +46,7 @@ export async function sandboxReaperWorkflow(): Promise<void> {
     return;
   }
 
-  // Patch for prioritized phases: pre-patch executions replay the legacy phase
-  // order. After deploy, pause the schedule, terminate any open
-  // sandboxReaperWorkflow, wait for the worker rollout to finish, then remove
-  // REAPER_PHASES_V1 and this patched() call immediately.
-  const phases = patched("sandbox-reaper-prioritized-phases")
-    ? REAPER_PHASES_V2
-    : REAPER_PHASES_V1;
-
-  for (const phase of phases) {
+  for (const phase of REAPER_PHASES) {
     let cursor: ReaperCursor | null = null;
     let processedBatches = 0;
 


### PR DESCRIPTION
## Description

Removes both Temporal patches from the sandbox reaper:

- `sandbox-reaper-prioritized-phases` (legacy V1 phase list)
- `sandbox-reaper-phase-pagination` (compat `reapStaleSandboxesActivity`)

The workflow always runs the prioritized paginated phase loop.

## Tests

Diff-only cleanup; no behavior change vs post-patch executions.

## Risk

Low if deploy follows the drain plan below. If an open pre-cleanup or marker-bearing `sandboxReaperWorkflow` is still running when new workers take over, Temporal can hit NonDeterministicError. With SKIP overlap, a stuck run blocks the schedule until terminated.

## Deploy Plan

Per region (us-central1 and europe-west1), after this ships:

1. Pause `sandbox-reaper-schedule`.
2. Terminate any Running `sandboxReaperWorkflow`.
3. Wait for full worker rollout (every replica on the new image).
4. Unpause (optionally trigger one run).

Do not delete the schedule; workers recreate it on boot. Pause survives restarts.