### PR TITLE
[front] enh: log conversation advisory lock hold time

### DIFF
--- a/front/lib/api/assistant/conversation/lock.ts
+++ b/front/lib/api/assistant/conversation/lock.ts
@@ -19,7 +19,7 @@ export async function getConversationRankVersionLock(
   conversation: ConversationWithoutContentType | ConversationResource,
   t: Transaction
 ) {
-  const now = new Date();
+  const startMs = performance.now();
   // Get a lock using the unique lock key (number withing postgresql BigInt range).
   const hash = md5(`conversation_message_rank_version_${conversation.id}`);
   const lockKey = parseInt(hash, 16) % 9999999999;
@@ -29,15 +29,29 @@ export async function getConversationRankVersionLock(
     replacements: { key: lockKey },
   });
 
+  const acquiredAtMs = performance.now();
+
   logger.info(
     {
       workspaceId: auth.getNonNullableWorkspace().sId,
       conversationId: conversation.sId,
-      duration: new Date().getTime() - now.getTime(),
+      waitMs: acquiredAtMs - startMs,
       lockKey,
     },
     "[ASSISTANT_TRACE] Advisory lock acquired"
   );
+
+  t.afterCommit(() => {
+    logger.info(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        conversationId: conversation.sId,
+        heldMs: performance.now() - acquiredAtMs,
+        lockKey,
+      },
+      "[ASSISTANT_TRACE] Advisory lock released"
+    );
+  });
 }
 
 export async function getNextConversationMessageRank(


### PR DESCRIPTION
## Description

First stack of two to get rid of xact_lock (will post a notebook to answer why).

Stack 1: Split the humongous transaction into smaller ones
Stack 2: Use row locks or unique indexes instead of an application lock.

What is not measured can't be improved, so step one of this quest to get rid of xact_log is to measure the time we spend holding a connection with it. We already have idle in tx logs as a proxy, but better have it twice.

logs will $$$, yes, will remove in the second stack.



## Tests

N/A

## Risk

Low

## Deploy Plan

Deploy front