### PR TITLE
Tell the model to copy skill names verbatim in the equipped-skills list

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/helpers.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.test.ts
@@ -221,7 +221,7 @@ The following skills are available for use with the skill_management__enable_ski
 - \`commit\`: Create a git commit with a descriptive message.
 - \`review-pr\`: Review a pull request for code quality and correctness.
 
-Pass \`skillName\` exactly as written between backticks above: same case, same punctuation, and including any leading \`[Category]\` prefix. Do not add brackets, invent a prefix, or otherwise reformat the name. Names are matched exactly, so a modified name will not be found.
+Pass \`skillName\` exactly as written between backticks above, character for character: same case, same spacing, same punctuation, same prefixes and suffixes. Copy the name rather than retyping it, and do not adjust it to match how other skills in the list are named. Names are matched exactly, so a modified name will not be found.
 </dust_system>`,
         },
       ],

--- a/front/lib/api/assistant/conversation_rendering/helpers.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.test.ts
@@ -218,8 +218,10 @@ describe("skill rendering helpers", () => {
           text: `<dust_system>
 The following skills are available for use with the skill_management__enable_skill tool:
 
-- **commit**: Create a git commit with a descriptive message.
-- **review-pr**: Review a pull request for code quality and correctness.
+- \`commit\`: Create a git commit with a descriptive message.
+- \`review-pr\`: Review a pull request for code quality and correctness.
+
+Pass \`skillName\` exactly as written between backticks above: same case, same punctuation, and including any leading \`[Category]\` prefix. Do not add brackets, invent a prefix, or otherwise reformat the name. Names are matched exactly, so a modified name will not be found.
 </dust_system>`,
         },
       ],

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -197,7 +197,7 @@ function constructSkillsSection({
     `Skill references can also appear as \`<skill id=\"...\" name=\"...\" />\` tags in user messages or enabled skill instructions. ` +
     "These tags are strong hints that the referenced skill is relevant, including when a skill author nested one skill inside another. " +
     `You can enable the skill using \`${toolDisplayName}\` with \`skillName\` set to the tag's \`name\` value, copied verbatim.\n` +
-    "Skill names are matched exactly. Always copy the name character for character from the available-skills list or the tag, and never reformat, re-case, or add a bracketed prefix to it.\n" +
+    "Skill names are matched exactly. Always copy the name character for character from the available-skills list or the tag, and never reformat or re-case it.\n" +
     "It is not useful to enable skills that are already enabled, this would only output the skill's content again.\n" +
     "Referenced skills may not appear in the available-skills list; a tag is enough to enable the skill by name. " +
     "Only enable skills you actually need, because enabling a skill loads its full instructions into context.\n" +

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -196,7 +196,8 @@ function constructSkillsSection({
     "Enable skills proactively when a user's request matches a skill's purpose.\n" +
     `Skill references can also appear as \`<skill id=\"...\" name=\"...\" />\` tags in user messages or enabled skill instructions. ` +
     "These tags are strong hints that the referenced skill is relevant, including when a skill author nested one skill inside another. " +
-    `You can enable the skill using \`${toolDisplayName}\` with \`skillName\` set to the tag's \`name\` value.\n` +
+    `You can enable the skill using \`${toolDisplayName}\` with \`skillName\` set to the tag's \`name\` value, copied verbatim.\n` +
+    "Skill names are matched exactly. Always copy the name character for character from the available-skills list or the tag, and never reformat, re-case, or add a bracketed prefix to it.\n" +
     "It is not useful to enable skills that are already enabled, this would only output the skill's content again.\n" +
     "Referenced skills may not appear in the available-skills list; a tag is enough to enable the skill by name. " +
     "Only enable skills you actually need, because enabling a skill loads its full instructions into context.\n" +

--- a/front/lib/api/assistant/skills_rendering.ts
+++ b/front/lib/api/assistant/skills_rendering.ts
@@ -43,9 +43,9 @@ export function renderEquippedSkillsUserMessage(
 
   const enableSkillToolName = `${SKILL_MANAGEMENT_SERVER_NAME}${TOOL_NAME_SEPARATOR}${ENABLE_SKILL_TOOL_NAME}`;
   // Names are rendered as code literals rather than bold text: `skillName` is matched exactly, and
-  // a literal is copied verbatim far more reliably than prose. Workspaces often name skills with a
-  // `[Category] Title` convention, and models otherwise regenerate names to fit that pattern —
-  // wrapping an unbracketed name, or inventing a category prefix — which never resolves.
+  // a literal is copied verbatim far more reliably than prose. Workspaces tend to develop their own
+  // naming conventions, and models otherwise regenerate names to fit the pattern they infer from
+  // the list instead of copying them, which never resolves.
   const lines = equippedSkills.map(
     ({ name, agentFacingDescription }) =>
       `- \`${name}\`: ${agentFacingDescription.replaceAll("\n", "\n  ")}`
@@ -55,10 +55,10 @@ export function renderEquippedSkillsUserMessage(
     `<dust_system>\n` +
       `The following skills are available for use with the ${enableSkillToolName} tool:\n\n` +
       `${lines.join("\n")}\n\n` +
-      `Pass \`skillName\` exactly as written between backticks above: same case, same ` +
-      `punctuation, and including any leading \`[Category]\` prefix. Do not add brackets, ` +
-      `invent a prefix, or otherwise reformat the name. Names are matched exactly, so a ` +
-      `modified name will not be found.\n` +
+      `Pass \`skillName\` exactly as written between backticks above, character for character: ` +
+      `same case, same spacing, same punctuation, same prefixes and suffixes. Copy the name ` +
+      `rather than retyping it, and do not adjust it to match how other skills in the list are ` +
+      `named. Names are matched exactly, so a modified name will not be found.\n` +
       `</dust_system>`
   );
 }

--- a/front/lib/api/assistant/skills_rendering.ts
+++ b/front/lib/api/assistant/skills_rendering.ts
@@ -42,15 +42,23 @@ export function renderEquippedSkillsUserMessage(
   }
 
   const enableSkillToolName = `${SKILL_MANAGEMENT_SERVER_NAME}${TOOL_NAME_SEPARATOR}${ENABLE_SKILL_TOOL_NAME}`;
+  // Names are rendered as code literals rather than bold text: `skillName` is matched exactly, and
+  // a literal is copied verbatim far more reliably than prose. Workspaces often name skills with a
+  // `[Category] Title` convention, and models otherwise regenerate names to fit that pattern —
+  // wrapping an unbracketed name, or inventing a category prefix — which never resolves.
   const lines = equippedSkills.map(
     ({ name, agentFacingDescription }) =>
-      `- **${name}**: ${agentFacingDescription.replaceAll("\n", "\n  ")}`
+      `- \`${name}\`: ${agentFacingDescription.replaceAll("\n", "\n  ")}`
   );
 
   return renderSystemSkillMessage(
     `<dust_system>\n` +
       `The following skills are available for use with the ${enableSkillToolName} tool:\n\n` +
-      `${lines.join("\n")}\n` +
+      `${lines.join("\n")}\n\n` +
+      `Pass \`skillName\` exactly as written between backticks above: same case, same ` +
+      `punctuation, and including any leading \`[Category]\` prefix. Do not add brackets, ` +
+      `invent a prefix, or otherwise reformat the name. Names are matched exactly, so a ` +
+      `modified name will not be found.\n` +
       `</dust_system>`
   );
 }


### PR DESCRIPTION
## Problem

`enable_skill` resolves `skillName` by exact, case-sensitive string equality — `skill.name === skillName` in `findAvailableSkillForAgentLoop`, and an exact SQL match in the `fetchByName` fallback. No trim, no case folding, no fuzzy fallback. On a miss it returns a bare `Skill "X" not found` with no candidate list.

Nothing in the prompt said any of that. There was no "verbatim" instruction anywhere in `skills_rendering.ts`, `generation.ts`, `discover_skills`, or the tool description.

The catalogue rendered each entry as `- **Name**: description`. In workspaces that name skills with a `[Category] Title` convention, models stop copying the string and start regenerating it to fit the pattern. Observed in production, all in one workspace where 64 of 124 discoverable names are bracketed:

| asked | actual skill | mutation |
|---|---|---|
| `[Pod Functions]` | `Pod Functions` | wrapped |
| `[Business Case - Company Overview]` | `Business Case - Company Overview` | wrapped |
| `[Support] Support Knowledge Lookup` | `Support Knowledge Lookup` | prefix invented |
| `[CX] Userstone of voice-Mail` | `CX_Userstone of voice-Mail` | separator rewritten |
| `[Team] Team Context` | `[GTM] Team Context` | wrong category |

Each of these skills existed and was in the list the model had been given.

## Change

- Render names as code literals (`` - `Pod Functions`: … ``) rather than bold text. Models copy backticked literals verbatim far more reliably than bolded prose, and it delimits the name from the description — which matters because many descriptions are multi-line.
- Add an explicit instruction in the same `<dust_system>` block, adjacent to the names rather than tens of thousands of characters away in the system prompt, naming the specific mutations rather than a generic "be exact".
- Add "copied verbatim" plus an exact-match note to the `<skill id="..." name="..." />` guidance in `constructSkillsSection`.

## Scope

This is mitigation, not a fix. The model is reconstructing names from an inferred schema, and an instruction competes with that rather than making it impossible. Accepting the skill `sId` — which the toolsets catalogue already exposes as `` (toolsetId: `sId`) `` right next to this one — is what would make the failure mode unreachable. Worth doing separately.

## Test

Updated the `renderEquippedSkillsUserMessage` expectation in `conversation_rendering/helpers.test.ts`. Rendering, generation, run_model, and skill_management suites pass; typecheck clean.