### PR TITLE
Write blocked tool attribution rows as pending and complete them once the action settles

### DIFF
--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
@@ -310,7 +310,7 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
     expect(toolItems[0].directCreditAmountMicro).toBeGreaterThanOrEqual(0);
   });
 
-  it("leaves an approved tool row untouched on a later re-finalize", async () => {
+  it("keeps a completed tool single and stable across a redundant re-finalize", async () => {
     const {
       auth,
       workspace,
@@ -341,17 +341,8 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
       conversationId,
     });
 
-    const completedAtAfterApproval = (
-      await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
-        auth,
-        {
-          agentMessageModelIds: [agentMessageModelId],
-          attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
-        }
-      )
-    ).find((item) => item.itemType === "tool")?.completedAt;
-
-    // A redundant finalize (e.g. a Temporal retry) must not re-complete or duplicate the row.
+    // A redundant finalize (e.g. a Temporal retry) re-upserts the same values. It must not duplicate
+    // the row or change the attributed evidence, and the row stays completed.
     await computeAndStoreAgentMessageConsumptionAttribution(auth, {
       agentMessageId,
       conversationId,
@@ -368,7 +359,12 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
     ).filter((item) => item.itemType === "tool");
 
     expect(toolItems).toHaveLength(1);
-    expect(toolItems[0].completedAt).toEqual(completedAtAfterApproval);
+    expect(toolItems[0]).toMatchObject({
+      agentMCPActionId: action.id,
+      outputTokensCount: TOKENS_PER_FOOTPRINT,
+      inputTokensCount: TOKENS_PER_FOOTPRINT,
+      completedAt: expect.any(Date),
+    });
   });
 
   it("writes nothing when the message has no runs", async () => {

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
@@ -200,6 +200,177 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
     ).toBe(OUTPUT_TOKENS_COUNT - REASONING_TOKENS_COUNT);
   });
 
+  it("writes a blocked tool as a pending row, carving its output but withholding the charge", async () => {
+    const {
+      auth,
+      workspace,
+      conversation,
+      run,
+      conversationId,
+      agentMessageId,
+      agentMessageModelId,
+    } = await setupSettledMessageWithUsage();
+
+    // The default factory status is "blocked_validation_required": the loop paused for approval and
+    // attribution runs while the tool has not executed yet.
+    const { action } = await AgentMCPActionFactory.create(auth, {
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId,
+      dustRunId: run.dustRunId,
+    });
+
+    await computeAndStoreAgentMessageConsumptionAttribution(auth, {
+      agentMessageId,
+      conversationId,
+    });
+
+    const items =
+      await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
+        auth,
+        {
+          agentMessageModelIds: [agentMessageModelId],
+          attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+        }
+      );
+
+    // The tool row is pending: the emitted call output is known and carved, but the result footprint
+    // and the direct charge wait for the action to settle.
+    const toolItem = items.find((item) => item.itemType === "tool");
+    expect(toolItem).toMatchObject({
+      itemType: "tool",
+      agentMCPActionId: action.id,
+      outputTokensCount: TOKENS_PER_FOOTPRINT,
+      inputTokensCount: null,
+      directCreditAmountMicro: null,
+      completedAt: null,
+    });
+    expect(toolItem?.grossAttributedCreditAmountMicro).toBeGreaterThan(0);
+
+    // The carve still applies while pending: the assistant output bucket is net of the emitted call.
+    const outputItem = items.find((item) => item.itemType === "output");
+    expect(
+      (outputItem?.outputTokensCount ?? 0) + (toolItem?.outputTokensCount ?? 0)
+    ).toBe(OUTPUT_TOKENS_COUNT - REASONING_TOKENS_COUNT);
+  });
+
+  it("completes the pending tool row in place once the blocked action is approved", async () => {
+    const {
+      auth,
+      workspace,
+      conversation,
+      run,
+      conversationId,
+      agentMessageId,
+      agentMessageModelId,
+    } = await setupSettledMessageWithUsage();
+
+    const { action } = await AgentMCPActionFactory.create(auth, {
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId,
+      dustRunId: run.dustRunId,
+    });
+
+    // First finalize, while the tool is still blocked: a pending row is written.
+    await computeAndStoreAgentMessageConsumptionAttribution(auth, {
+      agentMessageId,
+      conversationId,
+    });
+
+    // The user approves, the tool executes and succeeds, then the loop finalizes again.
+    await AgentMCPActionFactory.setStatus(auth, {
+      action,
+      status: "succeeded",
+    });
+    await computeAndStoreAgentMessageConsumptionAttribution(auth, {
+      agentMessageId,
+      conversationId,
+    });
+
+    const toolItems = (
+      await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
+        auth,
+        {
+          agentMessageModelIds: [agentMessageModelId],
+          attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+        }
+      )
+    ).filter((item) => item.itemType === "tool");
+
+    // The blocked pending row was completed in place, not duplicated: still one tool row, now
+    // carrying the result footprint and the direct charge.
+    expect(toolItems).toHaveLength(1);
+    expect(toolItems[0]).toMatchObject({
+      agentMCPActionId: action.id,
+      outputTokensCount: TOKENS_PER_FOOTPRINT,
+      inputTokensCount: TOKENS_PER_FOOTPRINT,
+      completedAt: expect.any(Date),
+    });
+    expect(toolItems[0].directCreditAmountMicro).toBeGreaterThanOrEqual(0);
+  });
+
+  it("leaves an approved tool row untouched on a later re-finalize", async () => {
+    const {
+      auth,
+      workspace,
+      conversation,
+      run,
+      conversationId,
+      agentMessageId,
+      agentMessageModelId,
+    } = await setupSettledMessageWithUsage();
+
+    const { action } = await AgentMCPActionFactory.create(auth, {
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId,
+      dustRunId: run.dustRunId,
+    });
+
+    await computeAndStoreAgentMessageConsumptionAttribution(auth, {
+      agentMessageId,
+      conversationId,
+    });
+    await AgentMCPActionFactory.setStatus(auth, {
+      action,
+      status: "succeeded",
+    });
+    await computeAndStoreAgentMessageConsumptionAttribution(auth, {
+      agentMessageId,
+      conversationId,
+    });
+
+    const completedAtAfterApproval = (
+      await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
+        auth,
+        {
+          agentMessageModelIds: [agentMessageModelId],
+          attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+        }
+      )
+    ).find((item) => item.itemType === "tool")?.completedAt;
+
+    // A redundant finalize (e.g. a Temporal retry) must not re-complete or duplicate the row.
+    await computeAndStoreAgentMessageConsumptionAttribution(auth, {
+      agentMessageId,
+      conversationId,
+    });
+
+    const toolItems = (
+      await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
+        auth,
+        {
+          agentMessageModelIds: [agentMessageModelId],
+          attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+        }
+      )
+    ).filter((item) => item.itemType === "tool");
+
+    expect(toolItems).toHaveLength(1);
+    expect(toolItems[0].completedAt).toEqual(completedAtAfterApproval);
+  });
+
   it("writes nothing when the message has no runs", async () => {
     const { authenticator: auth, workspace } = await createResourceTest({});
 

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
@@ -1,3 +1,4 @@
+import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import {
   AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
   buildRunUsageAttribution,
@@ -7,12 +8,17 @@ import { measureToolCallFootprints } from "@app/lib/api/assistant/agent_message_
 import type { Authenticator } from "@app/lib/auth";
 import { toolAwuFromAction } from "@app/lib/metronome/events";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import type { CompletedAgentMessageConsumptionItem } from "@app/lib/resources/agent_message_consumption_item_resource";
+import type {
+  CompletedAgentMessageConsumptionItem,
+  PendingToolConsumptionCompletion,
+  PendingToolConsumptionItem,
+} from "@app/lib/resources/agent_message_consumption_item_resource";
 import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import logger from "@app/logger/logger";
 import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
+import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
 import assert from "assert";
@@ -37,6 +43,13 @@ const CREDIT_AMOUNT_MICRO_PER_CREDIT = 1_000_000;
  * run usages or actions that are new since the last pass. Records are computed for the whole message
  * before any write, so a tokenization failure throws and the retry recomputes from scratch rather
  * than locking in a partial breakdown.
+ *
+ * A finalize also fires while the loop is paused on a tool awaiting approval, so an action can be
+ * seen here before it is final. Such an action has no result and no charge yet, and billing does not
+ * charge it, so its tool row is written pending: only the output the model already spent emitting the
+ * call, carved out of the assistant bucket like any other tool call. When a later finalize sees the
+ * action final, that pending row is completed in place with the result footprint and direct charge,
+ * rather than replaced (the row cannot be re-inserted past its idempotency key).
  */
 export async function computeAndStoreAgentMessageConsumptionAttribution(
   auth: Authenticator,
@@ -121,7 +134,34 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
     actionsByDustRunId.set(dustRunId, runActions);
   }
 
+  // Actions left pending by an earlier finalize (the message paused for approval, then resumed). A
+  // now-final one must be completed in place: an insert would be skipped by ignoreDuplicates on its
+  // frozen pending row, so the result footprint and direct charge would never land.
+  const priorItems =
+    await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(auth, {
+      agentMessageModelIds: [agentMessageModelId],
+      attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+    });
+  const pendingActionModelIdsBefore = new Set(
+    removeNulls(
+      priorItems
+        .filter((item) => item.itemType === "tool" && item.completedAt === null)
+        .map((item) => item.agentMCPActionId)
+    )
+  );
+
   const records: CompletedAgentMessageConsumptionItem[] = [];
+  // Tool calls whose action is still blocked (awaiting approval or authentication). Written pending:
+  // only the emitted call output is known, the result footprint and direct charge wait for the
+  // action to settle.
+  const pendingToolItems: PendingToolConsumptionItem[] = [];
+  // Completion evidence per action, applied below to any action that was already pending from an
+  // earlier pass. Keyed by action model id.
+  const completionByActionModelId = new Map<
+    ModelId,
+    PendingToolConsumptionCompletion
+  >();
+
   for (const usage of usages) {
     const dustRunId = dustRunIdByRunModelId.get(usage.runModelId);
     const runActions = (dustRunId && actionsByDustRunId.get(dustRunId)) || [];
@@ -202,6 +242,20 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
 
     toolCalls.forEach((toolCall) => {
       const { action, enrichedAction, footprint } = toolCall.tool;
+
+      // A blocked action carries no result and no charge yet, and billing does not charge it. Record
+      // only the emitted call output as a pending row. The rest lands once the action is final.
+      if (!isToolExecutionStatusFinal(action.status)) {
+        pendingToolItems.push({
+          action,
+          runUsageModelId: usage.runUsageModelId,
+          outputTokensCount: toolCall.outputTokensCount,
+          grossAttributedCreditAmountMicro:
+            toolCall.grossAttributedCreditAmountMicro,
+        });
+        return;
+      }
+
       const directCreditAmountMicro = Math.round(
         toolAwuFromAction(
           {
@@ -229,9 +283,20 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
         grossAttributedCreditAmountMicro:
           toolAttribution.grossAttributedCreditAmountMicro,
       });
+
+      completionByActionModelId.set(action.id, {
+        action,
+        inputTokensCount: toolAttribution.inputTokensCount,
+        directCreditAmountMicro: toolAttribution.directCreditAmountMicro,
+        grossAttributedCreditAmountMicro:
+          toolAttribution.grossAttributedCreditAmountMicro,
+      });
     });
   }
 
+  // Insert the model rows and the tool rows that are already final. A final action that carries a
+  // pending row from an earlier pass conflicts here and is skipped by ignoreDuplicates. It is
+  // completed just below instead.
   await AgentMessageConsumptionItemResource.insertCompletedItemsIdempotently(
     auth,
     {
@@ -241,4 +306,28 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
       records,
     }
   );
+
+  await AgentMessageConsumptionItemResource.insertPendingToolItemsIdempotently(
+    auth,
+    {
+      conversation,
+      attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+      items: pendingToolItems,
+    }
+  );
+
+  // Complete the actions that were pending on an earlier pass and have now settled. Bounded by the
+  // number of approvals resolved on this resume, which is small.
+  for (const actionModelId of pendingActionModelIdsBefore) {
+    const completion = completionByActionModelId.get(actionModelId);
+    if (completion) {
+      await AgentMessageConsumptionItemResource.completePendingToolItemIdempotently(
+        auth,
+        {
+          attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+          item: completion,
+        }
+      );
+    }
+  }
 }

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
@@ -10,7 +10,6 @@ import { toolAwuFromAction } from "@app/lib/metronome/events";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type {
   CompletedAgentMessageConsumptionItem,
-  PendingToolConsumptionCompletion,
   PendingToolConsumptionItem,
 } from "@app/lib/resources/agent_message_consumption_item_resource";
 import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
@@ -18,7 +17,6 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import logger from "@app/logger/logger";
 import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
-import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
 import assert from "assert";
@@ -33,8 +31,8 @@ const CREDIT_AMOUNT_MICRO_PER_CREDIT = 1_000_000;
  * This is analytics, not billing: the authoritative charge is computed and stored separately by the
  * credit pipeline. Here we explain the relative composition of that cost by writing, per run usage,
  * one row per model token bucket (input, output, reasoning) and one row per tool call. A tool row
- * carries the output tokens the model spent emitting the call, the input tokens its result occupied
- * in the next prompt, and the tool's direct credit charge.
+ * carries the output tokens the model spent emitting the call, the input tokens its result would
+ * occupy if carried into a later prompt, and the tool's direct credit charge.
  *
  * Runs once the message has settled, launched from the analytics queue by the finalize activities.
  * It is idempotent by (agent message, attribution version, run usage, item type) for model rows and
@@ -134,33 +132,11 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
     actionsByDustRunId.set(dustRunId, runActions);
   }
 
-  // Actions left pending by an earlier finalize (the message paused for approval, then resumed). A
-  // now-final one must be completed in place: an insert would be skipped by ignoreDuplicates on its
-  // frozen pending row, so the result footprint and direct charge would never land.
-  const priorItems =
-    await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(auth, {
-      agentMessageModelIds: [agentMessageModelId],
-      attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
-    });
-  const pendingActionModelIdsBefore = new Set(
-    removeNulls(
-      priorItems
-        .filter((item) => item.itemType === "tool" && item.completedAt === null)
-        .map((item) => item.agentMCPActionId)
-    )
-  );
-
   const records: CompletedAgentMessageConsumptionItem[] = [];
   // Tool calls whose action is still blocked (awaiting approval or authentication). Written pending:
   // only the emitted call output is known, the result footprint and direct charge wait for the
   // action to settle.
   const pendingToolItems: PendingToolConsumptionItem[] = [];
-  // Completion evidence per action, applied below to any action that was already pending from an
-  // earlier pass. Keyed by action model id.
-  const completionByActionModelId = new Map<
-    ModelId,
-    PendingToolConsumptionCompletion
-  >();
 
   for (const usage of usages) {
     const dustRunId = dustRunIdByRunModelId.get(usage.runModelId);
@@ -283,51 +259,17 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
         grossAttributedCreditAmountMicro:
           toolAttribution.grossAttributedCreditAmountMicro,
       });
-
-      completionByActionModelId.set(action.id, {
-        action,
-        inputTokensCount: toolAttribution.inputTokensCount,
-        directCreditAmountMicro: toolAttribution.directCreditAmountMicro,
-        grossAttributedCreditAmountMicro:
-          toolAttribution.grossAttributedCreditAmountMicro,
-      });
     });
   }
 
-  // Insert the model rows and the tool rows that are already final. A final action that carries a
-  // pending row from an earlier pass conflicts here and is skipped by ignoreDuplicates. It is
-  // completed just below instead.
-  await AgentMessageConsumptionItemResource.insertCompletedItemsIdempotently(
-    auth,
-    {
-      conversation,
-      agentMessageModelId,
-      attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
-      records,
-    }
-  );
-
-  await AgentMessageConsumptionItemResource.insertPendingToolItemsIdempotently(
-    auth,
-    {
-      conversation,
-      attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
-      items: pendingToolItems,
-    }
-  );
-
-  // Complete the actions that were pending on an earlier pass and have now settled. Bounded by the
-  // number of approvals resolved on this resume, which is small.
-  for (const actionModelId of pendingActionModelIdsBefore) {
-    const completion = completionByActionModelId.get(actionModelId);
-    if (completion) {
-      await AgentMessageConsumptionItemResource.completePendingToolItemIdempotently(
-        auth,
-        {
-          attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
-          item: completion,
-        }
-      );
-    }
-  }
+  // One atomic write for the whole pass. The resource inserts the model buckets and the final tools,
+  // completes in place any tool a prior pass left pending, and records the still-blocked tools as
+  // pending, so this materializer never coordinates a read followed by separate inserts and updates.
+  await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+    conversation,
+    agentMessageModelId,
+    attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+    records,
+    pendingToolItems,
+  });
 }

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
@@ -9,8 +9,10 @@ import { Err, Ok } from "@app/types/shared/result";
 
 /**
  * The two texts an MCP action contributes to the model's token budget: the tool call the model
- * emitted (output side) and the result the model then ingested (input side). Per-tool attribution
- * prices these two footprints, so V1 measures both.
+ * emitted (output side) and the result's renderable footprint (input side). The result is priced by
+ * the input it would occupy if carried into a later prompt, which it may never be (the message can
+ * end, or the tool can be denied, before any following turn). Per-tool attribution prices both
+ * footprints, so V1 measures them.
  */
 export interface ToolFootprintTexts {
   callText: string;
@@ -19,8 +21,8 @@ export interface ToolFootprintTexts {
 
 /**
  * The measured footprint of one MCP action, aligned by position with the input actions. Named after
- * the model budget each side consumes: the emitted call counts as output, the ingested result as
- * input.
+ * the model budget each side consumes: the emitted call counts as output, and the result counts as
+ * the input it would occupy if carried into a later prompt, which it may never be.
  */
 export interface ToolFootprintMeasurement {
   callOutputTokensCount: number;

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
@@ -30,9 +30,9 @@ export interface ToolFootprintMeasurement {
 }
 
 /**
- * One tool call to measure: the enriched action for the result the model ingested, and the raw
- * arguments string the model emitted for the call. The arguments come straight from the resource
- * rather than the serialized action, so they exclude the inputs Dust injects afterwards.
+ * One tool call to measure: the enriched action used to render the result, and the raw arguments
+ * string the model emitted for the call. The arguments come straight from the resource rather than
+ * the serialized action, so they exclude the inputs Dust injects afterwards.
  */
 export interface ToolCallFootprintInput {
   action: AgentMCPActionWithOutputType;
@@ -46,19 +46,18 @@ export function toolCallFootprintTexts({
   return {
     // The tool call as the model emitted it: its name plus the arguments it generated.
     callText: `${action.functionCallName}\n${functionCallArguments}`,
-    // The exact text the model saw for the result, shared with conversation rendering so the
-    // estimate never drifts from what was actually sent. Image content is not counted here: it is
-    // priced under a separate tile-based model, out of scope for text tokenization.
+    // The result's model-rendered text, shared with conversation rendering so the estimate tracks
+    // what would be sent. Image content is not counted here because it uses separate tile pricing.
     resultText: renderToolResultForModelAsText(action),
   };
 }
 
 /**
  * Measures, for each action, how many tokens the model spent emitting the tool call and how many the
- * returned result occupied in the following prompt. Results are order-aligned with `actions`.
+ * returned result would occupy if carried into a later prompt. Results stay aligned with `toolCalls`.
  *
  * Uses the exact tokenizer of the run's model through core, the same path conversation rendering
- * uses to size messages, so the counts (_almost_) match what the provider billed rather than a heuristic.
+ * uses to size messages, so the counts closely match provider tokenization rather than a heuristic.
  */
 export async function measureToolCallFootprints(
   auth: Authenticator,

--- a/front/lib/resources/agent_message_consumption_item_resource.test.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.test.ts
@@ -15,7 +15,7 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { RunFactory } from "@app/tests/utils/RunFactory";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { LightWorkspaceType } from "@app/types/user";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 const ATTRIBUTION_VERSION = 1;
 
@@ -192,6 +192,7 @@ describe("AgentMessageConsumptionItemResource", () => {
   it("inserts an already-final tool without a prior pending row", async () => {
     const { authenticator: auth, workspace } = await createResourceTest({});
     const context = await setupMessageWithEvidence(auth, workspace);
+    const findAllSpy = vi.spyOn(AgentMessageConsumptionItemModel, "findAll");
 
     await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
       conversation: context.conversation,
@@ -200,6 +201,8 @@ describe("AgentMessageConsumptionItemResource", () => {
       records: [completedTool(context.action, context.runUsageModelId)],
       pendingToolItems: [],
     });
+    expect(findAllSpy).not.toHaveBeenCalled();
+    findAllSpy.mockRestore();
 
     const tools = await listTools(auth, context.agentMessageModelId);
     expect(tools).toHaveLength(1);
@@ -222,9 +225,7 @@ describe("AgentMessageConsumptionItemResource", () => {
       agentMessageModelId: context.agentMessageModelId,
       attributionVersion: ATTRIBUTION_VERSION,
       records: [],
-      pendingToolItems: [
-        pendingTool(context.action, context.runUsageModelId),
-      ],
+      pendingToolItems: [pendingTool(context.action, context.runUsageModelId)],
     });
 
     const afterFirstPass = await listTools(auth, context.agentMessageModelId);
@@ -240,7 +241,12 @@ describe("AgentMessageConsumptionItemResource", () => {
       conversation: context.conversation,
       agentMessageModelId: context.agentMessageModelId,
       attributionVersion: ATTRIBUTION_VERSION,
-      records: [completedTool(context.action, context.runUsageModelId)],
+      records: [
+        {
+          ...completedTool(context.action, context.runUsageModelId),
+          outputTokensCount: 99,
+        },
+      ],
       pendingToolItems: [],
     });
 
@@ -249,11 +255,53 @@ describe("AgentMessageConsumptionItemResource", () => {
     expect(afterSettle[0]).toMatchObject({
       itemKey: `tool-action:${context.action.id}`,
       inputTokensCount: 40,
+      // The output footprint was already known when the pending row was created.
       outputTokensCount: 12,
       grossAttributedCreditAmountMicro: 2_000_000,
       directCreditAmountMicro: 1_000_000,
       completedAt: expect.any(Date),
     });
+  });
+
+  it("keeps completed tool evidence immutable on a re-finalize", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const context = await setupMessageWithEvidence(auth, workspace);
+    const original = completedTool(context.action, context.runUsageModelId);
+
+    await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+      conversation: context.conversation,
+      agentMessageModelId: context.agentMessageModelId,
+      attributionVersion: ATTRIBUTION_VERSION,
+      records: [original],
+      pendingToolItems: [],
+    });
+    const [before] = await listTools(auth, context.agentMessageModelId);
+
+    await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+      conversation: context.conversation,
+      agentMessageModelId: context.agentMessageModelId,
+      attributionVersion: ATTRIBUTION_VERSION,
+      records: [
+        {
+          ...original,
+          inputTokensCount: 41,
+          outputTokensCount: 13,
+          grossAttributedCreditAmountMicro: 3_000_000,
+          directCreditAmountMicro: 2_000_000,
+        },
+      ],
+      pendingToolItems: [],
+    });
+
+    const [after] = await listTools(auth, context.agentMessageModelId);
+    expect(after).toMatchObject({
+      inputTokensCount: 40,
+      outputTokensCount: 12,
+      grossAttributedCreditAmountMicro: 2_000_000,
+      directCreditAmountMicro: 1_000_000,
+    });
+    expect(after.completedAt).toEqual(before.completedAt);
+    expect(after.updatedAt).toEqual(before.updatedAt);
   });
 
   it("does not regress a completed tool back to pending", async () => {
@@ -274,15 +322,46 @@ describe("AgentMessageConsumptionItemResource", () => {
       agentMessageModelId: context.agentMessageModelId,
       attributionVersion: ATTRIBUTION_VERSION,
       records: [],
-      pendingToolItems: [
-        pendingTool(context.action, context.runUsageModelId),
-      ],
+      pendingToolItems: [pendingTool(context.action, context.runUsageModelId)],
     });
 
     const tools = await listTools(auth, context.agentMessageModelId);
     expect(tools).toHaveLength(1);
     expect(tools[0]).toMatchObject({
       inputTokensCount: 40,
+      directCreditAmountMicro: 1_000_000,
+      completedAt: expect.any(Date),
+    });
+  });
+
+  it("keeps final evidence when pending and completed passes race", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const context = await setupMessageWithEvidence(auth, workspace);
+
+    await Promise.all([
+      AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+        conversation: context.conversation,
+        agentMessageModelId: context.agentMessageModelId,
+        attributionVersion: ATTRIBUTION_VERSION,
+        records: [completedTool(context.action, context.runUsageModelId)],
+        pendingToolItems: [],
+      }),
+      AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+        conversation: context.conversation,
+        agentMessageModelId: context.agentMessageModelId,
+        attributionVersion: ATTRIBUTION_VERSION,
+        records: [],
+        pendingToolItems: [
+          pendingTool(context.action, context.runUsageModelId),
+        ],
+      }),
+    ]);
+
+    const tools = await listTools(auth, context.agentMessageModelId);
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toMatchObject({
+      inputTokensCount: 40,
+      outputTokensCount: 12,
       directCreditAmountMicro: 1_000_000,
       completedAt: expect.any(Date),
     });

--- a/front/lib/resources/agent_message_consumption_item_resource.test.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.test.ts
@@ -1,6 +1,10 @@
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMessageConsumptionItemModel } from "@app/lib/models/agent/agent_message_consumption_item";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import type {
+  CompletedToolConsumptionItem,
+  PendingToolConsumptionItem,
+} from "@app/lib/resources/agent_message_consumption_item_resource";
 import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -12,6 +16,8 @@ import { RunFactory } from "@app/tests/utils/RunFactory";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { LightWorkspaceType } from "@app/types/user";
 import { describe, expect, it } from "vitest";
+
+const ATTRIBUTION_VERSION = 1;
 
 async function setupMessageWithEvidence(
   auth: Authenticator,
@@ -54,6 +60,48 @@ async function setupMessageWithEvidence(
   };
 }
 
+// A blocked tool's pending row: the emitted call output is known, the result footprint and charge
+// are not.
+function pendingTool(
+  action: AgentMCPActionResource,
+  runUsageModelId: ModelId
+): PendingToolConsumptionItem {
+  return {
+    action,
+    runUsageModelId,
+    outputTokensCount: 12,
+    grossAttributedCreditAmountMicro: 400_000,
+  };
+}
+
+// A settled tool's completed row: result footprint and direct charge are now known.
+function completedTool(
+  action: AgentMCPActionResource,
+  runUsageModelId: ModelId
+): CompletedToolConsumptionItem {
+  return {
+    itemType: "tool",
+    runUsageModelId,
+    action,
+    inputTokensCount: 40,
+    outputTokensCount: 12,
+    grossAttributedCreditAmountMicro: 2_000_000,
+    directCreditAmountMicro: 1_000_000,
+  };
+}
+
+async function listTools(
+  auth: Authenticator,
+  agentMessageModelId: ModelId
+): Promise<AgentMessageConsumptionItemResource[]> {
+  const items =
+    await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(auth, {
+      agentMessageModelIds: [agentMessageModelId],
+      attributionVersion: ATTRIBUTION_VERSION,
+    });
+  return items.filter((item) => item.itemType === "tool");
+}
+
 describe("AgentMessageConsumptionItemResource", () => {
   it("keeps pending state exclusive to incomplete tools", async () => {
     const { authenticator: auth, workspace } = await createResourceTest({});
@@ -67,7 +115,7 @@ describe("AgentMessageConsumptionItemResource", () => {
       agentMCPActionId: null,
       itemKey: `run-usage:${context.runUsageModelId}:input`,
       itemType: "input",
-      attributionVersion: 1,
+      attributionVersion: ATTRIBUTION_VERSION,
       inputTokensCount: 100,
       outputTokensCount: null,
       grossAttributedCreditAmountMicro: 300_000,
@@ -87,7 +135,7 @@ describe("AgentMessageConsumptionItemResource", () => {
       agentMCPActionId: context.action.id,
       itemKey: `tool-action:${context.action.id}`,
       itemType: "tool",
-      attributionVersion: 1,
+      attributionVersion: ATTRIBUTION_VERSION,
       inputTokensCount: 40,
       outputTokensCount: 12,
       grossAttributedCreditAmountMicro: 300_000,
@@ -99,168 +147,145 @@ describe("AgentMessageConsumptionItemResource", () => {
     );
   });
 
-  it("keeps the first completed facts when insertion is retried", async () => {
+  it("inserts model buckets once and keeps the first values on a re-finalize", async () => {
     const { authenticator: auth, workspace } = await createResourceTest({});
     const context = await setupMessageWithEvidence(auth, workspace);
-    const records = [
-      {
-        itemType: "input" as const,
-        runUsageModelId: context.runUsageModelId,
-        inputTokensCount: 100,
-        grossAttributedCreditAmountMicro: 300_000,
-      },
-      {
-        itemType: "tool" as const,
-        runUsageModelId: context.runUsageModelId,
-        action: context.action,
-        inputTokensCount: 40,
-        outputTokensCount: 12,
-        grossAttributedCreditAmountMicro: 2_000_000,
-        directCreditAmountMicro: 1_000_000,
-      },
-    ];
 
-    await AgentMessageConsumptionItemResource.insertCompletedItemsIdempotently(
-      auth,
-      {
-        conversation: context.conversation,
-        agentMessageModelId: context.agentMessageModelId,
-        attributionVersion: 1,
-        records,
-      }
-    );
-    await AgentMessageConsumptionItemResource.insertCompletedItemsIdempotently(
-      auth,
-      {
-        conversation: context.conversation,
-        agentMessageModelId: context.agentMessageModelId,
-        attributionVersion: 1,
-        records: [
-          { ...records[0], inputTokensCount: 101 },
-          { ...records[1], inputTokensCount: 41 },
-        ],
-      }
-    );
+    const inputRow = {
+      itemType: "input" as const,
+      runUsageModelId: context.runUsageModelId,
+      inputTokensCount: 100,
+      grossAttributedCreditAmountMicro: 300_000,
+    };
+
+    await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+      conversation: context.conversation,
+      agentMessageModelId: context.agentMessageModelId,
+      attributionVersion: ATTRIBUTION_VERSION,
+      records: [inputRow],
+      pendingToolItems: [],
+    });
+    await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+      conversation: context.conversation,
+      agentMessageModelId: context.agentMessageModelId,
+      attributionVersion: ATTRIBUTION_VERSION,
+      records: [{ ...inputRow, inputTokensCount: 101 }],
+      pendingToolItems: [],
+    });
 
     const items =
       await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
         auth,
         {
           agentMessageModelIds: [context.agentMessageModelId],
-          attributionVersion: 1,
+          attributionVersion: ATTRIBUTION_VERSION,
         }
       );
-    expect(items).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          itemKey: `run-usage:${context.runUsageModelId}:input`,
-          inputTokensCount: 100,
-        }),
-        expect.objectContaining({
-          itemKey: `tool-action:${context.action.id}`,
-          inputTokensCount: 40,
-          outputTokensCount: 12,
-          directCreditAmountMicro: 1_000_000,
-        }),
-      ])
-    );
-    expect(items).toHaveLength(2);
-    expect(items.every((item) => item.completedAt !== null)).toBe(true);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      itemKey: `run-usage:${context.runUsageModelId}:input`,
+      inputTokensCount: 100,
+      completedAt: expect.any(Date),
+    });
   });
 
-  it("completes an approval-spanning tool once", async () => {
+  it("inserts an already-final tool without a prior pending row", async () => {
     const { authenticator: auth, workspace } = await createResourceTest({});
     const context = await setupMessageWithEvidence(auth, workspace);
 
-    await AgentMessageConsumptionItemResource.insertPendingToolItemIdempotently(
-      auth,
-      {
-        conversation: context.conversation,
-        attributionVersion: 1,
-        item: {
-          action: context.action,
-          runUsageModelId: context.runUsageModelId,
-          outputTokensCount: 12,
-          grossAttributedCreditAmountMicro: 400_000,
-        },
-      }
-    );
+    await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+      conversation: context.conversation,
+      agentMessageModelId: context.agentMessageModelId,
+      attributionVersion: ATTRIBUTION_VERSION,
+      records: [completedTool(context.action, context.runUsageModelId)],
+      pendingToolItems: [],
+    });
 
-    const completedItem = {
-      action: context.action,
+    const tools = await listTools(auth, context.agentMessageModelId);
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toMatchObject({
+      itemKey: `tool-action:${context.action.id}`,
       inputTokensCount: 40,
+      outputTokensCount: 12,
+      directCreditAmountMicro: 1_000_000,
+      completedAt: expect.any(Date),
+    });
+  });
+
+  it("completes a tool that an earlier pass left pending, in place", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const context = await setupMessageWithEvidence(auth, workspace);
+
+    // The tool was blocked when the first pass ran: only a pending row.
+    await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+      conversation: context.conversation,
+      agentMessageModelId: context.agentMessageModelId,
+      attributionVersion: ATTRIBUTION_VERSION,
+      records: [],
+      pendingToolItems: [
+        pendingTool(context.action, context.runUsageModelId),
+      ],
+    });
+
+    const afterFirstPass = await listTools(auth, context.agentMessageModelId);
+    expect(afterFirstPass).toHaveLength(1);
+    expect(afterFirstPass[0]).toMatchObject({
+      inputTokensCount: null,
+      directCreditAmountMicro: null,
+      completedAt: null,
+    });
+
+    // The tool settled: the second pass completes the same row through the upsert.
+    await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+      conversation: context.conversation,
+      agentMessageModelId: context.agentMessageModelId,
+      attributionVersion: ATTRIBUTION_VERSION,
+      records: [completedTool(context.action, context.runUsageModelId)],
+      pendingToolItems: [],
+    });
+
+    const afterSettle = await listTools(auth, context.agentMessageModelId);
+    expect(afterSettle).toHaveLength(1);
+    expect(afterSettle[0]).toMatchObject({
+      itemKey: `tool-action:${context.action.id}`,
+      inputTokensCount: 40,
+      outputTokensCount: 12,
       grossAttributedCreditAmountMicro: 2_000_000,
       directCreditAmountMicro: 1_000_000,
-    };
-    await AgentMessageConsumptionItemResource.completePendingToolItemIdempotently(
-      auth,
-      {
-        attributionVersion: 1,
-        item: completedItem,
-      }
-    );
-    await AgentMessageConsumptionItemResource.completePendingToolItemIdempotently(
-      auth,
-      {
-        attributionVersion: 1,
-        item: { ...completedItem, inputTokensCount: 41 },
-      }
-    );
-    await AgentMessageConsumptionItemResource.insertPendingToolItemIdempotently(
-      auth,
-      {
-        conversation: context.conversation,
-        attributionVersion: 1,
-        item: {
-          action: context.action,
-          runUsageModelId: context.runUsageModelId,
-          outputTokensCount: 12,
-          grossAttributedCreditAmountMicro: 400_000,
-        },
-      }
-    );
-
-    await expect(
-      AgentMessageConsumptionItemResource.listByAgentMessageModelIds(auth, {
-        agentMessageModelIds: [context.agentMessageModelId],
-        attributionVersion: 1,
-      })
-    ).resolves.toEqual([
-      expect.objectContaining({
-        itemKey: `tool-action:${context.action.id}`,
-        runUsageId: context.runUsageModelId,
-        inputTokensCount: 40,
-        outputTokensCount: 12,
-        grossAttributedCreditAmountMicro: 2_000_000,
-        directCreditAmountMicro: 1_000_000,
-        completedAt: expect.any(Date),
-      }),
-    ]);
+      completedAt: expect.any(Date),
+    });
   });
 
-  it("does not create a tool fact when no pending fact exists", async () => {
+  it("does not regress a completed tool back to pending", async () => {
     const { authenticator: auth, workspace } = await createResourceTest({});
     const context = await setupMessageWithEvidence(auth, workspace);
 
-    await AgentMessageConsumptionItemResource.completePendingToolItemIdempotently(
-      auth,
-      {
-        attributionVersion: 1,
-        item: {
-          action: context.action,
-          inputTokensCount: 40,
-          grossAttributedCreditAmountMicro: 2_000_000,
-          directCreditAmountMicro: 1_000_000,
-        },
-      }
-    );
+    await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+      conversation: context.conversation,
+      agentMessageModelId: context.agentMessageModelId,
+      attributionVersion: ATTRIBUTION_VERSION,
+      records: [completedTool(context.action, context.runUsageModelId)],
+      pendingToolItems: [],
+    });
 
-    await expect(
-      AgentMessageConsumptionItemResource.listByAgentMessageModelIds(auth, {
-        agentMessageModelIds: [context.agentMessageModelId],
-        attributionVersion: 1,
-      })
-    ).resolves.toHaveLength(0);
+    // A late or racing pass that still sees the tool as blocked must not overwrite the completed row.
+    await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+      conversation: context.conversation,
+      agentMessageModelId: context.agentMessageModelId,
+      attributionVersion: ATTRIBUTION_VERSION,
+      records: [],
+      pendingToolItems: [
+        pendingTool(context.action, context.runUsageModelId),
+      ],
+    });
+
+    const tools = await listTools(auth, context.agentMessageModelId);
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toMatchObject({
+      inputTokensCount: 40,
+      directCreditAmountMicro: 1_000_000,
+      completedAt: expect.any(Date),
+    });
   });
 
   it("deletes facts only for the requested owning messages", async () => {
@@ -274,19 +299,15 @@ describe("AgentMessageConsumptionItemResource", () => {
       runUsageModelId: ModelId;
       action: AgentMCPActionResource;
     }) => {
-      await AgentMessageConsumptionItemResource.insertPendingToolItemIdempotently(
-        auth,
-        {
-          conversation: context.conversation,
-          attributionVersion: 1,
-          item: {
-            action: context.action,
-            runUsageModelId: context.runUsageModelId,
-            outputTokensCount: 12,
-            grossAttributedCreditAmountMicro: 400_000,
-          },
-        }
-      );
+      await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+        conversation: context.conversation,
+        agentMessageModelId: context.agentMessageModelId,
+        attributionVersion: ATTRIBUTION_VERSION,
+        records: [],
+        pendingToolItems: [
+          pendingTool(context.action, context.runUsageModelId),
+        ],
+      });
     };
     await createToolFact(first);
     await createToolFact(second);
@@ -299,13 +320,13 @@ describe("AgentMessageConsumptionItemResource", () => {
     await expect(
       AgentMessageConsumptionItemResource.listByAgentMessageModelIds(auth, {
         agentMessageModelIds: [first.agentMessageModelId],
-        attributionVersion: 1,
+        attributionVersion: ATTRIBUTION_VERSION,
       })
     ).resolves.toHaveLength(0);
     await expect(
       AgentMessageConsumptionItemResource.listByAgentMessageModelIds(auth, {
         agentMessageModelIds: [second.agentMessageModelId],
-        attributionVersion: 1,
+        attributionVersion: ATTRIBUTION_VERSION,
       })
     ).resolves.toHaveLength(1);
   });

--- a/front/lib/resources/agent_message_consumption_item_resource.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.ts
@@ -5,6 +5,7 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err } from "@app/types/shared/result";
@@ -25,13 +26,6 @@ export type CompletedToolConsumptionItem = ConsumptionItemEvidenceBase & {
   inputTokensCount: number | null;
   /** Estimated tokens in the model output that emitted the tool name and arguments */
   outputTokensCount: number | null;
-  directCreditAmountMicro: number | null;
-};
-
-export type PendingToolConsumptionCompletion = ConsumptionItemEvidenceBase & {
-  action: AgentMCPActionResource;
-  /** Estimated tokens in the result returned by this tool execution */
-  inputTokensCount: number | null;
   directCreditAmountMicro: number | null;
 };
 
@@ -181,23 +175,72 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
     };
   }
 
-  static async insertCompletedItemsIdempotently(
+  private static pendingToolCreationAttributes(
+    auth: Authenticator,
+    {
+      conversationModelId,
+      attributionVersion,
+      item,
+      now,
+    }: {
+      conversationModelId: ModelId;
+      attributionVersion: number;
+      item: PendingToolConsumptionItem;
+      now: Date;
+    }
+  ): ConsumptionItemCreationAttributes {
+    return {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      conversationId: conversationModelId,
+      agentMessageId: item.action.agentMessageId,
+      runUsageId: item.runUsageModelId,
+      agentMCPActionId: item.action.id,
+      itemKey: `tool-action:${item.action.id}`,
+      itemType: "tool",
+      attributionVersion,
+      inputTokensCount: null,
+      outputTokensCount: item.outputTokensCount,
+      grossAttributedCreditAmountMicro: item.grossAttributedCreditAmountMicro,
+      directCreditAmountMicro: null,
+      completedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  /**
+   * Writes one message's attribution breakdown for a single pass, idempotently and atomically.
+   * Callers pass the whole desired set and this reconciles it in one transaction, so the materializer
+   * never coordinates a read then separate inserts and updates.
+   *
+   * Three write shapes, one per identity class:
+   * - Model buckets and already-final tools with no prior row are inserted, first write wins, so a
+   *   re-finalize with the same identity is a no-op.
+   * - A final tool is upserted on its (message, version, itemKey) identity, so a row a previous pass
+   *   left pending, because the tool was still blocked then, is completed in place here rather than
+   *   skipped by the insert.
+   * - A still-blocked tool is inserted pending and never overwrites an existing row, so a completed
+   *   row from a concurrent pass is not regressed to pending.
+   */
+  static async recordItemsIdempotently(
     auth: Authenticator,
     {
       conversation,
       agentMessageModelId,
       attributionVersion,
       records,
+      pendingToolItems,
       transaction,
     }: {
       conversation: ConversationResource;
       agentMessageModelId: ModelId;
       attributionVersion: number;
       records: CompletedAgentMessageConsumptionItem[];
+      pendingToolItems: PendingToolConsumptionItem[];
       transaction?: Transaction;
     }
   ): Promise<void> {
-    if (records.length === 0) {
+    if (records.length === 0 && pendingToolItems.length === 0) {
       return;
     }
 
@@ -210,129 +253,100 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
       ),
       "Tool consumption items must have the same agent message ID as the owning agent message"
     );
-
-    const now = new Date();
-    await this.model.bulkCreate(
-      records.map((record) =>
-        this.creationAttributes(auth, {
-          conversationModelId: conversation.id,
-          agentMessageModelId,
-          attributionVersion,
-          record,
-          now,
-        })
+    assert(
+      pendingToolItems.every(
+        (item) => item.action.agentMessageId === agentMessageModelId
       ),
-      {
-        ignoreDuplicates: true,
-        returning: false,
-        transaction,
-        // Sequelize disables validation by default for bulkCreate.
-        validate: true,
-      }
+      "Pending tool consumption items must have the same agent message ID as the owning agent message"
     );
-  }
-
-  static async insertPendingToolItemIdempotently(
-    auth: Authenticator,
-    {
-      conversation,
-      attributionVersion,
-      item,
-      transaction,
-    }: {
-      conversation: ConversationResource;
-      attributionVersion: number;
-      item: PendingToolConsumptionItem;
-      transaction?: Transaction;
-    }
-  ): Promise<void> {
-    return this.insertPendingToolItemsIdempotently(auth, {
-      conversation,
-      attributionVersion,
-      items: [item],
-      transaction,
-    });
-  }
-
-  static async insertPendingToolItemsIdempotently(
-    auth: Authenticator,
-    {
-      conversation,
-      attributionVersion,
-      items,
-      transaction,
-    }: {
-      conversation: ConversationResource;
-      attributionVersion: number;
-      items: PendingToolConsumptionItem[];
-      transaction?: Transaction;
-    }
-  ): Promise<void> {
-    if (items.length === 0) {
-      return;
-    }
 
     const now = new Date();
-    await this.model.bulkCreate(
-      items.map((item) => ({
-        workspaceId: auth.getNonNullableWorkspace().id,
-        conversationId: conversation.id,
-        agentMessageId: item.action.agentMessageId,
-        runUsageId: item.runUsageModelId,
-        agentMCPActionId: item.action.id,
-        itemKey: `tool-action:${item.action.id}`,
-        itemType: "tool",
-        attributionVersion,
-        inputTokensCount: null,
-        outputTokensCount: item.outputTokensCount,
-        grossAttributedCreditAmountMicro: item.grossAttributedCreditAmountMicro,
-        directCreditAmountMicro: null,
-        completedAt: null,
-        createdAt: now,
-        updatedAt: now,
-      })),
-      {
-        ignoreDuplicates: true,
-        returning: false,
-        transaction,
-        // Sequelize disables validation by default for bulkCreate.
-        validate: true,
-      }
+    const modelRecords = records.filter((record) => record.itemType !== "tool");
+    const completedToolRecords = records.filter(
+      (record) => record.itemType === "tool"
     );
-  }
 
-  static async completePendingToolItemIdempotently(
-    auth: Authenticator,
-    {
-      attributionVersion,
-      item,
-      transaction,
-    }: {
-      attributionVersion: number;
-      item: PendingToolConsumptionCompletion;
-      transaction?: Transaction;
-    }
-  ): Promise<void> {
-    await this.model.update(
-      {
-        itemType: "tool",
-        agentMCPActionId: item.action.id,
-        inputTokensCount: item.inputTokensCount,
-        grossAttributedCreditAmountMicro: item.grossAttributedCreditAmountMicro,
-        directCreditAmountMicro: item.directCreditAmountMicro,
-        completedAt: new Date(),
-      },
-      {
-        where: {
-          workspaceId: auth.getNonNullableWorkspace().id,
-          agentMCPActionId: item.action.id,
-          attributionVersion,
-          itemType: "tool",
-          completedAt: { [Op.is]: null },
-        },
-        transaction,
+    await withTransaction(async (t) => {
+      if (modelRecords.length > 0) {
+        // Model buckets: first write wins, so a re-finalize does not disturb an existing breakdown.
+        await this.model.bulkCreate(
+          modelRecords.map((record) =>
+            this.creationAttributes(auth, {
+              conversationModelId: conversation.id,
+              agentMessageModelId,
+              attributionVersion,
+              record,
+              now,
+            })
+          ),
+          {
+            ignoreDuplicates: true,
+            returning: false,
+            transaction: t,
+            // Sequelize disables validation by default for bulkCreate.
+            validate: true,
+          }
+        );
       }
-    );
+
+      if (completedToolRecords.length > 0) {
+        // Final tools: insert the row, or complete one an earlier pass left pending, in a single
+        // upsert on the message-version-itemKey identity. This is what lands an approved-after-pause
+        // tool that the insert above would skip.
+        await this.model.bulkCreate(
+          completedToolRecords.map((record) =>
+            this.creationAttributes(auth, {
+              conversationModelId: conversation.id,
+              agentMessageModelId,
+              attributionVersion,
+              record,
+              now,
+            })
+          ),
+          {
+            updateOnDuplicate: [
+              "runUsageId",
+              "inputTokensCount",
+              "outputTokensCount",
+              "grossAttributedCreditAmountMicro",
+              "directCreditAmountMicro",
+              "completedAt",
+              "updatedAt",
+            ],
+            conflictAttributes: [
+              "workspaceId",
+              "agentMessageId",
+              "attributionVersion",
+              "itemKey",
+            ],
+            returning: false,
+            transaction: t,
+            validate: true,
+          }
+        );
+      }
+
+      if (pendingToolItems.length > 0) {
+        // Blocked tools: record the pending row only if none exists, never overwriting a completed
+        // one, so a racing final pass keeps precedence.
+        await this.model.bulkCreate(
+          pendingToolItems.map((item) =>
+            this.pendingToolCreationAttributes(auth, {
+              conversationModelId: conversation.id,
+              attributionVersion,
+              item,
+              now,
+            })
+          ),
+          {
+            ignoreDuplicates: true,
+            returning: false,
+            transaction: t,
+            validate: true,
+          }
+        );
+      }
+    }, transaction);
   }
 
   static async listByAgentMessageModelIds(

--- a/front/lib/resources/agent_message_consumption_item_resource.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.ts
@@ -209,6 +209,114 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
   }
 
   /**
+   * Bulk-inserts final tools, then completes only conflicting rows that are still pending. The
+   * insert waits on concurrent writes to the unique action identity, so the following lookup sees
+   * the settled conflict state without requiring a lock or allowing a stale pending write to win.
+   *
+   * // TODO(2026-08-01 flav): Revisit based on how often it happens.
+   * A resumed approval pass resubmits facts from earlier passes. PostgreSQL allocates sequence
+   * values before detecting conflicts, so this can leave gaps in the primary key sequence. We
+   * accept that tradeoff to keep this write race-safe without a pre-read. The agent loop resumes
+   * only after every tool awaiting approval has been approved, so parallel approvals produce one
+   * resumed pass rather than one pass per tool.
+   */
+  private static async insertOrCompleteToolRecords(
+    auth: Authenticator,
+    {
+      conversationModelId,
+      agentMessageModelId,
+      attributionVersion,
+      records,
+      now,
+      transaction,
+    }: {
+      conversationModelId: ModelId;
+      agentMessageModelId: ModelId;
+      attributionVersion: number;
+      records: CompletedToolConsumptionItem[];
+      now: Date;
+      transaction: Transaction;
+    }
+  ): Promise<void> {
+    const insertedRows = await this.model.bulkCreate(
+      records.map((record) =>
+        this.creationAttributes(auth, {
+          conversationModelId,
+          agentMessageModelId,
+          attributionVersion,
+          record,
+          now,
+        })
+      ),
+      {
+        ignoreDuplicates: true,
+        returning: ["id"],
+        transaction,
+        // Sequelize disables validation by default for bulkCreate.
+        validate: true,
+      }
+    );
+
+    // PostgreSQL returns an ID only for rows inserted by ON CONFLICT DO NOTHING. Most passes create
+    // final tools directly, so they finish without the pending-row lookup below.
+    if (insertedRows.every((row) => Boolean(row.id))) {
+      return;
+    }
+
+    const recordByActionModelId = new Map(
+      records.map((record) => [record.action.id, record])
+    );
+    const pendingRows = await this.model.findAll({
+      attributes: ["id", "agentMCPActionId"],
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        agentMessageId: agentMessageModelId,
+        attributionVersion,
+        agentMCPActionId: { [Op.in]: [...recordByActionModelId.keys()] },
+        itemType: "tool",
+        completedAt: { [Op.is]: null },
+      },
+      transaction,
+    });
+
+    for (const pendingRow of pendingRows) {
+      const actionModelId = pendingRow.agentMCPActionId;
+      assert(
+        actionModelId !== null,
+        "A pending tool row must reference an action"
+      );
+      const record = recordByActionModelId.get(actionModelId);
+      assert(
+        record,
+        "A pending tool row must have matching completion evidence"
+      );
+
+      await this.model.update(
+        {
+          itemType: "tool",
+          agentMCPActionId: actionModelId,
+          inputTokensCount: record.inputTokensCount,
+          grossAttributedCreditAmountMicro:
+            record.grossAttributedCreditAmountMicro,
+          directCreditAmountMicro: record.directCreditAmountMicro,
+          completedAt: now,
+        },
+        {
+          where: {
+            id: pendingRow.id,
+            workspaceId: auth.getNonNullableWorkspace().id,
+            agentMessageId: agentMessageModelId,
+            attributionVersion,
+            itemType: "tool",
+            completedAt: { [Op.is]: null },
+          },
+          transaction,
+        }
+      );
+    }
+  }
+
+  /**
    * Writes one message's attribution breakdown for a single pass, idempotently and atomically.
    * Callers pass the whole desired set and this reconciles it in one transaction, so the materializer
    * never coordinates a read then separate inserts and updates.
@@ -216,9 +324,8 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
    * Three write shapes, one per identity class:
    * - Model buckets and already-final tools with no prior row are inserted, first write wins, so a
    *   re-finalize with the same identity is a no-op.
-   * - A final tool is upserted on its (message, version, itemKey) identity, so a row a previous pass
-   *   left pending, because the tool was still blocked then, is completed in place here rather than
-   *   skipped by the insert.
+   * - A final tool is upserted on its (message, version, itemKey) identity only while the existing
+   *   row is pending. This completes an approval-spanning tool without changing a completed fact.
    * - A still-blocked tool is inserted pending and never overwrites an existing row, so a completed
    *   row from a concurrent pass is not regressed to pending.
    */
@@ -290,40 +397,14 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
       }
 
       if (completedToolRecords.length > 0) {
-        // Final tools: insert the row, or complete one an earlier pass left pending, in a single
-        // upsert on the message-version-itemKey identity. This is what lands an approved-after-pause
-        // tool that the insert above would skip.
-        await this.model.bulkCreate(
-          completedToolRecords.map((record) =>
-            this.creationAttributes(auth, {
-              conversationModelId: conversation.id,
-              agentMessageModelId,
-              attributionVersion,
-              record,
-              now,
-            })
-          ),
-          {
-            updateOnDuplicate: [
-              "runUsageId",
-              "inputTokensCount",
-              "outputTokensCount",
-              "grossAttributedCreditAmountMicro",
-              "directCreditAmountMicro",
-              "completedAt",
-              "updatedAt",
-            ],
-            conflictAttributes: [
-              "workspaceId",
-              "agentMessageId",
-              "attributionVersion",
-              "itemKey",
-            ],
-            returning: false,
-            transaction: t,
-            validate: true,
-          }
-        );
+        await this.insertOrCompleteToolRecords(auth, {
+          conversationModelId: conversation.id,
+          agentMessageModelId,
+          attributionVersion,
+          records: completedToolRecords,
+          now,
+          transaction: t,
+        });
       }
 
       if (pendingToolItems.length > 0) {
@@ -342,6 +423,7 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
             ignoreDuplicates: true,
             returning: false,
             transaction: t,
+            // Sequelize disables validation by default for bulkCreate.
             validate: true,
           }
         );

--- a/front/lib/resources/agent_message_consumption_item_resource.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.ts
@@ -28,14 +28,14 @@ export type CompletedToolConsumptionItem = ConsumptionItemEvidenceBase & {
   directCreditAmountMicro: number | null;
 };
 
-type PendingToolConsumptionCompletion = ConsumptionItemEvidenceBase & {
+export type PendingToolConsumptionCompletion = ConsumptionItemEvidenceBase & {
   action: AgentMCPActionResource;
   /** Estimated tokens in the result returned by this tool execution */
   inputTokensCount: number | null;
   directCreditAmountMicro: number | null;
 };
 
-type PendingToolConsumptionItem = ConsumptionItemEvidenceBase & {
+export type PendingToolConsumptionItem = ConsumptionItemEvidenceBase & {
   action: AgentMCPActionResource;
   runUsageModelId: ModelId | null;
   /** Estimated tokens in the model output that emitted the tool name and arguments */
@@ -246,28 +246,51 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
       transaction?: Transaction;
     }
   ): Promise<void> {
+    return this.insertPendingToolItemsIdempotently(auth, {
+      conversation,
+      attributionVersion,
+      items: [item],
+      transaction,
+    });
+  }
+
+  static async insertPendingToolItemsIdempotently(
+    auth: Authenticator,
+    {
+      conversation,
+      attributionVersion,
+      items,
+      transaction,
+    }: {
+      conversation: ConversationResource;
+      attributionVersion: number;
+      items: PendingToolConsumptionItem[];
+      transaction?: Transaction;
+    }
+  ): Promise<void> {
+    if (items.length === 0) {
+      return;
+    }
+
     const now = new Date();
     await this.model.bulkCreate(
-      [
-        {
-          workspaceId: auth.getNonNullableWorkspace().id,
-          conversationId: conversation.id,
-          agentMessageId: item.action.agentMessageId,
-          runUsageId: item.runUsageModelId,
-          agentMCPActionId: item.action.id,
-          itemKey: `tool-action:${item.action.id}`,
-          itemType: "tool",
-          attributionVersion,
-          inputTokensCount: null,
-          outputTokensCount: item.outputTokensCount,
-          grossAttributedCreditAmountMicro:
-            item.grossAttributedCreditAmountMicro,
-          directCreditAmountMicro: null,
-          completedAt: null,
-          createdAt: now,
-          updatedAt: now,
-        },
-      ],
+      items.map((item) => ({
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId: conversation.id,
+        agentMessageId: item.action.agentMessageId,
+        runUsageId: item.runUsageModelId,
+        agentMCPActionId: item.action.id,
+        itemKey: `tool-action:${item.action.id}`,
+        itemType: "tool",
+        attributionVersion,
+        inputTokensCount: null,
+        outputTokensCount: item.outputTokensCount,
+        grossAttributedCreditAmountMicro: item.grossAttributedCreditAmountMicro,
+        directCreditAmountMicro: null,
+        completedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      })),
       {
         ignoreDuplicates: true,
         returning: false,

--- a/front/temporal/analytics_queue/client.test.ts
+++ b/front/temporal/analytics_queue/client.test.ts
@@ -1,0 +1,62 @@
+import type { AuthenticatorType } from "@app/lib/auth";
+import { launchStoreAgentMessageConsumptionAttributionWorkflow } from "@app/temporal/analytics_queue/client";
+import { QUEUE_NAME } from "@app/temporal/analytics_queue/config";
+import { makeAgentMessageAnalyticsWorkflowId } from "@app/temporal/analytics_queue/helpers";
+import { storeAgentMessageConsumptionAttributionV2Signal } from "@app/temporal/analytics_queue/signals";
+import { storeAgentMessageConsumptionAttributionV2Workflow } from "@app/temporal/analytics_queue/workflows";
+import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockSignalWithStart } = vi.hoisted(() => ({
+  mockSignalWithStart: vi.fn(),
+}));
+
+vi.mock("@app/lib/temporal", () => ({
+  getTemporalClientForFrontNamespace: vi.fn(async () => ({
+    workflow: {
+      signalWithStart: mockSignalWithStart,
+    },
+  })),
+}));
+
+describe("launchStoreAgentMessageConsumptionAttributionWorkflow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSignalWithStart.mockResolvedValue(undefined);
+  });
+
+  it("signals the replay-safe V2 workflow for every finalize", async () => {
+    const authType = { workspaceId: "w_test" } as AuthenticatorType;
+    const agentLoopArgs = {
+      agentMessageId: "agent_message_test",
+      conversationId: "conversation_test",
+    } as AgentLoopArgs;
+
+    const first = await launchStoreAgentMessageConsumptionAttributionWorkflow({
+      authType,
+      agentLoopArgs,
+    });
+    const second = await launchStoreAgentMessageConsumptionAttributionWorkflow({
+      authType,
+      agentLoopArgs,
+    });
+
+    expect(first.isOk()).toBe(true);
+    expect(second.isOk()).toBe(true);
+    expect(mockSignalWithStart).toHaveBeenCalledTimes(2);
+    expect(mockSignalWithStart).toHaveBeenCalledWith(
+      storeAgentMessageConsumptionAttributionV2Workflow,
+      expect.objectContaining({
+        args: [authType, { agentLoopArgs }],
+        taskQueue: QUEUE_NAME,
+        workflowId: `${makeAgentMessageAnalyticsWorkflowId({
+          agentMessageId: agentLoopArgs.agentMessageId,
+          conversationId: agentLoopArgs.conversationId,
+          workspaceId: authType.workspaceId,
+        })}-consumption-attribution-v2`,
+        signal: storeAgentMessageConsumptionAttributionV2Signal,
+        signalArgs: undefined,
+      })
+    );
+  });
+});

--- a/front/temporal/analytics_queue/client.test.ts
+++ b/front/temporal/analytics_queue/client.test.ts
@@ -1,9 +1,9 @@
-import type { AuthenticatorType } from "@app/lib/auth";
 import { launchStoreAgentMessageConsumptionAttributionWorkflow } from "@app/temporal/analytics_queue/client";
 import { QUEUE_NAME } from "@app/temporal/analytics_queue/config";
 import { makeAgentMessageAnalyticsWorkflowId } from "@app/temporal/analytics_queue/helpers";
 import { storeAgentMessageConsumptionAttributionV2Signal } from "@app/temporal/analytics_queue/signals";
 import { storeAgentMessageConsumptionAttributionV2Workflow } from "@app/temporal/analytics_queue/workflows";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -26,11 +26,17 @@ describe("launchStoreAgentMessageConsumptionAttributionWorkflow", () => {
   });
 
   it("signals the replay-safe V2 workflow for every finalize", async () => {
-    const authType = { workspaceId: "w_test" } as AuthenticatorType;
-    const agentLoopArgs = {
+    const { authenticator } = await createResourceTest({});
+    const authType = authenticator.toJSON();
+    const agentLoopArgs: AgentLoopArgs = {
       agentMessageId: "agent_message_test",
+      agentMessageVersion: 0,
       conversationId: "conversation_test",
-    } as AgentLoopArgs;
+      conversationTitle: null,
+      conversationBranchId: null,
+      userMessageId: "user_message_test",
+      userMessageVersion: 0,
+    };
 
     const first = await launchStoreAgentMessageConsumptionAttributionWorkflow({
       authType,

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -7,10 +7,10 @@ import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/analytics_queue/config";
 import { makeAgentMessageAnalyticsWorkflowId } from "@app/temporal/analytics_queue/helpers";
-import { storeAgentMessageConsumptionAttributionSignal } from "@app/temporal/analytics_queue/signals";
+import { storeAgentMessageConsumptionAttributionV2Signal } from "@app/temporal/analytics_queue/signals";
 import {
   storeAgentAnalyticsWorkflow,
-  storeAgentMessageConsumptionAttributionWorkflow,
+  storeAgentMessageConsumptionAttributionV2Workflow,
   storeAgentMessageFeedbackWorkflow,
 } from "@app/temporal/analytics_queue/workflows";
 import type {
@@ -117,7 +117,7 @@ export async function launchStoreAgentMessageConsumptionAttributionWorkflow({
       agentMessageId,
       conversationId,
       workspaceId,
-    }) + "-consumption-attribution";
+    }) + "-consumption-attribution-v2";
 
   try {
     // signalWithStart, not start: a message settles across several finalizes (pause for approval,
@@ -125,12 +125,12 @@ export async function launchStoreAgentMessageConsumptionAttributionWorkflow({
     // already-started, freezing a tool that was still blocked when the first pass ran. The signal
     // instead reruns a workflow already in flight and starts one otherwise.
     await client.workflow.signalWithStart(
-      storeAgentMessageConsumptionAttributionWorkflow,
+      storeAgentMessageConsumptionAttributionV2Workflow,
       {
         args: [authType, { agentLoopArgs }],
         taskQueue: QUEUE_NAME,
         workflowId,
-        signal: storeAgentMessageConsumptionAttributionSignal,
+        signal: storeAgentMessageConsumptionAttributionV2Signal,
         signalArgs: undefined,
         searchAttributes: {
           conversationId: [conversationId],

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -7,6 +7,7 @@ import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/analytics_queue/config";
 import { makeAgentMessageAnalyticsWorkflowId } from "@app/temporal/analytics_queue/helpers";
+import { storeAgentMessageConsumptionAttributionSignal } from "@app/temporal/analytics_queue/signals";
 import {
   storeAgentAnalyticsWorkflow,
   storeAgentMessageConsumptionAttributionWorkflow,
@@ -119,12 +120,18 @@ export async function launchStoreAgentMessageConsumptionAttributionWorkflow({
     }) + "-consumption-attribution";
 
   try {
-    await client.workflow.start(
+    // signalWithStart, not start: a message settles across several finalizes (pause for approval,
+    // resume, retries) and each must recompute. start would drop every pass after the first as
+    // already-started, freezing a tool that was still blocked when the first pass ran. The signal
+    // instead reruns a workflow already in flight and starts one otherwise.
+    await client.workflow.signalWithStart(
       storeAgentMessageConsumptionAttributionWorkflow,
       {
         args: [authType, { agentLoopArgs }],
         taskQueue: QUEUE_NAME,
         workflowId,
+        signal: storeAgentMessageConsumptionAttributionSignal,
+        signalArgs: undefined,
         searchAttributes: {
           conversationId: [conversationId],
           workspaceId: [workspaceId],
@@ -137,16 +144,14 @@ export async function launchStoreAgentMessageConsumptionAttributionWorkflow({
     );
     return new Ok(undefined);
   } catch (e) {
-    if (!(e instanceof WorkflowExecutionAlreadyStartedError)) {
-      logger.error(
-        {
-          workflowId,
-          agentMessageId,
-          error: e,
-        },
-        "Failed starting agent message consumption attribution workflow"
-      );
-    }
+    logger.error(
+      {
+        workflowId,
+        agentMessageId,
+        error: e,
+      },
+      "Failed starting agent message consumption attribution workflow"
+    );
 
     return new Err(normalizeError(e));
   }

--- a/front/temporal/analytics_queue/signals.ts
+++ b/front/temporal/analytics_queue/signals.ts
@@ -1,0 +1,9 @@
+import { defineSignal } from "@temporalio/workflow";
+
+// Signals a running consumption-attribution workflow that the message settled further (a tool was
+// approved, a retry landed) and its breakdown must be recomputed. A finalize fires this on every
+// pass, including while the loop is paused for approval, so a run in flight when a later pass arrives
+// reruns rather than dropping it.
+export const storeAgentMessageConsumptionAttributionSignal = defineSignal<
+  [void]
+>("store_agent_message_consumption_attribution_signal");

--- a/front/temporal/analytics_queue/signals.ts
+++ b/front/temporal/analytics_queue/signals.ts
@@ -4,6 +4,6 @@ import { defineSignal } from "@temporalio/workflow";
 // approved, a retry landed) and its breakdown must be recomputed. A finalize fires this on every
 // pass, including while the loop is paused for approval, so a run in flight when a later pass arrives
 // reruns rather than dropping it.
-export const storeAgentMessageConsumptionAttributionSignal = defineSignal<
+export const storeAgentMessageConsumptionAttributionV2Signal = defineSignal<
   [void]
->("store_agent_message_consumption_attribution_signal");
+>("store_agent_message_consumption_attribution_v2_signal");

--- a/front/temporal/analytics_queue/worker.ts
+++ b/front/temporal/analytics_queue/worker.ts
@@ -8,7 +8,7 @@ import * as activities from "@app/temporal/analytics_queue/activities";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import type { Context } from "@temporalio/activity";
 import { Worker } from "@temporalio/worker";
-
+import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 import { QUEUE_NAME } from "./config";
 
 // Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
@@ -35,6 +35,18 @@ export async function runAnalyticsWorker() {
           return new ActivityInboundLogInterceptor(ctx, logger);
         },
       ],
+    },
+    bundlerOptions: {
+      // Update the webpack config to use aliases from our tsconfig.json. This let us import code
+      // in the workflows and activities files using the @app/ prefix. We also need to ignore some
+      // modules that are not available in Temporal environment.
+      webpackConfigHook: (config) => {
+        const plugins = config.resolve?.plugins ?? [];
+
+        config.resolve!.plugins = [...plugins, new TsconfigPathsPlugin({})];
+        return config;
+      },
+      ignoreModules: ["child_process", "crypto", "stream"],
     },
   });
 

--- a/front/temporal/analytics_queue/workflows.ts
+++ b/front/temporal/analytics_queue/workflows.ts
@@ -1,10 +1,15 @@
 import type { AuthenticatorType } from "@app/lib/auth";
 import type * as activities from "@app/temporal/analytics_queue/activities";
+import { storeAgentMessageConsumptionAttributionSignal } from "@app/temporal/analytics_queue/signals";
 import type {
   AgentLoopArgs,
   AgentMessageRef,
 } from "@app/types/assistant/agent_run";
-import { proxyActivities } from "@temporalio/workflow";
+import { proxyActivities, setHandler, sleep } from "@temporalio/workflow";
+
+// Coalesce the finalize burst (a message settles across several passes: pause for approval, resume,
+// Temporal retries) into few recompute runs. Short because attribution is off the hot path.
+const CONSUMPTION_ATTRIBUTION_DEBOUNCE_MS = 15 * 1000;
 
 const {
   storeAgentAnalyticsActivity,
@@ -46,6 +51,12 @@ export async function storeAgentMessageFeedbackWorkflow(
   });
 }
 
+// Durable, coalesced recompute of one message's consumption breakdown. A finalize signals this
+// workflow on every pass through signalWithStart in the client. A pass arriving while a recompute is
+// in flight sets the flag again and the loop runs once more, so a tool approved during that window
+// is still reflected rather than dropped as an already-started start. The activity reads the whole
+// message from the database, so it needs no per-pass arguments beyond the stable agent message and
+// conversation ids carried by the first start.
 export async function storeAgentMessageConsumptionAttributionWorkflow(
   authType: AuthenticatorType,
   {
@@ -54,7 +65,17 @@ export async function storeAgentMessageConsumptionAttributionWorkflow(
     agentLoopArgs: AgentLoopArgs;
   }
 ): Promise<void> {
-  await storeAgentMessageConsumptionAttributionActivity(authType, {
-    agentLoopArgs,
+  let pendingRecompute = true;
+
+  setHandler(storeAgentMessageConsumptionAttributionSignal, () => {
+    pendingRecompute = true;
   });
+
+  while (pendingRecompute) {
+    await sleep(CONSUMPTION_ATTRIBUTION_DEBOUNCE_MS);
+    pendingRecompute = false;
+    await storeAgentMessageConsumptionAttributionActivity(authType, {
+      agentLoopArgs,
+    });
+  }
 }

--- a/front/temporal/analytics_queue/workflows.ts
+++ b/front/temporal/analytics_queue/workflows.ts
@@ -1,15 +1,11 @@
 import type { AuthenticatorType } from "@app/lib/auth";
 import type * as activities from "@app/temporal/analytics_queue/activities";
-import { storeAgentMessageConsumptionAttributionSignal } from "@app/temporal/analytics_queue/signals";
+import { storeAgentMessageConsumptionAttributionV2Signal } from "@app/temporal/analytics_queue/signals";
 import type {
   AgentLoopArgs,
   AgentMessageRef,
 } from "@app/types/assistant/agent_run";
-import { proxyActivities, setHandler, sleep } from "@temporalio/workflow";
-
-// Coalesce the finalize burst (a message settles across several passes: pause for approval, resume,
-// Temporal retries) into few recompute runs. Short because attribution is off the hot path.
-const CONSUMPTION_ATTRIBUTION_DEBOUNCE_MS = 15 * 1000;
+import { proxyActivities, setHandler } from "@temporalio/workflow";
 
 const {
   storeAgentAnalyticsActivity,
@@ -51,13 +47,25 @@ export async function storeAgentMessageFeedbackWorkflow(
   });
 }
 
-// Durable, coalesced recompute of one message's consumption breakdown. A finalize signals this
-// workflow on every pass through signalWithStart in the client. A pass arriving while a recompute is
-// in flight sets the flag again and the loop runs once more, so a tool approved during that window
-// is still reflected rather than dropped as an already-started start. The activity reads the whole
-// message from the database, so it needs no per-pass arguments beyond the stable agent message and
-// conversation ids carried by the first start.
+// Kept unchanged for executions started before the V2 signal workflow was deployed.
 export async function storeAgentMessageConsumptionAttributionWorkflow(
+  authType: AuthenticatorType,
+  {
+    agentLoopArgs,
+  }: {
+    agentLoopArgs: AgentLoopArgs;
+  }
+): Promise<void> {
+  await storeAgentMessageConsumptionAttributionActivity(authType, {
+    agentLoopArgs,
+  });
+}
+
+// Durable recompute of one message's consumption breakdown. New launches use this versioned
+// workflow, while the original workflow above remains available for replay. A finalize signals this
+// on every pass. A signal received while the activity runs requests one more pass, and a signal
+// received before it runs is covered by the activity reading the latest message state from the DB.
+export async function storeAgentMessageConsumptionAttributionV2Workflow(
   authType: AuthenticatorType,
   {
     agentLoopArgs,
@@ -67,12 +75,11 @@ export async function storeAgentMessageConsumptionAttributionWorkflow(
 ): Promise<void> {
   let pendingRecompute = true;
 
-  setHandler(storeAgentMessageConsumptionAttributionSignal, () => {
+  setHandler(storeAgentMessageConsumptionAttributionV2Signal, () => {
     pendingRecompute = true;
   });
 
   while (pendingRecompute) {
-    await sleep(CONSUMPTION_ATTRIBUTION_DEBOUNCE_MS);
     pendingRecompute = false;
     await storeAgentMessageConsumptionAttributionActivity(authType, {
       agentLoopArgs,

--- a/front/tests/utils/AgentMCPActionFactory.ts
+++ b/front/tests/utils/AgentMCPActionFactory.ts
@@ -134,6 +134,32 @@ export class AgentMCPActionFactory {
   }
 
   /**
+   * Transitions an existing action to a new status, as happens once a blocked tool is approved
+   * (or denied) and then settles. The action resource passed in is not mutated, so callers that
+   * need the new status should re-fetch.
+   */
+  static async setStatus(
+    auth: Authenticator,
+    {
+      action,
+      status,
+    }: {
+      action: AgentMCPActionResource;
+      status: ToolExecutionStatus;
+    }
+  ): Promise<void> {
+    await AgentMCPActionModel.update(
+      { status },
+      {
+        where: {
+          id: action.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+      }
+    );
+  }
+
+  /**
    * Creates an agent message (with a fresh test agent configuration) holding a single MCP
    * action, blocked on tool validation by default.
    */


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Attribution runs on every finalize, including while the loop is paused on a tool awaiting approval. Back then the action has not run, so it has no result and no charge, yet the first implementation wrote a fully completed row for it with a charge and the approval notice as the result, and the idempotency key froze that row so approval could never correct it. Billing dodges this by recomputing and overwriting the whole total each finalize, but attribution only appends, so a blocked tool has to be recorded pending and completed later.

This also required fixing how recomputations are scheduled. The existing launcher used a fixed workflow ID with a plain start. A finalize arriving while the workflow was already running was rejected as already started, potentially leaving a pending row without a later pass to complete it. New launches now use `signalWithStart` against a stable per-message V2 workflow. A signal received while attribution is being computed requests another pass, while signals received before computation are covered because the activity reads the latest message state from PostgreSQL.

The scheduling change uses a new workflow type, signal name, and workflow ID suffix. The original workflow remains exported with its original implementation so currently running executions can replay safely. New tasks use V2 from their first finalize.
For a task already running during deployment, its next finalize starts or signals V2, which reconstructs the complete attribution from PostgreSQL without requiring state from the earlier workflow execution.

A blocked tool row contains only the normalized output tokens and gross model contribution of the emitted call. Once every tool awaiting approval has been approved and the agent loop resumes, the next finalize completes that same row with the result footprint, direct charge, and completion timestamp. Auto-approved tools are written completed on their first pass.

The resource writes each pass atomically. Model facts and new tool facts use bulk inserts with first-write-wins semantics. When a final tool conflicts with an existing identity, the resource reads only conflicting rows that remain
pending and completes them with a second `completedAt IS NULL` guard. Completed facts cannot be overwritten, and a delayed blocked pass cannot regress a completed tool to pending, so overlapping and out-of-order passes converge on the same result.

> [!NOTE]
> PostgreSQL may consume primary-key sequence values for rows rejected by `ON CONFLICT DO NOTHING`. We accept those gaps to preserve race-safe writes without adding a pre-read or locking protocol. Worth noting that the loop resumes only when all pending actions are approved. Will monitor how often it happens, and I might revisit.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
