### PR TITLE
[front] fix: blocked-action cards on shared Frames

### DIFF
--- a/front/components/actions/blocked/PersonalAuthenticationCard.tsx
+++ b/front/components/actions/blocked/PersonalAuthenticationCard.tsx
@@ -6,7 +6,6 @@ import { getAvatarFromIcon } from "@app/components/resources/resources_icons";
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import type { MCPServerType } from "@app/lib/api/mcp";
-import { useAuth } from "@app/lib/auth/AuthContext";
 import {
   useCreatePersonalConnection,
   useMCPServer,
@@ -21,6 +20,9 @@ export type PersonalAuthResolutionOutcome = "completed" | "denied";
 
 interface PersonalAuthenticationCardProps {
   triggeringUser: UserType | null;
+  // The viewer looking at the card. Passed in rather than read from `AuthContext` because shared
+  // frames render this card outside of any AuthProvider.
+  currentUser: UserType;
   mcpServerId: string;
   owner: LightWorkspaceType;
   provider: OAuthProvider;
@@ -32,6 +34,7 @@ interface PersonalAuthenticationCardProps {
 
 export function PersonalAuthenticationCard({
   triggeringUser,
+  currentUser,
   mcpServerId,
   owner,
   provider,
@@ -39,7 +42,6 @@ export function PersonalAuthenticationCard({
   isResolving,
   onResolve,
 }: PersonalAuthenticationCardProps) {
-  const { user } = useAuth();
   const { server: mcpServer } = useMCPServer({
     owner,
     serverId: mcpServerId,
@@ -74,9 +76,9 @@ export function PersonalAuthenticationCard({
     () =>
       canCurrentUserRespondToParentUserMessage({
         parentUserId: triggeringUser?.sId,
-        currentUserId: user?.sId,
+        currentUserId: currentUser.sId,
       }),
-    [triggeringUser, user?.sId]
+    [triggeringUser, currentUser.sId]
   );
 
   const onConnectClick = async (mcpServer: MCPServerType) => {

--- a/front/components/actions/blocked/SandboxFunctionPersonalAuthCard.test.tsx
+++ b/front/components/actions/blocked/SandboxFunctionPersonalAuthCard.test.tsx
@@ -1,0 +1,156 @@
+import type { SandboxFunctionToolPersonalAuthRequiredEvent } from "@app/lib/actions/mcp_internal_actions/events";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SandboxFunctionPersonalAuthCard } from "./SandboxFunctionPersonalAuthCard";
+
+// `@app/lib/auth/AuthContext` is deliberately NOT mocked: shared frames render this card outside
+// any AuthProvider, so the component must not read the workspace/user from context.
+
+const resolveAuthenticationMock = vi.fn();
+const createPersonalConnectionMock = vi.fn();
+
+vi.mock("@app/lib/swr/tool_actions", () => ({
+  useResolveAuthentication: () => ({
+    resolveAuthentication: resolveAuthenticationMock,
+    isResolving: false,
+  }),
+}));
+
+vi.mock("@app/lib/swr/mcp_servers", () => ({
+  useCreatePersonalConnection: () => ({
+    createPersonalConnection: createPersonalConnectionMock,
+  }),
+  useMCPServer: () => ({
+    server: {
+      sId: "ims_1",
+      name: "Google Drive",
+      icon: undefined,
+      authorization: {
+        provider: "google_drive",
+        supported_use_cases: ["personal_actions"],
+      },
+    },
+  }),
+}));
+
+vi.mock("@app/lib/actions/mcp_helper", () => ({
+  getMcpServerDisplayName: (server: { name: string }) => server.name,
+}));
+
+vi.mock("@app/components/resources/resources_icons", () => ({
+  getAvatarFromIcon: () => null,
+}));
+
+vi.mock("@app/components/oauth/PersonalAuthCredentialOverrides", () => ({
+  areCredentialOverridesValid: () => true,
+  PersonalAuthCredentialOverrides: () => null,
+}));
+
+vi.mock("@app/types/oauth/lib", () => ({
+  getOverridablePersonalAuthInputs: () => null,
+}));
+
+vi.mock("@dust-tt/sparkle", () => ({
+  ActionCardBlock: ({
+    title,
+    description,
+    actions,
+  }: {
+    title: string;
+    description?: React.ReactNode;
+    actions?: React.ReactNode;
+  }) => (
+    <div>
+      <div>{title}</div>
+      <div>{description}</div>
+      <div>{actions}</div>
+    </div>
+  ),
+  Button: ({ label, onClick }: { label: string; onClick?: () => void }) => (
+    <button onClick={onClick}>{label}</button>
+  ),
+  Check: () => null,
+  XClose: () => null,
+}));
+
+const viewer = {
+  owner: { sId: "wId_1" } as LightWorkspaceType,
+  user: { sId: "user_1", fullName: "Ada Lovelace" } as UserType,
+};
+
+function makeEvent(
+  invocationId: string,
+  actionId: string
+): SandboxFunctionToolPersonalAuthRequiredEvent {
+  return {
+    type: "tool_personal_auth_required",
+    created: 0,
+    sandboxFunctionId: "sfn_1",
+    invocationId,
+    actionId,
+    userId: viewer.user.sId,
+    metadata: {
+      toolName: "get_worksheet",
+      mcpServerName: "google_drive",
+      agentName: "agent",
+      mcpServerDisplayName: "google_drive",
+      mcpServerId: "ims_1",
+    },
+    inputs: {},
+    authError: {
+      mcpServerId: "ims_1",
+      provider: "google_drive",
+      toolName: "get_worksheet",
+      message: "The tool get_worksheet requires personal authentication.",
+    },
+  } as SandboxFunctionToolPersonalAuthRequiredEvent;
+}
+
+describe("SandboxFunctionPersonalAuthCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createPersonalConnectionMock.mockResolvedValue({ success: true });
+    resolveAuthenticationMock.mockResolvedValue({ success: true });
+  });
+
+  it("renders outside of an AuthProvider, as on a shared frame", () => {
+    render(
+      <SandboxFunctionPersonalAuthCard
+        events={[makeEvent("sfi_1", "sfa_1")]}
+        viewer={viewer}
+        onResolved={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Google Drive authentication")).toBeDefined();
+    // The viewer triggered the invocation, so they can resolve it themselves.
+    expect(screen.getByText("Connect")).toBeDefined();
+  });
+
+  it("resolves every invocation waiting on the connection with a single card", async () => {
+    const onResolved = vi.fn();
+    render(
+      <SandboxFunctionPersonalAuthCard
+        events={[makeEvent("sfi_1", "sfa_1"), makeEvent("sfi_2", "sfa_2")]}
+        viewer={viewer}
+        onResolved={onResolved}
+      />
+    );
+
+    await userEvent.click(screen.getByText("Connect"));
+
+    expect(createPersonalConnectionMock).toHaveBeenCalledTimes(1);
+    expect(resolveAuthenticationMock).toHaveBeenCalledTimes(2);
+    expect(resolveAuthenticationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ invocationId: "sfi_1", actionId: "sfa_1" })
+    );
+    expect(resolveAuthenticationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ invocationId: "sfi_2", actionId: "sfa_2" })
+    );
+    expect(onResolved).toHaveBeenCalledTimes(1);
+  });
+});

--- a/front/components/actions/blocked/SandboxFunctionPersonalAuthCard.test.tsx
+++ b/front/components/actions/blocked/SandboxFunctionPersonalAuthCard.test.tsx
@@ -107,7 +107,7 @@ function makeEvent(
       toolName: "get_worksheet",
       message: "The tool get_worksheet requires personal authentication.",
     },
-  } as SandboxFunctionToolPersonalAuthRequiredEvent;
+  } satisfies SandboxFunctionToolPersonalAuthRequiredEvent;
 }
 
 describe("SandboxFunctionPersonalAuthCard", () => {

--- a/front/components/actions/blocked/SandboxFunctionPersonalAuthCard.tsx
+++ b/front/components/actions/blocked/SandboxFunctionPersonalAuthCard.tsx
@@ -1,37 +1,44 @@
 import type { PersonalAuthResolutionOutcome } from "@app/components/actions/blocked/PersonalAuthenticationCard";
 import { PersonalAuthenticationCard } from "@app/components/actions/blocked/PersonalAuthenticationCard";
+import type { FrameViewer } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
 import type { SandboxFunctionToolPersonalAuthRequiredEvent } from "@app/lib/actions/mcp_internal_actions/events";
-import { useAuth } from "@app/lib/auth/AuthContext";
 import { useResolveAuthentication } from "@app/lib/swr/tool_actions";
 
 interface SandboxFunctionPersonalAuthCardProps {
-  event: SandboxFunctionToolPersonalAuthRequiredEvent;
+  // Every invocation blocked on this MCP server: one trip through the authentication flow resolves
+  // them all, so they must not be presented (and resolved) one card at a time.
+  events: SandboxFunctionToolPersonalAuthRequiredEvent[];
+  // Viewer context is passed in: shared frames render this card outside of any AuthProvider.
+  viewer: FrameViewer;
   onResolved: () => void;
 }
 
 export function SandboxFunctionPersonalAuthCard({
-  event,
+  events,
+  viewer,
   onResolved,
 }: SandboxFunctionPersonalAuthCardProps) {
-  const { user, workspace } = useAuth();
+  const [{ authError }] = events;
 
   const { resolveAuthentication, isResolving } = useResolveAuthentication({
-    owner: workspace,
+    owner: viewer.owner,
   });
 
   const handleResolve = async (
     outcome: PersonalAuthResolutionOutcome
   ): Promise<boolean> => {
-    const result = await resolveAuthentication({
-      contextType: "sandbox_function",
-      sandboxFunctionId: event.sandboxFunctionId,
-      invocationId: event.invocationId,
-      actionId: event.actionId,
-      outcome,
-    });
+    for (const event of events) {
+      const result = await resolveAuthentication({
+        contextType: "sandbox_function",
+        sandboxFunctionId: event.sandboxFunctionId,
+        invocationId: event.invocationId,
+        actionId: event.actionId,
+        outcome,
+      });
 
-    if (!result.success) {
-      return false;
+      if (!result.success) {
+        return false;
+      }
     }
 
     onResolved();
@@ -40,11 +47,12 @@ export function SandboxFunctionPersonalAuthCard({
 
   return (
     <PersonalAuthenticationCard
-      triggeringUser={user}
-      mcpServerId={event.authError.mcpServerId}
-      owner={workspace}
-      provider={event.authError.provider}
-      scope={event.authError.scope}
+      triggeringUser={viewer.user}
+      currentUser={viewer.user}
+      mcpServerId={authError.mcpServerId}
+      owner={viewer.owner}
+      provider={authError.provider}
+      scope={authError.scope}
       isResolving={isResolving}
       onResolve={handleResolve}
     />

--- a/front/components/actions/blocked/SandboxFunctionToolApprovalCard.tsx
+++ b/front/components/actions/blocked/SandboxFunctionToolApprovalCard.tsx
@@ -1,24 +1,26 @@
 import { ToolValidationCard } from "@app/components/actions/blocked/ToolValidationCard";
+import type { FrameViewer } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { SandboxFunctionMCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
-import { useAuth } from "@app/lib/auth/AuthContext";
 import { useValidateAction } from "@app/lib/swr/tool_actions";
 import { useState } from "react";
 
 interface SandboxFunctionToolApprovalCardProps {
   event: SandboxFunctionMCPApproveExecutionEvent;
+  // Viewer context is passed in: shared frames render this card outside of any AuthProvider.
+  viewer: FrameViewer;
   onResolved: () => void;
 }
 
 export function SandboxFunctionToolApprovalCard({
   event,
+  viewer,
   onResolved,
 }: SandboxFunctionToolApprovalCardProps) {
-  const { user, workspace } = useAuth();
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const { validateAction, isValidating } = useValidateAction({
-    owner: workspace,
+    owner: viewer.owner,
     onError: setErrorMessage,
   });
 
@@ -46,8 +48,9 @@ export function SandboxFunctionToolApprovalCard({
   return (
     <ToolValidationCard
       validationRequest={event}
-      triggeringUser={user}
-      owner={workspace}
+      triggeringUser={viewer.user}
+      currentUser={viewer.user}
+      owner={viewer.owner}
       errorMessage={errorMessage}
       isValidating={isValidating}
       onValidate={handleValidation}

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -25,7 +25,6 @@ import {
 import { SANDBOX_FUNCTIONS_SERVER_NAME } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 import { WAKEUPS_SERVER_NAME } from "@app/lib/api/actions/servers/wakeups/metadata";
 import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
-import { useAuth } from "@app/lib/auth/AuthContext";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import {
@@ -191,6 +190,9 @@ type ToolValidationRequest = Pick<
 interface ToolValidationCardProps {
   validationRequest: ToolValidationRequest;
   triggeringUser: UserType | null;
+  // The viewer looking at the card. Passed in rather than read from `AuthContext` because shared
+  // frames render this card outside of any AuthProvider.
+  currentUser: UserType;
   owner: LightWorkspaceType;
   conversationId?: string | null;
   errorMessage: string | null;
@@ -203,6 +205,7 @@ interface ToolValidationCardProps {
 export function ToolValidationCard({
   validationRequest,
   triggeringUser,
+  currentUser,
   owner,
   conversationId,
   errorMessage,
@@ -210,16 +213,15 @@ export function ToolValidationCard({
   isPulsing = false,
   onValidate,
 }: ToolValidationCardProps) {
-  const { user } = useAuth();
   const [neverAskAgain, setNeverAskAgain] = useState(false);
 
   const canCurrentUserRespond = useMemo(
     () =>
       canCurrentUserRespondToParentUserMessage({
         parentUserId: validationRequest.userId,
-        currentUserId: user?.sId,
+        currentUserId: currentUser.sId,
       }),
-    [validationRequest.userId, user?.sId]
+    [validationRequest.userId, currentUser.sId]
   );
 
   const icon = validationRequest.metadata.icon
@@ -296,7 +298,7 @@ export function ToolValidationCard({
         <>
           <ToolValidationDetails
             blockedAction={validationRequest}
-            user={user}
+            user={currentUser}
             owner={owner}
             conversationId={conversationId}
             defaultExpanded={toolOverride?.detailsExpanded}

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -2,6 +2,7 @@ import type { PersonalAuthResolutionOutcome } from "@app/components/actions/bloc
 import { PersonalAuthenticationCard } from "@app/components/actions/blocked/PersonalAuthenticationCard";
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import type { AgentLoopBlockedToolExecution } from "@app/lib/actions/mcp";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { useResolveAuthentication } from "@app/lib/swr/tool_actions";
 import type { OAuthProvider } from "@app/types/oauth/lib";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
@@ -23,6 +24,7 @@ export function MCPServerPersonalAuthenticationRequired({
   provider,
   scope,
 }: MCPServerPersonalAuthenticationRequiredProps) {
+  const { user } = useAuth();
   const { removeCompletedAction } = useBlockedActionsContext();
 
   const { resolveAuthentication, isResolving } = useResolveAuthentication({
@@ -52,6 +54,7 @@ export function MCPServerPersonalAuthenticationRequired({
   return (
     <PersonalAuthenticationCard
       triggeringUser={triggeringUser}
+      currentUser={user}
       mcpServerId={mcpServerId}
       owner={owner}
       provider={provider}

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -88,6 +88,7 @@ export function MCPToolValidationRequired({
     <ToolValidationCard
       validationRequest={blockedAction}
       triggeringUser={triggeringUser}
+      currentUser={user}
       owner={owner}
       conversationId={conversationId}
       errorMessage={errorMessage}

--- a/front/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe.tsx
@@ -42,7 +42,7 @@ export function getAuthenticatedFrameUserIdentity(
 interface AuthenticatedVisualizationActionIframeProps
   extends Omit<
     VisualizationActionIframeProps,
-    "canInvokeFunctions" | "scopedUserIdentity"
+    "canInvokeFunctions" | "scopedUserIdentity" | "viewer"
   > {}
 
 export const AuthenticatedVisualizationActionIframe = forwardRef<
@@ -61,6 +61,11 @@ export const AuthenticatedVisualizationActionIframe = forwardRef<
       ref={ref}
       canInvokeFunctions={scopedUserIdentity !== undefined}
       scopedUserIdentity={scopedUserIdentity}
+      viewer={
+        authContext && scopedUserIdentity
+          ? { owner: authContext.workspace, user: authContext.user }
+          : null
+      }
     />
   );
 });

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -309,7 +309,12 @@ function SandboxFunctionBlockedAction({
       blockedActionCard = (
         <SandboxFunctionPersonalAuthCard
           key={eventId}
-          events={blockedActions.map((a) => a.event).filter(isPersonalAuth)}
+          events={blockedActions
+            .map((a) => a.event)
+            .filter(
+              (e): e is SandboxFunctionToolPersonalAuthRequiredEvent =>
+                e.type === "tool_personal_auth_required"
+            )}
           viewer={viewer}
           onResolved={onResolved}
         />
@@ -327,12 +332,6 @@ function SandboxFunctionBlockedAction({
       </div>
     </div>
   );
-}
-
-function isPersonalAuth(
-  event: SandboxFunctionBlockingEvent
-): event is SandboxFunctionToolPersonalAuthRequiredEvent {
-  return event.type === "tool_personal_auth_required";
 }
 
 // The blocked actions the next card presents: the oldest one, plus everything waiting on the same

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -34,6 +34,7 @@ import {
   assertNeverAndIgnore,
 } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
 import {
   AlertCircle,
   Button,
@@ -161,10 +162,19 @@ const getExtensionFromBlob = (blob: Blob): string => {
   return mimeToExt[blob.type] || "txt"; // Default to 'txt' if mime type is unknown.
 };
 
+// Workspace-scoped viewer of the frame. Needed by the blocked-action cards, which are also
+// rendered on shared frames, outside of any AuthProvider. Null for anonymous viewers, who cannot
+// invoke functions and therefore never get a blocked action.
+export interface FrameViewer {
+  owner: LightWorkspaceType;
+  user: UserType;
+}
+
 interface SandboxFunctionInvocationProps {
   workspaceId: string;
   functionId: string;
   invocationId: string;
+  onBlocked: (eventId: string, event: SandboxFunctionBlockingEvent) => void;
   onSettle: (
     invocationId: string,
     result: Result<unknown, SandboxFunctionCallError>
@@ -183,39 +193,16 @@ type QueuedBlockingEvent = {
   event: SandboxFunctionBlockingEvent;
 };
 
-// Consumes one invocation's event stream, settles the pending iframe call, and renders the
-// approval or authentication card over the frame while a tool is blocked on user input.
+// Consumes one invocation's event stream: reports the tool executions it blocks on and settles the
+// pending iframe call. Renders nothing — the blocked-action card is owned by the parent, which sees
+// every in-flight invocation.
 function SandboxFunctionInvocation({
   workspaceId,
   functionId,
   invocationId,
+  onBlocked,
   onSettle,
 }: SandboxFunctionInvocationProps) {
-  const [blockedActions, setBlockedActions] = useState<QueuedBlockingEvent[]>(
-    []
-  );
-
-  const enqueueBlockedAction = useCallback(
-    (eventId: string, event: SandboxFunctionBlockingEvent) => {
-      setBlockedActions((prev) => {
-        // The stream can re-deliver or supersede an event after a reconnect or a resolution:
-        // replace by actionId, keeping the newest delivery.
-        const existingIndex = prev.findIndex(
-          (a) => a.event.actionId === event.actionId
-        );
-        const entry = { eventId, event };
-        return existingIndex === -1
-          ? [...prev, entry]
-          : prev.map((a, index) => (index === existingIndex ? entry : a));
-      });
-    },
-    []
-  );
-
-  const removeBlockedAction = useCallback((eventId: string) => {
-    setBlockedActions((prev) => prev.filter((a) => a.eventId !== eventId));
-  }, []);
-
   const buildEventSourceURL = useCallback(
     (lastEvent: string | null) => {
       const esURL = `/api/sse/w/${workspaceId}/sandbox-functions/${functionId}/invocations/${invocationId}/events`;
@@ -249,7 +236,7 @@ function SandboxFunctionInvocation({
             break;
           case "tool_approve_execution":
           case "tool_personal_auth_required":
-            enqueueBlockedAction(eventPayload.eventId, eventPayload.data);
+            onBlocked(eventPayload.eventId, eventPayload.data);
             break;
           default:
             assertNeverAndIgnore(eventPayload.data);
@@ -266,7 +253,7 @@ function SandboxFunctionInvocation({
         );
       }
     },
-    [invocationId, onSettle, enqueueBlockedAction]
+    [invocationId, onSettle, onBlocked]
   );
 
   const onTerminalError = useCallback(() => {
@@ -286,44 +273,86 @@ function SandboxFunctionInvocation({
     { onTerminalError }
   );
 
-  const blockedAction = blockedActions.at(0);
-  if (!blockedAction) {
-    return null;
-  }
+  return null;
+}
+
+interface SandboxFunctionBlockedActionProps {
+  // The blocked actions the card resolves together, most often just one. A Frame can have several
+  // invocations in flight, and a single personal connection unblocks all of the ones waiting on it.
+  blockedActions: QueuedBlockingEvent[];
+  viewer: FrameViewer;
+  onResolved: () => void;
+}
+
+// Overlays the Frame while a tool is blocked on user input. Keyed by the delivery eventId of the
+// first entry so consecutive events of the same type never reuse local card state.
+function SandboxFunctionBlockedAction({
+  blockedActions,
+  viewer,
+  onResolved,
+}: SandboxFunctionBlockedActionProps) {
+  const [{ eventId, event }] = blockedActions;
 
   let blockedActionCard: React.ReactNode;
-  switch (blockedAction.event.type) {
+  switch (event.type) {
     case "tool_approve_execution":
       blockedActionCard = (
         <SandboxFunctionToolApprovalCard
-          key={blockedAction.eventId}
-          event={blockedAction.event}
-          onResolved={() => removeBlockedAction(blockedAction.eventId)}
+          key={eventId}
+          event={event}
+          viewer={viewer}
+          onResolved={onResolved}
         />
       );
       break;
     case "tool_personal_auth_required":
       blockedActionCard = (
         <SandboxFunctionPersonalAuthCard
-          key={blockedAction.eventId}
-          event={blockedAction.event}
-          onResolved={() => removeBlockedAction(blockedAction.eventId)}
+          key={eventId}
+          events={blockedActions.map((a) => a.event).filter(isPersonalAuth)}
+          viewer={viewer}
+          onResolved={onResolved}
         />
       );
       break;
     default:
-      assertNeverAndIgnore(blockedAction.event);
+      assertNeverAndIgnore(event);
       blockedActionCard = null;
   }
 
-  // Overlays the frame while the tool is blocked on user input. Cards are keyed by the delivery
-  // eventId so consecutive events of the same type never reuse local card state.
   return (
     <div className="absolute inset-0 z-10 flex items-center justify-center overflow-auto bg-muted-foreground/75 p-4">
       <div className="flex w-full max-w-xl justify-center">
         {blockedActionCard}
       </div>
     </div>
+  );
+}
+
+function isPersonalAuth(
+  event: SandboxFunctionBlockingEvent
+): event is SandboxFunctionToolPersonalAuthRequiredEvent {
+  return event.type === "tool_personal_auth_required";
+}
+
+// The blocked actions the next card presents: the oldest one, plus everything waiting on the same
+// personal connection, which one trip through the authentication flow resolves at once. Approvals
+// are per tool call, so they are never grouped.
+function nextBlockedActionGroup(
+  blockedActions: QueuedBlockingEvent[]
+): QueuedBlockingEvent[] | null {
+  const [blockedAction] = blockedActions;
+  if (!blockedAction) {
+    return null;
+  }
+  if (blockedAction.event.type !== "tool_personal_auth_required") {
+    return [blockedAction];
+  }
+  const { mcpServerId } = blockedAction.event.authError;
+  return blockedActions.filter(
+    (a) =>
+      a.event.type === "tool_personal_auth_required" &&
+      a.event.authError.mcpServerId === mcpServerId
   );
 }
 
@@ -570,6 +599,7 @@ export interface VisualizationActionIframeProps {
   onEditText?: EditTextFn;
   scopedUserIdentity?: ScopedWorkspaceUserIdentity;
   spaceId?: string;
+  viewer: FrameViewer | null;
   visualization: Visualization;
   vizUrl: string;
   workspaceId: string;
@@ -603,6 +633,38 @@ export const VisualizationActionIframe = forwardRef<
   }
   const invocationResolvers = invocationResolversRef.current;
 
+  // Tool executions blocked on user input, across every in-flight invocation.
+  const [blockedActions, setBlockedActions] = useState<QueuedBlockingEvent[]>(
+    []
+  );
+
+  const enqueueBlockedAction = useCallback(
+    (eventId: string, event: SandboxFunctionBlockingEvent) => {
+      setBlockedActions((prev) => {
+        // The stream can re-deliver or supersede an event after a reconnect or a resolution:
+        // replace by actionId, keeping the newest delivery.
+        const existingIndex = prev.findIndex(
+          (a) => a.event.actionId === event.actionId
+        );
+        const entry = { eventId, event };
+        return existingIndex === -1
+          ? [...prev, entry]
+          : prev.map((a, index) => (index === existingIndex ? entry : a));
+      });
+    },
+    []
+  );
+
+  const removeBlockedActions = useCallback(
+    (resolved: QueuedBlockingEvent[]) => {
+      const resolvedEventIds = new Set(resolved.map((a) => a.eventId));
+      setBlockedActions((prev) =>
+        prev.filter((a) => !resolvedEventIds.has(a.eventId))
+      );
+    },
+    []
+  );
+
   const waitForSandboxFunctionInvocationResult = useCallback(
     ({
       functionId,
@@ -627,6 +689,10 @@ export const VisualizationActionIframe = forwardRef<
       invocationResolvers.delete(invocationId);
       setActiveInvocations((prev) =>
         prev.filter((invocation) => invocation.invocationId !== invocationId)
+      );
+      // A settled invocation can no longer be unblocked: drop any card it was still waiting on.
+      setBlockedActions((prev) =>
+        prev.filter((a) => a.event.invocationId !== invocationId)
       );
       resolve?.(result);
     },
@@ -657,9 +723,15 @@ export const VisualizationActionIframe = forwardRef<
     onEditText,
     scopedUserIdentity,
     spaceId,
+    viewer,
     visualization,
     workspaceId,
   } = props;
+
+  const blockedActionGroup = useMemo(
+    () => nextBlockedActionGroup(blockedActions),
+    [blockedActions]
+  );
 
   const runtimeAccess = useMemo(() => {
     return getFrameRuntimeAccess(
@@ -851,9 +923,18 @@ export const VisualizationActionIframe = forwardRef<
           workspaceId={workspaceId}
           functionId={invocation.functionId}
           invocationId={invocation.invocationId}
+          onBlocked={enqueueBlockedAction}
           onSettle={settleSandboxFunctionInvocation}
         />
       ))}
+      {/* Anonymous viewers cannot invoke functions, so they never reach a blocked action. */}
+      {viewer && blockedActionGroup && (
+        <SandboxFunctionBlockedAction
+          blockedActions={blockedActionGroup}
+          viewer={viewer}
+          onResolved={() => removeBlockedActions(blockedActionGroup)}
+        />
+      )}
       <div
         className={cn(
           "relative w-full overflow-hidden",

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.test.ts
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   iframeProps: null as {
     canInvokeFunctions: boolean;
     scopedUserIdentity?: ScopedWorkspaceUserIdentity;
+    viewer: unknown;
   } | null,
   isAuthenticatedMember: true,
   isUserLoading: true,
@@ -23,6 +24,7 @@ vi.mock(
     VisualizationActionIframe: (props: {
       canInvokeFunctions: boolean;
       scopedUserIdentity?: ScopedWorkspaceUserIdentity;
+      viewer: unknown;
     }) => {
       mocks.iframeProps = props;
       return "frame-iframe";
@@ -138,6 +140,12 @@ describe("PublicFrameRenderer", () => {
         workspaceId: "w_current",
         user: expect.objectContaining({ sId: "usr_123" }),
       },
+      // Blocked-action cards run without an AuthProvider on a shared frame, so they get the
+      // viewer's workspace and user from here.
+      viewer: {
+        owner: { sId: "w_current" },
+        user: expect.objectContaining({ sId: "usr_123" }),
+      },
     });
   });
 
@@ -158,6 +166,7 @@ describe("PublicFrameRenderer", () => {
     expect(mocks.iframeProps).toMatchObject({
       canInvokeFunctions: false,
       scopedUserIdentity: undefined,
+      viewer: null,
     });
   });
 });

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
@@ -89,6 +89,15 @@ export function PublicFrameRenderer({
     isAuthenticatedMember,
     workspaceId
   );
+  // The shared frame has no AuthProvider, so the viewer context the blocked-action cards need is
+  // built from the workspace the viewer is a member of.
+  const viewerWorkspace = user?.workspaces.find(
+    (workspace) => workspace.sId === workspaceId
+  );
+  const viewer =
+    publicUserIdentity && user && viewerWorkspace
+      ? { owner: viewerWorkspace, user }
+      : null;
 
   if (
     isFrameLoading ||
@@ -139,6 +148,7 @@ export function PublicFrameRenderer({
             key={`viz-${fileId}`}
             canInvokeFunctions={publicUserIdentity !== undefined}
             scopedUserIdentity={publicUserIdentity}
+            viewer={viewer}
             isInDrawer
           />
         </div>


### PR DESCRIPTION
## Problem

Opening a shared Frame that calls a tool needing a personal connection (e.g. `get_worksheet` on Google Drive) failed instead of prompting to connect.

The `tool_personal_auth_required` event was delivered correctly, but `SandboxFunctionPersonalAuthCard` → `PersonalAuthenticationCard` calls `useAuth()`, which throws outside an `AuthProvider`. The public share bundle (`front-spa/src/share/ShareApp.tsx`) has no `AuthContext.Provider` — it only wraps routes in `RegionProvider` / `FetcherProvider` / `PostHogTracker` / `ErrorBoundary` — so the card threw on render and the error boundary replaced the whole page. `SandboxFunctionToolApprovalCard` / `ToolValidationCard` had the identical crash.

A second issue surfaced once the card rendered: a Frame fires several invocations in flight, each blocked on the same connection, and each mounted its own overlay. Connecting resolved only the first; the next card appeared on return from the OAuth flow, and any card not clicked through left its invocation blocked until the sandbox token expired and the invocation errored.

## Change

- `PersonalAuthenticationCard` / `ToolValidationCard`: drop `useAuth()`, take a `currentUser` prop. The two agent-loop callers pass it from their own `useAuth()`, unchanged behavior in the app.
- `SandboxFunctionPersonalAuthCard` / `SandboxFunctionToolApprovalCard`: take a `viewer` (`{ owner, user }`) prop.
- `VisualizationActionIframe` takes `viewer`; `AuthenticatedVisualizationActionIframe` derives it from `AuthContext`, `PublicFrameRenderer` from `useUser()` plus the workspace the viewer is a member of. Null for anonymous viewers, who cannot invoke functions and so never reach a blocked action.
- The blocked-action queue moves from `SandboxFunctionInvocation` (one per invocation) up to `VisualizationActionIframe`, which sees every in-flight invocation. `SandboxFunctionInvocation` is now stream-only and renders nothing. One overlay is shown, and all entries waiting on the same `mcpServerId` are resolved together by a single card. Approvals stay per tool call.
- Settling an invocation drops any card it was still waiting on, so a timed-out invocation cannot leave a stale card behind.

## Tests

- New `SandboxFunctionPersonalAuthCard.test.tsx`: renders with the real `AuthContext` module and no provider (fails with `useAuth must be used within AuthProvider` before this change), and asserts one Connect click resolves every invocation in the group.
- `PublicFrameRenderer.test.ts` extended to assert the `viewer` prop is populated for a member and null otherwise.

## Not addressed

Sandbox function invocation tokens expire after 2 minutes (`generateSandboxFunctionInvocationToken` default). While an action sits in `blocked_authentication_required` the sandbox keeps polling and gets a 401 once the token dies, erroring the invocation. A slow OAuth round trip can still lose the invocation — needs its own fix.
