### PR TITLE
[front] refactor: precompute createAgentMessages inputs before the message transaction

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -20,6 +20,7 @@ import {
   attributeUserFromWorkspaceAndEmail,
   createAgentMessages,
   createUserMessage,
+  resolveModelsForMentionedAgents,
 } from "@app/lib/api/assistant/conversation/messages";
 import {
   canAgentBeUsedInProjectConversation,
@@ -746,6 +747,7 @@ export async function postUserMessage(
   ]);
 
   let agentConfigurations = removeNulls(results[0]);
+  const restrictedAgentIds = new Set<string>();
 
   // Retired global agents can't be invoked (new conversations or new messages).
   // The internal `run_agent` path is exempt: some hidden sub-agents are retired.
@@ -810,6 +812,17 @@ export async function postUserMessage(
         },
       });
     }
+
+    if (isPartOfPod) {
+      const canAgentBeUsed = await canAgentBeUsedInProjectConversation(auth, {
+        configuration: agentConfig,
+        conversation,
+      });
+
+      if (!canAgentBeUsed) {
+        restrictedAgentIds.add(agentConfig.sId);
+      }
+    }
   }
 
   // TODO(2026-07-31 SEC): this allow spoofing as we trust blindly the user email from the metadata.
@@ -823,6 +836,11 @@ export async function postUserMessage(
     mentions,
     conversation,
     message: { type: "user_message" },
+  });
+
+  const resolvedModels = await resolveModelsForMentionedAgents(auth, {
+    agentConfigurations,
+    selection: modelSelection,
   });
 
   // In one big transaction create all Message, UserMessage, AgentMessage and Mention rows.
@@ -941,6 +959,8 @@ export async function postUserMessage(
             skipToolsValidation,
             nextMessageRank,
             userMessage: userMessageWithoutMentions,
+            resolvedModels,
+            restrictedAgentIds,
           },
           transaction: t,
         });
@@ -1210,6 +1230,24 @@ export async function editUserMessage(
     message: { type: "user_message" },
   });
 
+  const restrictedAgentIds = new Set<string>();
+  if (isPodConversation(conversation)) {
+    for (const agentConfig of agentConfigurations) {
+      const canAgentBeUsed = await canAgentBeUsedInProjectConversation(auth, {
+        configuration: agentConfig,
+        conversation,
+      });
+      if (!canAgentBeUsed) {
+        restrictedAgentIds.add(agentConfig.sId);
+      }
+    }
+  }
+
+  const resolvedModels = await resolveModelsForMentionedAgents(auth, {
+    agentConfigurations,
+    selection: message.requestedModel ?? undefined,
+  });
+
   try {
     // In one big transaction create all Message, UserMessage, AgentMessage, and Mention rows.
     const result = await withTransaction(async (t) => {
@@ -1304,6 +1342,8 @@ export async function editUserMessage(
               skipToolsValidation,
               nextMessageRank,
               userMessage: userMessageWithoutMentions,
+              resolvedModels,
+              restrictedAgentIds,
             },
             transaction: t,
           });
@@ -3106,6 +3146,23 @@ export async function updateAgentMessageWithFinalStatus(
   const completedAt = new Date();
   const owner = auth.getNonNullableWorkspace();
 
+  const restrictedAgentIds = new Set<string>();
+  if (isPodConversation(conversation) && agentMessage.configuration) {
+    const canAgentBeUsed = await canAgentBeUsedInProjectConversation(auth, {
+      configuration: agentMessage.configuration,
+      conversation,
+    });
+    if (!canAgentBeUsed) {
+      restrictedAgentIds.add(agentMessage.configuration.sId);
+    }
+  }
+
+  const defaultResolvedModels = agentMessage.configuration
+    ? await resolveModelsForMentionedAgents(auth, {
+        agentConfigurations: [agentMessage.configuration],
+      })
+    : null;
+
   const {
     promotedUserMessages,
     promotedAuth,
@@ -3265,6 +3322,15 @@ export async function updateAgentMessageWithFinalStatus(
       transaction: t,
     });
 
+    // The no-selection default was resolved before the transaction.
+    const resolvedModels =
+      defaultResolvedModels && !promotedUserMessage.requestedModel
+        ? defaultResolvedModels
+        : await resolveModelsForMentionedAgents(promotedAuth, {
+            agentConfigurations: [agentMessage.configuration],
+            selection: promotedUserMessage.requestedModel ?? undefined,
+          });
+
     // Create a new agent message using the last promoted user message.
     const { agentMessages } = await createAgentMessages(promotedAuth, {
       conversation,
@@ -3275,6 +3341,8 @@ export async function updateAgentMessageWithFinalStatus(
         skipToolsValidation: agentMessage.skipToolsValidation,
         nextMessageRank,
         userMessage: promotedUserMessages[promotedUserMessages.length - 1],
+        resolvedModels,
+        restrictedAgentIds,
       },
       transaction: t,
     });

--- a/front/lib/api/assistant/conversation/messages.test.ts
+++ b/front/lib/api/assistant/conversation/messages.test.ts
@@ -13,7 +13,9 @@ import {
   createAgentMessages,
   createCompactionMessage,
   createUserMessage,
+  resolveModelsForMentionedAgents,
 } from "@app/lib/api/assistant/conversation/messages";
+import { canAgentBeUsedInProjectConversation } from "@app/lib/api/assistant/conversation/permissions";
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import {
@@ -104,6 +106,10 @@ describe("createAgentMessages", () => {
         skipToolsValidation: false,
         nextMessageRank: 1,
         userMessage,
+        resolvedModels: await resolveModelsForMentionedAgents(auth, {
+          agentConfigurations: [agentConfig1],
+        }),
+        restrictedAgentIds: new Set<string>(),
       },
     });
 
@@ -184,6 +190,10 @@ describe("createAgentMessages", () => {
         skipToolsValidation: false,
         nextMessageRank: 1,
         userMessage,
+        resolvedModels: await resolveModelsForMentionedAgents(auth, {
+          agentConfigurations: [agentConfig1, agentConfig2],
+        }),
+        restrictedAgentIds: new Set<string>(),
       },
     });
 
@@ -256,6 +266,10 @@ describe("createAgentMessages", () => {
         skipToolsValidation: false,
         nextMessageRank: 1,
         userMessage,
+        resolvedModels: await resolveModelsForMentionedAgents(auth, {
+          agentConfigurations: [agentConfig1],
+        }),
+        restrictedAgentIds: new Set<string>(),
       },
     });
 
@@ -298,6 +312,10 @@ describe("createAgentMessages", () => {
         skipToolsValidation: false,
         nextMessageRank: 1,
         userMessage,
+        resolvedModels: await resolveModelsForMentionedAgents(auth, {
+          agentConfigurations: [agentConfig1],
+        }),
+        restrictedAgentIds: new Set<string>(),
       },
     });
 
@@ -333,6 +351,10 @@ describe("createAgentMessages", () => {
         skipToolsValidation: true,
         nextMessageRank: 1,
         userMessage,
+        resolvedModels: await resolveModelsForMentionedAgents(auth, {
+          agentConfigurations: [agentConfig1],
+        }),
+        restrictedAgentIds: new Set<string>(),
       },
     });
 
@@ -382,6 +404,10 @@ describe("createAgentMessages", () => {
         skipToolsValidation: true,
         nextMessageRank: 1,
         userMessage,
+        resolvedModels: await resolveModelsForMentionedAgents(auth, {
+          agentConfigurations: [agentConfig1],
+        }),
+        restrictedAgentIds: new Set<string>(),
       },
     });
 
@@ -427,6 +453,10 @@ describe("createAgentMessages", () => {
         skipToolsValidation: false,
         nextMessageRank: 1,
         userMessage,
+        resolvedModels: await resolveModelsForMentionedAgents(auth, {
+          agentConfigurations: [agentConfig1],
+        }),
+        restrictedAgentIds: new Set<string>(),
       },
     });
 
@@ -476,6 +506,10 @@ describe("createAgentMessages", () => {
         skipToolsValidation: false,
         nextMessageRank: 10,
         userMessage,
+        resolvedModels: await resolveModelsForMentionedAgents(auth, {
+          agentConfigurations: [agentConfig1, agentConfig2],
+        }),
+        restrictedAgentIds: new Set<string>(),
       },
     });
 
@@ -616,6 +650,10 @@ describe("createAgentMessages", () => {
           skipToolsValidation: false,
           nextMessageRank: 1,
           userMessage,
+          resolvedModels: await resolveModelsForMentionedAgents(auth, {
+            agentConfigurations: [agentConfigWithSpaces!],
+          }),
+          restrictedAgentIds: new Set<string>(),
         },
         transaction,
       });
@@ -743,6 +781,10 @@ describe("createAgentMessages", () => {
           skipToolsValidation: false,
           nextMessageRank: 1,
           userMessage,
+          resolvedModels: await resolveModelsForMentionedAgents(auth, {
+            agentConfigurations: [agentConfigWithSpaces!],
+          }),
+          restrictedAgentIds: new Set<string>(),
         },
         transaction,
       });
@@ -870,6 +912,10 @@ describe("createAgentMessages", () => {
           skipToolsValidation: false,
           nextMessageRank: 1,
           userMessage,
+          resolvedModels: await resolveModelsForMentionedAgents(auth, {
+            agentConfigurations: [agentConfigWithSpaces!],
+          }),
+          restrictedAgentIds: new Set<string>(),
         },
         transaction,
       });
@@ -928,6 +974,10 @@ describe("createAgentMessages", () => {
         skipToolsValidation: false,
         nextMessageRank: 1,
         userMessage,
+        resolvedModels: await resolveModelsForMentionedAgents(auth, {
+          agentConfigurations: [agentConfig1],
+        }),
+        restrictedAgentIds: new Set<string>(),
       },
     });
 
@@ -1038,6 +1088,11 @@ describe("createAgentMessages", () => {
         } satisfies AgentMention,
       ];
 
+      const canAgentBeUsed = await canAgentBeUsedInProjectConversation(auth, {
+        configuration: updatedAgentConfig!,
+        conversation: spaceConversation.toJSON(),
+      });
+
       const { agentMessages, richMentions } = await createAgentMessages(auth, {
         conversation: spaceConversation.toJSON(),
         metadata: {
@@ -1047,6 +1102,12 @@ describe("createAgentMessages", () => {
           skipToolsValidation: false,
           nextMessageRank: 1,
           userMessage,
+          resolvedModels: await resolveModelsForMentionedAgents(auth, {
+            agentConfigurations: [updatedAgentConfig!],
+          }),
+          restrictedAgentIds: canAgentBeUsed
+            ? new Set<string>()
+            : new Set([updatedAgentConfig!.sId]),
         },
       });
 
@@ -1182,6 +1243,14 @@ describe("createAgentMessages", () => {
         } satisfies AgentMention,
       ];
 
+      const canAgentBeUsed = await canAgentBeUsedInProjectConversation(
+        userAuth,
+        {
+          configuration: updatedAgentConfig,
+          conversation: spaceConversation.toJSON(),
+        }
+      );
+
       const { agentMessages, richMentions } = await createAgentMessages(
         userAuth,
         {
@@ -1193,6 +1262,12 @@ describe("createAgentMessages", () => {
             skipToolsValidation: false,
             nextMessageRank: 1,
             userMessage,
+            resolvedModels: await resolveModelsForMentionedAgents(userAuth, {
+              agentConfigurations: [updatedAgentConfig],
+            }),
+            restrictedAgentIds: canAgentBeUsed
+              ? new Set<string>()
+              : new Set([updatedAgentConfig.sId]),
           },
         }
       );
@@ -1314,6 +1389,14 @@ describe("createAgentMessages", () => {
         } satisfies AgentMention,
       ];
 
+      const canAgentBeUsed = await canAgentBeUsedInProjectConversation(
+        userAuth,
+        {
+          configuration: updatedAgentConfig,
+          conversation: spaceConversation.toJSON(),
+        }
+      );
+
       const { agentMessages, richMentions } = await createAgentMessages(
         userAuth,
         {
@@ -1325,6 +1408,12 @@ describe("createAgentMessages", () => {
             skipToolsValidation: false,
             nextMessageRank: 1,
             userMessage,
+            resolvedModels: await resolveModelsForMentionedAgents(userAuth, {
+              agentConfigurations: [updatedAgentConfig],
+            }),
+            restrictedAgentIds: canAgentBeUsed
+              ? new Set<string>()
+              : new Set([updatedAgentConfig.sId]),
           },
         }
       );
@@ -1437,6 +1526,14 @@ describe("createAgentMessages", () => {
         } satisfies AgentMention,
       ];
 
+      const canAgentBeUsed = await canAgentBeUsedInProjectConversation(
+        userAuth,
+        {
+          configuration: updatedAgentConfig,
+          conversation: spaceConversation.toJSON(),
+        }
+      );
+
       const { agentMessages, richMentions } = await createAgentMessages(
         userAuth,
         {
@@ -1448,6 +1545,12 @@ describe("createAgentMessages", () => {
             skipToolsValidation: false,
             nextMessageRank: 1,
             userMessage,
+            resolvedModels: await resolveModelsForMentionedAgents(userAuth, {
+              agentConfigurations: [updatedAgentConfig],
+            }),
+            restrictedAgentIds: canAgentBeUsed
+              ? new Set<string>()
+              : new Set([updatedAgentConfig.sId]),
           },
         }
       );
@@ -1586,6 +1689,14 @@ describe("createAgentMessages", () => {
         } satisfies AgentMention,
       ];
 
+      const canAgentBeUsed = await canAgentBeUsedInProjectConversation(
+        userAuth,
+        {
+          configuration: updatedAgentConfig,
+          conversation: spaceConversation.toJSON(),
+        }
+      );
+
       const { agentMessages, richMentions } = await createAgentMessages(
         userAuth,
         {
@@ -1597,6 +1708,12 @@ describe("createAgentMessages", () => {
             skipToolsValidation: false,
             nextMessageRank: 1,
             userMessage,
+            resolvedModels: await resolveModelsForMentionedAgents(userAuth, {
+              agentConfigurations: [updatedAgentConfig],
+            }),
+            restrictedAgentIds: canAgentBeUsed
+              ? new Set<string>()
+              : new Set([updatedAgentConfig.sId]),
           },
         }
       );

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -1,8 +1,5 @@
 import { signalAgentUsage } from "@app/lib/api/assistant/agent_usage";
-import {
-  canAgentBeUsedInProjectConversation,
-  updateConversationRequirements,
-} from "@app/lib/api/assistant/conversation/permissions";
+import { updateConversationRequirements } from "@app/lib/api/assistant/conversation/permissions";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
 import { resolvedModelFromAgentMessageRow } from "@app/lib/api/assistant/models";
 import { resolveModel } from "@app/lib/api/assistant/resolve_model";
@@ -34,10 +31,13 @@ import type {
   UserMessageType,
   UserMessageTypeWithoutMentions,
 } from "@app/types/assistant/conversation";
-import { isPodConversation } from "@app/types/assistant/conversation";
 import type { MentionType } from "@app/types/assistant/mentions";
 import { isAgentMention } from "@app/types/assistant/mentions";
-import type { ModelSelectionType } from "@app/types/assistant/models/types";
+import type {
+  ModelResolutionMethodType,
+  ModelSelectionType,
+  ResolvedRequestedModel,
+} from "@app/types/assistant/models/types";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -242,6 +242,33 @@ export async function createUserMessage(
   return createdUserMessage;
 }
 
+export interface AgentMessageModelResolution {
+  resolvedModel: ResolvedRequestedModel;
+  modelResolutionMethod: ModelResolutionMethodType;
+}
+
+export async function resolveModelsForMentionedAgents(
+  auth: Authenticator,
+  {
+    agentConfigurations,
+    selection,
+  }: {
+    agentConfigurations: LightAgentConfigurationType[];
+    selection?: ModelSelectionType;
+  }
+): Promise<Map<string, AgentMessageModelResolution>> {
+  const featureFlags = await getFeatureFlags(auth);
+
+  const resolutions = new Map<string, AgentMessageModelResolution>();
+  for (const configuration of agentConfigurations) {
+    resolutions.set(
+      configuration.sId,
+      await resolveModel(auth, { selection, configuration, featureFlags })
+    );
+  }
+  return resolutions;
+}
+
 export const createAgentMessages = async (
   auth: Authenticator,
   {
@@ -269,6 +296,8 @@ export const createAgentMessages = async (
           skipToolsValidation: boolean;
           nextMessageRank: number;
           userMessage: UserMessageTypeWithoutMentions;
+          resolvedModels: Map<string, AgentMessageModelResolution>;
+          restrictedAgentIds: Set<string>;
         }
       | {
           type: "approve_existing_mention";
@@ -277,6 +306,7 @@ export const createAgentMessages = async (
           skipToolsValidation: boolean;
           nextMessageRank: number;
           userMessage: UserMessageTypeWithoutMentions;
+          resolvedModels: Map<string, AgentMessageModelResolution>;
         };
     transaction?: Transaction;
   }
@@ -411,8 +441,6 @@ export const createAgentMessages = async (
     // falls through
     case "create":
       {
-        const featureFlags = await getFeatureFlags(auth);
-
         const uniqueAgentMentions =
           metadata.type === "approve_existing_mention"
             ? [{ configurationId: metadata.configuration.sId }]
@@ -438,40 +466,28 @@ export const createAgentMessages = async (
             if (metadata.type === "approve_existing_mention") {
               mentionRow = metadata.mentionRow;
             } else {
-              // In case of Project's conversation, we need to check if the agent configuration is
-              // using only the project spaces or open spaces. Otherwise we reject the mention and
-              // do not create the agent message.
-              if (isPodConversation(conversation)) {
-                const canAgentBeUsed =
-                  await canAgentBeUsedInProjectConversation(auth, {
-                    configuration,
-                    conversation,
-                    transaction,
-                  });
+              if (metadata.restrictedAgentIds.has(configuration.sId)) {
+                // This create the mentions from the original user message. Not to be mixed with
+                // the mentions from the agent message (which will be filled later).
+                const restrictedMentionRow = await MentionModel.create(
+                  {
+                    messageId: metadata.userMessage.id,
+                    agentConfigurationId: configuration.sId,
+                    workspaceId: owner.id,
+                    status: "agent_restricted_by_space_usage",
+                  },
+                  { transaction }
+                );
 
-                if (!canAgentBeUsed) {
-                  // This create the mentions from the original user message. Not to be mixed with
-                  // the mentions from the agent message (which will be filled later).
-                  const restrictedMentionRow = await MentionModel.create(
-                    {
-                      messageId: metadata.userMessage.id,
-                      agentConfigurationId: configuration.sId,
-                      workspaceId: owner.id,
-                      status: "agent_restricted_by_space_usage",
-                    },
-                    { transaction }
-                  );
+                results.push({
+                  mentionRow: restrictedMentionRow,
+                  agentAnswer: null,
+                  parentMessageId: metadata.userMessage.sId,
+                  parentAgentMessageId: null,
+                  configuration,
+                });
 
-                  results.push({
-                    mentionRow: restrictedMentionRow,
-                    agentAnswer: null,
-                    parentMessageId: metadata.userMessage.sId,
-                    parentAgentMessageId: null,
-                    configuration,
-                  });
-
-                  return;
-                }
+                return;
               }
 
               // This create the mentions from the original user message. Not to be mixed with the
@@ -487,14 +503,12 @@ export const createAgentMessages = async (
               );
             }
 
-            const { resolvedModel, modelResolutionMethod } = await resolveModel(
-              auth,
-              {
-                selection: metadata.userMessage.requestedModel ?? undefined,
-                configuration,
-                featureFlags,
-              }
+            const resolution = metadata.resolvedModels.get(configuration.sId);
+            assert(
+              resolution,
+              `Missing model resolution for agent configuration ${configuration.sId}`
             );
+            const { resolvedModel, modelResolutionMethod } = resolution;
 
             const agentMessageRow = await AgentMessageModel.create(
               {
@@ -504,9 +518,9 @@ export const createAgentMessages = async (
                 conversationId: conversation.id,
                 workspaceId: owner.id,
                 skipToolsValidation: metadata.skipToolsValidation,
-                resolvedProviderId: resolvedModel?.providerId ?? null,
-                resolvedModelId: resolvedModel?.modelId ?? null,
-                resolvedReasoningEffort: resolvedModel?.reasoningEffort ?? null,
+                resolvedProviderId: resolvedModel.providerId,
+                resolvedModelId: resolvedModel.modelId,
+                resolvedReasoningEffort: resolvedModel.reasoningEffort,
                 modelResolutionMethod,
               },
               { transaction }

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -33,7 +33,10 @@ import {
 import { registerUserAnswer } from "@app/lib/api/assistant/conversation/answer_user_question";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { dismissMention } from "@app/lib/api/assistant/conversation/mentions";
-import { createAgentMessages } from "@app/lib/api/assistant/conversation/messages";
+import {
+  createAgentMessages,
+  resolveModelsForMentionedAgents,
+} from "@app/lib/api/assistant/conversation/messages";
 import { resolveAuthentication } from "@app/lib/api/assistant/conversation/resolve_authentication";
 import { retryBlockedActions } from "@app/lib/api/assistant/conversation/retry_blocked_actions";
 import { validateAction } from "@app/lib/api/assistant/conversation/validate_actions";
@@ -676,6 +679,10 @@ describe("dismissMention", () => {
           skipToolsValidation: false,
           nextMessageRank: 1,
           userMessage,
+          resolvedModels: await resolveModelsForMentionedAgents(refreshedAuth, {
+            agentConfigurations: [agentConfig],
+          }),
+          restrictedAgentIds: new Set<string>(),
         },
       });
 

--- a/front/lib/api/assistant/conversation/validate_agent_mention.ts
+++ b/front/lib/api/assistant/conversation/validate_agent_mention.ts
@@ -8,7 +8,10 @@ import {
   getConversationRankVersionLock,
   getNextConversationMessageRank,
 } from "@app/lib/api/assistant/conversation/lock";
-import { createAgentMessages } from "@app/lib/api/assistant/conversation/messages";
+import {
+  createAgentMessages,
+  resolveModelsForMentionedAgents,
+} from "@app/lib/api/assistant/conversation/messages";
 import { publishMessageEventsOnMessagePostOrEdit } from "@app/lib/api/assistant/streaming/events";
 import type { Authenticator } from "@app/lib/auth";
 import { MentionModel } from "@app/lib/models/agent/conversation";
@@ -207,6 +210,11 @@ export async function validateAgentMention(
     "User approved a restricted agent mention"
   );
 
+  const resolvedModels = await resolveModelsForMentionedAgents(auth, {
+    agentConfigurations: [configuration],
+    selection: message.requestedModel ?? undefined,
+  });
+
   let agentMessages: AgentMessageType[];
   let updatedRichMentions: RichMentionWithStatus[];
 
@@ -242,6 +250,7 @@ export async function validateAgentMention(
           skipToolsValidation: false,
           nextMessageRank,
           userMessage: message,
+          resolvedModels,
         },
         transaction: t,
       });


### PR DESCRIPTION
## Description

createAgentMessages was doing three reads inside the big bad transaction: feature flags, model resolution (hits the DB on auto models) and the project space gating check. None of them need the lock, and the first two did not pass transaction.

Callers now compute all of this before the transaction and pass the results in.

Two subtleties:
- `canAgentBeUsedInProjectConversation` gating depends on branching (a branch lifts the restriction), so post derives the final answer in tx from branchId, no read needed.
- on the promote path the model selection comes from the promoted message, only known in tx. The no-selection default is resolved before, the explicit selection case (rare) stays inside.

## Tests

Existing tests adapted.

## Risk

Low
Blast radius: agent loop

## Deploy Plan

Deploy front
