### PR TITLE
fix: display updated skill editors after saving

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -188,6 +188,8 @@ export default function SkillBuilder({ skill, onSaved }: SkillBuilderProps) {
       type: "success",
     });
 
+    await mutateEditors({ editors: data.editors }, { revalidate: false });
+
     onSaved();
 
     if (isCreatingNew && result.value.sId) {


### PR DESCRIPTION
## Description

This PR fixes a bug where the skill editors list was not refreshed in the UI after saving a skill.

- After a successful save, `mutateEditors` is called with the updated editors data returned from the API response, with `revalidate: false` to avoid an unnecessary refetch.

## Tests

Manually.

## Risks

Low.

## Deploy Plan

Standard deployment.