### PR TITLE
feat: Add poolCapOverrideExpiresAt to memberships

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,3 @@ thoughts/*
 # Sandbox provider build scratch dirs
 /front/lib/api/sandbox/providers/sandbox-build-*/
 
-# Personal local-only dev scripts, not meant to be version-controlled
-/front/scripts/local/
-

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ thoughts/*
 # Sandbox provider build scratch dirs
 /front/lib/api/sandbox/providers/sandbox-build-*/
 
+# Personal local-only dev scripts, not meant to be version-controlled
+/front/scripts/local/
+

--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -262,7 +262,9 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
         targetUser,
         { role: "user" }
       );
-      await membership.updatePoolCapOverride(2500);
+      await membership.updatePoolCapOverride({
+        poolCapOverrideAwuCredits: 2500,
+      });
 
       await createPrivateApiMockRequest({
         method: "GET",
@@ -291,7 +293,9 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
         targetUser,
         { role: "user" }
       );
-      await membership.updatePoolCapOverride(1200);
+      await membership.updatePoolCapOverride({
+        poolCapOverrideAwuCredits: 1200,
+      });
 
       await createPrivateApiMockRequest({
         method: "PUT",

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -217,9 +217,10 @@ export async function setUserSpendLimit(
   // Persist the admin's intent first: the membership is the source of truth,
   // the Metronome alerts below are derived enforcement (a failed sync can be
   // retried and re-derives from this value).
-  await membership.updatePoolCapOverride(
-    limit.kind === "limited" ? limit.awuCredits : null
-  );
+  await membership.updatePoolCapOverride({
+    poolCapOverrideAwuCredits:
+      limit.kind === "limited" ? limit.awuCredits : null,
+  });
 
   switch (limit.kind) {
     case "unlimited": {

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -1598,12 +1598,29 @@ export class MembershipResource extends BaseResource<MembershipModel> {
    * excluded) of an active membership in place. `null` clears the override,
    * letting the seat-type default apply. Callers are responsible for syncing
    * the derived Metronome alerts.
+   *
+   * `poolCapOverrideExpiresAt` schedules an automatic revert back to the
+   * seat-type default (see the `spend_limit_expiration` Temporal sweep).
+   * Meaningless — and ignored by enforcement — when
+   * `poolCapOverrideAwuCredits` is null.
    */
   async updatePoolCapOverride(
-    poolCapOverrideAwuCredits: number | null,
+    {
+      poolCapOverrideAwuCredits,
+      poolCapOverrideExpiresAt,
+    }: {
+      poolCapOverrideAwuCredits: number | null;
+      poolCapOverrideExpiresAt?: Date | null;
+    },
     transaction?: Transaction
   ): Promise<void> {
-    await this.update({ poolCapOverrideAwuCredits }, transaction);
+    await this.update(
+      {
+        poolCapOverrideAwuCredits,
+        poolCapOverrideExpiresAt: poolCapOverrideExpiresAt ?? null,
+      },
+      transaction
+    );
   }
 
   /**
@@ -1653,9 +1670,10 @@ export class MembershipResource extends BaseResource<MembershipModel> {
           seatType: newSeatType,
           firstUsedAt: this.firstUsedAt,
           creditState: initialCreditStateForSeatType(newSeatType),
-          // The pool cap override survives the seat change: it's the
-          // pool-only portion, independent of the seat allowance.
+          // The pool cap override (and its expiry) survives the seat change:
+          // it's the pool-only portion, independent of the seat allowance.
           poolCapOverrideAwuCredits: this.poolCapOverrideAwuCredits,
+          poolCapOverrideExpiresAt: this.poolCapOverrideExpiresAt,
         },
         { transaction }
       );

--- a/front/lib/resources/storage/models/membership.ts
+++ b/front/lib/resources/storage/models/membership.ts
@@ -27,6 +27,11 @@ export class MembershipModel extends WorkspaceAwareModel<MembershipModel> {
   // `spend_threshold_reached` alert (threshold = override + seat allowance)
   // is derived from this value and remains the enforcement mechanism.
   declare poolCapOverrideAwuCredits: number | null;
+  // When the override should auto-revert to the seat-type default (see the
+  // `spend_limit_expiration` Temporal sweep). NULL means it never expires.
+  // Meaningless — and ignored by enforcement — when
+  // `poolCapOverrideAwuCredits` is null.
+  declare poolCapOverrideExpiresAt: Date | null;
 
   declare userId: ForeignKey<UserModel["id"]>;
   declare user: NonAttribute<UserModel>;
@@ -79,6 +84,11 @@ MembershipModel.init(
       allowNull: true,
       defaultValue: null,
     },
+    poolCapOverrideExpiresAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
+    },
   },
   {
     modelName: "membership",
@@ -98,6 +108,14 @@ MembershipModel.init(
       {
         fields: ["workspaceId", "firstUsedAt"],
         where: { firstUsedAt: { [Op.ne]: null } },
+        concurrently: true,
+      },
+      // Partial index backing the expiration sweep's cross-workspace lookup
+      // (see `getWorkspacesWithExpiredPoolCapOverride`).
+      {
+        fields: ["poolCapOverrideExpiresAt"],
+        where: { poolCapOverrideExpiresAt: { [Op.ne]: null } },
+        name: "memberships_pool_cap_override_expires_at",
         concurrently: true,
       },
     ],

--- a/front/migrations/20260605_backfill_membership_pool_cap_overrides.ts
+++ b/front/migrations/20260605_backfill_membership_pool_cap_overrides.ts
@@ -123,7 +123,9 @@ makeScript(
               : "Would backfill pool cap override."
           );
           if (execute) {
-            await membership.updatePoolCapOverride(poolCapOverrideAwuCredits);
+            await membership.updatePoolCapOverride({
+              poolCapOverrideAwuCredits,
+            });
           }
           updated++;
         }

--- a/front/migrations/pre-deploy/20260729153513_add_pool_cap_override_expires_at_to_memberships.sql
+++ b/front/migrations/pre-deploy/20260729153513_add_pool_cap_override_expires_at_to_memberships.sql
@@ -1,0 +1,14 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."memberships" ADD COLUMN "poolCapOverrideExpiresAt" timestamp with time zone;
+
+/*
+Statement 1
+  - Partial index for memberships.poolCapOverrideExpiresAt
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY memberships_pool_cap_override_expires_at ON public.memberships USING btree ("poolCapOverrideExpiresAt") WHERE ("poolCapOverrideExpiresAt" IS NOT NULL);


### PR DESCRIPTION
## Description

Until now, memberships stored the per-user pool-cap override but had no way to record when that override should revert to the seat-type default. This PR adds the data-model foundation for expiring those overrides, as the first step toward the approval flow and expiration scheduler described in [#29754](https://github.com/dust-tt/dust/issues/29754).

This PR adds a nullable `poolCapOverrideExpiresAt` timestamp to `memberships`, exposes it through the Sequelize model and `MembershipResource`, and adds a partial concurrent index for looking up memberships with an expiry. `updatePoolCapOverride` now accepts the override amount and optional expiry together; existing callers continue to set only the amount, which clears any expiry. Seat-type changes preserve both the override and its expiry. The existing `poolCapOverrideAwuCredits` value remains the enforcement source of truth, and no current caller starts setting expirations or automatically reverting overrides.

## Tests

The existing spend-limit API tests and backfill migration were updated for the new object-shaped `updatePoolCapOverride` API. Recorded PR checks passed for CodeQL, React Doctor, GitGuardian, and the change checks; the generic test jobs were skipped. No separate local test command or full-suite result was supplied.

## Risk

Low runtime risk: the schema change is additive and nullable, existing rows remain without an expiry, and the expiration scheduler and approval behavior are not introduced here. The main operational risk is applying the pre-deploy migration on the `memberships` table; the column addition uses short statement and lock timeouts, and the partial index is created concurrently.

The resource signature change requires all callers to pass the new object shape, which is covered by the updated callers in this diff. No rollback migration is included, so removing the column and index would require an explicit follow-up migration.

## Deploy Plan

1. Apply `front/migrations/pre-deploy/20260729153513_add_pool_cap_override_expires_at_to_memberships.sql` before application deployment.
2. Deploy `front` and `front-sse` together.
3. Deploy the follow-up expiration scheduler and approval-flow changes separately before enabling expiry-based behavior.

Related to #29754.