### PR TITLE
Disable agents picking in sidekick conversations

### DIFF
--- a/front/components/agent_builder/AgentBuilderSidekick.tsx
+++ b/front/components/agent_builder/AgentBuilderSidekick.tsx
@@ -85,8 +85,8 @@ function SidekickContent({
       actionsToShow: [
         "attachment",
         ...(subscription.plan.isByok ? [] : ["voice" as const]),
-        "agents-list" as const,
       ] satisfies InputBarAction[],
+      disableAgentMentions: true,
       clientSideMCPServerIds,
       skipToolsValidation: true,
     }),

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -569,6 +569,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
           draftKey={context.draftKey}
           disableAutoFocus={isMobile || hasUserAnswerRequired}
           disableUserMentions={!!agentBuilderContext}
+          disableAgentMentions={agentBuilderContext?.disableAgentMentions === true}
           actions={agentBuilderContext?.actionsToShow}
           isSubmitting={agentBuilderContext?.isSubmitting === true}
           isAgentBuilder={!!agentBuilderContext}

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -569,7 +569,9 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
           draftKey={context.draftKey}
           disableAutoFocus={isMobile || hasUserAnswerRequired}
           disableUserMentions={!!agentBuilderContext}
-          disableAgentMentions={agentBuilderContext?.disableAgentMentions === true}
+          disableAgentMentions={
+            agentBuilderContext?.disableAgentMentions === true
+          }
           actions={agentBuilderContext?.actionsToShow}
           isSubmitting={agentBuilderContext?.isSubmitting === true}
           isAgentBuilder={!!agentBuilderContext}

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -96,6 +96,7 @@ interface InputBarProps {
   actions?: InputBarContainerProps["actions"];
   disableAutoFocus: boolean;
   disableUserMentions?: boolean;
+  disableAgentMentions?: boolean;
   isFloating?: boolean;
   isFloatingWithoutMargin?: boolean;
   isSubmitting?: boolean;
@@ -126,6 +127,7 @@ export const InputBar = React.memo(function InputBar({
   actions = DEFAULT_INPUT_BAR_ACTIONS,
   disableAutoFocus = false,
   disableUserMentions,
+  disableAgentMentions,
   isAgentBuilder = false,
   isFloating = true,
   isSubmitting = false,
@@ -748,6 +750,7 @@ export const InputBar = React.memo(function InputBar({
             actions={actions}
             disableAutoFocus={disableAutoFocus}
             disableUserMentions={disableUserMentions}
+            disableAgentMentions={disableAgentMentions}
             allAgents={activeAgents}
             owner={owner}
             conversation={conversation}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -208,6 +208,10 @@ export interface InputBarContainerProps {
   space?: SpaceType;
   disableAutoFocus: boolean;
   disableUserMentions?: boolean;
+  // When true, agents cannot be mentioned or selected from the editor (no `@`
+  // suggestions, no agent switch on paste). Used to lock a conversation to a
+  // single agent (e.g. the agent builder sidekick).
+  disableAgentMentions?: boolean;
   fileUploaderService: FileUploaderService;
   getDraft: () => {
     text: string;
@@ -279,6 +283,7 @@ const InputBarContainer = ({
   actions,
   disableAutoFocus,
   disableUserMentions,
+  disableAgentMentions,
   isSubmitting,
   fileUploaderService,
   getDraft,
@@ -631,6 +636,9 @@ const InputBarContainer = ({
   );
 
   onFirstAgentMentionPasteRef.current = (agentId: string) => {
+    if (disableAgentMentions) {
+      return;
+    }
     const agent = agentsById.get(agentId);
     if (agent) {
       setSelectedSingleAgent(toRichAgentMentionType(agent));
@@ -740,6 +748,11 @@ const InputBarContainer = ({
     onEnterKeyDown: onEnterKeyDownWithShake,
     disableAutoFocus,
     disableUserMentions,
+    disableAgentMentions,
+    // In the input bar, disabling agent mentions means locking the
+    // conversation to its current agent, so also strip any agent mention that
+    // reaches the document (e.g. pasted content).
+    stripAgentMentions: disableAgentMentions,
     onUrlDetected: handleUrlDetected,
     onAgentSelect: onSingleAgentSelect,
     owner,

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -126,6 +126,9 @@ export type VirtuosoMessageListContext = {
     draftAgent?: LightAgentConfigurationType;
     isSubmitting: boolean;
     actionsToShow: InputBarContainerProps["actions"];
+    // Locks the conversation to its current agent: no `@` agent suggestions
+    // and no agent switch on paste (used by the sidekick).
+    disableAgentMentions?: boolean;
     resetConversation: () => void;
     clientSideMCPServerIds?: string[];
     skipToolsValidation?: boolean;

--- a/front/components/editor/extensions/MentionExtension.test.ts
+++ b/front/components/editor/extensions/MentionExtension.test.ts
@@ -62,6 +62,60 @@ describe("MentionExtension", () => {
     expect(attrs?.type).toBe("agent");
   });
 
+  describe("with stripAgentMentions", () => {
+    let strippingEditor: Editor;
+
+    beforeEach(() => {
+      strippingEditor = EditorFactory([
+        MentionExtension.configure({ stripAgentMentions: true }),
+      ]);
+    });
+
+    afterEach(() => {
+      strippingEditor.destroy();
+    });
+
+    it("should convert agent mentions to plain text", () => {
+      strippingEditor.commands.setContent(
+        "hello :mention[Code Assistant]{sId=agent-123} world",
+        {
+          contentType: "markdown",
+        }
+      );
+
+      const json = strippingEditor.getJSON();
+      expect(json.content).toEqual([
+        {
+          content: [
+            {
+              text: "hello @Code Assistant world",
+              type: "text",
+            },
+          ],
+          type: "paragraph",
+        },
+      ]);
+    });
+
+    it("should keep user mentions", () => {
+      strippingEditor.commands.setContent(
+        ":mention_user[John Doe]{sId=user-456} and :mention[Code Assistant]{sId=agent-123}",
+        {
+          contentType: "markdown",
+        }
+      );
+
+      const json = strippingEditor.getJSON();
+      const nodes = json.content?.[0]?.content ?? [];
+      const mentionNodes = nodes.filter((n) => n.type === "mention");
+      expect(mentionNodes).toHaveLength(1);
+      const attrs =
+        "attrs" in mentionNodes[0] ? mentionNodes[0].attrs : undefined;
+      expect(attrs?.type).toBe("user");
+      expect(strippingEditor.getText()).toContain("@Code Assistant");
+    });
+  });
+
   it("should handle user mention", () => {
     editor.commands.setContent(":mention_user[John Doe]{sId=user-456}", {
       contentType: "markdown",

--- a/front/components/editor/extensions/MentionExtension.tsx
+++ b/front/components/editor/extensions/MentionExtension.tsx
@@ -188,7 +188,10 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
         const agentMentions: { pos: number; nodeSize: number; text: string }[] =
           [];
         newState.doc.descendants((node, pos) => {
-          if (node.type.name === mentionNodeName && node.attrs.type === "agent") {
+          if (
+            node.type.name === mentionNodeName &&
+            node.attrs.type === "agent"
+          ) {
             const label: string = node.attrs.label ?? node.attrs.id ?? "";
             agentMentions.push({
               pos,
@@ -205,7 +208,11 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
         const tr = newState.tr;
         // Replace from last to first so earlier positions stay valid.
         for (const mention of agentMentions.reverse()) {
-          tr.insertText(mention.text, mention.pos, mention.pos + mention.nodeSize);
+          tr.insertText(
+            mention.text,
+            mention.pos,
+            mention.pos + mention.nodeSize
+          );
         }
         return tr;
       },

--- a/front/components/editor/extensions/MentionExtension.tsx
+++ b/front/components/editor/extensions/MentionExtension.tsx
@@ -25,6 +25,10 @@ interface MentionExtensionOptions extends MentionOptions {
   onFirstAgentMentionPasteRef?: RefObject<
     ((agentId: string) => void) | undefined
   >;
+  // When true, agent mention nodes are never allowed in the document: any that
+  // get inserted (paste, drag-drop, markdown content) are converted back to
+  // plain `@label` text. Used to lock a conversation to a single agent.
+  stripAgentMentions?: boolean;
 }
 
 export const MentionExtension = Mention.extend<MentionExtensionOptions>({
@@ -33,6 +37,7 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
       ...this.parent?.(),
       owner: {} as WorkspaceType,
       onFirstAgentMentionPasteRef: undefined,
+      stripAgentMentions: false,
     } as MentionExtensionOptions;
   },
 
@@ -164,11 +169,47 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
   },
 
   addProseMirrorPlugins(this) {
-    const { owner } = this.options;
+    const { owner, stripAgentMentions } = this.options;
     const editor = this.editor;
     const markdownManager = editor.markdown!; // we know it exists because we added the markdown plugin
+    const mentionNodeName = this.name;
 
     const parentPlugins = this.parent?.();
+
+    // Converts any agent mention node that made it into the document (paste,
+    // drag-drop, markdown insertion) back to plain `@label` text, so the
+    // conversation cannot be routed to another agent.
+    const stripAgentMentionsPlugin = new Plugin({
+      appendTransaction: (transactions, _oldState, newState) => {
+        if (!transactions.some((transaction) => transaction.docChanged)) {
+          return null;
+        }
+
+        const agentMentions: { pos: number; nodeSize: number; text: string }[] =
+          [];
+        newState.doc.descendants((node, pos) => {
+          if (node.type.name === mentionNodeName && node.attrs.type === "agent") {
+            const label: string = node.attrs.label ?? node.attrs.id ?? "";
+            agentMentions.push({
+              pos,
+              nodeSize: node.nodeSize,
+              text: `@${label}`,
+            });
+          }
+        });
+
+        if (agentMentions.length === 0) {
+          return null;
+        }
+
+        const tr = newState.tr;
+        // Replace from last to first so earlier positions stay valid.
+        for (const mention of agentMentions.reverse()) {
+          tr.insertText(mention.text, mention.pos, mention.pos + mention.nodeSize);
+        }
+        return tr;
+      },
+    });
     const addedPlugin = new Plugin({
       props: {
         handlePaste: (view, event, slice) => {
@@ -241,7 +282,11 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
       },
     });
 
-    return parentPlugins ? [...parentPlugins, addedPlugin] : [addedPlugin];
+    const addedPlugins = stripAgentMentions
+      ? [addedPlugin, stripAgentMentionsPlugin]
+      : [addedPlugin];
+
+    return parentPlugins ? [...parentPlugins, ...addedPlugins] : addedPlugins;
   },
 
   addKeyboardShortcuts() {

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -320,6 +320,11 @@ export interface CustomEditorProps {
   onInlineText?: (fileId: string, textContent: string) => void;
   // When true, agent suggestions are fully disabled (e.g. edit mode).
   disableAgentMentions?: boolean;
+  // When true, agent mention nodes are stripped from the document (converted
+  // back to plain text). Combined with disableAgentMentions, this locks the
+  // editor to a single agent. Do not set in edit mode, where the original
+  // message's agent mentions must be preserved.
+  stripAgentMentions?: boolean;
   onFirstAgentMentionPasteRef?: React.RefObject<
     ((agentId: string) => void) | undefined
   >;
@@ -352,6 +357,7 @@ export const buildEditorExtensions = ({
   spaceId,
   disableUserMentions,
   disableAgentMentions,
+  stripAgentMentions,
   onInlineText,
   onUrlDetected,
   onAgentSelect,
@@ -365,6 +371,7 @@ export const buildEditorExtensions = ({
   spaceId?: string;
   disableUserMentions?: boolean;
   disableAgentMentions?: boolean;
+  stripAgentMentions?: boolean;
   onInlineText?: (fileId: string, textContent: string) => void;
   onUrlDetected?: (candidate: UrlCandidate | NodeCandidate | null) => void;
   onAgentSelect?: (mention: RichMention) => void;
@@ -440,6 +447,7 @@ export const buildEditorExtensions = ({
     MentionExtension.configure({
       owner,
       onFirstAgentMentionPasteRef,
+      stripAgentMentions,
       HTMLAttributes: {
         class:
           "min-w-0 px-0 py-0 border-none outline-hidden focus:outline-hidden focus:border-none ring-0 focus:ring-0 text-highlight-500 font-semibold",
@@ -520,6 +528,7 @@ const useCustomEditor = ({
   longTextPasteCharsThreshold,
   onInlineText,
   disableAgentMentions,
+  stripAgentMentions,
   onFirstAgentMentionPasteRef,
   slashSuggestion,
   placeholderOverride,
@@ -534,6 +543,7 @@ const useCustomEditor = ({
         spaceId,
         disableUserMentions,
         disableAgentMentions,
+        stripAgentMentions,
         onInlineText,
         onUrlDetected,
         onAgentSelect,

--- a/front/lib/swr/mentions.tsx
+++ b/front/lib/swr/mentions.tsx
@@ -55,6 +55,10 @@ export function useMentionSuggestions({
 
   const searchParams = new URLSearchParams({ query: debouncedSearchQuery });
 
+  // Without any select param the endpoint returns both agents and users, so
+  // skip the fetch entirely when nothing is selectable.
+  const nothingSelectable = !select.agents && !select.users;
+
   if (select.agents) {
     searchParams.append("select", "agents");
   }
@@ -84,12 +88,12 @@ export function useMentionSuggestions({
     revalidateOnReconnect: false,
     // Cache suggestions for 5 minutes
     dedupingInterval: 5 * 60 * 1000,
-    disabled,
+    disabled: disabled || nothingSelectable,
   });
 
   return {
     suggestions: data?.suggestions ?? [],
-    isLoading: !error && !data,
+    isLoading: !error && !data && !(disabled || nothingSelectable),
     isError: !!error,
     mutate,
   };


### PR DESCRIPTION
## Description

Disable the agent picking in sidekick conversations:
 - no picker at the bottom
 - no mentions possible with `@dust`
 - strip agent mention from copy-pasting a mention

There is no reason to switch agent in this context, you should only talk to sidekick

<img width="1720" height="1726" alt="image" src="https://github.com/user-attachments/assets/aea53934-ae74-49b5-a354-9c2c91690153" />


## Tests

tested locally

## Risk

low

## Deploy Plan

deploy front
