### PR TITLE
[front] fix: prioritize prefix matches in capability search

### DIFF
--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -139,10 +139,10 @@ describe("searchCapabilityIndex ranking", () => {
   it("ranks title prefix matches above other fuzzy title matches", () => {
     const result = searchCapabilityIndex({
       items: [
-        { id: "contains", sortName: "create frame" },
-        { id: "prefix", sortName: "frame renderer" },
+        { id: "contains", sortName: "create guide" },
+        { id: "prefix", sortName: "guide builder" },
       ],
-      query: "frame",
+      query: "guide",
     });
 
     expect(result.map((item) => item.id)).toEqual(["prefix", "contains"]);

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -124,7 +124,7 @@ describe("searchCapabilityIndex ranking", () => {
     expect(result.map((item) => item.id)).toEqual(["a", "z"]);
   });
 
-  it("breaks non-prefix fuzzy ties alphabetically", () => {
+  it("sorts non-prefix substring matches alphabetically", () => {
     const result = searchCapabilityIndex({
       items: [
         { id: "ztestlonger", sortName: "ztestlonger" },

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -124,16 +124,28 @@ describe("searchCapabilityIndex ranking", () => {
     expect(result.map((item) => item.id)).toEqual(["a", "z"]);
   });
 
-  it("breaks fuzzy ties alphabetically when a query is provided", () => {
+  it("breaks non-prefix fuzzy ties alphabetically", () => {
     const result = searchCapabilityIndex({
       items: [
-        { id: "testlonger", sortName: "testlonger" },
+        { id: "ztestlonger", sortName: "ztestlonger" },
         { id: "longtest", sortName: "longtest" },
       ],
       query: "test",
     });
 
-    expect(result.map((item) => item.id)).toEqual(["longtest", "testlonger"]);
+    expect(result.map((item) => item.id)).toEqual(["longtest", "ztestlonger"]);
+  });
+
+  it("ranks title prefix matches above other fuzzy title matches", () => {
+    const result = searchCapabilityIndex({
+      items: [
+        { id: "contains", sortName: "create frame" },
+        { id: "prefix", sortName: "frame renderer" },
+      ],
+      query: "frame",
+    });
+
+    expect(result.map((item) => item.id)).toEqual(["prefix", "contains"]);
   });
 
   it("ranks title matches above description-only matches", () => {

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -6,7 +6,7 @@ import {
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewLightType } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
-import { compareForFuzzySort, subFilter } from "@app/lib/utils";
+import { compareForAutocompleteSort, subFilter } from "@app/lib/utils";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import React from "react";
 
@@ -62,18 +62,10 @@ export function searchCapabilityIndex<T extends CapabilitySearchIndexItem>({
     }
 
     if (a.titleMatches) {
-      const aIsPrefixMatch = a.item.sortName.startsWith(normalizedQuery);
-      const bIsPrefixMatch = b.item.sortName.startsWith(normalizedQuery);
-      if (aIsPrefixMatch !== bIsPrefixMatch) {
-        return aIsPrefixMatch ? -1 : 1;
-      }
-
-      return (
-        compareForFuzzySort(
-          normalizedQuery,
-          a.item.sortName,
-          b.item.sortName
-        ) || a.item.sortName.localeCompare(b.item.sortName)
+      return compareForAutocompleteSort(
+        normalizedQuery,
+        a.item.sortName,
+        b.item.sortName
       );
     }
 

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -62,6 +62,12 @@ export function searchCapabilityIndex<T extends CapabilitySearchIndexItem>({
     }
 
     if (a.titleMatches) {
+      const aIsPrefixMatch = a.item.sortName.startsWith(normalizedQuery);
+      const bIsPrefixMatch = b.item.sortName.startsWith(normalizedQuery);
+      if (aIsPrefixMatch !== bIsPrefixMatch) {
+        return aIsPrefixMatch ? -1 : 1;
+      }
+
       return (
         compareForFuzzySort(
           normalizedQuery,

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -216,6 +216,43 @@ export function subFilter(a: string, b: string) {
   return subFilterLastIndex(a, b) > -1;
 }
 
+function getAutocompleteMatchRank(query: string, candidate: string): number {
+  if (candidate === query) {
+    return 0;
+  }
+  if (candidate.startsWith(query)) {
+    return 1;
+  }
+  if (candidate.includes(query)) {
+    return 2;
+  }
+  if (subFilter(query, candidate)) {
+    return 3;
+  }
+  return 4;
+}
+
+/**
+ * Compares two strings for predictable autocomplete relevance.
+ * Exact matches rank first, followed by prefixes, substrings, and fuzzy matches.
+ * Candidates within the same tier are sorted alphabetically.
+ */
+export function compareForAutocompleteSort(
+  query: string,
+  a: string,
+  b: string
+) {
+  const normalizedQuery = query.toLowerCase();
+  const normalizedA = a.toLowerCase();
+  const normalizedB = b.toLowerCase();
+
+  const rankComparison =
+    getAutocompleteMatchRank(normalizedQuery, normalizedA) -
+    getAutocompleteMatchRank(normalizedQuery, normalizedB);
+
+  return rankComparison || normalizedA.localeCompare(normalizedB);
+}
+
 /**
  * Compares two strings for fuzzy relevance against a query.
  * First sort by substring, then by spread of subfilter, then exact match.

--- a/front/tests/lib/utils.test.ts
+++ b/front/tests/lib/utils.test.ts
@@ -1,5 +1,131 @@
-import { compareForFuzzySort } from "@app/lib/utils";
-import { expect, test } from "vitest";
+import {
+  compareForAutocompleteSort,
+  compareForFuzzySort,
+  subFilter,
+} from "@app/lib/utils";
+import { describe, expect, test } from "vitest";
+
+const AUTOCOMPLETE_SKILL_NAMES = [
+  "Frame",
+  "Frame Renderer",
+  "Framework Builder",
+  "Create Frame",
+  "Aesthetic Dust Frames",
+  "Fast Response Assistant Media Exporter",
+  "Framing Workshop",
+  "Presentation Designer",
+];
+
+function filterAndSortAutocompleteSkills(query: string): string[] {
+  const normalizedQuery = query.toLowerCase();
+
+  return AUTOCOMPLETE_SKILL_NAMES.filter((name) =>
+    subFilter(normalizedQuery, name.toLowerCase())
+  ).toSorted((a, b) => compareForAutocompleteSort(query, a, b));
+}
+
+describe("compareForAutocompleteSort", () => {
+  test.each([
+    {
+      behavior:
+        "ranks exact, prefix, substring, and fuzzy matches in that order",
+      query: "frame",
+      expected: [
+        "Frame",
+        "Frame Renderer",
+        "Framework Builder",
+        "Aesthetic Dust Frames",
+        "Create Frame",
+        "Fast Response Assistant Media Exporter",
+      ],
+    },
+    {
+      behavior: "sorts matches alphabetically within the prefix tier",
+      query: "fram",
+      expected: [
+        "Frame",
+        "Frame Renderer",
+        "Framework Builder",
+        "Framing Workshop",
+        "Aesthetic Dust Frames",
+        "Create Frame",
+        "Fast Response Assistant Media Exporter",
+      ],
+    },
+    {
+      behavior: "ranks a title prefix above fuzzy title matches",
+      query: "fa",
+      expected: [
+        "Fast Response Assistant Media Exporter",
+        "Aesthetic Dust Frames",
+        "Create Frame",
+        "Frame",
+        "Frame Renderer",
+        "Framework Builder",
+        "Framing Workshop",
+      ],
+    },
+    {
+      behavior: "sorts fuzzy-only matches alphabetically instead of by spread",
+      query: "frm",
+      expected: [
+        "Aesthetic Dust Frames",
+        "Create Frame",
+        "Fast Response Assistant Media Exporter",
+        "Frame",
+        "Frame Renderer",
+        "Framework Builder",
+        "Framing Workshop",
+      ],
+    },
+    {
+      behavior: "matches a query case-insensitively",
+      query: "FRAME",
+      expected: [
+        "Frame",
+        "Frame Renderer",
+        "Framework Builder",
+        "Aesthetic Dust Frames",
+        "Create Frame",
+        "Fast Response Assistant Media Exporter",
+      ],
+    },
+    {
+      behavior: "returns the single matching prefix without unrelated skills",
+      query: "create",
+      expected: ["Create Frame"],
+    },
+    {
+      behavior: "returns an empty list when no skill matches",
+      query: "zzz",
+      expected: [],
+    },
+    {
+      behavior: "sorts every skill alphabetically when the query is empty",
+      query: "",
+      expected: [
+        "Aesthetic Dust Frames",
+        "Create Frame",
+        "Fast Response Assistant Media Exporter",
+        "Frame",
+        "Frame Renderer",
+        "Framework Builder",
+        "Framing Workshop",
+        "Presentation Designer",
+      ],
+    },
+  ])("$behavior for '$query'", ({ query, expected }) => {
+    expect(filterAndSortAutocompleteSkills(query)).toEqual(expected);
+  });
+
+  test("ranks matching candidates before non-matches in an unfiltered list", () => {
+    expect(
+      ["Presentation Designer", "Create Frame", "Frame"].toSorted((a, b) =>
+        compareForAutocompleteSort("frame", a, b)
+      )
+    ).toEqual(["Frame", "Create Frame", "Presentation Designer"]);
+  });
+});
 
 test("compareForFuzzySort should correctly compare strings", () => {
   const dataLessThan = [

--- a/front/tests/lib/utils.test.ts
+++ b/front/tests/lib/utils.test.ts
@@ -6,14 +6,14 @@ import {
 import { describe, expect, test } from "vitest";
 
 const AUTOCOMPLETE_SKILL_NAMES = [
-  "Frame",
-  "Frame Renderer",
-  "Framework Builder",
-  "Create Frame",
-  "Aesthetic Dust Frames",
-  "Fast Response Assistant Media Exporter",
-  "Framing Workshop",
-  "Presentation Designer",
+  "Guide",
+  "Guide Builder",
+  "Guideline Toolkit",
+  "Create Guide",
+  "Product Guides",
+  "Generate Useful Insights for Data Export",
+  "Guiding Workshop",
+  "Automation Designer",
 ];
 
 function filterAndSortAutocompleteSkills(query: string): string[] {
@@ -29,71 +29,65 @@ describe("compareForAutocompleteSort", () => {
     {
       behavior:
         "ranks exact, prefix, substring, and fuzzy matches in that order",
-      query: "frame",
+      query: "guide",
       expected: [
-        "Frame",
-        "Frame Renderer",
-        "Framework Builder",
-        "Aesthetic Dust Frames",
-        "Create Frame",
-        "Fast Response Assistant Media Exporter",
+        "Guide",
+        "Guide Builder",
+        "Guideline Toolkit",
+        "Create Guide",
+        "Product Guides",
+        "Generate Useful Insights for Data Export",
       ],
     },
     {
       behavior: "sorts matches alphabetically within the prefix tier",
-      query: "fram",
+      query: "guid",
       expected: [
-        "Frame",
-        "Frame Renderer",
-        "Framework Builder",
-        "Framing Workshop",
-        "Aesthetic Dust Frames",
-        "Create Frame",
-        "Fast Response Assistant Media Exporter",
+        "Guide",
+        "Guide Builder",
+        "Guideline Toolkit",
+        "Guiding Workshop",
+        "Create Guide",
+        "Product Guides",
+        "Generate Useful Insights for Data Export",
       ],
     },
     {
       behavior: "ranks a title prefix above fuzzy title matches",
-      query: "fa",
+      query: "gen",
       expected: [
-        "Fast Response Assistant Media Exporter",
-        "Aesthetic Dust Frames",
-        "Create Frame",
-        "Frame",
-        "Frame Renderer",
-        "Framework Builder",
-        "Framing Workshop",
+        "Generate Useful Insights for Data Export",
+        "Guideline Toolkit",
       ],
     },
     {
       behavior: "sorts fuzzy-only matches alphabetically instead of by spread",
-      query: "frm",
+      query: "gde",
       expected: [
-        "Aesthetic Dust Frames",
-        "Create Frame",
-        "Fast Response Assistant Media Exporter",
-        "Frame",
-        "Frame Renderer",
-        "Framework Builder",
-        "Framing Workshop",
+        "Create Guide",
+        "Generate Useful Insights for Data Export",
+        "Guide",
+        "Guide Builder",
+        "Guideline Toolkit",
+        "Product Guides",
       ],
     },
     {
       behavior: "matches a query case-insensitively",
-      query: "FRAME",
+      query: "GUIDE",
       expected: [
-        "Frame",
-        "Frame Renderer",
-        "Framework Builder",
-        "Aesthetic Dust Frames",
-        "Create Frame",
-        "Fast Response Assistant Media Exporter",
+        "Guide",
+        "Guide Builder",
+        "Guideline Toolkit",
+        "Create Guide",
+        "Product Guides",
+        "Generate Useful Insights for Data Export",
       ],
     },
     {
       behavior: "returns the single matching prefix without unrelated skills",
       query: "create",
-      expected: ["Create Frame"],
+      expected: ["Create Guide"],
     },
     {
       behavior: "returns an empty list when no skill matches",
@@ -104,14 +98,14 @@ describe("compareForAutocompleteSort", () => {
       behavior: "sorts every skill alphabetically when the query is empty",
       query: "",
       expected: [
-        "Aesthetic Dust Frames",
-        "Create Frame",
-        "Fast Response Assistant Media Exporter",
-        "Frame",
-        "Frame Renderer",
-        "Framework Builder",
-        "Framing Workshop",
-        "Presentation Designer",
+        "Automation Designer",
+        "Create Guide",
+        "Generate Useful Insights for Data Export",
+        "Guide",
+        "Guide Builder",
+        "Guideline Toolkit",
+        "Guiding Workshop",
+        "Product Guides",
       ],
     },
   ])("$behavior for '$query'", ({ query, expected }) => {
@@ -120,10 +114,10 @@ describe("compareForAutocompleteSort", () => {
 
   test("ranks matching candidates before non-matches in an unfiltered list", () => {
     expect(
-      ["Presentation Designer", "Create Frame", "Frame"].toSorted((a, b) =>
-        compareForAutocompleteSort("frame", a, b)
+      ["Automation Designer", "Create Guide", "Guide"].toSorted((a, b) =>
+        compareForAutocompleteSort("guide", a, b)
       )
-    ).toEqual(["Frame", "Create Frame", "Presentation Designer"]);
+    ).toEqual(["Guide", "Create Guide", "Automation Designer"]);
   });
 });
 

--- a/front/tests/lib/utils.test.ts
+++ b/front/tests/lib/utils.test.ts
@@ -112,6 +112,76 @@ describe("compareForAutocompleteSort", () => {
     expect(filterAndSortAutocompleteSkills(query)).toEqual(expected);
   });
 
+  test.each([
+    {
+      behavior: "an exact match ranks above a longer prefix match",
+      query: "guide",
+      betterMatch: "Guide",
+      worseMatch: "Guide Builder",
+    },
+    {
+      behavior:
+        "a prefix match ranks above a substring match even when it is later alphabetically",
+      query: "guide",
+      betterMatch: "Guide Builder",
+      worseMatch: "Create Guide",
+    },
+    {
+      behavior:
+        "a substring match ranks above a fuzzy match even when it is later alphabetically",
+      query: "guide",
+      betterMatch: "Product Guides",
+      worseMatch: "Generate Useful Insights for Data Export",
+    },
+    {
+      behavior:
+        "a fuzzy match ranks above a non-match even when it is later alphabetically",
+      query: "guide",
+      betterMatch: "Generate Useful Insights for Data Export",
+      worseMatch: "Automation Designer",
+    },
+    {
+      behavior: "two prefix matches are ordered alphabetically",
+      query: "guid",
+      betterMatch: "Guide Builder",
+      worseMatch: "Guideline Toolkit",
+    },
+    {
+      behavior: "two substring matches are ordered alphabetically",
+      query: "guide",
+      betterMatch: "Create Guide",
+      worseMatch: "Product Guides",
+    },
+    {
+      behavior: "two fuzzy matches are ordered alphabetically",
+      query: "guide",
+      betterMatch: "Generate Useful Insights for Data Export",
+      worseMatch: "Great User Interface Design Example",
+    },
+    {
+      behavior: "two non-matches are ordered alphabetically",
+      query: "guide",
+      betterMatch: "Automation Designer",
+      worseMatch: "Workflow Runner",
+    },
+    {
+      behavior: "a multi-word prefix ranks above the same substring",
+      query: "guide b",
+      betterMatch: "Guide Builder",
+      worseMatch: "Create Guide Builder",
+    },
+  ])("$behavior", ({ query, betterMatch, worseMatch }) => {
+    expect(
+      [worseMatch, betterMatch].toSorted((a, b) =>
+        compareForAutocompleteSort(query, a, b)
+      )
+    ).toEqual([betterMatch, worseMatch]);
+  });
+
+  test("treats candidates that differ only by case as equally relevant", () => {
+    expect(compareForAutocompleteSort("guide", "Guide", "GUIDE")).toBe(0);
+  });
+
   test("ranks matching candidates before non-matches in an unfiltered list", () => {
     expect(
       ["Automation Designer", "Create Guide", "Guide"].toSorted((a, b) =>


### PR DESCRIPTION
## Description

Skill results in the slash command dropdown could feel unpredictable because of the fuzzyness of the search + how weird this fuzzy search sometimes behaves (contiguous title matches were tied in the fuzzy ranking, leading them to fall back to alphabetical order, even when one title started with the query).

This PR adds a new type of ranking, more suited for this kind of auto-complete UIs, where expectations are slightly different than a search bar. Capability search now ranks title prefix matches before other fuzzy title matches.

Will iterate a bit here, starting with a simple version.

## Tests

- Added tests that describe the expected behavior in a large variety of cases.

## Risk

- Low, only changes the order of results in the search.

## Deploy Plan

- Deploy front.
