### PR TITLE
Rename credits page to "Dust token credits"

### DIFF
--- a/marketing/pages/home/credits.tsx
+++ b/marketing/pages/home/credits.tsx
@@ -113,12 +113,11 @@ function Hero() {
           "mb-5 max-w-3xl text-balance text-foreground"
         )}
       >
-        Dust credits
+        Dust token credits
       </h1>
       <p className="copy-lg mb-9 max-w-2xl text-balance text-muted-foreground">
-        These are intelligence credits only, excluding separate action credits.
-        The figures are rounded up per model and execution, matching the
-        codebase conversion logic.
+        These are token credits only, excluding action credits. The figures are
+        rounded up per model and execution.
       </p>
     </section>
   );
@@ -251,8 +250,8 @@ export default function Credits({ providerSections }: CreditsPageProps) {
     <LazyMotion features={domAnimation}>
       <MotionConfig reducedMotion="user">
         <PageMetadata
-          title="Dust Credits: Model Credit Consumption"
-          description="Intelligence credit consumption per model on Dust, in credits per million input and output tokens."
+          title="Dust Token Credits: Model Credit Consumption"
+          description="Token credit consumption per model on Dust, in credits per million input and output tokens."
           pathname={router.asPath}
         />
         <Hero />


### PR DESCRIPTION
## Description

Updates the copy on the marketing credits page to use clearer terminology: renames "Dust credits" to "Dust token credits" and simplifies the hero subtitle to "These are token credits only, excluding action credits." (dropping the reference to "intelligence credits" and the mention of codebase conversion logic).

## Tests

Visual check on the marketing credits page.

## Risk

Low — copy-only change, no logic affected.

## Deploy Plan

Deploy marketing.