### PR TITLE
database perf: add partial index on conversations (workspaceId, updatedAt)

### DIFF
--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -117,6 +117,14 @@ ConversationModel.init(
         fields: ["workspaceId", "createdAt"],
         name: "conversations_workspace_id_created_at_idx",
       },
+      // Serves fetchPrivateConversationsPaginated: lets the planner walk
+      // private conversations in updatedAt order and stop at the page size.
+      {
+        fields: ["workspaceId", "updatedAt"],
+        name: "conversations_private_paginated_list_idx",
+        where: { spaceId: null, visibility: "unlisted" },
+        concurrently: true,
+      },
     ],
     sequelize: frontSequelize,
   }

--- a/front/migrations/pre-deploy/20260803164218_add_private_conversations_paginated_list_index.sql
+++ b/front/migrations/pre-deploy/20260803164218_add_private_conversations_paginated_list_index.sql
@@ -1,0 +1,7 @@
+/*
+Statement 0
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY conversations_private_paginated_list_idx ON public.conversations USING btree ("workspaceId", "updatedAt") WHERE (("spaceId" IS NULL) AND ((visibility)::text = 'unlisted'::text));


### PR DESCRIPTION
## Description

### The issue

The private conversation list (`GET /w/[wId]/assistant/conversations`, sidebar + MCP `conversations/list` tool) produces queries with thousands of bind parameters:

```sql
SELECT "id", "updatedAt" FROM "conversations"
WHERE "id" IN ($1, ..., $8783)  -- one param per conversation the user ever participated in
  AND "spaceId" IS NULL AND "visibility" = 'unlisted' AND "workspaceId" = ...
ORDER BY "updatedAt" DESC LIMIT 101;
```

`fetchPrivateConversationsPaginated` (in `front/lib/resources/conversation_resource.ts`) does the participant→conversation join in application space: it first loads **all** of the user's `conversation_participants` rows (~8.8k for heavy users), then injects every conversation id into an `IN` clause. Cost per page view:

- A first query shipping ~8.8k participation rows to Node and hydrating them as Sequelize instances.
- A ~60KB SQL statement that Postgres must receive, parse, and plan on every request.
- An expensive execution (~20,000 buffer hits for a 101-row page, per `EXPLAIN ANALYZE` on a heavy workspace/user).

Everything scales with the user's total participation count, on every page, forever.

### Proposed fix — part 1: SQL JOIN

https://github.com/dust-tt/dust/pull/29939

Replace the app-space join with an `INNER JOIN conversation_participants ON userId/workspaceId`. This is safe because the unique index on `(workspaceId, userId, conversationId)` guarantees at most one participant row per user per conversation, so the join cannot duplicate rows under the `LIMIT`. Participation data (`actionRequired`, `updated`) would then be fetched only for the returned page instead of upfront.

This removes the 60KB statement and the 8.8k-row prefetch, and lets the planner use a clean nested loop: walk the user's entries in the participants `(workspaceId, userId, conversationId)` index, probe `conversations_pkey` for each, then top-N sort.

### Proposed fix — part 2: partial index

https://github.com/dust-tt/dust/pull/29941

```sql
CREATE INDEX CONCURRENTLY conversations_workspace_updated_at_private_idx
  ON conversations ("workspaceId", "updatedAt" DESC)
  WHERE "spaceId" IS NULL AND visibility = 'unlisted';
```

The join alone is still O(user's participations): no index on `updatedAt` exists (only `createdAt`), so Postgres must visit every candidate conversation to sort. This partial index gives the planner a second plan: walk conversations in `updatedAt` order and probe participants per row, **stopping at the page size** — O(page) for active users. The planner picks per user between the two plans: participant-driven for sparse users, updatedAt-walk for whales. Both are good; the join is what makes both available.

Being partial, the index only covers private unlisted rows, so it stays well under the 200–900 MB of the existing composite indexes on the table.


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

lock front
merge
run migration
deploy
unlock front

