### PR TITLE
Remove stale branch conversation permission test

### DIFF
--- a/front/lib/api/assistant/conversation/permissions.test.ts
+++ b/front/lib/api/assistant/conversation/permissions.test.ts
@@ -84,41 +84,6 @@ describe("canAgentBeUsedInProjectConversation", () => {
     ).rejects.toThrow("Unexpected: conversation is not a project conversation");
   });
 
-  it("allows the agent on a branch conversation without evaluating space requirements", async () => {
-    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
-      workspace.sId
-    );
-    const user = auth.getNonNullableUser();
-    const projectSpace = await SpaceFactory.project(workspace, user.id);
-    await addUserToSpaceRegularGroup(
-      internalAdminAuth,
-      projectSpace,
-      user.toJSON()
-    );
-    await auth.refresh();
-
-    const conversation = await ConversationFactory.create(auth, {
-      agentConfigurationId: "test-agent",
-      messagesCreatedAt: [],
-      spaceId: projectSpace.id,
-    });
-    const conversationJson = await fetchConversationWithoutContent(
-      conversation.sId
-    );
-
-    const otherRestrictedSpace = await SpaceFactory.project(workspace);
-
-    await expect(
-      canAgentBeUsedInProjectConversation(auth, {
-        configuration: lightConfiguration([
-          projectSpace.sId,
-          otherRestrictedSpace.sId,
-        ]),
-        conversation: { ...conversationJson, branchId: "br_test_branch" },
-      })
-    ).resolves.toBe(true);
-  });
-
   it("allows the agent when requestedSpaceIds is empty", async () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId


### PR DESCRIPTION
### Description

`lib/api/assistant/conversation/permissions.test.ts > canAgentBeUsedInProjectConversation > allows the agent on a branch conversation without evaluating space requirements` is failing on `main`.

Commit 51c19ae1ba (*Remove ConversationBranch feature core*) intentionally removed this early return from `canAgentBeUsedInProjectConversation`:

```diff
-  // If we are in a branch, we can use the agent.
-  if (conversation.branchId) {
-    return true;
-  }
```

but did not delete the test covering it. Without the shortcut, the test's setup — a restricted project whose only member is the acting user, plus a restricted space the user does not belong to — falls through to the normal space evaluation and correctly resolves to `false`.

The behavior being asserted no longer exists, and the underlying scenario is already covered by *"rejects the agent when the sole project member is not in a required restricted space"*, so the test is simply removed.

### Risk

None, test-only change.

### Deploy Plan

Nothing to deploy.