### PR TITLE
[front] enh: Add the system_activation message origin

### DIFF
--- a/front/lib/api/analytics/source_labels.ts
+++ b/front/lib/api/analytics/source_labels.ts
@@ -2,7 +2,7 @@ import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 
 export type AnalyticsVisibleOrigin = Exclude<
   UserMessageOrigin,
-  "reinforced_skill_notification"
+  "reinforced_skill_notification" | "system_activation"
 >;
 
 export const SOURCE_ORIGIN_LABELS: Record<AnalyticsVisibleOrigin, string> = {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -508,6 +508,7 @@ export function isUserMessageContextValid(
     case "project_kickoff":
     case "reinforced_skill_notification":
     case "reinforcement":
+    case "system_activation":
     case "web":
       return false;
     default:

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -482,6 +482,8 @@ export function renderUserMessage(
         )}`
       );
     }
+  } else if (m.context.origin === "system_activation") {
+    metadataItems.push("- Source: Activation Pod nudge");
   } else if (m.context.origin) {
     metadataItems.push(`- Source: ${m.context.origin}`);
     if (m.context.origin === "slack") {

--- a/front/lib/api/programmatic_usage/common.ts
+++ b/front/lib/api/programmatic_usage/common.ts
@@ -38,6 +38,7 @@ export const USAGE_ORIGINS_CLASSIFICATION: Record<
   project_kickoff: "user",
   reinforced_skill_notification: "user",
   reinforcement: "programmatic",
+  system_activation: "user",
 };
 
 export const USER_USAGE_ORIGINS = Object.keys(

--- a/front/lib/notifications/workflows/conversation-unread.test.ts
+++ b/front/lib/notifications/workflows/conversation-unread.test.ts
@@ -96,6 +96,7 @@ describe("conversation-unread workflow business logic", () => {
     zendesk: false,
     reinforced_skill_notification: false,
     reinforcement: false,
+    system_activation: false,
   };
   describe("shouldSendNotificationForAgentAnswer", () => {
     it.each(

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -64,6 +64,7 @@ export const shouldSendNotificationForAgentAnswer = (
     case "agent_sidekick":
     case "reinforced_skill_notification":
     case "reinforcement":
+    case "system_activation":
       // Internal bootstrap conversations shouldn't trigger unread notifications.
       return false;
     case "api":

--- a/front/temporal/analytics_queue/activities/agent_analytics.ts
+++ b/front/temporal/analytics_queue/activities/agent_analytics.ts
@@ -65,7 +65,10 @@ import type {
 } from "@app/types/assistant/analytics";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
-import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
+import {
+  ACTIVATION_NUDGE_ORIGIN,
+  AGENT_MESSAGE_STATUSES_TO_TRACK,
+} from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 import { sha256 } from "@app/types/shared/utils/encryption";
 import type { WhereOptions } from "sequelize";
@@ -144,6 +147,14 @@ export async function storeAgentAnalyticsActivity(
 
   if (!userUserMessageRow) {
     throw new Error("User message not found");
+  }
+
+  // Activation Pod nudges are sent by us, not asked for by the user: they must
+  // not show up anywhere in analytics, not even as a 0-credit row (this drops
+  // them from the credits tables, per-agent usage, and the DAU signal the
+  // activation evaluator itself reads).
+  if (userUserMessageRow.userContextOrigin === ACTIVATION_NUDGE_ORIGIN) {
+    return;
   }
 
   await storeAgentAnalytics(auth, {

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -129,7 +129,17 @@ export type UserMessageOrigin =
   // (to be created).
   | "onboarding_conversation"
   // for internal use, for reinforced agent batch LLM operations
-  | "reinforcement";
+  | "reinforcement"
+  // Opening message of an Activation Pod nudge, authored by the system on the
+  // user's behalf. Server-only: it is not in `CLIENT_MESSAGE_ORIGINS` and
+  // `isUserMessageContextValid` rejects it on /v1/ for anything but a
+  // Dust-internal system key. It keeps nudges out of analytics and prices them
+  // as free usage (`FREE_ORIGINS`), which holds only because nothing else can
+  // ever carry it: the nudge has no author, so it can be neither edited nor
+  // retried, and user replies come back as `web`.
+  | "system_activation";
+
+export const ACTIVATION_NUDGE_ORIGIN = "system_activation" as const;
 
 export const HIDDEN_MESSAGE_ORIGINS: UserMessageOrigin[] = [
   "onboarding_conversation",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -400,6 +400,7 @@ const USER_MESSAGE_ORIGINS = [
   "project_kickoff",
   "reinforced_skill_notification",
   "reinforcement",
+  "system_activation",
 ] as const;
 
 const UserMessageOriginEnumSchema = z.enum(USER_MESSAGE_ORIGINS);


### PR DESCRIPTION
## Description

Add system activation message origin, which we will use to fund the nudge message (ala sidekick, but not the whole conversation)


## Tests

N/A

## Risk

Low

## Deploy Plan

Deploy front