### PR TITLE
Pricing: fix stripe invoice cleaning by matching all expected lines to remove

### DIFF
--- a/front/lib/plans/stripe.test.ts
+++ b/front/lib/plans/stripe.test.ts
@@ -1059,6 +1059,99 @@ describe("cleanAndFinalizeMetronomeDraftInvoice", () => {
     });
   });
 
+  it("should delete a commit-applied pair when the label is its own parenthesized group", async () => {
+    setupMetronomeDraftInvoice({
+      lines: [
+        makeMetronomeLine({
+          id: "l1",
+          amountCents: 5300,
+          description:
+            "Platform Seat (Yearly) (Platform Seat (Yearly) commitment: 53 seats)",
+        }),
+        makeMetronomeLine({
+          id: "l2",
+          amountCents: -5300,
+          description: "Platform Seat (Yearly) commitment: 53 seats applied",
+        }),
+        makeMetronomeLine({
+          id: "l3",
+          amountCents: 1900,
+          description: "Pro Seat",
+        }),
+      ],
+      totalCents: 1900,
+    });
+
+    const result = await cleanAndFinalizeMetronomeDraftInvoice({
+      invoiceId: "in_test",
+      workspaceId: "w_test",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.outcome).toBe("cleaned");
+    }
+    expect(mockInvoiceItems.del).toHaveBeenCalledWith("ii_l1");
+    expect(mockInvoiceItems.del).toHaveBeenCalledWith("ii_l2");
+    expect(mockInvoiceItems.del).not.toHaveBeenCalledWith("ii_l3");
+  });
+
+  it("should delete a commit-applied pair when the label is the last element of the qty/price group", async () => {
+    // a commit split across two positive lines, each offset by its
+    // own negative "applied" line, with the label embedded as
+    // "Name (qty, $price, label)". The same-amount line without the label
+    // (l3) must survive.
+    const commitLabel = "Business subscription activation (max monthly)";
+    setupMetronomeDraftInvoice({
+      lines: [
+        makeMetronomeLine({
+          id: "l1",
+          amountCents: 14980,
+          description: `Max Seat (prorated) (${commitLabel})`,
+        }),
+        makeMetronomeLine({
+          id: "l2",
+          amountCents: 20,
+          description: `Max Seat (0.0013440860215053763441, $150.00, ${commitLabel})`,
+        }),
+        makeMetronomeLine({
+          id: "l3",
+          amountCents: 14980,
+          description: "Max Seat (0.99865591397849462366, $150.00)",
+        }),
+        makeMetronomeLine({
+          id: "l4",
+          amountCents: -14980,
+          description: `${commitLabel} applied`,
+        }),
+        makeMetronomeLine({
+          id: "l5",
+          amountCents: -20,
+          description: `${commitLabel} applied`,
+        }),
+      ],
+      totalCents: 14980,
+    });
+
+    const result = await cleanAndFinalizeMetronomeDraftInvoice({
+      invoiceId: "in_test",
+      workspaceId: "w_test",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.outcome).toBe("cleaned");
+    }
+    expect(mockInvoiceItems.del).toHaveBeenCalledWith("ii_l1");
+    expect(mockInvoiceItems.del).toHaveBeenCalledWith("ii_l2");
+    expect(mockInvoiceItems.del).toHaveBeenCalledWith("ii_l4");
+    expect(mockInvoiceItems.del).toHaveBeenCalledWith("ii_l5");
+    expect(mockInvoiceItems.del).not.toHaveBeenCalledWith("ii_l3");
+    expect(mockInvoices.finalizeInvoice).toHaveBeenCalledWith("in_test", {
+      auto_advance: true,
+    });
+  });
+
   it("should delete negative lines without normalizing them", async () => {
     setupMetronomeDraftInvoice({
       lines: [

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1668,13 +1668,16 @@ const METRONOME_INVOICE_LINES_CLEANED_FLAG = "lines_cleaned";
  * Metronome represents a fully-applied commit/credit as a pair of lines on the
  * same invoice with equal and opposite amounts: a negative line whose
  * description is "<label> applied", and the positive usage/subscription line
- * it offsets, whose description contains "(<label>)" (e.g. a negative
+ * it offsets. The positive line references the label in one of two formats:
+ * as its own parenthesized group, "(<label>)" (e.g. a negative
  * "Platform Seat (Yearly) commitment: 53 seats applied" line offsetting a
  * positive "Platform Seat (Yearly) (Platform Seat (Yearly) commitment: 53
- * seats)" line). Neither line carries metadata identifying the pairing (there
- * is no such thing as `metronome_commit_id` on Stripe line items — Metronome
- * does not document or set one), so we match them by description + amount
- * instead.
+ * seats)" line), or as the last comma-separated element of the quantity/price
+ * group, ", <label>)" (e.g. "Max Seat (0.0013, $150.00, Business subscription
+ * activation (max monthly))"). Neither line carries metadata identifying the
+ * pairing (there is no such thing as `metronome_commit_id` on Stripe line
+ * items — Metronome does not document or set one), so we match them by
+ * description + amount instead.
  */
 function findCommitAppliedLineIds(
   lines: Stripe.InvoiceLineItem[]
@@ -1699,7 +1702,8 @@ function findCommitAppliedLineIds(
         !matchedLineIds.has(candidate.id) &&
         candidate.amount === -creditLine.amount &&
         candidate.currency === creditLine.currency &&
-        candidate.description?.includes(`(${label})`)
+        (candidate.description?.includes(`(${label})`) ||
+          candidate.description?.includes(`, ${label})`))
     );
 
     if (offsetLine) {


### PR DESCRIPTION
## Description

This issue created a draft for an invoice because a line to remove was not correctly matched.

Lines not correctly matched look like this:
<img width="1338" height="202" alt="image" src="https://github.com/user-attachments/assets/f0190bcc-6546-40a4-bbea-fbffa2e36c38" />


## Tests

added unit tests

## Risk

low, we have the check for drifts anyway

## Deploy Plan

deploy front
