### PR TITLE
[front] enh: harden files cat continuation and Sidekick config retrieval

### DIFF
--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -211,7 +211,7 @@ const FILES_TOOLS_COMMON_METADATA = [
         .optional()
         .describe(
           "Line number to start reading from (1-indexed, default 1). Use for direct jumps to a line; " +
-            "continuation footers provide `byte_offset` instead. Do not combine with `byte_offset`."
+            "continuation footers provide `byte_offset` instead. Ignored when `byte_offset` is provided."
         ),
       limit: z
         .number()

--- a/front/lib/api/actions/servers/files/tools/cat.test.ts
+++ b/front/lib/api/actions/servers/files/tools/cat.test.ts
@@ -344,19 +344,34 @@ describe("catHandler", () => {
     }
   });
 
-  it("rejects a call combining offset and byte_offset", async () => {
+  it("lets byte_offset take precedence when offset is also supplied", async () => {
+    // Production models often retain `offset: 1` from the first call while following a
+    // footer's `byte_offset`; the continuation must behave exactly as if only
+    // `byte_offset` had been passed.
     const { auth, conversation } = await setupProjectConversation();
-    const result = await catHandler(
-      {
-        path: `conversation-${conversation.sId}/big.txt`,
-        offset: 2,
-        byte_offset: 100,
-      },
-      makeExtra(auth, conversation)
+    const line = "A".repeat(30_000);
+    mockStoredFile(line + "\n", "text/plain");
+    const path = `conversation-${conversation.sId}/big.txt`;
+    const extra = makeExtra(auth, conversation);
+
+    const byteOffset = extractByteOffset(
+      textOf(await catHandler({ path }, extra))
     );
-    expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
-      expect(result.error.message).toContain("not both");
-    }
+
+    const withBoth = textOf(
+      await catHandler({ path, offset: 1, byte_offset: byteOffset }, extra)
+    );
+    const withByteOffsetOnly = textOf(
+      await catHandler({ path, byte_offset: byteOffset }, extra)
+    );
+
+    expect(withBoth).toBe(withByteOffsetOnly);
+    expect(withBoth).toContain("1 (cont.): ");
+
+    // A non-default offset alongside byte_offset is also ignored, not an error.
+    const withConflictingOffset = textOf(
+      await catHandler({ path, offset: 2, byte_offset: byteOffset }, extra)
+    );
+    expect(withConflictingOffset).toBe(withByteOffsetOnly);
   });
 });

--- a/front/lib/api/actions/servers/files/tools/cat.ts
+++ b/front/lib/api/actions/servers/files/tools/cat.ts
@@ -13,7 +13,6 @@ import { isReadableAsText } from "@app/lib/api/actions/servers/files/tools/utils
 import {
   byteOffsetBeyondEndMessage,
   fileChangedMessage,
-  OFFSET_EXCLUSIVITY_ERROR_MESSAGE,
   readTextFilePage,
   renderTextFilePage,
   TEXT_FILE_PAGE_CONTENT_BUDGET_BYTES,
@@ -114,12 +113,6 @@ export async function catHandler(
   }: { path: string; offset?: number; limit?: number; byte_offset?: number },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  if (byteOffset !== undefined && offset !== undefined) {
-    return new Err(
-      new MCPError(OFFSET_EXCLUSIVITY_ERROR_MESSAGE, { tracked: false })
-    );
-  }
-
   const conversationRes = requireAgentLoopConversation({ runContext });
   if (conversationRes.isErr()) {
     return conversationRes;
@@ -185,7 +178,9 @@ export async function catHandler(
     path,
     fileSizeBytes: sizeBytes,
     maxLines: limit ?? CAT_LINES_DEFAULT,
-    startLine: offset ?? 1,
+    // Models often default-fill `offset: 1` alongside a footer's `byte_offset`; the
+    // continuation must not depend on perfect argument hygiene, so `byte_offset` wins.
+    startLine: byteOffset !== undefined ? 1 : (offset ?? 1),
     byteOffset: byteOffset ?? null,
   });
 }

--- a/front/lib/api/assistant/global_agents/configurations/dust/agent_suggestions_shared.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/agent_suggestions_shared.ts
@@ -100,6 +100,8 @@ When you receive the agent instructions via \`get_agent_config\`, they come as \
 ["<p data-block-id=\\"7f3a2b1c\\">You are a helpful assistant.</p>"]
 \`\`\`
 
+A prompt edit replaces the entire target block. Never edit a block unless you have read that block's complete content, or unseen content may be deleted.
+
 <block_editing_principles>
 1. Targeting a block means REPLACING its content. You cannot add siblings to it (the system will reject it).
 - If the change fits inside the existing block → target that block, return one HTML element.

--- a/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
@@ -46,6 +46,12 @@ Follow this process for every interaction:
 Step 1: ALWAYS call \`get_agent_config\`. You risk outdated suggestions if you skip this even once.
 The ONLY exception is the first message of a conversation. NEVER call it on the first message, but NEVER skip this step otherwise.
 
+If the \`get_agent_config\` output is truncated and provides an archived-file path, treat the inline output as incomplete. Immediately read the archived file to the end with \`files__cat\`, following each returned \`byte_offset\` exactly.
+
+Do not reason about the configuration, build a plan, or call any \`suggest_*\` tool until the complete configuration has been retrieved — a truncated payload can hide later instructions and the agent's tools and skills entirely. This continuation is part of fetching the agent configuration and does not require heavy-work confirmation.
+
+If the archived file cannot be read completely, stop and tell the user. Do not make suggestions based on the partial configuration.
+
 Step 2: Understand the agent's workflow
 Reason about the agent based on the output of \`get_agent_config\`. Consider: goal, who interacts with it, how data flows in, what the output looks like.
 

--- a/front/lib/api/files/text_file_pagination.ts
+++ b/front/lib/api/files/text_file_pagination.ts
@@ -32,11 +32,9 @@ export const BYTE_OFFSET_SCHEMA = z
   .describe(
     "Byte position from the immediately preceding response's continuation footer (`byte_offset=N`). " +
       "Pass it back exactly to continue reading, whether the previous response ended at a line " +
-      "boundary or inside a line. Never compute or invent this value. Do not combine with `offset`."
+      "boundary or inside a line. Never compute or invent this value. Do not combine with " +
+      "`offset`; if both are provided, `byte_offset` takes precedence."
   );
-
-export const OFFSET_EXCLUSIVITY_ERROR_MESSAGE =
-  "Provide either `offset` or `byte_offset`, not both. Use `byte_offset` to continue from a previous response's footer, and `offset` to start reading at a specific line.";
 
 export function byteOffsetBeyondEndMessage(
   path: string,


### PR DESCRIPTION
## Description

Follow up of `#29513`. Two hardening changes for oversized-file continuation:

1. **`files cat`**: `byte_offset` now takes precedence when `offset` is also supplied — models often default-fill `offset: 1` alongside a footer's `byte_offset`. The mutual-exclusion rejection is removed; a call with both behaves exactly as if only `byte_offset` had been passed. The schema still discourages combining them.
2. **Sidekick**: workflow Step 1 now requires that an archived/truncated `get_agent_config` output be read to the end with `files__cat` (following each `byte_offset` exactly, no heavy-work confirmation) before reasoning, planning, or calling any `suggest_*` tool — and to stop and tell the user if the archive cannot be read completely. The block-editing section adds the edit-specific rule: a prompt edit replaces the entire target block, so never edit a block without having read its complete content.

## Tests

The `offset`+`byte_offset` rejection test is replaced by a precedence test: supplying both (default or conflicting `offset`) produces output identical to `byte_offset` alone. Pagination, cat, and BM25 tool-search suites pass (830 tests).

## Risk

Line-based reads and single-parameter continuations behave exactly as before (regression-tested). Worst case, a model that genuinely meant `offset` while also passing `byte_offset` gets the continuation instead of the line jump. Safe to rollback.

## Deploy Plan

- [ ] Deploy front.
- [ ] Verify Sidekick follows `byte_offset` continuations unprompted on a >20KB single-block config before suggesting edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)