### PR TITLE
Fix deferred first-message placeholders for restricted agents.

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -804,6 +804,27 @@ export const ConversationViewer = ({
                 }
               }
 
+              // Restricted agents never emit agent_message_new. Drop their
+              // optimistic placeholders (including deferred first-message ones)
+              // so they cannot collide on rank or look like a running agent.
+              const restrictedAgentIds = new Set(
+                userMessage.richMentions
+                  .filter(
+                    (m) =>
+                      isRichAgentMention(m) &&
+                      m.status === "agent_restricted_by_space_usage"
+                  )
+                  .map((m) => m.id)
+              );
+              if (restrictedAgentIds.size > 0) {
+                virtuosoMessageListRef.current.data.findAndDelete(
+                  (m) =>
+                    isPlaceholderMessage(m) &&
+                    isAgentMessageWithStreaming(m) &&
+                    restrictedAgentIds.has(m.configuration.sId)
+                );
+              }
+
               // Update the participants and the conversation list if the message is not from the current user.
               if (userMessage.user?.sId !== user.sId) {
                 void mutateConversationParticipants(
@@ -1237,10 +1258,16 @@ export const ConversationViewer = ({
 
         // Skip placeholder agent messages if there's already a running agent in the conversation
         // (steering: the message will be pending, no new agent message is created until the running
-        // one gracefully stops).
+        // one gracefully stops). Optimistic placeholders must not count — e.g. a leftover
+        // restricted-agent placeholder from the deferred first message.
         const hasRunningAgent = virtuosoMessageListRef.current.data
           .get()
-          .some((m) => m.type === "agent_message" && m.status === "created");
+          .some(
+            (m) =>
+              m.type === "agent_message" &&
+              m.status === "created" &&
+              !isPlaceholderMessage(m)
+          );
 
         if (hasRunningAgent && conversationId) {
           incrementPendingSteeringCount(conversationId);


### PR DESCRIPTION
## Description

Deferred first-message creates an optimistic agent placeholder in `ConversationViewer` before the server confirms the message. For restricted agents (`agent_restricted_by_space_usage`), `agent_message_new` is never emitted, so those placeholders survive indefinitely — showing a fake "running" agent next to the approve/decline card.

Two fixes in `ConversationViewer.tsx`:
- On `user_message_new`, collect restricted-agent sIds from `userMessage.richMentions` and `findAndDelete` their placeholders from the virtuoso list immediately.
- Exclude placeholder messages from the `hasRunningAgent` check so a stale restricted-agent placeholder doesn't block a follow-up send by triggering the steering path.

## Tests

Tested manually: sent a message mentioning a restricted agent with deferred first-message enabled — the fake running placeholder is dropped and the approve card renders correctly. Confirmed a quick follow-up message is not incorrectly throttled as steering.

## Risk

Low. Changes are scoped to optimistic UI state management in `ConversationViewer`. No data mutations or API changes. Placeholder cleanup only fires when `restrictedAgentIds.size > 0`. Rollback is safe.

## Deploy Plan

Deploy front.
