### PR TITLE
ttribute tool call output from the emitted arguments, not the augmented params

### DIFF
--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
@@ -137,7 +137,12 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
     // the input its result occupied. Everything is priced against this one usage below.
     const footprintsRes = await measureToolCallFootprints(auth, {
       modelId: usage.modelId,
-      actions: enrichedRunActions,
+      // TODO(2026-07-31 FLAV) Refactor `enrichActionsWithOutputItems` so it still returns the
+      // resource.
+      toolCalls: runActions.map((action, index) => ({
+        action: enrichedRunActions[index],
+        functionCallArguments: action.functionCallArguments,
+      })),
     });
     if (footprintsRes.isErr()) {
       throw new Error(

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.test.ts
@@ -1,3 +1,4 @@
+import type { ToolCallFootprintInput } from "@app/lib/api/assistant/agent_message_consumption_attribution/tool_footprint";
 import {
   measureToolCallFootprints,
   toolCallFootprintTexts,
@@ -44,24 +45,41 @@ function makeAction(
   };
 }
 
+// The emitted arguments are supplied separately from the resource, so tests default them to "{}".
+function footprintInput(
+  action: AgentMCPActionWithOutputType,
+  functionCallArguments = "{}"
+): ToolCallFootprintInput {
+  return { action, functionCallArguments };
+}
+
 // The auth is only forwarded to getLlmCredentials, which is mocked, so a bare stub is enough.
 const auth = {} as Authenticator;
 
 describe("toolCallFootprintTexts", () => {
-  it("serializes a call as its function name followed by JSON arguments", () => {
+  it("serializes a call from the emitted arguments, not the augmented params", () => {
     const { callText } = toolCallFootprintTexts(
-      makeAction({ functionCallName: "search", params: { query: "hello" } })
+      footprintInput(
+        makeAction({
+          functionCallName: "search",
+          // params also carries a Dust-injected input that must not be counted.
+          params: { query: "hello", injectedSecret: "x".repeat(500) },
+        }),
+        '{"query":"hello"}'
+      )
     );
 
-    expect(callText).toBe(`search\n${JSON.stringify({ query: "hello" })}`);
+    expect(callText).toBe('search\n{"query":"hello"}');
   });
 
   it("renders a denied action as the rejection notice, ignoring any output", () => {
     const { resultText } = toolCallFootprintTexts(
-      makeAction({
-        status: "denied",
-        output: [{ type: "text", text: "leaked" }],
-      })
+      footprintInput(
+        makeAction({
+          status: "denied",
+          output: [{ type: "text", text: "leaked" }],
+        })
+      )
     );
 
     expect(resultText).toBe(
@@ -71,7 +89,7 @@ describe("toolCallFootprintTexts", () => {
 
   it("renders an action awaiting validation as the validation notice", () => {
     const { resultText } = toolCallFootprintTexts(
-      makeAction({ status: "blocked_validation_required" })
+      footprintInput(makeAction({ status: "blocked_validation_required" }))
     );
 
     expect(resultText).toBe(
@@ -81,7 +99,7 @@ describe("toolCallFootprintTexts", () => {
 
   it("renders an empty output as the no-output notice", () => {
     const { resultText } = toolCallFootprintTexts(
-      makeAction({ status: "succeeded", output: [] })
+      footprintInput(makeAction({ status: "succeeded", output: [] }))
     );
 
     expect(resultText).toBe("Successfully executed action, no output.");
@@ -89,13 +107,15 @@ describe("toolCallFootprintTexts", () => {
 
   it("joins text output items with newlines", () => {
     const { resultText } = toolCallFootprintTexts(
-      makeAction({
-        status: "succeeded",
-        output: [
-          { type: "text", text: "first" },
-          { type: "text", text: "second" },
-        ],
-      })
+      footprintInput(
+        makeAction({
+          status: "succeeded",
+          output: [
+            { type: "text", text: "first" },
+            { type: "text", text: "second" },
+          ],
+        })
+      )
     );
 
     expect(resultText).toBe("first\nsecond");
@@ -103,15 +123,17 @@ describe("toolCallFootprintTexts", () => {
 
   it("serializes non-text output as JSON with the mime type stripped", () => {
     const { resultText } = toolCallFootprintTexts(
-      makeAction({
-        status: "succeeded",
-        output: [
-          {
-            type: "resource",
-            resource: { uri: "u", mimeType: "text/plain", text: "body" },
-          },
-        ],
-      })
+      footprintInput(
+        makeAction({
+          status: "succeeded",
+          output: [
+            {
+              type: "resource",
+              resource: { uri: "u", mimeType: "text/plain", text: "body" },
+            },
+          ],
+        })
+      )
     );
 
     expect(resultText).toBe(JSON.stringify([{ uri: "u", text: "body" }]));
@@ -131,7 +153,7 @@ describe("measureToolCallFootprints", () => {
   it("returns an empty result without tokenizing when there are no actions", async () => {
     const res = await measureToolCallFootprints(auth, {
       modelId: GPT_5_MODEL_ID,
-      actions: [],
+      toolCalls: [],
     });
 
     expect(res.isOk() && res.value).toEqual([]);
@@ -142,7 +164,7 @@ describe("measureToolCallFootprints", () => {
   it("fails when the run's model is not a known configuration", async () => {
     const res = await measureToolCallFootprints(auth, {
       modelId: "not-a-real-model",
-      actions: [makeAction()],
+      toolCalls: [footprintInput(makeAction())],
     });
 
     expect(res.isErr()).toBe(true);
@@ -150,19 +172,20 @@ describe("measureToolCallFootprints", () => {
   });
 
   it("measures the call and result footprint of each action, aligned by position", async () => {
-    const actions = [
-      makeAction({ functionCallName: "a", params: {} }),
-      makeAction({
-        functionCallName: "b",
-        params: {},
-        status: "succeeded",
-        output: [{ type: "text", text: "result-of-b" }],
-      }),
+    const toolCalls = [
+      footprintInput(makeAction({ functionCallName: "a" })),
+      footprintInput(
+        makeAction({
+          functionCallName: "b",
+          status: "succeeded",
+          output: [{ type: "text", text: "result-of-b" }],
+        })
+      ),
     ];
 
     const res = await measureToolCallFootprints(auth, {
       modelId: GPT_5_MODEL_ID,
-      actions,
+      toolCalls,
     });
 
     // Calls and results are tokenized as two homogeneous lists, each in input order.
@@ -194,7 +217,7 @@ describe("measureToolCallFootprints", () => {
 
     const res = await measureToolCallFootprints(auth, {
       modelId: GPT_5_MODEL_ID,
-      actions: [makeAction()],
+      toolCalls: [footprintInput(makeAction())],
     });
 
     expect(res.isErr() && res.error.message).toBe("core down");

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
@@ -27,17 +27,23 @@ export interface ToolFootprintMeasurement {
   resultInputTokensCount: number;
 }
 
-// The model emits a tool call as a function name plus its JSON arguments. This mirrors that shape so
-// the token count reflects what the model actually generated to invoke the tool.
-function serializeToolCallText(action: AgentMCPActionWithOutputType): string {
-  return `${action.functionCallName}\n${JSON.stringify(action.params)}`;
+/**
+ * One tool call to measure: the enriched action for the result the model ingested, and the raw
+ * arguments string the model emitted for the call. The arguments come straight from the resource
+ * rather than the serialized action, so they exclude the inputs Dust injects afterwards.
+ */
+export interface ToolCallFootprintInput {
+  action: AgentMCPActionWithOutputType;
+  functionCallArguments: string;
 }
 
-export function toolCallFootprintTexts(
-  action: AgentMCPActionWithOutputType
-): ToolFootprintTexts {
+export function toolCallFootprintTexts({
+  action,
+  functionCallArguments,
+}: ToolCallFootprintInput): ToolFootprintTexts {
   return {
-    callText: serializeToolCallText(action),
+    // The tool call as the model emitted it: its name plus the arguments it generated.
+    callText: `${action.functionCallName}\n${functionCallArguments}`,
     // The exact text the model saw for the result, shared with conversation rendering so the
     // estimate never drifts from what was actually sent. Image content is not counted here: it is
     // priced under a separate tile-based model, out of scope for text tokenization.
@@ -56,13 +62,13 @@ export async function measureToolCallFootprints(
   auth: Authenticator,
   {
     modelId,
-    actions,
+    toolCalls,
   }: {
     modelId: string;
-    actions: AgentMCPActionWithOutputType[];
+    toolCalls: ToolCallFootprintInput[];
   }
 ): Promise<Result<ToolFootprintMeasurement[], Error>> {
-  if (actions.length === 0) {
+  if (toolCalls.length === 0) {
     return new Ok([]);
   }
 
@@ -78,8 +84,8 @@ export async function measureToolCallFootprints(
   });
 
   // Tokenize the calls and the results as two homogeneous lists rather than one interleaved list, so
-  // each count maps back to its action by plain index, with no call-vs-result position juggling.
-  const footprints = actions.map(toolCallFootprintTexts);
+  // each count maps back to its call by plain index, with no call-vs-result position juggling.
+  const footprints = toolCalls.map(toolCallFootprintTexts);
   const [callCountsRes, resultCountsRes] = await Promise.all([
     tokenCountForTexts(
       footprints.map((footprint) => footprint.callText),

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1675,4 +1675,11 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   get functionCallName(): string {
     return this.stepContent.value.value.name;
   }
+
+  // The raw arguments string the model emitted, before Dust augments it with preconfigured values
+  // and secrets (those land in the serialized `params`). Kept off the serialized type so it stays
+  // server-side, where consumption attribution reads it.
+  get functionCallArguments(): string {
+    return this.stepContent.value.value.arguments;
+  }
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Per-tool consumption attribution measures how many tokens the model spent emitting each tool call so it can attribute that share of the run's output. It did this by tokenizing the action's params, which are the arguments after Dust augments them with preconfigured values and injected secrets. Those extra inputs were never generated by the model, so counting them overstated the attributed output for that call, and because that count also feeds the step that carves a call's emission out of the assistant output bucket, it distorted the surrounding model rows too.

This change tokenizes what the model actually emitted instead. The raw arguments string the model produced is read directly from the action resource on the server, through a small accessor next to the one that already exposes the call name, and the call footprint is built from that. It is deliberately not added to the serialized action type. That type is sent to the browser, and the augmented params already travel there, so introducing a second redundant field would only grow the client payload for something only the backend attribution path consumes. Keeping it server side also avoids widening a client contract for an internal need.

Left a TODO to improve the resource logic here.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
