### PR TITLE
[front] refactor: signal agent usage after the message transaction commits

### DIFF
--- a/front/lib/api/assistant/conversation/messages.test.ts
+++ b/front/lib/api/assistant/conversation/messages.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock signalAgentUsage before importing the module that uses it
 vi.mock("@app/lib/api/assistant/agent_usage", () => ({
-  signalAgentUsage: vi.fn(),
+  signalAgentUsage: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { signalAgentUsage } from "@app/lib/api/assistant/agent_usage";

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -40,12 +40,41 @@ import type {
 } from "@app/types/assistant/models/types";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import assert from "assert";
 import uniqBy from "lodash/uniqBy";
 import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
+
+function signalAgentUsageAfterCommit(
+  {
+    agentConfigurationId,
+    workspaceId,
+  }: {
+    agentConfigurationId: string;
+    workspaceId: string;
+  },
+  transaction?: Transaction
+) {
+  const signal = () => {
+    void signalAgentUsage({ agentConfigurationId, workspaceId }).catch(
+      (err) => {
+        logger.warn(
+          { err: normalizeError(err), agentConfigurationId, workspaceId },
+          "Failed to signal agent usage"
+        );
+      }
+    );
+  };
+
+  if (transaction) {
+    transaction.afterCommit(signal);
+  } else {
+    signal();
+  }
+}
 
 export async function attributeUserFromWorkspaceAndEmail(
   workspace: WorkspaceType | null,
@@ -367,10 +396,13 @@ export const createAgentMessages = async (
         );
 
         // Track agent usage when retrying an agent message.
-        void signalAgentUsage({
-          agentConfigurationId: agentConfiguration.sId,
-          workspaceId: owner.sId,
-        });
+        signalAgentUsageAfterCommit(
+          {
+            agentConfigurationId: agentConfiguration.sId,
+            workspaceId: owner.sId,
+          },
+          transaction
+        );
 
         results.push({
           agentAnswer: {
@@ -547,10 +579,13 @@ export const createAgentMessages = async (
                 : null;
 
             // Track agent usage when creating a new agent message.
-            void signalAgentUsage({
-              agentConfigurationId: configuration.sId,
-              workspaceId: owner.sId,
-            });
+            signalAgentUsageAfterCommit(
+              {
+                agentConfigurationId: configuration.sId,
+                workspaceId: owner.sId,
+              },
+              transaction
+            );
 
             results.push({
               agentAnswer: {


### PR DESCRIPTION


## Description


Add a transaction param + hook in signalAgentUsage, to avoid phantom reads when we cut into multiple smaller transactions (or no transaction at all) without a big lock 

## Tests

N/A

## Risk

Low, it's a no-op change

## Deploy Plan

Merge