### PR TITLE
Speed up Depot image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 **/target
 
 # misc
+.git
 .DS_Store
 **/*.pem
 **/dist

--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -183,69 +183,56 @@ runs:
           LATEST_TAGS+=("-t" "${REGISTRY}/${COMPONENT}:latest")
         fi
 
-        # Special handling for front component, build workers and front-api targets
+        # Special handling for front component: Bake builds both targets in parallel
+        # and deduplicates work in their shared base-deps stage.
         if [[ "$BASE_COMPONENT" == "front" ]]; then
-          echo "🏗️ Building front component with two targets (workers + front-api)"
+          echo "🏗️ Building front component with Bake (workers + front-api)"
 
-          # Build workers target
-          LATEST_TAGS_WORKERS=()
-          if [[ "$ENV" == "prod" && "$COMPONENT" == "$BASE_COMPONENT" && "${{ github.ref_name }}" == "main" ]]; then
-            LATEST_TAGS_WORKERS+=("-t" "${REGISTRY}/${COMPONENT}-workers:latest")
-          fi
-          depot build \
-            --project $DEPOT_PROJECT_ID \
-            --platform linux/amd64 \
-            --provenance=false \
-            --target workers \
-            --cache-from type=gha,scope=${{ inputs.component }}-deps \
-            --cache-from type=gha,scope=${{ inputs.component }}-workers \
-            --cache-to type=gha,mode=max,scope=${{ inputs.component }}-deps \
-            --cache-to type=gha,mode=max,scope=${{ inputs.component }}-workers \
-            -f ./dockerfiles/${BASE_COMPONENT}.Dockerfile \
-            -t ${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images/${COMPONENT}-workers:${{ inputs.commit_sha }} \
-            "${LATEST_TAGS_WORKERS[@]}" \
-            --build-arg COMMIT_HASH=${{ inputs.commit_sha }} \
-            --build-arg COMMIT_HASH_LONG=${{ inputs.commit_sha_long }} \
-            --build-arg DD_GIT_REPOSITORY_URL=https://github.com/dust-tt/dust \
-            --build-arg DD_GIT_COMMIT_SHA=${{ inputs.commit_sha_long }} \
-            ${build_args[@]} \
-            --push \
-            .
-
-          # Build front-api target. Insert `-api` after the base component so the prod image
-          # is `front-api` and the edge image is `front-api-edge` (parallel to `front`/`front-edge`).
+          # Insert `-api` after the base component so the prod image is `front-api`
+          # and the edge image is `front-api-edge` (parallel to `front`/`front-edge`).
           API_COMPONENT="${BASE_COMPONENT}-api${COMPONENT#${BASE_COMPONENT}}"
-          LATEST_TAGS_API=()
+
+          WORKERS_IMAGE_TAG="${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images/${COMPONENT}-workers:${{ inputs.commit_sha }}"
+          FRONT_API_IMAGE_TAG="${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images/${API_COMPONENT}:${{ inputs.commit_sha }}"
+          WORKERS_LATEST_IMAGE_TAG=""
+          FRONT_API_LATEST_IMAGE_TAG=""
+
+          BAKE_OVERRIDES=(
+            --set "*.args.COMMIT_HASH=${{ inputs.commit_sha }}"
+            --set "*.args.COMMIT_HASH_LONG=${{ inputs.commit_sha_long }}"
+            --set "*.args.DD_GIT_REPOSITORY_URL=https://github.com/dust-tt/dust"
+            --set "*.args.DD_GIT_COMMIT_SHA=${{ inputs.commit_sha_long }}"
+          )
+
+          # Convert the build arguments collected above to Bake target overrides.
+          for ((i = 1; i < ${#build_args[@]}; i += 2)); do
+            BAKE_OVERRIDES+=(--set "*.args.${build_args[$i]}")
+          done
+
           if [[ "$ENV" == "prod" && "$COMPONENT" == "$BASE_COMPONENT" && "${{ github.ref_name }}" == "main" ]]; then
-            LATEST_TAGS_API+=("-t" "${REGISTRY}/${API_COMPONENT}:latest")
+            WORKERS_LATEST_IMAGE_TAG="${REGISTRY}/${COMPONENT}-workers:latest"
+            FRONT_API_LATEST_IMAGE_TAG="${REGISTRY}/${API_COMPONENT}:latest"
           fi
-          depot build \
-            --project $DEPOT_PROJECT_ID \
-            --platform linux/amd64 \
+
+          export WORKERS_IMAGE_TAG FRONT_API_IMAGE_TAG
+          export WORKERS_LATEST_IMAGE_TAG FRONT_API_LATEST_IMAGE_TAG
+
+          FRONT_BUILD_STARTED_SECONDS=$SECONDS
+          depot bake \
+            --project "$DEPOT_PROJECT_ID" \
             --provenance=false \
-            --target front-api \
-            --cache-from type=gha,scope=${{ inputs.component }}-deps \
-            --cache-from type=gha,scope=${{ inputs.component }}-front-api \
-            --cache-to type=gha,mode=max,scope=${{ inputs.component }}-deps \
-            --cache-to type=gha,mode=max,scope=${{ inputs.component }}-front-api \
-            -f ./dockerfiles/${BASE_COMPONENT}.Dockerfile \
-            -t ${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images/${API_COMPONENT}:${{ inputs.commit_sha }} \
-            "${LATEST_TAGS_API[@]}" \
-            --build-arg COMMIT_HASH=${{ inputs.commit_sha }} \
-            --build-arg COMMIT_HASH_LONG=${{ inputs.commit_sha_long }} \
-            --build-arg DD_GIT_REPOSITORY_URL=https://github.com/dust-tt/dust \
-            --build-arg DD_GIT_COMMIT_SHA=${{ inputs.commit_sha_long }} \
-            ${build_args[@]} \
+            -f ./dockerfiles/front-bake.hcl \
+            "${BAKE_OVERRIDES[@]}" \
             --push \
-            .
+            front-images
+          echo "⏱️ Depot front Bake build and push took $((SECONDS - FRONT_BUILD_STARTED_SECONDS)) seconds"
         else
           # Standard single-target build for other components
+          BUILD_STARTED_SECONDS=$SECONDS
           depot build \
-            --project $DEPOT_PROJECT_ID \
+            --project "$DEPOT_PROJECT_ID" \
             --platform linux/amd64 \
             --provenance=false \
-            --cache-from type=gha,scope=${{ inputs.component }} \
-            --cache-to type=gha,mode=max,scope=${{ inputs.component }} \
             -f ./dockerfiles/${BASE_COMPONENT}.Dockerfile \
             -t ${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images/${COMPONENT}:${{ inputs.commit_sha }} \
             "${LATEST_TAGS[@]}" \
@@ -256,6 +243,7 @@ runs:
             ${build_args[@]} \
             --push \
             .
+          echo "⏱️ Depot build and push took $((SECONDS - BUILD_STARTED_SECONDS)) seconds"
         fi
 
     - name: Get current deployed version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,16 +88,16 @@ jobs:
     needs: [check-branch]
     runs-on: ubuntu-latest
     outputs:
-      short_sha: ${{ steps.short_sha.outputs.short_sha }}
-      long_sha: ${{ steps.short_sha.outputs.long_sha }}
+      short_sha: ${{ steps.commit_sha.outputs.short_sha }}
+      long_sha: ${{ steps.commit_sha.outputs.long_sha }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Get short sha
-        id: short_sha
-        run: echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-      - name: Get long sha
-        id: long_sha
-        run: echo "long_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Get commit SHAs
+        id: commit_sha
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          echo "short_sha=${COMMIT_SHA::7}" >> "$GITHUB_OUTPUT"
+          echo "long_sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
 
   notify-start:
     needs: [prepare]
@@ -106,6 +106,12 @@ jobs:
       thread_ts: ${{ steps.build_message.outputs.thread_ts }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            /.authors
+            /.github/actions/slack-notify/
+            /.github/actions/slack-check-deployment-blocked/
+          sparse-checkout-cone-mode: false
 
       - name: Notify Build And Deploy Start
         id: build_message
@@ -226,6 +232,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/slack-notify
 
       - name: Generate token
         id: generate-token

--- a/dockerfiles/front-bake.hcl
+++ b/dockerfiles/front-bake.hcl
@@ -1,0 +1,37 @@
+variable "WORKERS_IMAGE_TAG" {
+  default = ""
+}
+
+variable "WORKERS_LATEST_IMAGE_TAG" {
+  default = ""
+}
+
+variable "FRONT_API_IMAGE_TAG" {
+  default = ""
+}
+
+variable "FRONT_API_LATEST_IMAGE_TAG" {
+  default = ""
+}
+
+group "front-images" {
+  targets = ["workers", "front-api"]
+}
+
+target "_front-base" {
+  context    = "."
+  dockerfile = "./dockerfiles/front.Dockerfile"
+  platforms  = ["linux/amd64"]
+}
+
+target "workers" {
+  inherits = ["_front-base"]
+  target   = "workers"
+  tags     = compact([WORKERS_IMAGE_TAG, WORKERS_LATEST_IMAGE_TAG])
+}
+
+target "front-api" {
+  inherits = ["_front-base"]
+  target   = "front-api"
+  tags     = compact([FRONT_API_IMAGE_TAG, FRONT_API_LATEST_IMAGE_TAG])
+}

--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -16,7 +16,8 @@ COPY front/package.json ./front/
 COPY front-spa/package.json ./front-spa/
 COPY front-api/package.json ./front-api/
 
-RUN --mount=type=cache,id=npm-cache,target=/root/.npm npm ci -w sdks/js -w sparkle -w front -w front-spa -w front-api
+RUN --mount=type=cache,id=npm-cache,target=/root/.npm,sharing=locked \
+  npm ci --prefer-offline --no-audit --no-fund -w sdks/js -w sparkle -w front -w front-spa -w front-api
 
 # Build SDK
 WORKDIR /app/sdks/js
@@ -37,7 +38,7 @@ WORKDIR /app/front
 COPY /front .
 
 # Generate custom models TypeScript from JSON config (downloaded by CI)
-RUN npx tsx scripts/fetch-custom-models.ts
+RUN npm run generate:custom-models
 
 # Remove test files (shared optimization)
 RUN find . -name "*.test.ts" -delete
@@ -47,7 +48,7 @@ RUN find . -name "*.test.tsx" -delete
 COPY /scripts/db /app/scripts/db
 
 # Compile migration script so all runtime images have dist/migrate.js without needing TypeScript sources
-RUN npx esbuild scripts/migrate.ts --bundle --platform=node --target=node22 --alias:@app=. --packages=external --outfile=dist/migrate.js --sourcemap
+RUN npm run build:migrate
 
 # Copy front-api source (server.ts, app.ts, routes/, middleware/)
 WORKDIR /app/front-api

--- a/dockerfiles/front.Dockerfile.dockerignore
+++ b/dockerfiles/front.Dockerfile.dockerignore
@@ -1,0 +1,56 @@
+# The front image only builds these workspaces. Keeping this as an allowlist
+# prevents unrelated projects and local artifacts from entering its context.
+**
+
+!package.json
+!package-lock.json
+
+!sdks/
+!sdks/js/
+!sdks/js/**
+
+!sparkle/
+!sparkle/**
+
+!front/
+!front/**
+
+!front-spa/
+!front-spa/**
+
+!front-api/
+!front-api/**
+
+!scripts/
+!scripts/db/
+!scripts/db/**
+
+# Generated files within the included workspaces.
+**/node_modules
+**/target
+**/dist
+**/build
+**/coverage
+**/.next
+**/out
+**/.cache
+**/.vite
+**/.eslintcache
+**/storybook-static
+**/__pycache__
+**/*.pyc
+**/*.tsbuildinfo
+**/.DS_Store
+**/*.pem
+**/.env
+**/.env*.local
+**/.pnp
+**/.pnp.js
+**/npm-debug.log*
+**/yarn-debug.log*
+**/yarn-error.log*
+**/.pnpm-debug.log*
+**/next-env.d.ts
+
+# Static SPA assets are deployed separately and are not used by workers or front-api.
+front/public

--- a/front/package.json
+++ b/front/package.json
@@ -11,6 +11,7 @@
     "./types/*": "./types/*"
   },
   "scripts": {
+    "build:migrate": "esbuild scripts/migrate.ts --bundle --platform=node --target=node22 --alias:@app=. --packages=external --outfile=dist/migrate.js --sourcemap",
     "build:temporal-bundles": "tsx scripts/temporal-build/build-temporal-bundles.ts",
     "build:workers": "tsx esbuild.worker.ts",
     "start:worker": "USE_TEMPORAL_BUNDLES=true node dist/start_worker.js",
@@ -36,6 +37,7 @@
     "migration:mark:pre-deploy": "node ../scripts/db/run-migrate.cjs --command mark-pre-deploy --execute",
     "migration:mark:post-deploy": "node ../scripts/db/run-migrate.cjs --command mark-post-deploy --execute",
     "debug:profiler": "node ./scripts/debug/run_profiler.ts",
+    "generate:custom-models": "tsx scripts/fetch-custom-models.ts",
     "generate:hubspot-forms": "tsx scripts/generate-hubspot-forms.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
GitHub reported front image builds taking 10–18 minutes while Depot showed roughly two minutes of build time when caches were hit. The discrepancy came from GitHub timing the full composite action, including two sequential Depot builds, remote builder setup, context transfers, image pushes, and redundant GitHub Actions cache imports and mode=max exports.

Depot already provides a persistent BuildKit cache, so exporting the same layers to GitHub added network overhead
without useful caching benefits. Both regional jobs also wrote to identical cache scopes concurrently. This change
removes the external GitHub cache configuration. See Depot’s troubleshooting [guidance](https://depot.dev/docs/container-builds/troubleshooting).

The workers and front-api images are now built through a single Depot Bake invocation. This allows BuildKit to schedule both targets together and deduplicate their shared dependency stages. See Depot’s Docker Bake [documentation](https://depot.dev/docs/container-builds/how-to-guides/docker-bake).

The context investigation also found that Git history was included because `.git` was missing from `.dockerignore`. A
Dockerfile-specific allowlist now limits front builds to the workspaces they actually consume and excludes unrelated
projects, generated caches, and the 86 MB `front/public` tree, which is deployed separately with the SPA. A cold
worst-case local context probe dropped from 625.97 MB to 66.36 MB, an **89% reduction**. Both `workers` and `front-api` images were built successfully with the reduced context. See Docker’s build-context [documentation](https://docs.docker.com/build/concepts/context/).

Depot also suggested avoiding build-time npx downloads. Investigation showed that tsx and esbuild were already installed as development dependencies and that their Depot steps took only 1.0 and 0.3 seconds, so they were not the reported 20-second bottleneck. They are now invoked through local npm scripts to make that behavior explicit. The `npm` cache mount is retained with locked sharing, `npm ci` prefers cached packages, and audit and funding network requests are disabled during image construction.

Wall-clock timing is now logged around Depot commands so future GitHub and Depot timings can be compared directly. The Bake configuration was validated for production and non-production tags, both production image targets build locally, and YAML parsing, Bash syntax, actionlint, package-lock validation, secret scanning, formatting, and whitespace checks pass.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
