### PR TITLE
Delete dead schemas and types in internal MCP servers

### DIFF
--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -101,10 +101,6 @@ export const AshbyCandidateSearchResponseSchema = z
   .array(AshbyCandidateSchema)
   .optional();
 
-export type AshbyCandidateSearchResponse = z.infer<
-  typeof AshbyCandidateSearchResponseSchema
->;
-
 export const AshbyApplicationFeedbackListRequestSchema = z.object({
   applicationId: z.string(),
 });
@@ -174,10 +170,6 @@ export const AshbyApplicationFeedbackListResponseSchema = z.array(
   AshbyFeedbackSubmissionSchema
 );
 
-export type AshbyApplicationFeedbackListResponse = z.infer<
-  typeof AshbyApplicationFeedbackListResponseSchema
->;
-
 export const AshbyCandidateCreateNoteRequestSchema = z.object({
   candidateId: z.string(),
   note: z.object({
@@ -193,10 +185,6 @@ export type AshbyCandidateCreateNoteRequest = z.infer<
 export const AshbyCandidateCreateNoteResponseSchema = z
   .object({ id: z.string() })
   .passthrough();
-
-export type AshbyCandidateCreateNoteResponse = z.infer<
-  typeof AshbyCandidateCreateNoteResponseSchema
->;
 
 export const AshbyCandidateListNotesRequestSchema = z.object({
   candidateId: z.string(),
@@ -229,10 +217,6 @@ export const AshbyCandidateListNotesResponseSchema = z.array(
   AshbyCandidateNoteSchema
 );
 
-export type AshbyCandidateListNotesResponse = z.infer<
-  typeof AshbyCandidateListNotesResponseSchema
->;
-
 export const AshbyApplicationInfoRequestSchema = z.object({
   applicationId: z.string(),
 });
@@ -248,10 +232,6 @@ export const AshbyApplicationStatusSchema = z.enum([
   "Lead",
 ]);
 
-export type AshbyApplicationStatus = z.infer<
-  typeof AshbyApplicationStatusSchema
->;
-
 export const AshbyApplicationInfoResponseSchema = z
   .object({
     id: z.string(),
@@ -260,10 +240,6 @@ export const AshbyApplicationInfoResponseSchema = z
     candidateId: z.string().optional(),
   })
   .passthrough();
-
-export type AshbyApplicationInfoResponse = z.infer<
-  typeof AshbyApplicationInfoResponseSchema
->;
 
 // Opening list
 
@@ -274,8 +250,6 @@ export const AshbyOpeningStateSchema = z.enum([
   "Filled",
   "Open",
 ]);
-
-export type AshbyOpeningState = z.infer<typeof AshbyOpeningStateSchema>;
 
 export const AshbyOpeningLatestVersionSchema = z
   .object({
@@ -320,10 +294,6 @@ export const AshbyOpeningLatestVersionSchema = z
   })
   .passthrough();
 
-export type AshbyOpeningLatestVersion = z.infer<
-  typeof AshbyOpeningLatestVersionSchema
->;
-
 export const AshbyOpeningSchema = z
   .object({
     id: z.string(),
@@ -349,10 +319,6 @@ export type AshbyOpeningListRequest = z.infer<
 >;
 
 export const AshbyOpeningListResponseSchema = z.array(AshbyOpeningSchema);
-
-export type AshbyOpeningListResponse = z.infer<
-  typeof AshbyOpeningListResponseSchema
->;
 
 // Job list
 
@@ -391,10 +357,6 @@ export type AshbyUser = z.infer<typeof AshbyUserSchema>;
 
 export const AshbyUserSearchResponseSchema = z.array(AshbyUserSchema);
 
-export type AshbyUserSearchResponse = z.infer<
-  typeof AshbyUserSearchResponseSchema
->;
-
 // Referral form info
 
 export const AshbyReferralFormFieldSchema = z.object({
@@ -419,20 +381,12 @@ export const AshbyReferralFormFieldSchema = z.object({
   }),
 });
 
-export type AshbyReferralFormField = z.infer<
-  typeof AshbyReferralFormFieldSchema
->;
-
 export const AshbyReferralFormSectionSchema = z.object({
   title: z.string().optional(),
   descriptionHtml: z.string().optional(),
   descriptionPlain: z.string().optional(),
   fields: z.array(AshbyReferralFormFieldSchema),
 });
-
-export type AshbyReferralFormSection = z.infer<
-  typeof AshbyReferralFormSectionSchema
->;
 
 export const AshbyReferralFormInfoSchema = z
   .object({
@@ -451,10 +405,6 @@ export const AshbyReferralFormInfoSchema = z
 export type AshbyReferralFormInfo = z.infer<typeof AshbyReferralFormInfoSchema>;
 
 export const AshbyReferralFormInfoResponseSchema = AshbyReferralFormInfoSchema;
-
-export type AshbyReferralFormInfoResponse = z.infer<
-  typeof AshbyReferralFormInfoResponseSchema
->;
 
 // Referral tool input (as sent by the agent to the create_referral tool)
 
@@ -510,23 +460,7 @@ export const AshbyReferralCreateResponseSchema = z
   .passthrough()
   .optional();
 
-export type AshbyReferralCreateResponse = z.infer<
-  typeof AshbyReferralCreateResponseSchema
->;
-
 // Job posting list
-
-export const AshbyJobPostingEmploymentTypeSchema = z.enum([
-  "FullTime",
-  "PartTime",
-  "Intern",
-  "Contract",
-  "Temporary",
-]);
-
-export type AshbyJobPostingEmploymentType = z.infer<
-  typeof AshbyJobPostingEmploymentTypeSchema
->;
 
 export const AshbyJobPostingSchema = z
   .object({
@@ -570,10 +504,6 @@ export type AshbyJobPostingListRequest = z.infer<
 
 export const AshbyJobPostingListResponseSchema = z.array(AshbyJobPostingSchema);
 
-export type AshbyJobPostingListResponse = z.infer<
-  typeof AshbyJobPostingListResponseSchema
->;
-
 // Job posting info
 
 const AshbyDescriptionPartSchema = z.object({
@@ -605,24 +535,14 @@ export const AshbyJobPostingInfoSchema = z
   })
   .passthrough();
 
-export type AshbyJobPostingInfo = z.infer<typeof AshbyJobPostingInfoSchema>;
-
 export const AshbyJobPostingInfoResponseSchema =
   AshbyJobPostingInfoSchema.optional();
-
-export type AshbyJobPostingInfoResponse = z.infer<
-  typeof AshbyJobPostingInfoResponseSchema
->;
 
 // Job posting update
 
 export const AshbyJobPostingWorkplaceTypeSchema = z
   .enum(["OnSite", "Hybrid", "Remote"])
   .nullable();
-
-export type AshbyJobPostingWorkplaceType = z.infer<
-  typeof AshbyJobPostingWorkplaceTypeSchema
->;
 
 // Tool input schema (as sent by the agent to the update_job_posting tool).
 export const AshbyUpdateJobPostingInputSchema = z.object({
@@ -671,10 +591,6 @@ export const AshbyJobPostingUpdateResponseSchema = z
   })
   .passthrough()
   .optional();
-
-export type AshbyJobPostingUpdateResponse = z.infer<
-  typeof AshbyJobPostingUpdateResponseSchema
->;
 
 // Candidate info (detailed)
 
@@ -763,10 +679,6 @@ export type AshbyCandidateInfo = z.infer<typeof AshbyCandidateInfoSchema>;
 export const AshbyCandidateInfoResponseSchema =
   AshbyCandidateInfoSchema.optional();
 
-export type AshbyCandidateInfoResponse = z.infer<
-  typeof AshbyCandidateInfoResponseSchema
->;
-
 // Offer list
 
 export const AshbyOfferFormFieldValueSchema = z
@@ -775,10 +687,6 @@ export const AshbyOfferFormFieldValueSchema = z
     value: z.unknown().optional(),
   })
   .passthrough();
-
-export type AshbyOfferFormFieldValue = z.infer<
-  typeof AshbyOfferFormFieldValueSchema
->;
 
 export const AshbyOfferCustomFieldSchema = z
   .object({
@@ -789,8 +697,6 @@ export const AshbyOfferCustomFieldSchema = z
     valueLabel: z.union([z.string(), z.array(z.string())]).optional(),
   })
   .passthrough();
-
-export type AshbyOfferCustomField = z.infer<typeof AshbyOfferCustomFieldSchema>;
 
 export const AshbyOfferVersionSchema = z
   .object({
@@ -807,8 +713,6 @@ export const AshbyOfferVersionSchema = z
     customFields: z.array(AshbyOfferCustomFieldSchema).optional(),
   })
   .passthrough();
-
-export type AshbyOfferVersion = z.infer<typeof AshbyOfferVersionSchema>;
 
 export const AshbyOfferSchema = z
   .object({
@@ -830,10 +734,6 @@ export const AshbyOfferListRequestSchema = z.object({
 export type AshbyOfferListRequest = z.infer<typeof AshbyOfferListRequestSchema>;
 
 export const AshbyOfferListResponseSchema = z.array(AshbyOfferSchema);
-
-export type AshbyOfferListResponse = z.infer<
-  typeof AshbyOfferListResponseSchema
->;
 
 // Offer info
 
@@ -857,10 +757,6 @@ export const AshbyOfferInfoSchema = z
 export type AshbyOfferInfo = z.infer<typeof AshbyOfferInfoSchema>;
 
 export const AshbyOfferInfoResponseSchema = AshbyOfferInfoSchema.optional();
-
-export type AshbyOfferInfoResponse = z.infer<
-  typeof AshbyOfferInfoResponseSchema
->;
 
 // Job info (detailed)
 
@@ -895,5 +791,3 @@ export const AshbyJobInfoSchema = z
 export type AshbyJobInfo = z.infer<typeof AshbyJobInfoSchema>;
 
 export const AshbyJobInfoResponseSchema = AshbyJobInfoSchema.optional();
-
-export type AshbyJobInfoResponse = z.infer<typeof AshbyJobInfoResponseSchema>;

--- a/front/lib/api/actions/servers/clari_copilot/types.ts
+++ b/front/lib/api/actions/servers/clari_copilot/types.ts
@@ -123,7 +123,3 @@ export type ClariCallDetails = z.infer<typeof ClariCallDetailsSchema>;
 export const ClariCallDetailsResponseSchema = z.object({
   call: ClariCallDetailsSchema,
 });
-
-export type ClariCallDetailsResponse = z.infer<
-  typeof ClariCallDetailsResponseSchema
->;

--- a/front/lib/api/actions/servers/confluence/types.ts
+++ b/front/lib/api/actions/servers/confluence/types.ts
@@ -34,10 +34,6 @@ export type ConfluenceSearchRequest = z.infer<
   typeof ConfluenceSearchRequestSchema
 >;
 
-export type ConfluenceListPagesResult = z.infer<
-  typeof ConfluenceListPagesResultSchema
->;
-
 export const ConfluencePageBodySchema = z.object({
   storage: z
     .object({
@@ -130,16 +126,6 @@ export type ConfluenceV1SearchResult = z.infer<
   typeof ConfluenceV1SearchResultSchema
 >;
 
-export const ConfluenceListPagesResultSchema = z.object({
-  results: z.array(ConfluencePageSchema),
-  _links: z
-    .object({
-      next: z.string().optional(),
-      base: z.string(),
-    })
-    .optional(),
-});
-
 export const ConfluenceCreatePageRequestSchema = z.object({
   spaceId: z
     .string()
@@ -176,8 +162,6 @@ export const CreatePagePayloadSchema = z.object({
     })
     .optional(),
 });
-
-export type CreatePagePayload = z.infer<typeof CreatePagePayloadSchema>;
 
 export const ConfluenceUpdatePageRequestSchema = z.object({
   id: z.string().describe("The page ID"),
@@ -277,21 +261,6 @@ export const ConfluenceListSpacesResultSchema = z.object({
 
 export type ConfluenceListSpacesResult = z.infer<
   typeof ConfluenceListSpacesResultSchema
->;
-
-export const ConfluenceListSpacesRequestSchema = z.object({
-  limit: z
-    .number()
-    .optional()
-    .describe("Number of results per page (default 25)"),
-  cursor: z
-    .string()
-    .optional()
-    .describe("Pagination cursor from previous response for next page"),
-});
-
-export type ConfluenceListSpacesRequest = z.infer<
-  typeof ConfluenceListSpacesRequestSchema
 >;
 
 export type ConfluenceAncestor = {

--- a/front/lib/api/actions/servers/freshservice/types.ts
+++ b/front/lib/api/actions/servers/freshservice/types.ts
@@ -57,57 +57,6 @@ export const FreshserviceTicketSchema = z.object({
 
 export type FreshserviceTicket = z.infer<typeof FreshserviceTicketSchema>;
 
-export interface FreshserviceRequester {
-  id: number;
-  first_name: string;
-  last_name: string;
-  primary_email: string;
-  mobile_phone_number?: string;
-  work_phone_number?: string;
-  department_ids?: number[];
-  active: boolean;
-  created_at: string;
-  updated_at: string;
-}
-
-export interface FreshserviceDepartment {
-  id: number;
-  name: string;
-  description?: string;
-  head_user_id?: number;
-  prime_user_id?: number;
-  created_at: string;
-  updated_at: string;
-}
-
-export interface FreshserviceProduct {
-  id: number;
-  name: string;
-  description?: string;
-  asset_type_id: number;
-  manufacturer?: string;
-  status: string;
-  mode_of_procurement?: string;
-  created_at: string;
-  updated_at: string;
-}
-
-export interface FreshserviceServiceItem {
-  id: number;
-  name: string;
-  display_id: number;
-  category_id: number;
-  short_description?: string;
-  description?: string;
-  cost?: number;
-  cost_visibility: boolean;
-  delivery_time?: number;
-  delivery_time_visibility: boolean;
-  visibility: number;
-  created_at: string;
-  updated_at: string;
-}
-
 export interface FreshserviceServiceItemFieldChoice {
   id: number;
   value: string;
@@ -141,38 +90,6 @@ export interface FreshserviceServiceItemField {
   sections: any[];
   position?: number;
   date_only?: boolean;
-}
-
-export interface FreshserviceSolutionArticle {
-  id: number;
-  title: string;
-  description: string;
-  article_type: number;
-  folder_id: number;
-  category_id?: number;
-  status: number;
-  approval_status: number;
-  views: number;
-  thumbs_up: number;
-  thumbs_down: number;
-  tags?: string[];
-  keywords?: string[];
-  created_at: string;
-  updated_at: string;
-}
-
-export interface FreshserviceOnCallSchedule {
-  id: number;
-  name: string;
-  description?: string;
-  time_zone: string;
-  created_at: string;
-  updated_at: string;
-}
-
-// API Response interfaces
-export interface FreshserviceListResponse<T> {
-  [key: string]: T[];
 }
 
 export interface FreshserviceTicketFieldChoice {
@@ -209,20 +126,6 @@ export interface FreshserviceTicketField {
   position?: number;
   date_only?: boolean;
 }
-
-// Error codes
-export const FRESHSERVICE_ERROR_MESSAGES = {
-  AUTHENTICATION_REQUIRED:
-    "Authentication required. Please connect your Freshservice account.",
-  DOMAIN_NOT_CONFIGURED: "Freshservice domain not configured.",
-  TICKET_NOT_FOUND: "Ticket not found.",
-  REQUESTER_NOT_FOUND: "Requester not found.",
-  INVALID_PRIORITY:
-    "Invalid priority. Must be 1 (Low), 2 (Medium), 3 (High), or 4 (Urgent).",
-  INVALID_STATUS:
-    "Invalid status. Must be 2 (Open), 3 (Pending), 4 (Resolved), or 5 (Closed).",
-  API_ERROR: "API request failed",
-};
 
 // Default fields for list operations
 export const DEFAULT_TICKET_FIELDS_LIST = [

--- a/front/lib/api/actions/servers/jira/types.ts
+++ b/front/lib/api/actions/servers/jira/types.ts
@@ -189,27 +189,19 @@ export const ADFMarkSchema = z.object({
   attrs: z.record(z.any()).optional(),
 });
 
-export type ADFMark = z.infer<typeof ADFMarkSchema>;
-
 export const ADFTextNodeSchema = z.object({
   type: z.literal("text"),
   text: z.string(),
   marks: z.array(ADFMarkSchema).optional(),
 });
 
-export type ADFTextNode = z.infer<typeof ADFTextNodeSchema>;
-
 export const ADFHardBreakNodeSchema = z.object({
   type: z.literal("hardBreak"),
 });
 
-export type ADFHardBreakNode = z.infer<typeof ADFHardBreakNodeSchema>;
-
 export const ADFRuleNodeSchema = z.object({
   type: z.literal("rule"),
 });
-
-export type ADFRuleNode = z.infer<typeof ADFRuleNodeSchema>;
 
 // Explicit schemas for inline nodes we actively render
 export const ADFEmojiNodeSchema = z.object({
@@ -365,21 +357,6 @@ export const ADFDocumentSchema = z.object({
 
 export type ADFDocument = z.infer<typeof ADFDocumentSchema>;
 
-// Schema for update operations that allows ADF format for description and any string field
-export const JiraUpdateIssueRequestSchema = z
-  .record(
-    z.union([
-      z.string(),
-      ADFDocumentSchema,
-      z.object({}).passthrough(), // For complex field types like assignee, priority
-      z.array(z.string()), // For arrays like labels (most common case)
-      z.null(),
-    ])
-  )
-  .describe(
-    "Issue field updates - string fields can be plain text or ADF format"
-  );
-
 export const JiraSearchRequestSchema = z.object({
   jql: z.string(),
   maxResults: z.number(),
@@ -435,31 +412,6 @@ export const JiraIssueLinkTypeSchema = z.object({
   outward: z.string(),
 });
 
-export const JiraIssueLinkSchema = z.object({
-  id: z.string(),
-  type: JiraIssueLinkTypeSchema,
-  inwardIssue: z
-    .object({
-      key: z.string(),
-      fields: z
-        .object({
-          summary: z.string(),
-        })
-        .optional(),
-    })
-    .optional(),
-  outwardIssue: z
-    .object({
-      key: z.string(),
-      fields: z
-        .object({
-          summary: z.string(),
-        })
-        .optional(),
-    })
-    .optional(),
-});
-
 export const JiraCreateIssueLinkRequestSchema = z.object({
   type: z.object({
     name: z
@@ -498,8 +450,6 @@ export const JiraUserSchema = z.object({
   accountType: z.string(),
   active: z.boolean(),
 });
-
-export type JiraUser = z.infer<typeof JiraUserSchema>;
 
 export const JiraUsersSearchResultSchema = z.array(JiraUserSchema);
 
@@ -644,28 +594,7 @@ export const JiraCreateIssueRequestSchema = JiraIssueFieldsSchema.partial({
 export type JiraSearchResult = z.infer<typeof JiraSearchResultSchema>;
 export type JiraErrorResult = string;
 export type JiraIssue = z.infer<typeof JiraIssueSchema>;
-export type JiraProject = z.infer<typeof JiraProjectSchema>;
-export type JiraTransition = z.infer<typeof JiraTransitionSchema>;
 export type JiraComment = z.infer<typeof JiraCommentSchema>;
-export type JiraUserInfo = z.infer<typeof JiraUserInfoSchema>;
-export type JiraConnectionInfo = z.infer<typeof JiraConnectionInfoSchema>;
-export type JiraCreateIssueRequest = z.infer<
-  typeof JiraCreateIssueRequestSchema
->;
-export type JiraUpdateIssueRequest = z.infer<
-  typeof JiraUpdateIssueRequestSchema
->;
-export type JiraIssueLink = z.infer<typeof JiraIssueLinkSchema>;
-export type JiraIssueLinkType = z.infer<typeof JiraIssueLinkTypeSchema>;
-export type JiraCreateIssueLinkRequest = z.infer<
-  typeof JiraCreateIssueLinkRequestSchema
->;
-export type JiraAttachment = z.infer<typeof JiraAttachmentSchema>;
-export type JiraAttachmentsResult = z.infer<typeof JiraAttachmentsResultSchema>;
-export type JiraIssueWithAttachments = z.infer<
-  typeof JiraIssueWithAttachmentsSchema
->;
-
 export function isADFDocument(value: unknown): value is ADFDocument {
   return ADFDocumentSchema.safeParse(value).success;
 }

--- a/front/lib/api/actions/servers/productboard/types.ts
+++ b/front/lib/api/actions/servers/productboard/types.ts
@@ -157,31 +157,6 @@ export const ProductboardRelationshipsListResponseSchema = z.object({
   }),
 });
 
-export const ProductboardCustomFieldValueSchema = z
-  .object({
-    id: z.string().optional(),
-    label: z.string().optional(),
-    value: z.union([z.string(), z.number(), z.boolean()]).optional(),
-  })
-  .passthrough();
-
-export const ProductboardCustomFieldSchema = z
-  .object({
-    id: z.string(),
-    name: z.string(),
-    type: z.string(),
-    values: z.array(ProductboardCustomFieldValueSchema).optional(),
-  })
-  .passthrough();
-
-export type ProductboardCustomField = z.infer<
-  typeof ProductboardCustomFieldSchema
->;
-
-export const ProductboardCustomFieldsListResponseSchema = z.object({
-  data: z.array(ProductboardCustomFieldSchema),
-});
-
 export const ProductboardFieldLifecycleOpsSchema = z.object({
   set: z.boolean().default(false),
   clear: z.boolean().default(false),

--- a/front/lib/api/actions/servers/slab/types.ts
+++ b/front/lib/api/actions/servers/slab/types.ts
@@ -35,17 +35,6 @@ export interface SlabSearchResult {
   post: SlabPost;
 }
 
-export interface SlabPostSummary {
-  id: string;
-  title: string;
-  url: string;
-  contentPreview: string;
-  status: "published" | "draft" | "archived";
-  updatedAt: string;
-  author: string;
-  topics: string[];
-}
-
 export type RawPost = {
   id: string;
   title: string;

--- a/front/lib/api/actions/servers/statuspage/types.ts
+++ b/front/lib/api/actions/servers/statuspage/types.ts
@@ -19,10 +19,6 @@ export const RealTimeIncidentStatusSchema = z.enum([
   "resolved",
 ]);
 
-export type RealTimeIncidentStatus = z.infer<
-  typeof RealTimeIncidentStatusSchema
->;
-
 // All possible incident status values (including scheduled maintenance and postmortem)
 export const IncidentStatusSchema = z.enum([
   "investigating",
@@ -99,10 +95,6 @@ export const StatuspageIncidentUpdateSchema = z
   })
   .passthrough();
 
-export type StatuspageIncidentUpdate = z.infer<
-  typeof StatuspageIncidentUpdateSchema
->;
-
 // Incident schema
 export const StatuspageIncidentSchema = z
   .object({
@@ -140,8 +132,6 @@ export const ListIncidentsResponseSchema = z.array(StatuspageIncidentSchema);
 export type ListIncidentsResponse = z.infer<typeof ListIncidentsResponseSchema>;
 
 export const GetIncidentResponseSchema = StatuspageIncidentSchema;
-
-export type GetIncidentResponse = z.infer<typeof GetIncidentResponseSchema>;
 
 // Request types for creating/updating incidents
 export interface CreateIncidentRequest {

--- a/front/lib/api/actions/servers/ukg_ready/types.ts
+++ b/front/lib/api/actions/servers/ukg_ready/types.ts
@@ -254,12 +254,6 @@ export const UkgReadyPTORequestObjectSchema = z.object({
   bankCategory: z.number().optional(),
 });
 
-export const UkgReadyCreatePTORequestSchema = z
-  .object({
-    pto_request: UkgReadyPTORequestObjectSchema,
-  })
-  .passthrough();
-
 export const UkgReadyExecuteResultSchema = z
   .object({
     success_code: z.number().optional(),
@@ -286,9 +280,6 @@ export type UkgReadyPTORequestNote = z.infer<
 export type UkgReadySchedule = z.infer<typeof UkgReadyScheduleSchema>;
 export type UkgReadyPTORequestObject = z.infer<
   typeof UkgReadyPTORequestObjectSchema
->;
-export type UkgReadyCreatePTORequest = z.infer<
-  typeof UkgReadyCreatePTORequestSchema
 >;
 export type UkgReadyExecuteResult = z.infer<typeof UkgReadyExecuteResultSchema>;
 export type UkgReadyErrorResult = string;


### PR DESCRIPTION
One of five independent PRs from the same unused-export cleanup — #29802, #29803, #29804, #29807, #29809. Each is based on `main`, touches a disjoint set of files, and typechecks on its own, so they can be reviewed and merged in any order.

Second batch of the unused-export cleanup.

Scope: dead zod schemas and `z.infer` aliases in internal MCP server type modules — 71 declarations, ~364 lines, across nine servers. These model parts of a vendor API that no tool ever calls; a common shape when someone types the whole upstream surface and only a few tools get built.

| server | declarations removed |
|---|---|
| ashby | 28 |
| jira | 19 |
| freshservice | 8 |
| confluence | 5 |
| productboard | 4 |
| statuspage | 3 |
| ukg_ready | 2 |
| slab | 1 |
| clari_copilot | 1 |

## Pruned to a fixpoint, not one pass

Deleting a dead `z.infer` alias leaves the schema it was built from unreferenced. Removing only the aliases would have shifted the problem rather than fixed it, so each file was pruned repeatedly until nothing more was unreferenced. Eight schemas came out alongside the aliases they existed for — for example `ConfluenceListPagesResultSchema` behind `ConfluenceListPagesResult`, `JiraIssueLinkSchema` behind `JiraIssueLink`.

Every declaration was checked two ways before removal: no reference in any tracked `.ts`/`.tsx` in the repo, and no reference in the rest of its own file outside its own span.

## Not touched

`pod_manager` has three dead types too, but it is under active development this week (#29113 landed yesterday) and would conflict. It can go in a later batch.

Worth a reviewer's eye: if any of these schemas were deliberately written ahead of the tools that will use them, say so and I will restore them — they are one `git revert` away. Nothing here was referenced, so nothing changes at runtime either way.

## Test plan

- `npx tsgo --noEmit -p front/tsconfig.json` → clean. front's tsconfig includes `**/*.ts`, so a test file referencing any removed symbol would have failed here; none of the nine servers has tests of its own.
- `npx biome check --write front/lib/api/actions/servers` → clean (it dropped two imports the deletions orphaned).
- Verification pass repeated after applying: no remaining unreferenced declarations in the nine files.

