### PR TITLE
[MCP] Fix retrying blocked actions raised inside sub-agents

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -1,7 +1,7 @@
 import { retryAgentMessage } from "@app/lib/api/assistant/conversation";
-import { retryBlockedActions } from "@app/lib/api/assistant/conversation/retry_blocked_actions";
+import { retryBlockedActionsAndResumeAncestors } from "@app/lib/api/assistant/conversation/resume_ancestor_conversations";
+import { isNonBlockingRetryError } from "@app/lib/api/assistant/conversation/retry_blocked_actions";
 import { batchRenderMessages } from "@app/lib/api/assistant/messages";
-import { DustError } from "@app/lib/error";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { isAgentMessageType } from "@app/types/assistant/conversation";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -103,8 +103,6 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
     });
   }
 
-  const conversation = conversationResource.toJSON();
-
   const renderRes = await batchRenderMessages(
     auth,
     conversationResource,
@@ -135,32 +133,24 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
   // If the query parameter `blocked_only` is true, we retry only the blocked
   // actions.
   if (ctx.req.query("blocked_only") === "true") {
-    const retryBlockedActionsRes = await retryBlockedActions(
+    const retryBlockedActionsRes = await retryBlockedActionsAndResumeAncestors(
       auth,
-      conversation,
+      conversationResource,
       { messageId }
     );
 
     if (retryBlockedActionsRes.isErr()) {
       const { error } = retryBlockedActionsRes;
 
-      if (
-        error instanceof DustError &&
-        error.code === "agent_loop_already_running"
-      ) {
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: error.message,
-          },
-        });
+      // Nothing left to retry: the client's view is stale, not broken.
+      if (isNonBlockingRetryError(error)) {
+        return ctx.json({ message });
       }
 
       return apiError(ctx, {
         status_code: 500,
         api_error: {
-          type: "invalid_request_error",
+          type: "internal_server_error",
           message: "Failed to retry blocked actions.",
         },
       });

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1313,22 +1313,14 @@ function AgentMessageContent({
           : m
       );
 
-      // Retry on the event's conversationId, which may be coming from a subagent.
-      if (conversationAndMessage.conversationId !== conversationId) {
-        await retryHandler({
-          blockedOnly: true,
-          conversationId: conversationAndMessage.conversationId,
-          messageId: conversationAndMessage.messageId,
-        });
-      }
-      // Retry on the main conversation.
+      // May be a subagent's conversation; the backend walks up to wake its caller.
       await retryHandler({
-        conversationId,
         blockedOnly: true,
-        messageId: sId,
+        conversationId: conversationAndMessage.conversationId,
+        messageId: conversationAndMessage.messageId,
       });
     },
-    [conversationId, methods.data, retryHandler, sId]
+    [methods.data, retryHandler, sId]
   );
 
   // References logic.

--- a/front/lib/api/assistant/conversation/resume_ancestor_conversations.test.ts
+++ b/front/lib/api/assistant/conversation/resume_ancestor_conversations.test.ts
@@ -10,7 +10,10 @@ vi.mock(
 );
 
 import { createConversation } from "@app/lib/api/assistant/conversation";
-import { resumeAncestorConversations } from "@app/lib/api/assistant/conversation/resume_ancestor_conversations";
+import {
+  resumeAncestorConversations,
+  retryBlockedActionsAndResumeAncestors,
+} from "@app/lib/api/assistant/conversation/resume_ancestor_conversations";
 import { retryBlockedActions } from "@app/lib/api/assistant/conversation/retry_blocked_actions";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
@@ -180,5 +183,67 @@ describe("resumeAncestorConversations", () => {
     });
 
     expect(retryBlockedActions).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("retryBlockedActionsAndResumeAncestors", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const setup = await createResourceTest({});
+    workspace = setup.workspace;
+    auth = setup.authenticator;
+  });
+
+  it("wakes the caller after retrying a sub-agent's blocked actions", async () => {
+    const parent = await createAgenticConversation(auth, workspace);
+    const child = await createAgenticConversation(auth, workspace, {
+      agenticParentMessageId: parent.agentMessageId,
+    });
+
+    vi.mocked(retryBlockedActions).mockResolvedValue(new Ok(undefined));
+
+    const res = await retryBlockedActionsAndResumeAncestors(
+      auth,
+      child.conversation,
+      { messageId: child.agentMessageId }
+    );
+
+    expect(res.isOk()).toBe(true);
+    // Once for the child, once for the parked caller.
+    expect(retryBlockedActions).toHaveBeenCalledTimes(2);
+    expect(retryBlockedActions).toHaveBeenCalledWith(
+      auth,
+      expect.objectContaining({ sId: child.conversation.sId }),
+      expect.objectContaining({ messageId: child.agentMessageId })
+    );
+    expect(retryBlockedActions).toHaveBeenCalledWith(
+      auth,
+      expect.objectContaining({ sId: parent.conversation.sId }),
+      expect.objectContaining({ messageId: parent.agentMessageId })
+    );
+  });
+
+  it("does not walk ancestors when the retry itself failed", async () => {
+    const parent = await createAgenticConversation(auth, workspace);
+    const child = await createAgenticConversation(auth, workspace, {
+      agenticParentMessageId: parent.agentMessageId,
+    });
+
+    vi.mocked(retryBlockedActions).mockResolvedValue(
+      new Err(new DustError("no_blocked_actions", "No blocked actions found"))
+    );
+
+    const res = await retryBlockedActionsAndResumeAncestors(
+      auth,
+      child.conversation,
+      { messageId: child.agentMessageId }
+    );
+
+    expect(res.isErr()).toBe(true);
+    expect(retryBlockedActions).toHaveBeenCalledTimes(1);
   });
 });

--- a/front/lib/api/assistant/conversation/resume_ancestor_conversations.test.ts
+++ b/front/lib/api/assistant/conversation/resume_ancestor_conversations.test.ts
@@ -1,8 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@app/lib/api/assistant/conversation/retry_blocked_actions", () => ({
-  retryBlockedActions: vi.fn(),
-}));
+// Mock `retryBlockedActions` only; `isNonBlockingRetryError` must stay real.
+vi.mock(
+  import("@app/lib/api/assistant/conversation/retry_blocked_actions"),
+  async (importOriginal) => ({
+    ...(await importOriginal()),
+    retryBlockedActions: vi.fn(),
+  })
+);
 
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { resumeAncestorConversations } from "@app/lib/api/assistant/conversation/resume_ancestor_conversations";

--- a/front/lib/api/assistant/conversation/resume_ancestor_conversations.ts
+++ b/front/lib/api/assistant/conversation/resume_ancestor_conversations.ts
@@ -1,19 +1,11 @@
 import { MAX_CONVERSATION_DEPTH } from "@app/lib/api/assistant/conversation/constants";
-import { retryBlockedActions } from "@app/lib/api/assistant/conversation/retry_blocked_actions";
+import {
+  isNonBlockingRetryError,
+  retryBlockedActions,
+} from "@app/lib/api/assistant/conversation/retry_blocked_actions";
 import type { Authenticator } from "@app/lib/auth";
-import type { DustErrorCode } from "@app/lib/error";
-import { DustError } from "@app/lib/error";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
-
-// Outcomes that mean "this ancestor has nothing to resume", not "resuming failed": a handover
-// caller was never blocked, a sibling validation already relaunched it, or it reached a terminal
-// state. Higher ancestors may still be parked, so the walk continues.
-const NON_BLOCKING_RETRY_ERROR_CODES: DustErrorCode[] = [
-  "agent_loop_already_running",
-  "agent_message_not_resumable",
-  "no_blocked_actions",
-];
 
 /**
  * Walk up the agentic-parent chain from a freshly resumed agent message and
@@ -73,10 +65,7 @@ export async function resumeAncestorConversations(
         err: retryRes.error,
       };
 
-      if (
-        retryRes.error instanceof DustError &&
-        NON_BLOCKING_RETRY_ERROR_CODES.includes(retryRes.error.code)
-      ) {
+      if (isNonBlockingRetryError(retryRes.error)) {
         logger.info(logBlob, "Parent conversation had nothing to resume");
       } else {
         logger.error(

--- a/front/lib/api/assistant/conversation/resume_ancestor_conversations.ts
+++ b/front/lib/api/assistant/conversation/resume_ancestor_conversations.ts
@@ -4,8 +4,10 @@ import {
   retryBlockedActions,
 } from "@app/lib/api/assistant/conversation/retry_blocked_actions";
 import type { Authenticator } from "@app/lib/auth";
+import type { DustError } from "@app/lib/error";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
 
 /**
  * Walk up the agentic-parent chain from a freshly resumed agent message and
@@ -80,4 +82,29 @@ export async function resumeAncestorConversations(
       agentMessageId: parentAgentMessage.sId,
     };
   }
+}
+
+/**
+ * Retry blocked actions, then wake the callers — as every other resolution surface does.
+ * Relaunching a sub-agent's loop alone leaves its caller parked forever.
+ *
+ * Lives here, not in `retryBlockedActions`: the walk calls that and must not re-enter itself.
+ */
+export async function retryBlockedActionsAndResumeAncestors(
+  auth: Authenticator,
+  conversation: ConversationResource,
+  { messageId }: { messageId: string }
+): Promise<Result<void, Error | DustError>> {
+  const retryRes = await retryBlockedActions(auth, conversation.toJSON(), {
+    messageId,
+  });
+  if (retryRes.isErr()) {
+    return retryRes;
+  }
+
+  await resumeAncestorConversations(auth, conversation, {
+    agentMessageId: messageId,
+  });
+
+  return retryRes;
 }

--- a/front/lib/api/assistant/conversation/retry_blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/retry_blocked_actions.ts
@@ -2,6 +2,7 @@ import { isBlockedActionEvent } from "@app/lib/actions/mcp";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
+import type { DustErrorCode } from "@app/lib/error";
 import { DustError } from "@app/lib/error";
 import { MessageModel } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -9,6 +10,20 @@ import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+
+// "Nothing to resume", not "resuming failed". Callers must treat these as no-ops.
+const NON_BLOCKING_RETRY_ERROR_CODES: DustErrorCode[] = [
+  "agent_loop_already_running",
+  "agent_message_not_resumable",
+  "no_blocked_actions",
+];
+
+export function isNonBlockingRetryError(err: Error): boolean {
+  return (
+    err instanceof DustError &&
+    NON_BLOCKING_RETRY_ERROR_CODES.includes(err.code)
+  );
+}
 
 async function findUserMessageForRetry(
   auth: Authenticator,

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -18,10 +18,15 @@ vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
   }),
 }));
 
-// Mock the ancestor resume so we can assert on it without launching workflows
-vi.mock("@app/lib/api/assistant/conversation/retry_blocked_actions", () => ({
-  retryBlockedActions: vi.fn(),
-}));
+// Mock the ancestor resume so we can assert on it without launching workflows. Keep the rest of
+// the module real: `resumeAncestorConversations` needs `isNonBlockingRetryError`.
+vi.mock(
+  import("@app/lib/api/assistant/conversation/retry_blocked_actions"),
+  async (importOriginal) => ({
+    ...(await importOriginal()),
+    retryBlockedActions: vi.fn(),
+  })
+);
 
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";


### PR DESCRIPTION
## Description

Conversations blocked on a "Manual action required" prompt could not be resumed: `POST .../retry?blocked_only=true` returned 500 and the conversation stayed stuck. Two causes:

1. **The retry endpoint never woke the caller.** `retryBlockedActions` was the only blocked-action resolution surface that didn't walk the agentic-parent chain (unlike `validateAction`, `registerUserAnswer`, `resolveAuthentication`, `validateToolFromEmail`). Retrying a prompt raised inside a sub-agent relaunched the sub-agent's loop but left its caller parked in `blocked_child_action_input_required` forever.
2. **Benign outcomes were reported as 500s.** `retryBlockedActions` returns `no_blocked_actions` / `agent_message_not_resumable` / `agent_loop_already_running` — all meaning "nothing to resume", not "resuming failed". The route only special-cased the third and 500'd on the rest. The frontend made this systematic by firing a second retry on the main conversation after the sub-agent one, which raced it and reliably resolved to "nothing to retry".

Fixes:

- Extracted the shared `isNonBlockingRetryError` guard next to the code that produces those errors, replacing the duplicate list in `resume_ancestor_conversations.ts`.
- Added `retryBlockedActionsAndResumeAncestors`, used by the retry endpoint, so retry wakes the caller like every other surface. It lives outside `retryBlockedActions` so the ancestor walk can't re-enter itself.
- The endpoint now treats the three benign codes as a no-op (`200`) instead of `500`, and the 500 branch no longer mislabels itself `invalid_request_error`.
- Dropped the frontend's second, racy retry on the main conversation — the server-side walk covers it.

## Tests

Added 2 tests for `retryBlockedActionsAndResumeAncestors` (wakes the caller on success, doesn't walk when the retry itself failed). `resume_ancestor_conversations.test.ts` passes 7/7. Note: `validate_actions.test.ts` has 2 failures (`interrupted` / `gracefully_stopped`) that reproduce unchanged on `main`.

## Risk

Low. Behaviour change worth noting: `agent_loop_already_running` now returns `200` instead of `400` on this endpoint — no client branches on it (the SDK and `useRetryMessage` both ignore non-limit errors).

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`
