### PR TITLE
Wire agent mention approve/reject through the mentions API.

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/mentions.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/mentions.ts
@@ -2,6 +2,7 @@ import {
   dismissMention,
   validateUserMention,
 } from "@app/lib/api/assistant/conversation/mentions";
+import { validateAgentMention } from "@app/lib/api/assistant/conversation/validate_agent_mention";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { PostMentionActionResponseBody } from "@app/types/api/assistant/conversation/mentions";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -56,17 +57,7 @@ app.post(
       if (dismissMentionRes.isErr()) {
         return apiError(ctx, dismissMentionRes.error);
       }
-    } else {
-      if (type !== "user") {
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Only user mentions are supported.",
-          },
-        });
-      }
-
+    } else if (type === "user") {
       const validateUserMentionRes = await validateUserMention(auth, {
         conversationId: cId,
         userId: id,
@@ -76,6 +67,17 @@ app.post(
 
       if (validateUserMentionRes.isErr()) {
         return apiError(ctx, validateUserMentionRes.error);
+      }
+    } else {
+      const validateAgentMentionRes = await validateAgentMention(auth, {
+        conversationId: cId,
+        agentConfigurationId: id,
+        messageId: mId,
+        approvalState: action,
+      });
+
+      if (validateAgentMentionRes.isErr()) {
+        return apiError(ctx, validateAgentMentionRes.error);
       }
     }
 


### PR DESCRIPTION
## Description

The `POST .../mentions` route previously rejected any non-user mention type with a 400. Agent approve/reject actions (e.g. from a restricted agent mention flow) hit this same endpoint but weren't handled. The `else` branch is now split: `type === "user"` routes to `validateUserMention` as before, and everything else routes to `validateAgentMention` (imported from `validate_agent_mention.ts`), passing `conversationId`, `agentConfigurationId`, `messageId`, and `approvalState`.

## Tests

Tested manually by triggering agent mention approve/reject actions through the API and verifying the correct handler is invoked.

## Risk

Low. The change is additive — existing `dismiss` and `user` branches are untouched. The previous hard-reject for non-user types is replaced by a delegating else branch that already has its own error handling via `validateAgentMention`.

## Deploy Plan

Deploy front-api.
