### PR TITLE
settings page ui update

### DIFF
--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -727,6 +727,63 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
     expect(updatedSkill?.requestedSpaceIds).toContain(openSpace.id);
   });
 
+  it("rejects restricting a skill to two different Pods via additionalRequestedSpaceIds", async () => {
+    const { workspace, skill, globalGroup } = await setupTest({
+      requestUserRole: "admin",
+    });
+
+    const podA = await SpaceFactory.project(workspace);
+    await GroupSpaceFactory.associate(podA, globalGroup);
+    const podB = await SpaceFactory.project(workspace);
+    await GroupSpaceFactory.associate(podB, globalGroup);
+
+    const response = await patchSkill(workspace, skill.sId, {
+      name: skill.name,
+      agentFacingDescription: skill.agentFacingDescription,
+      userFacingDescription: skill.userFacingDescription,
+      instructions: skill.instructions,
+      icon: null,
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+      additionalRequestedSpaceIds: [podA.sId, podB.sId],
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("rejects restricting a skill to a Pod that already references a skill scoped to a different Pod", async () => {
+    const { workspace, skill, requestUserAuth, globalGroup } = await setupTest({
+      requestUserRole: "admin",
+    });
+
+    const podA = await SpaceFactory.project(workspace);
+    await GroupSpaceFactory.associate(podA, globalGroup);
+    const podB = await SpaceFactory.project(workspace);
+    await GroupSpaceFactory.associate(podB, globalGroup);
+
+    const childSkill = await SkillFactory.create(requestUserAuth, {
+      name: "Pod B Skill",
+      requestedSpaceIds: [podB.id],
+    });
+
+    const response = await patchSkill(workspace, skill.sId, {
+      name: skill.name,
+      agentFacingDescription: skill.agentFacingDescription,
+      userFacingDescription: skill.userFacingDescription,
+      instructions: `Use ${SkillFactory.serializeSkillReferenceTag(childSkill)}.`,
+      icon: null,
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+      additionalRequestedSpaceIds: [podA.sId],
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
   it("should preserve existing additional requested spaces when omitted", async () => {
     const { workspace, skill, requestUserAuth, globalGroup } = await setupTest({
       requestUserRole: "admin",

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -2,6 +2,7 @@ import { AttachedKnowledgeSchema } from "@app/lib/api/skills/schemas";
 import {
   getReferencedSkillSpaceModelIds,
   resolveAdditionalRequestedSpaceModelIds,
+  validateAtMostOnePodSpace,
 } from "@app/lib/api/skills/space_requirements";
 import { pruneOutdatedSkillEditSuggestions } from "@app/lib/reinforcement/skill_suggestion_pruning";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -391,6 +392,20 @@ app.patch(
       ...referencedSkillSpaceIds,
       ...additionalRequestedSpaceIds,
     ]);
+
+    const podSpaceValidation = await validateAtMostOnePodSpace(
+      auth,
+      requestedSpaceIds
+    );
+    if (podSpaceValidation.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: podSpaceValidation.error.message,
+        },
+      });
+    }
 
     // Validate file attachments if provided.
     let files: FileResource[] | undefined;

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -9,6 +9,7 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { isResourceSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import type {
@@ -393,10 +394,11 @@ app.patch(
       ...additionalRequestedSpaceIds,
     ]);
 
-    const podSpaceValidation = await validateAtMostOnePodSpace(
+    const requestedSpaces = await SpaceResource.fetchByModelIds(
       auth,
       requestedSpaceIds
     );
+    const podSpaceValidation = validateAtMostOnePodSpace(requestedSpaces);
     if (podSpaceValidation.isErr()) {
       return apiError(ctx, {
         status_code: 400,

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -518,6 +518,67 @@ describe("GET /api/w/:wId/skills", () => {
     expect(globalNames).not.toContain("Member Restricted Skill");
   });
 
+  it("with podSpaceId, includes global and that Pod's own skills but hides a different Pod's skill", async () => {
+    const { workspace, user, auth } = await setupTest("admin");
+
+    await SpaceFactory.defaults(auth);
+
+    const podSpace = await SpaceFactory.project(workspace, user.id);
+    const otherPodSpace = await SpaceFactory.project(workspace, user.id);
+
+    await SkillFactory.create(auth, { name: "Global Skill" });
+    await SkillFactory.create(auth, {
+      name: "Pod-Scoped Skill",
+      requestedSpaceIds: [podSpace.id],
+    });
+    await SkillFactory.create(auth, {
+      name: "Other Pod Skill",
+      requestedSpaceIds: [otherPodSpace.id],
+    });
+
+    const response = await getSkills(workspace, { podSpaceId: podSpace.sId });
+
+    expect(response.status).toBe(200);
+    const skillNames = (await response.json()).skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
+    expect(skillNames).toContain("Global Skill");
+    expect(skillNames).toContain("Pod-Scoped Skill");
+    expect(skillNames).not.toContain("Other Pod Skill");
+  });
+
+  it("with excludePodScopedSkills=true, hides every Pod-scoped skill but keeps global and non-Pod-restricted skills", async () => {
+    const { workspace, user, auth } = await setupTest("admin");
+
+    await SpaceFactory.defaults(auth);
+
+    const podSpace = await SpaceFactory.project(workspace, user.id);
+    const regularSpace = await SpaceFactory.regular(workspace);
+    await regularSpace.addMembers(auth, { userIds: [user.sId] });
+
+    await SkillFactory.create(auth, { name: "Global Skill" });
+    await SkillFactory.create(auth, {
+      name: "Pod-Scoped Skill",
+      requestedSpaceIds: [podSpace.id],
+    });
+    await SkillFactory.create(auth, {
+      name: "Regular Space Skill",
+      requestedSpaceIds: [regularSpace.id],
+    });
+
+    const response = await getSkills(workspace, {
+      excludePodScopedSkills: "true",
+    });
+
+    expect(response.status).toBe(200);
+    const skillNames = (await response.json()).skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
+    expect(skillNames).toContain("Global Skill");
+    expect(skillNames).toContain("Regular Space Skill");
+    expect(skillNames).not.toContain("Pod-Scoped Skill");
+  });
+
   it("should not return instructions or tools in skill list", async () => {
     const { workspace, auth, user } = await setupTest();
 
@@ -1179,6 +1240,61 @@ describe("POST /api/w/:wId/skills", () => {
     expect(response.status).toBe(200);
     const responseData = await response.json();
     expect(responseData.skill.requestedSpaceIds).toContain(openPod.sId);
+  });
+
+  it("rejects a skill restricted to two different Pods via additionalRequestedSpaceIds", async () => {
+    const { workspace, globalGroup, user } = await setupTest("builder");
+    await grantCreateSkillCapability(workspace, user);
+
+    const podA = await SpaceFactory.project(workspace);
+    await GroupSpaceFactory.associate(podA, globalGroup);
+    const podB = await SpaceFactory.project(workspace);
+    await GroupSpaceFactory.associate(podB, globalGroup);
+
+    const response = await postSkill(workspace, {
+      name: "Skill Restricted To Two Pods",
+      agentFacingDescription: "To use with two Pods",
+      userFacingDescription: "A skill with two selected Pods",
+      instructions: "Simple instructions",
+      icon: "PuzzleIcon",
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+      additionalRequestedSpaceIds: [podA.sId, podB.sId],
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("rejects a skill restricted to a Pod that already references a skill scoped to a different Pod", async () => {
+    const { auth, workspace, globalGroup, user } = await setupTest("builder");
+    await grantCreateSkillCapability(workspace, user);
+
+    const podA = await SpaceFactory.project(workspace);
+    await GroupSpaceFactory.associate(podA, globalGroup);
+    const podB = await SpaceFactory.project(workspace);
+    await GroupSpaceFactory.associate(podB, globalGroup);
+
+    const childSkill = await SkillFactory.create(auth, {
+      name: "Pod B Skill",
+      requestedSpaceIds: [podB.id],
+    });
+
+    const response = await postSkill(workspace, {
+      name: "Parent Skill",
+      agentFacingDescription: "To use with another skill",
+      userFacingDescription: "A skill with a conflicting Pod reference",
+      instructions: `Start with ${SkillFactory.serializeSkillReferenceTag(childSkill)}.`,
+      icon: "PuzzleIcon",
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+      additionalRequestedSpaceIds: [podA.sId],
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
   });
 
   it("creates a skill configuration with 2 tools", async () => {

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -185,7 +185,7 @@ app.get(
       });
     }
 
-    let resolvedPodSpaceId: number | null | undefined;
+    let resolvedPodSpaceModelId: number | null | undefined;
     if (podSpaceId) {
       const podSpace = await SpaceResource.fetchById(auth, podSpaceId);
       if (!podSpace) {
@@ -197,15 +197,15 @@ app.get(
           },
         });
       }
-      resolvedPodSpaceId = podSpace.id;
+      resolvedPodSpaceModelId = podSpace.id;
     } else if (excludePodScopedSkills) {
-      resolvedPodSpaceId = null;
+      resolvedPodSpaceModelId = null;
     }
 
     const allSkills = await SkillResource.listByWorkspace(auth, {
       status: skillStatus,
       globalSpaceOnly: globalSpaceOnly === "true",
-      podSpaceId: resolvedPodSpaceId,
+      podSpaceModelId: resolvedPodSpaceModelId,
       onlyCustom: onlyCustom === "true",
       availability,
       withInstructions: false,
@@ -468,10 +468,11 @@ app.post(
       ...additionalRequestedSpaceIdsRes.value,
     ]);
 
-    const podSpaceValidation = await validateAtMostOnePodSpace(
+    const requestedSpaces = await SpaceResource.fetchByModelIds(
       auth,
       requestedSpaceIds
     );
+    const podSpaceValidation = validateAtMostOnePodSpace(requestedSpaces);
     if (podSpaceValidation.isErr()) {
       return apiError(ctx, {
         status_code: 400,

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -3,11 +3,13 @@ import { AttachedKnowledgeSchema } from "@app/lib/api/skills/schemas";
 import {
   getReferencedSkillSpaceModelIds,
   resolveAdditionalRequestedSpaceModelIds,
+  validateAtMostOnePodSpace,
 } from "@app/lib/api/skills/space_requirements";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import type {
   GetSkillsResponseBody,
@@ -130,6 +132,9 @@ app.get(
     const withRelations = ctx.req.query("withRelations");
     const status = ctx.req.query("status");
     const globalSpaceOnly = ctx.req.query("globalSpaceOnly");
+    const podSpaceId = ctx.req.query("podSpaceId");
+    const excludePodScopedSkills =
+      ctx.req.query("excludePodScopedSkills") === "true";
     const onlyCustom = ctx.req.query("onlyCustom");
     // @deprecated Use availability instead. Kept while old clients still send it.
     const isDefault = ctx.req.query("isDefault");
@@ -180,9 +185,27 @@ app.get(
       });
     }
 
+    let resolvedPodSpaceId: number | null | undefined;
+    if (podSpaceId) {
+      const podSpace = await SpaceResource.fetchById(auth, podSpaceId);
+      if (!podSpace) {
+        return apiError(ctx, {
+          status_code: 404,
+          api_error: {
+            type: "space_not_found",
+            message: `Space "${podSpaceId}" was not found.`,
+          },
+        });
+      }
+      resolvedPodSpaceId = podSpace.id;
+    } else if (excludePodScopedSkills) {
+      resolvedPodSpaceId = null;
+    }
+
     const allSkills = await SkillResource.listByWorkspace(auth, {
       status: skillStatus,
       globalSpaceOnly: globalSpaceOnly === "true",
+      podSpaceId: resolvedPodSpaceId,
       onlyCustom: onlyCustom === "true",
       availability,
       withInstructions: false,
@@ -444,6 +467,20 @@ app.post(
       ...referencedSkillSpaceIds,
       ...additionalRequestedSpaceIdsRes.value,
     ]);
+
+    const podSpaceValidation = await validateAtMostOnePodSpace(
+      auth,
+      requestedSpaceIds
+    );
+    if (podSpaceValidation.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: podSpaceValidation.error.message,
+        },
+      });
+    }
 
     // Validate file attachments if provided.
     let files: FileResource[] | undefined;

--- a/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
@@ -1,4 +1,5 @@
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
+import { useSendNotification } from "@app/hooks/useNotification";
 import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
 import { useSpaceProjectsLookup } from "@app/lib/swr/spaces";
 import type { PodType, SpaceType } from "@app/types/space";
@@ -29,12 +30,14 @@ type SpaceRowData = {
   space: SpaceType | PodType;
   isSelected: boolean;
   isAlreadyRequested: boolean;
+  isBlockedByPodLimit: boolean;
   onToggle: () => void;
   onClick?: () => void;
 };
 
 interface SpaceSelectionPageProps {
   alreadyRequestedSpaceIds: Set<string>;
+  entityName?: "agent" | "skill";
   includeProjects?: boolean;
   selectedSpaces: string[];
   setSelectedSpaces: React.Dispatch<React.SetStateAction<string[]>>;
@@ -43,7 +46,7 @@ interface SpaceSelectionPageProps {
 }
 
 interface SpaceSelectionSheetProps
-  extends Omit<SpaceSelectionPageProps, "searchQuery"> {
+  extends Omit<SpaceSelectionPageProps, "searchQuery" | "entityName"> {
   entityName: "agent" | "skill";
   onClose: () => void;
   onSave: () => void;
@@ -100,6 +103,7 @@ export function SpaceSelectionSheet({
         <SheetContainer isListSelector>
           <SpaceSelectionPageContent
             alreadyRequestedSpaceIds={alreadyRequestedSpaceIds}
+            entityName={entityName}
             includeProjects={includeProjects}
             selectedSpaces={selectedSpaces}
             setSelectedSpaces={setSelectedSpaces}
@@ -126,6 +130,7 @@ export function SpaceSelectionSheet({
 
 function SpaceSelectionPageContent({
   alreadyRequestedSpaceIds,
+  entityName,
   includeProjects = true,
   selectedSpaces,
   setSelectedSpaces,
@@ -133,6 +138,8 @@ function SpaceSelectionPageContent({
   missingSpaceIds = [],
 }: SpaceSelectionPageProps) {
   const { spaces, owner } = useSpacesContext();
+  const sendNotification = useSendNotification();
+  const isPodLimitEnforced = entityName === "skill";
   const { spaces: missingSpaces } = useSpaceProjectsLookup({
     workspaceId: owner.sId,
     spaceIds: missingSpaceIds,
@@ -190,6 +197,7 @@ function SpaceSelectionPageContent({
           space,
           isSelected: selectedSpaceIds.has(space.sId) || isAlreadyRequested,
           isAlreadyRequested,
+          isBlockedByPodLimit: false,
           onToggle: () => handleSpaceToggle(space),
         };
       });
@@ -200,24 +208,59 @@ function SpaceSelectionPageContent({
     handleSpaceToggle,
   ]);
 
+  const selectedPodSpace = useMemo(() => {
+    if (!isPodLimitEnforced) {
+      return undefined;
+    }
+    return selectableSpaces.find(
+      (s): s is PodType =>
+        isProjectType(s) &&
+        (selectedSpaceIds.has(s.sId) || alreadyRequestedSpaceIds.has(s.sId))
+    );
+  }, [
+    isPodLimitEnforced,
+    selectableSpaces,
+    selectedSpaceIds,
+    alreadyRequestedSpaceIds,
+  ]);
+
+  const handleBlockedPodClick = useCallback(() => {
+    if (!selectedPodSpace) {
+      return;
+    }
+    sendNotification({
+      type: "warning",
+      title: "Only one Pod allowed",
+      description: `A skill can only be restricted to a single Pod. Remove "${getSpaceName(selectedPodSpace)}" first to pick a different one.`,
+    });
+  }, [selectedPodSpace, sendNotification]);
+
   const projectsTableData: SpaceRowData[] = useMemo(() => {
     return selectableSpaces
       .filter((s): s is PodType => isProjectType(s))
       .map((project) => {
         const isAlreadyRequested = alreadyRequestedSpaceIds.has(project.sId);
+        const isSelected =
+          selectedSpaceIds.has(project.sId) || isAlreadyRequested;
+        const isBlockedByPodLimit =
+          !isSelected &&
+          selectedPodSpace !== undefined &&
+          selectedPodSpace.sId !== project.sId;
         return {
           sId: project.sId,
           name: getSpaceName(project),
           description: project.description ?? undefined,
           space: project,
-          isSelected: selectedSpaceIds.has(project.sId) || isAlreadyRequested,
+          isSelected,
           isAlreadyRequested,
+          isBlockedByPodLimit,
           onToggle: () => handleSpaceToggle(project),
         };
       });
   }, [
     selectableSpaces,
     alreadyRequestedSpaceIds,
+    selectedPodSpace,
     selectedSpaceIds,
     handleSpaceToggle,
   ]);
@@ -279,14 +322,22 @@ function SpaceSelectionPageContent({
             <ListGroup>
               {projectsTableData.map((row) => {
                 const ProjectIcon = getSpaceIcon(row.space);
+                const isLocked =
+                  row.isAlreadyRequested || row.isBlockedByPodLimit;
                 const rowContent = (
                   <ListItem
                     key={row.sId}
                     itemsAlignment="center"
-                    onClick={row.isAlreadyRequested ? undefined : row.onToggle}
+                    onClick={
+                      row.isAlreadyRequested
+                        ? undefined
+                        : row.isBlockedByPodLimit
+                          ? handleBlockedPodClick
+                          : row.onToggle
+                    }
                     className={cn(
                       row.isSelected ? "bg-primary-50" : "",
-                      row.isAlreadyRequested
+                      isLocked
                         ? "cursor-not-allowed opacity-60"
                         : "cursor-pointer"
                     )}
@@ -303,8 +354,13 @@ function SpaceSelectionPageContent({
                     <Checkbox
                       checked={row.isSelected}
                       onCheckedChange={row.onToggle}
-                      disabled={row.isAlreadyRequested}
-                      onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                      disabled={isLocked}
+                      onClick={(e: React.MouseEvent) => {
+                        e.stopPropagation();
+                        if (row.isBlockedByPodLimit) {
+                          handleBlockedPodClick();
+                        }
+                      }}
                     />
                   </ListItem>
                 );
@@ -314,6 +370,17 @@ function SpaceSelectionPageContent({
                     <Tooltip
                       key={row.sId}
                       label="Used by other resources"
+                      side="right"
+                      trigger={rowContent}
+                    />
+                  );
+                }
+
+                if (row.isBlockedByPodLimit) {
+                  return (
+                    <Tooltip
+                      key={row.sId}
+                      label="A skill can only be restricted to a single Pod"
                       side="right"
                       trigger={rowContent}
                     />

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -162,6 +162,7 @@ export function CapabilitiesPickerItemsList({
 interface CapabilitiesPickerProps {
   owner: WorkspaceType;
   user: UserType | null;
+  conversationPodSpaceId?: string;
   selectedMCPServerViews: MCPServerViewLightType[];
   onSelect: (serverView: MCPServerViewLightType) => void;
   onSkillSelect: (skill: SkillWithoutInstructionsAndToolsType) => void;
@@ -174,6 +175,7 @@ interface CapabilitiesPickerProps {
 export function CapabilitiesPicker({
   owner,
   user,
+  conversationPodSpaceId,
   selectedMCPServerViews,
   onSelect,
   onSkillSelect,
@@ -258,6 +260,7 @@ export function CapabilitiesPicker({
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
+    podContext: conversationPodSpaceId ?? null,
     swrOptions: CAPABILITIES_SWR_OPTIONS,
   });
 

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -110,6 +110,9 @@ export const InputBarButtons = React.memo(function InputBarButtons({
   const spaceId = conversation?.spaceId ?? space?.sId ?? undefined;
 
   const isPod = space ? isProjectType(space) : false;
+  const conversationPodSpaceId =
+    conversation?.spaceId ??
+    (space && isProjectType(space) ? space.sId : undefined);
   const defaultAgentUnavailableLabel = isPod
     ? "This Pod's default agent isn't available to you, so @dust is used instead. Discuss with your Pod editors if you think this is an error."
     : "This conversation's default agent isn't available to you, so @dust is used instead. Discuss with your Workspace admin if you think this is an error.";
@@ -197,6 +200,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
     <CapabilitiesPicker
       owner={owner}
       user={user}
+      conversationPodSpaceId={conversationPodSpaceId}
       selectedMCPServerViews={selectedMCPServerViews}
       onSelect={onMCPServerViewSelect}
       onSkillSelect={onSkillSelect}

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -120,6 +120,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
     const { capabilityItems, isLoading } = useInputBarSlashCommandCapabilities({
       owner,
       query,
+      conversationPodSpaceId: spaceIdRef.current,
       selectedMCPServerViewIdsRef,
     });
 

--- a/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
@@ -61,11 +61,13 @@ export function useInputBarSlashCommandCapabilities({
   excludeSkillId,
   owner,
   query,
+  conversationPodSpaceId,
   selectedMCPServerViewIdsRef,
 }: {
   excludeSkillId?: string | null;
   owner: LightWorkspaceType;
   query: string;
+  conversationPodSpaceId?: string | null;
   selectedMCPServerViewIdsRef?: RefObject<Set<string>>;
 }) {
   const { spaces: globalSpaces, isSpacesLoading } = useSpaces({
@@ -76,6 +78,7 @@ export function useInputBarSlashCommandCapabilities({
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
+    podContext: conversationPodSpaceId ?? null,
     swrOptions: CAPABILITIES_SWR_OPTIONS,
   });
   // The JIT views endpoint only returns views whose tools can be enabled directly in a

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -176,6 +176,8 @@ export function PodSettingsTab({
   const { skills } = useSkills({
     owner,
     status: "active",
+    podContext: pod.sId,
+    disabled: !isDefaultSkillsEnabled,
   });
   const [skillSearchText, setSkillSearchText] = useState("");
   const [isSkillPickerOpen, setIsSkillPickerOpen] = useState(false);

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -177,7 +177,6 @@ export function PodSettingsTab({
     owner,
     status: "active",
     podContext: pod.sId,
-    disabled: !isDefaultSkillsEnabled,
   });
   const [skillSearchText, setSkillSearchText] = useState("");
   const [isSkillPickerOpen, setIsSkillPickerOpen] = useState(false);

--- a/front/lib/api/skills/space_requirements.ts
+++ b/front/lib/api/skills/space_requirements.ts
@@ -74,20 +74,18 @@ export async function getReferencedSkillSpaceModelIds(
   );
 }
 
-export async function validateAtMostOnePodSpace(
-  auth: Authenticator,
-  requestedSpaceIds: ModelId[]
-): Promise<Result<void, Error>> {
-  const podSpaceIds = await SpaceResource.fetchProjectSpaceIdsAmong(
-    auth,
-    requestedSpaceIds
-  );
+export function validateAtMostOnePodSpace(
+  requestedSpaces: SpaceResource[]
+): Result<void, Error> {
+  const podSpaceCount = requestedSpaces.filter((space) =>
+    space.isProject()
+  ).length;
 
-  if (podSpaceIds.length > 1) {
+  if (podSpaceCount > 1) {
     return new Err(
       new Error(
         "A skill can only be restricted to a single Pod, but this would restrict it to " +
-          `${podSpaceIds.length} different Pods.`
+          `${podSpaceCount} different Pods.`
       )
     );
   }

--- a/front/lib/api/skills/space_requirements.ts
+++ b/front/lib/api/skills/space_requirements.ts
@@ -73,3 +73,24 @@ export async function getReferencedSkillSpaceModelIds(
       .flatMap((skill) => skill.requestedSpaceIds)
   );
 }
+
+export async function validateAtMostOnePodSpace(
+  auth: Authenticator,
+  requestedSpaceIds: ModelId[]
+): Promise<Result<void, Error>> {
+  const podSpaceIds = await SpaceResource.fetchProjectSpaceIdsAmong(
+    auth,
+    requestedSpaceIds
+  );
+
+  if (podSpaceIds.length > 1) {
+    return new Err(
+      new Error(
+        "A skill can only be restricted to a single Pod, but this would restrict it to " +
+          `${podSpaceIds.length} different Pods.`
+      )
+    );
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1486,7 +1486,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       status = "active",
       limit,
       globalSpaceOnly,
-      podSpaceId,
+      podSpaceModelId,
       onlyCustom,
       availability,
       updatedAfter,
@@ -1498,7 +1498,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       status?: SkillStatus | SkillStatus[];
       limit?: number;
       globalSpaceOnly?: boolean;
-      podSpaceId?: ModelId | null;
+      podSpaceModelId?: ModelId | null;
       onlyCustom?: boolean;
       availability?: SkillAvailability | SkillAvailability[];
       updatedAfter?: Date;
@@ -1531,7 +1531,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       );
     }
 
-    if (podSpaceId === undefined) {
+    if (podSpaceModelId === undefined) {
       return filteredSkills;
     }
 
@@ -1549,7 +1549,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       if (skillPodSpaceIds.length === 0) {
         return true;
       }
-      return podSpaceId !== null && skillPodSpaceIds.includes(podSpaceId);
+      return (
+        podSpaceModelId !== null && skillPodSpaceIds.includes(podSpaceModelId)
+      );
     });
   }
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1486,6 +1486,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       status = "active",
       limit,
       globalSpaceOnly,
+      podSpaceId,
       onlyCustom,
       availability,
       updatedAfter,
@@ -1497,6 +1498,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       status?: SkillStatus | SkillStatus[];
       limit?: number;
       globalSpaceOnly?: boolean;
+      podSpaceId?: ModelId | null;
       onlyCustom?: boolean;
       availability?: SkillAvailability | SkillAvailability[];
       updatedAfter?: Date;
@@ -1520,14 +1522,35 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       withFileAttachments,
     });
 
+    let filteredSkills = skills;
+
     if (globalSpaceOnly) {
       const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
-      return skills.filter((skill) =>
+      filteredSkills = filteredSkills.filter((skill) =>
         skill.requestedSpaceIds.every((id) => id === globalSpace.id)
       );
     }
 
-    return skills;
+    if (podSpaceId === undefined) {
+      return filteredSkills;
+    }
+
+    const allRequestedSpaceIds = uniq(
+      filteredSkills.flatMap((skill) => skill.requestedSpaceIds)
+    );
+    const podSpaceIds = new Set<ModelId>(
+      await SpaceResource.fetchProjectSpaceIdsAmong(auth, allRequestedSpaceIds)
+    );
+
+    return filteredSkills.filter((skill) => {
+      const skillPodSpaceIds = skill.requestedSpaceIds.filter((id) =>
+        podSpaceIds.has(id)
+      );
+      if (skillPodSpaceIds.length === 0) {
+        return true;
+      }
+      return podSpaceId !== null && skillPodSpaceIds.includes(podSpaceId);
+    });
   }
 
   /**

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -649,6 +649,17 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return spaces ?? [];
   }
 
+  static async fetchProjectSpaceIdsAmong(
+    auth: Authenticator,
+    spaceModelIds: ModelId[]
+  ): Promise<ModelId[]> {
+    if (spaceModelIds.length === 0) {
+      return [];
+    }
+    const spaces = await this.fetchByModelIds(auth, spaceModelIds);
+    return spaces.filter((s) => s.isProject()).map((s) => s.id);
+  }
+
   static async dangerouslyFetchByModelIds(
     spaceModelIds: ModelId[]
   ): Promise<SpaceResource[]> {

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -100,6 +100,7 @@ export function useSkills({
   disabled,
   status,
   globalSpaceOnly,
+  podContext,
   availability,
   bypassEditorVisibility,
   swrOptions,
@@ -108,6 +109,7 @@ export function useSkills({
   disabled?: boolean;
   status?: SkillStatus;
   globalSpaceOnly?: boolean;
+  podContext?: string | null;
   availability?: SkillAvailability | SkillAvailability[];
   // Admin-only: bypass the editor-visibility rule and also list unpublished
   // (editors-only) skills the caller does not edit.
@@ -127,6 +129,13 @@ export function useSkills({
   }
   if (globalSpaceOnly) {
     queryParams.set("globalSpaceOnly", "true");
+  }
+  if (podContext !== undefined) {
+    if (podContext !== null) {
+      queryParams.set("podSpaceId", podContext);
+    } else {
+      queryParams.set("excludePodScopedSkills", "true");
+    }
   }
   if (availability) {
     const availabilities = Array.isArray(availability)


### PR DESCRIPTION
## Description
Updating the skills settings page UI to reflect the changes in [#29834](https://github.com/dust-tt/dust/pull/29834).

In a skill's settings page, once a user has restricted a skill to one pod, the other pods and spaces with the wrong membership are greyed out and can't be selected, with warning messages explaining why.

<img width="385" height="444" alt="Screenshot 2026-07-31 at 17 23 56" src="https://github.com/user-attachments/assets/b71ba882-89fe-4a76-9f29-ba487b79ecda" />

(That is the warning message that happens when you hover over another pod and attempt to add it as a restriction.)

## Tests
Local tests.

## Risk
Low risk.

## Deploy Plan
Deploy front.
