### PR TITLE
[AGENTS] Fix batch Set model for admins, require editorship to update an agent

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
@@ -1,7 +1,11 @@
-import { createPendingAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import {
+  createPendingAgentConfiguration,
+  getAgentConfiguration,
+} from "@app/lib/api/assistant/configuration/agent";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { setupAgentOwner } from "@app/tests/utils/AgentOwnerFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
@@ -125,6 +129,53 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId - additionalRequ
     expect(agentConfigurationModel?.requestedSpaceIds).toContain(
       openSpaceModelId
     );
+  });
+});
+
+describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId - non-editor admin", () => {
+  it("cannot edit the instructions of an agent it is not an editor of", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+      method: "PATCH",
+    });
+    await SpaceFactory.defaults(auth);
+
+    const { agentOwner, agentOwnerAuth } = await setupAgentOwner(
+      workspace,
+      "builder"
+    );
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(agentOwnerAuth);
+
+    const response = await patch(workspace, agent.sId, {
+      assistant: {
+        name: agent.name,
+        description: agent.description,
+        instructions: "Instructions rewritten by a non-editor admin",
+        pictureUrl: agent.pictureUrl,
+        status: "active",
+        scope: agent.scope,
+        model: {
+          providerId: agent.model.providerId,
+          modelId: agent.model.modelId,
+          temperature: agent.model.temperature,
+        },
+        actions: [],
+        templateId: null,
+        tags: [],
+        editors: [{ sId: agentOwner.sId }],
+        skills: [],
+        additionalRequestedSpaceIds: [],
+      },
+    });
+
+    expect(response.status).toBe(403);
+
+    const unchanged = await getAgentConfiguration(agentOwnerAuth, {
+      agentId: agent.sId,
+      variant: "light",
+    });
+    expect(unchanged?.instructions).toBe(agent.instructions);
   });
 });
 

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -99,7 +99,9 @@ app.patch(
       });
     }
 
-    if (!agent.canEdit && !auth.isAdmin()) {
+    // Editors only, admins included: an admin who wants to change an agent has to add themselves
+    // as an editor first. Batch operations on agents are a separate, admin-only path.
+    if (!agent.canEdit) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_model.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_model.test.ts
@@ -4,8 +4,10 @@ import {
 } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
 import { getModelsForAuth } from "@app/lib/model_tiers/enabled_models";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { setupAgentOwner } from "@app/tests/utils/AgentOwnerFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { honoApp } from "@front-api/app";
 import assert from "assert";
@@ -142,6 +144,49 @@ describe("POST /api/w/:wId/assistant/agent_configurations/batch_update_model", (
       variant: "light",
     });
     expect(updated?.model.modelId).toBe(INITIAL_MODEL.modelId);
+  });
+
+  it("updates an agent the admin is not an editor of", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const { agentOwnerAuth } = await setupAgentOwner(workspace, "builder");
+
+    // Authored by, and only editable by, someone else.
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      agentOwnerAuth,
+      { model: { ...INITIAL_MODEL } }
+    );
+    const target = await findTargetModel(auth);
+
+    const res = await postBatchUpdateModel(workspace, {
+      agentIds: [agent.sId],
+      modelId: target.modelId,
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.updatedAgentIds).toEqual([agent.sId]);
+    expect(body.skippedAgentIds).toEqual([]);
+
+    const updated = await getAgentConfiguration(agentOwnerAuth, {
+      agentId: agent.sId,
+      variant: "light",
+    });
+    assert(updated, "Expected the updated agent to be found.");
+    expect(updated.model.modelId).toBe(target.modelId);
+
+    // The editors were carried over untouched: the admin did not silently join the editor group
+    // on the way.
+    const editorGroup = await GroupResource.findEditorGroupForAgent(
+      agentOwnerAuth,
+      updated
+    );
+    assert(editorGroup.isOk(), "Expected the agent to have an editor group.");
+    const editors = await editorGroup.value.getActiveMembers(agentOwnerAuth);
+    expect(editors.map((e) => e.sId)).toEqual([
+      agentOwnerAuth.getNonNullableUser().sId,
+    ]);
   });
 
   it("rejects non-admin members", async () => {

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -875,7 +875,7 @@ export async function createAgentConfiguration(
             }
           }
 
-          if (!group.canWrite(auth) && auth.user()) {
+          if (!group.canAdministrate(auth) && auth.user()) {
             logger.error(
               {
                 workspaceId: owner.sId,


### PR DESCRIPTION
## Description

Batch "Set model" silently skipped every agent the acting admin was not an editor of, because the editor-group gate in `createAgentConfiguration` checked `canWrite` — which only group members hold — instead of `canAdministrate`, which admins hold and which is what `updateAgentPermissions` and the `/editors` endpoint already check; that gate fired even though the batch carries the existing editor list over unchanged, so it rejected a no-op. Relaxing it also unblocked the builder's `PATCH /agent_configurations/:aId` for non-editor admins, which is not what we want, so that route now requires editorship for everyone: an admin has to add themselves as an editor first — the flow the agent builder already implements through `BuilderEditorGateMessage` and the dedicated `/editors` endpoint.

## Tests

Two regression tests: batch model update on an agent owned by another user succeeds and leaves the editor group untouched; `PATCH /agent_configurations/:aId` by a non-editor admin returns 403 and leaves the instructions unchanged. Both verified to fail without their respective change. Ran the `agent_configurations` route suites (88 tests) and `lib/api/assistant/configuration` (36 tests).

## Risk

Non-editor admins can no longer update an agent through the agent API directly — they must add themselves as an editor first. The builder already gated its save on this, so the UI flow is unchanged; direct API consumers relying on the admin bypass would now get a 403.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`
