### PR TITLE
Filter overage requests history by decision, and search it by user

### DIFF
--- a/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
@@ -1,11 +1,63 @@
 import * as spendLimits from "@app/lib/metronome/alerts/spend_limits";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { MembershipUpgradeRequestResource } from "@app/lib/resources/membership_upgrade_request_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
-import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@app/lib/user_search/search"), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    searchAllUsers: vi.fn(
+      async ({
+        owner,
+        searchTerm,
+      }: {
+        owner: WorkspaceType;
+        searchTerm: string;
+      }) => {
+        const { memberships } =
+          await MembershipResource.getMembershipsForWorkspace({
+            workspace: owner,
+            includeUser: true,
+          });
+
+        const users = memberships
+          .map((m) => m.user)
+          .filter((u): u is NonNullable<typeof u> => u !== undefined);
+
+        const lowerSearchTerm = searchTerm.toLowerCase();
+        const filteredUsers = searchTerm.trim()
+          ? users.filter((user) => {
+              const email = user.email?.toLowerCase() || "";
+              const fullName =
+                `${user.firstName ?? ""} ${user.lastName ?? ""}`.toLowerCase();
+              return (
+                email.includes(lowerSearchTerm) ||
+                fullName.includes(lowerSearchTerm)
+              );
+            })
+          : users;
+
+        return new Ok({
+          users: filteredUsers.map((user) => ({
+            workspace_id: owner.sId,
+            user_id: user.sId,
+            email: user.email,
+            full_name: `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim(),
+            updated_at: user.updatedAt,
+          })),
+          total: filteredUsers.length,
+        });
+      }
+    ),
+  };
+});
+
+import { honoApp } from "@front-api/app";
 
 vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
   const actual = await vi.importActual<typeof spendLimits>(
@@ -501,6 +553,140 @@ describe("/api/w/[wId]/credits/upgrade-requests", () => {
       for (const id of secondPageIds) {
         expect(firstPageIds.has(id)).toBe(false);
       }
+    });
+
+    it("filters by decision", async () => {
+      const workspace = await creditPricedWorkspace();
+      const { user: approvedMember } = await createMemberRequest(workspace);
+      const { user: deniedMember } = await createMemberRequest(workspace);
+
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+      const { requests: pendingRequests } = await (
+        await honoApp.request(upgradeRequestsUrl(workspace.sId))
+      ).json();
+      const approvedRequestId = pendingRequests.find(
+        (r: { requester: { sId: string } }) =>
+          r.requester.sId === approvedMember.sId
+      ).sId;
+      const deniedRequestId = pendingRequests.find(
+        (r: { requester: { sId: string } }) =>
+          r.requester.sId === deniedMember.sId
+      ).sId;
+
+      await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}/${approvedRequestId}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "approved" }),
+        }
+      );
+      await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}/${deniedRequestId}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "denied" }),
+        }
+      );
+
+      const approvedResponse = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}?status=resolved&decision=approved`
+      );
+      const { requests: approvedRequests, total: approvedTotal } =
+        await approvedResponse.json();
+      expect(approvedTotal).toBe(1);
+      expect(approvedRequests).toHaveLength(1);
+      expect(approvedRequests[0].sId).toBe(approvedRequestId);
+
+      const deniedResponse = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}?status=resolved&decision=denied`
+      );
+      const { requests: deniedRequests, total: deniedTotal } =
+        await deniedResponse.json();
+      expect(deniedTotal).toBe(1);
+      expect(deniedRequests).toHaveLength(1);
+      expect(deniedRequests[0].sId).toBe(deniedRequestId);
+
+      const allResponse = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}?status=resolved`
+      );
+      expect((await allResponse.json()).total).toBe(2);
+    });
+
+    it("filters by requester name/email search", async () => {
+      const workspace = await creditPricedWorkspace();
+      const { user: matchingMember } = await createMemberRequest(workspace);
+      const { user: otherMember } = await createMemberRequest(workspace);
+
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+      const { requests: pendingRequests } = await (
+        await honoApp.request(upgradeRequestsUrl(workspace.sId))
+      ).json();
+      for (const request of pendingRequests) {
+        await honoApp.request(
+          `${upgradeRequestsUrl(workspace.sId)}/${request.sId}`,
+          {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ status: "denied" }),
+          }
+        );
+      }
+
+      const searchResponse = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}?status=resolved&search=${encodeURIComponent(matchingMember.email ?? "")}`
+      );
+      expect(searchResponse.status).toBe(200);
+      const { requests: searchResults, total: searchTotal } =
+        await searchResponse.json();
+      expect(searchTotal).toBe(1);
+      expect(searchResults).toHaveLength(1);
+      expect(searchResults[0].requester.sId).toBe(matchingMember.sId);
+      expect(
+        searchResults.some(
+          (r: { requester: { sId: string } }) =>
+            r.requester.sId === otherMember.sId
+        )
+      ).toBe(false);
+    });
+
+    it("returns an empty page when the search matches no requester", async () => {
+      const workspace = await creditPricedWorkspace();
+      await createMemberRequest(workspace);
+
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+      const { requests: pendingRequests } = await (
+        await honoApp.request(upgradeRequestsUrl(workspace.sId))
+      ).json();
+      await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}/${pendingRequests[0].sId}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "denied" }),
+        }
+      );
+
+      const searchResponse = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}?status=resolved&search=no-such-person`
+      );
+      expect(searchResponse.status).toBe(200);
+      const { requests, total } = await searchResponse.json();
+      expect(requests).toHaveLength(0);
+      expect(total).toBe(0);
     });
   });
 

--- a/front-api/routes/w/[wId]/credits/upgrade-requests.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.ts
@@ -54,10 +54,11 @@ const ResolveBodySchema = z
     }
   );
 
-// Omitted/"pending" preserves the requests queue behavior
 const ListUpgradeRequestsQuerySchema = z.object({
   status: z.union([z.literal("pending"), z.literal("resolved")]).optional(),
   offset: z.coerce.number().int().min(0).catch(0),
+  decision: z.union([z.literal("approved"), z.literal("denied")]).optional(),
+  search: z.string().optional(),
   format: z.union([z.literal("json"), z.literal("csv")]).optional(),
 });
 
@@ -119,12 +120,15 @@ app.get(
   validate("query", ListUpgradeRequestsQuerySchema),
   async (ctx) => {
     const auth = ctx.get("auth");
-    const { status, offset, format } = ctx.req.valid("query");
+    const { status, offset, decision, search, format } = ctx.req.valid("query");
 
     if (format === "csv") {
       // CSV export is only wired to the resolved-requests History tab; it
-      // always covers the full history.
-      const requests = await listAllResolvedUpgradeRequests(auth);
+      // always covers the full history matching the current filters.
+      const requests = await listAllResolvedUpgradeRequests(auth, {
+        decision,
+        search,
+      });
 
       ctx.header("Content-Type", "text/csv");
       ctx.header(
@@ -136,7 +140,7 @@ app.get(
 
     const { requests, total } =
       status === "resolved"
-        ? await listResolvedUpgradeRequests(auth, { offset })
+        ? await listResolvedUpgradeRequests(auth, { offset, decision, search })
         : {
             requests: await listPendingUpgradeRequests(auth),
             total: undefined,

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -74,6 +74,7 @@ import {
   useUserAllowedModelTiers,
   useWorkspaceAllowedModelTiers,
 } from "@app/lib/swr/model_tiers";
+import type { UpgradeRequestDecisionFilter } from "@app/lib/swr/upgrade_requests";
 import {
   UPGRADE_REQUESTS_HISTORY_PAGE_SIZE,
   upgradeRequestsHistoryCsvUrl,
@@ -185,6 +186,8 @@ export function UsagePage() {
     MembershipSeatType | "none" | null
   >(null);
   const [groupFilter, setGroupFilter] = useState<string | null>(null);
+  const [decisionFilter, setDecisionFilter] =
+    useState<UpgradeRequestDecisionFilter | null>(null);
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: DEFAULT_PAGE_SIZE,
@@ -215,11 +218,20 @@ export function UsagePage() {
     setPagination((prev) => ({ ...prev, pageIndex: 0 }));
   }, []);
 
-  // Name/email search is also applied server-side before pagination, so reset
-  // to the first page whenever the search term changes.
+  // The decision filter is applied server-side before pagination
+  const handleSetDecisionFilter = useCallback(
+    (next: UpgradeRequestDecisionFilter | null) => {
+      setDecisionFilter(next);
+      setHistoryPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    },
+    []
+  );
+
+  // Name/email search is also applied server-side before pagination
   const handleSetSearchTerm = useCallback((next: string) => {
     setSearchTerm(next);
     setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    setHistoryPagination((prev) => ({ ...prev, pageIndex: 0 }));
   }, []);
 
   const sort = sorting[0];
@@ -287,10 +299,15 @@ export function UsagePage() {
   } = useUpgradeRequestsHistory({
     workspaceId: owner.sId,
     pageIndex: historyPagination.pageIndex,
+    searchTerm,
+    decision: decisionFilter ?? undefined,
     disabled: membersTab !== "history",
   });
   const upgradeRequestsHistoryCsvDownload = useDownloadCsv({
-    url: upgradeRequestsHistoryCsvUrl(owner.sId),
+    url: upgradeRequestsHistoryCsvUrl(owner.sId, {
+      decision: decisionFilter ?? undefined,
+      search: searchTerm,
+    }),
     filename: `dust_upgrade_requests_history_${owner.sId}.csv`,
     disabled:
       isUpgradeRequestsHistoryLoading || upgradeRequestsHistory.length === 0,
@@ -951,6 +968,39 @@ export function UsagePage() {
     </DropdownMenu>
   );
 
+  const decisionFilterDropdown = (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          label={
+            decisionFilter === "approved"
+              ? "Approved"
+              : decisionFilter === "denied"
+                ? "Denied"
+                : "All decisions"
+          }
+          size="sm"
+          isSelect
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          label="All decisions"
+          onClick={() => handleSetDecisionFilter(null)}
+        />
+        <DropdownMenuItem
+          label="Approved"
+          onClick={() => handleSetDecisionFilter("approved")}
+        />
+        <DropdownMenuItem
+          label="Denied"
+          onClick={() => handleSetDecisionFilter("denied")}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+
   const groupsFilterDropdown = groups.length > 0 && (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -1196,10 +1246,13 @@ export function UsagePage() {
                     </div>
                   )}
                   {membersTab === "history" && (
-                    <CsvDownloadButton
-                      {...upgradeRequestsHistoryCsvDownload}
-                      label="Download to CSV"
-                    />
+                    <div className="flex flex-row items-center gap-2">
+                      {decisionFilterDropdown}
+                      <CsvDownloadButton
+                        {...upgradeRequestsHistoryCsvDownload}
+                        label="Download to CSV"
+                      />
+                    </div>
                   )}
                 </div>
                 <div className="flex flex-col gap-2 pt-2">

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -13,9 +13,13 @@ import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { MembershipUpgradeRequestResource } from "@app/lib/resources/membership_upgrade_request_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
 import type { UpgradeRequestResolution } from "@app/types/api/credits/upgrade_requests";
-import type { MembershipUpgradeRequestType } from "@app/types/memberships";
+import type {
+  MembershipUpgradeRequestStatus,
+  MembershipUpgradeRequestType,
+} from "@app/types/memberships";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -242,14 +246,50 @@ export async function listPendingUpgradeRequests(
 // Admin-only: resolved requests, for the history view, paginated.
 export const RESOLVED_UPGRADE_REQUESTS_HISTORY_PAGE_SIZE = 100;
 
+// The requester isn't joined in SQL so a name/email search
+// resolves matching users via the user search index first, then restricts the
+// resource query to their ids. Returns `null` when the search matched no one,
+// meaning callers should return an empty result rather than an unfiltered one.
+async function resolveSearchUserModelIds(
+  auth: Authenticator,
+  search: string | undefined
+): Promise<number[] | undefined | null> {
+  if (!search || search.trim().length === 0) {
+    return undefined;
+  }
+  const searchResult = await UserResource.searchAllUsers(auth, {
+    searchTerm: search.trim(),
+  });
+  if (searchResult.isErr()) {
+    throw searchResult.error;
+  }
+  const userModelIds = searchResult.value.users.map((u) => u.id);
+  return userModelIds.length === 0 ? null : userModelIds;
+}
+
 export async function listResolvedUpgradeRequests(
   auth: Authenticator,
-  { offset }: { offset: number }
+  {
+    offset,
+    decision,
+    search,
+  }: {
+    offset: number;
+    decision?: Exclude<MembershipUpgradeRequestStatus, "pending">;
+    search?: string;
+  }
 ): Promise<{ requests: MembershipUpgradeRequestType[]; total: number }> {
+  const userModelIds = await resolveSearchUserModelIds(auth, search);
+  if (userModelIds === null) {
+    return { requests: [], total: 0 };
+  }
+
   const { requests, total } =
     await MembershipUpgradeRequestResource.listResolvedByWorkspace(auth, {
       limit: RESOLVED_UPGRADE_REQUESTS_HISTORY_PAGE_SIZE,
       offset,
+      decision,
+      userModelIds,
     });
   return { requests: requests.map((r) => r.toJSON()), total };
 }
@@ -258,15 +298,32 @@ export async function listResolvedUpgradeRequests(
 // (not offset) pagination so a request resolved concurrently mid-export
 // can't shift page boundaries and cause a duplicated or omitted row.
 export async function listAllResolvedUpgradeRequests(
-  auth: Authenticator
+  auth: Authenticator,
+  {
+    decision,
+    search,
+  }: {
+    decision?: Exclude<MembershipUpgradeRequestStatus, "pending">;
+    search?: string;
+  } = {}
 ): Promise<MembershipUpgradeRequestType[]> {
+  const userModelIds = await resolveSearchUserModelIds(auth, search);
+  if (userModelIds === null) {
+    return [];
+  }
+
   const allRequests: MembershipUpgradeRequestType[] = [];
   let after: { resolvedAt: Date; id: ModelId } | null = null;
   while (true) {
     const requests =
       await MembershipUpgradeRequestResource.listResolvedByWorkspaceAfter(
         auth,
-        { limit: RESOLVED_UPGRADE_REQUESTS_HISTORY_PAGE_SIZE, after }
+        {
+          limit: RESOLVED_UPGRADE_REQUESTS_HISTORY_PAGE_SIZE,
+          after,
+          decision,
+          userModelIds,
+        }
       );
     allRequests.push(...requests.map((r) => r.toJSON()));
     if (requests.length < RESOLVED_UPGRADE_REQUESTS_HISTORY_PAGE_SIZE) {

--- a/front/lib/resources/membership_upgrade_request_resource.ts
+++ b/front/lib/resources/membership_upgrade_request_resource.ts
@@ -202,15 +202,28 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
     });
   }
 
-  // Resolved requests, most recent first
+  // Resolved requests, most recent first.
   static async listResolvedByWorkspace(
     auth: Authenticator,
-    { limit, offset }: { limit: number; offset: number }
+    {
+      limit,
+      offset,
+      decision,
+      userModelIds,
+    }: {
+      limit: number;
+      offset: number;
+      decision?: Exclude<MembershipUpgradeRequestStatus, "pending">;
+      userModelIds?: ModelId[];
+    }
   ): Promise<{ requests: MembershipUpgradeRequestResource[]; total: number }> {
     if (!auth.isManager()) {
       return { requests: [], total: 0 };
     }
-    const where = { status: { [Op.ne]: "pending" } };
+    const where = {
+      status: decision ?? { [Op.ne]: "pending" },
+      ...(userModelIds ? { userId: { [Op.in]: userModelIds } } : {}),
+    };
     const requests = await this.baseFetch(auth, {
       where,
       // `id` breaks ties between requests resolved at the same timestamp, so
@@ -234,27 +247,40 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
   // under a concurrent resolution (a newly resolved request is inserted at
   // the head, pushing every offset down), causing the caller to duplicate
   // or skip rows across pages; keyset pagination is immune to that because
-  // each page is bounded by the last row actually returned.
+  // each page is bounded by the last row actually returned. `decision` and
+  // `userModelIds` mirror the same filters as `listResolvedByWorkspace`, so
+  // the full-history export respects the History tab's decision filter and
+  // search bar.
   static async listResolvedByWorkspaceAfter(
     auth: Authenticator,
     {
       limit,
       after,
-    }: { limit: number; after: { resolvedAt: Date; id: ModelId } | null }
+      decision,
+      userModelIds,
+    }: {
+      limit: number;
+      after: { resolvedAt: Date; id: ModelId } | null;
+      decision?: Exclude<MembershipUpgradeRequestStatus, "pending">;
+      userModelIds?: ModelId[];
+    }
   ): Promise<MembershipUpgradeRequestResource[]> {
     if (!auth.isManager()) {
       return [];
     }
-    const statusFilter = { status: { [Op.ne]: "pending" } } as const;
+    const baseFilter = {
+      status: decision ?? { [Op.ne]: "pending" },
+      ...(userModelIds ? { userId: { [Op.in]: userModelIds } } : {}),
+    };
     const where = after
       ? {
-          ...statusFilter,
+          ...baseFilter,
           [Op.or]: [
             { resolvedAt: { [Op.lt]: after.resolvedAt } },
             { resolvedAt: after.resolvedAt, id: { [Op.lt]: after.id } },
           ],
         }
-      : statusFilter;
+      : baseFilter;
 
     return this.baseFetch(auth, {
       where,

--- a/front/lib/swr/upgrade_requests.ts
+++ b/front/lib/swr/upgrade_requests.ts
@@ -12,17 +12,36 @@ import type {
   PatchUpgradeRequestResponseBody,
   UpgradeRequestResolution,
 } from "@app/types/api/credits/upgrade_requests";
+import type { MembershipUpgradeRequestStatus } from "@app/types/memberships";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { Fetcher } from "swr";
+
+export type UpgradeRequestDecisionFilter = Exclude<
+  MembershipUpgradeRequestStatus,
+  "pending"
+>;
 
 function upgradeRequestsUrl(workspaceId: string): string {
   return `/api/w/${workspaceId}/credits/upgrade-requests`;
 }
 
-// CSV download link for the resolved-requests
-export function upgradeRequestsHistoryCsvUrl(workspaceId: string): string {
-  return `${upgradeRequestsUrl(workspaceId)}?format=csv`;
+// CSV download link for the resolved-requests, also apply filtering
+export function upgradeRequestsHistoryCsvUrl(
+  workspaceId: string,
+  {
+    decision,
+    search,
+  }: { decision?: UpgradeRequestDecisionFilter; search?: string } = {}
+): string {
+  const searchParams = new URLSearchParams({ format: "csv" });
+  if (decision) {
+    searchParams.set("decision", decision);
+  }
+  if (search && search.trim().length > 0) {
+    searchParams.set("search", search.trim());
+  }
+  return `${upgradeRequestsUrl(workspaceId)}?${searchParams.toString()}`;
 }
 
 function usageStatusUrl(workspaceId: string): string {
@@ -108,20 +127,42 @@ export const UPGRADE_REQUESTS_HISTORY_PAGE_SIZE = 100;
 export function useUpgradeRequestsHistory({
   workspaceId,
   pageIndex,
+  searchTerm = "",
+  decision,
   disabled,
 }: {
   workspaceId: string;
   pageIndex: number;
+  searchTerm?: string;
+  decision?: UpgradeRequestDecisionFilter;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const upgradeRequestsHistoryFetcher: Fetcher<GetUpgradeRequestsResponseBody> =
     fetcher;
 
+  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState(searchTerm);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedSearchTerm(searchTerm), 300);
+    return () => clearTimeout(id);
+  }, [searchTerm]);
+
   const offset = pageIndex * UPGRADE_REQUESTS_HISTORY_PAGE_SIZE;
 
+  const searchParams = new URLSearchParams({
+    status: "resolved",
+    offset: offset.toString(),
+  });
+  if (decision) {
+    searchParams.set("decision", decision);
+  }
+  if (debouncedSearchTerm.trim().length > 0) {
+    searchParams.set("search", debouncedSearchTerm.trim());
+  }
+
   const { data, error, mutate } = useSWRWithDefaults(
-    `${upgradeRequestsUrl(workspaceId)}?status=resolved&offset=${offset}`,
+    `${upgradeRequestsUrl(workspaceId)}?${searchParams.toString()}`,
     upgradeRequestsHistoryFetcher,
     { disabled, keepPreviousData: true }
   );


### PR DESCRIPTION
## Description
- The History tab (resolved upgrade/overage requests) can now be filtered by Decision (Approved / Denied), via a dropdown next to the CSV export button
- The shared search bar (already used to filter Members and Requests) now also filters the History tab by requester name/email, resolved server-side against the user search index and applied before pagination.
- The History CSV export now reflects the current decision filter and search term instead of always exporting the full resolved set.

## Deploy Plan
- Deploy front