### PR TITLE
Refactor pod conversations permissions to directly look at the conversation's pod access.

### DIFF
--- a/front/lib/api/assistant/conversation/branches.test.ts
+++ b/front/lib/api/assistant/conversation/branches.test.ts
@@ -437,11 +437,22 @@ describe("mergeConversationBranch", () => {
     const user = await UserFactory.basic();
     await MembershipFactory.associate(workspace, user, { role: "user" });
 
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const projectSpace = await SpaceFactory.project(workspace);
+    const addMemberRes = await projectSpace.addMembers(internalAdminAuth, {
+      userIds: [user.sId],
+    });
+    if (addMemberRes.isErr()) {
+      throw new Error(addMemberRes.error.message);
+    }
+
+    // Refresh auth so group membership is visible for pod conversation ACL.
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
       workspace.sId
     );
-    const projectSpace = await SpaceFactory.project(workspace);
 
     const task = await ProjectTaskResource.makeNew(auth, {
       spaceId: projectSpace.id,

--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -484,12 +484,12 @@ function mockContentNodeAttachments(nodeDataSourceViewId: number) {
 
 describe("createConversationFork", () => {
   it("creates the child conversation, sole participant, and lineage row", async () => {
-    const { auth, globalSpace, user } = await createPrivateApiMockRequest();
+    const { auth, user } = await createPrivateApiMockRequest();
 
     const parentConversation = await createConversation(auth, {
       title: "Parent conversation",
       visibility: "unlisted",
-      spaceId: globalSpace.id,
+      spaceId: null,
     });
 
     const userMessage = await createUserMessage(auth, {
@@ -520,7 +520,7 @@ describe("createConversationFork", () => {
     );
 
     expect(childConversation.title).toBeNull();
-    expect(childConversation.spaceId).toBe(globalSpace.sId);
+    expect(childConversation.spaceId).toBe(null);
     // Forks keep the parent's depth: depth > 0 marks run_agent sub-conversations,
     // which are hidden from space conversation lists.
     expect(childConversation.depth).toBe(parentConversation.depth);
@@ -761,7 +761,7 @@ describe("createConversationFork", () => {
     const parentConversation = await createConversation(auth, {
       title: "Parent conversation",
       visibility: "unlisted",
-      spaceId: globalSpace.id,
+      spaceId: null,
     });
 
     const enabledRemoteServer = await RemoteMCPServerFactory.create(workspace);
@@ -840,12 +840,12 @@ describe("createConversationFork", () => {
   });
 
   it("copies enabled conversation skills into the child conversation", async () => {
-    const { auth, globalSpace } = await createPrivateApiMockRequest();
+    const { auth } = await createPrivateApiMockRequest();
 
     const parentConversation = await createConversation(auth, {
       title: "Parent conversation",
       visibility: "unlisted",
-      spaceId: globalSpace.id,
+      spaceId: null,
     });
 
     const enabledSkill = await SkillFactory.create(auth, {
@@ -1799,7 +1799,7 @@ const untouched = "prefix${referencedFile.sId}suffix";`
     const parentConversation = await createConversation(auth, {
       title: "Parent conversation",
       visibility: "unlisted",
-      spaceId: globalSpace.id,
+      spaceId: null,
     });
     await ConversationModel.update(
       { requestedSpaceIds: [globalSpace.id, restrictedSpace.id] },

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -4076,7 +4076,10 @@ describe("Space Handling", () => {
     });
   });
 
-  describe("restricted project space access", () => {
+  // Pod conversation ACL (`spaceId` set): access is gated on read permission for the
+  // project space only. Extra `requestedSpaceIds` must not lock out pod members — that
+  // is the contract that lets a follow-up stop stripping agent/skill space requirements.
+  describe("pod conversation access", () => {
     it(
       "should not allow a user not in a restricted project space to fetch a conversation in that space",
       async () => {
@@ -4133,6 +4136,165 @@ describe("Space Handling", () => {
 
         // The conversation should not be accessible to the non-member user
         expect(fetchedConversation).toBeNull();
+        expect(
+          await ConversationResource.canAccess(nonMemberAuth, conversation.sId)
+        ).toBe("conversation_access_restricted");
+      },
+      RESTRICTED_PROJECT_SPACE_ACCESS_TEST_TIMEOUT_MS
+    );
+
+    it(
+      "should allow a project member to access a pod conversation even when requestedSpaceIds includes a restricted space they cannot read",
+      async () => {
+        const {
+          authenticator: adminAuth,
+          user: adminUser,
+          workspace,
+        } = await createResourceTest({ role: "admin" });
+
+        const memberUser = await UserFactory.basic();
+        await MembershipFactory.associate(workspace, memberUser, {
+          role: "user",
+        });
+
+        const projectSpace = await SpaceFactory.project(
+          workspace,
+          adminUser.id
+        );
+        const restrictedSpace = await SpaceFactory.regular(workspace);
+
+        // Restricted space: admin only. Project: admin + member.
+        const addRestrictedRes = await restrictedSpace.addMembers(adminAuth, {
+          userIds: [adminUser.sId],
+        });
+        assert(
+          addRestrictedRes.isOk(),
+          "Failed to add admin to restricted space"
+        );
+        const addProjectRes = await projectSpace.addMembers(adminAuth, {
+          userIds: [adminUser.sId, memberUser.sId],
+        });
+        assert(addProjectRes.isOk(), "Failed to add members to project space");
+
+        const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+          memberUser.sId,
+          workspace.sId
+        );
+        const refreshedAdminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+          adminUser.sId,
+          workspace.sId
+        );
+
+        const conversation = await ConversationResource.makeNew(
+          refreshedAdminAuth,
+          {
+            title: "Pod conversation with extra restricted requirement",
+            sId: generateRandomModelSId(),
+            spaceId: projectSpace.id,
+            requestedSpaceIds: [],
+          },
+          projectSpace
+        );
+
+        // Simulate accumulated agent/skill requirements (write path still strips these
+        // today; set them directly so this test locks the read ACL independently).
+        const updateRes = await ConversationResource.updateRequirements(
+          refreshedAdminAuth,
+          conversation.sId,
+          [projectSpace.id, restrictedSpace.id]
+        );
+        assert(updateRes.isOk(), "Failed to update conversation requirements");
+
+        // Under the old conjunctive ACL this would be denied; pod ACL only checks the project.
+        expect(
+          await ConversationResource.canAccess(memberAuth, conversation.sId)
+        ).toBe("allowed");
+        expect(
+          await ConversationResource.fetchById(memberAuth, conversation.sId)
+        ).not.toBeNull();
+        expect(
+          (await ConversationResource.listAll(memberAuth)).map((c) => c.sId)
+        ).toContain(conversation.sId);
+
+        // Non-member still denied even though they share the workspace.
+        const nonMemberUser = await UserFactory.basic();
+        await MembershipFactory.associate(workspace, nonMemberUser, {
+          role: "user",
+        });
+        const nonMemberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+          nonMemberUser.sId,
+          workspace.sId
+        );
+        expect(
+          await ConversationResource.canAccess(nonMemberAuth, conversation.sId)
+        ).toBe("conversation_access_restricted");
+        expect(
+          await ConversationResource.fetchById(nonMemberAuth, conversation.sId)
+        ).toBeNull();
+      },
+      RESTRICTED_PROJECT_SPACE_ACCESS_TEST_TIMEOUT_MS
+    );
+
+    it(
+      "should deny access to a pod conversation when its project space is deleted",
+      async () => {
+        const {
+          authenticator: adminAuth,
+          user: adminUser,
+          workspace,
+        } = await createResourceTest({ role: "admin" });
+
+        const projectSpace = await SpaceFactory.project(
+          workspace,
+          adminUser.id
+        );
+        const addMemberRes = await projectSpace.addMembers(adminAuth, {
+          userIds: [adminUser.sId],
+        });
+        assert(addMemberRes.isOk(), "Failed to add admin to project space");
+
+        const refreshedAdminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+          adminUser.sId,
+          workspace.sId
+        );
+
+        const conversation = await ConversationResource.makeNew(
+          refreshedAdminAuth,
+          {
+            title: "Pod conversation whose space will be deleted",
+            sId: generateRandomModelSId(),
+            spaceId: projectSpace.id,
+            requestedSpaceIds: [],
+          },
+          projectSpace
+        );
+
+        expect(
+          await ConversationResource.canAccess(
+            refreshedAdminAuth,
+            conversation.sId
+          )
+        ).toBe("allowed");
+
+        await projectSpace.delete(refreshedAdminAuth, { hardDelete: false });
+
+        expect(
+          await ConversationResource.canAccess(
+            refreshedAdminAuth,
+            conversation.sId
+          )
+        ).toBe("conversation_access_restricted");
+        expect(
+          await ConversationResource.fetchById(
+            refreshedAdminAuth,
+            conversation.sId
+          )
+        ).toBeNull();
+        expect(
+          (await ConversationResource.listAll(refreshedAdminAuth)).map(
+            (c) => c.sId
+          )
+        ).not.toContain(conversation.sId);
       },
       RESTRICTED_PROJECT_SPACE_ACCESS_TEST_TIMEOUT_MS
     );

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -943,10 +943,17 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       transaction,
     });
 
-    const uniqueSpaceIds = uniq([
-      // Include requestedSpaceIds from conversations.
-      ...conversations.flatMap((c) => c.requestedSpaceIds),
-    ]);
+    // Include both `spaceId` (pod ACL) and `requestedSpaceIds` (private conversation
+    // conjunctive ACL). Pod conversations must load their project space even when
+    // `requestedSpaceIds` later accumulates spaces the viewer cannot read.
+    const uniqueSpaceIds = removeNulls(
+      uniq([
+        ...conversations
+          .filter((c) => c.spaceId !== null)
+          .map((c) => c.spaceId),
+        ...conversations.flatMap((c) => c.requestedSpaceIds),
+      ])
+    );
 
     // Only fetch spaces if there are any used spaces.
     const spaces =
@@ -968,15 +975,47 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       );
     }
 
-    // Filter out conversations that reference missing/deleted spaces.
-    // There are two reasons why a space may be missing here:
+    const { podConversations, regularConversations } = conversations.reduce(
+      (acc, c) => {
+        if (c.spaceId !== null) {
+          acc.podConversations.push(
+            c as ConversationModel & { spaceId: ModelId }
+          );
+        } else {
+          acc.regularConversations.push(c);
+        }
+        return acc;
+      },
+      {
+        podConversations: [] as (ConversationModel & { spaceId: ModelId })[],
+        regularConversations: [] as ConversationModel[],
+      }
+    );
+
+    // Pod conversations (`spaceId` set): visibility is gated only on read access to
+    // the project space. Extra ids in `requestedSpaceIds` (agents, skills, …) do not
+    // further restrict who can open the conversation — they remain a runtime/scope
+    // concern, not a conjunctive ACL. Missing/deleted project spaces deny access.
+    const accessiblePodConversations: ConversationResource[] = podConversations
+      .filter(
+        (c) =>
+          spaceIdToSpaceMap.has(c.spaceId) &&
+          spaceIdToSpaceMap.get(c.spaceId)!.canRead(auth)
+      )
+      .map((c) => this.fromModel(c, spaceIdToSpaceMap.get(c.spaceId) ?? null));
+
+    // If there are no regular conversations, return the accessible pod conversations immediately.
+    if (regularConversations.length === 0) {
+      return accessiblePodConversations;
+    }
+
+    // Private conversations (`spaceId` null): viewer must be able to read every
+    // space in `requestedSpaceIds` (conjunctive ACL). Filter out conversations that
+    // reference missing/deleted spaces:
     // 1. When a space is deleted, conversations referencing it won't be deleted but should not be accessible.
     // 2. When a space belongs to another workspace (should not happen), conversations referencing it won't be accessible.
-
-    // Note from seb, for Space Conversations, we probably want to be more subtle about the conversation accessible logic.
-    // We should probably only filter out conversations where the spaceId is deleted but keep the one that referenced a deleted space.
     const foundSpaceIds = new Set(spaces.map((s) => s.id));
-    const validConversations = conversations
+    const validConversations = regularConversations
       .filter((c) => c.requestedSpaceIds.every((id) => foundSpaceIds.has(id)))
       .map((c) =>
         this.fromModel(
@@ -998,14 +1037,14 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     );
 
     if (spaceBasedAccessible.length === 0) {
-      return [];
+      return [...accessiblePodConversations, ...spaceBasedAccessible];
     }
 
     if (
       !this.isPrivateConversationUrlsByDefaultEnabled(auth) ||
       shouldByPassPrivateByDefaultUrlRestriction(auth)
     ) {
-      return spaceBasedAccessible;
+      return [...accessiblePodConversations, ...spaceBasedAccessible];
     }
 
     const participantRestrictedConversations = spaceBasedAccessible.filter(
@@ -1017,7 +1056,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     // No participant-restricted conversations, return the space-based accessible conversations.
     if (participantRestrictedConversations.length === 0) {
-      return spaceBasedAccessible;
+      return [...accessiblePodConversations, ...spaceBasedAccessible];
     }
 
     // For all participant-restricted conversations, check if the user is a participant. A userless
@@ -1045,13 +1084,16 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     // Return the space-based accessible conversations that are not participant-restricted.
     // Or are participant-restricted and the user is a participant.
-    return spaceBasedAccessible.filter(
-      (conversation) =>
-        !this.shouldApplyPrivateByDefaultUrlRestriction(conversation) ||
-        this.getConversationUrlAccessModeForPrivateByDefault(conversation) ===
-          "workspace_members" ||
-        participantConversationIds.has(conversation.id)
-    );
+    return [
+      ...accessiblePodConversations,
+      ...spaceBasedAccessible.filter(
+        (conversation) =>
+          !this.shouldApplyPrivateByDefaultUrlRestriction(conversation) ||
+          this.getConversationUrlAccessModeForPrivateByDefault(conversation) ===
+            "workspace_members" ||
+          participantConversationIds.has(conversation.id)
+      ),
+    ];
   }
 
   private static async canUserAccessPrivateByDefaultConversation(
@@ -1127,6 +1169,17 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     });
     if (!conversation) {
       return "conversation_not_found";
+    }
+
+    // Pod conversations: same contract as `baseFetchWithAuthorization` — only the
+    // project space's readability matters, not the full `requestedSpaceIds` set.
+    if (conversation.spaceId !== null) {
+      const spaces = await SpaceResource.fetchByModelIds(auth, [
+        conversation.spaceId,
+      ]);
+      return spaces.length > 0 && spaces[0].canRead(auth)
+        ? "allowed"
+        : "conversation_access_restricted";
     }
 
     try {
@@ -2868,19 +2921,18 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     if (uniqueSpaceIds.length > 0) {
       const spaces = await SpaceResource.fetchByModelIds(auth, uniqueSpaceIds);
-      for (const space of spaces) {
-        if (!space.isProject() || !space.isMember(auth)) {
-          continue;
-        }
-        const { conversations: spaceConvs } =
-          await this.listConversationsInSpacePaginated(auth, {
-            spaceId: space.sId,
-            // limit page size to the number of convs we are searching for to have a single page
-            pagination: { limit: modelIds.length },
-            restrictToConversationModelIds: modelIds,
-          });
-        for (const c of spaceConvs) {
-          visibleModelIds.add(c.id);
+      const spacesByModelId = new Map(spaces.map((s) => [s.id, s]));
+
+      for (const c of conversations) {
+        if (c.spaceId !== null) {
+          const space = spacesByModelId.get(c.spaceId);
+          // This almost replicates what we have in baseFetchWithAuthorization or canAccess.
+          // But with a slight difference: we do not only check if the space is readable by the auth.
+          // We check if the space is project (pod) and auth is a member.
+          // Theses are the same conversations as the ones that would be listed in the sidebar.
+          if (space && space.isProject() && space.isMember(auth)) {
+            visibleModelIds.add(c.id);
+          }
         }
       }
     }


### PR DESCRIPTION
## Description

Pod conversations (those with a non-null `spaceId`) now bypass the `requestedSpaceIds`-based access check entirely — they're accessible if and only if their pod space passes `canRead(auth)`. `getFilteredConversationsForAuth` splits incoming conversations into `podConversations` and `regularConversations`, resolves pod access directly from the already-fetched `spaceIdToSpaceMap`, and merges `accessiblePodConversations` at every early-return point. The single-conversation path in `canAccessConversation` gets the same early-exit via `SpaceResource.fetchByModelIds`. This removes the old TODO and fully implements the intended, simpler contract: pod conversations follow pod membership, not `requestedSpaceIds` logic.

## Tests

Tested locally.

## Risk

Low. Regular conversations are entirely unaffected — the split is based on `spaceId !== null`. Pod conversations now follow a stricter, cleaner path (`canRead(auth)` only), which is the correct invariant. Rollback-safe.

## Deploy Plan

Deploy front.
