### PR TITLE
[front] Fix messages_export credits test for billable_awu repoint

### DIFF
--- a/front/lib/api/analytics/messages_export.test.ts
+++ b/front/lib/api/analytics/messages_export.test.ts
@@ -62,7 +62,9 @@ describe("fetchMessageExportRows", () => {
     });
 
     mockMessageHits([
-      messageDoc({ cost: { full_awu: 7, llm_awu: 4, tool_awu: 3 } }),
+      messageDoc({
+        cost: { full_awu: 10, llm_awu: 4, tool_awu: 3, billable_awu: 7 },
+      }),
     ]);
 
     const result = await fetchMessageExportRows({


### PR DESCRIPTION
## Problem

`main` is red on the front test suite. The real failing test is:

`fetchMessageExportRows > correctly reports credits column` — `expected +0 to be 7`

The CI "Tests Report" mislabeled it as `node_modules/thread-stream/test/ts.test.ts` — the mikepenz junit annotation guesses the source file from the testcase classname when the junit XML has no `file=` attribute, and `...ts` matched `thread-stream/test/ts.test.ts`. The actual failing test is ours.

## Cause

#29734 repointed credit reads to `cost.billable_awu`:

```ts
credits: Math.round(doc.cost?.billable_awu ?? 0),
```

The test still seeded only `cost.full_awu`, so `credits` resolved to `0` and the `expected 7` assertion failed.

## Fix

Seed `billable_awu: 7` (with a distinct `full_awu: 10`) so the test asserts that `credits` tracks `billable_awu`, not `full_awu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)