### PR TITLE
[Model Tiers] Restrict group tier overrides to provisioned and manual groups

### DIFF
--- a/front/lib/model_tiers/group_kinds.test.ts
+++ b/front/lib/model_tiers/group_kinds.test.ts
@@ -5,13 +5,14 @@ import {
 import { describe, expect, it } from "vitest";
 
 describe("model tier override group kinds", () => {
-  it("only allows regular_auto and provisioned groups to carry overrides", () => {
+  it("only allows provisioned and manual groups to carry overrides", () => {
     expect(MODEL_TIER_OVERRIDE_GROUP_KINDS).toEqual([
-      "regular_auto",
       "provisioned",
+      "regular_manual",
     ]);
-    expect(isModelTierOverrideGroupKind("regular_auto")).toBe(true);
     expect(isModelTierOverrideGroupKind("provisioned")).toBe(true);
+    expect(isModelTierOverrideGroupKind("regular_manual")).toBe(true);
+    expect(isModelTierOverrideGroupKind("regular_auto")).toBe(false);
     expect(isModelTierOverrideGroupKind("global")).toBe(false);
     expect(isModelTierOverrideGroupKind("system")).toBe(false);
   });

--- a/front/lib/model_tiers/group_kinds.ts
+++ b/front/lib/model_tiers/group_kinds.ts
@@ -1,9 +1,12 @@
 import type { GroupKind } from "@app/types/groups";
 
-// Groups that can carry a model-tier override grant via setGroupMaxAllowedTier.
+// Groups that can carry a model-tier override grant via setGroupMaxAllowedTier. Matches the kinds
+// the Usage admin page lists (CAP_ELIGIBLE_GROUP_KINDS): user-managed collections only. regular_auto
+// groups are excluded — the ones holding models_tier grants are the per-user backing groups managed
+// by grantToUser, which resolve through the dedicated user-override path.
 export const MODEL_TIER_OVERRIDE_GROUP_KINDS = [
-  "regular_auto",
   "provisioned",
+  "regular_manual",
 ] as const satisfies readonly GroupKind[];
 
 type ModelTierOverrideGroupKind =

--- a/front/lib/resources/models_tier_resource.test.ts
+++ b/front/lib/resources/models_tier_resource.test.ts
@@ -18,7 +18,7 @@ describe("ModelsTierResource permissions", () => {
   beforeEach(async () => {
     workspace = await WorkspaceFactory.basic();
     await GroupFactory.defaults(workspace);
-    group = await GroupFactory.regularAuto(workspace, "tier-users");
+    group = await GroupFactory.regularManual(workspace, "tier-users");
     auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
   });
 
@@ -72,6 +72,22 @@ describe("ModelsTierResource permissions", () => {
     await ModelsTierResource.clearGroupMaxAllowedTier(auth, {
       groupId: group.sId,
     });
+    expect(await ModelsTierResource.listGroupAllowedTierNames(auth)).toEqual(
+      []
+    );
+  });
+
+  it("rejects a group tier override on a regular_auto group", async () => {
+    const autoGroup = await GroupFactory.regularAuto(workspace, "auto");
+
+    const result = await ModelsTierResource.setGroupMaxAllowedTier(auth, {
+      groupId: autoGroup.sId,
+      tierName: "premium",
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("invalid_request_error");
+    }
     expect(await ModelsTierResource.listGroupAllowedTierNames(auth)).toEqual(
       []
     );

--- a/front/lib/resources/models_tier_resource.ts
+++ b/front/lib/resources/models_tier_resource.ts
@@ -342,6 +342,14 @@ export class ModelsTierResource {
     if (groupRes.isErr()) {
       return groupRes;
     }
+    if (!isModelTierOverrideGroupKind(groupRes.value.kind)) {
+      return new Err(
+        new DustError(
+          "invalid_request_error",
+          "Model tier overrides only apply to provisioned or manual groups."
+        )
+      );
+    }
 
     await this.clearGroupTierGrants(auth, groupRes.value);
     await this.grantToGroup(auth, {


### PR DESCRIPTION
## Description

`MODEL_TIER_OVERRIDE_GROUP_KINDS` was `["regular_auto", "provisioned"]`, which contradicts both the product intent and the UI on two fronts:

- The Usage admin page only lists `provisioned` and `regular_manual` groups (`CAP_ELIGIBLE_GROUP_KINDS`), yet `regular_manual` was **not** in the override kinds. Since the write path (`setGroupMaxAllowedTier` and its route) never validated kinds, an admin could set a tier override on a manual group through the UI — the grant row was written, but the read paths (`listGroupAllowedTierNames`, resolution) filtered it out: the override neither displayed back nor applied. One workspace in US prod is currently in this state; its override starts working once this deploys.
- `regular_auto` **was** in the override kinds, but no UI offers such groups, there is no product use case (confirmed with product), and prod has zero non-backing regular_auto tier grants. Its inclusion only made the per-user backing groups double-count in group-override resolution (harmless today, since user overrides resolve through their own dedicated path keyed on the backing-group name).

This PR aligns the constant with the product intent (`["provisioned", "regular_manual"]`) and adds the missing kind validation in `setGroupMaxAllowedTier` (`invalid_request_error`). `clearGroupMaxAllowedTier` intentionally stays unrestricted so any stray grant remains removable.

This also makes "at most one regular_auto group per (grantType, resourceType, resourceId)" a globally true invariant — no path can grant an instance tuple to a non-backing regular_auto group anymore — which https://github.com/dust-tt/dust/pull/29805 builds on to enforce it.

## Risks

Blast radius: model-tier group overrides (Usage admin page). Behavior change: the one existing manual-group override in US prod becomes effective (it was set intentionally by that workspace's admin and silently ignored until now).
Risk: low

## Deploy Plan

- deploy front