### PR TITLE
feat: enforce per-user credit limit on any plans

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -64,7 +64,10 @@ import {
 } from "@app/lib/api/programmatic_usage/tracking";
 import { fetchLatestProjectContextFileContentFragment } from "@app/lib/api/projects/context";
 import { config as regionConfig } from "@app/lib/api/regions/config";
-import { isUserSpendLimitRateCapReached } from "@app/lib/api/users/spend_limit";
+import {
+  isNonCreditPricedUserSpendLimitReached,
+  isUserSpendLimitRateCapReached,
+} from "@app/lib/api/users/spend_limit";
 import { isModelAvailable } from "@app/lib/assistant";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
@@ -2523,13 +2526,18 @@ async function checkMessagesLimit(
   //   For API calls (no user), only the workspace pool applies via `isApiBlocked`.
   //   Pool-balance concurrency limiting (`checkPoolCreditConcurrencyLimit`) prevents
   //   close-to-0 attacks where many requests overshoot the pool before debits settle.
-  // - Legacy plans: programmatic credits checked via `checkProgrammaticUsageLimits`,
-  //   plus a credit-balance-scaled pre-emptive rate limit (`checkProgrammaticUsageRateLimit`).
+  // - Legacy plans: a per-user credit limit checked from the Redis fixed-window
+  //   counter (`isNonCreditPricedUserSpendLimitReached`), plus programmatic credits
+  //   checked via `checkProgrammaticUsageLimits` and a credit-balance-scaled
+  //   pre-emptive rate limit (`checkProgrammaticUsageRateLimit`).
   const owner = auth.getNonNullableWorkspace();
   const plan = auth.subscription()?.plan;
   const user = auth.user();
+  const isCreditPricedWorkspace = Boolean(
+    owner.metronomeCustomerId && plan && isCreditPricedPlan(plan)
+  );
 
-  if (owner.metronomeCustomerId && plan && isCreditPricedPlan(plan)) {
+  if (isCreditPricedWorkspace) {
     const blockedReason = user
       ? await isUserBlocked(owner, user)
       : (await isApiBlocked(owner.sId))
@@ -2669,7 +2677,33 @@ async function checkMessagesLimit(
         });
       }
     }
-  } else if (isProgrammaticUsage(auth, { userMessageOrigin: context.origin })) {
+  } else if (user && !isFreeOrigin(context.origin)) {
+    // Non-credit-priced plans: no workspace pool and no Metronome per-user cap,
+    // so the per-user credit limit is enforced solely from the Redis fixed-window
+    // counter, bucketed on the UTC calendar month. Admin-set (poke) workspace
+    // default, overridable per member. Free origins produce no billable usage,
+    // and API keys have no per-user limit (they are gated by the programmatic
+    // caps below). Flag-gated while we validate the counter; usage is recorded
+    // regardless (in credit_cost), so the flag only controls blocking.
+    const featureFlags = await getFeatureFlags(auth);
+    if (
+      featureFlags.includes("enforce_user_spend_limit_rate_cap") &&
+      (await isNonCreditPricedUserSpendLimitReached(auth, { user }))
+    ) {
+      return new Err({
+        status_code: 403,
+        api_error: {
+          type: "user_cap_reached",
+          message: "You have reached your personal usage cap.",
+        },
+      });
+    }
+  }
+
+  if (
+    !isCreditPricedWorkspace &&
+    isProgrammaticUsage(auth, { userMessageOrigin: context.origin })
+  ) {
     const limitsResult = await checkProgrammaticUsageLimits(auth);
     if (limitsResult.isErr()) {
       return new Err({

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -18,6 +18,7 @@ import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_reso
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
+import { spendLimitCycleOverrideForAuth } from "@app/lib/spend_limits/cycle";
 import {
   addRateLimiterCount,
   getTimeframeSecondsFromLiteral,
@@ -310,12 +311,16 @@ export async function computeAndStoreAgentMessageCredits(
   // limiter above. Gated behind the same feature flag as enforcement so the
   // counter only accrues where the backup is active; enforcement happens
   // pre-message in `checkMessagesLimit`.
+  // The cycle override keeps the counter on the same window
+  // enforcement reads: the contract billing period on credit-priced plans, the
+  // UTC calendar month elsewhere (no contract to anchor on).
   if (user && recordedCostDelta > 0) {
     const featureFlags = await getFeatureFlags(auth);
     if (featureFlags.includes("enforce_user_spend_limit_rate_cap")) {
       await recordUserSpendLimitUsage(auth, {
         user,
         incrementBy: recordedCostDelta,
+        cycle: spendLimitCycleOverrideForAuth(auth),
       });
     }
   }

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -4,6 +4,7 @@ import {
 } from "@app/lib/api/assistant/rate_limits";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
+import type { BillingCycle } from "@app/lib/client/subscription";
 import { listPerUserCreditBalanceAlertsForWorkspace } from "@app/lib/metronome/alerts/per_user_credit_balance";
 import type {
   MetronomeCapAlertIds,
@@ -45,6 +46,7 @@ import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usag
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { spendLimitCycleOverrideForAuth } from "@app/lib/spend_limits/cycle";
 import type { EffectiveSpendLimitSource } from "@app/lib/spend_limits/effective";
 import {
   resolveEffectiveSpendLimitAwuCredits,
@@ -240,6 +242,24 @@ async function fetchCreditsResetAt(
   return periodResult.value?.cycleEnd.toISOString() ?? null;
 }
 
+// The workspace's current Metronome contract billing period, or null when it
+// cannot be resolved (no contract, or a Metronome failure).
+async function resolveMetronomeCycle(
+  workspace: LightWorkspaceType
+): Promise<BillingCycle | null> {
+  const periodResult = await getCachedMetronomeCurrentBillingPeriod(
+    workspace.sId
+  );
+  if (periodResult.isErr()) {
+    logger.warn(
+      { err: periodResult.error, workspaceId: workspace.sId },
+      "[MembersUsage] Failed to resolve billing period"
+    );
+    return null;
+  }
+  return periodResult.value;
+}
+
 // Per-user consumed AWU credits for the current billing cycle, summed from the
 // analytics index (`cost.billable_awu`, precomputed at index time) by Elasticsearch.
 // This replaces the per-user Metronome usage scan that previously dominated the
@@ -258,33 +278,30 @@ async function fetchCreditsResetAt(
 // non-error work (0 when the only/last execution errored). This matches Metronome
 // without a status filter. Returns an empty map on any failure so the table still
 // renders (the consumed column shows 0).
+//
+// `cycle` forces the window instead of resolving the Metronome contract billing
+// period — used by workspaces that have no contract to anchor one on (see
+// `spendLimitCycleOverrideForAuth`).
 async function fetchConsumedAwuCreditsByUserId({
   workspace,
   userIds,
   freeSeatUserIds,
+  cycle,
 }: {
   workspace: LightWorkspaceType;
   userIds: string[];
   freeSeatUserIds: string[];
+  cycle?: BillingCycle;
 }): Promise<Map<string, number>> {
   if (userIds.length === 0) {
     return new Map();
   }
 
-  const periodResult = await getCachedMetronomeCurrentBillingPeriod(
-    workspace.sId
-  );
-  if (periodResult.isErr()) {
-    logger.warn(
-      { err: periodResult.error, workspaceId: workspace.sId },
-      "[MembersUsage] Failed to resolve billing period for consumed credits"
-    );
+  const resolvedCycle = cycle ?? (await resolveMetronomeCycle(workspace));
+  if (!resolvedCycle) {
     return new Map();
   }
-  if (!periodResult.value) {
-    return new Map();
-  }
-  const { cycleStart, cycleEnd } = periodResult.value;
+  const { cycleStart, cycleEnd } = resolvedCycle;
 
   const freeSeatUserIdSet = new Set(freeSeatUserIds);
 
@@ -371,7 +388,7 @@ async function fetchConsumedAwuCreditsByUserId({
  */
 export async function getEsConsumedAwuCreditsForUser(
   auth: Authenticator,
-  { user }: { user: UserResource }
+  { user, cycle }: { user: UserResource; cycle?: BillingCycle }
 ): Promise<number> {
   const workspace = auth.getNonNullableWorkspace();
   const membership =
@@ -384,6 +401,7 @@ export async function getEsConsumedAwuCreditsForUser(
     workspace,
     userIds: [user.sId],
     freeSeatUserIds,
+    cycle,
   });
   return consumedByUserId.get(user.sId) ?? 0;
 }
@@ -958,31 +976,87 @@ export async function getEffectiveSpendCapAwuCreditsForUser(
 }
 
 /**
+ * Resolves a single user's effective per-user spend cap in AWU credits on a
+ * workspace that is *not* on a credit-priced plan. Same precedence as
+ * `getEffectiveSpendCapAwuCreditsForUser` (per-user override > max group cap >
+ * workspace default) but resolved entirely from Postgres — no Metronome, since
+ * these workspaces have no contract to read seat allowances from.
+ *
+ * Consequences of having no contract:
+ *   - No seat allowance is added to any of the three values.
+ *   - A workspace default of 0 means "not configured", not "no pool access":
+ *     `defaultPoolCapAwuCredits` is `NOT NULL DEFAULT 0`, so every credit-usage
+ *     configuration row created for an unrelated reason (a discount, a usage cap)
+ *     carries a 0 that would otherwise cap every member at zero credits.
+ *
+ * Returns `null` when no cap applies.
+ */
+export async function getNonCreditPricedSpendCapAwuCreditsForUser(
+  auth: Authenticator,
+  { user }: { user: UserResource }
+): Promise<number | null> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const membership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user,
+      workspace,
+    });
+  if (!membership) {
+    return null;
+  }
+
+  const [creditUsageConfig, groupCapByUserModelId] = await Promise.all([
+    CreditUsageConfigurationResource.fetchByWorkspaceId(auth),
+    GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
+      workspace,
+      userModelIds: [user.id],
+    }),
+  ]);
+
+  // "none" seat users have no pool access, so their override is irrelevant.
+  const overrideAwuCredits =
+    membership.seatType !== "none"
+      ? membership.poolCapOverrideAwuCredits
+      : null;
+
+  const defaultPoolCapAwuCredits =
+    creditUsageConfig?.defaultPoolCapAwuCredits ?? 0;
+
+  return resolveEffectiveSpendLimitAwuCredits({
+    overrideAwuCredits,
+    groupCapAwuCredits: groupCapByUserModelId.get(user.id) ?? null,
+    defaultAwuCredits:
+      defaultPoolCapAwuCredits > 0 ? defaultPoolCapAwuCredits : null,
+  });
+}
+
+/**
  * Backfills/resyncs every active member's Redis fixed-window spend-cap counter
  * for the current billing cycle from the authoritative Elasticsearch usage,
  * overwriting the counter (SET) so it matches ES. Use after enabling the cap or
  * to repair drift (the counter otherwise only accrues from live messages and
  * starts at 0 mid-cycle). Returns the number of users whose counter was written.
+ *
+ * Resyncs whichever cycle the workspace is bucketed on — the Metronome contract
+ * billing period, or the UTC calendar month for workspaces without a contract —
+ * so it writes the same Redis keys enforcement reads.
  */
 export async function resyncSpendLimitCountersFromEsUsage(
   auth: Authenticator
 ): Promise<Result<{ updatedUserCount: number }, Error>> {
   const workspace = auth.getNonNullableWorkspace();
 
-  const periodResult = await getCachedMetronomeCurrentBillingPeriod(
-    workspace.sId
-  );
-  if (periodResult.isErr()) {
-    return new Err(periodResult.error);
-  }
-  if (!periodResult.value) {
+  const cycleOverride = spendLimitCycleOverrideForAuth(auth);
+  const cycle = cycleOverride ?? (await resolveMetronomeCycle(workspace));
+  if (!cycle) {
     return new Err(
       new Error("No active Metronome billing period to resync against.")
     );
   }
   const bounds = makeSpendLimitCycleWindowBounds(
-    periodResult.value.cycleStart,
-    periodResult.value.cycleEnd
+    cycle.cycleStart,
+    cycle.cycleEnd
   );
 
   const { memberships } = await MembershipResource.getActiveMemberships({
@@ -1008,6 +1082,7 @@ export async function resyncSpendLimitCountersFromEsUsage(
     workspace,
     userIds: users.map((u) => u.sId),
     freeSeatUserIds,
+    cycle,
   });
 
   const results = await concurrentExecutor(

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -976,62 +976,6 @@ export async function getEffectiveSpendCapAwuCreditsForUser(
 }
 
 /**
- * Resolves a single user's effective per-user spend cap in AWU credits on a
- * workspace that is *not* on a credit-priced plan. Same precedence as
- * `getEffectiveSpendCapAwuCreditsForUser` (per-user override > max group cap >
- * workspace default) but resolved entirely from Postgres — no Metronome, since
- * these workspaces have no contract to read seat allowances from.
- *
- * Consequences of having no contract:
- *   - No seat allowance is added to any of the three values.
- *   - A workspace default of 0 means "not configured", not "no pool access":
- *     `defaultPoolCapAwuCredits` is `NOT NULL DEFAULT 0`, so every credit-usage
- *     configuration row created for an unrelated reason (a discount, a usage cap)
- *     carries a 0 that would otherwise cap every member at zero credits.
- *
- * Returns `null` when no cap applies.
- */
-export async function getNonCreditPricedSpendCapAwuCreditsForUser(
-  auth: Authenticator,
-  { user }: { user: UserResource }
-): Promise<number | null> {
-  const workspace = auth.getNonNullableWorkspace();
-
-  const membership =
-    await MembershipResource.getActiveMembershipOfUserInWorkspace({
-      user,
-      workspace,
-    });
-  if (!membership) {
-    return null;
-  }
-
-  const [creditUsageConfig, groupCapByUserModelId] = await Promise.all([
-    CreditUsageConfigurationResource.fetchByWorkspaceId(auth),
-    GroupResource.listMaxPoolCapAwuCreditsByUserModelIdInWorkspace({
-      workspace,
-      userModelIds: [user.id],
-    }),
-  ]);
-
-  // "none" seat users have no pool access, so their override is irrelevant.
-  const overrideAwuCredits =
-    membership.seatType !== "none"
-      ? membership.poolCapOverrideAwuCredits
-      : null;
-
-  const defaultPoolCapAwuCredits =
-    creditUsageConfig?.defaultPoolCapAwuCredits ?? 0;
-
-  return resolveEffectiveSpendLimitAwuCredits({
-    overrideAwuCredits,
-    groupCapAwuCredits: groupCapByUserModelId.get(user.id) ?? null,
-    defaultAwuCredits:
-      defaultPoolCapAwuCredits > 0 ? defaultPoolCapAwuCredits : null,
-  });
-}
-
-/**
  * Backfills/resyncs every active member's Redis fixed-window spend-cap counter
  * for the current billing cycle from the authoritative Elasticsearch usage,
  * overwriting the counter (SET) so it matches ES. Use after enabling the cap or
@@ -1047,8 +991,9 @@ export async function resyncSpendLimitCountersFromEsUsage(
 ): Promise<Result<{ updatedUserCount: number }, Error>> {
   const workspace = auth.getNonNullableWorkspace();
 
-  const cycleOverride = spendLimitCycleOverrideForAuth(auth);
-  const cycle = cycleOverride ?? (await resolveMetronomeCycle(workspace));
+  const cycle =
+    spendLimitCycleOverrideForAuth(auth) ??
+    (await resolveMetronomeCycle(workspace));
   if (!cycle) {
     return new Err(
       new Error("No active Metronome billing period to resync against.")

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -38,6 +38,7 @@ export * from "./revoke_coupon";
 export * from "./revoke_users";
 export * from "./run_reinforcement_workflow";
 export * from "./send_onboarding_conversation";
+export * from "./set_default_user_credit_limit";
 export * from "./set_web_providers";
 export * from "./soft_delete_conversation";
 export * from "./sync_api_key_cap_alerts";

--- a/front/lib/api/poke/plugins/workspaces/resync_spend_limit_counters.ts
+++ b/front/lib/api/poke/plugins/workspaces/resync_spend_limit_counters.ts
@@ -1,6 +1,5 @@
 import { resyncSpendLimitCountersFromEsUsage } from "@app/lib/api/credits/members_usage";
 import { createPlugin } from "@app/lib/api/poke/types";
-import { isCreditPricedPlan } from "@app/types/plan";
 import { Err, Ok } from "@app/types/shared/result";
 
 export const resyncSpendLimitCountersPlugin = createPlugin({
@@ -9,17 +8,14 @@ export const resyncSpendLimitCountersPlugin = createPlugin({
     name: "Resync Spend-Limit Counters from Usage",
     description:
       "Overwrite each member's Redis fixed-window per-user spend-cap counter " +
-      "for the current billing cycle with their Elasticsearch-derived AWU " +
-      "consumption. Use to backfill the counter after enabling the cap, or to " +
-      "repair drift (the counter otherwise only accrues from live messages).",
+      "for the current cycle with their Elasticsearch-derived AWU consumption. " +
+      "Use to backfill the counter after enabling the cap, or to repair drift " +
+      "(the counter otherwise only accrues from live messages). Resyncs the " +
+      "cycle the workspace is enforced on: the Metronome contract billing " +
+      "period on credit-priced plans, the UTC calendar month elsewhere.",
     resourceTypes: ["workspaces"],
     args: {},
     requiredRoles: ["billing"],
-  },
-
-  isApplicableTo: (auth) => {
-    const plan = auth.plan();
-    return plan !== null && isCreditPricedPlan(plan);
   },
 
   execute: async (auth, _resource, _args) => {

--- a/front/lib/api/poke/plugins/workspaces/set_default_user_credit_limit.ts
+++ b/front/lib/api/poke/plugins/workspaces/set_default_user_credit_limit.ts
@@ -1,0 +1,118 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import {
+  getNonCreditPricedDefaultUserSpendLimit,
+  setNonCreditPricedDefaultUserSpendLimit,
+} from "@app/lib/api/workspace/default_user_spend_limit";
+import { getFeatureFlags } from "@app/lib/auth";
+import {
+  MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
+  MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
+} from "@app/types/credits";
+import { isCreditPricedPlan } from "@app/types/plan";
+import { Err, Ok } from "@app/types/shared/result";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const POKE_AUDIT_CONTEXT = { location: "poke" };
+
+const SetDefaultUserCreditLimitArgsSchema = z.object({
+  awuCredits: z
+    .number()
+    .int("The limit must be a whole number of credits")
+    .min(
+      MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
+      `The limit must be at least ${MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS} credits`
+    )
+    .max(
+      MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
+      `The limit must be at most ${MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS} credits`
+    ),
+});
+
+export const setDefaultUserCreditLimitPlugin = createPlugin({
+  manifest: {
+    id: "set-default-user-credit-limit",
+    name: "Set Per-Member Credit Limit (Legacy Plans)",
+    description:
+      "Set the workspace-wide per-member credit limit: the maximum number of " +
+      "AWU credits any single member can spend per calendar month. Applies to " +
+      "current and future members — it is a limit per member, not a shared " +
+      "workspace pool. Once a member reaches it they cannot send messages until " +
+      "the next month. Enforcement requires the " +
+      "`enforce_user_spend_limit_rate_cap` feature flag.",
+    resourceTypes: ["workspaces"],
+    args: {
+      awuCredits: {
+        type: "number",
+        variant: "text",
+        label: "Limit per member (AWU credits per calendar month)",
+        description:
+          "Credits each member can spend per calendar month (UTC). Set to 0 to " +
+          "remove the limit. Can be overridden for an individual member from " +
+          "the members table.",
+        async: true,
+      },
+    },
+    requiredRoles: ["billing"],
+  },
+  // Credit-priced workspaces have their own default (seat allowance + pool limit,
+  // mirrored to Metronome alerts): they set it through
+  // `manage-credit-usage-configuration` instead.
+  isApplicableTo: (auth) => {
+    const plan = auth.plan();
+    return plan === null || !isCreditPricedPlan(plan);
+  },
+  populateAsyncArgs: async (auth) => {
+    return new Ok({
+      awuCredits: await getNonCreditPricedDefaultUserSpendLimit(auth),
+    });
+  },
+  execute: async (auth, workspace, args) => {
+    if (!workspace) {
+      return new Err(new Error("Cannot find workspace."));
+    }
+
+    const validationResult =
+      SetDefaultUserCreditLimitArgsSchema.safeParse(args);
+    if (!validationResult.success) {
+      return new Err(new Error(fromError(validationResult.error).toString()));
+    }
+    const { awuCredits } = validationResult.data;
+
+    const result = await setNonCreditPricedDefaultUserSpendLimit(auth, {
+      awuCredits,
+      auditContext: POKE_AUDIT_CONTEXT,
+    });
+    if (result.isErr()) {
+      return new Err(new Error(result.error.message));
+    }
+
+    if (awuCredits === 0) {
+      return new Ok({
+        display: "text",
+        value:
+          "Removed the workspace per-member credit limit. Members with an " +
+          "individual limit set from the members table keep it.",
+      });
+    }
+
+    // The limit is stored and read regardless, but only enforced where the flag
+    // is on — say so rather than letting an admin believe it is live.
+    const featureFlags = await getFeatureFlags(auth);
+    const enforcementNote = featureFlags.includes(
+      "enforce_user_spend_limit_rate_cap"
+    )
+      ? ""
+      : " Enforcement is OFF for this workspace: enable the " +
+        "`enforce_user_spend_limit_rate_cap` feature flag to block messages " +
+        "once a member reaches their limit.";
+
+    return new Ok({
+      display: "text",
+      value:
+        `Every member of ${workspace.name} can now spend up to ` +
+        `${awuCredits.toLocaleString()} AWU credits per calendar ` +
+        `month.${enforcementNote}`,
+    });
+  },
+});

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -9,11 +9,13 @@ import {
 import {
   getEffectiveSpendCapAwuCreditsForUser,
   getEsConsumedAwuCreditsForUser,
+  getNonCreditPricedSpendCapAwuCreditsForUser,
 } from "@app/lib/api/credits/members_usage";
 import { reconcileUser } from "@app/lib/api/metronome/reconcile_credit_state";
 import { getUserForWorkspace } from "@app/lib/api/user";
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
+import type { BillingCycle } from "@app/lib/client/subscription";
 import {
   clearMetronomePerUserCapAlert,
   clearMetronomePerUserWarningAlert,
@@ -25,6 +27,7 @@ import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_t
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { currentCalendarMonthCycleUtc } from "@app/lib/spend_limits/cycle";
 import {
   addFixedWindowCount,
   type FixedWindowBounds,
@@ -393,7 +396,14 @@ async function readSpendLimitCountWithLazySeed(
     user,
     key,
     bounds,
-  }: { user: UserResource; key: string; bounds: FixedWindowBounds }
+    cycle,
+  }: {
+    user: UserResource;
+    key: string;
+    bounds: FixedWindowBounds;
+    // Forces the window the ES seed sums over, so it matches `bounds`.
+    cycle?: BillingCycle;
+  }
 ): Promise<number | null> {
   const countResult = await getFixedWindowCount({ key, bounds });
   if (countResult.isErr()) {
@@ -405,12 +415,51 @@ async function readSpendLimitCountWithLazySeed(
 
   const consumed = Math.max(
     0,
-    Math.round(await getEsConsumedAwuCreditsForUser(auth, { user }))
+    Math.round(await getEsConsumedAwuCreditsForUser(auth, { user, cycle }))
   );
   if (consumed > 0) {
     await setFixedWindowCount({ key, bounds, value: consumed, logger });
   }
   return consumed;
+}
+
+/**
+ * Compares the per-user fixed-window counter against `thresholdAwuCredits` over
+ * `bounds`. Shared by the credit-priced and non-credit-priced entry points below,
+ * which differ only in how the threshold and the cycle are resolved. Fails open
+ * (returns `false`) on a Redis read error.
+ */
+async function isSpendCapCounterReached(
+  auth: Authenticator,
+  {
+    user,
+    thresholdAwuCredits,
+    bounds,
+    cycle,
+  }: {
+    user: UserResource;
+    thresholdAwuCredits: number;
+    bounds: FixedWindowBounds;
+    cycle?: BillingCycle;
+  }
+): Promise<boolean> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const count = await readSpendLimitCountWithLazySeed(auth, {
+    user,
+    key: makeSpendLimitAwuCreditsRateLimitKeyForUser(workspace, user.toJSON()),
+    bounds,
+    cycle,
+  });
+  if (count === null) {
+    logger.error(
+      { workspaceId: workspace.sId, userId: user.sId },
+      "[SpendLimitRateCap] Failed to read fixed-window count; allowing message"
+    );
+    return false;
+  }
+
+  return count >= thresholdAwuCredits;
 }
 
 /**
@@ -439,20 +488,45 @@ export async function isUserSpendLimitRateCapReached(
     return false;
   }
 
-  const count = await readSpendLimitCountWithLazySeed(auth, {
+  return isSpendCapCounterReached(auth, {
     user,
-    key: makeSpendLimitAwuCreditsRateLimitKeyForUser(workspace, user.toJSON()),
+    thresholdAwuCredits: threshold,
     bounds,
   });
-  if (count === null) {
-    logger.error(
-      { workspaceId: workspace.sId, userId: user.sId },
-      "[SpendLimitRateCap] Failed to read fixed-window count; allowing message"
-    );
+}
+
+/**
+ * Per-user spend cap for workspaces that are *not* on a credit-priced plan. Same
+ * Redis fixed-window counter as `isUserSpendLimitRateCapReached`, with the two
+ * Metronome-dependent inputs replaced:
+ *   - the threshold comes from `getNonCreditPricedSpendCapAwuCreditsForUser`
+ *     (Postgres only — no seat allowance, no Metronome alert);
+ *   - the cycle is the UTC calendar month, since there is no contract billing
+ *     period to anchor on.
+ *
+ * The workspace credit pool and the Metronome per-user cap do not apply to these
+ * workspaces, so this is their only per-user credit gate. Returns `false` (does
+ * not block) when no cap is configured, or on a Redis read error (fail-open).
+ */
+export async function isNonCreditPricedUserSpendLimitReached(
+  auth: Authenticator,
+  { user }: { user: UserResource }
+): Promise<boolean> {
+  const threshold = await getNonCreditPricedSpendCapAwuCreditsForUser(auth, {
+    user,
+  });
+  if (threshold === null) {
     return false;
   }
 
-  return count >= threshold;
+  const cycle = currentCalendarMonthCycleUtc();
+
+  return isSpendCapCounterReached(auth, {
+    user,
+    thresholdAwuCredits: threshold,
+    bounds: makeSpendLimitCycleWindowBounds(cycle.cycleStart, cycle.cycleEnd),
+    cycle,
+  });
 }
 
 /**
@@ -462,10 +536,19 @@ export async function isUserSpendLimitRateCapReached(
  * is the newly-accrued delta for a message (not its running total — the caller
  * diffs against the previously-recorded amount so repeated finalizes don't
  * over-count). No-op when the billing period can't be resolved.
+ *
+ * Bucketed on the cycle the workspace is enforced on: the contract billing period
+ * by default, or `cycle` when the caller forces one (the UTC calendar month for
+ * workspaces with no contract — see `spendLimitCycleOverrideForAuth`). Reader and
+ * writer must agree here, or the counter accrues under a key nothing reads.
  */
 export async function recordUserSpendLimitUsage(
   auth: Authenticator,
-  { user, incrementBy }: { user: UserResource; incrementBy: number }
+  {
+    user,
+    incrementBy,
+    cycle,
+  }: { user: UserResource; incrementBy: number; cycle?: BillingCycle }
 ): Promise<void> {
   // Only whole positive credits are recordable (the counter is an integer
   // INCRBY); skip anything else rather than letting it reach the counter.
@@ -475,7 +558,9 @@ export async function recordUserSpendLimitUsage(
 
   const workspace = auth.getNonNullableWorkspace();
 
-  const bounds = await resolveSpendLimitCycleBounds(workspace);
+  const bounds = cycle
+    ? makeSpendLimitCycleWindowBounds(cycle.cycleStart, cycle.cycleEnd)
+    : await resolveSpendLimitCycleBounds(workspace);
   if (!bounds) {
     return;
   }

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -9,11 +9,11 @@ import {
 import {
   getEffectiveSpendCapAwuCreditsForUser,
   getEsConsumedAwuCreditsForUser,
-  getNonCreditPricedSpendCapAwuCreditsForUser,
 } from "@app/lib/api/credits/members_usage";
 import { reconcileUser } from "@app/lib/api/metronome/reconcile_credit_state";
 import { getUserForWorkspace } from "@app/lib/api/user";
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
+import { getNonCreditPricedDefaultUserSpendLimit } from "@app/lib/api/workspace/default_user_spend_limit";
 import type { Authenticator } from "@app/lib/auth";
 import type { BillingCycle } from "@app/lib/client/subscription";
 import {
@@ -499,23 +499,18 @@ export async function isUserSpendLimitRateCapReached(
  * Per-user spend cap for workspaces that are *not* on a credit-priced plan. Same
  * Redis fixed-window counter as `isUserSpendLimitRateCapReached`, with the two
  * Metronome-dependent inputs replaced:
- *   - the threshold comes from `getNonCreditPricedSpendCapAwuCreditsForUser`
- *     (Postgres only — no seat allowance, no Metronome alert);
+ *   - the threshold is the optional workspace-wide default.
  *   - the cycle is the UTC calendar month, since there is no contract billing
  *     period to anchor on.
  *
- * The workspace credit pool and the Metronome per-user cap do not apply to these
- * workspaces, so this is their only per-user credit gate. Returns `false` (does
- * not block) when no cap is configured, or on a Redis read error (fail-open).
+ * Returns `false` when no limit is configured, or on a Redis read error (fail-open).
  */
 export async function isNonCreditPricedUserSpendLimitReached(
   auth: Authenticator,
   { user }: { user: UserResource }
 ): Promise<boolean> {
-  const threshold = await getNonCreditPricedSpendCapAwuCreditsForUser(auth, {
-    user,
-  });
-  if (threshold === null) {
+  const threshold = await getNonCreditPricedDefaultUserSpendLimit(auth);
+  if (threshold === 0) {
     return false;
   }
 

--- a/front/lib/api/workspace/default_user_spend_limit.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.ts
@@ -356,3 +356,90 @@ export async function setDefaultUserSpendLimit(
 
   return new Ok({ awuCredits: poolAwuCredits });
 }
+
+/**
+ * Update the workspace-wide default per-user credit limit on a workspace that is
+ * *not* on a credit-priced plan, applying to current and future members.
+ *
+ * Writes the same column as `setDefaultUserSpendLimit` and nothing else: these
+ * workspaces have no Metronome contract, so there are no per-seat-type cap alerts
+ * to derive and no contract balances to reconcile. The limit is enforced from the
+ * Redis fixed-window per-user counter (`isNonCreditPricedUserSpendLimitReached`),
+ * which reads this column directly.
+ *
+ * 0 means "no limit" here — unlike under credit pricing, where it means "no pool
+ * access on top of the seat allowance".
+ */
+export async function setNonCreditPricedDefaultUserSpendLimit(
+  auth: Authenticator,
+  {
+    awuCredits,
+    auditContext,
+  }: {
+    awuCredits: number;
+    auditContext: AuditLogContext;
+  }
+): Promise<Result<DefaultUserSpendLimit, DefaultUserSpendLimitError>> {
+  if (
+    !Number.isInteger(awuCredits) ||
+    awuCredits < MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS ||
+    awuCredits > MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS
+  ) {
+    return new Err(
+      new DefaultUserSpendLimitError(
+        "invalid_threshold",
+        `awuCredits must be an integer between ${MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS} and ${MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS}.`
+      )
+    );
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+
+  // The config row is created lazily, so upsert it.
+  const existingConfig =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  const previousAwuCredits = existingConfig?.defaultPoolCapAwuCredits ?? 0;
+
+  if (existingConfig) {
+    await existingConfig.updateConfiguration(auth, {
+      defaultPoolCapAwuCredits: awuCredits,
+    });
+  } else {
+    await CreditUsageConfigurationResource.makeNew(auth, {
+      defaultDiscountPercent: 0,
+      usageCapCredits: null,
+      defaultPoolCapAwuCredits: awuCredits,
+    });
+  }
+
+  logger.info(
+    { workspaceId: workspace.sId, previousAwuCredits, awuCredits },
+    "[DefaultUserSpendLimit] set(non-credit-priced): default per-user spend limit updated"
+  );
+
+  void emitAuditLogEvent({
+    auth,
+    action: "workspace.default_user_spend_limit_updated",
+    targets: [buildAuditLogTarget("workspace", workspace)],
+    context: auditContext,
+    metadata: {
+      previous_awu_credits: String(previousAwuCredits),
+      new_awu_credits: String(awuCredits),
+    },
+  });
+
+  return new Ok({ awuCredits });
+}
+
+/**
+ * Read the workspace-wide default per-user credit limit on a workspace that is not
+ * on a credit-priced plan. Unlike `getDefaultUserSpendLimit` this does not require
+ * Metronome billing. 0 means no limit.
+ */
+export async function getNonCreditPricedDefaultUserSpendLimit(
+  auth: Authenticator
+): Promise<number> {
+  const config =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  return config?.defaultPoolCapAwuCredits ?? 0;
+}

--- a/front/lib/api/workspace/default_user_spend_limit.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.ts
@@ -432,9 +432,11 @@ export async function setNonCreditPricedDefaultUserSpendLimit(
 }
 
 /**
- * Read the workspace-wide default per-user credit limit on a workspace that is not
- * on a credit-priced plan. Unlike `getDefaultUserSpendLimit` this does not require
- * Metronome billing. 0 means no limit.
+ * Returns the workspace per-user credit limit for a workspace that is not
+ * on a credit-priced plan.
+ * In practice it returns the same value as `getDefaultUserSpendLimit`,
+ * but this doesn't require the workspace to be on a credit-priced plan, and the returned
+ * value should be interpreted differently: 0 means "no limit" here.
  */
 export async function getNonCreditPricedDefaultUserSpendLimit(
   auth: Authenticator

--- a/front/lib/spend_limits/cycle.ts
+++ b/front/lib/spend_limits/cycle.ts
@@ -1,0 +1,42 @@
+import type { Authenticator } from "@app/lib/auth";
+import type { BillingCycle } from "@app/lib/client/subscription";
+import { isCreditPricedPlan } from "@app/types/plan";
+
+/**
+ * The UTC calendar month containing `now`, used as the per-user spend-cap cycle
+ * for workspaces that are not on a credit-priced plan: they have no Metronome
+ * contract, so there is no invoiced billing period to anchor the cycle on.
+ *
+ * `cycleEnd` is the first instant of the next month (exclusive), matching the
+ * Metronome billing periods this stands in for.
+ */
+export function currentCalendarMonthCycleUtc(
+  now: Date = new Date()
+): BillingCycle {
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+
+  return {
+    cycleStart: new Date(Date.UTC(year, month, 1, 0, 0, 0, 0)),
+    cycleEnd: new Date(Date.UTC(year, month + 1, 1, 0, 0, 0, 0)),
+  };
+}
+
+/**
+ * The cycle to force on the per-user spend-cap helpers for this workspace, or
+ * `undefined` to let them resolve the Metronome contract billing period as usual.
+ *
+ * This is the single place that decides which cycle a workspace is bucketed on,
+ * so the reader (enforcement), the writer (usage recording) and the resync all
+ * land on the same Redis key.
+ */
+export function spendLimitCycleOverrideForAuth(
+  auth: Authenticator
+): BillingCycle | undefined {
+  const plan = auth.plan();
+  if (plan !== null && isCreditPricedPlan(plan)) {
+    return undefined;
+  }
+
+  return currentCalendarMonthCycleUtc();
+}


### PR DESCRIPTION
## Description

- Add a way to enforce per-user credit limit even on non CP plans.
- Reuse the existing logic for CP plan leveraging redis/ES backed rate limiter, but force period to current calendar month (CP plans rely on metronome's contract which is not available on non CP plans)
- Add a poke plugin to set the limit on legacy workspace plan
- Open the poke plugin that syncs counters to all workspaces

## Tests

1. set a workspace limit (`workspaces.defaultPoolCapAwuCredits`)
2. enable `enforce_user_spend_limit_rate_cap`
3. sync counters through plugin `Run Resync Spend-Limit Counters from Usage`
4. if cap is reached, see an error

<img width="849" height="205" alt="Screenshot 2026-07-31 at 18 13 13" src="https://github.com/user-attachments/assets/750eb0bd-4553-472e-be33-f63d80994d56" />
<img width="541" height="226" alt="Screenshot 2026-07-31 at 18 13 52" src="https://github.com/user-attachments/assets/c0a4a5ac-5ee0-4652-8109-d6f16a671f45" />

## Risk

Under feature flag. Safe to revert.

## Deploy Plan

Front only