### PR TITLE
[connectors] refactor: Type Slack webhook events with a discriminated payload union

### DIFF
--- a/connectors/package.json
+++ b/connectors/package.json
@@ -49,6 +49,7 @@
     "@napi-rs/blake-hash": "^1.3.6",
     "@notionhq/client": "^2.2.15",
     "@octokit/graphql": "^7.0.2",
+    "@slack/types": "^2.20.1",
     "@slack/web-api": "^7.10.0",
     "@temporalio/activity": "1.15.1",
     "@temporalio/client": "1.15.1",

--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -13,10 +13,8 @@ import { WorkflowExecutionAlreadyStartedError } from "@temporalio/common";
 import { getWeekStart } from "../lib/utils";
 import { QUEUE_NAME } from "./config";
 import { newWebhookSignal, syncChannelSignal } from "./signals";
-import type {
-  JoinChannelUseCaseType,
-  SlackWebhookEventPayload,
-} from "./workflows";
+import type { SlackWebhookEventPayload } from "./webhook_event";
+import type { JoinChannelUseCaseType } from "./workflows";
 import {
   joinChannelWorkflow,
   joinChannelWorkflowId,

--- a/connectors/src/connectors/slack/temporal/webhook_activities.ts
+++ b/connectors/src/connectors/slack/temporal/webhook_activities.ts
@@ -16,7 +16,8 @@ import {
   launchSlackSyncOneMessageWorkflow,
   launchSlackSyncOneThreadWorkflow,
 } from "@connectors/connectors/slack/temporal/client";
-import type { SlackWebhookEventPayload } from "@connectors/connectors/slack/temporal/workflows";
+import type { SlackWebhookEventPayload } from "@connectors/connectors/slack/temporal/webhook_event";
+import { SlackWebhookEventPayloadSchema } from "@connectors/connectors/slack/temporal/webhook_event";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { getDustAPI } from "@connectors/lib/api/dust_api";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
@@ -27,14 +28,21 @@ import mainLogger from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
+import type { ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES, normalizeError } from "@connectors/types";
-import { removeNulls } from "@dust-tt/client";
+import { assertNever, removeNulls } from "@dust-tt/client";
 import { Op } from "sequelize";
+import { fromError } from "zod-validation-error";
 
 interface SyncTarget {
   connector: ConnectorResource;
   slackConfiguration: SlackConfigurationResource;
 }
+
+type PayloadOfType<T extends SlackWebhookEventPayload["type"]> = Extract<
+  SlackWebhookEventPayload,
+  { type: T }
+>;
 
 /**
  * Resolves the connectors that may sync a channel: the channel must be
@@ -165,104 +173,84 @@ async function applyChannelRename(
 }
 
 /**
- * Syncs a message posted in a channel or a group. A target that fails is
- * logged and dropped: Slack has already been answered, and the other targets
- * still have to run.
+ * Renames a channel on every connector that syncs it.
  */
-async function syncChannelMessage(
-  event: SlackWebhookEventPayload,
+async function renameChannel(
+  { channelId, channelName }: PayloadOfType<"channel_renamed">,
   slackConfigurations: SlackConfigurationResource[],
   logger: Logger
 ) {
-  const { channelId, threadTs } = event;
-  if (!channelId) {
-    logger.info("Ignoring channel message without a channel");
-    return;
-  }
-
-  const channelName =
-    event.subtype === "channel_name" ? event.channelName : undefined;
-  // A deleted message carries its own timestamp: we re-sync the thread it
-  // belonged to, or the week it was posted in.
-  const messageTs =
-    event.subtype === "message_deleted" ? event.deletedTs : event.ts;
-
-  if (event.subtype === "channel_name" && !channelName) {
-    logger.info(
-      { slackChannelId: channelId },
-      "Ignoring channel_name event without a new name"
-    );
-    return;
-  }
-  if (!channelName && !threadTs && !messageTs) {
-    logger.info(
-      { slackChannelId: channelId },
-      "Ignoring message event without 'thread_ts' or message 'ts'"
-    );
-    return;
-  }
-
   const targets = await listSyncableConnectors(
     slackConfigurations,
     channelId,
     logger
   );
 
+  for (const target of targets) {
+    await applyChannelRename(target, { channelId, channelName });
+    logger.info(
+      {
+        connectorId: target.connector.id,
+        slackChannelId: channelId,
+        newName: channelName,
+      },
+      "Successfully processed Slack channel rename"
+    );
+  }
+}
+
+/**
+ * Syncs a message posted in a channel or a group: the thread it belongs to, or
+ * the week it was posted in.
+ */
+async function syncChannelMessage(
+  {
+    channelId,
+    messageTs,
+    threadTs,
+  }: { channelId: string; messageTs: string; threadTs?: string },
+  slackConfigurations: SlackConfigurationResource[],
+  logger: Logger
+) {
+  const targets = await listSyncableConnectors(
+    slackConfigurations,
+    channelId,
+    logger
+  );
+
+  // A message that belongs to a thread re-syncs the whole thread, a standalone
+  // one re-syncs the week it was posted in.
+  const launchSync = (connectorId: ModelId) =>
+    threadTs
+      ? launchSlackSyncOneThreadWorkflow(connectorId, channelId, threadTs)
+      : launchSlackSyncOneMessageWorkflow(connectorId, channelId, messageTs);
+
   // A target that fails does not stop the others, but it does fail the
   // activity: dropping the event would mean never syncing that thread.
-  const errors: Error[] = [];
+  const errors = removeNulls(
+    await concurrentExecutor(
+      targets,
+      async ({ connector }) => {
+        const res = await launchSync(connector.id);
+        if (res.isErr()) {
+          logger.error(
+            {
+              err: res.error,
+              connectorId: connector.id,
+              slackChannelId: channelId,
+              messageTs,
+              threadTs,
+            },
+            "Failed to launch Slack sync"
+          );
+          return res.error;
+        }
 
-  for (const target of targets) {
-    const { connector } = target;
-
-    if (channelName) {
-      await applyChannelRename(target, { channelId, channelName });
-      logger.info(
-        {
-          connectorId: connector.id,
-          slackChannelId: channelId,
-          newName: channelName,
-        },
-        "Successfully processed Slack channel rename"
-      );
-    } else if (threadTs) {
-      const res = await launchSlackSyncOneThreadWorkflow(
-        connector.id,
-        channelId,
-        threadTs
-      );
-      if (res.isErr()) {
-        logger.error(
-          {
-            err: res.error,
-            connectorId: connector.id,
-            slackChannelId: channelId,
-            threadTs,
-          },
-          "Failed to launch Slack thread sync"
-        );
-        errors.push(res.error);
-      }
-    } else if (messageTs) {
-      const res = await launchSlackSyncOneMessageWorkflow(
-        connector.id,
-        channelId,
-        messageTs
-      );
-      if (res.isErr()) {
-        logger.error(
-          {
-            err: res.error,
-            connectorId: connector.id,
-            slackChannelId: channelId,
-            messageTs,
-          },
-          "Failed to launch Slack messages sync"
-        );
-        errors.push(res.error);
-      }
-    }
-  }
+        return null;
+      },
+      { concurrency: 4 }
+    )
+  );
 
   if (errors.length > 0) {
     throw new Error(
@@ -273,19 +261,14 @@ async function syncChannelMessage(
 }
 
 async function handleAppMention(
-  event: SlackWebhookEventPayload,
+  { channelId, ts }: PayloadOfType<"app_mention">,
   teamId: string,
   logger: Logger
 ) {
-  if (!event.channelId || !event.ts) {
-    logger.info("Ignoring app_mention without a channel or a timestamp");
-    return;
-  }
-
   await handleDeprecatedChatBot({
     logger,
-    slackChannel: event.channelId,
-    slackMessageTs: event.ts,
+    slackChannel: channelId,
+    slackMessageTs: ts,
     slackTeamId: teamId,
   });
 }
@@ -323,22 +306,10 @@ async function resolveActiveBot(teamId: string, logger: Logger) {
 }
 
 async function handleDirectMessage(
-  event: SlackWebhookEventPayload,
+  { channelId, ts, userId }: PayloadOfType<"direct_message">,
   teamId: string,
   logger: Logger
 ) {
-  if (
-    event.subtype === "message_changed" ||
-    event.subtype === "message_deleted"
-  ) {
-    // Ignore message_changed and message_deleted events in private messages.
-    return;
-  }
-  if (!event.channelId || !event.ts) {
-    logger.info("Ignoring direct message without a channel or a timestamp");
-    return;
-  }
-
   const bot = await resolveActiveBot(teamId, logger);
   if (!bot) {
     logger.info(
@@ -347,31 +318,26 @@ async function handleDirectMessage(
     return;
   }
 
-  if (event.userId === bot.botUserId) {
+  if (userId === bot.botUserId) {
     // Message sent from the bot itself.
     return;
   }
 
   await handleDeprecatedChatBot({
     logger,
-    slackChannel: event.channelId,
-    slackMessageTs: event.ts,
+    slackChannel: channelId,
+    slackMessageTs: ts,
     slackTeamId: teamId,
   });
 }
 
 async function joinCreatedChannel(
-  event: SlackWebhookEventPayload,
+  { channelId, contextTeamId }: PayloadOfType<"channel_created">,
   logger: Logger
 ) {
-  if (!event.channelId || !event.contextTeamId) {
-    logger.info("Ignoring channel_created event without a channel");
-    return;
-  }
-
   const res = await onChannelCreation({
-    channelId: event.channelId,
-    contextTeamId: event.contextTeamId,
+    channelId,
+    contextTeamId,
     logger,
     provider: "slack",
   });
@@ -381,16 +347,10 @@ async function joinCreatedChannel(
 }
 
 async function announceBotJoinedPrivateChannel(
-  event: SlackWebhookEventPayload,
+  { channelId, userId }: PayloadOfType<"member_joined_channel">,
   teamId: string,
   logger: Logger
 ) {
-  const { channelId } = event;
-  if (!channelId) {
-    logger.info("Ignoring member_joined_channel event without a channel");
-    return;
-  }
-
   const bot = await resolveActiveBot(teamId, logger);
   if (!bot) {
     logger.info(
@@ -400,7 +360,7 @@ async function announceBotJoinedPrivateChannel(
   }
 
   // If the bot is not the one joining the channel, ignore.
-  if (event.userId !== bot.botUserId) {
+  if (userId !== bot.botUserId) {
     return;
   }
 
@@ -434,20 +394,24 @@ async function garbageCollectChannels(
   slackConfigurations: SlackConfigurationResource[],
   logger: Logger
 ) {
-  const errors: Error[] = [];
+  const errors = removeNulls(
+    await concurrentExecutor(
+      slackConfigurations,
+      async ({ connectorId }) => {
+        const res = await launchSlackGarbageCollectWorkflow(connectorId);
+        if (res.isErr()) {
+          logger.error(
+            { err: res.error, connectorId },
+            "Failed to launch Slack garbage collection"
+          );
+          return res.error;
+        }
 
-  for (const slackConfiguration of slackConfigurations) {
-    const res = await launchSlackGarbageCollectWorkflow(
-      slackConfiguration.connectorId
-    );
-    if (res.isErr()) {
-      logger.error(
-        { err: res.error, connectorId: slackConfiguration.connectorId },
-        "Failed to launch Slack garbage collection"
-      );
-      errors.push(res.error);
-    }
-  }
+        return null;
+      },
+      { concurrency: 4 }
+    )
+  );
 
   if (errors.length > 0) {
     throw new Error(
@@ -467,16 +431,35 @@ async function dispatchEvent(
     case "app_mention":
       return handleAppMention(event, teamId, logger);
 
-    case "message":
-      // Slack routes direct messages and channel messages through the same
-      // event type.
-      if (event.channelType === "im") {
-        return handleDirectMessage(event, teamId, logger);
-      }
-      if (event.channelType === "channel" || event.channelType === "group") {
-        return syncChannelMessage(event, slackConfigurations, logger);
-      }
-      return;
+    case "direct_message":
+      return handleDirectMessage(event, teamId, logger);
+
+    case "channel_message":
+      return syncChannelMessage(
+        {
+          channelId: event.channelId,
+          messageTs: event.ts,
+          threadTs: event.threadTs,
+        },
+        slackConfigurations,
+        logger
+      );
+
+    // A deleted message carries its own timestamp: we re-sync the thread it
+    // belonged to, or the week it was posted in.
+    case "channel_message_deleted":
+      return syncChannelMessage(
+        {
+          channelId: event.channelId,
+          messageTs: event.deletedTs,
+          threadTs: event.threadTs,
+        },
+        slackConfigurations,
+        logger
+      );
+
+    case "channel_renamed":
+      return renameChannel(event, slackConfigurations, logger);
 
     case "channel_created":
       return joinCreatedChannel(event, logger);
@@ -488,17 +471,8 @@ async function dispatchEvent(
     case "channel_deleted":
       return garbageCollectChannels(slackConfigurations, logger);
 
-    // The rename itself comes as a `message` event with the `channel_name`
-    // subtype, handled above.
-    case "channel_rename":
-      return;
-
     default:
-      logger.info(
-        { eventType: event.type },
-        "Webhook event type not supported"
-      );
-      return;
+      assertNever(event);
   }
 }
 
@@ -534,6 +508,17 @@ export async function processSlackWebhookEventActivity({
     `event_type:${event.type}`,
   ]);
 
+  // The payload was built by a webhook that may be running an older deploy, so
+  // it is validated once here rather than field by field in the handlers.
+  const payload = SlackWebhookEventPayloadSchema.safeParse(event);
+  if (!payload.success) {
+    logger.error(
+      { err: fromError(payload.error) },
+      "Dropping Slack webhook event: unexpected payload"
+    );
+    return;
+  }
+
   const slackConfigurations = await SlackConfigurationResource.listForTeamId(
     teamId,
     "slack"
@@ -546,7 +531,7 @@ export async function processSlackWebhookEventActivity({
   }
 
   try {
-    await dispatchEvent(event, teamId, slackConfigurations, logger);
+    await dispatchEvent(payload.data, teamId, slackConfigurations, logger);
   } catch (e) {
     logger.error(
       { err: normalizeError(e) },

--- a/connectors/src/connectors/slack/temporal/webhook_event.test.ts
+++ b/connectors/src/connectors/slack/temporal/webhook_event.test.ts
@@ -1,0 +1,274 @@
+import { toWebhookEventPayload } from "@connectors/connectors/slack/temporal/webhook_event";
+import type {
+  AppMentionEvent,
+  ChannelCreatedEvent,
+  ChannelDeletedEvent,
+  ChannelLeftEvent,
+  ChannelNameMessageEvent,
+  ChannelRenameEvent,
+  GenericMessageEvent,
+  MemberJoinedChannelEvent,
+  MessageChangedEvent,
+  MessageDeletedEvent,
+} from "@slack/types";
+import { describe, expect, it } from "vitest";
+
+// Fixtures are typed with the vendored Slack event interfaces, so a shape
+// change in `@slack/types` breaks this file rather than production.
+
+const APP_MENTION: AppMentionEvent = {
+  type: "app_mention",
+  channel: "C1",
+  ts: "1700000000.000100",
+  text: "<@U1> hello",
+  event_ts: "1700000000.000100",
+};
+
+const CHANNEL_MESSAGE: GenericMessageEvent = {
+  type: "message",
+  subtype: undefined,
+  channel: "C1",
+  channel_type: "channel",
+  user: "U1",
+  ts: "1700000000.000100",
+  event_ts: "1700000000.000100",
+  text: "secret message body",
+  attachments: [{ text: "forwarded body" }],
+};
+
+describe("toWebhookEventPayload", () => {
+  it("projects an app mention", () => {
+    expect(toWebhookEventPayload(APP_MENTION)).toEqual({
+      type: "app_mention",
+      channelId: "C1",
+      ts: "1700000000.000100",
+    });
+  });
+
+  it("projects a channel message, leaving its body behind", () => {
+    expect(toWebhookEventPayload(CHANNEL_MESSAGE)).toEqual({
+      type: "channel_message",
+      channelId: "C1",
+      ts: "1700000000.000100",
+      threadTs: undefined,
+    });
+  });
+
+  it("keeps the thread of a threaded message", () => {
+    const event: GenericMessageEvent = {
+      ...CHANNEL_MESSAGE,
+      thread_ts: "1699999999.000100",
+    };
+
+    expect(toWebhookEventPayload(event)).toMatchObject({
+      type: "channel_message",
+      threadTs: "1699999999.000100",
+    });
+  });
+
+  it("projects a private group message like a channel message", () => {
+    const event: GenericMessageEvent = {
+      ...CHANNEL_MESSAGE,
+      channel_type: "group",
+    };
+
+    expect(toWebhookEventPayload(event)).toMatchObject({
+      type: "channel_message",
+    });
+  });
+
+  it("projects a direct message", () => {
+    const event: GenericMessageEvent = {
+      ...CHANNEL_MESSAGE,
+      channel: "D1",
+      channel_type: "im",
+    };
+
+    expect(toWebhookEventPayload(event)).toEqual({
+      type: "direct_message",
+      channelId: "D1",
+      ts: "1700000000.000100",
+      userId: "U1",
+    });
+  });
+
+  it("drops an edited direct message", () => {
+    const event: MessageChangedEvent = {
+      type: "message",
+      subtype: "message_changed",
+      channel: "D1",
+      channel_type: "im",
+      hidden: true,
+      ts: "1700000000.000200",
+      event_ts: "1700000000.000200",
+      message: CHANNEL_MESSAGE,
+      previous_message: CHANNEL_MESSAGE,
+    };
+
+    expect(toWebhookEventPayload(event)).toBeNull();
+  });
+
+  it("projects an edited channel message onto the event timestamp", () => {
+    const event: MessageChangedEvent = {
+      type: "message",
+      subtype: "message_changed",
+      channel: "C1",
+      channel_type: "channel",
+      hidden: true,
+      ts: "1700000000.000200",
+      event_ts: "1700000000.000200",
+      message: CHANNEL_MESSAGE,
+      previous_message: CHANNEL_MESSAGE,
+    };
+
+    expect(toWebhookEventPayload(event)).toMatchObject({
+      type: "channel_message",
+      ts: "1700000000.000200",
+    });
+  });
+
+  it("projects a deleted message onto the deleted timestamp", () => {
+    const event: MessageDeletedEvent = {
+      type: "message",
+      subtype: "message_deleted",
+      channel: "C1",
+      channel_type: "channel",
+      hidden: true,
+      ts: "1700000000.000200",
+      deleted_ts: "1700000000.000100",
+      event_ts: "1700000000.000200",
+      previous_message: CHANNEL_MESSAGE,
+    };
+
+    expect(toWebhookEventPayload(event)).toEqual({
+      type: "channel_message_deleted",
+      channelId: "C1",
+      deletedTs: "1700000000.000100",
+      threadTs: undefined,
+    });
+  });
+
+  it("projects a channel rename", () => {
+    const event: ChannelNameMessageEvent = {
+      type: "message",
+      subtype: "channel_name",
+      channel: "C1",
+      channel_type: "channel",
+      team: "T1",
+      user: "U1",
+      name: "new-name",
+      old_name: "old-name",
+      text: "renamed the channel",
+      ts: "1700000000.000100",
+      event_ts: "1700000000.000100",
+    };
+
+    expect(toWebhookEventPayload(event)).toEqual({
+      type: "channel_renamed",
+      channelId: "C1",
+      channelName: "new-name",
+    });
+  });
+
+  it("flattens the channel object of a created channel", () => {
+    const event: ChannelCreatedEvent = {
+      type: "channel_created",
+      event_ts: "1700000000.000100",
+      channel: {
+        id: "C1",
+        context_team_id: "T1",
+        name: "new-channel",
+        name_normalized: "new-channel",
+        created: 1700000000,
+        creator: "U1",
+        is_channel: true,
+        is_shared: false,
+        is_org_shared: false,
+        is_archived: false,
+        is_frozen: false,
+        is_general: false,
+        is_group: false,
+        is_private: false,
+        is_ext_shared: false,
+        is_im: false,
+        is_mpim: false,
+        is_pending_ext_shared: false,
+      },
+    };
+
+    expect(toWebhookEventPayload(event)).toEqual({
+      type: "channel_created",
+      channelId: "C1",
+      contextTeamId: "T1",
+    });
+  });
+
+  it("projects a member joining a channel", () => {
+    const event: MemberJoinedChannelEvent = {
+      type: "member_joined_channel",
+      user: "U1",
+      channel: "C1",
+      channel_type: "C",
+      team: "T1",
+      event_ts: "1700000000.000100",
+    };
+
+    expect(toWebhookEventPayload(event)).toEqual({
+      type: "member_joined_channel",
+      channelId: "C1",
+      userId: "U1",
+    });
+  });
+
+  it("projects the events that trigger a garbage collection", () => {
+    const left: ChannelLeftEvent = {
+      type: "channel_left",
+      channel: "C1",
+      actor_id: "U1",
+      event_ts: "1700000000.000100",
+    };
+    const deleted: ChannelDeletedEvent = {
+      type: "channel_deleted",
+      channel: "C1",
+    };
+
+    expect(toWebhookEventPayload(left)).toEqual({ type: "channel_left" });
+    expect(toWebhookEventPayload(deleted)).toEqual({ type: "channel_deleted" });
+  });
+
+  it("drops the events we do not route", () => {
+    const renamed: ChannelRenameEvent = {
+      type: "channel_rename",
+      channel: {
+        id: "C1",
+        name: "new-name",
+        name_normalized: "new-name",
+        created: 1700000000,
+        is_channel: true,
+        is_mpim: false,
+      },
+      event_ts: "1700000000.000100",
+    };
+
+    // Renames are routed through the `channel_name` message subtype instead.
+    expect(toWebhookEventPayload(renamed)).toBeNull();
+    expect(
+      toWebhookEventPayload({ ...CHANNEL_MESSAGE, channel_type: "mpim" })
+    ).toBeNull();
+    expect(toWebhookEventPayload({ type: "reaction_added" })).toBeNull();
+  });
+
+  it("drops a malformed event rather than projecting half of it", () => {
+    expect(toWebhookEventPayload({ type: "app_mention" })).toBeNull();
+    expect(
+      toWebhookEventPayload({ type: "channel_created", channel: "C1" })
+    ).toBeNull();
+    expect(
+      toWebhookEventPayload({ ...CHANNEL_MESSAGE, subtype: "message_deleted" })
+    ).toBeNull();
+    expect(
+      toWebhookEventPayload({ ...CHANNEL_MESSAGE, subtype: "channel_name" })
+    ).toBeNull();
+    expect(toWebhookEventPayload(undefined)).toBeNull();
+  });
+});

--- a/connectors/src/connectors/slack/temporal/webhook_event.ts
+++ b/connectors/src/connectors/slack/temporal/webhook_event.ts
@@ -1,0 +1,253 @@
+import type {
+  AppMentionEvent,
+  ChannelCreatedEvent,
+  ChannelDeletedEvent,
+  ChannelLeftEvent,
+  ChannelNameMessageEvent,
+  GenericMessageEvent,
+  MemberJoinedChannelEvent,
+  MessageDeletedEvent,
+} from "@slack/types";
+import { z } from "zod";
+
+/**
+ * Projection of a Slack webhook event, built by the webhook handler and carried
+ * to `slackWebhookEventWorkflow`. One variant per routing decision, so a
+ * handler never has to re-check the fields it reads. Message text, blocks and
+ * attachments never leave the webhook.
+ */
+export const SlackWebhookEventPayloadSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("app_mention"),
+    channelId: z.string(),
+    ts: z.string(),
+  }),
+  z.object({
+    type: z.literal("direct_message"),
+    channelId: z.string(),
+    ts: z.string(),
+    // Absent on messages posted by a bot, which carry `bot_id` instead.
+    userId: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal("channel_message"),
+    channelId: z.string(),
+    ts: z.string(),
+    threadTs: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal("channel_message_deleted"),
+    channelId: z.string(),
+    // Timestamp of the deleted message, which is the one to re-sync.
+    deletedTs: z.string(),
+    threadTs: z.string().optional(),
+  }),
+  // Slack sends channel renames as a `channel_name` message subtype. The
+  // top-level `channel_rename` event carries no member list and is not routed.
+  z.object({
+    type: z.literal("channel_renamed"),
+    channelId: z.string(),
+    channelName: z.string(),
+  }),
+  z.object({
+    type: z.literal("channel_created"),
+    channelId: z.string(),
+    // Team the channel belongs to. Differs from the webhook team id on shared
+    // channels.
+    contextTeamId: z.string(),
+  }),
+  z.object({
+    type: z.literal("member_joined_channel"),
+    channelId: z.string(),
+    userId: z.string(),
+  }),
+  z.object({ type: z.literal("channel_left") }),
+  z.object({ type: z.literal("channel_deleted") }),
+]);
+
+export type SlackWebhookEventPayload = z.infer<
+  typeof SlackWebhookEventPayloadSchema
+>;
+
+// Raw Slack events, narrowed to the fields we route on. `satisfies` pins each
+// schema to the vendored Slack types, so a shape change breaks the build.
+
+const EventTypeSchema = z.object({ type: z.string() });
+
+const AppMentionEventSchema = z.object({
+  type: z.literal("app_mention"),
+  channel: z.string(),
+  ts: z.string(),
+}) satisfies z.ZodType<Pick<AppMentionEvent, "type" | "channel" | "ts">>;
+
+const MessageEventSchema = z.object({
+  type: z.literal("message"),
+  channel: z.string(),
+  channel_type: z.enum(["channel", "group", "im", "mpim", "app_home"]),
+  ts: z.string(),
+  subtype: z.string().optional(),
+  user: z.string().optional(),
+  thread_ts: z.string().optional(),
+  // Only on the `message_deleted` subtype.
+  deleted_ts: z.string().optional(),
+  // Only on the `channel_name` subtype.
+  name: z.string().optional(),
+}) satisfies z.ZodType<
+  Pick<GenericMessageEvent, "type" | "channel" | "channel_type" | "ts"> & {
+    subtype?: string;
+    user?: GenericMessageEvent["user"];
+    thread_ts?: GenericMessageEvent["thread_ts"];
+    deleted_ts?: MessageDeletedEvent["deleted_ts"];
+    name?: ChannelNameMessageEvent["name"];
+  }
+>;
+
+const ChannelCreatedEventSchema = z.object({
+  type: z.literal("channel_created"),
+  channel: z.object({ id: z.string(), context_team_id: z.string() }),
+}) satisfies z.ZodType<{
+  type: ChannelCreatedEvent["type"];
+  channel: Pick<ChannelCreatedEvent["channel"], "id" | "context_team_id">;
+}>;
+
+const MemberJoinedChannelEventSchema = z.object({
+  type: z.literal("member_joined_channel"),
+  channel: z.string(),
+  user: z.string(),
+}) satisfies z.ZodType<
+  Pick<MemberJoinedChannelEvent, "type" | "channel" | "user">
+>;
+
+const ChannelGoneEventSchema = z.object({
+  type: z.enum(["channel_left", "channel_deleted"]),
+}) satisfies z.ZodType<{
+  type: ChannelLeftEvent["type"] | ChannelDeletedEvent["type"];
+}>;
+
+/**
+ * Projects a raw Slack event onto the payload the workflow needs, or null when
+ * the event is not one we route or is missing the fields its variant needs.
+ * This is the only place that reads Slack's field names.
+ */
+export function toWebhookEventPayload(
+  event: unknown
+): SlackWebhookEventPayload | null {
+  const eventType = EventTypeSchema.safeParse(event);
+  if (!eventType.success) {
+    return null;
+  }
+
+  switch (eventType.data.type) {
+    case "app_mention": {
+      const parsed = AppMentionEventSchema.safeParse(event);
+      if (!parsed.success) {
+        return null;
+      }
+
+      return {
+        type: "app_mention",
+        channelId: parsed.data.channel,
+        ts: parsed.data.ts,
+      };
+    }
+
+    // Slack routes direct messages, channel messages, deletions and channel
+    // renames through the same event type.
+    case "message": {
+      const parsed = MessageEventSchema.safeParse(event);
+      if (!parsed.success) {
+        return null;
+      }
+      const { channel, channel_type: channelType, subtype } = parsed.data;
+
+      if (channelType === "im") {
+        // A direct message that was edited or deleted has nothing to answer.
+        if (subtype === "message_changed" || subtype === "message_deleted") {
+          return null;
+        }
+
+        return {
+          type: "direct_message",
+          channelId: channel,
+          ts: parsed.data.ts,
+          userId: parsed.data.user,
+        };
+      }
+
+      if (channelType !== "channel" && channelType !== "group") {
+        return null;
+      }
+
+      if (subtype === "channel_name") {
+        if (!parsed.data.name) {
+          return null;
+        }
+
+        return {
+          type: "channel_renamed",
+          channelId: channel,
+          channelName: parsed.data.name,
+        };
+      }
+
+      if (subtype === "message_deleted") {
+        if (!parsed.data.deleted_ts) {
+          return null;
+        }
+
+        return {
+          type: "channel_message_deleted",
+          channelId: channel,
+          deletedTs: parsed.data.deleted_ts,
+          threadTs: parsed.data.thread_ts,
+        };
+      }
+
+      return {
+        type: "channel_message",
+        channelId: channel,
+        ts: parsed.data.ts,
+        threadTs: parsed.data.thread_ts,
+      };
+    }
+
+    case "channel_created": {
+      const parsed = ChannelCreatedEventSchema.safeParse(event);
+      if (!parsed.success) {
+        return null;
+      }
+
+      return {
+        type: "channel_created",
+        channelId: parsed.data.channel.id,
+        contextTeamId: parsed.data.channel.context_team_id,
+      };
+    }
+
+    case "member_joined_channel": {
+      const parsed = MemberJoinedChannelEventSchema.safeParse(event);
+      if (!parsed.success) {
+        return null;
+      }
+
+      return {
+        type: "member_joined_channel",
+        channelId: parsed.data.channel,
+        userId: parsed.data.user,
+      };
+    }
+
+    case "channel_left":
+    case "channel_deleted": {
+      const parsed = ChannelGoneEventSchema.safeParse(event);
+      if (!parsed.success) {
+        return null;
+      }
+
+      return { type: parsed.data.type };
+    }
+
+    default:
+      return null;
+  }
+}

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -1,4 +1,5 @@
 import type * as activities from "@connectors/connectors/slack/temporal/activities";
+import type { SlackWebhookEventPayload } from "@connectors/connectors/slack/temporal/webhook_event";
 import type { ModelId } from "@connectors/types";
 import {
   allHandlersFinished,
@@ -20,29 +21,6 @@ const JOIN_CHANNEL_USE_CASES = [
   "set-permission",
 ] as const;
 export type JoinChannelUseCaseType = (typeof JOIN_CHANNEL_USE_CASES)[number];
-
-/**
- * Projection of a Slack webhook event, built by the webhook handler and carried
- * to `slackWebhookEventWorkflow`. Only the fields the handlers read are kept:
- * message text, blocks and attachments never leave the webhook.
- */
-export interface SlackWebhookEventPayload {
-  type: string;
-  subtype?: "message_changed" | "message_deleted" | "channel_name";
-  channelType?: "channel" | "group" | "im" | "mpim";
-  // Always an id: `channel_created` carries an object that the webhook handler
-  // flattens.
-  channelId?: string;
-  // New channel name, on the `channel_name` message subtype.
-  channelName?: string;
-  // Team the channel belongs to, on `channel_created`. Differs from the webhook
-  // team id on shared channels.
-  contextTeamId?: string;
-  userId?: string;
-  ts?: string;
-  threadTs?: string;
-  deletedTs?: string;
-}
 
 // Dynamic activity creation with fresh routing evaluation (enables retry queue switching).
 function getSlackActivities() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,6 +95,7 @@
         "@napi-rs/blake-hash": "^1.3.6",
         "@notionhq/client": "^2.2.15",
         "@octokit/graphql": "^7.0.2",
+        "@slack/types": "^2.20.1",
         "@slack/web-api": "^7.10.0",
         "@temporalio/activity": "1.15.1",
         "@temporalio/client": "1.15.1",


### PR DESCRIPTION
## Description

This pr uses slack's type + zod schema parsing and defines a DTO to map our code event's fanout to slack event subtypes.

The result is a cleaner switch case and separation of concerns, a bit more abstract over slack's event design (like why are channel rename message event ??)

## Tests

Added a bunch of tests

## Risk

Standard - risk of behavior change due to separating one big ball of code into a DTO and a new switch case.
Blast radius : slack connector and slack bot

## Plan

Deploy connectors