### PR TITLE
Skip indexing conversations exceeding size limit in projects datasource

### DIFF
--- a/connectors/src/connectors/dust_project/lib/sync_conversation.ts
+++ b/connectors/src/connectors/dust_project/lib/sync_conversation.ts
@@ -3,6 +3,7 @@ import {
   upsertDataSourceDocument,
   upsertDataSourceFolder,
 } from "@connectors/lib/data_sources";
+import { DataSourceQuotaExceededError } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
 import { DustProjectConversationResource } from "@connectors/resources/dust_project_conversation_resource";
 import type { DataSourceConfig, ModelId } from "@connectors/types";
@@ -310,6 +311,13 @@ export async function syncConversation({
 
     localLogger.info({ totalParts }, "Successfully synced conversation");
   } catch (error) {
+    if (error instanceof DataSourceQuotaExceededError) {
+      localLogger.warn(
+        { error },
+        "Skipping conversation exceeding plan document size limit."
+      );
+      return;
+    }
     localLogger.error({ error }, "Failed to sync conversation");
     throw error;
   }


### PR DESCRIPTION
## Description

Following the same pattern as #19116 for Intercom, this skips conversations exceeding the plan's document size limit in the dust_project connector instead of letting DataSourceQuotaExceededError propagate. Previously, a single oversized conversation caused dustProjectConversationsFullSyncActivity to fail on every retry, permanently blocking the full sync workflow. The skipped conversation is logged with a warning and simply omitted from the data source until the plan limit is raised.


## Tests

not tested

## Risk

easy to revert
very large conversations won't be indexed in project

## Deploy Plan

deploy connector
