### PR TITLE
Document user identity in Pod Function and Frame skills

### DIFF
--- a/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
@@ -110,6 +110,27 @@ The same decision rule applies regardless of where the data came from:
 - To let users download data, import \`triggerUserFileDownload\` from \`@dust/react-hooks\` and expose it through a button or other user action. Never auto-trigger downloads.
 - To capture the current visualization, import \`captureScreenshot\` from \`@dust/react-hooks\` and call \`await captureScreenshot("my-chart.png")\` or \`await captureScreenshot()\` from a user-triggered action.
 
+### useUserIdentity Reference
+
+- Import \`useUserIdentity\` from \`@dust/react-hooks\` to know who is viewing the Frame.
+- It returns \`{ isAuthenticated, isWorkspaceMember, user, isLoading, error }\`. When \`isAuthenticated\` is true, \`user\` is \`{ sId, firstName, lastName, fullName, image }\`; otherwise \`user\` is \`null\`.
+- \`isAuthenticated\` is only true for a signed-in member of the workspace that owns the Frame. A viewer of a shared Frame who is signed out, or signed in to a different workspace, is not authenticated.
+- Render the \`isLoading\` state, and treat \`error\` and the unauthenticated case identically: show the signed-out view rather than an error.
+
+\`\`\`tsx
+import { useUserIdentity } from "@dust/react-hooks";
+
+const { user, isAuthenticated, isLoading } = useUserIdentity();
+
+if (isLoading) { return <Spinner />; }
+if (!isAuthenticated) { return <SignedOutView />; }
+return <p>Welcome back, {user.firstName}</p>;
+\`\`\`
+
+- Use it to personalize: greet the viewer, preselect their rows, hide controls that would fail for them, or show a sign-in prompt instead of a dead button.
+- **It is not a security boundary.** It shapes what the interface offers, not what the viewer can do. Anything that must actually be restricted has to be enforced by the pod function behind it, which declares \`schema.userIdentity: "workspace_user_required"\` and reads the caller with \`currentUser()\`. Hiding a button is a courtesy; the function is the gate.
+- Never pass the identity you read here into a pod function as an argument. The function determines its own caller; a \`userId\` sent from the Frame names whoever the caller chooses.
+
 ### Interaction Rules
 
 - If an element looks clickable, it must do something visible: change selected state, expand content, copy with feedback, download, open a real link, or update the view.

--- a/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
@@ -115,7 +115,8 @@ The same decision rule applies regardless of where the data came from:
 - Import \`useUserIdentity\` from \`@dust/react-hooks\` to know who is viewing the Frame.
 - It returns \`{ isAuthenticated, isWorkspaceMember, user, isLoading, error }\`. When \`isAuthenticated\` is true, \`user\` is \`{ sId, firstName, lastName, fullName, image }\`; otherwise \`user\` is \`null\`.
 - \`isAuthenticated\` is only true for a signed-in member of the workspace that owns the Frame. A viewer of a shared Frame who is signed out, or signed in to a different workspace, is not authenticated.
-- Render the \`isLoading\` state, and treat \`error\` and the unauthenticated case identically: show the signed-out view rather than an error.
+- Render the \`isLoading\` state, and treat \`error\` and the unauthenticated case identically: fall back to the unauthenticated view rather than showing an error.
+- A Frame cannot sign anyone in. The viewer is already authenticated to Dust or they are not, and nothing the Frame renders can change that. When a Frame only makes sense for an authenticated member, render a plain view saying the content is unavailable to them, rather than a login prompt or a button that will not work.
 
 \`\`\`tsx
 import { useUserIdentity } from "@dust/react-hooks";
@@ -123,11 +124,11 @@ import { useUserIdentity } from "@dust/react-hooks";
 const { user, isAuthenticated, isLoading } = useUserIdentity();
 
 if (isLoading) { return <Spinner />; }
-if (!isAuthenticated) { return <SignedOutView />; }
+if (!isAuthenticated) { return <UnavailableToViewer />; }
 return <p>Welcome back, {user.firstName}</p>;
 \`\`\`
 
-- Use it for presentation only: greet the viewer by name, highlight the rows that are theirs, or show a sign-in prompt instead of a control that would do nothing for a signed-out viewer.
+- Use it for presentation only: greet the viewer by name, or highlight the rows that are theirs.
 - It tells you who is looking, not what they are allowed to do, and a Frame on its own holds no state to protect. Do not build access control out of it: whatever a Frame renders, its viewer can read.
 
 ### Interaction Rules

--- a/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
@@ -128,7 +128,7 @@ return <p>Welcome back, {user.firstName}</p>;
 \`\`\`
 
 - Use it to personalize: greet the viewer, preselect their rows, hide controls that would fail for them, or show a sign-in prompt instead of a dead button.
-- **It is not a security boundary.** It shapes what the interface offers, not what the viewer can do. Anything that must actually be restricted has to be enforced by the pod function behind it, which declares \`schema.userIdentity: "workspace_user_required"\` and reads the caller with \`currentUser()\`. Hiding a button is a courtesy; the function is the gate.
+- **It is not a security boundary.** It shapes what the interface offers, not what the viewer can do. Hiding a button is a courtesy; the pod function behind it is the gate, because it resolves its own caller with \`currentUser()\` no matter what the Frame claims. A function that must refuse anonymous callers outright declares \`schema.userIdentity: "workspace_user_required"\`, which makes the platform reject them before the function runs.
 - Never pass the identity you read here into a pod function as an argument. The function determines its own caller; a \`userId\` sent from the Frame names whoever the caller chooses.
 
 ### Interaction Rules

--- a/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
@@ -127,9 +127,8 @@ if (!isAuthenticated) { return <SignedOutView />; }
 return <p>Welcome back, {user.firstName}</p>;
 \`\`\`
 
-- Use it to personalize: greet the viewer, preselect their rows, hide controls that would fail for them, or show a sign-in prompt instead of a dead button.
-- **It is not a security boundary.** It shapes what the interface offers, not what the viewer can do. Hiding a button is a courtesy; the pod function behind it is the gate, because it resolves its own caller with \`currentUser()\` no matter what the Frame claims. A function that must refuse anonymous callers outright declares \`schema.userIdentity: "workspace_user_required"\`, which makes the platform reject them before the function runs.
-- Never pass the identity you read here into a pod function as an argument. The function determines its own caller; a \`userId\` sent from the Frame names whoever the caller chooses.
+- Use it for presentation only: greet the viewer by name, highlight the rows that are theirs, or show a sign-in prompt instead of a control that would do nothing for a signed-out viewer.
+- It tells you who is looking, not what they are allowed to do, and a Frame on its own holds no state to protect. Do not build access control out of it: whatever a Frame renders, its viewer can read.
 
 ### Interaction Rules
 

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -249,8 +249,9 @@ decides **what it does** for the caller it got.
 Declare the policy alongside the input and output schemas:
 
 - \`"optional"\` (the default when you omit the field) runs the function with or without a user.
-  Use it for functions that are the same for everyone: shared reference data, stateless
-  computation, Pod-wide reads.
+  It does not hide the caller: \`currentUser()\` still returns whoever called, and only returns
+  \`null\` when the invocation genuinely has no user. Use it when the function should still answer
+  a userless caller, and personalize from \`currentUser()\` when there happens to be one.
 - \`"workspace_user_required"\` refuses the call unless it comes from a current member of the Pod's
   workspace. Use it as soon as the function reads or writes anything that belongs to a person, or
   performs an action that should be attributable.

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -238,7 +238,83 @@ fall back to a generic message for the rest. The ones worth branching on are \`i
 function's own request failed, \`sandbox_function_not_found\`, and \`not_supported\`.
 
 Pod functions in shared Frames are available to authenticated members of the Pod's workspace;
-anonymous viewers cannot call them.`,
+anonymous viewers cannot call them.
+
+#### Knowing who called a function
+
+A function can require a caller and read who they are. These are two separate things: the
+\`schema.userIdentity\` policy decides **whether the function runs at all**, and \`currentUser()\`
+decides **what it does** for the caller it got.
+
+Declare the policy alongside the input and output schemas:
+
+- \`"optional"\` (the default when you omit the field) runs the function with or without a user.
+  Use it for functions that are the same for everyone: shared reference data, stateless
+  computation, Pod-wide reads.
+- \`"workspace_user_required"\` refuses the call unless it comes from a current member of the Pod's
+  workspace. Use it as soon as the function reads or writes anything that belongs to a person, or
+  performs an action that should be attributable.
+
+\`\`\`ts
+import { z } from "zod";
+import { currentUser } from "@dust/pod";
+
+export const schema = {
+  description: "List the notes belonging to the calling user.",
+  userIdentity: "workspace_user_required",
+  input: z.object({}),
+  output: z.object({ notes: z.array(z.object({ id: z.number(), body: z.string() })) }),
+};
+\`\`\`
+
+Inside \`fetch\`, \`currentUser()\` from \`@dust/pod\` returns the caller as
+\`{ sId, firstName, lastName, fullName, image }\`, or \`null\` when the invocation has no user.
+Under \`"workspace_user_required"\` the platform has already rejected userless calls, so a
+non-null user is guaranteed; under \`"optional"\` you must handle \`null\` yourself.
+
+The membership is re-checked against the Pod's workspace when the invocation runs, not just when
+it is queued, so a user removed from the workspace in between is refused.
+
+**Never take the caller's identity as an input.** An \`input\` field like \`userId\` is supplied by
+whoever calls the function and can name anyone. \`currentUser()\` is the only trustworthy source.
+
+\`\`\`ts
+// BAD: any caller can pass someone else's id.
+input: z.object({ userId: z.string() })
+
+// GOOD: the platform decides who the caller is.
+const user = currentUser();
+\`\`\`
+
+#### Per-user state and sessions
+
+Scope rows by \`currentUser().sId\`, which is stable for a user across calls, conversations, and
+Frames. That single column is what turns a shared Pod database into per-user state, so add it when
+you create the table rather than retrofitting it later (schema evolution is additive-only).
+
+\`\`\`ts
+// databases/notes.db.ts
+export const notes = sqliteTable("notes", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  userId: text("user_id"),        // currentUser().sId
+  body: text("body"),
+  createdAt: integer("created_at", { mode: "timestamp" }),
+}, (t) => [index("notes_user_idx").on(t.userId)]);
+
+// list-notes.ts, declared "workspace_user_required"
+const user = currentUser();
+const rows = db("notes").select().from(notes).where(eq(notes.userId, user.sId)).all();
+\`\`\`
+
+Filter by \`userId\` on **every** read and write, not only on the read that renders the screen: a
+function that fetches a row by its primary key and then updates it must still check the row belongs
+to the caller, otherwise a guessed id reaches another user's data.
+
+Split capabilities across functions rather than branching inside one. A \`list-notes\` and a
+\`delete-note\` published separately can carry different policies and are each easy to reason about;
+one \`notes\` function taking an \`action\` field is not. If a capability must be restricted to a
+subset of members, keep that list in the database and check it against \`currentUser().sId\` —
+the platform only tells you the caller is a workspace member, not what they are allowed to do.`,
   mcpServers: [{ name: SANDBOX_FUNCTIONS_SERVER_NAME }],
   version: 5,
   icon: "PuzzleIcon",

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -279,6 +279,11 @@ it is queued, so a user removed from the workspace in between is refused.
 **Never take the caller's identity as an input.** An \`input\` field like \`userId\` is supplied by
 whoever calls the function and can name anyone. \`currentUser()\` is the only trustworthy source.
 
+This matters most when a Frame calls the function. A Frame can read its viewer with
+\`useUserIdentity\`, but that is for what it displays; it decides nothing. The function resolves its
+own caller, so never accept an identity the Frame sends, and put the check that actually restricts
+something here rather than in the interface that renders the button.
+
 \`\`\`ts
 // BAD: any caller can pass someone else's id.
 input: z.object({ userId: z.string() })


### PR DESCRIPTION
## Description

Agents can now require and read the calling user, but neither skill said so. Instructions only; no runtime change.

- **Pod Functions skill** — new `Knowing who called a function` and `Per-user state and sessions` sections: `schema.userIdentity` (`optional` vs `workspace_user_required`) as the gate on whether the function runs, `currentUser()` from `@dust/pod` for who it got, scoping rows by `currentUser().sId`, filtering by owner on every read *and* write, and splitting capabilities across functions instead of branching on an `action` field.
- **Frames skill** — new `useUserIdentity Reference` next to `useFile`: return shape, loading and signed-out handling, and that it personalizes the interface only.

Both state the same rule from their own side: identity is never an input. A `userId` argument names whoever the caller chooses, so the Frame must not send one and the function must not accept one. `useUserIdentity` shapes the UI; `schema.userIdentity` plus `currentUser()` is the enforcement.

`interactive_workspace_user_required` is intentionally left undocumented for now.

## Tests

Global skill suites pass (19). `tsgo --noEmit` and biome clean.

## Risk

None. Skill `version` is unchanged, matching the convention for instruction-only edits.