### PR TITLE
[front] fix: accept Zendesk tickets without tags in API responses

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -364,7 +364,7 @@ export async function syncTicket({
       timestampMs: updatedAtDate.getTime(),
       tags: [
         ...tags,
-        ...filterCustomTags(ticket.tags, logger),
+        ...filterCustomTags(ticket.tags ?? [], logger),
         ...customFieldTags,
       ],
       parents,

--- a/connectors/src/connectors/zendesk/lib/types.ts
+++ b/connectors/src/connectors/zendesk/lib/types.ts
@@ -41,7 +41,7 @@ export const ZendeskTicketSchema = z
     organization_id: z.number().nullable().optional(),
     created_at: z.string(),
     updated_at: z.string(),
-    tags: z.array(z.string()),
+    tags: z.array(z.string()).optional(),
     custom_fields: z
       .array(
         z.object({

--- a/front/lib/api/actions/servers/zendesk/client.ts
+++ b/front/lib/api/actions/servers/zendesk/client.ts
@@ -90,6 +90,7 @@ class ZendeskClient {
 
   private async request<T extends z.Schema>(
     endpoint: string,
+    schemaName: string,
     schema: T,
     {
       method,
@@ -133,13 +134,14 @@ class ZendeskClient {
       logger.error(
         {
           endpoint,
+          schemaName,
           error: parseResult.error.message,
         },
         "[Zendesk] Invalid API response format"
       );
       return new Err(
         new Error(
-          `Invalid Zendesk API response format: ${parseResult.error.message}`
+          `Invalid Zendesk API response format for ${schemaName}: ${parseResult.error.message}`
         )
       );
     }
@@ -150,6 +152,7 @@ class ZendeskClient {
   async getTicket(ticketId: number): Promise<Result<ZendeskTicket, Error>> {
     const result = await this.request(
       `tickets/${ticketId}`,
+      "ZendeskTicketResponseSchema",
       ZendeskTicketResponseSchema
     );
 
@@ -165,6 +168,7 @@ class ZendeskClient {
   ): Promise<Result<ZendeskTicketMetrics, Error>> {
     const result = await this.request(
       `tickets/${ticketId}/metrics`,
+      "ZendeskTicketMetricsResponseSchema",
       ZendeskTicketMetricsResponseSchema
     );
 
@@ -194,6 +198,7 @@ class ZendeskClient {
 
     const result = await this.request(
       `search.json?${params.toString()}`,
+      "ZendeskSearchResponseSchema",
       ZendeskSearchResponseSchema
     );
 
@@ -210,6 +215,7 @@ class ZendeskClient {
   ): Promise<Result<ZendeskTicket, Error>> {
     const result = await this.request(
       `tickets/${ticketId}`,
+      "ZendeskTicketResponseSchema",
       ZendeskTicketResponseSchema,
       {
         method: "PUT",
@@ -237,6 +243,7 @@ class ZendeskClient {
   ): Promise<Result<ZendeskTicket, Error>> {
     const result = await this.request(
       `tickets/${ticketId}`,
+      "ZendeskTicketResponseSchema",
       ZendeskTicketResponseSchema,
       {
         method: "PUT",
@@ -268,6 +275,7 @@ class ZendeskClient {
     const idsParam = fieldIds.join(",");
     const result = await this.request(
       `ticket_fields/show_many?ids=${idsParam}`,
+      "ZendeskTicketFieldsResponseSchema",
       ZendeskTicketFieldsResponseSchema
     );
 
@@ -285,6 +293,7 @@ class ZendeskClient {
   } = {}): Promise<Result<ZendeskTicketField[], Error>> {
     const result = await this.request(
       `ticket_fields.json`,
+      "ZendeskTicketFieldsResponseSchema",
       ZendeskTicketFieldsResponseSchema
     );
 
@@ -307,6 +316,7 @@ class ZendeskClient {
     }
     const result = await this.request(
       `tickets/${ticketId}/comments?${params.toString()}`,
+      "ZendeskTicketCommentsResponseSchema",
       ZendeskTicketCommentsResponseSchema
     );
 
@@ -323,6 +333,7 @@ class ZendeskClient {
   ): Promise<Result<string[], Error>> {
     const result = await this.request(
       `tickets/${ticketId}/tags`,
+      "ZendeskTagsResponseSchema",
       ZendeskTagsResponseSchema,
       { method: "PUT", body: { tags } } // PUT = additive
     );
@@ -340,6 +351,7 @@ class ZendeskClient {
   ): Promise<Result<string[], Error>> {
     const result = await this.request(
       `tickets/${ticketId}/tags`,
+      "ZendeskTagsResponseSchema",
       ZendeskTagsResponseSchema,
       { method: "POST", body: { tags } } // POST = full replacement
     );
@@ -412,6 +424,7 @@ class ZendeskClient {
       const idsParam = chunk.join(",");
       const result = await this.request(
         `users/show_many?ids=${idsParam}`,
+        "ZendeskUsersResponseSchema",
         ZendeskUsersResponseSchema
       );
 

--- a/front/lib/api/actions/servers/zendesk/client.ts
+++ b/front/lib/api/actions/servers/zendesk/client.ts
@@ -90,7 +90,6 @@ class ZendeskClient {
 
   private async request<T extends z.Schema>(
     endpoint: string,
-    schemaName: string,
     schema: T,
     {
       method,
@@ -134,14 +133,13 @@ class ZendeskClient {
       logger.error(
         {
           endpoint,
-          schemaName,
           error: parseResult.error.message,
         },
         "[Zendesk] Invalid API response format"
       );
       return new Err(
         new Error(
-          `Invalid Zendesk API response format for ${schemaName}: ${parseResult.error.message}`
+          `Invalid Zendesk API response format: ${parseResult.error.message}`
         )
       );
     }
@@ -152,7 +150,6 @@ class ZendeskClient {
   async getTicket(ticketId: number): Promise<Result<ZendeskTicket, Error>> {
     const result = await this.request(
       `tickets/${ticketId}`,
-      "ZendeskTicketResponseSchema",
       ZendeskTicketResponseSchema
     );
 
@@ -168,7 +165,6 @@ class ZendeskClient {
   ): Promise<Result<ZendeskTicketMetrics, Error>> {
     const result = await this.request(
       `tickets/${ticketId}/metrics`,
-      "ZendeskTicketMetricsResponseSchema",
       ZendeskTicketMetricsResponseSchema
     );
 
@@ -198,7 +194,6 @@ class ZendeskClient {
 
     const result = await this.request(
       `search.json?${params.toString()}`,
-      "ZendeskSearchResponseSchema",
       ZendeskSearchResponseSchema
     );
 
@@ -215,7 +210,6 @@ class ZendeskClient {
   ): Promise<Result<ZendeskTicket, Error>> {
     const result = await this.request(
       `tickets/${ticketId}`,
-      "ZendeskTicketResponseSchema",
       ZendeskTicketResponseSchema,
       {
         method: "PUT",
@@ -243,7 +237,6 @@ class ZendeskClient {
   ): Promise<Result<ZendeskTicket, Error>> {
     const result = await this.request(
       `tickets/${ticketId}`,
-      "ZendeskTicketResponseSchema",
       ZendeskTicketResponseSchema,
       {
         method: "PUT",
@@ -275,7 +268,6 @@ class ZendeskClient {
     const idsParam = fieldIds.join(",");
     const result = await this.request(
       `ticket_fields/show_many?ids=${idsParam}`,
-      "ZendeskTicketFieldsResponseSchema",
       ZendeskTicketFieldsResponseSchema
     );
 
@@ -293,7 +285,6 @@ class ZendeskClient {
   } = {}): Promise<Result<ZendeskTicketField[], Error>> {
     const result = await this.request(
       `ticket_fields.json`,
-      "ZendeskTicketFieldsResponseSchema",
       ZendeskTicketFieldsResponseSchema
     );
 
@@ -316,7 +307,6 @@ class ZendeskClient {
     }
     const result = await this.request(
       `tickets/${ticketId}/comments?${params.toString()}`,
-      "ZendeskTicketCommentsResponseSchema",
       ZendeskTicketCommentsResponseSchema
     );
 
@@ -333,7 +323,6 @@ class ZendeskClient {
   ): Promise<Result<string[], Error>> {
     const result = await this.request(
       `tickets/${ticketId}/tags`,
-      "ZendeskTagsResponseSchema",
       ZendeskTagsResponseSchema,
       { method: "PUT", body: { tags } } // PUT = additive
     );
@@ -351,7 +340,6 @@ class ZendeskClient {
   ): Promise<Result<string[], Error>> {
     const result = await this.request(
       `tickets/${ticketId}/tags`,
-      "ZendeskTagsResponseSchema",
       ZendeskTagsResponseSchema,
       { method: "POST", body: { tags } } // POST = full replacement
     );
@@ -424,7 +412,6 @@ class ZendeskClient {
       const idsParam = chunk.join(",");
       const result = await this.request(
         `users/show_many?ids=${idsParam}`,
-        "ZendeskUsersResponseSchema",
         ZendeskUsersResponseSchema
       );
 

--- a/front/lib/api/actions/servers/zendesk/rendering.ts
+++ b/front/lib/api/actions/servers/zendesk/rendering.ts
@@ -45,7 +45,7 @@ export function renderTicket(
     lines.push(`Organization ID: ${ticket.organization_id}`);
   }
 
-  if (ticket.tags.length > 0) {
+  if (ticket.tags && ticket.tags.length > 0) {
     lines.push(`Tags: ${ticket.tags.join(", ")}`);
   }
 

--- a/front/lib/api/actions/servers/zendesk/types.ts
+++ b/front/lib/api/actions/servers/zendesk/types.ts
@@ -41,7 +41,7 @@ export const ZendeskTicketSchema = z
     organization_id: z.number().nullable().optional(),
     created_at: z.string(),
     updated_at: z.string(),
-    tags: z.array(z.string()),
+    tags: z.array(z.string()).optional(),
     custom_fields: z
       .array(
         z.object({


### PR DESCRIPTION
## Description

In the Zendesk MCP server we check the actual type of the response from Zendesk's API using zod schemas.
This allows us to make sure that we know precisely the type of the object we'll manipulate in the rest of the code, for instance preventing the use of a field that does not actually exist and keeping the code well typed.

We monitor the validation errors to be alerted on potential changes in the response type and potential data shapes we never saw up to now, which is what we saw [here](https://app.datadoghq.eu/logs?query=%22%5BZendesk%5D%20Invalid%20API%20response%20format%22&additional_filters=%5B%5D&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=193898&storage=hot&stream_sort=desc&viz=stream&from_ts=1785168932222&to_ts=1785773732222&live=true).

Since we type the rest of the code with the a type inferred from the schema, once we change the schema the typecheck tells us precisely if there's consumer code we need to update.
Practical example: we did `ticket.tags.length > 0` at some point. The zod validation allows us to reject a type that would fail it. Changing the zod, thus the type shows that this wouldn't work for the actual response we got, which we can easily tell from the typecheck.

This PR makes `tags` optional on the schema for Zendesk tickets.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
