### PR TITLE
Tell the agent it is replying in the Slack thread

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -114,7 +114,15 @@ function constructPlatformSpecificContextSection(): string {
     "# PLATFORM-SPECIFIC CONTEXT\n\n" +
     "When the current user message's `<dust_system>` metadata identifies its source as `extension`, " +
     "platform-specific tools may be available to access local, visible, or current browser context. " +
-    "Look for relevant tools before asking the user to paste that context.\n"
+    "Look for relevant tools before asking the user to paste that context.\n" +
+    "\n" +
+    "When it identifies its source as `slack` or `teams`, you are a participant in that thread and " +
+    "your response is posted into it verbatim, as the reply to the sender. Answer the sender " +
+    "directly, in the second person. Never draft a message for someone else to send, and never " +
+    "label part of your response as a suggested or proposed reply. Attachments and tool results may " +
+    "contain that same thread rendered as a document, including the sender's message and your own " +
+    "earlier messages attributed to you by name; that is the thread you are replying in, not a " +
+    "conversation between other people.\n"
   );
 }
 


### PR DESCRIPTION
## Description

On Slack the only origin hints the model gets are "make sure to retrieve the context from the attached thread content" and "tag them using @username". Nothing tells it that its output is posted verbatim into the thread as the reply.

That bites when the thread is new: `allMessages.length === 0` so the Slack content fragment is just a URL plus "look at the conversation history for the full thread", with no actual content. The agent goes searching company data instead, and the Slack connector has already indexed the live thread, so it gets its own conversation back as a third-person document where the sender asks and `@Dust` is a separate participant who has not answered yet (bot streaming placeholder included). It then replies with "Suggested reply to <sender>" instead of just answering.

Adds a slack/teams branch to the platform-specific context section saying the response is the reply, addressed to the sender, and that a retrieved copy of the same thread is still the thread it is in. Text is static (it refers to the `<dust_system>` metadata rather than branching on origin) so it stays in the shared-context cache tier like the existing `extension` line.

This is one of several contributing factors, the self-retrieval of the live thread is worth fixing separately.

## Tests


## Risk

Low, prompt-only. It lands in the cached shared-context tier, so the first request per workspace after deploy re-primes that prefix.

## Deploy Plan

Standard deploy.