### PR TITLE
Pin the clock in the seat remap scheduling tests

### DIFF
--- a/front/lib/metronome/seats.test.ts
+++ b/front/lib/metronome/seats.test.ts
@@ -15,7 +15,7 @@ import {
 import type { SeatLimit } from "@app/lib/resources/workspace_seat_limit_resource";
 import type { MembershipSeatType } from "@app/types/memberships";
 import type { LightWorkspaceType } from "@app/types/user";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/metronome/client", () => ({
   getMetronomeContractById: vi.fn(),
@@ -572,6 +572,11 @@ describe("remapMembershipSeatTypesForContract — scheduled-remap no-op", () => 
     seats: [{ seatType: "pro", awu: 8000 }],
   });
   const workspace = { sId: "ws_1", id: 1 } as unknown as LightWorkspaceType;
+  // `remapMembershipSeatTypesForContract` only schedules when `startingAt` is
+  // still in the future — a past `startingAt` applies immediately instead. The
+  // clock is pinned ahead of it so these tests don't start failing once the
+  // wall clock passes `startingAt`.
+  const now = new Date("2026-06-01T00:00:00.000Z");
   const startingAt = new Date("2026-08-01T00:00:00.000Z");
 
   function makeMembership(userId: number, seatType: MembershipSeatType) {
@@ -585,9 +590,15 @@ describe("remapMembershipSeatTypesForContract — scheduled-remap no-op", () => 
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
     mockGetProductSeatTypes.mockResolvedValue(productSeatTypes);
     mockFetchSeatLimitsByWorkspace.mockResolvedValue(new Map());
     mockFetchUsersByModelIds.mockResolvedValue([{ id: 1, sId: "user_1" }]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("schedules the change when there is no existing matching schedule", async () => {


### PR DESCRIPTION
### Description

Three tests in `lib/metronome/seats.test.ts > remapMembershipSeatTypesForContract — scheduled-remap no-op` are failing on `main`. They are a time bomb that went off today: the block hardcoded

```ts
const startingAt = new Date("2026-08-01T00:00:00.000Z");
```

and `remapMembershipSeatTypesForContract` applies a seat change immediately — rather than scheduling it — whenever `startingAt` is not in the future:

```ts
const applyImmediately =
  swapAt === "current-hour" || startingAt.getTime() <= Date.now();
```

Now that the wall clock is past that timestamp, the tests take the immediate path and call `updateMembershipSeat`, so the `scheduleSeatChange` assertions fail.

Worth noting: *"does not re-schedule when an existing scheduled row already matches the target"* was **passing vacuously** for the same reason — it asserts `scheduleSeatChange` was *not* called, which was trivially true on the immediate path. It now exercises the scheduling path it was written for, and still passes.

The fix pins the system time ahead of `startingAt` with fake timers, matching the pattern already used in `lib/metronome/contracts.test.ts` and `lib/credits/limits.test.ts`. No production code changes.

### Risk

None, test-only change.

### Deploy Plan

Nothing to deploy.