### PR TITLE
[front] fix: always add skill management server

### DIFF
--- a/front/lib/api/assistant/jit/skills.ts
+++ b/front/lib/api/assistant/jit/skills.ts
@@ -1,31 +1,19 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
-import type { Authenticator } from "@app/lib/auth";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import logger from "@app/logger/logger";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 
 /**
- * Get the skill_management MCP server if the agent has skills that can be enabled.
+ * Get the skill_management MCP server.
  */
-export async function getSkillManagementServer(
-  auth: Authenticator,
+export function getSkillManagementServer(
   agentConfiguration: AgentLoopExecutionData["agentConfiguration"],
   conversation: ConversationWithoutContentType,
   autoInternalViews: Map<AutoInternalMCPServerNameType, MCPServerViewResource>
-): Promise<ServerSideMCPServerConfigurationType | null> {
-  const { equippedSkills } = await SkillResource.listForAgentLoop(auth, {
-    agentConfiguration,
-    conversation,
-  });
-
-  if (equippedSkills.length === 0) {
-    return null;
-  }
-
+): ServerSideMCPServerConfigurationType | null {
   const skillManagementView = autoInternalViews.get("skill_management") ?? null;
 
   if (!skillManagementView) {

--- a/front/lib/api/assistant/jit/skills.ts
+++ b/front/lib/api/assistant/jit/skills.ts
@@ -6,9 +6,6 @@ import logger from "@app/logger/logger";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 
-/**
- * Get the skill_management MCP server.
- */
 export function getSkillManagementServer(
   agentConfiguration: AgentLoopExecutionData["agentConfiguration"],
   conversation: ConversationWithoutContentType,

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -190,7 +190,7 @@ describe("getJITServers", () => {
         await FeatureFlagFactory.basic(auth, "disable_computer_feature");
       });
 
-      it("should not include skill_management server when agent has no skills", async () => {
+      it("should include skill_management server when agent has no skills", async () => {
         await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
 
         const jitServers = await getJITServers(auth, {
@@ -203,10 +203,10 @@ describe("getJITServers", () => {
           (server) => server.name === "skill_management"
         );
 
-        expect(skillManagementServer).toBeUndefined();
+        expect(skillManagementServer).toBeDefined();
       });
 
-      it("should not include skill_management server when agent only has system skills", async () => {
+      it("should include skill_management server when agent only has system skills", async () => {
         await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
         await SkillFactory.linkGlobalSkillToAgent(auth, {
           globalSkillId: "discover_tools",
@@ -222,7 +222,7 @@ describe("getJITServers", () => {
           (server) => server.name === "skill_management"
         );
 
-        expect(skillManagementServer).toBeUndefined();
+        expect(skillManagementServer).toBeDefined();
       });
     });
 

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -205,25 +205,6 @@ describe("getJITServers", () => {
 
         expect(skillManagementServer).toBeDefined();
       });
-
-      it("should include skill_management server when agent only has system skills", async () => {
-        await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
-        await SkillFactory.linkGlobalSkillToAgent(auth, {
-          globalSkillId: "discover_tools",
-          agentConfigurationId: agentConfig.id,
-        });
-        const jitServers = await getJITServers(auth, {
-          agentConfiguration: agentConfig,
-          conversation: { ...conversation, spaceId: conversationsSpace.sId },
-          attachments: [],
-        });
-
-        const skillManagementServer = jitServers.find(
-          (server) => server.name === "skill_management"
-        );
-
-        expect(skillManagementServer).toBeDefined();
-      });
     });
 
     it("keeps configured custom skills equipped after enabling them, but not system skills", async () => {

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -56,8 +56,7 @@ async function getUnconditionalJITServers(
   );
   servers.push(commonUtilitiesServer);
 
-  const skillManagementServer = await getSkillManagementServer(
-    auth,
+  const skillManagementServer = getSkillManagementServer(
     agentConfiguration,
     conversation,
     autoInternalViews


### PR DESCRIPTION
## Description

Agents without any configured skills currently do not get the skill management server, which means they cannot enable a skill referenced from the input bar.

This PR always includes the skill management server when its MCP server view exists. This also removes the database lookup for equipped skills from JIT server setup (not a very costly one but still).

## Tests

- Updated tests.
- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
