### PR TITLE
feat: add banner when usage limit reached on legacy plans

### DIFF
--- a/front-api/routes/w/[wId]/usage-status.ts
+++ b/front-api/routes/w/[wId]/usage-status.ts
@@ -1,4 +1,6 @@
 import { getUpgradeRequestAvailabilityForUser } from "@app/lib/api/credits/upgrade_requests";
+import { isNonCreditPricedUserSpendLimitReached } from "@app/lib/api/users/spend_limit";
+import { getFeatureFlags } from "@app/lib/auth";
 import type {
   GetWorkspaceUsageStatusResponseBody,
   ProgrammaticCreditStatus,
@@ -28,15 +30,21 @@ app.get(
     const plan = auth.plan();
 
     const isCreditPriced = plan && isCreditPricedPlan(plan);
-    // Workspaces not on Metronome billing have no usage status to report.
+    // Workspaces not on Metronome billing have no usage status to report,
+    // unless we've overriden their default per-user credit limit.
     if (!workspace.metronomeCustomerId || !isCreditPriced) {
+      const featureFlags = await getFeatureFlags(auth);
+      const isLimitReached =
+        featureFlags.includes("enforce_user_spend_limit_rate_cap") &&
+        (await isNonCreditPricedUserSpendLimitReached(auth, { user }));
+
       return ctx.json({
         userNearCreditLimit: false,
         poolCreditState: "active",
         programmaticCreditStatus: "active",
         programmaticWarningReached: false,
         balanceThresholdReached: false,
-        userBlockedReason: null,
+        userBlockedReason: isLimitReached ? "user_cap_reached" : null,
         canRequestUpgrade: false,
         hasPendingUpgradeRequest: false,
         willAutoUpgrade: false,


### PR DESCRIPTION
## Description

Follow up to #29878, display a banner when limit is reached. Reuse the existing `/api/w/:wId/usage-status`

## Tests

<img width="849" height="257" alt="Screenshot 2026-07-31 at 21 34 27" src="https://github.com/user-attachments/assets/610e425a-764e-4220-87f0-cda49a775d82" />

## Risk

Low. Safe to rollback

## Deploy Plan

Frontend only