### PR TITLE
Align Batch edit spend limit with the Manage request modal

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -5,6 +5,7 @@ import { InviteEmailButtonWithModal } from "@app/components/members/InviteEmailB
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import { BulkChangeSeatModal } from "@app/components/workspace/BulkChangeSeatModal";
 import { BulkEditSpendLimitModal } from "@app/components/workspace/BulkEditSpendLimitModal";
+import { BulkManageSpendLimitModal } from "@app/components/workspace/BulkManageSpendLimitModal";
 import { BuyAwuCreditsDialog } from "@app/components/workspace/BuyAwuCreditsDialog";
 import { FreePlanUpgradeSection } from "@app/components/workspace/billing/FreePlanUpgradeSection";
 import {
@@ -593,10 +594,17 @@ export function UsagePage() {
   const { doBulkSetSpendLimit } = useBulkSetUserSpendLimit({
     workspaceId: owner.sId,
   });
-  const [isBulkSpendLimitOpen, setIsBulkSpendLimitOpen] = useState(false);
+  const [isBulkManageSpendLimitOpen, setIsBulkManageSpendLimitOpen] =
+    useState(false);
+  const [isBulkSetCreditAmountOpen, setIsBulkSetCreditAmountOpen] =
+    useState(false);
 
   const handleBatchEditSpendLimit = useCallback(() => {
-    setIsBulkSpendLimitOpen(true);
+    setIsBulkManageSpendLimitOpen(true);
+  }, []);
+
+  const handleBulkSetCreditAmount = useCallback(() => {
+    setIsBulkSetCreditAmountOpen(true);
   }, []);
 
   const { doBulkChangeSeatType } = useBulkChangeSeatType({
@@ -731,6 +739,19 @@ export function UsagePage() {
       doBulkSetSpendLimit,
     ]
   );
+
+  const handleBulkAllowUnlimitedSpend = useCallback(async () => {
+    const confirmed = await confirm({
+      title: "Use workspace default",
+      message: `Remove the custom spend limit for ${selection.selectedCount.toLocaleString("en-US")} members? They'll fall back to their group or workspace default cap.`,
+      validateLabel: "Use workspace default",
+      validateVariant: "primary",
+    });
+    if (!confirmed) {
+      return;
+    }
+    await handleBulkSpendLimitValidate({ kind: "unlimited" });
+  }, [confirm, selection.selectedCount, handleBulkSpendLimitValidate]);
 
   const handleBulkSeatChangePreview = useCallback(
     (seatType: PaidSeatType) =>
@@ -1295,9 +1316,16 @@ export function UsagePage() {
         upgradeRequestId={pendingApproveRequestId}
       />
 
+      <BulkManageSpendLimitModal
+        isOpen={isBulkManageSpendLimitOpen}
+        onClose={() => setIsBulkManageSpendLimitOpen(false)}
+        memberCount={selection.selectedCount}
+        onAllowUnlimitedSpend={handleBulkAllowUnlimitedSpend}
+        onSetCreditAmount={handleBulkSetCreditAmount}
+      />
       <BulkEditSpendLimitModal
-        isOpen={isBulkSpendLimitOpen}
-        onClose={() => setIsBulkSpendLimitOpen(false)}
+        isOpen={isBulkSetCreditAmountOpen}
+        onClose={() => setIsBulkSetCreditAmountOpen(false)}
         memberCount={selection.selectedCount}
         onValidate={handleBulkSpendLimitValidate}
       />

--- a/front/components/workspace/BulkEditSpendLimitModal.tsx
+++ b/front/components/workspace/BulkEditSpendLimitModal.tsx
@@ -6,23 +6,13 @@ import {
   DialogHeader,
   DialogTitle,
   Input,
-  RadioGroup,
-  RadioGroupItem,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 const MIN_AWU_CREDITS = 0;
 const MAX_AWU_CREDITS = 2_000_000;
 
-type SpendLimitKind = "default" | "override";
-
-function isSpendLimitKind(value: string): value is SpendLimitKind {
-  return value === "default" || value === "override";
-}
-
-type SpendLimit =
-  | { kind: "unlimited" }
-  | { kind: "limited"; awuCredits: number };
+type SpendLimit = { kind: "limited"; awuCredits: number };
 
 interface BulkEditSpendLimitModalProps {
   isOpen: boolean;
@@ -63,7 +53,6 @@ function BulkEditSpendLimitForm({
   memberCount,
   onValidate,
 }: BulkEditSpendLimitFormProps) {
-  const [kind, setKind] = useState<SpendLimitKind>("override");
   const [creditsInput, setCreditsInput] = useState<string>("");
   const [isSaving, setIsSaving] = useState(false);
   const [validationMessage, setValidationMessage] = useState<string | null>(
@@ -76,9 +65,6 @@ function BulkEditSpendLimitForm({
   }
 
   function validate(): SpendLimit | null {
-    if (kind === "default") {
-      return { kind: "unlimited" };
-    }
     const parsed = Number(creditsInput);
     if (!Number.isInteger(parsed) || parsed < MIN_AWU_CREDITS) {
       setValidationMessage(
@@ -111,8 +97,7 @@ function BulkEditSpendLimitForm({
     }
   }
 
-  const validateDisabled =
-    isSaving || (kind === "override" && creditsInput.length === 0);
+  const validateDisabled = isSaving || creditsInput.length === 0;
 
   return (
     <>
@@ -127,50 +112,24 @@ function BulkEditSpendLimitForm({
         </p>
       </DialogHeader>
       <DialogContainer>
-        <RadioGroup
-          value={kind}
-          onValueChange={(v) => {
-            if (isSpendLimitKind(v)) {
-              setKind(v);
-              setValidationMessage(null);
+        <div className="flex flex-col gap-1.5">
+          <Input
+            id="bulk-spend-credit-limit-input"
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            placeholder="1,000"
+            value={
+              creditsInput !== "" ? Number(creditsInput).toLocaleString() : ""
             }
-          }}
-          className="flex flex-col gap-3"
-        >
-          <RadioGroupItem
-            value="default"
-            id="bulk-spend-limit-default"
-            label="Use workspace default"
+            onChange={(e) => handleCreditsChange(e.target.value)}
+            isError={validationMessage !== null}
+            message={validationMessage ?? undefined}
+            messageStatus={validationMessage !== null ? "error" : undefined}
+            className="text-right"
+            suffix="credits/month"
           />
-          <RadioGroupItem
-            value="override"
-            id="bulk-spend-limit-override"
-            label="Use custom monthly limit"
-          />
-
-          {kind === "override" && (
-            <div className="flex flex-col gap-1.5 pl-6">
-              <Input
-                id="bulk-spend-credit-limit-input"
-                type="text"
-                inputMode="numeric"
-                pattern="[0-9]*"
-                placeholder="1,000"
-                value={
-                  creditsInput !== ""
-                    ? Number(creditsInput).toLocaleString()
-                    : ""
-                }
-                onChange={(e) => handleCreditsChange(e.target.value)}
-                isError={validationMessage !== null}
-                message={validationMessage ?? undefined}
-                messageStatus={validationMessage !== null ? "error" : undefined}
-                className="text-right"
-                suffix="credits/month"
-              />
-            </div>
-          )}
-        </RadioGroup>
+        </div>
       </DialogContainer>
       <DialogFooter
         leftButtonProps={{

--- a/front/components/workspace/BulkManageSpendLimitModal.tsx
+++ b/front/components/workspace/BulkManageSpendLimitModal.tsx
@@ -1,0 +1,103 @@
+import {
+  Avatar,
+  ChevronRight,
+  Coins02,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  Icon,
+  Infinity,
+  ListItem,
+} from "@dust-tt/sparkle";
+import type { ComponentType } from "react";
+
+interface ManageAction {
+  key: string;
+  icon: ComponentType<{ className?: string }>;
+  label: string;
+  description: string;
+  onClick: () => void;
+}
+
+interface BulkManageSpendLimitModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  memberCount: number;
+  onAllowUnlimitedSpend: () => void;
+  onSetCreditAmount: () => void;
+}
+
+export function BulkManageSpendLimitModal({
+  isOpen,
+  onClose,
+  memberCount,
+  onAllowUnlimitedSpend,
+  onSetCreditAmount,
+}: BulkManageSpendLimitModalProps) {
+  const actions: ManageAction[] = [
+    {
+      key: "allow-unlimited-spend",
+      icon: Infinity,
+      label: "Use workspace default",
+      description:
+        "Remove these members' custom limit; they'll fall back to their group or workspace default cap.",
+      onClick: onAllowUnlimitedSpend,
+    },
+    {
+      key: "set-credit-amount",
+      icon: Coins02,
+      label: "Set credit amount",
+      description: "Choose a specific spend limit for these members.",
+      onClick: onSetCreditAmount,
+    },
+  ];
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>
+            Edit spend limit for {memberCount.toLocaleString("en-US")} members
+          </DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          <div className="overflow-hidden rounded-2xl border border-border">
+            {actions.map((action, index) => (
+              <ListItem
+                key={action.key}
+                itemsAlignment="center"
+                hasSeparator={index < actions.length - 1}
+                onClick={() => {
+                  action.onClick();
+                  onClose();
+                }}
+              >
+                <Avatar
+                  icon={action.icon}
+                  size="sm"
+                  isRounded
+                  backgroundColor="bg-highlight-50"
+                />
+                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <span className="heading-sm text-foreground">
+                    {action.label}
+                  </span>
+                  <span className="copy-sm text-muted-foreground">
+                    {action.description}
+                  </span>
+                </div>
+                <Icon
+                  visual={ChevronRight}
+                  size="sm"
+                  className="text-muted-foreground"
+                />
+              </ListItem>
+            ))}
+          </div>
+        </DialogContainer>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Description

Until now, bulk editing a selection of members' spend limits used a radio-group form for choosing between the workspace default and a custom monthly limit. This differed from the settings-style action list used by the single-member Manage request modal and combined two distinct actions in one form.

This PR introduces a dedicated bulk Manage spend limit modal with two actions: **Allow unlimited spend** and **Set credit amount**. The unlimited-spend action now uses the same confirmation pattern as the single-member request-resolution flow and includes the selected member count before applying the existing bulk update. Setting a credit amount opens a focused input modal with the existing numeric validation.

The **Upgrade to max plan** action is intentionally not included because it does not apply to a bulk selection of members. The underlying bulk spend-limit update logic is unchanged. This PR is stacked on #29861.

## Tests

GitHub checks passed, including all test shards, lint, TypeScript checks, format check, React Doctor, and GitGuardian security checks.

## Risk

This is a user-facing change to the bulk spend-limit flow. The main risk is UI wiring or action-selection regressions; both actions continue to call the existing bulk update path, and unlimited spend now requires explicit confirmation before applying.

The previous workspace-default radio option is replaced by the explicit **Allow unlimited spend** action, so users will see a different flow for applying an unlimited limit. No backend, database, or permission changes are included, and rollback is a code-only revert. No UI-specific test or screenshot evidence was supplied beyond the passing repository checks.

## Deploy Plan

Deploy front. No database migration, backfill, or feature-flag activation is required for this change.