### PR TITLE
Script to delete branch messages + drop tables

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -140,6 +140,82 @@ async function destroyConversationDataSource(
   }
 }
 
+export async function destroyConversationMessages(
+  auth: Authenticator,
+  messages: MessageModel[]
+) {
+  const owner = auth.getNonNullableWorkspace();
+
+  // To preserve the DB, we delete messages in batches.
+  const messagesChunks = chunk(messages, DESTROY_MESSAGE_BATCH);
+  for (const messagesChunk of messagesChunks) {
+    const messageIds = messagesChunk.map((m) => m.id);
+    const userMessageIds = removeNulls(
+      messagesChunk.map((m) => m.userMessageId)
+    );
+    const agentMessageIds = removeNulls(
+      messagesChunk.map((m) => m.agentMessageId)
+    );
+    const compactionMessageIds = removeNulls(
+      messagesChunk.map((m) => m.compactionMessageId)
+    );
+    const contentFragmentIds = removeNulls(
+      messagesChunk.map((m) => m.contentFragmentId)
+    );
+
+    await AgentMessageConsumptionItemResource.deleteByAgentMessageModelIds(
+      auth,
+      {
+        agentMessageModelIds: agentMessageIds,
+      }
+    );
+
+    await destroyActionsRelatedResources(auth, agentMessageIds);
+
+    await UserMessageModel.destroy({
+      where: {
+        id: userMessageIds,
+        workspaceId: owner.id,
+      },
+    });
+    await AgentStepContentResource.deleteByAgentMessageIds(auth, {
+      agentMessageIds,
+    });
+    await AgentMessageFeedbackModel.destroy({
+      where: {
+        agentMessageId: agentMessageIds,
+        workspaceId: owner.id,
+      },
+    });
+
+    const whereAgentMessageSkill: WhereOptions<AgentMessageSkillModel> = {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      agentMessageId: agentMessageIds,
+    };
+    await AgentMessageSkillModel.destroy({
+      where: whereAgentMessageSkill,
+    });
+
+    await AgentMessageModel.destroy({
+      where: {
+        id: agentMessageIds,
+        workspaceId: owner.id,
+      },
+    });
+
+    await destroyContentFragments(auth, contentFragmentIds);
+
+    await CompactionMessageModel.destroy({
+      where: {
+        id: compactionMessageIds,
+        workspaceId: owner.id,
+      },
+    });
+
+    await destroyMessageRelatedResources(auth, messageIds);
+  }
+}
+
 // This belongs to the ConversationResource. The authenticator is expected to have access to the
 // groups involved in the conversation.
 export async function destroyConversation(
@@ -197,74 +273,7 @@ export async function destroyConversation(
       },
     });
 
-    // To preserve the DB, we delete messages in batches.
-    const messagesChunks = chunk(messages, DESTROY_MESSAGE_BATCH);
-    for (const messagesChunk of messagesChunks) {
-      const messageIds = messagesChunk.map((m) => m.id);
-      const userMessageIds = removeNulls(
-        messagesChunk.map((m) => m.userMessageId)
-      );
-      const agentMessageIds = removeNulls(
-        messagesChunk.map((m) => m.agentMessageId)
-      );
-      const compactionMessageIds = removeNulls(
-        messagesChunk.map((m) => m.compactionMessageId)
-      );
-      const contentFragmentIds = removeNulls(
-        messagesChunk.map((m) => m.contentFragmentId)
-      );
-
-      await AgentMessageConsumptionItemResource.deleteByAgentMessageModelIds(
-        auth,
-        {
-          agentMessageModelIds: agentMessageIds,
-        }
-      );
-
-      await destroyActionsRelatedResources(auth, agentMessageIds);
-
-      await UserMessageModel.destroy({
-        where: {
-          id: userMessageIds,
-          workspaceId: owner.id,
-        },
-      });
-      await AgentStepContentResource.deleteByAgentMessageIds(auth, {
-        agentMessageIds,
-      });
-      await AgentMessageFeedbackModel.destroy({
-        where: {
-          agentMessageId: agentMessageIds,
-          workspaceId: owner.id,
-        },
-      });
-
-      const whereAgentMessageSkill: WhereOptions<AgentMessageSkillModel> = {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        agentMessageId: agentMessageIds,
-      };
-      await AgentMessageSkillModel.destroy({
-        where: whereAgentMessageSkill,
-      });
-
-      await AgentMessageModel.destroy({
-        where: {
-          id: agentMessageIds,
-          workspaceId: owner.id,
-        },
-      });
-
-      await destroyContentFragments(auth, contentFragmentIds);
-
-      await CompactionMessageModel.destroy({
-        where: {
-          id: compactionMessageIds,
-          workspaceId: owner.id,
-        },
-      });
-
-      await destroyMessageRelatedResources(auth, messageIds);
-    }
+    await destroyConversationMessages(auth, messages);
 
     await destroyConversationDataSource(auth, {
       conversation: conversation.toJSON(),

--- a/front/migrations/20260803_delete_branch_messages.ts
+++ b/front/migrations/20260803_delete_branch_messages.ts
@@ -1,0 +1,51 @@
+import { destroyConversationMessages } from "@app/lib/api/assistant/conversation/destroy";
+import { Authenticator } from "@app/lib/auth";
+import { MessageModel } from "@app/lib/models/agent/conversation";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { makeScript } from "@app/scripts/helpers";
+import { Op } from "sequelize";
+
+makeScript({}, async ({ execute }, logger) => {
+  const workspaceIds = (
+    await MessageModel.findAll({
+      attributes: ["workspaceId"],
+      group: ["workspaceId"],
+      where: {
+        branchId: { [Op.ne]: null },
+      },
+    })
+  ).map((m) => m.workspaceId);
+  for (const workspaceId of workspaceIds) {
+    const workspace = await WorkspaceResource.fetchByModelId(workspaceId);
+    if (!workspace) {
+      logger.error({ workspaceId }, "Workspace not found");
+      continue;
+    }
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const messages = await MessageModel.findAll({
+      attributes: [
+        "id",
+        "userMessageId",
+        "agentMessageId",
+        "contentFragmentId",
+        "compactionMessageId",
+      ],
+      where: {
+        branchId: { [Op.ne]: null },
+        workspaceId,
+      },
+    });
+
+    if (execute) {
+      await destroyConversationMessages(auth, messages);
+    } else {
+      logger.info(
+        { workspaceId, messagesCount: messages.length },
+        "Would delete branch messages"
+      );
+    }
+  }
+
+  logger.info({ execute }, "Completed delete branch messages");
+});

--- a/front/migrations/post-deploy/20260803071008_remove_conversation_branchs_and_model_tiers_tables..sql
+++ b/front/migrations/post-deploy/20260803071008_remove_conversation_branchs_and_model_tiers_tables..sql
@@ -1,0 +1,14 @@
+SET
+  SESSION statement_timeout = 1200000;
+
+SET
+  SESSION lock_timeout = 3000;
+
+-- Need to run the 20260803_delete_branch_messages migration to delete the branch messages first.
+DROP TABLE "public"."conversation_branches";
+
+DROP TABLE "public"."group_allowed_advanced_models";
+
+DROP TABLE "public"."user_allowed_advanced_models";
+
+DROP TABLE "public"."workspace_allowed_advanced_models";


### PR DESCRIPTION
## Description

Went for a full deletion because we cannot have 2 messages sharing the same rank in a conversation so I couldn't just put the branch messages in the main convo (branchId = null).

I think it's okay because branch messages only exist to be merged in the main conversation (or ignored).

Two cleanup steps following the `ConversationBranch` removal (PR #29871) and `AdvancedModel` table removal (PR #28792):

- Extracts message-deletion logic from `destroyConversation` into a standalone `destroyConversationMessages` export, reused by the new migration script.
- Adds `20260803_delete_branch_messages.ts`: iterates all workspaces, finds `MessageModel` rows where `branchId IS NOT NULL`, and destroys them (with their associated user/agent/content/compaction sub-records) using `destroyConversationMessages`.
- Adds a post-deploy SQL migration to `DROP TABLE` for `conversation_branches`, `group_allowed_advanced_models`, `user_allowed_advanced_models`, and `workspace_allowed_advanced_models` — all dead tables with no remaining code references.

## Tests

Tested locally in dry-run mode (`execute=false`) to verify the workspace scan and message count logging. The `destroyConversationMessages` function is a straight extraction of existing, battle-tested logic from `destroyConversation`.

## Risk

Medium. Dropping 4 DB tables is irreversible. Mitigated by:
- All code references were already removed in prior PRs; no active reads/writes against these tables.
- The script must run and complete successfully before the SQL drop — enforced by the comment in the migration file.
- Dry-run mode available on the script before executing.
- Rollback of the table drops would require restoring from a DB snapshot.

## Deploy Plan

1. Deploy `front`.
2. Run the `20260803_delete_branch_messages.ts` script in dry-run first (`execute=false`), then with `execute=true`.
3. Once the script completes, run the post-deploy SQL migration to drop `conversation_branches`, `group_allowed_advanced_models`, `user_allowed_advanced_models`, and `workspace_allowed_advanced_models`.
