### PR TITLE
docs: note OpenAI-compatible custom provider for multi-model gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Custom AI agent platform to speed up your work.
 
 Check out our [user guides and developer platform](https://docs.dust.tt)
 
-> **Note:** The same OpenAI Python client pattern also works with any OpenAI-compatible multi-model gateway when you are not running Dust locally — for example [DaoXE](https://daoxe.com?utm_source=github&utm_medium=pr&utm_campaign=dao-xe-docs) at `https://api.daoxe.com/v1`.
+> **Note:** The same OpenAI Python client pattern also works with any OpenAI-compatible multi-model gateway when you are not running Dust locally — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`.
 
 ## We're hiring
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Custom AI agent platform to speed up your work.
 
 Check out our [user guides and developer platform](https://docs.dust.tt)
 
+> **Note:** The same OpenAI Python client pattern also works with any OpenAI-compatible multi-model gateway when you are not running Dust locally — for example [DaoXE](https://daoxe.com?utm_source=github&utm_medium=pr&utm_campaign=dao-xe-docs) at `https://api.daoxe.com/v1`.
+
 ## We're hiring
 
 - [About Us](https://dust.tt/home/about)


### PR DESCRIPTION
## What
Added a brief note about using OpenAI-compatible multi-model gateways (example: DaoXE) as a custom provider.

## Why
Help users who want to use multi-model gateways without self-hosting Dust.

## How
- Inserted a short note in README.md with UTM-tracked link for analytics.
- No code changes, docs only.

### Changes
- README.md: added DaoXE multi-model gateway note with UTM.

### Checklist
- [x] Docs only
- [x] No breaking changes
- [x] Link includes UTM parameters