### PR TITLE
Persist the run linkage on agent step content for consumption attribution

### DIFF
--- a/front/lib/api/assistant/agent_message_consumption_attribution/attribution_builder.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/attribution_builder.ts
@@ -1,3 +1,8 @@
+// This module explains the relative composition of an agent message's cost. It does not
+// reproduce the bill: the authoritative charge is the Metronome AWU amount, rounded up per
+// execution. These attributed micro-credits are un-rounded and cache-naive, so they are not
+// expected to sum to the billed amount. Their job is to rank what drove the cost, not to
+// reconcile euros.
 import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
 import { MODEL_COST_MICRO_USD_PER_AWU_CREDIT } from "@app/lib/metronome/constants";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
@@ -88,8 +93,12 @@ function creditAmountMicroFromCostMicroUsd(costMicroUsd: number): number {
 }
 
 /**
- * Derives cache-naive input and output rates from model pricing. Empty usages use one token for the
- * rate calculation to avoid division by zero.
+ * Derives input and output rates from model pricing, intentionally cache-naive: every token is
+ * priced at full rate. We do not try to attribute cache discounts to individual items because
+ * reconstructing which tokens were served from cache is too hard to do fairly. The bet is that
+ * every token is paid in full at least once, so full-price attribution is a fair floor for what a
+ * component costs, and it ranks cost drivers correctly even though it overstates absolute credits.
+ * Empty usages use one token for the rate calculation to avoid division by zero.
  */
 function getRunTokenRates(usage: RunUsageForAttribution): {
   inputCostMicroUsdPerToken: number;

--- a/front/lib/models/agent/agent_message_consumption_item.ts
+++ b/front/lib/models/agent/agent_message_consumption_item.ts
@@ -73,6 +73,11 @@ function validateConsumptionItemShape(
   }
 }
 
+// Each row explains one component of an agent message's cost (a model token bucket or a tool
+// call). The credit amounts here are an attribution ledger, not the bill: they are un-rounded
+// micro-credits priced cache-naive, whereas the authoritative charge is the Metronome AWU amount
+// rounded up per execution. These rows are not expected to sum to the billed amount; they rank
+// what drove the cost. See attribution_builder.ts for the pricing rationale.
 export class AgentMessageConsumptionItemModel extends WorkspaceAwareModel<AgentMessageConsumptionItemModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;

--- a/front/lib/models/agent/agent_step_content.ts
+++ b/front/lib/models/agent/agent_step_content.ts
@@ -15,6 +15,11 @@ export class AgentStepContentModel extends WorkspaceAwareModel<AgentStepContentM
   declare version: number;
   declare type: AgentContentItemType["type"];
   declare value: AgentContentItemType;
+  // dustRunId of the model run that emitted this content. Anchors consumption attribution: it lets
+  // an async job map a RunUsage (RunModel.dustRunId) to the step contents that run produced.
+  // Nullable: backfilled null for existing rows, and content not produced by a model run may lack
+  // one. Not indexed on purpose: the job fetches by agentMessageId then groups by dustRunId.
+  declare dustRunId: string | null;
 
   declare agentMessage?: NonAttribute<AgentMessageModel>;
 }
@@ -70,6 +75,10 @@ AgentStepContentModel.init(
     value: {
       type: DataTypes.JSONB,
       allowNull: false,
+    },
+    dustRunId: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
   },
   {

--- a/front/lib/resources/agent_step_content/cache.ts
+++ b/front/lib/resources/agent_step_content/cache.ts
@@ -7,8 +7,10 @@ import groupBy from "lodash/groupBy";
 
 export const AGENT_STEP_CONTENT_CACHE_TTL_MS = 2 * 60 * 60 * 1000; // 2 hours
 
-// Bump the `:v1` suffix any time the cached value shape changes, so stale entries
-// from previous formats are orphaned instead of mis-parsed.
+// Bump the version any time the cached value shape changes, so stale entries from previous formats
+// are orphaned instead of mis-parsed.
+const AGENT_STEP_CONTENT_CACHE_VERSION = 2;
+
 export function agentStepContentCacheKey({
   workspaceId,
   agentMessageId,
@@ -16,7 +18,7 @@ export function agentStepContentCacheKey({
   workspaceId: ModelId;
   agentMessageId: ModelId;
 }): string {
-  return `agent_step_contents:w:${workspaceId}:am:${agentMessageId}:v1`;
+  return `agent_step_contents:w:${workspaceId}:am:${agentMessageId}:v${AGENT_STEP_CONTENT_CACHE_VERSION}`;
 }
 
 export function agentStepContentHashField({
@@ -38,6 +40,7 @@ export type CachedAgentStepContent = {
   version: number;
   type: AgentContentItemType["type"];
   value: AgentContentItemType;
+  dustRunId: string | null;
   createdAt: string;
   updatedAt: string;
 };
@@ -155,6 +158,7 @@ function isCachedAgentStepContent(
     typeof v.type === "string" &&
     v.value !== null &&
     typeof v.value === "object" &&
+    (v.dustRunId === null || typeof v.dustRunId === "string") &&
     typeof v.createdAt === "string" &&
     typeof v.updatedAt === "string"
   );
@@ -269,30 +273,4 @@ export async function tryHydrateAgentStepContentsFromCache({
     );
     return null;
   }
-}
-
-export function toCachedAgentStepContent(blob: {
-  id: ModelId;
-  workspaceId: ModelId;
-  agentMessageId: ModelId;
-  step: number;
-  index: number;
-  version: number;
-  type: AgentContentItemType["type"];
-  value: AgentContentItemType;
-  createdAt: Date;
-  updatedAt: Date;
-}): CachedAgentStepContent {
-  return {
-    id: blob.id,
-    workspaceId: blob.workspaceId,
-    agentMessageId: blob.agentMessageId,
-    step: blob.step,
-    index: blob.index,
-    version: blob.version,
-    type: blob.type,
-    value: blob.value,
-    createdAt: blob.createdAt.toISOString(),
-    updatedAt: blob.updatedAt.toISOString(),
-  };
 }

--- a/front/lib/resources/agent_step_content_resource.test.ts
+++ b/front/lib/resources/agent_step_content_resource.test.ts
@@ -440,4 +440,56 @@ describe("AgentStepContentResource.createNewVersions", () => {
     const created = await AgentStepContentResource.createNewVersions([]);
     expect(created).toEqual([]);
   });
+
+  it("persists dustRunId (null when omitted) through the cache and Postgres", async () => {
+    const created = await AgentStepContentResource.createNewVersions([
+      {
+        workspaceId,
+        agentMessageId: agentMessage.id,
+        step: 0,
+        index: 0,
+        type: "text_content",
+        value: makeTextContent("emitted by a run"),
+        dustRunId: "dust_run_abc",
+      },
+      {
+        workspaceId,
+        agentMessageId: agentMessage.id,
+        step: 0,
+        index: 1,
+        type: "text_content",
+        value: makeTextContent("no run"),
+        // dustRunId omitted -> stored as null.
+      },
+    ]);
+
+    expect(
+      created.toSorted((a, b) => a.index - b.index).map((c) => c.dustRunId)
+    ).toEqual(["dust_run_abc", null]);
+
+    // Cache path: createNewVersions warms Redis, so this fetch is served from it.
+    const fromCache = await AgentStepContentResource.fetchByAgentMessages(
+      authenticator,
+      { agentMessageIds: [agentMessage.id] }
+    );
+    expect(
+      fromCache.toSorted((a, b) => a.index - b.index).map((c) => c.dustRunId)
+    ).toEqual(["dust_run_abc", null]);
+
+    // Postgres path: bust the cache so the next fetch reads the persisted rows.
+    const redis = await getRedisCacheClient({
+      origin: "agent_step_content_cache",
+    });
+    await redis.del(
+      agentStepContentCacheKey({ workspaceId, agentMessageId: agentMessage.id })
+    );
+
+    const fromPostgres = await AgentStepContentResource.fetchByAgentMessages(
+      authenticator,
+      { agentMessageIds: [agentMessage.id] }
+    );
+    expect(
+      fromPostgres.toSorted((a, b) => a.index - b.index).map((c) => c.dustRunId)
+    ).toEqual(["dust_run_abc", null]);
+  });
 });

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -3,9 +3,8 @@ import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
+import type { CachedAgentStepContent } from "@app/lib/resources/agent_step_content/cache";
 import {
-  type CachedAgentStepContent,
-  toCachedAgentStepContent,
   tryHydrateAgentStepContentsFromCache,
   warmAgentStepContentCacheMany,
 } from "@app/lib/resources/agent_step_content/cache";
@@ -180,9 +179,27 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       version: cached.version,
       type: cached.type,
       value: cached.value,
+      dustRunId: cached.dustRunId,
       createdAt: new Date(cached.createdAt),
       updatedAt: new Date(cached.updatedAt),
     });
+  }
+
+  // Serialize into the Redis cache shape. Inverse of `fromCached`.
+  private toCachedJSON(): CachedAgentStepContent {
+    return {
+      id: this.id,
+      workspaceId: this.workspaceId,
+      agentMessageId: this.agentMessageId,
+      step: this.step,
+      index: this.index,
+      version: this.version,
+      type: this.type,
+      value: this.value,
+      dustRunId: this.dustRunId,
+      createdAt: this.createdAt.toISOString(),
+      updatedAt: this.updatedAt.toISOString(),
+    };
   }
 
   private static async fetchByAgentMessagesFromPostgres(
@@ -393,7 +410,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
 
     // Re-warm so the next fetch within the TTL can skip TOAST.
     void warmAgentStepContentCacheMany(
-      missResources.map((r) => toCachedAgentStepContent(r))
+      missResources.map((r) => r.toCachedJSON())
     );
 
     return [...hitResources, ...missResources].toSorted(
@@ -548,9 +565,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       (row) => new AgentStepContentResource(this.model, row.get())
     );
 
-    await warmAgentStepContentCacheMany(
-      resources.map((r) => toCachedAgentStepContent(r))
-    );
+    await warmAgentStepContentCacheMany(resources.map((r) => r.toCachedJSON()));
 
     return resources;
   }

--- a/front/migrations/pre-deploy/20260731105444_add_dust_run_id_to_agent_step_contents.sql
+++ b/front/migrations/pre-deploy/20260731105444_add_dust_run_id_to_agent_step_contents.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_step_contents" ADD COLUMN "dustRunId" character varying(255) COLLATE "pg_catalog"."default";

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -1001,6 +1001,9 @@ export async function runModel(
       index,
       type: content.type,
       value: content,
+      // Same run id appended to AgentMessage.runIds below. Lets consumption attribution join a
+      // RunUsage (RunModel.dustRunId) to the contents this run emitted.
+      dustRunId,
     }))
   );
 
@@ -1268,6 +1271,7 @@ export async function runModel(
         internalMCPServerId: mcpServerView.internalMCPServerId,
         inputSchema: {},
         availability: "auto_hidden_builder",
+
         permission: "never_ask",
         toolServerId: mcpServerView.internalMCPServerId,
         mcpServerName: "missing_action_catcher" as InternalMCPServerNameType,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Consumption attribution needs to explain what drove a message's cost, split across prompt tokens, generated tokens, reasoning and each tool call. That breakdown is computed asynchronously after the message completes, since it tokenizes text through core and has no business on the agent loop. To attribute a recorded run usage to the content it produced, the job needs a link that the schema doesn't have today: usage rows point only to a run, and generated contents point nowhere back.

This adds that link. Each generated content now stores the identifier of the model run that emitted it, written in the loop from the same value the message already records, so the two are guaranteed to match. The job can then group a message's contents by run and hand each run's usage and contents to the attribution builder.

Only interactive model output carries the identifier. Synthetic content, tool result text, errors and the batch path leave it empty, and title generation and compaction stay out of scope. Run grain is enough because one interactive run records exactly one usage. It keys on the run identifier, not the step number, which is reused across versions and re-executions. The column is unindexed since the job reaches these rows through the message.

The cache shape learned the field and its version was bumped so stale entries are dropped.

The migration is a pre-deploy nullable column, no backfill.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] Apply SQL migration
- [ ] Deploy front
