### PR TITLE
[front] BACK15: serialized shapes belong to the Resource

### DIFF
--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -266,6 +266,14 @@ endpoint handlers.
 
 The Type interface is not to be used in the backend.
 
+**Every serialized shape belongs to the Resource, not to its callers.** A Resource has a small,
+named set of ways to be serialized — `toJSON`, and audience-specific variants following the
+`to<Audience>JSON` convention already in use (`toPokeJSON`, `toLogJSON`, `toJSONForLLM`). Callers
+pick one; they do not assemble their own. Concretely, code in `lib/api/*`, handlers or components
+must not build a wire shape by reading a Resource's fields, and must not spread `toJSON()` and add
+fields to it. If a caller needs a shape that no existing method produces, add a new
+`to<Audience>JSON` on the Resource next to the others.
+
 ### [BACK16] Keep API handlers thin — business logic belongs in `lib/api/*`
 
 API handlers (under `front-api/routes/`) should be limited to:


### PR DESCRIPTION
## Description

Clarifies `[BACK15]` in `front/CODING_RULES.md`.

The rule required a Resource to have a `toJSON` method, but said nothing about who may build the shapes a Resource is serialized into. Under that reading, `{ ...resource.toJSON(), extraField }` in `lib/api/*` looks compliant — the Resource *does* have a `toJSON`, the caller just extends it. That is how a poke serialization ended up assembled in the business layer in a recent branch, and it is the same thing @flvndvd asked for on #29254 ("Resources have a `toJSON` function, they should have a few well identified ways to be serialized. This responsibility is also part of the resource itself. Let's add a `toPokeJSON` on the resource if needed.").

The added paragraph states that:

- a Resource has a small, named set of serializations — `toJSON` plus audience-specific `to<Audience>JSON` variants, documenting the convention already in the codebase (`toPokeJSON`, `toLogJSON`, `toJSONForLLM`);
- callers pick one rather than assembling their own, and specifically must not spread `toJSON()` and add fields;
- a caller needing a shape no method produces adds a method to the Resource.

Documentation only — no code changes.

## Tests

N/A.

## Risk

None. Documentation only.

## Deploy Plan

Nothing to deploy.