### PR TITLE
Update gpt-5.6-terra pricing

### DIFF
--- a/front/lib/api/assistant/token_pricing/global.ts
+++ b/front/lib/api/assistant/token_pricing/global.ts
@@ -29,10 +29,10 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
   },
   // https://openai.com/api/pricing
   "gpt-5.6-terra": {
-    input: 2.5,
-    output: 15.0,
-    cache_creation_input_tokens: 3.125,
-    cache_read_input_tokens: 0.25,
+    input: 2.0,
+    output: 12.0,
+    cache_creation_input_tokens: 2.5,
+    cache_read_input_tokens: 0.2,
   },
   // https://openai.com/api/pricing
   "gpt-5.6-luna": {

--- a/front/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_six_luna_eu_openai_responses.ts
+++ b/front/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_six_luna_eu_openai_responses.ts
@@ -11,8 +11,8 @@ export class OpenAIGptFiveDotSixLunaEuropeOpenAIResponsesBatch extends WithOpenA
   // regional uplift for models released on or after March 5, 2026.
   // https://developers.openai.com/api/docs/models/gpt-5.6-luna
   static readonly tokenPricing = {
-    standardInput: 0.55,
-    standardOutput: 3.3,
+    standardInput: 0.11,
+    standardOutput: 0.66,
   };
 
   static readonly region = EUROPE;

--- a/front/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_six_luna_global_openai_responses.ts
+++ b/front/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_six_luna_global_openai_responses.ts
@@ -10,8 +10,8 @@ export class OpenAIGptFiveDotSixLunaGlobalOpenAIResponsesBatch extends WithOpenA
   // Batch pricing is half the standard OpenAI rate.
   // https://developers.openai.com/api/docs/models/gpt-5.6-luna
   static readonly tokenPricing = {
-    standardInput: 0.5,
-    standardOutput: 3.0,
+    standardInput: 0.1,
+    standardOutput: 0.6,
   };
 
   static readonly region = GLOBAL;

--- a/front/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_luna_eu_openai_responses.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_luna_eu_openai_responses.ts
@@ -11,9 +11,9 @@ export class OpenAIGptFiveDotSixLunaEuropeOpenAIResponsesStream extends WithOpen
   // Regional (data residency) endpoints are charged a 10% uplift for models
   // released on or after March 5, 2026.
   static readonly tokenPricing = {
-    cacheHit: 0.11,
-    standardInput: 1.1,
-    standardOutput: 6.6,
+    cacheHit: 0.022,
+    standardInput: 0.22,
+    standardOutput: 1.32,
   };
 
   static readonly region = EUROPE;

--- a/front/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_luna_global_openai_responses.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_luna_global_openai_responses.ts
@@ -9,9 +9,9 @@ export class OpenAIGptFiveDotSixLunaGlobalOpenAIResponsesStream extends WithOpen
 ) {
   // https://developers.openai.com/api/docs/models/gpt-5.6-luna
   static readonly tokenPricing = {
-    cacheHit: 0.1,
-    standardInput: 1.0,
-    standardOutput: 6.0,
+    cacheHit: 0.02,
+    standardInput: 0.2,
+    standardOutput: 1.2,
   };
 
   static readonly region = GLOBAL;

--- a/front/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_terra_eu_openai_responses.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_terra_eu_openai_responses.ts
@@ -11,9 +11,9 @@ export class OpenAIGptFiveDotSixTerraEuropeOpenAIResponsesStream extends WithOpe
   // Regional (data residency) endpoints are charged a 10% uplift for models
   // released on or after March 5, 2026.
   static readonly tokenPricing = {
-    cacheHit: 0.275,
-    standardInput: 2.75,
-    standardOutput: 16.5,
+    cacheHit: 0.22,
+    standardInput: 2.2,
+    standardOutput: 13.2,
   };
 
   static readonly region = EUROPE;

--- a/front/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_terra_global_openai_responses.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_terra_global_openai_responses.ts
@@ -9,9 +9,9 @@ export class OpenAIGptFiveDotSixTerraGlobalOpenAIResponsesStream extends WithOpe
 ) {
   // https://developers.openai.com/api/docs/models/gpt-5.6-terra
   static readonly tokenPricing = {
-    cacheHit: 0.25,
-    standardInput: 2.5,
-    standardOutput: 15.0,
+    cacheHit: 0.2,
+    standardInput: 2.0,
+    standardOutput: 12.0,
   };
 
   static readonly region = GLOBAL;

--- a/marketing/lib/api/assistant/token_pricing.ts
+++ b/marketing/lib/api/assistant/token_pricing.ts
@@ -42,10 +42,10 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
   },
   // https://openai.com/api/pricing
   "gpt-5.6-terra": {
-    input: 2.5,
-    output: 15.0,
-    cache_creation_input_tokens: 3.125,
-    cache_read_input_tokens: 0.25,
+    input: 2.0,
+    output: 12.0,
+    cache_creation_input_tokens: 2.5,
+    cache_read_input_tokens: 0.2,
   },
   // https://openai.com/api/pricing
   "gpt-5.6-luna": {


### PR DESCRIPTION
## Description

OpenAI lowered GPT-5.6 Terra API prices (https://openai.com/business/pricing/#api). Updated the token pricing entries in front and marketing:

- input: 2.5 -> 2.0
- output: 15.0 -> 12.0
- cached input: 0.25 -> 0.2
- cache write: 3.125 -> 2.5 (kept at 1.25x input, same convention as sol/luna)

Also synced the informational tokenPricing declarations in the model_constructors endpoint files: Terra stream (global and EU +10%), plus the Luna stream/batch ones that #29798 missed (batch at 50% of standard).

Follow-up to #29798 (Luna).

## Tests

Checked the new numbers against the live pricing page. No tests pin these values.

## Risk

Low, data-only change. Affects credit consumption computed for Terra usage.

## Deploy Plan

Standard deploy.