### PR TITLE
Address user_memory MCP server review comments

### DIFF
--- a/front/lib/api/actions/servers/user_memory/metadata.ts
+++ b/front/lib/api/actions/servers/user_memory/metadata.ts
@@ -5,6 +5,10 @@ export const USER_MEMORY_SERVER_NAME = "user_memory" as const;
 export const USER_MEMORY_READ_TOOL_NAME = "read";
 export const USER_MEMORY_EDIT_TOOL_NAME = "edit";
 
+// The tool descriptions deliberately name the user's "MEMORY.md": pointing the
+// model at a concrete markdown memory file is relatively industry-standard and
+// reinforces the expected recall/update behavior, even though the file itself is
+// an implementation detail on our end.
 export const USER_MEMORY_TOOLS_METADATA = [
   {
     name: USER_MEMORY_READ_TOOL_NAME,
@@ -27,7 +31,9 @@ export const USER_MEMORY_TOOLS_METADATA = [
       oldStr: z
         .string()
         .describe(
-          "The exact, contiguous text to find in the user's personal memory and replace. It must match a unique span of the current memory. Pass an empty string to initialize memory that is currently empty."
+          "The exact, contiguous text to find in the user's personal memory " +
+            "and replace. It must match a unique span of the current memory. " +
+            "Pass an empty string to initialize memory that is currently empty."
         ),
       newStr: z
         .string()
@@ -50,7 +56,7 @@ export const USER_MEMORY_SERVER = {
     name: USER_MEMORY_SERVER_NAME,
     version: "1.0.0",
     description:
-      "Store and retrieve the current user's personal memory in a single MEMORY.md file, shared across the user's agents.",
+      "Store and retrieve the current user's personal memory, shared across the user's agents.",
     authorization: null,
     icon: "ActionLightbulbIcon",
     documentationUrl: null,

--- a/front/lib/api/actions/servers/user_memory/tools/index.ts
+++ b/front/lib/api/actions/servers/user_memory/tools/index.ts
@@ -18,7 +18,7 @@ import { MAX_USER_MEMORY_CONTENT_LENGTH } from "@app/types/api/me/memory";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-async function openUserMemory(
+async function resolveUserMemoryFile(
   auth: Authenticator
 ): Promise<Result<{ fs: DustFileSystem; path: string }, MCPError>> {
   const user = auth.user();
@@ -40,7 +40,7 @@ async function openUserMemory(
 
 const handlers: ToolHandlers<typeof USER_MEMORY_TOOLS_METADATA> = {
   [USER_MEMORY_READ_TOOL_NAME]: async (_, { auth }) => {
-    const memoryResult = await openUserMemory(auth);
+    const memoryResult = await resolveUserMemoryFile(auth);
     if (memoryResult.isErr()) {
       return memoryResult;
     }
@@ -66,7 +66,7 @@ const handlers: ToolHandlers<typeof USER_MEMORY_TOOLS_METADATA> = {
   },
 
   [USER_MEMORY_EDIT_TOOL_NAME]: async ({ oldStr, newStr }, { auth }) => {
-    const memoryResult = await openUserMemory(auth);
+    const memoryResult = await resolveUserMemoryFile(auth);
     if (memoryResult.isErr()) {
       return memoryResult;
     }

--- a/front/lib/resources/skill/code_defined/system/user_memory.ts
+++ b/front/lib/resources/skill/code_defined/system/user_memory.ts
@@ -18,24 +18,54 @@ const EDIT_TOOL_NAME = getPrefixedToolName(
   USER_MEMORY_EDIT_TOOL_NAME
 );
 
-const USER_MEMORY_INSTRUCTIONS = `
-You have a persistent, user-scoped memory kept in a single \`MEMORY.md\` file that is shared across all of this user's conversations and agents. Use it to remember durable facts and preferences about the user so you can personalize your responses over time.
+const USER_MEMORY_INSTRUCTIONS = `<memory_guidelines>
+You have a persistent, user-scoped memory kept in a single \`MEMORY.md\` file, shared across all of this user's conversations and agents.
 
-**Recall before answering**: call \`${READ_TOOL_NAME}\` to load what you already know about the user, especially when personalization would help.
+<critical_behavior>
+Recall the user's memory with the \`${READ_TOOL_NAME}\` tool when prior context about the user is likely to change your answer: recurring workflows, personal preferences, ongoing projects, or requests that assume context you don't have. Do not recall for general knowledge requests.
 
-**Record durable context**: call \`${EDIT_TOOL_NAME}\` to save new long-lived facts, preferences, or context, and to correct or remove entries that are no longer accurate. \`${EDIT_TOOL_NAME}\` replaces an exact snippet of \`MEMORY.md\`:
+Add, edit, or remove memories with the \`${EDIT_TOOL_NAME}\` tool, which replaces an exact snippet of \`MEMORY.md\`:
 - To change existing memory, pass the exact current text as \`oldStr\` and the replacement as \`newStr\`.
-- To add the very first memory when it is empty, pass an empty \`oldStr\` and the new content as \`newStr\`.
+- To add the first memory when it is empty, pass an empty \`oldStr\` and the new content as \`newStr\`.
 - To delete a memory, pass an empty \`newStr\`.
+</critical_behavior>
 
-Store durable, user-level information that helps you personalize future responses, such as:
-- Who they are: role, team, and areas of responsibility.
-- How they like to work: communication style and tone, level of detail, preferred output formats, and language.
-- Stable context: recurring projects and goals, key people or teams they work with, the tools and tech stack they use, and their timezone or location.
-- Explicit instructions they ask you to remember for next time.
+<memory_strategy>
+Think of memory as building a "user manual" for this person:
+- Extract facts worth remembering (use judgment, not everything is memory-worthy)
+- Consolidate similar memories to avoid redundancy
+- Update facts when they change rather than accumulating outdated versions
+- Memory should let you provide increasingly personalized and efficient help over time
+</memory_strategy>
 
-Do NOT store secrets, credentials, one-off task details, or anything specific to the current conversation that won't matter later.
-`;
+<what_to_remember>
+High-value memories (save):
+- Identity and role: job title, team, responsibilities
+- Preferences: communication style, detail level, output formats, language
+- Context: ongoing projects, goals, deadlines, constraints
+- Expertise: knowledge level, skills, areas where they need support
+- Decisions: technical choices, strategic directions, agreed approaches
+- Tools and workflows: software they use, processes they follow
+
+Low-value memories (skip):
+- Temporal states: "working on X today", "currently debugging"
+- One-off queries without broader context
+- Secrets, credentials, or anything specific to the current conversation
+- Information readily available in their data sources
+- General knowledge or facts that don't relate to their personal context
+</what_to_remember>
+
+<memory_usage>
+Use memories to:
+- Skip redundant questions (e.g., don't ask their role if you already know it)
+- Tailor complexity to their expertise level automatically
+- Proactively offer relevant suggestions based on their patterns
+- Maintain continuity across conversations (reference past decisions naturally)
+- Adapt tone and format to their preferences without being asked
+
+Never explicitly say "I remember" or "based on our previous conversation", just apply the context naturally.
+</memory_usage>
+</memory_guidelines>`;
 
 export const userMemorySkill = {
   sId: "user_memory",


### PR DESCRIPTION
## Description

- Rename openUserMemory to resolveUserMemoryFile
- drop the user-facing MEMORY.md mention from the server description
- document why the agent-facing tool descriptions name MEMORY.md
- wrap a long describe line
- instruct the agent to read memory when the user message doesn't refer to general knowledge but to personal information (preferences, ...)

## Tests

Tested locally 

## Risk

Low risk

## Deploy Plan

Deploy front 
