### PR TITLE
Add fullscreen mode for Pods Sheet in Files

### DIFF
--- a/front/components/pod/files/PodFrameSheet.tsx
+++ b/front/components/pod/files/PodFrameSheet.tsx
@@ -7,6 +7,9 @@ import { useFileContent, useFileMetadata } from "@app/lib/swr/files";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Button,
+  cn,
+  Maximize01,
+  Minimize01,
   Sheet,
   SheetClose,
   SheetContent,
@@ -15,7 +18,7 @@ import {
   Spinner,
   XClose,
 } from "@dust-tt/sparkle";
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface PodFrameSheetProps {
   fileId: string | null;
@@ -44,6 +47,7 @@ export function PodFrameSheet({
 }: PodFrameSheetProps) {
   const { vizUrl } = useAuth();
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
 
   const { fileContent } = useFileContent({
     fileId,
@@ -56,9 +60,24 @@ export function PodFrameSheet({
     owner,
   });
 
+  useEffect(() => {
+    if (!isOpen) {
+      setIsFullscreen(false);
+    }
+  }, [isOpen]);
+
   return (
     <Sheet open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <SheetContent size="xl">
+      <SheetContent
+        size="xl"
+        className={cn(isFullscreen && "inset-0 sm:max-w-none")}
+        onEscapeKeyDown={(e) => {
+          if (isFullscreen) {
+            e.preventDefault();
+            setIsFullscreen(false);
+          }
+        }}
+      >
         <SheetHeader hideButton>
           <div className="flex items-center gap-2">
             <SheetTitle className="flex-1 truncate">
@@ -82,6 +101,15 @@ export function PodFrameSheet({
                   framePath={framePath}
                   fileName={fileName}
                   hidden={isArchived}
+                />
+                <Button
+                  icon={isFullscreen ? Minimize01 : Maximize01}
+                  variant="ghost"
+                  size="sm"
+                  tooltip={
+                    isFullscreen ? "Exit full screen" : "Open in full screen"
+                  }
+                  onClick={() => setIsFullscreen((prev) => !prev)}
                 />
               </div>
             )}


### PR DESCRIPTION
## Description

`PodFrameSheet` gains a fullscreen toggle. A `Maximize01`/`Minimize01` button in the sheet header toggles `isFullscreen` state, which applies `inset-0 sm:max-w-none` to `SheetContent` to cover the viewport. Escape key in fullscreen exits fullscreen instead of closing the sheet. Fullscreen state resets when the sheet closes.

<img width="833" height="1391" alt="file-94ea4ea9a3c16460027d2f0b111e8d3e" src="https://github.com/user-attachments/assets/7cece4d1-4dfe-4766-8c02-0a502b93354c" />
<img width="1540" height="1394" alt="file-525076c2234a55b7e32caf76575a9988" src="https://github.com/user-attachments/assets/6d2352d9-ebe3-46e4-9799-5881fe112504" />


## Tests

Tested locally — opened a file in a Pod, toggled fullscreen on/off, verified Escape exits fullscreen without closing the sheet, and confirmed state resets on sheet close.

## Risk

Low. Pure UI state change isolated to `PodFrameSheet`. No logic, data, or API changes. Fully reversible.

## Deploy Plan

Deploy front.
