### PR TITLE
db: udpate default skill version availability

### DIFF
--- a/front/migrations/pre-deploy/20260731172006_skill_version_default_availability.sql
+++ b/front/migrations/pre-deploy/20260731172006_skill_version_default_availability.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_versions" ALTER COLUMN "availability" SET DEFAULT 'editors'::character varying;


### PR DESCRIPTION
## Description

This PR updates the default value of the `availability` column on the `skill_versions` table to `'editors'`.

## Tests

Manually.

## Risks

Low. The migration only changes the default value for new rows and does not affect existing data. It is easily reversible by resetting the default.

## Deploy Plan

Run the migration.