### PR TITLE
[front] fix: do not report an unreachable OAuth service as personal authentication required

### DIFF
--- a/front/lib/actions/mcp_authentication.test.ts
+++ b/front/lib/actions/mcp_authentication.test.ts
@@ -1,14 +1,76 @@
 import {
+  getConnectionForMCPServer,
   getMCPServerAdminAuthenticationReason,
   MCPServerRequiresAdminAuthenticationError,
 } from "@app/lib/actions/mcp_authentication";
-import { DustError } from "@app/lib/error";
-import { describe, expect, it } from "vitest";
+import { getMCPConnectionAccessToken } from "@app/lib/actions/mcp_oauth_access_token";
+import type { Authenticator } from "@app/lib/auth";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/actions/mcp_oauth_access_token", () => ({
+  getMCPConnectionAccessToken: vi.fn(),
+}));
+
+vi.mock("@app/lib/resources/mcp_server_connection_resource", () => ({
+  MCPServerConnectionResource: { findByMCPServer: vi.fn() },
+}));
+
+const auth = {
+  getNonNullableWorkspace: () => ({ sId: "wId_test" }),
+} as unknown as Authenticator;
+
+describe("getConnectionForMCPServer", () => {
+  beforeEach(() => {
+    vi.mocked(MCPServerConnectionResource.findByMCPServer).mockResolvedValue(
+      new Ok({ connectionId: "con_test" } as MCPServerConnectionResource)
+    );
+  });
+
+  it("reports an unreachable OAuth service separately from a broken token", async () => {
+    vi.mocked(getMCPConnectionAccessToken).mockResolvedValue(
+      new Err({
+        code: "unexpected_network_error",
+        message:
+          "Unexpected network error from OAuthAPI: TypeError: fetch failed",
+      })
+    );
+
+    const result = await getConnectionForMCPServer(auth, {
+      mcpServerId: "ims_test",
+      connectionType: "personal",
+    });
+
+    // The connection exists; only the token fetch failed on the network. Callers must be able to
+    // tell this from a credential problem, which is the only case re-authenticating can fix.
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("oauth_service_unreachable");
+    }
+  });
+
+  it("keeps a genuine token failure as an access-token error", async () => {
+    vi.mocked(getMCPConnectionAccessToken).mockResolvedValue(
+      new Err({ code: "token_revoked_error", message: "token revoked" })
+    );
+
+    const result = await getConnectionForMCPServer(auth, {
+      mcpServerId: "ims_test",
+      connectionType: "personal",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("mcp_access_token_error");
+    }
+  });
+});
 
 describe("MCP admin authentication mapping", () => {
   it("maps a missing workspace connection to setup", () => {
     const reason = getMCPServerAdminAuthenticationReason(
-      new DustError("connection_not_found", "Connection not found")
+      "connection_not_found"
     );
     const error = new MCPServerRequiresAdminAuthenticationError(
       "ims_test",
@@ -23,10 +85,7 @@ describe("MCP admin authentication mapping", () => {
 
   it("maps a broken workspace token to reconnect", () => {
     const reason = getMCPServerAdminAuthenticationReason(
-      new DustError(
-        "mcp_access_token_error",
-        "Failed to get access token for MCP server"
-      )
+      "mcp_access_token_error"
     );
     const error = new MCPServerRequiresAdminAuthenticationError(
       "ims_test",

--- a/front/lib/actions/mcp_authentication.ts
+++ b/front/lib/actions/mcp_authentication.ts
@@ -29,7 +29,11 @@ export async function getConnectionForMCPServer(
       access_token_expiry: number | null;
       scrubbed_raw_json: unknown;
     },
-    DustError<"mcp_access_token_error" | "connection_not_found">
+    DustError<
+      | "mcp_access_token_error"
+      | "connection_not_found"
+      | "oauth_service_unreachable"
+    >
   >
 > {
   const localLogger = logger.child({
@@ -76,6 +80,17 @@ export async function getConnectionForMCPServer(
       { error: tokenResult.error },
       "Failed to get access token for MCP server"
     );
+    // Failing to reach the OAuth service is not a credential problem: the connection is there and
+    // its token may well be valid. Kept distinct from `mcp_access_token_error` so callers surface
+    // a retryable failure instead of asking the user to authenticate again, which cannot help.
+    if (tokenResult.error.code === "unexpected_network_error") {
+      return new Err(
+        new DustError(
+          "oauth_service_unreachable",
+          "Could not reach the authentication service"
+        )
+      );
+    }
     return new Err(
       new DustError(
         "mcp_access_token_error",
@@ -172,8 +187,10 @@ export class MCPServerRateLimitedError extends Error {
   }
 }
 
+// `oauth_service_unreachable` is deliberately absent: it is not an authentication problem, so
+// callers must handle it before deciding what the admin should do.
 export function getMCPServerAdminAuthenticationReason(
-  error: DustError<"mcp_access_token_error" | "connection_not_found">
+  code: "mcp_access_token_error" | "connection_not_found"
 ): MCPServerAdminAuthenticationReason {
-  return error.code === "connection_not_found" ? "setup" : "reconnect";
+  return code === "connection_not_found" ? "setup" : "reconnect";
 }

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -311,6 +311,19 @@ async function resolveRemoteServerOAuthToken(
 
   // Connection failed — return the appropriate error.
   const { provider, scope } = authorization;
+  const { code } = c.error;
+
+  // An unreachable OAuth service says nothing about the connection: it exists, and no amount of
+  // authenticating fixes the network. Surface it as a plain failure so the caller reports a
+  // retryable error instead of prompting for authentication.
+  if (code === "oauth_service_unreachable") {
+    return new Err(
+      new Error(
+        "Could not reach the authentication service to retrieve the credentials for this " +
+          "tool. Please try again."
+      )
+    );
+  }
 
   switch (connectionType) {
     case "personal": {
@@ -347,7 +360,7 @@ async function resolveRemoteServerOAuthToken(
           mcpServerId,
           provider,
           scope,
-          getMCPServerAdminAuthenticationReason(c.error)
+          getMCPServerAdminAuthenticationReason(code)
         )
       );
     default:
@@ -498,6 +511,19 @@ export async function connectToMCPServer(
                   "Internal server workspace authentication failed"
                 );
 
+                // An unreachable OAuth service says nothing about the connection: it exists, and
+                // no amount of authenticating fixes the network. Surface it as a plain connection
+                // failure so the caller reports a retryable tool error instead of prompting the
+                // user (or, for personal tools, pausing the run waiting on them).
+                if (c.error.code === "oauth_service_unreachable") {
+                  return new Err(
+                    new Error(
+                      "Could not reach the authentication service to retrieve the credentials " +
+                        "for this tool. Please try again."
+                    )
+                  );
+                }
+
                 // Use the admin-configured scope restriction if set, otherwise
                 // fall back to the full scope from server metadata.
                 const scope =
@@ -539,7 +565,7 @@ export async function connectToMCPServer(
                       params.mcpServerId,
                       serverInfo.authorization.provider,
                       scope,
-                      getMCPServerAdminAuthenticationReason(c.error)
+                      getMCPServerAdminAuthenticationReason(c.error.code)
                     )
                   );
                 } else {

--- a/front/lib/api/poke/mcp_diagnostics.ts
+++ b/front/lib/api/poke/mcp_diagnostics.ts
@@ -1007,12 +1007,9 @@ export async function runMCPDiagnostics(
               admin_reason:
                 connType === "workspace"
                   ? getMCPServerAdminAuthenticationReason(
-                      new DustError(
-                        connectionRes.error.code === "connection_not_found"
-                          ? "connection_not_found"
-                          : "mcp_access_token_error",
-                        connectionRes.error.message
-                      )
+                      connectionRes.error.code === "connection_not_found"
+                        ? "connection_not_found"
+                        : "mcp_access_token_error"
                     )
                   : undefined,
             },

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -46,6 +46,7 @@ export type DustErrorCode =
   | "action_not_found"
   | "action_not_blocked"
   | "mcp_access_token_error"
+  | "oauth_service_unreachable"
   // Triggers errors
   | "webhook_source_not_found"
   // Space errors


### PR DESCRIPTION
## Problem

When the OAuth service is unreachable, users are told to authenticate — a flow that cannot possibly fix a network failure.

Seen in prod today: `front-sandbox-functions-worker` could not reach the OAuth service (missing from its NetworkPolicy allowlist, fixed in dust-tt/dust-infra#950). The connection existed and its token was probably valid, but `getConnectionForMCPServer` collapsed the network failure into `mcp_access_token_error`, and `connectToMCPServer` maps that to `MCPServerPersonalAuthenticationRequiredError` for any `personal_actions` tool whose workspace connection row exists. Result: a Frame calling a Google Drive tool showed an authentication card ~23s in (two 10s connect timeouts), and authenticating changed nothing — the retry hit the same unreachable service and the function failed.

Every OAuth blip anywhere in the fleet produces the same misleading prompt, and for personal tools it pauses the run waiting on a user who cannot unblock it.

## Change

`getMCPConnectionAccessToken` already returns the OAuth API's error code, which distinguishes `unexpected_network_error` from real credential failures. That distinction was being discarded:

- `getConnectionForMCPServer` now returns a new `oauth_service_unreachable` code for `unexpected_network_error`, keeping `mcp_access_token_error` for genuine token problems — where re-authenticating *is* the right answer.
- Both places that map a connection failure to an authentication error (`resolveRemoteServerOAuthToken` and `connectToMCPServer`) return a plain error for the unreachable case. Callers surface it as a normal tool error (`connection_failed` → `isError: true` with the message), so the agent sees a retryable failure and sandbox function invocations get an error instead of a pause nobody can resolve.
- `getMCPServerAdminAuthenticationReason` now takes the error *code* rather than a `DustError`, so the fact that `oauth_service_unreachable` must be handled before that decision is visible in the type rather than left to a comment. This also drops a throwaway `DustError` construction in the Poke diagnostics call site.

No change to behavior for missing connections (`connection_not_found` → admin setup) or broken tokens (`mcp_access_token_error` → reconnect / personal re-auth).

## Tests

`mcp_authentication.test.ts` covers both directions: a network error maps to `oauth_service_unreachable`, and any other token failure stays `mcp_access_token_error`. The existing admin-reason tests move to the code-based signature.

## Note

This does not make the failing tool succeed — only dust-tt/dust-infra#950 does that. It stops a network outage from masquerading as a user problem.
