### PR TITLE
Stop creating conversation branches for restricted Pod agents.

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -2892,7 +2892,7 @@ describe("postUserMessage", () => {
     });
   });
 
-  describe("restricted agent branch creation", () => {
+  describe("restricted agent in project conversation", () => {
     let projectSpace: Awaited<ReturnType<typeof SpaceFactory.project>>;
     let anotherProjectSpace: Awaited<ReturnType<typeof SpaceFactory.project>>;
     let projectConversation: ConversationType;
@@ -3013,12 +3013,12 @@ describe("postUserMessage", () => {
       );
     }
 
-    describe("with projects feature flag enabled regarding branches", () => {
+    describe("when posting with a restricted agent", () => {
       beforeEach(async () => {
         await setupProjectWithRestrictedAgent();
       });
 
-      it("should create a branch and put first message in branch when posting with restricted agent", async () => {
+      it("does not create a branch and records a restricted mention without an agent message", async () => {
         const user = auth.getNonNullableUser();
         const userJson = user.toJSON();
 
@@ -3058,29 +3058,33 @@ describe("postUserMessage", () => {
             auth,
             projectConversation.id
           );
-        expect(branchesAfter.length).toBe(1);
-        const branch = branchesAfter[0];
+        expect(branchesAfter.length).toBe(0);
 
-        const newUserMessageId = result.value.userMessage.id;
         const newUserMessageRow = await MessageModel.findOne({
           where: {
-            id: newUserMessageId,
+            id: result.value.userMessage.id,
             workspaceId: workspace.id,
           },
         });
         expect(newUserMessageRow).not.toBeNull();
-        expect(newUserMessageRow!.branchId).toBe(branch.id);
+        expect(newUserMessageRow!.branchId).toBeNull();
 
-        const agentMessages = result.value.agentMessages;
-        expect(agentMessages.length).toBe(1);
-        const agentMessageRow = await MessageModel.findOne({
+        expect(result.value.agentMessages.length).toBe(0);
+
+        const mentionRow = await MentionModel.findOne({
           where: {
-            id: agentMessages[0].id,
+            messageId: result.value.userMessage.id,
             workspaceId: workspace.id,
+            agentConfigurationId: agentWithDifferentSpace.sId,
           },
         });
-        expect(agentMessageRow).not.toBeNull();
-        expect(agentMessageRow!.branchId).toBe(branch.id);
+        expect(mentionRow).not.toBeNull();
+        expect(mentionRow!.status).toBe("agent_restricted_by_space_usage");
+
+        const agentMentions =
+          result.value.userMessage.richMentions.filter(isRichAgentMention);
+        expect(agentMentions).toHaveLength(1);
+        expect(agentMentions[0].status).toBe("agent_restricted_by_space_usage");
 
         rateLimiterSpy.mockRestore();
       });
@@ -3093,33 +3097,23 @@ describe("postUserMessage", () => {
           .spyOn(rateLimiterModule, "rateLimiter")
           .mockResolvedValue(100);
 
-        const firstPost = await postUserMessage(auth, {
-          conversationResource: projectConversationResource,
-          content: `First message @${agentWithDifferentSpace.name}`,
-          mentions: [{ configurationId: agentWithDifferentSpace.sId }],
-          context: {
-            username: userJson.username,
-            timezone: "UTC",
-            fullName: userJson.fullName,
-            email: userJson.email,
-            profilePictureUrl: userJson.image,
-            origin: "web",
+        // Manually open a legacy branch — restricted agents no longer auto-create one.
+        const previousMessage = await MessageModel.findOne({
+          where: {
+            conversationId: projectConversation.id,
+            workspaceId: workspace.id,
+            branchId: null,
           },
-          skipToolsValidation: false,
+          order: [["rank", "DESC"]],
         });
+        expect(previousMessage).not.toBeNull();
 
-        expect(firstPost.isOk()).toBe(true);
-        if (!firstPost.isOk()) {
-          return;
-        }
-
-        const branchesAfterFirstPost =
-          await ConversationBranchResource.listForConversation(
-            auth,
-            projectConversation.id
-          );
-        expect(branchesAfterFirstPost.length).toBe(1);
-        const branchId = branchesAfterFirstPost[0].sId;
+        const branch = await ConversationBranchResource.makeNew(auth, {
+          conversationId: projectConversation.id,
+          previousMessageId: previousMessage!.id,
+          state: "open",
+          userId: user.id,
+        });
 
         const convInBranchResource = await fetchConversationResource(
           auth,
@@ -3128,7 +3122,7 @@ describe("postUserMessage", () => {
 
         const secondPost = await postUserMessage(auth, {
           conversationResource: convInBranchResource,
-          branchId,
+          branchId: branch.sId,
           content: "Second message in branch",
           mentions: [],
           context: {
@@ -3154,23 +3148,18 @@ describe("postUserMessage", () => {
           },
         });
         expect(secondUserMessageRow).not.toBeNull();
-        const branchRow = await ConversationBranchResource.fetchById(
-          auth,
-          branchId
-        );
-        expect(branchRow).not.toBeNull();
-        expect(secondUserMessageRow!.branchId).toBe(branchRow!.id);
+        expect(secondUserMessageRow!.branchId).toBe(branch.id);
 
         rateLimiterSpy.mockRestore();
       });
     });
 
-    describe("with empty conversation and projects feature flag enabled", () => {
+    describe("with empty conversation", () => {
       beforeEach(async () => {
         await setupProjectWithRestrictedAgent({ messagesCreatedAt: [] });
       });
 
-      it("should create a branch with an anchor message when first message mentions a restricted agent", async () => {
+      it("does not create a branch or anchor when first message mentions a restricted agent", async () => {
         const user = auth.getNonNullableUser();
         const userJson = user.toJSON();
 
@@ -3205,32 +3194,24 @@ describe("postUserMessage", () => {
             auth,
             projectConversation.id
           );
-        expect(branchesAfter.length).toBe(1);
-        const branch = branchesAfter[0];
+        expect(branchesAfter.length).toBe(0);
 
-        // Anchor message: rank 0, empty content, origin "branch_anchor".
         const anchorMessageRow = await MessageModel.findOne({
           where: {
             conversationId: projectConversation.id,
             workspaceId: workspace.id,
-            rank: 0,
-            branchId: null,
           },
           include: [
             {
               model: UserMessageModel,
               as: "userMessage",
               required: true,
+              where: { userContextOrigin: "branch_anchor" },
             },
           ],
         });
-        expect(anchorMessageRow).not.toBeNull();
-        expect(anchorMessageRow!.userMessage!.content).toBe("");
-        expect(anchorMessageRow!.userMessage!.userContextOrigin).toBe(
-          "branch_anchor"
-        );
+        expect(anchorMessageRow).toBeNull();
 
-        // The actual user message lives on the branch at rank 1.
         const newUserMessageRow = await MessageModel.findOne({
           where: {
             id: result.value.userMessage.id,
@@ -3238,21 +3219,11 @@ describe("postUserMessage", () => {
           },
         });
         expect(newUserMessageRow).not.toBeNull();
-        expect(newUserMessageRow!.branchId).toBe(branch.id);
-        expect(newUserMessageRow!.rank).toBe(1);
+        expect(newUserMessageRow!.branchId).toBeNull();
+        expect(newUserMessageRow!.rank).toBe(0);
 
-        // Agent message also lives on the branch.
-        expect(result.value.agentMessages.length).toBe(1);
-        const agentMessageRow = await MessageModel.findOne({
-          where: {
-            id: result.value.agentMessages[0].id,
-            workspaceId: workspace.id,
-          },
-        });
-        expect(agentMessageRow).not.toBeNull();
-        expect(agentMessageRow!.branchId).toBe(branch.id);
+        expect(result.value.agentMessages.length).toBe(0);
 
-        // Mention is approved (not restricted) because it lives on a branch.
         const mentionRow = await MentionModel.findOne({
           where: {
             messageId: result.value.userMessage.id,
@@ -3261,12 +3232,12 @@ describe("postUserMessage", () => {
           },
         });
         expect(mentionRow).not.toBeNull();
-        expect(mentionRow!.status).toBe("approved");
+        expect(mentionRow!.status).toBe("agent_restricted_by_space_usage");
 
         rateLimiterSpy.mockRestore();
       });
 
-      it("should create a branch anchor when the conversation only contains content fragments", async () => {
+      it("does not create a branch when the conversation only contains content fragments", async () => {
         const user = auth.getNonNullableUser();
         const userJson = user.toJSON();
         const dsViewInGlobalSpace = await DataSourceViewFactory.folder(
@@ -3341,29 +3312,7 @@ describe("postUserMessage", () => {
             auth,
             projectConversation.id
           );
-        expect(branchesAfter.length).toBe(1);
-        const branch = branchesAfter[0];
-
-        const anchorMessageRow = await MessageModel.findOne({
-          where: {
-            conversationId: projectConversation.id,
-            workspaceId: workspace.id,
-            rank: 1,
-            branchId: null,
-          },
-          include: [
-            {
-              model: UserMessageModel,
-              as: "userMessage",
-              required: true,
-            },
-          ],
-        });
-        expect(anchorMessageRow).not.toBeNull();
-        expect(anchorMessageRow!.userMessage!.content).toBe("");
-        expect(anchorMessageRow!.userMessage!.userContextOrigin).toBe(
-          "branch_anchor"
-        );
+        expect(branchesAfter.length).toBe(0);
 
         const newUserMessageRow = await MessageModel.findOne({
           where: {
@@ -3372,8 +3321,19 @@ describe("postUserMessage", () => {
           },
         });
         expect(newUserMessageRow).not.toBeNull();
-        expect(newUserMessageRow!.branchId).toBe(branch.id);
-        expect(newUserMessageRow!.rank).toBe(2);
+        expect(newUserMessageRow!.branchId).toBeNull();
+
+        expect(result.value.agentMessages.length).toBe(0);
+
+        const mentionRow = await MentionModel.findOne({
+          where: {
+            messageId: result.value.userMessage.id,
+            workspaceId: workspace.id,
+            agentConfigurationId: agentWithDifferentSpace.sId,
+          },
+        });
+        expect(mentionRow).not.toBeNull();
+        expect(mentionRow!.status).toBe("agent_restricted_by_space_usage");
 
         rateLimiterSpy.mockRestore();
       });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -772,7 +772,6 @@ export async function postUserMessage(
   ]);
 
   let agentConfigurations = removeNulls(results[0]);
-  let shouldCreateBranch = false;
 
   // Retired global agents can't be invoked (new conversations or new messages).
   // The internal `run_agent` path is exempt: some hidden sub-agents are retired.
@@ -837,16 +836,6 @@ export async function postUserMessage(
         },
       });
     }
-
-    // When the agent is not usable, we will create a branch.
-    if (isPartOfPod) {
-      const canAgentBeUsed = await canAgentBeUsedInProjectConversation(auth, {
-        configuration: agentConfig,
-        conversation,
-      });
-
-      shouldCreateBranch = shouldCreateBranch || !canAgentBeUsed;
-    }
   }
 
   // Resolve the message author before the transaction: the email attribution reads must not run
@@ -865,93 +854,6 @@ export async function postUserMessage(
     // connection pool, resulting in a deadlock.
     await getConversationRankVersionLock(auth, conversation, t);
 
-    let nextMessageRank: number | undefined;
-
-    // We will do best effort to create a branch, but there a several conditions that we will not create a branch.
-    // - User is null, cannot create branch without a user, should never happen, but we will log an error and continue.
-    // - Message has user mentions, we don't support multiple users in a branch yet.
-    // - Last message in conversation has no content should never happen, but we will log an error and continue.
-    // If we do not create a branch, the user will receive a notification that the agent is not usable.
-    if (shouldCreateBranch) {
-      if (user === null) {
-        // Should never happen, but we will log an error and continue.
-        logger.error("User is null, cannot create branch without a user.");
-      } else if (mentions.some(isUserMention)) {
-        logger.info(
-          "Message has user mentions, for now we do not support branching with user mentions."
-        );
-      } else {
-        const branchContext =
-          await conversationResource.getBranchCreationContext(auth, {
-            branchId: conversation.branchId,
-            transaction: t,
-          });
-        const shouldCreateAnchorMessage =
-          branchContext.isEmpty || branchContext.onlyContentFragments;
-
-        if (shouldCreateAnchorMessage) {
-          // Create an invisible anchor message so the branch has a previousMessageId
-          // to reference. If the conversation only contains content fragments, keep
-          // them before the anchor so they remain attached to the branch context.
-          const anchorMessageRank =
-            branchContext.maxRank !== null ? branchContext.maxRank + 1 : 0;
-          const anchorMessage = await createUserMessage(auth, {
-            conversation,
-            content: "",
-            metadata: {
-              type: "create",
-              user: user.toJSON(),
-              rank: anchorMessageRank,
-              context: {
-                ...context,
-                origin: "branch_anchor",
-              },
-              requestedModel: modelSelection ?? null,
-            },
-            transaction: t,
-          });
-
-          const branch = await ConversationBranchResource.makeNew(
-            auth,
-            {
-              conversationId: conversation.id,
-              previousMessageId: anchorMessage.id,
-              state: "open",
-              userId: user.id,
-            },
-            t
-          );
-
-          conversation.branchId = branch.sId;
-          nextMessageRank = anchorMessageRank + 1;
-        } else {
-          const previousMessage = branchContext.lastMessage;
-          if (!previousMessage) {
-            logger.error(
-              "Last message in conversation has no content, cannot create branch."
-            );
-          } else {
-            // Create a new branch for the conversation.
-            const branch = await ConversationBranchResource.makeNew(
-              auth,
-              {
-                conversationId: conversation.id,
-                previousMessageId: previousMessage.id,
-                state: "open",
-                userId: user.id,
-              },
-              t
-            );
-
-            // Update the conversation with the new branch id so the rest of the functions will operate on the branch.
-            conversation.branchId = branch.sId;
-            // Set the next message rank to the rank of the previous message plus one.
-            nextMessageRank = previousMessage.rank + 1;
-          }
-        }
-      }
-    }
-
     // We clear the hasError flag of a conversation when posting a new user message.
     if (conversation.hasError) {
       await ConversationResource.clearHasError(
@@ -963,7 +865,7 @@ export async function postUserMessage(
       );
     }
 
-    nextMessageRank ??= await getNextConversationMessageRank(auth, {
+    let nextMessageRank = await getNextConversationMessageRank(auth, {
       conversation,
       transaction: t,
     });


### PR DESCRIPTION
## Description

Removes the auto-branch logic from `postUserMessage` for restricted Pod agents. Previously, mentioning an agent that lacked access to the Pod's space would trigger `ConversationBranchResource.makeNew` — complete with optional anchor messages — and silently route the reply into a new branch. Now, the mention is recorded directly on the main conversation with status `agent_restricted_by_space_usage`, no agent message is created, and no branch is opened. Deletes ~93 lines of branching logic (`shouldCreateBranch`, `getBranchCreationContext`, anchor-message creation) from `postUserMessage`.

## Tests

Updated existing integration tests in `conversation.test.ts` to reflect the new behavior: assert `branchesAfter.length === 0`, `agentMessages.length === 0`, and `mentionRow.status === "agent_restricted_by_space_usage"`. Covered non-empty conversations, empty conversations (previously created an anchor), and content-fragment-only conversations.

## Risk

Low. The branch-creation path was a Pod-specific code branch gated on `isPartOfPod` and `canAgentBeUsedInProjectConversation`. Existing conversations on branches are unaffected; the restriction-status mention path already existed. Rollback is a revert with no schema changes to undo.

## Deploy Plan

Deploy front.
