### PR TITLE
[front] fix: Authorless messages never use personal credentials

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -199,6 +199,7 @@ app.post(
         agentConfiguration,
         conversation,
         agentMessage: placeholderAgentMessage,
+        userMessage,
         clientSideActionConfigurations: clientSideMCPActionConfigurations,
       },
       { jitServers, skillServers, systemSkillServers }

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -97,6 +97,7 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { fromEvent } from "@app/lib/utils/events";
 import logger from "@app/logger/logger";
+import { isSystemAuthoredUserMessage } from "@app/types/assistant/conversation";
 import type { OAuthProvider } from "@app/types/oauth/lib";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -1075,9 +1076,26 @@ export async function tryListMCPTools(
     preFetchedViews.map((view) => [view.sId, view])
   );
 
+  // An admin scoping a server to `personal_actions` decided it runs on each
+  // person's own credentials. A message nobody wrote (posted by Dust on the
+  // user's behalf) has no person to run as, so those servers are left out of the
+  // tool list entirely: running them on the workspace connection instead would
+  // quietly override that decision.
+  const listableActionsWithOrigin = isSystemAuthoredUserMessage(
+    agentLoopListToolsContext.userMessage
+  )
+    ? mcpServerActionsWithOrigin.filter(({ action }) => {
+        if (!isServerSideMCPServerConfiguration(action)) {
+          return true;
+        }
+        const view = preFetchedMcpServerViews.get(action.mcpServerViewId);
+        return view?.oAuthUseCase !== "personal_actions";
+      })
+    : mcpServerActionsWithOrigin;
+
   // Discover all tools exposed by all available MCP servers.
   const results = await concurrentExecutor(
-    mcpServerActionsWithOrigin,
+    listableActionsWithOrigin,
     async ({ action, isFromSkillServer }) => {
       let connectionParams: MCPConnectionParams;
       if (isServerSideMCPServerConfiguration(action)) {

--- a/front/lib/actions/personal_actions_listing.test.ts
+++ b/front/lib/actions/personal_actions_listing.test.ts
@@ -1,0 +1,96 @@
+import { buildServerSideMCPServerConfiguration } from "@app/lib/actions/configuration/helpers";
+import { tryListMCPTools } from "@app/lib/actions/mcp_actions";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { describe, expect, it } from "vitest";
+
+// Lists the tools an agent sees when answering `content`, with a single
+// personal-actions MCP server configured.
+async function listedServerNames({
+  authorless,
+}: {
+  authorless: boolean;
+}): Promise<string[]> {
+  const { authenticator, globalSpace, workspace } = await createResourceTest({
+    role: "admin",
+  });
+
+  const agentConfiguration = await AgentConfigurationFactory.createTestAgent(
+    authenticator,
+    { name: "Test Agent", description: "Test Agent" }
+  );
+
+  // google_calendar is OAuth-backed, so an admin can scope it to personal
+  // credentials.
+  const internalServer = await InternalMCPServerInMemoryResource.makeNew(
+    authenticator,
+    { name: "google_calendar", useCase: "personal_actions" }
+  );
+  const view = await MCPServerViewFactory.create(
+    workspace,
+    internalServer.id,
+    globalSpace
+  );
+  const updateRes = await view.updateOAuthUseCase(
+    authenticator,
+    "personal_actions"
+  );
+  if (updateRes.isErr()) {
+    throw new Error("Expected the OAuth use case update to succeed.");
+  }
+
+  const conversation = await ConversationFactory.create(authenticator, {
+    agentConfigurationId: agentConfiguration.sId,
+    messagesCreatedAt: [],
+  });
+  const { agentMessage } = await ConversationFactory.createAgentMessage(
+    authenticator,
+    { workspace, conversation, agentConfig: agentConfiguration }
+  );
+  const { userMessage } = await ConversationFactory.createUserMessage({
+    auth: authenticator,
+    workspace,
+    conversation,
+    content: "Hello",
+    // The agent message factory sits at rank 0.
+    rank: 1,
+    authorless,
+  });
+
+  const serverToolsAndInstructions = await tryListMCPTools(
+    authenticator,
+    {
+      agentConfiguration,
+      agentMessage,
+      userMessage,
+      clientSideActionConfigurations: [],
+      conversation,
+    },
+    {
+      jitServers: [
+        buildServerSideMCPServerConfiguration({ mcpServerView: view }),
+      ],
+      skillServers: [],
+      systemSkillServers: [],
+    }
+  );
+
+  return serverToolsAndInstructions.map(({ serverName }) => serverName);
+}
+
+describe("tryListMCPTools personal-actions servers", () => {
+  it("lists a personal-actions server when a person wrote the message", async () => {
+    expect(await listedServerNames({ authorless: false })).toContain(
+      "google_calendar"
+    );
+  });
+
+  it("leaves it out for a message nobody wrote", async () => {
+    expect(await listedServerNames({ authorless: true })).not.toContain(
+      "google_calendar"
+    );
+  });
+});

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -185,6 +185,10 @@ export type AgentLoopListToolsContext = {
   clientSideActionConfigurations?: ClientSideMCPServerConfigurationType[];
   conversation: ConversationType;
   agentMessage: AgentMessageType;
+  // Needed at listing time to know whether a person wrote the message this run
+  // answers: servers an admin scoped to personal credentials are not listed for
+  // a message nobody wrote (see `tryListMCPTools`).
+  userMessage: UserMessageType;
 };
 
 // Context available to tool handlers at execution time: tools only ever run on a connection

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -621,6 +621,58 @@ describe("retryAgentMessage", () => {
     expect(publishAgentMessagesEvents).not.toHaveBeenCalled();
   });
 
+  it("should return error when the parent user message has no author", async () => {
+    // A fresh conversation, so the authorless message is not steered into the
+    // pending path by the running agent message the factory sets up.
+    const emptyConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+    const emptyConversationResource = await fetchConversationResource(
+      auth,
+      emptyConversation.sId
+    );
+
+    const user = auth.getNonNullableUser().toJSON();
+    const postResult = await postUserMessage(auth, {
+      conversationResource: emptyConversationResource,
+      content: "Posted by Dust on the user's behalf",
+      mentions: [{ configurationId: agentConfig.sId }],
+      context: {
+        username: user.username,
+        timezone: "UTC",
+        fullName: user.fullName,
+        email: null,
+        profilePictureUrl: null,
+        origin: "system_activation",
+      },
+      skipToolsValidation: false,
+      skipDustAutoMention: true,
+      doNotAssociateUser: true,
+    });
+    if (postResult.isErr()) {
+      throw new Error("Failed to post the authorless message");
+    }
+    expect(postResult.value.userMessage.user).toBeNull();
+    expect(postResult.value.agentMessages).toHaveLength(1);
+
+    vi.clearAllMocks();
+
+    const result = await retryAgentMessage(auth, {
+      conversationResource: emptyConversationResource,
+      message: postResult.value.agentMessages[0],
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.status_code).toBe(403);
+      expect(result.error.api_error.type).toBe("workspace_auth_error");
+      expect(result.error.api_error.message).toContain("cannot be retried");
+    }
+    expect(launchAgentLoopWorkflow).not.toHaveBeenCalled();
+    expect(publishAgentMessagesEvents).not.toHaveBeenCalled();
+  });
+
   describe("project conversation space restrictions", () => {
     let projectSpace: Awaited<ReturnType<typeof SpaceFactory.project>>;
     let anotherProjectSpace: Awaited<ReturnType<typeof SpaceFactory.project>>;
@@ -3133,6 +3185,9 @@ describe("compactConversation", () => {
 describe("editUserMessage", () => {
   let auth: Authenticator;
   let workspace: Awaited<ReturnType<typeof createResourceTest>>["workspace"];
+  let globalGroup: Awaited<
+    ReturnType<typeof createResourceTest>
+  >["globalGroup"];
   let conversationResource: ConversationResource;
   let agentConfig1: LightAgentConfigurationType;
   let agentConfig2: LightAgentConfigurationType;
@@ -3142,6 +3197,7 @@ describe("editUserMessage", () => {
     const setup = await createResourceTest({});
     auth = setup.authenticator;
     workspace = setup.workspace;
+    globalGroup = setup.globalGroup;
 
     agentConfig1 = await AgentConfigurationFactory.createTestAgent(auth, {
       name: "Test Agent 1",
@@ -3506,6 +3562,54 @@ describe("editUserMessage", () => {
       // Verify launchAgentLoopWorkflow was NOT called (no agent mentions)
       expect(launchAgentLoopWorkflow).not.toHaveBeenCalled();
     }
+  });
+
+  it("should refuse to edit a message that has no author, including under API key auth", async () => {
+    const user = auth.getNonNullableUser().toJSON();
+    const postResult = await postUserMessage(auth, {
+      conversationResource,
+      content: "Posted by Dust on the user's behalf",
+      mentions: [],
+      context: {
+        username: user.username,
+        timezone: "UTC",
+        fullName: user.fullName,
+        email: null,
+        profilePictureUrl: null,
+        origin: "system_activation",
+      },
+      skipToolsValidation: false,
+      skipDustAutoMention: true,
+      doNotAssociateUser: true,
+    });
+    if (postResult.isErr()) {
+      throw new Error("Failed to post the authorless message");
+    }
+    const authorlessMessage = postResult.value.userMessage;
+    expect(authorlessMessage.user).toBeNull();
+
+    // A key has no `auth.user()` either, so the author check used to compare
+    // null against null and let this through.
+    const systemKey = await KeyFactory.system(globalGroup);
+    const { workspaceAuth: keyAuth } = await Authenticator.fromKey(
+      systemKey,
+      workspace.sId
+    );
+
+    const result = await editUserMessage(keyAuth, {
+      conversationResource,
+      message: authorlessMessage,
+      content: "Edited by an API key",
+      mentions: [],
+      skipToolsValidation: false,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.status_code).toBe(403);
+      expect(result.error.api_error.type).toBe("workspace_auth_error");
+    }
+    expect(launchAgentLoopWorkflow).not.toHaveBeenCalled();
   });
 });
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -158,6 +158,7 @@ import {
   ConversationError,
   isAgentMessageType,
   isPodConversation,
+  isSystemAuthoredUserMessage,
   isUserMessageType,
   UNRESUMABLE_AGENT_MESSAGE_STATUSES,
 } from "@app/types/assistant/conversation";
@@ -1083,6 +1084,20 @@ function canAccessAgent(
 
 class UserMessageError extends Error {}
 
+// A system-authored message has no author to be, so nobody passes this. Testing
+// that first also stops an API key, which has no `auth.user()` either, from
+// matching null against null.
+function isUserMessageAuthor(
+  auth: Authenticator,
+  message: UserMessageType
+): boolean {
+  if (isSystemAuthoredUserMessage(message)) {
+    return false;
+  }
+
+  return auth.user()?.id === message.user?.id;
+}
+
 /**
  * This method creates a new user message version. If a new message contains agent mentions, it will create new agent messages,
  * only when there are no agent messages after the edited user message.
@@ -1121,7 +1136,7 @@ export async function editUserMessage(
     });
   }
 
-  if (auth.user()?.id !== message.user?.id) {
+  if (!isUserMessageAuthor(auth, message)) {
     return new Err({
       status_code: 403,
       api_error: {
@@ -1749,6 +1764,18 @@ export async function retryAgentMessage(
       api_error: {
         type: "invalid_request_error",
         message: "Could not find the parent user message for this retry.",
+      },
+    });
+  }
+
+  // Retrying would replay the parent's server-set origin, which can carry free
+  // usage.
+  if (isSystemAuthoredUserMessage(parentUserMessage)) {
+    return new Err({
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "The answer to a message posted by Dust cannot be retried.",
       },
     });
   }

--- a/front/lib/api/assistant/skill_actions.test.ts
+++ b/front/lib/api/assistant/skill_actions.test.ts
@@ -122,6 +122,14 @@ describe("resolveSkillMCPServers", () => {
         agentConfig: agentConfiguration,
       }
     );
+    const { userMessage } = await ConversationFactory.createUserMessage({
+      auth: authenticator,
+      workspace,
+      conversation,
+      content: "Hello",
+      // The agent message factory sits at rank 0.
+      rank: 1,
+    });
 
     const skills = await SkillResource.fetchByIds(authenticator, [
       "discover_knowledge",
@@ -159,6 +167,7 @@ describe("resolveSkillMCPServers", () => {
       {
         agentConfiguration,
         agentMessage,
+        userMessage,
         clientSideActionConfigurations: [],
         conversation,
       },
@@ -222,6 +231,14 @@ describe("resolveSkillMCPServers", () => {
         agentConfig: agentConfiguration,
       }
     );
+    const { userMessage } = await ConversationFactory.createUserMessage({
+      auth: authenticator,
+      workspace,
+      conversation,
+      content: "Hello",
+      // The agent message factory sits at rank 0.
+      rank: 1,
+    });
 
     const autoInternalViews =
       await MCPServerViewResource.getMCPServerViewsForAutoInternalToolsAsMap(
@@ -241,6 +258,7 @@ describe("resolveSkillMCPServers", () => {
       {
         agentConfiguration,
         agentMessage,
+        userMessage,
         clientSideActionConfigurations: [],
         conversation,
       },

--- a/front/scripts/investigate_render_conversation.ts
+++ b/front/scripts/investigate_render_conversation.ts
@@ -171,6 +171,7 @@ makeScript(
         agentConfiguration,
         conversation,
         agentMessage: placeholderAgentMessage,
+        userMessage,
         clientSideActionConfigurations: clientSideMCPActionConfigurations,
       },
       { jitServers, skillServers, systemSkillServers }

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -183,6 +183,7 @@ async function listAvailableTools(
       agentConfiguration,
       conversation,
       agentMessage,
+      userMessage,
       clientSideActionConfigurations: clientSideMCPActionConfigurations,
     },
     {

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -531,6 +531,7 @@ export async function runModel(
             agentConfiguration,
             conversation,
             agentMessage,
+            userMessage,
             clientSideActionConfigurations: clientSideMCPActionConfigurations,
           },
           { jitServers, skillServers, systemSkillServers }

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -247,6 +247,7 @@ export class ConversationFactory {
     rank = 0,
     agenticMessageType,
     agenticOriginMessageId,
+    authorless = false,
   }: {
     auth: Authenticator;
     workspace: WorkspaceType;
@@ -254,11 +255,13 @@ export class ConversationFactory {
     content: string;
     origin?: UserMessageOrigin;
     rank?: number;
+    // Posted by Dust on the user's behalf, so no author on the row.
+    authorless?: boolean;
     agenticMessageType?: "run_agent" | "agent_handover";
     agenticOriginMessageId?: string;
   }): Promise<{ messageRow: MessageModel; userMessage: UserMessageType }> {
     const userMessageRow = await UserMessageModel.create({
-      userId: auth.getNonNullableUser().id,
+      userId: authorless ? null : auth.getNonNullableUser().id,
       conversationId: conversation.id,
       workspaceId: workspace.id,
       content,
@@ -290,7 +293,7 @@ export class ConversationFactory {
       visibility: messageRow.visibility,
       version: 0,
       branchId: null,
-      user: auth.getNonNullableUser().toJSON(),
+      user: authorless ? null : auth.getNonNullableUser().toJSON(),
       mentions: [],
       richMentions: [],
       content: userMessageRow.content,

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -239,6 +239,18 @@ export function isUserMessageTypeWithContentFragments(
   return arg.type === "user_message" && "contentFragments" in arg;
 }
 
+/**
+ * A user message with no author was posted by Dust on someone's behalf rather
+ * than written by them, which only server code can do (`postUserMessage`'s
+ * `doNotAssociateUser`). Such a message is nobody's to edit, its answer nobody's
+ * to retry, and it never runs on anyone's personal tool credentials.
+ */
+export function isSystemAuthoredUserMessage(
+  message: Pick<UserMessageType, "user">
+): boolean {
+  return message.user === null;
+}
+
 export function isHiddenMessageOrigin(origin: UserMessageOrigin): boolean {
   return HIDDEN_MESSAGE_ORIGINS.includes(origin);
 }


### PR DESCRIPTION
## Description

@Fraggle 

This PR introduces the concept of authorless messages (origin = system) used by activation, but could be used elsewhere too.

The idea is that, we may as a system post user messages, but never use any of the said user's credentials. And to do this I chose to make these messages authorless.

This is clearly a tradeoff as it introduces complexity (see the code touched) and if you see a simpler way to achieve the same goal, I know you will tell me 😄 


## Tests

Added some tests

## Risk

Low
Blast radius: Tool calling 😓 

## Deploy Plan

Deploy front