### PR TITLE
Show approve/decline for restricted agents in Pod conversations.

### DIFF
--- a/front/components/assistant/conversation/MentionInvalid.tsx
+++ b/front/components/assistant/conversation/MentionInvalid.tsx
@@ -23,9 +23,7 @@ interface MentionInvalidProps {
   mention: Extract<
     RichMentionWithStatus,
     {
-      status:
-        | "user_restricted_by_conversation_access"
-        | "agent_restricted_by_space_usage";
+      status: "user_restricted_by_conversation_access";
     }
   >;
   conversation: ConversationWithoutContentType;
@@ -70,62 +68,32 @@ export function MentionInvalid({
     return null;
   }
 
-  switch (mention.status) {
-    case "user_restricted_by_conversation_access": {
-      // Show warning message without approve/reject buttons
-      // Different message for project conversations (non-editor can't add members)
-      const isPodConv = isPodConversation(conversation);
-      const message = isPodConv
-        ? "is not a member of this Pod and only Pod editors can add new members."
-        : "doesn't have access to this conversation's spaces and won't be able to view it nor be invited.";
+  // Show warning message without approve/reject buttons
+  // Different message for project conversations (non-editor can't add members)
+  const isPodConv = isPodConversation(conversation);
+  const warningMessage = isPodConv
+    ? "is not a member of this Pod and only Pod editors can add new members."
+    : "doesn't have access to this conversation's spaces and won't be able to view it nor be invited.";
 
-      return (
-        <ContentMessage variant="warning" className="my-3 w-full max-w-full">
-          <div className="flex items-center gap-2">
-            <Icon visual={AlertCircle} className="hidden sm:block" />
-            <div>
-              <span className="font-semibold">{mention.label}</span> {message}
-            </div>
-            <div className="ml-auto">
-              <Button
-                label="Dismiss"
-                variant="outline"
-                size="xs"
-                icon={XClose}
-                disabled={isSubmitting}
-                onClick={handleDismiss}
-              />
-            </div>
-          </div>
-        </ContentMessage>
-      );
-      break;
-    }
-    case "agent_restricted_by_space_usage": {
-      return (
-        <ContentMessage variant="warning" className="my-3 w-full max-w-full">
-          <div className="flex items-center gap-2">
-            <Icon visual={AlertCircle} className="hidden sm:block" />
-            <div>
-              <span className="font-semibold">{mention.label}</span> can't be
-              invoked as it is configured to use at least one space that the
-              conversation cannot use. Pods conversations cannot use private
-              spaces.
-            </div>
-            <div className="ml-auto">
-              <Button
-                label="Dismiss"
-                variant="outline"
-                size="xs"
-                icon={XClose}
-                disabled={isSubmitting}
-                onClick={handleDismiss}
-              />
-            </div>
-          </div>
-        </ContentMessage>
-      );
-      break;
-    }
-  }
+  return (
+    <ContentMessage variant="warning" className="my-3 w-full max-w-full">
+      <div className="flex items-center gap-2">
+        <Icon visual={AlertCircle} className="hidden sm:block" />
+        <div>
+          <span className="font-semibold">{mention.label}</span>{" "}
+          {warningMessage}
+        </div>
+        <div className="ml-auto">
+          <Button
+            label="Dismiss"
+            variant="outline"
+            size="xs"
+            icon={XClose}
+            disabled={isSubmitting}
+            onClick={handleDismiss}
+          />
+        </div>
+      </div>
+    </ContentMessage>
+  );
 }

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -84,8 +84,10 @@ export function MentionValidationRequired({
     return null;
   }
 
+  const { status } = mention;
+
   let title: string;
-  switch (mention.status) {
+  switch (status) {
     case "agent_restricted_by_space_usage":
       title = `Run ${mention.label} in this Pod conversation?`;
       break;
@@ -96,11 +98,11 @@ export function MentionValidationRequired({
       title = `Invite ${mention.label} to this conversation?`;
       break;
     default:
-      assertNever(mention.status);
+      assertNever(status);
   }
 
   let description: ReactNode;
-  switch (mention.status) {
+  switch (status) {
     case "agent_restricted_by_space_usage":
       description = (
         <>
@@ -134,11 +136,11 @@ export function MentionValidationRequired({
       );
       break;
     default:
-      assertNever(mention.status);
+      assertNever(status);
   }
 
   let approveLabel: string;
-  switch (mention.status) {
+  switch (status) {
     case "agent_restricted_by_space_usage":
       approveLabel = "Run agent";
       break;
@@ -149,7 +151,7 @@ export function MentionValidationRequired({
       approveLabel = "Invite";
       break;
     default:
-      assertNever(mention.status);
+      assertNever(status);
   }
 
   const visual =

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -7,6 +7,7 @@ import type {
   ConversationWithoutContentType,
   RichMentionWithStatus,
 } from "@app/types/assistant/conversation";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import {
   ActionCardBlock,
@@ -14,6 +15,7 @@ import {
   Button,
   MessageChatSquare,
 } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 
 type ValidatableMention = Extract<
@@ -43,15 +45,12 @@ export function MentionValidationRequired({
 }: MentionValidationRequiredProps) {
   const { user } = useAuth();
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const isProjectMembership = mention.status === "pending_project_membership";
-  const isRestrictedAgent =
-    mention.status === "agent_restricted_by_space_usage";
 
   const { validateMention } = useMentionValidation({
     workspaceId: owner.sId,
     conversationId: conversation.sId,
     messageId: message.sId,
-    isProjectConversation: isProjectMembership,
+    isProjectConversation: mention.status === "pending_project_membership",
   });
 
   const canCurrentUserRespond = useMemo(
@@ -85,37 +84,73 @@ export function MentionValidationRequired({
     return null;
   }
 
-  const title = isRestrictedAgent
-    ? `Run ${mention.label} in this Pod conversation?`
-    : isProjectMembership
-      ? `Add ${mention.label} to this Pod?`
-      : `Invite ${mention.label} to this conversation?`;
+  let title: string;
+  switch (mention.status) {
+    case "agent_restricted_by_space_usage":
+      title = `Run ${mention.label} in this Pod conversation?`;
+      break;
+    case "pending_project_membership":
+      title = `Add ${mention.label} to this Pod?`;
+      break;
+    case "pending_conversation_access":
+      title = `Invite ${mention.label} to this conversation?`;
+      break;
+    default:
+      assertNever(mention.status);
+  }
 
-  const description = isRestrictedAgent ? (
-    <>
-      <span className="font-semibold">{mention.label}</span> uses at least one
-      private space. If you run it here, its outputs will be visible to Pod
-      members who may not have access to those spaces.
-    </>
-  ) : isAgentMessageWithStreaming(message) ? (
-    <>
-      <span className="font-semibold">@{message.configuration.name}</span>{" "}
-      mentioned <span className="font-semibold">{mention.label}</span>.
-      {isProjectMembership
-        ? " Do you want to add them to this Pod?"
-        : " Do you want to invite them? They'll see the full history and be able to reply."}
-    </>
-  ) : isProjectMembership ? (
-    "They'll have access to all Pod conversations."
-  ) : (
-    "They'll see the full history and be able to reply."
-  );
+  let description: ReactNode;
+  switch (mention.status) {
+    case "agent_restricted_by_space_usage":
+      description = (
+        <>
+          <span className="font-semibold">{mention.label}</span> uses at least
+          one private space. If you run it here, its outputs will be visible to
+          Pod members who may not have access to those spaces.
+        </>
+      );
+      break;
+    case "pending_project_membership":
+      description = isAgentMessageWithStreaming(message) ? (
+        <>
+          <span className="font-semibold">@{message.configuration.name}</span>{" "}
+          mentioned <span className="font-semibold">{mention.label}</span>. Do
+          you want to add them to this Pod?
+        </>
+      ) : (
+        "They'll have access to all Pod conversations."
+      );
+      break;
+    case "pending_conversation_access":
+      description = isAgentMessageWithStreaming(message) ? (
+        <>
+          <span className="font-semibold">@{message.configuration.name}</span>{" "}
+          mentioned <span className="font-semibold">{mention.label}</span>. Do
+          you want to invite them? They'll see the full history and be able to
+          reply.
+        </>
+      ) : (
+        "They'll see the full history and be able to reply."
+      );
+      break;
+    default:
+      assertNever(mention.status);
+  }
 
-  const approveLabel = isRestrictedAgent
-    ? "Run agent"
-    : isProjectMembership
-      ? "Add to Pod"
-      : "Invite";
+  let approveLabel: string;
+  switch (mention.status) {
+    case "agent_restricted_by_space_usage":
+      approveLabel = "Run agent";
+      break;
+    case "pending_project_membership":
+      approveLabel = "Add to Pod";
+      break;
+    case "pending_conversation_access":
+      approveLabel = "Invite";
+      break;
+    default:
+      assertNever(mention.status);
+  }
 
   const visual =
     mention.type === "agent" ? (

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -16,15 +16,20 @@ import {
 } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
 
+type ValidatableMention = Extract<
+  RichMentionWithStatus,
+  {
+    status:
+      | "pending_conversation_access"
+      | "pending_project_membership"
+      | "agent_restricted_by_space_usage";
+  }
+>;
+
 interface MentionValidationRequiredProps {
   triggeringUser: UserType | null;
   owner: LightWorkspaceType;
-  mention: Extract<
-    RichMentionWithStatus,
-    {
-      status: "pending_conversation_access" | "pending_project_membership";
-    }
-  >;
+  mention: ValidatableMention;
   conversation: ConversationWithoutContentType;
   message: VirtuosoMessage;
 }
@@ -39,6 +44,8 @@ export function MentionValidationRequired({
   const { user } = useAuth();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const isProjectMembership = mention.status === "pending_project_membership";
+  const isRestrictedAgent =
+    mention.status === "agent_restricted_by_space_usage";
 
   const { validateMention } = useMentionValidation({
     workspaceId: owner.sId,
@@ -74,15 +81,23 @@ export function MentionValidationRequired({
     }
   };
 
-  if (!canCurrentUserRespond) {
+  if (!canCurrentUserRespond || mention.dismissed) {
     return null;
   }
 
-  const title = isProjectMembership
-    ? `Add ${mention.label} to this Pod?`
-    : `Invite ${mention.label} to this conversation?`;
+  const title = isRestrictedAgent
+    ? `Run ${mention.label} in this Pod conversation?`
+    : isProjectMembership
+      ? `Add ${mention.label} to this Pod?`
+      : `Invite ${mention.label} to this conversation?`;
 
-  const description = isAgentMessageWithStreaming(message) ? (
+  const description = isRestrictedAgent ? (
+    <>
+      <span className="font-semibold">{mention.label}</span> uses at least one
+      private space. If you run it here, its outputs will be visible to Pod
+      members who may not have access to those spaces.
+    </>
+  ) : isAgentMessageWithStreaming(message) ? (
     <>
       <span className="font-semibold">@{message.configuration.name}</span>{" "}
       mentioned <span className="font-semibold">{mention.label}</span>.
@@ -96,11 +111,24 @@ export function MentionValidationRequired({
     "They'll see the full history and be able to reply."
   );
 
+  const approveLabel = isRestrictedAgent
+    ? "Run agent"
+    : isProjectMembership
+      ? "Add to Pod"
+      : "Invite";
+
+  const visual =
+    mention.type === "agent" ? (
+      <Avatar visual={mention.pictureUrl} size="sm" />
+    ) : (
+      <Avatar icon={MessageChatSquare} size="sm" />
+    );
+
   return (
     <div className="my-3">
       <ActionCardBlock
         title={title}
-        visual={<Avatar icon={MessageChatSquare} size="sm" />}
+        visual={visual}
         description={description}
         actions={
           <div className="flex flex-wrap justify-end gap-2">
@@ -114,7 +142,7 @@ export function MentionValidationRequired({
             <Button
               variant="highlight"
               size="sm"
-              label={isProjectMembership ? "Add to Pod" : "Invite"}
+              label={approveLabel}
               disabled={isSubmitting}
               isLoading={isSubmitting}
               onClick={handleApprove}

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -384,7 +384,8 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
 
               if (
                 mention.status === "pending_conversation_access" ||
-                mention.status === "pending_project_membership"
+                mention.status === "pending_project_membership" ||
+                mention.status === "agent_restricted_by_space_usage"
               ) {
                 return (
                   <MentionValidationRequired
@@ -397,8 +398,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
                   />
                 );
               } else if (
-                mention.status === "user_restricted_by_conversation_access" ||
-                mention.status === "agent_restricted_by_space_usage"
+                mention.status === "user_restricted_by_conversation_access"
               ) {
                 return (
                   <MentionInvalid

--- a/front/lib/swr/mentions.tsx
+++ b/front/lib/swr/mentions.tsx
@@ -200,9 +200,12 @@ export function useMentionValidation({
           sendNotification({
             type: "success",
             title: "Success",
-            description: isProjectConversation
-              ? `${mention.label} has been added to the Pod, and added to the conversation`
-              : `${mention.label} has been invited to the conversation.`,
+            description:
+              mention.type === "agent"
+                ? `${mention.label} will run in this conversation.`
+                : isProjectConversation
+                  ? `${mention.label} has been added to the Pod, and added to the conversation`
+                  : `${mention.label} has been invited to the conversation.`,
           });
         }
 


### PR DESCRIPTION
## Description

`agent_restricted_by_space_usage` mentions were previously handled by `MentionInvalid` as a dead-end warning (dismiss only). They now route through `MentionValidationRequired`, giving Pod editors an approve/decline card: title "Run [agent] in this Pod conversation?", with copy explaining that private-space outputs will be visible to Pod members. `MentionInvalid` is narrowed to `user_restricted_by_conversation_access` only and its switch is collapsed. `MentionValidationRequired` gains a `ValidatableMention` union type, an `isRestrictedAgent` branch for title/description/`approveLabel`, the agent's avatar instead of the generic chat icon, and a `dismissed` guard on the early return. Success notification copy in `useMentionValidation` is updated for the agent case.

<img width="788" height="325" alt="image" src="https://github.com/user-attachments/assets/37cbba7b-1a40-4a12-84bc-964da326f84f" />

## Tests

Tested locally in a Pod conversation with an agent configured to use a private space.

## Risk

Low. Front-only, no API or DB changes. The `agent_restricted_by_space_usage` branch previously had no actionable path; adding approve/decline is additive and safe to roll back.

## Deploy Plan

Deploy front.
