### PR TITLE
[MCP] resume the sub-agent caller on every approval surface

### DIFF
--- a/front-api/lib/api/assistant/conversation/resolve_authentication.ts
+++ b/front-api/lib/api/assistant/conversation/resolve_authentication.ts
@@ -38,15 +38,13 @@ export function makeResolveAuthenticationApp(
       });
     }
 
-    const { actionId, outcome, resumeAncestorConversations } =
-      ctx.req.valid("json");
+    const { actionId, outcome } = ctx.req.valid("json");
 
     const result = await resolveAuthentication(auth, conversation, {
       actionId,
       messageId: mId,
       outcome,
       kind,
-      resumeAncestorConversations,
     });
 
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -13,7 +13,6 @@ const ParamsSchema = z.object({
 const ValidateActionSchema = z.object({
   actionId: z.string(),
   approved: z.enum(["approved", "rejected", "always_approved"]),
-  resumeAncestorConversations: z.boolean().optional(),
 });
 
 // Mounted at /api/w/:wId/assistant/conversations/:cId/messages/:mId/validate-action.
@@ -39,14 +38,12 @@ app.post(
       });
     }
 
-    const { actionId, approved, resumeAncestorConversations } =
-      ctx.req.valid("json");
+    const { actionId, approved } = ctx.req.valid("json");
 
     const result = await validateAction(auth, conversation, {
       actionId,
       approvalState: approved,
       messageId: mId,
-      resumeAncestorConversations,
     });
 
     if (result.isErr()) {

--- a/front/lib/api/assistant/conversation/answer_user_question.ts
+++ b/front/lib/api/assistant/conversation/answer_user_question.ts
@@ -194,6 +194,9 @@ export async function registerUserAnswer(
     "User question answered, agent loop resumed"
   );
 
-  // A sub-agent's caller sits in `blocked_child_action_input_required` until we relaunch it.
-  return resumeAncestorConversations(auth, conversation, { agentMessageId });
+  // A sub-agent's caller sits in `blocked_child_action_input_required` until we relaunch it. The
+  // answer is already committed, so a failed wake-up is logged, never returned.
+  await resumeAncestorConversations(auth, conversation, { agentMessageId });
+
+  return new Ok(undefined);
 }

--- a/front/lib/api/assistant/conversation/answer_user_question.ts
+++ b/front/lib/api/assistant/conversation/answer_user_question.ts
@@ -3,6 +3,7 @@ import type { UserQuestionAnswer } from "@app/lib/actions/types";
 import { isSandboxChildActionInfo } from "@app/lib/actions/types";
 import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
+import { resumeAncestorConversations } from "@app/lib/api/assistant/conversation/resume_ancestor_conversations";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import { resolveSandboxChildBlock } from "@app/lib/api/sandbox/sandbox_child_block";
@@ -193,5 +194,6 @@ export async function registerUserAnswer(
     "User question answered, agent loop resumed"
   );
 
-  return new Ok(undefined);
+  // A sub-agent's caller sits in `blocked_child_action_input_required` until we relaunch it.
+  return resumeAncestorConversations(auth, conversation, { agentMessageId });
 }

--- a/front/lib/api/assistant/conversation/resolve_authentication.ts
+++ b/front/lib/api/assistant/conversation/resolve_authentication.ts
@@ -222,10 +222,13 @@ export async function resolveAuthentication(
   );
 
   // A sub-agent's caller sits in `blocked_child_action_input_required` until we relaunch it, so
-  // this must run whatever the surface the authentication was resolved from.
-  return resumeAncestorConversationsHelper(auth, conversation, {
+  // this must run whatever the surface the authentication was resolved from. The resolution is
+  // already committed, so a failed wake-up is logged, never returned.
+  await resumeAncestorConversationsHelper(auth, conversation, {
     agentMessageId,
   });
+
+  return new Ok(undefined);
 }
 
 export const ResolveAuthenticationSchema = z.object({

--- a/front/lib/api/assistant/conversation/resolve_authentication.ts
+++ b/front/lib/api/assistant/conversation/resolve_authentication.ts
@@ -52,13 +52,11 @@ export async function resolveAuthentication(
     messageId,
     outcome,
     kind = "authentication",
-    resumeAncestorConversations = false,
   }: {
     actionId: string;
     messageId: string;
     outcome: ResolveAuthenticationOutcome;
     kind?: ResolveAuthenticationKind;
-    resumeAncestorConversations?: boolean;
   }
 ): Promise<Result<void, DustError>> {
   const { blockedStatus, isMatchingEvent, label } = KIND_CONFIG[kind];
@@ -223,10 +221,8 @@ export async function resolveAuthentication(
     `${label} ${outcome}, agent loop resumed`
   );
 
-  if (!resumeAncestorConversations) {
-    return new Ok(undefined);
-  }
-
+  // A sub-agent's caller sits in `blocked_child_action_input_required` until we relaunch it, so
+  // this must run whatever the surface the authentication was resolved from.
   return resumeAncestorConversationsHelper(auth, conversation, {
     agentMessageId,
   });
@@ -235,5 +231,4 @@ export async function resolveAuthentication(
 export const ResolveAuthenticationSchema = z.object({
   actionId: z.string(),
   outcome: z.enum(["completed", "denied"]),
-  resumeAncestorConversations: z.boolean().optional(),
 });

--- a/front/lib/api/assistant/conversation/resume_ancestor_conversations.test.ts
+++ b/front/lib/api/assistant/conversation/resume_ancestor_conversations.test.ts
@@ -89,11 +89,10 @@ describe("resumeAncestorConversations", () => {
       )
     );
 
-    const res = await resumeAncestorConversations(auth, child.conversation, {
+    await resumeAncestorConversations(auth, child.conversation, {
       agentMessageId: child.agentMessageId,
     });
 
-    expect(res.isOk()).toBe(true);
     // Starting the parent is a no-op (a sibling won the race), but we still walk
     // up and attempt to resume the grandparent so it is not stranded.
     expect(retryBlockedActions).toHaveBeenCalledTimes(2);
@@ -109,31 +108,54 @@ describe("resumeAncestorConversations", () => {
     );
   });
 
-  it("returns Err when retrying blocked actions fails for another reason", async () => {
+  it("keeps walking up when an ancestor has nothing to resume", async () => {
+    const grandParent = await createAgenticConversation(auth, workspace);
+    const parent = await createAgenticConversation(auth, workspace, {
+      agenticParentMessageId: grandParent.agentMessageId,
+    });
+    const child = await createAgenticConversation(auth, workspace, {
+      agenticParentMessageId: parent.agentMessageId,
+    });
+
+    // Benign for the caller (handover parent, or already resumed by a sibling validation): the
+    // grandparent may still be parked, so the walk must not stop here.
+    vi.mocked(retryBlockedActions).mockResolvedValue(
+      new Err(new DustError("no_blocked_actions", "No blocked actions found"))
+    );
+
+    await resumeAncestorConversations(auth, child.conversation, {
+      agentMessageId: child.agentMessageId,
+    });
+
+    expect(retryBlockedActions).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not surface a failed wake-up to the caller", async () => {
     const parent = await createAgenticConversation(auth, workspace);
     const child = await createAgenticConversation(auth, workspace, {
       agenticParentMessageId: parent.agentMessageId,
     });
 
+    // The user's decision is already committed by the time we get here, so an unexpected failure
+    // must be logged, never thrown or returned.
     vi.mocked(retryBlockedActions).mockResolvedValue(
-      new Err(new Error("No blocked actions found"))
+      new Err(new Error("Temporal is down"))
     );
 
-    const res = await resumeAncestorConversations(auth, child.conversation, {
-      agentMessageId: child.agentMessageId,
-    });
-
-    expect(res.isErr()).toBe(true);
+    await expect(
+      resumeAncestorConversations(auth, child.conversation, {
+        agentMessageId: child.agentMessageId,
+      })
+    ).resolves.toBeUndefined();
   });
 
-  it("returns Ok without retrying when there is no agentic parent", async () => {
+  it("does not retry when there is no agentic parent", async () => {
     const root = await createAgenticConversation(auth, workspace);
 
-    const res = await resumeAncestorConversations(auth, root.conversation, {
+    await resumeAncestorConversations(auth, root.conversation, {
       agentMessageId: root.agentMessageId,
     });
 
-    expect(res.isOk()).toBe(true);
     expect(retryBlockedActions).not.toHaveBeenCalled();
   });
 
@@ -148,11 +170,10 @@ describe("resumeAncestorConversations", () => {
 
     vi.mocked(retryBlockedActions).mockResolvedValue(new Ok(undefined));
 
-    const res = await resumeAncestorConversations(auth, child.conversation, {
+    await resumeAncestorConversations(auth, child.conversation, {
       agentMessageId: child.agentMessageId,
     });
 
-    expect(res.isOk()).toBe(true);
     expect(retryBlockedActions).toHaveBeenCalledTimes(2);
   });
 });

--- a/front/lib/api/assistant/conversation/resume_ancestor_conversations.ts
+++ b/front/lib/api/assistant/conversation/resume_ancestor_conversations.ts
@@ -1,22 +1,34 @@
 import { MAX_CONVERSATION_DEPTH } from "@app/lib/api/assistant/conversation/constants";
 import { retryBlockedActions } from "@app/lib/api/assistant/conversation/retry_blocked_actions";
 import type { Authenticator } from "@app/lib/auth";
+import type { DustErrorCode } from "@app/lib/error";
 import { DustError } from "@app/lib/error";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
-import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
+
+// Outcomes that mean "this ancestor has nothing to resume", not "resuming failed": a handover
+// caller was never blocked, a sibling validation already relaunched it, or it reached a terminal
+// state. Higher ancestors may still be parked, so the walk continues.
+const NON_BLOCKING_RETRY_ERROR_CODES: DustErrorCode[] = [
+  "agent_loop_already_running",
+  "agent_message_not_resumable",
+  "no_blocked_actions",
+];
 
 /**
  * Walk up the agentic-parent chain from a freshly resumed agent message and
  * relaunch every parentAgentMessage agent message that is still blocked waiting on its
  * child to complete (run_agent scenario).
+ *
+ * Best-effort by design: callers reach this after the user's decision is already committed (status
+ * flipped, audit emitted, child relaunched), so a failed wake-up must be logged, never reported as
+ * a failed approval.
  */
 export async function resumeAncestorConversations(
   auth: Authenticator,
   conversation: ConversationResource,
   { agentMessageId }: { agentMessageId: string }
-): Promise<Result<void, DustError<"internal_error">>> {
+): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
 
   let cursor: {
@@ -54,25 +66,22 @@ export async function resumeAncestorConversations(
     );
 
     if (retryRes.isErr()) {
-      const isAlreadyRunning =
-        retryRes.error instanceof DustError &&
-        retryRes.error.code === "agent_loop_already_running";
+      const logBlob = {
+        workspaceId: owner.sId,
+        parentConversationId: parentConversation.sId,
+        parentAgentMessageId: parentAgentMessage.sId,
+        err: retryRes.error,
+      };
 
-      if (!isAlreadyRunning) {
+      if (
+        retryRes.error instanceof DustError &&
+        NON_BLOCKING_RETRY_ERROR_CODES.includes(retryRes.error.code)
+      ) {
+        logger.info(logBlob, "Parent conversation had nothing to resume");
+      } else {
         logger.error(
-          {
-            workspaceId: owner.sId,
-            parentConversationId: parentConversation.sId,
-            parentAgentMessageId: parentAgentMessage.sId,
-            err: retryRes.error,
-          },
+          logBlob,
           "Failed to retry blocked actions on parent conversation"
-        );
-        return new Err(
-          new DustError(
-            "internal_error",
-            "Failed to resume parent conversation"
-          )
         );
       }
     }
@@ -82,6 +91,4 @@ export async function resumeAncestorConversations(
       agentMessageId: parentAgentMessage.sId,
     };
   }
-
-  return new Ok(undefined);
 }

--- a/front/lib/api/assistant/conversation/retry_blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/retry_blocked_actions.ts
@@ -2,7 +2,7 @@ import { isBlockedActionEvent } from "@app/lib/actions/mcp";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
-import type { DustError } from "@app/lib/error";
+import { DustError } from "@app/lib/error";
 import { MessageModel } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
@@ -70,14 +70,23 @@ async function findUserMessageForRetry(
     });
 
   if (blockedActions.length === 0) {
-    return new Err(new Error("No blocked actions found"));
+    // Not a failure: the message simply has nothing waiting on user input (already resumed, or
+    // reached here through a handover whose caller was never blocked).
+    return new Err(
+      new DustError("no_blocked_actions", "No blocked actions found")
+    );
   }
 
   // Blocked actions of a message that can no longer resume are stale leftovers: retrying them
   // would relaunch an agent loop that was already terminated. All blocked actions belong to the
   // same agent message, so checking the first one is enough.
   if (!(await blockedActions[0].canAgentMessageResume(auth))) {
-    return new Err(new Error("Agent message can no longer resume"));
+    return new Err(
+      new DustError(
+        "agent_message_not_resumable",
+        "Agent message can no longer resume"
+      )
+    );
   }
 
   // Purge blocked actions event message from the stream:

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -18,6 +18,11 @@ vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
   }),
 }));
 
+// Mock the ancestor resume so we can assert on it without launching workflows
+vi.mock("@app/lib/api/assistant/conversation/retry_blocked_actions", () => ({
+  retryBlockedActions: vi.fn(),
+}));
+
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
@@ -33,6 +38,7 @@ import {
 } from "@app/lib/api/assistant/conversation/mentions";
 import { createAgentMessages } from "@app/lib/api/assistant/conversation/messages";
 import { resolveAuthentication } from "@app/lib/api/assistant/conversation/resolve_authentication";
+import { retryBlockedActions } from "@app/lib/api/assistant/conversation/retry_blocked_actions";
 import { validateAction } from "@app/lib/api/assistant/conversation/validate_actions";
 import {
   publishAgentMessagesEvents,
@@ -65,6 +71,7 @@ import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { AgentMention, MentionType } from "@app/types/assistant/mentions";
 import { isRichUserMention } from "@app/types/assistant/mentions";
+import { Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
 
 describe("dismissMention", () => {
@@ -1182,6 +1189,78 @@ describe("validateAction", () => {
 
       // Verify agent loop was launched
       expect(vi.mocked(launchAgentLoopWorkflow)).toHaveBeenCalled();
+    });
+  });
+
+  describe("sub-agent conversations", () => {
+    it("should resume the calling conversation whatever the approval surface", async () => {
+      // The caller (e.g. an orchestrator running `run_agent`) sits in
+      // `blocked_child_action_input_required` until its loop is relaunched. Resuming it must not
+      // depend on the client that approved: Slack, Teams and the public API all land here.
+      const parentConversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: "test-agent",
+        messagesCreatedAt: [],
+        visibility: "unlisted",
+      });
+      const parentAgentMessage =
+        await ConversationFactory.createAgentMessageWithRank({
+          workspace,
+          conversationId: parentConversation.id,
+          rank: 0,
+          agentConfigurationId: "test-agent",
+        });
+
+      // The sub-agent conversation: its user message points back at the caller's agent message.
+      const { messageRow: childUserMessage } =
+        await ConversationFactory.createUserMessage({
+          auth,
+          workspace,
+          conversation,
+          content: "Prepare the brief",
+          agenticMessageType: "run_agent",
+          agenticOriginMessageId: parentAgentMessage.sId,
+        });
+
+      const childAgentMessageRow = await AgentMessageModel.create({
+        conversationId: conversation.id,
+        workspaceId: workspace.id,
+        status: "created",
+        agentConfigurationId: "test-agent",
+        agentConfigurationVersion: 0,
+        skipToolsValidation: false,
+      });
+      const childAgentMessage = await MessageModel.create({
+        workspaceId: workspace.id,
+        sId: generateRandomModelSId(),
+        conversationId: conversation.id,
+        rank: 1,
+        parentId: childUserMessage.id,
+        agentMessageId: childAgentMessageRow.id,
+      });
+
+      const { actionId } = await createBlockedAction({
+        agentMessageId: childAgentMessageRow.id,
+      });
+
+      vi.mocked(retryBlockedActions).mockResolvedValue(new Ok(undefined));
+
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+
+      const result = await validateAction(auth, conversationResource!, {
+        actionId,
+        approvalState: "approved",
+        messageId: childAgentMessage.sId,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(vi.mocked(retryBlockedActions)).toHaveBeenCalledWith(
+        auth,
+        expect.objectContaining({ sId: parentConversation.sId }),
+        expect.objectContaining({ messageId: parentAgentMessage.sId })
+      );
     });
   });
 

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -35,12 +35,10 @@ export async function validateAction(
     actionId,
     approvalState,
     messageId,
-    resumeAncestorConversations = false,
   }: {
     actionId: string;
     approvalState: ActionApprovalStateType;
     messageId: string;
-    resumeAncestorConversations?: boolean;
   }
 ): Promise<Result<void, DustError>> {
   const owner = auth.getNonNullableWorkspace();
@@ -297,10 +295,8 @@ export async function validateAction(
     `Action ${approvalState === "approved" ? "approved" : "rejected"} by user`
   );
 
-  if (!resumeAncestorConversations) {
-    return new Ok(undefined);
-  }
-
+  // A sub-agent's caller sits in `blocked_child_action_input_required` until we relaunch it, so
+  // this must run whatever the surface the approval came from (web, Slack, Teams, public API).
   return resumeAncestorConversationsHelper(auth, conversation, {
     agentMessageId,
   });

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -297,7 +297,10 @@ export async function validateAction(
 
   // A sub-agent's caller sits in `blocked_child_action_input_required` until we relaunch it, so
   // this must run whatever the surface the approval came from (web, Slack, Teams, public API).
-  return resumeAncestorConversationsHelper(auth, conversation, {
+  // The approval is already committed, so a failed wake-up is logged, never returned.
+  await resumeAncestorConversationsHelper(auth, conversation, {
     agentMessageId,
   });
+
+  return new Ok(undefined);
 }

--- a/front/lib/api/assistant/email/validate_tool_from_email.ts
+++ b/front/lib/api/assistant/email/validate_tool_from_email.ts
@@ -3,6 +3,7 @@ import {
   getMCPApprovalStateFromUserApprovalState,
   isMCPApproveExecutionEvent,
 } from "@app/lib/actions/mcp";
+import { resumeAncestorConversations } from "@app/lib/api/assistant/conversation/resume_ancestor_conversations";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import { Authenticator } from "@app/lib/auth";
@@ -355,6 +356,12 @@ export async function validateActionFromEmail(
     },
     `[email] Action ${approvalState === "approved" ? "approved" : "rejected"} via email`
   );
+
+  // A sub-agent's caller sits in `blocked_child_action_input_required` until we relaunch it. The
+  // email validation itself already succeeded, so the wake-up outcome is not propagated.
+  await resumeAncestorConversations(auth, conversationResource, {
+    agentMessageId: messageId,
+  });
 
   return new Ok({
     conversationId: conversationModel.sId,

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -59,6 +59,8 @@ export type DustErrorCode =
   | "conversation_not_found"
   | "failed_to_copy_files"
   | "no_unread_messages_found"
+  | "no_blocked_actions"
+  | "agent_message_not_resumable"
   | "no_whitelisted_model_found"
   | "generation_failed"
   | "invalid_conversation"

--- a/front/lib/swr/tool_actions.ts
+++ b/front/lib/swr/tool_actions.ts
@@ -74,7 +74,6 @@ function getResolveAuthenticationRequest(
         body: {
           actionId: request.actionId,
           outcome: request.outcome,
-          resumeAncestorConversations: true,
         },
       };
     case "sandbox_function":
@@ -113,7 +112,6 @@ function getValidateActionRequest(
         body: {
           actionId: request.actionId,
           approved: request.approved,
-          resumeAncestorConversations: true,
         },
       };
     case "sandbox_function":


### PR DESCRIPTION
## Description

Waking a parked orchestrator after its sub-agent's tool was approved was opt-in via a flag only the web app sent, so approvals from Slack, Teams, email or the public API resumed the sub-agent but left the caller stuck in `blocked_child_action_input_required` forever; the wake-up is now unconditional, also covers user questions and the email path, and is best-effort so a committed approval is never reported as failed.

## Tests

Added a regression test in `validate_actions.test.ts` (verified it fails without the fix) plus updated `resume_ancestor_conversations.test.ts`.

## Risk

Non-web approvals now trigger one extra agent-loop relaunch per ancestor, which adds latency to the validate-action request.

Monitor "Failed to retry blocked actions on parent conversation" in DD after deploy

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`
