### PR TITLE
[MEMBERS] Fix resending legacy builder invitations

### DIFF
--- a/front/lib/api/signup.ts
+++ b/front/lib/api/signup.ts
@@ -19,16 +19,8 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import type { ActiveRoleType, LightWorkspaceType } from "@app/types/user";
-
-// The `builder` role is deprecated: it can only be granted through the `dust-builders` provisioning
-// group, never through invitations. Any pending or legacy `builder` invitation resolves to a
-// regular `user` membership when accepted.
-function membershipRoleForInvitation(
-  initialRole: ActiveRoleType
-): ActiveRoleType {
-  return initialRole === "builder" ? "user" : initialRole;
-}
+import type { LightWorkspaceType } from "@app/types/user";
+import { toAssignableRole } from "@app/types/user";
 
 // `membershipInvite` flow: we know we can add the user to the associated `workspaceId` as all the
 // checks (decoding the JWT) have been run before. Simply create the membership if it does not
@@ -94,7 +86,7 @@ export async function handleMembershipInvite({
     const updateRes = await updateMembershipRoleAndTrack({
       user,
       workspace: lightWorkspace,
-      newRole: membershipRoleForInvitation(membershipInvite.initialRole),
+      newRole: toAssignableRole(membershipInvite.initialRole),
       allowTerminated: true,
       author: "no-author",
     });
@@ -113,7 +105,7 @@ export async function handleMembershipInvite({
     await createAndTrackMembership({
       workspace: lightWorkspace,
       user,
-      role: membershipRoleForInvitation(membershipInvite.initialRole),
+      role: toAssignableRole(membershipInvite.initialRole),
       origin: "invited",
       requestedSeatType: membershipInvite.seatType,
     });
@@ -170,7 +162,7 @@ export async function handleEnterpriseSignUpFlow(
     await createAndTrackMembership({
       workspace: lightWorkspace,
       user,
-      role: membershipRoleForInvitation(
+      role: toAssignableRole(
         pendingMembershipInvitation?.initialRole ?? "user"
       ),
       origin: pendingMembershipInvitation ? "invited" : "auto-joined",

--- a/front/lib/invitations.ts
+++ b/front/lib/invitations.ts
@@ -9,7 +9,8 @@ import type {
 import type { MembershipInvitationType } from "@app/types/membership_invitation";
 import type { MembershipSeatType } from "@app/types/memberships";
 import { isString } from "@app/types/shared/utils/general";
-import type { ActiveRoleType, RoleType, WorkspaceType } from "@app/types/user";
+import type { ActiveRoleType, WorkspaceType } from "@app/types/user";
+import { toAssignableRole } from "@app/types/user";
 import type { NotificationType } from "@dust-tt/sparkle";
 import { mutate } from "swr";
 
@@ -30,7 +31,7 @@ export async function updateInvitation({
 }: {
   owner: WorkspaceType;
   invitation: MembershipInvitationType;
-  newRole?: RoleType; // Optional parameter for role change
+  newRole?: ActiveRoleType; // Optional parameter for role change
   sendNotification: (notificationData: NotificationType) => void;
   confirm?: (confirmData: ConfirmDataType) => Promise<boolean>;
 }) {
@@ -48,7 +49,7 @@ export async function updateInvitation({
 
   const body = {
     status: newRole ? invitation.status : "revoked",
-    initialRole: newRole ?? invitation.initialRole,
+    initialRole: toAssignableRole(newRole ?? invitation.initialRole),
   };
 
   const res = await clientFetch(
@@ -103,7 +104,8 @@ export async function sendInvitations({
 }) {
   const body: PostInvitationRequestBody = emails.map((email) => ({
     email,
-    role: invitationRole,
+    // A pending invitation may still carry the deprecated `builder` role; resend it as `user`.
+    role: toAssignableRole(invitationRole),
     seatType: seatType ?? null,
   }));
 

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -63,6 +63,13 @@ export const AssignableRoleSchema = ActiveRoleSchema.refine(isAssignableRole, {
   message: "The 'builder' role can no longer be assigned.",
 });
 
+// Maps a possibly-legacy role to one that can still be assigned: `builder` resolves to a regular
+// `user`. Use this when re-submitting a role read from an existing invitation or membership (e.g.
+// resending a pending `builder` invitation), which the API would otherwise reject.
+export function toAssignableRole(role: ActiveRoleType): AssignableRoleType {
+  return role === "builder" ? "user" : role;
+}
+
 export type WorkspaceSharingPolicy =
   | "workspace_only"
   | "workspace_and_emails"


### PR DESCRIPTION
## Description

Pending invitations created with the now-deprecated `builder` role are resent (and revoked) as `member`, instead of failing validation because `builder` can no longer be assigned.

## Tests

Tested locally; `front/lib/api/signup.test.ts` still passes.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`