### PR TITLE
Reconcile consumption attribution with billed credits

### DIFF
--- a/front/lib/api/assistant/agent_message_consumption_attribution/read.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/read.test.ts
@@ -207,6 +207,31 @@ describe("getAgentMessageConsumption", () => {
     ]);
   });
 
+  it("assigns an unattributed billed residual to agent work", async () => {
+    const { auth, conversation, runUsageModelId, agentMessage } =
+      await setupMessage();
+
+    await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+      conversation,
+      agentMessageModelId: agentMessage.agentMessageId,
+      attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+      records: modelRecords(runUsageModelId),
+      pendingToolItems: [],
+    });
+
+    const consumption = await getAgentMessageConsumption(auth, {
+      conversation,
+      agentMessageId: agentMessage.sId,
+    });
+
+    expect(consumption?.details).toMatchObject({
+      grossAttributedCredits: BILLED_CREDITS,
+      estimatedCacheSavingsCredits: 0,
+      agentWorkCredits: BILLED_CREDITS,
+      tools: [],
+    });
+  });
+
   it("withholds details when the active rows do not cover every current run bucket", async () => {
     const { auth, conversation, runUsageModelId, agentMessage } =
       await setupMessage();

--- a/front/lib/api/assistant/agent_message_consumption_attribution/read.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/read.ts
@@ -20,6 +20,57 @@ function creditsFromMicroCredits(microCredits: number): number {
   return microCredits / MICRO_CREDITS_PER_CREDIT;
 }
 
+/**
+ * Reconciles stable attribution estimates with the exact billed total without changing stored
+ * rows. Any shortfall is assigned to agent work because it cannot be safely attributed to a tool.
+ */
+function buildConsumptionTotals({
+  items,
+  billedCredits,
+}: {
+  items: AgentMessageConsumptionItemResource[];
+  billedCredits: number | null;
+}): {
+  grossAttributedCredits: number;
+  agentWorkCredits: number;
+  estimatedCacheSavingsCredits: number | null;
+} {
+  const storedGrossAttributedCreditAmountMicro = items.reduce(
+    (total, item) => total + item.grossAttributedCreditAmountMicro,
+    0
+  );
+  const storedAgentWorkCreditAmountMicro = items.reduce(
+    (total, item) =>
+      item.itemType === "tool"
+        ? total
+        : total + item.grossAttributedCreditAmountMicro,
+    0
+  );
+  const billedCreditAmountMicro =
+    billedCredits === null ? null : billedCredits * MICRO_CREDITS_PER_CREDIT;
+  const unattributedBilledCreditAmountMicro =
+    billedCreditAmountMicro === null
+      ? 0
+      : Math.max(
+          billedCreditAmountMicro - storedGrossAttributedCreditAmountMicro,
+          0
+        );
+  const grossAttributedCredits = creditsFromMicroCredits(
+    storedGrossAttributedCreditAmountMicro + unattributedBilledCreditAmountMicro
+  );
+
+  return {
+    grossAttributedCredits,
+    agentWorkCredits: creditsFromMicroCredits(
+      storedAgentWorkCreditAmountMicro + unattributedBilledCreditAmountMicro
+    ),
+    estimatedCacheSavingsCredits:
+      billedCredits === null
+        ? null
+        : Math.max(grossAttributedCredits - billedCredits, 0),
+  };
+}
+
 /** Ensures every provider-reported model bucket has a row for the active attribution version. */
 function hasCompleteModelAttribution(
   items: AgentMessageConsumptionItemResource[],
@@ -241,25 +292,14 @@ export async function getAgentMessageConsumption(
     return unavailableResponse;
   }
 
-  const grossAttributedCredits = creditsFromMicroCredits(
-    facts.items.reduce(
-      (total, item) => total + item.grossAttributedCreditAmountMicro,
-      0
-    )
-  );
-  const agentWorkCredits = creditsFromMicroCredits(
-    facts.items.reduce(
-      (total, item) =>
-        item.itemType === "tool"
-          ? total
-          : total + item.grossAttributedCreditAmountMicro,
-      0
-    )
-  );
-  const estimatedCacheSavingsCredits =
-    facts.billedCredits === null
-      ? null
-      : Math.max(grossAttributedCredits - facts.billedCredits, 0);
+  const {
+    grossAttributedCredits,
+    agentWorkCredits,
+    estimatedCacheSavingsCredits,
+  } = buildConsumptionTotals({
+    items: facts.items,
+    billedCredits: facts.billedCredits,
+  });
 
   return {
     billedCredits: facts.billedCredits,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Agent message consumption details can currently report gross attributed credits below the exact billed credits. Stored
attribution rows are estimates, while `AgentMessage.costCredits` remains the authoritative bill, so exposing this shortfall produces a contradictory explanation. It can diverge quickly as `costCredits` is rounded on each agent loop where items are not.

This change reconciles the read projection without modifying stored attribution. When the billed total exceeds the stored gross attribution, the difference is added to both the displayed gross total and “Agent work and context.” Tool attribution remains unchanged because there is no evidence that would safely assign the residual to a specific tool.

When stored gross attribution exceeds the bill, the existing estimated cache savings remains the difference between those values. No attribution rows, provider usage, cache counters, pricing logic, attribution versions, or billing behavior are changed.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
