### PR TITLE
Fix front typecheck on main

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -22,7 +22,10 @@ import {
   createUserMessage,
   resolveModelsForMentionedAgents,
 } from "@app/lib/api/assistant/conversation/messages";
-import { updateConversationRequirements } from "@app/lib/api/assistant/conversation/permissions";
+import {
+  canAgentBeUsedInProjectConversation,
+  updateConversationRequirements,
+} from "@app/lib/api/assistant/conversation/permissions";
 import { ensureConversationTitle } from "@app/lib/api/assistant/conversation/title";
 import { RUNNING_AGENT_SWITCH_BLOCK_MESSAGE } from "@app/lib/api/assistant/errors";
 import { isRetiredGlobalAgent } from "@app/lib/api/assistant/global_agents/global_agents";

--- a/front/lib/api/sandbox_functions/workspace_user.ts
+++ b/front/lib/api/sandbox_functions/workspace_user.ts
@@ -11,7 +11,7 @@ type SandboxFunctionAuthorization =
   | { authorized: true; user: UserResource | null }
   | { authorized: false; errorMessage: string };
 
-async function getAuthenticatedWorkspaceUser(
+export async function getAuthenticatedWorkspaceUser(
   auth: Authenticator
 ): Promise<UserResource | null> {
   const user = auth.user();


### PR DESCRIPTION
## Description

`main` does not typecheck. Two unrelated regressions landed today; `tsgo --noEmit` over `front` reports four errors on a clean checkout of `ca7e57068f`.

- `conversation.ts` calls `canAgentBeUsedInProjectConversation` in three places without importing it. Added it to the existing import from `conversation/permissions`.
- `workspace_user.ts` lost the `export` on `getAuthenticatedWorkspaceUser` in #29850, but `sandbox_function_invocation_resource.ts` imports it. Restored the export.

## Tests

`tsgo --noEmit` is clean. Existing permissions and invocation-resource suites pass (56 tests). No behaviour change.

## Risk

None; imports and visibility only.

## Note

Neither regression was caught by CI: the test shards and format-check pass, and no PR job runs a full `front` typecheck. Worth adding one.