### PR TITLE
[front] chore: ignore React Doctor combine iterations rule

### DIFF
--- a/doctor.config.json
+++ b/doctor.config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://react.doctor/schema/config.json",
   "rules": {
-    "react-doctor/only-export-components": "off"
+    "react-doctor/only-export-components": "off",
+    "react-doctor/js-combine-iterations": "off"
   }
 }


### PR DESCRIPTION
## Description

React Doctor's combine-iterations recommendation are quite noisy in CI checks and usually not very relevant.

This PR disables `react-doctor/js-combine-iterations` in the repository config while preserving the existing `only-export-components` override.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- No deploy.