### PR TITLE
Deprecate agent_memory for dust global agent when user_memory flag is on

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -342,7 +342,10 @@ function _getDustLikeGlobalAgent(
       }
     : dummyModelConfiguration;
 
-  const hasAgentMemory = agentMemoryMCPServerView !== null;
+  // Once the workspace has the `user_memory` feature flag, personal memory is
+  // owned by user_memory, so we deprecate agent_memory for the dust global agent.
+  const hasAgentMemory =
+    agentMemoryMCPServerView !== null && !featureFlags.includes("user_memory");
 
   const instructions = buildInstructions({
     hasDeepDive,


### PR DESCRIPTION
## Description

Once the feature flag for user_memory is on we want to backfill the agent_memory of the dust global agent into user_memory and then remove agent_memory tool from the dust global agent. 

## Tests

Tested locally that the dust global agent didn't have agent_memory once the FF was on

## Risk

Low 

## Deploy Plan

Deploy front once backfill done from agent_memory to user_memory