### PR TITLE
Opt: bulk insert agent_step_content for the same step.

### DIFF
--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -253,21 +253,25 @@ export async function storeLlmResult(
     });
 
   // Create step content entries from LLM events.
-  let index = 0;
-  for (const event of events) {
+  const stepContentBlobs = events.flatMap((event) => {
     const stepContent = eventToStoredStepContent(event);
-    if (stepContent) {
-      await AgentStepContentResource.createNewVersion({
+    if (!stepContent) {
+      return [];
+    }
+    return [
+      {
         agentMessageId: agentMessageModel.id,
         workspaceId: workspace.id,
         step: 0,
-        index,
         type: stepContent.type,
         value: stepContent,
-      });
-      index++;
-    }
-  }
+      },
+    ];
+  });
+
+  await AgentStepContentResource.createNewVersions(
+    stepContentBlobs.map((blob, index) => ({ ...blob, index }))
+  );
 
   return {
     agentMessageModelId: agentMessageModel.id,

--- a/front/lib/resources/agent_step_content/cache.ts
+++ b/front/lib/resources/agent_step_content/cache.ts
@@ -5,7 +5,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import groupBy from "lodash/groupBy";
 
-export const AGENT_STEP_CONTENT_CACHE_TTL_MS = 15 * 60 * 1000;
+export const AGENT_STEP_CONTENT_CACHE_TTL_MS = 2 * 60 * 60 * 1000; // 2 hours
 
 // Bump the `:v1` suffix any time the cached value shape changes, so stale entries
 // from previous formats are orphaned instead of mis-parsed.
@@ -91,7 +91,51 @@ export async function warmAgentStepContentCache(
 export async function warmAgentStepContentCacheMany(
   contents: CachedAgentStepContent[]
 ): Promise<void> {
-  await Promise.all(contents.map((c) => warmAgentStepContentCache(c)));
+  if (contents.length === 0) {
+    return;
+  }
+  if (contents.length === 1) {
+    await warmAgentStepContentCache(contents[0]);
+    return;
+  }
+
+  const byKey = groupBy(contents, (c) =>
+    agentStepContentCacheKey({
+      workspaceId: c.workspaceId,
+      agentMessageId: c.agentMessageId,
+    })
+  );
+
+  try {
+    const redis = await getRedisCacheClient({
+      origin: "agent_step_content_cache",
+    });
+
+    for (const [key, group] of Object.entries(byKey)) {
+      const multi = redis.multi();
+      for (const content of group) {
+        multi.hSet(
+          key,
+          agentStepContentHashField({
+            step: content.step,
+            index: content.index,
+          }),
+          JSON.stringify(content)
+        );
+      }
+      multi.pExpire(key, AGENT_STEP_CONTENT_CACHE_TTL_MS);
+      await multi.exec();
+    }
+  } catch (err) {
+    logger.warn(
+      {
+        err: normalizeError(err),
+        count: contents.length,
+        agentMessageIds: [...new Set(contents.map((c) => c.agentMessageId))],
+      },
+      "Failed to warm agent step content cache (bulk)"
+    );
+  }
 }
 
 function isCachedAgentStepContent(

--- a/front/lib/resources/agent_step_content_resource.test.ts
+++ b/front/lib/resources/agent_step_content_resource.test.ts
@@ -287,3 +287,157 @@ describe("AgentStepContentResource Redis cache", () => {
     );
   });
 });
+
+describe("AgentStepContentResource.createNewVersions", () => {
+  let authenticator: Authenticator;
+  let workspaceId: number;
+  let agentMessage: AgentMessageModel;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    authenticator = setup.authenticator;
+    workspaceId = setup.workspace.id;
+
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      {
+        name: "Step Content Bulk Create Agent",
+      }
+    );
+    const [message] = await createAgentMessages(authenticator, {
+      count: 1,
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+    });
+    agentMessage = message;
+  });
+
+  it("inserts multiple contents in one roundtrip with version 0", async () => {
+    const created = await AgentStepContentResource.createNewVersions([
+      {
+        workspaceId,
+        agentMessageId: agentMessage.id,
+        step: 0,
+        index: 0,
+        type: "text_content",
+        value: makeTextContent("first"),
+      },
+      {
+        workspaceId,
+        agentMessageId: agentMessage.id,
+        step: 0,
+        index: 1,
+        type: "text_content",
+        value: makeTextContent("second"),
+      },
+    ]);
+
+    expect(created).toHaveLength(2);
+    expect(created.map((c) => c.index)).toEqual([0, 1]);
+    expect(created.map((c) => c.version)).toEqual([0, 0]);
+    expect(created.map((c) => (c.value as AgentTextContentType).value)).toEqual(
+      ["first", "second"]
+    );
+
+    const fetched = await AgentStepContentResource.fetchByAgentMessages(
+      authenticator,
+      { agentMessageIds: [agentMessage.id] }
+    );
+    expect(fetched).toHaveLength(2);
+  });
+
+  it("bumps versions when re-inserting the same step/index pairs", async () => {
+    await AgentStepContentResource.createNewVersions([
+      {
+        workspaceId,
+        agentMessageId: agentMessage.id,
+        step: 0,
+        index: 0,
+        type: "text_content",
+        value: makeTextContent("v0-a"),
+      },
+      {
+        workspaceId,
+        agentMessageId: agentMessage.id,
+        step: 0,
+        index: 1,
+        type: "text_content",
+        value: makeTextContent("v0-b"),
+      },
+    ]);
+
+    const created = await AgentStepContentResource.createNewVersions([
+      {
+        workspaceId,
+        agentMessageId: agentMessage.id,
+        step: 0,
+        index: 0,
+        type: "text_content",
+        value: makeTextContent("v1-a"),
+      },
+      {
+        workspaceId,
+        agentMessageId: agentMessage.id,
+        step: 0,
+        index: 1,
+        type: "text_content",
+        value: makeTextContent("v1-b"),
+      },
+    ]);
+
+    expect(created.map((c) => c.version)).toEqual([1, 1]);
+
+    const fetched = await AgentStepContentResource.fetchByAgentMessages(
+      authenticator,
+      { agentMessageIds: [agentMessage.id] }
+    );
+    expect(fetched).toHaveLength(2);
+    expect(
+      fetched
+        .toSorted((a, b) => a.index - b.index)
+        .map((c) => (c.value as AgentTextContentType).value)
+    ).toEqual(["v1-a", "v1-b"]);
+  });
+
+  it("warms Redis for all inserted contents", async () => {
+    const created = await AgentStepContentResource.createNewVersions([
+      {
+        workspaceId,
+        agentMessageId: agentMessage.id,
+        step: 0,
+        index: 0,
+        type: "text_content",
+        value: makeTextContent("cached-0"),
+      },
+      {
+        workspaceId,
+        agentMessageId: agentMessage.id,
+        step: 0,
+        index: 1,
+        type: "text_content",
+        value: makeTextContent("cached-1"),
+      },
+    ]);
+
+    const redis = await getRedisCacheClient({
+      origin: "agent_step_content_cache",
+    });
+    const key = agentStepContentCacheKey({
+      workspaceId,
+      agentMessageId: agentMessage.id,
+    });
+    const hash = await redis.hGetAll(key);
+
+    expect(
+      JSON.parse(hash[agentStepContentHashField({ step: 0, index: 0 })]).id
+    ).toBe(created[0].id);
+    expect(
+      JSON.parse(hash[agentStepContentHashField({ step: 0, index: 1 })]).id
+    ).toBe(created[1].id);
+  });
+
+  it("returns an empty array for an empty input", async () => {
+    const created = await AgentStepContentResource.createNewVersions([]);
+    expect(created).toEqual([]);
+  });
+});

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -7,7 +7,6 @@ import {
   type CachedAgentStepContent,
   toCachedAgentStepContent,
   tryHydrateAgentStepContentsFromCache,
-  warmAgentStepContentCache,
   warmAgentStepContentCacheMany,
 } from "@app/lib/resources/agent_step_content/cache";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -15,7 +14,6 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import { withTransaction } from "@app/lib/utils/sql_utils";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import type {
@@ -126,17 +124,6 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     return agentMessages
       .filter((a) => allowedAgentIds.has(a.agentConfigurationId))
       .map((a) => a.id);
-  }
-
-  private static async makeNew(
-    blob: CreationAttributes<AgentStepContentModel>,
-    transaction?: Transaction
-  ): Promise<AgentStepContentResource> {
-    const agentStepContent = await this.model.create(blob, {
-      transaction,
-    });
-
-    return new AgentStepContentResource(this.model, agentStepContent.get());
   }
 
   public static async fetchByModelIds(
@@ -495,52 +482,77 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     };
   }
 
-  static async createNewVersion({
-    agentMessageId,
-    workspaceId,
-    step,
-    index,
-    type,
-    value,
-  }: Omit<
-    CreationAttributes<AgentStepContentModel>,
-    "version"
-  >): Promise<AgentStepContentResource> {
-    const resource = await withTransaction(async (transaction: Transaction) => {
-      const existingContent = await this.model.findAll({
-        where: {
-          agentMessageId,
-          step,
-          index,
-          workspaceId,
-        },
-        order: [["version", "DESC"]],
-        attributes: ["version"],
-        limit: 1,
-        transaction,
-      });
+  static async createNewVersion(
+    blob: Omit<CreationAttributes<AgentStepContentModel>, "version">
+  ): Promise<AgentStepContentResource> {
+    const [resource] = await this.createNewVersions([blob]);
+    return resource;
+  }
 
-      const currentMaxVersion =
-        existingContent.length > 0 ? existingContent[0].version + 1 : 0;
+  /**
+   * Bulk-insert step contents with correct per-(step, index) versioning
+   * (one version lookup + one INSERT). Prefer this over looping
+   * `createNewVersion` when persisting multiple contents for a step.
+   */
+  static async createNewVersions(
+    blobs: Omit<CreationAttributes<AgentStepContentModel>, "version">[]
+  ): Promise<AgentStepContentResource[]> {
+    if (blobs.length === 0) {
+      return [];
+    }
 
-      return this.makeNew(
-        {
-          agentMessageId,
-          workspaceId,
-          step,
-          index,
-          version: currentMaxVersion,
-          type,
-          value,
-        },
-        transaction
-      );
+    const { workspaceId, agentMessageId, step } = blobs[0];
+    assert(
+      blobs.every(
+        (blob) =>
+          blob.workspaceId === workspaceId &&
+          blob.agentMessageId === agentMessageId &&
+          blob.step === step
+      ),
+      "createNewVersions requires all blobs to share the same workspaceId, agentMessageId, and step"
+    );
+
+    const indexes = [...new Set(blobs.map((blob) => blob.index))];
+    const existingContent = await this.model.findAll({
+      where: {
+        workspaceId,
+        agentMessageId,
+        step,
+        index: { [Op.in]: indexes },
+      },
+      attributes: ["index", "version"],
     });
 
-    // Warm after commit so readers never see uncommitted rows in Redis.
-    await warmAgentStepContentCache(toCachedAgentStepContent(resource));
+    const maxVersionByIndex = new Map<number, number>();
+    for (const row of existingContent) {
+      const current = maxVersionByIndex.get(row.index);
+      if (current === undefined || row.version > current) {
+        maxVersionByIndex.set(row.index, row.version);
+      }
+    }
 
-    return resource;
+    const rowsToCreate = blobs.map((blob) => {
+      const maxVersion = maxVersionByIndex.get(blob.index);
+      const version = maxVersion !== undefined ? maxVersion + 1 : 0;
+      // Advance so duplicate indexes in the same batch get consecutive versions.
+      maxVersionByIndex.set(blob.index, version);
+      return { ...blob, version };
+    });
+
+    const created = await this.model.bulkCreate(rowsToCreate, {
+      validate: true,
+      returning: true,
+    });
+
+    const resources = created.map(
+      (row) => new AgentStepContentResource(this.model, row.get())
+    );
+
+    await warmAgentStepContentCacheMany(
+      resources.map((r) => toCachedAgentStepContent(r))
+    );
+
+    return resources;
   }
 
   get sId(): string {

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -993,19 +993,21 @@ export async function runModel(
 
   // Create AgentStepContent for each content item (reasoning, text, function calls)
   // This replaces the original agent_step_content event emission
-  for (const [index, content] of output.contents.entries()) {
-    const stepContent = await AgentStepContentResource.createNewVersion({
+  const stepContents = await AgentStepContentResource.createNewVersions(
+    output.contents.map((content, index) => ({
       workspaceId: conversation.owner.id,
       agentMessageId: agentMessage.agentMessageId,
       step,
       index,
       type: content.type,
       value: content,
-    });
+    }))
+  );
 
+  for (const [i, content] of output.contents.entries()) {
     // If this is a function call content, track the step content ID
     if (content.type === "function_call") {
-      updatedFunctionCallStepContentIds[content.value.id] = stepContent.id;
+      updatedFunctionCallStepContentIds[content.value.id] = stepContents[i].id;
     }
   }
 


### PR DESCRIPTION
## Description

`AgentStepContentResource.createNewVersions` replaces the per-item loop that called `createNewVersion` (and its per-call transaction + individual Redis write) with a single version-lookup `findAll`, a single `bulkCreate`, and one Redis pipeline. Callers in `runModel` and `storeLlmResult` are migrated to the new method. `createNewVersion` is kept as a thin wrapper.

Also upgrades `warmAgentStepContentCacheMany` to use `MULTI`/`EXEC` per cache key instead of `Promise.all` over individual `hSet` calls, and bumps the cache TTL from 15 min to 2 hours.

## Tests

Added unit tests for `createNewVersions`: bulk insert with correct version 0, version bumping on re-insert, Redis warming verification, and empty-input guard. Tested locally.

## Risk

Low. No schema change, no migration. The new path drops the per-item transaction in favor of an unguarded `bulkCreate`; concurrent retries on the same `(agentMessageId, step, index)` could produce duplicate versions, but that was already possible with the old non-serializable transactions. `createNewVersion` (single-item path) is unchanged in behavior.

## Deploy Plan

Deploy `front`.
