### PR TITLE
Attribute enabled skill context to tool consumption

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -291,7 +291,7 @@ export type AgentActionRunningEvents =
   | AgentLoopMCPApproveExecutionEvent
   | AgentLoopToolNotificationEvent;
 
-const MAX_DESCRIPTION_LENGTH = 1024;
+export const MAX_TOOL_DESCRIPTION_LENGTH = 1024;
 
 /**
  * Builds a tool specification for the given MCP action configuration.
@@ -310,7 +310,8 @@ export function buildToolSpecification(
   return {
     name: actionConfiguration.name,
     description:
-      actionConfiguration.description?.slice(0, MAX_DESCRIPTION_LENGTH) ?? "",
+      actionConfiguration.description?.slice(0, MAX_TOOL_DESCRIPTION_LENGTH) ??
+      "",
     inputSchema,
     ...(actionConfiguration.eager ? { eager: true } : {}),
   };

--- a/front/lib/api/assistant/agent_message_consumption_attribution/attribution_builder.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/attribution_builder.ts
@@ -8,11 +8,11 @@ import { MODEL_COST_MICRO_USD_PER_AWU_CREDIT } from "@app/lib/metronome/constant
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import assert from "assert";
 
-// Version 1 attributed the model token buckets only. Version 2 adds per-tool rows and, as a result,
-// nets the tool-call emission out of the assistant output bucket, so its rows are not comparable to
-// version 1's. Bumping keeps the two regimes as separate, self-consistent sets rather than mixing
-// them under one version when a pre-v2 message is re-finalized.
-export const AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION = 2;
+// Version 1 attributed the model token buckets only. Version 2 added per-tool rows and netted the
+// tool-call emission out of the assistant output bucket. Version 3 expands an enabled skill's tool
+// input footprint with the instructions and tool definitions that the action adds to later model
+// requests. Each version remains a separate, self-consistent set of rows.
+export const AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION = 3;
 
 const CREDIT_AMOUNT_MICRO_PER_CREDIT = 1_000_000;
 

--- a/front/lib/api/assistant/agent_message_consumption_attribution/enabled_skill_footprint.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/enabled_skill_footprint.ts
@@ -7,9 +7,10 @@ import { renderEnabledSkillUserMessageFromInstructions } from "@app/lib/api/assi
 import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
 
-const EMPTY_INPUT_SCHEMA = {
-  type: "object" as const,
+const EMPTY_INPUT_SCHEMA: JSONSchema = {
+  type: "object",
   properties: {},
   required: [],
 };

--- a/front/lib/api/assistant/agent_message_consumption_attribution/enabled_skill_footprint.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/enabled_skill_footprint.ts
@@ -7,6 +7,7 @@ import { renderEnabledSkillUserMessageFromInstructions } from "@app/lib/api/assi
 import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import { removeNulls } from "@app/types/shared/utils/general";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 const EMPTY_INPUT_SCHEMA: JSONSchema = {
@@ -20,10 +21,7 @@ function enabledSkillIdsFromAction(
 ): string[] {
   return [
     ...new Set(
-      (action.output ?? []).flatMap((outputBlock) => {
-        const skillId = getEnableSkillIdFromOutputBlock(outputBlock);
-        return skillId ? [skillId] : [];
-      })
+      removeNulls((action.output ?? []).map(getEnableSkillIdFromOutputBlock))
     ),
   ];
 }

--- a/front/lib/api/assistant/agent_message_consumption_attribution/enabled_skill_footprint.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/enabled_skill_footprint.ts
@@ -1,0 +1,138 @@
+import { MAX_TOOL_DESCRIPTION_LENGTH } from "@app/lib/actions/mcp";
+import { hideInternalConfiguration } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { tryGetPrefixedToolName } from "@app/lib/actions/tool_name_utils";
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { getEnableSkillIdFromOutputBlock } from "@app/lib/api/actions/servers/skill_management/rendering";
+import { renderEnabledSkillUserMessageFromInstructions } from "@app/lib/api/assistant/skills_rendering";
+import type { Authenticator } from "@app/lib/auth";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+
+const EMPTY_INPUT_SCHEMA = {
+  type: "object" as const,
+  properties: {},
+  required: [],
+};
+
+function enabledSkillIdsFromAction(
+  action: AgentMCPActionWithOutputType
+): string[] {
+  return [
+    ...new Set(
+      (action.output ?? []).flatMap((outputBlock) => {
+        const skillId = getEnableSkillIdFromOutputBlock(outputBlock);
+        return skillId ? [skillId] : [];
+      })
+    ),
+  ];
+}
+
+/**
+ * Rebuilds the definitions contributed by one enabled skill from its persisted server views. The
+ * agent loop can apply further context-dependent filtering when it lists tools, so these remain an
+ * attribution estimate rather than a copy of a provider request.
+ */
+function enabledSkillToolDefinitions(
+  skill: SkillResource
+): AgentActionSpecification[] {
+  const definitions: AgentActionSpecification[] = [];
+
+  for (const configuration of skill.mcpServerConfigurations) {
+    const serverName =
+      configuration.serverNameOverride ??
+      configuration.view.name ??
+      configuration.view.getServerDisplayMetadata().name;
+    const disabledToolNames = new Set(
+      configuration.view.getToolPermissions
+        .filter(({ enabled }) => !enabled)
+        .map(({ toolName }) => toolName)
+    );
+
+    for (const tool of configuration.view.getServerTools()) {
+      if (disabledToolNames.has(tool.name)) {
+        continue;
+      }
+
+      const prefixedName = tryGetPrefixedToolName(serverName, tool.name);
+      if (prefixedName.isErr()) {
+        continue;
+      }
+
+      const inputSchema = tool.inputSchema ?? EMPTY_INPUT_SCHEMA;
+      definitions.push({
+        name: prefixedName.value,
+        description: tool.description.slice(0, MAX_TOOL_DESCRIPTION_LENGTH),
+        inputSchema:
+          configuration.view.internalMCPServerId === null
+            ? inputSchema
+            : hideInternalConfiguration(inputSchema),
+      });
+    }
+  }
+
+  return definitions.sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function enabledSkillInputText(skill: SkillResource): string {
+  const instructionsMessage = renderEnabledSkillUserMessageFromInstructions({
+    skill,
+  });
+  const instructionsText = instructionsMessage.content.flatMap((content) =>
+    content.type === "text" ? [content.text] : []
+  );
+  const toolDefinitions = enabledSkillToolDefinitions(skill);
+
+  return [
+    ...instructionsText,
+    ...(toolDefinitions.length > 0
+      ? [
+          JSON.stringify(
+            toolDefinitions.map(({ name, description, inputSchema }) => ({
+              name,
+              description,
+              inputSchema,
+            }))
+          ),
+        ]
+      : []),
+  ].join("\n");
+}
+
+/**
+ * Resolves the additional model input caused by successful enable-skill actions. A normal action
+ * has no entry. An enable-skill action contributes the instructions rendered as a user message and
+ * the definitions of the tools exposed by the skill.
+ */
+export async function getEnabledSkillInputTextByActionId(
+  auth: Authenticator,
+  actions: AgentMCPActionWithOutputType[]
+): Promise<ReadonlyMap<string, string>> {
+  const enabledSkillIdsByAction = actions.map((action) => ({
+    action,
+    skillIds: enabledSkillIdsFromAction(action),
+  }));
+  const skillIds = [
+    ...new Set(enabledSkillIdsByAction.flatMap(({ skillIds }) => skillIds)),
+  ];
+  if (skillIds.length === 0) {
+    return new Map();
+  }
+
+  const skills = await SkillResource.fetchByIds(auth, skillIds);
+  const inputTextBySkillId = new Map(
+    skills.map((skill) => [skill.sId, enabledSkillInputText(skill)])
+  );
+
+  return new Map(
+    enabledSkillIdsByAction.flatMap(({ action, skillIds }) => {
+      const inputTexts = skillIds.flatMap((skillId) => {
+        const inputText = inputTextBySkillId.get(skillId);
+        return inputText !== undefined ? [inputText] : [];
+      });
+
+      return inputTexts.length > 0
+        ? [[action.sId, inputTexts.join("\n")] as const]
+        : [];
+    })
+  );
+}

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
@@ -1,14 +1,18 @@
+import { makeEnableSkillResultOutput } from "@app/lib/api/actions/servers/skill_management/rendering";
 import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
 import { computeAndStoreAgentMessageConsumptionAttribution } from "@app/lib/api/assistant/agent_message_consumption_attribution/store";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { tokenCountForTexts } from "@app/lib/tokenization";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { RunFactory } from "@app/tests/utils/RunFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -24,12 +28,16 @@ const INPUT_TOKENS_COUNT = 100;
 const OUTPUT_TOKENS_COUNT = 20;
 const REASONING_TOKENS_COUNT = 5;
 
-// Every tokenized footprint counts as this many tokens, so tool-call output and result-input
+// Every tokenized footprint counts as this many tokens, so tool-call output and tool input
 // footprints are deterministic in the assertions below.
 const TOKENS_PER_FOOTPRINT = 2;
 
 async function setupSettledMessageWithUsage() {
-  const { authenticator: auth, workspace } = await createResourceTest({});
+  const {
+    authenticator: auth,
+    globalSpace,
+    workspace,
+  } = await createResourceTest({ role: "admin" });
 
   const agentConfiguration = await AgentConfigurationFactory.createTestAgent(
     auth,
@@ -54,6 +62,7 @@ async function setupSettledMessageWithUsage() {
 
   return {
     auth,
+    globalSpace,
     workspace,
     conversation,
     run,
@@ -199,6 +208,81 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
     expect(
       (outputItem?.outputTokensCount ?? 0) + (toolItem?.outputTokensCount ?? 0)
     ).toBe(OUTPUT_TOKENS_COUNT - REASONING_TOKENS_COUNT);
+  });
+
+  it("attributes enabled skill instructions and tool definitions to the tool input", async () => {
+    const {
+      auth,
+      globalSpace,
+      workspace,
+      conversation,
+      run,
+      conversationId,
+      agentMessageId,
+      agentMessageModelId,
+    } = await setupSettledMessageWithUsage();
+
+    const internalServer = await InternalMCPServerInMemoryResource.makeNew(
+      auth,
+      {
+        name: "common_utilities",
+        useCase: null,
+      }
+    );
+    const mcpServerView = await MCPServerViewFactory.create(
+      workspace,
+      internalServer.id,
+      globalSpace
+    );
+    const skill = await SkillFactory.create(auth, {
+      instructions: "Follow the enabled skill instructions.",
+      mcpServerViews: [mcpServerView],
+      name: "Measured Skill",
+    });
+    await AgentMCPActionFactory.create(auth, {
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId,
+      status: "succeeded",
+      dustRunId: run.dustRunId,
+      output: [
+        makeEnableSkillResultOutput({
+          skillId: skill.sId,
+          text: `Skill "${skill.name}" has been enabled.`,
+        }),
+      ],
+    });
+
+    // Character counts let this assertion verify the exact combined text handed to tokenization.
+    vi.mocked(tokenCountForTexts).mockImplementation(
+      async (texts) => new Ok(texts.map((text) => text.length))
+    );
+
+    await computeAndStoreAgentMessageConsumptionAttribution(auth, {
+      agentMessageId,
+      conversationId,
+    });
+
+    const [, inputTokenizationCall] = vi.mocked(tokenCountForTexts).mock.calls;
+    const [inputTexts] = inputTokenizationCall;
+    expect(inputTexts).toHaveLength(1);
+    expect(inputTexts[0]).toContain(
+      "<dust_system>\n<Measured Skill>\nFollow the enabled skill instructions."
+    );
+    expect(inputTexts[0]).toContain(
+      '"name":"common_utilities__set_conversation_title"'
+    );
+
+    const items =
+      await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
+        auth,
+        {
+          agentMessageModelIds: [agentMessageModelId],
+          attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+        }
+      );
+    const toolItem = items.find((item) => item.itemType === "tool");
+    expect(toolItem?.inputTokensCount).toBe(inputTexts[0].length);
   });
 
   it("writes a blocked tool as a pending row, carving its output but withholding the charge", async () => {

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
@@ -248,7 +248,7 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
       const toolAttribution = buildToolAttribution({
         usage,
         toolCall,
-        inputTokensCount: footprint.resultInputTokensCount,
+        inputTokensCount: footprint.inputTokensCount,
         directCreditAmountMicro,
       });
 

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.test.ts
@@ -73,7 +73,7 @@ describe("toolCallFootprintTexts", () => {
   });
 
   it("renders a denied action as the rejection notice, ignoring any output", () => {
-    const { resultText } = toolCallFootprintTexts(
+    const { inputText } = toolCallFootprintTexts(
       footprintInput(
         makeAction({
           status: "denied",
@@ -82,31 +82,31 @@ describe("toolCallFootprintTexts", () => {
       )
     );
 
-    expect(resultText).toBe(
+    expect(inputText).toBe(
       "The user rejected or skipped this specific action execution. Using this action is hence forbidden for this message."
     );
   });
 
   it("renders an action awaiting validation as the validation notice", () => {
-    const { resultText } = toolCallFootprintTexts(
+    const { inputText } = toolCallFootprintTexts(
       footprintInput(makeAction({ status: "blocked_validation_required" }))
     );
 
-    expect(resultText).toBe(
+    expect(inputText).toBe(
       "The user must manually validate this action before it can be executed."
     );
   });
 
   it("renders an empty output as the no-output notice", () => {
-    const { resultText } = toolCallFootprintTexts(
+    const { inputText } = toolCallFootprintTexts(
       footprintInput(makeAction({ status: "succeeded", output: [] }))
     );
 
-    expect(resultText).toBe("Successfully executed action, no output.");
+    expect(inputText).toBe("Successfully executed action, no output.");
   });
 
   it("joins text output items with newlines", () => {
-    const { resultText } = toolCallFootprintTexts(
+    const { inputText } = toolCallFootprintTexts(
       footprintInput(
         makeAction({
           status: "succeeded",
@@ -118,11 +118,11 @@ describe("toolCallFootprintTexts", () => {
       )
     );
 
-    expect(resultText).toBe("first\nsecond");
+    expect(inputText).toBe("first\nsecond");
   });
 
   it("serializes non-text output as JSON with the mime type stripped", () => {
-    const { resultText } = toolCallFootprintTexts(
+    const { inputText } = toolCallFootprintTexts(
       footprintInput(
         makeAction({
           status: "succeeded",
@@ -136,7 +136,7 @@ describe("toolCallFootprintTexts", () => {
       )
     );
 
-    expect(resultText).toBe(JSON.stringify([{ uri: "u", text: "body" }]));
+    expect(inputText).toBe(JSON.stringify([{ uri: "u", text: "body" }]));
   });
 });
 
@@ -188,11 +188,11 @@ describe("measureToolCallFootprints", () => {
       toolCalls,
     });
 
-    // Calls and results are tokenized as two homogeneous lists, each in input order.
+    // Calls and inputs are tokenized as two homogeneous lists, each in input order.
     const [callTexts] = vi.mocked(tokenCountForTexts).mock.calls[0];
-    const [resultTexts] = vi.mocked(tokenCountForTexts).mock.calls[1];
+    const [inputTexts] = vi.mocked(tokenCountForTexts).mock.calls[1];
     expect(callTexts).toEqual(["a\n{}", "b\n{}"]);
-    expect(resultTexts).toEqual([
+    expect(inputTexts).toEqual([
       "Successfully executed action, no output.",
       "result-of-b",
     ]);
@@ -200,12 +200,11 @@ describe("measureToolCallFootprints", () => {
     expect(res.isOk() && res.value).toEqual([
       {
         callOutputTokensCount: "a\n{}".length,
-        resultInputTokensCount: "Successfully executed action, no output."
-          .length,
+        inputTokensCount: "Successfully executed action, no output.".length,
       },
       {
         callOutputTokensCount: "b\n{}".length,
-        resultInputTokensCount: "result-of-b".length,
+        inputTokensCount: "result-of-b".length,
       },
     ]);
   });

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
@@ -1,3 +1,4 @@
+import { getEnabledSkillInputTextByActionId } from "@app/lib/api/assistant/agent_message_consumption_attribution/enabled_skill_footprint";
 import { renderToolResultForModelAsText } from "@app/lib/api/assistant/conversation_rendering/helpers";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
@@ -9,24 +10,24 @@ import { Err, Ok } from "@app/types/shared/result";
 
 /**
  * The two texts an MCP action contributes to the model's token budget: the tool call the model
- * emitted (output side) and the result's renderable footprint (input side). The result is priced by
- * the input it would occupy if carried into a later prompt, which it may never be (the message can
- * end, or the tool can be denied, before any following turn). Per-tool attribution prices both
- * footprints, so V1 measures them.
+ * emitted on the output side and the model input created by the execution. Most tools only create a
+ * renderable result. Enabling a skill also creates an instruction message and tool definitions.
  */
 export interface ToolFootprintTexts {
   callText: string;
-  resultText: string;
+  /** Model input created by the execution, not parameters passed into the tool. */
+  inputText: string;
 }
 
 /**
  * The measured footprint of one MCP action, aligned by position with the input actions. Named after
- * the model budget each side consumes: the emitted call counts as output, and the result counts as
- * the input it would occupy if carried into a later prompt, which it may never be.
+ * the model budget each side consumes. The emitted call counts as output, and everything the
+ * execution adds to later model requests counts as input.
  */
 export interface ToolFootprintMeasurement {
   callOutputTokensCount: number;
-  resultInputTokensCount: number;
+  /** Tokens added to model input by the execution, not tokens in the tool arguments. */
+  inputTokensCount: number;
 }
 
 /**
@@ -39,22 +40,25 @@ export interface ToolCallFootprintInput {
   functionCallArguments: string;
 }
 
-export function toolCallFootprintTexts({
-  action,
-  functionCallArguments,
-}: ToolCallFootprintInput): ToolFootprintTexts {
+export function toolCallFootprintTexts(
+  { action, functionCallArguments }: ToolCallFootprintInput,
+  additionalInputText?: string
+): ToolFootprintTexts {
   return {
     // The tool call as the model emitted it: its name plus the arguments it generated.
     callText: `${action.functionCallName}\n${functionCallArguments}`,
-    // The result's model-rendered text, shared with conversation rendering so the estimate tracks
-    // what would be sent. Image content is not counted here because it uses separate tile pricing.
-    resultText: renderToolResultForModelAsText(action),
+    // Tool input means the model input created by this execution. Most tools contribute only their
+    // rendered result. Enabling a skill also adds its instructions and tool definitions to later
+    // requests, so those consequences belong to the same tool row.
+    inputText: [renderToolResultForModelAsText(action), additionalInputText]
+      .filter((text): text is string => text !== undefined)
+      .join("\n"),
   };
 }
 
 /**
- * Measures, for each action, how many tokens the model spent emitting the tool call and how many the
- * returned result would occupy if carried into a later prompt. Results stay aligned with `toolCalls`.
+ * Measures, for each action, how many tokens the model spent emitting the tool call and how many
+ * input tokens the execution contributes. Results stay aligned with `toolCalls`.
  *
  * Uses the exact tokenizer of the run's model through core, the same path conversation rendering
  * uses to size messages, so the counts closely match provider tokenization rather than a heuristic.
@@ -84,17 +88,28 @@ export async function measureToolCallFootprints(
     skipEmbeddingApiKeyRequirement: true,
   });
 
-  // Tokenize the calls and the results as two homogeneous lists rather than one interleaved list, so
-  // each count maps back to its call by plain index, with no call-vs-result position juggling.
-  const footprints = toolCalls.map(toolCallFootprintTexts);
-  const [callCountsRes, resultCountsRes] = await Promise.all([
+  const enabledSkillInputTextByActionId =
+    await getEnabledSkillInputTextByActionId(
+      auth,
+      toolCalls.map(({ action }) => action)
+    );
+
+  // Tokenize the calls and inputs as two homogeneous lists so each count maps back to its call by
+  // plain index, with no call-vs-input position juggling.
+  const footprints = toolCalls.map((toolCall) =>
+    toolCallFootprintTexts(
+      toolCall,
+      enabledSkillInputTextByActionId.get(toolCall.action.sId)
+    )
+  );
+  const [callCountsRes, inputCountsRes] = await Promise.all([
     tokenCountForTexts(
       footprints.map((footprint) => footprint.callText),
       model,
       credentials
     ),
     tokenCountForTexts(
-      footprints.map((footprint) => footprint.resultText),
+      footprints.map((footprint) => footprint.inputText),
       model,
       credentials
     ),
@@ -102,17 +117,17 @@ export async function measureToolCallFootprints(
   if (callCountsRes.isErr()) {
     return callCountsRes;
   }
-  if (resultCountsRes.isErr()) {
-    return resultCountsRes;
+  if (inputCountsRes.isErr()) {
+    return inputCountsRes;
   }
 
   const callCounts = callCountsRes.value;
-  const resultCounts = resultCountsRes.value;
+  const inputCounts = inputCountsRes.value;
 
   return new Ok(
     footprints.map((_, index) => ({
       callOutputTokensCount: callCounts[index],
-      resultInputTokensCount: resultCounts[index],
+      inputTokensCount: inputCounts[index],
     }))
   );
 }

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -32,6 +32,7 @@ import type {
   MCPServerType,
   MCPServerViewLightType,
   MCPServerViewType,
+  MCPToolType,
 } from "@app/lib/api/mcp";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
@@ -1323,6 +1324,16 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       default:
         assertNever(this.serverType);
     }
+  }
+
+  /**
+   * Returns the persisted tool definitions exposed by this server view. Remote views must have
+   * been fetched with the cached tools heavy attribute.
+   */
+  getServerTools(): readonly MCPToolType[] {
+    return this.serverType === "remote"
+      ? this.getRemoteMCPServerResource().getCachedTools()
+      : this.getInternalMCPServerResource().toJSON().tools;
   }
 
   /**

--- a/front/tests/utils/AgentMCPActionFactory.ts
+++ b/front/tests/utils/AgentMCPActionFactory.ts
@@ -2,7 +2,10 @@ import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
-import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
+import {
+  AgentMCPActionModel,
+  AgentMCPActionOutputItemModel,
+} from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import type { MessageModel } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -16,6 +19,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { WorkspaceType } from "@app/types/user";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 export class AgentMCPActionFactory {
   // Monotonic counter: step content indexes only need to be unique within an agent message.
@@ -34,6 +38,7 @@ export class AgentMCPActionFactory {
       status = "blocked_validation_required",
       step = 1,
       dustRunId = null,
+      output = [],
     }: {
       workspace: WorkspaceType;
       conversationModelId: ModelId;
@@ -41,6 +46,7 @@ export class AgentMCPActionFactory {
       status?: ToolExecutionStatus;
       step?: number;
       dustRunId?: string | null;
+      output?: CallToolResult["content"];
     }
   ): Promise<{
     action: AgentMCPActionResource;
@@ -118,6 +124,18 @@ export class AgentMCPActionFactory {
       agentMCPActionId: action.id,
       stepContentId: stepContent.id,
     });
+
+    if (output.length > 0) {
+      await AgentMCPActionOutputItemModel.bulkCreate(
+        output.map((content) => ({
+          workspaceId: workspace.id,
+          agentMCPActionId: action.id,
+          content,
+          contentGcsPath: null,
+          citations: null,
+        }))
+      );
+    }
 
     const actionResource = await AgentMCPActionResource.fetchById(
       auth,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Enabling a skill expands subsequent model input beyond the result returned by `enable_skill`. It injects the skill
instructions as a user message and exposes the tools configured by that skill. Consumption attribution previously
measured only the rendered action result, which understated the input footprint caused by enabling a skill.

This change reconstructs the additional input from the persisted skill and MCP server views. It applies the existing
tool-name prefixing, disabled-tool filtering, internal schema cleanup, and description limit before combining the
definitions and instructions with the rendered tool result. The combined text is tokenized and attributed to the same
tool row.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
