### PR TITLE
Export upgrade-requests history to CSV

### DIFF
--- a/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
@@ -503,4 +503,104 @@ describe("/api/w/[wId]/credits/upgrade-requests", () => {
       }
     });
   });
+
+  describe("GET ?format=csv (history export)", () => {
+    it("streams a CSV of the resolved requests", async () => {
+      const workspace = await creditPricedWorkspace();
+      const { user: member } = await createMemberRequest(workspace);
+
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+      const { sId: requestId } = (
+        await (await honoApp.request(upgradeRequestsUrl(workspace.sId))).json()
+      ).requests[0];
+
+      await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}/${requestId}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "denied" }),
+        }
+      );
+
+      const csvResponse = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}?format=csv`
+      );
+
+      expect(csvResponse.status).toBe(200);
+      expect(csvResponse.headers.get("Content-Type")).toBe("text/csv");
+      expect(csvResponse.headers.get("Content-Disposition")).toBe(
+        'attachment; filename="dust_upgrade_requests_history.csv"'
+      );
+
+      const csv = await csvResponse.text();
+      const [header, row] = csv.trim().split("\n");
+      expect(header).toBe(
+        "requesterName,requesterEmail,requestedAt,granted,until,reason,status,resolvedAt,resolvedBy"
+      );
+      expect(row).toContain(member.email);
+      expect(row).toContain("Denied");
+    });
+
+    it("returns 403 when caller is a user", async () => {
+      const workspace = await creditPricedWorkspace();
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "user",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}?format=csv`
+      );
+
+      expect(response.status).toBe(403);
+    });
+
+    it("exports every resolved request, not just the first page", async () => {
+      const workspace = await creditPricedWorkspace();
+      const { user: member, auth: memberAuth } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+          role: "user",
+          workspace,
+        });
+
+      const totalResolvedRequests = 101;
+      for (let i = 0; i < totalResolvedRequests; i++) {
+        const created = await MembershipUpgradeRequestResource.createPending(
+          memberAuth,
+          { user: member, reason: null }
+        );
+        if (created.isErr()) {
+          throw created.error;
+        }
+        await created.value.markAsResolved(memberAuth, {
+          status: i % 2 === 0 ? "approved" : "denied",
+          resolvedByUser: member,
+        });
+      }
+
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+
+      const csvResponse = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}?format=csv`
+      );
+      expect(csvResponse.status).toBe(200);
+
+      const csv = await csvResponse.text();
+      const rows = csv.trim().split("\n");
+      // Header + one row per resolved request, beyond the 100-per-page cap
+      // the JSON endpoint enforces.
+      expect(rows).toHaveLength(totalResolvedRequests + 1);
+    });
+  });
 });

--- a/front-api/routes/w/[wId]/credits/upgrade-requests.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.ts
@@ -2,10 +2,12 @@ import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import type { ResolveUpgradeRequestError } from "@app/lib/api/credits/upgrade_requests";
 import {
   createUpgradeRequest,
+  listAllResolvedUpgradeRequests,
   listPendingUpgradeRequests,
   listResolvedUpgradeRequests,
   resolveUpgradeRequest,
 } from "@app/lib/api/credits/upgrade_requests";
+import { upgradeRequestsToCsv } from "@app/lib/api/credits/upgrade_requests_export";
 import { UserSpendLimitError } from "@app/lib/api/users/spend_limit";
 import type {
   GetUpgradeRequestsResponseBody,
@@ -56,6 +58,7 @@ const ResolveBodySchema = z
 const ListUpgradeRequestsQuerySchema = z.object({
   status: z.union([z.literal("pending"), z.literal("resolved")]).optional(),
   offset: z.coerce.number().int().min(0).catch(0),
+  format: z.union([z.literal("json"), z.literal("csv")]).optional(),
 });
 
 const CreateUpgradeRequestBodySchema = z.object({
@@ -114,17 +117,33 @@ app.get(
   "/",
   ensureIsManager(),
   validate("query", ListUpgradeRequestsQuerySchema),
-  async (ctx): HandlerResult<GetUpgradeRequestsResponseBody> => {
+  async (ctx) => {
     const auth = ctx.get("auth");
-    const { status, offset } = ctx.req.valid("query");
-    if (status === "resolved") {
-      const { requests, total } = await listResolvedUpgradeRequests(auth, {
-        offset,
-      });
-      return ctx.json({ requests, total });
+    const { status, offset, format } = ctx.req.valid("query");
+
+    if (format === "csv") {
+      // CSV export is only wired to the resolved-requests History tab; it
+      // always covers the full history.
+      const requests = await listAllResolvedUpgradeRequests(auth);
+
+      ctx.header("Content-Type", "text/csv");
+      ctx.header(
+        "Content-Disposition",
+        'attachment; filename="dust_upgrade_requests_history.csv"'
+      );
+      return ctx.body(upgradeRequestsToCsv(requests));
     }
-    const requests = await listPendingUpgradeRequests(auth);
-    return ctx.json({ requests });
+
+    const { requests, total } =
+      status === "resolved"
+        ? await listResolvedUpgradeRequests(auth, { offset })
+        : {
+            requests: await listPendingUpgradeRequests(auth),
+            total: undefined,
+          };
+
+    const body: GetUpgradeRequestsResponseBody = { requests, total };
+    return ctx.json(body);
   }
 );
 

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -2,6 +2,7 @@ import type { WorkspaceLimit } from "@app/components/app/ReachedLimitPopup";
 import { ReachedLimitPopup } from "@app/components/app/ReachedLimitPopup";
 import { ConfirmContext } from "@app/components/Confirm";
 import { InviteEmailButtonWithModal } from "@app/components/members/InviteEmailButtonWithModal";
+import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import { BulkChangeSeatModal } from "@app/components/workspace/BulkChangeSeatModal";
 import { BulkEditSpendLimitModal } from "@app/components/workspace/BulkEditSpendLimitModal";
 import { BuyAwuCreditsDialog } from "@app/components/workspace/BuyAwuCreditsDialog";
@@ -25,6 +26,7 @@ import { ModelTiersSettingsCard } from "@app/components/workspace/usage/ModelTie
 import { UsageNotificationsCard } from "@app/components/workspace/usage/UsageNotificationsCard";
 import { UsageProgrammaticLimitCard } from "@app/components/workspace/usage/UsageProgrammaticLimitCard";
 import { UsageSettingsCard } from "@app/components/workspace/usage/UsageSettingsCard";
+import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
 import { useMembersSelection } from "@app/hooks/useMembersSelection";
 import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
@@ -73,6 +75,7 @@ import {
 } from "@app/lib/swr/model_tiers";
 import {
   UPGRADE_REQUESTS_HISTORY_PAGE_SIZE,
+  upgradeRequestsHistoryCsvUrl,
   useResolveUpgradeRequest,
   useUpgradeRequests,
   useUpgradeRequestsHistory,
@@ -284,6 +287,12 @@ export function UsagePage() {
     workspaceId: owner.sId,
     pageIndex: historyPagination.pageIndex,
     disabled: membersTab !== "history",
+  });
+  const upgradeRequestsHistoryCsvDownload = useDownloadCsv({
+    url: upgradeRequestsHistoryCsvUrl(owner.sId),
+    filename: `dust_upgrade_requests_history_${owner.sId}.csv`,
+    disabled:
+      isUpgradeRequestsHistoryLoading || upgradeRequestsHistory.length === 0,
   });
 
   const filteredUpgradeRequests = useMemo(() => {
@@ -1164,6 +1173,12 @@ export function UsagePage() {
                       )}
                       {seatFilterDropdown}
                     </div>
+                  )}
+                  {membersTab === "history" && (
+                    <CsvDownloadButton
+                      {...upgradeRequestsHistoryCsvDownload}
+                      label="Download to CSV"
+                    />
                   )}
                 </div>
                 <div className="flex flex-col gap-2 pt-2">

--- a/front/components/workspace/UpgradeRequestsHistoryTable.tsx
+++ b/front/components/workspace/UpgradeRequestsHistoryTable.tsx
@@ -1,9 +1,14 @@
-import { seatTypeDisplayName } from "@app/components/workspace/billing/seatTypeUtils";
 import { buildMemberNameColumn } from "@app/components/workspace/member_name_column";
 import { getSeatIconColorClass } from "@app/components/workspace/seat_styles";
-import type { SpendLimitExpiryKind } from "@app/types/api/users/spend_limit";
+import {
+  formatUpgradeRequestDate,
+  UPGRADE_REQUEST_REASON_LABEL,
+  upgradeRequestGrant,
+  upgradeRequestGrantedLabel,
+  upgradeRequestStatusLabel,
+  upgradeRequestUntilLabel,
+} from "@app/lib/api/credits/upgrade_requests_display";
 import type { MembershipUpgradeRequestType } from "@app/types/memberships";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
 import {
   AlertCircle,
@@ -40,34 +45,6 @@ type Info = CellContext<RowData, string>;
 
 const nameColumn = buildMemberNameColumn<RowData>("User");
 
-const REASON_LABEL = "Reached credit limit";
-
-function formatDate(epochMs: number): string {
-  return new Date(epochMs).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    timeZone: "UTC",
-  });
-}
-
-function durationLabel(expiryKind: SpendLimitExpiryKind | null): string | null {
-  if (expiryKind === null) {
-    return null;
-  }
-  switch (expiryKind) {
-    case "one_day":
-      return "1 day";
-    case "next_credit_reset":
-      return "Until next billing";
-    case "never":
-      return "Forever";
-    default:
-      assertNeverAndIgnore(expiryKind);
-      return null;
-  }
-}
-
 const issuedColumn: ColumnDef<RowData, string> = {
   id: "issued" as const,
   header: "Requested",
@@ -75,7 +52,7 @@ const issuedColumn: ColumnDef<RowData, string> = {
   cell: (info: Info) => (
     <DataTable.CellContent>
       <span className="text-sm text-muted-foreground">
-        {formatDate(info.row.original.createdAt)}
+        {formatUpgradeRequestDate(info.row.original.createdAt)}
       </span>
     </DataTable.CellContent>
   ),
@@ -91,54 +68,18 @@ const grantedColumn: ColumnDef<RowData, string> = {
   header: "Granted",
   enableSorting: false,
   cell: (info: Info) => {
-    const {
-      status,
-      grantedAwuCredits,
-      grantedUnlimitedSpend,
-      grantedSeatType,
-    } = info.row.original.request;
-
-    if (status !== "approved") {
-      return (
-        <DataTable.CellContent>
-          <span className="text-sm text-muted-foreground">—</span>
-        </DataTable.CellContent>
-      );
-    }
-
-    if (grantedSeatType) {
-      return (
-        <DataTable.CellContent>
-          <span
-            className={`text-sm font-medium ${getSeatIconColorClass(grantedSeatType)}`}
-          >
-            Upgraded to {seatTypeDisplayName(grantedSeatType)}
-          </span>
-        </DataTable.CellContent>
-      );
-    }
-
-    if (grantedUnlimitedSpend) {
-      return (
-        <DataTable.CellContent>
-          <span className="text-sm">Unlimited spend</span>
-        </DataTable.CellContent>
-      );
-    }
-
-    if (grantedAwuCredits !== null) {
-      return (
-        <DataTable.CellContent>
-          <span className="text-sm">
-            {grantedAwuCredits.toLocaleString("en-US")} credits
-          </span>
-        </DataTable.CellContent>
-      );
-    }
+    const grant = upgradeRequestGrant(info.row.original.request);
+    const label = upgradeRequestGrantedLabel(grant);
+    const className =
+      grant.kind === "none"
+        ? "text-sm text-muted-foreground"
+        : grant.kind === "seat_upgrade"
+          ? `text-sm font-medium ${getSeatIconColorClass(grant.seatType)}`
+          : "text-sm";
 
     return (
       <DataTable.CellContent>
-        <span className="text-sm text-muted-foreground">—</span>
+        <span className={className}>{label}</span>
       </DataTable.CellContent>
     );
   },
@@ -153,36 +94,13 @@ const untilColumn: ColumnDef<RowData, string> = {
   id: "until" as const,
   header: "For",
   enableSorting: false,
-  cell: (info: Info) => {
-    const {
-      status,
-      grantedAwuCredits,
-      grantedExpiryKind,
-      grantedUnlimitedSpend,
-      grantedSeatType,
-    } = info.row.original.request;
-
-    const hasGrant =
-      grantedAwuCredits !== null || grantedUnlimitedSpend || grantedSeatType;
-    if (status !== "approved" || !hasGrant) {
-      return (
-        <DataTable.CellContent>
-          <span className="text-sm text-muted-foreground">—</span>
-        </DataTable.CellContent>
-      );
-    }
-
-    const label =
-      grantedSeatType || grantedUnlimitedSpend
-        ? "Forever"
-        : (durationLabel(grantedExpiryKind) ?? "—");
-
-    return (
-      <DataTable.CellContent>
-        <span className="text-sm text-muted-foreground">{label}</span>
-      </DataTable.CellContent>
-    );
-  },
+  cell: (info: Info) => (
+    <DataTable.CellContent>
+      <span className="text-sm text-muted-foreground">
+        {upgradeRequestUntilLabel(info.row.original.request)}
+      </span>
+    </DataTable.CellContent>
+  ),
   meta: {
     className: "w-28",
   },
@@ -191,7 +109,9 @@ const untilColumn: ColumnDef<RowData, string> = {
 function ReasonCell({ reason }: { reason: string | null }) {
   if (!reason) {
     return (
-      <span className="text-sm text-muted-foreground">{REASON_LABEL}</span>
+      <span className="text-sm text-muted-foreground">
+        {UPGRADE_REQUEST_REASON_LABEL}
+      </span>
     );
   }
 
@@ -241,11 +161,11 @@ const statusColumn: ColumnDef<RowData, string> = {
     const { status } = info.row.original.request;
     return (
       <DataTable.CellContent>
-        {status === "approved" ? (
-          <Chip size="xs" color="success" label="Approved" />
-        ) : (
-          <Chip size="xs" color="warning" label="Denied" />
-        )}
+        <Chip
+          size="xs"
+          color={status === "approved" ? "success" : "warning"}
+          label={upgradeRequestStatusLabel(status)}
+        />
       </DataTable.CellContent>
     );
   },
@@ -263,7 +183,7 @@ const resolvedAtColumn: ColumnDef<RowData, string> = {
     return (
       <DataTable.CellContent>
         <span className="text-sm text-muted-foreground">
-          {resolvedAt ? formatDate(resolvedAt) : "—"}
+          {resolvedAt ? formatUpgradeRequestDate(resolvedAt) : "—"}
         </span>
       </DataTable.CellContent>
     );

--- a/front/components/workspace/analytics/CsvDownloadButton.tsx
+++ b/front/components/workspace/analytics/CsvDownloadButton.tsx
@@ -4,19 +4,24 @@ interface CsvDownloadButtonProps {
   isDownloading: boolean;
   disabled: boolean;
   handleDownload: () => void;
+  // Icon-only by default (existing analytics charts/tables); pass a label
+  // where the button isn't next to other obvious export context.
+  label?: string;
 }
 
 export function CsvDownloadButton({
   isDownloading,
   disabled,
   handleDownload,
+  label,
 }: CsvDownloadButtonProps) {
   return (
     <Button
       icon={Download01}
+      label={label}
       variant="outline"
       size="xs"
-      tooltip="Download CSV"
+      tooltip={label ? undefined : "Download CSV"}
       onClick={handleDownload}
       disabled={disabled}
       isLoading={isDownloading}

--- a/front/components/workspace/billing/seatTypeUtils.ts
+++ b/front/components/workspace/billing/seatTypeUtils.ts
@@ -1,5 +1,5 @@
-import type { MembershipSeatType } from "@app/types/memberships";
-import { toBaseSeatType } from "@app/types/memberships";
+export { seatTypeDisplayName } from "@app/types/memberships";
+
 import {
   AlertCircle,
   CoinsStacked01,
@@ -9,19 +9,6 @@ import {
   LayersTwo01,
 } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
-
-const SEAT_TYPE_DISPLAY_NAMES: Record<string, string> = {
-  free: "Free",
-  pro: "Pro",
-  max: "Max",
-  workspace: "Platform",
-  none: "None",
-};
-
-export function seatTypeDisplayName(seatType: MembershipSeatType): string {
-  const base = toBaseSeatType(seatType);
-  return SEAT_TYPE_DISPLAY_NAMES[base] ?? base;
-}
 
 export const SEAT_TYPE_ICONS: Record<string, ComponentType> = {
   none: AlertCircle,

--- a/front/lib/api/credits/upgrade_requests.test.ts
+++ b/front/lib/api/credits/upgrade_requests.test.ts
@@ -1,0 +1,100 @@
+import {
+  listAllResolvedUpgradeRequests,
+  RESOLVED_UPGRADE_REQUESTS_HISTORY_PAGE_SIZE,
+} from "@app/lib/api/credits/upgrade_requests";
+import { Authenticator } from "@app/lib/auth";
+import { MembershipUpgradeRequestResource } from "@app/lib/resources/membership_upgrade_request_resource";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { Result } from "@app/types/shared/result";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+function unwrap<T, E>(result: Result<T, E>): T {
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function setupWorkspaceWithAdminAndMember() {
+  const workspace = await WorkspaceFactory.metronome({
+    metronomeCustomerId: "cust_test_xxx",
+  });
+  const adminUser = await UserFactory.basic();
+  const memberUser = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
+  await MembershipFactory.associate(workspace, memberUser, { role: "user" });
+  const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    adminUser.sId,
+    workspace.sId
+  );
+  return { workspace, adminAuth, memberUser };
+}
+
+async function createResolvedRequest(
+  adminAuth: Authenticator,
+  memberUser: Awaited<ReturnType<typeof UserFactory.basic>>
+) {
+  const request = unwrap(
+    await MembershipUpgradeRequestResource.createPending(adminAuth, {
+      user: memberUser,
+      reason: null,
+    })
+  );
+  await request.markAsResolved(adminAuth, {
+    status: "denied",
+    resolvedByUser: memberUser,
+  });
+  return request;
+}
+
+describe("listAllResolvedUpgradeRequests", () => {
+  it("does not duplicate or drop rows when a request is resolved between page fetches", async () => {
+    const { adminAuth, memberUser } = await setupWorkspaceWithAdminAndMember();
+
+    // More than one page's worth of pre-existing resolved requests, so the
+    // export has to fetch at least two pages.
+    const preExistingCount = RESOLVED_UPGRADE_REQUESTS_HISTORY_PAGE_SIZE + 50;
+    const preExistingIds: string[] = [];
+    for (let i = 0; i < preExistingCount; i++) {
+      const request = await createResolvedRequest(adminAuth, memberUser);
+      preExistingIds.push(request.sId);
+    }
+
+    const original =
+      MembershipUpgradeRequestResource.listResolvedByWorkspaceAfter.bind(
+        MembershipUpgradeRequestResource
+      );
+    const spy = vi.spyOn(
+      MembershipUpgradeRequestResource,
+      "listResolvedByWorkspaceAfter"
+    );
+    let concurrentRequestId: string | null = null;
+    spy.mockImplementation(async (auth, opts) => {
+      const page = await original(auth, opts);
+      if (spy.mock.calls.length === 1) {
+        // Simulate another admin resolving a brand-new request in the gap
+        // between this page's fetch and the next one being issued.
+        const concurrent = await createResolvedRequest(adminAuth, memberUser);
+        concurrentRequestId = concurrent.sId;
+      }
+      return page;
+    });
+
+    const exported = await listAllResolvedUpgradeRequests(adminAuth);
+    const exportedIds = exported.map((r) => r.sId);
+
+    expect(spy.mock.calls.length).toBeGreaterThan(1);
+    expect(new Set(exportedIds).size).toBe(exportedIds.length);
+    for (const id of preExistingIds) {
+      expect(exportedIds).toContain(id);
+    }
+    expect(exportedIds).toHaveLength(preExistingCount);
+    expect(exportedIds).not.toContain(concurrentRequestId);
+  });
+});

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -16,6 +16,7 @@ import { MembershipUpgradeRequestResource } from "@app/lib/resources/membership_
 import logger from "@app/logger/logger";
 import type { UpgradeRequestResolution } from "@app/types/api/credits/upgrade_requests";
 import type { MembershipUpgradeRequestType } from "@app/types/memberships";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -251,6 +252,30 @@ export async function listResolvedUpgradeRequests(
       offset,
     });
   return { requests: requests.map((r) => r.toJSON()), total };
+}
+
+// Admin-only: every resolved request, keyset-paginated fetching. Keyset
+// (not offset) pagination so a request resolved concurrently mid-export
+// can't shift page boundaries and cause a duplicated or omitted row.
+export async function listAllResolvedUpgradeRequests(
+  auth: Authenticator
+): Promise<MembershipUpgradeRequestType[]> {
+  const allRequests: MembershipUpgradeRequestType[] = [];
+  let after: { resolvedAt: Date; id: ModelId } | null = null;
+  while (true) {
+    const requests =
+      await MembershipUpgradeRequestResource.listResolvedByWorkspaceAfter(
+        auth,
+        { limit: RESOLVED_UPGRADE_REQUESTS_HISTORY_PAGE_SIZE, after }
+      );
+    allRequests.push(...requests.map((r) => r.toJSON()));
+    if (requests.length < RESOLVED_UPGRADE_REQUESTS_HISTORY_PAGE_SIZE) {
+      break;
+    }
+    const last = requests[requests.length - 1];
+    after = { resolvedAt: last.resolvedAt ?? new Date(0), id: last.id };
+  }
+  return allRequests;
 }
 
 // Admin-only: record the outcome of a request. The request is claimed first

--- a/front/lib/api/credits/upgrade_requests_display.ts
+++ b/front/lib/api/credits/upgrade_requests_display.ts
@@ -1,0 +1,112 @@
+import type { SpendLimitExpiryKind } from "@app/types/api/users/spend_limit";
+import type {
+  MembershipSeatType,
+  MembershipUpgradeRequestType,
+} from "@app/types/memberships";
+import { seatTypeDisplayName } from "@app/types/memberships";
+import {
+  assertNever,
+  assertNeverAndIgnore,
+} from "@app/types/shared/utils/assert_never";
+
+// Shareable to avoid unintentional behavior drift
+
+export const UPGRADE_REQUEST_REASON_LABEL = "Reached credit limit";
+
+export function formatUpgradeRequestDate(epochMs: number): string {
+  return new Date(epochMs).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+export function upgradeRequestDurationLabel(
+  expiryKind: SpendLimitExpiryKind | null
+): string | null {
+  if (expiryKind === null) {
+    return null;
+  }
+  switch (expiryKind) {
+    case "one_day":
+      return "1 day";
+    case "next_credit_reset":
+      return "Until next billing";
+    case "never":
+      return "Forever";
+    default:
+      assertNeverAndIgnore(expiryKind);
+      return null;
+  }
+}
+
+export type UpgradeRequestGrant =
+  | { kind: "none" }
+  | { kind: "seat_upgrade"; seatType: MembershipSeatType }
+  | { kind: "unlimited_spend" }
+  | { kind: "credits"; amountAwuCredits: number };
+
+export function upgradeRequestGrant(
+  request: MembershipUpgradeRequestType
+): UpgradeRequestGrant {
+  const { status, grantedAwuCredits, grantedUnlimitedSpend, grantedSeatType } =
+    request;
+
+  if (status !== "approved") {
+    return { kind: "none" };
+  }
+  if (grantedSeatType) {
+    return { kind: "seat_upgrade", seatType: grantedSeatType };
+  }
+  if (grantedUnlimitedSpend) {
+    return { kind: "unlimited_spend" };
+  }
+  if (grantedAwuCredits !== null) {
+    return { kind: "credits", amountAwuCredits: grantedAwuCredits };
+  }
+  return { kind: "none" };
+}
+
+export function upgradeRequestGrantedLabel(grant: UpgradeRequestGrant): string {
+  switch (grant.kind) {
+    case "none":
+      return "—";
+    case "seat_upgrade":
+      return `Upgraded to ${seatTypeDisplayName(grant.seatType)}`;
+    case "unlimited_spend":
+      return "Unlimited spend";
+    case "credits":
+      return `${grant.amountAwuCredits.toLocaleString("en-US")} credits`;
+    default:
+      return assertNever(grant);
+  }
+}
+
+export function upgradeRequestUntilLabel(
+  request: MembershipUpgradeRequestType
+): string {
+  const {
+    status,
+    grantedAwuCredits,
+    grantedExpiryKind,
+    grantedUnlimitedSpend,
+    grantedSeatType,
+  } = request;
+
+  const hasGrant =
+    grantedAwuCredits !== null || grantedUnlimitedSpend || grantedSeatType;
+  if (status !== "approved" || !hasGrant) {
+    return "—";
+  }
+  if (grantedSeatType || grantedUnlimitedSpend) {
+    return "Forever";
+  }
+  return upgradeRequestDurationLabel(grantedExpiryKind) ?? "—";
+}
+
+export function upgradeRequestStatusLabel(
+  status: MembershipUpgradeRequestType["status"]
+): string {
+  return status === "approved" ? "Approved" : "Denied";
+}

--- a/front/lib/api/credits/upgrade_requests_export.test.ts
+++ b/front/lib/api/credits/upgrade_requests_export.test.ts
@@ -1,0 +1,65 @@
+import { UPGRADE_REQUEST_REASON_LABEL } from "@app/lib/api/credits/upgrade_requests_display";
+import {
+  toUpgradeRequestExportRow,
+  UPGRADE_REQUEST_EXPORT_HEADERS,
+  upgradeRequestsToCsv,
+} from "@app/lib/api/credits/upgrade_requests_export";
+import type { MembershipUpgradeRequestType } from "@app/types/memberships";
+import { describe, expect, it } from "vitest";
+
+function baseRequest(
+  overrides: Partial<MembershipUpgradeRequestType> = {}
+): MembershipUpgradeRequestType {
+  return {
+    sId: "upr_test_xxx",
+    status: "denied",
+    createdAt: Date.parse("2026-01-01T00:00:00Z"),
+    resolvedAt: Date.parse("2026-01-02T00:00:00Z"),
+    reason: "Need more credits",
+    requester: {
+      sId: "user_test_xxx",
+      name: "Test Requester",
+      email: "requester@example.com",
+      image: null,
+      seatType: null,
+    },
+    resolvedBy: {
+      sId: "user_admin_xxx",
+      name: "Test Admin",
+      image: null,
+    },
+    grantedAwuCredits: null,
+    grantedExpiryKind: null,
+    grantedUnlimitedSpend: false,
+    grantedSeatType: null,
+    ...overrides,
+  };
+}
+
+describe("toUpgradeRequestExportRow", () => {
+  it("falls back to the default label for an empty-string reason, like the History table does", () => {
+    const row = toUpgradeRequestExportRow(baseRequest({ reason: "" }));
+    expect(row.reason).toBe(UPGRADE_REQUEST_REASON_LABEL);
+  });
+
+  it("falls back to the default label for a null reason", () => {
+    const row = toUpgradeRequestExportRow(baseRequest({ reason: null }));
+    expect(row.reason).toBe(UPGRADE_REQUEST_REASON_LABEL);
+  });
+
+  it("preserves a non-empty reason", () => {
+    const row = toUpgradeRequestExportRow(
+      baseRequest({ reason: "Need more credits" })
+    );
+    expect(row.reason).toBe("Need more credits");
+  });
+});
+
+describe("upgradeRequestsToCsv", () => {
+  it("emits the export headers followed by one row per request", () => {
+    const csv = upgradeRequestsToCsv([baseRequest()]);
+    const [header, row] = csv.trim().split("\n");
+    expect(header).toBe(UPGRADE_REQUEST_EXPORT_HEADERS.join(","));
+    expect(row).toContain("requester@example.com");
+  });
+});

--- a/front/lib/api/credits/upgrade_requests_export.ts
+++ b/front/lib/api/credits/upgrade_requests_export.ts
@@ -1,0 +1,66 @@
+import { rowsToCsv } from "@app/lib/api/analytics/csv_utils";
+import {
+  formatUpgradeRequestDate,
+  UPGRADE_REQUEST_REASON_LABEL,
+  upgradeRequestGrant,
+  upgradeRequestGrantedLabel,
+  upgradeRequestStatusLabel,
+  upgradeRequestUntilLabel,
+} from "@app/lib/api/credits/upgrade_requests_display";
+import type { MembershipUpgradeRequestType } from "@app/types/memberships";
+
+// Mirrors what the History tab's table actually renders
+// not the raw request fields to avoid confusing the user
+export interface UpgradeRequestExportRow {
+  requesterName: string;
+  requesterEmail: string;
+  requestedAt: string;
+  granted: string;
+  until: string;
+  reason: string;
+  status: string;
+  resolvedAt: string;
+  resolvedBy: string;
+}
+
+export const UPGRADE_REQUEST_EXPORT_HEADERS: (keyof UpgradeRequestExportRow)[] =
+  [
+    "requesterName",
+    "requesterEmail",
+    "requestedAt",
+    "granted",
+    "until",
+    "reason",
+    "status",
+    "resolvedAt",
+    "resolvedBy",
+  ];
+
+function formatDateOrEmpty(epochMs: number | null): string {
+  return epochMs === null ? "—" : formatUpgradeRequestDate(epochMs);
+}
+
+export function toUpgradeRequestExportRow(
+  request: MembershipUpgradeRequestType
+): UpgradeRequestExportRow {
+  return {
+    requesterName: request.requester.name,
+    requesterEmail: request.requester.email ?? "",
+    requestedAt: formatUpgradeRequestDate(request.createdAt),
+    granted: upgradeRequestGrantedLabel(upgradeRequestGrant(request)),
+    until: upgradeRequestUntilLabel(request),
+    reason: request.reason || UPGRADE_REQUEST_REASON_LABEL,
+    status: upgradeRequestStatusLabel(request.status),
+    resolvedAt: formatDateOrEmpty(request.resolvedAt),
+    resolvedBy: request.resolvedBy?.name ?? "—",
+  };
+}
+
+export function upgradeRequestsToCsv(
+  requests: MembershipUpgradeRequestType[]
+): string {
+  return rowsToCsv(
+    UPGRADE_REQUEST_EXPORT_HEADERS,
+    requests.map(toUpgradeRequestExportRow)
+  );
+}

--- a/front/lib/resources/membership_upgrade_request_resource.ts
+++ b/front/lib/resources/membership_upgrade_request_resource.ts
@@ -229,6 +229,43 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
     return { requests, total };
   }
 
+  // Resolved requests, most recent first, keyset-paginated on
+  // (resolvedAt, id) rather than offset. Offset pagination would shift
+  // under a concurrent resolution (a newly resolved request is inserted at
+  // the head, pushing every offset down), causing the caller to duplicate
+  // or skip rows across pages; keyset pagination is immune to that because
+  // each page is bounded by the last row actually returned.
+  static async listResolvedByWorkspaceAfter(
+    auth: Authenticator,
+    {
+      limit,
+      after,
+    }: { limit: number; after: { resolvedAt: Date; id: ModelId } | null }
+  ): Promise<MembershipUpgradeRequestResource[]> {
+    if (!auth.isManager()) {
+      return [];
+    }
+    const statusFilter = { status: { [Op.ne]: "pending" } } as const;
+    const where = after
+      ? {
+          ...statusFilter,
+          [Op.or]: [
+            { resolvedAt: { [Op.lt]: after.resolvedAt } },
+            { resolvedAt: after.resolvedAt, id: { [Op.lt]: after.id } },
+          ],
+        }
+      : statusFilter;
+
+    return this.baseFetch(auth, {
+      where,
+      order: [
+        ["resolvedAt", "DESC"],
+        ["id", "DESC"],
+      ],
+      limit,
+    });
+  }
+
   // Fetching an arbitrary request by id is a business-admin operation (a
   // manager or full admin resolves it from the usage page).
   static async fetchById(

--- a/front/lib/swr/upgrade_requests.ts
+++ b/front/lib/swr/upgrade_requests.ts
@@ -20,6 +20,11 @@ function upgradeRequestsUrl(workspaceId: string): string {
   return `/api/w/${workspaceId}/credits/upgrade-requests`;
 }
 
+// CSV download link for the resolved-requests
+export function upgradeRequestsHistoryCsvUrl(workspaceId: string): string {
+  return `${upgradeRequestsUrl(workspaceId)}?format=csv`;
+}
+
 function usageStatusUrl(workspaceId: string): string {
   return `/api/w/${workspaceId}/usage-status`;
 }

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -106,6 +106,19 @@ export function toBaseSeatType(
   return seatType;
 }
 
+const SEAT_TYPE_DISPLAY_NAMES: Record<string, string> = {
+  free: "Free",
+  pro: "Pro",
+  max: "Max",
+  workspace: "Platform",
+  none: "None",
+};
+
+export function seatTypeDisplayName(seatType: MembershipSeatType): string {
+  const base = toBaseSeatType(seatType);
+  return SEAT_TYPE_DISPLAY_NAMES[base] ?? base;
+}
+
 /**
  * Map a membership seat type to its normalized pool-limit seat type.
  * Returns null for `free` seats (they have a fixed lifetime allocation with


### PR DESCRIPTION
## Description

Until now, admins and managers could view resolved upgrade requests in the paginated History tab, but could not download the history. This PR adds a **Download to CSV** action to the History tab in the workspace Usage page.

The UI calls the existing upgrade-requests endpoint with `format=csv`. The API remains manager-only and returns a CSV attachment containing every resolved request, paging internally so exports are not limited by the JSON endpoint's 100-request page size. The export uses the same derived grant, duration, status, reason, and date labels as the rendered table through shared display helpers, preventing the two representations from drifting.

The existing JSON listing, request resolution behavior, and pagination remain unchanged. This change does not add migrations or modify the underlying request data.

## Tests

Added API regression coverage for:

- CSV headers, content-disposition, rendered values, and resolved-request export.
- Authorization: regular users receive `403`.
- Full-history exports containing more than the 100-request JSON page limit.

## Risk

The export is protected by the existing manager authorization middleware, but it intentionally includes the full resolved history, including requester and resolver names/emails, reasons, and outcomes. For workspaces with a large history, the server fetches all rows and builds the CSV before returning it, which may increase request latency and memory usage.

No database schema or data changes are included, and rollback is a code-only revert. Existing JSON consumers are unaffected.

## Deploy Plan

Deploy front. No database migration, backfill, or feature-flag activation is required for this change.