### PR TITLE
Stop charging tool credits for denied tool calls

### DIFF
--- a/front/lib/actions/statuses.ts
+++ b/front/lib/actions/statuses.ts
@@ -53,6 +53,27 @@ export function isToolExecutionStatusFinal(
   );
 }
 
+// The final statuses the tool actually ran under. `denied` is final but never executed: the user
+// rejected the approval, declined the authentication, or ended the message while the call sat
+// blocked. Charges are per invocation, so none of those are charged, while the model tokens spent
+// emitting the call are still billed as intelligence through the run usage. `errored` stays
+// billable, since the tool was invoked and failed on its own terms.
+const TOOL_EXECUTION_BILLABLE_STATUSES = [
+  "succeeded",
+  "errored",
+] as const satisfies readonly ToolExecutionFinalStatus[];
+
+type ToolExecutionBillableStatus =
+  (typeof TOOL_EXECUTION_BILLABLE_STATUSES)[number];
+
+export function isToolExecutionStatusBillable(
+  state: ToolExecutionStatus
+): state is ToolExecutionBillableStatus {
+  return TOOL_EXECUTION_BILLABLE_STATUSES.includes(
+    state as ToolExecutionBillableStatus
+  );
+}
+
 export function isToolExecutionStatusBlocked(
   state: ToolExecutionStatus
 ): state is ToolExecutionBlockedStatus {

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
@@ -190,7 +190,8 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
       inputTokensCount: TOKENS_PER_FOOTPRINT,
     });
     expect(toolItem?.grossAttributedCreditAmountMicro).toBeGreaterThan(0);
-    expect(toolItem?.directCreditAmountMicro).toBeGreaterThanOrEqual(0);
+    // The tool ran, so it carries the per-invocation charge of its cost category.
+    expect(toolItem?.directCreditAmountMicro).toBeGreaterThan(0);
 
     // The tokens the model spent emitting the tool call are carved out of the assistant output
     // bucket, so the two together still sum to the completion tokens net of reasoning.
@@ -254,6 +255,62 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
     ).toBe(OUTPUT_TOKENS_COUNT - REASONING_TOKENS_COUNT);
   });
 
+  it("completes the pending tool row with no charge once the blocked action is denied", async () => {
+    const {
+      auth,
+      workspace,
+      conversation,
+      run,
+      conversationId,
+      agentMessageId,
+      agentMessageModelId,
+    } = await setupSettledMessageWithUsage();
+
+    const { action } = await AgentMCPActionFactory.create(auth, {
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId,
+      dustRunId: run.dustRunId,
+    });
+
+    // First finalize, while the tool is still blocked: a pending row is written.
+    await computeAndStoreAgentMessageConsumptionAttribution(auth, {
+      agentMessageId,
+      conversationId,
+    });
+
+    // The user rejects the approval, so the tool never runs, then the loop finalizes again.
+    await AgentMCPActionFactory.setStatus(auth, {
+      action,
+      status: "denied",
+    });
+    await computeAndStoreAgentMessageConsumptionAttribution(auth, {
+      agentMessageId,
+      conversationId,
+    });
+
+    const toolItems = (
+      await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
+        auth,
+        {
+          agentMessageModelIds: [agentMessageModelId],
+          attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+        }
+      )
+    ).filter((item) => item.itemType === "tool");
+
+    // The row settles with no per-invocation charge. What stays attributed is the output the
+    // model spent emitting the call.
+    expect(toolItems).toHaveLength(1);
+    expect(toolItems[0]).toMatchObject({
+      agentMCPActionId: action.id,
+      outputTokensCount: TOKENS_PER_FOOTPRINT,
+      directCreditAmountMicro: 0,
+      completedAt: expect.any(Date),
+    });
+    expect(toolItems[0].grossAttributedCreditAmountMicro).toBeGreaterThan(0);
+  });
+
   it("completes the pending tool row in place once the blocked action is approved", async () => {
     const {
       auth,
@@ -307,7 +364,7 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
       inputTokensCount: TOKENS_PER_FOOTPRINT,
       completedAt: expect.any(Date),
     });
-    expect(toolItems[0].directCreditAmountMicro).toBeGreaterThanOrEqual(0);
+    expect(toolItems[0].directCreditAmountMicro).toBeGreaterThan(0);
   });
 
   it("keeps a completed tool single and stable across a redundant re-finalize", async () => {

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
@@ -232,11 +232,14 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
         return;
       }
 
+      // Zero for a denied call, which billing does not charge. Its emitted output tokens stay
+      // attributed here.
       const directCreditAmountMicro = Math.round(
         toolAwuFromAction(
           {
             toolName: enrichedAction.toolName,
             internalMCPServerName: enrichedAction.internalMCPServerName,
+            status: action.status,
           },
           triggeringUserMessageOrigin
         ) * CREDIT_AMOUNT_MICRO_PER_CREDIT

--- a/front/lib/api/assistant/credit_cost.test.ts
+++ b/front/lib/api/assistant/credit_cost.test.ts
@@ -125,8 +125,13 @@ describe("toolAwuFromActions", () => {
           {
             toolName: "websearch",
             internalMCPServerName: "web_search_&_browse",
+            status: "succeeded",
           }, // basic = 1
-          { toolName: "semantic_search", internalMCPServerName: "search" }, // advanced = 3
+          {
+            toolName: "semantic_search",
+            internalMCPServerName: "search",
+            status: "succeeded",
+          }, // advanced = 3
         ],
         TEST_CONTEXT_ORIGIN
       )
@@ -136,7 +141,13 @@ describe("toolAwuFromActions", () => {
   it("treats unknown / external servers as advanced (3)", () => {
     expect(
       toolAwuFromActions(
-        [{ toolName: "custom_tool", internalMCPServerName: null }],
+        [
+          {
+            toolName: "custom_tool",
+            internalMCPServerName: null,
+            status: "succeeded",
+          },
+        ],
         TEST_CONTEXT_ORIGIN
       )
     ).toBe(3);
@@ -146,13 +157,70 @@ describe("toolAwuFromActions", () => {
     // agent_memory has toolCategory "basic" + freeUsage true — contributes 0.
     expect(
       toolAwuFromActions(
-        [{ toolName: "retrieve", internalMCPServerName: "agent_memory" }],
+        [
+          {
+            toolName: "retrieve",
+            internalMCPServerName: "agent_memory",
+            status: "succeeded",
+          },
+        ],
         TEST_CONTEXT_ORIGIN
       )
     ).toBe(0);
     expect(
       toolAwuFromActions(
-        [{ toolName: "record_entries", internalMCPServerName: "agent_memory" }],
+        [
+          {
+            toolName: "record_entries",
+            internalMCPServerName: "agent_memory",
+            status: "succeeded",
+          },
+        ],
+        TEST_CONTEXT_ORIGIN
+      )
+    ).toBe(0);
+  });
+
+  it("charges for a tool that ran and failed on its own terms", () => {
+    expect(
+      toolAwuFromActions(
+        [
+          {
+            toolName: "semantic_search",
+            internalMCPServerName: "search",
+            status: "errored",
+          },
+        ],
+        TEST_CONTEXT_ORIGIN
+      )
+    ).toBe(3);
+  });
+
+  it("does not charge for a denied tool, which never reached the tool", () => {
+    expect(
+      toolAwuFromActions(
+        [
+          {
+            toolName: "semantic_search",
+            internalMCPServerName: "search",
+            status: "denied",
+          },
+        ],
+        TEST_CONTEXT_ORIGIN
+      )
+    ).toBe(0);
+  });
+
+  it("does not charge for a tool still awaiting approval", () => {
+    expect(
+      toolAwuFromActions(
+        [
+          {
+            toolName: "semantic_search",
+            internalMCPServerName: "search",
+            status: "blocked_validation_required",
+          },
+        ],
         TEST_CONTEXT_ORIGIN
       )
     ).toBe(0);
@@ -175,7 +243,7 @@ describe("computeAgentMessageCredits", () => {
     expect(credits).toBe(4);
   });
 
-  it("ignores non-final actions", () => {
+  it("ignores actions that have not run yet", () => {
     const credits = computeAgentMessageCredits({
       runUsages: [],
       actions: [
@@ -188,6 +256,36 @@ describe("computeAgentMessageCredits", () => {
       contextOrigin: TEST_CONTEXT_ORIGIN,
     });
     expect(credits).toBeNull();
+  });
+
+  it("ignores denied actions, which the user rejected before they ran", () => {
+    const credits = computeAgentMessageCredits({
+      runUsages: [],
+      actions: [
+        {
+          toolName: "semantic_search",
+          internalMCPServerName: "search",
+          status: "denied",
+        },
+      ],
+      contextOrigin: TEST_CONTEXT_ORIGIN,
+    });
+    expect(credits).toBeNull();
+  });
+
+  it("bills the intelligence spent emitting a call the user then denied", () => {
+    const credits = computeAgentMessageCredits({
+      runUsages: [usage({ costMicroUsd: 8500 })], // 1 intelligence credit
+      actions: [
+        {
+          toolName: "semantic_search",
+          internalMCPServerName: "search",
+          status: "denied",
+        },
+      ], // no tool credits
+      contextOrigin: TEST_CONTEXT_ORIGIN,
+    });
+    expect(credits).toBe(1);
   });
 
   it("returns null when there is no billable usage", () => {

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -1,6 +1,6 @@
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
-import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
+import { isToolExecutionStatusBillable } from "@app/lib/actions/statuses";
 import { getToolNameFromFunctionCallName } from "@app/lib/actions/tool_display_labels";
 import { makeFairUseAwuCreditsRateLimitKeyForUser } from "@app/lib/api/assistant/rate_limits";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
@@ -152,7 +152,9 @@ export function buildAgentMessageCreditsBreakdownFromAnalytics({
       toolName: action.toolName,
       internalMCPServerName: action.internalMCPServerName,
       toolCostCategory,
-      free: matched.cost_awu === 0 && isToolExecutionStatusFinal(action.status),
+      // "Free" means the tool ran and its category priced it at zero, not that it never ran.
+      free:
+        matched.cost_awu === 0 && isToolExecutionStatusBillable(action.status),
       awu: matched.cost_awu,
     });
   }
@@ -174,11 +176,13 @@ export function computeAgentMessageCredits({
   actions: CreditActionMinimalInput[];
   contextOrigin: UserMessageOrigin | null;
 }): number | null {
-  const finalActions = actions.filter((a) =>
-    isToolExecutionStatusFinal(a.status)
+  // Unbillable actions already price at 0 through toolAwuFromAction. Filtering them here settles
+  // the other question, whether the message has anything to bill at all.
+  const billableActions = actions.filter((a) =>
+    isToolExecutionStatusBillable(a.status)
   );
 
-  if (runUsages.length === 0 && finalActions.length === 0) {
+  if (runUsages.length === 0 && billableActions.length === 0) {
     return null;
   }
 
@@ -187,7 +191,7 @@ export function computeAgentMessageCredits({
   // action), so it is grouping-invariant and stays message-level.
   return (
     intelligenceAwuFromRunUsagesGroupedByRunKey(runUsages, contextOrigin) +
-    toolAwuFromActions(finalActions, contextOrigin)
+    toolAwuFromActions(billableActions, contextOrigin)
   );
 }
 

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -3,6 +3,8 @@ import {
   type InternalMCPServerNameType,
   isInternalMCPServerName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
+import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
+import { isToolExecutionStatusBillable } from "@app/lib/actions/statuses";
 import { TOOL_COST_CATEGORIES, type ToolCostCategory } from "@app/lib/api/mcp";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
@@ -217,14 +219,14 @@ export function intelligenceAwuFromRunUsagesGroupedByRunKey(
   return total;
 }
 
-// Tool (platform action) credits for a set of executed actions. Each action
-// costs a fixed number of credits depending on its credit cost category
-// (free = 0, basic = 1, advanced = 3). Callers should pass only final-status
-// actions (matching the usage_queue extraction) so this equals the billed amount.
+// Tool (platform action) credits for a set of actions. Each action costs a
+// fixed number of credits depending on its credit cost category (free = 0,
+// basic = 1, advanced = 3).
 export function toolAwuFromActions(
   actions: {
     internalMCPServerName: InternalMCPServerNameType | null;
     toolName: string;
+    status: ToolExecutionStatus;
   }[],
   contextOrigin: UserMessageOrigin | null
 ): number {
@@ -237,10 +239,15 @@ export function toolAwuFromAction(
   action: {
     toolName: string;
     internalMCPServerName: InternalMCPServerNameType | null;
+    status: ToolExecutionStatus;
   },
   contextOrigin: UserMessageOrigin | null
 ): number {
   if (isFreeOrigin(contextOrigin)) {
+    return 0;
+  }
+  // The single gate on billable status. Every surface that prices a tool call goes through here.
+  if (!isToolExecutionStatusBillable(action.status)) {
     return 0;
   }
   const { toolCostCategory, freeUsage } = getToolBillingInfo(
@@ -390,7 +397,7 @@ interface ToolAction {
   toolName: string;
   mcpServerId: string | null;
   internalMCPServerName: InternalMCPServerNameType | null;
-  status: string;
+  status: ToolExecutionStatus;
   executionDurationMs: number | null;
 }
 

--- a/front/temporal/analytics_queue/activities/agent_analytics.ts
+++ b/front/temporal/analytics_queue/activities/agent_analytics.ts
@@ -6,7 +6,6 @@ import {
   SEARCH_TOOL_NAME,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { isSearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import { updateAnalyticsFeedback } from "@app/lib/analytics/feedback";
 import { resolvedModelFromAgentMessageRow } from "@app/lib/api/assistant/models";
@@ -436,9 +435,11 @@ async function collectToolUsageFromMessage(
     const toolName =
       actionResource.functionCallName.split(TOOL_NAME_SEPARATOR).pop() ??
       actionResource.functionCallName;
-    const cost_awu = isToolExecutionStatusFinal(actionResource.status)
-      ? toolAwuFromAction({ toolName, internalMCPServerName }, contextOrigin)
-      : 0;
+    // Same pricing gate as the billing pipeline, so this snapshot matches what was emitted.
+    const cost_awu = toolAwuFromAction(
+      { toolName, internalMCPServerName, status: actionResource.status },
+      contextOrigin
+    );
 
     return {
       step_index: actionResource.stepContent.step,

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -1,4 +1,4 @@
-import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
+import { isToolExecutionStatusBillable } from "@app/lib/actions/statuses";
 import { reconcileApiKey } from "@app/lib/api/metronome/reconcile_credit_state";
 import { syncMetronomeSeatCountForWorkspace } from "@app/lib/api/metronome/seat_sync";
 import {
@@ -359,16 +359,16 @@ export async function emitMetronomeUsageEventsActivity(
   });
   const runUsages = await RunResource.listRunUsagesForRuns(auth, { runs });
 
-  // Get MCP actions — filter to this execution's steps if startStep is available,
-  // and only include actions with a final status (succeeded/errored/denied).
-  // Actions with blocked/transient status haven't been executed yet and shouldn't be billed.
+  // Get MCP actions, filtered to this execution's steps if startStep is available, and to the
+  // actions that reached the tool. The Metronome rate card prices every tool_use_v3 event it
+  // receives, so an unbillable call has to be dropped here rather than flagged on the event.
   const allMcpActions = await AgentMCPActionResource.listByAgentMessageIds(
     auth,
     [agentMessage.id]
   );
   const mcpActions = allMcpActions.filter((a) => {
     const json = a.toJSON();
-    if (!isToolExecutionStatusFinal(json.status)) {
+    if (!isToolExecutionStatusBillable(json.status)) {
       return false;
     }
     if (


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We charge credits per tool invocation, but the billing pipeline decided what counted as an invocation by asking whether the action had reached a terminal state. Denied actions are terminal and were therefore charged the full weight of their cost category, one credit for basic tools and three for advanced ones, even though the tool never ran.

An action becomes denied in three ways, none of which involve running anything:
- the user rejects the approval prompt
- the user declines the personal authentication
- the message ends on an unresumable status while calls are still sitting blocked, at which point every blocked call on that message is swept to denied at once

This PR introduces a dedicated helper (which surface that this code did not age well, given all the code path required to be updated to use it). 

> [!NOTE]
> It does not change previous bill, only changes moving forward or if ES were to be backfilled again


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
