### PR TITLE
[front] fix: refine skill autocomplete search ranking

### DIFF
--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -124,7 +124,7 @@ describe("searchCapabilityIndex ranking", () => {
     expect(result.map((item) => item.id)).toEqual(["a", "z"]);
   });
 
-  it("sorts non-prefix substring matches alphabetically", () => {
+  it("ranks earlier substring matches first", () => {
     const result = searchCapabilityIndex({
       items: [
         { id: "ztestlonger", sortName: "ztestlonger" },
@@ -133,7 +133,7 @@ describe("searchCapabilityIndex ranking", () => {
       query: "test",
     });
 
-    expect(result.map((item) => item.id)).toEqual(["longtest", "ztestlonger"]);
+    expect(result.map((item) => item.id)).toEqual(["ztestlonger", "longtest"]);
   });
 
   it("ranks title prefix matches above other fuzzy title matches", () => {

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -127,13 +127,54 @@ describe("searchCapabilityIndex ranking", () => {
   it("ranks earlier substring matches first", () => {
     const result = searchCapabilityIndex({
       items: [
-        { id: "ztestlonger", sortName: "ztestlonger" },
-        { id: "longtest", sortName: "longtest" },
+        { id: "later", sortName: "create detailed guide" },
+        { id: "earlier", sortName: "create guide" },
       ],
-      query: "test",
+      query: "guide",
     });
 
-    expect(result.map((item) => item.id)).toEqual(["ztestlonger", "longtest"]);
+    expect(result.map((item) => item.id)).toEqual(["earlier", "later"]);
+  });
+
+  it("normalizes query whitespace and casing before ranking", () => {
+    const result = searchCapabilityIndex({
+      items: [
+        { id: "prefix", sortName: "guide builder" },
+        { id: "exact", sortName: "guide" },
+      ],
+      query: "  GUIDE  ",
+    });
+
+    expect(result.map((item) => item.id)).toEqual(["exact", "prefix"]);
+  });
+
+  it("ranks matches before applying the result limit", () => {
+    const result = searchCapabilityIndex({
+      items: [
+        {
+          id: "fuzzy",
+          sortName: "generate useful insights for data export",
+        },
+        { id: "substring", sortName: "create guide" },
+        { id: "prefix", sortName: "guide builder" },
+        { id: "exact", sortName: "guide" },
+      ],
+      limit: 2,
+      query: "guide",
+    });
+
+    expect(result.map((item) => item.id)).toEqual(["exact", "prefix"]);
+  });
+
+  it("does not mutate the search index", () => {
+    const items = [
+      { id: "substring", sortName: "create guide" },
+      { id: "exact", sortName: "guide" },
+    ];
+
+    searchCapabilityIndex({ items, query: "guide" });
+
+    expect(items.map((item) => item.id)).toEqual(["substring", "exact"]);
   });
 
   it("ranks title prefix matches above other fuzzy title matches", () => {

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -216,26 +216,37 @@ export function subFilter(a: string, b: string) {
   return subFilterLastIndex(a, b) > -1;
 }
 
-function getAutocompleteMatchRank(query: string, candidate: string): number {
+interface AutocompleteMatch {
+  matchStart: number | null;
+  rank: number;
+}
+
+function getAutocompleteMatch(
+  query: string,
+  candidate: string
+): AutocompleteMatch {
   if (candidate === query) {
-    return 0;
+    return { matchStart: 0, rank: 0 };
   }
   if (candidate.startsWith(query)) {
-    return 1;
+    return { matchStart: 0, rank: 1 };
   }
-  if (candidate.includes(query)) {
-    return 2;
+
+  const substringStart = candidate.indexOf(query);
+  if (substringStart !== -1) {
+    return { matchStart: substringStart, rank: 2 };
   }
   if (subFilter(query, candidate)) {
-    return 3;
+    return { matchStart: null, rank: 3 };
   }
-  return 4;
+  return { matchStart: null, rank: 4 };
 }
 
 /**
  * Compares two strings for predictable autocomplete relevance.
  * Exact matches rank first, followed by prefixes, substrings, and fuzzy matches.
- * Candidates within the same tier are sorted alphabetically.
+ * Within the same tier, earlier and shorter matches rank first, followed by an
+ * alphabetical comparison that preserves the candidates' original casing.
  */
 export function compareForAutocompleteSort(
   query: string,
@@ -246,11 +257,30 @@ export function compareForAutocompleteSort(
   const normalizedA = a.toLowerCase();
   const normalizedB = b.toLowerCase();
 
-  const rankComparison =
-    getAutocompleteMatchRank(normalizedQuery, normalizedA) -
-    getAutocompleteMatchRank(normalizedQuery, normalizedB);
+  if (normalizedQuery.length === 0) {
+    return a.localeCompare(b);
+  }
 
-  return rankComparison || normalizedA.localeCompare(normalizedB);
+  const matchA = getAutocompleteMatch(normalizedQuery, normalizedA);
+  const matchB = getAutocompleteMatch(normalizedQuery, normalizedB);
+  const rankComparison = matchA.rank - matchB.rank;
+  if (rankComparison !== 0) {
+    return rankComparison;
+  }
+
+  if (
+    matchA.matchStart !== null &&
+    matchB.matchStart !== null &&
+    matchA.matchStart !== matchB.matchStart
+  ) {
+    return matchA.matchStart - matchB.matchStart;
+  }
+
+  if (matchA.rank < 4 && a.length !== b.length) {
+    return a.length - b.length;
+  }
+
+  return a.localeCompare(b);
 }
 
 /**

--- a/front/tests/lib/utils.test.ts
+++ b/front/tests/lib/utils.test.ts
@@ -8,12 +8,23 @@ import { describe, expect, test } from "vitest";
 const AUTOCOMPLETE_SKILL_NAMES = [
   "Guide",
   "Guide Builder",
+  "Guide Analytics",
+  "Guidebook Publisher",
   "Guideline Toolkit",
+  "Guided Tour",
   "Create Guide",
+  "Draft A Guide",
   "Product Guides",
+  "Team Guide Catalog",
   "Generate Useful Insights for Data Export",
+  "Great User Interface Design Example",
+  "Gather Updates Into Detailed Email",
+  "Guidance Planner",
   "Guiding Workshop",
   "Automation Designer",
+  "Workflow Runner",
+  "Knowledge Organizer",
+  "Audit Checklist",
 ];
 
 function filterAndSortAutocompleteSkills(query: string): string[] {
@@ -32,10 +43,18 @@ describe("compareForAutocompleteSort", () => {
       query: "guide",
       expected: [
         "Guide",
+        "Guided Tour",
         "Guide Builder",
+        "Guide Analytics",
         "Guideline Toolkit",
+        "Guidebook Publisher",
+        "Team Guide Catalog",
         "Create Guide",
+        "Draft A Guide",
         "Product Guides",
+        "Guidance Planner",
+        "Gather Updates Into Detailed Email",
+        "Great User Interface Design Example",
         "Generate Useful Insights for Data Export",
       ],
     },
@@ -44,11 +63,19 @@ describe("compareForAutocompleteSort", () => {
       query: "guid",
       expected: [
         "Guide",
+        "Guided Tour",
         "Guide Builder",
+        "Guide Analytics",
+        "Guidance Planner",
         "Guiding Workshop",
         "Guideline Toolkit",
+        "Guidebook Publisher",
+        "Team Guide Catalog",
         "Create Guide",
+        "Draft A Guide",
         "Product Guides",
+        "Gather Updates Into Detailed Email",
+        "Great User Interface Design Example",
         "Generate Useful Insights for Data Export",
       ],
     },
@@ -57,7 +84,12 @@ describe("compareForAutocompleteSort", () => {
       query: "gen",
       expected: [
         "Generate Useful Insights for Data Export",
+        "Guide Analytics",
+        "Guidance Planner",
         "Guideline Toolkit",
+        "Knowledge Organizer",
+        "Gather Updates Into Detailed Email",
+        "Great User Interface Design Example",
       ],
     },
     {
@@ -65,10 +97,18 @@ describe("compareForAutocompleteSort", () => {
       query: "gde",
       expected: [
         "Guide",
+        "Guided Tour",
         "Create Guide",
+        "Draft A Guide",
         "Guide Builder",
         "Product Guides",
+        "Guide Analytics",
+        "Guidance Planner",
         "Guideline Toolkit",
+        "Team Guide Catalog",
+        "Guidebook Publisher",
+        "Gather Updates Into Detailed Email",
+        "Great User Interface Design Example",
         "Generate Useful Insights for Data Export",
       ],
     },
@@ -77,10 +117,18 @@ describe("compareForAutocompleteSort", () => {
       query: "GUIDE",
       expected: [
         "Guide",
+        "Guided Tour",
         "Guide Builder",
+        "Guide Analytics",
         "Guideline Toolkit",
+        "Guidebook Publisher",
+        "Team Guide Catalog",
         "Create Guide",
+        "Draft A Guide",
         "Product Guides",
+        "Guidance Planner",
+        "Gather Updates Into Detailed Email",
+        "Great User Interface Design Example",
         "Generate Useful Insights for Data Export",
       ],
     },
@@ -98,14 +146,25 @@ describe("compareForAutocompleteSort", () => {
       behavior: "sorts every skill alphabetically when the query is empty",
       query: "",
       expected: [
+        "Audit Checklist",
         "Automation Designer",
         "Create Guide",
+        "Draft A Guide",
+        "Gather Updates Into Detailed Email",
         "Generate Useful Insights for Data Export",
+        "Great User Interface Design Example",
+        "Guidance Planner",
         "Guide",
+        "Guide Analytics",
         "Guide Builder",
+        "Guidebook Publisher",
+        "Guided Tour",
         "Guideline Toolkit",
         "Guiding Workshop",
+        "Knowledge Organizer",
         "Product Guides",
+        "Team Guide Catalog",
+        "Workflow Runner",
       ],
     },
   ])("$behavior for '$query'", ({ query, expected }) => {
@@ -193,6 +252,32 @@ describe("compareForAutocompleteSort", () => {
       betterMatch: "Zoo Guide",
       worseMatch: "Any Guide Reference",
     },
+    {
+      behavior:
+        "a substring match beats a much shorter fuzzy candidate because match tier wins first",
+      query: "guide",
+      betterMatch: "Create A Comprehensive Guide",
+      worseMatch: "G-u-i-d-e",
+    },
+    {
+      behavior:
+        "the first occurrence determines position when a candidate contains the query twice",
+      query: "guide",
+      betterMatch: "Use Guide Then Guide",
+      worseMatch: "Build A Detailed Guide",
+    },
+    {
+      behavior: "a prefix followed by punctuation still ranks as a prefix",
+      query: "guide-",
+      betterMatch: "Guide-Builder",
+      worseMatch: "Create Guide-Builder",
+    },
+    {
+      behavior: "Unicode casing is normalized when assigning match tiers",
+      query: "ÉTUDE",
+      betterMatch: "Étude",
+      worseMatch: "Étude Builder",
+    },
   ])("$behavior", ({ query, betterMatch, worseMatch }) => {
     expect(
       [worseMatch, betterMatch].toSorted((a, b) =>
@@ -211,6 +296,10 @@ describe("compareForAutocompleteSort", () => {
 
     expect(comparison).not.toBe(0);
     expect(Math.sign(comparison)).toBe(-Math.sign(reverseComparison));
+  });
+
+  test("returns a tie for identical candidates", () => {
+    expect(compareForAutocompleteSort("guide", "Guide", "Guide")).toBe(0);
   });
 
   test("ranks matching candidates before non-matches in an unfiltered list", () => {

--- a/front/tests/lib/utils.test.ts
+++ b/front/tests/lib/utils.test.ts
@@ -40,13 +40,13 @@ describe("compareForAutocompleteSort", () => {
       ],
     },
     {
-      behavior: "sorts matches alphabetically within the prefix tier",
+      behavior: "prioritizes shorter matches within the prefix tier",
       query: "guid",
       expected: [
         "Guide",
         "Guide Builder",
-        "Guideline Toolkit",
         "Guiding Workshop",
+        "Guideline Toolkit",
         "Create Guide",
         "Product Guides",
         "Generate Useful Insights for Data Export",
@@ -61,15 +61,15 @@ describe("compareForAutocompleteSort", () => {
       ],
     },
     {
-      behavior: "sorts fuzzy-only matches alphabetically instead of by spread",
+      behavior: "sorts fuzzy-only matches by length instead of by spread",
       query: "gde",
       expected: [
-        "Create Guide",
-        "Generate Useful Insights for Data Export",
         "Guide",
+        "Create Guide",
         "Guide Builder",
-        "Guideline Toolkit",
         "Product Guides",
+        "Guideline Toolkit",
+        "Generate Useful Insights for Data Export",
       ],
     },
     {
@@ -141,22 +141,31 @@ describe("compareForAutocompleteSort", () => {
       worseMatch: "Automation Designer",
     },
     {
-      behavior: "two prefix matches are ordered alphabetically",
+      behavior:
+        "a shorter prefix match ranks first even when it is later alphabetically",
       query: "guid",
-      betterMatch: "Guide Builder",
-      worseMatch: "Guideline Toolkit",
+      betterMatch: "Guiding Lab",
+      worseMatch: "Guide Automation",
     },
     {
-      behavior: "two substring matches are ordered alphabetically",
-      query: "guide",
-      betterMatch: "Create Guide",
-      worseMatch: "Product Guides",
+      behavior:
+        "equally positioned and equally short prefix matches are ordered alphabetically",
+      query: "guid",
+      betterMatch: "Guide Alpha",
+      worseMatch: "Guide Bravo",
     },
     {
-      behavior: "two fuzzy matches are ordered alphabetically",
+      behavior:
+        "equally positioned and equally short substring matches are ordered alphabetically",
       query: "guide",
-      betterMatch: "Generate Useful Insights for Data Export",
-      worseMatch: "Great User Interface Design Example",
+      betterMatch: "Create Guide A",
+      worseMatch: "Create Guide B",
+    },
+    {
+      behavior: "equally short fuzzy matches are ordered alphabetically",
+      query: "gde",
+      betterMatch: "Great Data Export",
+      worseMatch: "Green Data Engine",
     },
     {
       behavior: "two non-matches are ordered alphabetically",
@@ -170,6 +179,20 @@ describe("compareForAutocompleteSort", () => {
       betterMatch: "Guide Builder",
       worseMatch: "Create Guide Builder",
     },
+    {
+      behavior:
+        "an earlier substring ranks first even when it is longer and later alphabetically",
+      query: "guide",
+      betterMatch: "Use Guide Reference",
+      worseMatch: "A Very Long Guide",
+    },
+    {
+      behavior:
+        "a shorter substring ranks first when both matches start at the same position",
+      query: "guide",
+      betterMatch: "Zoo Guide",
+      worseMatch: "Any Guide Reference",
+    },
   ])("$behavior", ({ query, betterMatch, worseMatch }) => {
     expect(
       [worseMatch, betterMatch].toSorted((a, b) =>
@@ -178,8 +201,16 @@ describe("compareForAutocompleteSort", () => {
     ).toEqual([betterMatch, worseMatch]);
   });
 
-  test("treats candidates that differ only by case as equally relevant", () => {
-    expect(compareForAutocompleteSort("guide", "Guide", "GUIDE")).toBe(0);
+  test("uses original casing as the final alphabetical tie-breaker", () => {
+    const comparison = compareForAutocompleteSort("guide", "Guide", "GUIDE");
+    const reverseComparison = compareForAutocompleteSort(
+      "guide",
+      "GUIDE",
+      "Guide"
+    );
+
+    expect(comparison).not.toBe(0);
+    expect(Math.sign(comparison)).toBe(-Math.sign(reverseComparison));
   });
 
   test("ranks matching candidates before non-matches in an unfiltered list", () => {


### PR DESCRIPTION
## Description

This PR improves how results of the skill slash command are sorted.
Results within the same match tier (see https://github.com/dust-tt/dust/pull/29912) could still feel arbitrary, with alphabetical order placing a long label ahead of one where the query appears earlier.

This PR matches within each existing relevance tier now prefer an earlier occurrence, then a shorter label, then original-case alphabetical order. Empty-query ordering remains alphabetical.

## Tests

- Expanded autocomplete ranking coverage.

## Risk

- Low, changes capability search ordering only.

## Deploy Plan

- Deploy front.
