### PR TITLE
[front] enh: polish skill favorite toggle feedback + add tab

### DIFF
--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -73,6 +73,13 @@ export function ManageSkillsPage() {
   const { hasPermission } = useWorkspacePermissions();
   const { hasFeature } = useFeatureFlags();
   const hasSkillFavorites = hasFeature("skill_favorites");
+  const skillManagerTabs = useMemo(
+    () =>
+      SKILL_MANAGER_TABS.filter(
+        (tab) => tab.id !== "favorites" || hasSkillFavorites
+      ),
+    [hasSkillFavorites]
+  );
   const [selectedSkillOverride, setSelectedSkillOverride] = useState<
     GetSkillsWithRelationsResponseBody["skills"][number] | null
   >(null);
@@ -116,12 +123,12 @@ export function ManageSkillsPage() {
     if (
       selectedTab &&
       isValidTab(selectedTab) &&
-      SKILL_MANAGER_TABS.some((t) => t.id === selectedTab)
+      skillManagerTabs.some((t) => t.id === selectedTab)
     ) {
       return selectedTab;
     }
     return "active";
-  }, [selectedTab]);
+  }, [selectedTab, skillManagerTabs]);
 
   const canBypassEditorVisibility = isAdmin;
   const isBypassEditorVisibilityEnabled =
@@ -171,6 +178,9 @@ export function ManageSkillsPage() {
     const editableByMeSkills = sortedActiveSkills.filter((s) =>
       s.relations.editors?.some((e) => e.sId === user?.sId)
     );
+    const favoriteSkills = sortSkillsByName(
+      activeSkills.filter((s) => s.isFavorite)
+    );
 
     return {
       active: filterBySearch(
@@ -183,6 +193,11 @@ export function ManageSkillsPage() {
         searchLower,
         isSearchActive
       ),
+      favorites: filterBySearch(
+        filterByAvailability(favoriteSkills, availabilityFilter),
+        searchLower,
+        isSearchActive
+      ),
       archived: filterBySearch(
         filterByAvailability(sortedArchivedSkills, availabilityFilter),
         searchLower,
@@ -192,6 +207,7 @@ export function ManageSkillsPage() {
   }, [
     sortedActiveSkills,
     sortedArchivedSkills,
+    activeSkills,
     skillSearch,
     user,
     isSearchActive,
@@ -427,7 +443,7 @@ export function ManageSkillsPage() {
           <div className="flex flex-col pt-3">
             <Tabs value={activeTab}>
               <TabsList>
-                {SKILL_MANAGER_TABS.map((tab) => (
+                {skillManagerTabs.map((tab) => (
                   <TabsTrigger
                     key={tab.id}
                     value={tab.id}

--- a/front/components/pages/builder/skills/utils.ts
+++ b/front/components/pages/builder/skills/utils.ts
@@ -6,7 +6,11 @@ import {
   type SkillWithoutInstructionsAndToolsWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 
-export type SkillManagerTabType = "active" | "editable_by_me" | "archived";
+export type SkillManagerTabType =
+  | "active"
+  | "editable_by_me"
+  | "favorites"
+  | "archived";
 
 interface SkillManagerTab {
   id: SkillManagerTabType;
@@ -20,6 +24,11 @@ export const SKILL_MANAGER_TABS: SkillManagerTab[] = [
     id: "editable_by_me",
     label: "Editable by me",
     description: "Skills you can edit",
+  },
+  {
+    id: "favorites",
+    label: "Favorites",
+    description: "Skills you favorited",
   },
   { id: "archived", label: "Archived", description: "Archived skills" },
 ];

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -23,7 +23,7 @@ interface SkillDetailsButtonBarProps {
   onFavoriteChange?: (
     skill: GetSkillsWithRelationsResponseBody["skills"][number],
     isFavorite: boolean
-  ) => void;
+  ) => Promise<void>;
 }
 
 export function SkillDetailsButtonBar({

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -40,7 +40,7 @@ type SkillDetailsProps = {
   onFavoriteChange?: (
     skill: GetSkillsWithRelationsResponseBody["skills"][number],
     isFavorite: boolean
-  ) => void;
+  ) => Promise<void>;
   owner: WorkspaceType;
   user: UserType;
   replaceOnEdit?: boolean;
@@ -160,7 +160,7 @@ type DescriptionSectionProps = {
   onFavoriteChange?: (
     skill: GetSkillsWithRelationsResponseBody["skills"][number],
     isFavorite: boolean
-  ) => void;
+  ) => Promise<void>;
 };
 
 const DescriptionSection = ({

--- a/front/components/skills/SkillFavoriteButton.tsx
+++ b/front/components/skills/SkillFavoriteButton.tsx
@@ -6,10 +6,11 @@ import {
   StarFilled,
 } from "@dust-tt/sparkle";
 import type { MouseEvent } from "react";
+import { useState } from "react";
 
 type SkillFavoriteButtonProps = {
   isFavorite: boolean;
-  onFavoriteChange: (isFavorite: boolean) => void;
+  onFavoriteChange: (isFavorite: boolean) => Promise<void>;
   skill: SkillWithoutInstructionsAndToolsType;
   size?: "icon" | "icon-xs";
   variant?: ButtonVariantType;
@@ -22,18 +23,28 @@ export function SkillFavoriteButton({
   size = "icon",
   variant = "ghost-secondary",
 }: SkillFavoriteButtonProps) {
+  const [isUpdating, setIsUpdating] = useState(false);
   const nextIsFavorite = !isFavorite;
+
+  const handleClick = async (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    setIsUpdating(true);
+    try {
+      await onFavoriteChange(nextIsFavorite);
+    } finally {
+      setIsUpdating(false);
+    }
+  };
 
   return (
     <Button
       size={size}
       variant={variant}
       icon={isFavorite ? StarFilled : Star01}
+      isLoading={isUpdating}
+      aria-pressed={isFavorite}
       tooltip={`${nextIsFavorite ? "Favorite" : "Unfavorite"} ${skill.name}`}
-      onClick={(event: MouseEvent<HTMLButtonElement>) => {
-        event.stopPropagation();
-        onFavoriteChange(nextIsFavorite);
-      }}
+      onClick={handleClick}
     />
   );
 }


### PR DESCRIPTION
## Description

This PR fixes two issues:
- Favorite skills are currently impossible to find as a list.
- The favorite toggle remains interactive while an update is running, causing the UI to feel glitchy on updates.

This PR adds a feature-gated Favorites tab next to Editable by me.
The favorite button now also shows a loading state, prevents repeated toggles until the request completes, and exposes its state through `aria-pressed`.

## Tests

- Tested locally.

## Risk

- Low. Behind the `skill_favorites` feature flag.

## Deploy Plan

- Deploy front.
