### PR TITLE
[Activation] Notification fix: Only send email notifications for nudge conversation first message

### DIFF
--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -1240,6 +1240,9 @@ export function createProjectManagerTools(
         // Get origin and timezone from the current conversation
         let origin: UserMessageOrigin = "web";
         let timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        // Sub-conversations created on behalf of an agent are nested one level below their parent
+        let parentConversationDepth = 0;
+        let originMessageId: string | null = null;
 
         if (isAgentLoopRunContext(toolContext?.runContext)) {
           const userMessage = toolContext.runContext.conversation.content
@@ -1249,6 +1252,8 @@ export function createProjectManagerTools(
             origin = userMessage.context.origin ?? origin;
             timezone = userMessage.context.timezone ?? timezone;
           }
+          parentConversationDepth = toolContext.runContext.conversation.depth;
+          originMessageId = toolContext.runContext.agentMessage.sId;
         }
         if (isSandboxFunctionRunContext(toolContext?.runContext)) {
           timezone =
@@ -1283,10 +1288,12 @@ export function createProjectManagerTools(
           mentions = [{ configurationId: matchedAgentId }];
         }
 
-        // Create conversation in the project space
+        // Create conversation in the project space, nested under the parent so it
+        // stays hidden from the pod's conversation list and notifications.
         const conversationResource = await createConversation(auth, {
           title: params.title,
           visibility: "unlisted",
+          depth: parentConversationDepth + 1,
           spaceId: pod.id,
         });
 
@@ -1308,6 +1315,14 @@ export function createProjectManagerTools(
             selectedMCPServerViewIds: [],
             lastTriggerRunAt: null,
           },
+          ...(originMessageId
+            ? {
+                agenticMessageData: {
+                  type: "run_agent",
+                  originMessageId,
+                },
+              }
+            : {}),
           skipToolsValidation: false,
           doNotAssociateUser: true,
           skipDustAutoMention: true,

--- a/front/lib/notifications/triggers/project-new-conversation.test.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.test.ts
@@ -1,19 +1,38 @@
 import { Authenticator } from "@app/lib/auth";
-import { filterMembersByNotifyCondition } from "@app/lib/notifications/triggers/project-new-conversation";
+import { getNovuClient } from "@app/lib/notifications";
+import {
+  filterMembersByNotifyCondition,
+  notifyActivationConversationAgentReplied,
+} from "@app/lib/notifications/triggers/project-new-conversation";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import {
   CONVERSATION_NOTIFICATION_METADATA_KEYS,
   DEFAULT_NOTIFICATION_CONDITION,
   type NotificationCondition,
 } from "@app/types/notification_preferences";
 import type { LightWorkspaceType } from "@app/types/user";
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// Mock Novu client so tests can assert whether the activation email was triggered.
+vi.mock(import("@app/lib/notifications"), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    getNovuClient: vi.fn().mockResolvedValue({
+      triggerBulk: vi.fn().mockResolvedValue({ result: [] }),
+    }),
+  };
+});
 
 describe("filterMembersByNotifyCondition", () => {
   let workspace: LightWorkspaceType;
@@ -262,5 +281,57 @@ describe("filterMembersByNotifyCondition", () => {
         [user1.sId, user2.sId].sort()
       );
     });
+  });
+});
+
+describe("notifyActivationConversationAgentReplied", () => {
+  let auth: Authenticator;
+  let user: UserResource;
+  let pod: SpaceResource;
+  let agent: LightAgentConfigurationType;
+
+  beforeEach(async () => {
+    const result = await createResourceTest({ role: "user" });
+    user = result.user;
+    auth = result.authenticator;
+
+    pod = await SpaceFactory.project(result.workspace, user.id);
+    await ActivationPodResource.makeNew(auth, { pod, user });
+
+    agent = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "ActivationAgent",
+      description: "Test",
+    });
+
+    vi.mocked(getNovuClient).mockClear();
+  });
+
+  test("triggers the activation email for a root conversation in an activation pod", async () => {
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+      spaceId: pod.id,
+    });
+
+    await notifyActivationConversationAgentReplied(auth, {
+      conversationId: conversation.sId,
+    });
+
+    expect(vi.mocked(getNovuClient)).toHaveBeenCalled();
+  });
+
+  test("does not trigger the activation email for a nested sub-conversation", async () => {
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+      spaceId: pod.id,
+      depth: 1,
+    });
+
+    await notifyActivationConversationAgentReplied(auth, {
+      conversationId: conversation.sId,
+    });
+
+    expect(vi.mocked(getNovuClient)).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/notifications/triggers/project-new-conversation.test.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@app/lib/notifications/triggers/project-new-conversation";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -13,6 +14,7 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import {
@@ -289,6 +291,7 @@ describe("notifyActivationConversationAgentReplied", () => {
   let user: UserResource;
   let pod: SpaceResource;
   let agent: LightAgentConfigurationType;
+  let activationTrigger: TriggerResource;
 
   beforeEach(async () => {
     const result = await createResourceTest({ role: "user" });
@@ -296,21 +299,31 @@ describe("notifyActivationConversationAgentReplied", () => {
     auth = result.authenticator;
 
     pod = await SpaceFactory.project(result.workspace, user.id);
-    await ActivationPodResource.makeNew(auth, { pod, user });
 
     agent = await AgentConfigurationFactory.createTestAgent(auth, {
       name: "ActivationAgent",
       description: "Test",
     });
 
+    activationTrigger = await TriggerFactory.webhook(auth, {
+      agentConfigurationId: agent.sId,
+      spaceId: pod.id,
+    });
+    await ActivationPodResource.makeNew(auth, {
+      pod,
+      user,
+      trigger: activationTrigger,
+    });
+
     vi.mocked(getNovuClient).mockClear();
   });
 
-  test("triggers the activation email for a root conversation in an activation pod", async () => {
+  test("triggers the activation email for the pod's nudge-created conversation", async () => {
     const conversation = await ConversationFactory.create(auth, {
       agentConfigurationId: agent.sId,
       messagesCreatedAt: [],
       spaceId: pod.id,
+      triggerId: activationTrigger.id,
     });
 
     await notifyActivationConversationAgentReplied(auth, {
@@ -326,6 +339,21 @@ describe("notifyActivationConversationAgentReplied", () => {
       messagesCreatedAt: [],
       spaceId: pod.id,
       depth: 1,
+      triggerId: activationTrigger.id,
+    });
+
+    await notifyActivationConversationAgentReplied(auth, {
+      conversationId: conversation.sId,
+    });
+
+    expect(vi.mocked(getNovuClient)).not.toHaveBeenCalled();
+  });
+
+  test("does not trigger the activation email for a conversation the user starts", async () => {
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+      spaceId: pod.id,
     });
 
     await notifyActivationConversationAgentReplied(auth, {

--- a/front/lib/notifications/triggers/project-new-conversation.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.ts
@@ -256,6 +256,11 @@ export async function notifyActivationConversationAgentReplied(
     return;
   }
 
+  // Skip sub-conversations
+  if (conversationResource.depth > 0) {
+    return;
+  }
+
   const conversation = conversationResource.toJSON();
   if (!isPodConversation(conversation)) {
     return;

--- a/front/lib/notifications/triggers/project-new-conversation.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.ts
@@ -272,7 +272,12 @@ export async function notifyActivationConversationAgentReplied(
   }
 
   const activationPod = await ActivationPodResource.fetchBySpace(auth, space);
-  if (activationPod === null) {
+  // Only the conversation created by the pod's own activation nudge trigger gets the notification
+  if (
+    activationPod === null ||
+    activationPod.triggerId === null ||
+    conversationResource.triggerId !== activationPod.triggerId
+  ) {
     return;
   }
 

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -97,6 +97,7 @@ export class ConversationFactory {
       spaceId,
       visibility = "unlisted",
       depth,
+      triggerId,
       t,
     }: {
       agentConfigurationId: string;
@@ -106,6 +107,7 @@ export class ConversationFactory {
       spaceId?: ModelId;
       visibility?: ConversationVisibility;
       depth?: number;
+      triggerId?: ModelId | null;
       t?: Transaction;
     }
   ): Promise<ConversationType> {
@@ -116,6 +118,7 @@ export class ConversationFactory {
       title: "Test Conversation",
       visibility,
       depth,
+      triggerId,
       spaceId: spaceId ?? null,
     });
 

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -96,6 +96,7 @@ export class ConversationFactory {
       requestedSpaceIds,
       spaceId,
       visibility = "unlisted",
+      depth,
       t,
     }: {
       agentConfigurationId: string;
@@ -104,6 +105,7 @@ export class ConversationFactory {
       requestedSpaceIds?: ModelId[];
       spaceId?: ModelId;
       visibility?: ConversationVisibility;
+      depth?: number;
       t?: Transaction;
     }
   ): Promise<ConversationType> {
@@ -113,6 +115,7 @@ export class ConversationFactory {
     const conversation = await createConversation(auth, {
       title: "Test Conversation",
       visibility,
+      depth,
       spaceId: spaceId ?? null,
     });
 


### PR DESCRIPTION
## Description
Do not send email notifications for each sub-conversation created when the activation skill calls an agent to do something and for conversations started by the user in the activation pod.
- For conversations created through the `pod_manager.create_conversation` tool, added depth so that nested conversations are parent depth + 1, and tagged the posted message with agenticMessageData so the user isn't added as a participant.
- Check and only send a notification for conversations with depth 0 (not nested conversations)
- Check that the `conversationResource.triggerId === activationPod.triggerId` before sending an email notification
     - Unread conversations/messages in the activation pod that don't go through the trigger are now treated as normal conversations and go through the conversation-unread notification workflow.

## Tests
Added tests to front/lib/notifications/triggers/project-new-conversation.test.ts for sending an email for the parent conversation and not sending an email for the nested conversation.

## Risk
Low

## Deploy Plan
Deploy Main