### PR TITLE
[front] fix: clarify ask user question placeholder

### DIFF
--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -523,7 +523,9 @@ describe("UserAnswerRequired", () => {
 
     const keyboardContainer = getKeyboardContainer(container);
     const alphaOption = screen.getByRole("button", { name: /Alpha/i });
-    const customInput = screen.getByPlaceholderText("Type something else");
+    const customInput = screen.getByPlaceholderText(
+      "Tell the agent what to do differently"
+    );
 
     await waitFor(() => expect(keyboardContainer).toHaveFocus());
     expect(alphaOption).toHaveClass("bg-primary-100");
@@ -563,7 +565,9 @@ describe("UserAnswerRequired", () => {
     );
 
     const alphaOption = screen.getByRole("button", { name: /Alpha/i });
-    const customInput = screen.getByPlaceholderText("Type something else");
+    const customInput = screen.getByPlaceholderText(
+      "Tell the agent what to do differently"
+    );
 
     await user.click(alphaOption);
     expect(alphaOption).toHaveAttribute("data-selected", "true");
@@ -586,7 +590,9 @@ describe("UserAnswerRequired", () => {
     const keyboardContainer = getKeyboardContainer(container);
     const alphaOption = screen.getByRole("button", { name: /Alpha/i });
     const betaOption = screen.getByRole("button", { name: /Beta/i });
-    const customInput = screen.getByPlaceholderText("Type something else");
+    const customInput = screen.getByPlaceholderText(
+      "Tell the agent what to do differently"
+    );
 
     await user.click(customInput);
     expect(customInput).toHaveFocus();
@@ -643,7 +649,9 @@ describe("UserAnswerRequired", () => {
       />
     );
 
-    const customInput = screen.getByPlaceholderText("Type something else");
+    const customInput = screen.getByPlaceholderText(
+      "Tell the agent what to do differently"
+    );
 
     await user.type(customInput, "Other answer");
     await user.keyboard("{Enter}");

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -340,7 +340,7 @@ export function UserAnswerRequired({
             inputRef={customResponseInputRef}
             id={`custom-response-${blockedAction.actionId}`}
             name="custom-response"
-            placeholder="Type something else"
+            placeholder="Tell the agent what to do differently"
             value={answerDraft.customResponse}
             disabled={isSubmitting}
             onFocus={() => {


### PR DESCRIPTION
## Description

The free-text option in the ask user question UI card currently says "Type something else", which is very generic.

This PR updates the placeholder to "Tell the agent what to do differently" to catch attention a bit better.

## Tests

- Updated existing tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
