### PR TITLE
Hide First Activation Message

### DIFF
--- a/front/lib/api/activation/queries/user_day_cells.ts
+++ b/front/lib/api/activation/queries/user_day_cells.ts
@@ -2,7 +2,10 @@ import { searchAnalytics } from "@app/lib/api/elasticsearch";
 import { USAGE_ORIGINS_CLASSIFICATION } from "@app/lib/api/programmatic_usage/common";
 import { TOOL_COST_CATEGORY_AWU_WEIGHTS } from "@app/lib/metronome/events";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
-import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
+import {
+  ACTIVATION_NUDGE_ORIGIN,
+  AGENT_MESSAGE_STATUSES_TO_TRACK,
+} from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
@@ -18,7 +21,10 @@ import type { estypes } from "@elastic/elasticsearch";
 
 const FRAME_SERVER_NAME = "interactive_content";
 const RUN_AGENT_SERVER_NAME = "run_agent";
-const TRIGGERED_ORIGIN: UserMessageOrigin = "triggered";
+const NON_ORGANIC_ORIGINS: UserMessageOrigin[] = [
+  "triggered",
+  ACTIVATION_NUDGE_ORIGIN,
+];
 
 // Programmatic origins are dropped from the query entirely
 const PROGRAMMATIC_ORIGINS: UserMessageOrigin[] = (
@@ -28,7 +34,7 @@ const PROGRAMMATIC_ORIGINS: UserMessageOrigin[] = (
 ).filter((origin) => USAGE_ORIGINS_CLASSIFICATION[origin] === "programmatic");
 
 // Origins that make a day count as a daily active user day: human-initiated
-// organic ("user") origins, with `triggered` deliberately EXCLUDED.
+// organic ("user") origins, with the non-organic ones deliberately EXCLUDED.
 const DAU_ORIGINS: UserMessageOrigin[] = (
   Object.keys(
     USAGE_ORIGINS_CLASSIFICATION
@@ -36,7 +42,7 @@ const DAU_ORIGINS: UserMessageOrigin[] = (
 ).filter(
   (origin) =>
     USAGE_ORIGINS_CLASSIFICATION[origin] === "user" &&
-    origin !== TRIGGERED_ORIGIN
+    !NON_ORGANIC_ORIGINS.includes(origin)
 );
 
 // Hard cap on users per call. The composite page size is sized so that the

--- a/front/lib/api/activation/trigger.ts
+++ b/front/lib/api/activation/trigger.ts
@@ -1,9 +1,11 @@
 import type { Authenticator } from "@app/lib/auth";
-import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import {
   resolveTriggerSpaceId,
   TriggerResource,
 } from "@app/lib/resources/trigger_resource";
+import type { TriggerType } from "@app/types/assistant/triggers";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
@@ -165,6 +167,16 @@ export async function createActivationTrigger(
   }
 
   return new Ok({ triggerId: triggerRes.value.sId });
+}
+
+// True when `trigger` is the activation trigger provisioned for `pod`, as
+// opposed to a trigger the user created in the same pod.
+export async function isActivationTrigger(
+  auth: Authenticator,
+  { pod, trigger }: { pod: SpaceResource; trigger: TriggerType }
+): Promise<boolean> {
+  const activationPod = await ActivationPodResource.fetchBySpace(auth, pod);
+  return activationPod?.triggerId === trigger.id;
 }
 
 // Fires the activation trigger for a single pod by emitting an internal webhook

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -1,3 +1,4 @@
+import { isActivationTrigger } from "@app/lib/api/activation/trigger";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import {
   createConversation,
@@ -21,7 +22,11 @@ import { getWebhookRequestPayloadFromGCS } from "@app/lib/triggers/webhook";
 import logger from "@app/logger/logger";
 import { makeTriggerScheduleId } from "@app/temporal/triggers/schedule_client";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import {
+  ACTIVATION_NUDGE_ORIGIN,
+  type ConversationWithoutContentType,
+  type UserMessageOrigin,
+} from "@app/types/assistant/conversation";
 import type { TriggerType } from "@app/types/assistant/triggers";
 import type { WakeUpType } from "@app/types/assistant/wakeups";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
@@ -32,6 +37,24 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 class TriggerNonRetryableError extends Error {}
+
+async function bootstrapMessageOrigin({
+  auth,
+  trigger,
+  pod,
+}: {
+  auth: Authenticator;
+  trigger: TriggerType;
+  pod: SpaceResource | null;
+}): Promise<UserMessageOrigin> {
+  if (pod && (await isActivationTrigger(auth, { pod, trigger }))) {
+    return ACTIVATION_NUDGE_ORIGIN;
+  }
+
+  return trigger.kind === "webhook" && trigger.executionMode === "programmatic"
+    ? "triggered_programmatic"
+    : "triggered";
+}
 
 async function createConversationForAgentConfiguration({
   auth,
@@ -49,8 +72,9 @@ async function createConversationForAgentConfiguration({
   Result<ConversationWithoutContentType, APIErrorWithContentfulStatusCode>
 > {
   let spaceModelId: ModelId | null = null;
+  let pod: SpaceResource | null = null;
   if (trigger.spaceId) {
-    const pod = await SpaceResource.fetchById(auth, trigger.spaceId);
+    pod = await SpaceResource.fetchById(auth, trigger.spaceId);
     if (pod && pod.isProject() && (pod.isOpen() || pod.isMember(auth))) {
       spaceModelId = pod.id;
     } else {
@@ -74,10 +98,7 @@ async function createConversationForAgentConfiguration({
     fullName: auth.getNonNullableUser().fullName(),
     email: auth.getNonNullableUser().email,
     profilePictureUrl: null,
-    origin:
-      trigger.kind === "webhook" && trigger.executionMode === "programmatic"
-        ? ("triggered_programmatic" as const)
-        : ("triggered" as const),
+    origin: await bootstrapMessageOrigin({ auth, trigger, pod }),
     lastTriggerRunAt: lastRunAt?.getTime() ?? null,
   };
 

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -146,6 +146,7 @@ export const HIDDEN_MESSAGE_ORIGINS: UserMessageOrigin[] = [
   "project_kickoff",
   "reinforced_skill_notification",
   "wakeup",
+  ACTIVATION_NUDGE_ORIGIN,
 ];
 
 /**


### PR DESCRIPTION
## Summary

- Hiding first activation message of a conversation by utilizing the system_activation event source.
- Important Note: This is technically spoof-able right now because the 

## Testing

- Send an activation nudge; verify the conversation does not appear in the conversation list.
- Verify the nudge conversation is not counted as a DAU day in analytics.
- POST to the activation webhook URL externally; verify 404.
- Check the admin API for a workspace with an activation webhook source; verify `urlSecret` is empty.
- Confirm the `agent_schedule` Temporal worker starts without errors after the `isCronScheduleConfig` inline.

## Risk

Low. The nudge origin tagging and DAU exclusion are additive. The webhook 404 is security-hardening with no functional regression (activation nudges have never relied on external posting). The Temporal fix addresses an existing silent bug.