### PR TITLE
[AGENT-LOOP] Motivate the model to write an answer when tool use is disabled

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -41,6 +41,7 @@ import type {
   ConversationWithoutContentType,
   UserMessageType,
 } from "@app/types/assistant/conversation";
+import type { UserMessageTypeModel } from "@app/types/assistant/generation";
 import type { WorkspaceType } from "@app/types/user";
 import moment from "moment-timezone";
 
@@ -507,4 +508,27 @@ export function constructPromptMultiActions(
   ].filter((s) => s.content.trim() !== "");
 
   return allSections;
+}
+
+// `tool_choice: "none"` is invisible to the model: it plans a tool call, can't
+// emit one, and ends the turn with only a thinking block, which surfaces as an
+// `empty_content` error. Goes in the messages, not the system prompt, to keep
+// the cached prefix.
+export function renderToolUseDisabledUserMessage(): UserMessageTypeModel {
+  return {
+    role: "user",
+    name: "system",
+    content: [
+      {
+        type: "text",
+        text:
+          "<dust_system>\n" +
+          "Tools are unavailable for this step: you cannot call one, and no further step " +
+          "will run. Write your final answer to the user now, based on what you already " +
+          "have. If you found nothing, could not complete the task, or were blocked, say " +
+          "so explicitly and explain why. Do not end this turn without a written answer.\n" +
+          "</dust_system>",
+      },
+    ],
+  };
 }

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -16,7 +16,10 @@ import { computeStepContexts } from "@app/lib/actions/utils";
 import { createClientSideMCPServerConfigurations } from "@app/lib/api/actions/mcp_client_side";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
 import { categorizeConversationRenderErrorMessage } from "@app/lib/api/assistant/errors";
-import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
+import {
+  constructPromptMultiActions,
+  renderToolUseDisabledUserMessage,
+} from "@app/lib/api/assistant/generation";
 import { buildToolsetsContext } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
 import {
   globalAgentInjectsToolsets,
@@ -703,6 +706,14 @@ export async function runModel(
     });
 
     return null;
+  }
+
+  if (disableToolUse) {
+    // Tool choice "none" alone leaves the model with nothing to do; spell it out
+    // so it writes an answer. Its tokens sit outside the render budget.
+    modelConversationRes.value.modelConversation.messages.push(
+      renderToolUseDisabledUserMessage()
+    );
   }
 
   const { specifications, missingReplayedToolNames } =

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -1049,6 +1049,12 @@ export async function runModel(
         stopReason: stopReason ?? "unknown",
         contentCount: output.contents.length,
         contentTypes: output.contents.map((c) => c.type),
+        reasoningEffort: modelInfo.reasoningEffort,
+        chainOfThoughtLength: (
+          nativeChainOfThought ||
+          contentParser.getChainOfThought() ||
+          ""
+        ).length,
         prunedContext: modelConversationRes.value.prunedContext,
         inputTokens: modelConversationRes.value.tokensUsed,
         toolSearchEnabled,


### PR DESCRIPTION
## Description

Claude Sonnet 4.6 and GPT 5.6 Luna sometimes end a turn with a reasoning block and no text at all — the agent loop then has nothing to publish and surfaces an `empty_content` ("No answer generated") or `max_step_reached` error, even though the model reached a conclusion. `tool_choice: "none"` on those steps (last step, or the retry after an empty one) is invisible to the model, so it plans a tool call, finds it cannot emit one, and goes silent instead: this appends an explicit instruction after the conversation history telling it that tools are unavailable and that it must write an answer — including saying so when it found nothing or was blocked. Also logs `reasoningEffort` and `chainOfThoughtLength` on empty turns so reasoning-only turns are distinguishable from genuinely empty ones.

Next steps: monitor whether we still see "The agent stopped without producing an answer." — the new `reasoningEffort` / `chainOfThoughtLength` fields on the empty-turn log tell us whether the remaining cases are reasoning-only turns or genuinely empty ones.

## Tests

Tested locally by forcing tool use off from the first step.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`