### PR TITLE
[front] refactor: collapse createAgentMessages to a single agent mention

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -3240,7 +3240,7 @@ describe("editUserMessage", () => {
     }
   });
 
-  it("should create an agent message per mention when editing with several agents", async () => {
+  it("should create a single agent message when editing with several agents", async () => {
     const mentions: MentionType[] = [
       {
         configurationId: agentConfig1.sId,
@@ -3258,17 +3258,16 @@ describe("editUserMessage", () => {
       skipToolsValidation: false,
     });
 
-    // Several agent mentions are only logged, the public API still relies on them.
+    // The edit is still accepted, only the first mentioned agent answers.
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
       const { userMessage, agentMessages } = result.value;
 
-      expect(agentMessages.length).toBe(2);
+      expect(agentMessages.length).toBe(1);
 
       const agentMentions = userMessage.richMentions.filter(isRichAgentMention);
-      expect(agentMentions.map((m) => m.id).sort()).toEqual(
-        [agentConfig1.sId, agentConfig2.sId].sort()
-      );
+      expect(agentMentions.length).toBe(1);
+      expect(agentMentions[0].id).toBe(agentMessages[0].configuration.sId);
     }
   });
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -20,10 +20,10 @@ import {
   attributeUserFromWorkspaceAndEmail,
   createAgentMessages,
   createUserMessage,
-  resolveModelsForMentionedAgents,
+  resolveModelForMentionedAgent,
 } from "@app/lib/api/assistant/conversation/messages";
 import {
-  canAgentBeUsedInProjectConversation,
+  isAgentRestrictedBySpaceUsage,
   updateConversationRequirements,
 } from "@app/lib/api/assistant/conversation/permissions";
 import { ensureConversationTitle } from "@app/lib/api/assistant/conversation/title";
@@ -730,7 +730,6 @@ export async function postUserMessage(
   ]);
 
   let agentConfigurations = removeNulls(results[0]);
-  const restrictedAgentIds = new Set<string>();
 
   // Retired global agents can't be invoked (new conversations or new messages).
   // The internal `run_agent` path is exempt: some hidden sub-agents are retired.
@@ -795,17 +794,6 @@ export async function postUserMessage(
         },
       });
     }
-
-    if (isPartOfPod) {
-      const canAgentBeUsed = await canAgentBeUsedInProjectConversation(auth, {
-        configuration: agentConfig,
-        conversation,
-      });
-
-      if (!canAgentBeUsed) {
-        restrictedAgentIds.add(agentConfig.sId);
-      }
-    }
   }
 
   // TODO(2026-07-31 SEC): this allow spoofing as we trust blindly the user email from the metadata.
@@ -821,10 +809,17 @@ export async function postUserMessage(
     message: { type: "user_message" },
   });
 
-  const resolvedModels = await resolveModelsForMentionedAgents(auth, {
-    agentConfigurations,
-    selection: modelSelection,
+  const mentionedAgentConfiguration = agentConfigurations[0] ?? null;
+  const mentionedAgentRestricted = await isAgentRestrictedBySpaceUsage(auth, {
+    configuration: mentionedAgentConfiguration,
+    conversation,
   });
+  const modelResolution = mentionedAgentConfiguration
+    ? await resolveModelForMentionedAgent(auth, {
+        configuration: mentionedAgentConfiguration,
+        selection: modelSelection,
+      })
+    : null;
 
   // In one big transaction create all Message, UserMessage, AgentMessage and Mention rows.
   const { userMessage, agentMessages } = await withTransaction(async (t) => {
@@ -937,13 +932,12 @@ export async function postUserMessage(
           conversation,
           metadata: {
             type: "create",
-            mentions,
-            agentConfigurations,
+            agentConfiguration: mentionedAgentConfiguration,
             skipToolsValidation,
             nextMessageRank,
             userMessage: userMessageWithoutMentions,
-            resolvedModels,
-            restrictedAgentIds,
+            modelResolution,
+            isRestrictedBySpaceUsage: mentionedAgentRestricted,
           },
           transaction: t,
         });
@@ -1202,44 +1196,25 @@ export async function editUserMessage(
     }
   }
 
-  // Multiple agent mentions are still accepted (the public API relies on them), we only track
-  // them while we move to a single mention per message.
-  const agentMentionCount = mentions.filter(isAgentMention).length;
-  if (agentMentionCount > 1) {
-    logger.warn(
-      {
-        agentMentionCount,
-        conversationId: conversation.sId,
-        messageId: message.sId,
-        workspaceId: owner.sId,
-      },
-      "Editing a user message with multiple agent mentions."
-    );
-  }
-
   const resolvedUserMentions = await resolveUserMentions(auth, {
     mentions,
     conversation,
     message: { type: "user_message" },
   });
 
-  const restrictedAgentIds = new Set<string>();
-  if (isPodConversation(conversation)) {
-    for (const agentConfig of agentConfigurations) {
-      const canAgentBeUsed = await canAgentBeUsedInProjectConversation(auth, {
-        configuration: agentConfig,
-        conversation,
-      });
-      if (!canAgentBeUsed) {
-        restrictedAgentIds.add(agentConfig.sId);
-      }
-    }
-  }
+  const mentionedAgentConfiguration = agentConfigurations[0] ?? null;
 
-  const resolvedModels = await resolveModelsForMentionedAgents(auth, {
-    agentConfigurations,
-    selection: message.requestedModel ?? undefined,
+  const mentionedAgentRestricted = await isAgentRestrictedBySpaceUsage(auth, {
+    configuration: mentionedAgentConfiguration,
+    conversation,
   });
+
+  const modelResolution = mentionedAgentConfiguration
+    ? await resolveModelForMentionedAgent(auth, {
+        configuration: mentionedAgentConfiguration,
+        selection: message.requestedModel ?? undefined,
+      })
+    : null;
 
   try {
     // In one big transaction create all Message, UserMessage, AgentMessage, and Mention rows.
@@ -1329,13 +1304,12 @@ export async function editUserMessage(
             conversation,
             metadata: {
               type: "create",
-              mentions,
-              agentConfigurations,
+              agentConfiguration: mentionedAgentConfiguration,
               skipToolsValidation,
               nextMessageRank,
               userMessage: userMessageWithoutMentions,
-              resolvedModels,
-              restrictedAgentIds,
+              modelResolution,
+              isRestrictedBySpaceUsage: mentionedAgentRestricted,
             },
             transaction: t,
           });
@@ -3127,20 +3101,17 @@ export async function updateAgentMessageWithFinalStatus(
   const completedAt = new Date();
   const owner = auth.getNonNullableWorkspace();
 
-  const restrictedAgentIds = new Set<string>();
-  if (isPodConversation(conversation) && agentMessage.configuration) {
-    const canAgentBeUsed = await canAgentBeUsedInProjectConversation(auth, {
+  const agentRestrictedBySpaceUsage = await isAgentRestrictedBySpaceUsage(
+    auth,
+    {
       configuration: agentMessage.configuration,
       conversation,
-    });
-    if (!canAgentBeUsed) {
-      restrictedAgentIds.add(agentMessage.configuration.sId);
     }
-  }
+  );
 
-  const defaultResolvedModels = agentMessage.configuration
-    ? await resolveModelsForMentionedAgents(auth, {
-        agentConfigurations: [agentMessage.configuration],
+  const defaultModelResolution = agentMessage.configuration
+    ? await resolveModelForMentionedAgent(auth, {
+        configuration: agentMessage.configuration,
       })
     : null;
 
@@ -3304,11 +3275,11 @@ export async function updateAgentMessageWithFinalStatus(
     });
 
     // The no-selection default was resolved before the transaction.
-    const resolvedModels =
-      defaultResolvedModels && !promotedUserMessage.requestedModel
-        ? defaultResolvedModels
-        : await resolveModelsForMentionedAgents(promotedAuth, {
-            agentConfigurations: [agentMessage.configuration],
+    const modelResolution =
+      defaultModelResolution && !promotedUserMessage.requestedModel
+        ? defaultModelResolution
+        : await resolveModelForMentionedAgent(promotedAuth, {
+            configuration: agentMessage.configuration,
             selection: promotedUserMessage.requestedModel ?? undefined,
           });
 
@@ -3317,13 +3288,12 @@ export async function updateAgentMessageWithFinalStatus(
       conversation,
       metadata: {
         type: "create",
-        mentions: [{ configurationId: agentMessage.configuration.sId }],
-        agentConfigurations: [agentMessage.configuration],
+        agentConfiguration: agentMessage.configuration,
         skipToolsValidation: agentMessage.skipToolsValidation,
         nextMessageRank,
         userMessage: promotedUserMessages[promotedUserMessages.length - 1],
-        resolvedModels,
-        restrictedAgentIds,
+        modelResolution,
+        isRestrictedBySpaceUsage: agentRestrictedBySpaceUsage,
       },
       transaction: t,
     });

--- a/front/lib/api/assistant/conversation/messages.test.ts
+++ b/front/lib/api/assistant/conversation/messages.test.ts
@@ -13,7 +13,7 @@ import {
   createAgentMessages,
   createCompactionMessage,
   createUserMessage,
-  resolveModelsForMentionedAgents,
+  resolveModelForMentionedAgent,
 } from "@app/lib/api/assistant/conversation/messages";
 import { canAgentBeUsedInProjectConversation } from "@app/lib/api/assistant/conversation/permissions";
 import { Authenticator } from "@app/lib/auth";
@@ -52,7 +52,7 @@ describe("createAgentMessages", () => {
   let auth: Authenticator;
   let conversation: ConversationType;
   let agentConfig1: LightAgentConfigurationType;
-  let agentConfig2: LightAgentConfigurationType;
+  let _agentConfig2: LightAgentConfigurationType;
 
   beforeEach(async () => {
     // Reset mocks before each test
@@ -69,7 +69,7 @@ describe("createAgentMessages", () => {
       description: "First test agent",
     });
 
-    agentConfig2 = await AgentConfigurationFactory.createTestAgent(auth, {
+    _agentConfig2 = await AgentConfigurationFactory.createTestAgent(auth, {
       name: "Test Agent 2",
       description: "Second test agent",
     });
@@ -91,25 +91,26 @@ describe("createAgentMessages", () => {
         content: `Hello @${agentConfig1.name}`,
       });
 
-    const mentions: MentionType[] = [
+    const _mentions: MentionType[] = [
       {
         configurationId: agentConfig1.sId,
       } satisfies AgentMention,
     ];
 
+    const modelResolution = await resolveModelForMentionedAgent(auth, {
+      configuration: agentConfig1,
+    });
+
     const { agentMessages, richMentions } = await createAgentMessages(auth, {
       conversation,
       metadata: {
         type: "create",
-        mentions,
-        agentConfigurations: [agentConfig1],
+        agentConfiguration: agentConfig1,
         skipToolsValidation: false,
         nextMessageRank: 1,
         userMessage,
-        resolvedModels: await resolveModelsForMentionedAgents(auth, {
-          agentConfigurations: [agentConfig1],
-        }),
-        restrictedAgentIds: new Set<string>(),
+        modelResolution,
+        isRestrictedBySpaceUsage: false,
       },
     });
 
@@ -163,139 +164,7 @@ describe("createAgentMessages", () => {
     });
   });
 
-  it("should create multiple agent messages for multiple mentions", async () => {
-    const { messageRow, userMessage } =
-      await ConversationFactory.createUserMessage({
-        auth,
-        workspace,
-        conversation,
-        content: `Hello @${agentConfig1.name} and @${agentConfig2.name}`,
-      });
-
-    const mentions: MentionType[] = [
-      {
-        configurationId: agentConfig1.sId,
-      } as AgentMention,
-      {
-        configurationId: agentConfig2.sId,
-      } as AgentMention,
-    ];
-
-    const { agentMessages, richMentions } = await createAgentMessages(auth, {
-      conversation,
-      metadata: {
-        type: "create",
-        mentions,
-        agentConfigurations: [agentConfig1, agentConfig2],
-        skipToolsValidation: false,
-        nextMessageRank: 1,
-        userMessage,
-        resolvedModels: await resolveModelsForMentionedAgents(auth, {
-          agentConfigurations: [agentConfig1, agentConfig2],
-        }),
-        restrictedAgentIds: new Set<string>(),
-      },
-    });
-
-    expect(agentMessages).toHaveLength(2);
-    expect(agentMessages[0].configuration.sId).toBe(agentConfig1.sId);
-    expect(agentMessages[1].configuration.sId).toBe(agentConfig2.sId);
-
-    // Verify richMentions are returned correctly
-    expect(richMentions).toHaveLength(2);
-    const agent1Mention = richMentions.find((m) => m.id === agentConfig1.sId);
-    const agent2Mention = richMentions.find((m) => m.id === agentConfig2.sId);
-    expect(agent1Mention).toBeDefined();
-    expect(agent2Mention).toBeDefined();
-    if (agent1Mention && isRichAgentMention(agent1Mention)) {
-      expect(agent1Mention.type).toBe("agent");
-      expect(agent1Mention.label).toBe(agentConfig1.name);
-      expect(agent1Mention.status).toBe("approved");
-    }
-    if (agent2Mention && isRichAgentMention(agent2Mention)) {
-      expect(agent2Mention.type).toBe("agent");
-      expect(agent2Mention.label).toBe(agentConfig2.name);
-      expect(agent2Mention.status).toBe("approved");
-    }
-
-    // Verify both mentions were created
-    const mentionsInDb = await MentionModel.findAll({
-      where: {
-        workspaceId: workspace.id,
-        messageId: messageRow.id,
-      },
-    });
-    expect(mentionsInDb).toHaveLength(2);
-
-    // Verify signalAgentUsage was called for each agent configuration
-    expect(signalAgentUsage).toHaveBeenCalledTimes(2);
-    expect(signalAgentUsage).toHaveBeenCalledWith({
-      agentConfigurationId: agentConfig1.sId,
-      workspaceId: workspace.sId,
-    });
-    expect(signalAgentUsage).toHaveBeenCalledWith({
-      agentConfigurationId: agentConfig2.sId,
-      workspaceId: workspace.sId,
-    });
-  });
-
-  it("should skip mentions for configurations not in the list", async () => {
-    const { userMessage } = await ConversationFactory.createUserMessage({
-      auth,
-      workspace,
-      conversation,
-      content: "Hello agent",
-    });
-
-    const mentions: MentionType[] = [
-      {
-        configurationId: agentConfig1.sId,
-      } as AgentMention,
-      {
-        configurationId: "non-existent-agent",
-      } as AgentMention,
-    ];
-
-    // Only pass agentConfig1, not the non-existent one
-    const { agentMessages, richMentions } = await createAgentMessages(auth, {
-      conversation,
-      metadata: {
-        type: "create",
-        mentions,
-        agentConfigurations: [agentConfig1],
-        skipToolsValidation: false,
-        nextMessageRank: 1,
-        userMessage,
-        resolvedModels: await resolveModelsForMentionedAgents(auth, {
-          agentConfigurations: [agentConfig1],
-        }),
-        restrictedAgentIds: new Set<string>(),
-      },
-    });
-
-    // Should only create one agent message for the valid configuration
-    expect(agentMessages).toHaveLength(1);
-    expect(agentMessages[0].configuration.sId).toBe(agentConfig1.sId);
-
-    // Verify richMentions only contains the valid agent mention
-    expect(richMentions).toHaveLength(1);
-    if (isRichAgentMention(richMentions[0])) {
-      expect(richMentions[0].id).toBe(agentConfig1.sId);
-      expect(richMentions[0].status).toBe("approved");
-    }
-
-    // Verify signalAgentUsage was called only for the valid configuration
-    expect(signalAgentUsage).toHaveBeenCalledTimes(1);
-    expect(signalAgentUsage).toHaveBeenCalledWith({
-      agentConfigurationId: agentConfig1.sId,
-      workspaceId: workspace.sId,
-    });
-
-    // Note: runAgentLoopWorkflow is no longer called from createAgentMessages.
-    // It's now called from postUserMessage/editUserMessage after the transaction commits.
-  });
-
-  it("should return empty array when no agent mentions are provided", async () => {
+  it("should create nothing when no agent configuration is provided", async () => {
     const { userMessage } = await ConversationFactory.createUserMessage({
       auth,
       workspace,
@@ -307,24 +176,21 @@ describe("createAgentMessages", () => {
       conversation,
       metadata: {
         type: "create",
-        mentions: [],
-        agentConfigurations: [agentConfig1],
+        agentConfiguration: null,
         skipToolsValidation: false,
         nextMessageRank: 1,
         userMessage,
-        resolvedModels: await resolveModelsForMentionedAgents(auth, {
-          agentConfigurations: [agentConfig1],
-        }),
-        restrictedAgentIds: new Set<string>(),
+        modelResolution: null,
+        isRestrictedBySpaceUsage: false,
       },
     });
 
     expect(agentMessages).toHaveLength(0);
 
-    // Verify richMentions is empty when no agent mentions are provided
+    // Verify richMentions is empty when no agent is mentioned
     expect(richMentions).toHaveLength(0);
 
-    // Verify signalAgentUsage was not called when no agent mentions are provided
+    // Verify signalAgentUsage was not called when no agent is mentioned
     expect(signalAgentUsage).not.toHaveBeenCalled();
   });
 
@@ -336,25 +202,26 @@ describe("createAgentMessages", () => {
       content: `Hello @${agentConfig1.name}`,
     });
 
-    const mentions: MentionType[] = [
+    const _mentions: MentionType[] = [
       {
         configurationId: agentConfig1.sId,
       } as AgentMention,
     ];
 
+    const modelResolution = await resolveModelForMentionedAgent(auth, {
+      configuration: agentConfig1,
+    });
+
     const { agentMessages, richMentions } = await createAgentMessages(auth, {
       conversation,
       metadata: {
         type: "create",
-        mentions,
-        agentConfigurations: [agentConfig1],
+        agentConfiguration: agentConfig1,
         skipToolsValidation: true,
         nextMessageRank: 1,
         userMessage,
-        resolvedModels: await resolveModelsForMentionedAgents(auth, {
-          agentConfigurations: [agentConfig1],
-        }),
-        restrictedAgentIds: new Set<string>(),
+        modelResolution,
+        isRestrictedBySpaceUsage: false,
       },
     });
 
@@ -389,25 +256,26 @@ describe("createAgentMessages", () => {
       agenticOriginMessageId: originMessageId,
     });
 
-    const mentions: MentionType[] = [
+    const _mentions: MentionType[] = [
       {
         configurationId: agentConfig1.sId,
       } as AgentMention,
     ];
 
+    const modelResolution = await resolveModelForMentionedAgent(auth, {
+      configuration: agentConfig1,
+    });
+
     const { agentMessages, richMentions } = await createAgentMessages(auth, {
       conversation,
       metadata: {
         type: "create",
-        mentions,
-        agentConfigurations: [agentConfig1],
+        agentConfiguration: agentConfig1,
         skipToolsValidation: true,
         nextMessageRank: 1,
         userMessage,
-        resolvedModels: await resolveModelsForMentionedAgents(auth, {
-          agentConfigurations: [agentConfig1],
-        }),
-        restrictedAgentIds: new Set<string>(),
+        modelResolution,
+        isRestrictedBySpaceUsage: false,
       },
     });
 
@@ -438,25 +306,26 @@ describe("createAgentMessages", () => {
       origin: "web",
     });
 
-    const mentions: MentionType[] = [
+    const _mentions: MentionType[] = [
       {
         configurationId: agentConfig1.sId,
       } as AgentMention,
     ];
 
+    const modelResolution = await resolveModelForMentionedAgent(auth, {
+      configuration: agentConfig1,
+    });
+
     const { agentMessages, richMentions } = await createAgentMessages(auth, {
       conversation,
       metadata: {
         type: "create",
-        mentions,
-        agentConfigurations: [agentConfig1],
+        agentConfiguration: agentConfig1,
         skipToolsValidation: false,
         nextMessageRank: 1,
         userMessage,
-        resolvedModels: await resolveModelsForMentionedAgents(auth, {
-          agentConfigurations: [agentConfig1],
-        }),
-        restrictedAgentIds: new Set<string>(),
+        modelResolution,
+        isRestrictedBySpaceUsage: false,
       },
     });
 
@@ -474,71 +343,6 @@ describe("createAgentMessages", () => {
     expect(signalAgentUsage).toHaveBeenCalledTimes(1);
     expect(signalAgentUsage).toHaveBeenCalledWith({
       agentConfigurationId: agentConfig1.sId,
-      workspaceId: workspace.sId,
-    });
-  });
-
-  it("should increment message rank correctly for multiple agent messages", async () => {
-    const { userMessage } = await ConversationFactory.createUserMessage({
-      auth,
-      workspace,
-      conversation,
-      content: `Hello @${agentConfig1.name} and @${agentConfig2.name}`,
-    });
-
-    const mentions: MentionType[] = [
-      {
-        configurationId: agentConfig1.sId,
-      } as AgentMention,
-      {
-        configurationId: agentConfig2.sId,
-      } as AgentMention,
-    ];
-
-    const nextMessageRank = 10;
-
-    const { agentMessages, richMentions } = await createAgentMessages(auth, {
-      conversation,
-      metadata: {
-        type: "create",
-        mentions,
-        agentConfigurations: [agentConfig1, agentConfig2],
-        skipToolsValidation: false,
-        nextMessageRank: 10,
-        userMessage,
-        resolvedModels: await resolveModelsForMentionedAgents(auth, {
-          agentConfigurations: [agentConfig1, agentConfig2],
-        }),
-        restrictedAgentIds: new Set<string>(),
-      },
-    });
-
-    expect(agentMessages).toHaveLength(2);
-    // Note: The function increments nextMessageRank internally, so ranks should be 10 and 11
-    expect(agentMessages[0].rank).toBe(nextMessageRank);
-    expect(agentMessages[1].rank).toBe(nextMessageRank + 1);
-
-    // Verify richMentions are returned correctly
-    expect(richMentions).toHaveLength(2);
-    const agent1Mention = richMentions.find((m) => m.id === agentConfig1.sId);
-    const agent2Mention = richMentions.find((m) => m.id === agentConfig2.sId);
-    expect(agent1Mention).toBeDefined();
-    expect(agent2Mention).toBeDefined();
-    if (agent1Mention && isRichAgentMention(agent1Mention)) {
-      expect(agent1Mention.status).toBe("approved");
-    }
-    if (agent2Mention && isRichAgentMention(agent2Mention)) {
-      expect(agent2Mention.status).toBe("approved");
-    }
-
-    // Verify signalAgentUsage was called for each agent configuration
-    expect(signalAgentUsage).toHaveBeenCalledTimes(2);
-    expect(signalAgentUsage).toHaveBeenCalledWith({
-      agentConfigurationId: agentConfig1.sId,
-      workspaceId: workspace.sId,
-    });
-    expect(signalAgentUsage).toHaveBeenCalledWith({
-      agentConfigurationId: agentConfig2.sId,
       workspaceId: workspace.sId,
     });
   });
@@ -623,7 +427,7 @@ describe("createAgentMessages", () => {
       content: `Hello @${agentConfig.name}`,
     });
 
-    const mentions: MentionType[] = [
+    const _mentions: MentionType[] = [
       {
         configurationId: agentConfig.sId,
       } satisfies AgentMention,
@@ -639,21 +443,22 @@ describe("createAgentMessages", () => {
     expect(agentConfigWithSpaces?.requestedSpaceIds).toContain(space1.sId);
     expect(agentConfigWithSpaces?.requestedSpaceIds).toContain(space2.sId);
 
+    const modelResolution = await resolveModelForMentionedAgent(auth, {
+      configuration: agentConfigWithSpaces!,
+    });
+
     // Call createAgentMessages
     const { richMentions } = await withTransaction(async (transaction) => {
       return createAgentMessages(auth, {
         conversation: testConversation,
         metadata: {
           type: "create",
-          mentions,
-          agentConfigurations: [agentConfigWithSpaces!],
+          agentConfiguration: agentConfigWithSpaces!,
           skipToolsValidation: false,
           nextMessageRank: 1,
           userMessage,
-          resolvedModels: await resolveModelsForMentionedAgents(auth, {
-            agentConfigurations: [agentConfigWithSpaces!],
-          }),
-          restrictedAgentIds: new Set<string>(),
+          modelResolution,
+          isRestrictedBySpaceUsage: false,
         },
         transaction,
       });
@@ -754,7 +559,7 @@ describe("createAgentMessages", () => {
       content: `Hello @${agentConfig.name}`,
     });
 
-    const mentions: MentionType[] = [
+    const _mentions: MentionType[] = [
       {
         configurationId: agentConfig.sId,
       } satisfies AgentMention,
@@ -770,21 +575,22 @@ describe("createAgentMessages", () => {
     expect(agentConfigWithSpaces?.requestedSpaceIds).toContain(space1.sId);
     expect(agentConfigWithSpaces?.requestedSpaceIds).toContain(space2.sId);
 
+    const modelResolution = await resolveModelForMentionedAgent(auth, {
+      configuration: agentConfigWithSpaces!,
+    });
+
     // Call createAgentMessages
     const { richMentions } = await withTransaction(async (transaction) => {
       return createAgentMessages(auth, {
         conversation: testConversation,
         metadata: {
           type: "create",
-          mentions,
-          agentConfigurations: [agentConfigWithSpaces!],
+          agentConfiguration: agentConfigWithSpaces!,
           skipToolsValidation: false,
           nextMessageRank: 1,
           userMessage,
-          resolvedModels: await resolveModelsForMentionedAgents(auth, {
-            agentConfigurations: [agentConfigWithSpaces!],
-          }),
-          restrictedAgentIds: new Set<string>(),
+          modelResolution,
+          isRestrictedBySpaceUsage: false,
         },
         transaction,
       });
@@ -885,7 +691,7 @@ describe("createAgentMessages", () => {
       content: `Hello @${agentConfig.name}`,
     });
 
-    const mentions: MentionType[] = [
+    const _mentions: MentionType[] = [
       {
         configurationId: agentConfig.sId,
       } satisfies AgentMention,
@@ -901,21 +707,22 @@ describe("createAgentMessages", () => {
     expect(agentConfigWithSpaces?.requestedSpaceIds).toContain(space1.sId);
     expect(agentConfigWithSpaces?.requestedSpaceIds).toContain(space2.sId);
 
+    const modelResolution = await resolveModelForMentionedAgent(auth, {
+      configuration: agentConfigWithSpaces!,
+    });
+
     // Call createAgentMessages
     const { richMentions } = await withTransaction(async (transaction) => {
       return createAgentMessages(auth, {
         conversation: testConversation,
         metadata: {
           type: "create",
-          mentions,
-          agentConfigurations: [agentConfigWithSpaces!],
+          agentConfiguration: agentConfigWithSpaces!,
           skipToolsValidation: false,
           nextMessageRank: 1,
           userMessage,
-          resolvedModels: await resolveModelsForMentionedAgents(auth, {
-            agentConfigurations: [agentConfigWithSpaces!],
-          }),
-          restrictedAgentIds: new Set<string>(),
+          modelResolution,
+          isRestrictedBySpaceUsage: false,
         },
         transaction,
       });
@@ -941,73 +748,6 @@ describe("createAgentMessages", () => {
     expect(requestedSpaceIdsAfter).toHaveLength(2);
     expect(requestedSpaceIdsAfter).toContain(space1.sId);
     expect(requestedSpaceIdsAfter).toContain(space2.sId);
-  });
-
-  it("should deduplicate agent mentions and create only unique agent messages", async () => {
-    const { messageRow, userMessage } =
-      await ConversationFactory.createUserMessage({
-        auth,
-        workspace,
-        conversation,
-        content: `Hello @${agentConfig1.name}`,
-      });
-
-    // Create duplicate mentions for the same agent
-    const mentions: MentionType[] = [
-      {
-        configurationId: agentConfig1.sId,
-      } as AgentMention,
-      {
-        configurationId: agentConfig1.sId,
-      } as AgentMention,
-      {
-        configurationId: agentConfig1.sId,
-      } as AgentMention,
-    ];
-
-    const { agentMessages, richMentions } = await createAgentMessages(auth, {
-      conversation,
-      metadata: {
-        type: "create",
-        mentions,
-        agentConfigurations: [agentConfig1],
-        skipToolsValidation: false,
-        nextMessageRank: 1,
-        userMessage,
-        resolvedModels: await resolveModelsForMentionedAgents(auth, {
-          agentConfigurations: [agentConfig1],
-        }),
-        restrictedAgentIds: new Set<string>(),
-      },
-    });
-
-    // Should only create one agent message despite 3 duplicate mentions
-    expect(agentMessages).toHaveLength(1);
-    expect(agentMessages[0].configuration.sId).toBe(agentConfig1.sId);
-
-    // Should only have one rich mention
-    expect(richMentions).toHaveLength(1);
-    expect(richMentions[0].id).toBe(agentConfig1.sId);
-    if (isRichAgentMention(richMentions[0])) {
-      expect(richMentions[0].status).toBe("approved");
-    }
-
-    // Verify only one mention was created in the database
-    const mentionsInDb = await MentionModel.findAll({
-      where: {
-        workspaceId: workspace.id,
-        messageId: messageRow.id,
-      },
-    });
-    expect(mentionsInDb).toHaveLength(1);
-    expect(mentionsInDb[0].agentConfigurationId).toBe(agentConfig1.sId);
-
-    // Verify signalAgentUsage was called only once
-    expect(signalAgentUsage).toHaveBeenCalledTimes(1);
-    expect(signalAgentUsage).toHaveBeenCalledWith({
-      agentConfigurationId: agentConfig1.sId,
-      workspaceId: workspace.sId,
-    });
   });
 
   describe("conversations that belong to a space", () => {
@@ -1082,7 +822,7 @@ describe("createAgentMessages", () => {
         content: `Hello @${agentConfig.name}`,
       });
 
-      const mentions: MentionType[] = [
+      const _mentions: MentionType[] = [
         {
           configurationId: agentConfig.sId,
         } satisfies AgentMention,
@@ -1093,21 +833,20 @@ describe("createAgentMessages", () => {
         conversation: spaceConversation.toJSON(),
       });
 
+      const modelResolution = await resolveModelForMentionedAgent(auth, {
+        configuration: updatedAgentConfig!,
+      });
+
       const { agentMessages, richMentions } = await createAgentMessages(auth, {
         conversation: spaceConversation.toJSON(),
         metadata: {
           type: "create",
-          mentions,
-          agentConfigurations: [updatedAgentConfig!],
+          agentConfiguration: updatedAgentConfig!,
           skipToolsValidation: false,
           nextMessageRank: 1,
           userMessage,
-          resolvedModels: await resolveModelsForMentionedAgents(auth, {
-            agentConfigurations: [updatedAgentConfig!],
-          }),
-          restrictedAgentIds: canAgentBeUsed
-            ? new Set<string>()
-            : new Set([updatedAgentConfig!.sId]),
+          modelResolution,
+          isRestrictedBySpaceUsage: !canAgentBeUsed,
         },
       });
 
@@ -1237,7 +976,7 @@ describe("createAgentMessages", () => {
         content: `Hello @${agentConfig.name}`,
       });
 
-      const mentions: MentionType[] = [
+      const _mentions: MentionType[] = [
         {
           configurationId: agentConfig.sId,
         } satisfies AgentMention,
@@ -1251,23 +990,22 @@ describe("createAgentMessages", () => {
         }
       );
 
+      const modelResolution = await resolveModelForMentionedAgent(userAuth, {
+        configuration: updatedAgentConfig,
+      });
+
       const { agentMessages, richMentions } = await createAgentMessages(
         userAuth,
         {
           conversation: spaceConversation.toJSON(),
           metadata: {
             type: "create",
-            mentions,
-            agentConfigurations: [updatedAgentConfig],
+            agentConfiguration: updatedAgentConfig,
             skipToolsValidation: false,
             nextMessageRank: 1,
             userMessage,
-            resolvedModels: await resolveModelsForMentionedAgents(userAuth, {
-              agentConfigurations: [updatedAgentConfig],
-            }),
-            restrictedAgentIds: canAgentBeUsed
-              ? new Set<string>()
-              : new Set([updatedAgentConfig.sId]),
+            modelResolution,
+            isRestrictedBySpaceUsage: !canAgentBeUsed,
           },
         }
       );
@@ -1383,7 +1121,7 @@ describe("createAgentMessages", () => {
         content: `Hello @${agentConfig.name}`,
       });
 
-      const mentions: MentionType[] = [
+      const _mentions: MentionType[] = [
         {
           configurationId: agentConfig.sId,
         } satisfies AgentMention,
@@ -1397,23 +1135,22 @@ describe("createAgentMessages", () => {
         }
       );
 
+      const modelResolution = await resolveModelForMentionedAgent(userAuth, {
+        configuration: updatedAgentConfig,
+      });
+
       const { agentMessages, richMentions } = await createAgentMessages(
         userAuth,
         {
           conversation: spaceConversation.toJSON(),
           metadata: {
             type: "create",
-            mentions,
-            agentConfigurations: [updatedAgentConfig],
+            agentConfiguration: updatedAgentConfig,
             skipToolsValidation: false,
             nextMessageRank: 1,
             userMessage,
-            resolvedModels: await resolveModelsForMentionedAgents(userAuth, {
-              agentConfigurations: [updatedAgentConfig],
-            }),
-            restrictedAgentIds: canAgentBeUsed
-              ? new Set<string>()
-              : new Set([updatedAgentConfig.sId]),
+            modelResolution,
+            isRestrictedBySpaceUsage: !canAgentBeUsed,
           },
         }
       );
@@ -1520,7 +1257,7 @@ describe("createAgentMessages", () => {
         content: `Hello @${agentConfig.name}`,
       });
 
-      const mentions: MentionType[] = [
+      const _mentions: MentionType[] = [
         {
           configurationId: agentConfig.sId,
         } satisfies AgentMention,
@@ -1534,23 +1271,22 @@ describe("createAgentMessages", () => {
         }
       );
 
+      const modelResolution = await resolveModelForMentionedAgent(userAuth, {
+        configuration: updatedAgentConfig,
+      });
+
       const { agentMessages, richMentions } = await createAgentMessages(
         userAuth,
         {
           conversation: spaceConversation.toJSON(),
           metadata: {
             type: "create",
-            mentions,
-            agentConfigurations: [updatedAgentConfig],
+            agentConfiguration: updatedAgentConfig,
             skipToolsValidation: false,
             nextMessageRank: 1,
             userMessage,
-            resolvedModels: await resolveModelsForMentionedAgents(userAuth, {
-              agentConfigurations: [updatedAgentConfig],
-            }),
-            restrictedAgentIds: canAgentBeUsed
-              ? new Set<string>()
-              : new Set([updatedAgentConfig.sId]),
+            modelResolution,
+            isRestrictedBySpaceUsage: !canAgentBeUsed,
           },
         }
       );
@@ -1683,7 +1419,7 @@ describe("createAgentMessages", () => {
         content: `Hello @${agentConfig.name}`,
       });
 
-      const mentions: MentionType[] = [
+      const _mentions: MentionType[] = [
         {
           configurationId: agentConfig.sId,
         } satisfies AgentMention,
@@ -1697,23 +1433,22 @@ describe("createAgentMessages", () => {
         }
       );
 
+      const modelResolution = await resolveModelForMentionedAgent(userAuth, {
+        configuration: updatedAgentConfig,
+      });
+
       const { agentMessages, richMentions } = await createAgentMessages(
         userAuth,
         {
           conversation: spaceConversation.toJSON(),
           metadata: {
             type: "create",
-            mentions,
-            agentConfigurations: [updatedAgentConfig],
+            agentConfiguration: updatedAgentConfig,
             skipToolsValidation: false,
             nextMessageRank: 1,
             userMessage,
-            resolvedModels: await resolveModelsForMentionedAgents(userAuth, {
-              agentConfigurations: [updatedAgentConfig],
-            }),
-            restrictedAgentIds: canAgentBeUsed
-              ? new Set<string>()
-              : new Set([updatedAgentConfig.sId]),
+            modelResolution,
+            isRestrictedBySpaceUsage: !canAgentBeUsed,
           },
         }
       );

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -15,7 +15,6 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { isEmailValid } from "@app/lib/utils";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
@@ -30,8 +29,6 @@ import type {
   UserMessageType,
   UserMessageTypeWithoutMentions,
 } from "@app/types/assistant/conversation";
-import type { MentionType } from "@app/types/assistant/mentions";
-import { isAgentMention } from "@app/types/assistant/mentions";
 import type {
   ModelResolutionMethodType,
   ModelSelectionType,
@@ -43,7 +40,6 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import assert from "assert";
-import uniqBy from "lodash/uniqBy";
 import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
 
@@ -273,26 +269,19 @@ export interface AgentMessageModelResolution {
   modelResolutionMethod: ModelResolutionMethodType;
 }
 
-export async function resolveModelsForMentionedAgents(
+export async function resolveModelForMentionedAgent(
   auth: Authenticator,
   {
-    agentConfigurations,
+    configuration,
     selection,
   }: {
-    agentConfigurations: LightAgentConfigurationType[];
+    configuration: LightAgentConfigurationType;
     selection?: ModelSelectionType;
   }
-): Promise<Map<string, AgentMessageModelResolution>> {
+): Promise<AgentMessageModelResolution> {
   const featureFlags = await getFeatureFlags(auth);
 
-  const resolutions = new Map<string, AgentMessageModelResolution>();
-  for (const configuration of agentConfigurations) {
-    resolutions.set(
-      configuration.sId,
-      await resolveModel(auth, { selection, configuration, featureFlags })
-    );
-  }
-  return resolutions;
+  return resolveModel(auth, { selection, configuration, featureFlags });
 }
 
 export const createAgentMessages = async (
@@ -317,13 +306,12 @@ export const createAgentMessages = async (
         }
       | {
           type: "create";
-          mentions: MentionType[];
-          agentConfigurations: LightAgentConfigurationType[];
+          agentConfiguration: LightAgentConfigurationType | null;
           skipToolsValidation: boolean;
           nextMessageRank: number;
           userMessage: UserMessageTypeWithoutMentions;
-          resolvedModels: Map<string, AgentMessageModelResolution>;
-          restrictedAgentIds: Set<string>;
+          modelResolution: AgentMessageModelResolution | null;
+          isRestrictedBySpaceUsage: boolean;
         }
       | {
           type: "approve_existing_mention";
@@ -332,7 +320,7 @@ export const createAgentMessages = async (
           skipToolsValidation: boolean;
           nextMessageRank: number;
           userMessage: UserMessageTypeWithoutMentions;
-          resolvedModels: Map<string, AgentMessageModelResolution>;
+          modelResolution: AgentMessageModelResolution | null;
         };
     transaction?: Transaction;
   }
@@ -466,152 +454,115 @@ export const createAgentMessages = async (
     // falls through
     case "create":
       {
-        const uniqueAgentMentions =
+        const configuration =
           metadata.type === "approve_existing_mention"
-            ? [{ configurationId: metadata.configuration.sId }]
-            : uniqBy(
-                metadata.mentions.filter(isAgentMention),
-                (mention) => mention.configurationId
-              );
-
-        // Multiple agent mentions are still accepted (the public API relies on them), we only
-        // track them while we move to a single mention per message.
-        if (uniqueAgentMentions.length > 1) {
-          logger.warn(
-            {
-              agentMentionCount: uniqueAgentMentions.length,
-              conversationId: conversation.sId,
-              workspaceId: owner.sId,
-            },
-            "Creating agent messages for multiple agent mentions."
-          );
+            ? metadata.configuration
+            : metadata.agentConfiguration;
+        if (!configuration) {
+          break;
         }
 
-        await concurrentExecutor(
-          uniqueAgentMentions,
-          async (mention) => {
-            const configuration =
-              metadata.type === "approve_existing_mention"
-                ? metadata.configuration
-                : metadata.agentConfigurations.find(
-                    (ac) => ac.sId === mention.configurationId
-                  );
-            if (!configuration) {
-              return;
-            }
-
-            let mentionRow: MentionModel;
-            if (metadata.type === "approve_existing_mention") {
-              mentionRow = metadata.mentionRow;
-            } else {
-              if (metadata.restrictedAgentIds.has(configuration.sId)) {
-                // This create the mentions from the original user message. Not to be mixed with
-                // the mentions from the agent message (which will be filled later).
-                const restrictedMentionRow = await MentionModel.create(
-                  {
-                    messageId: metadata.userMessage.id,
-                    agentConfigurationId: configuration.sId,
-                    workspaceId: owner.id,
-                    status: "agent_restricted_by_space_usage",
-                  },
-                  { transaction }
-                );
-
-                results.push({
-                  mentionRow: restrictedMentionRow,
-                  agentAnswer: null,
-                  parentMessageId: metadata.userMessage.sId,
-                  parentAgentMessageId: null,
-                  configuration,
-                });
-
-                return;
-              }
-
-              // This create the mentions from the original user message. Not to be mixed with the
-              // mentions from the agent message (which will be filled later).
-              mentionRow = await MentionModel.create(
-                {
-                  messageId: metadata.userMessage.id,
-                  agentConfigurationId: configuration.sId,
-                  workspaceId: owner.id,
-                  status: "approved",
-                },
-                { transaction }
-              );
-            }
-
-            const resolution = metadata.resolvedModels.get(configuration.sId);
-            assert(
-              resolution,
-              `Missing model resolution for agent configuration ${configuration.sId}`
-            );
-            const { resolvedModel, modelResolutionMethod } = resolution;
-
-            const agentMessageRow = await AgentMessageModel.create(
+        let mentionRow: MentionModel;
+        if (metadata.type === "approve_existing_mention") {
+          mentionRow = metadata.mentionRow;
+        } else {
+          if (metadata.isRestrictedBySpaceUsage) {
+            // This create the mentions from the original user message. Not to be mixed with
+            // the mentions from the agent message (which will be filled later).
+            const restrictedMentionRow = await MentionModel.create(
               {
-                status: "created",
+                messageId: metadata.userMessage.id,
                 agentConfigurationId: configuration.sId,
-                agentConfigurationVersion: configuration.version,
-                conversationId: conversation.id,
                 workspaceId: owner.id,
-                skipToolsValidation: metadata.skipToolsValidation,
-                resolvedProviderId: resolvedModel.providerId,
-                resolvedModelId: resolvedModel.modelId,
-                resolvedReasoningEffort: resolvedModel.reasoningEffort,
-                modelResolutionMethod,
+                status: "agent_restricted_by_space_usage",
               },
               { transaction }
-            );
-            const messageRow = await MessageModel.create(
-              {
-                sId: generateRandomModelSId(),
-                rank: metadata.nextMessageRank++,
-                conversationId: conversation.id,
-                branchId: null,
-                parentId: metadata.userMessage.id,
-                agentMessageId: agentMessageRow.id,
-                workspaceId: owner.id,
-              },
-              { transaction }
-            );
-
-            // This will tweak the UI a bit.
-            const parentAgentMessageId =
-              metadata.userMessage.agenticMessageData?.type === "agent_handover"
-                ? metadata.userMessage.agenticMessageData.originMessageId
-                : null;
-
-            // Track agent usage when creating a new agent message.
-            signalAgentUsageAfterCommit(
-              {
-                agentConfigurationId: configuration.sId,
-                workspaceId: owner.sId,
-              },
-              transaction
             );
 
             results.push({
-              agentAnswer: {
-                agentMessageRow,
-                messageRow,
-              },
-              parentAgentMessageId,
+              mentionRow: restrictedMentionRow,
+              agentAnswer: null,
               parentMessageId: metadata.userMessage.sId,
+              parentAgentMessageId: null,
               configuration,
-              mentionRow,
             });
-          },
-          {
-            // TODO(20260423 jd)
-            // all callsites of this function pass a transaction
-            // so concurent executor is purely cosmetic
-            // eventually we will get rid of these monstruous transactions
-            // so not putting a for loop
-            // and downsizing from 10 to max peak concurrency - 1
-            concurrency: 4,
+
+            break;
           }
+
+          // This create the mentions from the original user message. Not to be mixed with the
+          // mentions from the agent message (which will be filled later).
+          mentionRow = await MentionModel.create(
+            {
+              messageId: metadata.userMessage.id,
+              agentConfigurationId: configuration.sId,
+              workspaceId: owner.id,
+              status: "approved",
+            },
+            { transaction }
+          );
+        }
+
+        const resolution = metadata.modelResolution;
+        assert(
+          resolution,
+          `Missing model resolution for agent configuration ${configuration.sId}`
         );
+        const { resolvedModel, modelResolutionMethod } = resolution;
+
+        const agentMessageRow = await AgentMessageModel.create(
+          {
+            status: "created",
+            agentConfigurationId: configuration.sId,
+            agentConfigurationVersion: configuration.version,
+            conversationId: conversation.id,
+            workspaceId: owner.id,
+            skipToolsValidation: metadata.skipToolsValidation,
+            resolvedProviderId: resolvedModel.providerId,
+            resolvedModelId: resolvedModel.modelId,
+            resolvedReasoningEffort: resolvedModel.reasoningEffort,
+            modelResolutionMethod,
+          },
+          { transaction }
+        );
+        const messageRow = await MessageModel.create(
+          {
+            sId: generateRandomModelSId(),
+            rank: metadata.nextMessageRank,
+            conversationId: conversation.id,
+            branchId: null,
+            parentId: metadata.userMessage.id,
+            agentMessageId: agentMessageRow.id,
+            workspaceId: owner.id,
+          },
+          { transaction }
+        );
+
+        // This will tweak the UI a bit.
+        const parentAgentMessageId =
+          metadata.userMessage.agenticMessageData?.type === "agent_handover"
+            ? metadata.userMessage.agenticMessageData.originMessageId
+            : null;
+
+        // Track agent usage when creating a new agent message.
+        signalAgentUsageAfterCommit(
+          {
+            agentConfigurationId: configuration.sId,
+            workspaceId: owner.sId,
+          },
+          transaction
+        );
+
+        results.push({
+          agentAnswer: {
+            agentMessageRow,
+            messageRow,
+          },
+          parentAgentMessageId,
+          parentMessageId: metadata.userMessage.sId,
+          configuration,
+          mentionRow,
+        });
       }
       break;
     default:

--- a/front/lib/api/assistant/conversation/permissions.ts
+++ b/front/lib/api/assistant/conversation/permissions.ts
@@ -165,6 +165,26 @@ export async function canAgentBeUsedInProjectConversation(
   return true;
 }
 
+export async function isAgentRestrictedBySpaceUsage(
+  auth: Authenticator,
+  {
+    configuration,
+    conversation,
+  }: {
+    configuration: LightAgentConfigurationType | null;
+    conversation: ConversationWithoutContentType;
+  }
+): Promise<boolean> {
+  if (!configuration || !isPodConversation(conversation)) {
+    return false;
+  }
+
+  return !(await canAgentBeUsedInProjectConversation(auth, {
+    configuration,
+    conversation,
+  }));
+}
+
 /**
  * Update the conversation requestedSpaceIds based on the mentioned agents. This function is purely
  * additive - requirements are never removed.

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -35,7 +35,7 @@ import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { dismissMention } from "@app/lib/api/assistant/conversation/mentions";
 import {
   createAgentMessages,
-  resolveModelsForMentionedAgents,
+  resolveModelForMentionedAgent,
 } from "@app/lib/api/assistant/conversation/messages";
 import { resolveAuthentication } from "@app/lib/api/assistant/conversation/resolve_authentication";
 import { retryBlockedActions } from "@app/lib/api/assistant/conversation/retry_blocked_actions";
@@ -663,26 +663,30 @@ describe("dismissMention", () => {
         }
       );
 
-      const agentMentions: MentionType[] = [
+      const _agentMentions: MentionType[] = [
         {
           configurationId: agentConfig.sId,
         } satisfies AgentMention,
       ];
+
+      const modelResolution = await resolveModelForMentionedAgent(
+        refreshedAuth,
+        {
+          configuration: agentConfig,
+        }
+      );
 
       // Create agent message properly so it appears in conversation content
       const { agentMessages } = await createAgentMessages(refreshedAuth, {
         conversation: refreshedConversation.value,
         metadata: {
           type: "create",
-          mentions: agentMentions,
-          agentConfigurations: [agentConfig],
+          agentConfiguration: agentConfig,
           skipToolsValidation: false,
           nextMessageRank: 1,
           userMessage,
-          resolvedModels: await resolveModelsForMentionedAgents(refreshedAuth, {
-            agentConfigurations: [agentConfig],
-          }),
-          restrictedAgentIds: new Set<string>(),
+          modelResolution,
+          isRestrictedBySpaceUsage: false,
         },
       });
 

--- a/front/lib/api/assistant/conversation/validate_agent_mention.ts
+++ b/front/lib/api/assistant/conversation/validate_agent_mention.ts
@@ -10,7 +10,7 @@ import {
 } from "@app/lib/api/assistant/conversation/lock";
 import {
   createAgentMessages,
-  resolveModelsForMentionedAgents,
+  resolveModelForMentionedAgent,
 } from "@app/lib/api/assistant/conversation/messages";
 import { publishMessageEventsOnMessagePostOrEdit } from "@app/lib/api/assistant/streaming/events";
 import type { Authenticator } from "@app/lib/auth";
@@ -230,8 +230,8 @@ export async function validateAgentMention(
     "User approved a restricted agent mention"
   );
 
-  const resolvedModels = await resolveModelsForMentionedAgents(auth, {
-    agentConfigurations: [configuration],
+  const modelResolution = await resolveModelForMentionedAgent(auth, {
+    configuration,
     selection: message.requestedModel ?? undefined,
   });
 
@@ -272,7 +272,7 @@ export async function validateAgentMention(
           skipToolsValidation: false,
           nextMessageRank,
           userMessage: message,
-          resolvedModels,
+          modelResolution,
         },
         transaction: t,
       });


### PR DESCRIPTION
## Description

Currently we do a lot of things in 2 big transactions (postUserMessage and editUserMessage), with a lock and some network I/O.
This stack is about removing everything that can be removed from this big transaction, with this PR being the final step: propagate the  "one agent mention per postUserMessage / editUserMessage" all the way down.

We currently have this sitting at the top of postUserMessage (used by both v1 and private)

```
  // Steering invariants: enforce single agent loop per conversation.
  if (explicitAgentMentions.length > 1) {
    return new Err({
      status_code: 400,
      api_error: {
        type: "invalid_request_error",
        message: "Only one agent can be mentioned per message.",
      },
    });
  }
```

Yet we still have a [concurrentExecutor](https://github.com/dust-tt/dust/pull/29838/changes#diff-539f8a721a6829d9a966dad341ba48671e39aff72aa06fd96141ac5a9e1446ebL490) on unique agent mentions. A vestige of before-steering times.

This PR is more about cleanup than anything else


## Tests

Tested locally
Tested in front-edge

## Risk

Low
Blast radius: postUserMessage / editUserMessage

## Deploy Plan

- Deploy front