### PR TITLE
github connector: Fix connectors-worker crash (Z_BUF_ERROR: unexpected end of file) during GitHub tarball extraction

### DIFF
--- a/connectors/src/connectors/github/lib/code/tar_extraction.ts
+++ b/connectors/src/connectors/github/lib/code/tar_extraction.ts
@@ -370,7 +370,10 @@ export async function extractGitHubTarballToGCS(
       // those late emissions — pipeline() still rejects with the original error.
       const gunzipStream = gunzip();
       gunzipStream.on("error", (err) => {
-        childLogger.warn({ err }, "Gunzip stream error during tarball extraction");
+        childLogger.warn(
+          { err },
+          "Gunzip stream error during tarball extraction"
+        );
       });
       await pipeline(tarballStream, gunzipStream, extract);
 

--- a/connectors/src/connectors/github/lib/code/tar_extraction.ts
+++ b/connectors/src/connectors/github/lib/code/tar_extraction.ts
@@ -364,7 +364,15 @@ export async function extractGitHubTarballToGCS(
       });
 
       // Stream: GitHub tarball -> gunzip -> tar extract -> GCS upload.
-      await pipeline(tarballStream, gunzip(), extract);
+      // gunzip-maybe's inner zlib stream can re-emit its error (e.g. Z_BUF_ERROR on a
+      // truncated download) after pipeline() has settled and detached its listeners; an
+      // 'error' event with no listener crashes the process. This listener only absorbs
+      // those late emissions — pipeline() still rejects with the original error.
+      const gunzipStream = gunzip();
+      gunzipStream.on("error", (err) => {
+        childLogger.warn({ err }, "Gunzip stream error during tarball extraction");
+      });
+      await pipeline(tarballStream, gunzipStream, extract);
 
       // Validate content-length if provided.
       if (contentLength !== null && bytesReceived < contentLength) {

--- a/connectors/src/connectors/github/lib/code/tar_extraction.ts
+++ b/connectors/src/connectors/github/lib/code/tar_extraction.ts
@@ -230,6 +230,17 @@ export async function extractGitHubTarballToGCS(
     let bytesReceived = 0;
 
     extract.on("entry", (header, stream, next) => {
+      // When extraction aborts mid-entry (e.g. Z_BUF_ERROR on a truncated download),
+      // tar-stream destroys in-flight entry streams with that error. Without a listener,
+      // the resulting 'error' event crashes the process (uncaught exception). pipeline()
+      // still rejects with the original error, so the retry logic is unaffected.
+      stream.on("error", (err) => {
+        childLogger.warn(
+          { err, path: header.name },
+          "Tar entry stream error during extraction"
+        );
+      });
+
       // The tar archive is streamed sequentially, meaning you must drain each entry's stream
       // as you get them or else the main extract stream will receive backpressure and stop reading.
       const drainAndNext = () => {
@@ -364,18 +375,7 @@ export async function extractGitHubTarballToGCS(
       });
 
       // Stream: GitHub tarball -> gunzip -> tar extract -> GCS upload.
-      // gunzip-maybe's inner zlib stream can re-emit its error (e.g. Z_BUF_ERROR on a
-      // truncated download) after pipeline() has settled and detached its listeners; an
-      // 'error' event with no listener crashes the process. This listener only absorbs
-      // those late emissions — pipeline() still rejects with the original error.
-      const gunzipStream = gunzip();
-      gunzipStream.on("error", (err) => {
-        childLogger.warn(
-          { err },
-          "Gunzip stream error during tarball extraction"
-        );
-      });
-      await pipeline(tarballStream, gunzipStream, extract);
+      await pipeline(tarballStream, gunzip(), extract);
 
       // Validate content-length if provided.
       if (contentLength !== null && bytesReceived < contentLength) {


### PR DESCRIPTION
## Description

When a GitHub tarball download is truncated (connection reset, timeout on large repos), zlib raises Z_BUF_ERROR. This is expected and we already have retry logic for it: pipeline() rejects, and the extraction loop retries with a fresh stream.

The problem is a race after that. When pipeline() settles, it detaches its error listeners from the streams — but the gunzip stream wraps a native zlib handle that is still processing a chunk asynchronously. On a later event-loop tick, the native code hits the truncated data and the stream emits a second 'error' event, at a point where no listener is attached anymore. In Node, an 'error' event with zero listeners is thrown as an uncaught exception, which crashes the whole worker:
```
Error: unexpected end of file
at genericNodeError (node:internal/errors:985:15)
at wrappedFn (node:internal/errors:539:14)
at Zlib.zlibOnError [as onerror] (node:zlib:190:17)
```

The fix is to attach a persistent 'error' listener to the gunzip stream that just logs a warning. It changes nothing about control flow — pipeline() still rejects with the original error and the retry logic behaves exactly as before — it only ensures the late zombie emission has a subscriber instead of killing the process.


## Tests

no tested

## Risk

low, easy to revert

## Deploy Plan

deploy connector
