### PR TITLE
[Skills] Restricted skills fix scoping

### DIFF
--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -853,6 +853,63 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
     expect(data.skill.requestedSpaceIds).toContain(restrictedSpace.sId);
   });
 
+  it("rejects restricting a skill to two different Pods via additionalRequestedSpaceIds", async () => {
+    const { workspace, skill, globalGroup } = await setupTest({
+      requestUserRole: "admin",
+    });
+
+    const podA = await SpaceFactory.project(workspace);
+    await GroupSpaceFactory.associate(podA, globalGroup);
+    const podB = await SpaceFactory.project(workspace);
+    await GroupSpaceFactory.associate(podB, globalGroup);
+
+    const response = await patchSkill(workspace, skill.sId, {
+      name: skill.name,
+      agentFacingDescription: skill.agentFacingDescription,
+      userFacingDescription: skill.userFacingDescription,
+      instructions: skill.instructions,
+      icon: null,
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+      additionalRequestedSpaceIds: [podA.sId, podB.sId],
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("rejects restricting a skill to a Pod that already references a skill scoped to a different Pod", async () => {
+    const { workspace, skill, requestUserAuth, globalGroup } = await setupTest({
+      requestUserRole: "admin",
+    });
+
+    const podA = await SpaceFactory.project(workspace);
+    await GroupSpaceFactory.associate(podA, globalGroup);
+    const podB = await SpaceFactory.project(workspace);
+    await GroupSpaceFactory.associate(podB, globalGroup);
+
+    const childSkill = await SkillFactory.create(requestUserAuth, {
+      name: "Pod B Skill",
+      requestedSpaceIds: [podB.id],
+    });
+
+    const response = await patchSkill(workspace, skill.sId, {
+      name: skill.name,
+      agentFacingDescription: skill.agentFacingDescription,
+      userFacingDescription: skill.userFacingDescription,
+      instructions: `Use ${SkillFactory.serializeSkillReferenceTag(childSkill)}.`,
+      icon: null,
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+      additionalRequestedSpaceIds: [podA.sId],
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
   it("should preserve existing additional requested spaces when omitted", async () => {
     const { workspace, skill, requestUserAuth, globalGroup } = await setupTest({
       requestUserRole: "admin",

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -3,6 +3,7 @@ import {
   findSkillEditorsWithoutSpaceAccess,
   getReferencedSkillSpaceModelIds,
   resolveAdditionalRequestedSpaceModelIds,
+  validateAtMostOnePodSpace,
 } from "@app/lib/api/skills/space_requirements";
 import { hasFeatureFlag } from "@app/lib/auth";
 import { pruneOutdatedSkillEditSuggestions } from "@app/lib/reinforcement/skill_suggestion_pruning";
@@ -408,6 +409,20 @@ app.patch(
       ...referencedSkillSpaceIds,
       ...additionalRequestedSpaceIds,
     ]);
+
+    const podSpaceValidation = await validateAtMostOnePodSpace(
+      auth,
+      requestedSpaceIds
+    );
+    if (podSpaceValidation.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: podSpaceValidation.error.message,
+        },
+      });
+    }
 
     // Adding a restricted space can lock out editors that are already on the skill. `updateSkill`
     // also makes the caller an editor, so they are part of the set to validate.

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -410,10 +410,11 @@ app.patch(
       ...additionalRequestedSpaceIds,
     ]);
 
-    const podSpaceValidation = await validateAtMostOnePodSpace(
+    const requestedSpaces = await SpaceResource.fetchByModelIds(
       auth,
       requestedSpaceIds
     );
+    const podSpaceValidation = validateAtMostOnePodSpace(requestedSpaces);
     if (podSpaceValidation.isErr()) {
       return apiError(ctx, {
         status_code: 400,

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -554,7 +554,7 @@ describe("GET /api/w/:wId/skills", () => {
       requestedSpaceIds: [otherPodSpace.id],
     });
 
-    const response = await getSkills(workspace, { podSpaceId: podSpace.sId });
+    const response = await getSkills(workspace, { podId: podSpace.sId });
 
     expect(response.status).toBe(200);
     const skillNames = (await response.json()).skills.map(
@@ -595,6 +595,20 @@ describe("GET /api/w/:wId/skills", () => {
     expect(skillNames).toContain("Global Skill");
     expect(skillNames).toContain("Regular Space Skill");
     expect(skillNames).not.toContain("Pod-Scoped Skill");
+  });
+
+  it("rejects combining globalSpaceOnly with podId as mutually exclusive scopes", async () => {
+    const { workspace, user, auth } = await setupTest("admin");
+
+    await SpaceFactory.defaults(auth);
+    const podSpace = await SpaceFactory.project(workspace, user.id);
+
+    const response = await getSkills(workspace, {
+      globalSpaceOnly: "true",
+      podId: podSpace.sId,
+    });
+
+    expect(response.status).toBe(400);
   });
 
   it("should not return instructions or tools in skill list", async () => {

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -536,6 +536,67 @@ describe("GET /api/w/:wId/skills", () => {
     expect(globalNames).not.toContain("Member Restricted Skill");
   });
 
+  it("with podSpaceId, includes global and that Pod's own skills but hides a different Pod's skill", async () => {
+    const { workspace, user, auth } = await setupTest("admin");
+
+    await SpaceFactory.defaults(auth);
+
+    const podSpace = await SpaceFactory.project(workspace, user.id);
+    const otherPodSpace = await SpaceFactory.project(workspace, user.id);
+
+    await SkillFactory.create(auth, { name: "Global Skill" });
+    await SkillFactory.create(auth, {
+      name: "Pod-Scoped Skill",
+      requestedSpaceIds: [podSpace.id],
+    });
+    await SkillFactory.create(auth, {
+      name: "Other Pod Skill",
+      requestedSpaceIds: [otherPodSpace.id],
+    });
+
+    const response = await getSkills(workspace, { podSpaceId: podSpace.sId });
+
+    expect(response.status).toBe(200);
+    const skillNames = (await response.json()).skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
+    expect(skillNames).toContain("Global Skill");
+    expect(skillNames).toContain("Pod-Scoped Skill");
+    expect(skillNames).not.toContain("Other Pod Skill");
+  });
+
+  it("with excludePodScopedSkills=true, hides every Pod-scoped skill but keeps global and non-Pod-restricted skills", async () => {
+    const { workspace, user, auth } = await setupTest("admin");
+
+    await SpaceFactory.defaults(auth);
+
+    const podSpace = await SpaceFactory.project(workspace, user.id);
+    const regularSpace = await SpaceFactory.regular(workspace);
+    await regularSpace.addMembers(auth, { userIds: [user.sId] });
+
+    await SkillFactory.create(auth, { name: "Global Skill" });
+    await SkillFactory.create(auth, {
+      name: "Pod-Scoped Skill",
+      requestedSpaceIds: [podSpace.id],
+    });
+    await SkillFactory.create(auth, {
+      name: "Regular Space Skill",
+      requestedSpaceIds: [regularSpace.id],
+    });
+
+    const response = await getSkills(workspace, {
+      excludePodScopedSkills: "true",
+    });
+
+    expect(response.status).toBe(200);
+    const skillNames = (await response.json()).skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
+    expect(skillNames).toContain("Global Skill");
+    expect(skillNames).toContain("Regular Space Skill");
+    expect(skillNames).not.toContain("Pod-Scoped Skill");
+  });
+
   it("should not return instructions or tools in skill list", async () => {
     const { workspace, auth, user } = await setupTest();
 
@@ -1402,6 +1463,61 @@ describe("POST /api/w/:wId/skills", () => {
     expect(response.status).toBe(200);
     const responseData = await response.json();
     expect(responseData.skill.requestedSpaceIds).toContain(openPod.sId);
+  });
+
+  it("rejects a skill restricted to two different Pods via additionalRequestedSpaceIds", async () => {
+    const { workspace, globalGroup, user } = await setupTest("builder");
+    await grantCreateSkillCapability(workspace, user);
+
+    const podA = await SpaceFactory.project(workspace);
+    await GroupSpaceFactory.associate(podA, globalGroup);
+    const podB = await SpaceFactory.project(workspace);
+    await GroupSpaceFactory.associate(podB, globalGroup);
+
+    const response = await postSkill(workspace, {
+      name: "Skill Restricted To Two Pods",
+      agentFacingDescription: "To use with two Pods",
+      userFacingDescription: "A skill with two selected Pods",
+      instructions: "Simple instructions",
+      icon: "PuzzleIcon",
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+      additionalRequestedSpaceIds: [podA.sId, podB.sId],
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("rejects a skill restricted to a Pod that already references a skill scoped to a different Pod", async () => {
+    const { auth, workspace, globalGroup, user } = await setupTest("builder");
+    await grantCreateSkillCapability(workspace, user);
+
+    const podA = await SpaceFactory.project(workspace);
+    await GroupSpaceFactory.associate(podA, globalGroup);
+    const podB = await SpaceFactory.project(workspace);
+    await GroupSpaceFactory.associate(podB, globalGroup);
+
+    const childSkill = await SkillFactory.create(auth, {
+      name: "Pod B Skill",
+      requestedSpaceIds: [podB.id],
+    });
+
+    const response = await postSkill(workspace, {
+      name: "Parent Skill",
+      agentFacingDescription: "To use with another skill",
+      userFacingDescription: "A skill with a conflicting Pod reference",
+      instructions: `Start with ${SkillFactory.serializeSkillReferenceTag(childSkill)}.`,
+      icon: "PuzzleIcon",
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+      additionalRequestedSpaceIds: [podA.sId],
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
   });
 
   it("creates a skill configuration with 2 tools", async () => {

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -3,12 +3,14 @@ import { AttachedKnowledgeSchema } from "@app/lib/api/skills/schemas";
 import {
   getReferencedSkillSpaceModelIds,
   resolveAdditionalRequestedSpaceModelIds,
+  validateAtMostOnePodSpace,
 } from "@app/lib/api/skills/space_requirements";
 import { hasFeatureFlag } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import type {
   GetSkillsResponseBody,
@@ -133,6 +135,9 @@ app.get(
     const withMessageCount = ctx.req.query("withMessageCount") === "true";
     const status = ctx.req.query("status");
     const globalSpaceOnly = ctx.req.query("globalSpaceOnly");
+    const podSpaceId = ctx.req.query("podSpaceId");
+    const excludePodScopedSkills =
+      ctx.req.query("excludePodScopedSkills") === "true";
     const onlyCustom = ctx.req.query("onlyCustom");
     // @deprecated Use availability instead. Kept while old clients still send it.
     const isDefault = ctx.req.query("isDefault");
@@ -183,9 +188,27 @@ app.get(
       });
     }
 
+    let resolvedPodSpaceId: number | null | undefined;
+    if (podSpaceId) {
+      const podSpace = await SpaceResource.fetchById(auth, podSpaceId);
+      if (!podSpace) {
+        return apiError(ctx, {
+          status_code: 404,
+          api_error: {
+            type: "space_not_found",
+            message: `Space "${podSpaceId}" was not found.`,
+          },
+        });
+      }
+      resolvedPodSpaceId = podSpace.id;
+    } else if (excludePodScopedSkills) {
+      resolvedPodSpaceId = null;
+    }
+
     const allSkills = await SkillResource.listByWorkspace(auth, {
       status: skillStatus,
       globalSpaceOnly: globalSpaceOnly === "true",
+      podSpaceId: resolvedPodSpaceId,
       onlyCustom: onlyCustom === "true",
       availability,
       withInstructions: false,
@@ -478,6 +501,20 @@ app.post(
       ...referencedSkillSpaceIds,
       ...additionalRequestedSpaceIdsRes.value,
     ]);
+
+    const podSpaceValidation = await validateAtMostOnePodSpace(
+      auth,
+      requestedSpaceIds
+    );
+    if (podSpaceValidation.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: podSpaceValidation.error.message,
+        },
+      });
+    }
 
     // Validate file attachments if provided.
     let files: FileResource[] | undefined;

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -188,7 +188,7 @@ app.get(
       });
     }
 
-    let resolvedPodSpaceId: number | null | undefined;
+    let resolvedPodSpaceModelId: number | null | undefined;
     if (podSpaceId) {
       const podSpace = await SpaceResource.fetchById(auth, podSpaceId);
       if (!podSpace) {
@@ -200,15 +200,15 @@ app.get(
           },
         });
       }
-      resolvedPodSpaceId = podSpace.id;
+      resolvedPodSpaceModelId = podSpace.id;
     } else if (excludePodScopedSkills) {
-      resolvedPodSpaceId = null;
+      resolvedPodSpaceModelId = null;
     }
 
     const allSkills = await SkillResource.listByWorkspace(auth, {
       status: skillStatus,
       globalSpaceOnly: globalSpaceOnly === "true",
-      podSpaceId: resolvedPodSpaceId,
+      podSpaceModelId: resolvedPodSpaceModelId,
       onlyCustom: onlyCustom === "true",
       availability,
       withInstructions: false,
@@ -502,10 +502,11 @@ app.post(
       ...additionalRequestedSpaceIdsRes.value,
     ]);
 
-    const podSpaceValidation = await validateAtMostOnePodSpace(
+    const requestedSpaces = await SpaceResource.fetchByModelIds(
       auth,
       requestedSpaceIds
     );
+    const podSpaceValidation = validateAtMostOnePodSpace(requestedSpaces);
     if (podSpaceValidation.isErr()) {
       return apiError(ctx, {
         status_code: 400,

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -9,6 +9,7 @@ import { hasFeatureFlag } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type { SkillSpaceScopeFilter } from "@app/lib/resources/skill/skill_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
@@ -134,8 +135,10 @@ app.get(
     const withRelations = ctx.req.query("withRelations");
     const withMessageCount = ctx.req.query("withMessageCount") === "true";
     const status = ctx.req.query("status");
-    const globalSpaceOnly = ctx.req.query("globalSpaceOnly");
-    const podSpaceId = ctx.req.query("podSpaceId");
+    const globalSpaceOnly = ctx.req.query("globalSpaceOnly") === "true";
+    const podId = ctx.req.query("podId");
+    // Used outside any Pod context (e.g. the workspace-wide command palette, or a
+    // conversation not attached to a Pod) so Pod-restricted skills stay unsearchable there.
     const excludePodScopedSkills =
       ctx.req.query("excludePodScopedSkills") === "true";
     const onlyCustom = ctx.req.query("onlyCustom");
@@ -188,27 +191,42 @@ app.get(
       });
     }
 
-    let resolvedPodSpaceModelId: number | null | undefined;
-    if (podSpaceId) {
-      const podSpace = await SpaceResource.fetchById(auth, podSpaceId);
+    if (
+      [globalSpaceOnly, !!podId, excludePodScopedSkills].filter(Boolean)
+        .length > 1
+    ) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "Only one of globalSpaceOnly, podId, or excludePodScopedSkills may be set.",
+        },
+      });
+    }
+
+    let spaceScope: SkillSpaceScopeFilter | undefined;
+    if (globalSpaceOnly) {
+      spaceScope = { mode: "global_only" };
+    } else if (podId) {
+      const podSpace = await SpaceResource.fetchById(auth, podId);
       if (!podSpace) {
         return apiError(ctx, {
           status_code: 404,
           api_error: {
             type: "space_not_found",
-            message: `Space "${podSpaceId}" was not found.`,
+            message: `Space "${podId}" was not found.`,
           },
         });
       }
-      resolvedPodSpaceModelId = podSpace.id;
+      spaceScope = { mode: "pod", podSpaceModelId: podSpace.id };
     } else if (excludePodScopedSkills) {
-      resolvedPodSpaceModelId = null;
+      spaceScope = { mode: "exclude_pod_scoped" };
     }
 
     const allSkills = await SkillResource.listByWorkspace(auth, {
       status: skillStatus,
-      globalSpaceOnly: globalSpaceOnly === "true",
-      podSpaceModelId: resolvedPodSpaceModelId,
+      spaceScope,
       onlyCustom: onlyCustom === "true",
       availability,
       withInstructions: false,

--- a/front/components/assistant/CapabilitiesPicker.test.tsx
+++ b/front/components/assistant/CapabilitiesPicker.test.tsx
@@ -94,6 +94,8 @@ vi.mock(import("@app/lib/swr/skill_configurations"), () => ({
     isSkillsLoading: false,
     mutateSkills: vi.fn(async () => undefined),
   }),
+  skillSpaceScopeForConversation: (podId?: string | null) =>
+    podId ? { mode: "pod", podId } : { mode: "excludePodScoped" },
 }));
 
 vi.mock(import("@app/lib/swr/useIsMobile"), () => ({

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -165,6 +165,7 @@ export function CapabilitiesPickerItemsList({
 interface CapabilitiesPickerProps {
   owner: WorkspaceType;
   user: UserType | null;
+  conversationPodSpaceId?: string;
   selectedMCPServerViews: MCPServerViewLightType[];
   onSelect: (serverView: MCPServerViewLightType) => void;
   onSkillSelect: (skill: SkillWithoutInstructionsAndToolsType) => void;
@@ -182,6 +183,7 @@ interface CapabilitiesPickerProps {
 export function CapabilitiesPicker({
   owner,
   user,
+  conversationPodSpaceId,
   selectedMCPServerViews,
   onSelect,
   onSkillSelect,
@@ -238,6 +240,7 @@ export function CapabilitiesPicker({
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
+    podContext: conversationPodSpaceId ?? null,
     swrOptions: CAPABILITIES_SWR_OPTIONS,
   });
 

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -240,7 +240,9 @@ export function CapabilitiesPicker({
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
-    podContext: conversationPodSpaceId ?? null,
+    spaceScope: conversationPodSpaceId
+      ? { mode: "pod", podId: conversationPodSpaceId }
+      : { mode: "excludePodScoped" },
     swrOptions: CAPABILITIES_SWR_OPTIONS,
   });
 

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -16,7 +16,10 @@ import {
   useAvailableMCPServers,
   useJITMCPServerViewsFromSpaces,
 } from "@app/lib/swr/mcp_servers";
-import { useSkills } from "@app/lib/swr/skill_configurations";
+import {
+  skillSpaceScopeForConversation,
+  useSkills,
+} from "@app/lib/swr/skill_configurations";
 import { useSpaces } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import {
@@ -240,9 +243,7 @@ export function CapabilitiesPicker({
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
-    spaceScope: conversationPodSpaceId
-      ? { mode: "pod", podId: conversationPodSpaceId }
-      : { mode: "excludePodScoped" },
+    spaceScope: skillSpaceScopeForConversation(conversationPodSpaceId),
     swrOptions: CAPABILITIES_SWR_OPTIONS,
   });
 

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -319,6 +319,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
             attachedNodes={attachedNodes}
             conversation={conversation}
             spaceId={spaceId}
+            conversationPodSpaceId={conversationPodSpaceId}
             selectedSpaceIds={selectedSpaceIds}
             onSelectedSpaceIdsChange={onSelectedSpaceIdsChange}
             spaces={spaces}

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -140,6 +140,9 @@ export const InputBarButtons = React.memo(function InputBarButtons({
   const spaceId = conversation?.spaceId ?? space?.sId ?? undefined;
 
   const isPod = space ? isProjectType(space) : false;
+  const conversationPodSpaceId =
+    conversation?.spaceId ??
+    (space && isProjectType(space) ? space.sId : undefined);
   const defaultAgentUnavailableLabel = isPod
     ? "This Pod's default agent isn't available to you, so @dust is used instead. Discuss with your Pod editors if you think this is an error."
     : "This conversation's default agent isn't available to you, so @dust is used instead. Discuss with your Workspace admin if you think this is an error.";
@@ -236,6 +239,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
     <CapabilitiesPicker
       owner={owner}
       user={user}
+      conversationPodSpaceId={conversationPodSpaceId}
       selectedMCPServerViews={selectedMCPServerViews}
       onSelect={onMCPServerViewSelect}
       onSkillSelect={onSkillSelect}

--- a/front/components/assistant/conversation/input_bar/InputBarPlusMenu.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarPlusMenu.tsx
@@ -57,6 +57,7 @@ interface InputBarPlusMenuProps {
   attachedNodes: DataSourceViewContentNode[];
   conversation?: ConversationWithoutContentType;
   spaceId?: string;
+  conversationPodSpaceId?: string;
   selectedSpaceIds: string[];
   onSelectedSpaceIdsChange: (spaceIds: string[]) => void;
   spaces?: SelectableConversationSpaceType[];
@@ -84,6 +85,7 @@ export function InputBarPlusMenu({
   attachedNodes,
   conversation,
   spaceId,
+  conversationPodSpaceId,
   selectedSpaceIds,
   onSelectedSpaceIdsChange,
   spaces,
@@ -129,6 +131,7 @@ export function InputBarPlusMenu({
       type={isMobile ? "dropdown" : "subdropdown"}
       owner={owner}
       user={user}
+      conversationPodSpaceId={conversationPodSpaceId}
       selectedMCPServerViews={selectedMCPServerViews}
       onSelect={onMCPServerViewSelect}
       onSkillSelect={onSkillSelect}

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -138,6 +138,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
     const { capabilityItems, isLoading } = useInputBarSlashCommandCapabilities({
       owner,
       query,
+      conversationPodSpaceId: spaceIdRef.current,
       selectedMCPServerViewIdsRef,
     });
 

--- a/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
@@ -62,11 +62,13 @@ export function useInputBarSlashCommandCapabilities({
   excludeSkillId,
   owner,
   query,
+  conversationPodSpaceId,
   selectedMCPServerViewIdsRef,
 }: {
   excludeSkillId?: string | null;
   owner: LightWorkspaceType;
   query: string;
+  conversationPodSpaceId?: string | null;
   selectedMCPServerViewIdsRef?: RefObject<Set<string>>;
 }) {
   const { spaces: globalSpaces, isSpacesLoading } = useSpaces({
@@ -77,6 +79,7 @@ export function useInputBarSlashCommandCapabilities({
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
+    podContext: conversationPodSpaceId ?? null,
     swrOptions: CAPABILITIES_SWR_OPTIONS,
   });
   // The JIT views endpoint only returns views whose tools can be enabled directly in a

--- a/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
@@ -79,7 +79,9 @@ export function useInputBarSlashCommandCapabilities({
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
-    podContext: conversationPodSpaceId ?? null,
+    spaceScope: conversationPodSpaceId
+      ? { mode: "pod", podId: conversationPodSpaceId }
+      : { mode: "excludePodScoped" },
     swrOptions: CAPABILITIES_SWR_OPTIONS,
   });
   // The JIT views endpoint only returns views whose tools can be enabled directly in a

--- a/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
@@ -9,7 +9,10 @@ import {
   useJITMCPServerViewsFromSpaces,
   useMCPServerViewsFromSpaces,
 } from "@app/lib/swr/mcp_servers";
-import { useSkills } from "@app/lib/swr/skill_configurations";
+import {
+  skillSpaceScopeForConversation,
+  useSkills,
+} from "@app/lib/swr/skill_configurations";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { RefObject } from "react";
@@ -79,9 +82,7 @@ export function useInputBarSlashCommandCapabilities({
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
-    spaceScope: conversationPodSpaceId
-      ? { mode: "pod", podId: conversationPodSpaceId }
-      : { mode: "excludePodScoped" },
+    spaceScope: skillSpaceScopeForConversation(conversationPodSpaceId),
     swrOptions: CAPABILITIES_SWR_OPTIONS,
   });
   // The JIT views endpoint only returns views whose tools can be enabled directly in a

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -192,7 +192,6 @@ export function PodSettingsTab({
     owner,
     status: "active",
     podContext: pod.sId,
-    disabled: !isDefaultSkillsEnabled,
   });
   const [skillSearchText, setSkillSearchText] = useState("");
   const [isSkillPickerOpen, setIsSkillPickerOpen] = useState(false);

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -191,7 +191,7 @@ export function PodSettingsTab({
   const { skills } = useSkills({
     owner,
     status: "active",
-    podContext: pod.sId,
+    spaceScope: { mode: "pod", podId: pod.sId },
   });
   const [skillSearchText, setSkillSearchText] = useState("");
   const [isSkillPickerOpen, setIsSkillPickerOpen] = useState(false);

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -191,6 +191,8 @@ export function PodSettingsTab({
   const { skills } = useSkills({
     owner,
     status: "active",
+    podContext: pod.sId,
+    disabled: !isDefaultSkillsEnabled,
   });
   const [skillSearchText, setSkillSearchText] = useState("");
   const [isSkillPickerOpen, setIsSkillPickerOpen] = useState(false);

--- a/front/lib/api/poke/plugins/spaces/activation_management.ts
+++ b/front/lib/api/poke/plugins/spaces/activation_management.ts
@@ -403,7 +403,7 @@ export const activationManagementPlugin = createPlugin({
     const [skills, agents, groups] = await Promise.all([
       SkillResource.listByWorkspace(auth, {
         status: "active",
-        globalSpaceOnly: true,
+        spaceScope: { mode: "global_only" },
         withInstructions: false,
         withTools: false,
         withFileAttachments: false,

--- a/front/lib/api/skills/space_requirements.ts
+++ b/front/lib/api/skills/space_requirements.ts
@@ -124,3 +124,24 @@ export async function getReferencedSkillSpaceModelIds(
       .flatMap((skill) => skill.requestedSpaceIds)
   );
 }
+
+export async function validateAtMostOnePodSpace(
+  auth: Authenticator,
+  requestedSpaceIds: ModelId[]
+): Promise<Result<void, Error>> {
+  const podSpaceIds = await SpaceResource.fetchProjectSpaceIdsAmong(
+    auth,
+    requestedSpaceIds
+  );
+
+  if (podSpaceIds.length > 1) {
+    return new Err(
+      new Error(
+        "A skill can only be restricted to a single Pod, but this would restrict it to " +
+          `${podSpaceIds.length} different Pods.`
+      )
+    );
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/api/skills/space_requirements.ts
+++ b/front/lib/api/skills/space_requirements.ts
@@ -125,20 +125,18 @@ export async function getReferencedSkillSpaceModelIds(
   );
 }
 
-export async function validateAtMostOnePodSpace(
-  auth: Authenticator,
-  requestedSpaceIds: ModelId[]
-): Promise<Result<void, Error>> {
-  const podSpaceIds = await SpaceResource.fetchProjectSpaceIdsAmong(
-    auth,
-    requestedSpaceIds
-  );
+export function validateAtMostOnePodSpace(
+  requestedSpaces: SpaceResource[]
+): Result<void, Error> {
+  const podSpaceCount = requestedSpaces.filter((space) =>
+    space.isProject()
+  ).length;
 
-  if (podSpaceIds.length > 1) {
+  if (podSpaceCount > 1) {
     return new Err(
       new Error(
         "A skill can only be restricted to a single Pod, but this would restrict it to " +
-          `${podSpaceIds.length} different Pods.`
+          `${podSpaceCount} different Pods.`
       )
     );
   }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -104,6 +104,7 @@ import type {
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import {
   isNumber,
@@ -130,6 +131,26 @@ export type SkillMCPServerConfiguration = {
   childAgentId?: string;
   serverNameOverride?: string;
 };
+
+// Restricts `listByWorkspace` to a single space-visibility scope. Modeled as one
+// discriminated union (rather than separate `globalSpaceOnly`/`podSpaceModelId` params) so a
+// caller cannot ask for two contradictory scopes at once (e.g. "global only" + "this Pod's
+// skills", which would always resolve to zero Pod-scoped matches).
+//
+// Independent from availability/editor-group governance (`availability`, `canWrite`,
+// `canAdministrate`): those gate who may see an individual skill regardless of Pod, this gates
+// which Pod's skills are in scope regardless of who's asking. Omitting `spaceScope` entirely
+// means "every Pod" — used by workspace-wide callers (dedup checks, analytics/export) and by
+// admin governance views that intentionally span all Pods.
+export type SkillSpaceScopeFilter =
+  // Only skills requesting exclusively the global space (excludes every space-restricted
+  // skill, Pod-scoped or not).
+  | { mode: "global_only" }
+  // Excludes Pod-scoped skills but keeps skills restricted to non-Pod spaces. Used outside
+  // any Pod context, where a Pod-restricted skill must stay unsearchable.
+  | { mode: "exclude_pod_scoped" }
+  // Only this Pod's own skills, plus skills not scoped to any Pod.
+  | { mode: "pod"; podSpaceModelId: ModelId };
 
 type SkillReferenceTarget = {
   icon: string | null;
@@ -1526,8 +1547,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     {
       status = "active",
       limit,
-      globalSpaceOnly,
-      podSpaceModelId,
+      spaceScope,
       onlyCustom,
       availability,
       updatedAfter,
@@ -1538,8 +1558,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }: {
       status?: SkillStatus | SkillStatus[];
       limit?: number;
-      globalSpaceOnly?: boolean;
-      podSpaceModelId?: ModelId | null;
+      spaceScope?: SkillSpaceScopeFilter;
       onlyCustom?: boolean;
       availability?: SkillAvailability | SkillAvailability[];
       updatedAfter?: Date;
@@ -1563,37 +1582,46 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       withFileAttachments,
     });
 
-    let filteredSkills = skills;
-
-    if (globalSpaceOnly) {
-      const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
-      filteredSkills = filteredSkills.filter((skill) =>
-        skill.requestedSpaceIds.every((id) => id === globalSpace.id)
-      );
+    if (!spaceScope) {
+      return skills;
     }
 
-    if (podSpaceModelId === undefined) {
-      return filteredSkills;
-    }
-
-    const allRequestedSpaceIds = uniq(
-      filteredSkills.flatMap((skill) => skill.requestedSpaceIds)
-    );
-    const podSpaceIds = new Set<ModelId>(
-      await SpaceResource.fetchProjectSpaceIdsAmong(auth, allRequestedSpaceIds)
-    );
-
-    return filteredSkills.filter((skill) => {
-      const skillPodSpaceIds = skill.requestedSpaceIds.filter((id) =>
-        podSpaceIds.has(id)
-      );
-      if (skillPodSpaceIds.length === 0) {
-        return true;
+    switch (spaceScope.mode) {
+      case "global_only": {
+        const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+        return skills.filter((skill) =>
+          skill.requestedSpaceIds.every((id) => id === globalSpace.id)
+        );
       }
-      return (
-        podSpaceModelId !== null && skillPodSpaceIds.includes(podSpaceModelId)
-      );
-    });
+      case "exclude_pod_scoped":
+
+      case "pod": {
+        const allRequestedSpaceIds = uniq(
+          skills.flatMap((skill) => skill.requestedSpaceIds)
+        );
+        const podSpaceIds = new Set<ModelId>(
+          await SpaceResource.fetchProjectSpaceIdsAmong(
+            auth,
+            allRequestedSpaceIds
+          )
+        );
+
+        return skills.filter((skill) => {
+          const skillPodSpaceIds = skill.requestedSpaceIds.filter((id) =>
+            podSpaceIds.has(id)
+          );
+          if (skillPodSpaceIds.length === 0) {
+            return true;
+          }
+          return (
+            spaceScope.mode === "pod" &&
+            skillPodSpaceIds.includes(spaceScope.podSpaceModelId)
+          );
+        });
+      }
+      default:
+        return assertNever(spaceScope);
+    }
   }
 
   /**

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1594,7 +1594,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         );
       }
       case "exclude_pod_scoped":
-
       case "pod": {
         const allRequestedSpaceIds = uniq(
           skills.flatMap((skill) => skill.requestedSpaceIds)

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1527,6 +1527,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       status = "active",
       limit,
       globalSpaceOnly,
+      podSpaceId,
       onlyCustom,
       availability,
       updatedAfter,
@@ -1538,6 +1539,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       status?: SkillStatus | SkillStatus[];
       limit?: number;
       globalSpaceOnly?: boolean;
+      podSpaceId?: ModelId | null;
       onlyCustom?: boolean;
       availability?: SkillAvailability | SkillAvailability[];
       updatedAfter?: Date;
@@ -1561,14 +1563,35 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       withFileAttachments,
     });
 
+    let filteredSkills = skills;
+
     if (globalSpaceOnly) {
       const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
-      return skills.filter((skill) =>
+      filteredSkills = filteredSkills.filter((skill) =>
         skill.requestedSpaceIds.every((id) => id === globalSpace.id)
       );
     }
 
-    return skills;
+    if (podSpaceId === undefined) {
+      return filteredSkills;
+    }
+
+    const allRequestedSpaceIds = uniq(
+      filteredSkills.flatMap((skill) => skill.requestedSpaceIds)
+    );
+    const podSpaceIds = new Set<ModelId>(
+      await SpaceResource.fetchProjectSpaceIdsAmong(auth, allRequestedSpaceIds)
+    );
+
+    return filteredSkills.filter((skill) => {
+      const skillPodSpaceIds = skill.requestedSpaceIds.filter((id) =>
+        podSpaceIds.has(id)
+      );
+      if (skillPodSpaceIds.length === 0) {
+        return true;
+      }
+      return podSpaceId !== null && skillPodSpaceIds.includes(podSpaceId);
+    });
   }
 
   /**

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1527,7 +1527,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       status = "active",
       limit,
       globalSpaceOnly,
-      podSpaceId,
+      podSpaceModelId,
       onlyCustom,
       availability,
       updatedAfter,
@@ -1539,7 +1539,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       status?: SkillStatus | SkillStatus[];
       limit?: number;
       globalSpaceOnly?: boolean;
-      podSpaceId?: ModelId | null;
+      podSpaceModelId?: ModelId | null;
       onlyCustom?: boolean;
       availability?: SkillAvailability | SkillAvailability[];
       updatedAfter?: Date;
@@ -1572,7 +1572,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       );
     }
 
-    if (podSpaceId === undefined) {
+    if (podSpaceModelId === undefined) {
       return filteredSkills;
     }
 
@@ -1590,7 +1590,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       if (skillPodSpaceIds.length === 0) {
         return true;
       }
-      return podSpaceId !== null && skillPodSpaceIds.includes(podSpaceId);
+      return (
+        podSpaceModelId !== null && skillPodSpaceIds.includes(podSpaceModelId)
+      );
     });
   }
 

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -710,6 +710,17 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return spaces ?? [];
   }
 
+  static async fetchProjectSpaceIdsAmong(
+    auth: Authenticator,
+    spaceModelIds: ModelId[]
+  ): Promise<ModelId[]> {
+    if (spaceModelIds.length === 0) {
+      return [];
+    }
+    const spaces = await this.fetchByModelIds(auth, spaceModelIds);
+    return spaces.filter((s) => s.isProject()).map((s) => s.id);
+  }
+
   static async dangerouslyFetchByModelIds(
     spaceModelIds: ModelId[]
   ): Promise<SpaceResource[]> {

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -27,6 +27,7 @@ import type {
 } from "@app/types/assistant/skill_configuration";
 import { isAPIErrorResponse } from "@app/types/error";
 import { Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useState } from "react";
@@ -97,12 +98,23 @@ export function useSkill({
   };
 }
 
+// Restricts the listed skills to a single space-visibility scope. Modeled as one
+// discriminated union so a caller cannot request two contradictory scopes at once
+export type SkillsSpaceScopeParam =
+  // Skills with no restrictions
+  | { mode: "globalOnly" }
+  // Excludes Pod-scoped skills but keeps other space-restricted skills. Used outside any Pod
+  // context (ex. a conversation not attached to a Pod), where a Pod-restricted skill must
+  // stay unsearchable.
+  | { mode: "excludePodScoped" }
+  // Only this Pod's own skills, plus skills with no restrictions.
+  | { mode: "pod"; podId: string };
+
 export function useSkills({
   owner,
   disabled,
   status,
-  globalSpaceOnly,
-  podContext,
+  spaceScope,
   availability,
   bypassEditorVisibility,
   swrOptions,
@@ -110,8 +122,7 @@ export function useSkills({
   owner: LightWorkspaceType;
   disabled?: boolean;
   status?: SkillStatus;
-  globalSpaceOnly?: boolean;
-  podContext?: string | null;
+  spaceScope?: SkillsSpaceScopeParam;
   availability?: SkillAvailability | SkillAvailability[];
   // Admin-only: bypass the editor-visibility rule and also list unpublished
   // (editors-only) skills the caller does not edit.
@@ -129,14 +140,19 @@ export function useSkills({
   if (status) {
     queryParams.set("status", status);
   }
-  if (globalSpaceOnly) {
-    queryParams.set("globalSpaceOnly", "true");
-  }
-  if (podContext !== undefined) {
-    if (podContext !== null) {
-      queryParams.set("podSpaceId", podContext);
-    } else {
-      queryParams.set("excludePodScopedSkills", "true");
+  if (spaceScope) {
+    switch (spaceScope.mode) {
+      case "globalOnly":
+        queryParams.set("globalSpaceOnly", "true");
+        break;
+      case "excludePodScoped":
+        queryParams.set("excludePodScopedSkills", "true");
+        break;
+      case "pod":
+        queryParams.set("podId", spaceScope.podId);
+        break;
+      default:
+        assertNever(spaceScope);
     }
   }
   if (availability) {

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -110,6 +110,14 @@ export type SkillsSpaceScopeParam =
   // Only this Pod's own skills, plus skills with no restrictions.
   | { mode: "pod"; podId: string };
 
+export function skillSpaceScopeForConversation(
+  conversationPodSpaceId: string | null | undefined
+): SkillsSpaceScopeParam {
+  return conversationPodSpaceId
+    ? { mode: "pod", podId: conversationPodSpaceId }
+    : { mode: "excludePodScoped" };
+}
+
 export function useSkills({
   owner,
   disabled,

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -102,6 +102,7 @@ export function useSkills({
   disabled,
   status,
   globalSpaceOnly,
+  podContext,
   availability,
   bypassEditorVisibility,
   swrOptions,
@@ -110,6 +111,7 @@ export function useSkills({
   disabled?: boolean;
   status?: SkillStatus;
   globalSpaceOnly?: boolean;
+  podContext?: string | null;
   availability?: SkillAvailability | SkillAvailability[];
   // Admin-only: bypass the editor-visibility rule and also list unpublished
   // (editors-only) skills the caller does not edit.
@@ -129,6 +131,13 @@ export function useSkills({
   }
   if (globalSpaceOnly) {
     queryParams.set("globalSpaceOnly", "true");
+  }
+  if (podContext !== undefined) {
+    if (podContext !== null) {
+      queryParams.set("podSpaceId", podContext);
+    } else {
+      queryParams.set("excludePodScopedSkills", "true");
+    }
   }
   if (availability) {
     const availabilities = Array.isArray(availability)


### PR DESCRIPTION
## Description

Restricted skills must be scoped to at most one Pod. Otherwise, a skill that can access Pod-specific data could become visible to members of another Pod or to workspace-level users.

This PR enforces that rule in two places:

- **At creation and update time**, a skill is rejected if its requested spaces, including spaces inherited through nested skill references, contain more than one Pod.
- **At selection time**, Pod-scoped skills are filtered out before they reach the UI. They are not merely rejected after selection, so they remain unsearchable outside the intended scope.

### Three-mode skill visibility filter

The old boolean `globalSpaceOnly` flag was replaced with a discriminated `spaceScope` filter. The three modes are mutually exclusive:

1. **`global_only`**: return only skills restricted exclusively to the workspace global space. This is used by workspace-global skills
2. **`exclude_pod_scoped`**: return global skills and skills restricted to non-Pod spaces, while hiding every skill restricted to a Pod. This is used when the current conversation is not in a Pod. This is required since a user should be able to use a skill restricted to a space throughout all of their conversations.
3. **`pod`**: return global skills, non-Pod-restricted skills, and skills belonging to the current Pod, while hiding skills belonging to other Pods. This is used when the current conversation is in a Pod.

The API exposes these scopes through the mutually exclusive `globalSpaceOnly`, `excludePodScopedSkills`, and `podId` query parameters. Frontend callers derive the appropriate scope from the conversation context and use it consistently in the slash-command picker, capabilities picker, and Pod skill settings. The union-based API prevents callers from accidentally combining contradictory visibility rules.

A UI update for the skills settings page will follow in the next PR.

## Tests

Added and updated API route coverage for:

- Listing skills in each of the three visibility modes.
- Rejecting mutually exclusive scope parameters.
- Rejecting skills restricted to multiple Pods at creation time.
- Rejecting skills restricted to multiple Pods when updating an existing skill, including nested skill references.

Relevant test files:

- `front-api/routes/w/[wId]/skills/index.test.ts`
- `front-api/routes/w/[wId]/skills/[sId]/index.test.ts`

Local validation performed: `git diff --check`. The focused test suites were not run locally; final validation is expected through PR CI.

## Risk

Low risk. The change affects restricted-skill validation and visibility filtering only. Existing unrestricted skills and skills restricted to non-Pod spaces remain visible under the same conditions. No database migration is required, and the change is straightforward to roll back.

## Deploy Plan

Deploy front. No migration or ordering dependency is required.
