### PR TITLE
Display credit attribution in agent messages

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -8,6 +8,7 @@ import { AttachmentCitation } from "@app/components/assistant/conversation/attac
 import { markdownCitationToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
 import { BlockedAction } from "@app/components/assistant/conversation/BlockedAction";
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
+import { CreditCostSubmenu } from "@app/components/assistant/conversation/CreditCostSubmenu";
 import { DeletedMessage } from "@app/components/assistant/conversation/DeletedMessage";
 import { ErrorMessage } from "@app/components/assistant/conversation/ErrorMessage";
 import type { FeedbackSelectorBaseProps } from "@app/components/assistant/conversation/FeedbackSelector";
@@ -264,6 +265,7 @@ export function AgentMessage({
   const [streamId, setStreamId] = useState<string>(`message-${sId}`);
   const { hasFeature } = useFeatureFlags();
   const isCollapsibleEnabled = hasFeature("collapsible_messages");
+  const hasConsumptionDetails = hasFeature("conversation_consumption_details");
 
   const [isRetryHandlerProcessing, setIsRetryHandlerProcessing] =
     useState<boolean>(false);
@@ -982,7 +984,22 @@ export function AgentMessage({
           <DropdownMenuContent align="end">
             {(creditCostItem || isCreditCostLoading) && (
               <>
-                {creditCostItem ? (
+                {hasConsumptionDetails ? (
+                  <CreditCostSubmenu
+                    credits={
+                      refreshedAgentMessage?.costCredits ??
+                      agentMessage.costCredits
+                    }
+                    subAgentCredits={
+                      refreshedAgentMessage?.subAgentCostCredits ??
+                      agentMessage.subAgentCostCredits
+                    }
+                    conversationId={conversationId}
+                    messageId={agentMessage.sId}
+                    workspaceId={owner.sId}
+                    isCostLoading={isCreditCostLoading}
+                  />
+                ) : creditCostItem ? (
                   <DropdownMenuItem {...creditCostItem} />
                 ) : (
                   <DropdownMenuItem

--- a/front/components/assistant/conversation/CreditCostSubmenu.test.tsx
+++ b/front/components/assistant/conversation/CreditCostSubmenu.test.tsx
@@ -1,0 +1,188 @@
+import { CreditCostSubmenu } from "@app/components/assistant/conversation/CreditCostSubmenu";
+import type { AgentMessageConsumptionToolDetails } from "@app/types/assistant/agent_message_consumption";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ComponentProps, ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockUseAgentMessageConsumption } = vi.hoisted(() => ({
+  mockUseAgentMessageConsumption: vi.fn(),
+}));
+
+vi.mock("@app/hooks/conversations/useAgentMessageConsumption", () => ({
+  useAgentMessageConsumption: mockUseAgentMessageConsumption,
+}));
+
+vi.mock("@app/components/assistant/conversation/actions/inline/utils", () => ({
+  getActionStepIcon: () => () => null,
+}));
+
+vi.mock("@app/components/resources/resources_icons", () => ({
+  InternalActionIcons: {
+    ActionBrainIcon: () => null,
+  },
+}));
+
+vi.mock("@dust-tt/sparkle", () => ({
+  ChevronRight: () => null,
+  ShapesPlus: () => null,
+  DropdownMenuItem: ({
+    label,
+    description,
+    endComponent,
+    disabled,
+  }: {
+    label: string;
+    description?: string;
+    endComponent?: ReactNode;
+    disabled?: boolean;
+  }) => (
+    <div data-disabled={disabled || undefined}>
+      <span>{label}</span>
+      {description && <span>{description}</span>}
+      {endComponent && <span>{endComponent}</span>}
+    </div>
+  ),
+  DropdownMenuLabel: ({ label }: { label: string }) => <div>{label}</div>,
+  DropdownMenuPortal: ({ children }: { children: ReactNode }) => children,
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuSub: ({
+    children,
+    onOpenChange,
+  }: {
+    children: ReactNode;
+    onOpenChange?: (open: boolean) => void;
+  }) => (
+    <div>
+      <button type="button" onClick={() => onOpenChange?.(true)}>
+        Open credit details
+      </button>
+      {children}
+    </div>
+  ),
+  DropdownMenuSubContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuSubTrigger: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}));
+
+const makeTool = (
+  toolName: string,
+  label: string,
+  grossAttributedCredits: number,
+  overrides: Partial<AgentMessageConsumptionToolDetails> = {}
+): AgentMessageConsumptionToolDetails => ({
+  label,
+  internalMCPServerName: null,
+  toolName,
+  callCount: 1,
+  grossAttributedCredits,
+  directCredits: 0,
+  pending: false,
+  ...overrides,
+});
+
+const defaultProps: ComponentProps<typeof CreditCostSubmenu> = {
+  credits: 10,
+  subAgentCredits: 0,
+  conversationId: "conversation_test",
+  messageId: "message_test",
+  workspaceId: "workspace_test",
+  isCostLoading: false,
+};
+
+describe("CreditCostSubmenu", () => {
+  beforeEach(() => {
+    mockUseAgentMessageConsumption.mockReset();
+  });
+
+  it("shows the three largest tool contributions and groups the remaining tools", () => {
+    mockUseAgentMessageConsumption.mockReturnValue({
+      consumption: {
+        billedCredits: 12,
+        details: {
+          attributionVersion: 2,
+          grossAttributedCredits: 22,
+          estimatedCacheSavingsCredits: 2,
+          agentWorkCredits: 4,
+          tools: [
+            makeTool("files", "File tool", 2),
+            makeTool("calendar", "Calendar tool", 7.06, { callCount: 2 }),
+            makeTool("title", "Title tool", 1),
+            makeTool("search", "Search tool", 5),
+            makeTool("web", "Web tool", 3),
+          ],
+        },
+      },
+      isConsumptionLoading: false,
+      mutateConsumption: vi.fn(),
+    });
+
+    render(<CreditCostSubmenu {...defaultProps} subAgentCredits={3} />);
+
+    expect(screen.getByText("Calendar tool")).toBeInTheDocument();
+    expect(screen.getByText("7.1 credits")).toBeInTheDocument();
+    expect(screen.getByText("Search tool")).toBeInTheDocument();
+    expect(screen.getByText("Web tool")).toBeInTheDocument();
+    expect(screen.queryByText("File tool")).not.toBeInTheDocument();
+    expect(screen.queryByText("Title tool")).not.toBeInTheDocument();
+    expect(screen.getByText("Other tools")).toBeInTheDocument();
+    expect(screen.getByText("2 tools, 2 uses")).toBeInTheDocument();
+    expect(screen.getByText("Saved through reuse")).toBeInTheDocument();
+    expect(screen.getByText("Agent work and context")).toBeInTheDocument();
+    expect(
+      screen.getByText("Longer conversations require more context to process")
+    ).toBeInTheDocument();
+    expect(screen.getByText("This message")).toBeInTheDocument();
+    expect(screen.getByText("Sub-agents")).toBeInTheDocument();
+    expect(screen.getByText("Calendar tool").parentElement).toHaveAttribute(
+      "data-disabled",
+      "true"
+    );
+  });
+
+  it("keeps the exact charge visible when attribution details are unavailable", () => {
+    mockUseAgentMessageConsumption.mockReturnValue({
+      consumption: { billedCredits: 12, details: null },
+      isConsumptionLoading: false,
+      mutateConsumption: vi.fn(),
+    });
+
+    render(<CreditCostSubmenu {...defaultProps} />);
+
+    expect(screen.getByText("12 credits")).toBeInTheDocument();
+    expect(
+      screen.getByText("Detailed explanation unavailable")
+    ).toBeInTheDocument();
+  });
+
+  it("loads details on first open and revalidates on later opens", () => {
+    const mutateConsumption = vi.fn();
+    mockUseAgentMessageConsumption.mockReturnValue({
+      consumption: undefined,
+      isConsumptionLoading: false,
+      mutateConsumption,
+    });
+
+    render(<CreditCostSubmenu {...defaultProps} />);
+
+    expect(mockUseAgentMessageConsumption).toHaveBeenLastCalledWith(
+      expect.objectContaining({ disabled: true })
+    );
+
+    const openButton = screen.getByRole("button", {
+      name: "Open credit details",
+    });
+    fireEvent.click(openButton);
+
+    expect(mockUseAgentMessageConsumption).toHaveBeenLastCalledWith(
+      expect.objectContaining({ disabled: false })
+    );
+    expect(mutateConsumption).not.toHaveBeenCalled();
+
+    fireEvent.click(openButton);
+
+    expect(mutateConsumption).toHaveBeenCalledOnce();
+  });
+});

--- a/front/components/assistant/conversation/CreditCostSubmenu.tsx
+++ b/front/components/assistant/conversation/CreditCostSubmenu.tsx
@@ -1,0 +1,229 @@
+import { getActionStepIcon } from "@app/components/assistant/conversation/actions/inline/utils";
+import { InternalActionIcons } from "@app/components/resources/resources_icons";
+import { useAgentMessageConsumption } from "@app/hooks/conversations/useAgentMessageConsumption";
+import { formatCredits } from "@app/lib/client/credits";
+import type { AgentMessageConsumptionToolDetails } from "@app/types/assistant/agent_message_consumption";
+import {
+  ChevronRight,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuPortal,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  ShapesPlus,
+} from "@dust-tt/sparkle";
+import type { ComponentType } from "react";
+import { useState } from "react";
+
+const MAX_VISIBLE_TOOLS = 3;
+
+function formatCreditValue(credits: number): string {
+  return `${formatCredits(credits)} credits`;
+}
+
+function toolDescription(tool: AgentMessageConsumptionToolDetails): string {
+  const descriptions = [
+    `${tool.callCount} ${tool.callCount === 1 ? "use" : "uses"}`,
+  ];
+
+  if (tool.pending) {
+    descriptions.push("Still running");
+  }
+
+  return descriptions.join(" · ");
+}
+
+interface ReadonlyCostItemProps {
+  description?: string;
+  icon?: ComponentType<{ className?: string }>;
+  label: string;
+  value: string;
+}
+
+function ReadonlyCostItem({
+  description,
+  icon,
+  label,
+  value,
+}: ReadonlyCostItemProps) {
+  return (
+    <DropdownMenuItem
+      aria-label={`${label}, ${description ? `${description}, ` : ""}${value}`}
+      disabled
+      label={label}
+      description={description}
+      icon={icon}
+      endComponent={value}
+      className="cursor-default font-normal text-foreground data-[disabled]:text-foreground"
+    />
+  );
+}
+
+interface ReadonlyNoticeProps {
+  description: string;
+  label: string;
+}
+
+function ReadonlyNotice({ description, label }: ReadonlyNoticeProps) {
+  return (
+    <DropdownMenuItem
+      aria-label={`${label}. ${description}`}
+      disabled
+      label={label}
+      description={description}
+      className="cursor-default font-normal data-[disabled]:text-muted-foreground"
+    />
+  );
+}
+
+interface CreditCostSubmenuProps {
+  conversationId: string;
+  credits: number | null | undefined;
+  isCostLoading: boolean;
+  messageId: string;
+  subAgentCredits: number | null | undefined;
+  workspaceId: string;
+}
+
+// TODO(2026-08-03 OBSERVABILITY) Temporary component, design and implementation will be improved in the future.
+export function CreditCostSubmenu({
+  conversationId,
+  credits,
+  isCostLoading,
+  messageId,
+  subAgentCredits,
+  workspaceId,
+}: CreditCostSubmenuProps) {
+  const [hasOpened, setHasOpened] = useState(false);
+  const { consumption, isConsumptionLoading, mutateConsumption } =
+    useAgentMessageConsumption({
+      conversationId,
+      workspaceId,
+      messageId,
+      disabled: !hasOpened,
+    });
+
+  const ownCredits = consumption?.billedCredits ?? credits ?? 0;
+  const childCredits = subAgentCredits ?? 0;
+  const totalCredits = ownCredits + childCredits;
+  const details = consumption?.details;
+
+  if (!isCostLoading && totalCredits <= 0) {
+    return null;
+  }
+
+  const rankedTools = details
+    ? [...details.tools].sort(
+        (left, right) =>
+          right.grossAttributedCredits - left.grossAttributedCredits
+      )
+    : [];
+  const visibleTools = rankedTools.slice(0, MAX_VISIBLE_TOOLS);
+  const remainingTools = rankedTools.slice(MAX_VISIBLE_TOOLS);
+  const remainingToolCredits = remainingTools.reduce(
+    (total, tool) => total + tool.grossAttributedCredits,
+    0
+  );
+  const remainingToolCallCount = remainingTools.reduce(
+    (total, tool) => total + tool.callCount,
+    0
+  );
+
+  return (
+    <DropdownMenuSub
+      onOpenChange={(open) => {
+        if (!open) {
+          return;
+        }
+        if (hasOpened) {
+          void mutateConsumption();
+        } else {
+          setHasOpened(true);
+        }
+      }}
+    >
+      <DropdownMenuSubTrigger>
+        <span className="flex min-w-44 flex-1 items-center gap-2">
+          <span className="flex-1">Credit cost</span>
+          {isCostLoading ? (
+            <span className="h-3 w-8 animate-pulse rounded bg-muted-foreground/20" />
+          ) : (
+            <span className="font-normal text-muted-foreground">
+              {formatCredits(totalCredits)}
+            </span>
+          )}
+          <ChevronRight className="h-3 w-3 text-muted-foreground" />
+        </span>
+      </DropdownMenuSubTrigger>
+      <DropdownMenuPortal>
+        <DropdownMenuSubContent className="w-80">
+          <DropdownMenuLabel label="Charged" />
+          <ReadonlyCostItem
+            label="This message"
+            value={isCostLoading ? "Updating" : formatCreditValue(ownCredits)}
+          />
+          {childCredits > 0 && (
+            <ReadonlyCostItem
+              label="Sub-agents"
+              value={
+                isCostLoading ? "Updating" : formatCreditValue(childCredits)
+              }
+            />
+          )}
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel label="Estimated work before savings" />
+          {isConsumptionLoading && !consumption ? (
+            <div
+              aria-busy="true"
+              aria-live="polite"
+              className="flex min-h-9 items-center px-2 py-1.5 text-sm text-muted-foreground"
+            >
+              <span className="flex-1">Loading details</span>
+              <span className="h-3 w-8 animate-pulse rounded bg-muted-foreground/20" />
+            </div>
+          ) : details ? (
+            <>
+              <ReadonlyCostItem
+                label="Agent work and context"
+                description="Longer conversations require more context to process"
+                value={formatCreditValue(details.agentWorkCredits)}
+                icon={InternalActionIcons.ActionBrainIcon}
+              />
+              {visibleTools.map((tool) => (
+                <ReadonlyCostItem
+                  key={`${tool.internalMCPServerName ?? "external"}:${tool.toolName}:${tool.label}`}
+                  label={tool.label}
+                  description={toolDescription(tool)}
+                  value={formatCreditValue(tool.grossAttributedCredits)}
+                  icon={getActionStepIcon(tool)}
+                />
+              ))}
+              {remainingTools.length > 0 && (
+                <ReadonlyCostItem
+                  label="Other tools"
+                  description={`${remainingTools.length} ${remainingTools.length === 1 ? "tool" : "tools"}, ${remainingToolCallCount} ${remainingToolCallCount === 1 ? "use" : "uses"}`}
+                  value={formatCreditValue(remainingToolCredits)}
+                  icon={ShapesPlus}
+                />
+              )}
+              {details.estimatedCacheSavingsCredits !== null &&
+                details.estimatedCacheSavingsCredits > 0 && (
+                  <ReadonlyCostItem
+                    label="Saved through reuse"
+                    value={`−${formatCreditValue(details.estimatedCacheSavingsCredits)}`}
+                  />
+                )}
+            </>
+          ) : (
+            <ReadonlyNotice
+              label="Detailed explanation unavailable"
+              description="The exact charge above is authoritative."
+            />
+          )}
+        </DropdownMenuSubContent>
+      </DropdownMenuPortal>
+    </DropdownMenuSub>
+  );
+}

--- a/front/hooks/conversations/useAgentMessageConsumption.ts
+++ b/front/hooks/conversations/useAgentMessageConsumption.ts
@@ -24,7 +24,7 @@ export function useAgentMessageConsumption({
 
   return {
     consumption: data,
-    isConsumptionLoading: isLoading || isValidating,
+    isConsumptionLoading: !disabled && (isLoading || isValidating),
     mutateConsumption: mutate,
   };
 }

--- a/front/hooks/conversations/useAgentMessageConsumption.ts
+++ b/front/hooks/conversations/useAgentMessageConsumption.ts
@@ -1,0 +1,30 @@
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { AgentMessageConsumptionResponse } from "@app/types/assistant/agent_message_consumption";
+import type { Fetcher } from "swr";
+
+export function useAgentMessageConsumption({
+  conversationId,
+  workspaceId,
+  messageId,
+  disabled,
+}: {
+  conversationId: string;
+  workspaceId: string;
+  messageId: string;
+  disabled: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const consumptionFetcher: Fetcher<AgentMessageConsumptionResponse> = fetcher;
+
+  const { data, isLoading, isValidating, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/assistant/conversations/${conversationId}/messages/${messageId}/consumption`,
+    consumptionFetcher,
+    { disabled, revalidateOnFocus: false }
+  );
+
+  return {
+    consumption: data,
+    isConsumptionLoading: isLoading || isValidating,
+    mutateConsumption: mutate,
+  };
+}

--- a/front/lib/actions/tool_display_labels.test.ts
+++ b/front/lib/actions/tool_display_labels.test.ts
@@ -1,5 +1,6 @@
 import {
   getStaticToolDisplayLabelsFromFunctionCallName,
+  getToolAggregateDisplayLabel,
   getToolDisplayLabels,
   getToolNameFromFunctionCallName,
 } from "@app/lib/actions/tool_display_labels";
@@ -241,5 +242,25 @@ describe("getStaticToolDisplayLabelsFromFunctionCallName", () => {
       running: "Retrieving GitHub pull request",
       done: "Retrieve GitHub pull request",
     });
+  });
+});
+
+describe("getToolAggregateDisplayLabel", () => {
+  it("uses the generic label instead of one execution's inputs", () => {
+    expect(
+      getToolAggregateDisplayLabel({
+        functionCallName: "web_search_&_browse__websearch",
+        toolName: "websearch",
+      })
+    ).toBe("Web search");
+  });
+
+  it("humanizes the tool name when no static label exists", () => {
+    expect(
+      getToolAggregateDisplayLabel({
+        functionCallName: "custom_server__prepare_report",
+        toolName: "prepare_report",
+      })
+    ).toBe("Prepare Report");
   });
 });

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -1150,6 +1150,19 @@ export function getStaticToolDisplayLabelsFromFunctionCallName(
   return null;
 }
 
+export function getToolAggregateDisplayLabel({
+  functionCallName,
+  toolName,
+}: {
+  functionCallName: string;
+  toolName: string;
+}): string {
+  return (
+    getStaticToolDisplayLabelsFromFunctionCallName(functionCallName)?.done ??
+    asDisplayName(toolName)
+  );
+}
+
 export function getToolCallDisplayLabel(
   functionCallName: string,
   context: "running" | "done" = "done"

--- a/front/lib/api/assistant/agent_message_consumption_attribution/read.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/read.test.ts
@@ -151,6 +151,7 @@ describe("getAgentMessageConsumption", () => {
         agentWorkCredits: 4,
         tools: [
           expect.objectContaining({
+            label: "Test Tool",
             callCount: 2,
             grossAttributedCredits: 9,
             directCredits: 4,

--- a/front/lib/api/assistant/agent_message_consumption_attribution/read.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/read.ts
@@ -1,5 +1,5 @@
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
-import { getActionOneLineLabel } from "@app/lib/api/assistant/action_one_line_label";
+import { getToolAggregateDisplayLabel } from "@app/lib/actions/tool_display_labels";
 import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -153,7 +153,7 @@ function buildToolDetails({
     }
 
     groupedTools.set(identity, {
-      label: getActionOneLineLabel(serialized),
+      label: getToolAggregateDisplayLabel(serialized),
       internalMCPServerName: serialized.internalMCPServerName,
       toolName: serialized.toolName,
       callCount: 1,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

> [!WARNING]
> This is not the final design, just a way to check a few messages as we make progress

This PR adds a credit-cost submenu to agent messages behind the `conversation_consumption_details` feature flag. It keeps the exact billed credits prominent, then explains the estimated work through agent work and context, tool usage, sub-agent charges, and cache savings without exposing token accounting.

Repeated tool executions use a generic tool label and are grouped together. The submenu displays the three largest tool
contributions and combines the remainder into an “Other tools” row to keep its height predictable.

Attribution details are fetched only when the submenu is first opened and refreshed on later openings. Existing data remains visible during revalidation, and window focus does not trigger additional requests.

<img width="976" height="902" alt="image" src="https://github.com/user-attachments/assets/97289afc-cbe0-4e00-98f2-420b7f3693ad" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
