### PR TITLE
fix: show revoked frame-grant email in audit logs

### DIFF
--- a/front-api/routes/w/[wId]/files/[fileId]/share/grants.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/share/grants.test.ts
@@ -267,7 +267,7 @@ describe("sharing grants endpoint", () => {
         action: "frame.email_grant_revoked",
         metadata: {
           frame_name: "test-frame.tsx",
-          grant_id: String(grantId),
+          email: "alice@example.com",
         },
         targets: [
           expect.objectContaining({ type: "workspace", id: workspace.sId }),

--- a/front-api/routes/w/[wId]/files/[fileId]/share/grants.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/share/grants.ts
@@ -191,7 +191,7 @@ app.delete(
       context: getAuditLogContext(auth),
       metadata: {
         frame_name: file.fileName ?? file.sId,
-        grant_id: String(grantId),
+        email: result.value.email,
       },
     });
 

--- a/front/admin/audit_log_schemas/frame.email_grant_revoked.json
+++ b/front/admin/audit_log_schemas/frame.email_grant_revoked.json
@@ -6,7 +6,7 @@
   ],
   "metadata": {
     "frame_name": "string",
-    "grant_id": "string",
+    "email": "string",
     "actor_type": "string"
   }
 }

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -31,7 +31,7 @@
   "file.moved": 1,
   "frame.authorized_files_updated": 1,
   "frame.email_grant_added": 2,
-  "frame.email_grant_revoked": 2,
+  "frame.email_grant_revoked": 3,
   "frame.share_scope_updated": 2,
   "group.advanced_model_access_updated": 1,
   "group.member_added": 1,

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -2082,7 +2082,7 @@ export class FileResource extends BaseResource<FileModel> {
     grantId,
   }: {
     grantId: ModelId;
-  }): Promise<Result<undefined, DustError>> {
+  }): Promise<Result<{ email: string }, DustError>> {
     assert(
       this.isInteractiveContent,
       "revokeSharingGrant requires interactive content file"
@@ -2106,7 +2106,7 @@ export class FileResource extends BaseResource<FileModel> {
 
     await grant.update({ revokedAt: new Date() });
 
-    return new Ok(undefined);
+    return new Ok({ email: grant.email });
   }
 
   static async recordGrantView(


### PR DESCRIPTION
Replaces the opaque `grant_id` metadata on `frame.email_grant_revoked` with the revoked grantee email.

The revoke resource returns the email from the same row it revokes; the WorkOS schema is registered at v3 and the version map is included.

Validation:
- Biome
- audit-schema lint
- focused test is blocked locally before collection by the existing missing `@novu/framework` dependency