### PR TITLE
Pricing: allow pro plan to buy up to 1000$ instead of 50$/user/month

### DIFF
--- a/front/lib/credits/limits.test.ts
+++ b/front/lib/credits/limits.test.ts
@@ -1,5 +1,4 @@
 import type { Authenticator } from "@app/lib/auth";
-import * as common from "@app/lib/credits/common";
 import { getCustomerPaymentStatus } from "@app/lib/credits/free";
 import { getCreditPurchaseLimits } from "@app/lib/credits/limits";
 import { isEnterpriseSubscription } from "@app/lib/plans/stripe";
@@ -46,7 +45,6 @@ function makeSubscription(
 
 describe("getCreditPurchaseLimits", () => {
   let auth: Authenticator;
-  let countEligibleUsersSpy: MockInstance;
   let sumCommittedCreditsSpy: MockInstance;
   let fetchProgrammaticConfigSpy: MockInstance;
   let listPendingCommittedSpy: MockInstance;
@@ -58,10 +56,6 @@ describe("getCreditPurchaseLimits", () => {
 
     const { authenticator } = await createResourceTest({ role: "admin" });
     auth = authenticator;
-
-    countEligibleUsersSpy = vi
-      .spyOn(common, "countEligibleUsersForCredits")
-      .mockResolvedValue(10);
 
     sumCommittedCreditsSpy = vi
       .spyOn(CreditResource, "sumCommittedCreditsPurchasedInPeriod")
@@ -78,7 +72,6 @@ describe("getCreditPurchaseLimits", () => {
 
   afterEach(() => {
     vi.useRealTimers();
-    countEligibleUsersSpy.mockRestore();
     sumCommittedCreditsSpy.mockRestore();
     fetchProgrammaticConfigSpy.mockRestore();
     listPendingCommittedSpy.mockRestore();
@@ -232,9 +225,7 @@ describe("getCreditPurchaseLimits", () => {
       vi.mocked(getCustomerPaymentStatus).mockResolvedValue("paying");
     });
 
-    it("should calculate limit based on user count ($50/user)", async () => {
-      countEligibleUsersSpy.mockResolvedValue(10);
-
+    it("should allow a flat $1000 per billing cycle", async () => {
       const result = await getCreditPurchaseLimits(auth, {
         type: "stripe-subscription",
         stripeSubscription: makeSubscription(),
@@ -242,82 +233,11 @@ describe("getCreditPurchaseLimits", () => {
 
       expect(result).toEqual({
         canPurchase: true,
-        maxAmountMicroUsd: 500_000_000, // 10 users * $50 = $500 in microUsd
+        maxAmountMicroUsd: 1_000_000_000, // Flat $1000
       });
     });
 
-    it("should cap at $1000 for large teams", async () => {
-      countEligibleUsersSpy.mockResolvedValue(100);
-
-      const result = await getCreditPurchaseLimits(auth, {
-        type: "stripe-subscription",
-        stripeSubscription: makeSubscription(),
-      });
-
-      expect(result).toEqual({
-        canPurchase: true,
-        maxAmountMicroUsd: 1_000_000_000, // Capped at $1000
-      });
-    });
-
-    it("should allow $50 for single user", async () => {
-      countEligibleUsersSpy.mockResolvedValue(1);
-
-      const result = await getCreditPurchaseLimits(auth, {
-        type: "stripe-subscription",
-        stripeSubscription: makeSubscription(),
-      });
-
-      expect(result).toEqual({
-        canPurchase: true,
-        maxAmountMicroUsd: 50_000_000, // 1 user * $50 in microUsd
-      });
-    });
-
-    it("should allow $250 for 5 users", async () => {
-      countEligibleUsersSpy.mockResolvedValue(5);
-
-      const result = await getCreditPurchaseLimits(auth, {
-        type: "stripe-subscription",
-        stripeSubscription: makeSubscription(),
-      });
-
-      expect(result).toEqual({
-        canPurchase: true,
-        maxAmountMicroUsd: 250_000_000, // 5 users * $50 = $250 in microUsd
-      });
-    });
-
-    it("should cap exactly at $1000 for 20 users", async () => {
-      countEligibleUsersSpy.mockResolvedValue(20);
-
-      const result = await getCreditPurchaseLimits(auth, {
-        type: "stripe-subscription",
-        stripeSubscription: makeSubscription(),
-      });
-
-      expect(result).toEqual({
-        canPurchase: true,
-        maxAmountMicroUsd: 1_000_000_000, // 20 users * $50 = $1000 (exactly at cap)
-      });
-    });
-
-    it("should cap at $1000 for more than 20 users", async () => {
-      countEligibleUsersSpy.mockResolvedValue(25);
-
-      const result = await getCreditPurchaseLimits(auth, {
-        type: "stripe-subscription",
-        stripeSubscription: makeSubscription(),
-      });
-
-      expect(result).toEqual({
-        canPurchase: true,
-        maxAmountMicroUsd: 1_000_000_000, // Capped at $1000
-      });
-    });
-
-    it("should subtract already purchased credits from per-user limit", async () => {
-      countEligibleUsersSpy.mockResolvedValue(10); // $500 limit
+    it("should subtract already purchased credits from the limit", async () => {
       sumCommittedCreditsSpy.mockResolvedValue(200_000_000); // $200 already purchased
 
       const result = await getCreditPurchaseLimits(auth, {
@@ -327,13 +247,12 @@ describe("getCreditPurchaseLimits", () => {
 
       expect(result).toEqual({
         canPurchase: true,
-        maxAmountMicroUsd: 300_000_000, // $500 - $200 = $300
+        maxAmountMicroUsd: 800_000_000, // $1000 - $200 = $800
       });
     });
 
-    it("should return 0 if per-user limit is exhausted", async () => {
-      countEligibleUsersSpy.mockResolvedValue(5); // $250 limit
-      sumCommittedCreditsSpy.mockResolvedValue(250_000_000); // $250 already purchased
+    it("should return 0 if the limit is exhausted", async () => {
+      sumCommittedCreditsSpy.mockResolvedValue(1_000_000_000); // $1000 already purchased
 
       const result = await getCreditPurchaseLimits(auth, {
         type: "stripe-subscription",

--- a/front/lib/credits/limits.ts
+++ b/front/lib/credits/limits.ts
@@ -1,6 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
 import { getBillingCycleFromDay } from "@app/lib/client/subscription";
-import { countEligibleUsersForCredits } from "@app/lib/credits/common";
 import { getCustomerPaymentStatus } from "@app/lib/credits/free";
 import { isEnterprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import { isEnterpriseSubscription } from "@app/lib/plans/stripe";
@@ -9,9 +8,7 @@ import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/progr
 import type { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import type Stripe from "stripe";
 
-// $50 per user per month for Pro subscriptions.
-const MAX_PRO_CREDIT_PER_USER_MICRO_USD = 50_000_000;
-// $1000 absolute cap for Pro subscriptions.
+// $1000 flat cap per billing cycle for Pro subscriptions.
 const MAX_PRO_CREDIT_TOTAL_MICRO_USD = 1_000_000_000;
 // $1000 minimum cap for Enterprise subscriptions.
 const MIN_ENTERPRISE_CREDIT_MICRO_USD = 1_000_000_000;
@@ -36,7 +33,7 @@ type CreditPurchaseLimitsContext =
  * Rules:
  * - Pro in trial: cannot purchase credits (Stripe-billed only)
  * - Pro with payment issues: cannot purchase credits (Stripe-billed only)
- * - Pro paying: $50/user/month, capped at $1000 per billing cycle
+ * - Pro paying: flat $1000 per billing cycle
  * - Enterprise: max($1000, half of pay-as-you-go cap) per billing cycle
  *
  * Metronome-only workspaces skip the trial / payment-issue checks (no Stripe
@@ -104,13 +101,8 @@ export async function getCreditPurchaseLimits(
     return { canPurchase: false, reason: "pending_payment" };
   }
 
-  // Pro paying: $50/user/month, capped at $1000 per billing cycle.
-  const workspace = auth.getNonNullableWorkspace();
-  const userCount = await countEligibleUsersForCredits(workspace);
-  const cycleMaxMicroUsd = Math.min(
-    userCount * MAX_PRO_CREDIT_PER_USER_MICRO_USD,
-    MAX_PRO_CREDIT_TOTAL_MICRO_USD
-  );
+  // Pro paying: flat $1000 per billing cycle.
+  const cycleMaxMicroUsd = MAX_PRO_CREDIT_TOTAL_MICRO_USD;
 
   const alreadyPurchased =
     await CreditResource.sumCommittedCreditsPurchasedInPeriod(

--- a/front/lib/credits/limits.ts
+++ b/front/lib/credits/limits.ts
@@ -102,8 +102,6 @@ export async function getCreditPurchaseLimits(
   }
 
   // Pro paying: flat $1000 per billing cycle.
-  const cycleMaxMicroUsd = MAX_PRO_CREDIT_TOTAL_MICRO_USD;
-
   const alreadyPurchased =
     await CreditResource.sumCommittedCreditsPurchasedInPeriod(
       auth,
@@ -113,7 +111,10 @@ export async function getCreditPurchaseLimits(
 
   return {
     canPurchase: true,
-    maxAmountMicroUsd: Math.max(0, cycleMaxMicroUsd - alreadyPurchased),
+    maxAmountMicroUsd: Math.max(
+      0,
+      MAX_PRO_CREDIT_TOTAL_MICRO_USD - alreadyPurchased
+    ),
   };
 }
 


### PR DESCRIPTION
## Description

Previous limit is `1000$` for enterprise and `min(1000, 50 * users)` for pro plan.

This move the limit up to 1000$, same as enterprise.

No UI to update at they display these values

## Tests



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

dceploy front
