### PR TITLE
[poke] drill into a pod function's invocations and their MCP actions

### DIFF
--- a/front-api/middlewares/ctx.ts
+++ b/front-api/middlewares/ctx.ts
@@ -4,6 +4,7 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import type { PokeRole } from "@app/lib/poke/roles";
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { createHono } from "@front-api/lib/hono";
@@ -30,6 +31,12 @@ export type PokeCtx = SessionCtx & {
 export type PokeProjectCtx = PokeCtx & {
   Variables: {
     space: SpaceResource;
+  };
+};
+
+export type PokePodFunctionCtx = PokeProjectCtx & {
+  Variables: {
+    podFunction: SandboxFunctionResource;
   };
 };
 
@@ -77,6 +84,7 @@ export const sessionApp = () => createHono<SessionCtx>();
 export const workspaceApp = () => createHono<WorkspaceAwareCtx>();
 export const pokeApp = () => createHono<PokeCtx>();
 export const pokeProjectApp = () => createHono<PokeProjectCtx>();
+export const pokePodFunctionApp = () => createHono<PokePodFunctionCtx>();
 export const publicApiApp = () => createHono<PublicApiCtx>();
 export const sandboxApp = () => createHono<SandboxCtx>();
 export const skillApp = () => createHono<SkillCtx>();

--- a/front-api/middlewares/with_projects.ts
+++ b/front-api/middlewares/with_projects.ts
@@ -1,5 +1,9 @@
+import { fetchProjectPodFunction } from "@app/lib/api/poke/pod_functions";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import type { PokeProjectCtx } from "@front-api/middlewares/ctx";
+import type {
+  PokePodFunctionCtx,
+  PokeProjectCtx,
+} from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { createMiddleware } from "hono/factory";
 
@@ -30,6 +34,36 @@ export function withProject() {
     }
 
     ctx.set("space", space);
+    await next();
+  });
+}
+
+/**
+ * Resolves the `:functionId` route param into the pod function of the context project, 404s if it
+ * belongs to another pod, and stashes it on the context under `podFunction`.
+ *
+ * Apply after `withProject()` so `ctx.get("space")` is available.
+ */
+export function withPodFunction() {
+  return createMiddleware<PokePodFunctionCtx>(async (ctx, next) => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
+    const functionId = ctx.req.param("functionId");
+
+    const podFunction = functionId
+      ? await fetchProjectPodFunction(auth, space, functionId)
+      : null;
+    if (!podFunction) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "sandbox_function_not_found",
+          message: "Pod function not found.",
+        },
+      });
+    }
+
+    ctx.set("podFunction", podFunction);
     await next();
   });
 }

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/pod-functions/[functionId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/pod-functions/[functionId]/index.ts
@@ -1,0 +1,42 @@
+import {
+  getProjectPodFunctionDetails,
+  getProjectPodFunctionSource,
+} from "@app/lib/api/poke/pod_functions";
+import type {
+  PokeGetPodFunction,
+  PokeGetPodFunctionSource,
+} from "@app/lib/api/poke/projects";
+import { pokePodFunctionApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { withPodFunction } from "@front-api/middlewares/with_projects";
+
+import invocations from "./invocations";
+
+// Mounted at /api/poke/workspaces/:wId/projects/:projectId/pod-functions/:functionId.
+const app = pokePodFunctionApp();
+
+app.use("*", withPodFunction());
+
+/** @ignoreswagger */
+app.get("/", async (ctx): HandlerResult<PokeGetPodFunction> => {
+  const auth = ctx.get("auth");
+  const podFunction = ctx.get("podFunction");
+
+  const details = await getProjectPodFunctionDetails(auth, podFunction);
+
+  return ctx.json({ podFunction: details });
+});
+
+/** @ignoreswagger */
+app.get("/source", async (ctx): HandlerResult<PokeGetPodFunctionSource> => {
+  const auth = ctx.get("auth");
+  const podFunction = ctx.get("podFunction");
+
+  const source = await getProjectPodFunctionSource(auth, podFunction);
+
+  return ctx.json({ source });
+});
+
+app.route("/invocations", invocations);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/pod-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/pod-functions/[functionId]/invocations.test.ts
@@ -1,0 +1,286 @@
+import type { Authenticator } from "@app/lib/auth";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SandboxFunctionMCPActionFactory } from "@app/tests/utils/SandboxFunctionMCPActionFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { sandboxFunctionContentType } from "@app/types/files";
+import { honoApp } from "@front-api/app";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { beforeEach, describe, expect, it } from "vitest";
+
+beforeEach(() => {
+  fileStorageMock.reset();
+});
+
+const inputSchema: JSONSchema = {
+  type: "object",
+  properties: { message: { type: "string" } },
+};
+
+const outputSchema: JSONSchema = {
+  type: "object",
+  properties: { ok: { type: "boolean" } },
+};
+
+async function createPodFunction(
+  auth: Authenticator,
+  space: Awaited<ReturnType<typeof SpaceFactory.project>>,
+  slug: string
+) {
+  const file = await FileFactory.create(auth, null, {
+    contentType: sandboxFunctionContentType,
+    fileName: `${slug}.ts`,
+    fileSize: 100,
+    status: "created",
+    useCase: "project_context",
+    useCaseMetadata: { spaceId: space.sId },
+  });
+
+  return SandboxFunctionResource.makeNew(auth, {
+    space,
+    file,
+    slug,
+    description: `Run ${slug}.`,
+    inputSchema,
+    outputSchema,
+  });
+}
+
+async function setup() {
+  const { workspace, auth } = await createPrivateApiMockRequest({
+    isSuperUser: true,
+    role: "admin",
+  });
+
+  const space = await SpaceFactory.project(workspace);
+  const podFunction = await createPodFunction(auth, space, "run-function");
+
+  const succeededInvocation = await SandboxFunctionInvocationResource.makeNew(
+    auth,
+    { sandboxFunction: podFunction, input: { message: "first" } }
+  );
+  await succeededInvocation.succeed({ ok: true });
+
+  const erroredInvocation = await SandboxFunctionInvocationResource.makeNew(
+    auth,
+    { sandboxFunction: podFunction, input: { message: "second" } }
+  );
+  await erroredInvocation.fail(new Error("boom"));
+
+  const server = await InternalMCPServerInMemoryResource.makeNew(auth, {
+    name: "common_utilities",
+    useCase: null,
+  });
+  const mcpServerView = await MCPServerViewFactory.create(
+    workspace,
+    server.id,
+    space
+  );
+  const action = await SandboxFunctionMCPActionFactory.create(auth, {
+    invocation: erroredInvocation,
+    mcpServerView,
+  });
+  const outputResult = await action.createOutputItems(auth, [
+    { content: { type: "text", text: "tool output" } },
+  ]);
+  expect(outputResult.isOk()).toBe(true);
+  await action.markAsErrored({ executionDurationMs: 120 });
+
+  return {
+    action,
+    auth,
+    erroredInvocation,
+    mcpServerView,
+    podFunction,
+    space,
+    succeededInvocation,
+    workspace,
+  };
+}
+
+function podFunctionUrl(
+  workspaceId: string,
+  spaceId: string,
+  functionId: string
+) {
+  return `/api/poke/workspaces/${workspaceId}/projects/${spaceId}/pod-functions/${functionId}`;
+}
+
+describe("GET /api/poke/workspaces/:wId/projects/:projectId/pod-functions/:functionId", () => {
+  it("returns the function with its schemas and bundle file", async () => {
+    const { workspace, space, podFunction } = await setup();
+
+    const response = await honoApp.request(
+      podFunctionUrl(workspace.sId, space.sId, podFunction.sId)
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.podFunction).toMatchObject({
+      sId: podFunction.sId,
+      slug: "run-function",
+      fileId: podFunction.file.sId,
+      inputSchema,
+      outputSchema,
+    });
+  });
+
+  it("serves the published bundle source", async () => {
+    const { workspace, space, podFunction } = await setup();
+
+    const source =
+      "export default async function run() { return { ok: true }; }";
+    fileStorageMock.setFileContent(() => source);
+
+    const response = await honoApp.request(
+      `${podFunctionUrl(workspace.sId, space.sId, podFunction.sId)}/source`
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.source).toBe(source);
+  });
+
+  it("404s for a function that belongs to another pod", async () => {
+    const { workspace, auth, space } = await setup();
+
+    const otherSpace = await SpaceFactory.project(workspace);
+    const otherFunction = await createPodFunction(
+      auth,
+      otherSpace,
+      "other-function"
+    );
+
+    const response = await honoApp.request(
+      podFunctionUrl(workspace.sId, space.sId, otherFunction.sId)
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("401s for a non-superuser", async () => {
+    const { workspace, space, podFunction } = await setup();
+    await createPrivateApiMockRequest({ role: "admin", workspace });
+
+    const response = await honoApp.request(
+      podFunctionUrl(workspace.sId, space.sId, podFunction.sId)
+    );
+
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("GET .../pod-functions/:functionId/invocations", () => {
+  it("lists invocations newest first, with action counts and without payloads", async () => {
+    const { workspace, space, podFunction, erroredInvocation } = await setup();
+
+    const response = await honoApp.request(
+      `${podFunctionUrl(workspace.sId, space.sId, podFunction.sId)}/invocations`
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.items).toHaveLength(2);
+    expect(data.items[0]).toMatchObject({
+      sId: erroredInvocation.sId,
+      status: "errored",
+      origin: "delegated",
+      mcpActionCount: 1,
+    });
+    expect(data.items[1]).toMatchObject({ status: "succeeded" });
+    // The listing is DB-only: payloads are served by the per-invocation endpoint.
+    expect(data.items[0].input).toBeUndefined();
+    expect(data.items[0].result).toBeUndefined();
+  });
+
+  it("filters on status", async () => {
+    const { workspace, space, podFunction, succeededInvocation } =
+      await setup();
+
+    const response = await honoApp.request(
+      `${podFunctionUrl(workspace.sId, space.sId, podFunction.sId)}/invocations?status=succeeded`
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.items.map((item: { sId: string }) => item.sId)).toEqual([
+      succeededInvocation.sId,
+    ]);
+  });
+});
+
+describe("GET .../invocations/:invocationId", () => {
+  it("returns the hydrated payload and its MCP actions", async () => {
+    const { workspace, space, podFunction, erroredInvocation, action } =
+      await setup();
+
+    const response = await honoApp.request(
+      `${podFunctionUrl(workspace.sId, space.sId, podFunction.sId)}/invocations/${erroredInvocation.sId}`
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.invocation).toMatchObject({
+      sId: erroredInvocation.sId,
+      status: "errored",
+      input: { message: "second" },
+      error: { code: "invocation_failed", message: "boom" },
+    });
+    expect(data.invocation.mcpActions).toHaveLength(1);
+    expect(data.invocation.mcpActions[0]).toMatchObject({
+      sId: action.sId,
+      toolName: "math_operation",
+      status: "errored",
+      executionDurationMs: 120,
+      hasOutput: true,
+      mcpServerName: "common_utilities",
+    });
+  });
+
+  it("404s for an invocation of another function", async () => {
+    const { workspace, auth, space, podFunction } = await setup();
+
+    const otherFunction = await createPodFunction(auth, space, "other-in-pod");
+    const otherInvocation = await SandboxFunctionInvocationResource.makeNew(
+      auth,
+      { sandboxFunction: otherFunction, input: undefined }
+    );
+
+    const response = await honoApp.request(
+      `${podFunctionUrl(workspace.sId, space.sId, podFunction.sId)}/invocations/${otherInvocation.sId}`
+    );
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("GET .../invocations/:invocationId/actions/:actionId/output", () => {
+  it("returns the stored MCP action output", async () => {
+    const { workspace, space, podFunction, erroredInvocation, action } =
+      await setup();
+
+    const response = await honoApp.request(
+      `${podFunctionUrl(workspace.sId, space.sId, podFunction.sId)}/invocations/${erroredInvocation.sId}/actions/${action.sId}/output`
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.output).toEqual([{ type: "text", text: "tool output" }]);
+  });
+
+  it("404s for an action of another invocation", async () => {
+    const { workspace, space, podFunction, succeededInvocation, action } =
+      await setup();
+
+    const response = await honoApp.request(
+      `${podFunctionUrl(workspace.sId, space.sId, podFunction.sId)}/invocations/${succeededInvocation.sId}/actions/${action.sId}/output`
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/pod-functions/[functionId]/invocations.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/pod-functions/[functionId]/invocations.ts
@@ -1,0 +1,140 @@
+import {
+  getProjectPodFunctionInvocation,
+  getProjectPodFunctionMCPActionOutput,
+  listProjectPodFunctionInvocations,
+} from "@app/lib/api/poke/pod_functions";
+import type {
+  PokeGetPodFunctionInvocation,
+  PokeGetPodFunctionMCPActionOutput,
+  PokeListPodFunctionInvocations,
+} from "@app/lib/api/poke/projects";
+import {
+  SANDBOX_FUNCTION_INVOCATION_ORIGINS,
+  SANDBOX_FUNCTION_INVOCATION_STATUSES,
+} from "@app/types/api/sandbox_functions";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { pokePodFunctionApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const DEFAULT_INVOCATIONS_LIMIT = 25;
+const MAX_INVOCATIONS_LIMIT = 200;
+
+const InvocationsQuerySchema = z.object({
+  limit: z.coerce
+    .number()
+    .int()
+    .positive()
+    .max(MAX_INVOCATIONS_LIMIT)
+    .default(DEFAULT_INVOCATIONS_LIMIT),
+  status: z.enum(SANDBOX_FUNCTION_INVOCATION_STATUSES).optional(),
+  origin: z.enum(SANDBOX_FUNCTION_INVOCATION_ORIGINS).optional(),
+});
+
+const InvocationParamsSchema = z.object({
+  invocationId: z.string().min(1),
+});
+
+const ActionOutputParamsSchema = z.object({
+  invocationId: z.string().min(1),
+  actionId: z.string().min(1),
+});
+
+// Mounted at
+// /api/poke/workspaces/:wId/projects/:projectId/pod-functions/:functionId/invocations.
+const app = pokePodFunctionApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  validate("query", InvocationsQuerySchema),
+  async (ctx): HandlerResult<PokeListPodFunctionInvocations> => {
+    const auth = ctx.get("auth");
+    const podFunction = ctx.get("podFunction");
+    const { limit, status, origin } = ctx.req.valid("query");
+
+    const items = await listProjectPodFunctionInvocations(auth, {
+      sandboxFunction: podFunction,
+      limit,
+      statuses: status ? [status] : undefined,
+      origins: origin ? [origin] : undefined,
+    });
+
+    return ctx.json({ items });
+  }
+);
+
+/** @ignoreswagger */
+app.get(
+  "/:invocationId",
+  validate("param", InvocationParamsSchema),
+  async (ctx): HandlerResult<PokeGetPodFunctionInvocation> => {
+    const auth = ctx.get("auth");
+    const podFunction = ctx.get("podFunction");
+    const { invocationId } = ctx.req.valid("param");
+
+    const invocation = await getProjectPodFunctionInvocation(auth, {
+      sandboxFunction: podFunction,
+      invocationId,
+    });
+    if (!invocation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "sandbox_function_invocation_not_found",
+          message: "Invocation not found.",
+        },
+      });
+    }
+
+    return ctx.json({ invocation });
+  }
+);
+
+/** @ignoreswagger */
+app.get(
+  "/:invocationId/actions/:actionId/output",
+  validate("param", ActionOutputParamsSchema),
+  async (ctx): HandlerResult<PokeGetPodFunctionMCPActionOutput> => {
+    const auth = ctx.get("auth");
+    const podFunction = ctx.get("podFunction");
+    const { invocationId, actionId } = ctx.req.valid("param");
+
+    const outputResult = await getProjectPodFunctionMCPActionOutput(auth, {
+      sandboxFunction: podFunction,
+      invocationId,
+      actionId,
+    });
+    if (outputResult.isErr()) {
+      switch (outputResult.error.type) {
+        case "action_not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "action_not_found",
+              message: outputResult.error.message,
+            },
+          });
+        case "output_read_failed":
+          return apiError(
+            ctx,
+            {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: "Failed to read the MCP action output.",
+              },
+            },
+            outputResult.error
+          );
+        default:
+          return assertNever(outputResult.error.type);
+      }
+    }
+
+    return ctx.json(outputResult.value);
+  }
+);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/pod-functions/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/pod-functions/index.ts
@@ -3,6 +3,8 @@ import type { PokeListProjectPodFunctions } from "@app/lib/api/poke/projects";
 import { pokeProjectApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
+import functionId from "./[functionId]";
+
 // Mounted at /api/poke/workspaces/:wId/projects/:projectId/pod-functions.
 const app = pokeProjectApp();
 
@@ -15,5 +17,7 @@ app.get("/", async (ctx): HandlerResult<PokeListProjectPodFunctions> => {
 
   return ctx.json({ items });
 });
+
+app.route("/:functionId", functionId);
 
 export default app;

--- a/front-spa/src/poke/routes.tsx
+++ b/front-spa/src/poke/routes.tsx
@@ -22,6 +22,7 @@ import { MembershipsPage } from "@dust-tt/front/components/poke/pages/Membership
 import { NotionRequestsPage } from "@dust-tt/front/components/poke/pages/NotionRequestsPage";
 import { PlansPage } from "@dust-tt/front/components/poke/pages/PlansPage";
 import { PluginsPage } from "@dust-tt/front/components/poke/pages/PluginsPage";
+import { PodFunctionPage } from "@dust-tt/front/components/poke/pages/PodFunctionPage";
 import { PokefyPage } from "@dust-tt/front/components/poke/pages/PokefyPage";
 import { ProductionChecksPage } from "@dust-tt/front/components/poke/pages/ProductionChecksPage";
 import { SkillDetailsPage } from "@dust-tt/front/components/poke/pages/SkillDetailsPage";
@@ -140,6 +141,10 @@ export const routes: RouteObject[] = [
           {
             path: "spaces/:spaceId/mcp_server_views/:svId",
             element: <MCPServerViewPage />,
+          },
+          {
+            path: "spaces/:spaceId/pod_functions/:functionId",
+            element: <PodFunctionPage />,
           },
           {
             path: "webhook-sources/:wsId",

--- a/front/components/poke/pages/PodFunctionPage.tsx
+++ b/front/components/poke/pages/PodFunctionPage.tsx
@@ -1,0 +1,72 @@
+import { PodFunctionInvocations } from "@app/components/poke/projects/pod_functions/invocations";
+import { PodFunctionSource } from "@app/components/poke/projects/pod_functions/source";
+import { ViewPodFunctionTable } from "@app/components/poke/projects/pod_functions/view";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { useRequiredPathParam } from "@app/lib/platform";
+import { usePokePageMetadata } from "@app/poke/swr/currentPage";
+import { usePokePodFunction } from "@app/poke/swr/pod_function_details";
+import { LinkWrapper, Spinner } from "@dust-tt/sparkle";
+
+export function PodFunctionPage() {
+  const owner = useWorkspace();
+
+  const spaceId = useRequiredPathParam("spaceId");
+  const functionId = useRequiredPathParam("functionId");
+
+  const { podFunction, isLoading, isError } = usePokePodFunction({
+    owner,
+    projectId: spaceId,
+    functionId,
+  });
+
+  usePokePageMetadata({
+    name: podFunction?.slug,
+    subtitle: owner.name,
+    sId: functionId,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError || !podFunction) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <p>Error loading pod function details.</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <h3 className="text-xl font-bold">
+        Pod Function {podFunction.slug} in pod{" "}
+        <LinkWrapper
+          href={`/poke/${owner.sId}/spaces/${spaceId}`}
+          className="text-highlight-500"
+        >
+          {spaceId}
+        </LinkWrapper>
+      </h3>
+      <div className="flex flex-row gap-x-6">
+        <ViewPodFunctionTable podFunction={podFunction} />
+        <div className="mt-4 flex grow flex-col">
+          <PodFunctionSource
+            functionId={functionId}
+            owner={owner}
+            projectId={spaceId}
+          />
+          <PodFunctionInvocations
+            functionId={functionId}
+            owner={owner}
+            projectId={spaceId}
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/front/components/poke/projects/pod_functions/columns.tsx
+++ b/front/components/poke/projects/pod_functions/columns.tsx
@@ -1,16 +1,31 @@
 import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import type { PokePodFunction } from "@app/lib/api/poke/projects";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import { LinkWrapper } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
-export function makeColumnsForProjectPodFunction(): ColumnDef<PokePodFunction>[] {
+export function makeColumnsForProjectPodFunction({
+  owner,
+  projectId,
+}: {
+  owner: LightWorkspaceType;
+  projectId: string;
+}): ColumnDef<PokePodFunction>[] {
   return [
     {
       accessorKey: "slug",
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Slug" />
       ),
-      cell: ({ row }) => row.original.slug,
+      cell: ({ row }) => (
+        <LinkWrapper
+          href={`/poke/${owner.sId}/spaces/${projectId}/pod_functions/${row.original.sId}`}
+          className="text-highlight-500"
+        >
+          {row.original.slug}
+        </LinkWrapper>
+      ),
     },
     {
       accessorKey: "description",

--- a/front/components/poke/projects/pod_functions/invocations.tsx
+++ b/front/components/poke/projects/pod_functions/invocations.tsx
@@ -1,0 +1,287 @@
+import { PokeJsonBlock } from "@app/components/poke/projects/pod_functions/json_block";
+import { InvocationMCPActions } from "@app/components/poke/projects/pod_functions/mcp_actions";
+import type { PokePodFunctionInvocation } from "@app/lib/api/poke/projects";
+import {
+  usePokePodFunctionInvocation,
+  usePokePodFunctionInvocations,
+} from "@app/poke/swr/pod_function_details";
+import type {
+  SandboxFunctionInvocationOrigin,
+  SandboxFunctionInvocationStatus,
+} from "@app/types/api/sandbox_functions";
+import {
+  SANDBOX_FUNCTION_INVOCATION_ORIGINS,
+  SANDBOX_FUNCTION_INVOCATION_STATUSES,
+} from "@app/types/api/sandbox_functions";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  Chip,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  ContentMessageInline,
+  Separator,
+  Spinner,
+} from "@dust-tt/sparkle";
+import moment from "moment";
+import type { ComponentProps } from "react";
+import { useState } from "react";
+
+const PAGE_SIZE = 25;
+
+type ChipColor = ComponentProps<typeof Chip>["color"];
+
+function colorForInvocationStatus(
+  status: SandboxFunctionInvocationStatus
+): ChipColor {
+  switch (status) {
+    case "succeeded":
+      return "success";
+    case "errored":
+      return "warning";
+    case "created":
+      return "info";
+    default:
+      assertNeverAndIgnore(status);
+      return "primary";
+  }
+}
+
+// The invocation row records no duration of its own: `updatedAt` is the moment the terminal status
+// was written, so the elapsed time is only meaningful once the invocation has settled.
+function elapsedLabel(invocation: PokePodFunctionInvocation): string | null {
+  if (invocation.status === "created") {
+    return null;
+  }
+
+  const elapsedMs =
+    new Date(invocation.updatedAt).getTime() -
+    new Date(invocation.createdAt).getTime();
+
+  return `~${(elapsedMs / 1000).toFixed(1)}s`;
+}
+
+interface PodFunctionInvocationsProps {
+  functionId: string;
+  owner: LightWorkspaceType;
+  projectId: string;
+}
+
+export function PodFunctionInvocations({
+  functionId,
+  owner,
+  projectId,
+}: PodFunctionInvocationsProps) {
+  const [limit, setLimit] = useState(PAGE_SIZE);
+  const [status, setStatus] = useState<
+    SandboxFunctionInvocationStatus | undefined
+  >(undefined);
+  const [origin, setOrigin] = useState<
+    SandboxFunctionInvocationOrigin | undefined
+  >(undefined);
+
+  const { invocations, isLoading, isError } = usePokePodFunctionInvocations({
+    owner,
+    projectId,
+    functionId,
+    limit,
+    status,
+    origin,
+  });
+
+  const hasMore = invocations.length === limit;
+
+  return (
+    <div className="border-material-200 my-4 flex min-h-24 flex-col rounded-lg border bg-muted-background">
+      <div className="flex justify-between gap-3 rounded-t-lg bg-primary-300 p-4">
+        <h2 className="text-md font-bold">Invocations</h2>
+      </div>
+      <div className="flex flex-grow flex-col gap-2 p-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <Chip
+            color={status === undefined ? "highlight" : "primary"}
+            size="xs"
+            label="All statuses"
+            className="cursor-pointer select-none"
+            onClick={() => {
+              setStatus(undefined);
+              setLimit(PAGE_SIZE);
+            }}
+          />
+          {SANDBOX_FUNCTION_INVOCATION_STATUSES.map((s) => (
+            <Chip
+              key={s}
+              color={status === s ? "highlight" : "primary"}
+              size="xs"
+              label={s}
+              className="cursor-pointer select-none"
+              onClick={() => {
+                setStatus(s);
+                setLimit(PAGE_SIZE);
+              }}
+            />
+          ))}
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Chip
+            color={origin === undefined ? "highlight" : "primary"}
+            size="xs"
+            label="All origins"
+            className="cursor-pointer select-none"
+            onClick={() => {
+              setOrigin(undefined);
+              setLimit(PAGE_SIZE);
+            }}
+          />
+          {SANDBOX_FUNCTION_INVOCATION_ORIGINS.map((o) => (
+            <Chip
+              key={o}
+              color={origin === o ? "highlight" : "primary"}
+              size="xs"
+              label={o}
+              className="cursor-pointer select-none"
+              onClick={() => {
+                setOrigin(o);
+                setLimit(PAGE_SIZE);
+              }}
+            />
+          ))}
+        </div>
+        {isLoading ? (
+          <div className="flex items-center gap-2 pt-2">
+            <Spinner size="sm" />
+            <span className="text-sm text-muted-foreground">
+              Loading invocations...
+            </span>
+          </div>
+        ) : isError ? (
+          <ContentMessageInline variant="warning" className="mt-2">
+            Unable to load invocations.
+          </ContentMessageInline>
+        ) : invocations.length === 0 ? (
+          <p className="pt-2 text-sm text-muted-foreground">
+            No invocation matches these filters.
+          </p>
+        ) : (
+          <>
+            <div className="flex flex-col px-4">
+              {invocations.map((invocation, idx) => (
+                <div key={invocation.sId}>
+                  <InvocationRow
+                    functionId={functionId}
+                    invocation={invocation}
+                    owner={owner}
+                    projectId={projectId}
+                  />
+                  {idx < invocations.length - 1 && <Separator />}
+                </div>
+              ))}
+            </div>
+            {hasMore && (
+              <div className="flex justify-center pt-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  label="Load more"
+                  onClick={() => setLimit((prev) => prev + PAGE_SIZE)}
+                />
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface InvocationRowProps {
+  functionId: string;
+  invocation: PokePodFunctionInvocation;
+  owner: LightWorkspaceType;
+  projectId: string;
+}
+
+function InvocationRow({
+  functionId,
+  invocation,
+  owner,
+  projectId,
+}: InvocationRowProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const {
+    invocation: details,
+    isLoading,
+    isError,
+  } = usePokePodFunctionInvocation({
+    owner,
+    projectId,
+    functionId,
+    invocationId: invocation.sId,
+    disabled: !isOpen,
+  });
+
+  const elapsed = elapsedLabel(invocation);
+
+  return (
+    <Collapsible defaultOpen={false} onOpenChange={setIsOpen}>
+      <CollapsibleTrigger>
+        <div className="my-2 flex w-full items-center justify-between gap-4">
+          <span className="text-sm">
+            {moment(new Date(invocation.createdAt)).calendar(undefined, {
+              sameDay: "[Today at] LTS",
+              lastDay: "[Yesterday at] LTS",
+              lastWeek: "[Last] dddd [at] LTS",
+            })}
+          </span>
+          <div className="flex items-center gap-3 text-xs text-muted-foreground">
+            <span>{invocation.user ?? "—"}</span>
+            <span>{invocation.origin ?? "unknown origin"}</span>
+            {elapsed && <span>{elapsed}</span>}
+            <span>{invocation.mcpActionCount} MCP actions</span>
+            <Chip
+              color={colorForInvocationStatus(invocation.status)}
+              size="xs"
+              label={invocation.status}
+              className="select-none"
+            />
+          </div>
+        </div>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        {isLoading ? (
+          <div className="flex items-center gap-2 pb-2">
+            <Spinner size="sm" />
+            <span className="text-sm text-muted-foreground">
+              Loading invocation...
+            </span>
+          </div>
+        ) : isError || !details ? (
+          <ContentMessageInline variant="warning" className="mb-2">
+            Unable to load this invocation.
+          </ContentMessageInline>
+        ) : (
+          <div className="flex flex-col gap-2 pb-2 pl-4">
+            <PokeJsonBlock defaultOpen label="Input" value={details.input} />
+            <PokeJsonBlock defaultOpen label="Result" value={details.result} />
+            {details.error && (
+              <PokeJsonBlock defaultOpen label="Error" value={details.error} />
+            )}
+            <span className="pt-2 text-sm font-semibold">
+              MCP actions ({details.mcpActions.length})
+            </span>
+            <InvocationMCPActions
+              actions={details.mcpActions}
+              functionId={functionId}
+              invocationId={invocation.sId}
+              owner={owner}
+              projectId={projectId}
+            />
+          </div>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/front/components/poke/projects/pod_functions/json_block.tsx
+++ b/front/components/poke/projects/pod_functions/json_block.tsx
@@ -1,0 +1,45 @@
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  Label,
+} from "@dust-tt/sparkle";
+import { JsonViewer } from "@textea/json-viewer";
+
+interface PokeJsonBlockProps {
+  defaultOpen?: boolean;
+  emptyMessage?: string;
+  label: string;
+  value: unknown;
+}
+
+export function PokeJsonBlock({
+  defaultOpen = false,
+  emptyMessage = "Not recorded.",
+  label,
+  value,
+}: PokeJsonBlockProps) {
+  const { isDark } = useTheme();
+
+  return (
+    <Collapsible defaultOpen={defaultOpen}>
+      <CollapsibleTrigger>
+        <Label className="cursor-pointer">{label}</Label>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        {value === undefined || value === null ? (
+          <p className="py-1 text-sm text-muted-foreground">{emptyMessage}</p>
+        ) : (
+          <JsonViewer
+            className="max-h-96 overflow-auto py-2"
+            defaultInspectDepth={2}
+            rootName={false}
+            theme={isDark ? "dark" : "light"}
+            value={value}
+          />
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/front/components/poke/projects/pod_functions/mcp_actions.tsx
+++ b/front/components/poke/projects/pod_functions/mcp_actions.tsx
@@ -1,0 +1,158 @@
+import { PokeJsonBlock } from "@app/components/poke/projects/pod_functions/json_block";
+import type { ToolExecutionBaseStatus } from "@app/lib/actions/statuses";
+import type { PokePodFunctionMCPAction } from "@app/lib/api/poke/projects";
+import { usePokePodFunctionMCPActionOutput } from "@app/poke/swr/pod_function_details";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Chip,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  ContentMessageInline,
+  LinkWrapper,
+  Separator,
+  Spinner,
+} from "@dust-tt/sparkle";
+import type { ComponentProps } from "react";
+import { useState } from "react";
+
+type ChipColor = ComponentProps<typeof Chip>["color"];
+
+function colorForActionStatus(status: ToolExecutionBaseStatus): ChipColor {
+  switch (status) {
+    case "succeeded":
+      return "success";
+    case "errored":
+    case "denied":
+      return "warning";
+    case "running":
+    case "blocked_authentication_required":
+    case "blocked_validation_required":
+      return "info";
+    default:
+      assertNeverAndIgnore(status);
+      return "primary";
+  }
+}
+
+interface InvocationMCPActionsProps {
+  actions: PokePodFunctionMCPAction[];
+  functionId: string;
+  invocationId: string;
+  owner: LightWorkspaceType;
+  projectId: string;
+}
+
+export function InvocationMCPActions({
+  actions,
+  functionId,
+  invocationId,
+  owner,
+  projectId,
+}: InvocationMCPActionsProps) {
+  if (actions.length === 0) {
+    return (
+      <p className="py-1 text-sm text-muted-foreground">
+        No MCP actions for this invocation.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col">
+      {actions.map((action, idx) => (
+        <div key={action.sId}>
+          <MCPActionRow
+            action={action}
+            functionId={functionId}
+            invocationId={invocationId}
+            owner={owner}
+            projectId={projectId}
+          />
+          {idx < actions.length - 1 && <Separator />}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface MCPActionRowProps {
+  action: PokePodFunctionMCPAction;
+  functionId: string;
+  invocationId: string;
+  owner: LightWorkspaceType;
+  projectId: string;
+}
+
+function MCPActionRow({
+  action,
+  functionId,
+  invocationId,
+  owner,
+  projectId,
+}: MCPActionRowProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { output, isLoading, isError } = usePokePodFunctionMCPActionOutput({
+    owner,
+    projectId,
+    functionId,
+    invocationId,
+    actionId: action.sId,
+    disabled: !isOpen || !action.hasOutput,
+  });
+
+  return (
+    <Collapsible defaultOpen={false} onOpenChange={setIsOpen}>
+      <CollapsibleTrigger>
+        <div className="my-2 flex w-full items-center justify-between gap-4">
+          <span className="font-mono text-sm">{action.toolName}</span>
+          <div className="flex items-center gap-3 text-xs text-muted-foreground">
+            {action.mcpServerName && <span>{action.mcpServerName}</span>}
+            {action.executionDurationMs !== null && (
+              <span>{action.executionDurationMs}ms</span>
+            )}
+            <Chip
+              color={colorForActionStatus(action.status)}
+              size="xs"
+              label={action.status}
+              className="select-none"
+            />
+          </div>
+        </div>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="flex flex-col gap-2 pb-2 pl-4">
+          {action.mcpServerViewId && (
+            <LinkWrapper
+              href={`/poke/${owner.sId}/spaces/${projectId}/mcp_server_views/${action.mcpServerViewId}`}
+              className="text-xs text-highlight-500"
+            >
+              View MCP server view
+            </LinkWrapper>
+          )}
+          <PokeJsonBlock defaultOpen label="Inputs" value={action.inputs} />
+          {!action.hasOutput ? (
+            <p className="py-1 text-sm text-muted-foreground">
+              No output recorded.
+            </p>
+          ) : isError ? (
+            <ContentMessageInline variant="warning">
+              Unable to load the action output.
+            </ContentMessageInline>
+          ) : isLoading ? (
+            <div className="flex items-center gap-2 py-1">
+              <Spinner size="sm" />
+              <span className="text-sm text-muted-foreground">
+                Loading output...
+              </span>
+            </div>
+          ) : (
+            <PokeJsonBlock defaultOpen label="Output" value={output} />
+          )}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/front/components/poke/projects/pod_functions/source.tsx
+++ b/front/components/poke/projects/pod_functions/source.tsx
@@ -1,0 +1,69 @@
+import { usePokePodFunctionSource } from "@app/poke/swr/pod_function_details";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  CodeBlock,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  ContentMessageInline,
+  Label,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+interface PodFunctionSourceProps {
+  functionId: string;
+  owner: LightWorkspaceType;
+  projectId: string;
+}
+
+export function PodFunctionSource({
+  functionId,
+  owner,
+  projectId,
+}: PodFunctionSourceProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { source, isLoading, isError } = usePokePodFunctionSource({
+    owner,
+    projectId,
+    functionId,
+    disabled: !isOpen,
+  });
+
+  return (
+    <div className="border-material-200 my-4 flex flex-col rounded-lg border bg-muted-background">
+      <div className="flex justify-between gap-3 rounded-t-lg bg-primary-300 p-4">
+        <h2 className="text-md font-bold">Bundle</h2>
+      </div>
+      <div className="flex flex-col p-4">
+        <Collapsible defaultOpen={false} onOpenChange={setIsOpen}>
+          <CollapsibleTrigger>
+            <Label className="cursor-pointer">Published source</Label>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            {isLoading ? (
+              <div className="flex items-center gap-2 pt-2">
+                <Spinner size="sm" />
+                <span className="text-sm text-muted-foreground">
+                  Loading source...
+                </span>
+              </div>
+            ) : isError || source === null ? (
+              <ContentMessageInline variant="warning" className="mt-2">
+                Unable to load the published bundle.
+              </ContentMessageInline>
+            ) : (
+              <CodeBlock
+                wrapLongLines
+                className="language-typescript mt-2 max-h-[32rem] overflow-auto"
+              >
+                {source}
+              </CodeBlock>
+            )}
+          </CollapsibleContent>
+        </Collapsible>
+      </div>
+    </div>
+  );
+}

--- a/front/components/poke/projects/pod_functions/table.tsx
+++ b/front/components/poke/projects/pod_functions/table.tsx
@@ -25,7 +25,7 @@ export function ProjectPodFunctionDataTable({
     >
       {(items) => (
         <PokeDataTable
-          columns={makeColumnsForProjectPodFunction()}
+          columns={makeColumnsForProjectPodFunction({ owner, projectId })}
           data={items}
         />
       )}

--- a/front/components/poke/projects/pod_functions/view.tsx
+++ b/front/components/poke/projects/pod_functions/view.tsx
@@ -1,0 +1,87 @@
+import { PokeJsonBlock } from "@app/components/poke/projects/pod_functions/json_block";
+import {
+  PokeTable,
+  PokeTableBody,
+  PokeTableCell,
+  PokeTableCellWithCopy,
+  PokeTableHead,
+  PokeTableRow,
+} from "@app/components/poke/shadcn/ui/table";
+import type { PokePodFunctionDetails } from "@app/lib/api/poke/projects";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+
+interface ViewPodFunctionTableProps {
+  podFunction: PokePodFunctionDetails;
+}
+
+export function ViewPodFunctionTable({
+  podFunction,
+}: ViewPodFunctionTableProps) {
+  return (
+    <div className="flex flex-col space-y-8">
+      <div className="flex justify-between gap-3">
+        <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-md flex-grow pb-4 font-bold">Overview</h2>
+          </div>
+          <PokeTable>
+            <PokeTableBody>
+              <PokeTableRow>
+                <PokeTableHead>Slug</PokeTableHead>
+                <PokeTableCellWithCopy label={podFunction.slug} />
+              </PokeTableRow>
+              <PokeTableRow>
+                <PokeTableHead>sId</PokeTableHead>
+                <PokeTableCellWithCopy label={podFunction.sId} />
+              </PokeTableRow>
+              <PokeTableRow>
+                <PokeTableHead>Description</PokeTableHead>
+                <PokeTableCell>{podFunction.description}</PokeTableCell>
+              </PokeTableRow>
+              <PokeTableRow>
+                <PokeTableHead>Author</PokeTableHead>
+                <PokeTableCell>{podFunction.author ?? "—"}</PokeTableCell>
+              </PokeTableRow>
+              <PokeTableRow>
+                <PokeTableHead>User identity</PokeTableHead>
+                <PokeTableCell>
+                  {podFunction.userIdentity ?? "optional"}
+                </PokeTableCell>
+              </PokeTableRow>
+              <PokeTableRow>
+                <PokeTableHead>Bundle file</PokeTableHead>
+                <PokeTableCellWithCopy label={podFunction.fileId} />
+              </PokeTableRow>
+              <PokeTableRow>
+                <PokeTableHead>Created At</PokeTableHead>
+                <PokeTableCell>
+                  {formatTimestampToFriendlyDate(
+                    new Date(podFunction.createdAt).getTime()
+                  )}
+                </PokeTableCell>
+              </PokeTableRow>
+              <PokeTableRow>
+                <PokeTableHead>Updated At</PokeTableHead>
+                <PokeTableCell>
+                  {formatTimestampToFriendlyDate(
+                    new Date(podFunction.updatedAt).getTime()
+                  )}
+                </PokeTableCell>
+              </PokeTableRow>
+            </PokeTableBody>
+          </PokeTable>
+          <div className="flex flex-col gap-2 pt-4">
+            <PokeJsonBlock
+              label="Input schema"
+              value={podFunction.inputSchema}
+            />
+            <PokeJsonBlock
+              label="Output schema"
+              value={podFunction.outputSchema}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/lib/api/poke/pod_functions.ts
+++ b/front/lib/api/poke/pod_functions.ts
@@ -1,8 +1,23 @@
-import type { PokePodFunction } from "@app/lib/api/poke/projects";
+import type {
+  PokeGetPodFunctionMCPActionOutput,
+  PokePodFunction,
+  PokePodFunctionDetails,
+  PokePodFunctionInvocation,
+  PokePodFunctionInvocationDetails,
+  PokePodFunctionMCPAction,
+} from "@app/lib/api/poke/projects";
 import type { Authenticator } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
+import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import type {
+  SandboxFunctionInvocationOrigin,
+  SandboxFunctionInvocationStatus,
+} from "@app/types/api/sandbox_functions";
+import { Err, Ok, type Result } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 
 export async function listProjectPodFunctions(
@@ -26,4 +41,204 @@ export async function listProjectPodFunctions(
 
     return sandboxFunction.toPokeJSON(author);
   });
+}
+
+/**
+ * Resolves a pod function within a given pod. `SandboxFunctionResource.fetchById` is only
+ * workspace-scoped, so the pod check is what keeps a function of another pod from being read
+ * through this pod's URL.
+ */
+export async function fetchProjectPodFunction(
+  auth: Authenticator,
+  space: SpaceResource,
+  podFunctionId: string
+): Promise<SandboxFunctionResource | null> {
+  const sandboxFunction = await SandboxFunctionResource.fetchById(
+    auth,
+    podFunctionId
+  );
+  if (!sandboxFunction || sandboxFunction.spaceId !== space.id) {
+    return null;
+  }
+
+  return sandboxFunction;
+}
+
+export async function getProjectPodFunctionDetails(
+  auth: Authenticator,
+  sandboxFunction: SandboxFunctionResource
+): Promise<PokePodFunctionDetails> {
+  const { userId } = sandboxFunction.file;
+  const [author] = userId ? await UserResource.fetchByModelIds([userId]) : [];
+
+  return sandboxFunction.toPokeDetailsJSON(author ?? null);
+}
+
+export async function listProjectPodFunctionInvocations(
+  auth: Authenticator,
+  {
+    sandboxFunction,
+    limit,
+    statuses,
+    origins,
+  }: {
+    sandboxFunction: SandboxFunctionResource;
+    limit: number;
+    statuses?: SandboxFunctionInvocationStatus[];
+    origins?: SandboxFunctionInvocationOrigin[];
+  }
+): Promise<PokePodFunctionInvocation[]> {
+  const rows = await SandboxFunctionInvocationResource.listRows(auth, {
+    sandboxFunction,
+    limit,
+    statuses,
+    origins,
+  });
+
+  const users = await UserResource.fetchByModelIds(
+    removeNulls(rows.map((row) => row.userId))
+  );
+  const usersByModelId = new Map(users.map((user) => [user.id, user]));
+
+  return rows.map((row) =>
+    SandboxFunctionInvocationResource.rowToPokeJSON(
+      row,
+      row.userId !== null ? (usersByModelId.get(row.userId) ?? null) : null
+    )
+  );
+}
+
+/**
+ * The published bundle of a pod function. Poke cannot reuse `/poke/:wId/files/:sId` for it: that
+ * page only serves `interactive_content` files, and a bundle is a `project_context` one.
+ */
+export async function getProjectPodFunctionSource(
+  auth: Authenticator,
+  sandboxFunction: SandboxFunctionResource
+): Promise<string> {
+  const readStream = sandboxFunction.file.getReadStream({
+    auth,
+    version: "original",
+  });
+
+  const chunks: Buffer[] = [];
+  for await (const chunk of readStream) {
+    chunks.push(chunk);
+  }
+
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+async function renderMCPActions(
+  auth: Authenticator,
+  actions: SandboxFunctionMCPActionResource[]
+): Promise<PokePodFunctionMCPAction[]> {
+  const mcpServerViews = await MCPServerViewResource.fetchByModelIds(
+    auth,
+    actions.map((action) => action.mcpServerViewId)
+  );
+  const mcpServerViewsByModelId = new Map(
+    mcpServerViews.map((mcpServerView) => [mcpServerView.id, mcpServerView])
+  );
+
+  return actions.map((action) =>
+    action.toPokeJSON(
+      mcpServerViewsByModelId.get(action.mcpServerViewId) ?? null
+    )
+  );
+}
+
+export async function getProjectPodFunctionInvocation(
+  auth: Authenticator,
+  {
+    sandboxFunction,
+    invocationId,
+  }: {
+    sandboxFunction: SandboxFunctionResource;
+    invocationId: string;
+  }
+): Promise<PokePodFunctionInvocationDetails | null> {
+  const invocation = await SandboxFunctionInvocationResource.fetchById(auth, {
+    sandboxFunction,
+    invocationId,
+    access: "admin",
+  });
+  if (!invocation) {
+    return null;
+  }
+
+  const actions = await SandboxFunctionMCPActionResource.listByInvocation(
+    auth,
+    invocation
+  );
+  const mcpActions = await renderMCPActions(auth, actions);
+
+  const [user] = invocation.userId
+    ? await UserResource.fetchByModelIds([invocation.userId])
+    : [];
+
+  return invocation.toPokeJSON(user ?? null, mcpActions);
+}
+
+export class PodFunctionMCPActionOutputError extends Error {
+  constructor(
+    readonly type: "action_not_found" | "output_read_failed",
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+export async function getProjectPodFunctionMCPActionOutput(
+  auth: Authenticator,
+  {
+    sandboxFunction,
+    invocationId,
+    actionId,
+  }: {
+    sandboxFunction: SandboxFunctionResource;
+    invocationId: string;
+    actionId: string;
+  }
+): Promise<
+  Result<PokeGetPodFunctionMCPActionOutput, PodFunctionMCPActionOutputError>
+> {
+  const invocation = await SandboxFunctionInvocationResource.fetchById(auth, {
+    sandboxFunction,
+    invocationId,
+    access: "admin",
+  });
+  if (!invocation) {
+    return new Err(
+      new PodFunctionMCPActionOutputError(
+        "action_not_found",
+        "Invocation not found."
+      )
+    );
+  }
+
+  const action = await SandboxFunctionMCPActionResource.fetchById(
+    auth,
+    actionId
+  );
+  if (!action || action.sandboxFunctionInvocationId !== invocation.id) {
+    return new Err(
+      new PodFunctionMCPActionOutputError(
+        "action_not_found",
+        "MCP action not found."
+      )
+    );
+  }
+
+  const outputResult = await action.readOutput();
+  if (outputResult.isErr()) {
+    return new Err(
+      new PodFunctionMCPActionOutputError(
+        "output_read_failed",
+        outputResult.error.message
+      )
+    );
+  }
+
+  return new Ok({ output: outputResult.value });
 }

--- a/front/lib/api/poke/projects.ts
+++ b/front/lib/api/poke/projects.ts
@@ -1,7 +1,16 @@
 import type { ProjectKnowledgeFromConnectorItem } from "@app/lib/api/projects/context";
 import type { ProjectWithAdminMetadata } from "@app/lib/api/projects/list";
+import type { StoredSandboxFunctionCallError } from "@app/lib/resources/sandbox_function_invocation_resource";
+import type {
+  SandboxFunctionInvocationOrigin,
+  SandboxFunctionInvocationStatus,
+  SandboxFunctionMCPActionType,
+  SandboxFunctionUserIdentityPolicy,
+} from "@app/types/api/sandbox_functions";
 import type { PodMetadataType } from "@app/types/project_metadata";
 import type { PodTaskType } from "@app/types/project_task";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 export type PokeProjectType = ProjectWithAdminMetadata;
 
@@ -46,4 +55,54 @@ export type PokePodFunction = {
 
 export type PokeListProjectPodFunctions = {
   items: PokePodFunction[];
+};
+
+export type PokePodFunctionDetails = PokePodFunction & {
+  fileId: string;
+  userIdentity: SandboxFunctionUserIdentityPolicy | null;
+  inputSchema: JSONSchema;
+  outputSchema: JSONSchema;
+};
+
+export type PokeGetPodFunction = {
+  podFunction: PokePodFunctionDetails;
+};
+
+export type PokeGetPodFunctionSource = {
+  source: string;
+};
+
+export type PokePodFunctionInvocation = {
+  sId: string;
+  status: SandboxFunctionInvocationStatus;
+  origin: SandboxFunctionInvocationOrigin | null;
+  user: string | null;
+  createdAt: string;
+  updatedAt: string;
+  mcpActionCount: number;
+};
+
+export type PokeListPodFunctionInvocations = {
+  items: PokePodFunctionInvocation[];
+};
+
+export type PokePodFunctionMCPAction = SandboxFunctionMCPActionType & {
+  mcpServerViewId: string | null;
+  mcpServerName: string | null;
+  hasOutput: boolean;
+};
+
+export type PokePodFunctionInvocationDetails = PokePodFunctionInvocation & {
+  input: unknown;
+  result: unknown;
+  error: StoredSandboxFunctionCallError | null;
+  mcpActions: PokePodFunctionMCPAction[];
+};
+
+export type PokeGetPodFunctionInvocation = {
+  invocation: PokePodFunctionInvocationDetails;
+};
+
+export type PokeGetPodFunctionMCPActionOutput = {
+  output: CallToolResult["content"] | null;
 };

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -3,6 +3,11 @@ import {
   getPodSandboxFunctionsMountPoint,
   podDatabaseExecEnvVars,
 } from "@app/lib/api/files/mount_path";
+import type {
+  PokePodFunctionInvocation,
+  PokePodFunctionInvocationDetails,
+  PokePodFunctionMCPAction,
+} from "@app/lib/api/poke/projects";
 import {
   generateExecId,
   generateSandboxFunctionInvocationToken,
@@ -67,7 +72,25 @@ const GCS_CONCURRENCY = 4;
 const SANDBOX_FUNCTION_INVOCATION_DATA_VERSION = 2;
 const POD_USER_IDENTITY_ENV = "DUST_POD_USER_IDENTITY";
 
-type SandboxFunctionInvocationReadAccess = "viewer" | "system";
+// "admin" reads every invocation of the function without resolving a workspace user: poke
+// operators are dust superusers, not members of the workspace they inspect, so "viewer" would
+// find no user and return nothing. Kept distinct from "system", which is reserved for paths that
+// already validated a server-owned invocation token.
+type SandboxFunctionInvocationReadAccess = "viewer" | "system" | "admin";
+
+// A listing row: the DB columns only, without the invocation's GCS blob. `baseFetch` always
+// hydrates the blob, and an unhydrated resource reports `input: undefined` rather than "not
+// loaded", so a listing that skipped the download could not hand back resources without breaking
+// that invariant. Callers that need a payload fetch the one invocation they care about.
+export type SandboxFunctionInvocationRow = {
+  sId: string;
+  status: SandboxFunctionInvocationStatus;
+  origin: SandboxFunctionInvocationOrigin | null;
+  userId: ModelId | null;
+  createdAt: Date;
+  updatedAt: Date;
+  mcpActionCount: number;
+};
 
 // `code` is not narrowed to `SandboxFunctionCallErrorCode`: it is forwarded from whatever
 // classified the failure (runner, API error type, front), and a code introduced by a newer deploy
@@ -78,7 +101,9 @@ const StoredCallErrorSchema = z.object({
   status: z.number().optional(),
 });
 
-type StoredSandboxFunctionCallError = z.infer<typeof StoredCallErrorSchema>;
+export type StoredSandboxFunctionCallError = z.infer<
+  typeof StoredCallErrorSchema
+>;
 
 const InvocationDataBaseSchema = z.object({
   input: z.unknown().optional(),
@@ -656,6 +681,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         break;
       }
       case "system":
+      case "admin":
         viewerModelId = undefined;
         break;
       default:
@@ -741,6 +767,55 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     );
   }
 
+  // Newest-first page of listing rows, no GCS read. See `SandboxFunctionInvocationRow`.
+  static async listRows(
+    auth: Authenticator,
+    {
+      sandboxFunction,
+      limit,
+      statuses,
+      origins,
+    }: {
+      sandboxFunction: SandboxFunctionResource;
+      limit: number;
+      statuses?: SandboxFunctionInvocationStatus[];
+      origins?: SandboxFunctionInvocationOrigin[];
+    }
+  ): Promise<SandboxFunctionInvocationRow[]> {
+    const invocations = await this.model.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        sandboxFunctionId: sandboxFunction.id,
+        ...(statuses && statuses.length > 0 ? { status: statuses } : {}),
+        ...(origins && origins.length > 0 ? { origin: origins } : {}),
+      },
+      order: [
+        ["createdAt", "DESC"],
+        ["id", "DESC"],
+      ],
+      limit,
+    });
+
+    const mcpActionCounts =
+      await SandboxFunctionMCPActionResource.countByInvocationModelIds(
+        auth,
+        invocations.map((invocation) => invocation.id)
+      );
+
+    return invocations.map((invocation) => ({
+      sId: this.modelIdToSId({
+        id: invocation.id,
+        workspaceId: invocation.workspaceId,
+      }),
+      status: invocation.status,
+      origin: invocation.origin,
+      userId: invocation.userId,
+      createdAt: invocation.createdAt,
+      updatedAt: invocation.updatedAt,
+      mcpActionCount: mcpActionCounts.get(invocation.id) ?? 0,
+    }));
+  }
+
   static async deleteAllForSandboxFunction(
     sandboxFunction: SandboxFunctionResource,
     { transaction }: { transaction?: Transaction } = {}
@@ -794,6 +869,49 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     } catch (error) {
       return new Err(normalizeError(error));
     }
+  }
+
+  // Poke's listing shape. Static because the listing works off rows rather than resources (see
+  // `SandboxFunctionInvocationRow`), and both entry points must produce the same shape.
+  static rowToPokeJSON(
+    row: SandboxFunctionInvocationRow,
+    user: UserResource | null
+  ): PokePodFunctionInvocation {
+    return {
+      sId: row.sId,
+      status: row.status,
+      origin: row.origin,
+      user: user ? user.fullName() : null,
+      createdAt: row.createdAt.toISOString(),
+      updatedAt: row.updatedAt.toISOString(),
+      mcpActionCount: row.mcpActionCount,
+    };
+  }
+
+  // The listing shape plus the GCS-backed payload this resource carries once hydrated, and the
+  // MCP actions the caller resolved for it.
+  toPokeJSON(
+    user: UserResource | null,
+    mcpActions: PokePodFunctionMCPAction[]
+  ): PokePodFunctionInvocationDetails {
+    return {
+      ...SandboxFunctionInvocationResource.rowToPokeJSON(
+        {
+          sId: this.sId,
+          status: this.status,
+          origin: this.origin,
+          userId: this.userId,
+          createdAt: this.createdAt,
+          updatedAt: this.updatedAt,
+          mcpActionCount: mcpActions.length,
+        },
+        user
+      ),
+      input: this.input,
+      result: this.result,
+      error: this.error ?? null,
+      mcpActions,
+    };
   }
 
   toJSON(): SandboxFunctionInvocationType {

--- a/front/lib/resources/sandbox_function_mcp_action_resource.ts
+++ b/front/lib/resources/sandbox_function_mcp_action_resource.ts
@@ -1,6 +1,7 @@
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ToolExecutionBaseStatus } from "@app/lib/actions/statuses";
 import type { ToolOutputItemType } from "@app/lib/actions/types";
+import type { PokePodFunctionMCPAction } from "@app/lib/api/poke/projects";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import {
@@ -156,6 +157,48 @@ export class SandboxFunctionMCPActionResource extends BaseResource<SandboxFuncti
     });
 
     return action ?? null;
+  }
+
+  // Oldest-first: the actions of a single invocation, in the order the function called them.
+  static async listByInvocation(
+    auth: Authenticator,
+    invocation: SandboxFunctionInvocationResource
+  ): Promise<SandboxFunctionMCPActionResource[]> {
+    return this.baseFetch(auth, {
+      where: { sandboxFunctionInvocationId: invocation.id },
+      order: [
+        ["createdAt", "ASC"],
+        ["id", "ASC"],
+      ],
+    });
+  }
+
+  // Counts the actions of each invocation, keyed by invocation model id. Counting the fetched ids
+  // in memory rather than grouping in SQL keeps the result typed; the row count is bounded by the
+  // caller's page of invocations times their tool calls.
+  static async countByInvocationModelIds(
+    auth: Authenticator,
+    invocationModelIds: ModelId[]
+  ): Promise<Map<ModelId, number>> {
+    const counts = new Map<ModelId, number>();
+    if (invocationModelIds.length === 0) {
+      return counts;
+    }
+
+    const actions = await this.model.findAll({
+      attributes: ["sandboxFunctionInvocationId"],
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        sandboxFunctionInvocationId: invocationModelIds,
+      },
+    });
+
+    for (const action of actions) {
+      const invocationModelId = action.sandboxFunctionInvocationId;
+      counts.set(invocationModelId, (counts.get(invocationModelId) ?? 0) + 1);
+    }
+
+    return counts;
   }
 
   static async fetchByModelIdWithAuth(
@@ -449,6 +492,21 @@ export class SandboxFunctionMCPActionResource extends BaseResource<SandboxFuncti
       inputs: this.inputs,
       status: this.status,
       executionDurationMs: this.executionDurationMs,
+    };
+  }
+
+  // `mcpServerView` names the tool's server and links to it; it is null when the view has since
+  // been deleted. The output itself stays behind `readOutput`, poke fetches it on demand.
+  toPokeJSON(
+    mcpServerView: MCPServerViewResource | null
+  ): PokePodFunctionMCPAction {
+    return {
+      ...this.toJSON(),
+      mcpServerViewId: mcpServerView?.sId ?? null,
+      mcpServerName: mcpServerView
+        ? mcpServerView.getServerDisplayMetadata().name
+        : null,
+      hasOutput: this.outputGcsPath !== null,
     };
   }
 }

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -1,4 +1,7 @@
-import type { PokePodFunction } from "@app/lib/api/poke/projects";
+import type {
+  PokePodFunction,
+  PokePodFunctionDetails,
+} from "@app/lib/api/poke/projects";
 import { SandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
 import { authorizeSandboxFunctionInvocation } from "@app/lib/api/sandbox_functions/workspace_user";
 import type { Authenticator } from "@app/lib/auth";
@@ -444,6 +447,18 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       createdAt: this.createdAt.toISOString(),
       updatedAt: this.updatedAt.toISOString(),
       author: author ? author.fullName() : null,
+    };
+  }
+
+  // The listing shape plus what only a single-function view needs: its contract and the bundle
+  // file it was published from.
+  toPokeDetailsJSON(author: UserResource | null): PokePodFunctionDetails {
+    return {
+      ...this.toPokeJSON(author),
+      fileId: this.file.sId,
+      userIdentity: this.userIdentity,
+      inputSchema: this.inputSchema,
+      outputSchema: this.outputSchema,
     };
   }
 

--- a/front/poke/swr/pod_function_details.ts
+++ b/front/poke/swr/pod_function_details.ts
@@ -1,0 +1,159 @@
+import type {
+  PokeGetPodFunction,
+  PokeGetPodFunctionInvocation,
+  PokeGetPodFunctionMCPActionOutput,
+  PokeGetPodFunctionSource,
+  PokeListPodFunctionInvocations,
+  PokePodFunctionInvocation,
+} from "@app/lib/api/poke/projects";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type {
+  SandboxFunctionInvocationOrigin,
+  SandboxFunctionInvocationStatus,
+} from "@app/types/api/sandbox_functions";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { Fetcher } from "swr";
+
+interface PodFunctionScope {
+  owner: LightWorkspaceType;
+  projectId: string;
+  functionId: string;
+}
+
+function podFunctionUrl({ owner, projectId, functionId }: PodFunctionScope) {
+  return `/api/poke/workspaces/${owner.sId}/projects/${projectId}/pod-functions/${functionId}`;
+}
+
+export function usePokePodFunction({
+  owner,
+  projectId,
+  functionId,
+  disabled,
+}: PodFunctionScope & { disabled?: boolean }) {
+  const { fetcher } = useFetcher();
+  const podFunctionFetcher: Fetcher<PokeGetPodFunction> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    podFunctionUrl({ owner, projectId, functionId }),
+    podFunctionFetcher,
+    { disabled }
+  );
+
+  return {
+    podFunction: data?.podFunction ?? null,
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}
+
+export function usePokePodFunctionSource({
+  owner,
+  projectId,
+  functionId,
+  disabled,
+}: PodFunctionScope & { disabled?: boolean }) {
+  const { fetcher } = useFetcher();
+  const sourceFetcher: Fetcher<PokeGetPodFunctionSource> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `${podFunctionUrl({ owner, projectId, functionId })}/source`,
+    sourceFetcher,
+    { disabled }
+  );
+
+  return {
+    source: data?.source ?? null,
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}
+
+export function usePokePodFunctionInvocations({
+  owner,
+  projectId,
+  functionId,
+  limit,
+  status,
+  origin,
+  disabled,
+}: PodFunctionScope & {
+  limit: number;
+  status?: SandboxFunctionInvocationStatus;
+  origin?: SandboxFunctionInvocationOrigin;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const invocationsFetcher: Fetcher<PokeListPodFunctionInvocations> = fetcher;
+
+  const params = new URLSearchParams({ limit: limit.toString() });
+  if (status) {
+    params.set("status", status);
+  }
+  if (origin) {
+    params.set("origin", origin);
+  }
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `${podFunctionUrl({ owner, projectId, functionId })}/invocations?${params.toString()}`,
+    invocationsFetcher,
+    { disabled }
+  );
+
+  return {
+    invocations: data?.items ?? emptyArray<PokePodFunctionInvocation>(),
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}
+
+export function usePokePodFunctionInvocation({
+  owner,
+  projectId,
+  functionId,
+  invocationId,
+  disabled,
+}: PodFunctionScope & { invocationId: string; disabled?: boolean }) {
+  const { fetcher } = useFetcher();
+  const invocationFetcher: Fetcher<PokeGetPodFunctionInvocation> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `${podFunctionUrl({ owner, projectId, functionId })}/invocations/${invocationId}`,
+    invocationFetcher,
+    { disabled }
+  );
+
+  return {
+    invocation: data?.invocation ?? null,
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}
+
+export function usePokePodFunctionMCPActionOutput({
+  owner,
+  projectId,
+  functionId,
+  invocationId,
+  actionId,
+  disabled,
+}: PodFunctionScope & {
+  invocationId: string;
+  actionId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const outputFetcher: Fetcher<PokeGetPodFunctionMCPActionOutput> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `${podFunctionUrl({ owner, projectId, functionId })}/invocations/${invocationId}/actions/${actionId}/output`,
+    outputFetcher,
+    { disabled }
+  );
+
+  return {
+    output: data?.output ?? null,
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -164,6 +164,7 @@ const API_ERROR_TYPES = [
   "skill_not_found",
   "skill_github_repository_not_found",
   "sandbox_function_not_found",
+  "sandbox_function_invocation_not_found",
   // Projects
   "project_metadata_not_found",
   // Suggestions


### PR DESCRIPTION
## Description

Poke lists a pod's functions (#29254) but stops there — there is no way to see whether a function ever ran, with what input, or which tools it called. The data is already recorded (`SandboxFunctionInvocationModel` plus its GCS payload, and `SandboxFunctionMCPActionModel`); until now only agents could read it, through the `inspect_invocations` MCP tool.

Clicking a slug in the Pod Functions table now opens `spaces/:spaceId/pod_functions/:functionId`:

- **Overview** — slug, sId, description, author, user identity policy, bundle file id, timestamps, and the input/output JSON schemas.
- **Bundle** — the published source, fetched on expand.
- **Invocations** — status and origin filters, 25 per page with "load more". Each row shows time, user, origin, elapsed time and MCP action count; expanding it reveals input/result/error and the MCP actions; expanding an action reveals its inputs and its output.

Notable choices:

- **Payloads stay lazy.** Invocation payloads and tool outputs are GCS objects, so the listing endpoint returns DB rows only and the page reads at most one blob per invocation the operator actually opens. `SandboxFunctionInvocationResource.listRows` returns rows rather than resources on purpose: `baseFetch` always hydrates the blob, and an unhydrated resource reports `input: undefined` rather than "not loaded", so handing back unhydrated resources would break that invariant.
- **A new `"admin"` read access.** Poke operators are dust superusers, not members of the workspace they inspect, so `"viewer"` resolves no workspace user and returns nothing. Kept distinct from `"system"`, which is documented as the mode for paths that already validated a server-owned invocation token.
- **`withPodFunction()` middleware**, alongside the existing `withProject()`, so the three handlers read `ctx.get("podFunction")` instead of each re-fetching and re-validating. It 404s a function belonging to a different pod — `SandboxFunctionResource.fetchById` is only workspace-scoped, so without that check a sibling pod's function would be readable through this pod's URL.
- **The bundle is served by the function's own `/source` endpoint** rather than linked to `/poke/:wId/files/:sId`, which only serves `interactive_content` files and 400s on a `project_context` bundle.
- **Serialization lives on the Resources** (`toPokeDetailsJSON`, `toPokeJSON`, `rowToPokeJSON`), per @flvndvd's review on #29254; `lib/api/poke/pod_functions.ts` only fetches and joins.

## Tests

10 functional tests in `front-api/routes/poke/.../pod-functions/[functionId]/invocations.test.ts`, built with the existing factories: function details, bundle source, cross-pod function 404, non-superuser 401, invocation ordering + action counts + payload-free listing, status filtering, hydrated detail with MCP action metadata, invocation-of-another-function 404, action output, and action-of-another-invocation 404.

The existing 107 `sandbox_function` tests still pass. `tsgo` is clean in front, front-api and front-spa.

## Risk

Low. Read-only, poke-only, additive. The one change to shared code is the extra `"admin"` arm in `SandboxFunctionInvocationReadAccess`, which no existing caller passes. Safe to revert.

## Deploy Plan

Nothing special — no migration, no config.