### PR TITLE
Store usage type of the runs

### DIFF
--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -5,6 +5,7 @@ import { getToolNameFromFunctionCallName } from "@app/lib/actions/tool_display_l
 import { makeFairUseAwuCreditsRateLimitKeyForUser } from "@app/lib/api/assistant/rate_limits";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
 import type { ToolCostCategory } from "@app/lib/api/mcp";
+import { isProgrammaticUsage } from "@app/lib/api/programmatic_usage/tracking";
 import { recordUserSpendLimitUsage } from "@app/lib/api/users/spend_limit";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -15,7 +16,6 @@ import {
   intelligenceAwuFromRunUsagesGroupedByRunKey,
   toolAwuFromActions,
 } from "@app/lib/metronome/events";
-import { isProgrammaticUsage } from "@app/lib/api/programmatic_usage/tracking";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { RunUsageType } from "@app/lib/resources/run_resource";

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -11,9 +11,11 @@ import { getFeatureFlags } from "@app/lib/auth";
 import {
   computeRunKey,
   getToolBillingInfo,
+  getUsageType,
   intelligenceAwuFromRunUsagesGroupedByRunKey,
   toolAwuFromActions,
 } from "@app/lib/metronome/events";
+import { isProgrammaticUsage } from "@app/lib/api/programmatic_usage/tracking";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
@@ -249,8 +251,25 @@ export async function computeAndStoreAgentMessageCredits(
     });
   }
 
+  // Fetch the message's runs once — reused to compute cost and to tag usage type.
+  const runs = await RunResource.listByDustRunIds(auth, {
+    dustRunIds: [...new Set(runIds ?? [])],
+  });
+
+  // Persist the billing usage type on the run usages so free/user/programmatic
+  // consumption can be queried directly (e.g. free-usage monitoring). Reuses the
+  // same origin-based classification as the Metronome events.
+  const messageOrigin = triggeringUserMessageOrigin ?? "web";
+  await RunResource.setUsageTypeForRuns(auth, {
+    runs,
+    usageType: getUsageType(
+      isProgrammaticUsage(auth, { userMessageOrigin: messageOrigin }),
+      messageOrigin
+    ),
+  });
+
   const [runUsages, actions] = await Promise.all([
-    fetchRunUsagesForAgentMessage(auth, runIds),
+    RunResource.listRunUsagesForRuns(auth, { runs }),
     AgentMCPActionResource.listByAgentMessageIds(auth, [agentMessageModelId]),
   ]);
 
@@ -321,19 +340,4 @@ export async function computeAndStoreAgentMessageCredits(
   }
 
   return costCredits;
-}
-
-async function fetchRunUsagesForAgentMessage(
-  auth: Authenticator,
-  runIds: string[] | null
-): Promise<(RunUsageType & { runKey: string | null })[]> {
-  const dustRunIds = [...new Set(runIds ?? [])];
-  if (dustRunIds.length === 0) {
-    return [];
-  }
-
-  // All runs are fetched from this message's own runIds, so every usage they
-  // produce belongs to this message.
-  const runs = await RunResource.listByDustRunIds(auth, { dustRunIds });
-  return RunResource.listRunUsagesForRuns(auth, { runs });
 }

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -1,5 +1,4 @@
 import config from "@app/lib/api/config";
-import { USAGE_TYPE_FREE } from "@app/lib/metronome/constants";
 import type { LLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import {
   createLLMTraceId,
@@ -27,6 +26,7 @@ import { emitTokenUsageMetrics } from "@app/lib/api/llm/usage_metrics";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustBatchEndpointConstructor } from "@app/lib/llms/batch/dust_batch_endpoint";
 import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { USAGE_TYPE_FREE } from "@app/lib/metronome/constants";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { getStatsDClient } from "@app/lib/utils/statsd";

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -1,4 +1,5 @@
 import config from "@app/lib/api/config";
+import { USAGE_TYPE_FREE } from "@app/lib/metronome/constants";
 import type { LLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import {
   createLLMTraceId,
@@ -360,19 +361,32 @@ export abstract class LLM<
           workspaceId: this.authenticator.getNonNullableWorkspace().id,
         });
 
+        // Classify usage at creation for internal/utility LLM operations
+        // (everything except the agent conversation itself): they are never
+        // billed and never processed by the usage queue, so they are free.
+        // agent_conversation runs are left untagged here and classified
+        // (free/user/programmatic) by the usage queue, which knows the
+        // triggering message origin.
+        const usageType =
+          this.context.operationType === "agent_conversation"
+            ? undefined
+            : USAGE_TYPE_FREE;
+
         // Run usage is only populated if the run is successful.
         if (buffer.runTokenUsage) {
           await run.recordTokenUsage(
             this.authenticator,
             buffer.runTokenUsage,
             this.modelId,
-            { inferenceRegion: this.metadata.inferenceRegion }
+            { inferenceRegion: this.metadata.inferenceRegion, usageType }
           );
         }
 
         const simulatedRunUsages = this.getSimulatedRunUsages();
         if (simulatedRunUsages) {
-          await run.recordRunUsage(this.authenticator, simulatedRunUsages);
+          await run.recordRunUsage(this.authenticator, simulatedRunUsages, {
+            usageType,
+          });
         }
 
         yield currentEvent;

--- a/front/lib/resources/run_resource.test.ts
+++ b/front/lib/resources/run_resource.test.ts
@@ -60,3 +60,38 @@ describe("RunResource reasoning token usage", () => {
     expect(usages[0]?.reasoningTokens).toBeNull();
   });
 });
+
+describe("RunResource.setUsageTypeForRuns", () => {
+  it("stamps the usage type on the run's usage rows", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const run = await RunResource.makeNew({
+      appId: null,
+      dustRunId: generateRandomModelSId(),
+      runType: "deploy",
+      useWorkspaceCredentials: false,
+      workspaceId: workspace.id,
+    });
+
+    await run.recordTokenUsage(
+      auth,
+      {
+        inputTokens: 1_000,
+        totalOutputTokens: 100,
+        totalTokens: 1_100,
+      },
+      GPT_5_MINI_MODEL_CONFIG.modelId
+    );
+
+    await RunResource.setUsageTypeForRuns(auth, {
+      runs: [run],
+      usageType: "free",
+    });
+
+    const usages = await RunResource.listRunUsagesForRuns(auth, {
+      runs: [run],
+    });
+
+    expect(usages).toHaveLength(1);
+    expect(usages[0]?.usageType).toBe("free");
+  });
+});

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -5,6 +5,7 @@ import {
 import type { TokenUsage } from "@app/lib/api/llm/types/events";
 import type { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
+import type { UsageType } from "@app/lib/metronome/types";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { AppModel } from "@app/lib/resources/storage/models/apps";
 import {
@@ -55,6 +56,7 @@ interface RunUsageWithRunKeyType extends RunUsageType {
   runKey: string | null;
   runUsageModelId: ModelId;
   runModelId: ModelId;
+  usageType: UsageType | null;
 }
 
 type FetchRunOptions<T extends boolean> = {
@@ -213,6 +215,26 @@ export class RunResource extends BaseResource<RunModel> {
     );
   }
 
+  // Stamp the billing usage type onto the usage rows of the given runs.
+  static async setUsageTypeForRuns(
+    auth: Authenticator,
+    { runs, usageType }: { runs: RunResource[]; usageType: UsageType }
+  ): Promise<void> {
+    const runModelIds = runs.map((run) => run.id);
+    if (runModelIds.length === 0) {
+      return;
+    }
+    await RunUsageModel.update(
+      { usageType },
+      {
+        where: {
+          runId: { [Op.in]: runModelIds },
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+      }
+    );
+  }
+
   static async listRunUsagesForRuns(
     auth: Authenticator,
     {
@@ -253,6 +275,7 @@ export class RunResource extends BaseResource<RunModel> {
       cacheCreationTokens: usage.cacheCreationTokens,
       costMicroUsd: usage.costMicroUsd,
       isBatch: usage.isBatch,
+      usageType: usage.usageType,
     }));
   }
 
@@ -365,7 +388,15 @@ export class RunResource extends BaseResource<RunModel> {
    * Run usage.
    */
 
-  async recordRunUsage(auth: Authenticator, usages: RunUsageType[]) {
+  // `usageType` tags the created rows with their billing usage type. Pass it for
+  // operations whose type is known at creation (e.g. internal/utility LLM calls
+  // are free); leave it undefined for agent-conversation runs, which the usage
+  // queue classifies from the triggering message origin.
+  async recordRunUsage(
+    auth: Authenticator,
+    usages: RunUsageType[],
+    { usageType }: { usageType?: UsageType } = {}
+  ) {
     await RunUsageModel.bulkCreate(
       usages.map(
         ({
@@ -390,6 +421,7 @@ export class RunResource extends BaseResource<RunModel> {
           cacheCreationTokens: cacheCreationTokens ?? null,
           costMicroUsd,
           isBatch,
+          usageType: usageType ?? null,
         })
       )
     );
@@ -447,7 +479,12 @@ export class RunResource extends BaseResource<RunModel> {
     {
       isBatch = false,
       inferenceRegion = "global",
-    }: { isBatch?: boolean; inferenceRegion?: InferenceRegionType } = {}
+      usageType,
+    }: {
+      isBatch?: boolean;
+      inferenceRegion?: InferenceRegionType;
+      usageType?: UsageType;
+    } = {}
   ) {
     const modelConfig = getModelConfigByModelId(modelId);
 
@@ -469,19 +506,23 @@ export class RunResource extends BaseResource<RunModel> {
       inferenceRegion,
     });
 
-    return this.recordRunUsage(auth, [
-      {
-        cacheCreationTokens: usage.cacheCreationTokens,
-        cachedTokens: usage.cachedTokens ?? null,
-        completionTokens: usage.totalOutputTokens,
-        reasoningTokens: usage.reasoningTokens ?? null,
-        modelId: modelConfig.modelId,
-        promptTokens: usage.inputTokens,
-        providerId: modelConfig.providerId,
-        costMicroUsd: usageCostMicroUsd,
-        isBatch,
-      },
-    ]);
+    return this.recordRunUsage(
+      auth,
+      [
+        {
+          cacheCreationTokens: usage.cacheCreationTokens,
+          cachedTokens: usage.cachedTokens ?? null,
+          completionTokens: usage.totalOutputTokens,
+          reasoningTokens: usage.reasoningTokens ?? null,
+          modelId: modelConfig.modelId,
+          promptTokens: usage.inputTokens,
+          providerId: modelConfig.providerId,
+          costMicroUsd: usageCostMicroUsd,
+          isBatch,
+        },
+      ],
+      { usageType }
+    );
   }
 
   async listRunUsages(auth: Authenticator): Promise<RunUsageType[]> {

--- a/front/lib/resources/storage/models/runs.ts
+++ b/front/lib/resources/storage/models/runs.ts
@@ -1,3 +1,4 @@
+import type { UsageType } from "@app/lib/metronome/types";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { AppModel } from "@app/lib/resources/storage/models/apps";
@@ -85,6 +86,13 @@ export class RunUsageModel extends WorkspaceAwareModel<RunUsageModel> {
 
   declare costMicroUsd: number;
   declare isBatch: boolean;
+  // Billing usage type (free / user / programmatic). Internal/utility LLM
+  // operations are tagged free at creation (they are never billed); agent
+  // conversation runs are tagged by the usage queue from the triggering
+  // message's origin via getUsageType. Nullable: agent conversation rows are
+  // briefly null between creation and the usage queue, and legacy/app runs are
+  // never tagged.
+  declare usageType: UsageType | null;
 }
 
 RunUsageModel.init(
@@ -129,6 +137,11 @@ RunUsageModel.init(
       type: DataTypes.BOOLEAN,
       defaultValue: false,
       allowNull: false,
+    },
+    usageType: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
     },
   },
   {

--- a/front/migrations/pre-deploy/20260731154825_add_usage_type_to_run_usages.sql
+++ b/front/migrations/pre-deploy/20260731154825_add_usage_type_to_run_usages.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."run_usages" ADD COLUMN "usageType" character varying(255) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying;


### PR DESCRIPTION
## Description

Storing all the run usage type (user / programmatic / free) so we can track the actual free consumption of the users.

The new column is nullable for 2 reasons:
 - conversations run stay null for ashort while until after the run when have access to the usage type depending on the origin 
 - we don't backfill the past data (would be very expensive query for no benefit)

## Tests

testd manually + added unit tests

## Risk

low

## Deploy Plan

lock front
merge
pre deploy script
deploy front
unlock front