### PR TITLE
feat: prompt user when message cost crosses threshold

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -1,5 +1,7 @@
 import { retryAgentMessage } from "@app/lib/api/assistant/conversation";
+import { resumeAfterCreditApproval } from "@app/lib/api/assistant/conversation/resume_credit_approval";
 import { retryBlockedActions } from "@app/lib/api/assistant/conversation/retry_blocked_actions";
+import { CREDIT_APPROVAL_REQUIRED_ERROR_CODE } from "@app/lib/api/assistant/credit_approval";
 import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import { DustError } from "@app/lib/error";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -137,16 +139,19 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
   }
 
   // If the query parameter `blocked_only` is true, we retry only the blocked
-  // actions.
+  // actions, or resume the message from where it left off if it was waiting for credit approval.
   if (ctx.req.query("blocked_only") === "true") {
-    const retryBlockedActionsRes = await retryBlockedActions(
-      auth,
-      conversation,
-      { messageId }
-    );
+    const retryBlockedAction =
+      messageModel.agentMessage.errorCode ===
+      CREDIT_APPROVAL_REQUIRED_ERROR_CODE;
+    const resumeFn = retryBlockedAction
+      ? resumeAfterCreditApproval
+      : retryBlockedActions;
 
-    if (retryBlockedActionsRes.isErr()) {
-      const { error } = retryBlockedActionsRes;
+    const resumeRes = await resumeFn(auth, conversation, { messageId });
+
+    if (resumeRes.isErr()) {
+      const { error } = resumeRes;
 
       if (
         error instanceof DustError &&
@@ -165,7 +170,9 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
         status_code: 500,
         api_error: {
           type: "invalid_request_error",
-          message: "Failed to retry blocked actions.",
+          message: retryBlockedAction
+            ? "Failed to retry blocked action."
+            : "Failed to resume message.",
         },
       });
     }

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -8,6 +8,7 @@ import { AttachmentCitation } from "@app/components/assistant/conversation/attac
 import { markdownCitationToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
 import { BlockedAction } from "@app/components/assistant/conversation/BlockedAction";
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
+import { CreditApprovalRequired } from "@app/components/assistant/conversation/CreditApprovalRequired";
 import { DeletedMessage } from "@app/components/assistant/conversation/DeletedMessage";
 import { ErrorMessage } from "@app/components/assistant/conversation/ErrorMessage";
 import type { FeedbackSelectorBaseProps } from "@app/components/assistant/conversation/FeedbackSelector";
@@ -332,8 +333,11 @@ export function AgentMessage({
   const sendNotification = useSendNotification();
   const confirm = useContext(ConfirmContext);
 
-  const { enqueueBlockedAction, removeAllBlockedActionsForMessage } =
-    useBlockedActionsContext();
+  const {
+    enqueueBlockedAction,
+    markConversationActionRequired,
+    removeAllBlockedActionsForMessage,
+  } = useBlockedActionsContext();
 
   const { mutateConversationAttachments } = useConversationAttachments({
     conversationId,
@@ -482,8 +486,24 @@ export function AgentMessage({
               conversationId,
             });
             break;
-          case "agent_generation_cancelled":
           case "agent_error":
+            // The credit safety net rides on `agent_error`, but it parks the run waiting on the
+            // user rather than ending it: surface the conversation in the sidebar Inbox instead of
+            // clearing the flag the server just set. Other errors fall through to the cleanup.
+            if (
+              eventPayload.data.error.metadata?.category ===
+              "credit_approval_required"
+            ) {
+              void markConversationActionRequired({ conversationId });
+              break;
+            }
+            void removeAllBlockedActionsForMessage({
+              messageId: sId,
+              conversationId,
+            });
+            break;
+
+          case "agent_generation_cancelled":
           case "generation_tokens":
             // We can remove all blocked actions for this message (especially useful to let other users see the message updates)
             void removeAllBlockedActionsForMessage({
@@ -529,6 +549,7 @@ export function AgentMessage({
       [
         enqueueBlockedAction,
         sId,
+        markConversationActionRequired,
         removeAllBlockedActionsForMessage,
         conversationId,
         owner,
@@ -1581,19 +1602,36 @@ function AgentMessageContent({
             </div>
           </div>
         )}
-        {agentMessage.status === "failed" && (
-          <ErrorMessage
-            error={
-              agentMessage.error ?? {
-                message: "Unexpected Error",
-                code: "unexpected_error",
-                metadata: {},
-              }
-            }
-            retryHandler={async () =>
-              retryHandler({ conversationId, messageId: agentMessage.sId })
+        {/* The credit safety net stops the message through an `agent_error`, but nothing failed:
+            the message stays "created" and resumable, so it gets a "continue" prompt that picks up
+            where the loop stopped rather than a "retry" that would re-run (and re-charge) it. */}
+        {agentMessage.error?.metadata?.category ===
+        "credit_approval_required" ? (
+          <CreditApprovalRequired
+            error={agentMessage.error}
+            triggeringUser={triggeringUser}
+            resumeHandler={() =>
+              retryHandlerWithResetState({
+                conversationId,
+                messageId: agentMessage.sId,
+              })
             }
           />
+        ) : (
+          agentMessage.status === "failed" && (
+            <ErrorMessage
+              error={
+                agentMessage.error ?? {
+                  message: "Unexpected Error",
+                  code: "unexpected_error",
+                  metadata: {},
+                }
+              }
+              retryHandler={async () =>
+                retryHandler({ conversationId, messageId: agentMessage.sId })
+              }
+            />
+          )
         )}
       </div>
     </CitationsContext.Provider>

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -33,6 +33,7 @@ type BlockedActionsContextType = {
     messageId: string;
     conversationId: string;
   }) => void;
+  markConversationActionRequired: (params: { conversationId: string }) => void;
   hasPendingValidations: (userId: string) => boolean;
   getBlockedActions: (userId: string) => AgentLoopBlockedToolExecution[];
   getFirstBlockedActionForMessage: (
@@ -237,6 +238,26 @@ export function BlockedActionsProvider({
     options: { disabled: true },
   });
 
+  // Counterpart of the cache update in `removeAllBlockedActionsForMessage`: the server sets
+  // `actionRequired` on the participant row, but the sidebar reads it from the conversations list,
+  // which is not revalidated while the user sits in the conversation. Without this the run would
+  // only surface in the Inbox after a full refetch, which is exactly when the user no longer needs
+  // to be told.
+  const markConversationActionRequired = useCallback(
+    ({ conversationId }: { conversationId: string }) => {
+      void mutateConversations(
+        (currentData: ConversationListItemType[] | undefined) =>
+          currentData?.map((c) =>
+            c.sId === conversationId && !c.actionRequired
+              ? { ...c, actionRequired: true }
+              : c
+          ),
+        { revalidate: false }
+      );
+    },
+    [mutateConversations]
+  );
+
   const removeAllBlockedActionsForMessage = useCallback(
     ({
       messageId,
@@ -287,6 +308,7 @@ export function BlockedActionsProvider({
       enqueueBlockedAction,
       removeCompletedAction,
       removeAllBlockedActionsForMessage,
+      markConversationActionRequired,
       hasPendingValidations,
       getBlockedActions,
       getFirstBlockedActionForMessage,
@@ -298,6 +320,7 @@ export function BlockedActionsProvider({
       enqueueBlockedAction,
       removeCompletedAction,
       removeAllBlockedActionsForMessage,
+      markConversationActionRequired,
       hasPendingValidations,
       getBlockedActions,
       getFirstBlockedActionForMessage,

--- a/front/components/assistant/conversation/CreditApprovalRequired.tsx
+++ b/front/components/assistant/conversation/CreditApprovalRequired.tsx
@@ -1,0 +1,59 @@
+import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import { useSubmitFunction } from "@app/lib/client/utils";
+import type { GenericErrorContent } from "@app/types/assistant/agent";
+import type { UserType } from "@app/types/user";
+import { Button, ContentMessage, InfoCircle, Play } from "@dust-tt/sparkle";
+
+interface CreditApprovalRequiredProps {
+  error: GenericErrorContent;
+  triggeringUser: UserType | null;
+  resumeHandler: () => Promise<void>;
+}
+
+export function CreditApprovalRequired({
+  error,
+  triggeringUser,
+  resumeHandler,
+}: CreditApprovalRequiredProps) {
+  const { user } = useAuth();
+  const { submit: resume, isSubmitting: isResuming } = useSubmitFunction(
+    async () => resumeHandler()
+  );
+
+  const canCurrentUserRespond = canCurrentUserRespondToParentUserMessage({
+    parentUserId: triggeringUser?.sId,
+    currentUserId: user?.sId,
+  });
+
+  return (
+    <ContentMessage
+      title={`${error.metadata?.errorTitle ?? "This message is using a lot of credits"}`}
+      variant="golden"
+      className="flex flex-col gap-3"
+      icon={InfoCircle}
+    >
+      <div className="whitespace-normal break-words">{error.message}</div>
+      {canCurrentUserRespond ? (
+        <div className="flex flex-col gap-2 pt-3 sm:flex-row">
+          <Button
+            variant="outline"
+            size="xs"
+            icon={Play}
+            label="Continue"
+            onClick={resume}
+            disabled={isResuming}
+          />
+        </div>
+      ) : (
+        <div className="pt-3 text-sm text-muted-foreground">
+          Waiting for{" "}
+          <span className="font-semibold">
+            {triggeringUser?.fullName ?? "another user"}
+          </span>{" "}
+          to decide whether to continue.
+        </div>
+      )}
+    </ContentMessage>
+  );
+}

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -718,10 +718,19 @@ export function useAgentMessageStream({
           break;
 
         case "tool_error":
-        case "agent_error":
-          isStreamTerminated.current = true;
-          updateMessageThrottled.cancel();
+        case "agent_error": {
           const error = eventPayload.data.error;
+          // The credit safety net stops the loop through an `agent_error`, but nothing failed: the
+          // message is parked awaiting the user's answer and resumes in place, on this same stream.
+          // So it stays "created" (like one blocked on a tool validation) and does not stop the
+          // stream — otherwise the resumed run would be invisible until a reload.
+          const isCreditApprovalRequest =
+            error.metadata?.category === "credit_approval_required";
+
+          if (!isCreditApprovalRequest) {
+            isStreamTerminated.current = true;
+          }
+          updateMessageThrottled.cancel();
           mapMessagesWithAutoScroll((m) => {
             if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
               return m;
@@ -737,7 +746,7 @@ export function useAgentMessageStream({
             });
             return {
               ...m,
-              status: "failed",
+              status: isCreditApprovalRequest ? m.status : "failed",
               error: error,
               ...(contentCleared ? { content: null } : {}),
               streaming: {
@@ -749,6 +758,7 @@ export function useAgentMessageStream({
             };
           });
           break;
+        }
 
         case "agent_context_pruned":
           mapMessagesWithAutoScroll((m) =>

--- a/front/lib/api/assistant/conversation/resume_credit_approval.ts
+++ b/front/lib/api/assistant/conversation/resume_credit_approval.ts
@@ -1,0 +1,148 @@
+import {
+  AGENT_MESSAGE_CREDIT_APPROVAL_THRESHOLD,
+  CREDIT_APPROVAL_REQUIRED_ERROR_CODE,
+  fetchCreditApprovalStep,
+} from "@app/lib/api/assistant/credit_approval";
+import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
+import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
+import type { Authenticator } from "@app/lib/auth";
+import type { DustError } from "@app/lib/error";
+import {
+  AgentMessageModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
+import logger from "@app/logger/logger";
+import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { UNRESUMABLE_AGENT_MESSAGE_STATUSES } from "@app/types/assistant/conversation";
+import type { Result } from "@app/types/shared/result";
+import { Err } from "@app/types/shared/result";
+
+/**
+ * The user answered "yes, keep going" to the per-message credit prompt: clear the stop and resume
+ * the message on the step it never got to run.
+ *
+ * Unlike `retryAgentMessage`, this does NOT create a new message version — re-running the message
+ * from scratch would burn every credit it already spent, which is the opposite of what the safety
+ * net is for. The message never left "created" while parked, so the loop just picks up where it
+ * stopped.
+ *
+ * The `error` step content recording the request survives this reset, and that is what keeps the
+ * gate from ever asking this message again (see `fetchCreditApprovalStep`).
+ */
+export async function resumeAfterCreditApproval(
+  auth: Authenticator,
+  conversation: ConversationWithoutContentType,
+  { messageId }: { messageId: string }
+): Promise<Result<void, Error | DustError<"agent_loop_already_running">>> {
+  const workspaceId = auth.getNonNullableWorkspace().id;
+
+  const message = await MessageModel.findOne({
+    where: {
+      conversationId: conversation.id,
+      sId: messageId,
+      workspaceId,
+    },
+    include: [
+      {
+        model: AgentMessageModel,
+        as: "agentMessage",
+        required: true,
+      },
+    ],
+  });
+
+  if (!message?.agentMessage || !message.parentId) {
+    return new Err(new Error("Agent message not found"));
+  }
+
+  const { agentMessage } = message;
+
+  if (agentMessage.errorCode !== CREDIT_APPROVAL_REQUIRED_ERROR_CODE) {
+    return new Err(new Error("No pending credit approval for this message"));
+  }
+
+  // The message stays "created" while parked, but it can still have been cancelled or interrupted
+  // in the meantime — resuming then would relaunch a run the user already abandoned.
+  if (UNRESUMABLE_AGENT_MESSAGE_STATUSES.includes(agentMessage.status)) {
+    return new Err(new Error("Agent message can no longer resume"));
+  }
+
+  const parentMessage = await MessageModel.findOne({
+    where: {
+      id: message.parentId,
+      conversationId: conversation.id,
+      workspaceId,
+    },
+    attributes: ["sId", "version"],
+  });
+
+  if (!parentMessage) {
+    return new Err(new Error("User message not found"));
+  }
+
+  const resumeStep = await fetchCreditApprovalStep(auth, {
+    agentMessageModelId: agentMessage.id,
+  });
+
+  if (resumeStep === null) {
+    return new Err(new Error("Credit approval step content not found"));
+  }
+
+  // Read before clearing the error columns below: this is the cost the user was shown and
+  // approved, which is what makes the resume log comparable to the interrupt one.
+  const approvedCostCredits = agentMessage.errorMetadata?.costCredits;
+
+  // Clear the stop so the UI stops rendering the prompt. The status was never moved off "created"
+  // (this is a pause, not a failure), so there is nothing to restore there.
+  await AgentMessageModel.update(
+    {
+      errorCode: null,
+      errorMessage: null,
+      errorMetadata: null,
+    },
+    { where: { id: agentMessage.id, workspaceId } }
+  );
+
+  // Drop the prompt from the stream so a client reconnecting with a `lastEventId` predating it
+  // doesn't replay a question that has been answered.
+  await getRedisHybridManager().removeEvent((event) => {
+    const payload = JSON.parse(event.message["payload"]);
+
+    return (
+      payload.type === "agent_error" &&
+      payload.error?.code === CREDIT_APPROVAL_REQUIRED_ERROR_CODE
+    );
+  }, getMessageChannelId(messageId));
+
+  const launchRes = await launchAgentLoopWorkflow({
+    auth,
+    agentLoopArgs: {
+      agentMessageId: message.sId,
+      agentMessageVersion: message.version,
+      conversationId: conversation.sId,
+      conversationTitle: conversation.title,
+      conversationBranchId: message.getBranchId(),
+      userMessageId: parentMessage.sId,
+      userMessageVersion: parentMessage.version,
+    },
+    startStep: resumeStep,
+  });
+
+  // Pairs with the "interrupted" log in `finalizeCreditApprovalRequest`
+  logger.info(
+    {
+      agentMessageId: messageId,
+      conversationId: conversation.sId,
+      costCredits: approvedCostCredits,
+      relaunched: launchRes.isOk(),
+      step: resumeStep,
+      thresholdCredits: AGENT_MESSAGE_CREDIT_APPROVAL_THRESHOLD,
+      userId: auth.user()?.sId ?? null,
+      workspaceId: auth.getNonNullableWorkspace().sId,
+    },
+    "[CreditApproval] Agent loop resumed: user approved continuing past the credit threshold"
+  );
+
+  return launchRes;
+}

--- a/front/lib/api/assistant/credit_approval.ts
+++ b/front/lib/api/assistant/credit_approval.ts
@@ -1,0 +1,126 @@
+import type { Authenticator } from "@app/lib/auth";
+import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
+import {
+  AgentMessageModel,
+  MessageModel,
+  UserMessageModel,
+} from "@app/lib/models/agent/conversation";
+import type { ModelId } from "@app/types/shared/model_id";
+import { Op } from "sequelize";
+
+/**
+ * Above this many credits consumed by a single agent message (recursively, sub-conversations
+ * included), the agent loop stops and asks the user whether to continue.
+ * TODO: make this a workspace-level setting, and/or a per-message override.
+ */
+export const AGENT_MESSAGE_CREDIT_APPROVAL_THRESHOLD = 1_000;
+
+/**
+ * Error code carried by the `agent_error` event that stops the loop on the credit threshold. It is
+ * also the durable "we already asked" latch: `processEventForDatabase` writes every `agent_error`
+ * as an `error` step content, and step contents are never deleted — so a message that has ever
+ * asked keeps that row forever, even after the error columns are cleared on resume.
+ */
+export const CREDIT_APPROVAL_REQUIRED_ERROR_CODE = "credit_approval_required";
+
+export const CREDIT_APPROVAL_REQUIRED_ERROR_TITLE =
+  "This message is using a lot of credits";
+
+export function creditApprovalRequiredMessage(costCredits: number): string {
+  return `This message has consumed ${costCredits} credits and has not yet finished, do you want to continue?`;
+}
+
+export interface CreditApprovalContext {
+  agentMessageModelId: ModelId;
+  isRootAgentMessage: boolean;
+}
+
+/**
+ * Whether this run belongs to a root message or to a sub-agent, plus the model id the rest of the
+ * gate keys off.
+ *
+ * Read fresh from the rows (never from the possibly-cached conversation) since it gates whether we
+ * interrupt the loop.
+ */
+export async function fetchCreditApprovalContext(
+  auth: Authenticator,
+  {
+    agentMessageId,
+    userMessageId,
+  }: {
+    agentMessageId: string;
+    userMessageId: string;
+  }
+): Promise<CreditApprovalContext | null> {
+  const workspaceId = auth.getNonNullableWorkspace().id;
+
+  const messages = await MessageModel.findAll({
+    attributes: ["sId"],
+    where: {
+      sId: { [Op.in]: [agentMessageId, userMessageId] },
+      workspaceId,
+    },
+    include: [
+      {
+        model: AgentMessageModel,
+        as: "agentMessage",
+        attributes: ["id"],
+        required: false,
+      },
+      {
+        model: UserMessageModel,
+        as: "userMessage",
+        attributes: ["agenticOriginMessageId"],
+        required: false,
+      },
+    ],
+  });
+
+  const agentMessage = messages.find(
+    (m) => m.sId === agentMessageId
+  )?.agentMessage;
+  if (!agentMessage) {
+    return null;
+  }
+
+  const userMessage = messages.find(
+    (m) => m.sId === userMessageId
+  )?.userMessage;
+
+  return {
+    agentMessageModelId: agentMessage.id,
+    // A user message with an agentic origin was posted by another agent (run_agent / handover), so
+    // this run is a descendant, not the message the user is waiting on.
+    isRootAgentMessage: !userMessage?.agenticOriginMessageId,
+  };
+}
+
+/**
+ * Returns the step number of the first `error` step content that has the credit approval error code.
+ * Useful to know if approval has already been asked for this message, and if so, at which step.
+ * The step number is used to resume the message from that step.
+ */
+export async function fetchCreditApprovalStep(
+  auth: Authenticator,
+  { agentMessageModelId }: { agentMessageModelId: ModelId }
+): Promise<number | null> {
+  const errorContents = await AgentStepContentModel.findAll({
+    attributes: ["step", "value"],
+    where: {
+      agentMessageId: agentMessageModelId,
+      workspaceId: auth.getNonNullableWorkspace().id,
+      type: "error",
+    },
+  });
+
+  const steps = errorContents
+    .filter(({ value }) => {
+      return (
+        value.type === "error" &&
+        value.value.code === CREDIT_APPROVAL_REQUIRED_ERROR_CODE
+      );
+    })
+    .map((content) => content.step);
+
+  return steps.length > 0 ? Math.max(...steps) : null;
+}

--- a/front/lib/api/assistant/credit_check.test.ts
+++ b/front/lib/api/assistant/credit_check.test.ts
@@ -1,5 +1,9 @@
-import { checkPoolCreditGate } from "@app/lib/api/assistant/credit_check";
-import type { Authenticator } from "@app/lib/auth";
+import { AGENT_MESSAGE_CREDIT_APPROVAL_THRESHOLD } from "@app/lib/api/assistant/credit_approval";
+import {
+  checkMessageCreditApprovalGate,
+  checkPoolCreditGate,
+} from "@app/lib/api/assistant/credit_check";
+import type { Authenticator, AuthMethodType } from "@app/lib/auth";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -8,11 +12,33 @@ const {
   mockIsApiBlocked,
   mockIsProgrammaticApiBlocked,
   mockIsProgrammaticUsage,
+  mockComputeAgentMessageCredits,
+  mockFetchCreditApprovalContext,
+  mockFetchCreditApprovalStep,
+  mockGetFeatureFlags,
 } = vi.hoisted(() => ({
   mockIsUserBlocked: vi.fn(),
   mockIsApiBlocked: vi.fn(),
   mockIsProgrammaticApiBlocked: vi.fn(),
   mockIsProgrammaticUsage: vi.fn(),
+  mockComputeAgentMessageCredits: vi.fn(),
+  mockFetchCreditApprovalContext: vi.fn(),
+  mockFetchCreditApprovalStep: vi.fn(),
+  mockGetFeatureFlags: vi.fn(),
+}));
+
+vi.mock("@app/lib/auth", () => ({
+  getFeatureFlags: mockGetFeatureFlags,
+}));
+
+vi.mock("@app/lib/api/assistant/credit_approval", () => ({
+  AGENT_MESSAGE_CREDIT_APPROVAL_THRESHOLD: 100,
+  fetchCreditApprovalContext: mockFetchCreditApprovalContext,
+  fetchCreditApprovalStep: mockFetchCreditApprovalStep,
+}));
+
+vi.mock("@app/lib/api/assistant/credit_cost", () => ({
+  computeAgentMessageCredits: mockComputeAgentMessageCredits,
 }));
 
 vi.mock("@app/lib/metronome/user_block", () => ({
@@ -37,10 +63,12 @@ function makeAuth({
   isCreditPriced = true,
   metronomeCustomerId = "metro_123",
   hasUser = true,
+  authMethod = "session",
 }: {
   isCreditPriced?: boolean;
   metronomeCustomerId?: string | null;
   hasUser?: boolean;
+  authMethod?: AuthMethodType;
 } = {}): Authenticator {
   const plan = isCreditPriced
     ? { code: "ENT_NEW_CREDIT", limits: {} }
@@ -50,6 +78,7 @@ function makeAuth({
     getNonNullableWorkspace: () => ({ sId: "ws_test", metronomeCustomerId }),
     subscription: () => ({ plan }),
     user: () => (hasUser ? { sId: "user_test" } : null),
+    authMethod: () => authMethod,
   } as unknown as Authenticator;
 }
 
@@ -153,5 +182,132 @@ describe("checkPoolCreditGate", () => {
     mockIsUserBlocked.mockRejectedValue(new Error("redis unavailable"));
     const auth = makeAuth();
     await expect(callGate(auth)).rejects.toThrow("redis unavailable");
+  });
+});
+
+function callApprovalGate(
+  auth: Authenticator,
+  userMessageOrigin: UserMessageOrigin | null = "web"
+) {
+  return checkMessageCreditApprovalGate(auth, {
+    agentMessageId: "msg_1",
+    userMessageId: "usr_msg_1",
+    userMessageOrigin,
+  });
+}
+
+function mockCostCredits(costCredits: number | null) {
+  mockComputeAgentMessageCredits.mockResolvedValue({
+    agentMessageModelId: 1,
+    costCredits,
+    previousCostCredits: null,
+  });
+}
+
+describe("checkMessageCreditApprovalGate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchCreditApprovalContext.mockResolvedValue({
+      agentMessageModelId: 1,
+      isRootAgentMessage: true,
+    });
+    mockFetchCreditApprovalStep.mockResolvedValue(null);
+    mockCostCredits(0);
+    mockIsProgrammaticUsage.mockReturnValue(false);
+    mockGetFeatureFlags.mockResolvedValue(["credit_approval_gate"]);
+  });
+
+  it("never asks when the feature flag is off", async () => {
+    mockGetFeatureFlags.mockResolvedValue([]);
+    mockCostCredits(AGENT_MESSAGE_CREDIT_APPROVAL_THRESHOLD + 1);
+
+    const result = await callApprovalGate(makeAuth());
+
+    expect(result).toEqual({ shouldStop: false, reason: null });
+    expect(mockFetchCreditApprovalContext).not.toHaveBeenCalled();
+    expect(mockComputeAgentMessageCredits).not.toHaveBeenCalled();
+  });
+
+  it("asks for approval once the cost is strictly above the threshold", async () => {
+    mockCostCredits(AGENT_MESSAGE_CREDIT_APPROVAL_THRESHOLD + 1);
+
+    const result = await callApprovalGate(makeAuth());
+
+    expect(result).toEqual({
+      shouldStop: true,
+      reason: "credit_approval_required",
+      costCredits: AGENT_MESSAGE_CREDIT_APPROVAL_THRESHOLD + 1,
+    });
+  });
+
+  it("does not ask when the cost sits exactly on the threshold", async () => {
+    mockCostCredits(AGENT_MESSAGE_CREDIT_APPROVAL_THRESHOLD);
+
+    const result = await callApprovalGate(makeAuth());
+
+    expect(result).toEqual({ shouldStop: false, reason: null });
+  });
+
+  it("does not ask when nothing billable is attributed to the message yet", async () => {
+    mockCostCredits(null);
+
+    const result = await callApprovalGate(makeAuth());
+
+    expect(result).toEqual({ shouldStop: false, reason: null });
+  });
+
+  it("never asks twice: a message that already asked short-circuits before computing the cost", async () => {
+    mockFetchCreditApprovalStep.mockResolvedValue(2);
+    mockCostCredits(AGENT_MESSAGE_CREDIT_APPROVAL_THRESHOLD + 1);
+
+    const result = await callApprovalGate(makeAuth());
+
+    expect(result).toEqual({ shouldStop: false, reason: null });
+    expect(mockComputeAgentMessageCredits).not.toHaveBeenCalled();
+  });
+
+  it("does not ask when the agent message row is gone", async () => {
+    mockFetchCreditApprovalContext.mockResolvedValue(null);
+
+    const result = await callApprovalGate(makeAuth());
+
+    expect(result).toEqual({ shouldStop: false, reason: null });
+    expect(mockComputeAgentMessageCredits).not.toHaveBeenCalled();
+  });
+
+  it("leaves sub-agent runs alone — the root message's cost already covers them", async () => {
+    mockFetchCreditApprovalContext.mockResolvedValue({
+      agentMessageModelId: 1,
+      isRootAgentMessage: false,
+    });
+
+    const result = await callApprovalGate(makeAuth());
+
+    expect(result).toEqual({ shouldStop: false, reason: null });
+    expect(mockComputeAgentMessageCredits).not.toHaveBeenCalled();
+  });
+
+  it("never asks on a programmatic origin: nobody is there to answer", async () => {
+    mockIsProgrammaticUsage.mockReturnValue(true);
+    mockCostCredits(AGENT_MESSAGE_CREDIT_APPROVAL_THRESHOLD + 1);
+
+    const result = await callApprovalGate(makeAuth(), "api");
+
+    expect(result).toEqual({ shouldStop: false, reason: null });
+    expect(mockFetchCreditApprovalContext).not.toHaveBeenCalled();
+    expect(mockComputeAgentMessageCredits).not.toHaveBeenCalled();
+  });
+
+  it("never asks on API-key auth, even when the run carries no origin", async () => {
+    mockCostCredits(AGENT_MESSAGE_CREDIT_APPROVAL_THRESHOLD + 1);
+
+    const result = await callApprovalGate(
+      makeAuth({ authMethod: "api_key" }),
+      null
+    );
+
+    expect(result).toEqual({ shouldStop: false, reason: null });
+    expect(mockIsProgrammaticUsage).not.toHaveBeenCalled();
+    expect(mockFetchCreditApprovalContext).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/assistant/credit_check.ts
+++ b/front/lib/api/assistant/credit_check.ts
@@ -1,5 +1,12 @@
+import {
+  AGENT_MESSAGE_CREDIT_APPROVAL_THRESHOLD,
+  fetchCreditApprovalContext,
+  fetchCreditApprovalStep,
+} from "@app/lib/api/assistant/credit_approval";
+import { computeAgentMessageCredits } from "@app/lib/api/assistant/credit_cost";
 import { isProgrammaticUsage } from "@app/lib/api/programmatic_usage/tracking";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import {
   isApiBlocked,
   isProgrammaticApiBlocked,
@@ -10,7 +17,14 @@ import { isCreditPricedPlan } from "@app/types/plan";
 
 export type CreditCheckResult =
   | { shouldStop: false; reason: null }
-  | { shouldStop: true; reason: "credits_exhausted" };
+  | { shouldStop: true; reason: "credits_exhausted" }
+  // Not a failure: the message crossed the per-message credit threshold and the loop parks itself
+  // until the user says whether to continue. See `checkMessageCreditApprovalGate`.
+  | {
+      shouldStop: true;
+      reason: "credit_approval_required";
+      costCredits: number;
+    };
 
 const DO_NOT_STOP: CreditCheckResult = { shouldStop: false, reason: null };
 
@@ -52,4 +66,75 @@ export async function checkPoolCreditGate(
   }
 
   return DO_NOT_STOP;
+}
+
+/**
+ * Determines whether the agent loop should stop because a single message is running away with credits.
+ */
+export async function checkMessageCreditApprovalGate(
+  auth: Authenticator,
+  {
+    agentMessageId,
+    userMessageId,
+    userMessageOrigin,
+  }: {
+    agentMessageId: string;
+    // sId of the user message that started this run. Used to tell a root message from a sub-agent
+    // one: only the root asks, since its cost already covers its descendants.
+    userMessageId: string;
+    userMessageOrigin: UserMessageOrigin | null;
+  }
+): Promise<CreditCheckResult> {
+  const featureFlags = await getFeatureFlags(auth);
+  if (!featureFlags.includes("credit_approval_gate")) {
+    return DO_NOT_STOP;
+  }
+
+  // The point of this gate is to prompt the user when a single message runs away with credits.
+  // Skip programmatic and API-key usage: nobody is around to answer the prompt.
+  if (
+    auth.authMethod() === "api_key" ||
+    (userMessageOrigin && isProgrammaticUsage(auth, { userMessageOrigin }))
+  ) {
+    return DO_NOT_STOP;
+  }
+
+  const approvalContext = await fetchCreditApprovalContext(auth, {
+    agentMessageId,
+    userMessageId,
+  });
+
+  if (!approvalContext) {
+    return DO_NOT_STOP;
+  }
+
+  // For now only check the root message.
+  // TODO: break the loop from sub-agents and bubble the approval request up to the root message.
+  if (!approvalContext.isRootAgentMessage) {
+    return DO_NOT_STOP;
+  }
+
+  // If the user has already been asked once for this message, don't ask again.
+  const askedAtStep = await fetchCreditApprovalStep(auth, {
+    agentMessageModelId: approvalContext.agentMessageModelId,
+  });
+  if (askedAtStep !== null) {
+    return DO_NOT_STOP;
+  }
+
+  const computed = await computeAgentMessageCredits(auth, { agentMessageId });
+  // Null means nothing billable is attributed to the message yet — not a zero-cost message.
+  if (computed?.costCredits == null) {
+    return DO_NOT_STOP;
+  }
+
+  if (computed.costCredits <= AGENT_MESSAGE_CREDIT_APPROVAL_THRESHOLD) {
+    return DO_NOT_STOP;
+  }
+
+  return {
+    shouldStop: true,
+    reason: "credit_approval_required",
+    costCredits: computed.costCredits,
+  };
 }

--- a/front/lib/api/assistant/credit_cost.test.ts
+++ b/front/lib/api/assistant/credit_cost.test.ts
@@ -1,4 +1,4 @@
-import { computeAgentMessageCredits } from "@app/lib/api/assistant/credit_cost";
+import { computeCreditsFromUsage } from "@app/lib/api/assistant/credit_cost";
 import {
   awuFromMicroUsd,
   intelligenceAwuFromRunUsages,
@@ -159,9 +159,9 @@ describe("toolAwuFromActions", () => {
   });
 });
 
-describe("computeAgentMessageCredits", () => {
+describe("computeCreditsFromUsage", () => {
   it("sums intelligence and tool credits", () => {
-    const credits = computeAgentMessageCredits({
+    const credits = computeCreditsFromUsage({
       runUsages: [usage({ costMicroUsd: 8500 })], // 1 intelligence credit
       actions: [
         {
@@ -176,7 +176,7 @@ describe("computeAgentMessageCredits", () => {
   });
 
   it("ignores non-final actions", () => {
-    const credits = computeAgentMessageCredits({
+    const credits = computeCreditsFromUsage({
       runUsages: [],
       actions: [
         {
@@ -192,7 +192,7 @@ describe("computeAgentMessageCredits", () => {
 
   it("returns null when there is no billable usage", () => {
     expect(
-      computeAgentMessageCredits({
+      computeCreditsFromUsage({
         runUsages: [],
         actions: [],
         contextOrigin: TEST_CONTEXT_ORIGIN,
@@ -201,7 +201,7 @@ describe("computeAgentMessageCredits", () => {
   });
 
   it("costs 0 for free-origin usage (e.g. agent_sidekick), LLM and tools alike", () => {
-    const credits = computeAgentMessageCredits({
+    const credits = computeCreditsFromUsage({
       runUsages: [usage({ costMicroUsd: 8500 })], // would be 1 intelligence credit
       actions: [
         {
@@ -217,7 +217,7 @@ describe("computeAgentMessageCredits", () => {
 
   it("still returns null for free-origin usage when there is nothing to track", () => {
     expect(
-      computeAgentMessageCredits({
+      computeCreditsFromUsage({
         runUsages: [],
         actions: [],
         contextOrigin: "agent_sidekick",

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -31,6 +31,7 @@ import {
   AGENT_MESSAGE_STATUSES_TO_TRACK,
   type UserMessageOrigin,
 } from "@app/types/assistant/conversation";
+import type { ModelId } from "@app/types/shared/model_id";
 
 interface CreditActionMinimalInput {
   toolName: string;
@@ -162,7 +163,7 @@ export function buildAgentMessageCreditsBreakdownFromAnalytics({
   };
 }
 
-export function computeAgentMessageCredits({
+export function computeCreditsFromUsage({
   runUsages,
   actions,
   contextOrigin,
@@ -189,30 +190,23 @@ export function computeAgentMessageCredits({
 }
 
 /**
- * Compute the agent message credit cost once at the end of the agentic loop and persist it on the
- * agent message. Returns the computed value (or null when there is nothing to track).
+ * Return the credit cost accrued so far by an agent message: its own
+ * intelligence + tool cost, from its full accumulated runIds and all final-status actions.
  *
- * Called from the finalize activities (alongside the Metronome usage events it is derived from),
- * not from the hot terminal-event path, so publishing the terminal events stays lightweight. The
- * value is not pushed on any event — clients read it from the messages / conversation API on their
- * next revalidation.
- *
- * Computes from the message's full accumulated runIds + all final-status actions (the message-level
- * total), so re-runs (interrupt/resume) overwrite the stored value with the complete cost. Only
- * persists for statuses we track for billing, matching the Metronome gate.
- *
- * Before recomputing, this execution's runs are tagged with their runKey (from `dustRunIds`) so the
- * intelligence cost is ceiled per agent-loop execution — exactly matching the per-execution
- * Metronome events. Tagging is idempotent (same runIds → same runKey), so it stays overwrite-safe
- * across Temporal retries.
+ * Returns null when the message is gone or its status is not one we bill for, so callers can tell
+ * "nothing to account for" from "costs zero".
  */
-export async function computeAndStoreAgentMessageCredits(
+export async function computeAgentMessageCredits(
   auth: Authenticator,
   {
     agentMessageId,
     dustRunIds,
   }: { agentMessageId: string; dustRunIds?: string[] }
-): Promise<number | null> {
+): Promise<{
+  agentMessageModelId: ModelId;
+  costCredits: number | null;
+  previousCostCredits: number | null;
+} | null> {
   const creditContext =
     await ConversationResource.fetchAgentMessageCreditContext(auth, {
       agentMessageId,
@@ -254,7 +248,7 @@ export async function computeAndStoreAgentMessageCredits(
     AgentMCPActionResource.listByAgentMessageIds(auth, [agentMessageModelId]),
   ]);
 
-  const costCredits = computeAgentMessageCredits({
+  const costCredits = computeCreditsFromUsage({
     runUsages,
     actions: actions.map((action) => ({
       toolName: getToolNameFromFunctionCallName(action.functionCallName),
@@ -263,6 +257,45 @@ export async function computeAndStoreAgentMessageCredits(
     })),
     contextOrigin: triggeringUserMessageOrigin,
   });
+
+  return { agentMessageModelId, costCredits, previousCostCredits };
+}
+
+/**
+ * Compute the agent message credit cost once at the end of the agentic loop and persist it on the
+ * agent message. Returns the computed value (or null when there is nothing to track).
+ *
+ * Called from the finalize activities (alongside the Metronome usage events it is derived from),
+ * not from the hot terminal-event path, so publishing the terminal events stays lightweight. The
+ * value is not pushed on any event — clients read it from the messages / conversation API on their
+ * next revalidation.
+ *
+ * Computes from the message's full accumulated runIds + all final-status actions (the message-level
+ * total), so re-runs (interrupt/resume) overwrite the stored value with the complete cost. Only
+ * persists for statuses we track for billing, matching the Metronome gate.
+ *
+ * Before recomputing, this execution's runs are tagged with their runKey (from `dustRunIds`) so the
+ * intelligence cost is ceiled per agent-loop execution — exactly matching the per-execution
+ * Metronome events. Tagging is idempotent (same runIds → same runKey), so it stays overwrite-safe
+ * across Temporal retries.
+ */
+export async function computeAndStoreAgentMessageCredits(
+  auth: Authenticator,
+  {
+    agentMessageId,
+    dustRunIds,
+  }: { agentMessageId: string; dustRunIds?: string[] }
+): Promise<number | null> {
+  const computed = await computeAgentMessageCredits(auth, {
+    agentMessageId,
+    dustRunIds,
+  });
+
+  if (!computed) {
+    return null;
+  }
+
+  const { agentMessageModelId, costCredits, previousCostCredits } = computed;
 
   await ConversationResource.updateAgentMessageCostCredits(auth, {
     agentMessageModelId,

--- a/front/lib/api/assistant/streaming/helpers.ts
+++ b/front/lib/api/assistant/streaming/helpers.ts
@@ -1,4 +1,6 @@
+import { CREDIT_APPROVAL_REQUIRED_ERROR_CODE } from "@app/lib/api/assistant/credit_approval";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
+import { TERMINAL_AGENT_MESSAGE_EVENT_TYPES } from "@app/lib/api/assistant/streaming/types";
 import type {
   AgentErrorEvent,
   AgentMessageSuccessEvent,
@@ -18,9 +20,49 @@ export function isEndOfStreamEvent(event: unknown): event is EndOfStreamEvent {
   );
 }
 
+/**
+ * The credit safety net stops the loop through an `agent_error` because that event already carries
+ * the persistence we need, but nothing failed: the message is parked awaiting the user's answer and
+ * resumes in place, exactly like one blocked on a tool validation.
+ *
+ * So it must not be treated as terminal anywhere — not for the message status, not for the
+ * conversation flags, and not for the stream lifecycle.
+ */
+// Deliberately not a type predicate: callers use it inside an already-narrowed `agent_error` case,
+// where narrowing to `AgentErrorEvent` would collapse the negative branch to `never`.
+export function isCreditApprovalRequestEvent(
+  event: AgentMessageEvents
+): boolean {
+  return (
+    event.type === "agent_error" &&
+    event.error.code === CREDIT_APPROVAL_REQUIRED_ERROR_CODE
+  );
+}
+
+export function isTerminalAgentMessageEvent(
+  event: AgentMessageEvents
+): boolean {
+  if (isCreditApprovalRequestEvent(event)) {
+    return false;
+  }
+
+  return TERMINAL_AGENT_MESSAGE_EVENT_TYPES.includes(event.type);
+}
+
 export function isEndOfAgentMessageStreamEvent(
   event: AgentMessageEvents
 ): event is AgentMessageSuccessEvent | AgentErrorEvent {
+  // Publishing an `end-of-stream` marker for a credit-approval stop would close the server
+  // generator and latch the client's EventSource shut for good, so the resumed run would only show
+  // up on a page reload.
+  //
+  // Public-API blocking mode also keys off `end-of-stream`, but it can never observe this: the
+  // per-message gate bails out on programmatic and API-key usage (see
+  // `checkMessageCreditApprovalGate`).
+  if (isCreditApprovalRequestEvent(event)) {
+    return false;
+  }
+
   return ["agent_message_success", "agent_error"].includes(event.type);
 }
 

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -1,10 +1,19 @@
 import { renderAgentMessageContentView } from "@app/lib/api/assistant/activity_steps";
 import { updateAgentMessageWithFinalStatus } from "@app/lib/api/assistant/conversation";
+import {
+  AGENT_MESSAGE_CREDIT_APPROVAL_THRESHOLD,
+  CREDIT_APPROVAL_REQUIRED_ERROR_CODE,
+  CREDIT_APPROVAL_REQUIRED_ERROR_TITLE,
+  creditApprovalRequiredMessage,
+} from "@app/lib/api/assistant/credit_approval";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
 import { resolvedModelFromAgentMessageRow } from "@app/lib/api/assistant/models";
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
+import {
+  isCreditApprovalRequestEvent,
+  isTerminalAgentMessageEvent,
+} from "@app/lib/api/assistant/streaming/helpers";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
-import { TERMINAL_AGENT_MESSAGE_EVENT_TYPES } from "@app/lib/api/assistant/streaming/types";
 import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
 import { Authenticator as AuthenticatorClass } from "@app/lib/auth";
 import {
@@ -12,6 +21,7 @@ import {
   getDelimitersConfiguration,
 } from "@app/lib/llms/agent_message_content_parser";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
+import { notifyManualActionRequired } from "@app/lib/notifications/workflows/manual-action-required";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
@@ -87,6 +97,12 @@ export async function updateAgentMessageDBAndMemory(
           | {
               type: "prunedContext";
               prunedContext: true;
+            }
+          | {
+              // Stores an error the message can be resumed from, without the terminal transition
+              // that `type: "error"` performs. See `isCreditApprovalRequestEvent`.
+              type: "resumableError";
+              error: ToolErrorEvent["error"];
             };
       }
 ): Promise<boolean> {
@@ -188,6 +204,20 @@ export async function updateAgentMessageDBAndMemory(
       }
       break;
 
+    case "resumableError":
+      {
+        await AgentMessageModel.update(
+          {
+            errorCode: update.error.code,
+            errorMessage: update.error.message,
+            errorMetadata: update.error.metadata,
+          },
+          { where }
+        );
+        agentMessage.error = update.error;
+      }
+      break;
+
     default:
       assertNever(update);
   }
@@ -262,21 +292,35 @@ export async function processEventForDatabase(
 
   switch (event.type) {
     case "agent_error": {
-      // Store error in database.
-      const applied = await markAgentMessageAsFailed(auth, {
-        agentMessage,
-        conversation,
-        error: event.error,
-      });
+      // A credit-approval request is a pause, not a failure: the message stays "created" and
+      // resumable, like one parked on a tool validation. Finalizing it would deny its blocked
+      // actions, promote queued messages and close it for good, and flagging the conversation as
+      // errored would misreport a run the user can still continue.
+      if (isCreditApprovalRequestEvent(event)) {
+        await updateAgentMessageDBAndMemory(auth, {
+          agentMessage,
+          update: {
+            type: "resumableError",
+            error: event.error,
+          },
+        });
+      } else {
+        // Store error in database.
+        const applied = await markAgentMessageAsFailed(auth, {
+          agentMessage,
+          conversation,
+          error: event.error,
+        });
 
-      if (!applied) {
-        return false;
+        if (!applied) {
+          return false;
+        }
+
+        // Mark the conversation as errored.
+        await ConversationResource.markHasError(auth, {
+          conversation,
+        });
       }
-
-      // Mark the conversation as errored.
-      await ConversationResource.markHasError(auth, {
-        conversation,
-      });
 
       await AgentStepContentResource.createNewVersion({
         workspaceId: auth.getNonNullableWorkspace().id,
@@ -364,7 +408,7 @@ export async function processEventForDatabase(
       break;
   }
 
-  if (TERMINAL_AGENT_MESSAGE_EVENT_TYPES.includes(event.type)) {
+  if (isTerminalAgentMessageEvent(event)) {
     await ConversationResource.setIsRunningAgentLoop(auth, {
       conversation,
       isRunningAgentLoop: false,
@@ -386,7 +430,7 @@ async function processEventForUnreadState(
   }
 ) {
   // If the event is a done event, we want to mark the conversation as unread for all participants.
-  if (TERMINAL_AGENT_MESSAGE_EVENT_TYPES.includes(event.type)) {
+  if (isTerminalAgentMessageEvent(event)) {
     // Publish the agent message done event that will be handled on the client-side.
     await publishConversationRelatedEvent({
       conversationId: conversation.sId,
@@ -832,6 +876,84 @@ export async function finalizeGracefulStop(
       conversationId: conversation.sId,
     },
     "Agent generation gracefully stopped"
+  );
+}
+
+/**
+ * Credit approval request: publishes the resumable `credit_approval_required` agent error.
+ *
+ * Reuses the `agent_error` MessageEvent rather than introducing a stop of its own,
+ * and writes an `error` step content to keep track of the approval request (see `fetchCreditApprovalStep`).
+ */
+export async function finalizeCreditApprovalRequest(
+  authType: AuthenticatorType,
+  agentLoopArgs: AgentLoopArgs,
+  { costCredits }: { costCredits: number }
+): Promise<void> {
+  const runAgentDataRes = await getAgentLoopData(authType, agentLoopArgs);
+  if (runAgentDataRes.isErr()) {
+    if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
+      logger.info(
+        {
+          conversationId: agentLoopArgs.conversationId,
+          agentMessageId: agentLoopArgs.agentMessageId,
+        },
+        "Message or conversation was deleted, exiting"
+      );
+      return;
+    }
+    throw new Error(
+      `Failed to get run agent data: ${runAgentDataRes.error.message}`
+    );
+  }
+  const { auth, agentConfiguration, agentMessage, conversation } =
+    runAgentDataRes.value;
+
+  // Record a step after the last one that produced content.
+  const step = (maxBy(agentMessage.contents, "step")?.step ?? 0) + 1;
+
+  await updateResourceAndPublishEvent(auth, {
+    event: {
+      type: "agent_error",
+      created: Date.now(),
+      configurationId: agentConfiguration.sId,
+      messageId: agentMessage.sId,
+      error: {
+        code: CREDIT_APPROVAL_REQUIRED_ERROR_CODE,
+        message: creditApprovalRequiredMessage(costCredits),
+        metadata: {
+          category: CREDIT_APPROVAL_REQUIRED_ERROR_CODE,
+          errorTitle: CREDIT_APPROVAL_REQUIRED_ERROR_TITLE,
+          costCredits,
+          thresholdCredits: AGENT_MESSAGE_CREDIT_APPROVAL_THRESHOLD,
+        },
+      },
+      runIds: agentLoopArgs.dustRunIds ?? [],
+    },
+    agentMessage,
+    conversation,
+    step,
+  });
+
+  // Same signal as a tool awaiting validation: the conversation needs the user before it can go
+  // any further.
+  await ConversationResource.markAsActionRequired(auth, { conversation });
+
+  if (!conversation.actionRequired) {
+    notifyManualActionRequired(auth, { conversationId: conversation.sId });
+  }
+
+  // Paired with the "resumed" log in `resumeAfterCreditApproval`
+  logger.info(
+    {
+      agentMessageId: agentMessage.sId,
+      conversationId: conversation.sId,
+      costCredits,
+      step,
+      thresholdCredits: AGENT_MESSAGE_CREDIT_APPROVAL_THRESHOLD,
+      workspaceId: auth.getNonNullableWorkspace().sId,
+    },
+    "[CreditApproval] Agent loop interrupted: per-message credit threshold crossed"
   );
 }
 

--- a/front/temporal/agent_loop/activities/credit_check.test.ts
+++ b/front/temporal/agent_loop/activities/credit_check.test.ts
@@ -1,10 +1,12 @@
 import { checkCreditsActivity } from "@app/temporal/agent_loop/activities/credit_check";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockFromJson, mockCheckPoolCreditGate } = vi.hoisted(() => ({
-  mockFromJson: vi.fn(),
-  mockCheckPoolCreditGate: vi.fn(),
-}));
+const { mockFromJson, mockCheckPoolCreditGate, mockCheckMessageCreditGate } =
+  vi.hoisted(() => ({
+    mockFromJson: vi.fn(),
+    mockCheckPoolCreditGate: vi.fn(),
+    mockCheckMessageCreditGate: vi.fn(),
+  }));
 
 vi.mock("@app/lib/auth", () => ({
   Authenticator: { fromJsonWithRefrehedGroups: mockFromJson },
@@ -12,6 +14,7 @@ vi.mock("@app/lib/auth", () => ({
 
 vi.mock("@app/lib/api/assistant/credit_check", () => ({
   checkPoolCreditGate: mockCheckPoolCreditGate,
+  checkMessageCreditApprovalGate: mockCheckMessageCreditGate,
 }));
 
 const FAKE_AUTH = {
@@ -22,6 +25,10 @@ describe("checkCreditsActivity (pure decision)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFromJson.mockResolvedValue(FAKE_AUTH);
+    mockCheckMessageCreditGate.mockResolvedValue({
+      shouldStop: false,
+      reason: null,
+    });
   });
 
   it("returns the gate's no-stop result unchanged", async () => {
@@ -77,6 +84,52 @@ describe("checkCreditsActivity (pure decision)", () => {
 
     expect(mockCheckPoolCreditGate).toHaveBeenCalledWith(FAKE_AUTH, {
       userMessageOrigin: null,
+    });
+  });
+
+  it("skips the per-message gate when the workspace pool is already exhausted", async () => {
+    mockCheckPoolCreditGate.mockResolvedValue({
+      shouldStop: true,
+      reason: "credits_exhausted",
+    });
+
+    await checkCreditsActivity({} as never, {
+      agentLoopArgs: {} as never,
+    });
+
+    expect(mockCheckMessageCreditGate).not.toHaveBeenCalled();
+  });
+
+  it("returns the per-message gate's approval request when the pool is fine", async () => {
+    mockCheckPoolCreditGate.mockResolvedValue({
+      shouldStop: false,
+      reason: null,
+    });
+    mockCheckMessageCreditGate.mockResolvedValue({
+      shouldStop: true,
+      reason: "credit_approval_required",
+      costCredits: 300,
+    });
+
+    const result = await checkCreditsActivity({} as never, {
+      agentLoopArgs: {
+        agentMessageId: "msg_1",
+        agentMessageVersion: 0,
+        conversationId: "conv_1",
+        userMessageId: "usr_msg_1",
+        userMessageOrigin: "web",
+      } as never,
+    });
+
+    expect(result).toEqual({
+      shouldStop: true,
+      reason: "credit_approval_required",
+      costCredits: 300,
+    });
+    expect(mockCheckMessageCreditGate).toHaveBeenCalledWith(FAKE_AUTH, {
+      agentMessageId: "msg_1",
+      userMessageId: "usr_msg_1",
+      userMessageOrigin: "web",
     });
   });
 });

--- a/front/temporal/agent_loop/activities/credit_check.ts
+++ b/front/temporal/agent_loop/activities/credit_check.ts
@@ -1,5 +1,6 @@
 import {
   type CreditCheckResult,
+  checkMessageCreditApprovalGate,
   checkPoolCreditGate,
 } from "@app/lib/api/assistant/credit_check";
 import { Authenticator, type AuthenticatorType } from "@app/lib/auth";
@@ -11,7 +12,17 @@ export async function checkCreditsActivity(
 ): Promise<CreditCheckResult> {
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
 
-  return checkPoolCreditGate(auth, {
+  const poolGateResult = await checkPoolCreditGate(auth, {
+    userMessageOrigin: agentLoopArgs.userMessageOrigin ?? null,
+  });
+  if (poolGateResult.shouldStop) {
+    return poolGateResult;
+  }
+
+  // The workspace pool is fine; check whether this single message is running away with credits.
+  return checkMessageCreditApprovalGate(auth, {
+    agentMessageId: agentLoopArgs.agentMessageId,
+    userMessageId: agentLoopArgs.userMessageId,
     userMessageOrigin: agentLoopArgs.userMessageOrigin ?? null,
   });
 }

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -11,6 +11,7 @@ import {
 import {
   creditsExhaustedMessage,
   finalizeCancellation,
+  finalizeCreditApprovalRequest,
   finalizeCreditStop,
   finalizeGracefulStop,
   finalizeInterruption,
@@ -143,6 +144,26 @@ export async function finalizeCreditStoppedAgentLoopActivity(
       agentMessageId: agentLoopArgs.agentMessageId,
     }),
     sendEmailReplyOnError(auth, agentLoopArgs, creditsExhaustedMessage(auth)),
+  ]);
+}
+
+export async function finalizeCreditApprovalRequiredAgentLoopActivity(
+  authType: AuthenticatorType,
+  agentLoopArgs: AgentLoopArgs,
+  { costCredits }: { costCredits: number }
+): Promise<void> {
+  await finalizeCreditApprovalRequest(authType, agentLoopArgs, { costCredits });
+
+  const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
+
+  await Promise.all([
+    snapshotAgentMessageSkills(auth, agentLoopArgs),
+    launchAgentMessageAnalytics(auth, agentLoopArgs),
+    launchAgentMessageConsumptionAttribution(auth, agentLoopArgs),
+    launchTrackProgrammaticUsage(auth, agentLoopArgs),
+    launchEmitMetronomeUsageEvents(auth, agentLoopArgs),
+    computeAndStoreAgentMessageCredits(auth, agentLoopArgs),
+    conversationUnreadNotification(auth, agentLoopArgs),
   ]);
 }
 

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -15,6 +15,7 @@ import { checkCreditsActivity } from "@app/temporal/agent_loop/activities/credit
 import { ensureConversationTitleActivity } from "@app/temporal/agent_loop/activities/ensure_conversation_title";
 import {
   finalizeCancelledAgentLoopActivity,
+  finalizeCreditApprovalRequiredAgentLoopActivity,
   finalizeCreditStoppedAgentLoopActivity,
   finalizeErroredAgentLoopActivity,
   finalizeGracefullyStoppedAgentLoopActivity,
@@ -64,6 +65,7 @@ export async function runAgentLoopWorker() {
       finalizeSuccessfulAgentLoopActivity,
       finalizeGracefullyStoppedAgentLoopActivity,
       finalizeCreditStoppedAgentLoopActivity,
+      finalizeCreditApprovalRequiredAgentLoopActivity,
       finalizeCancelledAgentLoopActivity,
       finalizeInterruptedAgentLoopActivity,
       finalizeErroredAgentLoopActivity,

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -140,6 +140,7 @@ const {
   finalizeSuccessfulAgentLoopActivity,
   finalizeGracefullyStoppedAgentLoopActivity,
   finalizeCreditStoppedAgentLoopActivity,
+  finalizeCreditApprovalRequiredAgentLoopActivity,
   finalizeCancelledAgentLoopActivity,
   finalizeInterruptedAgentLoopActivity,
   finalizeErroredAgentLoopActivity,
@@ -233,6 +234,10 @@ export async function agentLoopWorkflow({
   // Credit stop: the per-step gate found the workspace pool exhausted.
   let creditStopRequested = false;
 
+  // Credit approval: the per-step gate found this message consumed more than the credit threshold, so the
+  // loop stops and asks the user whether to continue. Set at most once per message.
+  let creditApprovalRequest: { costCredits: number } | null = null;
+
   const runIds: string[] = [];
 
   try {
@@ -322,7 +327,13 @@ export async function agentLoopWorkflow({
           },
         });
         if (creditCheckResult.shouldStop) {
-          creditStopRequested = true;
+          if (creditCheckResult.reason === "credit_approval_required") {
+            creditApprovalRequest = {
+              costCredits: creditCheckResult.costCredits,
+            };
+          } else {
+            creditStopRequested = true;
+          }
           break;
         }
       }
@@ -358,6 +369,12 @@ export async function agentLoopWorkflow({
           await finalizeCreditStoppedAgentLoopActivity(
             authType,
             argsWithRunIds
+          );
+        } else if (creditApprovalRequest) {
+          await finalizeCreditApprovalRequiredAgentLoopActivity(
+            authType,
+            argsWithRunIds,
+            creditApprovalRequest
           );
         } else {
           await finalizeSuccessfulAgentLoopActivity(authType, argsWithRunIds);

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -249,6 +249,7 @@ export const AgentErrorCategories = [
   "unknown_error",
   "invalid_response_format_configuration",
   "credits_exhausted",
+  "credit_approval_required",
 ] as const;
 
 export type AgentErrorCategory = (typeof AgentErrorCategories)[number];

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -320,6 +320,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable the per-user spend-cap backup: record per-user AWU usage into the Redis fixed-window counter and enforce it at message send (blocks with user_cap_reached). When off, usage is neither recorded nor enforced.",
     stage: "dust_only",
   },
+  credit_approval_gate: {
+    description:
+      "Enable the per-message credit safety net: a single message whose cost crosses the threshold stops at the next step boundary and asks the user whether to continue.",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -804,6 +804,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "user_memory"
   | "similar_agents_check"
   | "enforce_user_spend_limit_rate_cap"
+  | "credit_approval_gate"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Stop the loop and ask the user for permission to continue when a message is consuming more than a given credit threshold.
Current threshold currently hardcoded at 1,000 credits. Under feature flag.

- This piggy back on the `checkCreditsActivity` which is performed after every steps:  in addition to check workspace credit usage, checks the message consumption. It does so by recomputing on the fly the message cost credit (extracted from `computeAndStoreAgentMessageCredits`).
- The check is only done at the root message, so sub agent messages won't be interrupted until the parent step is done.
- Reuses the agent error event and mark the conversation as blocked / needs action.
- A step content is created to persist that we asked for permission. We resume using the existing `/retry` endpoint from this step
- A message can only be interrupted once.

## Tests

ut + tested manually with a low threshold:
<img width="1019" height="363" alt="Screenshot 2026-07-31 at 14 56 21" src="https://github.com/user-attachments/assets/cc3f5d39-e442-4943-b5bb-4525d934a34a" />

## Risk

Under feature flag. Safe to rollback.

## Deploy Plan

Front only