### PR TITLE
[dust-hive] enh: name Codex sessions after hive env name

### DIFF
--- a/x/henry/dust-hive/src/commands/open.ts
+++ b/x/henry/dust-hive/src/commands/open.ts
@@ -16,6 +16,7 @@ interface OpenOptions {
   warmCommand?: string | undefined;
   noAttach?: boolean | undefined;
   initialCommand?: string | undefined;
+  initialInput?: string | undefined;
   compact?: boolean | undefined;
   unifiedLogs?: boolean | undefined;
 }
@@ -45,6 +46,7 @@ export async function openCommand(
     envShPath,
     warmCommand: options.warmCommand,
     initialCommand: options.initialCommand,
+    initialInput: options.initialInput,
     compact: options.compact,
     unifiedLogs: options.unifiedLogs,
   };

--- a/x/henry/dust-hive/src/commands/spawn.ts
+++ b/x/henry/dust-hive/src/commands/spawn.ts
@@ -339,6 +339,7 @@ function buildOpenOptions(
   warmCommand?: string;
   noAttach?: boolean;
   initialCommand?: string;
+  initialInput?: string;
   compact?: boolean;
   unifiedLogs?: boolean;
 } {
@@ -346,12 +347,22 @@ function buildOpenOptions(
     warmCommand?: string;
     noAttach?: boolean;
     initialCommand?: string;
+    initialInput?: string;
     compact?: boolean;
     unifiedLogs?: boolean;
   } = {};
   if (options.warm) openOpts.warmCommand = `dust-hive warm ${name}`;
   if (options.noAttach) openOpts.noAttach = true;
-  if (options.command) openOpts.initialCommand = options.command;
+  if (options.command) {
+    openOpts.initialCommand = options.command;
+    if (options.command === "codex") {
+      const sessionName = name
+        .split("-")
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(" ");
+      openOpts.initialInput = `/rename ${sessionName}`;
+    }
+  }
   if (options.compact) openOpts.compact = true;
   if (options.unifiedLogs) openOpts.unifiedLogs = true;
   return openOpts;

--- a/x/henry/dust-hive/src/lib/multiplexer/tmux.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/tmux.ts
@@ -170,14 +170,25 @@ export class TmuxAdapter implements MultiplexerAdapter {
   // ============================================================
 
   generateLayout(config: LayoutConfig): string {
-    const { envName, worktreePath, envShPath, unifiedLogs, warmCommand, initialCommand } = config;
+    const {
+      envName,
+      worktreePath,
+      envShPath,
+      unifiedLogs,
+      warmCommand,
+      initialCommand,
+      initialInput,
+    } = config;
     const shellPath = getUserShell();
     const sessionName = `${SESSION_PREFIX}${envName}`;
     const mainWindowName = envName;
 
     // Build the shell command that runs in the main window
+    const initialInputCommand = initialInput
+      ? `(sleep 3; tmux send-keys -t "$TMUX_PANE" ${shellQuote(initialInput)}; sleep 1; tmux send-keys -t "$TMUX_PANE" Enter) & `
+      : "";
     const shellCommand = initialCommand
-      ? `source ${shellQuote(envShPath)} && ${initialCommand}; exec ${shellQuote(shellPath)}`
+      ? `source ${shellQuote(envShPath)} && ${initialInputCommand}${initialCommand}; exec ${shellQuote(shellPath)}`
       : `source ${shellQuote(envShPath)} && exec ${shellQuote(shellPath)}`;
 
     // Use window names instead of indices to avoid base-index issues

--- a/x/henry/dust-hive/src/lib/multiplexer/types.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/types.ts
@@ -41,6 +41,8 @@ export interface LayoutConfig {
   warmCommand?: string | undefined;
   /** Optional initial command to run in the main shell before dropping to interactive shell */
   initialCommand?: string | undefined;
+  /** Optional input to send to the initial command after it starts */
+  initialInput?: string | undefined;
 }
 
 /**


### PR DESCRIPTION
## Description

Codex sessions started through `dhx` can be difficult to find in the desktop's app session picker since they are named after the last user message.

This PR names the session after the hive env name; e.g. if I do `dhx some-cool-feature` the session will be named `Some Cool Feature`.

Only for tmux, not Zellij.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- No deploy.
