### PR TITLE
[front] enh: Dust-funded activation runs

### DIFF
--- a/front/lib/api/assistant/credit_cost.test.ts
+++ b/front/lib/api/assistant/credit_cost.test.ts
@@ -224,4 +224,19 @@ describe("computeAgentMessageCredits", () => {
       })
     ).toBeNull();
   });
+
+  it("costs 0 for the Activation Pod nudge, LLM and tools alike", () => {
+    const credits = computeAgentMessageCredits({
+      runUsages: [usage({ costMicroUsd: 8500 })], // would be 1 intelligence credit
+      actions: [
+        {
+          toolName: "semantic_search",
+          internalMCPServerName: "search",
+          status: "succeeded",
+        },
+      ], // would be 3 tool credits
+      contextOrigin: "system_activation",
+    });
+    expect(credits).toBe(0);
+  });
 });

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -96,7 +96,13 @@ export function getToolBillingInfo(
 // Origins whose entire conversation is free (platform-assistive, not
 // user-requested output).
 export const FREE_ORIGINS: ReadonlySet<UserMessageOrigin> =
-  new Set<UserMessageOrigin>(["agent_sidekick"]);
+  new Set<UserMessageOrigin>([
+    "agent_sidekick",
+    // Only the Activation Pod nudge ever carries this origin: it is server-only,
+    // and the nudge has no author so it can neither be edited nor retried. User
+    // replies come back as `web` and bill normally.
+    "system_activation",
+  ]);
 
 export function isFreeOrigin(origin: UserMessageOrigin | null): boolean {
   if (origin == null) {


### PR DESCRIPTION
## Description

Add system_activation to the FREE_ORIGINS
This is the only change needed, only the first message (nudge) can use this (modulo small period between this PR and the next two), replies by user will use the web origin like any message.

## Tests

Added a test

## Risk

Low

## Deploy Plan

Deploy front