### PR TITLE
[dust-hive] fix: open dhb on the base workspace

### DIFF
--- a/x/henry/dust-hive/completions/dust-hive.bash
+++ b/x/henry/dust-hive/completions/dust-hive.bash
@@ -568,7 +568,7 @@ dhb() {
 
   base="$(_dust_hive_base_port "$query")" || return
   port=$((base + offset))
-  url="http://localhost:${port}"
+  url="http://localhost:${port}/w/DevWkSpace/"
 
   echo "Opening $url"
   open "$url"

--- a/x/henry/dust-hive/completions/dust-hive.zsh
+++ b/x/henry/dust-hive/completions/dust-hive.zsh
@@ -539,7 +539,7 @@ function dhb {
 
   base="$(_dust_hive_base_port "$query")" || return
   port=$((base + offset))
-  url="http://localhost:${port}"
+  url="http://localhost:${port}/w/DevWkSpace/"
 
   echo "Opening $url"
   open "$url"


### PR DESCRIPTION
## Description

`dhb` currently opens the matched environment app root, which does not select a workspace. It now keeps deriving the SPA port from the environment port range and opens `/w/DevWkSpace/` so the browser lands on the base development workspace instead of sometimes redirecting to a random one.

## Tests

- Tested locally with Bash and Zsh using multiple environment base ports.

## Risk

- Low.

## Deploy Plan

- No deploy.