### PR TITLE
[front] enh: edit agent editors from info page

### DIFF
--- a/front/components/assistant/details/AgentDetailsSheet.tsx
+++ b/front/components/assistant/details/AgentDetailsSheet.tsx
@@ -400,6 +400,7 @@ export function AgentDetailsSheet({
                       </TabsContent>
                       <TabsContent value="editors">
                         <AgentEditorsTab
+                          key={agentConfiguration.sId}
                           owner={owner}
                           user={user}
                           agentConfiguration={agentConfiguration}

--- a/front/components/assistant/details/tabs/AgentEditorsTab.tsx
+++ b/front/components/assistant/details/tabs/AgentEditorsTab.tsx
@@ -1,7 +1,6 @@
-import { ManageUsersPanel } from "@app/components/assistant/conversation/space/ManageUsersPanel";
-import type {
-  SearchMemberType,
-  SearchMemberWithWorkspaceType,
+import {
+  MemberSelectionTable,
+  type SearchMemberWithWorkspaceType,
 } from "@app/components/members/MemberSelectionTable";
 import { MembersList } from "@app/components/members/MembersList";
 import { useEditors, useUpdateEditors } from "@app/lib/swr/agent_editors";
@@ -22,7 +21,11 @@ export function AgentEditorsTab({
   user,
   agentConfiguration,
 }: AgentEditorsTabProps) {
-  const [isManageEditorsOpen, setIsManageEditorsOpen] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [selectedEditorIds, setSelectedEditorIds] = useState<Set<string>>(
+    new Set()
+  );
   const updateEditors = useUpdateEditors({
     owner,
     agentConfigurationId: agentConfiguration.sId,
@@ -35,30 +38,73 @@ export function AgentEditorsTab({
   const isCurrentUserEditor =
     editors.findIndex((u) => u.sId === user.sId) !== -1;
 
+  const currentEditorIds = new Set(editors.map((editor) => editor.sId));
+  const addEditorIds = Array.from(selectedEditorIds).filter(
+    (editorId) => !currentEditorIds.has(editorId)
+  );
+  const removeEditorIds = Array.from(currentEditorIds).filter(
+    (editorId) => !selectedEditorIds.has(editorId)
+  );
+  const hasEditorChanges =
+    addEditorIds.length > 0 || removeEditorIds.length > 0;
+
   const onRemoveMember = async (user: SearchMemberWithWorkspaceType) => {
     if (isCurrentUserEditor) {
       await updateEditors({ removeEditorIds: [user.sId], addEditorIds: [] });
     }
   };
 
-  const onEditorsChange = async (newEditors: SearchMemberType[]) => {
-    const currentEditorIds = new Set(editors.map((editor) => editor.sId));
-    const newEditorIds = new Set(newEditors.map((editor) => editor.sId));
-    const addEditorIds = Array.from(newEditorIds).filter(
-      (editorId) => !currentEditorIds.has(editorId)
-    );
-    const removeEditorIds = Array.from(currentEditorIds).filter(
-      (editorId) => !newEditorIds.has(editorId)
-    );
-
-    if (addEditorIds.length === 0 && removeEditorIds.length === 0) {
+  const onSaveEditors = async () => {
+    if (!hasEditorChanges || isSaving) {
       return;
     }
 
-    await updateEditors({ addEditorIds, removeEditorIds });
+    setIsSaving(true);
+    try {
+      const didUpdate = await updateEditors({ addEditorIds, removeEditorIds });
+      if (didUpdate) {
+        setIsEditing(false);
+      }
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   const canManageEditors = agentConfiguration.canEdit || isAdmin(owner);
+
+  if (canManageEditors && isEditing) {
+    return (
+      <div className="flex flex-col gap-4">
+        <MemberSelectionTable
+          owner={owner}
+          selectedMemberIds={selectedEditorIds}
+          onSelectionChange={(editorIds) => {
+            setSelectedEditorIds(editorIds);
+          }}
+          initialMembers={editors}
+        />
+        <div className="flex justify-end gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            label="Cancel"
+            disabled={isSaving}
+            onClick={() => setIsEditing(false)}
+            type="button"
+          />
+          <Button
+            variant="highlight"
+            size="sm"
+            label="Save"
+            disabled={!hasEditorChanges || isSaving}
+            isLoading={isSaving}
+            onClick={onSaveEditors}
+            type="button"
+          />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-4">
@@ -70,16 +116,13 @@ export function AgentEditorsTab({
             icon={Users01}
             label="Manage editors"
             disabled={isEditorsLoading || isEditorsError}
-            onClick={() => setIsManageEditorsOpen(true)}
+            onClick={() => {
+              setSelectedEditorIds(
+                new Set(editors.map((editor) => editor.sId))
+              );
+              setIsEditing(true);
+            }}
             type="button"
-          />
-          <ManageUsersPanel
-            isOpen={isManageEditorsOpen}
-            setIsOpen={setIsManageEditorsOpen}
-            owner={owner}
-            mode="editors-only"
-            editors={editors}
-            onEditorsChange={onEditorsChange}
           />
         </div>
       )}

--- a/front/components/assistant/details/tabs/AgentEditorsTab.tsx
+++ b/front/components/assistant/details/tabs/AgentEditorsTab.tsx
@@ -1,23 +1,22 @@
+import { AddEditorDropdown } from "@app/components/members/AddEditorsDropdown";
 import type { SearchMemberWithWorkspaceType } from "@app/components/members/MemberSelectionTable";
 import { MembersList } from "@app/components/members/MembersList";
 import { useEditors, useUpdateEditors } from "@app/lib/swr/agent_editors";
-import { useSearchMembers } from "@app/lib/swr/memberships";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import { editorUserSchema } from "@app/types/editors";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
-import {
-  Avatar,
-  Button,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSearchbar,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-  Plus,
-  Spinner,
-} from "@dust-tt/sparkle";
-import { useState } from "react";
+import { Button, Plus } from "@dust-tt/sparkle";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMemo } from "react";
+import { useController, useForm } from "react-hook-form";
+import { z } from "zod";
+
+const editorsFormSchema = z.object({
+  editors: z.array(editorUserSchema),
+});
+
+type EditorsFormData = z.infer<typeof editorsFormSchema>;
 
 type AgentEditorsTabProps = {
   owner: WorkspaceType;
@@ -30,15 +29,6 @@ export function AgentEditorsTab({
   user,
   agentConfiguration,
 }: AgentEditorsTabProps) {
-  const [isEditorPickerOpen, setIsEditorPickerOpen] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
-  const [searchText, setSearchText] = useState("");
-  const [addedEditors, setAddedEditors] = useState<
-    SearchMemberWithWorkspaceType[]
-  >([]);
-  const [removedEditorIds, setRemovedEditorIds] = useState<Set<string>>(
-    new Set()
-  );
   const updateEditors = useUpdateEditors({
     owner,
     agentConfigurationId: agentConfiguration.sId,
@@ -47,168 +37,100 @@ export function AgentEditorsTab({
     owner,
     agentConfigurationId: agentConfiguration.sId,
   });
-  const { members: workspaceMembers, isLoading: areWorkspaceMembersLoading } =
-    useSearchMembers({
-      workspaceId: owner.sId,
-      searchTerm: searchText,
-      pageIndex: 0,
-      pageSize: 25,
-      disabled: !isEditorPickerOpen,
-    });
 
   const canManageEditors = agentConfiguration.canEdit || isAdmin(owner);
+  const formValues = useMemo<EditorsFormData>(() => ({ editors }), [editors]);
+  const form = useForm<EditorsFormData>({
+    defaultValues: { editors: [] },
+    values: formValues,
+    resetOptions: { keepDirtyValues: true },
+    resolver: zodResolver(editorsFormSchema),
+  });
+  const { field: editorsField } = useController({
+    control: form.control,
+    name: "editors",
+  });
+  const selectedEditors = editorsField.value;
   const persistedEditorIds = new Set(editors.map((editor) => editor.sId));
-  const addedEditorIds = new Set(addedEditors.map((editor) => editor.sId));
-  const visibleEditors = [
-    ...editors.filter((editor) => !removedEditorIds.has(editor.sId)),
-    ...addedEditors.filter((editor) => !persistedEditorIds.has(editor.sId)),
-  ];
-  const visibleEditorIds = new Set(visibleEditors.map((editor) => editor.sId));
-  const addEditorIds = addedEditors
-    .map((editor) => editor.sId)
-    .filter((editorId) => !persistedEditorIds.has(editorId));
-  const removeEditorIds = Array.from(removedEditorIds).filter((editorId) =>
-    persistedEditorIds.has(editorId)
-  );
-  const hasChanges = addEditorIds.length > 0 || removeEditorIds.length > 0;
+  const hasChanges =
+    editors.length !== selectedEditors.length ||
+    selectedEditors.some((editor) => !persistedEditorIds.has(editor.sId));
 
   const onRemoveMember = (user: SearchMemberWithWorkspaceType) => {
-    if (!canManageEditors || isSaving) {
+    if (!canManageEditors || form.formState.isSubmitting) {
       return;
     }
 
-    if (addedEditorIds.has(user.sId)) {
-      setAddedEditors((current) =>
-        current.filter((editor) => editor.sId !== user.sId)
-      );
-      return;
-    }
-
-    setRemovedEditorIds((current) => new Set(current).add(user.sId));
+    editorsField.onChange(
+      selectedEditors.filter((editor) => editor.sId !== user.sId)
+    );
   };
 
   const onAddEditor = (editor: SearchMemberWithWorkspaceType) => {
-    if (isSaving || visibleEditorIds.has(editor.sId)) {
+    if (
+      form.formState.isSubmitting ||
+      selectedEditors.some((selected) => selected.sId === editor.sId)
+    ) {
       return;
     }
 
-    if (persistedEditorIds.has(editor.sId)) {
-      setRemovedEditorIds((current) => {
-        const next = new Set(current);
-        next.delete(editor.sId);
-        return next;
-      });
+    editorsField.onChange([...selectedEditors, editor]);
+  };
+
+  const onSave = form.handleSubmit(async ({ editors: nextEditors }) => {
+    if (!hasChanges) {
       return;
     }
 
-    setAddedEditors((current) => [...current, editor]);
-  };
-
-  const resetChanges = () => {
-    setAddedEditors([]);
-    setRemovedEditorIds(new Set());
-  };
-
-  const onSave = async () => {
-    if (!hasChanges || isSaving) {
-      return;
+    const nextEditorIds = new Set(nextEditors.map((editor) => editor.sId));
+    const didUpdate = await updateEditors({
+      addEditorIds: nextEditors
+        .filter((editor) => !persistedEditorIds.has(editor.sId))
+        .map((editor) => editor.sId),
+      removeEditorIds: editors
+        .filter((editor) => !nextEditorIds.has(editor.sId))
+        .map((editor) => editor.sId),
+    });
+    if (didUpdate) {
+      form.reset({ editors: nextEditors });
     }
-
-    setIsSaving(true);
-    try {
-      const didUpdate = await updateEditors({
-        addEditorIds,
-        removeEditorIds,
-      });
-      if (didUpdate) {
-        resetChanges();
-      }
-    } finally {
-      setIsSaving(false);
-    }
-  };
+  });
 
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-semibold">Editors</h3>
         {canManageEditors && (
-          <DropdownMenu
-            open={isEditorPickerOpen}
-            onOpenChange={(open) => {
-              setIsEditorPickerOpen(open);
-              if (!open) {
-                setSearchText("");
-              }
-            }}
-          >
-            <DropdownMenuTrigger asChild>
+          <AddEditorDropdown
+            owner={owner}
+            editors={selectedEditors}
+            onAddEditor={onAddEditor}
+            trigger={
               <Button
                 variant="outline"
                 size="sm"
                 icon={Plus}
                 label="Add editors"
-                disabled={isEditorsLoading || isEditorsError || isSaving}
+                disabled={
+                  isEditorsLoading ||
+                  isEditorsError ||
+                  form.formState.isSubmitting
+                }
                 type="button"
               />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              className="w-80"
-              align="end"
-              dropdownHeaders={
-                <>
-                  <DropdownMenuSearchbar
-                    name="search-editors"
-                    placeholder="Search members"
-                    value={searchText}
-                    onChange={setSearchText}
-                  />
-                  <DropdownMenuSeparator />
-                </>
-              }
-            >
-              {areWorkspaceMembersLoading ? (
-                <div className="flex h-24 items-center justify-center">
-                  <Spinner size="sm" />
-                </div>
-              ) : workspaceMembers.length > 0 ? (
-                workspaceMembers.map((member) => (
-                  <DropdownMenuItem
-                    key={member.sId}
-                    label={member.fullName}
-                    description={member.email}
-                    icon={() => (
-                      <Avatar
-                        name={member.fullName}
-                        visual={member.image ?? undefined}
-                        size="sm"
-                        isRounded
-                      />
-                    )}
-                    truncateText
-                    disabled={visibleEditorIds.has(member.sId) || isSaving}
-                    onClick={() => onAddEditor(member)}
-                    onSelect={(event) => event.preventDefault()}
-                  />
-                ))
-              ) : (
-                <div className="flex h-24 items-center justify-center text-sm text-muted-foreground">
-                  No members found
-                </div>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
+            }
+          />
         )}
       </div>
       <MembersList
         currentUser={user}
         membersData={{
-          members: visibleEditors.map((user) => ({
+          members: selectedEditors.map((user) => ({
             ...user,
             workspace: owner,
           })),
           isLoading: isEditorsLoading,
-          totalMembersCount: visibleEditors.length,
+          totalMembersCount: selectedEditors.length,
           mutateRegardlessOfQueryParams: () => Promise.resolve(undefined),
         }}
         showColumns={canManageEditors ? ["name", "remove"] : ["name"]}
@@ -221,16 +143,16 @@ export function AgentEditorsTab({
             variant="outline"
             size="sm"
             label="Cancel"
-            disabled={!hasChanges || isSaving}
-            onClick={resetChanges}
+            disabled={!hasChanges || form.formState.isSubmitting}
+            onClick={() => form.reset(formValues)}
             type="button"
           />
           <Button
             variant="highlight"
             size="sm"
             label="Save"
-            disabled={!hasChanges || isSaving}
-            isLoading={isSaving}
+            disabled={!hasChanges || form.formState.isSubmitting}
+            isLoading={form.formState.isSubmitting}
             onClick={onSave}
             type="button"
           />

--- a/front/components/assistant/details/tabs/AgentEditorsTab.tsx
+++ b/front/components/assistant/details/tabs/AgentEditorsTab.tsx
@@ -1,8 +1,15 @@
-import type { SearchMemberWithWorkspaceType } from "@app/components/members/MemberSelectionTable";
+import { ManageUsersPanel } from "@app/components/assistant/conversation/space/ManageUsersPanel";
+import type {
+  SearchMemberType,
+  SearchMemberWithWorkspaceType,
+} from "@app/components/members/MemberSelectionTable";
 import { MembersList } from "@app/components/members/MembersList";
 import { useEditors, useUpdateEditors } from "@app/lib/swr/agent_editors";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { UserType, WorkspaceType } from "@app/types/user";
+import { isAdmin } from "@app/types/user";
+import { Button, Users01 } from "@dust-tt/sparkle";
+import { useState } from "react";
 
 type AgentEditorsTabProps = {
   owner: WorkspaceType;
@@ -15,11 +22,12 @@ export function AgentEditorsTab({
   user,
   agentConfiguration,
 }: AgentEditorsTabProps) {
+  const [isManageEditorsOpen, setIsManageEditorsOpen] = useState(false);
   const updateEditors = useUpdateEditors({
     owner,
     agentConfigurationId: agentConfiguration.sId,
   });
-  const { editors, isEditorsLoading } = useEditors({
+  const { editors, isEditorsLoading, isEditorsError } = useEditors({
     owner,
     agentConfigurationId: agentConfiguration.sId,
   });
@@ -33,8 +41,48 @@ export function AgentEditorsTab({
     }
   };
 
+  const onEditorsChange = async (newEditors: SearchMemberType[]) => {
+    const currentEditorIds = new Set(editors.map((editor) => editor.sId));
+    const newEditorIds = new Set(newEditors.map((editor) => editor.sId));
+    const addEditorIds = Array.from(newEditorIds).filter(
+      (editorId) => !currentEditorIds.has(editorId)
+    );
+    const removeEditorIds = Array.from(currentEditorIds).filter(
+      (editorId) => !newEditorIds.has(editorId)
+    );
+
+    if (addEditorIds.length === 0 && removeEditorIds.length === 0) {
+      return;
+    }
+
+    await updateEditors({ addEditorIds, removeEditorIds });
+  };
+
+  const canManageEditors = agentConfiguration.canEdit || isAdmin(owner);
+
   return (
     <div className="flex flex-col gap-4">
+      {canManageEditors && (
+        <div>
+          <Button
+            variant="outline"
+            size="sm"
+            icon={Users01}
+            label="Manage editors"
+            disabled={isEditorsLoading || isEditorsError}
+            onClick={() => setIsManageEditorsOpen(true)}
+            type="button"
+          />
+          <ManageUsersPanel
+            isOpen={isManageEditorsOpen}
+            setIsOpen={setIsManageEditorsOpen}
+            owner={owner}
+            mode="editors-only"
+            editors={editors}
+            onEditorsChange={onEditorsChange}
+          />
+        </div>
+      )}
       <MembersList
         currentUser={user}
         membersData={{

--- a/front/components/assistant/details/tabs/AgentEditorsTab.tsx
+++ b/front/components/assistant/details/tabs/AgentEditorsTab.tsx
@@ -1,13 +1,22 @@
-import {
-  MemberSelectionTable,
-  type SearchMemberWithWorkspaceType,
-} from "@app/components/members/MemberSelectionTable";
+import type { SearchMemberWithWorkspaceType } from "@app/components/members/MemberSelectionTable";
 import { MembersList } from "@app/components/members/MembersList";
 import { useEditors, useUpdateEditors } from "@app/lib/swr/agent_editors";
+import { useSearchMembers } from "@app/lib/swr/memberships";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
-import { Button, Users01 } from "@dust-tt/sparkle";
+import {
+  Avatar,
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSearchbar,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Plus,
+  Spinner,
+} from "@dust-tt/sparkle";
 import { useState } from "react";
 
 type AgentEditorsTabProps = {
@@ -21,11 +30,9 @@ export function AgentEditorsTab({
   user,
   agentConfiguration,
 }: AgentEditorsTabProps) {
-  const [isEditing, setIsEditing] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
-  const [selectedEditorIds, setSelectedEditorIds] = useState<Set<string>>(
-    new Set()
-  );
+  const [isEditorPickerOpen, setIsEditorPickerOpen] = useState(false);
+  const [isAddingEditor, setIsAddingEditor] = useState(false);
+  const [searchText, setSearchText] = useState("");
   const updateEditors = useUpdateEditors({
     owner,
     agentConfigurationId: agentConfiguration.sId,
@@ -34,98 +41,41 @@ export function AgentEditorsTab({
     owner,
     agentConfigurationId: agentConfiguration.sId,
   });
+  const { members: workspaceMembers, isLoading: areWorkspaceMembersLoading } =
+    useSearchMembers({
+      workspaceId: owner.sId,
+      searchTerm: searchText,
+      pageIndex: 0,
+      pageSize: 25,
+      disabled: !isEditorPickerOpen,
+    });
 
-  const isCurrentUserEditor =
-    editors.findIndex((u) => u.sId === user.sId) !== -1;
-
-  const currentEditorIds = new Set(editors.map((editor) => editor.sId));
-  const addEditorIds = Array.from(selectedEditorIds).filter(
-    (editorId) => !currentEditorIds.has(editorId)
-  );
-  const removeEditorIds = Array.from(currentEditorIds).filter(
-    (editorId) => !selectedEditorIds.has(editorId)
-  );
-  const hasEditorChanges =
-    addEditorIds.length > 0 || removeEditorIds.length > 0;
+  const canManageEditors = agentConfiguration.canEdit || isAdmin(owner);
+  const editorIds = new Set(editors.map((editor) => editor.sId));
 
   const onRemoveMember = async (user: SearchMemberWithWorkspaceType) => {
-    if (isCurrentUserEditor) {
+    if (canManageEditors) {
       await updateEditors({ removeEditorIds: [user.sId], addEditorIds: [] });
     }
   };
 
-  const onSaveEditors = async () => {
-    if (!hasEditorChanges || isSaving) {
+  const onAddEditor = async (editorId: string) => {
+    if (isAddingEditor || editorIds.has(editorId)) {
       return;
     }
 
-    setIsSaving(true);
+    setIsEditorPickerOpen(false);
+    setSearchText("");
+    setIsAddingEditor(true);
     try {
-      const didUpdate = await updateEditors({ addEditorIds, removeEditorIds });
-      if (didUpdate) {
-        setIsEditing(false);
-      }
+      await updateEditors({ addEditorIds: [editorId], removeEditorIds: [] });
     } finally {
-      setIsSaving(false);
+      setIsAddingEditor(false);
     }
   };
 
-  const canManageEditors = agentConfiguration.canEdit || isAdmin(owner);
-
-  if (canManageEditors && isEditing) {
-    return (
-      <div className="flex flex-col gap-4">
-        <MemberSelectionTable
-          owner={owner}
-          selectedMemberIds={selectedEditorIds}
-          onSelectionChange={(editorIds) => {
-            setSelectedEditorIds(editorIds);
-          }}
-          initialMembers={editors}
-        />
-        <div className="flex justify-end gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            label="Cancel"
-            disabled={isSaving}
-            onClick={() => setIsEditing(false)}
-            type="button"
-          />
-          <Button
-            variant="highlight"
-            size="sm"
-            label="Save"
-            disabled={!hasEditorChanges || isSaving}
-            isLoading={isSaving}
-            onClick={onSaveEditors}
-            type="button"
-          />
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="flex flex-col gap-4">
-      {canManageEditors && (
-        <div>
-          <Button
-            variant="outline"
-            size="sm"
-            icon={Users01}
-            label="Manage editors"
-            disabled={isEditorsLoading || isEditorsError}
-            onClick={() => {
-              setSelectedEditorIds(
-                new Set(editors.map((editor) => editor.sId))
-              );
-              setIsEditing(true);
-            }}
-            type="button"
-          />
-        </div>
-      )}
       <MembersList
         currentUser={user}
         membersData={{
@@ -137,10 +87,79 @@ export function AgentEditorsTab({
           totalMembersCount: editors.length,
           mutateRegardlessOfQueryParams: () => Promise.resolve(undefined),
         }}
-        showColumns={isCurrentUserEditor ? ["name", "remove"] : ["name"]}
+        showColumns={canManageEditors ? ["name", "remove"] : ["name"]}
         onRemoveMemberClick={onRemoveMember}
         onRowClick={function noRefCheck() {}}
       />
+      {canManageEditors && (
+        <div>
+          <DropdownMenu
+            open={isEditorPickerOpen}
+            onOpenChange={(open) => {
+              setIsEditorPickerOpen(open);
+              if (!open) {
+                setSearchText("");
+              }
+            }}
+          >
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                icon={Plus}
+                label="Add editors"
+                disabled={isEditorsLoading || isEditorsError}
+                isLoading={isAddingEditor}
+                type="button"
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              className="w-80"
+              align="start"
+              dropdownHeaders={
+                <>
+                  <DropdownMenuSearchbar
+                    name="search-editors"
+                    placeholder="Search members"
+                    value={searchText}
+                    onChange={setSearchText}
+                  />
+                  <DropdownMenuSeparator />
+                </>
+              }
+            >
+              {areWorkspaceMembersLoading ? (
+                <div className="flex h-24 items-center justify-center">
+                  <Spinner size="sm" />
+                </div>
+              ) : workspaceMembers.length > 0 ? (
+                workspaceMembers.map((member) => (
+                  <DropdownMenuItem
+                    key={member.sId}
+                    label={member.fullName}
+                    description={member.email}
+                    icon={() => (
+                      <Avatar
+                        name={member.fullName}
+                        visual={member.image ?? undefined}
+                        size="sm"
+                        isRounded
+                      />
+                    )}
+                    truncateText
+                    disabled={editorIds.has(member.sId)}
+                    onClick={() => void onAddEditor(member.sId)}
+                  />
+                ))
+              ) : (
+                <div className="flex h-24 items-center justify-center text-sm text-muted-foreground">
+                  No members found
+                </div>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      )}
     </div>
   );
 }

--- a/front/components/assistant/details/tabs/AgentEditorsTab.tsx
+++ b/front/components/assistant/details/tabs/AgentEditorsTab.tsx
@@ -76,23 +76,9 @@ export function AgentEditorsTab({
 
   return (
     <div className="flex flex-col gap-4">
-      <MembersList
-        currentUser={user}
-        membersData={{
-          members: editors.map((user) => ({
-            ...user,
-            workspace: owner,
-          })),
-          isLoading: isEditorsLoading,
-          totalMembersCount: editors.length,
-          mutateRegardlessOfQueryParams: () => Promise.resolve(undefined),
-        }}
-        showColumns={canManageEditors ? ["name", "remove"] : ["name"]}
-        onRemoveMemberClick={onRemoveMember}
-        onRowClick={function noRefCheck() {}}
-      />
-      {canManageEditors && (
-        <div>
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold">Editors</h3>
+        {canManageEditors && (
           <DropdownMenu
             open={isEditorPickerOpen}
             onOpenChange={(open) => {
@@ -107,7 +93,7 @@ export function AgentEditorsTab({
                 variant="outline"
                 size="sm"
                 icon={Plus}
-                label="Add editors"
+                label="Add editor"
                 disabled={isEditorsLoading || isEditorsError}
                 isLoading={isAddingEditor}
                 type="button"
@@ -115,7 +101,7 @@ export function AgentEditorsTab({
             </DropdownMenuTrigger>
             <DropdownMenuContent
               className="w-80"
-              align="start"
+              align="end"
               dropdownHeaders={
                 <>
                   <DropdownMenuSearchbar
@@ -158,8 +144,23 @@ export function AgentEditorsTab({
               )}
             </DropdownMenuContent>
           </DropdownMenu>
-        </div>
-      )}
+        )}
+      </div>
+      <MembersList
+        currentUser={user}
+        membersData={{
+          members: editors.map((user) => ({
+            ...user,
+            workspace: owner,
+          })),
+          isLoading: isEditorsLoading,
+          totalMembersCount: editors.length,
+          mutateRegardlessOfQueryParams: () => Promise.resolve(undefined),
+        }}
+        showColumns={canManageEditors ? ["name", "remove"] : ["name"]}
+        onRemoveMemberClick={onRemoveMember}
+        onRowClick={function noRefCheck() {}}
+      />
     </div>
   );
 }

--- a/front/components/assistant/details/tabs/AgentEditorsTab.tsx
+++ b/front/components/assistant/details/tabs/AgentEditorsTab.tsx
@@ -31,8 +31,14 @@ export function AgentEditorsTab({
   agentConfiguration,
 }: AgentEditorsTabProps) {
   const [isEditorPickerOpen, setIsEditorPickerOpen] = useState(false);
-  const [isAddingEditor, setIsAddingEditor] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   const [searchText, setSearchText] = useState("");
+  const [addedEditors, setAddedEditors] = useState<
+    SearchMemberWithWorkspaceType[]
+  >([]);
+  const [removedEditorIds, setRemovedEditorIds] = useState<Set<string>>(
+    new Set()
+  );
   const updateEditors = useUpdateEditors({
     owner,
     agentConfigurationId: agentConfiguration.sId,
@@ -51,26 +57,74 @@ export function AgentEditorsTab({
     });
 
   const canManageEditors = agentConfiguration.canEdit || isAdmin(owner);
-  const editorIds = new Set(editors.map((editor) => editor.sId));
+  const persistedEditorIds = new Set(editors.map((editor) => editor.sId));
+  const addedEditorIds = new Set(addedEditors.map((editor) => editor.sId));
+  const visibleEditors = [
+    ...editors.filter((editor) => !removedEditorIds.has(editor.sId)),
+    ...addedEditors.filter((editor) => !persistedEditorIds.has(editor.sId)),
+  ];
+  const visibleEditorIds = new Set(visibleEditors.map((editor) => editor.sId));
+  const addEditorIds = addedEditors
+    .map((editor) => editor.sId)
+    .filter((editorId) => !persistedEditorIds.has(editorId));
+  const removeEditorIds = Array.from(removedEditorIds).filter((editorId) =>
+    persistedEditorIds.has(editorId)
+  );
+  const hasChanges = addEditorIds.length > 0 || removeEditorIds.length > 0;
 
-  const onRemoveMember = async (user: SearchMemberWithWorkspaceType) => {
-    if (canManageEditors) {
-      await updateEditors({ removeEditorIds: [user.sId], addEditorIds: [] });
-    }
-  };
-
-  const onAddEditor = async (editorId: string) => {
-    if (isAddingEditor || editorIds.has(editorId)) {
+  const onRemoveMember = (user: SearchMemberWithWorkspaceType) => {
+    if (!canManageEditors || isSaving) {
       return;
     }
 
-    setIsEditorPickerOpen(false);
-    setSearchText("");
-    setIsAddingEditor(true);
+    if (addedEditorIds.has(user.sId)) {
+      setAddedEditors((current) =>
+        current.filter((editor) => editor.sId !== user.sId)
+      );
+      return;
+    }
+
+    setRemovedEditorIds((current) => new Set(current).add(user.sId));
+  };
+
+  const onAddEditor = (editor: SearchMemberWithWorkspaceType) => {
+    if (isSaving || visibleEditorIds.has(editor.sId)) {
+      return;
+    }
+
+    if (persistedEditorIds.has(editor.sId)) {
+      setRemovedEditorIds((current) => {
+        const next = new Set(current);
+        next.delete(editor.sId);
+        return next;
+      });
+      return;
+    }
+
+    setAddedEditors((current) => [...current, editor]);
+  };
+
+  const resetChanges = () => {
+    setAddedEditors([]);
+    setRemovedEditorIds(new Set());
+  };
+
+  const onSave = async () => {
+    if (!hasChanges || isSaving) {
+      return;
+    }
+
+    setIsSaving(true);
     try {
-      await updateEditors({ addEditorIds: [editorId], removeEditorIds: [] });
+      const didUpdate = await updateEditors({
+        addEditorIds,
+        removeEditorIds,
+      });
+      if (didUpdate) {
+        resetChanges();
+      }
     } finally {
-      setIsAddingEditor(false);
+      setIsSaving(false);
     }
   };
 
@@ -93,9 +147,8 @@ export function AgentEditorsTab({
                 variant="outline"
                 size="sm"
                 icon={Plus}
-                label="Add editor"
-                disabled={isEditorsLoading || isEditorsError}
-                isLoading={isAddingEditor}
+                label="Add editors"
+                disabled={isEditorsLoading || isEditorsError || isSaving}
                 type="button"
               />
             </DropdownMenuTrigger>
@@ -133,8 +186,9 @@ export function AgentEditorsTab({
                       />
                     )}
                     truncateText
-                    disabled={editorIds.has(member.sId)}
-                    onClick={() => void onAddEditor(member.sId)}
+                    disabled={visibleEditorIds.has(member.sId) || isSaving}
+                    onClick={() => onAddEditor(member)}
+                    onSelect={(event) => event.preventDefault()}
                   />
                 ))
               ) : (
@@ -149,18 +203,39 @@ export function AgentEditorsTab({
       <MembersList
         currentUser={user}
         membersData={{
-          members: editors.map((user) => ({
+          members: visibleEditors.map((user) => ({
             ...user,
             workspace: owner,
           })),
           isLoading: isEditorsLoading,
-          totalMembersCount: editors.length,
+          totalMembersCount: visibleEditors.length,
           mutateRegardlessOfQueryParams: () => Promise.resolve(undefined),
         }}
         showColumns={canManageEditors ? ["name", "remove"] : ["name"]}
         onRemoveMemberClick={onRemoveMember}
         onRowClick={function noRefCheck() {}}
       />
+      {canManageEditors && (
+        <div className="flex justify-end gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            label="Cancel"
+            disabled={!hasChanges || isSaving}
+            onClick={resetChanges}
+            type="button"
+          />
+          <Button
+            variant="highlight"
+            size="sm"
+            label="Save"
+            disabled={!hasChanges || isSaving}
+            isLoading={isSaving}
+            onClick={onSave}
+            type="button"
+          />
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Description

Agent editors can now be managed directly from the agent info page. Editors can search workspace members from a compact picker, add one without opening another sheet, and remove existing editors from the current list.

This PR is limited to agents. The equivalent skill flow was handled separately in #29917

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.