### PR TITLE
[front] chore: remove the skill favorites feature flag

### DIFF
--- a/front-api/routes/w/[wId]/skills/[sId]/favorite.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/favorite.ts
@@ -4,7 +4,6 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
 import type { SuccessResponseBody } from "@front-api/routes/types";
 import type { Context, TypedResponse } from "hono";
 import { z } from "zod";
@@ -41,7 +40,6 @@ async function loadSkill(
 /** @ignoreswagger */
 app.post(
   "/",
-  withFeatureFlag("skill_favorites"),
   validate("param", ParamsSchema),
   async (ctx): HandlerResult<SuccessResponseBody> => {
     const auth = ctx.get("auth");
@@ -70,7 +68,6 @@ app.post(
 /** @ignoreswagger */
 app.delete(
   "/",
-  withFeatureFlag("skill_favorites"),
   validate("param", ParamsSchema),
   async (ctx): HandlerResult<SuccessResponseBody> => {
     const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -6,7 +6,6 @@ import {
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
@@ -204,30 +203,10 @@ describe("GET /api/w/:wId/skills/:sId", () => {
     expect(data.skill.relations.usage.skills).toEqual([]);
   });
 
-  it("should not expose favorite state when the feature flag is disabled", async () => {
+  it("should include favorite state", async () => {
     const { workspace, skill, requestUserAuth } = await setupTest({
       requestUserRole: "admin",
     });
-
-    const result = await skill.setFavorite(requestUserAuth, true);
-    expect(result.isOk()).toBe(true);
-
-    const response = await getSkill(workspace, skill.sId);
-    expect(response.status).toBe(200);
-    const data = await response.json();
-    expect(data.skill).not.toHaveProperty("isFavorite");
-
-    const relationsResponse = await getSkillWithRelations(workspace, skill.sId);
-    expect(relationsResponse.status).toBe(200);
-    const relationsData = await relationsResponse.json();
-    expect(relationsData.skill).not.toHaveProperty("isFavorite");
-  });
-
-  it("should include favorite state when the feature flag is enabled", async () => {
-    const { workspace, skill, requestUserAuth } = await setupTest({
-      requestUserRole: "admin",
-    });
-    await FeatureFlagFactory.basic(requestUserAuth, "skill_favorites");
 
     const result = await skill.setFavorite(requestUserAuth, true);
     expect(result.isOk()).toBe(true);

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -4,7 +4,6 @@ import {
   getReferencedSkillSpaceModelIds,
   resolveAdditionalRequestedSpaceModelIds,
 } from "@app/lib/api/skills/space_requirements";
-import { hasFeatureFlag } from "@app/lib/auth";
 import { pruneOutdatedSkillEditSuggestions } from "@app/lib/reinforcement/skill_suggestion_pruning";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -124,13 +123,7 @@ app.get(
 
     const withRelations = ctx.req.query("withRelations");
 
-    const hasSkillFavorites = await hasFeatureFlag(auth, "skill_favorites");
-    let favoriteState: { isFavorite?: boolean } = {};
-    if (hasSkillFavorites) {
-      const isFavorite = await skill.isFavoriteForCurrentUser(auth);
-      favoriteState = { isFavorite };
-    }
-
+    const isFavorite = await skill.isFavoriteForCurrentUser(auth);
     const serializedSkill = skill.toJSON(auth);
 
     if (withRelations === "true") {
@@ -167,11 +160,11 @@ app.get(
       };
 
       return ctx.json({
-        skill: { ...skillWithRelations, ...favoriteState },
+        skill: { ...skillWithRelations, isFavorite },
       } satisfies GetSkillWithRelationsResponseBody);
     }
     return ctx.json({
-      skill: { ...serializedSkill, ...favoriteState },
+      skill: { ...serializedSkill, isFavorite },
     } satisfies GetSkillResponseBody);
   }
 );

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -10,7 +10,6 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
@@ -607,48 +606,8 @@ describe("GET /api/w/:wId/skills", () => {
     }
   });
 
-  it("should not expose or mutate favorite state when the feature flag is disabled", async () => {
-    const { workspace, auth } = await setupTest();
-
-    const skill = await SkillFactory.create(auth, {
-      name: "Disabled Favorite Candidate",
-    });
-    const result = await skill.setFavorite(auth, true);
-    expect(result.isOk()).toBe(true);
-
-    const response = await getSkills(workspace);
-    expect(response.status).toBe(200);
-    const responseBody: GetSkillsResponseBody = await response.json();
-    const listedSkill = responseBody.skills.find((s) => s.sId === skill.sId);
-    expect(listedSkill).not.toHaveProperty("isFavorite");
-
-    const relationsResponse = await getSkills(workspace, {
-      withRelations: "true",
-    });
-    expect(relationsResponse.status).toBe(200);
-    const relationsResponseBody: GetSkillsWithRelationsResponseBody =
-      await relationsResponse.json();
-    const relationsSkill = relationsResponseBody.skills.find(
-      (s) => s.sId === skill.sId
-    );
-    expect(relationsSkill).not.toHaveProperty("isFavorite");
-
-    const favoriteResponse = await favoriteSkill(workspace, skill.sId);
-    expect(favoriteResponse.status).toBe(403);
-    expect((await favoriteResponse.json()).error.type).toBe(
-      "feature_flag_not_found"
-    );
-
-    const unfavoriteResponse = await unfavoriteSkill(workspace, skill.sId);
-    expect(unfavoriteResponse.status).toBe(403);
-    expect((await unfavoriteResponse.json()).error.type).toBe(
-      "feature_flag_not_found"
-    );
-  });
-
   it("should include favorite state for custom skills", async () => {
     const { workspace, auth } = await setupTest();
-    await FeatureFlagFactory.basic(auth, "skill_favorites");
 
     const skill = await SkillFactory.create(auth, {
       name: "Favorite Candidate",
@@ -698,8 +657,7 @@ describe("GET /api/w/:wId/skills", () => {
   });
 
   it("should include favorite state for global skills", async () => {
-    const { workspace, auth } = await setupTest();
-    await FeatureFlagFactory.basic(auth, "skill_favorites");
+    const { workspace } = await setupTest();
 
     const favoriteResponse = await favoriteSkill(workspace, "frames");
     expect(favoriteResponse.status).toBe(200);
@@ -713,7 +671,6 @@ describe("GET /api/w/:wId/skills", () => {
 
   it("should not update favorite state for archived skills", async () => {
     const { workspace, auth } = await setupTest();
-    await FeatureFlagFactory.basic(auth, "skill_favorites");
 
     const skill = await SkillFactory.create(auth, {
       name: "Archived Favorite Candidate",

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -4,7 +4,6 @@ import {
   getReferencedSkillSpaceModelIds,
   resolveAdditionalRequestedSpaceModelIds,
 } from "@app/lib/api/skills/space_requirements";
-import { hasFeatureFlag } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -192,13 +191,9 @@ app.get(
       withTools: false,
       withFileAttachments: false,
     });
-    const hasSkillFavorites = await hasFeatureFlag(auth, "skill_favorites");
-    let favoriteSkillIds = new Set<string>();
-    if (hasSkillFavorites) {
-      const favoriteSkills =
-        await SkillResource.listFavoritesForCurrentUser(auth);
-      favoriteSkillIds = new Set(favoriteSkills.map((skill) => skill.sId));
-    }
+    const favoriteSkills =
+      await SkillResource.listFavoritesForCurrentUser(auth);
+    const favoriteSkillIds = new Set(favoriteSkills.map((skill) => skill.sId));
 
     const canCreateSkill = await auth.hasWorkspacePermission("create", "skill");
 
@@ -241,9 +236,6 @@ app.get(
       );
 
       const skillsWithRelations = skills.map((sc) => {
-        const favoriteState: { isFavorite?: boolean } = hasSkillFavorites
-          ? { isFavorite: favoriteSkillIds.has(sc.sId) }
-          : {};
         const {
           instructions,
           instructionsHtml,
@@ -287,7 +279,7 @@ app.get(
               }
             ),
           },
-          ...favoriteState,
+          isFavorite: favoriteSkillIds.has(sc.sId),
         } satisfies GetSkillsWithRelationsResponseBody["skills"][number];
       });
 
@@ -296,9 +288,6 @@ app.get(
 
     return ctx.json({
       skills: skills.map((sc) => {
-        const favoriteState: { isFavorite?: boolean } = hasSkillFavorites
-          ? { isFavorite: favoriteSkillIds.has(sc.sId) }
-          : {};
         const {
           instructions,
           instructionsHtml,
@@ -308,7 +297,7 @@ app.get(
 
         return {
           ...skillWithoutInstructionsAndTools,
-          ...favoriteState,
+          isFavorite: favoriteSkillIds.has(sc.sId),
         } satisfies GetSkillsResponseBody["skills"][number];
       }),
     });

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -31,11 +31,7 @@ import {
 } from "@app/components/sparkle/AppLayoutContext";
 import { useHashParam } from "@app/hooks/useHashParams";
 import { useQueryParams } from "@app/hooks/useQueryParams";
-import {
-  useAuth,
-  useFeatureFlags,
-  useWorkspace,
-} from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { SKILL_ICON } from "@app/lib/skill";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import {
@@ -75,15 +71,6 @@ export function ManageSkillsPage() {
   const owner = useWorkspace();
   const { user, isAdmin } = useAuth();
   const { hasPermission } = useWorkspacePermissions();
-  const { hasFeature } = useFeatureFlags();
-  const hasSkillFavorites = hasFeature("skill_favorites");
-  const skillManagerTabs = useMemo(
-    () =>
-      SKILL_MANAGER_TABS.filter(
-        (tab) => tab.id !== "favorites" || hasSkillFavorites
-      ),
-    [hasSkillFavorites]
-  );
   const [selectedSkillOverride, setSelectedSkillOverride] = useState<
     GetSkillsWithRelationsResponseBody["skills"][number] | null
   >(null);
@@ -128,12 +115,12 @@ export function ManageSkillsPage() {
     if (
       selectedTab &&
       isValidTab(selectedTab) &&
-      skillManagerTabs.some((t) => t.id === selectedTab)
+      SKILL_MANAGER_TABS.some((t) => t.id === selectedTab)
     ) {
       return selectedTab;
     }
     return "active";
-  }, [selectedTab, skillManagerTabs]);
+  }, [selectedTab]);
 
   const canCreateSkill = hasPermission("create", "skill");
 
@@ -403,7 +390,7 @@ export function ManageSkillsPage() {
       <SkillDetailsSheet
         skill={selectedSkill}
         onClose={() => handleSkillSelect(null)}
-        onFavoriteChange={hasSkillFavorites ? handleFavoriteChange : undefined}
+        onFavoriteChange={handleFavoriteChange}
         user={user}
         owner={owner}
       />
@@ -490,7 +477,7 @@ export function ManageSkillsPage() {
           <div className="flex flex-col pt-3">
             <Tabs value={activeTab}>
               <TabsList>
-                {skillManagerTabs.map((tab) => (
+                {SKILL_MANAGER_TABS.map((tab) => (
                   <TabsTrigger
                     key={tab.id}
                     value={tab.id}

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -206,33 +206,7 @@ describe("getJITServers", () => {
         expect(skillManagementServer).toBeDefined();
       });
 
-      it("does not equip favorite skills when the feature flag is disabled", async () => {
-        await SkillFactory.linkGlobalSkillToAgent(auth, {
-          globalSkillId: "discover_skills",
-          agentConfigurationId: agentConfig.id,
-        });
-
-        const skill = await SkillFactory.create(auth, {
-          name: "Disabled Favorite Skill",
-        });
-        const favoriteResult = await skill.setFavorite(auth, true);
-        expect(favoriteResult.isOk()).toBe(true);
-
-        const { equippedSkills, favoriteSkills } =
-          await SkillResource.listForAgentLoop(auth, {
-            agentConfiguration: agentConfig,
-            conversation: {
-              ...conversation,
-              spaceId: conversationsSpace.sId,
-            },
-          });
-        expect(equippedSkills.map((s) => s.sId)).not.toContain(skill.sId);
-        expect(favoriteSkills.map((s) => s.sId)).not.toContain(skill.sId);
-      });
-
       it("does not equip favorite skills without discover_skills", async () => {
-        await FeatureFlagFactory.basic(auth, "skill_favorites");
-
         const skill = await SkillFactory.create(auth, {
           name: "Favorite Skill Without Discovery",
         });
@@ -251,9 +225,8 @@ describe("getJITServers", () => {
         expect(favoriteSkills.map((s) => s.sId)).not.toContain(skill.sId);
       });
 
-      it("equips favorite skills when discovery and favorites are enabled", async () => {
+      it("equips favorite skills when discovery is enabled", async () => {
         await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
-        await FeatureFlagFactory.basic(auth, "skill_favorites");
         await SkillFactory.linkGlobalSkillToAgent(auth, {
           globalSkillId: "discover_skills",
           agentConfigurationId: agentConfig.id,
@@ -288,7 +261,6 @@ describe("getJITServers", () => {
       });
 
       it("keeps discoverable favorites in the shared equipped skills", async () => {
-        await FeatureFlagFactory.basic(auth, "skill_favorites");
         await SkillFactory.linkGlobalSkillToAgent(auth, {
           globalSkillId: "discover_skills",
           agentConfigurationId: agentConfig.id,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -10,7 +10,6 @@ import {
   hasSharedMembership,
 } from "@app/lib/api/user";
 import type { Authenticator } from "@app/lib/auth";
-import { hasFeatureFlag } from "@app/lib/auth";
 import { hasAll } from "@app/lib/matcher/operators/array";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
@@ -1779,13 +1778,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         agentLoopData,
         effectiveSpaceIds,
       });
-      const hasSkillFavorites = await hasFeatureFlag(auth, "skill_favorites");
-      if (hasSkillFavorites) {
-        favoriteSkills = await this.listFavoritesForCurrentUser(auth, {
-          agentLoopData,
-          effectiveSpaceIds,
-        });
-      }
+      favoriteSkills = await this.listFavoritesForCurrentUser(auth, {
+        agentLoopData,
+        effectiveSpaceIds,
+      });
     }
 
     const sortByName = (a: SkillResource, b: SkillResource) =>

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -253,11 +253,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable the Plan Mode skill: agents maintain a live plan.md for genuinely multi-step tasks, with an optional human-approval checkpoint.",
     stage: "dust_only",
   },
-  skill_favorites: {
-    description:
-      "Enable user favorites for skills, including favorite controls and runtime skill availability.",
-    stage: "dust_only",
-  },
   allow_old_notion_mcp: {
     description:
       "Allow individual workspaces to keep using the old internal Notion MCP server alongside the official one",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -778,7 +778,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "legacy_billing"
   | "plan_mode"
   | "pod_frame_tabs"
-  | "skill_favorites"
   | "poke_mcp"
   | "restricted_spaces_in_input_bar"
   | "salesforce_synced_queries"


### PR DESCRIPTION
## Description

This PR removes the feature flag on `skill_favorites`.

Favorite skills are both a UI feature: better personal skill management, and an agentic one: agents with Discover Skills are aware of the user's favorite selection.

It's materialized through a Star button in the Skill info page and a tab in Manage Skills.

## Tests

- Updated tests.
- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
