### PR TITLE
Expose agent message consumption details

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -6940,6 +6940,141 @@
         }
       }
     },
+    "/api/w/{wId}/assistant/conversations/{cId}/messages/{mId}/consumption": {
+      "get": {
+        "summary": "Get an agent message credit attribution",
+        "description": "Returns the exact billed credits and, when available, an estimated cache-naive attribution grouped into agent work and tools.",
+        "tags": [
+          "Private Messages"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "mId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Credit attribution for the agent message",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "billedCredits",
+                    "details"
+                  ],
+                  "properties": {
+                    "billedCredits": {
+                      "type": "number",
+                      "nullable": true,
+                      "description": "Authoritative credits billed for this agent message."
+                    },
+                    "details": {
+                      "type": "object",
+                      "nullable": true,
+                      "description": "Cache-naive estimated attribution. Null when the active attribution version is unavailable or incomplete.",
+                      "required": [
+                        "attributionVersion",
+                        "grossAttributedCredits",
+                        "estimatedCacheSavingsCredits",
+                        "agentWorkCredits",
+                        "tools"
+                      ],
+                      "properties": {
+                        "attributionVersion": {
+                          "type": "integer"
+                        },
+                        "grossAttributedCredits": {
+                          "type": "number"
+                        },
+                        "estimatedCacheSavingsCredits": {
+                          "type": "number",
+                          "nullable": true
+                        },
+                        "agentWorkCredits": {
+                          "type": "number"
+                        },
+                        "tools": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "label",
+                              "internalMCPServerName",
+                              "toolName",
+                              "callCount",
+                              "grossAttributedCredits",
+                              "directCredits",
+                              "pending"
+                            ],
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "internalMCPServerName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "toolName": {
+                                "type": "string"
+                              },
+                              "callCount": {
+                                "type": "integer"
+                              },
+                              "grossAttributedCredits": {
+                                "type": "number"
+                              },
+                              "directCredits": {
+                                "type": "number"
+                              },
+                              "pending": {
+                                "type": "boolean"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The workspace does not have access to consumption details"
+          },
+          "404": {
+            "description": "Conversation or agent message not found"
+          }
+        }
+      }
+    },
     "/api/w/{wId}/assistant/conversations/{cId}/messages/{mId}/edit": {
       "post": {
         "summary": "Edit a message",

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/consumption.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/consumption.test.ts
@@ -1,0 +1,81 @@
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+const BILLED_CREDITS = 7;
+
+async function setupMessage() {
+  const { auth, workspace } = await createPrivateApiMockRequest({
+    role: "user",
+    method: "GET",
+  });
+  const agentConfiguration = await AgentConfigurationFactory.createTestAgent(
+    auth,
+    { name: "Consumption endpoint" }
+  );
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: agentConfiguration.sId,
+    messagesCreatedAt: [],
+  });
+  const { agentMessage } = await ConversationFactory.createAgentMessage(auth, {
+    workspace,
+    conversation,
+    agentConfig: agentConfiguration,
+  });
+  await ConversationResource.updateAgentMessageCostCredits(auth, {
+    agentMessageModelId: agentMessage.agentMessageId,
+    costCredits: BILLED_CREDITS,
+  });
+
+  return { auth, workspace, conversation, agentMessage };
+}
+
+function getConsumption({
+  workspaceId,
+  conversationId,
+  messageId,
+}: {
+  workspaceId: string;
+  conversationId: string;
+  messageId: string;
+}) {
+  return honoApp.request(
+    `/api/w/${workspaceId}/assistant/conversations/${conversationId}/messages/${messageId}/consumption`
+  );
+}
+
+describe("GET /api/w/:wId/assistant/conversations/:cId/messages/:mId/consumption", () => {
+  it("returns the exact bill while attribution is unavailable", async () => {
+    const { auth, workspace, conversation, agentMessage } =
+      await setupMessage();
+    await FeatureFlagFactory.basic(auth, "conversation_consumption_details");
+
+    const response = await getConsumption({
+      workspaceId: workspace.sId,
+      conversationId: conversation.sId,
+      messageId: agentMessage.sId,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      billedCredits: BILLED_CREDITS,
+      details: null,
+    });
+  });
+
+  it("rejects workspaces without the feature flag", async () => {
+    const { workspace, conversation, agentMessage } = await setupMessage();
+
+    const response = await getConsumption({
+      workspaceId: workspace.sId,
+      conversationId: conversation.sId,
+      messageId: agentMessage.sId,
+    });
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/consumption.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/consumption.ts
@@ -1,0 +1,150 @@
+import { getAgentMessageConsumption } from "@app/lib/api/assistant/agent_message_consumption_attribution/read";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { AgentMessageConsumptionResponse } from "@app/types/assistant/agent_message_consumption";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+  mId: z.string(),
+});
+
+const app = workspaceApp();
+
+app.use(withFeatureFlag("conversation_consumption_details"));
+
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/conversations/{cId}/messages/{mId}/consumption:
+ *   get:
+ *     summary: Get an agent message credit attribution
+ *     description: Returns the exact billed credits and, when available, an estimated cache-naive attribution grouped into agent work and tools.
+ *     tags:
+ *       - Private Messages
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: mId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Credit attribution for the agent message
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required:
+ *                 - billedCredits
+ *                 - details
+ *               properties:
+ *                 billedCredits:
+ *                   type: number
+ *                   nullable: true
+ *                   description: Authoritative credits billed for this agent message.
+ *                 details:
+ *                   type: object
+ *                   nullable: true
+ *                   description: Cache-naive estimated attribution. Null when the active attribution version is unavailable or incomplete.
+ *                   required:
+ *                     - attributionVersion
+ *                     - grossAttributedCredits
+ *                     - estimatedCacheSavingsCredits
+ *                     - agentWorkCredits
+ *                     - tools
+ *                   properties:
+ *                     attributionVersion:
+ *                       type: integer
+ *                     grossAttributedCredits:
+ *                       type: number
+ *                     estimatedCacheSavingsCredits:
+ *                       type: number
+ *                       nullable: true
+ *                     agentWorkCredits:
+ *                       type: number
+ *                     tools:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         required:
+ *                           - label
+ *                           - internalMCPServerName
+ *                           - toolName
+ *                           - callCount
+ *                           - grossAttributedCredits
+ *                           - directCredits
+ *                           - pending
+ *                         properties:
+ *                           label:
+ *                             type: string
+ *                           internalMCPServerName:
+ *                             type: string
+ *                             nullable: true
+ *                           toolName:
+ *                             type: string
+ *                           callCount:
+ *                             type: integer
+ *                           grossAttributedCredits:
+ *                             type: number
+ *                           directCredits:
+ *                             type: number
+ *                           pending:
+ *                             type: boolean
+ *       403:
+ *         description: The workspace does not have access to consumption details
+ *       404:
+ *         description: Conversation or agent message not found
+ */
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<AgentMessageConsumptionResponse> => {
+    const auth = ctx.get("auth");
+    const { cId, mId } = ctx.req.valid("param");
+
+    const conversation = await ConversationResource.fetchById(auth, cId);
+    if (!conversation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: "Conversation not found.",
+        },
+      });
+    }
+
+    const consumption = await getAgentMessageConsumption(auth, {
+      conversation,
+      agentMessageId: mId,
+    });
+    if (!consumption) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "message_not_found",
+          message: "Agent message not found.",
+        },
+      });
+    }
+
+    return ctx.json(consumption);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
@@ -20,6 +20,7 @@ import { z } from "zod";
 
 import actions from "./actions";
 import answerQuestion from "./answer-question";
+import consumption from "./consumption";
 import edit from "./edit";
 import events from "./events";
 import feedbacks from "./feedbacks";
@@ -286,6 +287,7 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
 
 app.route("/actions", actions);
 app.route("/answer-question", answerQuestion);
+app.route("/consumption", consumption);
 app.route("/edit", edit);
 app.route("/events", events);
 app.route("/feedbacks", feedbacks);

--- a/front-api/vite.setup.ts
+++ b/front-api/vite.setup.ts
@@ -4,6 +4,14 @@ import { vi } from "vitest";
 
 import "../front/vite.setup.ts";
 
+// Front-api tests exercise server behavior and do not enable browser development mode.
+vi.mock("@app/components/dev/devModeConstants", () => {
+  return {
+    DEV_MODE_ACTIVE: false,
+    DEV_MODE_STORAGE_KEY: "dust_dev_mode",
+  };
+});
+
 vi.mock("@app/lib/api/config", async (importOriginal) => {
   const { createAppConfigMock } = await import(
     "@app/tests/utils/mocks/app_config"

--- a/front/lib/api/assistant/action_one_line_label.ts
+++ b/front/lib/api/assistant/action_one_line_label.ts
@@ -1,0 +1,31 @@
+import type { AgentMCPActionType } from "@app/types/actions";
+import { asDisplayName } from "@app/types/shared/utils/string_utils";
+
+type ActionWithDisplayLabel = Pick<
+  AgentMCPActionType,
+  | "displayLabels"
+  | "functionCallName"
+  | "internalMCPServerName"
+  | "params"
+  | "toolName"
+>;
+
+export function getActionOneLineLabel(
+  action: ActionWithDisplayLabel,
+  context: "running" | "done" = "done"
+): string {
+  if (
+    action.internalMCPServerName === "sandbox" &&
+    action.toolName === "add_egress_domain" &&
+    typeof action.params?.domain === "string"
+  ) {
+    return context === "running"
+      ? `Requesting access to ${action.params.domain}`
+      : `Request access to ${action.params.domain}`;
+  }
+
+  return (
+    action.displayLabels?.[context] ??
+    (action.functionCallName ? asDisplayName(action.functionCallName) : "Tool")
+  );
+}

--- a/front/lib/api/assistant/activity_steps.ts
+++ b/front/lib/api/assistant/activity_steps.ts
@@ -1,3 +1,4 @@
+import { getActionOneLineLabel } from "@app/lib/api/assistant/action_one_line_label";
 import {
   AgentMessageContentParser,
   getCoTDelimitersConfiguration,
@@ -14,31 +15,8 @@ import {
   isAgentTextContent,
 } from "@app/types/assistant/agent_message_content";
 import type { InlineActivityStep } from "@app/types/assistant/conversation";
-import { asDisplayName } from "@app/types/shared/utils/string_utils";
 
-/**
- * Compute the display label for an action (one-line summary).
- * Pure function with no browser dependencies — usable server-side and client-side.
- */
-export function getActionOneLineLabel(
-  action: AgentMCPActionWithOutputType,
-  context: "running" | "done" = "done"
-): string {
-  if (
-    action.internalMCPServerName === "sandbox" &&
-    action.toolName === "add_egress_domain" &&
-    typeof action.params?.domain === "string"
-  ) {
-    return context === "running"
-      ? `Requesting access to ${action.params.domain}`
-      : `Request access to ${action.params.domain}`;
-  }
-
-  return (
-    action.displayLabels?.[context] ??
-    (action.functionCallName ? asDisplayName(action.functionCallName) : "Tool")
-  );
-}
+export { getActionOneLineLabel } from "@app/lib/api/assistant/action_one_line_label";
 
 // Ensure at least one whitespace boundary between adjacent text fragments when
 // reconstructing content from step contents. If neither the previous fragment

--- a/front/lib/api/assistant/agent_message_consumption_attribution/read.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/read.test.ts
@@ -1,0 +1,231 @@
+import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
+import { getAgentMessageConsumption } from "@app/lib/api/assistant/agent_message_consumption_attribution/read";
+import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { RunFactory } from "@app/tests/utils/RunFactory";
+import type { ModelId } from "@app/types/shared/model_id";
+import { describe, expect, it } from "vitest";
+
+const BILLED_CREDITS = 10;
+const INPUT_GROSS_CREDITS_MICRO = 2_000_000;
+const OUTPUT_GROSS_CREDITS_MICRO = 1_000_000;
+const REASONING_GROSS_CREDITS_MICRO = 1_000_000;
+
+async function setupMessage() {
+  const { authenticator: auth, workspace } = await createResourceTest({});
+  const agentConfiguration = await AgentConfigurationFactory.createTestAgent(
+    auth,
+    { name: `Consumption ${generateRandomModelSId()}` }
+  );
+  const createdConversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: agentConfiguration.sId,
+    messagesCreatedAt: [],
+  });
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    createdConversation.sId
+  );
+  if (!conversation) {
+    throw new Error("Just-created conversation not found.");
+  }
+  const { run, runUsageModelId } = await RunFactory.createWithUsage(auth, {
+    inputTokens: 100,
+    outputTokens: 20,
+    reasoningTokens: 5,
+  });
+  const { agentMessage } = await ConversationFactory.createAgentMessage(auth, {
+    workspace,
+    conversation,
+    agentConfig: agentConfiguration,
+    runIds: [run.dustRunId],
+  });
+  await ConversationResource.updateAgentMessageCostCredits(auth, {
+    agentMessageModelId: agentMessage.agentMessageId,
+    costCredits: BILLED_CREDITS,
+  });
+
+  return {
+    auth,
+    workspace,
+    conversation,
+    run,
+    runUsageModelId,
+    agentMessage,
+  };
+}
+
+function modelRecords(runUsageModelId: ModelId) {
+  return [
+    {
+      itemType: "input" as const,
+      runUsageModelId,
+      inputTokensCount: 100,
+      grossAttributedCreditAmountMicro: INPUT_GROSS_CREDITS_MICRO,
+    },
+    {
+      itemType: "output" as const,
+      runUsageModelId,
+      outputTokensCount: 15,
+      grossAttributedCreditAmountMicro: OUTPUT_GROSS_CREDITS_MICRO,
+    },
+    {
+      itemType: "reasoning" as const,
+      runUsageModelId,
+      outputTokensCount: 5,
+      grossAttributedCreditAmountMicro: REASONING_GROSS_CREDITS_MICRO,
+    },
+  ];
+}
+
+describe("getAgentMessageConsumption", () => {
+  it("groups repeated tools and keeps the exact bill separate from estimated attribution", async () => {
+    const {
+      auth,
+      workspace,
+      conversation,
+      run,
+      runUsageModelId,
+      agentMessage,
+    } = await setupMessage();
+    const { action: firstAction } = await AgentMCPActionFactory.create(auth, {
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId: agentMessage.agentMessageId,
+      status: "succeeded",
+      dustRunId: run.dustRunId,
+      step: 1,
+    });
+    const { action: secondAction } = await AgentMCPActionFactory.create(auth, {
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId: agentMessage.agentMessageId,
+      status: "succeeded",
+      dustRunId: run.dustRunId,
+      step: 2,
+    });
+
+    await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+      conversation,
+      agentMessageModelId: agentMessage.agentMessageId,
+      attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+      records: [
+        ...modelRecords(runUsageModelId),
+        {
+          itemType: "tool",
+          runUsageModelId,
+          action: firstAction,
+          inputTokensCount: 20,
+          outputTokensCount: 5,
+          grossAttributedCreditAmountMicro: 5_000_000,
+          directCreditAmountMicro: 3_000_000,
+        },
+        {
+          itemType: "tool",
+          runUsageModelId,
+          action: secondAction,
+          inputTokensCount: 10,
+          outputTokensCount: 4,
+          grossAttributedCreditAmountMicro: 4_000_000,
+          directCreditAmountMicro: 1_000_000,
+        },
+      ],
+      pendingToolItems: [],
+    });
+
+    const consumption = await getAgentMessageConsumption(auth, {
+      conversation,
+      agentMessageId: agentMessage.sId,
+    });
+
+    expect(consumption).toEqual({
+      billedCredits: BILLED_CREDITS,
+      details: {
+        attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+        grossAttributedCredits: 13,
+        estimatedCacheSavingsCredits: 3,
+        agentWorkCredits: 4,
+        tools: [
+          expect.objectContaining({
+            callCount: 2,
+            grossAttributedCredits: 9,
+            directCredits: 4,
+            pending: false,
+            toolName: "test_tool",
+          }),
+        ],
+      },
+    });
+  });
+
+  it("exposes a blocked tool as pending without inventing a direct charge", async () => {
+    const {
+      auth,
+      workspace,
+      conversation,
+      run,
+      runUsageModelId,
+      agentMessage,
+    } = await setupMessage();
+    const { action } = await AgentMCPActionFactory.create(auth, {
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId: agentMessage.agentMessageId,
+      dustRunId: run.dustRunId,
+    });
+
+    await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+      conversation,
+      agentMessageModelId: agentMessage.agentMessageId,
+      attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+      records: modelRecords(runUsageModelId),
+      pendingToolItems: [
+        {
+          action,
+          runUsageModelId,
+          outputTokensCount: 5,
+          grossAttributedCreditAmountMicro: 1_000_000,
+        },
+      ],
+    });
+
+    const consumption = await getAgentMessageConsumption(auth, {
+      conversation,
+      agentMessageId: agentMessage.sId,
+    });
+
+    expect(consumption?.details?.tools).toEqual([
+      expect.objectContaining({
+        callCount: 1,
+        directCredits: 0,
+        pending: true,
+      }),
+    ]);
+  });
+
+  it("withholds details when the active rows do not cover every current run bucket", async () => {
+    const { auth, conversation, runUsageModelId, agentMessage } =
+      await setupMessage();
+
+    await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+      conversation,
+      agentMessageModelId: agentMessage.agentMessageId,
+      attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+      records: modelRecords(runUsageModelId).filter(
+        (record) => record.itemType !== "output"
+      ),
+      pendingToolItems: [],
+    });
+
+    await expect(
+      getAgentMessageConsumption(auth, {
+        conversation,
+        agentMessageId: agentMessage.sId,
+      })
+    ).resolves.toEqual({ billedCredits: BILLED_CREDITS, details: null });
+  });
+});

--- a/front/lib/api/assistant/agent_message_consumption_attribution/read.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/read.ts
@@ -1,0 +1,274 @@
+import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
+import { getActionOneLineLabel } from "@app/lib/api/assistant/action_one_line_label";
+import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
+import type { Authenticator } from "@app/lib/auth";
+import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import type { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
+import { AgentMessageConsumptionItemResource as ConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { RunResource } from "@app/lib/resources/run_resource";
+import type { AgentMCPActionType } from "@app/types/actions";
+import type {
+  AgentMessageConsumptionResponse,
+  AgentMessageConsumptionToolDetails,
+} from "@app/types/assistant/agent_message_consumption";
+import type { ModelId } from "@app/types/shared/model_id";
+
+const MICRO_CREDITS_PER_CREDIT = 1_000_000;
+
+function creditsFromMicroCredits(microCredits: number): number {
+  return microCredits / MICRO_CREDITS_PER_CREDIT;
+}
+
+/** Ensures every provider-reported model bucket has a row for the active attribution version. */
+function hasCompleteModelAttribution(
+  items: AgentMessageConsumptionItemResource[],
+  usages: Awaited<ReturnType<typeof RunResource.listRunUsagesForRuns>>
+): boolean {
+  const itemTypesByRunUsageModelId = new Map<ModelId, Set<string>>();
+
+  for (const item of items) {
+    if (item.itemType === "tool" || item.runUsageId === null) {
+      continue;
+    }
+
+    const itemTypes =
+      itemTypesByRunUsageModelId.get(item.runUsageId) ?? new Set();
+    itemTypes.add(item.itemType);
+    itemTypesByRunUsageModelId.set(item.runUsageId, itemTypes);
+  }
+
+  return usages.every((usage) => {
+    const itemTypes = itemTypesByRunUsageModelId.get(usage.runUsageModelId);
+    return (
+      itemTypes?.has("input") === true &&
+      itemTypes.has("output") &&
+      (usage.reasoningTokens === null || itemTypes.has("reasoning"))
+    );
+  });
+}
+
+/** Ensures every attributable action has a row and every settled action has final evidence. */
+function hasCompleteToolAttribution({
+  actions,
+  items,
+  dustRunIdsWithUsage,
+}: {
+  actions: AgentMCPActionResource[];
+  items: AgentMessageConsumptionItemResource[];
+  dustRunIdsWithUsage: Set<string>;
+}): boolean {
+  const toolItemByActionModelId = new Map<
+    ModelId,
+    AgentMessageConsumptionItemResource
+  >();
+  for (const item of items) {
+    if (item.itemType === "tool" && item.agentMCPActionId !== null) {
+      toolItemByActionModelId.set(item.agentMCPActionId, item);
+    }
+  }
+  const actionModelIds = new Set(actions.map((action) => action.id));
+
+  for (const actionModelId of toolItemByActionModelId.keys()) {
+    if (!actionModelIds.has(actionModelId)) {
+      return false;
+    }
+  }
+
+  for (const action of actions) {
+    const dustRunId = action.stepContent.dustRunId;
+    if (!dustRunId || !dustRunIdsWithUsage.has(dustRunId)) {
+      continue;
+    }
+
+    const item = toolItemByActionModelId.get(action.id);
+    if (!item) {
+      return false;
+    }
+    if (
+      isToolExecutionStatusFinal(action.status) &&
+      item.completedAt === null
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function toolIdentity(action: AgentMCPActionType): string {
+  const serverIdentity =
+    action.mcpServerId ??
+    action.internalMCPServerName ??
+    action.functionCallName;
+
+  return `${serverIdentity}:${action.toolName}`;
+}
+
+/** Groups repeated executions by tool identity while preserving first-use display order. */
+function buildToolDetails({
+  actions,
+  items,
+}: {
+  actions: AgentMCPActionResource[];
+  items: AgentMessageConsumptionItemResource[];
+}): AgentMessageConsumptionToolDetails[] | null {
+  const actionByModelId = new Map(actions.map((action) => [action.id, action]));
+  const groupedTools = new Map<
+    string,
+    AgentMessageConsumptionToolDetails & { firstStep: number }
+  >();
+
+  for (const item of items) {
+    if (item.itemType !== "tool" || item.agentMCPActionId === null) {
+      continue;
+    }
+
+    const action = actionByModelId.get(item.agentMCPActionId);
+    if (!action) {
+      return null;
+    }
+
+    const serialized = action.toJSON();
+    const identity = toolIdentity(serialized);
+    const current = groupedTools.get(identity);
+    const grossAttributedCredits = creditsFromMicroCredits(
+      item.grossAttributedCreditAmountMicro
+    );
+    const directCredits = creditsFromMicroCredits(
+      item.directCreditAmountMicro ?? 0
+    );
+
+    if (current) {
+      groupedTools.set(identity, {
+        ...current,
+        callCount: current.callCount + 1,
+        grossAttributedCredits:
+          current.grossAttributedCredits + grossAttributedCredits,
+        directCredits: current.directCredits + directCredits,
+        pending: current.pending || item.completedAt === null,
+        firstStep: Math.min(current.firstStep, serialized.step),
+      });
+      continue;
+    }
+
+    groupedTools.set(identity, {
+      label: getActionOneLineLabel(serialized),
+      internalMCPServerName: serialized.internalMCPServerName,
+      toolName: serialized.toolName,
+      callCount: 1,
+      grossAttributedCredits,
+      directCredits,
+      pending: item.completedAt === null,
+      firstStep: serialized.step,
+    });
+  }
+
+  return [...groupedTools.values()]
+    .sort((left, right) => left.firstStep - right.firstStep)
+    .map(({ firstStep: _firstStep, ...tool }) => tool);
+}
+
+/**
+ * Builds the end-user explanation for one agent message. Provider and token facts stay behind this
+ * interface. If the active attribution version does not cover the message's current runs and tools,
+ * the exact bill remains available while details are withheld.
+ */
+export async function getAgentMessageConsumption(
+  auth: Authenticator,
+  {
+    conversation,
+    agentMessageId,
+  }: {
+    conversation: ConversationResource;
+    agentMessageId: string;
+  }
+): Promise<AgentMessageConsumptionResponse | null> {
+  const facts = await ConsumptionItemResource.fetchMessageConsumptionFacts(
+    auth,
+    {
+      conversation,
+      agentMessageId,
+      attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+    }
+  );
+  if (!facts) {
+    return null;
+  }
+
+  const unavailableResponse: AgentMessageConsumptionResponse = {
+    billedCredits: facts.billedCredits,
+    details: null,
+  };
+  if (facts.items.length === 0 || facts.dustRunIds.length === 0) {
+    return unavailableResponse;
+  }
+
+  const runs = await RunResource.listByDustRunIds(auth, {
+    dustRunIds: facts.dustRunIds,
+  });
+  const usages = await RunResource.listRunUsagesForRuns(auth, { runs });
+  if (usages.length === 0) {
+    return unavailableResponse;
+  }
+
+  const dustRunIdByRunModelId = new Map(
+    runs.map((run) => [run.id, run.dustRunId])
+  );
+  const dustRunIdsWithUsage = new Set(
+    usages.flatMap((usage) => {
+      const dustRunId = dustRunIdByRunModelId.get(usage.runModelId);
+      return dustRunId ? [dustRunId] : [];
+    })
+  );
+
+  if (
+    !hasCompleteModelAttribution(facts.items, usages) ||
+    !hasCompleteToolAttribution({
+      actions: facts.actions,
+      items: facts.items,
+      dustRunIdsWithUsage,
+    })
+  ) {
+    return unavailableResponse;
+  }
+
+  const tools = buildToolDetails({
+    actions: facts.actions,
+    items: facts.items,
+  });
+  if (!tools) {
+    return unavailableResponse;
+  }
+
+  const grossAttributedCredits = creditsFromMicroCredits(
+    facts.items.reduce(
+      (total, item) => total + item.grossAttributedCreditAmountMicro,
+      0
+    )
+  );
+  const agentWorkCredits = creditsFromMicroCredits(
+    facts.items.reduce(
+      (total, item) =>
+        item.itemType === "tool"
+          ? total
+          : total + item.grossAttributedCreditAmountMicro,
+      0
+    )
+  );
+  const estimatedCacheSavingsCredits =
+    facts.billedCredits === null
+      ? null
+      : Math.max(grossAttributedCredits - facts.billedCredits, 0);
+
+  return {
+    billedCredits: facts.billedCredits,
+    details: {
+      attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+      grossAttributedCredits,
+      estimatedCacheSavingsCredits,
+      agentWorkCredits,
+      tools,
+    },
+  };
+}

--- a/front/lib/resources/agent_message_consumption_item_resource.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.ts
@@ -1,6 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMessageConsumptionItemModel } from "@app/lib/models/agent/agent_message_consumption_item";
-import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -461,6 +461,50 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
     });
 
     return items.map((item) => new this(this.model, item.get()));
+  }
+
+  /**
+   * Resolves one public message identity to the persisted facts needed by the consumption reader.
+   * Keeping that resolution here prevents Sequelize models and numeric IDs from leaking into the
+   * read module or route.
+   */
+  static async fetchMessageConsumptionFacts(
+    auth: Authenticator,
+    {
+      conversation,
+      agentMessageId,
+      attributionVersion,
+    }: {
+      conversation: ConversationResource;
+      agentMessageId: string;
+      attributionVersion: number;
+    }
+  ): Promise<{
+    billedCredits: number | null;
+    dustRunIds: string[];
+    items: AgentMessageConsumptionItemResource[];
+    actions: AgentMCPActionResource[];
+  } | null> {
+    const messageRes = await conversation.getMessageById(auth, agentMessageId);
+    if (messageRes.isErr() || !messageRes.value.agentMessage) {
+      return null;
+    }
+
+    const agentMessage = messageRes.value.agentMessage;
+    const [items, actions] = await Promise.all([
+      this.listByAgentMessageModelIds(auth, {
+        agentMessageModelIds: [agentMessage.id],
+        attributionVersion,
+      }),
+      AgentMCPActionResource.listByAgentMessageIds(auth, [agentMessage.id]),
+    ]);
+
+    return {
+      billedCredits: agentMessage.costCredits,
+      dustRunIds: [...new Set(agentMessage.runIds ?? [])],
+      items,
+      actions,
+    };
   }
 
   static async deleteByAgentMessageModelIds(

--- a/front/types/assistant/agent_message_consumption.ts
+++ b/front/types/assistant/agent_message_consumption.ts
@@ -1,3 +1,5 @@
+import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+
 export const AGENT_MESSAGE_CONSUMPTION_ITEM_TYPES = [
   "system",
   "input",
@@ -8,3 +10,26 @@ export const AGENT_MESSAGE_CONSUMPTION_ITEM_TYPES = [
 
 export type AgentMessageConsumptionItemType =
   (typeof AGENT_MESSAGE_CONSUMPTION_ITEM_TYPES)[number];
+
+export type AgentMessageConsumptionToolDetails = {
+  label: string;
+  internalMCPServerName: InternalMCPServerNameType | null;
+  toolName: string;
+  callCount: number;
+  grossAttributedCredits: number;
+  directCredits: number;
+  pending: boolean;
+};
+
+export type AgentMessageConsumptionDetails = {
+  attributionVersion: number;
+  grossAttributedCredits: number;
+  estimatedCacheSavingsCredits: number | null;
+  agentWorkCredits: number;
+  tools: AgentMessageConsumptionToolDetails[];
+};
+
+export type AgentMessageConsumptionResponse = {
+  billedCredits: number | null;
+  details: AgentMessageConsumptionDetails | null;
+};

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -223,6 +223,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable collapsible messages in conversations",
     stage: "dust_only",
   },
+  conversation_consumption_details: {
+    description:
+      "Show the detailed credit attribution for agent messages in conversations",
+    stage: "dust_only",
+  },
   poke_mcp: {
     description: "Enable the Poke MCP server for cross-workspace data access.",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -791,6 +791,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "xai_feature"
   | "conversations_slack_notifications"
   | "collapsible_messages"
+  | "conversation_consumption_details"
   | "use_dust_keys"
   | "browser_extension_mcp_tools"
   | "sensitivity_labels"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds a feature-flagged private endpoint for reading the credit consumption of one agent message. It returns `AgentMessage.costCredits` as the authoritative billed value and, when materialization is complete, a cache-naive attribution grouped into agent work and recognizable tool activity.

The reader validates attribution coverage against the message’s model usages and tool actions before returning details. Runs and actions are used only as internal source facts and are never exposed by the endpoint. If attribution is missing, incomplete, or inconsistent, the response still returns the exact billed credits with attribution details set to null.

Tool executions are grouped by tool identity and retain their display label, call count, attributed credits, direct credits, and completion state. The response contains no provider usage, token counts, tool arguments, tool results, run records, or
action records.

UI is coming in a follow up PR.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
