### PR TITLE
Use Input's built-in suffix prop in BulkEditSpendLimitModal

### DIFF
--- a/front/components/workspace/BulkEditSpendLimitModal.tsx
+++ b/front/components/workspace/BulkEditSpendLimitModal.tsx
@@ -150,30 +150,24 @@ function BulkEditSpendLimitForm({
 
           {kind === "override" && (
             <div className="flex flex-col gap-1.5 pl-6">
-              <div className="relative">
-                <Input
-                  id="bulk-spend-credit-limit-input"
-                  type="text"
-                  inputMode="numeric"
-                  pattern="[0-9]*"
-                  placeholder="1,000"
-                  value={
-                    creditsInput !== ""
-                      ? Number(creditsInput).toLocaleString()
-                      : ""
-                  }
-                  onChange={(e) => handleCreditsChange(e.target.value)}
-                  isError={validationMessage !== null}
-                  message={validationMessage ?? undefined}
-                  messageStatus={
-                    validationMessage !== null ? "error" : undefined
-                  }
-                  className="pr-28 text-right"
-                />
-                <span className="copy-sm pointer-events-none absolute right-3 top-0 flex h-9 items-center text-muted-foreground dark:text-muted-foreground-night">
-                  credits/month
-                </span>
-              </div>
+              <Input
+                id="bulk-spend-credit-limit-input"
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                placeholder="1,000"
+                value={
+                  creditsInput !== ""
+                    ? Number(creditsInput).toLocaleString()
+                    : ""
+                }
+                onChange={(e) => handleCreditsChange(e.target.value)}
+                isError={validationMessage !== null}
+                message={validationMessage ?? undefined}
+                messageStatus={validationMessage !== null ? "error" : undefined}
+                className="text-right"
+                suffix="credits/month"
+              />
             </div>
           )}
         </RadioGroup>


### PR DESCRIPTION
## Summary

Small follow-up, not part of the overage-admin-approval stack.

`BulkEditSpendLimitModal` hand-rolled a unit-label overlay (`relative` wrapper + absolutely-positioned `<span>` + `pr-28` padding hack) to show "credits/month" inside the amount input. Sparkle's `Input` component already has a built-in `suffix` prop for exactly this (a flanking unit/currency box), so this swaps the hack for that.

Prompted by [this review comment](https://github.com/dust-tt/dust/pull/29754#discussion_r3702285431) on #29754, which flagged the same pattern in `EditSpendLimitModal` (fixed there directly since it's in that stack) and noted the identical duplication here.

## Test plan

- [ ] Open the bulk edit spend limit modal, select "Use custom monthly limit", confirm the "credits/month" suffix renders correctly and the input still validates/formats as before