### PR TITLE
[front] enh: manage skill editors from info page

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/SkillInfoPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SkillInfoPage.tsx
@@ -70,7 +70,12 @@ export function SkillInfoPage({
             </TabsContent>
             <TabsContent value="editors">
               {hasRelations(skill) && (
-                <SkillEditorsTab skill={skill} owner={owner} user={user} />
+                <SkillEditorsTab
+                  key={skill.sId}
+                  skill={skill}
+                  owner={owner}
+                  user={user}
+                />
               )}
             </TabsContent>
           </div>

--- a/front/components/members/AddEditorsDropdown.tsx
+++ b/front/components/members/AddEditorsDropdown.tsx
@@ -1,0 +1,97 @@
+import type { SearchMemberWithWorkspaceType } from "@app/components/members/MemberSelectionTable";
+import { useSearchMembers } from "@app/lib/swr/memberships";
+import type { WorkspaceType } from "@app/types/user";
+import {
+  Avatar,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSearchbar,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { type ReactElement, useState } from "react";
+
+interface AddEditorDropdownProps {
+  owner: WorkspaceType;
+  editors: Array<{ sId: string }>;
+  onAddEditor: (editor: SearchMemberWithWorkspaceType) => void;
+  trigger: ReactElement;
+}
+
+export function AddEditorDropdown({
+  owner,
+  editors,
+  onAddEditor,
+  trigger,
+}: AddEditorDropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchText, setSearchText] = useState("");
+  const { members, isLoading } = useSearchMembers({
+    workspaceId: owner.sId,
+    searchTerm: searchText,
+    pageIndex: 0,
+    pageSize: 25,
+    disabled: !isOpen,
+  });
+
+  return (
+    <DropdownMenu
+      open={isOpen}
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        if (!open) {
+          setSearchText("");
+        }
+      }}
+    >
+      <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="w-80"
+        align="end"
+        dropdownHeaders={
+          <>
+            <DropdownMenuSearchbar
+              name="search-editors"
+              placeholder="Search members"
+              value={searchText}
+              onChange={setSearchText}
+            />
+            <DropdownMenuSeparator />
+          </>
+        }
+      >
+        {isLoading ? (
+          <div className="flex h-24 items-center justify-center">
+            <Spinner size="sm" />
+          </div>
+        ) : members.length > 0 ? (
+          members.map((member) => (
+            <DropdownMenuItem
+              key={member.sId}
+              label={member.fullName}
+              description={member.email}
+              icon={() => (
+                <Avatar
+                  name={member.fullName}
+                  visual={member.image ?? undefined}
+                  size="sm"
+                  isRounded
+                />
+              )}
+              truncateText
+              disabled={editors.some((editor) => editor.sId === member.sId)}
+              onClick={() => onAddEditor(member)}
+              onSelect={(event) => event.preventDefault()}
+            />
+          ))
+        ) : (
+          <div className="flex h-24 items-center justify-center text-sm text-muted-foreground">
+            No members found
+          </div>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/front/components/skills/SkillEditorsTab.tsx
+++ b/front/components/skills/SkillEditorsTab.tsx
@@ -73,23 +73,9 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
 
   return (
     <div className="flex flex-col gap-4">
-      <MembersList
-        currentUser={user}
-        membersData={{
-          members: editors.map((user) => ({
-            ...user,
-            workspace: owner,
-          })),
-          isLoading: isEditorsLoading,
-          totalMembersCount: editors.length,
-          mutateRegardlessOfQueryParams: () => Promise.resolve(undefined),
-        }}
-        showColumns={skill.canAdministrate ? ["name", "remove"] : ["name"]}
-        onRemoveMemberClick={onRemoveMember}
-        onRowClick={function noRefCheck() {}}
-      />
-      {skill.canAdministrate && (
-        <div>
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold">Editors</h3>
+        {skill.canAdministrate && (
           <DropdownMenu
             open={isEditorPickerOpen}
             onOpenChange={(open) => {
@@ -104,7 +90,7 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
                 variant="outline"
                 size="sm"
                 icon={Plus}
-                label="Add editors"
+                label="Add editor"
                 disabled={isEditorsLoading || isEditorsError}
                 isLoading={isAddingEditor}
                 type="button"
@@ -112,7 +98,7 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
             </DropdownMenuTrigger>
             <DropdownMenuContent
               className="w-80"
-              align="start"
+              align="end"
               dropdownHeaders={
                 <>
                   <DropdownMenuSearchbar
@@ -155,8 +141,23 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
               )}
             </DropdownMenuContent>
           </DropdownMenu>
-        </div>
-      )}
+        )}
+      </div>
+      <MembersList
+        currentUser={user}
+        membersData={{
+          members: editors.map((user) => ({
+            ...user,
+            workspace: owner,
+          })),
+          isLoading: isEditorsLoading,
+          totalMembersCount: editors.length,
+          mutateRegardlessOfQueryParams: () => Promise.resolve(undefined),
+        }}
+        showColumns={skill.canAdministrate ? ["name", "remove"] : ["name"]}
+        onRemoveMemberClick={onRemoveMember}
+        onRowClick={function noRefCheck() {}}
+      />
     </div>
   );
 }

--- a/front/components/skills/SkillEditorsTab.tsx
+++ b/front/components/skills/SkillEditorsTab.tsx
@@ -1,7 +1,6 @@
-import { ManageUsersPanel } from "@app/components/assistant/conversation/space/ManageUsersPanel";
-import type {
-  SearchMemberType,
-  SearchMemberWithWorkspaceType,
+import {
+  MemberSelectionTable,
+  type SearchMemberWithWorkspaceType,
 } from "@app/components/members/MemberSelectionTable";
 import { MembersList } from "@app/components/members/MembersList";
 import {
@@ -20,7 +19,11 @@ type AgentEditorsTabProps = {
 };
 
 export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
-  const [isManageEditorsOpen, setIsManageEditorsOpen] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [selectedEditorIds, setSelectedEditorIds] = useState<Set<string>>(
+    new Set()
+  );
   const updateEditors = useUpdateSkillEditors({
     owner,
     skillId: skill.sId,
@@ -33,28 +36,71 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
   const isCurrentUserEditor =
     editors.findIndex((u) => u.sId === user.sId) !== -1;
 
+  const currentEditorIds = new Set(editors.map((editor) => editor.sId));
+  const addEditorIds = Array.from(selectedEditorIds).filter(
+    (editorId) => !currentEditorIds.has(editorId)
+  );
+  const removeEditorIds = Array.from(currentEditorIds).filter(
+    (editorId) => !selectedEditorIds.has(editorId)
+  );
+  const hasEditorChanges =
+    addEditorIds.length > 0 || removeEditorIds.length > 0;
+
   const onRemoveMember = async (user: SearchMemberWithWorkspaceType) => {
     if (isCurrentUserEditor) {
       await updateEditors({ removeEditorIds: [user.sId], addEditorIds: [] });
     }
   };
 
-  const onEditorsChange = async (newEditors: SearchMemberType[]) => {
-    const currentEditorIds = new Set(editors.map((editor) => editor.sId));
-    const newEditorIds = new Set(newEditors.map((editor) => editor.sId));
-    const addEditorIds = Array.from(newEditorIds).filter(
-      (editorId) => !currentEditorIds.has(editorId)
-    );
-    const removeEditorIds = Array.from(currentEditorIds).filter(
-      (editorId) => !newEditorIds.has(editorId)
-    );
-
-    if (addEditorIds.length === 0 && removeEditorIds.length === 0) {
+  const onSaveEditors = async () => {
+    if (!hasEditorChanges || isSaving) {
       return;
     }
 
-    await updateEditors({ addEditorIds, removeEditorIds });
+    setIsSaving(true);
+    try {
+      const didUpdate = await updateEditors({ addEditorIds, removeEditorIds });
+      if (didUpdate) {
+        setIsEditing(false);
+      }
+    } finally {
+      setIsSaving(false);
+    }
   };
+
+  if (skill.canAdministrate && isEditing) {
+    return (
+      <div className="flex flex-col gap-4">
+        <MemberSelectionTable
+          owner={owner}
+          selectedMemberIds={selectedEditorIds}
+          onSelectionChange={(editorIds) => {
+            setSelectedEditorIds(editorIds);
+          }}
+          initialMembers={editors}
+        />
+        <div className="flex justify-end gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            label="Cancel"
+            disabled={isSaving}
+            onClick={() => setIsEditing(false)}
+            type="button"
+          />
+          <Button
+            variant="highlight"
+            size="sm"
+            label="Save"
+            disabled={!hasEditorChanges || isSaving}
+            isLoading={isSaving}
+            onClick={onSaveEditors}
+            type="button"
+          />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-4">
@@ -66,16 +112,13 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
             icon={Users01}
             label="Manage editors"
             disabled={isEditorsLoading || isEditorsError}
-            onClick={() => setIsManageEditorsOpen(true)}
+            onClick={() => {
+              setSelectedEditorIds(
+                new Set(editors.map((editor) => editor.sId))
+              );
+              setIsEditing(true);
+            }}
             type="button"
-          />
-          <ManageUsersPanel
-            isOpen={isManageEditorsOpen}
-            setIsOpen={setIsManageEditorsOpen}
-            owner={owner}
-            mode="editors-only"
-            editors={editors}
-            onEditorsChange={onEditorsChange}
           />
         </div>
       )}

--- a/front/components/skills/SkillEditorsTab.tsx
+++ b/front/components/skills/SkillEditorsTab.tsx
@@ -1,25 +1,24 @@
+import { AddEditorDropdown } from "@app/components/members/AddEditorsDropdown";
 import type { SearchMemberWithWorkspaceType } from "@app/components/members/MemberSelectionTable";
 import { MembersList } from "@app/components/members/MembersList";
-import { useSearchMembers } from "@app/lib/swr/memberships";
 import {
   useSkillEditors,
   useUpdateSkillEditors,
 } from "@app/lib/swr/skill_editors";
 import type { SkillWithRelationsType } from "@app/types/assistant/skill_configuration";
+import { editorUserSchema } from "@app/types/editors";
 import type { UserType, WorkspaceType } from "@app/types/user";
-import {
-  Avatar,
-  Button,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSearchbar,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-  Plus,
-  Spinner,
-} from "@dust-tt/sparkle";
-import { useState } from "react";
+import { Button, Plus } from "@dust-tt/sparkle";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMemo } from "react";
+import { useController, useForm } from "react-hook-form";
+import { z } from "zod";
+
+const editorsFormSchema = z.object({
+  editors: z.array(editorUserSchema),
+});
+
+type EditorsFormData = z.infer<typeof editorsFormSchema>;
 
 type AgentEditorsTabProps = {
   owner: WorkspaceType;
@@ -28,15 +27,6 @@ type AgentEditorsTabProps = {
 };
 
 export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
-  const [isEditorPickerOpen, setIsEditorPickerOpen] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
-  const [searchText, setSearchText] = useState("");
-  const [addedEditors, setAddedEditors] = useState<
-    SearchMemberWithWorkspaceType[]
-  >([]);
-  const [removedEditorIds, setRemovedEditorIds] = useState<Set<string>>(
-    new Set()
-  );
   const updateEditors = useUpdateSkillEditors({
     owner,
     skillId: skill.sId,
@@ -45,167 +35,99 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
     owner,
     skillId: skill.sId,
   });
-  const { members: workspaceMembers, isLoading: areWorkspaceMembersLoading } =
-    useSearchMembers({
-      workspaceId: owner.sId,
-      searchTerm: searchText,
-      pageIndex: 0,
-      pageSize: 25,
-      disabled: !isEditorPickerOpen,
-    });
 
+  const formValues = useMemo<EditorsFormData>(() => ({ editors }), [editors]);
+  const form = useForm<EditorsFormData>({
+    defaultValues: { editors: [] },
+    values: formValues,
+    resetOptions: { keepDirtyValues: true },
+    resolver: zodResolver(editorsFormSchema),
+  });
+  const { field: editorsField } = useController({
+    control: form.control,
+    name: "editors",
+  });
+  const selectedEditors = editorsField.value;
   const persistedEditorIds = new Set(editors.map((editor) => editor.sId));
-  const addedEditorIds = new Set(addedEditors.map((editor) => editor.sId));
-  const visibleEditors = [
-    ...editors.filter((editor) => !removedEditorIds.has(editor.sId)),
-    ...addedEditors.filter((editor) => !persistedEditorIds.has(editor.sId)),
-  ];
-  const visibleEditorIds = new Set(visibleEditors.map((editor) => editor.sId));
-  const addEditorIds = addedEditors
-    .map((editor) => editor.sId)
-    .filter((editorId) => !persistedEditorIds.has(editorId));
-  const removeEditorIds = Array.from(removedEditorIds).filter((editorId) =>
-    persistedEditorIds.has(editorId)
-  );
-  const hasChanges = addEditorIds.length > 0 || removeEditorIds.length > 0;
+  const hasChanges =
+    editors.length !== selectedEditors.length ||
+    selectedEditors.some((editor) => !persistedEditorIds.has(editor.sId));
 
   const onRemoveMember = (user: SearchMemberWithWorkspaceType) => {
-    if (!skill.canAdministrate || isSaving) {
+    if (!skill.canAdministrate || form.formState.isSubmitting) {
       return;
     }
 
-    if (addedEditorIds.has(user.sId)) {
-      setAddedEditors((current) =>
-        current.filter((editor) => editor.sId !== user.sId)
-      );
-      return;
-    }
-
-    setRemovedEditorIds((current) => new Set(current).add(user.sId));
+    editorsField.onChange(
+      selectedEditors.filter((editor) => editor.sId !== user.sId)
+    );
   };
 
   const onAddEditor = (editor: SearchMemberWithWorkspaceType) => {
-    if (isSaving || visibleEditorIds.has(editor.sId)) {
+    if (
+      form.formState.isSubmitting ||
+      selectedEditors.some((selected) => selected.sId === editor.sId)
+    ) {
       return;
     }
 
-    if (persistedEditorIds.has(editor.sId)) {
-      setRemovedEditorIds((current) => {
-        const next = new Set(current);
-        next.delete(editor.sId);
-        return next;
-      });
+    editorsField.onChange([...selectedEditors, editor]);
+  };
+
+  const onSave = form.handleSubmit(async ({ editors: nextEditors }) => {
+    if (!hasChanges) {
       return;
     }
 
-    setAddedEditors((current) => [...current, editor]);
-  };
-
-  const resetChanges = () => {
-    setAddedEditors([]);
-    setRemovedEditorIds(new Set());
-  };
-
-  const onSave = async () => {
-    if (!hasChanges || isSaving) {
-      return;
+    const nextEditorIds = new Set(nextEditors.map((editor) => editor.sId));
+    const didUpdate = await updateEditors({
+      addEditorIds: nextEditors
+        .filter((editor) => !persistedEditorIds.has(editor.sId))
+        .map((editor) => editor.sId),
+      removeEditorIds: editors
+        .filter((editor) => !nextEditorIds.has(editor.sId))
+        .map((editor) => editor.sId),
+    });
+    if (didUpdate) {
+      form.reset({ editors: nextEditors });
     }
-
-    setIsSaving(true);
-    try {
-      const didUpdate = await updateEditors({
-        addEditorIds,
-        removeEditorIds,
-      });
-      if (didUpdate) {
-        resetChanges();
-      }
-    } finally {
-      setIsSaving(false);
-    }
-  };
+  });
 
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-semibold">Editors</h3>
         {skill.canAdministrate && (
-          <DropdownMenu
-            open={isEditorPickerOpen}
-            onOpenChange={(open) => {
-              setIsEditorPickerOpen(open);
-              if (!open) {
-                setSearchText("");
-              }
-            }}
-          >
-            <DropdownMenuTrigger asChild>
+          <AddEditorDropdown
+            owner={owner}
+            editors={selectedEditors}
+            onAddEditor={onAddEditor}
+            trigger={
               <Button
                 variant="outline"
                 size="sm"
                 icon={Plus}
                 label="Add editors"
-                disabled={isEditorsLoading || isEditorsError || isSaving}
+                disabled={
+                  isEditorsLoading ||
+                  isEditorsError ||
+                  form.formState.isSubmitting
+                }
                 type="button"
               />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              className="w-80"
-              align="end"
-              dropdownHeaders={
-                <>
-                  <DropdownMenuSearchbar
-                    name="search-editors"
-                    placeholder="Search members"
-                    value={searchText}
-                    onChange={setSearchText}
-                  />
-                  <DropdownMenuSeparator />
-                </>
-              }
-            >
-              {areWorkspaceMembersLoading ? (
-                <div className="flex h-24 items-center justify-center">
-                  <Spinner size="sm" />
-                </div>
-              ) : workspaceMembers.length > 0 ? (
-                workspaceMembers.map((member) => (
-                  <DropdownMenuItem
-                    key={member.sId}
-                    label={member.fullName}
-                    description={member.email}
-                    icon={() => (
-                      <Avatar
-                        name={member.fullName}
-                        visual={member.image ?? undefined}
-                        size="sm"
-                        isRounded
-                      />
-                    )}
-                    truncateText
-                    disabled={visibleEditorIds.has(member.sId) || isSaving}
-                    onClick={() => onAddEditor(member)}
-                    onSelect={(event) => event.preventDefault()}
-                  />
-                ))
-              ) : (
-                <div className="flex h-24 items-center justify-center text-sm text-muted-foreground">
-                  No members found
-                </div>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
+            }
+          />
         )}
       </div>
       <MembersList
         currentUser={user}
         membersData={{
-          members: visibleEditors.map((user) => ({
+          members: selectedEditors.map((user) => ({
             ...user,
             workspace: owner,
           })),
           isLoading: isEditorsLoading,
-          totalMembersCount: visibleEditors.length,
+          totalMembersCount: selectedEditors.length,
           mutateRegardlessOfQueryParams: () => Promise.resolve(undefined),
         }}
         showColumns={skill.canAdministrate ? ["name", "remove"] : ["name"]}
@@ -218,16 +140,16 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
             variant="outline"
             size="sm"
             label="Cancel"
-            disabled={!hasChanges || isSaving}
-            onClick={resetChanges}
+            disabled={!hasChanges || form.formState.isSubmitting}
+            onClick={() => form.reset(formValues)}
             type="button"
           />
           <Button
             variant="highlight"
             size="sm"
             label="Save"
-            disabled={!hasChanges || isSaving}
-            isLoading={isSaving}
+            disabled={!hasChanges || form.formState.isSubmitting}
+            isLoading={form.formState.isSubmitting}
             onClick={onSave}
             type="button"
           />

--- a/front/components/skills/SkillEditorsTab.tsx
+++ b/front/components/skills/SkillEditorsTab.tsx
@@ -29,8 +29,14 @@ type AgentEditorsTabProps = {
 
 export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
   const [isEditorPickerOpen, setIsEditorPickerOpen] = useState(false);
-  const [isAddingEditor, setIsAddingEditor] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   const [searchText, setSearchText] = useState("");
+  const [addedEditors, setAddedEditors] = useState<
+    SearchMemberWithWorkspaceType[]
+  >([]);
+  const [removedEditorIds, setRemovedEditorIds] = useState<Set<string>>(
+    new Set()
+  );
   const updateEditors = useUpdateSkillEditors({
     owner,
     skillId: skill.sId,
@@ -48,26 +54,74 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
       disabled: !isEditorPickerOpen,
     });
 
-  const editorIds = new Set(editors.map((editor) => editor.sId));
+  const persistedEditorIds = new Set(editors.map((editor) => editor.sId));
+  const addedEditorIds = new Set(addedEditors.map((editor) => editor.sId));
+  const visibleEditors = [
+    ...editors.filter((editor) => !removedEditorIds.has(editor.sId)),
+    ...addedEditors.filter((editor) => !persistedEditorIds.has(editor.sId)),
+  ];
+  const visibleEditorIds = new Set(visibleEditors.map((editor) => editor.sId));
+  const addEditorIds = addedEditors
+    .map((editor) => editor.sId)
+    .filter((editorId) => !persistedEditorIds.has(editorId));
+  const removeEditorIds = Array.from(removedEditorIds).filter((editorId) =>
+    persistedEditorIds.has(editorId)
+  );
+  const hasChanges = addEditorIds.length > 0 || removeEditorIds.length > 0;
 
-  const onRemoveMember = async (user: SearchMemberWithWorkspaceType) => {
-    if (skill.canAdministrate) {
-      await updateEditors({ removeEditorIds: [user.sId], addEditorIds: [] });
-    }
-  };
-
-  const onAddEditor = async (editorId: string) => {
-    if (isAddingEditor || editorIds.has(editorId)) {
+  const onRemoveMember = (user: SearchMemberWithWorkspaceType) => {
+    if (!skill.canAdministrate || isSaving) {
       return;
     }
 
-    setIsEditorPickerOpen(false);
-    setSearchText("");
-    setIsAddingEditor(true);
+    if (addedEditorIds.has(user.sId)) {
+      setAddedEditors((current) =>
+        current.filter((editor) => editor.sId !== user.sId)
+      );
+      return;
+    }
+
+    setRemovedEditorIds((current) => new Set(current).add(user.sId));
+  };
+
+  const onAddEditor = (editor: SearchMemberWithWorkspaceType) => {
+    if (isSaving || visibleEditorIds.has(editor.sId)) {
+      return;
+    }
+
+    if (persistedEditorIds.has(editor.sId)) {
+      setRemovedEditorIds((current) => {
+        const next = new Set(current);
+        next.delete(editor.sId);
+        return next;
+      });
+      return;
+    }
+
+    setAddedEditors((current) => [...current, editor]);
+  };
+
+  const resetChanges = () => {
+    setAddedEditors([]);
+    setRemovedEditorIds(new Set());
+  };
+
+  const onSave = async () => {
+    if (!hasChanges || isSaving) {
+      return;
+    }
+
+    setIsSaving(true);
     try {
-      await updateEditors({ addEditorIds: [editorId], removeEditorIds: [] });
+      const didUpdate = await updateEditors({
+        addEditorIds,
+        removeEditorIds,
+      });
+      if (didUpdate) {
+        resetChanges();
+      }
     } finally {
-      setIsAddingEditor(false);
+      setIsSaving(false);
     }
   };
 
@@ -90,9 +144,8 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
                 variant="outline"
                 size="sm"
                 icon={Plus}
-                label="Add editor"
-                disabled={isEditorsLoading || isEditorsError}
-                isLoading={isAddingEditor}
+                label="Add editors"
+                disabled={isEditorsLoading || isEditorsError || isSaving}
                 type="button"
               />
             </DropdownMenuTrigger>
@@ -130,8 +183,9 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
                       />
                     )}
                     truncateText
-                    disabled={editorIds.has(member.sId)}
-                    onClick={() => void onAddEditor(member.sId)}
+                    disabled={visibleEditorIds.has(member.sId) || isSaving}
+                    onClick={() => onAddEditor(member)}
+                    onSelect={(event) => event.preventDefault()}
                   />
                 ))
               ) : (
@@ -146,18 +200,39 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
       <MembersList
         currentUser={user}
         membersData={{
-          members: editors.map((user) => ({
+          members: visibleEditors.map((user) => ({
             ...user,
             workspace: owner,
           })),
           isLoading: isEditorsLoading,
-          totalMembersCount: editors.length,
+          totalMembersCount: visibleEditors.length,
           mutateRegardlessOfQueryParams: () => Promise.resolve(undefined),
         }}
         showColumns={skill.canAdministrate ? ["name", "remove"] : ["name"]}
         onRemoveMemberClick={onRemoveMember}
         onRowClick={function noRefCheck() {}}
       />
+      {skill.canAdministrate && (
+        <div className="flex justify-end gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            label="Cancel"
+            disabled={!hasChanges || isSaving}
+            onClick={resetChanges}
+            type="button"
+          />
+          <Button
+            variant="highlight"
+            size="sm"
+            label="Save"
+            disabled={!hasChanges || isSaving}
+            isLoading={isSaving}
+            onClick={onSave}
+            type="button"
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/front/components/skills/SkillEditorsTab.tsx
+++ b/front/components/skills/SkillEditorsTab.tsx
@@ -130,7 +130,7 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
           totalMembersCount: selectedEditors.length,
           mutateRegardlessOfQueryParams: () => Promise.resolve(undefined),
         }}
-        showColumns={skill.canAdministrate ? ["name", "remove"] : ["name"]}
+        showColumns={["name", "remove"]}
         onRemoveMemberClick={onRemoveMember}
         onRowClick={function noRefCheck() {}}
       />

--- a/front/components/skills/SkillEditorsTab.tsx
+++ b/front/components/skills/SkillEditorsTab.tsx
@@ -130,7 +130,7 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
           totalMembersCount: selectedEditors.length,
           mutateRegardlessOfQueryParams: () => Promise.resolve(undefined),
         }}
-        showColumns={["name", "remove"]}
+        showColumns={skill.canAdministrate ? ["name", "remove"] : ["name"]}
         onRemoveMemberClick={onRemoveMember}
         onRowClick={function noRefCheck() {}}
       />

--- a/front/components/skills/SkillEditorsTab.tsx
+++ b/front/components/skills/SkillEditorsTab.tsx
@@ -1,4 +1,8 @@
-import type { SearchMemberWithWorkspaceType } from "@app/components/members/MemberSelectionTable";
+import { ManageUsersPanel } from "@app/components/assistant/conversation/space/ManageUsersPanel";
+import type {
+  SearchMemberType,
+  SearchMemberWithWorkspaceType,
+} from "@app/components/members/MemberSelectionTable";
 import { MembersList } from "@app/components/members/MembersList";
 import {
   useSkillEditors,
@@ -6,6 +10,8 @@ import {
 } from "@app/lib/swr/skill_editors";
 import type { SkillWithRelationsType } from "@app/types/assistant/skill_configuration";
 import type { UserType, WorkspaceType } from "@app/types/user";
+import { Button, Users01 } from "@dust-tt/sparkle";
+import { useState } from "react";
 
 type AgentEditorsTabProps = {
   owner: WorkspaceType;
@@ -14,11 +20,12 @@ type AgentEditorsTabProps = {
 };
 
 export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
+  const [isManageEditorsOpen, setIsManageEditorsOpen] = useState(false);
   const updateEditors = useUpdateSkillEditors({
     owner,
     skillId: skill.sId,
   });
-  const { editors, isEditorsLoading } = useSkillEditors({
+  const { editors, isEditorsLoading, isEditorsError } = useSkillEditors({
     owner,
     skillId: skill.sId,
   });
@@ -32,8 +39,46 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
     }
   };
 
+  const onEditorsChange = async (newEditors: SearchMemberType[]) => {
+    const currentEditorIds = new Set(editors.map((editor) => editor.sId));
+    const newEditorIds = new Set(newEditors.map((editor) => editor.sId));
+    const addEditorIds = Array.from(newEditorIds).filter(
+      (editorId) => !currentEditorIds.has(editorId)
+    );
+    const removeEditorIds = Array.from(currentEditorIds).filter(
+      (editorId) => !newEditorIds.has(editorId)
+    );
+
+    if (addEditorIds.length === 0 && removeEditorIds.length === 0) {
+      return;
+    }
+
+    await updateEditors({ addEditorIds, removeEditorIds });
+  };
+
   return (
     <div className="flex flex-col gap-4">
+      {skill.canAdministrate && (
+        <div>
+          <Button
+            variant="outline"
+            size="sm"
+            icon={Users01}
+            label="Manage editors"
+            disabled={isEditorsLoading || isEditorsError}
+            onClick={() => setIsManageEditorsOpen(true)}
+            type="button"
+          />
+          <ManageUsersPanel
+            isOpen={isManageEditorsOpen}
+            setIsOpen={setIsManageEditorsOpen}
+            owner={owner}
+            mode="editors-only"
+            editors={editors}
+            onEditorsChange={onEditorsChange}
+          />
+        </div>
+      )}
       <MembersList
         currentUser={user}
         membersData={{

--- a/front/components/skills/SkillEditorsTab.tsx
+++ b/front/components/skills/SkillEditorsTab.tsx
@@ -1,15 +1,24 @@
-import {
-  MemberSelectionTable,
-  type SearchMemberWithWorkspaceType,
-} from "@app/components/members/MemberSelectionTable";
+import type { SearchMemberWithWorkspaceType } from "@app/components/members/MemberSelectionTable";
 import { MembersList } from "@app/components/members/MembersList";
+import { useSearchMembers } from "@app/lib/swr/memberships";
 import {
   useSkillEditors,
   useUpdateSkillEditors,
 } from "@app/lib/swr/skill_editors";
 import type { SkillWithRelationsType } from "@app/types/assistant/skill_configuration";
 import type { UserType, WorkspaceType } from "@app/types/user";
-import { Button, Users01 } from "@dust-tt/sparkle";
+import {
+  Avatar,
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSearchbar,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Plus,
+  Spinner,
+} from "@dust-tt/sparkle";
 import { useState } from "react";
 
 type AgentEditorsTabProps = {
@@ -19,11 +28,9 @@ type AgentEditorsTabProps = {
 };
 
 export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
-  const [isEditing, setIsEditing] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
-  const [selectedEditorIds, setSelectedEditorIds] = useState<Set<string>>(
-    new Set()
-  );
+  const [isEditorPickerOpen, setIsEditorPickerOpen] = useState(false);
+  const [isAddingEditor, setIsAddingEditor] = useState(false);
+  const [searchText, setSearchText] = useState("");
   const updateEditors = useUpdateSkillEditors({
     owner,
     skillId: skill.sId,
@@ -32,96 +39,40 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
     owner,
     skillId: skill.sId,
   });
+  const { members: workspaceMembers, isLoading: areWorkspaceMembersLoading } =
+    useSearchMembers({
+      workspaceId: owner.sId,
+      searchTerm: searchText,
+      pageIndex: 0,
+      pageSize: 25,
+      disabled: !isEditorPickerOpen,
+    });
 
-  const isCurrentUserEditor =
-    editors.findIndex((u) => u.sId === user.sId) !== -1;
-
-  const currentEditorIds = new Set(editors.map((editor) => editor.sId));
-  const addEditorIds = Array.from(selectedEditorIds).filter(
-    (editorId) => !currentEditorIds.has(editorId)
-  );
-  const removeEditorIds = Array.from(currentEditorIds).filter(
-    (editorId) => !selectedEditorIds.has(editorId)
-  );
-  const hasEditorChanges =
-    addEditorIds.length > 0 || removeEditorIds.length > 0;
+  const editorIds = new Set(editors.map((editor) => editor.sId));
 
   const onRemoveMember = async (user: SearchMemberWithWorkspaceType) => {
-    if (isCurrentUserEditor) {
+    if (skill.canAdministrate) {
       await updateEditors({ removeEditorIds: [user.sId], addEditorIds: [] });
     }
   };
 
-  const onSaveEditors = async () => {
-    if (!hasEditorChanges || isSaving) {
+  const onAddEditor = async (editorId: string) => {
+    if (isAddingEditor || editorIds.has(editorId)) {
       return;
     }
 
-    setIsSaving(true);
+    setIsEditorPickerOpen(false);
+    setSearchText("");
+    setIsAddingEditor(true);
     try {
-      const didUpdate = await updateEditors({ addEditorIds, removeEditorIds });
-      if (didUpdate) {
-        setIsEditing(false);
-      }
+      await updateEditors({ addEditorIds: [editorId], removeEditorIds: [] });
     } finally {
-      setIsSaving(false);
+      setIsAddingEditor(false);
     }
   };
 
-  if (skill.canAdministrate && isEditing) {
-    return (
-      <div className="flex flex-col gap-4">
-        <MemberSelectionTable
-          owner={owner}
-          selectedMemberIds={selectedEditorIds}
-          onSelectionChange={(editorIds) => {
-            setSelectedEditorIds(editorIds);
-          }}
-          initialMembers={editors}
-        />
-        <div className="flex justify-end gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            label="Cancel"
-            disabled={isSaving}
-            onClick={() => setIsEditing(false)}
-            type="button"
-          />
-          <Button
-            variant="highlight"
-            size="sm"
-            label="Save"
-            disabled={!hasEditorChanges || isSaving}
-            isLoading={isSaving}
-            onClick={onSaveEditors}
-            type="button"
-          />
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="flex flex-col gap-4">
-      {skill.canAdministrate && (
-        <div>
-          <Button
-            variant="outline"
-            size="sm"
-            icon={Users01}
-            label="Manage editors"
-            disabled={isEditorsLoading || isEditorsError}
-            onClick={() => {
-              setSelectedEditorIds(
-                new Set(editors.map((editor) => editor.sId))
-              );
-              setIsEditing(true);
-            }}
-            type="button"
-          />
-        </div>
-      )}
       <MembersList
         currentUser={user}
         membersData={{
@@ -133,10 +84,79 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
           totalMembersCount: editors.length,
           mutateRegardlessOfQueryParams: () => Promise.resolve(undefined),
         }}
-        showColumns={isCurrentUserEditor ? ["name", "remove"] : ["name"]}
+        showColumns={skill.canAdministrate ? ["name", "remove"] : ["name"]}
         onRemoveMemberClick={onRemoveMember}
         onRowClick={function noRefCheck() {}}
       />
+      {skill.canAdministrate && (
+        <div>
+          <DropdownMenu
+            open={isEditorPickerOpen}
+            onOpenChange={(open) => {
+              setIsEditorPickerOpen(open);
+              if (!open) {
+                setSearchText("");
+              }
+            }}
+          >
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                icon={Plus}
+                label="Add editors"
+                disabled={isEditorsLoading || isEditorsError}
+                isLoading={isAddingEditor}
+                type="button"
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              className="w-80"
+              align="start"
+              dropdownHeaders={
+                <>
+                  <DropdownMenuSearchbar
+                    name="search-editors"
+                    placeholder="Search members"
+                    value={searchText}
+                    onChange={setSearchText}
+                  />
+                  <DropdownMenuSeparator />
+                </>
+              }
+            >
+              {areWorkspaceMembersLoading ? (
+                <div className="flex h-24 items-center justify-center">
+                  <Spinner size="sm" />
+                </div>
+              ) : workspaceMembers.length > 0 ? (
+                workspaceMembers.map((member) => (
+                  <DropdownMenuItem
+                    key={member.sId}
+                    label={member.fullName}
+                    description={member.email}
+                    icon={() => (
+                      <Avatar
+                        name={member.fullName}
+                        visual={member.image ?? undefined}
+                        size="sm"
+                        isRounded
+                      />
+                    )}
+                    truncateText
+                    disabled={editorIds.has(member.sId)}
+                    onClick={() => void onAddEditor(member.sId)}
+                  />
+                ))
+              ) : (
+                <div className="flex h-24 items-center justify-center text-sm text-muted-foreground">
+                  No members found
+                </div>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/9897.

Skill editors can currently be removed from the skill info page, but new editors cannot be added there.

This PR allows adding editors from the existing members tab.
Users who cannot administrate the skill keep the existing read-only list.

<img width="557" height="763" alt="image" src="https://github.com/user-attachments/assets/a3cd757c-89ac-4a1b-803d-4acd07c7d6b2" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
