### PR TITLE
[front] refactor: resolve user mentions before the message transaction

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -12,7 +12,10 @@ import {
   getConversationRankVersionLock,
   getNextConversationMessageRank,
 } from "@app/lib/api/assistant/conversation/lock";
-import { createUserMentions } from "@app/lib/api/assistant/conversation/mentions";
+import {
+  createUserMentions,
+  resolveUserMentions,
+} from "@app/lib/api/assistant/conversation/mentions";
 import {
   attributeUserFromWorkspaceAndEmail,
   createAgentMessages,
@@ -849,14 +852,18 @@ export async function postUserMessage(
     }
   }
 
-  // Resolve the message author before the transaction: the email attribution reads must not run
-  // while the conversation advisory lock is held.
   // TODO(2026-07-31 SEC): this allow spoofing as we trust blindly the user email from the metadata.
   let messageUser = doNotAssociateUser ? null : (user?.toJSON() ?? null);
   messageUser ??= await attributeUserFromWorkspaceAndEmail(
     owner,
     context.email
   );
+
+  const resolvedUserMentions = await resolveUserMentions(auth, {
+    mentions,
+    conversation,
+    message: { type: "user_message" },
+  });
 
   // In one big transaction create all Message, UserMessage, AgentMessage and Mention rows.
   const { userMessage, agentMessages } = await withTransaction(async (t) => {
@@ -1022,7 +1029,7 @@ export async function postUserMessage(
     });
 
     const richMentions = await createUserMentions(auth, {
-      mentions,
+      resolvedMentions: resolvedUserMentions,
       message: userMessageWithoutMentions,
       conversation,
       transaction: t,
@@ -1324,6 +1331,12 @@ export async function editUserMessage(
     }
   }
 
+  const resolvedUserMentions = await resolveUserMentions(auth, {
+    mentions,
+    conversation,
+    message: { type: "user_message" },
+  });
+
   try {
     // In one big transaction create all Message, UserMessage, AgentMessage, and Mention rows.
     const result = await withTransaction(async (t) => {
@@ -1381,7 +1394,7 @@ export async function editUserMessage(
       });
 
       const richMentions = await createUserMentions(auth, {
-        mentions,
+        resolvedMentions: resolvedUserMentions,
         message: userMessageWithoutMentions,
         conversation,
         transaction: t,
@@ -1536,10 +1549,16 @@ export async function handleAgentMessage(
 
   const richMentions: RichMentionWithStatus[] = [];
   if (userMentions.length > 0) {
+    const resolvedUserMentions = await resolveUserMentions(auth, {
+      mentions: userMentions,
+      conversation,
+      message: agentMessage,
+    });
+
     await withTransaction(async (t) => {
       richMentions.push(
         ...(await createUserMentions(auth, {
-          mentions: userMentions,
+          resolvedMentions: resolvedUserMentions,
           message: agentMessage,
           conversation,
           transaction: t,

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -2,7 +2,6 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agen
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import {
-  createUserMentions,
   getMentionStatus,
   validateUserMention,
 } from "@app/lib/api/assistant/conversation/mentions";
@@ -26,6 +25,7 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { resolveAndCreateUserMentions } from "@app/tests/utils/mentions";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -74,7 +74,7 @@ describe("createAgentMessages", () => {
       },
     ];
 
-    const result = await createUserMentions(auth, {
+    const result = await resolveAndCreateUserMentions(auth, {
       mentions,
       message: userMessage,
       conversation,
@@ -141,7 +141,7 @@ describe("createAgentMessages", () => {
       },
     ];
 
-    const result = await createUserMentions(auth, {
+    const result = await resolveAndCreateUserMentions(auth, {
       mentions,
       message: userMessage,
       conversation,
@@ -216,7 +216,7 @@ describe("createAgentMessages", () => {
 
     const mentions: MentionType[] = [];
 
-    const result = await createUserMentions(auth, {
+    const result = await resolveAndCreateUserMentions(auth, {
       mentions,
       message: userMessage,
       conversation,
@@ -268,7 +268,7 @@ describe("createAgentMessages", () => {
       } as AgentMention,
     ];
 
-    const result = await createUserMentions(auth, {
+    const result = await resolveAndCreateUserMentions(auth, {
       mentions,
       message: userMessage,
       conversation,
@@ -325,7 +325,7 @@ describe("createAgentMessages", () => {
       },
     ];
 
-    const result = await createUserMentions(auth, {
+    const result = await resolveAndCreateUserMentions(auth, {
       mentions,
       message: userMessage,
       conversation,
@@ -374,7 +374,7 @@ describe("createAgentMessages", () => {
         },
       ];
 
-      const result = await createUserMentions(auth, {
+      const result = await resolveAndCreateUserMentions(auth, {
         mentions,
         message: userMessage,
         conversation,
@@ -437,7 +437,7 @@ describe("createAgentMessages", () => {
         },
       ];
 
-      const result = await createUserMentions(auth, {
+      const result = await resolveAndCreateUserMentions(auth, {
         mentions,
         message: agentMessage,
         conversation,
@@ -481,7 +481,7 @@ describe("createAgentMessages", () => {
         },
       ];
 
-      const result = await createUserMentions(auth, {
+      const result = await resolveAndCreateUserMentions(auth, {
         mentions,
         message: agentMessage,
         conversation,
@@ -588,7 +588,7 @@ describe("createAgentMessages", () => {
         },
       ];
 
-      const result = await createUserMentions(auth, {
+      const result = await resolveAndCreateUserMentions(auth, {
         mentions,
         message: agentMessage,
         conversation: updatedConversation,
@@ -694,7 +694,7 @@ describe("createAgentMessages", () => {
         },
       ];
 
-      const result = await createUserMentions(auth, {
+      const result = await resolveAndCreateUserMentions(auth, {
         mentions,
         message: agentMessage,
         conversation: updatedConversation,
@@ -800,7 +800,7 @@ describe("createAgentMessages", () => {
         },
       ];
 
-      const result = await createUserMentions(auth, {
+      const result = await resolveAndCreateUserMentions(auth, {
         mentions,
         message: agentMessage,
         conversation: updatedConversation,
@@ -884,7 +884,7 @@ describe("createAgentMessages", () => {
         },
       ];
 
-      const result = await createUserMentions(auth, {
+      const result = await resolveAndCreateUserMentions(auth, {
         mentions,
         message: userMessage,
         conversation: restrictedConversation,
@@ -987,7 +987,7 @@ describe("createAgentMessages", () => {
         },
       ];
 
-      const result = await createUserMentions(auth, {
+      const result = await resolveAndCreateUserMentions(auth, {
         mentions,
         message: userMessage,
         conversation: openConversation,
@@ -1089,7 +1089,7 @@ describe("createAgentMessages", () => {
         },
       ];
 
-      const result = await createUserMentions(auth, {
+      const result = await resolveAndCreateUserMentions(auth, {
         mentions,
         message: agentMessage,
         conversation: restrictedConversation,
@@ -1176,7 +1176,7 @@ describe("createAgentMessages", () => {
         },
       ];
 
-      const result = await createUserMentions(userAuth, {
+      const result = await resolveAndCreateUserMentions(userAuth, {
         mentions,
         message: agentMessage,
         conversation: projectConversation,
@@ -1255,7 +1255,7 @@ describe("createAgentMessages", () => {
         },
       ];
 
-      const result = await createUserMentions(userAuth, {
+      const result = await resolveAndCreateUserMentions(userAuth, {
         mentions,
         message: agentMessage,
         conversation: projectConversation,

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -55,11 +55,15 @@ import uniqBy from "lodash/uniqBy";
 import type { Transaction } from "sequelize";
 import { getConversation } from "./fetch";
 
+export type MentionTargetMessage =
+  | Pick<UserMessageTypeWithoutMentions, "type">
+  | Pick<AgentMessageTypeWithoutMentions, "type" | "configuration">;
+
 export async function getMentionStatus(
   auth: Authenticator,
   data: {
     conversation: ConversationWithoutContentType;
-    message: UserMessageTypeWithoutMentions | AgentMessageTypeWithoutMentions;
+    message: MentionTargetMessage;
     isParticipant: boolean;
     mentionedUser: UserResource;
   }
@@ -125,22 +129,24 @@ export async function getMentionStatus(
   return "pending_conversation_access";
 }
 
-export const createUserMentions = async (
+export interface ResolvedUserMention {
+  user: UserType;
+  isParticipant: boolean;
+  status: MentionStatusType;
+}
+
+export async function resolveUserMentions(
   auth: Authenticator,
   {
     mentions,
-    message,
     conversation,
-    transaction,
+    message,
   }: {
     mentions: MentionType[];
-    message: AgentMessageTypeWithoutMentions | UserMessageTypeWithoutMentions;
     conversation: ConversationWithoutContentType;
-    transaction?: Transaction;
+    message: MentionTargetMessage;
   }
-): Promise<RichMentionWithStatus[]> => {
-  const usersById = new Map<ModelId, UserType>();
-
+): Promise<ResolvedUserMention[]> {
   // Deduplicate mentions before processing
   const uniqueMentions = uniqBy(
     mentions.filter(isUserMention),
@@ -151,8 +157,7 @@ export const createUserMentions = async (
     return [];
   }
 
-  // Store user mentions in the database with bounded concurrency.
-  const mentionModels = await concurrentExecutor(
+  const resolvedMentions = await concurrentExecutor(
     uniqueMentions,
     async (mention) => {
       // check if the user exists in the workspace before creating the mention
@@ -162,8 +167,6 @@ export const createUserMentions = async (
       if (!user) {
         return undefined;
       }
-
-      usersById.set(user.id, user.toJSON());
 
       const isParticipant =
         await ConversationResource.isConversationParticipant(auth, {
@@ -182,7 +185,36 @@ export const createUserMentions = async (
         mentionedUser: user,
       });
 
-      const mentionModel = await MentionModel.create(
+      return { user: user.toJSON(), isParticipant, status };
+    },
+    { concurrency: 4 }
+  );
+
+  return removeNulls(resolvedMentions);
+}
+
+export const createUserMentions = async (
+  auth: Authenticator,
+  {
+    resolvedMentions,
+    message,
+    conversation,
+    transaction,
+  }: {
+    resolvedMentions: ResolvedUserMention[];
+    message: AgentMessageTypeWithoutMentions | UserMessageTypeWithoutMentions;
+    conversation: ConversationWithoutContentType;
+    transaction?: Transaction;
+  }
+): Promise<RichMentionWithStatus[]> => {
+  const usersById = new Map<ModelId, UserType>();
+  const mentionModels: MentionModel[] = [];
+
+  for (const { user, isParticipant, status } of resolvedMentions) {
+    usersById.set(user.id, user);
+
+    mentionModels.push(
+      await MentionModel.create(
         {
           messageId: message.id,
           userId: user.id,
@@ -190,25 +222,23 @@ export const createUserMentions = async (
           status,
         },
         { transaction }
-      );
+      )
+    );
 
-      if (!isParticipant && status === "approved") {
-        await ConversationResource.upsertParticipation(auth, {
-          conversation,
-          action: "subscribed",
-          user: user.toJSON(),
-          lastReadAt: null,
-          transaction,
-        });
-      }
-      return mentionModel;
-    },
-    { concurrency: 4 }
-  );
+    if (!isParticipant && status === "approved") {
+      await ConversationResource.upsertParticipation(auth, {
+        conversation,
+        action: "subscribed",
+        user,
+        lastReadAt: null,
+        transaction,
+      });
+    }
+  }
 
   return getRichMentionsWithStatusForMessage(
     message.id,
-    removeNulls(mentionModels),
+    mentionModels,
     usersById,
     new Map() // No agent configurations in the users mentions.
   );

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -32,10 +32,7 @@ import {
 } from "@app/lib/api/assistant/conversation";
 import { registerUserAnswer } from "@app/lib/api/assistant/conversation/answer_user_question";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import {
-  createUserMentions,
-  dismissMention,
-} from "@app/lib/api/assistant/conversation/mentions";
+import { dismissMention } from "@app/lib/api/assistant/conversation/mentions";
 import { createAgentMessages } from "@app/lib/api/assistant/conversation/messages";
 import { resolveAuthentication } from "@app/lib/api/assistant/conversation/resolve_authentication";
 import { retryBlockedActions } from "@app/lib/api/assistant/conversation/retry_blocked_actions";
@@ -66,6 +63,7 @@ import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { resolveAndCreateUserMentions } from "@app/tests/utils/mentions";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
@@ -448,7 +446,7 @@ describe("dismissMention", () => {
         },
       ];
 
-      await createUserMentions(auth, {
+      await resolveAndCreateUserMentions(auth, {
         mentions,
         message: userMessage,
         conversation,
@@ -557,7 +555,7 @@ describe("dismissMention", () => {
         },
       ];
 
-      await createUserMentions(otherUserAuth, {
+      await resolveAndCreateUserMentions(otherUserAuth, {
         mentions,
         message: userMessage,
         conversation: restrictedConversation,
@@ -638,7 +636,7 @@ describe("dismissMention", () => {
         },
       ];
 
-      await createUserMentions(refreshedAuth, {
+      await resolveAndCreateUserMentions(refreshedAuth, {
         mentions,
         message: userMessage,
         conversation: restrictedConversation,

--- a/front/tests/utils/mentions.ts
+++ b/front/tests/utils/mentions.ts
@@ -1,0 +1,34 @@
+import {
+  createUserMentions,
+  resolveUserMentions,
+} from "@app/lib/api/assistant/conversation/mentions";
+import type { Authenticator } from "@app/lib/auth";
+import type {
+  AgentMessageTypeWithoutMentions,
+  ConversationWithoutContentType,
+  UserMessageTypeWithoutMentions,
+} from "@app/types/assistant/conversation";
+import type { MentionType } from "@app/types/assistant/mentions";
+
+export async function resolveAndCreateUserMentions(
+  auth: Authenticator,
+  {
+    mentions,
+    message,
+    conversation,
+  }: {
+    mentions: MentionType[];
+    message: AgentMessageTypeWithoutMentions | UserMessageTypeWithoutMentions;
+    conversation: ConversationWithoutContentType;
+  }
+) {
+  return createUserMentions(auth, {
+    resolvedMentions: await resolveUserMentions(auth, {
+      mentions,
+      conversation,
+      message,
+    }),
+    message,
+    conversation,
+  });
+}


### PR DESCRIPTION


## Description

Split mentions resolution and creation into resolution, and creation.
This is one step in the direction of removing all the un-necessary stuff out of a big transaction with a xact_lock
Then put the resolution before the big bad transaction.



## Tests

Existing tests

## Risk

Low

## Deploy Plan

- [ ] Deploy front