### PR TITLE
[Analytics] Require admin scope for exports

### DIFF
--- a/front-api/routes/v1/w/[wId]/analytics/export.test.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/export.test.ts
@@ -1,7 +1,7 @@
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
-import { ENSURE_IS_BUILDER_ERROR_MESSAGE } from "@front-api/middlewares/ensure_role";
+import { ENSURE_IS_ADMIN_ERROR_MESSAGE } from "@front-api/middlewares/ensure_role";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/api/assistant/observability/messages_metrics", async () => ({
@@ -225,12 +225,16 @@ describe("GET /api/v1/w/[wId]/analytics/export", () => {
     expect(response.status).toBe(200);
   });
 
-  // TODO(api-key-scopes): once builder keys are migrated to admin scope and the
-  // temporary fallback in export.ts is removed, change this to expect 403.
-  it("returns 200 for builder API key (temporary backward-compat)", async () => {
+  it("returns 403 for builder API key", async () => {
     const { response } = await setupTest({ role: "builder" });
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "workspace_auth_error",
+        message: ENSURE_IS_ADMIN_ERROR_MESSAGE,
+      },
+    });
   });
 
   it("returns 403 for read-only API key (insufficient scope)", async () => {
@@ -240,7 +244,7 @@ describe("GET /api/v1/w/[wId]/analytics/export", () => {
     expect(await response.json()).toEqual({
       error: {
         type: "workspace_auth_error",
-        message: ENSURE_IS_BUILDER_ERROR_MESSAGE,
+        message: ENSURE_IS_ADMIN_ERROR_MESSAGE,
       },
     });
   });

--- a/front-api/routes/v1/w/[wId]/analytics/export.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/export.ts
@@ -84,17 +84,14 @@ import {
 } from "@app/lib/api/analytics/export_tables";
 import { GetAnalyticsExportRequestSchema } from "@dust-tt/client";
 import { publicApiApp } from "@front-api/middlewares/ctx";
-import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
 
 // Mounted at /api/v1/w/:wId/analytics/export. publicApiAuth is applied by the
 // parent v1 workspace sub-app, so ctx.get("auth") is always available here.
 const app = publicApiApp();
 
-// TODO(api-key-scopes): tighten to admin-only once existing builder-scoped
-// integrations have been migrated to admin keys. Builder is temporarily
-// accepted to avoid breaking current callers.
-app.get("/", ensureIsBuilder(), async (ctx) => {
+app.get("/", ensureIsAdmin(), async (ctx) => {
   const auth = ctx.get("auth");
 
   if (!auth.isKey()) {


### PR DESCRIPTION
## Description

Restricts workspace analytics exports to API keys with admin scope. Builder-scoped keys were temporarily accepted during migration; this restores the intended admin-only boundary and updates the permission tests.

## Risks

Blast radius: Analytics export requests made with non-admin API keys.
Risk: standard

## Deploy Plan

- Deploy front-api.

## Test

- [x] Verified admin API keys are accepted while builder and read-only API keys are rejected.