### PR TITLE
fix: Revert DB spend-limit writes when Metronome sync fails

### DIFF
--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -6,7 +6,7 @@ import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_ap
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -374,6 +374,88 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
           workspace,
         });
       expect(updatedMembership?.poolCapOverrideAwuCredits).toBe(1500);
+    });
+
+    it("reverts the DB override when the Metronome cap alert upsert fails", async () => {
+      vi.mocked(spendLimits.upsertMetronomePerUserCapAlert).mockResolvedValue(
+        new Err(new Error("Metronome unavailable"))
+      );
+
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const targetUser = await UserFactory.basic();
+      const membership = await MembershipFactory.associate(
+        workspace,
+        targetUser,
+        { role: "user" }
+      );
+      await membership.updatePoolCapOverride({
+        poolCapOverrideAwuCredits: 900,
+      });
+
+      await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        spendLimitUrl(workspace.sId, targetUser.sId),
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ kind: "limited", awuCredits: 1500 }),
+        }
+      );
+
+      expect(response.status).toBe(502);
+
+      const updatedMembership =
+        await MembershipResource.getActiveMembershipOfUserInWorkspace({
+          user: targetUser,
+          workspace,
+        });
+      expect(updatedMembership?.poolCapOverrideAwuCredits).toBe(900);
+    });
+
+    it("reverts the DB override when the Metronome cap alert clear fails", async () => {
+      vi.mocked(spendLimits.clearMetronomePerUserCapAlert).mockResolvedValue(
+        new Err(new Error("Metronome unavailable"))
+      );
+
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const targetUser = await UserFactory.basic();
+      const membership = await MembershipFactory.associate(
+        workspace,
+        targetUser,
+        { role: "user" }
+      );
+      await membership.updatePoolCapOverride({
+        poolCapOverrideAwuCredits: 900,
+      });
+
+      await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        spendLimitUrl(workspace.sId, targetUser.sId),
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ kind: "unlimited" }),
+        }
+      );
+
+      expect(response.status).toBe(502);
+
+      const updatedMembership =
+        await MembershipResource.getActiveMembershipOfUserInWorkspace({
+          user: targetUser,
+          workspace,
+        });
+      expect(updatedMembership?.poolCapOverrideAwuCredits).toBe(900);
     });
   });
 });

--- a/front/lib/api/groups/spend_limit.test.ts
+++ b/front/lib/api/groups/spend_limit.test.ts
@@ -10,7 +10,7 @@ import * as seatTypes from "@app/lib/metronome/seat_types";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { MembershipSeatType } from "@app/types/memberships";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import type { Subscription } from "@metronome/sdk/resources";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -217,6 +217,42 @@ describe("setGroupSpendLimit", () => {
     expect(
       groupCapAlert.upsertMetronomeGroupCapAlertForSeatType
     ).not.toHaveBeenCalled();
+    expect(workosAudit.emitAuditLogEvent).not.toHaveBeenCalled();
+  });
+
+  it("reverts the DB pool cap when the Metronome cap alert upsert fails", async () => {
+    vi.mocked(
+      groupCapAlert.upsertMetronomeGroupCapAlertForSeatType
+    ).mockResolvedValue(new Err(new Error("Metronome unavailable")));
+
+    const workspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const group = await GroupResource.makeNew({
+      name: "Sales",
+      workspaceId: workspace.id,
+      kind: "provisioned",
+      workOSGroupId: "fake-sales",
+    });
+    await group.updatePoolCap(auth, 10_000);
+
+    const result = await setGroupSpendLimit(auth, {
+      groupId: group.sId,
+      limit: { kind: "limited", awuCredits: 25_000 },
+      auditContext: AUDIT_CONTEXT,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.type).toBe("metronome_error");
+    }
+
+    const reloaded = await GroupResource.fetchById(auth, group.sId);
+    if (reloaded.isErr()) {
+      throw reloaded.error;
+    }
+    expect(reloaded.value.poolCapAwuCredits).toBe(10_000);
     expect(workosAudit.emitAuditLogEvent).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/groups/spend_limit.ts
+++ b/front/lib/api/groups/spend_limit.ts
@@ -278,8 +278,7 @@ export async function setGroupSpendLimit(
     poolCapAwuCredits,
   });
   if (syncResult.isErr()) {
-    // Metronome sync failed, so the DB and Metronome would otherwise be left
-    // out of sync until someone retries — put the DB value back.
+    // Metronome sync failed, restore DB values.
     await group.updatePoolCap(auth, previousPoolCapAwuCredits);
     logger.error(
       {

--- a/front/lib/api/groups/spend_limit.ts
+++ b/front/lib/api/groups/spend_limit.ts
@@ -260,6 +260,7 @@ export async function setGroupSpendLimit(
   }
 
   const poolCapAwuCredits = limit.kind === "limited" ? limit.awuCredits : null;
+  const previousPoolCapAwuCredits = group.poolCapAwuCredits;
 
   // Persist the admin's intent first: the group column is the source of truth,
   // the Metronome alerts below are derived enforcement (a failed sync can be
@@ -277,6 +278,18 @@ export async function setGroupSpendLimit(
     poolCapAwuCredits,
   });
   if (syncResult.isErr()) {
+    // Metronome sync failed, so the DB and Metronome would otherwise be left
+    // out of sync until someone retries — put the DB value back.
+    await group.updatePoolCap(auth, previousPoolCapAwuCredits);
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        groupId: group.sId,
+        previousPoolCapAwuCredits,
+        err: syncResult.error,
+      },
+      "[GroupSpendLimit] set: failed to sync cap alerts; reverted DB pool cap"
+    );
     return new Err(syncResult.error);
   }
 

--- a/front/lib/api/groups/spend_limit.ts
+++ b/front/lib/api/groups/spend_limit.ts
@@ -18,6 +18,7 @@ import {
   getSeatSubscriptionsFromContract,
 } from "@app/lib/metronome/seat_types";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import { revertOnSyncFailure } from "@app/lib/spend_limits/revert_on_sync_failure";
 import logger from "@app/logger/logger";
 import type {
   GroupSpendLimit,
@@ -272,23 +273,25 @@ export async function setGroupSpendLimit(
     );
   }
 
-  const syncResult = await syncGroupCapAlertsForGroup({
-    workspace,
-    groupId: group.sId,
-    poolCapAwuCredits,
-  });
-  if (syncResult.isErr()) {
-    // Metronome sync failed, restore DB values.
-    await group.updatePoolCap(auth, previousPoolCapAwuCredits);
-    logger.error(
-      {
+  const syncResult = await revertOnSyncFailure(
+    await syncGroupCapAlertsForGroup({
+      workspace,
+      groupId: group.sId,
+      poolCapAwuCredits,
+    }),
+    {
+      revert: async () => {
+        await group.updatePoolCap(auth, previousPoolCapAwuCredits);
+      },
+      logContext: {
+        scope: "group",
         workspaceId: workspace.sId,
         groupId: group.sId,
         previousPoolCapAwuCredits,
-        err: syncResult.error,
       },
-      "[GroupSpendLimit] set: failed to sync cap alerts; reverted DB pool cap"
-    );
+    }
+  );
+  if (syncResult.isErr()) {
     return new Err(syncResult.error);
   }
 

--- a/front/lib/api/keys/spend_limit.test.ts
+++ b/front/lib/api/keys/spend_limit.test.ts
@@ -1,0 +1,107 @@
+import { setApiKeySpendLimit } from "@app/lib/api/keys/spend_limit";
+import { Authenticator } from "@app/lib/auth";
+import * as apiKeyCapAlert from "@app/lib/metronome/alerts/api_key_caps";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { KeyResource } from "@app/lib/resources/key_resource";
+import { KeyFactory } from "@app/tests/utils/KeyFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/alerts/api_key_caps", async () => {
+  const actual = await vi.importActual<typeof apiKeyCapAlert>(
+    "@app/lib/metronome/alerts/api_key_caps"
+  );
+  return {
+    ...actual,
+    clearMetronomeApiKeyCapAlert: vi.fn(),
+    upsertMetronomeApiKeyCapAlert: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.mocked(apiKeyCapAlert.clearMetronomeApiKeyCapAlert).mockResolvedValue(
+    new Ok(undefined)
+  );
+  vi.mocked(apiKeyCapAlert.upsertMetronomeApiKeyCapAlert).mockResolvedValue(
+    new Ok({ alertId: "alert_key_cap_xxx" })
+  );
+});
+
+describe("setApiKeySpendLimit", () => {
+  it("persists the cap and upserts the Metronome alert", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const { globalGroup } =
+      await GroupResource.makeDefaultsForWorkspace(workspace);
+    const key = await KeyFactory.regular(globalGroup);
+
+    const result = await setApiKeySpendLimit(auth, {
+      keyModelId: key.id,
+      limit: { kind: "limited", awuCredits: 25_000 },
+    });
+
+    expect(result.isOk()).toBe(true);
+    const reloaded = await KeyResource.fetchByWorkspaceAndId({
+      workspace,
+      id: key.id,
+    });
+    expect(reloaded?.monthlyCapAwuCredits).toBe(25_000);
+  });
+
+  it("reverts the DB cap when the Metronome cap alert upsert fails", async () => {
+    vi.mocked(apiKeyCapAlert.upsertMetronomeApiKeyCapAlert).mockResolvedValue(
+      new Err(new Error("Metronome unavailable"))
+    );
+
+    const workspace = await WorkspaceFactory.creditPriced();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const { globalGroup } =
+      await GroupResource.makeDefaultsForWorkspace(workspace);
+    const key = await KeyFactory.regular(globalGroup);
+    await key.updateMonthlyCapAwuCredits(10_000);
+
+    const result = await setApiKeySpendLimit(auth, {
+      keyModelId: key.id,
+      limit: { kind: "limited", awuCredits: 25_000 },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.type).toBe("metronome_error");
+    }
+    const reloaded = await KeyResource.fetchByWorkspaceAndId({
+      workspace,
+      id: key.id,
+    });
+    expect(reloaded?.monthlyCapAwuCredits).toBe(10_000);
+  });
+
+  it("reverts the DB cap when the Metronome cap alert clear fails", async () => {
+    vi.mocked(apiKeyCapAlert.clearMetronomeApiKeyCapAlert).mockResolvedValue(
+      new Err(new Error("Metronome unavailable"))
+    );
+
+    const workspace = await WorkspaceFactory.creditPriced();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const { globalGroup } =
+      await GroupResource.makeDefaultsForWorkspace(workspace);
+    const key = await KeyFactory.regular(globalGroup);
+    await key.updateMonthlyCapAwuCredits(10_000);
+
+    const result = await setApiKeySpendLimit(auth, {
+      keyModelId: key.id,
+      limit: { kind: "unlimited" },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.type).toBe("metronome_error");
+    }
+    const reloaded = await KeyResource.fetchByWorkspaceAndId({
+      workspace,
+      id: key.id,
+    });
+    expect(reloaded?.monthlyCapAwuCredits).toBe(10_000);
+  });
+});

--- a/front/lib/api/keys/spend_limit.ts
+++ b/front/lib/api/keys/spend_limit.ts
@@ -8,6 +8,7 @@ import {
   upsertMetronomeApiKeyCapAlert,
 } from "@app/lib/metronome/alerts/api_key_caps";
 import { KeyResource } from "@app/lib/resources/key_resource";
+import { revertOnSyncFailure } from "@app/lib/spend_limits/revert_on_sync_failure";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type {
@@ -142,25 +143,29 @@ export async function setApiKeySpendLimit(
     limit.kind === "limited" ? limit.awuCredits : null
   );
 
+  const revert = () =>
+    key.updateMonthlyCapAwuCredits(previousMonthlyCapAwuCredits);
+
   switch (limit.kind) {
     case "unlimited": {
-      const clearResult = await clearMetronomeApiKeyCapAlert({
-        metronomeCustomerId,
-        workspaceId: workspace.sId,
-        keyName: key.name,
-      });
-      if (clearResult.isErr()) {
-        // Metronome sync failed, restore DB values.
-        await key.updateMonthlyCapAwuCredits(previousMonthlyCapAwuCredits);
-        logger.error(
-          {
+      const clearResult = await revertOnSyncFailure(
+        await clearMetronomeApiKeyCapAlert({
+          metronomeCustomerId,
+          workspaceId: workspace.sId,
+          keyName: key.name,
+        }),
+        {
+          revert,
+          logContext: {
+            scope: "api_key",
+            operation: "clear_cap_alert",
             workspaceId: workspace.sId,
             keyName: key.name,
             previousMonthlyCapAwuCredits,
-            err: clearResult.error,
           },
-          "[Metronome ApiKeyCap] set(unlimited): failed to clear cap alert; reverted DB cap"
-        );
+        }
+      );
+      if (clearResult.isErr()) {
         return new Err(
           new ApiKeySpendLimitError(
             "metronome_error",
@@ -171,26 +176,26 @@ export async function setApiKeySpendLimit(
       break;
     }
     case "limited": {
-      const upsertResult = await upsertMetronomeApiKeyCapAlert({
-        metronomeCustomerId,
-        workspaceId: workspace.sId,
-        keyName: key.name,
-        awuCredits: limit.awuCredits,
-      });
-      if (upsertResult.isErr()) {
-        // Metronome sync failed, so the DB and Metronome would otherwise be
-        // left out of sync until someone retries — put the DB value back.
-        await key.updateMonthlyCapAwuCredits(previousMonthlyCapAwuCredits);
-        logger.error(
-          {
+      const upsertResult = await revertOnSyncFailure(
+        await upsertMetronomeApiKeyCapAlert({
+          metronomeCustomerId,
+          workspaceId: workspace.sId,
+          keyName: key.name,
+          awuCredits: limit.awuCredits,
+        }),
+        {
+          revert,
+          logContext: {
+            scope: "api_key",
+            operation: "upsert_cap_alert",
             workspaceId: workspace.sId,
             keyName: key.name,
             awuCredits: limit.awuCredits,
             previousMonthlyCapAwuCredits,
-            err: upsertResult.error,
           },
-          "[Metronome ApiKeyCap] set(limited): failed to upsert cap alert; reverted DB cap"
-        );
+        }
+      );
+      if (upsertResult.isErr()) {
         return new Err(
           new ApiKeySpendLimitError(
             "metronome_error",

--- a/front/lib/api/keys/spend_limit.ts
+++ b/front/lib/api/keys/spend_limit.ts
@@ -137,6 +137,7 @@ export async function setApiKeySpendLimit(
   );
 
   // Persist the admin's intent first (source of truth), then derive the alert.
+  const previousMonthlyCapAwuCredits = key.monthlyCapAwuCredits;
   await key.updateMonthlyCapAwuCredits(
     limit.kind === "limited" ? limit.awuCredits : null
   );
@@ -149,13 +150,17 @@ export async function setApiKeySpendLimit(
         keyName: key.name,
       });
       if (clearResult.isErr()) {
+        // Metronome sync failed, so the DB and Metronome would otherwise be
+        // left out of sync until someone retries — put the DB value back.
+        await key.updateMonthlyCapAwuCredits(previousMonthlyCapAwuCredits);
         logger.error(
           {
             workspaceId: workspace.sId,
             keyName: key.name,
+            previousMonthlyCapAwuCredits,
             err: clearResult.error,
           },
-          "[Metronome ApiKeyCap] set(unlimited): failed to clear cap alert"
+          "[Metronome ApiKeyCap] set(unlimited): failed to clear cap alert; reverted DB cap"
         );
         return new Err(
           new ApiKeySpendLimitError(
@@ -174,14 +179,18 @@ export async function setApiKeySpendLimit(
         awuCredits: limit.awuCredits,
       });
       if (upsertResult.isErr()) {
+        // Metronome sync failed, so the DB and Metronome would otherwise be
+        // left out of sync until someone retries — put the DB value back.
+        await key.updateMonthlyCapAwuCredits(previousMonthlyCapAwuCredits);
         logger.error(
           {
             workspaceId: workspace.sId,
             keyName: key.name,
             awuCredits: limit.awuCredits,
+            previousMonthlyCapAwuCredits,
             err: upsertResult.error,
           },
-          "[Metronome ApiKeyCap] set(limited): failed to upsert cap alert"
+          "[Metronome ApiKeyCap] set(limited): failed to upsert cap alert; reverted DB cap"
         );
         return new Err(
           new ApiKeySpendLimitError(

--- a/front/lib/api/keys/spend_limit.ts
+++ b/front/lib/api/keys/spend_limit.ts
@@ -150,8 +150,7 @@ export async function setApiKeySpendLimit(
         keyName: key.name,
       });
       if (clearResult.isErr()) {
-        // Metronome sync failed, so the DB and Metronome would otherwise be
-        // left out of sync until someone retries — put the DB value back.
+        // Metronome sync failed, restore DB values.
         await key.updateMonthlyCapAwuCredits(previousMonthlyCapAwuCredits);
         logger.error(
           {

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -29,6 +29,7 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { currentCalendarMonthCycleUtc } from "@app/lib/spend_limits/cycle";
+import { revertOnSyncFailure } from "@app/lib/spend_limits/revert_on_sync_failure";
 import {
   addFixedWindowCount,
   type FixedWindowBounds,
@@ -226,26 +227,30 @@ export async function setUserSpendLimit(
       limit.kind === "limited" ? limit.awuCredits : null,
   });
 
+  const revert = () =>
+    membership.revertPoolCapOverride(previousPoolCapOverride);
+
   switch (limit.kind) {
     case "unlimited": {
-      const clearResult = await clearMetronomePerUserCapAlert({
-        metronomeCustomerId: workspace.metronomeCustomerId,
-        workspaceId: workspace.sId,
-        userId: user.sId,
-      });
-      if (clearResult.isErr()) {
-        // Metronome sync failed, put the DB value back.
-        await membership.revertPoolCapOverride(previousPoolCapOverride);
-        logger.error(
-          {
+      const clearResult = await revertOnSyncFailure(
+        await clearMetronomePerUserCapAlert({
+          metronomeCustomerId: workspace.metronomeCustomerId,
+          workspaceId: workspace.sId,
+          userId: user.sId,
+        }),
+        {
+          revert,
+          logContext: {
+            scope: "user",
+            operation: "clear_cap_alert",
             workspaceId: workspace.sId,
             metronomeCustomerId: workspace.metronomeCustomerId,
             userId: user.sId,
             previousAwuCredits,
-            err: clearResult.error,
           },
-          "[Metronome PerUserCap] failed to update metronome, overage is still active."
-        );
+        }
+      );
+      if (clearResult.isErr()) {
         return new Err(
           new UserSpendLimitError("metronome_error", clearResult.error.message)
         );
@@ -273,27 +278,27 @@ export async function setUserSpendLimit(
         membership
       );
       const totalAwuCredits = limit.awuCredits + seatAllowanceAwuCredits;
-      const upsertResult = await upsertMetronomePerUserCapAlert({
-        metronomeCustomerId: workspace.metronomeCustomerId,
-        workspaceId: workspace.sId,
-        userId: user.sId,
-        awuCredits: totalAwuCredits,
-      });
-      if (upsertResult.isErr()) {
-        // Metronome sync failed, so the DB and Metronome would otherwise be
-        // left out of sync until someone retries, put the DB value back.
-        await membership.revertPoolCapOverride(previousPoolCapOverride);
-        logger.error(
-          {
+      const upsertResult = await revertOnSyncFailure(
+        await upsertMetronomePerUserCapAlert({
+          metronomeCustomerId: workspace.metronomeCustomerId,
+          workspaceId: workspace.sId,
+          userId: user.sId,
+          awuCredits: totalAwuCredits,
+        }),
+        {
+          revert,
+          logContext: {
+            scope: "user",
+            operation: "upsert_cap_alert",
             workspaceId: workspace.sId,
             userId: user.sId,
             awuCredits: totalAwuCredits,
             seatAllowance: seatAllowanceAwuCredits,
             previousAwuCredits,
-            err: upsertResult.error,
           },
-          "[Metronome PerUserCap] Failed to upsert per-user cap alert; reverted DB override"
-        );
+        }
+      );
+      if (upsertResult.isErr()) {
         return new Err(
           new UserSpendLimitError("metronome_error", upsertResult.error.message)
         );
@@ -402,45 +407,52 @@ export async function expireUserSpendLimitOverride(
     poolCapOverrideExpiresAt: null,
   });
 
-  const clearResult = await clearMetronomePerUserCapAlert({
-    metronomeCustomerId: workspace.metronomeCustomerId,
-    workspaceId: workspace.sId,
-    userId: user.sId,
-  });
-  if (clearResult.isErr()) {
-    // Metronome is still enforcing the old cap, so put the DB override back
-    // in place rather than leaving it cleared: keeps DB and Metronome
-    // consistent
-    await membership.revertPoolCapOverride(previousPoolCapOverride);
-    logger.error(
-      {
+  // On any Metronome failure below, the DB override is put back rather than
+  // left cleared: keeps DB and Metronome consistent, and the membership still
+  // matches `listActiveWithExpiredPoolCapOverride` so the next sweep retries it.
+  const revert = () =>
+    membership.revertPoolCapOverride(previousPoolCapOverride);
+
+  const clearResult = await revertOnSyncFailure(
+    await clearMetronomePerUserCapAlert({
+      metronomeCustomerId: workspace.metronomeCustomerId,
+      workspaceId: workspace.sId,
+      userId: user.sId,
+    }),
+    {
+      revert,
+      logContext: {
+        scope: "user",
+        operation: "expire_clear_cap_alert",
         workspaceId: workspace.sId,
         userId: user.sId,
         previousAwuCredits,
-        err: clearResult.error,
       },
-      "[SpendLimitExpiration] Failed to clear per-user cap alert; reverted DB override back, will retry on next sweep"
-    );
+    }
+  );
+  if (clearResult.isErr()) {
     return new Err(
       new UserSpendLimitError("metronome_error", clearResult.error.message)
     );
   }
-  const clearWarningResult = await clearMetronomePerUserWarningAlert({
-    metronomeCustomerId: workspace.metronomeCustomerId,
-    workspaceId: workspace.sId,
-    userId: user.sId,
-  });
-  if (clearWarningResult.isErr()) {
-    await membership.revertPoolCapOverride(previousPoolCapOverride);
-    logger.error(
-      {
+  const clearWarningResult = await revertOnSyncFailure(
+    await clearMetronomePerUserWarningAlert({
+      metronomeCustomerId: workspace.metronomeCustomerId,
+      workspaceId: workspace.sId,
+      userId: user.sId,
+    }),
+    {
+      revert,
+      logContext: {
+        scope: "user",
+        operation: "expire_clear_warning_alert",
         workspaceId: workspace.sId,
         userId: user.sId,
         previousAwuCredits,
-        err: clearWarningResult.error,
       },
-      "[SpendLimitExpiration] Failed to clear warning alert; reverted DB override back, will retry on next sweep"
-    );
+    }
+  );
+  if (clearWarningResult.isErr()) {
     return new Err(
       new UserSpendLimitError(
         "metronome_error",

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -408,8 +408,7 @@ export async function expireUserSpendLimitOverride(
   });
 
   // On any Metronome failure below, the DB override is put back rather than
-  // left cleared: keeps DB and Metronome consistent, and the membership still
-  // matches `listActiveWithExpiredPoolCapOverride` so the next sweep retries it.
+  // left cleared: keeps DB and Metronome consistent
   const revert = () =>
     membership.revertPoolCapOverride(previousPoolCapOverride);
 

--- a/front/lib/api/workspace/default_user_spend_limit.test.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.test.ts
@@ -289,7 +289,7 @@ describe("setDefaultUserSpendLimit", () => {
     expect(workosAudit.emitAuditLogEvent).not.toHaveBeenCalled();
   });
 
-  it("surfaces upsert failures as metronome_error and skips audit", async () => {
+  it("surfaces upsert failures as metronome_error, skips audit, and deletes the newly created config row", async () => {
     const workspace = await WorkspaceFactory.metronome({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
     });
@@ -308,5 +308,36 @@ describe("setDefaultUserSpendLimit", () => {
       expect(result.error.type).toBe("metronome_error");
     }
     expect(workosAudit.emitAuditLogEvent).not.toHaveBeenCalled();
+    // No config existed before the call, so the failed sync must not leave
+    // a stale row behind.
+    expect(
+      await CreditUsageConfigurationResource.fetchByWorkspaceId(auth)
+    ).toBeNull();
+  });
+
+  it("reverts an existing config row back to its previous value when the upsert fails", async () => {
+    const workspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await CreditUsageConfigurationResource.makeNew(auth, {
+      defaultDiscountPercent: 0,
+      usageCapCredits: null,
+      defaultPoolCapAwuCredits: 10_000,
+    });
+    vi.mocked(
+      defaultUserCapAlert.upsertMetronomeDefaultUserCapAlertForSeatType
+    ).mockResolvedValue(new Err(new Error("metronome down")));
+
+    const result = await setDefaultUserSpendLimit(auth, {
+      awuCredits: 25_000,
+      auditContext: AUDIT_CONTEXT,
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(workosAudit.emitAuditLogEvent).not.toHaveBeenCalled();
+    const reloaded =
+      await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+    expect(reloaded?.defaultPoolCapAwuCredits).toBe(10_000);
   });
 });

--- a/front/lib/api/workspace/default_user_spend_limit.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.ts
@@ -322,10 +322,8 @@ export async function setDefaultUserSpendLimit(
   // Sync per-seat-type Metronome alerts from the newly persisted value.
   const syncResult = await syncDefaultPoolCapAlertsForWorkspace(workspace);
   if (syncResult.isErr()) {
-    // Metronome sync failed, so the DB and Metronome would otherwise be left
-    // out of sync until someone retries — put the DB value back. There was no
-    // row before this call, so undo by deleting the one just created rather
-    // than leaving a stale `defaultPoolCapAwuCredits: 0` row behind.
+    // Metronome sync failed, restore DB values. There was no
+    // row before this call, so undo by deleting the one just created.
     if (existingConfig) {
       await existingConfig.updateConfiguration(auth, {
         defaultPoolCapAwuCredits: previousAwuCredits,

--- a/front/lib/api/workspace/default_user_spend_limit.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.ts
@@ -16,6 +16,7 @@ import {
   getSeatSubscriptionsFromContract,
 } from "@app/lib/metronome/seat_types";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import { revertOnSyncFailure } from "@app/lib/spend_limits/revert_on_sync_failure";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type {
@@ -320,26 +321,29 @@ export async function setDefaultUserSpendLimit(
   }
 
   // Sync per-seat-type Metronome alerts from the newly persisted value.
-  const syncResult = await syncDefaultPoolCapAlertsForWorkspace(workspace);
-  if (syncResult.isErr()) {
-    // Metronome sync failed, restore DB values. There was no
-    // row before this call, so undo by deleting the one just created.
-    if (existingConfig) {
-      await existingConfig.updateConfiguration(auth, {
-        defaultPoolCapAwuCredits: previousAwuCredits,
-      });
-    } else {
-      await createdConfig?.delete(auth);
-    }
-    logger.error(
-      {
+  const syncResult = await revertOnSyncFailure(
+    await syncDefaultPoolCapAlertsForWorkspace(workspace),
+    {
+      // There was no row before this call, so undo by deleting the one just
+      // created.
+      revert: async () => {
+        if (existingConfig) {
+          await existingConfig.updateConfiguration(auth, {
+            defaultPoolCapAwuCredits: previousAwuCredits,
+          });
+        } else {
+          await createdConfig?.delete(auth);
+        }
+      },
+      logContext: {
+        scope: "default_user",
         workspaceId: workspace.sId,
         metronomeCustomerId,
         previousAwuCredits,
-        err: syncResult.error,
       },
-      "[DefaultUserSpendLimit] set: failed to sync cap alerts; reverted DB pool cap"
-    );
+    }
+  );
+  if (syncResult.isErr()) {
     return new Err(syncResult.error);
   }
 

--- a/front/lib/api/workspace/default_user_spend_limit.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.ts
@@ -297,21 +297,51 @@ export async function setDefaultUserSpendLimit(
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
   const previousAwuCredits = existingConfig?.defaultPoolCapAwuCredits ?? 0;
 
+  let createdConfig: CreditUsageConfigurationResource | null = null;
   if (existingConfig) {
     await existingConfig.updateConfiguration(auth, {
       defaultPoolCapAwuCredits: poolAwuCredits,
     });
   } else {
-    await CreditUsageConfigurationResource.makeNew(auth, {
+    const makeNewResult = await CreditUsageConfigurationResource.makeNew(auth, {
       defaultDiscountPercent: 0,
       usageCapCredits: null,
       defaultPoolCapAwuCredits: poolAwuCredits,
     });
+    if (makeNewResult.isErr()) {
+      return new Err(
+        new DefaultUserSpendLimitError(
+          "metronome_error",
+          makeNewResult.error.message
+        )
+      );
+    }
+    createdConfig = makeNewResult.value;
   }
 
   // Sync per-seat-type Metronome alerts from the newly persisted value.
   const syncResult = await syncDefaultPoolCapAlertsForWorkspace(workspace);
   if (syncResult.isErr()) {
+    // Metronome sync failed, so the DB and Metronome would otherwise be left
+    // out of sync until someone retries — put the DB value back. There was no
+    // row before this call, so undo by deleting the one just created rather
+    // than leaving a stale `defaultPoolCapAwuCredits: 0` row behind.
+    if (existingConfig) {
+      await existingConfig.updateConfiguration(auth, {
+        defaultPoolCapAwuCredits: previousAwuCredits,
+      });
+    } else {
+      await createdConfig?.delete(auth);
+    }
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        metronomeCustomerId,
+        previousAwuCredits,
+        err: syncResult.error,
+      },
+      "[DefaultUserSpendLimit] set: failed to sync cap alerts; reverted DB pool cap"
+    );
     return new Err(syncResult.error);
   }
 

--- a/front/lib/spend_limits/revert_on_sync_failure.ts
+++ b/front/lib/spend_limits/revert_on_sync_failure.ts
@@ -2,12 +2,9 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 
 /**
- * Every spend-limit setter persists the caller's intent to Postgres first (the
- * source of truth) and only then derives the Metronome alerts from it. When
- * that derived sync fails, the DB write must be rolled back — otherwise DB and
- * Metronome are left diverged until someone retries. This wraps that
- * revert-then-log step so each spend-limit setter doesn't restate it around
- * every Metronome call it makes.
+ * Every spend-limit setter persists the caller's intent to Postgres first
+ * and only then derives the Metronome alerts from it. When
+ * that derived sync fails, the DB write must be rolled back
  */
 export async function revertOnSyncFailure<T, E>(
   result: Result<T, E>,

--- a/front/lib/spend_limits/revert_on_sync_failure.ts
+++ b/front/lib/spend_limits/revert_on_sync_failure.ts
@@ -1,0 +1,30 @@
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+
+/**
+ * Every spend-limit setter persists the caller's intent to Postgres first (the
+ * source of truth) and only then derives the Metronome alerts from it. When
+ * that derived sync fails, the DB write must be rolled back — otherwise DB and
+ * Metronome are left diverged until someone retries. This wraps that
+ * revert-then-log step so each spend-limit setter doesn't restate it around
+ * every Metronome call it makes.
+ */
+export async function revertOnSyncFailure<T, E>(
+  result: Result<T, E>,
+  {
+    revert,
+    logContext,
+  }: {
+    revert: () => Promise<void>;
+    logContext: Record<string, unknown>;
+  }
+): Promise<Result<T, E>> {
+  if (result.isErr()) {
+    await revert();
+    logger.error(
+      { ...logContext, err: result.error },
+      "[SpendLimit] Metronome sync failed; reverted DB value"
+    );
+  }
+  return result;
+}


### PR DESCRIPTION
## Description

Until now, the spend-limit setters persisted the new value to Postgres before synchronizing the derived Metronome cap alerts. If a Metronome upsert or clear failed, the database retained the new value while Metronome could still be enforcing the previous one, leaving the two systems out of sync until a retry or manual intervention.

This PR captures the previous value before writing and centralizes the failure path in `revertOnSyncFailure`. On a Metronome sync error, it restores the previous group, API key, or user override; for a newly created default-user configuration, it deletes the row instead. The error is still returned to the caller, and failed operations continue to skip audit events. Successful synchronization and the existing database-first source-of-truth behavior are unchanged.

Regression coverage covers group, API key, per-user upsert and clear, and default-user configurations with both newly created and existing rows. Related stacked change: [#29921](https://github.com/dust-tt/dust/pull/29921).

## Tests

- Added regression tests for group, API key, per-user endpoint upsert and clear, and default-user configuration rollback paths.

## Risk

This changes the failure path for spend-limit writes and reduces the risk of database/Metronome drift. There is no schema migration or change to the successful path. The operation still fails when Metronome synchronization fails, but the database value is restored before the error is returned. If the compensating database write itself fails, the rollback cannot complete and the resulting inconsistency still requires operational attention.

## Deploy Plan

The change is application-only; no migration, backfill, feature flag, or special rollout order. Just deploy front.