### PR TITLE
[marketing] promo banner for Dust for GTM Engineers event

### DIFF
--- a/marketing/components/home/PromoBanner.tsx
+++ b/marketing/components/home/PromoBanner.tsx
@@ -6,15 +6,15 @@ import { useEffect, useState } from "react";
 // Set to null when there's nothing to promote.
 // =============================================================================
 const CURRENT_PROMO: PromoConfig | null = {
-  id: "dust-for-solutions-engineers-jul30",
+  id: "dust-for-gtm-engineers-aug5",
   image: "/static/landing/GTM_Engineers_Webinar_Banner.png",
-  link: "https://watch.getcontrast.io/register/dust-dust-for-solutions-engineers?utm_source=website",
+  link: "https://watch.getcontrast.io/register/dust-dust-for-gtm-engineers-2?utm_source=website",
   badge: "Online Event",
-  title: "Dust for Solutions Engineers",
-  time: "July 30 · 9:00am PT / 6:00pm CET",
+  title: "Dust for GTM Engineers",
+  time: "August 5 · 9:00am PT / 6:00pm CET",
   linkLabel: "Register Now",
-  // Banner auto-hides after this date (a few hours after the July 30th event).
-  expiresAt: new Date("2026-07-30T13:00:00-07:00"),
+  // Banner auto-hides after this date (a few hours after the August 5th event).
+  expiresAt: new Date("2026-08-05T13:00:00-07:00"),
 };
 // =============================================================================
 


### PR DESCRIPTION
## Description

Updates the marketing promo banner to advertise the upcoming **Dust for GTM Engineers** online event (August 5) replacing the previous **Dust for Solutions Engineers** event (July 30). Updates the event id, registration link, title, date, and banner expiry accordingly.

## Tests

Visual check on the marketing site — the banner should display the new event title, date, and registration link, and auto-hide after August 5 at 1:00 PM PT.

## Risk

None — config-only change to a banner component.

## Deploy Plan

Deploy marketing