### PR TITLE
[front] fix: allow removing self+provisioned users in skill/agent editors

### DIFF
--- a/front/components/assistant/details/tabs/AgentEditorsTab.tsx
+++ b/front/components/assistant/details/tabs/AgentEditorsTab.tsx
@@ -36,6 +36,7 @@ export function AgentEditorsTab({
   return (
     <div className="flex flex-col gap-4">
       <MembersList
+        allowRemoveAnyMember
         currentUser={user}
         membersData={{
           members: editors.map((user) => ({

--- a/front/components/assistant/details/tabs/AgentEditorsTab.tsx
+++ b/front/components/assistant/details/tabs/AgentEditorsTab.tsx
@@ -36,7 +36,7 @@ export function AgentEditorsTab({
   return (
     <div className="flex flex-col gap-4">
       <MembersList
-        allowRemoveAnyMember
+        allowRemoveSelfAndProvisionedUsers
         currentUser={user}
         membersData={{
           members: editors.map((user) => ({

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -132,14 +132,10 @@ const memberColumns = [
     header: "",
     cell: (info: Info) => (
       <DataTable.CellContent>
-        {info.row.original.isCurrentUser ? (
-          <></>
-        ) : (
-          <IconButton
-            icon={XClose}
-            onClick={info.row.original.onRemoveMemberClick}
-          />
-        )}
+        <IconButton
+          icon={XClose}
+          onClick={info.row.original.onRemoveMemberClick}
+        />
       </DataTable.CellContent>
     ),
     meta: {

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -132,8 +132,7 @@ const memberColumns = [
     header: "",
     cell: (info: Info) => (
       <DataTable.CellContent>
-        {info.row.original.isCurrentUser ||
-        info.row.original.origin === "provisioned" ? (
+        {info.row.original.isCurrentUser ? (
           <></>
         ) : (
           <IconButton

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -64,13 +64,13 @@ function getTableRows({
   onClick,
   onRemoveMemberClick,
   currentUserId,
-  allowRemoveAnyMember,
+  allowRemoveSelfAndProvisionedUsers,
 }: {
   allUsers: SearchMemberWithWorkspaceType[];
   onClick: (user: SearchMemberWithWorkspaceType) => void;
   onRemoveMemberClick?: (user: SearchMemberWithWorkspaceType) => void;
   currentUserId: string;
-  allowRemoveAnyMember: boolean;
+  allowRemoveSelfAndProvisionedUsers: boolean;
 }): RowData[] {
   return allUsers.map((user) => {
     const fullUser = isFullUserType(user);
@@ -86,7 +86,8 @@ function getTableRows({
       groups: user.workspace.groups ?? [],
       isCurrentUser,
       canRemove:
-        allowRemoveAnyMember || (!isCurrentUser && origin !== "provisioned"),
+        allowRemoveSelfAndProvisionedUsers ||
+        (!isCurrentUser && origin !== "provisioned"),
       onClick: () => onClick(user),
       onRemoveMemberClick: () => onRemoveMemberClick?.(user),
       origin,
@@ -177,7 +178,7 @@ const memberColumns = [
 ];
 
 interface MembersListProps {
-  allowRemoveAnyMember?: boolean;
+  allowRemoveSelfAndProvisionedUsers?: boolean;
   currentUser: UserType | null;
   membersData: MembersData;
   onRowClick: (user: SearchMemberWithWorkspaceType) => void;
@@ -188,7 +189,7 @@ interface MembersListProps {
 }
 
 export function MembersList({
-  allowRemoveAnyMember = false,
+  allowRemoveSelfAndProvisionedUsers = false,
   currentUser,
   membersData,
   onRowClick,
@@ -213,14 +214,14 @@ export function MembersList({
       onClick: onRowClick,
       onRemoveMemberClick,
       currentUserId: currentUser?.sId ?? "current-user-not-loaded",
-      allowRemoveAnyMember,
+      allowRemoveSelfAndProvisionedUsers,
     });
   }, [
     members,
     onRowClick,
     onRemoveMemberClick,
     currentUser?.sId,
-    allowRemoveAnyMember,
+    allowRemoveSelfAndProvisionedUsers,
   ]);
 
   return (

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -33,6 +33,7 @@ type RowData = {
   status: "Active" | "Unregistered";
   groups: string[];
   isCurrentUser: boolean;
+  canRemove: boolean;
   onClick: () => void;
   onRemoveMemberClick?: () => void;
   origin?: MembershipOriginType;
@@ -63,14 +64,18 @@ function getTableRows({
   onClick,
   onRemoveMemberClick,
   currentUserId,
+  allowRemoveAnyMember,
 }: {
   allUsers: SearchMemberWithWorkspaceType[];
   onClick: (user: SearchMemberWithWorkspaceType) => void;
   onRemoveMemberClick?: (user: SearchMemberWithWorkspaceType) => void;
   currentUserId: string;
+  allowRemoveAnyMember: boolean;
 }): RowData[] {
   return allUsers.map((user) => {
     const fullUser = isFullUserType(user);
+    const isCurrentUser = user.sId === currentUserId;
+    const origin = fullUser ? user.origin : undefined;
     return {
       icon: user.image ?? "",
       name: user.fullName,
@@ -79,10 +84,12 @@ function getTableRows({
       role: user.workspace.role ?? "none",
       status: fullUser && user.lastLoginAt === null ? "Unregistered" : "Active",
       groups: user.workspace.groups ?? [],
-      isCurrentUser: user.sId === currentUserId,
+      isCurrentUser,
+      canRemove:
+        allowRemoveAnyMember || (!isCurrentUser && origin !== "provisioned"),
       onClick: () => onClick(user),
       onRemoveMemberClick: () => onRemoveMemberClick?.(user),
-      origin: fullUser ? user.origin : undefined,
+      origin,
     };
   });
 }
@@ -132,10 +139,12 @@ const memberColumns = [
     header: "",
     cell: (info: Info) => (
       <DataTable.CellContent>
-        <IconButton
-          icon={XClose}
-          onClick={info.row.original.onRemoveMemberClick}
-        />
+        {info.row.original.canRemove && (
+          <IconButton
+            icon={XClose}
+            onClick={info.row.original.onRemoveMemberClick}
+          />
+        )}
       </DataTable.CellContent>
     ),
     meta: {
@@ -168,6 +177,7 @@ const memberColumns = [
 ];
 
 interface MembersListProps {
+  allowRemoveAnyMember?: boolean;
   currentUser: UserType | null;
   membersData: MembersData;
   onRowClick: (user: SearchMemberWithWorkspaceType) => void;
@@ -178,6 +188,7 @@ interface MembersListProps {
 }
 
 export function MembersList({
+  allowRemoveAnyMember = false,
   currentUser,
   membersData,
   onRowClick,
@@ -202,8 +213,15 @@ export function MembersList({
       onClick: onRowClick,
       onRemoveMemberClick,
       currentUserId: currentUser?.sId ?? "current-user-not-loaded",
+      allowRemoveAnyMember,
     });
-  }, [members, onRowClick, onRemoveMemberClick, currentUser?.sId]);
+  }, [
+    members,
+    onRowClick,
+    onRemoveMemberClick,
+    currentUser?.sId,
+    allowRemoveAnyMember,
+  ]);
 
   return (
     <>

--- a/front/components/skills/SkillEditorsTab.tsx
+++ b/front/components/skills/SkillEditorsTab.tsx
@@ -120,6 +120,7 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
         )}
       </div>
       <MembersList
+        allowRemoveAnyMember
         currentUser={user}
         membersData={{
           members: selectedEditors.map((user) => ({
@@ -130,7 +131,7 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
           totalMembersCount: selectedEditors.length,
           mutateRegardlessOfQueryParams: () => Promise.resolve(undefined),
         }}
-        showColumns={skill.canAdministrate ? ["name", "remove"] : ["name"]}
+        showColumns={["name", "remove"]}
         onRemoveMemberClick={onRemoveMember}
         onRowClick={function noRefCheck() {}}
       />

--- a/front/components/skills/SkillEditorsTab.tsx
+++ b/front/components/skills/SkillEditorsTab.tsx
@@ -120,7 +120,7 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
         )}
       </div>
       <MembersList
-        allowRemoveAnyMember
+        allowRemoveSelfAndProvisionedUsers
         currentUser={user}
         membersData={{
           members: selectedEditors.map((user) => ({

--- a/front/components/skills/SkillEditorsTab.tsx
+++ b/front/components/skills/SkillEditorsTab.tsx
@@ -131,7 +131,7 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
           totalMembersCount: selectedEditors.length,
           mutateRegardlessOfQueryParams: () => Promise.resolve(undefined),
         }}
-        showColumns={["name", "remove"]}
+        showColumns={skill.canAdministrate ? ["name", "remove"] : ["name"]}
         onRemoveMemberClick={onRemoveMember}
         onRowClick={function noRefCheck() {}}
       />


### PR DESCRIPTION
## Description

When editing lists of skill (resp. agent) editors from the skill (resp. agent) info page one currently cannot remove oneself. Some users are also semi-randomly not removable. This behavior is inherited from the component `MembersList`, which was initially used for adding/removing members from spaces.

This PR adds an opt-in for removing oneself and provisioned users, enabled only by the skill and agent editor lists.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
