### PR TITLE
[Admin Governance] Serialize user-level grants on a grant-tuple advisory lock

### DIFF
--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -17,8 +17,7 @@ describe("GroupPermissionResource", () => {
     workspace = await WorkspaceFactory.basic();
     await GroupFactory.defaults(workspace);
     groupA = await GroupFactory.regularAuto(workspace, "A");
-    // Manual: a second regular_auto group may not share an instance-level tuple with groupA.
-    groupB = await GroupFactory.regularManual(workspace, "B");
+    groupB = await GroupFactory.regularAuto(workspace, "B");
     auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
   });
 
@@ -76,33 +75,6 @@ describe("GroupPermissionResource", () => {
           resourceId: 5,
         })
       ).rejects.toThrow(/not allowed/);
-    });
-
-    it("rejects a second regular_auto group on the same tuple", async () => {
-      await GroupPermissionResource.grant(auth, {
-        group: groupA,
-        grantType: "editor",
-        resourceType: "agent",
-        resourceId: 7,
-      });
-
-      const otherAutoGroup = await GroupFactory.regularAuto(workspace, "C");
-      await expect(
-        GroupPermissionResource.grant(auth, {
-          group: otherAutoGroup,
-          grantType: "editor",
-          resourceType: "agent",
-          resourceId: 7,
-        })
-      ).rejects.toThrow(/regular_auto/);
-
-      // A non-auto group on the same tuple stays legal (grants are additive across groups).
-      await GroupPermissionResource.grant(auth, {
-        group: groupB,
-        grantType: "editor",
-        resourceType: "agent",
-        resourceId: 7,
-      });
     });
 
     it("rejects a group from another workspace", async () => {
@@ -357,19 +329,19 @@ describe("GroupPermissionResource", () => {
       await GroupPermissionResource.grantMany(auth, {
         grants: [
           {
-            group: groupB,
+            group: groupA,
             grantType: "reader",
             resourceType: "space",
             resourceId: 1,
           },
           {
-            group: groupB,
+            group: groupA,
             grantType: "reader",
             resourceType: "space",
             resourceId: 1,
           },
           {
-            group: groupB,
+            group: groupA,
             grantType: "reader",
             resourceType: "space",
             resourceId: 2,
@@ -378,7 +350,7 @@ describe("GroupPermissionResource", () => {
       });
 
       const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupB.id],
+        groupModelIds: [groupA.id],
       });
       expect(grants).toHaveLength(2);
     });
@@ -388,7 +360,7 @@ describe("GroupPermissionResource", () => {
         GroupPermissionResource.grantMany(auth, {
           grants: [
             {
-              group: groupB,
+              group: groupA,
               grantType: "reader",
               resourceType: "space",
               resourceId: -1,
@@ -396,21 +368,6 @@ describe("GroupPermissionResource", () => {
           ],
         })
       ).rejects.toThrow(/instance-level/);
-    });
-
-    it("grantMany rejects regular_auto groups", async () => {
-      await expect(
-        GroupPermissionResource.grantMany(auth, {
-          grants: [
-            {
-              group: groupA,
-              grantType: "reader",
-              resourceType: "space",
-              resourceId: 1,
-            },
-          ],
-        })
-      ).rejects.toThrow(/regular_auto/);
     });
   });
 

--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -17,7 +17,8 @@ describe("GroupPermissionResource", () => {
     workspace = await WorkspaceFactory.basic();
     await GroupFactory.defaults(workspace);
     groupA = await GroupFactory.regularAuto(workspace, "A");
-    groupB = await GroupFactory.regularAuto(workspace, "B");
+    // Manual: a second regular_auto group may not share an instance-level tuple with groupA.
+    groupB = await GroupFactory.regularManual(workspace, "B");
     auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
   });
 
@@ -75,6 +76,33 @@ describe("GroupPermissionResource", () => {
           resourceId: 5,
         })
       ).rejects.toThrow(/not allowed/);
+    });
+
+    it("rejects a second regular_auto group on the same tuple", async () => {
+      await GroupPermissionResource.grant(auth, {
+        group: groupA,
+        grantType: "editor",
+        resourceType: "agent",
+        resourceId: 7,
+      });
+
+      const otherAutoGroup = await GroupFactory.regularAuto(workspace, "C");
+      await expect(
+        GroupPermissionResource.grant(auth, {
+          group: otherAutoGroup,
+          grantType: "editor",
+          resourceType: "agent",
+          resourceId: 7,
+        })
+      ).rejects.toThrow(/regular_auto/);
+
+      // A non-auto group on the same tuple stays legal (grants are additive across groups).
+      await GroupPermissionResource.grant(auth, {
+        group: groupB,
+        grantType: "editor",
+        resourceType: "agent",
+        resourceId: 7,
+      });
     });
 
     it("rejects a group from another workspace", async () => {
@@ -329,19 +357,19 @@ describe("GroupPermissionResource", () => {
       await GroupPermissionResource.grantMany(auth, {
         grants: [
           {
-            group: groupA,
+            group: groupB,
             grantType: "reader",
             resourceType: "space",
             resourceId: 1,
           },
           {
-            group: groupA,
+            group: groupB,
             grantType: "reader",
             resourceType: "space",
             resourceId: 1,
           },
           {
-            group: groupA,
+            group: groupB,
             grantType: "reader",
             resourceType: "space",
             resourceId: 2,
@@ -350,7 +378,7 @@ describe("GroupPermissionResource", () => {
       });
 
       const grants = await GroupPermissionResource.listForGroups(auth, {
-        groupModelIds: [groupA.id],
+        groupModelIds: [groupB.id],
       });
       expect(grants).toHaveLength(2);
     });
@@ -360,7 +388,7 @@ describe("GroupPermissionResource", () => {
         GroupPermissionResource.grantMany(auth, {
           grants: [
             {
-              group: groupA,
+              group: groupB,
               grantType: "reader",
               resourceType: "space",
               resourceId: -1,
@@ -368,6 +396,21 @@ describe("GroupPermissionResource", () => {
           ],
         })
       ).rejects.toThrow(/instance-level/);
+    });
+
+    it("grantMany rejects regular_auto groups", async () => {
+      await expect(
+        GroupPermissionResource.grantMany(auth, {
+          grants: [
+            {
+              group: groupA,
+              grantType: "reader",
+              resourceType: "space",
+              resourceId: 1,
+            },
+          ],
+        })
+      ).rejects.toThrow(/regular_auto/);
     });
   });
 

--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -446,6 +446,38 @@ describe("GroupPermissionResource", () => {
       expect(await group[0].isMember(user)).toBe(true);
     });
 
+    it("is idempotent for a repeat grant to the same user", async () => {
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "user" });
+
+      const spec = {
+        user: user.toJSON(),
+        grantType: "reader" as const,
+        resourceType: "space" as const,
+        resourceId: 42,
+      };
+      await GroupPermissionResource.grantToUser(auth, spec);
+      const repeat = await GroupPermissionResource.grantToUser(auth, spec);
+      expect(repeat.isOk()).toBe(true);
+
+      const grants = await GroupPermissionResource.listForGroups(auth, {
+        groupModelIds: (
+          await GroupResource.listAllWorkspaceGroups(auth, {
+            groupKinds: ["regular_auto"],
+          })
+        ).map((group) => group.id),
+        grantType: "reader",
+        resourceType: "space",
+        resourceId: 42,
+      });
+      expect(grants).toHaveLength(1);
+
+      const [backingGroup] = await GroupResource.fetchByModelIds(auth, [
+        grants[0].groupId,
+      ]);
+      expect(await backingGroup.getMemberCount(auth)).toBe(1);
+    });
+
     it("reuses the existing regular_auto group for a second user", async () => {
       const user1 = await UserFactory.basic();
       const user2 = await UserFactory.basic();

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -672,7 +672,13 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     },
     transaction: Transaction
   ): Promise<void> {
-    const key = `group_permissions:${auth.getNonNullableWorkspace().id}:${resourceType}:${resourceId}:${grantType}`;
+    // Type-wide (-1) transitions keep the pre-resourceId key format so pods running older code
+    // mutually exclude with newer ones across a rolling deploy or rollback.
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const key =
+      resourceId === WHOLE_TYPE_RESOURCE_ID
+        ? `group_permissions:${workspaceId}:${resourceType}:${grantType}`
+        : `group_permissions:${workspaceId}:${resourceType}:${resourceId}:${grantType}`;
     // biome-ignore lint/plugin/noRawSql: advisory lock requires raw SQL
     await frontSequelize.query("SELECT pg_advisory_xact_lock(hashtext(:key))", {
       replacements: { key },

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -153,7 +153,8 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
   }
 
   // Find the regular_auto group that already holds an instance-level grant for the given tuple.
-  // At most one such group is expected per (grantType, resourceType, resourceId).
+  // At most one such group exists per (grantType, resourceType, resourceId): grantToUser and
+  // revokeFromUser serialize on the grant-tuple advisory lock (getGrantLock).
   private static async findRegularAutoGroupForGrant(
     auth: Authenticator,
     {
@@ -191,13 +192,16 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
   }
 
   // Grant a user access to a resource by adding them to the regular_auto group that holds the
-  // grant. Creates the group and calls grant() on first use. Idempotent for repeat grants to the
-  // same user.
+  // grant. Creates the group and calls grant() on first use — the grant-tuple lock serializes
+  // concurrent first grants so only one regular_auto group is ever created. Idempotent for repeat
+  // grants to the same user.
   static async grantToUser(
     auth: Authenticator,
     { user, grantType, resourceType, resourceId, transaction }: UserGrantSpec
   ): Promise<Result<undefined, Error>> {
     return withTransaction(async (t) => {
+      await this.getGrantLock(auth, { grantType, resourceType, resourceId }, t);
+
       let group = await this.findRegularAutoGroupForGrant(auth, {
         grantType,
         resourceType,
@@ -243,6 +247,8 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     { user, grantType, resourceType, resourceId, transaction }: UserGrantSpec
   ): Promise<Result<undefined, Error>> {
     return withTransaction(async (t) => {
+      await this.getGrantLock(auth, { grantType, resourceType, resourceId }, t);
+
       const group = await this.findRegularAutoGroupForGrant(auth, {
         grantType,
         resourceType,
@@ -646,15 +652,27 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     });
   }
 
-  // Serialize concurrent transitions for the same capability. Without this, two transactions can
-  // each clear the -1 rows and then insert, leaving both the everybody row and specific-group rows
-  // (overgranting). The transaction-scoped advisory lock releases on commit/rollback.
-  private static async getCapabilityLock(
+  // Serialize concurrent writes on the same grant tuple. The transaction-scoped advisory lock
+  // releases on commit/rollback. Two uses:
+  //   - capability transitions (resourceId = -1): without it, two transactions can each clear the
+  //     -1 rows and then insert, leaving both the everybody row and specific-group rows
+  //     (overgranting);
+  //   - user-level grants: serializes grantToUser's find-or-create against itself and against
+  //     revokeFromUser's delete-when-empty, guaranteeing at most one regular_auto group per tuple.
+  private static async getGrantLock(
     auth: Authenticator,
-    { grantType, resourceType }: CapabilitySpec,
+    {
+      grantType,
+      resourceType,
+      resourceId,
+    }: {
+      grantType: GrantType;
+      resourceType: GroupPermissionResourceType;
+      resourceId: number;
+    },
     transaction: Transaction
   ): Promise<void> {
-    const key = `group_permissions:${auth.getNonNullableWorkspace().id}:${resourceType}:${grantType}`;
+    const key = `group_permissions:${auth.getNonNullableWorkspace().id}:${resourceType}:${resourceId}:${grantType}`;
     // biome-ignore lint/plugin/noRawSql: advisory lock requires raw SQL
     await frontSequelize.query("SELECT pg_advisory_xact_lock(hashtext(:key))", {
       replacements: { key },
@@ -674,7 +692,11 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     assert(globalGroup, "Workspace is missing its global group.");
 
     await withTransaction(async (t) => {
-      await this.getCapabilityLock(auth, capability, t);
+      await this.getGrantLock(
+        auth,
+        { ...capability, resourceId: WHOLE_TYPE_RESOURCE_ID },
+        t
+      );
       await this.disable(auth, capability, { transaction: t });
       await this.grantTypeWide(auth, {
         group: globalGroup,
@@ -705,7 +727,11 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     }
 
     await withTransaction(async (t) => {
-      await this.getCapabilityLock(auth, capability, t);
+      await this.getGrantLock(
+        auth,
+        { ...capability, resourceId: WHOLE_TYPE_RESOURCE_ID },
+        t
+      );
       await this.disable(auth, capability, { transaction: t });
       await this.grantTypeWideForGroups(auth, {
         groups,

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -118,9 +118,6 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
 
   // Grant an instance-level permission (a specific resource). Idempotent: the unique index dedupes,
   // so granting twice is a no-op. Type-wide grants (resourceId = -1) go through dedicated methods.
-  // A regular_auto group is the single backing group of its tuple: granting one when a different
-  // regular_auto group already holds the tuple is rejected (under the grant-tuple lock, so
-  // concurrent inserts cannot slip through).
   // TODO(admin-governance): Decide whether system group should be rejected here (and in
   // revoke) or left to callers; align with setGroups / setForEverybody conventions.
   static async grant(
@@ -141,38 +138,18 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     assertValidGrant({ grantType, resourceType, resourceId });
 
     const workspaceId = auth.getNonNullableWorkspace().id;
-    return withTransaction(async (t) => {
-      if (group.kind === "regular_auto") {
-        await this.getGrantLock(
-          auth,
-          { grantType, resourceType, resourceId },
-          t
-        );
-        const existing = await this.findRegularAutoGroupForGrant(auth, {
-          grantType,
-          resourceType,
-          resourceId,
-          transaction: t,
-        });
-        assert(
-          !existing || existing.id === group.id,
-          "Another regular_auto group already holds this grant tuple."
-        );
-      }
+    const [row] = await GroupPermissionModel.findOrCreate({
+      where: {
+        workspaceId,
+        groupId: group.id,
+        grantType,
+        resourceType,
+        resourceId,
+      },
+      transaction,
+    });
 
-      const [row] = await GroupPermissionModel.findOrCreate({
-        where: {
-          workspaceId,
-          groupId: group.id,
-          grantType,
-          resourceType,
-          resourceId,
-        },
-        transaction: t,
-      });
-
-      return new this(GroupPermissionModel, row.get());
-    }, transaction);
+    return new this(GroupPermissionModel, row.get());
   }
 
   // Find the regular_auto group that already holds an instance-level grant for the given tuple.
@@ -526,9 +503,7 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
   }
 
   // Batch of instance-level grants (one INSERT, unique index dedupes). Each is validated; -1 is
-  // rejected here as in `grant` — type-wide grants use the dedicated methods above. regular_auto
-  // groups are rejected: their one-group-per-tuple check is per-row (see grant), which would
-  // defeat the batch — grant them through grant()/grantToUser instead.
+  // rejected here as in `grant` — type-wide grants use the dedicated methods above.
   static async grantMany(
     auth: Authenticator,
     {
@@ -551,10 +526,6 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
       assert(
         resourceId > 0,
         "grantMany is instance-level; use the dedicated type-wide methods for -1 grants."
-      );
-      assert(
-        group.kind !== "regular_auto",
-        "grantMany cannot target regular_auto groups; use grant()/grantToUser."
       );
       this.assertGroupInWorkspace(auth, group);
       assertValidGrant({ grantType, resourceType, resourceId });

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -118,6 +118,9 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
 
   // Grant an instance-level permission (a specific resource). Idempotent: the unique index dedupes,
   // so granting twice is a no-op. Type-wide grants (resourceId = -1) go through dedicated methods.
+  // A regular_auto group is the single backing group of its tuple: granting one when a different
+  // regular_auto group already holds the tuple is rejected (under the grant-tuple lock, so
+  // concurrent inserts cannot slip through).
   // TODO(admin-governance): Decide whether system group should be rejected here (and in
   // revoke) or left to callers; align with setGroups / setForEverybody conventions.
   static async grant(
@@ -138,18 +141,38 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     assertValidGrant({ grantType, resourceType, resourceId });
 
     const workspaceId = auth.getNonNullableWorkspace().id;
-    const [row] = await GroupPermissionModel.findOrCreate({
-      where: {
-        workspaceId,
-        groupId: group.id,
-        grantType,
-        resourceType,
-        resourceId,
-      },
-      transaction,
-    });
+    return withTransaction(async (t) => {
+      if (group.kind === "regular_auto") {
+        await this.getGrantLock(
+          auth,
+          { grantType, resourceType, resourceId },
+          t
+        );
+        const existing = await this.findRegularAutoGroupForGrant(auth, {
+          grantType,
+          resourceType,
+          resourceId,
+          transaction: t,
+        });
+        assert(
+          !existing || existing.id === group.id,
+          "Another regular_auto group already holds this grant tuple."
+        );
+      }
 
-    return new this(GroupPermissionModel, row.get());
+      const [row] = await GroupPermissionModel.findOrCreate({
+        where: {
+          workspaceId,
+          groupId: group.id,
+          grantType,
+          resourceType,
+          resourceId,
+        },
+        transaction: t,
+      });
+
+      return new this(GroupPermissionModel, row.get());
+    }, transaction);
   }
 
   // Find the regular_auto group that already holds an instance-level grant for the given tuple.
@@ -503,7 +526,9 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
   }
 
   // Batch of instance-level grants (one INSERT, unique index dedupes). Each is validated; -1 is
-  // rejected here as in `grant` — type-wide grants use the dedicated methods above.
+  // rejected here as in `grant` — type-wide grants use the dedicated methods above. regular_auto
+  // groups are rejected: their one-group-per-tuple check is per-row (see grant), which would
+  // defeat the batch — grant them through grant()/grantToUser instead.
   static async grantMany(
     auth: Authenticator,
     {
@@ -526,6 +551,10 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
       assert(
         resourceId > 0,
         "grantMany is instance-level; use the dedicated type-wide methods for -1 grants."
+      );
+      assert(
+        group.kind !== "regular_auto",
+        "grantMany cannot target regular_auto groups; use grant()/grantToUser."
       );
       this.assertGroupInWorkspace(auth, group);
       assertValidGrant({ grantType, resourceType, resourceId });

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -175,10 +175,9 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     }, transaction);
   }
 
-  // Find the regular_auto group backing user-level grants for the given tuple. grantToUser and
-  // revokeFromUser serialize on the grant-tuple advisory lock (getGrantLock), so they never create
-  // a second backing group. Caveat: other regular_auto groups can legitimately hold the same tuple
-  // (e.g. a space-members group carrying a model-tier override) and are not told apart here.
+  // Find the regular_auto group backing user-level grants for the given tuple. At most one exists
+  // per (grantType, resourceType, resourceId): grantToUser and revokeFromUser serialize on the
+  // grant-tuple advisory lock (getGrantLock), and grant() rejects a second regular_auto group.
   private static async findRegularAutoGroupForGrant(
     auth: Authenticator,
     {

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -118,6 +118,9 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
 
   // Grant an instance-level permission (a specific resource). Idempotent: the unique index dedupes,
   // so granting twice is a no-op. Type-wide grants (resourceId = -1) go through dedicated methods.
+  // A regular_auto group is the single backing group of its tuple: granting one when a different
+  // regular_auto group already holds the tuple is rejected (under the grant-tuple lock, so
+  // concurrent inserts cannot slip through).
   // TODO(admin-governance): Decide whether system group should be rejected here (and in
   // revoke) or left to callers; align with setGroups / setForEverybody conventions.
   static async grant(
@@ -138,18 +141,38 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     assertValidGrant({ grantType, resourceType, resourceId });
 
     const workspaceId = auth.getNonNullableWorkspace().id;
-    const [row] = await GroupPermissionModel.findOrCreate({
-      where: {
-        workspaceId,
-        groupId: group.id,
-        grantType,
-        resourceType,
-        resourceId,
-      },
-      transaction,
-    });
+    return withTransaction(async (t) => {
+      if (group.kind === "regular_auto") {
+        await this.getGrantLock(
+          auth,
+          { grantType, resourceType, resourceId },
+          t
+        );
+        const existing = await this.findRegularAutoGroupForGrant(auth, {
+          grantType,
+          resourceType,
+          resourceId,
+          transaction: t,
+        });
+        assert(
+          !existing || existing.id === group.id,
+          "Another regular_auto group already holds this grant tuple."
+        );
+      }
 
-    return new this(GroupPermissionModel, row.get());
+      const [row] = await GroupPermissionModel.findOrCreate({
+        where: {
+          workspaceId,
+          groupId: group.id,
+          grantType,
+          resourceType,
+          resourceId,
+        },
+        transaction: t,
+      });
+
+      return new this(GroupPermissionModel, row.get());
+    }, transaction);
   }
 
   // Find the regular_auto group backing user-level grants for the given tuple. grantToUser and
@@ -504,7 +527,9 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
   }
 
   // Batch of instance-level grants (one INSERT, unique index dedupes). Each is validated; -1 is
-  // rejected here as in `grant` — type-wide grants use the dedicated methods above.
+  // rejected here as in `grant` — type-wide grants use the dedicated methods above. regular_auto
+  // groups are rejected: their one-group-per-tuple check is per-row (see grant), which would
+  // defeat the batch — grant them through grant()/grantToUser instead.
   static async grantMany(
     auth: Authenticator,
     {
@@ -527,6 +552,10 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
       assert(
         resourceId > 0,
         "grantMany is instance-level; use the dedicated type-wide methods for -1 grants."
+      );
+      assert(
+        group.kind !== "regular_auto",
+        "grantMany cannot target regular_auto groups; use grant()/grantToUser."
       );
       this.assertGroupInWorkspace(auth, group);
       assertValidGrant({ grantType, resourceType, resourceId });

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -254,7 +254,8 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
         user,
         transaction: t,
       });
-      if (addResult.isErr()) {
+      // Repeat grant for the same user: the desired end state already holds, stay idempotent.
+      if (addResult.isErr() && addResult.error.code !== "user_already_member") {
         return addResult;
       }
 

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -152,9 +152,10 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     return new this(GroupPermissionModel, row.get());
   }
 
-  // Find the regular_auto group that already holds an instance-level grant for the given tuple.
-  // At most one such group exists per (grantType, resourceType, resourceId): grantToUser and
-  // revokeFromUser serialize on the grant-tuple advisory lock (getGrantLock).
+  // Find the regular_auto group backing user-level grants for the given tuple. grantToUser and
+  // revokeFromUser serialize on the grant-tuple advisory lock (getGrantLock), so they never create
+  // a second backing group. Caveat: other regular_auto groups can legitimately hold the same tuple
+  // (e.g. a space-members group carrying a model-tier override) and are not told apart here.
   private static async findRegularAutoGroupForGrant(
     auth: Authenticator,
     {

--- a/front/lib/resources/models_tier_resource.test.ts
+++ b/front/lib/resources/models_tier_resource.test.ts
@@ -77,6 +77,32 @@ describe("ModelsTierResource permissions", () => {
     );
   });
 
+  it("keeps user and group tier overrides on the same tier independent", async () => {
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+
+    const userResult = await ModelsTierResource.setUserMaxAllowedTier(auth, {
+      userId: user.sId,
+      tierName: "balanced",
+    });
+    expect(userResult.isOk()).toBe(true);
+
+    // A group override on the same tier lands on the same grant tuple as the user's backing
+    // group, through a second group — both must coexist.
+    const groupResult = await ModelsTierResource.setGroupMaxAllowedTier(auth, {
+      groupId: group.sId,
+      tierName: "balanced",
+    });
+    expect(groupResult.isOk()).toBe(true);
+
+    expect(await ModelsTierResource.listUserAllowedTierNames(auth)).toEqual([
+      { userId: user.sId, maxTierName: "balanced" },
+    ]);
+    expect(
+      await ModelsTierResource.listGroupAllowedTierNames(auth)
+    ).toContainEqual({ groupId: group.sId, maxTierName: "balanced" });
+  });
+
   it("rejects a group tier override on a regular_auto group", async () => {
     const autoGroup = await GroupFactory.regularAuto(workspace, "auto");
 


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/29896 (merged), which removed the last path granting instance tuples to non-backing regular_auto groups and made the invariant below globally true.

`grantToUser` finds-or-creates the `regular_auto` group backing a grant tuple (grantType, resourceType, resourceId) with no serialization: two concurrent first grants for the same tuple can both miss the existing group and try to create a duplicate. A duplicate backing group would make the grant ambiguous (`findRegularAutoGroupForGrant` picks arbitrarily), meaning a revoke could remove a user from one group while they retain access through the other. Today the duplicate is only prevented *accidentally*: `autoGroupName` is deterministic and the `groups (workspaceId, name)` unique index makes the losing transaction fail — a user-visible error held together by a display string.

Two layers, both in `GroupPermissionResource` (the single write path for `group_permissions`):

1. **Serialization** — the capability advisory lock (`getCapabilityLock`) is generalized into `getGrantLock`, keyed on the full grant tuple, and taken at the top of `grantToUser` and `revokeFromUser`. Concurrent first grants now serialize: the second transaction waits, finds the backing group created by the first, and adds its member gracefully instead of erroring. Locking `revokeFromUser` too closes the grant-vs-delete race: its delete-when-empty branch could otherwise act on a stale member count and wipe a concurrently added member's access. A repeat grant for an already-member user now returns Ok (idempotent, as documented) instead of propagating `user_already_member`.

2. **Enforcement at the choke point** — `grant()` rejects wiring a `regular_auto` group to a tuple that a *different* `regular_auto` group already holds (checked under the tuple lock), and `grantMany` rejects `regular_auto` groups outright (per-row checks would defeat the batch; auto grants go through `grant()`/`grantToUser`). This covers every resource-mediated path, not just `grantToUser`. (History note: this was reverted mid-PR while model-tier group overrides could still target regular_auto groups, and re-landed once #29896 removed that path.)

Type-wide (-1) capability transitions (`setForEverybody` / `setGroups`) keep the pre-existing lock key format so old and new pods mutually exclude across a rolling deploy or rollback; instance grants use a new key that includes `resourceId`.

The lock behavior itself has no new test: the test harness wraps each test in a single CLS transaction shared by all calls, where `pg_advisory_xact_lock` is reentrant, so a concurrency test would pass with or without the lock. The `grant()`/`grantMany` rejection paths, grantToUser idempotency, and user/group tier override coexistence are functionally tested.

## Risks

Blast radius: model-tier user grants (only current `grantToUser`/`revokeFromUser` callers) and governance capability transitions (unchanged lock key); `grant()` now rejects a second regular_auto group per tuple — no remaining caller can do this.
Risk: low

## Deploy Plan

- deploy front