### PR TITLE
Allow retry of restricted agents already in a Pod conversation.

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -791,22 +791,26 @@ describe("retryAgentMessage", () => {
       vi.clearAllMocks();
     });
 
-    it("should return error when agent is restricted by space usage in project conversation with more than one manual member on that project", async () => {
+    it("should succeed when retrying an agent that is restricted by space usage in a project conversation", async () => {
+      // Agent messages already present in a Pod conversation were either usable
+      // at creation time or approved via validateAgentMention; retry must work.
+      const rateLimiterSpy = vi
+        .spyOn(rateLimiterModule, "rateLimiter")
+        .mockResolvedValue(100);
+
       const result = await retryAgentMessage(auth, {
         conversationResource: projectConversationResource,
         message: projectAgentMessage,
       });
 
-      expect(result.isErr()).toBe(true);
-      if (result.isErr()) {
-        expect(result.error.status_code).toBe(400);
-        expect(result.error.api_error.type).toBe("invalid_request_error");
-        expect(result.error.api_error.message).toContain(
-          "restricted by space usage"
-        );
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
       }
-      expect(launchAgentLoopWorkflow).not.toHaveBeenCalled();
-      expect(publishAgentMessagesEvents).not.toHaveBeenCalled();
+      expect(launchAgentLoopWorkflow).toHaveBeenCalled();
+      expect(publishAgentMessagesEvents).toHaveBeenCalled();
+
+      rateLimiterSpy.mockRestore();
     });
 
     it("should succeed when agent uses the same project space", async () => {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -21,10 +21,7 @@ import {
   createAgentMessages,
   createUserMessage,
 } from "@app/lib/api/assistant/conversation/messages";
-import {
-  canAgentBeUsedInProjectConversation,
-  updateConversationRequirements,
-} from "@app/lib/api/assistant/conversation/permissions";
+import { updateConversationRequirements } from "@app/lib/api/assistant/conversation/permissions";
 import { ensureConversationTitle } from "@app/lib/api/assistant/conversation/title";
 import { RUNNING_AGENT_SWITCH_BLOCK_MESSAGE } from "@app/lib/api/assistant/errors";
 import { isRetiredGlobalAgent } from "@app/lib/api/assistant/global_agents/global_agents";
@@ -1777,22 +1774,8 @@ export async function retryAgentMessage(
     });
   }
 
-  if (isPodConversation(conversation)) {
-    const canAgentBeUsed = await canAgentBeUsedInProjectConversation(auth, {
-      configuration: retryAgentConfiguration,
-      conversation,
-    });
-    if (!canAgentBeUsed) {
-      return new Err({
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message:
-            "Invalid agent message retry request, the agent is restricted by space usage.",
-        },
-      });
-    }
-  }
+  // Restricted-space agents may already exist in a Pod conversation after the
+  // user approved the mention. Retry must not re-apply canAgentBeUsedInProjectConversation.
 
   let agentMessageResult: {
     agentMessage: AgentMessageType;


### PR DESCRIPTION
## Description

`retryAgentMessage` was calling `canAgentBeUsedInProjectConversation` on retry, which blocked users from retrying a restricted agent in a Pod conversation — even when that agent message already existed (approved via `validateAgentMention` or usable at creation time). Removed the check from the retry path: once an agent message exists in the conversation, the access decision was already made upstream and retry should go through unconditionally.

## Tests

Updated the existing unit test in `conversation.test.ts` that previously asserted a 400 error on retry of a restricted agent in a project conversation — it now asserts success and verifies `launchAgentLoopWorkflow` and `publishAgentMessagesEvents` are called.

## Risk

Low. The removed guard was overly conservative and only applied on the retry path. The initial agent message creation and mention approval paths are unaffected. Rollback is safe — reverting re-adds the guard.

## Deploy Plan

Deploy front.
