### PR TITLE
feat: remove become builder from dev tools

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -24,12 +24,7 @@ import { isAgentMention } from "@app/types/assistant/mentions";
 import type { SubscriptionType } from "@app/types/plan";
 import { isDevelopment } from "@app/types/shared/env";
 import type { UserTypeWithWorkspaces, WorkspaceType } from "@app/types/user";
-import {
-  isOnlyAdmin,
-  isOnlyBuilder,
-  isOnlyManager,
-  isOnlyUser,
-} from "@app/types/user";
+import { isOnlyAdmin, isOnlyManager, isOnlyUser } from "@app/types/user";
 import { datadogLogs } from "@datadog/browser-logs";
 import {
   Avatar,
@@ -52,7 +47,6 @@ import {
   FirefoxLogo,
   Heart,
   Icon,
-  Lightbulb04,
   LogOut01,
   MessageChatCircle,
   MessagePlusCircle,
@@ -166,7 +160,7 @@ export function UserMenu({ user, owner, subscription }: UserMenuProps) {
     typeof navigator !== "undefined" && /firefox/i.test(navigator.userAgent);
 
   const forceRoleUpdate = useMemo(
-    () => async (role: "user" | "builder" | "admin" | "manager") => {
+    () => async (role: "user" | "admin" | "manager") => {
       const result = await forceUserRole(user, owner, role, featureFlags);
       if (result.isOk()) {
         sendNotification({
@@ -434,13 +428,6 @@ export function UserMenu({ user, owner, subscription }: UserMenuProps) {
                         label="Become Manager"
                         onClick={() => forceRoleUpdate("manager")}
                         icon={Star01}
-                      />
-                    )}
-                    {!isOnlyBuilder(owner) && (
-                      <DropdownMenuItem
-                        label="Become Builder"
-                        onClick={() => forceRoleUpdate("builder")}
-                        icon={Lightbulb04}
                       />
                     )}
                     {!isOnlyUser(owner) && (

--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -11,7 +11,7 @@ export function showDebugTools(flags: WhitelistableFeature[]) {
 export async function forceUserRole(
   user: UserType,
   owner: LightWorkspaceType,
-  role: "user" | "builder" | "admin" | "manager",
+  role: "user" | "admin" | "manager",
   featureFlags: WhitelistableFeature[]
 ) {
   // Ideally we should check if the user is dust super user but we don't have this information in the front-end

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -338,15 +338,6 @@ export function isOnlyUser(
   return owner.role === "user";
 }
 
-export function isOnlyBuilder(
-  owner: WorkspaceType | null
-): owner is WorkspaceType & { role: "builder" } {
-  if (!owner) {
-    return false;
-  }
-  return owner.role === "builder";
-}
-
 export function isOnlyAdmin(
   owner: WorkspaceType | null
 ): owner is WorkspaceType & { role: "admin" } {


### PR DESCRIPTION
## Description

This PR removes the "Become Builder" option from the developer tools in the user menu.

## Tests

Manually.

## Risks

Low.

## Deploy Plan

Standard deployment.