### PR TITLE
[front] Activation: recommendations-for-you pill + pinned sidebar section

### DIFF
--- a/front/components/assistant/conversation/ActivationNextSteps.tsx
+++ b/front/components/assistant/conversation/ActivationNextSteps.tsx
@@ -5,15 +5,12 @@ import {
   useActivationRecommendations,
   useUpdateActivationRecommendation,
 } from "@app/lib/swr/activation";
-import { classNames } from "@app/lib/utils";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   ActionSparklesIcon,
+  ArrowRight,
   Button,
-  ChevronDown,
-  CornerDownLeft,
-  Icon,
   PopoverContent,
   PopoverRoot,
   PopoverTrigger,
@@ -79,21 +76,13 @@ export function ActivationNextSteps({
   return (
     <PopoverRoot open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>
-        <button
-          type="button"
-          className={classNames(
-            "flex items-center gap-1.5 rounded-full px-3 py-1.5",
-            "bg-highlight-50 text-sm font-medium text-highlight-600",
-            "transition-colors hover:bg-highlight-100"
-          )}
-        >
-          <Icon visual={ActionSparklesIcon} size="xs" />
-          <span>Your next steps</span>
-          <span className="flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-highlight-500 px-1 text-xs font-semibold text-white">
-            {recommendations.length}
-          </span>
-          <Icon visual={ChevronDown} size="xs" />
-        </button>
+        <Button
+          variant="highlight"
+          size="sm"
+          icon={ActionSparklesIcon}
+          label="Recommendations for you"
+          isSelect
+        />
       </PopoverTrigger>
       <PopoverContent
         align="center"
@@ -101,37 +90,47 @@ export function ActivationNextSteps({
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
         <div className="flex flex-col">
+          {/* Says what these are, why the user is seeing them, and that
+              nothing runs without confirmation. */}
+          <div className="border-b border-border p-4">
+            <p className="text-xs text-muted-foreground">
+              We picked a few next steps for you that fit how you already work.
+              Open a conversation and we'll walk you through it.
+            </p>
+          </div>
           {recommendations.map((rec) => (
             <div
               key={rec.sId}
-              className={classNames(
-                "flex w-full items-center gap-2 px-3 py-2.5",
-                "border-b border-border last:border-b-0",
-                "hover:bg-muted-background"
-              )}
+              className="flex w-full items-start gap-2 border-b border-border p-4 last:border-b-0 hover:bg-muted-background"
             >
               <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                <span className="truncate text-sm font-semibold text-foreground">
+                <span className="text-sm font-semibold text-foreground">
                   {rec.title}
                 </span>
                 <span className="line-clamp-2 text-xs text-muted-foreground">
                   {rec.content}
                 </span>
               </div>
-              <Button
-                icon={XClose}
-                size="mini"
-                variant="ghost-secondary"
-                tooltip="Dismiss"
-                onClick={(e) => void handleDismiss(e, rec)}
-              />
-              <Button
-                icon={CornerDownLeft}
-                size="mini"
-                variant="ghost-secondary"
-                tooltip="Try this"
-                onClick={() => handleSelect(rec)}
-              />
+              <div className="flex shrink-0 items-center gap-1">
+                <Button
+                  icon={XClose}
+                  tooltip="Not for me"
+                  size="xs"
+                  variant="ghost"
+                  onClick={(e) => void handleDismiss(e, rec)}
+                />
+                <Button
+                  icon={ArrowRight}
+                  label={
+                    rec.conversationId
+                      ? "Open conversation"
+                      : "Start conversation"
+                  }
+                  size="xs"
+                  variant="highlight"
+                  onClick={() => handleSelect(rec)}
+                />
+              </div>
             </div>
           ))}
         </div>

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -43,6 +43,7 @@ import { CONVERSATIONS_UPDATED_EVENT } from "@app/lib/notifications/events";
 import { useAppRouter } from "@app/lib/platform";
 import { SKILL_ICON } from "@app/lib/skill";
 import { getSpaceIcon } from "@app/lib/spaces";
+import { useActivationRecommendations } from "@app/lib/swr/activation";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
@@ -64,6 +65,7 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { PodListItemType, PodType, SpaceType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
 import {
+  ActionSparklesIcon,
   ArrowRight,
   Avatar,
   Brackets,
@@ -1622,6 +1624,30 @@ function NavigationListWithInbox({
   const [scrollViewport, setScrollViewport] = useState<HTMLDivElement | null>(
     null
   );
+  // Conversations opened from an activation recommendation are pinned into
+  // their own highlighted "Recommendations for you" section at the top and
+  // pulled out of the other sections so they only appear once. The recs are
+  // fetched once (SWR dedupes) and carry the conversation they opened.
+  const { recommendations: activationRecommendations } =
+    useActivationRecommendations({ workspaceId: owner.sId });
+  const activationConversationIds = useMemo(
+    () =>
+      new Set(
+        activationRecommendations
+          .map((rec) => rec.conversationId)
+          .filter((id): id is string => id !== null)
+      ),
+    [activationRecommendations]
+  );
+  const activationConversations = useMemo(
+    () => conversations.filter((c) => activationConversationIds.has(c.sId)),
+    [conversations, activationConversationIds]
+  );
+  const nonActivationConversations = useMemo(
+    () => conversations.filter((c) => !activationConversationIds.has(c.sId)),
+    [conversations, activationConversationIds]
+  );
+
   const {
     readConversations,
     inboxConversations,
@@ -1629,10 +1655,10 @@ function NavigationListWithInbox({
     triggeredConversations,
   } = useMemo(() => {
     return getGroupConversationsByUnreadAndActionRequired(
-      conversations,
+      nonActivationConversations,
       titleFilter
     );
-  }, [conversations, titleFilter]);
+  }, [nonActivationConversations, titleFilter]);
 
   const { markAllAsRead, isMarkingAllAsRead } = useMarkAllConversationsAsRead({
     owner,
@@ -1680,6 +1706,48 @@ function NavigationListWithInbox({
     >
       <div className="flex flex-col gap-4">
         <AnimatePresence initial={false}>
+          {activationConversations.length > 0 && (
+            <motion.div
+              key="recommendations"
+              style={GRID_STYLE}
+              animate={GRID_ANIMATE}
+              exit={GRID_EXIT}
+              transition={{ duration: 0.2, ease: "easeOut" }}
+            >
+              <div className="overflow-hidden">
+                <NavigationListCollapsibleSection
+                  label="Recommendations for you"
+                  icon={ActionSparklesIcon}
+                  count={activationConversations.length}
+                  className="bg-highlight-50 rounded-xl border border-highlight-200 p-1 mx-sidebar-side-spacing"
+                >
+                  {activationConversations.map((conversation) => (
+                    <motion.div
+                      key={conversation.sId}
+                      style={GRID_STYLE}
+                      animate={GRID_ANIMATE}
+                      exit={GRID_EXIT}
+                      transition={{ ease: "easeOut", duration: 0.1 }}
+                    >
+                      <div className="overflow-hidden">
+                        <ConversationListItem
+                          conversation={conversation}
+                          isMultiSelect={isMultiSelect}
+                          selectedConversations={selectedConversations}
+                          toggleConversationSelection={
+                            toggleConversationSelection
+                          }
+                          activeConversationId={activeConversationId}
+                          owner={owner}
+                          showStatusDot={false}
+                        />
+                      </div>
+                    </motion.div>
+                  ))}
+                </NavigationListCollapsibleSection>
+              </div>
+            </motion.div>
+          )}
           {triggeredConversations.length > 0 && (
             <motion.div
               key="triggered"


### PR DESCRIPTION
## Summary
- Cleaning up UX on the "Next Steps For You" button (which is now recommendations for you)
- Adding a pinned section to highlight recommendation conversations. We will have a subsequent change to rework the entire inbox in the coming days, but keeping that entirely out of scope.  

## Risk

Low - this is impossible to be seen by users right now because recommendation creation is behind FF

## Testing
<img width="1427" height="714" alt="Screenshot 2026-07-30 at 3 21 46 PM" src="https://github.com/user-attachments/assets/f2fedf72-3c31-4f8d-8566-45368fe3fe3b" />

## Deploy
1. Deploy front