### PR TITLE
[front] Bump max AWU credit spend limit to 2M

### DIFF
--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -23,7 +23,7 @@ import {
 import { useEffect, useRef, useState } from "react";
 
 const MIN_AWU_CREDITS = 0;
-const MAX_AWU_CREDITS = 1_000_000;
+const MAX_AWU_CREDITS = 2_000_000;
 
 type SpendLimitKind = "default" | "override";
 


### PR DESCRIPTION
## Summary

Raises `MAX_AWU_CREDITS` from **1,000,000 → 2,000,000** in `EditSpendLimitModal`, so workspaces can set a spend limit up to 2M AWU credits.

## Testing

- `npx tsgo --noEmit` — 0 errors on the changed file

## Risk

Minimal — a single UI-side constant (the max value the spend-limit input accepts). No API, schema, or billing-logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)