### PR TITLE
[front] fix: run origin message lookup inside the message transaction

### DIFF
--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -166,6 +166,7 @@ export async function createUserMessage(
           sId: originMessageId,
           agentMessageId: { [Op.not]: null },
         },
+        transaction,
       })
     : null;
 


### PR DESCRIPTION
## Description

side 🚗 : we used to not pass transaction on message creation inside the big bad transaction.

## Tests

N/A

## Risk

Low

## Deploy Plan

Deploy front