### PR TITLE
[front] enh: show skills in Tools "Used By" column

### DIFF
--- a/front-api/routes/w/[wId]/mcp/usage.ts
+++ b/front-api/routes/w/[wId]/mcp/usage.ts
@@ -1,16 +1,37 @@
 import { getToolsUsage } from "@app/lib/api/agent_actions";
-import type { GetMCPServersUsageResponseBody } from "@app/lib/api/mcp";
+import type {
+  GetMCPServersUsageResponseBody,
+  GetMCPServersUsageWithSkillsResponseBody,
+} from "@app/lib/api/mcp";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const QuerySchema = z.object({
+  withSkills: z.enum(["true", "false"]).optional(),
+});
 
 // Mounted at /api/w/:wId/mcp/usage.
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get("/", async (ctx): HandlerResult<GetMCPServersUsageResponseBody> => {
-  const auth = ctx.get("auth");
-  const usage = await getToolsUsage(auth);
-  return ctx.json({ usage });
-});
+app.get(
+  "/",
+  validate("query", QuerySchema),
+  async (
+    ctx
+  ): HandlerResult<
+    GetMCPServersUsageResponseBody | GetMCPServersUsageWithSkillsResponseBody
+  > => {
+    const auth = ctx.get("auth");
+    const { withSkills } = ctx.req.valid("query");
+    const usage =
+      withSkills === "true"
+        ? await getToolsUsage(auth, { withSkills: true })
+        : await getToolsUsage(auth);
+    return ctx.json({ usage });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/mcp/usage.ts
+++ b/front-api/routes/w/[wId]/mcp/usage.ts
@@ -27,6 +27,7 @@ app.get(
     const auth = ctx.get("auth");
     const { withSkills } = ctx.req.valid("query");
 
+    // TODO(2024-08-04 aubin): Remove the withSkills compatibility path once legacy frontend traffic has drained.
     if (withSkills === "true") {
       const usage = await getToolsUsage(auth, { withSkills: true });
       return ctx.json({ usage });

--- a/front-api/routes/w/[wId]/mcp/usage.ts
+++ b/front-api/routes/w/[wId]/mcp/usage.ts
@@ -26,10 +26,13 @@ app.get(
   > => {
     const auth = ctx.get("auth");
     const { withSkills } = ctx.req.valid("query");
-    const usage =
-      withSkills === "true"
-        ? await getToolsUsage(auth, { withSkills: true })
-        : await getToolsUsage(auth);
+
+    if (withSkills === "true") {
+      const usage = await getToolsUsage(auth, { withSkills: true });
+      return ctx.json({ usage });
+    }
+
+    const usage = await getToolsUsage(auth);
     return ctx.json({ usage });
   }
 );

--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -4,6 +4,7 @@ import {
 } from "@app/components/actions/mcp/AddToolsDialog";
 import { CreateMCPServerDialog } from "@app/components/actions/mcp/create/CreateMCPServerDialog";
 import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
+import { SkillDetailsSheetById } from "@app/components/command_palette/SkillDetailsSheetById";
 import { ACTION_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHeaders";
 import { UsedByButton } from "@app/components/spaces/UsedByButton";
 import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
@@ -26,7 +27,7 @@ import {
 } from "@app/lib/swr/mcp_servers";
 import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import type { AgentsUsageType } from "@app/types/data_source";
+import type { SkillUsageType } from "@app/types/assistant/skill_configuration";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
@@ -37,7 +38,7 @@ import { useMemo, useState } from "react";
 type RowData = {
   mcpServer: MCPServerType;
   mcpServerView?: MCPServerViewType;
-  usage: AgentsUsageType | null;
+  usage: SkillUsageType | null;
   isConnected: boolean;
   account: string;
   spaces: SpaceType[];
@@ -112,6 +113,7 @@ export const AdminActionsList = ({
   });
 
   const [assistantSId, setAssistantSId] = useState<string | null>(null);
+  const [skillId, setSkillId] = useState<string | null>(null);
 
   const { usage } = useMCPServersUsage({
     owner,
@@ -184,7 +186,7 @@ export const AdminActionsList = ({
           );
           const spaceIds =
             mcpServerWithViews?.views.map((v) => v.spaceId) ?? [];
-          const agentsUsage =
+          const serverUsage =
             usage && mcpServerView ? usage[mcpServerView.server.sId] : null;
 
           const account =
@@ -199,7 +201,7 @@ export const AdminActionsList = ({
             mcpServerView,
             account,
             spaces: spaces.filter((s) => spaceIds?.includes(s.sId)),
-            usage: agentsUsage,
+            usage: serverUsage,
             isConnected: !!connections.find(
               (c) =>
                 c.internalMCPServerId === mcpServerWithViews.sId ||
@@ -269,18 +271,20 @@ export const AdminActionsList = ({
         },
       },
       {
-        header: "Used by",
+        id: "usedBy",
+        header: () => <div className="flex w-full justify-center">Used by</div>,
         accessorFn: (row: RowData) => row.usage?.count ?? 0,
         cell: (info) => (
-          <DataTable.CellContent>
+          <div className="flex h-12 w-full items-center justify-center">
             <UsedByButton
               usage={info.row.original.usage}
               onItemClick={setAssistantSId}
+              onSkillClick={setSkillId}
             />
-          </DataTable.CellContent>
+          </div>
         ),
         meta: {
-          className: "hidden @sm:w-5 @sm:table-cell",
+          className: "hidden px-0 @sm:w-32 @sm:table-cell",
         },
       },
       {
@@ -383,6 +387,12 @@ export const AdminActionsList = ({
         user={user}
         agentId={assistantSId}
         onClose={() => setAssistantSId(null)}
+      />
+      <SkillDetailsSheetById
+        owner={owner}
+        user={user}
+        skillId={skillId}
+        onClose={() => setSkillId(null)}
       />
       <CreateMCPServerDialog
         isOpen={isCreateOpen}

--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -112,7 +112,7 @@ export const AdminActionsList = ({
     owner,
   });
 
-  const [assistantSId, setAssistantSId] = useState<string | null>(null);
+  const [agentId, setAgentId] = useState<string | null>(null);
   const [skillId, setSkillId] = useState<string | null>(null);
 
   const { usage } = useMCPServersUsage({
@@ -278,7 +278,7 @@ export const AdminActionsList = ({
           <div className="flex h-12 w-full items-center justify-center">
             <UsedByButton
               usage={info.row.original.usage}
-              onItemClick={setAssistantSId}
+              onItemClick={setAgentId}
               onSkillClick={setSkillId}
             />
           </div>
@@ -385,8 +385,8 @@ export const AdminActionsList = ({
       <AgentDetailsSheet
         owner={owner}
         user={user}
-        agentId={assistantSId}
-        onClose={() => setAssistantSId(null)}
+        agentId={agentId}
+        onClose={() => setAgentId(null)}
       />
       <SkillDetailsSheetById
         owner={owner}

--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -28,6 +28,7 @@ import {
 import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { SkillUsageType } from "@app/types/assistant/skill_configuration";
+import type { AgentsUsageType } from "@app/types/data_source";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
@@ -38,7 +39,7 @@ import { useMemo, useState } from "react";
 type RowData = {
   mcpServer: MCPServerType;
   mcpServerView?: MCPServerViewType;
-  usage: SkillUsageType | null;
+  usage: AgentsUsageType | SkillUsageType | null;
   isConnected: boolean;
   account: string;
   spaces: SpaceType[];

--- a/front/components/command_palette/SkillDetailsSheetById.tsx
+++ b/front/components/command_palette/SkillDetailsSheetById.tsx
@@ -25,6 +25,7 @@ export function SkillDetailsSheetById({
   return (
     <SkillDetailsSheet
       skill={skill ?? null}
+      open={skillId !== null}
       owner={owner}
       user={user}
       onClose={onClose}

--- a/front/components/command_palette/SkillDetailsSheetById.tsx
+++ b/front/components/command_palette/SkillDetailsSheetById.tsx
@@ -15,7 +15,7 @@ export function SkillDetailsSheetById({
   skillId,
   onClose,
 }: SkillDetailsSheetByIdProps) {
-  const { skill } = useSkill({
+  const { skill, isSkillError, mutateSkill } = useSkill({
     workspaceId: owner.sId,
     skillId,
     withRelations: true,
@@ -26,6 +26,8 @@ export function SkillDetailsSheetById({
     <SkillDetailsSheet
       skill={skill ?? null}
       open={skillId !== null}
+      isError={isSkillError}
+      onRetry={mutateSkill}
       owner={owner}
       user={user}
       onClose={onClose}

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -36,6 +36,7 @@ import { useState } from "react";
 
 type SkillDetailsProps = {
   skill: GetSkillsWithRelationsResponseBody["skills"][number] | null;
+  open?: boolean;
   onClose: () => void;
   onFavoriteChange?: (
     skill: GetSkillsWithRelationsResponseBody["skills"][number],
@@ -48,12 +49,15 @@ type SkillDetailsProps = {
 
 export function SkillDetailsSheet({
   skill,
+  open,
   onClose,
   onFavoriteChange,
   user,
   owner,
   replaceOnEdit,
 }: SkillDetailsProps) {
+  const isOpen = open ?? skill !== null;
+
   // Fetch the full skill (with instructions/tools) for the content section,
   // since the list endpoint may not include them.
   const { skill: fullSkill, isSkillLoading } = useSkill({
@@ -63,12 +67,12 @@ export function SkillDetailsSheet({
   });
 
   return (
-    <Sheet open={skill !== null} onOpenChange={onClose}>
+    <Sheet open={isOpen} onOpenChange={onClose}>
       <SheetContent size="lg" className="pb-4">
         <VisuallyHidden>
           <SheetTitle />
         </VisuallyHidden>
-        {skill && (
+        {skill ? (
           <>
             <SheetHeader>
               <DescriptionSection
@@ -93,7 +97,11 @@ export function SkillDetailsSheet({
               )}
             </SheetContainer>
           </>
-        )}
+        ) : isOpen ? (
+          <div className="flex h-full w-full items-center justify-center">
+            <Spinner size="lg" />
+          </div>
+        ) : null}
       </SheetContent>
     </Sheet>
   );

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -17,6 +17,7 @@ import type { UserType, WorkspaceType } from "@app/types/user";
 import {
   Button,
   ContentMessage,
+  ContentMessageAction,
   InfoCircle,
   RefreshCw02,
   Sheet,
@@ -37,6 +38,8 @@ import { useState } from "react";
 type SkillDetailsProps = {
   skill: GetSkillsWithRelationsResponseBody["skills"][number] | null;
   open?: boolean;
+  isError?: boolean;
+  onRetry?: () => void;
   onClose: () => void;
   onFavoriteChange?: (
     skill: GetSkillsWithRelationsResponseBody["skills"][number],
@@ -50,6 +53,8 @@ type SkillDetailsProps = {
 export function SkillDetailsSheet({
   skill,
   open,
+  isError = false,
+  onRetry,
   onClose,
   onFavoriteChange,
   user,
@@ -60,7 +65,12 @@ export function SkillDetailsSheet({
 
   // Fetch the full skill (with instructions/tools) for the content section,
   // since the list endpoint may not include them.
-  const { skill: fullSkill, isSkillLoading } = useSkill({
+  const {
+    skill: fullSkill,
+    isSkillLoading,
+    isSkillError: isFullSkillError,
+    mutateSkill: retryFullSkill,
+  } = useSkill({
     workspaceId: owner.sId,
     skillId: skill?.sId ?? null,
     disabled: !skill,
@@ -84,7 +94,9 @@ export function SkillDetailsSheet({
               />
             </SheetHeader>
             <SheetContainer className="pb-4">
-              {isSkillLoading || !fullSkill ? (
+              {!fullSkill && isFullSkillError ? (
+                <SkillLoadError onRetry={retryFullSkill} />
+              ) : isSkillLoading || !fullSkill ? (
                 <div className="flex justify-center py-8">
                   <Spinner size="lg" />
                 </div>
@@ -97,6 +109,8 @@ export function SkillDetailsSheet({
               )}
             </SheetContainer>
           </>
+        ) : isError ? (
+          <SkillLoadError onRetry={onRetry} />
         ) : isOpen ? (
           <div className="flex h-full w-full items-center justify-center">
             <Spinner size="lg" />
@@ -104,6 +118,31 @@ export function SkillDetailsSheet({
         ) : null}
       </SheetContent>
     </Sheet>
+  );
+}
+
+function SkillLoadError({ onRetry }: { onRetry?: () => void }) {
+  return (
+    <div className="flex h-full w-full items-center justify-center p-4">
+      <ContentMessage
+        title="Unable to load skill"
+        variant="warning"
+        icon={InfoCircle}
+        size="lg"
+        action={
+          onRetry ? (
+            <ContentMessageAction
+              icon={RefreshCw02}
+              label="Retry"
+              variant="warning"
+              onClick={onRetry}
+            />
+          ) : undefined
+        }
+      >
+        The skill could not be loaded. Please try again.
+      </ContentMessage>
+    </div>
   );
 }
 

--- a/front/lib/api/agent_actions.test.ts
+++ b/front/lib/api/agent_actions.test.ts
@@ -1,0 +1,105 @@
+import { getToolsUsage } from "@app/lib/api/agent_actions";
+import { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { AgentMCPServerConfigurationFactory } from "@app/tests/utils/AgentMCPServerConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { beforeAll, describe, expect, it } from "vitest";
+
+describe("getToolsUsage", () => {
+  beforeAll(() => {
+    process.env.FRONT_DATABASE_READ_REPLICA_URI =
+      process.env.FRONT_DATABASE_URI;
+  });
+
+  it("aggregates usage with the caller's visibility", async () => {
+    const testContext = await createResourceTest({ role: "admin" });
+    const server = await RemoteMCPServerFactory.create(testContext.workspace);
+    const firstView = await MCPServerViewFactory.create(
+      testContext.workspace,
+      server.sId,
+      testContext.globalSpace
+    );
+    const regularSpace = await SpaceFactory.regular(testContext.workspace);
+    const secondView = await MCPServerViewFactory.create(
+      testContext.workspace,
+      server.sId,
+      regularSpace
+    );
+    const visibleAgent = await AgentConfigurationFactory.createTestAgent(
+      testContext.authenticator,
+      { name: "Visible agent", scope: "visible" }
+    );
+    const hiddenAgent = await AgentConfigurationFactory.createTestAgent(
+      testContext.authenticator,
+      { name: "Hidden agent", scope: "hidden" }
+    );
+    await AgentMCPServerConfigurationFactory.create(
+      testContext.authenticator,
+      testContext.globalSpace,
+      { agent: visibleAgent, mcpServerView: firstView }
+    );
+    await AgentMCPServerConfigurationFactory.create(
+      testContext.authenticator,
+      testContext.globalSpace,
+      { agent: hiddenAgent, mcpServerView: firstView }
+    );
+    const publishedSkill = await SkillFactory.create(
+      testContext.authenticator,
+      {
+        name: "Published skill",
+        availability: "workspace_users",
+        mcpServerViews: [firstView, secondView],
+      }
+    );
+    const unpublishedSkill = await SkillFactory.create(
+      testContext.authenticator,
+      {
+        name: "Unpublished skill",
+        availability: "editors",
+        mcpServerViews: [firstView],
+      }
+    );
+    await SkillFactory.create(testContext.authenticator, {
+      name: "Archived skill",
+      status: "archived",
+      mcpServerViews: [firstView],
+    });
+
+    const adminUsage = await getToolsUsage(testContext.authenticator);
+
+    expect(adminUsage[server.sId]?.count).toBe(4);
+    expect(adminUsage[server.sId]?.agents.map((agent) => agent.sId)).toEqual([
+      hiddenAgent.sId,
+      visibleAgent.sId,
+    ]);
+    expect(adminUsage[server.sId]?.skills.map((skill) => skill.sId)).toEqual([
+      publishedSkill.sId,
+      unpublishedSkill.sId,
+    ]);
+
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(testContext.workspace, user, {
+      role: "builder",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      testContext.workspace.sId
+    );
+
+    const memberUsage = await getToolsUsage(auth);
+
+    expect(memberUsage[server.sId]?.count).toBe(2);
+    expect(memberUsage[server.sId]?.agents.map((agent) => agent.sId)).toEqual([
+      visibleAgent.sId,
+    ]);
+    expect(memberUsage[server.sId]?.skills.map((skill) => skill.sId)).toEqual([
+      publishedSkill.sId,
+    ]);
+  });
+});

--- a/front/lib/api/agent_actions.test.ts
+++ b/front/lib/api/agent_actions.test.ts
@@ -17,7 +17,7 @@ describe("getToolsUsage", () => {
       process.env.FRONT_DATABASE_URI;
   });
 
-  it("aggregates all active usage", async () => {
+  it("aggregates usage with the caller's visibility", async () => {
     const testContext = await createResourceTest({ role: "admin" });
     const server = await RemoteMCPServerFactory.create(testContext.workspace);
     const firstView = await MCPServerViewFactory.create(
@@ -71,6 +71,18 @@ describe("getToolsUsage", () => {
       mcpServerViews: [firstView],
     });
 
+    const adminUsage = await getToolsUsage(testContext.authenticator);
+
+    expect(adminUsage[server.sId]?.count).toBe(4);
+    expect(adminUsage[server.sId]?.agents.map((agent) => agent.sId)).toEqual([
+      hiddenAgent.sId,
+      visibleAgent.sId,
+    ]);
+    expect(adminUsage[server.sId]?.skills.map((skill) => skill.sId)).toEqual([
+      publishedSkill.sId,
+      unpublishedSkill.sId,
+    ]);
+
     const user = await UserFactory.basic();
     await MembershipFactory.associate(testContext.workspace, user, {
       role: "builder",
@@ -82,14 +94,12 @@ describe("getToolsUsage", () => {
 
     const memberUsage = await getToolsUsage(auth);
 
-    expect(memberUsage[server.sId]?.count).toBe(4);
+    expect(memberUsage[server.sId]?.count).toBe(2);
     expect(memberUsage[server.sId]?.agents.map((agent) => agent.sId)).toEqual([
-      hiddenAgent.sId,
       visibleAgent.sId,
     ]);
     expect(memberUsage[server.sId]?.skills.map((skill) => skill.sId)).toEqual([
       publishedSkill.sId,
-      unpublishedSkill.sId,
     ]);
   });
 });

--- a/front/lib/api/agent_actions.test.ts
+++ b/front/lib/api/agent_actions.test.ts
@@ -17,7 +17,7 @@ describe("getToolsUsage", () => {
       process.env.FRONT_DATABASE_URI;
   });
 
-  it("aggregates usage with the caller's visibility", async () => {
+  it("aggregates all active usage", async () => {
     const testContext = await createResourceTest({ role: "admin" });
     const server = await RemoteMCPServerFactory.create(testContext.workspace);
     const firstView = await MCPServerViewFactory.create(
@@ -71,18 +71,6 @@ describe("getToolsUsage", () => {
       mcpServerViews: [firstView],
     });
 
-    const adminUsage = await getToolsUsage(testContext.authenticator);
-
-    expect(adminUsage[server.sId]?.count).toBe(4);
-    expect(adminUsage[server.sId]?.agents.map((agent) => agent.sId)).toEqual([
-      hiddenAgent.sId,
-      visibleAgent.sId,
-    ]);
-    expect(adminUsage[server.sId]?.skills.map((skill) => skill.sId)).toEqual([
-      publishedSkill.sId,
-      unpublishedSkill.sId,
-    ]);
-
     const user = await UserFactory.basic();
     await MembershipFactory.associate(testContext.workspace, user, {
       role: "builder",
@@ -94,12 +82,14 @@ describe("getToolsUsage", () => {
 
     const memberUsage = await getToolsUsage(auth);
 
-    expect(memberUsage[server.sId]?.count).toBe(2);
+    expect(memberUsage[server.sId]?.count).toBe(4);
     expect(memberUsage[server.sId]?.agents.map((agent) => agent.sId)).toEqual([
+      hiddenAgent.sId,
       visibleAgent.sId,
     ]);
     expect(memberUsage[server.sId]?.skills.map((skill) => skill.sId)).toEqual([
       publishedSkill.sId,
+      unpublishedSkill.sId,
     ]);
   });
 });

--- a/front/lib/api/agent_actions.test.ts
+++ b/front/lib/api/agent_actions.test.ts
@@ -71,7 +71,14 @@ describe("getToolsUsage", () => {
       mcpServerViews: [firstView],
     });
 
-    const adminUsage = await getToolsUsage(testContext.authenticator);
+    const legacyUsage = await getToolsUsage(testContext.authenticator);
+
+    expect(legacyUsage[server.sId]?.count).toBe(2);
+    expect(legacyUsage[server.sId]).not.toHaveProperty("skills");
+
+    const adminUsage = await getToolsUsage(testContext.authenticator, {
+      withSkills: true,
+    });
 
     expect(adminUsage[server.sId]?.count).toBe(4);
     expect(adminUsage[server.sId]?.agents.map((agent) => agent.sId)).toEqual([
@@ -92,7 +99,7 @@ describe("getToolsUsage", () => {
       testContext.workspace.sId
     );
 
-    const memberUsage = await getToolsUsage(auth);
+    const memberUsage = await getToolsUsage(auth, { withSkills: true });
 
     expect(memberUsage[server.sId]?.count).toBe(2);
     expect(memberUsage[server.sId]?.agents.map((agent) => agent.sId)).toEqual([

--- a/front/lib/api/agent_actions.ts
+++ b/front/lib/api/agent_actions.ts
@@ -1,6 +1,5 @@
 import { remoteMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { Authenticator } from "@app/lib/auth";
-import { GroupResource } from "@app/lib/resources/group_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
 import type {
@@ -22,52 +21,6 @@ interface MCPServerUsageRow {
   names: string[];
   sIds: string[];
   pictureUrls: string[];
-}
-
-type UsageVisibility = "all" | "accessible";
-
-/**
- * Returns the list of agent IDs visible to the current user (used for
- * non-admin visibility filtering).
- */
-async function getVisibleAgentIds(auth: Authenticator): Promise<ModelId[]> {
-  const groups = await GroupResource.findAgentIdsForGroups(
-    auth,
-    auth.groupModelIds()
-  );
-  return groups.map((g) => g.agentConfigurationId);
-}
-
-/**
- * Builds the visibility WHERE clause and query replacements.
- */
-async function buildVisibilityFilter(
-  auth: Authenticator,
-  visibility: UsageVisibility
-): Promise<{
-  clause: string;
-  params: Record<string, unknown>;
-}> {
-  const workspaceId = auth.getNonNullableWorkspace().id;
-
-  if (visibility === "all") {
-    return {
-      clause: `ac."status" = 'active' AND ac."workspaceId" = :workspace_id`,
-      params: { workspace_id: workspaceId },
-    };
-  }
-
-  const agentIds = await getVisibleAgentIds(auth);
-
-  return {
-    clause: `ac."status" = 'active'
-        AND ac."workspaceId" = :workspace_id
-        AND (ac."scope" = 'visible' OR ac."id" IN (:agent_ids))`,
-    params: {
-      workspace_id: workspaceId,
-      agent_ids: agentIds.length > 0 ? agentIds : [-1],
-    },
-  };
 }
 
 function rowToUsageEntry(
@@ -96,8 +49,7 @@ function rowToUsageEntry(
 }
 
 async function fetchSkillsByMCPServer(
-  auth: Authenticator,
-  visibility: UsageVisibility
+  auth: Authenticator
 ): Promise<Map<string, UsedBySkillType[]>> {
   const skills = await SkillResource.listByWorkspace(auth, {
     status: "active",
@@ -108,14 +60,6 @@ async function fetchSkillsByMCPServer(
 
   const skillsByMCPServer = new Map<string, UsedBySkillType[]>();
   for (const skill of skills) {
-    if (
-      visibility === "accessible" &&
-      skill.availability === "editors" &&
-      !skill.canWrite(auth)
-    ) {
-      continue;
-    }
-
     const usedBySkill: UsedBySkillType = {
       sId: skill.sId,
       name: skill.name,
@@ -146,9 +90,7 @@ export async function getToolsUsage(
     return {};
   }
 
-  const visibility: UsageVisibility = auth.isAdmin() ? "all" : "accessible";
   const replicaDb = getFrontReplicaDbConnection();
-  const { clause, params } = await buildVisibilityFilter(auth, visibility);
 
   // biome-ignore lint/plugin/noRawSql: Read-only analytics query on replica.
   const rows = await replicaDb.query<MCPServerUsageRow>(
@@ -164,12 +106,15 @@ export async function getToolsUsage(
       ON amsc."agentConfigurationId" = ac."id"
     INNER JOIN mcp_server_views msv
       ON msv."id" = amsc."mcpServerViewId"
-    WHERE ${clause}
+    WHERE ac."status" = 'active' AND ac."workspaceId" = :workspace_id
     GROUP BY msv."internalMCPServerId", msv."remoteMCPServerId"
     `,
-    { replacements: params, type: QueryTypes.SELECT }
+    {
+      replacements: { workspace_id: owner.id },
+      type: QueryTypes.SELECT,
+    }
   );
-  const skillsByMCPServer = await fetchSkillsByMCPServer(auth, visibility);
+  const skillsByMCPServer = await fetchSkillsByMCPServer(auth);
 
   const result: MCPServersUsage = {};
   for (const row of rows) {

--- a/front/lib/api/agent_actions.ts
+++ b/front/lib/api/agent_actions.ts
@@ -7,6 +7,7 @@ import type {
   SkillUsageType,
   UsedBySkillType,
 } from "@app/types/assistant/skill_configuration";
+import type { AgentsUsageType } from "@app/types/data_source";
 import type { ModelId } from "@app/types/shared/model_id";
 import { QueryTypes } from "sequelize";
 
@@ -14,6 +15,7 @@ import { QueryTypes } from "sequelize";
 // If it is a problem, let's add caching
 const DISABLE_QUERIES = false;
 
+export type MCPServersUsageByAgent = Record<string, AgentsUsageType>;
 export type MCPServersUsage = Record<string, SkillUsageType>;
 
 interface MCPServerUsageRow {
@@ -69,7 +71,7 @@ async function buildVisibilityFilter(auth: Authenticator): Promise<{
 function rowToUsageEntry(
   row: MCPServerUsageRow,
   workspaceId: ModelId
-): { key: string; usage: SkillUsageType } {
+): { key: string; usage: AgentsUsageType } {
   const key =
     row.internalMCPServerId ||
     remoteMCPServerNameToSId({
@@ -86,7 +88,6 @@ function rowToUsageEntry(
         name: row.names[index],
         pictureUrl: row.pictureUrls[index],
       })),
-      skills: [],
     },
   };
 }
@@ -129,9 +130,17 @@ async function fetchSkillsByMCPServer(
   return skillsByMCPServer;
 }
 
-export async function getToolsUsage(
+export function getToolsUsage(
   auth: Authenticator
-): Promise<MCPServersUsage> {
+): Promise<MCPServersUsageByAgent>;
+export function getToolsUsage(
+  auth: Authenticator,
+  options: { withSkills: true }
+): Promise<MCPServersUsage>;
+export async function getToolsUsage(
+  auth: Authenticator,
+  options?: { withSkills: true }
+): Promise<MCPServersUsageByAgent | MCPServersUsage> {
   const owner = auth.workspace();
 
   if (!owner || !auth.isUser()) {
@@ -165,21 +174,33 @@ export async function getToolsUsage(
     `,
     { replacements: params, type: QueryTypes.SELECT }
   );
-  const skillsByMCPServer = await fetchSkillsByMCPServer(auth);
-
-  const result: MCPServersUsage = {};
+  const result: MCPServersUsageByAgent = {};
   for (const row of rows) {
     const { key, usage } = rowToUsageEntry(row, owner.id);
     result[key] = usage;
   }
 
+  if (!options?.withSkills) {
+    return result;
+  }
+
+  const skillsByMCPServer = await fetchSkillsByMCPServer(auth);
+  const resultWithSkills: MCPServersUsage = {};
+  for (const [mcpServerId, usage] of Object.entries(result)) {
+    resultWithSkills[mcpServerId] = {
+      count: usage.count,
+      agents: usage.agents,
+      skills: [],
+    };
+  }
+
   for (const [mcpServerId, skills] of skillsByMCPServer) {
-    const usage = result[mcpServerId];
+    const usage = resultWithSkills[mcpServerId];
     if (usage) {
       usage.skills = skills;
       usage.count += skills.length;
     } else {
-      result[mcpServerId] = {
+      resultWithSkills[mcpServerId] = {
         count: skills.length,
         agents: [],
         skills,
@@ -187,5 +208,5 @@ export async function getToolsUsage(
     }
   }
 
-  return result;
+  return resultWithSkills;
 }

--- a/front/lib/api/agent_actions.ts
+++ b/front/lib/api/agent_actions.ts
@@ -1,5 +1,6 @@
 import { remoteMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
 import type {
@@ -21,6 +22,52 @@ interface MCPServerUsageRow {
   names: string[];
   sIds: string[];
   pictureUrls: string[];
+}
+
+type UsageVisibility = "all" | "accessible";
+
+/**
+ * Returns the list of agent IDs visible to the current user (used for
+ * non-admin visibility filtering).
+ */
+async function getVisibleAgentIds(auth: Authenticator): Promise<ModelId[]> {
+  const groups = await GroupResource.findAgentIdsForGroups(
+    auth,
+    auth.groupModelIds()
+  );
+  return groups.map((g) => g.agentConfigurationId);
+}
+
+/**
+ * Builds the visibility WHERE clause and query replacements.
+ */
+async function buildVisibilityFilter(
+  auth: Authenticator,
+  visibility: UsageVisibility
+): Promise<{
+  clause: string;
+  params: Record<string, unknown>;
+}> {
+  const workspaceId = auth.getNonNullableWorkspace().id;
+
+  if (visibility === "all") {
+    return {
+      clause: `ac."status" = 'active' AND ac."workspaceId" = :workspace_id`,
+      params: { workspace_id: workspaceId },
+    };
+  }
+
+  const agentIds = await getVisibleAgentIds(auth);
+
+  return {
+    clause: `ac."status" = 'active'
+        AND ac."workspaceId" = :workspace_id
+        AND (ac."scope" = 'visible' OR ac."id" IN (:agent_ids))`,
+    params: {
+      workspace_id: workspaceId,
+      agent_ids: agentIds.length > 0 ? agentIds : [-1],
+    },
+  };
 }
 
 function rowToUsageEntry(
@@ -49,7 +96,8 @@ function rowToUsageEntry(
 }
 
 async function fetchSkillsByMCPServer(
-  auth: Authenticator
+  auth: Authenticator,
+  visibility: UsageVisibility
 ): Promise<Map<string, UsedBySkillType[]>> {
   const skills = await SkillResource.listByWorkspace(auth, {
     status: "active",
@@ -60,6 +108,14 @@ async function fetchSkillsByMCPServer(
 
   const skillsByMCPServer = new Map<string, UsedBySkillType[]>();
   for (const skill of skills) {
+    if (
+      visibility === "accessible" &&
+      skill.availability === "editors" &&
+      !skill.canWrite(auth)
+    ) {
+      continue;
+    }
+
     const usedBySkill: UsedBySkillType = {
       sId: skill.sId,
       name: skill.name,
@@ -90,7 +146,9 @@ export async function getToolsUsage(
     return {};
   }
 
+  const visibility: UsageVisibility = auth.isAdmin() ? "all" : "accessible";
   const replicaDb = getFrontReplicaDbConnection();
+  const { clause, params } = await buildVisibilityFilter(auth, visibility);
 
   // biome-ignore lint/plugin/noRawSql: Read-only analytics query on replica.
   const rows = await replicaDb.query<MCPServerUsageRow>(
@@ -106,15 +164,12 @@ export async function getToolsUsage(
       ON amsc."agentConfigurationId" = ac."id"
     INNER JOIN mcp_server_views msv
       ON msv."id" = amsc."mcpServerViewId"
-    WHERE ac."status" = 'active' AND ac."workspaceId" = :workspace_id
+    WHERE ${clause}
     GROUP BY msv."internalMCPServerId", msv."remoteMCPServerId"
     `,
-    {
-      replacements: { workspace_id: owner.id },
-      type: QueryTypes.SELECT,
-    }
+    { replacements: params, type: QueryTypes.SELECT }
   );
-  const skillsByMCPServer = await fetchSkillsByMCPServer(auth);
+  const skillsByMCPServer = await fetchSkillsByMCPServer(auth, visibility);
 
   const result: MCPServersUsage = {};
   for (const row of rows) {

--- a/front/lib/api/agent_actions.ts
+++ b/front/lib/api/agent_actions.ts
@@ -1,8 +1,12 @@
 import { remoteMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
-import type { AgentsUsageType } from "@app/types/data_source";
+import type {
+  SkillUsageType,
+  UsedBySkillType,
+} from "@app/types/assistant/skill_configuration";
 import type { ModelId } from "@app/types/shared/model_id";
 import { QueryTypes } from "sequelize";
 
@@ -10,7 +14,7 @@ import { QueryTypes } from "sequelize";
 // If it is a problem, let's add caching
 const DISABLE_QUERIES = false;
 
-export type MCPServersUsageByAgent = Record<string, AgentsUsageType>;
+export type MCPServersUsage = Record<string, SkillUsageType>;
 
 interface MCPServerUsageRow {
   internalMCPServerId: string | null;
@@ -19,6 +23,8 @@ interface MCPServerUsageRow {
   sIds: string[];
   pictureUrls: string[];
 }
+
+type UsageVisibility = "all" | "accessible";
 
 /**
  * Returns the list of agent IDs visible to the current user (used for
@@ -33,16 +39,18 @@ async function getVisibleAgentIds(auth: Authenticator): Promise<ModelId[]> {
 }
 
 /**
- * Builds the visibility WHERE clause and query replacements depending on
- * whether the caller is an admin or a regular user.
+ * Builds the visibility WHERE clause and query replacements.
  */
-async function buildVisibilityFilter(auth: Authenticator): Promise<{
+async function buildVisibilityFilter(
+  auth: Authenticator,
+  visibility: UsageVisibility
+): Promise<{
   clause: string;
   params: Record<string, unknown>;
 }> {
   const workspaceId = auth.getNonNullableWorkspace().id;
 
-  if (auth.isAdmin()) {
+  if (visibility === "all") {
     return {
       clause: `ac."status" = 'active' AND ac."workspaceId" = :workspace_id`,
       params: { workspace_id: workspaceId },
@@ -65,7 +73,7 @@ async function buildVisibilityFilter(auth: Authenticator): Promise<{
 function rowToUsageEntry(
   row: MCPServerUsageRow,
   workspaceId: ModelId
-): { key: string; usage: AgentsUsageType } {
+): { key: string; usage: SkillUsageType } {
   const key =
     row.internalMCPServerId ||
     remoteMCPServerNameToSId({
@@ -82,32 +90,68 @@ function rowToUsageEntry(
         name: row.names[index],
         pictureUrl: row.pictureUrls[index],
       })),
+      skills: [],
     },
   };
 }
 
+async function fetchSkillsByMCPServer(
+  auth: Authenticator,
+  visibility: UsageVisibility
+): Promise<Map<string, UsedBySkillType[]>> {
+  const skills = await SkillResource.listByWorkspace(auth, {
+    status: "active",
+    withInstructions: false,
+    withTools: true,
+    withFileAttachments: false,
+  });
+
+  const skillsByMCPServer = new Map<string, UsedBySkillType[]>();
+  for (const skill of skills) {
+    if (
+      visibility === "accessible" &&
+      skill.availability === "editors" &&
+      !skill.canWrite(auth)
+    ) {
+      continue;
+    }
+
+    const usedBySkill: UsedBySkillType = {
+      sId: skill.sId,
+      name: skill.name,
+      icon: skill.icon,
+    };
+    for (const mcpServerId of new Set(
+      skill.mcpServerViews.map((view) => view.mcpServerId)
+    )) {
+      const usedBySkills = skillsByMCPServer.get(mcpServerId) ?? [];
+      usedBySkills.push(usedBySkill);
+      skillsByMCPServer.set(mcpServerId, usedBySkills);
+    }
+  }
+
+  for (const usedBySkills of skillsByMCPServer.values()) {
+    usedBySkills.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  return skillsByMCPServer;
+}
+
 export async function getToolsUsage(
   auth: Authenticator
-): Promise<MCPServersUsageByAgent> {
-  const owner = auth.workspace();
-
-  // This condition is critical it checks that we can identify the workspace and that the current
-  // auth is a user for this workspace. Checking `auth.isUser()` is critical as it would otherwise
-  // be possible to access data sources without being authenticated.
-  if (!owner || !auth.isUser()) {
-    return {};
-  }
+): Promise<MCPServersUsage> {
+  const owner = auth.getNonNullableWorkspace();
 
   if (DISABLE_QUERIES) {
     return {};
   }
 
+  const visibility: UsageVisibility = auth.isAdmin() ? "all" : "accessible";
   const replicaDb = getFrontReplicaDbConnection();
-
-  const { clause, params } = await buildVisibilityFilter(auth);
+  const { clause, params } = await buildVisibilityFilter(auth, visibility);
 
   // biome-ignore lint/plugin/noRawSql: Read-only analytics query on replica.
-  const rows = await replicaDb.query<MCPServerUsageRow>(
+  const rowsPromise = replicaDb.query<MCPServerUsageRow>(
     `
     SELECT
       msv."internalMCPServerId",
@@ -125,11 +169,30 @@ export async function getToolsUsage(
     `,
     { replacements: params, type: QueryTypes.SELECT }
   );
+  const [rows, skillsByMCPServer] = await Promise.all([
+    rowsPromise,
+    fetchSkillsByMCPServer(auth, visibility),
+  ]);
 
-  const result: MCPServersUsageByAgent = {};
+  const result: MCPServersUsage = {};
   for (const row of rows) {
     const { key, usage } = rowToUsageEntry(row, owner.id);
     result[key] = usage;
   }
+
+  for (const [mcpServerId, skills] of skillsByMCPServer) {
+    const usage = result[mcpServerId];
+    if (usage) {
+      usage.skills = skills;
+      usage.count += skills.length;
+    } else {
+      result[mcpServerId] = {
+        count: skills.length,
+        agents: [],
+        skills,
+      };
+    }
+  }
+
   return result;
 }

--- a/front/lib/api/agent_actions.ts
+++ b/front/lib/api/agent_actions.ts
@@ -151,7 +151,7 @@ export async function getToolsUsage(
   const { clause, params } = await buildVisibilityFilter(auth, visibility);
 
   // biome-ignore lint/plugin/noRawSql: Read-only analytics query on replica.
-  const rowsPromise = replicaDb.query<MCPServerUsageRow>(
+  const rows = await replicaDb.query<MCPServerUsageRow>(
     `
     SELECT
       msv."internalMCPServerId",
@@ -169,10 +169,7 @@ export async function getToolsUsage(
     `,
     { replacements: params, type: QueryTypes.SELECT }
   );
-  const [rows, skillsByMCPServer] = await Promise.all([
-    rowsPromise,
-    fetchSkillsByMCPServer(auth, visibility),
-  ]);
+  const skillsByMCPServer = await fetchSkillsByMCPServer(auth, visibility);
 
   const result: MCPServersUsage = {};
   for (const row of rows) {

--- a/front/lib/api/agent_actions.ts
+++ b/front/lib/api/agent_actions.ts
@@ -24,8 +24,6 @@ interface MCPServerUsageRow {
   pictureUrls: string[];
 }
 
-type UsageVisibility = "all" | "accessible";
-
 /**
  * Returns the list of agent IDs visible to the current user (used for
  * non-admin visibility filtering).
@@ -41,16 +39,13 @@ async function getVisibleAgentIds(auth: Authenticator): Promise<ModelId[]> {
 /**
  * Builds the visibility WHERE clause and query replacements.
  */
-async function buildVisibilityFilter(
-  auth: Authenticator,
-  visibility: UsageVisibility
-): Promise<{
+async function buildVisibilityFilter(auth: Authenticator): Promise<{
   clause: string;
   params: Record<string, unknown>;
 }> {
   const workspaceId = auth.getNonNullableWorkspace().id;
 
-  if (visibility === "all") {
+  if (auth.isAdmin()) {
     return {
       clause: `ac."status" = 'active' AND ac."workspaceId" = :workspace_id`,
       params: { workspace_id: workspaceId },
@@ -96,26 +91,22 @@ function rowToUsageEntry(
 }
 
 async function fetchSkillsByMCPServer(
-  auth: Authenticator,
-  visibility: UsageVisibility
+  auth: Authenticator
 ): Promise<Map<string, UsedBySkillType[]>> {
-  const skills = await SkillResource.listByWorkspace(auth, {
+  const workspaceSkills = await SkillResource.listByWorkspace(auth, {
     status: "active",
     withInstructions: false,
     withTools: true,
     withFileAttachments: false,
   });
+  const skills = auth.isAdmin()
+    ? workspaceSkills
+    : workspaceSkills.filter(
+        (skill) => skill.availability !== "editors" || skill.canWrite(auth)
+      );
 
   const skillsByMCPServer = new Map<string, UsedBySkillType[]>();
   for (const skill of skills) {
-    if (
-      visibility === "accessible" &&
-      skill.availability === "editors" &&
-      !skill.canWrite(auth)
-    ) {
-      continue;
-    }
-
     const usedBySkill: UsedBySkillType = {
       sId: skill.sId,
       name: skill.name,
@@ -146,9 +137,8 @@ export async function getToolsUsage(
     return {};
   }
 
-  const visibility: UsageVisibility = auth.isAdmin() ? "all" : "accessible";
   const replicaDb = getFrontReplicaDbConnection();
-  const { clause, params } = await buildVisibilityFilter(auth, visibility);
+  const { clause, params } = await buildVisibilityFilter(auth);
 
   // biome-ignore lint/plugin/noRawSql: Read-only analytics query on replica.
   const rows = await replicaDb.query<MCPServerUsageRow>(
@@ -169,7 +159,7 @@ export async function getToolsUsage(
     `,
     { replacements: params, type: QueryTypes.SELECT }
   );
-  const skillsByMCPServer = await fetchSkillsByMCPServer(auth, visibility);
+  const skillsByMCPServer = await fetchSkillsByMCPServer(auth);
 
   const result: MCPServersUsage = {};
   for (const row of rows) {

--- a/front/lib/api/agent_actions.ts
+++ b/front/lib/api/agent_actions.ts
@@ -37,7 +37,8 @@ async function getVisibleAgentIds(auth: Authenticator): Promise<ModelId[]> {
 }
 
 /**
- * Builds the visibility WHERE clause and query replacements.
+ * Builds the visibility WHERE clause and query replacements depending on
+ * whether the caller is an admin or a regular user.
  */
 async function buildVisibilityFilter(auth: Authenticator): Promise<{
   clause: string;
@@ -131,13 +132,18 @@ async function fetchSkillsByMCPServer(
 export async function getToolsUsage(
   auth: Authenticator
 ): Promise<MCPServersUsage> {
-  const owner = auth.getNonNullableWorkspace();
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isUser()) {
+    return {};
+  }
 
   if (DISABLE_QUERIES) {
     return {};
   }
 
   const replicaDb = getFrontReplicaDbConnection();
+
   const { clause, params } = await buildVisibilityFilter(auth);
 
   // biome-ignore lint/plugin/noRawSql: Read-only analytics query on replica.

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -17,7 +17,7 @@ import {
   isLightServerSideMCPToolConfiguration,
   isServerSideMCPToolConfiguration,
 } from "@app/lib/actions/types/guards";
-import type { MCPServersUsageByAgent } from "@app/lib/api/agent_actions";
+import type { MCPServersUsage } from "@app/lib/api/agent_actions";
 import type {
   PatchMCPServerBodySchema,
   PostRequestActionsAccessBodySchema,
@@ -228,7 +228,7 @@ export type DeleteMCPServerResponseBody = {
 };
 
 export type GetMCPServersUsageResponseBody = {
-  usage: MCPServersUsageByAgent;
+  usage: MCPServersUsage;
 };
 
 export type SyncMCPServerResponseBody = {

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -17,7 +17,10 @@ import {
   isLightServerSideMCPToolConfiguration,
   isServerSideMCPToolConfiguration,
 } from "@app/lib/actions/types/guards";
-import type { MCPServersUsage } from "@app/lib/api/agent_actions";
+import type {
+  MCPServersUsage,
+  MCPServersUsageByAgent,
+} from "@app/lib/api/agent_actions";
 import type {
   PatchMCPServerBodySchema,
   PostRequestActionsAccessBodySchema,
@@ -228,6 +231,10 @@ export type DeleteMCPServerResponseBody = {
 };
 
 export type GetMCPServersUsageResponseBody = {
+  usage: MCPServersUsageByAgent;
+};
+
+export type GetMCPServersUsageWithSkillsResponseBody = {
   usage: MCPServersUsage;
 };
 

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -13,6 +13,7 @@ import type {
   GetMCPServerResponseBody,
   GetMCPServersResponseBody,
   GetMCPServersUsageResponseBody,
+  GetMCPServersUsageWithSkillsResponseBody,
   GetMCPServerViewsListResponseBody,
   GetMCPServerViewsNotActivatedResponseBody,
   MCPServerType,
@@ -959,9 +960,11 @@ export function useMCPServersUsage({
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
-  const configFetcher: Fetcher<GetMCPServersUsageResponseBody> = fetcher;
+  const configFetcher: Fetcher<
+    GetMCPServersUsageResponseBody | GetMCPServersUsageWithSkillsResponseBody
+  > = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/mcp/usage`,
+    `/api/w/${owner.sId}/mcp/usage?withSkills=true`,
     configFetcher,
     {
       disabled,


### PR DESCRIPTION
## Description

Admins can currently see which agents use an MCP server from Spaces > Tools, but not which skills.

This PR adds the skills in the "Used By" column, with the same design as in "Manage Skills"

<img width="331" height="452" alt="image" src="https://github.com/user-attachments/assets/11e748c2-7fcc-4c73-a14d-56b40522cbbc" />

This change is retro-compatible: the backend keeps sending agents only for now, the new frontend opts into skill usage with `withSkills=true`. Once we don't get any legacy client any more, a follow-up PR will remove the opt-in and have the backend always send both skills and agents.

## Tests

- Added tests.
- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
