### PR TITLE
Update gpt-5.6-luna pricing

### DIFF
--- a/front/lib/api/assistant/token_pricing/global.ts
+++ b/front/lib/api/assistant/token_pricing/global.ts
@@ -36,10 +36,10 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
   },
   // https://openai.com/api/pricing
   "gpt-5.6-luna": {
-    input: 1.0,
-    output: 6.0,
-    cache_creation_input_tokens: 1.25,
-    cache_read_input_tokens: 0.1,
+    input: 0.2,
+    output: 1.2,
+    cache_creation_input_tokens: 0.25,
+    cache_read_input_tokens: 0.02,
   },
   // https://openai.com/api/pricing
   "gpt-5.5": {

--- a/marketing/lib/api/assistant/token_pricing.ts
+++ b/marketing/lib/api/assistant/token_pricing.ts
@@ -49,10 +49,10 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
   },
   // https://openai.com/api/pricing
   "gpt-5.6-luna": {
-    input: 1.0,
-    output: 6.0,
-    cache_creation_input_tokens: 1.25,
-    cache_read_input_tokens: 0.1,
+    input: 0.2,
+    output: 1.2,
+    cache_creation_input_tokens: 0.25,
+    cache_read_input_tokens: 0.02,
   },
   // https://openai.com/api/pricing
   "gpt-5.5": {


### PR DESCRIPTION
## Description

OpenAI divided GPT-5.6 Luna API prices by five (https://openai.com/business/pricing/#api). Updated the token pricing entries in front and marketing:

- input: 1.0 -> 0.2
- output: 6.0 -> 1.2
- cached input: 0.1 -> 0.02
- cache write: 1.25 -> 0.25 (kept at 1.25x input, same convention as sol/terra)

## Tests

Checked the new numbers against the live pricing page. No tests pin these values.

## Risk

Low, data-only change. Affects credit consumption computed for Luna usage.

## Deploy Plan

Standard deploy.