### PR TITLE
poke: add /poke/wid/connectors/cid route so connector id is resolved for in correct region

### DIFF
--- a/front-spa/src/poke/routes.tsx
+++ b/front-spa/src/poke/routes.tsx
@@ -124,6 +124,10 @@ export const routes: RouteObject[] = [
             path: "data_sources/:dsId/view",
             element: <DataSourceViewPage />,
           },
+          {
+            path: "connectors/:connectorId",
+            element: <ConnectorRedirectPage />,
+          },
           { path: "groups/:groupId", element: <GroupPage /> },
           { path: "files/:sId", element: <FramePage /> },
           { path: "skills/:sId", element: <SkillDetailsPage /> },

--- a/front/lib/production_checks/checks/check_paused_connectors.ts
+++ b/front/lib/production_checks/checks/check_paused_connectors.ts
@@ -62,7 +62,9 @@ export const checkPausedConnectors: CheckFunction = async (
   if (connectorsToReport.length > 0) {
     const actionLinks: ActionLink[] = connectorsToReport.map((c) => ({
       label: `Connector: ${c.id} (workspace: ${c.workspaceId})`,
-      url: `/poke/connectors/${c.id}`,
+      // Workspace-scoped so poke switches to the workspace's region before
+      // resolving the connector (numeric ids are per-region).
+      url: `/poke/${c.workspaceId}/connectors/${c.id}`,
     }));
     reportFailure(
       { connectorsToReport, actionLinks },


### PR DESCRIPTION
## Description

The link displayed by the production check is broken for europe because poke tries to resolve the link in US where the connector id does not exist.
Prefixing by the workspaceId first redirect to the correct region so the search should work as expected. 

## Tests

not tested

## Risk

low, purely poke UI

## Deploy Plan

deploy front
