### PR TITLE
[front] Activation: rename to Dust Training + workflow/prompt polish

### DIFF
--- a/front/lib/api/activation/trigger.ts
+++ b/front/lib/api/activation/trigger.ts
@@ -23,7 +23,7 @@ import { randomUUID } from "crypto";
 export const ACTIVATION_WEBHOOK_SOURCE_NAME = "Activation";
 const ACTIVATION_POD_ID_FIELD = "podId";
 const ACTIVATION_USER_ID_FIELD = "userId";
-const ACTIVATION_TRIGGER_CUSTOM_PROMPT = "Run the activation workflow.";
+const ACTIVATION_TRIGGER_CUSTOM_PROMPT = "Run the Dust Training workflow.";
 
 // A resource type that the activation nudge should drive the user toward
 export type ActivationNudgePushedResourceType = "skill" | "agent";

--- a/front/lib/notifications/email-templates/activation-new-conversation.tsx
+++ b/front/lib/notifications/email-templates/activation-new-conversation.tsx
@@ -68,7 +68,7 @@ const ActivationNewConversationEmailTemplate = ({
         Hi {name}!
         <br />
         <br />
-        Introducing your activation experience:
+        Welcome to your Dust Training environment:
         <br />
         The place where Dust works for you.
       </p>

--- a/front/lib/notifications/workflows/activation-new-conversation.ts
+++ b/front/lib/notifications/workflows/activation-new-conversation.ts
@@ -171,7 +171,7 @@ export const activationNewConversationWorkflow = workflow(
         });
 
         return {
-          subject: `[Dust] ${details.subject}`,
+          subject: `[Dust] Recommendation For You: ${details.subject}`,
           body,
         };
       },

--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -56,11 +56,11 @@ Frame + AGENTS.md updated.
 - Avoid unexplained technical jargon. Never refer to a Dust concept without explaining it first. Explain a concept instead of jeopardizing clarity. Utilize the Dust Support skill to generate educational content.
 
 # Workflow
-Stages are a map, not memory. At the start of each turn, choose the stage from observable state (AGENTS.md, pinned Frame, open
-recommendation record).
+This workflow is MANDATORY. Never deviate from it or it risks breaking the user experience.
 
-## Opening burst (Stages 1–5) — one asynchronous message
+## Opening burst (Stages 1–5) — One asynchronous message
 Enter at the start of each session. Accuracy > tool-call thrift here.
+In this phase, avoid using tools that require human in the loop.
 
 1. Define Overall Goal — if \`pod-[podId]/AGENTS.md\` is missing, research + write it; else skip the full write.
 2. Set up Pod Frame — if no pinned pod Frame, create from template; else skip.
@@ -68,14 +68,17 @@ Enter at the start of each session. Accuracy > tool-call thrift here.
 4. Create Plan — research and prefetch everything needed to execute the Session Goal.
 5. Present the Plan — starting with a single recommendation on first steps; hydrate Frame; show one action card.
 
-## Synchronous phase (Stages 6–8) — spans turns
+## Synchronous phase (Stages 6–8) — spans pauses on one agent message
 Minimize tool calls; never skip workflow quality. Each turn, enter the stage whose condition holds:
 
 6. Execute — enter when the user accepted the open recommendation (\`actionMessage\`). Run it for real; result visible as its own frame.
-7. Session Goal Follow-ups — enter when execution just finished. Usefulness check, then offer save Skill and/or schedule trigger (single
-approval chain). Append Frame tile.
+7. Session Goal Follow-ups — enter when execution just finished. Usefulness check, then offer save Skill and/or schedule trigger. Append Frame tile.
 8. Recap — enter when follow-ups are resolved (accepted or declined). Summarize; update Frame + AGENTS.md; return to Stage 3 for the next
 Session Goal.
+
+\`ask_user_question\` pauses the agent loop on the *current* agent message; when the user answers, the loop resumes on that same message
+(it does not create a new agent message). Stages 6–8 may include multiple such pauses. After each resume, continue the stage checklist — do not wait for a free-form user message to advance, and once
+follow-ups are resolved continue into Stage 8 in that same resumed run.
 
 On dismiss (\`dismissMessage\`) at any card: \`update_recommendation\` → \`dismissed\`, append AGENTS.md \`# Progress\` / Frame open threads,
 then offer a next Session Goal (back toward Stage 3) — do not execute.
@@ -292,13 +295,13 @@ them by the Dust team (or "set up for you on Dust") in order to achieve a concre
    generic product tour.
 2. Frame directive — output the Frame (the pinned pod overview) inline in the message, and explicitly ask them to click it to open the overview.
 3. Present exactly ONE action card with the first recommendation (first step of the plan).
-4. If it isn't quite right, offer the 2 quick replies. After either flow, re-lock a Session Goal (Stage 3) and Present the Plan again.
+4. Send a message explaining that this was generated off current knowledge and if you want to provide more detail about your work habits, select when of the options below. Then offer 2 quick replies. After either flow, re-lock a Session Goal (Stage 3) and Present the Plan again.
    - :quickReply[Ask me questions to learn more about my work]{message="Ask me questions to learn more about my work"}
    - :quickReply[Scan my connected sources to find my real repetitive work]{message="Scan my connected sources to find my real repetitive work"}
 
 ## Subsequent Pod Messages
-One warm line on why this recommendation (evidence), then the action card. No re-orientation. Prefer evidence in the card body / Frame
-plan.
+Short friendly introduction to explain we have a recommendation just for you. Then one warm line on why this recommendation.
+No full re-orientation, but ALWAYS re-introduce and link to the pinned Frame. Prefer evidence in the card body / Frame plan.
 
 ## Presenting the Recommendation
 
@@ -313,7 +316,7 @@ description of the action_card.
 
 Before presenting the recommendation, ALWAYS call the tool \`create_recommendation\` to create the recommendation record in the database.
 
-Then, on the first recommendation of the conversation, call \`set_conversation_title\` to give this conversation a descriptive title based on the recommendation, formatted as "Activation Recommendation: <action>" (e.g. "Activation Recommendation: Simplify weekly reporting").
+Then, on the first recommendation of the conversation, call \`set_conversation_title\` to give this conversation a descriptive title based on the recommendation, formatted as (e.g. "Simplify weekly reporting").
 This replaces the generic auto-generated title and is what the user sees in their conversation list and the activation email subject.
 Ensure that the title is around 6 words long.
 
@@ -347,14 +350,14 @@ This is a container directive: the opening \`:::action_card{...}\` line holds th
 
 Once the user accepts, execute the Session Goal's current plan step for real:
 - Read the context file you saved in Stage 4 for the prefetched data, then execute the recommendation whose record is open.
+- Ask at most one clarifying question before running, and only if genuinely blocking; otherwise run with sensible defaults and let the
 - Deliver the result as its OWN separate frame (conversation stays action-focused; the result Frame is what the user reads). Abide by
 all of our core guidelines, but you have the ability to be flexible and creative. This is the lead selling point of the entire flow.
 You need to build a Frame that can properly convey the result of the action.
-- When the result is a side effect elsewhere (a created Jira issue, an updated CRM record), reflect the concrete outcome in the result
-frame. Never just report "it's done".
-- Ask at most one clarifying question before running, and only if genuinely blocking; otherwise run with sensible defaults and let the
 user correct the output.
-- Update the pinned Frame \`PLAN\` step statuses as you go (completed step → \`done\`, next → \`current\`) and refresh \`NEXT_STEP\` to match.
+- Present the result Frame to the user with a warm message explaining this is the result of the action you just took. NEVER assume the user will find it otherwise.
+- Do NOT yet update the pinned Frame's tiles. That will happen in the next stage.
+- Call \`update_recommendation\` with \`status: "executed"\` once the run completes, and append a tile to the pinned pod Frame \`TILES\`.
 - If this requires a complex workflow, use the Go Deep tool to break it down into smaller steps to avoid bloating the context window.
 
 ### When a required source is missing user authentication
@@ -382,7 +385,8 @@ do not re-explain the Session Goal in prose — the Frame already shows it.
 First, provide \`ask_user_question\` to the user to see if this was useful. Include 3 options: Useful, Not Useful, Provide Feedback. Update the recommendation lifecycle based on the user's response:
 - Accept (the \`actionMessage\` arrives) → call \`update_recommendation\` with \`status: "executed"\`
 - Decline (the \`dismissMessage\` arrives) → call \`update_recommendation\` with \`status: "dismissed"\`
-You MUST add a tile to the pinned pod Frame for what was just completed (append to the \`TILES\` array) so it accumulates a record of what this pod has done.
+
+After a response, this is when you MUST add a tile to the pinned pod Frame for what was just completed (append to the \`TILES\` array) so it accumulates a record of what this pod has done.
 
 Next, decide whether to offer skill and/or trigger creation. Skip the offer when ANY of these hold:
 - A similar skill already exists (NEVER offer a duplicate).
@@ -393,6 +397,7 @@ nothing.
 If offering, call a single \`ask_user_question\`:
 - Include an option to build the trigger and/or skill (combined). You SHOULD include multiple cadence options for triggers since it is
 subjective at what time or frequency the user will want it to run.
+- On resume, create what they chose (or skip if declined), then continue into Stage 8 in this same resumed run.
 
 # Stage 8 — Recap
 Make the recap feel like a real accomplishment with a brief, tasteful celebration grounded in what was completed in this conversation.
@@ -401,7 +406,7 @@ You MUST:
 - Update the pinned pod Frame (PLAN statuses, NEXT_STEP, TILES, clear or refresh SESSION_GOAL for the next loop as appropriate)
 - Append AGENTS.md \`# Progress\` (completed win, dismissals, user corrections)
 
-Close the loop with \`quickReply\` tool to ask the user if they would like another recommendation (next Session Goal → return to Stage 3).
+Close the loop with \`quickReply\` to ask the user if they would like another recommendation (next Session Goal → return to Stage 3).
 If the user has never scanned their connected sources, lead with the scan option as the top option.
 `.trim();
 
@@ -459,11 +464,11 @@ async function buildActivationContext(
 }
 
 export const activationSkill = {
-  sId: "activation",
+  sId: "dust_training",
   kind: "global",
-  name: "Activation",
+  name: "Dust Training",
   userFacingDescription:
-    "Get a recommendation for the next best action to get more value from Dust, then execute it and make it a habit.",
+    "Get a recommendation for the next best action to get more value from Dust",
   agentFacingDescription:
     "Use when training a user in a Pod: define/follow the Overall Goal (AGENTS.md), set a Session Goal as a sub-goal, present one plan step as a recommendation, " +
     "execute it, optionally save as a skill or schedule a trigger, and keep the pod Frame + AGENTS.md current.",

--- a/front/lib/resources/skill/code_defined/global/static_files/activation_pod_frame_template.ts
+++ b/front/lib/resources/skill/code_defined/global/static_files/activation_pod_frame_template.ts
@@ -27,8 +27,7 @@ const WHY_THIS_POD =
 // Second-person digest of AGENTS.md (Destination + Who). Not the full file.
 const OVERALL_GOAL_HIGHLIGHTS: string[] = [
   "You're in Marketing at Acme — you live in HubSpot, Slack, and weekly stakeholder updates.",
-  "Overall goal: get you running recurring reporting and meeting prep from Dust, not by hand.",
-  "Must-hit: one real digest you keep, then one briefing before a key meeting.",
+  "Goal: get you running recurring reporting and meeting prep from Dust, not by hand.",
 ];
 
 const SESSION_GOAL =
@@ -230,7 +229,7 @@ function FullView() {
       <Reveal i={2}>
         <div className="rounded-2xl border border-indigo-200 bg-card p-5 shadow-sm dark:border-indigo-900/50">
           <Kicker>This session</Kicker>
-          <p className="mt-2 text-lg font-semibold leading-snug tracking-tight text-foreground">
+          <p className="mt-5 text-sm font-medium text-foreground">
             {SESSION_GOAL}
           </p>
           <div className="mt-5 border-t border-border pt-4">


### PR DESCRIPTION
## Summary

- Activation skill prompt changes only
- Addressing minor feedback
- Customer facing renaming activation -> training
 
## Testing

Local testing

## Risk

Low — Not customer facing yet

## Deploy
1. Deploy front