### PR TITLE
Require a reason for upgrade requests (admin-configurable)

### DIFF
--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -238,7 +238,7 @@ function UsageSection({ owner, onClose, visible }: UsageSectionProps) {
     disabled: !isCreditBased || !visible,
   });
 
-  const { hasPendingUpgradeRequest } = useWorkspaceUsageStatus({
+  const { hasPendingUpgradeRequest, requireReason } = useWorkspaceUsageStatus({
     owner,
     disabled: isManager || !isCreditBased || !visible,
   });
@@ -274,6 +274,7 @@ function UsageSection({ owner, onClose, visible }: UsageSectionProps) {
               hasPendingUpgradeRequest={hasPendingUpgradeRequest}
               variant="button"
               isManager={isManager}
+              requireReason={requireReason}
               onManagerNavigate={onClose}
             />
           </div>

--- a/front/components/assistant/conversation/input_bar/InputBarUsageBanner.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarUsageBanner.tsx
@@ -16,6 +16,7 @@ export function InputBarUsageBanner({ owner }: InputBarUsageBannerProps) {
     hasPendingUpgradeRequest,
     userBlockedReason,
     willAutoUpgrade,
+    requireReason,
   } = useWorkspaceUsageStatus({
     owner,
   });
@@ -39,6 +40,7 @@ export function InputBarUsageBanner({ owner }: InputBarUsageBannerProps) {
               owner={owner}
               hasPendingUpgradeRequest={hasPendingUpgradeRequest}
               isManager={isManager}
+              requireReason={requireReason}
             />
           </div>
         )}

--- a/front/components/credits/UsageUpgradeButton.tsx
+++ b/front/components/credits/UsageUpgradeButton.tsx
@@ -72,14 +72,17 @@ export function UsageUpgradeButton({
     const result = await doRequestUpgrade({
       reason: trimmedReason.length > 0 ? trimmedReason : undefined,
     });
-    if (result.ok) {
+    if (result.isOk()) {
       setRequested(true);
       setIsDialogOpen(false);
       form.reset();
       return;
     }
-    if (result.errorType === "invalid_request_error") {
-      form.setError("reason", { type: "manual", message: result.message });
+    if (result.error.errorType === "invalid_request_error") {
+      form.setError("reason", {
+        type: "manual",
+        message: result.error.message,
+      });
     }
   };
 

--- a/front/components/credits/UsageUpgradeButton.tsx
+++ b/front/components/credits/UsageUpgradeButton.tsx
@@ -18,11 +18,21 @@ import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 
-const requestUpgradeFormSchema = z.object({
-  reason: z.string().trim().max(MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS),
-});
+function getRequestUpgradeFormSchema(requireReason: boolean) {
+  return z.object({
+    reason: requireReason
+      ? z
+          .string()
+          .trim()
+          .min(1, "A reason is required to submit an upgrade request.")
+          .max(MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS)
+      : z.string().trim().max(MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS),
+  });
+}
 
-type RequestUpgradeFormValues = z.infer<typeof requestUpgradeFormSchema>;
+type RequestUpgradeFormValues = z.infer<
+  ReturnType<typeof getRequestUpgradeFormSchema>
+>;
 
 type UsageUpgradeButtonVariant = "link" | "button";
 
@@ -31,6 +41,7 @@ interface UsageUpgradeButtonProps {
   hasPendingUpgradeRequest: boolean;
   variant?: UsageUpgradeButtonVariant;
   isManager?: boolean;
+  requireReason?: boolean;
   onManagerNavigate?: () => void;
 }
 
@@ -42,6 +53,7 @@ export function UsageUpgradeButton({
   hasPendingUpgradeRequest,
   variant = "link",
   isManager = false,
+  requireReason = false,
   onManagerNavigate,
 }: UsageUpgradeButtonProps) {
   const { doRequestUpgrade } = useRequestUpgrade({ workspaceId: owner.sId });
@@ -49,7 +61,7 @@ export function UsageUpgradeButton({
   const [requested, setRequested] = useState(false);
 
   const form = useForm<RequestUpgradeFormValues>({
-    resolver: zodResolver(requestUpgradeFormSchema),
+    resolver: zodResolver(getRequestUpgradeFormSchema(requireReason)),
     defaultValues: { reason: "" },
   });
 
@@ -57,13 +69,17 @@ export function UsageUpgradeButton({
 
   const onSubmit = async (values: RequestUpgradeFormValues) => {
     const trimmedReason = values.reason.trim();
-    const ok = await doRequestUpgrade({
+    const result = await doRequestUpgrade({
       reason: trimmedReason.length > 0 ? trimmedReason : undefined,
     });
-    if (ok) {
+    if (result.ok) {
       setRequested(true);
       setIsDialogOpen(false);
       form.reset();
+      return;
+    }
+    if (result.errorType === "invalid_request_error") {
+      form.setError("reason", { type: "manual", message: result.message });
     }
   };
 
@@ -143,7 +159,11 @@ export function UsageUpgradeButton({
                 </p>
                 <BaseFormFieldSection<HTMLTextAreaElement>
                   fieldName="reason"
-                  title="Help your admin decide"
+                  title={
+                    requireReason
+                      ? "Help your admin decide (required)"
+                      : "Help your admin decide"
+                  }
                 >
                   {({
                     registerRef,

--- a/front/components/workspace/usage/LockedSection.tsx
+++ b/front/components/workspace/usage/LockedSection.tsx
@@ -10,12 +10,14 @@ interface LockedSectionProps {
   locked: boolean;
   children: React.ReactNode;
   className?: string;
+  tooltipContent?: React.ReactNode;
 }
 
 export function LockedSection({
   locked,
   children,
   className,
+  tooltipContent = "Top up your credit pool to enable these settings",
 }: LockedSectionProps) {
   if (!locked) {
     return <>{children}</>;
@@ -36,9 +38,7 @@ export function LockedSection({
             <div className="absolute inset-0 cursor-not-allowed" />
           </TooltipTrigger>
         </div>
-        <TooltipContent>
-          Top up your credit pool to enable these settings
-        </TooltipContent>
+        <TooltipContent>{tooltipContent}</TooltipContent>
       </TooltipRoot>
     </TooltipProvider>
   );

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -36,48 +36,27 @@ export function UsageSettingsCard({
   const { usageSettings, isUsageSettingsLoading } = useUsageSettings({
     workspaceId,
   });
-  const { doUpdateUsageSettings } = useUpdateUsageSettings({ workspaceId });
+  const { doUpdateUsageSettings, isUpdatingUsageSettings } =
+    useUpdateUsageSettings({ workspaceId });
 
-  const [isSavingAllowUpgradeRequest, setIsSavingAllowUpgradeRequest] =
-    useState(false);
-  const [
-    isSavingRequireUpgradeRequestReason,
-    setIsSavingRequireUpgradeRequestReason,
-  ] = useState(false);
-  const [isSavingAutoSeatUpgrade, setIsSavingAutoSeatUpgrade] = useState(false);
   const [isEditingDefaultLimit, setIsEditingDefaultLimit] = useState(false);
 
   const handleToggleAllowUpgradeRequest = async () => {
-    setIsSavingAllowUpgradeRequest(true);
-    try {
-      await doUpdateUsageSettings({
-        allowUpgradeRequest: !usageSettings.allowUpgradeRequest,
-      });
-    } finally {
-      setIsSavingAllowUpgradeRequest(false);
-    }
+    await doUpdateUsageSettings({
+      allowUpgradeRequest: !usageSettings.allowUpgradeRequest,
+    });
   };
 
   const handleToggleRequireUpgradeRequestReason = async () => {
-    setIsSavingRequireUpgradeRequestReason(true);
-    try {
-      await doUpdateUsageSettings({
-        requireUpgradeRequestReason: !usageSettings.requireUpgradeRequestReason,
-      });
-    } finally {
-      setIsSavingRequireUpgradeRequestReason(false);
-    }
+    await doUpdateUsageSettings({
+      requireUpgradeRequestReason: !usageSettings.requireUpgradeRequestReason,
+    });
   };
 
   const handleToggleAutoSeatUpgrade = async () => {
-    setIsSavingAutoSeatUpgrade(true);
-    try {
-      await doUpdateUsageSettings({
-        autoSeatUpgradeEnabled: !usageSettings.autoSeatUpgradeEnabled,
-      });
-    } finally {
-      setIsSavingAutoSeatUpgrade(false);
-    }
+    await doUpdateUsageSettings({
+      autoSeatUpgradeEnabled: !usageSettings.autoSeatUpgradeEnabled,
+    });
   };
 
   const currentDefaultLimit = defaultUserSpendLimit?.awuCredits ?? 0;
@@ -148,9 +127,7 @@ export function UsageSettingsCard({
             <SliderToggle
               selected={usageSettings.allowUpgradeRequest}
               disabled={
-                readOnly ||
-                isSavingAllowUpgradeRequest ||
-                isUsageSettingsLoading
+                readOnly || isUpdatingUsageSettings || isUsageSettingsLoading
               }
               onClick={() => void handleToggleAllowUpgradeRequest()}
             />
@@ -167,7 +144,7 @@ export function UsageSettingsCard({
               }
               disabled={
                 readOnly ||
-                isSavingRequireUpgradeRequestReason ||
+                isUpdatingUsageSettings ||
                 isUsageSettingsLoading ||
                 !usageSettings.allowUpgradeRequest
               }
@@ -200,7 +177,7 @@ export function UsageSettingsCard({
               }
               disabled={
                 readOnly ||
-                isSavingAutoSeatUpgrade ||
+                isUpdatingUsageSettings ||
                 isUsageSettingsLoading ||
                 !usageSettings.autoSeatUpgradeAvailable
               }

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -133,25 +133,30 @@ export function UsageSettingsCard({
             />
           }
         />
-        <SettingsList.Row
-          title="Require a reason for upgrade requests"
-          description="Members must explain why they need an upgrade before their request can be submitted."
-          action={
-            <SliderToggle
-              selected={
-                usageSettings.allowUpgradeRequest &&
-                usageSettings.requireUpgradeRequestReason
-              }
-              disabled={
-                readOnly ||
-                isUpdatingUsageSettings ||
-                isUsageSettingsLoading ||
-                !usageSettings.allowUpgradeRequest
-              }
-              onClick={() => void handleToggleRequireUpgradeRequestReason()}
-            />
-          }
-        />
+        <LockedSection
+          locked={!usageSettings.allowUpgradeRequest}
+          tooltipContent="Enable upgrade requests to enable this setting"
+        >
+          <SettingsList.Row
+            title="Require a reason for upgrade requests"
+            description="Members must explain why they need an upgrade before their request can be submitted."
+            action={
+              <SliderToggle
+                selected={
+                  usageSettings.allowUpgradeRequest &&
+                  usageSettings.requireUpgradeRequestReason
+                }
+                disabled={
+                  readOnly ||
+                  isUpdatingUsageSettings ||
+                  isUsageSettingsLoading ||
+                  !usageSettings.allowUpgradeRequest
+                }
+                onClick={() => void handleToggleRequireUpgradeRequestReason()}
+              />
+            }
+          />
+        </LockedSection>
         <SettingsList.Row
           title="Auto-upgrade seats"
           description={

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -40,6 +40,10 @@ export function UsageSettingsCard({
 
   const [isSavingAllowUpgradeRequest, setIsSavingAllowUpgradeRequest] =
     useState(false);
+  const [
+    isSavingRequireUpgradeRequestReason,
+    setIsSavingRequireUpgradeRequestReason,
+  ] = useState(false);
   const [isSavingAutoSeatUpgrade, setIsSavingAutoSeatUpgrade] = useState(false);
   const [isEditingDefaultLimit, setIsEditingDefaultLimit] = useState(false);
 
@@ -51,6 +55,17 @@ export function UsageSettingsCard({
       });
     } finally {
       setIsSavingAllowUpgradeRequest(false);
+    }
+  };
+
+  const handleToggleRequireUpgradeRequestReason = async () => {
+    setIsSavingRequireUpgradeRequestReason(true);
+    try {
+      await doUpdateUsageSettings({
+        requireUpgradeRequestReason: !usageSettings.requireUpgradeRequestReason,
+      });
+    } finally {
+      setIsSavingRequireUpgradeRequestReason(false);
     }
   };
 
@@ -138,6 +153,25 @@ export function UsageSettingsCard({
                 isUsageSettingsLoading
               }
               onClick={() => void handleToggleAllowUpgradeRequest()}
+            />
+          }
+        />
+        <SettingsList.Row
+          title="Require a reason for upgrade requests"
+          description="Members must explain why they need an upgrade before their request can be submitted."
+          action={
+            <SliderToggle
+              selected={
+                usageSettings.allowUpgradeRequest &&
+                usageSettings.requireUpgradeRequestReason
+              }
+              disabled={
+                readOnly ||
+                isSavingRequireUpgradeRequestReason ||
+                isUsageSettingsLoading ||
+                !usageSettings.allowUpgradeRequest
+              }
+              onClick={() => void handleToggleRequireUpgradeRequestReason()}
             />
           }
         />

--- a/front/lib/swr/upgrade_requests.ts
+++ b/front/lib/swr/upgrade_requests.ts
@@ -21,6 +21,13 @@ function usageStatusUrl(workspaceId: string): string {
   return `/api/w/${workspaceId}/usage-status`;
 }
 
+export type RequestUpgradeResult =
+  | { ok: true }
+  // "invalid_request_error" here means the reason the member supplied didn't
+  // satisfy the workspace's requirements (missing when required, too long).
+  // The caller surfaces that inline on the reason field instead of a toast.
+  | { ok: false; errorType: string; message: string };
+
 // Member-initiated: request a spend-limit upgrade for the current user. On
 // success the usage-status read is revalidated so the banner reflects the now
 // pending request.
@@ -29,7 +36,7 @@ export function useRequestUpgrade({ workspaceId }: { workspaceId: string }) {
   const { mutate } = useSWRWithDefaults(usageStatusUrl(workspaceId), null);
 
   const doRequestUpgrade = useCallback(
-    async ({ reason }: { reason?: string }): Promise<boolean> => {
+    async ({ reason }: { reason?: string }): Promise<RequestUpgradeResult> => {
       const res = await clientFetch(upgradeRequestsUrl(workspaceId), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -38,12 +45,18 @@ export function useRequestUpgrade({ workspaceId }: { workspaceId: string }) {
 
       if (!res.ok) {
         const errorData = await getErrorFromResponse(res);
-        sendNotification({
-          type: "error",
-          title: "Failed to request an upgrade",
-          description: errorData.message,
-        });
-        return false;
+        const errorType =
+          "type" in errorData ? errorData.type : "unknown_error";
+        // A rejected reason is shown inline on the field by the caller, not as
+        // a toast.
+        if (errorType !== "invalid_request_error") {
+          sendNotification({
+            type: "error",
+            title: "Failed to request an upgrade",
+            description: errorData.message,
+          });
+        }
+        return { ok: false, errorType, message: errorData.message };
       }
 
       await mutate();
@@ -52,7 +65,7 @@ export function useRequestUpgrade({ workspaceId }: { workspaceId: string }) {
         title: "Upgrade requested",
         description: "Your workspace admins have been notified.",
       });
-      return true;
+      return { ok: true };
     },
     [workspaceId, sendNotification, mutate]
   );

--- a/front/lib/swr/upgrade_requests.ts
+++ b/front/lib/swr/upgrade_requests.ts
@@ -23,9 +23,6 @@ function usageStatusUrl(workspaceId: string): string {
 
 export type RequestUpgradeResult =
   | { ok: true }
-  // "invalid_request_error" here means the reason the member supplied didn't
-  // satisfy the workspace's requirements (missing when required, too long).
-  // The caller surfaces that inline on the reason field instead of a toast.
   | { ok: false; errorType: string; message: string };
 
 // Member-initiated: request a spend-limit upgrade for the current user. On

--- a/front/lib/swr/upgrade_requests.ts
+++ b/front/lib/swr/upgrade_requests.ts
@@ -9,6 +9,8 @@ import {
 } from "@app/lib/swr/swr";
 import type { GetUpgradeRequestsResponseBody } from "@app/types/api/credits/upgrade_requests";
 import type { MembershipUpgradeRequestStatus } from "@app/types/memberships";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { useCallback } from "react";
 import type { Fetcher } from "swr";
@@ -21,9 +23,8 @@ function usageStatusUrl(workspaceId: string): string {
   return `/api/w/${workspaceId}/usage-status`;
 }
 
-export type RequestUpgradeResult =
-  | { ok: true }
-  | { ok: false; errorType: string; message: string };
+export type RequestUpgradeError = { errorType: string; message: string };
+export type RequestUpgradeResult = Result<void, RequestUpgradeError>;
 
 // Member-initiated: request a spend-limit upgrade for the current user. On
 // success the usage-status read is revalidated so the banner reflects the now
@@ -53,7 +54,7 @@ export function useRequestUpgrade({ workspaceId }: { workspaceId: string }) {
             description: errorData.message,
           });
         }
-        return { ok: false, errorType, message: errorData.message };
+        return new Err({ errorType, message: errorData.message });
       }
 
       await mutate();
@@ -62,7 +63,7 @@ export function useRequestUpgrade({ workspaceId }: { workspaceId: string }) {
         title: "Upgrade requested",
         description: "Your workspace admins have been notified.",
       });
-      return { ok: true };
+      return new Ok(undefined);
     },
     [workspaceId, sendNotification, mutate]
   );

--- a/front/lib/swr/usage_settings.ts
+++ b/front/lib/swr/usage_settings.ts
@@ -31,6 +31,7 @@ const PutDefaultUserSpendLimitResponseSchema = z.object({
 
 interface UsageSettings {
   allowUpgradeRequest: boolean;
+  requireUpgradeRequestReason: boolean;
   autoSeatUpgradeEnabled: boolean;
   autoSeatUpgradeAvailable: boolean;
   topUpEnabled: boolean;
@@ -44,6 +45,7 @@ interface UsageNotifications {
 
 const DEFAULT_USAGE_SETTINGS: UsageSettings = {
   allowUpgradeRequest: true,
+  requireUpgradeRequestReason: false,
   autoSeatUpgradeEnabled: false,
   autoSeatUpgradeAvailable: false,
   topUpEnabled: false,
@@ -99,6 +101,8 @@ export function useUsageSettings({ workspaceId }: { workspaceId: string }) {
     ...(data
       ? {
           allowUpgradeRequest: data.configuration.allowMemberUpgradeRequests,
+          requireUpgradeRequestReason:
+            data.configuration.requireUpgradeRequestReason,
           autoSeatUpgradeEnabled: data.configuration.autoSeatUpgradeEnabled,
           autoSeatUpgradeAvailable: data.configuration.autoSeatUpgradeAvailable,
           topUpEnabled: data.configuration.topUpEnabled,
@@ -129,6 +133,9 @@ export function useUpdateUsageSettings({
       const body: Record<string, unknown> = {};
       if (patch.allowUpgradeRequest !== undefined) {
         body.allowMemberUpgradeRequests = patch.allowUpgradeRequest;
+      }
+      if (patch.requireUpgradeRequestReason !== undefined) {
+        body.requireUpgradeRequestReason = patch.requireUpgradeRequestReason;
       }
       if (patch.autoSeatUpgradeEnabled !== undefined) {
         body.autoSeatUpgradeEnabled = patch.autoSeatUpgradeEnabled;

--- a/front/lib/swr/usage_settings.ts
+++ b/front/lib/swr/usage_settings.ts
@@ -16,7 +16,7 @@ import type {
   PutDefaultUserSpendLimitResponseBody,
 } from "@app/types/api/workspace/default_user_spend_limit";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import type { Fetcher } from "swr";
 import { mutate } from "swr";
 import { z } from "zod";
@@ -127,6 +127,7 @@ export function useUpdateUsageSettings({
     getCreditUsageConfigurationEndpoint(workspaceId),
     null
   );
+  const [isUpdatingUsageSettings, setIsUpdatingUsageSettings] = useState(false);
 
   const doUpdateUsageSettings = useCallback(
     async (patch: Partial<UsageSettings>): Promise<boolean> => {
@@ -145,27 +146,32 @@ export function useUpdateUsageSettings({
         return true;
       }
 
-      const result = await patchCreditUsageConfiguration(workspaceId, body);
-      if (!result.ok) {
-        sendNotification({
-          type: "error",
-          title: "Failed to update usage settings",
-          description: result.message,
-        });
-        return false;
-      }
+      setIsUpdatingUsageSettings(true);
+      try {
+        const result = await patchCreditUsageConfiguration(workspaceId, body);
+        if (!result.ok) {
+          sendNotification({
+            type: "error",
+            title: "Failed to update usage settings",
+            description: result.message,
+          });
+          return false;
+        }
 
-      await mutate();
-      sendNotification({
-        type: "success",
-        title: "Usage settings updated",
-      });
-      return true;
+        await mutate();
+        sendNotification({
+          type: "success",
+          title: "Usage settings updated",
+        });
+        return true;
+      } finally {
+        setIsUpdatingUsageSettings(false);
+      }
     },
     [workspaceId, sendNotification, mutate]
   );
 
-  return { doUpdateUsageSettings };
+  return { doUpdateUsageSettings, isUpdatingUsageSettings };
 }
 
 export function useUsageNotifications({

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -316,6 +316,7 @@ export function useWorkspaceUsageStatus({
     canRequestUpgrade: data?.canRequestUpgrade ?? false,
     hasPendingUpgradeRequest: data?.hasPendingUpgradeRequest ?? false,
     willAutoUpgrade: data?.willAutoUpgrade ?? false,
+    requireReason: data?.requireReason ?? false,
     isUsageStatusLoading: !error && !data && !disabled,
   };
 }


### PR DESCRIPTION
## Description

This PR completes the user-facing flow for the configurable upgrade-request reason requirement introduced in #30314 and enforced by #30315.

Workspace admins can enable **Require a reason for upgrade requests** from the usage settings. The toggle is disabled when upgrade requests are disabled, while the existing read-only and loading protections remain in place.

For members, the upgrade-request form now receives the requirement from the usage-status endpoint, validates a trimmed non-empty reason client-side, and labels the field as required. Invalid request errors from the API are shown inline on the reason field instead of as a generic error toast; other request failures continue to use the existing notification behavior. The setting defaults to disabled, so existing workspaces retain the current optional-reason behavior.

This is the final change in the stack: #30314 → #30315 → #29858. No screenshot is included because testing evidence or a recording was not provided for this draft.

## Tests

## Risk

The main user-visible change applies only when a workspace enables the setting: members must provide a non-empty reason before submitting an upgrade request. The backend enforcement in #30315 remains the source of truth, so the client-side validation does not weaken the requirement.

The API error handling changes how `invalid_request_error` responses are presented by this form: they are rendered inline, while unrelated failures still show a toast. The setting defaults to `false`, and the admin toggle is unavailable when upgrade requests are disabled. If this UI PR is reverted independently while #30315 remains deployed, the backend will continue enforcing the setting but clients may no longer receive the inline validation experience.

## Deploy Plan

Deploy the stack in order: #30314 first, then #30315, and finally this PR. Run the migration from prodbox before the application relies on the new configuration field. Generate the updated API documentation with `npm -w front-api run docs` and use the **Deploy OpenAPI Docs** GitHub Action to publish the changes to https://docs.dust.tt/reference.