### PR TITLE
Clear duplicate restricted agent mentions on approve/reject/dismiss.

### DIFF
--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -374,44 +374,59 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
           )}
           {data.visibility !== "deleted" &&
             !isCompactionMessage(data) &&
-            data.richMentions.map((mention, index) => {
-              // To please the type checker
-              if (!context.conversation) {
-                return null;
-              }
-
-              // :warning: make sure to use the index in the key, as the mention.id is the userId
-
-              if (
-                mention.status === "pending_conversation_access" ||
-                mention.status === "pending_project_membership" ||
-                mention.status === "agent_restricted_by_space_usage"
-              ) {
+            data.richMentions
+              .filter((mention, index, mentions) => {
+                // Deduplicate restricted-agent cards: duplicate MentionModel rows for
+                // the same agent would otherwise render multiple pending approvals.
+                if (mention.status !== "agent_restricted_by_space_usage") {
+                  return true;
+                }
                 return (
-                  <MentionValidationRequired
-                    key={index}
-                    mention={mention}
-                    message={data}
-                    owner={context.owner}
-                    triggeringUser={triggeringUser}
-                    conversation={context.conversation}
-                  />
+                  mentions.findIndex(
+                    (m) =>
+                      m.status === "agent_restricted_by_space_usage" &&
+                      m.id === mention.id
+                  ) === index
                 );
-              } else if (
-                mention.status === "user_restricted_by_conversation_access"
-              ) {
-                return (
-                  <MentionInvalid
-                    key={index}
-                    mention={mention}
-                    message={data}
-                    owner={context.owner}
-                    triggeringUser={triggeringUser}
-                    conversation={context.conversation}
-                  />
-                );
-              }
-            })}
+              })
+              .map((mention, index) => {
+                // To please the type checker
+                if (!context.conversation) {
+                  return null;
+                }
+
+                // :warning: make sure to use the index in the key, as the mention.id is the userId
+
+                if (
+                  mention.status === "pending_conversation_access" ||
+                  mention.status === "pending_project_membership" ||
+                  mention.status === "agent_restricted_by_space_usage"
+                ) {
+                  return (
+                    <MentionValidationRequired
+                      key={index}
+                      mention={mention}
+                      message={data}
+                      owner={context.owner}
+                      triggeringUser={triggeringUser}
+                      conversation={context.conversation}
+                    />
+                  );
+                } else if (
+                  mention.status === "user_restricted_by_conversation_access"
+                ) {
+                  return (
+                    <MentionInvalid
+                      key={index}
+                      mention={mention}
+                      message={data}
+                      owner={context.owner}
+                      triggeringUser={triggeringUser}
+                      conversation={context.conversation}
+                    />
+                  );
+                }
+              })}
         </div>
       </>
     );

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -644,19 +644,29 @@ export async function dismissMention(
       !isCompactionMessageType(latestMessage) &&
       latestMessage.richMentions.some(predicate)
     ) {
-      const mentionModel = await MentionModel.findOne({
+      const mentionModels = await MentionModel.findAll({
         where: {
           workspaceId: conversation.owner.id,
           messageId: latestMessage.id,
           ...(type === "user"
-            ? { userId: userIdForQuery }
-            : { agentConfigurationId: id }),
+            ? {
+                userId: userIdForQuery,
+                status: "user_restricted_by_conversation_access",
+              }
+            : {
+                agentConfigurationId: id,
+                status: "agent_restricted_by_space_usage",
+              }),
         },
       });
-      if (!mentionModel) {
+      if (mentionModels.length === 0) {
         continue;
       }
-      await mentionModel.update({ dismissed: true });
+      // Instance updates avoid Sequelize bulk-update validation that requires
+      // userId/agentConfigurationId on the partial payload.
+      await Promise.all(
+        mentionModels.map((m) => m.update({ dismissed: true }))
+      );
       const newRichMentions = latestMessage.richMentions.map((m) =>
         predicate(m)
           ? {

--- a/front/lib/api/assistant/conversation/validate_agent_mention.test.ts
+++ b/front/lib/api/assistant/conversation/validate_agent_mention.test.ts
@@ -333,4 +333,84 @@ describe("validateAgentMention", () => {
     }
     expect(launchAgentLoopWorkflow).not.toHaveBeenCalled();
   });
+
+  it("approves all duplicate restricted mention rows for the same agent", async () => {
+    const existing = await MentionModel.findOne({
+      where: {
+        workspaceId: workspace.id,
+        messageId: userMessageId,
+        agentConfigurationId: agentWithDifferentSpace.sId,
+        status: "agent_restricted_by_space_usage",
+      },
+    });
+    expect(existing).not.toBeNull();
+    if (!existing) {
+      throw new Error("Expected restricted mention row");
+    }
+
+    // Simulate a duplicate MentionModel row (same agent, same message).
+    await MentionModel.create({
+      workspaceId: workspace.id,
+      messageId: userMessageId,
+      agentConfigurationId: agentWithDifferentSpace.sId,
+      status: "agent_restricted_by_space_usage",
+      dismissed: false,
+    });
+
+    const rateLimiterSpy = vi
+      .spyOn(rateLimiterModule, "rateLimiter")
+      .mockResolvedValue(100);
+
+    const result = await validateAgentMention(auth, {
+      conversationId: projectConversation.sId,
+      agentConfigurationId: agentWithDifferentSpace.sId,
+      messageId: userMessageSId,
+      approvalState: "approved",
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    const mentionRows = await MentionModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        messageId: userMessageId,
+        agentConfigurationId: agentWithDifferentSpace.sId,
+      },
+    });
+    expect(mentionRows).toHaveLength(2);
+    expect(mentionRows.every((m) => m.status === "approved")).toBe(true);
+
+    const allChildMessages = await MessageModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        conversationId: projectConversation.id,
+        parentId: userMessageId,
+      },
+    });
+    expect(
+      allChildMessages.filter((m) => m.agentMessageId !== null)
+    ).toHaveLength(1);
+
+    const publishedCalls = vi.mocked(publishMessageEventsOnMessagePostOrEdit)
+      .mock.calls;
+    const lastPublish = publishedCalls[publishedCalls.length - 1];
+    const publishedMessage = lastPublish?.[1] as
+      | { richMentions?: { id: string; status: string }[] }
+      | undefined;
+    const pendingRestricted =
+      publishedMessage?.richMentions?.filter(
+        (m) =>
+          m.id === agentWithDifferentSpace.sId &&
+          m.status === "agent_restricted_by_space_usage"
+      ) ?? [];
+    expect(pendingRestricted).toHaveLength(0);
+
+    const approvedForAgent =
+      publishedMessage?.richMentions?.filter(
+        (m) => m.id === agentWithDifferentSpace.sId && m.status === "approved"
+      ) ?? [];
+    expect(approvedForAgent).toHaveLength(1);
+
+    rateLimiterSpy.mockRestore();
+  });
 });

--- a/front/lib/api/assistant/conversation/validate_agent_mention.ts
+++ b/front/lib/api/assistant/conversation/validate_agent_mention.ts
@@ -120,7 +120,7 @@ export async function validateAgentMention(
   }
 
   if (!isApproval) {
-    const mentionModel = await MentionModel.findOne({
+    const mentionModels = await MentionModel.findAll({
       where: {
         workspaceId: conversation.owner.id,
         messageId: message.id,
@@ -128,7 +128,7 @@ export async function validateAgentMention(
         status: "agent_restricted_by_space_usage",
       },
     });
-    if (!mentionModel) {
+    if (mentionModels.length === 0) {
       return new Err({
         status_code: 404,
         api_error: {
@@ -137,18 +137,38 @@ export async function validateAgentMention(
         },
       });
     }
-
-    await mentionModel.update({ status: "rejected" });
+    // Instance updates avoid Sequelize bulk-update validation that requires
+    // userId/agentConfigurationId on the partial payload.
+    await Promise.all(
+      mentionModels.map((m) => m.update({ status: "rejected" }))
+    );
 
     const newRichMentions = message.richMentions.map((m) =>
-      isRichAgentMention(m) && m.id === agentConfigurationId
+      isRichAgentMention(m) &&
+      m.id === agentConfigurationId &&
+      m.status === "agent_restricted_by_space_usage"
         ? { ...m, status: "rejected" as const }
         : m
     );
+    // Collapse duplicate rejected entries for this agent into one.
+    const seenRejectedAgent = new Set<string>();
+    const collapsedRichMentions = newRichMentions.filter((m) => {
+      if (
+        isRichAgentMention(m) &&
+        m.id === agentConfigurationId &&
+        m.status === "rejected"
+      ) {
+        if (seenRejectedAgent.has(m.id)) {
+          return false;
+        }
+        seenRejectedAgent.add(m.id);
+      }
+      return true;
+    });
     const updatedUserMessage: UserMessageType = {
       ...message,
-      richMentions: newRichMentions,
-      mentions: newRichMentions.map(toMentionType),
+      richMentions: collapsedRichMentions,
+      mentions: collapsedRichMentions.map(toMentionType),
     };
 
     await publishMessageEventsOnMessagePostOrEdit(
@@ -214,7 +234,7 @@ export async function validateAgentMention(
     const created = await withTransaction(async (t) => {
       await getConversationRankVersionLock(auth, conversation, t);
 
-      const mentionModel = await MentionModel.findOne({
+      const mentionModels = await MentionModel.findAll({
         where: {
           workspaceId: conversation.owner.id,
           messageId: message.id,
@@ -224,9 +244,11 @@ export async function validateAgentMention(
         transaction: t,
         lock: t.LOCK.UPDATE,
       });
-      if (!mentionModel) {
+      if (mentionModels.length === 0) {
         throw new Error("Restricted agent mention not found");
       }
+
+      const [primaryMention, ...duplicateMentions] = mentionModels;
 
       const nextMessageRank = await getNextConversationMessageRank(auth, {
         conversation,
@@ -237,7 +259,7 @@ export async function validateAgentMention(
         conversation,
         metadata: {
           type: "approve_existing_mention",
-          mentionRow: mentionModel,
+          mentionRow: primaryMention,
           configuration,
           skipToolsValidation: false,
           nextMessageRank,
@@ -246,14 +268,32 @@ export async function validateAgentMention(
         transaction: t,
       });
 
+      // Clear any duplicate restricted rows for the same agent on this message
+      // so the UI does not keep a ghost pending card after approval.
+      if (duplicateMentions.length > 0) {
+        // Instance updates avoid Sequelize bulk-update validation that requires
+        // userId/agentConfigurationId on the partial payload.
+        await Promise.all(
+          duplicateMentions.map((m) =>
+            m.update({ status: "approved" }, { transaction: t })
+          )
+        );
+      }
+
       await ConversationResource.markAsUpdated(auth, { conversation, t });
 
-      const updatedRichMentions = message.richMentions.map((m) => {
-        if (isRichAgentMention(m) && m.id === agentConfigurationId) {
-          return richMentions[0] ?? { ...m, status: "approved" as const };
-        }
-        return m;
-      });
+      const approvedRichMention =
+        richMentions[0] ??
+        ({
+          ...restrictedMention,
+          status: "approved" as const,
+        } satisfies RichMentionWithStatus);
+
+      // Collapse duplicate rich mentions for this agent into a single approved entry.
+      const otherMentions = message.richMentions.filter(
+        (m) => !(isRichAgentMention(m) && m.id === agentConfigurationId)
+      );
+      const updatedRichMentions = [...otherMentions, approvedRichMention];
 
       return { agentMessages, updatedRichMentions };
     });


### PR DESCRIPTION
## Description

When the same restricted agent accumulated multiple `MentionModel` rows on a message (e.g. due to retries), acting on any one row via approve, reject, or dismiss left the remaining rows in their original state, causing ghost pending-approval cards to persist in the UI.

- `validateAgentMention` (approve): `findOne` → `findAll`; primary row drives `approve_existing_mention`, duplicate rows are all marked `approved` within the same transaction. Published `richMentions` collapse all agent entries into a single approved one.
- `validateAgentMention` (reject): same `findAll` pattern; all rows set to `rejected`; duplicate `rejected` entries deduplicated in `richMentions` via a `seenRejectedAgent` Set before publishing.
- `dismissMention`: `findOne` → `findAll`; all matching rows marked `dismissed: true`. Query now also filters by `status` to avoid touching unrelated rows.
- `MessageItem`: adds a `filter` before `map` on `richMentions` to deduplicate `agent_restricted_by_space_usage` cards by `(status, id)` as a defensive frontend layer.

## Tests

Added a unit test to `validate_agent_mention.test.ts` that seeds a duplicate `MentionModel` row, approves the mention, and asserts: both DB rows reach `approved`, only one agent message child is created, and the published `richMentions` contains exactly one approved entry for the agent (zero still-pending ones).

## Risk

Low. Front-only change — no DB schema or migration. Existing duplicate rows in the DB are now fully resolved on the next approve/reject/dismiss action rather than partially. Rollback is safe: reverting restores the prior single-row behaviour.

## Deploy Plan

Deploy front.
