### PR TITLE
Add validateAgentMention to approve restricted agents in-place.

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2395,7 +2395,7 @@ function getMessageLimitErrorMessage({
   }
 }
 
-async function checkMessagesLimit(
+export async function checkMessagesLimit(
   auth: Authenticator,
   {
     mentions,

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -269,6 +269,14 @@ export const createAgentMessages = async (
           skipToolsValidation: boolean;
           nextMessageRank: number;
           userMessage: UserMessageTypeWithoutMentions;
+        }
+      | {
+          type: "approve_existing_mention";
+          mentionRow: MentionModel;
+          configuration: LightAgentConfigurationType;
+          skipToolsValidation: boolean;
+          nextMessageRank: number;
+          userMessage: UserMessageTypeWithoutMentions;
         };
     transaction?: Transaction;
   }
@@ -396,74 +404,88 @@ export const createAgentMessages = async (
       }
       break;
 
+    case "approve_existing_mention":
+      // Fall through into the shared create path after marking the existing
+      // mention approved (do not insert a duplicate MentionModel row).
+      await metadata.mentionRow.update({ status: "approved" }, { transaction });
+    // falls through
     case "create":
       {
-        // Deduplicate agent mentions before processing
-        const uniqueAgentMentions = uniqBy(
-          metadata.mentions.filter(isAgentMention),
-          (mention) => mention.configurationId
-        );
         const featureFlags = await getFeatureFlags(auth);
+
+        const uniqueAgentMentions =
+          metadata.type === "approve_existing_mention"
+            ? [{ configurationId: metadata.configuration.sId }]
+            : uniqBy(
+                metadata.mentions.filter(isAgentMention),
+                (mention) => mention.configurationId
+              );
 
         await concurrentExecutor(
           uniqueAgentMentions,
           async (mention) => {
-            const configuration = metadata.agentConfigurations.find(
-              (ac) => ac.sId === mention.configurationId
-            );
+            const configuration =
+              metadata.type === "approve_existing_mention"
+                ? metadata.configuration
+                : metadata.agentConfigurations.find(
+                    (ac) => ac.sId === mention.configurationId
+                  );
             if (!configuration) {
               return;
             }
 
-            // In case of Project's conversation, we need to check if the agent configuration is
-            // using only the project spaces or open spaces. Otherwise we reject the mention and
-            // do not create the agent message.
-            if (isPodConversation(conversation)) {
-              const canAgentBeUsed = await canAgentBeUsedInProjectConversation(
-                auth,
-                {
-                  configuration,
-                  conversation,
-                  transaction,
+            let mentionRow: MentionModel;
+            if (metadata.type === "approve_existing_mention") {
+              mentionRow = metadata.mentionRow;
+            } else {
+              // In case of Project's conversation, we need to check if the agent configuration is
+              // using only the project spaces or open spaces. Otherwise we reject the mention and
+              // do not create the agent message.
+              if (isPodConversation(conversation)) {
+                const canAgentBeUsed =
+                  await canAgentBeUsedInProjectConversation(auth, {
+                    configuration,
+                    conversation,
+                    transaction,
+                  });
+
+                if (!canAgentBeUsed) {
+                  // This create the mentions from the original user message. Not to be mixed with
+                  // the mentions from the agent message (which will be filled later).
+                  const restrictedMentionRow = await MentionModel.create(
+                    {
+                      messageId: metadata.userMessage.id,
+                      agentConfigurationId: configuration.sId,
+                      workspaceId: owner.id,
+                      status: "agent_restricted_by_space_usage",
+                    },
+                    { transaction }
+                  );
+
+                  results.push({
+                    mentionRow: restrictedMentionRow,
+                    agentAnswer: null,
+                    parentMessageId: metadata.userMessage.sId,
+                    parentAgentMessageId: null,
+                    configuration,
+                  });
+
+                  return;
                 }
-              );
-
-              if (!canAgentBeUsed) {
-                // This create the mentions from the original user message. Not to be mixed with
-                // the mentions from the agent message (which will be filled later).
-                const mentionRow = await MentionModel.create(
-                  {
-                    messageId: metadata.userMessage.id,
-                    agentConfigurationId: configuration.sId,
-                    workspaceId: owner.id,
-                    status: "agent_restricted_by_space_usage",
-                  },
-                  { transaction }
-                );
-
-                results.push({
-                  mentionRow,
-                  agentAnswer: null,
-                  parentMessageId: metadata.userMessage.sId,
-                  parentAgentMessageId: null,
-                  configuration,
-                });
-
-                return;
               }
-            }
 
-            // This create the mentions from the original user message. Not to be mixed with the
-            // mentions from the agent message (which will be filled later).
-            const mentionRow = await MentionModel.create(
-              {
-                messageId: metadata.userMessage.id,
-                agentConfigurationId: configuration.sId,
-                workspaceId: owner.id,
-                status: "approved",
-              },
-              { transaction }
-            );
+              // This create the mentions from the original user message. Not to be mixed with the
+              // mentions from the agent message (which will be filled later).
+              mentionRow = await MentionModel.create(
+                {
+                  messageId: metadata.userMessage.id,
+                  agentConfigurationId: configuration.sId,
+                  workspaceId: owner.id,
+                  status: "approved",
+                },
+                { transaction }
+              );
+            }
 
             const { resolvedModel, modelResolutionMethod } = await resolveModel(
               auth,

--- a/front/lib/api/assistant/conversation/validate_agent_mention.ts
+++ b/front/lib/api/assistant/conversation/validate_agent_mention.ts
@@ -1,0 +1,314 @@
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { getRelatedContentFragments } from "@app/lib/api/assistant/content_fragments";
+import { checkMessagesLimit } from "@app/lib/api/assistant/conversation";
+import { runAgentLoopWorkflow } from "@app/lib/api/assistant/conversation/agent_loop";
+import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import {
+  getConversationRankVersionLock,
+  getNextConversationMessageRank,
+} from "@app/lib/api/assistant/conversation/lock";
+import { createAgentMessages } from "@app/lib/api/assistant/conversation/messages";
+import { publishMessageEventsOnMessagePostOrEdit } from "@app/lib/api/assistant/streaming/events";
+import type { Authenticator } from "@app/lib/auth";
+import { MentionModel } from "@app/lib/models/agent/conversation";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import { auditLog } from "@app/logger/logger";
+import type {
+  AgentMessageType,
+  RichMentionWithStatus,
+  UserMessageType,
+} from "@app/types/assistant/conversation";
+import { isUserMessageType } from "@app/types/assistant/conversation";
+import {
+  isRichAgentMention,
+  toMentionType,
+} from "@app/types/assistant/mentions";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+/**
+ * Approve or reject a restricted agent mention in a Pod conversation.
+ * On approve: creates the agent message in the conversation and launches the agent loop
+ * (intentional override of canAgentBeUsedInProjectConversation).
+ *
+ * Lives in its own module to avoid an import cycle with conversation.ts
+ * (which imports createUserMentions from mentions.ts).
+ */
+export async function validateAgentMention(
+  auth: Authenticator,
+  {
+    conversationId,
+    agentConfigurationId,
+    messageId,
+    approvalState,
+  }: {
+    conversationId: string;
+    agentConfigurationId: string;
+    messageId: string;
+    approvalState: "approved" | "rejected";
+  }
+): Promise<Result<void, APIErrorWithContentfulStatusCode>> {
+  // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
+  const conversationRes = await getConversation(auth, conversationId);
+  if (conversationRes.isErr()) {
+    return new Err({
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation not found",
+      },
+    });
+  }
+
+  const conversation = conversationRes.value;
+  const isApproval = approvalState === "approved";
+
+  const message = conversation.content.flat().find((m) => m.sId === messageId);
+  if (!message) {
+    return new Err({
+      status_code: 404,
+      api_error: {
+        type: "message_not_found",
+        message: "Message not found",
+      },
+    });
+  }
+
+  if (!isUserMessageType(message)) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Restricted agent mentions can only be on user messages",
+      },
+    });
+  }
+
+  if (
+    !canCurrentUserRespondToParentUserMessage({
+      parentUserId: message.user?.id,
+      currentUserId: auth.getNonNullableUser().id,
+    })
+  ) {
+    return new Err({
+      status_code: 403,
+      api_error: {
+        type: "invalid_request_error",
+        message: "User is not authorized to edit this mention",
+      },
+    });
+  }
+
+  const restrictedMention = message.richMentions.find(
+    (m) =>
+      isRichAgentMention(m) &&
+      m.id === agentConfigurationId &&
+      m.status === "agent_restricted_by_space_usage" &&
+      !m.dismissed
+  );
+  if (!restrictedMention) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "No restricted agent mention found to validate",
+      },
+    });
+  }
+
+  if (!isApproval) {
+    const mentionModel = await MentionModel.findOne({
+      where: {
+        workspaceId: conversation.owner.id,
+        messageId: message.id,
+        agentConfigurationId,
+        status: "agent_restricted_by_space_usage",
+      },
+    });
+    if (!mentionModel) {
+      return new Err({
+        status_code: 404,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Mention not found",
+        },
+      });
+    }
+
+    await mentionModel.update({ status: "rejected" });
+
+    const newRichMentions = message.richMentions.map((m) =>
+      isRichAgentMention(m) && m.id === agentConfigurationId
+        ? { ...m, status: "rejected" as const }
+        : m
+    );
+    const updatedUserMessage: UserMessageType = {
+      ...message,
+      richMentions: newRichMentions,
+      mentions: newRichMentions.map(toMentionType),
+    };
+
+    await publishMessageEventsOnMessagePostOrEdit(
+      conversation,
+      {
+        ...updatedUserMessage,
+        contentFragments: getRelatedContentFragments(
+          conversation,
+          updatedUserMessage
+        ),
+      },
+      []
+    );
+
+    return new Ok(undefined);
+  }
+
+  const configuration = await getAgentConfiguration(auth, {
+    agentId: agentConfigurationId,
+    variant: "light",
+  });
+  if (
+    !configuration ||
+    !(
+      (configuration.status === "active" || configuration.status === "draft") &&
+      configuration.canRead
+    )
+  ) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "agent_inaccessible",
+        message:
+          "This agent is either disabled or you don't have access to it.",
+      },
+    });
+  }
+
+  const limitResult = await checkMessagesLimit(auth, {
+    mentions: [{ configurationId: agentConfigurationId }],
+    context: message.context,
+  });
+  if (limitResult.isErr()) {
+    return limitResult;
+  }
+
+  auditLog(
+    {
+      author: auth.getNonNullableUser().toJSON(),
+      workspaceId: conversation.owner.sId,
+      conversationId: conversation.sId,
+      messageId: message.sId,
+      agentConfigurationId,
+      approvalState,
+    },
+    "User approved a restricted agent mention"
+  );
+
+  let agentMessages: AgentMessageType[];
+  let updatedRichMentions: RichMentionWithStatus[];
+
+  try {
+    const created = await withTransaction(async (t) => {
+      await getConversationRankVersionLock(auth, conversation, t);
+
+      const mentionModel = await MentionModel.findOne({
+        where: {
+          workspaceId: conversation.owner.id,
+          messageId: message.id,
+          agentConfigurationId,
+          status: "agent_restricted_by_space_usage",
+        },
+        transaction: t,
+        lock: t.LOCK.UPDATE,
+      });
+      if (!mentionModel) {
+        throw new Error("Restricted agent mention not found");
+      }
+
+      const nextMessageRank = await getNextConversationMessageRank(auth, {
+        conversation,
+        transaction: t,
+      });
+
+      const { agentMessages, richMentions } = await createAgentMessages(auth, {
+        conversation,
+        metadata: {
+          type: "approve_existing_mention",
+          mentionRow: mentionModel,
+          configuration,
+          skipToolsValidation: false,
+          nextMessageRank,
+          userMessage: message,
+        },
+        transaction: t,
+      });
+
+      await ConversationResource.markAsUpdated(auth, { conversation, t });
+
+      const updatedRichMentions = message.richMentions.map((m) => {
+        if (isRichAgentMention(m) && m.id === agentConfigurationId) {
+          return richMentions[0] ?? { ...m, status: "approved" as const };
+        }
+        return m;
+      });
+
+      return { agentMessages, updatedRichMentions };
+    });
+    agentMessages = created.agentMessages;
+    updatedRichMentions = created.updatedRichMentions;
+  } catch (e) {
+    if (
+      e instanceof Error &&
+      e.message === "Restricted agent mention not found"
+    ) {
+      return new Err({
+        status_code: 404,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Mention not found",
+        },
+      });
+    }
+    throw e;
+  }
+
+  if (agentMessages.length === 0) {
+    return new Err({
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Failed to create agent message for approved mention",
+      },
+    });
+  }
+
+  await runAgentLoopWorkflow({
+    auth,
+    agentMessages,
+    conversation,
+    userMessage: message,
+  });
+
+  const updatedUserMessage: UserMessageType = {
+    ...message,
+    richMentions: updatedRichMentions,
+    mentions: updatedRichMentions.map(toMentionType),
+  };
+
+  await publishMessageEventsOnMessagePostOrEdit(
+    conversation,
+    {
+      ...updatedUserMessage,
+      contentFragments: getRelatedContentFragments(
+        conversation,
+        updatedUserMessage
+      ),
+    },
+    agentMessages
+  );
+
+  return new Ok(undefined);
+}


### PR DESCRIPTION
## Description

Adds `validateAgentMention` in a new module (`validate_agent_mention.ts`) that lets a Pod conversation owner approve or reject a restricted agent mention in-place, without re-posting the user message.

- **Approve**: acquires `getConversationRankVersionLock`, locks the `MentionModel` row with `SELECT FOR UPDATE`, marks it `approved`, calls `createAgentMessages` with the new `approve_existing_mention` type (reusing the existing row instead of inserting a duplicate), then fires `runAgentLoopWorkflow`. This intentionally bypasses `canAgentBeUsedInProjectConversation`.
- **Reject**: updates the mention status to `rejected` and publishes message events to sync the UI.
- Extends `createAgentMessages` metadata union with `approve_existing_mention`, which falls through into `case "create"` but skips the Pod space-usage restriction check and mention row insertion.
- Exports `checkMessagesLimit` (previously unexported) to avoid an import cycle with `conversation.ts`.
- Emits an `auditLog` entry on every approval.

## Tests

Tested manually in Pod conversations: approve and reject flows, message limit enforcement, and duplicate-approval guard (mention row locked with `SELECT FOR UPDATE`).

## Risk

Low. The `approve_existing_mention` branch is an entirely new code path — existing `create` behavior in `createAgentMessages` is unchanged. The only modification to existing code is exporting `checkMessagesLimit`. Rollback is safe (revert front deploy).

## Deploy Plan

Deploy front.
