### PR TITLE
[dust-hive] fix: limit dhb completion to warm hives

### DIFF
--- a/x/henry/dust-hive/completions/dust-hive.bash
+++ b/x/henry/dust-hive/completions/dust-hive.bash
@@ -642,7 +642,7 @@ _dhc()  { local COMP_WORDS=("dust-hive" "cool" "${COMP_WORDS[@]:1}"); local COMP
 _dhx()  { local COMP_WORDS=("dust-hive" "spawn" "${COMP_WORDS[@]:1}"); local COMP_CWORD=$(( COMP_CWORD + 1 )); _dust_hive_complete; }
 _dhb() {
   if (( COMP_CWORD == 1 )); then
-    COMPREPLY=($(compgen -W "$(_dust_hive_envs)" -- "${COMP_WORDS[COMP_CWORD]}"))
+    COMPREPLY=($(compgen -W "$(_dust_hive_warm_envs)" -- "${COMP_WORDS[COMP_CWORD]}"))
   fi
 }
 _dhdb() {

--- a/x/henry/dust-hive/completions/dust-hive.zsh
+++ b/x/henry/dust-hive/completions/dust-hive.zsh
@@ -611,7 +611,7 @@ function _dhd  { local words=("dust-hive" "destroy" "${(@)words[2,-1]}"); local 
 function _dhw  { local words=("dust-hive" "warm" "${(@)words[2,-1]}"); local CURRENT=$((CURRENT+1)); _dust-hive; }
 function _dhc  { local words=("dust-hive" "cool" "${(@)words[2,-1]}"); local CURRENT=$((CURRENT+1)); _dust-hive; }
 function _dhx  { local words=("dust-hive" "spawn" "${(@)words[2,-1]}"); local CURRENT=$((CURRENT+1)); _dust-hive; }
-function _dhb  { _arguments '1::worktree:_dust_hive_envs'; }
+function _dhb  { _arguments '1::worktree:_dust_hive_warm_envs'; }
 function _dhdb_database {
   local cur="${words[CURRENT]}"
   local use_unmatched=0


### PR DESCRIPTION
## Description

`dhb` opens a running environment app, but its completion currently suggests stopped and cold environments too. Bash and Zsh completion now reuse the existing warm-environment selector so only warm hives are suggested.

This only changes completion. Manually entered environment names remain accepted.

## Tests

- Tested locally with Bash and Zsh completion helpers.

## Risk

- Low.

## Deploy Plan

- No deploy.