### PR TITLE
UI polish for Pods.

### DIFF
--- a/front/components/pages/pod/PodPage.tsx
+++ b/front/components/pages/pod/PodPage.tsx
@@ -10,15 +10,16 @@ import {
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
+import { classNames } from "@app/lib/utils";
 import {
   CheckCircle,
   Folder,
   MessageChatSquare,
+  NavTabPill,
+  NavTabPillList,
+  NavTabPillTrigger,
   Settings01,
   Spinner,
-  Tabs,
-  TabsList,
-  TabsTrigger,
 } from "@dust-tt/sparkle";
 
 export function PodPage() {
@@ -44,7 +45,7 @@ export function PodPage() {
       defaultValue: DEFAULT_POD_UI_PREFERENCES,
     });
 
-  const compactPodTabs = useIsMobile();
+  const isMobile = useIsMobile();
 
   const { currentTab, handleTabChange } = usePodTabs({
     podId,
@@ -76,38 +77,32 @@ export function PodPage() {
 
   return (
     <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden">
-      <Tabs
+      <NavTabPill
+        className="pt-2"
+        defaultValue="conversations"
         value={currentTab}
         onValueChange={(value) => handleTabChange(value as PodTab)}
-        className="flex min-h-0 flex-1 flex-col overflow-hidden pt-2"
       >
-        <div className="flex shrink-0 items-start justify-between border-b border-separator pl-14 pr-6 lg:px-6">
-          <TabsList border={false}>
-            <TabsTrigger
-              value="conversations"
-              label={compactPodTabs ? undefined : "Conversations"}
-              tooltip={compactPodTabs ? "Conversations" : undefined}
-              icon={MessageChatSquare}
-            />
-            <TabsTrigger
-              value="tasks"
-              label={compactPodTabs ? undefined : "Tasks"}
-              tooltip={compactPodTabs ? "Tasks" : undefined}
-              icon={CheckCircle}
-            />
-            <TabsTrigger
-              value="files"
-              label={compactPodTabs ? undefined : "Files"}
-              tooltip={compactPodTabs ? "Files" : undefined}
-              icon={Folder}
-            />
-            <TabsTrigger
-              value="settings"
-              label={compactPodTabs ? undefined : "Settings"}
-              tooltip={compactPodTabs ? "Settings" : undefined}
-              icon={Settings01}
-            />
-          </TabsList>
+        <div
+          className={classNames(
+            "flex shrink-0 items-center justify-between border-b border-separator pb-2 px-2",
+            isMobile && "pl-12"
+          )}
+        >
+          <NavTabPillList>
+            <NavTabPillTrigger value="conversations" icon={MessageChatSquare}>
+              Conversations
+            </NavTabPillTrigger>
+            <NavTabPillTrigger value="tasks" icon={CheckCircle}>
+              Tasks
+            </NavTabPillTrigger>
+            <NavTabPillTrigger value="files" icon={Folder}>
+              Files
+            </NavTabPillTrigger>
+            <NavTabPillTrigger value="settings" icon={Settings01}>
+              Settings
+            </NavTabPillTrigger>
+          </NavTabPillList>
 
           {podInfo.kind === "project" &&
             (podInfo.isMember || !podInfo.isRestricted) && (
@@ -130,7 +125,7 @@ export function PodPage() {
           setPodUiPreferences={setPodUiPreferences}
           mutatePodInfo={mutatePodInfo}
         />
-      </Tabs>
+      </NavTabPill>
     </div>
   );
 }

--- a/front/components/pod/PodHeaderActions.tsx
+++ b/front/components/pod/PodHeaderActions.tsx
@@ -68,7 +68,7 @@ export function PodHeaderActions({
     <>
       <div className="flex items-center gap-2">
         {members.length > 0 && (
-          <div className="hidden sm:flex sm:h-9 sm:items-center">
+          <div className="hidden md:flex md:h-9 md:items-center">
             <Avatar.Stack
               avatars={members.map((member) => ({
                 name: member.fullName ?? member.username,

--- a/front/components/pod/PodPageContent.tsx
+++ b/front/components/pod/PodPageContent.tsx
@@ -23,7 +23,7 @@ import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { TabsContent } from "@dust-tt/sparkle";
+import { NavTabPillContent } from "@dust-tt/sparkle";
 import { useCallback, useState } from "react";
 
 type PodInfo = NonNullable<ReturnType<typeof useSpaceInfo>["spaceInfo"]>;
@@ -173,7 +173,7 @@ export function PodPageContent({
 
   return (
     <>
-      <TabsContent value="conversations">
+      <NavTabPillContent value="conversations">
         <PodConversationsTab
           owner={owner}
           user={user}
@@ -189,26 +189,26 @@ export function PodPageContent({
           onSubmit={handleConversationCreation}
           onNavigateToTasks={() => onTabChange("tasks")}
         />
-      </TabsContent>
-      <TabsContent value="tasks">
+      </NavTabPillContent>
+      <NavTabPillContent value="tasks">
         <PodTasksTab
           owner={owner}
           podInfo={podInfo}
           taskOwnerFilter={podUiPreferences.tasksOwnerFilter}
           onTaskOwnerFilterChange={handleTaskOwnerFilterChange}
         />
-      </TabsContent>
-      <TabsContent value="files">
+      </NavTabPillContent>
+      <NavTabPillContent value="files">
         <PodFilesTab owner={owner} pod={podInfo} />
-      </TabsContent>
-      <TabsContent value="settings">
+      </NavTabPillContent>
+      <NavTabPillContent value="settings">
         <PodSettingsTab
           key={podInfo.sId}
           owner={owner}
           pod={podInfo}
           onOpenMembersPanel={() => setIsInvitePanelOpen(true)}
         />
-      </TabsContent>
+      </NavTabPillContent>
       <ManageUsersPanel
         isOpen={isInvitePanelOpen}
         setIsOpen={setIsInvitePanelOpen}

--- a/front/components/pod/conversation/PodConversationListItem.tsx
+++ b/front/components/pod/conversation/PodConversationListItem.tsx
@@ -21,7 +21,7 @@ export function PodConversationListItem({
   return (
     <>
       <ConversationListItem
-        className="border-t-0 border-b-0"
+        className="border-t-0 border-b-0 rounded-2xl hover:bg-hover"
         key={conversation.id}
         textAnimation={conversation.isRunningAgentLoop ? "streaming" : "none"}
         conversation={{
@@ -30,6 +30,7 @@ export function PodConversationListItem({
           description: stripMarkdown(conversation.description ?? ""),
           updatedAt: new Date(conversation.updated),
         }}
+        unread={conversation.unreadMessageCount > 0}
         creator={{
           fullName: conversation.creator?.name ?? "",
           portrait: conversation.creator?.visual ?? "",

--- a/front/components/pod/conversation/PodConversationsTab.tsx
+++ b/front/components/pod/conversation/PodConversationsTab.tsx
@@ -15,7 +15,9 @@ import { useSearchPodConversations } from "@app/hooks/useSearchPodConversations"
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { getRandomGreetingForName } from "@app/lib/client/greetings";
 import { useAppRouter } from "@app/lib/platform";
+import { getSpaceIcon } from "@app/lib/spaces";
 import { usePodDefaultSkills, usePodMetadata } from "@app/lib/swr/pods";
+import { useIsWidthConstrained } from "@app/lib/swr/useIsMobile";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { PodConversationListItemType } from "@app/types/api/assistant/conversation/spaces";
 import type { GetSpaceResponseBody } from "@app/types/api/spaces";
@@ -34,9 +36,11 @@ import {
   Button,
   ButtonsSwitch,
   ButtonsSwitchList,
+  CheckDouble,
   Chip,
   cn,
   EmptyCTA,
+  Icon,
   ListGroup,
   ListItemSection,
   LoadingBlock,
@@ -151,7 +155,7 @@ export function PodConversationsTab({
     limit: 10,
     initialSearchText: "",
   });
-
+  const isWidthConstrained = useIsWidthConstrained();
   const conversationsByDate: Record<GroupLabel, PodConversationListItemType[]> =
     useMemo(() => {
       return conversations.length
@@ -175,9 +179,10 @@ export function PodConversationsTab({
   );
 
   const [greeting, setGreeting] = useState<string>("");
+  // biome-ignore lint/correctness/useExhaustiveDependencies: force re-render when podInfo.name changes
   useEffect(() => {
     setGreeting(getRandomGreetingForName(user.firstName));
-  }, [user.firstName]);
+  }, [user.firstName, podInfo.name]);
 
   const isFilteredEmpty = !isConversationsLoading && !isPodEmpty && !hasHistory;
   const isSingleMemberPod = podInfo.members.length === 1;
@@ -199,14 +204,15 @@ export function PodConversationsTab({
             <div className="flex w-full justify-center">
               <ActivationNextSteps owner={owner} podId={podInfo.sId} />
             </div>
-            <div className="flex w-full items-center justify-center gap-2">
+            <div className="flex w-full items-center gap-2">
+              <Icon visual={getSpaceIcon(podInfo)} />
               <h2
                 className={cn(
                   "heading-2xl text-foreground",
                   podInfo.archivedAt && "text-muted-foreground"
                 )}
               >
-                {greeting}
+                {podInfo.name} - {greeting}
               </h2>
               {podInfo.archivedAt && (
                 <Chip size="xs" color="warning" label="Archived" />
@@ -227,7 +233,7 @@ export function PodConversationsTab({
                 draftKey={`space-${podInfo.sId}-new-conversation`}
                 space={podInfo}
                 disableAutoFocus={false}
-                placeholder={`Get work done in ${podInfo.name}`}
+                placeholder={`Get work done...`}
                 defaultAgentId={defaultAgentId}
                 isDefaultAgentLoading={isPodMetadataLoading}
                 defaultSkills={defaultSkills}
@@ -262,61 +268,12 @@ export function PodConversationsTab({
             /* Space conversations section */
             <div className="w-full">
               <div className="flex flex-col gap-3">
-                <div className="my-3 flex min-w-0 flex-row gap-2 px-3">
-                  <div className="min-w-0 flex-1">
-                    <SearchInputWithPopover
-                      name="conversation-search"
-                      value={searchText}
-                      onChange={setSearchText}
-                      placeholder={`Search in ${podInfo.name}`}
-                      open={isSearchPopoverOpen && searchText.trim().length > 0}
-                      onOpenChange={setIsSearchPopoverOpen}
-                      items={searchResults}
-                      isLoading={isSearching}
-                      noResults={
-                        searchText.trim().length > 0 && !isSearching
-                          ? isSearchError
-                            ? "Failed to search conversations. Please try again."
-                            : "No conversations found."
-                          : ""
-                      }
-                      displayItemCount={true}
-                      renderItem={(conversation, selected) => {
-                        const conversationLabel =
-                          getConversationDisplayTitle(conversation);
-                        const time = moment(conversation.updated).fromNow();
-
-                        return (
-                          <div
-                            className={cn(
-                              "cursor-pointer px-3 py-2 hover:bg-primary-50",
-                              selected && "bg-primary-100"
-                            )}
-                            onClick={() => navigateToConversation(conversation)}
-                          >
-                            <div className="flex items-center justify-between gap-2">
-                              <div className="min-w-0 flex-1 truncate">
-                                <div className="text-sm font-medium text-foreground">
-                                  {conversationLabel}
-                                </div>
-                              </div>
-                              <div className="shrink-0 text-xs text-muted-foreground">
-                                {time}
-                              </div>
-                            </div>
-                          </div>
-                        );
-                      }}
-                      onItemSelect={navigateToConversation}
-                    />
-                  </div>
-                </div>
                 <div className="flex flex-row items-center justify-between gap-3">
                   {!isSingleMemberPod && (
                     <ButtonsSwitchList
                       key={conversationFilter}
                       defaultValue={conversationFilter}
-                      size="xs"
+                      size={isWidthConstrained ? "xs" : "sm"}
                     >
                       <ButtonsSwitch
                         value="with_me"
@@ -338,10 +295,56 @@ export function PodConversationsTab({
                       />
                     </ButtonsSwitchList>
                   )}
+                  <SearchInputWithPopover
+                    name="conversation-search"
+                    value={searchText}
+                    onChange={setSearchText}
+                    placeholder={`Search...`}
+                    open={isSearchPopoverOpen && searchText.trim().length > 0}
+                    onOpenChange={setIsSearchPopoverOpen}
+                    items={searchResults}
+                    isLoading={isSearching}
+                    noResults={
+                      searchText.trim().length > 0 && !isSearching
+                        ? isSearchError
+                          ? "Failed to search conversations. Please try again."
+                          : "No conversations found."
+                        : ""
+                    }
+                    displayItemCount={true}
+                    renderItem={(conversation, selected) => {
+                      const conversationLabel =
+                        getConversationDisplayTitle(conversation);
+                      const time = moment(conversation.updated).fromNow();
+
+                      return (
+                        <div
+                          className={cn(
+                            "cursor-pointer px-3 py-2 hover:bg-primary-50",
+                            selected && "bg-primary-100"
+                          )}
+                          onClick={() => navigateToConversation(conversation)}
+                        >
+                          <div className="flex items-center justify-between gap-2">
+                            <div className="min-w-0 flex-1 truncate">
+                              <div className="text-sm font-medium text-foreground">
+                                {conversationLabel}
+                              </div>
+                            </div>
+                            <div className="shrink-0 text-xs text-muted-foreground">
+                              {time}
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    }}
+                    onItemSelect={navigateToConversation}
+                  />
                   <Button
-                    size="xs"
+                    size="sm"
                     variant="outline"
-                    label="Mark all as read"
+                    icon={CheckDouble}
+                    label={isWidthConstrained ? undefined : "Mark all as read"}
                     className="shrink-0"
                     onClick={() => markAllAsRead(unreadConversationIds)}
                     isLoading={isMarkingAllAsRead}
@@ -378,7 +381,7 @@ export function PodConversationsTab({
                       return (
                         <div key={dateLabel}>
                           <ListItemSection>{dateLabel}</ListItemSection>
-                          <ListGroup className="border-b-0">
+                          <ListGroup className="border-b-0 border-t-0">
                             {dateConversations
                               .toSorted((a, b) => b.updated - a.updated)
                               .map((conversation) => (

--- a/front/components/pod/tasks/PodTaskScopeFilter.tsx
+++ b/front/components/pod/tasks/PodTaskScopeFilter.tsx
@@ -30,7 +30,7 @@ export function PodTaskScopeFilter() {
   return (
     <div className="flex items-center gap-2">
       <ButtonsSwitchList
-        size="xs"
+        size={isMobile ? "xs" : "sm"}
         defaultValue={taskOwnerFilter.peopleScope}
         onValueChange={(value) => {
           if (isPodTaskPeopleScope(value)) {

--- a/front/components/pod/tasks/PodTaskUserSection.tsx
+++ b/front/components/pod/tasks/PodTaskUserSection.tsx
@@ -130,7 +130,7 @@ export function PodTaskUserSection({
         </Card>
       )}
       {regularTasks.length > 0 && (
-        <div className="flex flex-col gap-1">
+        <div className="flex flex-col gap-2 ml-9">
           {regularTasks.map((task) => (
             <EditableTaskItem key={task.sId} task={task} />
           ))}

--- a/front/components/pod/tasks/PodTasksPanelMain.tsx
+++ b/front/components/pod/tasks/PodTasksPanelMain.tsx
@@ -20,7 +20,7 @@ export function PodTasksPanelMain() {
     normalizePodTaskSearchNeedle(debouncedTaskSearchQuery) !== "";
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-6 mt-4">
       {isTasksLoading || frozenLastReadAt === undefined ? (
         <div className="flex justify-center py-4">
           <Spinner size="sm" />

--- a/sparkle/src/components/ConversationListItem.tsx
+++ b/sparkle/src/components/ConversationListItem.tsx
@@ -86,6 +86,7 @@ export function ReplySection({
 }
 
 export interface ConversationListItemProps {
+  unread: boolean;
   conversation: {
     id: string;
     title: string;
@@ -113,6 +114,7 @@ export interface ConversationListItemProps {
 
 export function ConversationListItem({
   conversation,
+  unread,
   avatar,
   creator,
   time,
@@ -194,7 +196,16 @@ export function ConversationListItem({
             )}
           </div>
           <div className="flex shrink-0 items-center gap-2 text-xs text-muted-foreground">
-            <span className="font-normal">{time}</span>
+            {unread && (
+              <div
+                className={cn(
+                  "heading-xs flex flex-shrink-0 items-center justify-center rounded-full h-2 w-2 m-1 bg-highlight-500"
+                )}
+              />
+            )}
+            <span className={cn("font-normal", unread && "text-highlight")}>
+              {time}
+            </span>
           </div>
         </div>
         {conversation.description && (

--- a/sparkle/src/stories/ConversationListItem.stories.tsx
+++ b/sparkle/src/stories/ConversationListItem.stories.tsx
@@ -41,12 +41,14 @@ const mockConversation = {
 
 export const OneOnOneWithReply: Story = {
   args: {
+    unread: true,
     conversation: mockConversation,
     time: "14:30",
   },
   render: () => (
     <ListGroup>
       <ConversationListItem
+        unread={true}
         conversation={mockConversation}
         avatar={{
           name: "Alice",
@@ -76,12 +78,14 @@ export const OneOnOneWithReply: Story = {
 
 export const GroupConversationWithReply: Story = {
   args: {
+    unread: false,
     conversation: mockConversation,
     time: "14:30",
   },
   render: () => (
     <ListGroup>
       <ConversationListItem
+        unread={false}
         conversation={mockConversation}
         creator={{
           fullName: "Bob",
@@ -138,6 +142,7 @@ const mentionAvatars = [
 
 export const WithMentions: Story = {
   args: {
+    unread: true,
     conversation: mockConversation,
     time: "14:30",
   },
@@ -145,6 +150,7 @@ export const WithMentions: Story = {
     <ListGroup>
       {/* 2 Mentions on 4 unreads (23 replies) */}
       <ConversationListItem
+        unread={true}
         conversation={{
           ...mockConversation,
           title: "All different counts",
@@ -167,6 +173,7 @@ export const WithMentions: Story = {
       />
       {/* 2 Mentions (5 replies) — mentions == unreads */}
       <ConversationListItem
+        unread={true}
         conversation={{
           ...mockConversation,
           title: "Mentions equal unreads",
@@ -189,6 +196,7 @@ export const WithMentions: Story = {
       />
       {/* 2 Mentions on 4 unreads — unreads == replies */}
       <ConversationListItem
+        unread={true}
         conversation={{
           ...mockConversation,
           title: "Unreads equal replies",
@@ -211,6 +219,7 @@ export const WithMentions: Story = {
       />
       {/* 2 Mentions — all counts equal */}
       <ConversationListItem
+        unread={true}
         conversation={{
           ...mockConversation,
           title: "All counts equal",
@@ -233,6 +242,7 @@ export const WithMentions: Story = {
       />
       {/* 1 Mention — singular */}
       <ConversationListItem
+        unread={true}
         conversation={{
           ...mockConversation,
           title: "Single mention",


### PR DESCRIPTION
## Description

UI polish across Pod conversations and tasks views from @Duncid request:

- In `PodConversationsTab`, moves `SearchInputWithPopover` inline with the filter/actions row (was a standalone row above), upgrades button sizes from `xs` to `sm`, and makes `ButtonsSwitchList` and the "Mark all as read" button label responsive via `useIsWidthConstrained` (icon-only on narrow viewports using `CheckDouble`).
- In `PodConversationListItem`, adds `rounded-2xl hover:bg-hover` to conversation rows for visual consistency.
- In `PodTasksPanelMain` and `PodTaskUserSection`, tightens spacing with adjusted gap and margin values.

<img width="1229" height="969" alt="image" src="https://github.com/user-attachments/assets/9ef27b5b-1d45-4068-8685-6c67fdeec9bc" />
<img width="1078" height="1090" alt="image" src="https://github.com/user-attachments/assets/92f80187-861d-49bb-9511-5ea5f6885381" />


## Tests

Tested locally across Pod conversations and tasks views at narrow and wide viewport widths.

## Risk

Low. Front-only layout and style changes with no logic, API, or data impact.

## Deploy Plan

Deploy front.
