### PR TITLE
[SANDBOX] Stop finished bash actions from being marked blocked again

### DIFF
--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -444,7 +444,8 @@ export async function runSandboxBashTool(
     ]);
   }
 
-  void revokeExecToken({ sbId: sandbox.sId, execId }).catch((err) =>
+  // Awaited: leftover background processes still hold this token and can call `/call`.
+  await revokeExecToken({ sbId: sandbox.sId, execId }).catch((err) =>
     logger.error({ error: err }, "Failed to revoke exec token")
   );
 

--- a/front/lib/api/sandbox/create_child_action.test.ts
+++ b/front/lib/api/sandbox/create_child_action.test.ts
@@ -408,6 +408,39 @@ describe("createSandboxChildAction", () => {
     expect(vi.mocked(launchSandboxChildToolWorkflow)).not.toHaveBeenCalled();
   });
 
+  it("rejects calls from a `dsbx` process that outlived its parent bash action", async () => {
+    await setToolPermission("medium");
+
+    // The bash call returned, but its in-sandbox process issues one more `/call`.
+    const parentAction = await AgentMCPActionResource.fetchById(
+      auth,
+      parentActionId
+    );
+    if (!parentAction) {
+      throw new Error("Expected the parent action to exist.");
+    }
+    await parentAction.updateStatus("succeeded");
+
+    const result = await callChildTool();
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("Expected the orphaned child call to fail.");
+    }
+    expect(result.error.message).toBe(
+      "Parent action already completed with status succeeded."
+    );
+    expect(vi.mocked(launchSandboxChildToolWorkflow)).not.toHaveBeenCalled();
+    expect(vi.mocked(updateResourceAndPublishEvent)).not.toHaveBeenCalled();
+
+    // The parent must keep its final status: no resurrection.
+    const reloadedParent = await AgentMCPActionResource.fetchById(
+      auth,
+      parentActionId
+    );
+    expect(reloadedParent?.status).toBe("succeeded");
+  });
+
   it("defaults to high stake and blocks when the tool has no configured permission", async () => {
     const result = await callChildTool();
 

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -5,6 +5,7 @@ import {
 } from "@app/lib/actions/mcp_actions";
 import type { AgentLoopMCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
+import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import { makeMCPApproveExecutionEventBase } from "@app/lib/actions/tool_approval_events";
 import { tryGetPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
@@ -92,6 +93,16 @@ export async function createSandboxChildAction(
   );
   if (!parentAction) {
     return new Err(new Error("Parent action not found."));
+  }
+
+  // A `dsbx` process can outlive its bash tool call. Serving it would set this finished
+  // action's status back to blocked, leaving two steps blocked on one message.
+  if (isToolExecutionStatusFinal(parentAction.status)) {
+    return new Err(
+      new Error(
+        `Parent action already completed with status ${parentAction.status}.`
+      )
+    );
   }
 
   const agentMessageRes = await conversationResource.getMessageById(


### PR DESCRIPTION
## Description

A program left running inside the sandbox after its `bash` tool call finished could still reach `/call` and create a child action against that finished action, which set the action's status back to blocked and left two steps blocked on the same agent message (`All blocked actions must be from the same step, got 27, 24`, breaking every resume path); fixed by awaiting the exec-token revocation when a `bash` command completes, and refusing child calls whose parent action already reached a final status.

## Tests

Added a test covering a child call against a finished parent action; `create_child_action` and sandbox `tools` suites pass locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`
