### PR TITLE
Attribute per-tool consumption for settled agent messages

### DIFF
--- a/front/lib/api/assistant/agent_message_consumption_attribution/attribution_builder.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/attribution_builder.ts
@@ -8,7 +8,11 @@ import { MODEL_COST_MICRO_USD_PER_AWU_CREDIT } from "@app/lib/metronome/constant
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import assert from "assert";
 
-export const AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION = 1;
+// Version 1 attributed the model token buckets only. Version 2 adds per-tool rows and, as a result,
+// nets the tool-call emission out of the assistant output bucket, so its rows are not comparable to
+// version 1's. Bumping keeps the two regimes as separate, self-consistent sets rather than mixing
+// them under one version when a pre-v2 message is re-finalized.
+export const AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION = 2;
 
 const CREDIT_AMOUNT_MICRO_PER_CREDIT = 1_000_000;
 

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
@@ -1,16 +1,32 @@
 import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
 import { computeAndStoreAgentMessageConsumptionAttribution } from "@app/lib/api/assistant/agent_message_consumption_attribution/store";
+import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { tokenCountForTexts } from "@app/lib/tokenization";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { RunFactory } from "@app/tests/utils/RunFactory";
-import { describe, expect, it } from "vitest";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/provider_credentials", () => ({
+  getLlmCredentials: vi.fn(),
+}));
+
+vi.mock("@app/lib/tokenization", () => ({
+  tokenCountForTexts: vi.fn(),
+}));
 
 const INPUT_TOKENS_COUNT = 100;
 const OUTPUT_TOKENS_COUNT = 20;
 const REASONING_TOKENS_COUNT = 5;
+
+// Every tokenized footprint counts as this many tokens, so tool-call output and result-input
+// footprints are deterministic in the assertions below.
+const TOKENS_PER_FOOTPRINT = 2;
 
 async function setupSettledMessageWithUsage() {
   const { authenticator: auth, workspace } = await createResourceTest({});
@@ -38,6 +54,9 @@ async function setupSettledMessageWithUsage() {
 
   return {
     auth,
+    workspace,
+    conversation,
+    run,
     conversationId: conversation.sId,
     agentMessageId: agentMessage.sId,
     agentMessageModelId: agentMessage.agentMessageId,
@@ -45,6 +64,14 @@ async function setupSettledMessageWithUsage() {
 }
 
 describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getLlmCredentials).mockResolvedValue({} as never);
+    vi.mocked(tokenCountForTexts).mockImplementation(
+      async (texts) => new Ok(texts.map(() => TOKENS_PER_FOOTPRINT))
+    );
+  });
+
   it("writes one input, output and reasoning row per run usage", async () => {
     const { auth, conversationId, agentMessageId, agentMessageModelId } =
       await setupSettledMessageWithUsage();
@@ -117,6 +144,60 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
       "output",
       "reasoning",
     ]);
+  });
+
+  it("writes a tool row per action and carves the tool output from the assistant output", async () => {
+    const {
+      auth,
+      workspace,
+      conversation,
+      run,
+      conversationId,
+      agentMessageId,
+      agentMessageModelId,
+    } = await setupSettledMessageWithUsage();
+
+    const { action } = await AgentMCPActionFactory.create(auth, {
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId,
+      status: "succeeded",
+      // Stamp the action's step content with the run that emitted it, which is how attribution ties
+      // a tool call back to its run usage.
+      dustRunId: run.dustRunId,
+    });
+
+    await computeAndStoreAgentMessageConsumptionAttribution(auth, {
+      agentMessageId,
+      conversationId,
+    });
+
+    const items =
+      await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
+        auth,
+        {
+          agentMessageModelIds: [agentMessageModelId],
+          attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+        }
+      );
+
+    const toolItem = items.find((item) => item.itemType === "tool");
+    expect(toolItem).toMatchObject({
+      itemType: "tool",
+      agentMCPActionId: action.id,
+      // The tool call emission and its result footprint each tokenize to TOKENS_PER_FOOTPRINT.
+      outputTokensCount: TOKENS_PER_FOOTPRINT,
+      inputTokensCount: TOKENS_PER_FOOTPRINT,
+    });
+    expect(toolItem?.grossAttributedCreditAmountMicro).toBeGreaterThan(0);
+    expect(toolItem?.directCreditAmountMicro).toBeGreaterThanOrEqual(0);
+
+    // The tokens the model spent emitting the tool call are carved out of the assistant output
+    // bucket, so the two together still sum to the completion tokens net of reasoning.
+    const outputItem = items.find((item) => item.itemType === "output");
+    expect(
+      (outputItem?.outputTokensCount ?? 0) + (toolItem?.outputTokensCount ?? 0)
+    ).toBe(OUTPUT_TOKENS_COUNT - REASONING_TOKENS_COUNT);
   });
 
   it("writes nothing when the message has no runs", async () => {

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
@@ -9,7 +9,6 @@ import { toolAwuFromAction } from "@app/lib/metronome/events";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { CompletedAgentMessageConsumptionItem } from "@app/lib/resources/agent_message_consumption_item_resource";
 import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
-import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import logger from "@app/logger/logger";
@@ -90,9 +89,9 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
   const runs = await RunResource.listByDustRunIds(auth, { dustRunIds });
   const usages = await RunResource.listRunUsagesForRuns(auth, { runs });
 
-  // Group the message's tool calls by the run that emitted them. Actions do not carry a run id
-  // directly; they reach it through their step content's dustRunId, which is the same identifier the
-  // run usages are keyed by.
+  // Group the message's tool calls by the run that emitted them. Each action carries its emitting
+  // step content, whose dustRunId identifies that run and is the same identifier the run usages are
+  // keyed by.
   const actions = await AgentMCPActionResource.listByAgentMessageIds(auth, [
     agentMessageModelId,
   ]);
@@ -105,22 +104,15 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
     enrichedActions.map((action) => [action.id, action])
   );
 
-  const stepContents = await AgentStepContentResource.fetchByModelIds(
-    auth,
-    removeNulls([...new Set(actions.map((action) => action.stepContentId))])
-  );
-  const dustRunIdByStepContentId = new Map(
-    stepContents.map((stepContent) => [stepContent.id, stepContent.dustRunId])
-  );
   const dustRunIdByRunModelId = new Map(
     runs.map((run) => [run.id, run.dustRunId])
   );
 
   const actionsByDustRunId = new Map<string, AgentMCPActionResource[]>();
   for (const action of actions) {
-    const dustRunId = dustRunIdByStepContentId.get(action.stepContentId);
+    const dustRunId = action.stepContent.dustRunId;
     if (!dustRunId) {
-      // Legacy step contents predate dustRunId stamping; their actions cannot be tied to a run, so
+      // Legacy step contents predate dustRunId stamping. Their actions cannot be tied to a run, so
       // they are left out of the tool attribution rather than guessed.
       continue;
     }

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
@@ -146,16 +146,26 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
     }
     const footprints = footprintsRes.value;
 
+    // Pair each tool call with its enriched form and measured footprint once, here. This is the only
+    // place alignment is assumed: measureToolCallFootprints returns counts positioned by the actions
+    // it received, and enrichedRunActions is aligned with runActions (the length assert above proves
+    // removeNulls dropped nothing), so index i is the same tool call across all three. From here each
+    // call carries its own data through the builder, so nothing downstream re-derives the position.
+    const measuredToolCalls = runActions.map((action, index) => ({
+      action,
+      enrichedAction: enrichedRunActions[index],
+      footprint: footprints[index],
+    }));
+
     // A single partition of the usage: the tool calls take their share of the output budget, and the
     // model buckets take the rest (so the output row here is net of tool emission).
-    const { modelItems, toolCalls } =
-      buildRunUsageAttribution<AgentMCPActionResource>({
-        usage,
-        toolCalls: runActions.map((action, index) => ({
-          tool: action,
-          measuredOutputTokensCount: footprints[index].callOutputTokensCount,
-        })),
-      });
+    const { modelItems, toolCalls } = buildRunUsageAttribution({
+      usage,
+      toolCalls: measuredToolCalls.map((measured) => ({
+        tool: measured,
+        measuredOutputTokensCount: measured.footprint.callOutputTokensCount,
+      })),
+    });
 
     for (const item of modelItems) {
       switch (item.itemType) {
@@ -185,9 +195,8 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
       }
     }
 
-    toolCalls.forEach((toolCall, index) => {
-      const action = toolCall.tool;
-      const enrichedAction = enrichedRunActions[index];
+    toolCalls.forEach((toolCall) => {
+      const { action, enrichedAction, footprint } = toolCall.tool;
       const directCreditAmountMicro = Math.round(
         toolAwuFromAction(
           {
@@ -201,7 +210,7 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
       const toolAttribution = buildToolAttribution({
         usage,
         toolCall,
-        inputTokensCount: footprints[index].resultInputTokensCount,
+        inputTokensCount: footprint.resultInputTokensCount,
         directCreditAmountMicro,
       });
 

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
@@ -1,31 +1,43 @@
 import {
   AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
   buildRunUsageAttribution,
+  buildToolAttribution,
 } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
+import { measureToolCallFootprints } from "@app/lib/api/assistant/agent_message_consumption_attribution/tool_footprint";
 import type { Authenticator } from "@app/lib/auth";
+import { toolAwuFromAction } from "@app/lib/metronome/events";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { CompletedAgentMessageConsumptionItem } from "@app/lib/resources/agent_message_consumption_item_resource";
 import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
+import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import logger from "@app/logger/logger";
 import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { removeNulls } from "@app/types/shared/utils/general";
+import assert from "assert";
+
+// AWU (the credit unit tool charges are denominated in) expressed in micro-credits, matching how the
+// model token buckets store their attributed credits.
+const CREDIT_AMOUNT_MICRO_PER_CREDIT = 1_000_000;
 
 /**
- * Records the per-run token attribution breakdown for one settled agent message.
+ * Records the per-run consumption attribution breakdown for one settled agent message.
  *
  * This is analytics, not billing: the authoritative charge is computed and stored separately by the
- * credit pipeline. Here we explain the relative composition of that cost by writing one row per
- * model token bucket (input, output, reasoning) for each of the message's run usages.
- *
- * V0.5 covers the model buckets only. Per-tool attribution (the split of the input footprint of
- * each tool result and its direct credits) is a later version and needs tokenization, so it is not
- * produced here: the builder is called with no tool calls.
+ * credit pipeline. Here we explain the relative composition of that cost by writing, per run usage,
+ * one row per model token bucket (input, output, reasoning) and one row per tool call. A tool row
+ * carries the output tokens the model spent emitting the call, the input tokens its result occupied
+ * in the next prompt, and the tool's direct credit charge.
  *
  * Runs once the message has settled, launched from the analytics queue by the finalize activities.
- * It is idempotent by (agent message, attribution version, run usage, item type): a re-finalize
- * (interrupt/resume, tool confirmation, Temporal retry) re-inserts the same identities as no-ops
- * and adds rows only for run usages that are new since the last pass.
+ * It is idempotent by (agent message, attribution version, run usage, item type) for model rows and
+ * by (agent message, attribution version, action) for tool rows: a re-finalize (interrupt/resume,
+ * tool confirmation, Temporal retry) re-inserts the same identities as no-ops and adds rows only for
+ * run usages or actions that are new since the last pass. Records are computed for the whole message
+ * before any write, so a tokenization failure throws and the retry recomputes from scratch rather
+ * than locking in a partial breakdown.
  */
 export async function computeAndStoreAgentMessageConsumptionAttribution(
   auth: Authenticator,
@@ -48,7 +60,8 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
     return;
   }
 
-  const { agentMessageModelId, status, runIds } = creditContext;
+  const { agentMessageModelId, status, runIds, triggeringUserMessageOrigin } =
+    creditContext;
 
   // Attribution only explains what was billed, so it mirrors the billing status gate: an untracked
   // status has no charge to compose.
@@ -77,40 +90,141 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
   const runs = await RunResource.listByDustRunIds(auth, { dustRunIds });
   const usages = await RunResource.listRunUsagesForRuns(auth, { runs });
 
-  const records: CompletedAgentMessageConsumptionItem[] = usages.flatMap(
-    (usage) => {
-      const { modelItems } = buildRunUsageAttribution<never>({
-        usage,
-        toolCalls: [],
-      });
-
-      return modelItems.map((item): CompletedAgentMessageConsumptionItem => {
-        switch (item.itemType) {
-          case "input":
-            return {
-              itemType: "input",
-              runUsageModelId: usage.runUsageModelId,
-              inputTokensCount: item.inputTokensCount,
-              grossAttributedCreditAmountMicro:
-                item.grossAttributedCreditAmountMicro,
-            };
-
-          case "output":
-          case "reasoning":
-            return {
-              itemType: item.itemType,
-              runUsageModelId: usage.runUsageModelId,
-              outputTokensCount: item.outputTokensCount,
-              grossAttributedCreditAmountMicro:
-                item.grossAttributedCreditAmountMicro,
-            };
-
-          default:
-            return assertNever(item);
-        }
-      });
-    }
+  // Group the message's tool calls by the run that emitted them. Actions do not carry a run id
+  // directly; they reach it through their step content's dustRunId, which is the same identifier the
+  // run usages are keyed by.
+  const actions = await AgentMCPActionResource.listByAgentMessageIds(auth, [
+    agentMessageModelId,
+  ]);
+  const enrichedActions =
+    await AgentMCPActionResource.enrichActionsWithOutputItems(auth, {
+      actions,
+      ignoreContent: false,
+    });
+  const enrichedActionById = new Map(
+    enrichedActions.map((action) => [action.id, action])
   );
+
+  const stepContents = await AgentStepContentResource.fetchByModelIds(
+    auth,
+    removeNulls([...new Set(actions.map((action) => action.stepContentId))])
+  );
+  const dustRunIdByStepContentId = new Map(
+    stepContents.map((stepContent) => [stepContent.id, stepContent.dustRunId])
+  );
+  const dustRunIdByRunModelId = new Map(
+    runs.map((run) => [run.id, run.dustRunId])
+  );
+
+  const actionsByDustRunId = new Map<string, AgentMCPActionResource[]>();
+  for (const action of actions) {
+    const dustRunId = dustRunIdByStepContentId.get(action.stepContentId);
+    if (!dustRunId) {
+      // Legacy step contents predate dustRunId stamping; their actions cannot be tied to a run, so
+      // they are left out of the tool attribution rather than guessed.
+      continue;
+    }
+    const runActions = actionsByDustRunId.get(dustRunId) ?? [];
+    runActions.push(action);
+    actionsByDustRunId.set(dustRunId, runActions);
+  }
+
+  const records: CompletedAgentMessageConsumptionItem[] = [];
+  for (const usage of usages) {
+    const dustRunId = dustRunIdByRunModelId.get(usage.runModelId);
+    const runActions = (dustRunId && actionsByDustRunId.get(dustRunId)) || [];
+    const enrichedRunActions = removeNulls(
+      runActions.map((action) => enrichedActionById.get(action.id))
+    );
+    assert(
+      enrichedRunActions.length === runActions.length,
+      "Every action must have an enriched counterpart"
+    );
+
+    // Token footprints of this run's tool calls: the output the model spent emitting each call and
+    // the input its result occupied. Everything is priced against this one usage below.
+    const footprintsRes = await measureToolCallFootprints(auth, {
+      modelId: usage.modelId,
+      actions: enrichedRunActions,
+    });
+    if (footprintsRes.isErr()) {
+      throw new Error(
+        `[ConsumptionAttribution] Failed to tokenize tool footprints: ${footprintsRes.error.message}`
+      );
+    }
+    const footprints = footprintsRes.value;
+
+    // A single partition of the usage: the tool calls take their share of the output budget, and the
+    // model buckets take the rest (so the output row here is net of tool emission).
+    const { modelItems, toolCalls } =
+      buildRunUsageAttribution<AgentMCPActionResource>({
+        usage,
+        toolCalls: runActions.map((action, index) => ({
+          tool: action,
+          measuredOutputTokensCount: footprints[index].callOutputTokensCount,
+        })),
+      });
+
+    for (const item of modelItems) {
+      switch (item.itemType) {
+        case "input":
+          records.push({
+            itemType: "input",
+            runUsageModelId: usage.runUsageModelId,
+            inputTokensCount: item.inputTokensCount,
+            grossAttributedCreditAmountMicro:
+              item.grossAttributedCreditAmountMicro,
+          });
+          break;
+
+        case "output":
+        case "reasoning":
+          records.push({
+            itemType: item.itemType,
+            runUsageModelId: usage.runUsageModelId,
+            outputTokensCount: item.outputTokensCount,
+            grossAttributedCreditAmountMicro:
+              item.grossAttributedCreditAmountMicro,
+          });
+          break;
+
+        default:
+          assertNever(item);
+      }
+    }
+
+    toolCalls.forEach((toolCall, index) => {
+      const action = toolCall.tool;
+      const enrichedAction = enrichedRunActions[index];
+      const directCreditAmountMicro = Math.round(
+        toolAwuFromAction(
+          {
+            toolName: enrichedAction.toolName,
+            internalMCPServerName: enrichedAction.internalMCPServerName,
+          },
+          triggeringUserMessageOrigin
+        ) * CREDIT_AMOUNT_MICRO_PER_CREDIT
+      );
+
+      const toolAttribution = buildToolAttribution({
+        usage,
+        toolCall,
+        inputTokensCount: footprints[index].resultInputTokensCount,
+        directCreditAmountMicro,
+      });
+
+      records.push({
+        itemType: "tool",
+        runUsageModelId: usage.runUsageModelId,
+        action,
+        inputTokensCount: toolAttribution.inputTokensCount,
+        outputTokensCount: toolAttribution.outputTokensCount,
+        directCreditAmountMicro: toolAttribution.directCreditAmountMicro,
+        grossAttributedCreditAmountMicro:
+          toolAttribution.grossAttributedCreditAmountMicro,
+      });
+    });
+  }
 
   await AgentMessageConsumptionItemResource.insertCompletedItemsIdempotently(
     auth,

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.test.ts
@@ -1,0 +1,202 @@
+import {
+  measureToolCallFootprints,
+  toolCallFootprintTexts,
+} from "@app/lib/api/assistant/agent_message_consumption_attribution/tool_footprint";
+import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import type { Authenticator } from "@app/lib/auth";
+import { tokenCountForTexts } from "@app/lib/tokenization";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import { GPT_5_MODEL_ID } from "@app/types/assistant/models/openai";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/provider_credentials", () => ({
+  getLlmCredentials: vi.fn(),
+}));
+
+vi.mock("@app/lib/tokenization", () => ({
+  tokenCountForTexts: vi.fn(),
+}));
+
+function makeAction(
+  overrides: Partial<AgentMCPActionWithOutputType> = {}
+): AgentMCPActionWithOutputType {
+  return {
+    id: 1,
+    sId: "action_1",
+    createdAt: 0,
+    updatedAt: 0,
+    agentMessageId: 1,
+    internalMCPServerName: null,
+    toolName: "search",
+    mcpServerId: null,
+    functionCallName: "search",
+    functionCallId: "call_1",
+    params: { query: "hello" },
+    citationsAllocated: 0,
+    status: "succeeded",
+    step: 0,
+    executionDurationMs: null,
+    displayLabels: null,
+    output: null,
+    generatedFiles: [],
+    ...overrides,
+  };
+}
+
+// The auth is only forwarded to getLlmCredentials, which is mocked, so a bare stub is enough.
+const auth = {} as Authenticator;
+
+describe("toolCallFootprintTexts", () => {
+  it("serializes a call as its function name followed by JSON arguments", () => {
+    const { callText } = toolCallFootprintTexts(
+      makeAction({ functionCallName: "search", params: { query: "hello" } })
+    );
+
+    expect(callText).toBe(`search\n${JSON.stringify({ query: "hello" })}`);
+  });
+
+  it("renders a denied action as the rejection notice, ignoring any output", () => {
+    const { resultText } = toolCallFootprintTexts(
+      makeAction({
+        status: "denied",
+        output: [{ type: "text", text: "leaked" }],
+      })
+    );
+
+    expect(resultText).toBe(
+      "The user rejected or skipped this specific action execution. Using this action is hence forbidden for this message."
+    );
+  });
+
+  it("renders an action awaiting validation as the validation notice", () => {
+    const { resultText } = toolCallFootprintTexts(
+      makeAction({ status: "blocked_validation_required" })
+    );
+
+    expect(resultText).toBe(
+      "The user must manually validate this action before it can be executed."
+    );
+  });
+
+  it("renders an empty output as the no-output notice", () => {
+    const { resultText } = toolCallFootprintTexts(
+      makeAction({ status: "succeeded", output: [] })
+    );
+
+    expect(resultText).toBe("Successfully executed action, no output.");
+  });
+
+  it("joins text output items with newlines", () => {
+    const { resultText } = toolCallFootprintTexts(
+      makeAction({
+        status: "succeeded",
+        output: [
+          { type: "text", text: "first" },
+          { type: "text", text: "second" },
+        ],
+      })
+    );
+
+    expect(resultText).toBe("first\nsecond");
+  });
+
+  it("serializes non-text output as JSON with the mime type stripped", () => {
+    const { resultText } = toolCallFootprintTexts(
+      makeAction({
+        status: "succeeded",
+        output: [
+          {
+            type: "resource",
+            resource: { uri: "u", mimeType: "text/plain", text: "body" },
+          },
+        ],
+      })
+    );
+
+    expect(resultText).toBe(JSON.stringify([{ uri: "u", text: "body" }]));
+  });
+});
+
+describe("measureToolCallFootprints", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getLlmCredentials).mockResolvedValue({} as never);
+    // Count is the character length of each text, keeping the assertions readable.
+    vi.mocked(tokenCountForTexts).mockImplementation(
+      async (texts) => new Ok(texts.map((text) => text.length))
+    );
+  });
+
+  it("returns an empty result without tokenizing when there are no actions", async () => {
+    const res = await measureToolCallFootprints(auth, {
+      modelId: GPT_5_MODEL_ID,
+      actions: [],
+    });
+
+    expect(res.isOk() && res.value).toEqual([]);
+    expect(tokenCountForTexts).not.toHaveBeenCalled();
+    expect(getLlmCredentials).not.toHaveBeenCalled();
+  });
+
+  it("fails when the run's model is not a known configuration", async () => {
+    const res = await measureToolCallFootprints(auth, {
+      modelId: "not-a-real-model",
+      actions: [makeAction()],
+    });
+
+    expect(res.isErr()).toBe(true);
+    expect(tokenCountForTexts).not.toHaveBeenCalled();
+  });
+
+  it("measures the call and result footprint of each action, aligned by position", async () => {
+    const actions = [
+      makeAction({ functionCallName: "a", params: {} }),
+      makeAction({
+        functionCallName: "b",
+        params: {},
+        status: "succeeded",
+        output: [{ type: "text", text: "result-of-b" }],
+      }),
+    ];
+
+    const res = await measureToolCallFootprints(auth, {
+      modelId: GPT_5_MODEL_ID,
+      actions,
+    });
+
+    // Calls and results are tokenized as two homogeneous lists, each in input order.
+    const [callTexts] = vi.mocked(tokenCountForTexts).mock.calls[0];
+    const [resultTexts] = vi.mocked(tokenCountForTexts).mock.calls[1];
+    expect(callTexts).toEqual(["a\n{}", "b\n{}"]);
+    expect(resultTexts).toEqual([
+      "Successfully executed action, no output.",
+      "result-of-b",
+    ]);
+
+    expect(res.isOk() && res.value).toEqual([
+      {
+        callOutputTokensCount: "a\n{}".length,
+        resultInputTokensCount: "Successfully executed action, no output."
+          .length,
+      },
+      {
+        callOutputTokensCount: "b\n{}".length,
+        resultInputTokensCount: "result-of-b".length,
+      },
+    ]);
+  });
+
+  it("propagates a tokenizer failure", async () => {
+    vi.mocked(tokenCountForTexts).mockResolvedValue(
+      new Err(new Error("core down"))
+    );
+
+    const res = await measureToolCallFootprints(auth, {
+      modelId: GPT_5_MODEL_ID,
+      actions: [makeAction()],
+    });
+
+    expect(res.isErr() && res.error.message).toBe("core down");
+  });
+});

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
@@ -1,0 +1,110 @@
+import { renderToolResultForModelAsText } from "@app/lib/api/assistant/conversation_rendering/helpers";
+import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import type { Authenticator } from "@app/lib/auth";
+import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
+import { tokenCountForTexts } from "@app/lib/tokenization";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+/**
+ * The two texts an MCP action contributes to the model's token budget: the tool call the model
+ * emitted (output side) and the result the model then ingested (input side). Per-tool attribution
+ * prices these two footprints, so V1 measures both.
+ */
+export interface ToolFootprintTexts {
+  callText: string;
+  resultText: string;
+}
+
+/**
+ * The measured footprint of one MCP action, aligned by position with the input actions. Named after
+ * the model budget each side consumes: the emitted call counts as output, the ingested result as
+ * input.
+ */
+export interface ToolFootprintMeasurement {
+  callOutputTokensCount: number;
+  resultInputTokensCount: number;
+}
+
+// The model emits a tool call as a function name plus its JSON arguments. This mirrors that shape so
+// the token count reflects what the model actually generated to invoke the tool.
+function serializeToolCallText(action: AgentMCPActionWithOutputType): string {
+  return `${action.functionCallName}\n${JSON.stringify(action.params)}`;
+}
+
+export function toolCallFootprintTexts(
+  action: AgentMCPActionWithOutputType
+): ToolFootprintTexts {
+  return {
+    callText: serializeToolCallText(action),
+    // The exact text the model saw for the result, shared with conversation rendering so the
+    // estimate never drifts from what was actually sent. Image content is not counted here: it is
+    // priced under a separate tile-based model, out of scope for text tokenization.
+    resultText: renderToolResultForModelAsText(action),
+  };
+}
+
+/**
+ * Measures, for each action, how many tokens the model spent emitting the tool call and how many the
+ * returned result occupied in the following prompt. Results are order-aligned with `actions`.
+ *
+ * Uses the exact tokenizer of the run's model through core, the same path conversation rendering
+ * uses to size messages, so the counts (_almost_) match what the provider billed rather than a heuristic.
+ */
+export async function measureToolCallFootprints(
+  auth: Authenticator,
+  {
+    modelId,
+    actions,
+  }: {
+    modelId: string;
+    actions: AgentMCPActionWithOutputType[];
+  }
+): Promise<Result<ToolFootprintMeasurement[], Error>> {
+  if (actions.length === 0) {
+    return new Ok([]);
+  }
+
+  const model = getModelConfigByModelId(modelId);
+  if (!model) {
+    return new Err(
+      new Error(`Cannot tokenize tool footprints: unknown model ${modelId}.`)
+    );
+  }
+
+  const credentials = await getLlmCredentials(auth, {
+    skipEmbeddingApiKeyRequirement: true,
+  });
+
+  // Tokenize the calls and the results as two homogeneous lists rather than one interleaved list, so
+  // each count maps back to its action by plain index, with no call-vs-result position juggling.
+  const footprints = actions.map(toolCallFootprintTexts);
+  const [callCountsRes, resultCountsRes] = await Promise.all([
+    tokenCountForTexts(
+      footprints.map((footprint) => footprint.callText),
+      model,
+      credentials
+    ),
+    tokenCountForTexts(
+      footprints.map((footprint) => footprint.resultText),
+      model,
+      credentials
+    ),
+  ]);
+  if (callCountsRes.isErr()) {
+    return callCountsRes;
+  }
+  if (resultCountsRes.isErr()) {
+    return resultCountsRes;
+  }
+  const callCounts = callCountsRes.value;
+  const resultCounts = resultCountsRes.value;
+
+  return new Ok(
+    footprints.map((_, index) => ({
+      callOutputTokensCount: callCounts[index],
+      resultInputTokensCount: resultCounts[index],
+    }))
+  );
+}

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
@@ -98,6 +98,7 @@ export async function measureToolCallFootprints(
   if (resultCountsRes.isErr()) {
     return resultCountsRes;
   }
+
   const callCounts = callCountsRes.value;
   const resultCounts = resultCountsRes.value;
 

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -65,6 +65,59 @@ function compactResourceItem(item: CallToolResult["content"][number]) {
   return resource;
 }
 
+// The fixed notice the model sees for an action that did not run (denied or blocked), or null when
+// the action executed and its output should be rendered instead.
+function toolResultStatusNotice(
+  status: AgentMCPActionWithOutputType["status"]
+): string | null {
+  switch (status) {
+    case "denied":
+      return "The user rejected or skipped this specific action execution. Using this action is hence forbidden for this message.";
+
+    case "blocked_authentication_required":
+      return "The user must manually authenticate to use this action before it can be executed.";
+
+    case "blocked_validation_required":
+    case "blocked_child_action_input_required":
+      return "The user must manually validate this action before it can be executed.";
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * The model-visible text of a tool result: the status notice for actions that did not run, otherwise
+ * the executed output serialized as text. This is the single source of truth for how a tool result
+ * reads to the model, shared by conversation rendering and consumption attribution so the two never
+ * drift.
+ *
+ * Image content is not represented here. Vision-capable rendering emits images as a structured
+ * payload alongside the text (see renderActionForMultiActionsModel). Every other caller uses the
+ * text view this returns, in which a non-text result falls back to its JSON serialization.
+ */
+export function renderToolResultForModelAsText(
+  action: AgentMCPActionWithOutputType
+): string {
+  const notice = toolResultStatusNotice(action.status);
+  if (notice !== null) {
+    return notice;
+  }
+
+  const outputItems = removeNulls(
+    action.output?.map(rewriteContentForModel) ?? []
+  );
+  if (outputItems.length === 0) {
+    return "Successfully executed action, no output.";
+  }
+
+  if (outputItems.every((item) => isTextContent(item))) {
+    return outputItems.map((item) => item.text).join("\n");
+  }
+
+  return JSON.stringify(outputItems.map(compactResourceItem));
+}
+
 async function getDustFileSystemDownloadUrl(
   auth: Authenticator,
   filePath: string
@@ -131,36 +184,13 @@ async function renderActionForMultiActionsModel(
   model: ModelConfigurationType,
   { conversationId }: { conversationId: string }
 ): Promise<FunctionMessageTypeModel> {
-  if (action.status === "denied") {
+  const notice = toolResultStatusNotice(action.status);
+  if (notice !== null) {
     return {
       role: "function" as const,
       name: action.functionCallName,
       function_call_id: action.functionCallId,
-      content:
-        "The user rejected or skipped this specific action execution. Using this action is hence forbidden for this message.",
-    };
-  }
-
-  if (action.status === "blocked_authentication_required") {
-    return {
-      role: "function" as const,
-      name: action.functionCallName,
-      function_call_id: action.functionCallId,
-      content:
-        "The user must manually authenticate to use this action before it can be executed.",
-    };
-  }
-
-  if (
-    action.status === "blocked_validation_required" ||
-    action.status === "blocked_child_action_input_required"
-  ) {
-    return {
-      role: "function" as const,
-      name: action.functionCallName,
-      function_call_id: action.functionCallId,
-      content:
-        "The user must manually validate this action before it can be executed.",
+      content: notice,
     };
   }
 
@@ -168,12 +198,10 @@ async function renderActionForMultiActionsModel(
     action.output?.map(rewriteContentForModel) ?? []
   );
 
-  let output: string | Content[];
-  if (outputItems.length === 0) {
-    output = "Successfully executed action, no output.";
-  } else if (outputItems.every((item) => isTextContent(item))) {
-    output = outputItems.map((item) => item.text).join("\n");
-  } else if (
+  // Vision-capable models receive images as a structured payload with the text interleaved. This is
+  // the one case that needs async signed URLs, so it stays here rather than in the shared text view.
+  // Every other case delegates to renderToolResultForModelAsText below.
+  if (
     model.supportsVision &&
     outputItems.some((item) => isModelVisionImage(item))
   ) {
@@ -210,16 +238,19 @@ async function renderActionForMultiActionsModel(
         }
       }
     }
-    output = contentArray;
-  } else {
-    output = JSON.stringify(outputItems.map(compactResourceItem));
+    return {
+      role: "function" as const,
+      name: action.functionCallName,
+      function_call_id: action.functionCallId,
+      content: contentArray,
+    };
   }
 
   return {
     role: "function" as const,
     name: action.functionCallName,
     function_call_id: action.functionCallId,
-    content: output,
+    content: renderToolResultForModelAsText(action),
   };
 }
 

--- a/front/tests/utils/AgentMCPActionFactory.ts
+++ b/front/tests/utils/AgentMCPActionFactory.ts
@@ -90,6 +90,10 @@ export class AgentMCPActionFactory {
       mcpServerName: "test_server",
     };
 
+    // TODO(Adrien): Drop column if not used anymore.
+    // The action's stepContentId column is left null on purpose, mirroring production: the action is
+    // tied to its step content through the tool execution row below, not through this column. Setting
+    // it here would hide code paths that resolve the step content the real way.
     const action = await AgentMCPActionModel.create({
       workspaceId: workspace.id,
       agentMessageId: agentMessageModelId,
@@ -98,7 +102,6 @@ export class AgentMCPActionFactory {
       citationsAllocated: 0,
       augmentedInputs: {},
       toolConfiguration,
-      stepContentId: stepContent.id,
       stepContext: {
         citationsCount: 0,
         citationsOffset: 0,

--- a/front/tests/utils/AgentMCPActionFactory.ts
+++ b/front/tests/utils/AgentMCPActionFactory.ts
@@ -33,12 +33,14 @@ export class AgentMCPActionFactory {
       agentMessageModelId,
       status = "blocked_validation_required",
       step = 1,
+      dustRunId = null,
     }: {
       workspace: WorkspaceType;
       conversationModelId: ModelId;
       agentMessageModelId: ModelId;
       status?: ToolExecutionStatus;
       step?: number;
+      dustRunId?: string | null;
     }
   ): Promise<{
     action: AgentMCPActionResource;
@@ -52,6 +54,7 @@ export class AgentMCPActionFactory {
       step,
       index: currentIndex,
       version: 0,
+      dustRunId,
       type: "function_call",
       value: {
         type: "function_call",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Earlier PR taught consumption attribution to record how a settled agent message's cost breaks down across the model token buckets, meaning the prompt it read, the answer it generated, and the reasoning it spent. That left the tool calls invisible, folded anonymously into the output. This change makes each tool call its own line in the breakdown.

For every tool a message invokes, it now measures two footprints with the run model's exact tokenizer (expect some margin errors but it should provide a good representation and we could still call the providers' API), the same path conversation rendering uses to size messages. The first is the output the model spent emitting the call itself, its name and arguments. The second is the input that the tool's result occupied in the following prompt. The result footprint is measured against the exact text the model saw, which is now produced by a single shared routine so the estimate can never drift from what conversation rendering actually sent. Alongside those token footprints, each tool row also carries the tool's own direct credit charge. The tokens the model spent emitting a call are carved out of the assistant output bucket, so the pieces of a run still sum to the whole rather than double counting.

This remains analytics and not billing. The credit amounts are un-rounded and priced cache naive, they explain the relative composition of a cost rather than reproduce the invoice, and the authoritative charge is still computed elsewhere. The work runs once a message reaches a terminal state, launched from the analytics side, and it is idempotent, so a retry or a resumed message re-inserts the same identities as no-ops and only adds what is genuinely new. Because the whole breakdown is computed before anything is written, a tokenization failure leaves the previous state untouched and lets the retry start clean.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
