### PR TITLE
feat: Add grant-snapshot columns to membership_upgrade_requests

### DIFF
--- a/front/lib/resources/storage/models/membership_upgrade_requests.ts
+++ b/front/lib/resources/storage/models/membership_upgrade_requests.ts
@@ -2,7 +2,8 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
-import type { MembershipUpgradeRequestStatus } from "@app/types/memberships";
+import type { SpendLimitExpiryKind } from "@app/types/api/users/spend_limit";
+import type { MembershipUpgradeRequestStatus, MembershipSeatType } from "@app/types/memberships";
 import {
   MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS,
   MEMBERSHIP_UPGRADE_REQUEST_PENDING_STATUS,
@@ -24,6 +25,12 @@ export class MembershipUpgradeRequestModel extends WorkspaceAwareModel<Membershi
 
   // Why the member needs the raised limit - Optional
   declare reason: string | null;
+
+  // Snapshot of what was actually granted when this (approved) request was resolved
+  declare grantedAwuCredits: number | null;
+  declare grantedExpiryKind: SpendLimitExpiryKind | null;
+  declare grantedUnlimitedSpend: CreationOptional<boolean>;
+  declare grantedSeatType: MembershipSeatType | null;
 
   // The member who requested the upgrade.
   declare userId: ForeignKey<UserModel["id"]>;
@@ -61,6 +68,26 @@ MembershipUpgradeRequestModel.init(
       allowNull: true,
       defaultValue: null,
     },
+    grantedAwuCredits: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
+    },
+    grantedExpiryKind: {
+      type: DataTypes.STRING(24),
+      allowNull: true,
+      defaultValue: null,
+    },
+    grantedUnlimitedSpend: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    grantedSeatType: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
+    },
   },
   {
     modelName: "membership_upgrade_request",
@@ -82,6 +109,12 @@ MembershipUpgradeRequestModel.init(
       {
         fields: ["resolvedByUserId"],
         name: "membership_upgrade_requests_resolved_by_user_idx",
+      },
+      // Admin history view: resolved requests for a workspace, newest first
+      // (see `listResolvedByWorkspace`).
+      {
+        fields: ["workspaceId", "resolvedAt"],
+        name: "membership_upgrade_requests_workspace_resolved_at_idx",
       },
     ],
   }

--- a/front/migrations/pre-deploy/20260729160542_add_grant_snapshot_to_membership_upgrade_requests.sql
+++ b/front/migrations/pre-deploy/20260729160542_add_grant_snapshot_to_membership_upgrade_requests.sql
@@ -1,0 +1,35 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."membership_upgrade_requests" ADD COLUMN "grantedAwuCredits" integer;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."membership_upgrade_requests" ADD COLUMN "grantedExpiryKind" character varying(24) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying;
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."membership_upgrade_requests" ADD COLUMN "grantedUnlimitedSpend" boolean NOT NULL DEFAULT false;
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."membership_upgrade_requests" ADD COLUMN "grantedSeatType" character varying(255) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying;
+
+/*
+Statement 4
+  - Index for membership_upgrade_requests(workspaceId, resolvedAt) history listing
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY membership_upgrade_requests_workspace_resolved_at_idx ON public.membership_upgrade_requests USING btree ("workspaceId", "resolvedAt");


### PR DESCRIPTION
## Description

Until now, `membership_upgrade_requests` stored the request and resolution metadata but not the effective grant that was applied when an admin approved it. This PR adds four fields that snapshot the resolved grant: `grantedAwuCredits`, `grantedExpiryKind`, `grantedUnlimitedSpend`, and `grantedSeatType`. It also adds a `(workspaceId, resolvedAt)` index to support newest-first listings of resolved requests for the upcoming admin history view.

This is a storage and schema change only. It does not alter approval behavior, change a member's seat type or spend limits, or add the history read/population logic. Existing rows retain `NULL` for the nullable snapshot fields and `false` for `grantedUnlimitedSpend` until the follow-up logic populates these values.

Part of the stacked change that includes [#29921](https://github.com/dust-tt/dust/pull/29921) and the follow-up [#29961](https://github.com/dust-tt/dust/pull/29961).

## Tests


## Risk

The migration is additive: it introduces nullable columns, a boolean with a `false` default, and a concurrent index, so existing request data and approval behavior are preserved. The main operational risk is migration execution on the existing `membership_upgrade_requests` table; the migration uses short statement and lock timeouts for the column additions and creates the index concurrently. Consumers of the new fields must handle `NULL` values for historical requests. Application rollback does not require removing the added columns.

## Deploy Plan

Apply the pre-deploy migration before deploying any follow-up code that writes or reads the grant snapshot fields. No backfill or manual data migration is included in this PR; historical rows remain unset until the follow-up population logic is deployed.