### PR TITLE
Remove the pod_default_agent and pod_default_skills feature flags

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -18,7 +18,6 @@ vi.mock("@app/temporal/project_task/client", () => ({
 }));
 
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -174,7 +173,6 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/project_metadata", () => {
     const { workspace, auth } = await createPrivateApiMockRequest({
       role: "admin",
     });
-    await FeatureFlagFactory.basic(auth, "pod_default_skills");
 
     const projectSpace = await SpaceFactory.project(workspace);
     const skillA = await SkillFactory.create(auth, { name: "Skill A" });
@@ -215,10 +213,9 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/project_metadata", () => {
   });
 
   it("rejects unknown default skill ids", async () => {
-    const { workspace, auth } = await createPrivateApiMockRequest({
+    const { workspace } = await createPrivateApiMockRequest({
       role: "admin",
     });
-    await FeatureFlagFactory.basic(auth, "pod_default_skills");
 
     const projectSpace = await SpaceFactory.project(workspace);
 
@@ -228,22 +225,6 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/project_metadata", () => {
 
     expect(response.status).toBe(400);
     expect((await response.json()).error.type).toBe("invalid_request_error");
-  });
-
-  it("ignores default skills when the feature flag is off", async () => {
-    const { workspace, auth } = await createPrivateApiMockRequest({
-      role: "admin",
-    });
-
-    const projectSpace = await SpaceFactory.project(workspace);
-    const skill = await SkillFactory.create(auth, { name: "Skill A" });
-
-    const response = await patchMetadata(workspace, projectSpace.sId, {
-      defaultSkillIds: [skill.sId],
-    });
-
-    expect(response.status).toBe(200);
-    expect((await response.json()).projectMetadata.defaultSkillIds).toEqual([]);
   });
 
   it("restarts project tasks workflow when unarchiving a project", async () => {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -1,6 +1,5 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { validatePinnedFramePath } from "@app/lib/api/projects/pinned_frame";
-import { getFeatureFlags } from "@app/lib/auth";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import {
@@ -78,10 +77,6 @@ app.patch(
 
     const body = ctx.req.valid("json");
 
-    const featureFlags = await getFeatureFlags(auth);
-    const defaultAgentEnabled = featureFlags.includes("pod_default_agent");
-    const defaultSkillsEnabled = featureFlags.includes("pod_default_skills");
-
     if (body.pinnedFramePath !== undefined) {
       const validation = await validatePinnedFramePath(
         auth,
@@ -101,8 +96,7 @@ app.patch(
 
     // Validate the default agent exists and is usable (handles both global agents like
     // "claude-4.5-sonnet" and workspace agents). A null value clears the default (@dust).
-    // Gated behind the pod_default_agent feature flag.
-    if (defaultAgentEnabled && body.defaultAgentId) {
+    if (body.defaultAgentId) {
       const agent = await getAgentConfiguration(auth, {
         agentId: body.defaultAgentId,
         variant: "extra_light",
@@ -119,7 +113,7 @@ app.patch(
     }
 
     let resolvedDefaultSkills: SkillResource[] | null = null;
-    if (defaultSkillsEnabled && body.defaultSkillIds !== undefined) {
+    if (body.defaultSkillIds !== undefined) {
       const requestedSkillIds = [...new Set(body.defaultSkillIds)];
       const skills = await SkillResource.fetchByIds(auth, requestedSkillIds);
       const skillBySId = new Map(skills.map((skill) => [skill.sId, skill]));
@@ -158,9 +152,7 @@ app.patch(
         todoGenerationEnabled: body.todoGenerationEnabled ?? false,
         initialTodoAnalysisLookback: body.initialTodoAnalysisLookback ?? null,
         pinnedFramePath: body.pinnedFramePath ?? null,
-        defaultAgentId: defaultAgentEnabled
-          ? (body.defaultAgentId ?? null)
-          : null,
+        defaultAgentId: body.defaultAgentId ?? null,
       });
       if (resolvedDefaultSkills) {
         await metadata.setDefaultSkills(auth, resolvedDefaultSkills);
@@ -210,7 +202,7 @@ app.patch(
       if (body.pinnedFramePath !== undefined) {
         await metadata.updatePinnedFramePath(body.pinnedFramePath);
       }
-      if (defaultAgentEnabled && body.defaultAgentId !== undefined) {
+      if (body.defaultAgentId !== undefined) {
         await metadata.updateDefaultAgentId(body.defaultAgentId);
       }
       if (resolvedDefaultSkills) {

--- a/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
@@ -116,7 +116,6 @@ export function usePodTasksPanelState({
     owner,
     podDefaultAgentId: podMetadata?.defaultAgentId,
     hasWorkspaceDefaultAgentFeature: hasFeature("workspace_default_agent"),
-    hasPodDefaultAgentFeature: hasFeature("pod_default_agent"),
   });
 
   const podMembers = useMemo(() => {

--- a/front/components/markdown/TaskDirectiveBlock.tsx
+++ b/front/components/markdown/TaskDirectiveBlock.tsx
@@ -106,7 +106,6 @@ function TaskMarkdownPopoverStartChrome({
     owner,
     podDefaultAgentId: podMetadata?.defaultAgentId,
     hasWorkspaceDefaultAgentFeature: hasFeature("workspace_default_agent"),
-    hasPodDefaultAgentFeature: hasFeature("pod_default_agent"),
   });
 
   const hasConversationLink =

--- a/front/components/pod/conversation/PodConversationsTab.tsx
+++ b/front/components/pod/conversation/PodConversationsTab.tsx
@@ -119,7 +119,6 @@ export function PodConversationsTab({
     owner,
     podDefaultAgentId: podMetadata?.defaultAgentId,
     hasWorkspaceDefaultAgentFeature: hasFeature("workspace_default_agent"),
-    hasPodDefaultAgentFeature: hasFeature("pod_default_agent"),
   });
 
   const { defaultSkills, isDefaultSkillsLoading } = usePodDefaultSkills({

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -98,9 +98,6 @@ export function PodSettingsTab({
   const { hasFeature } = useFeatureFlags();
   const { isAdmin } = useAuth();
   const hasWorkspaceDefaultAgentFeature = hasFeature("workspace_default_agent");
-  const isDefaultAgentEnabled =
-    hasFeature("pod_default_agent") || hasWorkspaceDefaultAgentFeature;
-  const isDefaultSkillsEnabled = hasFeature("pod_default_skills");
   // The pod sandbox network allowlist is workspace-admin only (matching the
   // API) and part of the Sandbox Functions surface.
   // Mirrors the API gate (workspace-admin + sandbox_functions FF; pod
@@ -133,7 +130,6 @@ export function PodSettingsTab({
     owner,
     podDefaultAgentId: podMetadata?.defaultAgentId,
     hasWorkspaceDefaultAgentFeature,
-    hasPodDefaultAgentFeature: hasFeature("pod_default_agent"),
   });
   // Fall back to @dust when the default agent isn't available to the
   // current user (e.g. unpublished/deleted). This is the agent shown in the
@@ -180,7 +176,6 @@ export function PodSettingsTab({
   const { skills } = useSkills({
     owner,
     status: "active",
-    disabled: !isDefaultSkillsEnabled,
   });
   const [skillSearchText, setSkillSearchText] = useState("");
   const [isSkillPickerOpen, setIsSkillPickerOpen] = useState(false);
@@ -549,150 +544,144 @@ export function PodSettingsTab({
           </div>
         </div>
 
-        {isDefaultAgentEnabled && (
-          <div className="flex w-full flex-col gap-2">
-            <div className="heading-lg">Default agent</div>
-            <p className="text-sm text-muted-foreground">
-              The agent pre-selected when anyone starts a new conversation in
-              this Pod.{" "}
-              {hasWorkspaceDefaultAgentFeature &&
-                "When unset, it inherits the Workspace default agent."}
-            </p>
-            <div className="flex items-center gap-2">
-              {isPodEditor ? (
-                <>
-                  <AgentPicker
-                    owner={owner}
-                    agents={agentConfigurations}
-                    showFooterButtons={false}
-                    onItemClick={(agent) => saveDefaultAgent(agent.sId)}
-                    pickerButton={renderDefaultAgentPill(true)}
-                  />
-                  {/* Clearing the pod default reverts to inheriting the
-                      workspace default. Only shown when the workspace-default
-                      feature is on and an explicit pod default is set. */}
-                  {hasWorkspaceDefaultAgentFeature &&
-                    podMetadata?.defaultAgentId && (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        icon={XCircle}
-                        tooltip="Reset to workspace default"
-                        onClick={() => void saveDefaultAgent(null)}
-                      />
-                    )}
-                </>
-              ) : (
-                renderDefaultAgentPill(false)
-              )}
-            </div>
-          </div>
-        )}
-
-        {isDefaultSkillsEnabled && (
-          <div className="flex w-full flex-col gap-2">
-            <div className="heading-lg">Default Skills</div>
-            <p className="text-sm text-muted-foreground">
-              The skills pre-selected when anyone starts a new conversation in
-              this Pod. Members can still edit the skills in each conversation.
-            </p>
-            <div className="flex flex-wrap items-center gap-2">
-              {/* Selected skills, each rendered as a pill matching conversation styling.
-               Editors get an inline remove control. */}
-              {selectedDefaultSkills.map((skill) => (
-                <div
-                  key={skill.sId}
-                  aria-label={`Default skill: ${skill.name}`}
-                  className={cn(
-                    DEFAULT_PILL_BASE_CLASSNAME,
-                    !isPodEditor && "opacity-50"
-                  )}
-                >
-                  <Avatar size="xs" icon={getSkillAvatarIcon(skill)} />
-                  <span className="grow truncate notranslate">
-                    {skill.name}
-                  </span>
-                  {isPodEditor && (
-                    <button
-                      type="button"
-                      aria-label={`Remove ${skill.name}`}
-                      className="-mr-1 flex items-center text-faint hover:text-primary"
-                      onClick={() => void removeDefaultSkill(skill.sId)}
-                    >
-                      <Icon visual={XCircle} size="xs" />
-                    </button>
-                  )}
-                </div>
-              ))}
-              {isPodEditor && (
-                <DropdownMenu
-                  open={isSkillPickerOpen}
-                  onOpenChange={(open) => {
-                    setIsSkillPickerOpen(open);
-                    if (open) {
-                      setSkillSearchText("");
-                    }
-                  }}
-                >
-                  <DropdownMenuTrigger asChild>
-                    <button
-                      type="button"
-                      aria-label="Add a default skill"
-                      className={cn(
-                        DEFAULT_PILL_BASE_CLASSNAME,
-                        DEFAULT_PILL_INTERACTIVE_CLASSNAME
-                      )}
-                    >
-                      <Icon visual={ShapesPlus} size="xs" />
-                      <span className="grow truncate">Add skill</span>
-                      <Icon
-                        visual={ChevronDown}
-                        size="xs"
-                        className="-mr-1 text-faint"
-                      />
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent
-                    className="w-80"
-                    align="start"
-                    dropdownHeaders={skillPickerDropdownHeaders}
-                  >
-                    <CapabilitiesPickerItemsList
-                      emptyMessage={
-                        normalizedSkillSearch.length > 0
-                          ? "No skills found"
-                          : "No more skills to add"
-                      }
-                      items={addableSkills.map((skill) => {
-                        const SkillAvatar = getSkillAvatarIcon(skill);
-
-                        return {
-                          kind: "skill" as const,
-                          skill,
-                          id: `pod-default-skills-picker-${skill.sId}`,
-                          icon: <SkillAvatar size="xs" />,
-                          label: skill.name,
-                          sortName: skill.name.toLowerCase(),
-                          description: skill.userFacingDescription ?? undefined,
-                        };
-                      })}
-                      onItemSelect={(item) => {
-                        if (item.kind === "skill") {
-                          void addDefaultSkill(item.skill.sId);
-                        }
-                      }}
+        <div className="flex w-full flex-col gap-2">
+          <div className="heading-lg">Default agent</div>
+          <p className="text-sm text-muted-foreground">
+            The agent pre-selected when anyone starts a new conversation in this
+            Pod.{" "}
+            {hasWorkspaceDefaultAgentFeature &&
+              "When unset, it inherits the Workspace default agent."}
+          </p>
+          <div className="flex items-center gap-2">
+            {isPodEditor ? (
+              <>
+                <AgentPicker
+                  owner={owner}
+                  agents={agentConfigurations}
+                  showFooterButtons={false}
+                  onItemClick={(agent) => saveDefaultAgent(agent.sId)}
+                  pickerButton={renderDefaultAgentPill(true)}
+                />
+                {/* Clearing the pod default reverts to inheriting the
+                    workspace default. Only shown when the workspace-default
+                    feature is on and an explicit pod default is set. */}
+                {hasWorkspaceDefaultAgentFeature &&
+                  podMetadata?.defaultAgentId && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      icon={XCircle}
+                      tooltip="Reset to workspace default"
+                      onClick={() => void saveDefaultAgent(null)}
                     />
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )}
-              {!isPodEditor && selectedDefaultSkills.length === 0 && (
-                <p className="text-sm text-muted-foreground">
-                  No default skills configured.
-                </p>
-              )}
-            </div>
+                  )}
+              </>
+            ) : (
+              renderDefaultAgentPill(false)
+            )}
           </div>
-        )}
+        </div>
+
+        <div className="flex w-full flex-col gap-2">
+          <div className="heading-lg">Default Skills</div>
+          <p className="text-sm text-muted-foreground">
+            The skills pre-selected when anyone starts a new conversation in
+            this Pod. Members can still edit the skills in each conversation.
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            {/* Selected skills, each rendered as a pill matching conversation styling.
+             Editors get an inline remove control. */}
+            {selectedDefaultSkills.map((skill) => (
+              <div
+                key={skill.sId}
+                aria-label={`Default skill: ${skill.name}`}
+                className={cn(
+                  DEFAULT_PILL_BASE_CLASSNAME,
+                  !isPodEditor && "opacity-50"
+                )}
+              >
+                <Avatar size="xs" icon={getSkillAvatarIcon(skill)} />
+                <span className="grow truncate notranslate">{skill.name}</span>
+                {isPodEditor && (
+                  <button
+                    type="button"
+                    aria-label={`Remove ${skill.name}`}
+                    className="-mr-1 flex items-center text-faint hover:text-primary"
+                    onClick={() => void removeDefaultSkill(skill.sId)}
+                  >
+                    <Icon visual={XCircle} size="xs" />
+                  </button>
+                )}
+              </div>
+            ))}
+            {isPodEditor && (
+              <DropdownMenu
+                open={isSkillPickerOpen}
+                onOpenChange={(open) => {
+                  setIsSkillPickerOpen(open);
+                  if (open) {
+                    setSkillSearchText("");
+                  }
+                }}
+              >
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="Add a default skill"
+                    className={cn(
+                      DEFAULT_PILL_BASE_CLASSNAME,
+                      DEFAULT_PILL_INTERACTIVE_CLASSNAME
+                    )}
+                  >
+                    <Icon visual={ShapesPlus} size="xs" />
+                    <span className="grow truncate">Add skill</span>
+                    <Icon
+                      visual={ChevronDown}
+                      size="xs"
+                      className="-mr-1 text-faint"
+                    />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  className="w-80"
+                  align="start"
+                  dropdownHeaders={skillPickerDropdownHeaders}
+                >
+                  <CapabilitiesPickerItemsList
+                    emptyMessage={
+                      normalizedSkillSearch.length > 0
+                        ? "No skills found"
+                        : "No more skills to add"
+                    }
+                    items={addableSkills.map((skill) => {
+                      const SkillAvatar = getSkillAvatarIcon(skill);
+
+                      return {
+                        kind: "skill" as const,
+                        skill,
+                        id: `pod-default-skills-picker-${skill.sId}`,
+                        icon: <SkillAvatar size="xs" />,
+                        label: skill.name,
+                        sortName: skill.name.toLowerCase(),
+                        description: skill.userFacingDescription ?? undefined,
+                      };
+                    })}
+                    onItemSelect={(item) => {
+                      if (item.kind === "skill") {
+                        void addDefaultSkill(item.skill.sId);
+                      }
+                    }}
+                  />
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+            {!isPodEditor && selectedDefaultSkills.length === 0 && (
+              <p className="text-sm text-muted-foreground">
+                No default skills configured.
+              </p>
+            )}
+          </div>
+        </div>
 
         <div className="flex w-full flex-col gap-2">
           <div className="flex flex-col border-y border-border">

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -64,7 +64,6 @@ import { listPodsForScope } from "@app/lib/api/projects/list";
 import { validatePinnedFramePath } from "@app/lib/api/projects/pinned_frame";
 import { createSpaceAndGroup } from "@app/lib/api/spaces";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { notifyPodMembersAdded } from "@app/lib/notifications/workflows/pod-added-as-member";
 import { seedInitialPodTasks } from "@app/lib/project_task/seed_initial_pod_tasks";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -430,16 +429,6 @@ export function createProjectManagerTools(
           return new Err(
             new MCPError(
               "You do not have permission to edit this Pod's default agent",
-              { tracked: false }
-            )
-          );
-        }
-
-        const featureFlags = await getFeatureFlags(auth);
-        if (!featureFlags.includes("pod_default_agent")) {
-          return new Err(
-            new MCPError(
-              "Setting a Pod default agent is not enabled for this workspace.",
               { tracked: false }
             )
           );

--- a/front/lib/api/projects/default_agent.ts
+++ b/front/lib/api/projects/default_agent.ts
@@ -1,6 +1,5 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
@@ -12,11 +11,6 @@ export async function resolvePodDefaultAgentId(
   auth: Authenticator,
   space: SpaceResource
 ): Promise<string> {
-  const featureFlags = await getFeatureFlags(auth);
-  if (!featureFlags.includes("pod_default_agent")) {
-    return GLOBAL_AGENTS_SID.DUST;
-  }
-
   const metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
   const candidateId = metadata?.defaultAgentId ?? null;
   if (!candidateId || candidateId === GLOBAL_AGENTS_SID.DUST) {

--- a/front/lib/project_task/start_agent.ts
+++ b/front/lib/project_task/start_agent.ts
@@ -131,18 +131,12 @@ async function resolveDefaultAgentIdForTask(
   const hasWorkspaceDefaultAgent = featureFlags.includes(
     "workspace_default_agent"
   );
-  const hasPodDefaultAgent = featureFlags.includes("pod_default_agent");
-  let podDefaultAgentId: string | null = null;
-  if (hasPodDefaultAgent || hasWorkspaceDefaultAgent) {
-    const metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
-    podDefaultAgentId = metadata?.defaultAgentId ?? null;
-  }
+  const metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
 
   const candidateId = resolveDefaultAgentId({
     owner: auth.getNonNullableWorkspace(),
-    podDefaultAgentId,
+    podDefaultAgentId: metadata?.defaultAgentId ?? null,
     hasWorkspaceDefaultAgentFeature: hasWorkspaceDefaultAgent,
-    hasPodDefaultAgentFeature: hasPodDefaultAgent,
   });
   if (!candidateId || candidateId === GLOBAL_AGENTS_SID.DUST) {
     return GLOBAL_AGENTS_SID.DUST;

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -10,7 +10,6 @@ import type {
   GetProjectContextResponseBody,
   PostProjectContextContentNodeResponseBody as PostPodContextContentNodeResponseBody,
 } from "@app/lib/api/projects/context";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { flattenPodTasksWithStableAssigneeOrder } from "@app/lib/project_task/display_order";
 import type { PostSeedInitialPodTasksResponseBody } from "@app/lib/project_task/seed_initial_pod_tasks";
@@ -1102,25 +1101,18 @@ export function usePodDefaultSkills({
   podId: string;
   disabled?: boolean;
 }) {
-  const { hasFeature } = useFeatureFlags();
-  const hasPodDefaultSkillsFeature = hasFeature("pod_default_skills");
-  const enabled = hasPodDefaultSkillsFeature && !disabled;
-
   const { podMetadata, isPodMetadataLoading } = usePodMetadata({
     workspaceId: owner.sId,
     podId,
-    disabled: !enabled,
+    disabled,
   });
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
-    disabled: !enabled,
+    disabled,
   });
 
   const defaultSkills = useMemo(() => {
-    if (!hasPodDefaultSkillsFeature) {
-      return undefined;
-    }
     const skillBySId = new Map(skills.map((skill) => [skill.sId, skill]));
     // Preserve the stored order.
     return (podMetadata?.defaultSkillIds ?? []).flatMap((skillId) => {
@@ -1129,7 +1121,7 @@ export function usePodDefaultSkills({
         ? [{ sId: skill.sId, name: skill.name, icon: skill.icon }]
         : [];
     });
-  }, [hasPodDefaultSkillsFeature, skills, podMetadata?.defaultSkillIds]);
+  }, [skills, podMetadata?.defaultSkillIds]);
 
   return {
     defaultSkills,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -277,16 +277,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Admin Governance: govern skill publication. Shows the skill state (availability) dropdown in the UI, defaults new skills to unpublished (editors-only), and allows unpublishing a skill.",
     stage: "dust_only",
   },
-  pod_default_agent: {
-    description:
-      "Per-pod default agent: pre-select an agent for new conversations started in a project (pod).",
-    stage: "dust_only",
-  },
-  pod_default_skills: {
-    description:
-      "Per-pod default skills: pre-insert skills into new conversations started in a pod.",
-    stage: "dust_only",
-  },
   workspace_default_agent: {
     description:
       "Workspace default agent: admins can pre-select a workspace-wide default agent for new conversations.",

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -125,21 +125,15 @@ export function resolveDefaultAgentId({
   owner,
   podDefaultAgentId,
   hasWorkspaceDefaultAgentFeature,
-  hasPodDefaultAgentFeature,
 }: {
   owner: LightWorkspaceType;
   podDefaultAgentId: string | null | undefined;
   hasWorkspaceDefaultAgentFeature: boolean;
-  hasPodDefaultAgentFeature: boolean;
 }): string | null {
   const workspaceDefaultAgentId = hasWorkspaceDefaultAgentFeature
     ? getWorkspaceDefaultAgentId(owner)
     : null;
-  const resolvedPodDefaultAgentId =
-    hasPodDefaultAgentFeature || hasWorkspaceDefaultAgentFeature
-      ? (podDefaultAgentId ?? null)
-      : null;
-  return resolvedPodDefaultAgentId ?? workspaceDefaultAgentId;
+  return podDefaultAgentId ?? workspaceDefaultAgentId;
 }
 
 export type WorkspaceType = LightWorkspaceType & {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -774,8 +774,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "self_improvement_beta_tester"
   | "legacy_billing"
   | "plan_mode"
-  | "pod_default_agent"
-  | "pod_default_skills"
   | "poke_mcp"
   | "restricted_spaces_in_input_bar"
   | "salesforce_synced_queries"


### PR DESCRIPTION
Both flags are enabled for every workspace, so every gated branch was already taken everywhere. This drops them so the pod default agent and pod default skills behave as always-on.

### Changes

- `front/types/shared/feature_flags.ts` + `sdks/js/src/types.ts` — dropped both flag entries.
- `front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts` — removed the `getFeatureFlags` call and the four gated branches (agent validation, skill resolution, `makeNew` `defaultAgentId`, `updateDefaultAgentId`).
- `front/types/user.ts` — `resolveDefaultAgentId` loses its `hasPodDefaultAgentFeature` parameter. The old `hasPod || hasWorkspace` gate was always true, so the function already reduced to `podDefaultAgentId ?? workspaceDefault`. Updated all call sites.
- `front/lib/api/projects/default_agent.ts` — removed the early `@dust` return.
- `front/lib/project_task/start_agent.ts` — pod metadata is now unconditionally fetched (it already was in practice).
- `front/lib/api/actions/servers/pod_manager/tools/index.ts` — removed the "not enabled for this workspace" error from `set_default_agent`.
- `front/lib/swr/pods.ts` — `usePodDefaultSkills` no longer consults flags; its `return undefined` branch was unreachable. `InputBarContainer` keeps its `undefined` guard for the callers that don't pass the prop at all.
- `front/components/pod/settings/PodSettingsTab.tsx` — unwrapped the "Default agent" and "Default Skills" sections, which were already rendering everywhere.

### Behavior

No user-visible change. `workspace_default_agent` is untouched and its precedence is unchanged — a pod-level default still wins, and the workspace default still only applies when the pod has none. That held before because the pod flag was on; it now holds unconditionally.

The deleted test, `ignores default skills when the feature flag is off`, only reached that path because the test factory withheld a flag that is granted everywhere in production, so it covered unreachable code.

### Testing

- `npx tsgo --noEmit` clean for `front` and `front-api`
- biome clean on all changed files
- `project_metadata` suites pass (15 tests across the private and v1 routes)
