### PR TITLE
[Skill Builder] Gate auto-discoverable availability

### DIFF
--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -220,34 +220,19 @@ app.patch(
 
     // With skill publication governance, changing a skill's availability requires the
     // workspace-level permission to publish skills — even for editors.
-    if (hasSkillPublicationGovernance) {
-      if (
-        availabilityChanged &&
-        !(await auth.hasWorkspacePermission("publish", "skill"))
-      ) {
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "app_auth_error",
-            message:
-              "You don't have permission to change this skill's availability.",
-          },
-        });
-      }
-      if (
-        availabilityChanged &&
-        requestedAvailability === "users_and_agents" &&
-        !(await auth.hasWorkspacePermission("make_discoverable", "skill"))
-      ) {
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "app_auth_error",
-            message:
-              "You don't have permission to change this skill's availability to this setting.",
-          },
-        });
-      }
+    if (
+      hasSkillPublicationGovernance &&
+      availabilityChanged &&
+      !(await auth.hasWorkspacePermission("publish", "skill"))
+    ) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message:
+            "You don't have permission to change this skill's availability.",
+        },
+      });
     }
 
     // without make skill discoverable permission, a user can neither make a skill

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -220,19 +220,34 @@ app.patch(
 
     // With skill publication governance, changing a skill's availability requires the
     // workspace-level permission to publish skills — even for editors.
-    if (
-      hasSkillPublicationGovernance &&
-      availabilityChanged &&
-      !(await auth.hasWorkspacePermission("publish", "skill"))
-    ) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "app_auth_error",
-          message:
-            "You don't have permission to change this skill's availability.",
-        },
-      });
+    if (hasSkillPublicationGovernance) {
+      if (
+        availabilityChanged &&
+        !(await auth.hasWorkspacePermission("publish", "skill"))
+      ) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "app_auth_error",
+            message:
+              "You don't have permission to change this skill's availability.",
+          },
+        });
+      }
+      if (
+        availabilityChanged &&
+        requestedAvailability === "users_and_agents" &&
+        !(await auth.hasWorkspacePermission("make_discoverable", "skill"))
+      ) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "app_auth_error",
+            message:
+              "You don't have permission to change this skill's availability to this setting.",
+          },
+        });
+      }
     }
 
     // without make skill discoverable permission, a user can neither make a skill

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -884,6 +884,52 @@ describe("POST /api/w/:wId/skills", () => {
     expect(response.status).toBe(403);
   });
 
+  it("requires the make-discoverable permission to create an auto-discoverable skill", async () => {
+    const { auth, workspace, user } = await setupTest("builder");
+    await grantCreateSkillCapability(workspace, user);
+    await FeatureFlagFactory.basic(auth, "admin_governance_skill_publication");
+
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const publisherGroup = await GroupFactory.regularAuto(
+      workspace,
+      `skill-publisher-${user.sId}`
+    );
+    await GroupFactory.withMembers(adminAuth, publisherGroup, [user]);
+    await GroupPermissionResource.grantTypeWide(adminAuth, {
+      group: publisherGroup,
+      grantType: "publish",
+      resourceType: "skill",
+    });
+
+    const body = {
+      name: "Auto-discoverable Skill",
+      agentFacingDescription: "To use in various situations",
+      userFacingDescription: "A skill",
+      instructions: "Instructions",
+      icon: "PuzzleIcon",
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+      availability: "users_and_agents",
+    };
+
+    let response = await postSkill(workspace, body);
+    expect(response.status).toBe(403);
+
+    await GroupPermissionResource.grantTypeWide(adminAuth, {
+      group: publisherGroup,
+      grantType: "make_discoverable",
+      resourceType: "skill",
+    });
+
+    response = await postSkill(workspace, body);
+    expect(response.status).toBe(200);
+    const responseData = await response.json();
+    expect(responseData.skill.availability).toBe("users_and_agents");
+  });
+
   it("lets an admin create a published skill when governance is on", async () => {
     const { auth, workspace } = await setupTest("admin");
     await FeatureFlagFactory.basic(auth, "admin_governance_skill_publication");

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -323,34 +323,34 @@ app.post(
     // With skill publication governance, explicitly creating a skill already published
     // (anything other than editors-only) requires the workspace-level permission to publish
     // skills. The default availability is exempt so plain creation keeps working.
-    if (hasSkillPublicationGovernance) {
-      if (
-        requestedAvailability !== undefined &&
-        requestedAvailability !== "editors" &&
-        !(await auth.hasWorkspacePermission("publish", "skill"))
-      ) {
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "app_auth_error",
-            message:
-              "You don't have permission to change this skill's availability.",
-          },
-        });
-      }
-      if (
-        requestedAvailability === "users_and_agents" &&
-        !(await auth.hasWorkspacePermission("make_discoverable", "skill"))
-      ) {
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "app_auth_error",
-            message:
-              "You don't have permission to create a skill with that availability.",
-          },
-        });
-      }
+    if (
+      hasSkillPublicationGovernance &&
+      requestedAvailability !== undefined &&
+      requestedAvailability !== "editors" &&
+      !(await auth.hasWorkspacePermission("publish", "skill"))
+    ) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message:
+            "You don't have permission to change this skill's availability.",
+        },
+      });
+    }
+    if (
+      hasSkillPublicationGovernance &&
+      requestedAvailability === "users_and_agents" &&
+      !(await auth.hasWorkspacePermission("make_discoverable", "skill"))
+    ) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message:
+            "You don't have permission to create a skill with that availability.",
+        },
+      });
     }
 
     const availability =

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -323,20 +323,34 @@ app.post(
     // With skill publication governance, explicitly creating a skill already published
     // (anything other than editors-only) requires the workspace-level permission to publish
     // skills. The default availability is exempt so plain creation keeps working.
-    if (
-      hasSkillPublicationGovernance &&
-      requestedAvailability !== undefined &&
-      requestedAvailability !== "editors" &&
-      !(await auth.hasWorkspacePermission("publish", "skill"))
-    ) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "app_auth_error",
-          message:
-            "You don't have permission to change this skill's availability.",
-        },
-      });
+    if (hasSkillPublicationGovernance) {
+      if (
+        requestedAvailability !== undefined &&
+        requestedAvailability !== "editors" &&
+        !(await auth.hasWorkspacePermission("publish", "skill"))
+      ) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "app_auth_error",
+            message:
+              "You don't have permission to change this skill's availability.",
+          },
+        });
+      }
+      if (
+        requestedAvailability === "users_and_agents" &&
+        !(await auth.hasWorkspacePermission("make_discoverable", "skill"))
+      ) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "app_auth_error",
+            message:
+              "You don't have permission to create a skill with that availability.",
+          },
+        });
+      }
     }
 
     const availability =


### PR DESCRIPTION
## Description

Require the `make_discoverable` skill permission, in addition to publication permission, when the skill builder creates a skill with availability set to users and agents. This keeps auto-discoverability under the dedicated governance setting.

## Risks

Blast radius: Skill creation when skill publication governance is enabled.
Risk: low

## Deploy Plan

- deploy front-api

## Tests

- [x] Private skill POST endpoint test suite (40 tests)