### PR TITLE
[front] enh: show "When to use" section in skill info

### DIFF
--- a/front/components/editor/SkillDescriptionEditor.tsx
+++ b/front/components/editor/SkillDescriptionEditor.tsx
@@ -104,7 +104,7 @@ export function SkillDescriptionEditorContent({
   return (
     <EditorContent
       editor={editor}
-      className={cn(className, "leading-7 text-base")}
+      className={cn("leading-7 text-base", className)}
     />
   );
 }
@@ -119,5 +119,5 @@ export function SkillDescriptionReadOnlyEditor({
     isReadOnly: true,
   });
 
-  return <SkillDescriptionEditorContent editor={editor} />;
+  return <SkillDescriptionEditorContent editor={editor} className="text-sm" />;
 }

--- a/front/components/editor/SkillDescriptionEditor.tsx
+++ b/front/components/editor/SkillDescriptionEditor.tsx
@@ -61,7 +61,7 @@ export function useSkillDescriptionEditor({
               attributes: {
                 class: cn(
                   editorVariants(),
-                  "h-40 max-h-96 cursor-text resize-none"
+                  "h-60 max-h-96 cursor-text resize-none"
                 ),
               },
             },

--- a/front/components/editor/SkillDescriptionEditor.tsx
+++ b/front/components/editor/SkillDescriptionEditor.tsx
@@ -1,3 +1,4 @@
+import { editorVariants } from "@app/components/editor/editorStyles";
 import { AgentInstructionDiffExtension } from "@app/components/editor/extensions/agent_builder/AgentInstructionDiffExtension";
 import { cn } from "@dust-tt/sparkle";
 import { Placeholder } from "@tiptap/extensions";
@@ -32,12 +33,14 @@ function buildSkillDescriptionExtensions(): Extensions {
 
 interface UseSkillDescriptionEditorProps {
   content: string;
+  isReadOnly?: boolean;
   onUpdate?: (props: { editor: Editor; transaction: Transaction }) => void;
   onBlur?: () => void;
 }
 
 export function useSkillDescriptionEditor({
   content,
+  isReadOnly = false,
   onUpdate,
   onBlur,
 }: UseSkillDescriptionEditorProps) {
@@ -48,22 +51,31 @@ export function useSkillDescriptionEditor({
   const editor = useEditor(
     {
       extensions,
-      editable: true,
+      editable: !isReadOnly,
       immediatelyRender: false,
       onUpdate,
       onBlur,
+      editorProps: isReadOnly
+        ? {
+            attributes: {
+              class: cn(
+                editorVariants(),
+                "h-40 max-h-96 cursor-text resize-none"
+              ),
+            },
+          }
+        : undefined,
     },
-    [extensions]
+    [extensions, isReadOnly]
   );
 
   // Set initial content after editor is created.
   useEffect(() => {
-    if (
-      editor &&
-      content &&
-      !initialContentSetRef.current &&
-      !editor.isDestroyed
-    ) {
+    const shouldSetContent = isReadOnly
+      ? editor?.getText().trim() !== content
+      : !!content && !initialContentSetRef.current;
+
+    if (editor && shouldSetContent && !editor.isDestroyed) {
       requestAnimationFrame(() => {
         if (editor && !editor.isDestroyed) {
           editor.commands.setContent(`<p>${content}</p>`, {
@@ -73,7 +85,7 @@ export function useSkillDescriptionEditor({
         }
       });
     }
-  }, [editor, content]);
+  }, [editor, content, isReadOnly]);
 
   return { editor };
 }
@@ -93,4 +105,17 @@ export function SkillDescriptionEditorContent({
       className={cn(className, "leading-7 text-base")}
     />
   );
+}
+
+export function SkillDescriptionReadOnlyEditor({
+  content,
+}: {
+  content: string;
+}) {
+  const { editor } = useSkillDescriptionEditor({
+    content,
+    isReadOnly: true,
+  });
+
+  return <SkillDescriptionEditorContent editor={editor} />;
 }

--- a/front/components/editor/SkillDescriptionEditor.tsx
+++ b/front/components/editor/SkillDescriptionEditor.tsx
@@ -55,16 +55,18 @@ export function useSkillDescriptionEditor({
       immediatelyRender: false,
       onUpdate,
       onBlur,
-      editorProps: isReadOnly
+      ...(isReadOnly
         ? {
-            attributes: {
-              class: cn(
-                editorVariants(),
-                "h-40 max-h-96 cursor-text resize-none"
-              ),
+            editorProps: {
+              attributes: {
+                class: cn(
+                  editorVariants(),
+                  "h-40 max-h-96 cursor-text resize-none"
+                ),
+              },
             },
           }
-        : undefined,
+        : {}),
     },
     [extensions, isReadOnly]
   );

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -21,7 +21,7 @@ import { useController, useFormContext } from "react-hook-form";
 const FIELD_NAME = "agentFacingDescription";
 const DEBOUNCE_DELAY_MS = 250;
 const MIN_DESCRIPTION_LENGTH = 10;
-const DESCRIPTION_EDITOR_SIZE = "h-40 max-h-96";
+const DESCRIPTION_EDITOR_SIZE = "h-60 max-h-96";
 
 export function SkillBuilderAgentFacingDescriptionSection() {
   const { owner, skillId } = useSkillBuilderContext();

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -98,11 +98,7 @@ export function SkillInfoTab({
     setKnowledgeItems(items);
   }, []);
 
-  const showAgentFacingDescription =
-    !!skill.instructions && !!skill.agentFacingDescription;
-
   const showSeparator =
-    showAgentFacingDescription ||
     !!skill.instructions ||
     knowledgeItems.length > 0 ||
     skill.fileAttachments.length > 0 ||
@@ -121,7 +117,7 @@ export function SkillInfoTab({
 
       {showSeparator ? <Separator /> : null}
 
-      {showAgentFacingDescription && (
+      {skill.instructions && skill.agentFacingDescription && (
         <div className="flex flex-col gap-4">
           <div className="heading-lg text-foreground">
             {SKILL_INVOCATION_LABEL}

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -9,6 +9,7 @@ import {
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
+import { SKILL_INVOCATION_LABEL } from "@app/lib/skills/labels";
 import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
 import { useSkills } from "@app/lib/swr/skill_configurations";
 import { useSpaces } from "@app/lib/swr/spaces";
@@ -97,6 +98,7 @@ export function SkillInfoTab({
   }, []);
 
   const showSeparator =
+    !!skill.agentFacingDescription ||
     !!skill.instructions ||
     knowledgeItems.length > 0 ||
     skill.fileAttachments.length > 0 ||
@@ -114,6 +116,17 @@ export function SkillInfoTab({
       ) : null}
 
       {showSeparator ? <Separator /> : null}
+
+      {skill.agentFacingDescription && (
+        <div className="flex flex-col gap-4">
+          <div className="heading-lg text-foreground">
+            {SKILL_INVOCATION_LABEL}
+          </div>
+          <div className="whitespace-pre-wrap text-sm text-foreground">
+            {skill.agentFacingDescription}
+          </div>
+        </div>
+      )}
 
       {skill.instructions && (
         <div className="dd-privacy-mask flex flex-col gap-4">

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -98,8 +98,11 @@ export function SkillInfoTab({
     setKnowledgeItems(items);
   }, []);
 
+  const showAgentFacingDescription =
+    showDescription && !!skill.agentFacingDescription;
+
   const showSeparator =
-    !!skill.agentFacingDescription ||
+    showAgentFacingDescription ||
     !!skill.instructions ||
     knowledgeItems.length > 0 ||
     skill.fileAttachments.length > 0 ||
@@ -118,7 +121,7 @@ export function SkillInfoTab({
 
       {showSeparator ? <Separator /> : null}
 
-      {skill.agentFacingDescription && (
+      {showAgentFacingDescription && (
         <div className="flex flex-col gap-4">
           <div className="heading-lg text-foreground">
             {SKILL_INVOCATION_LABEL}

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -1,6 +1,7 @@
 import { KnowledgeChip } from "@app/components/editor/extensions/skill_builder/KnowledgeChip";
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
 import { isFullKnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
+import { SkillDescriptionReadOnlyEditor } from "@app/components/editor/SkillDescriptionEditor";
 import { SkillInstructionsReadOnlyEditor } from "@app/components/skills/SkillInstructionsReadOnlyEditor";
 import {
   getMcpServerViewDescription,
@@ -122,9 +123,9 @@ export function SkillInfoTab({
           <div className="heading-lg text-foreground">
             {SKILL_INVOCATION_LABEL}
           </div>
-          <div className="whitespace-pre-wrap text-sm text-foreground">
-            {skill.agentFacingDescription}
-          </div>
+          <SkillDescriptionReadOnlyEditor
+            content={skill.agentFacingDescription}
+          />
         </div>
       )}
 

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -99,7 +99,7 @@ export function SkillInfoTab({
   }, []);
 
   const showAgentFacingDescription =
-    showDescription && !!skill.agentFacingDescription;
+    !!skill.instructions && !!skill.agentFacingDescription;
 
   const showSeparator =
     showAgentFacingDescription ||


### PR DESCRIPTION
## Description

Skill info pages show the user-facing summary and guidelines, but not the agent-facing description that explains when the skill should be used.

This PR adds it.

<img width="510" height="879" alt="image" src="https://github.com/user-attachments/assets/4b219c39-f878-4d9c-8dfe-07c5b7aeb51a" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
