### PR TITLE
feat: Resource, API, and expiration logic for upgrade-request grants

### DIFF
--- a/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
@@ -1,8 +1,39 @@
+import * as spendLimits from "@app/lib/metronome/alerts/spend_limits";
+import { MembershipUpgradeRequestResource } from "@app/lib/resources/membership_upgrade_request_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
 import { honoApp } from "@front-api/app";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
+  const actual = await vi.importActual<typeof spendLimits>(
+    "@app/lib/metronome/alerts/spend_limits"
+  );
+  return {
+    ...actual,
+    upsertMetronomePerUserCapAlert: vi.fn(),
+    clearMetronomePerUserCapAlert: vi.fn(),
+    upsertMetronomePerUserWarningAlert: vi.fn(),
+    clearMetronomePerUserWarningAlert: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.mocked(spendLimits.upsertMetronomePerUserCapAlert).mockResolvedValue(
+    new Ok({ alertId: "alert_test_xxx" })
+  );
+  vi.mocked(spendLimits.clearMetronomePerUserCapAlert).mockResolvedValue(
+    new Ok(undefined)
+  );
+  vi.mocked(spendLimits.upsertMetronomePerUserWarningAlert).mockResolvedValue(
+    new Ok(null)
+  );
+  vi.mocked(spendLimits.clearMetronomePerUserWarningAlert).mockResolvedValue(
+    new Ok(undefined)
+  );
+});
 
 function upgradeRequestsUrl(wId: string) {
   return `/api/w/${wId}/credits/upgrade-requests`;
@@ -228,6 +259,248 @@ describe("/api/w/[wId]/credits/upgrade-requests", () => {
       );
 
       expect(response.status).toBe(403);
+    });
+  });
+
+  describe("GET ?status=resolved (history)", () => {
+    it("only lists resolved requests, most recently resolved first", async () => {
+      const workspace = await creditPricedWorkspace();
+      const { user: member } = await createMemberRequest(workspace);
+
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+      const { sId: requestId } = (
+        await (await honoApp.request(upgradeRequestsUrl(workspace.sId))).json()
+      ).requests[0];
+
+      const resolvedListBeforeResolve = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}?status=resolved`
+      );
+      expect((await resolvedListBeforeResolve.json()).requests).toHaveLength(0);
+
+      await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}/${requestId}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "denied" }),
+        }
+      );
+
+      const resolvedListResponse = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}?status=resolved`
+      );
+      expect(resolvedListResponse.status).toBe(200);
+      const { requests: resolvedRequests } = await resolvedListResponse.json();
+      expect(resolvedRequests).toHaveLength(1);
+      expect(resolvedRequests[0].sId).toBe(requestId);
+      expect(resolvedRequests[0].status).toBe("denied");
+      expect(resolvedRequests[0].requester.sId).toBe(member.sId);
+
+      // Still absent from the pending list.
+      const pendingListResponse = await honoApp.request(
+        upgradeRequestsUrl(workspace.sId)
+      );
+      expect((await pendingListResponse.json()).requests).toHaveLength(0);
+    });
+
+    it("PATCH with grantedSeatType snapshots the seat upgrade for history", async () => {
+      const workspace = await creditPricedWorkspace();
+      await createMemberRequest(workspace);
+
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+      const { sId: requestId } = (
+        await (await honoApp.request(upgradeRequestsUrl(workspace.sId))).json()
+      ).requests[0];
+
+      const patchResponse = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}/${requestId}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            status: "approved",
+            grantedSeatType: "max",
+          }),
+        }
+      );
+      expect(patchResponse.status).toBe(200);
+
+      const resolvedListResponse = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}?status=resolved`
+      );
+      const { requests } = await resolvedListResponse.json();
+      expect(requests[0].grantedSeatType).toBe("max");
+      expect(requests[0].grantedAwuCredits).toBeNull();
+      expect(requests[0].grantedUnlimitedSpend).toBe(false);
+    });
+
+    it("PATCH approves the request through the seat-approval flow (seat-type update then resolve)", async () => {
+      const workspace = await creditPricedWorkspace();
+      const { user: member } = await createMemberRequest(workspace);
+
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+      const { sId: requestId } = (
+        await (await honoApp.request(upgradeRequestsUrl(workspace.sId))).json()
+      ).requests[0];
+
+      // Mirrors the UI flow: the seat-type mutation is a separate call from
+      // the resolution, exactly as `ChangeSeatModal` does before resolving.
+      const seatTypeResponse = await honoApp.request(
+        `/api/w/${workspace.sId}/members/${member.sId}/seat-type`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ seatType: "max" }),
+        }
+      );
+      expect(seatTypeResponse.status).toBe(200);
+
+      const patchResponse = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}/${requestId}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            status: "approved",
+            grantedSeatType: "max",
+          }),
+        }
+      );
+      expect(patchResponse.status).toBe(200);
+
+      const resolvedListResponse = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}?status=resolved`
+      );
+      const { requests } = await resolvedListResponse.json();
+      expect(requests[0].status).toBe("approved");
+      expect(requests[0].grantedSeatType).toBe("max");
+    });
+
+    it("only one of two concurrent approvals succeeds, and the surviving grant matches the winner", async () => {
+      const workspace = await creditPricedWorkspace();
+      await createMemberRequest(workspace);
+
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+      const { sId: requestId } = (
+        await (await honoApp.request(upgradeRequestsUrl(workspace.sId))).json()
+      ).requests[0];
+
+      const resolveUrl = `${upgradeRequestsUrl(workspace.sId)}/${requestId}`;
+      const [approveResponse, denyResponse] = await Promise.all([
+        honoApp.request(resolveUrl, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            status: "approved",
+            limit: { kind: "unlimited" },
+          }),
+        }),
+        honoApp.request(resolveUrl, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "denied" }),
+        }),
+      ]);
+
+      // Exactly one of the two concurrent resolutions wins; the other gets a
+      // 409 rather than silently overwriting the winner's resolution.
+      const statuses = [approveResponse.status, denyResponse.status].sort();
+      expect(statuses).toEqual([200, 409]);
+
+      const resolvedListResponse = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}?status=resolved`
+      );
+      const { requests } = await resolvedListResponse.json();
+      expect(requests).toHaveLength(1);
+      const resolved = requests[0];
+
+      // The persisted status and the persisted grant must agree on which
+      // admin's resolution actually won — never a split-brain where one
+      // admin's status "wins" while the other admin's side effect lingers.
+      if (resolved.status === "approved") {
+        expect(approveResponse.status).toBe(200);
+        expect(resolved.grantedUnlimitedSpend).toBe(true);
+      } else {
+        expect(resolved.status).toBe("denied");
+        expect(denyResponse.status).toBe(200);
+        expect(resolved.grantedUnlimitedSpend).toBe(false);
+        expect(resolved.grantedAwuCredits).toBeNull();
+      }
+    });
+
+    it("paginates resolved requests 100 per page", async () => {
+      const workspace = await creditPricedWorkspace();
+      const { user: member, auth: memberAuth } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+          role: "user",
+          workspace,
+        });
+
+      const totalResolvedRequests = 101;
+      for (let i = 0; i < totalResolvedRequests; i++) {
+        const created = await MembershipUpgradeRequestResource.createPending(
+          memberAuth,
+          { user: member, reason: null }
+        );
+        if (created.isErr()) {
+          throw created.error;
+        }
+        await created.value.markAsResolved(memberAuth, {
+          status: i % 2 === 0 ? "approved" : "denied",
+          resolvedByUser: member,
+        });
+      }
+
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+
+      const firstPageResponse = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}?status=resolved`
+      );
+      expect(firstPageResponse.status).toBe(200);
+      const firstPage = await firstPageResponse.json();
+      expect(firstPage.requests).toHaveLength(100);
+      expect(firstPage.total).toBe(totalResolvedRequests);
+
+      const secondPageResponse = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}?status=resolved&offset=100`
+      );
+      expect(secondPageResponse.status).toBe(200);
+      const secondPage = await secondPageResponse.json();
+      expect(secondPage.requests).toHaveLength(1);
+      expect(secondPage.total).toBe(totalResolvedRequests);
+
+      // The two pages are disjoint and together cover every resolved request.
+      const firstPageIds = new Set(
+        firstPage.requests.map((r: { sId: string }) => r.sId)
+      );
+      const secondPageIds = new Set(
+        secondPage.requests.map((r: { sId: string }) => r.sId)
+      );
+      expect(firstPageIds.size).toBe(100);
+      for (const id of secondPageIds) {
+        expect(firstPageIds.has(id)).toBe(false);
+      }
     });
   });
 });

--- a/front-api/routes/w/[wId]/credits/upgrade-requests.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.ts
@@ -3,6 +3,7 @@ import type { ResolveUpgradeRequestError } from "@app/lib/api/credits/upgrade_re
 import {
   createUpgradeRequest,
   listPendingUpgradeRequests,
+  listResolvedUpgradeRequests,
   resolveUpgradeRequest,
 } from "@app/lib/api/credits/upgrade_requests";
 import { UserSpendLimitError } from "@app/lib/api/users/spend_limit";
@@ -12,7 +13,10 @@ import type {
   PostUpgradeRequestResponseBody,
 } from "@app/types/api/credits/upgrade_requests";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
-import { MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS } from "@app/types/memberships";
+import {
+  MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS,
+  MEMBERSHIP_SEAT_TYPES,
+} from "@app/types/memberships";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
@@ -28,13 +32,31 @@ const ParamsSchema = z.object({
   requestId: z.string(),
 });
 
-const ResolveBodySchema = z.discriminatedUnion("status", [
-  z.object({ status: z.literal("denied") }),
-  z.object({
-    status: z.literal("approved"),
-    limit: UpdateUserSpendLimitBodySchema.optional(),
-  }),
-]);
+const ResolveBodySchema = z
+  .discriminatedUnion("status", [
+    z.object({ status: z.literal("denied") }),
+    z.object({
+      status: z.literal("approved"),
+      limit: UpdateUserSpendLimitBodySchema.optional(),
+      // Set when the admin resolved the request via "Upgrade to max plan"
+      grantedSeatType: z.enum(MEMBERSHIP_SEAT_TYPES).optional(),
+    }),
+  ])
+  // A request is granted at most one of a spend limit or a seat upgrade.
+  .refine(
+    (data) =>
+      !(data.status === "approved" && data.limit && data.grantedSeatType),
+    {
+      message: "Cannot set both `limit` and `grantedSeatType`.",
+      path: ["grantedSeatType"],
+    }
+  );
+
+// Omitted/"pending" preserves the requests queue behavior
+const ListUpgradeRequestsQuerySchema = z.object({
+  status: z.union([z.literal("pending"), z.literal("resolved")]).optional(),
+  offset: z.coerce.number().int().min(0).catch(0),
+});
 
 const CreateUpgradeRequestBodySchema = z.object({
   reason: z
@@ -91,8 +113,16 @@ const app = workspaceApp();
 app.get(
   "/",
   ensureIsManager(),
+  validate("query", ListUpgradeRequestsQuerySchema),
   async (ctx): HandlerResult<GetUpgradeRequestsResponseBody> => {
     const auth = ctx.get("auth");
+    const { status, offset } = ctx.req.valid("query");
+    if (status === "resolved") {
+      const { requests, total } = await listResolvedUpgradeRequests(auth, {
+        offset,
+      });
+      return ctx.json({ requests, total });
+    }
     const requests = await listPendingUpgradeRequests(auth);
     return ctx.json({ requests });
   }

--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -1,7 +1,9 @@
+import { Authenticator } from "@app/lib/auth";
 import * as spendLimits from "@app/lib/metronome/alerts/spend_limits";
 import * as planType from "@app/lib/metronome/plan_type";
 import * as seatTypes from "@app/lib/metronome/seat_types";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { MembershipUpgradeRequestResource } from "@app/lib/resources/membership_upgrade_request_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -496,6 +498,57 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
           workspace,
         });
       expect(updatedMembership?.poolCapOverrideAwuCredits).toBe(900);
+    });
+
+    it("records the grant on a linked upgrade request", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+      });
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      const requestResult =
+        await MembershipUpgradeRequestResource.createPending(adminAuth, {
+          user: targetUser,
+          reason: null,
+        });
+      if (requestResult.isErr()) {
+        throw requestResult.error;
+      }
+      const requestId = requestResult.value.sId;
+
+      await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        spendLimitUrl(workspace.sId, targetUser.sId),
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            kind: "limited",
+            awuCredits: 750,
+            expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+            expiryKind: "one_day",
+            requestId,
+          }),
+        }
+      );
+      expect(response.status).toBe(200);
+
+      const updatedRequest = await MembershipUpgradeRequestResource.fetchById(
+        adminAuth,
+        requestId
+      );
+      expect(updatedRequest?.grantedAwuCredits).toBe(750);
+      expect(updatedRequest?.grantedExpiryKind).toBe("one_day");
+      expect(updatedRequest?.grantedUnlimitedSpend).toBe(false);
+      expect(updatedRequest?.grantedSeatType).toBeNull();
     });
   });
 });

--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
@@ -6,9 +6,10 @@ import {
   setUserSpendLimit,
   type UserSpendLimitError,
 } from "@app/lib/api/users/spend_limit";
-import type {
-  GetUserSpendLimitResponseBody,
-  PutUserSpendLimitResponseBody,
+import {
+  type GetUserSpendLimitResponseBody,
+  type PutUserSpendLimitResponseBody,
+  SPEND_LIMIT_EXPIRY_KINDS,
 } from "@app/types/api/users/spend_limit";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -18,26 +19,36 @@ import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
+// Set when this save resolves a specific upgrade request (the admin used
+// "Use workspace default" or "Set credit amount" from the requests table).
+// Snapshots the granted amount/expiry onto that request for the history view.
+const RequestIdSchema = z.object({ requestId: z.string().optional() });
+
 export const UpdateUserSpendLimitBodySchema = z.discriminatedUnion("kind", [
-  z.object({ kind: z.literal("unlimited") }),
-  z.object({
-    kind: z.literal("limited"),
-    awuCredits: z
-      .number()
-      .int()
-      .min(MIN_USER_SPEND_LIMIT_AWU_CREDITS)
-      .max(MAX_USER_SPEND_LIMIT_AWU_CREDITS),
-    // Epoch ms at which the override auto-reverts to unlimited.
-    // Omitted/null means it never expires.
-    expiresAt: z
-      .number()
-      .int()
-      .positive()
-      .refine((value) => value > Date.now(), {
-        message: "expiresAt must be in the future.",
-      })
-      .nullish(),
-  }),
+  z.object({ kind: z.literal("unlimited") }).merge(RequestIdSchema),
+  z
+    .object({
+      kind: z.literal("limited"),
+      awuCredits: z
+        .number()
+        .int()
+        .min(MIN_USER_SPEND_LIMIT_AWU_CREDITS)
+        .max(MAX_USER_SPEND_LIMIT_AWU_CREDITS),
+      // Epoch ms at which the override auto-reverts to unlimited.
+      // Omitted/null means it never expires.
+      expiresAt: z
+        .number()
+        .int()
+        .positive()
+        .refine((value) => value > Date.now(), {
+          message: "expiresAt must be in the future.",
+        })
+        .nullish(),
+      // Which preset `expiresAt` was resolved from — a history-only
+      // snapshot hint, not used for enforcement.
+      expiryKind: z.enum(SPEND_LIMIT_EXPIRY_KINDS).optional(),
+    })
+    .merge(RequestIdSchema),
 ]);
 
 const ParamsSchema = z.object({
@@ -70,6 +81,14 @@ export function spendLimitErrorToApiError(
         api_error: {
           type: "internal_server_error",
           message: "Failed to update spend limit in billing system.",
+        },
+      };
+    case "request_invalid":
+      return {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: error.message,
         },
       };
     default:
@@ -131,10 +150,12 @@ app.put(
     const { uId } = ctx.req.valid("param");
 
     const auditContext = getAuditLogContext(auth);
+    const { requestId, ...limit } = ctx.req.valid("json");
     const result = await setUserSpendLimit(auth, {
       userId: uId,
-      limit: ctx.req.valid("json"),
+      limit,
       auditContext,
+      requestId,
     });
     if (result.isErr()) {
       return apiError(ctx, spendLimitErrorToApiError(result.error));

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -348,26 +348,34 @@ export function UsagePage() {
   );
   // Shared by approval flows before resolving the request.
   const resolveRequestApproved = useCallback(
-    async (requestId: string): Promise<void> => {
+    async (
+      requestId: string,
+      grantedSeatType?: MembershipSeatType
+    ): Promise<void> => {
       await doResolveUpgradeRequest({
         requestId,
-        resolution: { status: "approved" },
+        resolution: grantedSeatType
+          ? { status: "approved", grantedSeatType }
+          : { status: "approved" },
       });
     },
     [doResolveUpgradeRequest]
   );
-  const handleApproveOnModalSaved = useCallback(async () => {
-    if (!pendingApproveRequestId) {
-      return;
-    }
-    const requestId = pendingApproveRequestId;
-    setRequestResolving(requestId, true);
-    try {
-      await resolveRequestApproved(requestId);
-    } finally {
-      setRequestResolving(requestId, false);
-    }
-  }, [pendingApproveRequestId, resolveRequestApproved, setRequestResolving]);
+  const handleApproveOnModalSaved = useCallback(
+    async (grantedSeatType?: MembershipSeatType) => {
+      if (!pendingApproveRequestId) {
+        return;
+      }
+      const requestId = pendingApproveRequestId;
+      setRequestResolving(requestId, true);
+      try {
+        await resolveRequestApproved(requestId, grantedSeatType);
+      } finally {
+        setRequestResolving(requestId, false);
+      }
+    },
+    [pendingApproveRequestId, resolveRequestApproved, setRequestResolving]
+  );
   const handleDenyRequest = useCallback(
     async (request: MembershipUpgradeRequestType) => {
       const confirmed = await confirm({
@@ -638,13 +646,16 @@ export function UsagePage() {
     [confirm, doUpdateSeatType, handleSeatChangePendingChange, clearSelection]
   );
 
-  const handleSeatMutationSaved = useCallback(() => {
-    // Seat mutations can move a member in or out of the currently filtered set
-    // (for example with the seat filter), which makes the cross-page selection
-    // stale.
-    clearSelection();
-    handleApproveOnModalSaved();
-  }, [handleApproveOnModalSaved, clearSelection]);
+  const handleSeatMutationSaved = useCallback(
+    (seatType: MembershipSeatType) => {
+      // Seat mutations can move a member in or out of the currently filtered
+      // set (for example with the seat filter), which makes the cross-page
+      // selection stale.
+      clearSelection();
+      handleApproveOnModalSaved(seatType);
+    },
+    [handleApproveOnModalSaved, clearSelection]
+  );
 
   // Rows to spin while a bulk update runs — the request returns once the bulk
   // workflow has completed. For an "all matching" selection only the current

--- a/front/components/workspace/ChangeSeatModal.tsx
+++ b/front/components/workspace/ChangeSeatModal.tsx
@@ -78,8 +78,9 @@ interface ChangeSeatModalProps {
   seatPlans: SeatPlanResponseBody;
   onSavingChange?: (memberId: string, isSaving: boolean) => void;
   // Fired once the seat change has been persisted successfully (not on cancel
-  // or a no-op close). Used to resolve a linked upgrade request as approved.
-  onSaved?: () => void;
+  // or a no-op close), with the seat type it was changed to. Used to resolve
+  // a linked upgrade request as approved, snapshotting the granted seat.
+  onSaved?: (seatType: MembershipSeatType) => void;
 }
 
 export function ChangeSeatModal({
@@ -320,7 +321,7 @@ export function ChangeSeatModal({
         hasSeatPool: (seatPlans[selectedSeat]?.awuCredits ?? 0) > 0,
       });
       if (ok) {
-        onSaved?.();
+        onSaved?.(selectedSeat);
         onClose();
       }
     } finally {

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -238,7 +238,31 @@ export async function listPendingUpgradeRequests(
   return requests.map((r) => r.toJSON());
 }
 
-// Admin-only: record the outcome of a request.
+// Admin-only: resolved requests, for the history view, paginated.
+export const RESOLVED_UPGRADE_REQUESTS_HISTORY_PAGE_SIZE = 100;
+
+export async function listResolvedUpgradeRequests(
+  auth: Authenticator,
+  { offset }: { offset: number }
+): Promise<{ requests: MembershipUpgradeRequestType[]; total: number }> {
+  const { requests, total } =
+    await MembershipUpgradeRequestResource.listResolvedByWorkspace(auth, {
+      limit: RESOLVED_UPGRADE_REQUESTS_HISTORY_PAGE_SIZE,
+      offset,
+    });
+  return { requests: requests.map((r) => r.toJSON()), total };
+}
+
+// Admin-only: record the outcome of a request. The request is claimed first
+// via a compare-and-set on `status = 'pending'` — see `markAsResolved` — so
+// that two admins resolving the same request concurrently can't both apply
+// conflicting side effects: only the admin whose CAS observes `pending`
+// proceeds past the claim. An approval that carries a `limit` then syncs the
+// requester's spend limit; if that sync fails, the claim is rolled back via
+// `revertToPending` so the request remains resolvable instead of being stuck
+// approved with no limit ever applied. `grantedSeatType`, when resolved via
+// "Upgrade to max plan", and the spend-limit grant (recorded inside
+// `setUserSpendLimit`) are snapshotted onto the request for the history view.
 export async function resolveUpgradeRequest(
   auth: Authenticator,
   {
@@ -269,28 +293,10 @@ export async function resolveUpgradeRequest(
     );
   }
 
-  // Apply the spend-limit change first, before flipping the request to
-  // resolved. `setUserSpendLimit` is idempotent (it converges to the
-  // requested limit however many times it's called), so if the process
-  // crashes right after this call, the request is still visible as pending
-  // and the next resolution attempt just re-applies the same limit and
-  // succeeds. Doing this the other way around — resolving first — would
-  // instead risk a crash leaving the request permanently "approved" with the
-  // limit never actually applied.
-  if (resolution.status === "approved" && resolution.limit) {
-    const spendLimitResult = await setUserSpendLimit(auth, {
-      userId: request.requester.sId,
-      limit: resolution.limit,
-      auditContext: auditContext ?? { location: "internal" },
-    });
-    if (spendLimitResult.isErr()) {
-      return new Err(spendLimitResult.error);
-    }
-  }
-
-  // Compare-and-set on `status = 'pending'`: if another admin resolved this
-  // request concurrently between the fetch above and here, this fails rather
-  // than silently overwriting their resolution.
+  // Claim the request first: compare-and-set on `status = 'pending'`. If
+  // another admin resolved this request concurrently between the fetch above
+  // and here, this fails rather than letting both admins' side effects below
+  // race against each other.
   const resolvedByUser = auth.getNonNullableUser();
   const result = await request.markAsResolved(auth, {
     status: resolution.status,
@@ -303,11 +309,31 @@ export async function resolveUpgradeRequest(
         workspaceId: auth.getNonNullableWorkspace().sId,
         resolutionStatus: resolution.status,
       },
-      "[UpgradeRequest] Request was resolved concurrently by another admin after its spend limit was applied"
+      "[UpgradeRequest] Request was resolved concurrently by another admin"
     );
     return new Err(
       new UpgradeRequestError("request_not_pending", result.error.message)
     );
+  }
+
+  if (resolution.status === "approved" && resolution.limit) {
+    const spendLimitResult = await setUserSpendLimit(auth, {
+      userId: request.requester.sId,
+      limit: resolution.limit,
+      auditContext: auditContext ?? { location: "internal" },
+      requestId: request.sId,
+    });
+    if (spendLimitResult.isErr()) {
+      // The claim succeeded but applying the limit failed (e.g. a Metronome
+      // sync error): roll the claim back so the request stays pending and
+      // this (or another) resolution attempt can retry it.
+      await request.revertToPending();
+      return new Err(spendLimitResult.error);
+    }
+  }
+
+  if (resolution.status === "approved" && resolution.grantedSeatType) {
+    await request.recordSeatUpgrade(resolution.grantedSeatType);
   }
 
   void emitAuditLogEvent({

--- a/front/lib/api/users/spend_limit.test.ts
+++ b/front/lib/api/users/spend_limit.test.ts
@@ -1,0 +1,253 @@
+import * as workosAudit from "@app/lib/api/audit/workos_audit";
+import * as reconcileCreditState from "@app/lib/api/metronome/reconcile_credit_state";
+import { setUserSpendLimit } from "@app/lib/api/users/spend_limit";
+import { Authenticator } from "@app/lib/auth";
+import * as perUserAlerts from "@app/lib/metronome/alerts/spend_limits";
+import * as seatTypes from "@app/lib/metronome/seat_types";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { MembershipUpgradeRequestResource } from "@app/lib/resources/membership_upgrade_request_resource";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+function unwrap<T, E>(result: Result<T, E>): T {
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+}
+
+vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
+  const actual = await vi.importActual<typeof perUserAlerts>(
+    "@app/lib/metronome/alerts/spend_limits"
+  );
+  return {
+    ...actual,
+    upsertMetronomePerUserCapAlert: vi.fn(),
+    upsertMetronomePerUserWarningAlert: vi.fn(),
+    clearMetronomePerUserCapAlert: vi.fn(),
+    clearMetronomePerUserWarningAlert: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/metronome/seat_types", async () => {
+  const actual = await vi.importActual<typeof seatTypes>(
+    "@app/lib/metronome/seat_types"
+  );
+  return {
+    ...actual,
+    getSeatAllowancesByNormalizedSeatType: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/api/audit/workos_audit", async () => {
+  const actual = await vi.importActual<typeof workosAudit>(
+    "@app/lib/api/audit/workos_audit"
+  );
+  return {
+    ...actual,
+    emitAuditLogEvent: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/api/metronome/reconcile_credit_state", async () => {
+  const actual = await vi.importActual<typeof reconcileCreditState>(
+    "@app/lib/api/metronome/reconcile_credit_state"
+  );
+  return {
+    ...actual,
+    reconcileUser: vi.fn(),
+  };
+});
+
+const METRONOME_CUSTOMER_ID = "cust_test_xxx";
+const AUDIT_CONTEXT = { location: "127.0.0.1" };
+
+beforeEach(() => {
+  vi.mocked(perUserAlerts.upsertMetronomePerUserCapAlert).mockResolvedValue(
+    new Ok({ alertId: "alert_user_cap_xxx" })
+  );
+  vi.mocked(perUserAlerts.upsertMetronomePerUserWarningAlert).mockResolvedValue(
+    new Ok({ alertId: "alert_user_warning_xxx" })
+  );
+  vi.mocked(perUserAlerts.clearMetronomePerUserCapAlert).mockResolvedValue(
+    new Ok(undefined)
+  );
+  vi.mocked(perUserAlerts.clearMetronomePerUserWarningAlert).mockResolvedValue(
+    new Ok(undefined)
+  );
+  vi.mocked(seatTypes.getSeatAllowancesByNormalizedSeatType).mockResolvedValue(
+    {}
+  );
+  vi.mocked(workosAudit.emitAuditLogEvent).mockResolvedValue(undefined);
+  vi.mocked(reconcileCreditState.reconcileUser).mockResolvedValue(
+    new Ok({} as never)
+  );
+});
+
+async function setupWorkspaceWithAdminAndMember() {
+  const workspace = await WorkspaceFactory.metronome({
+    metronomeCustomerId: METRONOME_CUSTOMER_ID,
+  });
+  const adminUser = await UserFactory.basic();
+  const memberUser = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
+  await MembershipFactory.associate(workspace, memberUser, { role: "user" });
+  const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    adminUser.sId,
+    workspace.sId
+  );
+  return { workspace, adminAuth, memberUser };
+}
+
+describe("setUserSpendLimit requestId handling", () => {
+  it("rejects a requestId that does not belong to the target user", async () => {
+    const { adminAuth, memberUser } = await setupWorkspaceWithAdminAndMember();
+    const otherUser = await UserFactory.basic();
+    const workspace = adminAuth.getNonNullableWorkspace();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+    const otherRequest = unwrap(
+      await MembershipUpgradeRequestResource.createPending(adminAuth, {
+        user: otherUser,
+        reason: null,
+      })
+    );
+
+    const result = await setUserSpendLimit(adminAuth, {
+      userId: memberUser.sId,
+      limit: { kind: "limited", awuCredits: 5_000 },
+      auditContext: AUDIT_CONTEXT,
+      requestId: otherRequest.sId,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.type).toBe("request_invalid");
+    }
+    expect(perUserAlerts.upsertMetronomePerUserCapAlert).not.toHaveBeenCalled();
+
+    const membership =
+      await MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user: memberUser,
+        workspace,
+      });
+    expect(membership?.poolCapOverrideAwuCredits).toBeNull();
+  });
+
+  it("rejects a requestId for a request that is no longer pending", async () => {
+    const { adminAuth, memberUser } = await setupWorkspaceWithAdminAndMember();
+    const request = unwrap(
+      await MembershipUpgradeRequestResource.createPending(adminAuth, {
+        user: memberUser,
+        reason: null,
+      })
+    );
+    await request.markAsResolved(adminAuth, {
+      status: "denied",
+      resolvedByUser: adminAuth.getNonNullableUser(),
+    });
+
+    const result = await setUserSpendLimit(adminAuth, {
+      userId: memberUser.sId,
+      limit: { kind: "limited", awuCredits: 5_000 },
+      auditContext: AUDIT_CONTEXT,
+      requestId: request.sId,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.type).toBe("request_invalid");
+    }
+    expect(perUserAlerts.upsertMetronomePerUserCapAlert).not.toHaveBeenCalled();
+  });
+
+  it("reverts both the membership override and the request grant snapshot when the Metronome sync fails", async () => {
+    const { adminAuth, memberUser } = await setupWorkspaceWithAdminAndMember();
+    const workspace = adminAuth.getNonNullableWorkspace();
+    const request = unwrap(
+      await MembershipUpgradeRequestResource.createPending(adminAuth, {
+        user: memberUser,
+        reason: null,
+      })
+    );
+
+    // Simulate a previously-applied grant: the membership already carries an
+    // override and the request already snapshots it.
+    const membership =
+      await MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user: memberUser,
+        workspace,
+      });
+    if (!membership) {
+      throw new Error("Expected an active membership.");
+    }
+    await membership.updatePoolCapOverride({
+      poolCapOverrideAwuCredits: 3_000,
+      poolCapOverrideExpiresAt: null,
+    });
+    await request.recordGrant({
+      kind: "limited",
+      awuCredits: 3_000,
+      expiryKind: null,
+    });
+
+    vi.mocked(perUserAlerts.upsertMetronomePerUserCapAlert).mockResolvedValue(
+      new Err(new Error("Metronome unavailable"))
+    );
+
+    const result = await setUserSpendLimit(adminAuth, {
+      userId: memberUser.sId,
+      limit: { kind: "limited", awuCredits: 9_000 },
+      auditContext: AUDIT_CONTEXT,
+      requestId: request.sId,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.type).toBe("metronome_error");
+    }
+
+    const reloadedMembership =
+      await MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user: memberUser,
+        workspace,
+      });
+    expect(reloadedMembership?.poolCapOverrideAwuCredits).toBe(3_000);
+
+    const reloadedRequest = await MembershipUpgradeRequestResource.fetchById(
+      adminAuth,
+      request.sId
+    );
+    expect(reloadedRequest?.grantedAwuCredits).toBe(3_000);
+    expect(reloadedRequest?.grantedUnlimitedSpend).toBe(false);
+  });
+
+  it("records the grant snapshot on the linked pending request when the update succeeds", async () => {
+    const { adminAuth, memberUser } = await setupWorkspaceWithAdminAndMember();
+    const request = unwrap(
+      await MembershipUpgradeRequestResource.createPending(adminAuth, {
+        user: memberUser,
+        reason: null,
+      })
+    );
+
+    const result = await setUserSpendLimit(adminAuth, {
+      userId: memberUser.sId,
+      limit: { kind: "limited", awuCredits: 5_000 },
+      auditContext: AUDIT_CONTEXT,
+      requestId: request.sId,
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    const reloadedRequest = await MembershipUpgradeRequestResource.fetchById(
+      adminAuth,
+      request.sId
+    );
+    expect(reloadedRequest?.grantedAwuCredits).toBe(5_000);
+    expect(reloadedRequest?.grantedUnlimitedSpend).toBe(false);
+  });
+});

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -26,6 +26,7 @@ import {
 import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
 import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { MembershipUpgradeRequestResource } from "@app/lib/resources/membership_upgrade_request_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { currentCalendarMonthCycleUtc } from "@app/lib/spend_limits/cycle";
@@ -36,6 +37,7 @@ import {
   getFixedWindowCount,
   setFixedWindowCount,
 } from "@app/lib/utils/rate_limiter";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type {
   GetUserSpendLimitResponse,
@@ -54,7 +56,8 @@ export const MAX_USER_SPEND_LIMIT_AWU_CREDITS = 2_000_000;
 type UserSpendLimitErrorType =
   | "user_not_found"
   | "workspace_not_metronome_billed"
-  | "metronome_error";
+  | "metronome_error"
+  | "request_invalid";
 
 export class UserSpendLimitError extends Error {
   constructor(
@@ -172,10 +175,14 @@ export async function setUserSpendLimit(
     userId,
     limit,
     auditContext,
+    requestId,
   }: {
     userId: string;
     limit: UserSpendLimit;
     auditContext: AuditLogContext;
+    // Set when this save resolves a specific upgrade request.
+    // Snapshots the granted amount/expiry
+    requestId?: string | null;
   }
 ): Promise<Result<SetUserSpendLimitResponse, UserSpendLimitError>> {
   const workspace = auth.getNonNullableWorkspace();
@@ -241,23 +248,87 @@ export async function setUserSpendLimit(
     );
   }
 
-  // Persist the admin's intent first: the membership is the source of truth,
-  // the Metronome alerts below are derived enforcement (a failed sync can be
-  // retried and re-derives from this value).
+  // Captured before the transaction below (and the Metronome sync further
+  // down) so a failed sync can revert the membership back to exactly this
+  // state: the membership is the source of truth, the Metronome alerts are
+  // derived enforcement.
   const previousPoolCapOverride = membership.poolCapOverrideSnapshot;
   const previousAwuCredits = previousPoolCapOverride.poolCapOverrideAwuCredits;
 
-  await membership.updatePoolCapOverride({
-    poolCapOverrideAwuCredits:
-      limit.kind === "limited" ? limit.awuCredits : null,
-    poolCapOverrideExpiresAt:
-      limit.kind === "limited" && limit.expiresAt
-        ? new Date(limit.expiresAt)
-        : null,
+  // The membership override and its linked-request grant snapshot must land
+  // together for consistency. The request must belong to `userId` and must
+  // not have been resolved to a conflicting outcome. `resolveUpgradeRequest`
+  // claims the request via its own compare-and-set on `status = 'pending'`
+  // before calling this, so by the time this runs the status is expected to
+  // already be "approved" (not "pending") — `pending` is only accepted for
+  // callers that apply the limit without going through that claim step.
+  let request: MembershipUpgradeRequestResource | null = null;
+  if (requestId) {
+    request = await MembershipUpgradeRequestResource.fetchById(auth, requestId);
+    if (
+      !request ||
+      request.requester.sId !== user.sId ||
+      request.status === "denied"
+    ) {
+      logger.warn(
+        {
+          workspaceId: workspace.sId,
+          userId: user.sId,
+          requestId,
+          requestFound: !!request,
+          requestStatus: request?.status,
+        },
+        "[Metronome PerUserCap] set: linked upgrade request not found, mismatched, or denied"
+      );
+      return new Err(
+        new UserSpendLimitError(
+          "request_invalid",
+          "The linked upgrade request could not be found, does not belong to this user, or was denied."
+        )
+      );
+    }
+  }
+  const previousGrantSnapshot = request?.grantSnapshot ?? null;
+
+  await withTransaction(async (transaction) => {
+    // Persist the admin's intent first: the membership is the source of
+    // truth, the Metronome alerts below are derived enforcement (a failed
+    // sync can be retried and re-derives from this value).
+    await membership.updatePoolCapOverride(
+      {
+        poolCapOverrideAwuCredits:
+          limit.kind === "limited" ? limit.awuCredits : null,
+        poolCapOverrideExpiresAt:
+          limit.kind === "limited" && limit.expiresAt
+            ? new Date(limit.expiresAt)
+            : null,
+      },
+      transaction
+    );
+
+    if (request) {
+      await request.recordGrant(
+        limit.kind === "limited"
+          ? {
+              kind: "limited",
+              awuCredits: limit.awuCredits,
+              expiryKind: limit.expiryKind ?? null,
+            }
+          : { kind: limit.kind },
+        { transaction }
+      );
+    }
   });
 
-  const revert = () =>
-    membership.revertPoolCapOverride(previousPoolCapOverride);
+  // On a Metronome failure below, both the membership override and the
+  // linked request's grant snapshot are put back: the DB write is only
+  // valid once the derived Metronome sync has actually succeeded.
+  const revert = async () => {
+    await membership.revertPoolCapOverride(previousPoolCapOverride);
+    if (request && previousGrantSnapshot) {
+      await request.revertGrant(previousGrantSnapshot);
+    }
+  };
 
   switch (limit.kind) {
     case "unlimited": {

--- a/front/lib/resources/membership_upgrade_request_resource.ts
+++ b/front/lib/resources/membership_upgrade_request_resource.ts
@@ -8,6 +8,7 @@ import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import type { SpendLimitExpiryKind } from "@app/types/api/users/spend_limit";
 import type {
   MembershipSeatType,
   MembershipUpgradeRequestStatus,
@@ -18,9 +19,18 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
+import { Op } from "sequelize";
 
 export interface MembershipUpgradeRequestResource
   extends ReadonlyAttributesType<MembershipUpgradeRequestModel> {}
+
+type GrantSnapshot = Pick<
+  Attributes<MembershipUpgradeRequestModel>,
+  | "grantedAwuCredits"
+  | "grantedExpiryKind"
+  | "grantedUnlimitedSpend"
+  | "grantedSeatType"
+>;
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpgradeRequestModel> {
@@ -29,6 +39,7 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
 
   readonly requester: UserResource;
   readonly requesterSeatType: MembershipSeatType | null;
+  readonly resolvedByUser: UserResource | null;
 
   constructor(
     _: ModelStatic<MembershipUpgradeRequestModel>,
@@ -36,14 +47,17 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
     {
       requester,
       requesterSeatType,
+      resolvedByUser,
     }: {
       requester: UserResource;
       requesterSeatType: MembershipSeatType | null;
+      resolvedByUser?: UserResource | null;
     }
   ) {
     super(MembershipUpgradeRequestModel, blob);
     this.requester = requester;
     this.requesterSeatType = requesterSeatType;
+    this.resolvedByUser = resolvedByUser ?? null;
   }
 
   get sId(): string {
@@ -129,6 +143,17 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
     );
     const requesterByModelId = new Map(requesters.map((u) => [u.id, u]));
 
+    const resolvedByUserModelIds = rows.flatMap((r) =>
+      r.resolvedByUserId !== null ? [r.resolvedByUserId] : []
+    );
+    const resolvedByUsers =
+      resolvedByUserModelIds.length > 0
+        ? await UserResource.fetchByModelIds(resolvedByUserModelIds)
+        : [];
+    const resolvedByUserByModelId = new Map(
+      resolvedByUsers.map((u) => [u.id, u])
+    );
+
     const { memberships } = await MembershipResource.getActiveMemberships({
       users: requesters,
       workspace: auth.getNonNullableWorkspace(),
@@ -146,6 +171,10 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
         new this(this.model, r.get(), {
           requester,
           requesterSeatType: seatTypeByUserModelId.get(r.userId) ?? null,
+          resolvedByUser:
+            r.resolvedByUserId !== null
+              ? (resolvedByUserByModelId.get(r.resolvedByUserId) ?? null)
+              : null,
         }),
       ];
     });
@@ -171,6 +200,33 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
       where: { status: "pending" },
       order: [["createdAt", "DESC"]],
     });
+  }
+
+  // Resolved requests, most recent first
+  static async listResolvedByWorkspace(
+    auth: Authenticator,
+    { limit, offset }: { limit: number; offset: number }
+  ): Promise<{ requests: MembershipUpgradeRequestResource[]; total: number }> {
+    if (!auth.isManager()) {
+      return { requests: [], total: 0 };
+    }
+    const where = { status: { [Op.ne]: "pending" } };
+    const requests = await this.baseFetch(auth, {
+      where,
+      // `id` breaks ties between requests resolved at the same timestamp, so
+      // offset pagination stays stable across pages.
+      order: [
+        ["resolvedAt", "DESC"],
+        ["id", "DESC"],
+      ],
+      limit,
+      offset,
+    });
+
+    const total = await this.model.count({
+      where: { ...where, workspaceId: auth.getNonNullableWorkspace().id },
+    });
+    return { requests, total };
   }
 
   // Fetching an arbitrary request by id is a business-admin operation (a
@@ -226,6 +282,78 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
     return new Ok(undefined);
   }
 
+  // Snapshot of the currently-recorded grant, so a failed downstream sync can
+  // restore it exactly (mirrors `MembershipResource.poolCapOverrideSnapshot`).
+  get grantSnapshot(): GrantSnapshot {
+    return {
+      grantedAwuCredits: this.grantedAwuCredits,
+      grantedExpiryKind: this.grantedExpiryKind,
+      grantedUnlimitedSpend: this.grantedUnlimitedSpend,
+      grantedSeatType: this.grantedSeatType,
+    };
+  }
+
+  // Restore a grant from a snapshot. Used when a resolution's downstream
+  // effect (e.g. syncing the approved spend limit to Metronome) fails after
+  // the grant was already recorded, so the request doesn't claim a grant that
+  // was never actually applied.
+  async revertGrant(
+    snapshot: GrantSnapshot,
+    transaction?: Transaction
+  ): Promise<void> {
+    await this.update(snapshot, transaction);
+  }
+
+  // Snapshot the spend-limit override actually granted when this (approved)
+  // request was resolved
+  async recordGrant(
+    limit:
+      | { kind: "unlimited" }
+      | {
+          kind: "limited";
+          awuCredits: number;
+          expiryKind?: SpendLimitExpiryKind | null;
+        },
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    await this.update(
+      {
+        grantedAwuCredits: limit.kind === "limited" ? limit.awuCredits : null,
+        grantedExpiryKind:
+          limit.kind === "limited" ? (limit.expiryKind ?? null) : null,
+        grantedUnlimitedSpend: limit.kind === "unlimited",
+        grantedSeatType: null,
+      },
+      transaction
+    );
+  }
+
+  // Revert a resolution back to `pending` after a downstream side effect
+  // applied while claiming this request (e.g. the linked spend-limit sync)
+  // failed.
+  async revertToPending(transaction?: Transaction): Promise<void> {
+    await this.update(
+      { status: "pending", resolvedByUserId: null, resolvedAt: null },
+      transaction
+    );
+  }
+
+  // Snapshot the seat this (approved) request was resolved to
+  async recordSeatUpgrade(
+    seatType: MembershipSeatType,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    await this.update(
+      {
+        grantedSeatType: seatType,
+        grantedAwuCredits: null,
+        grantedExpiryKind: null,
+        grantedUnlimitedSpend: false,
+      },
+      transaction
+    );
+  }
+
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
@@ -267,6 +395,17 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
         image: this.requester.imageUrl ?? null,
         seatType: this.requesterSeatType,
       },
+      resolvedBy: this.resolvedByUser
+        ? {
+            sId: this.resolvedByUser.sId,
+            name: this.resolvedByUser.fullName() || this.resolvedByUser.name,
+            image: this.resolvedByUser.imageUrl ?? null,
+          }
+        : null,
+      grantedAwuCredits: this.grantedAwuCredits,
+      grantedExpiryKind: this.grantedExpiryKind,
+      grantedUnlimitedSpend: this.grantedUnlimitedSpend,
+      grantedSeatType: this.grantedSeatType,
     };
   }
 

--- a/front/lib/resources/storage/models/membership_upgrade_requests.ts
+++ b/front/lib/resources/storage/models/membership_upgrade_requests.ts
@@ -3,7 +3,10 @@ import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { SpendLimitExpiryKind } from "@app/types/api/users/spend_limit";
-import type { MembershipUpgradeRequestStatus, MembershipSeatType } from "@app/types/memberships";
+import type {
+  MembershipSeatType,
+  MembershipUpgradeRequestStatus,
+} from "@app/types/memberships";
 import {
   MAX_UPGRADE_REQUEST_REASON_LENGTH_CHARS,
   MEMBERSHIP_UPGRADE_REQUEST_PENDING_STATUS,

--- a/front/types/api/credits/upgrade_requests.ts
+++ b/front/types/api/credits/upgrade_requests.ts
@@ -1,8 +1,14 @@
 import type { UserSpendLimit } from "@app/types/api/users/spend_limit";
-import type { MembershipUpgradeRequestType } from "@app/types/memberships";
+import type {
+  MembershipSeatType,
+  MembershipUpgradeRequestType,
+} from "@app/types/memberships";
 
 export type GetUpgradeRequestsResponseBody = {
   requests: MembershipUpgradeRequestType[];
+  // Total resolved-request count, for the history view's pagination. Absent
+  // for the (unpaginated) pending-requests list.
+  total?: number;
 };
 
 export type PostUpgradeRequestResponseBody = {
@@ -11,7 +17,12 @@ export type PostUpgradeRequestResponseBody = {
 
 export type UpgradeRequestResolution =
   | { status: "denied" }
-  | { status: "approved"; limit?: UserSpendLimit };
+  | {
+      status: "approved";
+      limit?: UserSpendLimit;
+      // Set when the admin resolved the request via "Upgrade to max plan".
+      grantedSeatType?: MembershipSeatType;
+    };
 
 export type PatchUpgradeRequestResponseBody = {
   request: MembershipUpgradeRequestType;

--- a/front/types/api/users/spend_limit.ts
+++ b/front/types/api/users/spend_limit.ts
@@ -14,12 +14,12 @@ export type UserSpendLimit =
       // Epoch ms at which the override auto-reverts to unlimited. Omitted/null
       // means it never expires.
       expiresAt?: number | null;
+      expiryKind?: SpendLimitExpiryKind;
     };
 
 export type GetUserSpendLimitResponse = UserSpendLimit & {
-  // Epoch ms of this workspace's next AWU credit pool reset (Metronome
-  // billing period boundary), if resolvable from an active Metronome
-  // contract.
+  // Epoch ms of this workspace's next AWU credit pool reset
+  // if resolvable from an active Metronome contract.
   nextCreditResetAt: number | null;
 };
 

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -1,4 +1,5 @@
 import { NEAR_LIMIT_FRACTION } from "@app/lib/metronome/constants";
+import type { SpendLimitExpiryKind } from "@app/types/api/users/spend_limit";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export const MEMBERSHIP_ROLE_TYPES = [
@@ -303,6 +304,16 @@ export interface MembershipUpgradeRequestType {
     image: string | null;
     seatType: MembershipSeatType | null;
   };
+  resolvedBy: {
+    sId: string;
+    name: string;
+    image: string | null;
+  } | null;
+  // Snapshot of what was actually granted.
+  grantedAwuCredits: number | null;
+  grantedExpiryKind: SpendLimitExpiryKind | null;
+  grantedUnlimitedSpend: boolean;
+  grantedSeatType: MembershipSeatType | null;
 }
 
 /**


### PR DESCRIPTION
## Description

Until now, upgrade requests could be resolved, but the effective grant was not exposed in a history-oriented API and concurrent resolutions could apply conflicting side effects before the status compare-and-set completed. This PR adds the resource and API behavior needed for resolved-request history and records the grant that was actually applied.

The upgrade-request endpoint now supports manager-only `GET ?status=resolved` queries with stable newest-first ordering, offset pagination, a page size of 100, and a total count. Responses include the resolving admin and the grant snapshot. Pending-request behavior remains unchanged when `status` is omitted. Approval payloads can now carry either a spend-limit grant or a `grantedSeatType` for the “Upgrade to max plan” flow, but not both. The selected seat type is passed through the UI approval flow so it is recorded correctly.

Spend-limit updates accept an optional `requestId` and `expiryKind`. When linked to a request, the membership override and grant snapshot are written together, and the request ID is validated against the target user and request state. The grant snapshot is reverted if the downstream Metronome sync fails. Resolution now claims the request first with a pending-status compare-and-set, preventing two admins from applying competing resolutions; failed spend-limit application reverts the claim to pending so it can be retried.

This PR does not add the history UI. It depends on the schema and index migration from [#29960](https://github.com/dust-tt/dust/pull/29960).

## Tests

- Added API coverage for resolved-request filtering, ordering, pagination, grant snapshots, seat-approval wiring, and concurrent resolution behavior.
- Added spend-limit coverage for request validation, successful grant recording, and rollback after a Metronome failure.

## Risk

The main behavioral change is the ordering of request resolution: the request is claimed before the external spend-limit side effect, which closes the concurrent-approval race. Explicit Metronome failures roll the request back to pending and restore the previous membership and grant snapshot. Because the database update and external Metronome sync cannot be one atomic transaction, a process failure between the claim and the external sync remains an operational recovery risk. The new API fields are additive, while resolved-request consumers must handle nullable grant snapshots for older records and denied requests.

## Deploy Plan

Deploy the pre-deploy schema migration from [#29960](https://github.com/dust-tt/dust/pull/29960) before deploying this application change. No additional migration, backfill, feature flag, or manual rollout step is included in this PR. Monitor upgrade-request resolution and Metronome synchronization errors after deployment.