### PR TITLE
Remove obsolete branchId args from front-api message routes.

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -141,8 +141,6 @@ app.post(
       });
     }
 
-    const branchId = messageModel.getBranchId() ?? null;
-
     const renderRes = await batchRenderMessages(
       auth,
       conversationResource,
@@ -174,7 +172,6 @@ app.post(
 
     const editedMessageRes = await editUserMessage(auth, {
       conversationResource,
-      branchId,
       message,
       content,
       mentions,

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -84,8 +84,6 @@ app.post(
       });
     }
 
-    const branchId = messageModel.getBranchId() ?? null;
-
     const renderRes = await batchRenderMessages(
       auth,
       conversationResource,
@@ -115,7 +113,6 @@ app.post(
 
     const retriedMessageRes = await retryAgentMessage(auth, {
       conversationResource,
-      branchId,
       message,
     });
     if (retriedMessageRes.isErr()) {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -137,8 +137,6 @@ app.post(
       });
     }
 
-    const branchId = messageModel.getBranchId() ?? null;
-
     const renderRes = await batchRenderMessages(
       auth,
       conversationResource,
@@ -171,7 +169,6 @@ app.post(
 
     const editedMessageRes = await editUserMessage(auth, {
       conversationResource,
-      branchId,
       message,
       content,
       mentions,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
@@ -223,11 +223,7 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
     });
   }
 
-  const branchId = message.getBranchId() ?? null;
-  const conversation = {
-    ...conversationResource.toJSON(),
-    branchId,
-  };
+  const conversation = conversationResource.toJSON();
 
   const renderRes = await batchRenderMessages(
     auth,
@@ -251,7 +247,6 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
     const deleteResult = await softDeleteUserMessageAndReplies(auth, {
       message: renderedMessage,
       conversationResource,
-      branchId,
     });
     if (deleteResult.isErr()) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -103,11 +103,7 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
     });
   }
 
-  const branchId = messageModel.getBranchId() ?? null;
-  const conversation = {
-    ...conversationResource.toJSON(),
-    branchId,
-  };
+  const conversation = conversationResource.toJSON();
 
   const renderRes = await batchRenderMessages(
     auth,
@@ -175,7 +171,6 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
 
   const retriedMessageRes = await retryAgentMessage(auth, {
     conversationResource,
-    branchId,
     message,
   });
   if (retriedMessageRes.isErr()) {


### PR DESCRIPTION
## Description

Follow-up to the `ConversationBranch` removal: drops leftover `branchId` arguments from the front-api `edit`, `retry`, and `delete` message route handlers. `editUserMessage`, `retryAgentMessage`, and `softDeleteUserMessageAndReplies` no longer accept `branchId`, so these call sites were breaking `tsgo` type-checking. Also removes the `conversation` spread that injected `branchId` into the object passed to `batchRenderMessages` in the `w/` (non-v1) routes.

## Tests

Dead-code removal with no logic change — verified that `tsgo` compilation passes after the cleanup.

## Risk

Low. Removes arguments that are no longer accepted by the callee signatures; no behavior change at runtime since `branchId` was already hardcoded to `null` across the agent loop.

## Deploy Plan

Deploy front-api.
