### PR TITLE
[front] enh: add Usage column to Skills table

### DIFF
--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -8,6 +8,7 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { discoverToolsSkill } from "@app/lib/resources/skill/code_defined/system/discover_tools";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
@@ -740,6 +741,74 @@ describe("GET /api/w/:wId/skills", () => {
 });
 
 describe("GET /api/w/:wId/skills?withRelations=true", () => {
+  it("should return the number of messages using each skill", async () => {
+    const { workspace, user } = await setupTest();
+
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const skill = await SkillFactory.create(auth, {
+      name: "Skill Used In Messages",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+
+    await skill.enableForAgent(auth, {
+      agentConfiguration: agent,
+      conversation,
+    });
+
+    const firstAgentMessage =
+      await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conversation.id,
+        rank: 0,
+        agentConfigurationId: agent.sId,
+      });
+    if (!firstAgentMessage.agentMessageId) {
+      throw new Error("Expected an agent message");
+    }
+    await SkillResource.snapshotConversationSkillsForMessage(auth, {
+      agentConfigurationId: agent.sId,
+      agentMessageId: firstAgentMessage.agentMessageId,
+      conversationId: conversation.id,
+    });
+
+    const secondAgentMessage =
+      await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conversation.id,
+        rank: 1,
+        agentConfigurationId: agent.sId,
+      });
+    if (!secondAgentMessage.agentMessageId) {
+      throw new Error("Expected an agent message");
+    }
+    await SkillResource.snapshotConversationSkillsForMessage(auth, {
+      agentConfigurationId: agent.sId,
+      agentMessageId: secondAgentMessage.agentMessageId,
+      conversationId: conversation.id,
+    });
+
+    const response = await getSkills(workspace, {
+      withRelations: "true",
+      withMessageCount: "true",
+    });
+
+    expect(response.status).toBe(200);
+    const responseBody: GetSkillsWithRelationsResponseBody =
+      await response.json();
+    const skillResult = responseBody.skills.find(
+      (listedSkill) => listedSkill.sId === skill.sId
+    );
+
+    expect(skillResult?.messageCount).toBe(2);
+  });
+
   it("should return skills with usage when linked to agents", async () => {
     const { workspace, user } = await setupTest();
 
@@ -848,6 +917,7 @@ describe("GET /api/w/:wId/skills?withRelations=true", () => {
         usage: { count: 0, agents: [], skills: [] },
       },
     });
+    expect(skillResult).not.toHaveProperty("messageCount");
   });
 
   it("should return child skills", async () => {

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -128,6 +128,7 @@ app.get(
     // @deprecated viewType query param is ignored — instructions and tools
     // are never returned from the list endpoint. Use GET /skills/:sId for full details.
     const withRelations = ctx.req.query("withRelations");
+    const withMessageCount = ctx.req.query("withMessageCount") === "true";
     const status = ctx.req.query("status");
     const globalSpaceOnly = ctx.req.query("globalSpaceOnly");
     const onlyCustom = ctx.req.query("onlyCustom");
@@ -216,6 +217,9 @@ app.get(
 
     if (withRelations === "true") {
       const usageMap = await SkillResource.batchFetchUsage(auth, skills);
+      const messageCountMap = withMessageCount
+        ? await SkillResource.batchFetchMessageCounts(auth, skills)
+        : null;
       const editorsMap = await SkillResource.batchListEditors(auth, skills);
       const editedByUsersMap = await SkillResource.batchFetchEditedByUsers(
         auth,
@@ -253,6 +257,9 @@ app.get(
 
         return {
           ...skillWithoutInstructionsAndTools,
+          ...(messageCountMap
+            ? { messageCount: messageCountMap.get(sc.sId) ?? 0 }
+            : {}),
           relations: {
             usage: usageWithSkills,
             editors: editors ? editors.map((e) => e.toJSON()) : null,

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -217,9 +217,13 @@ app.get(
 
     if (withRelations === "true") {
       const usageMap = await SkillResource.batchFetchUsage(auth, skills);
-      const messageCountMap = withMessageCount
-        ? await SkillResource.batchFetchMessageCounts(auth, skills)
-        : null;
+      let messageCountMap: Map<string, number> | null = null;
+      if (withMessageCount) {
+        messageCountMap = await SkillResource.batchFetchMessageCounts(
+          auth,
+          skills
+        );
+      }
       const editorsMap = await SkillResource.batchListEditors(auth, skills);
       const editedByUsersMap = await SkillResource.batchFetchEditedByUsers(
         auth,

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -134,6 +134,7 @@ export function ManageSkillsPage() {
     owner,
     status: "active",
     bypassEditorVisibility: isBypassEditorVisibilityEnabled,
+    withMessageCount: true,
   });
 
   const {
@@ -144,6 +145,7 @@ export function ManageSkillsPage() {
     status: "archived",
     disabled: selectedTab !== "archived",
     bypassEditorVisibility: isBypassEditorVisibilityEnabled,
+    withMessageCount: true,
   });
 
   const {

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -174,7 +174,7 @@ const usageColumn: ColumnDef<RowData, number> = {
     />
   ),
   meta: {
-    className: "hidden @sm:w-16 @sm:table-cell",
+    className: "hidden @sm:w-20 @sm:table-cell",
     tooltip: "All-time messages",
   },
 };

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -39,6 +39,7 @@ type RowData = {
   availability: SkillAvailability;
   editors: UserType[] | null;
   usage: SkillUsageType;
+  messageCount: number;
   updatedAt: number | null;
   createdAt: number | null;
   onClick: () => void;
@@ -163,6 +164,21 @@ const usedByColumn = (
   },
 });
 
+const usageColumn: ColumnDef<RowData, number> = {
+  header: "Usage",
+  accessorKey: "messageCount",
+  cell: (info: CellContext<RowData, number>) => (
+    <DataTable.BasicCellContent
+      className="font-mono"
+      label={info.getValue().toLocaleString()}
+    />
+  ),
+  meta: {
+    className: "hidden @sm:w-16 @sm:table-cell",
+    tooltip: "All-time messages",
+  },
+};
+
 const lastEditedColumn = {
   header: "Last Edited",
   accessorKey: "updatedAt",
@@ -204,6 +220,7 @@ const getTableColumns = ({
    * - Name (always)
    * - Access (hidden on mobile)
    * - Used by (hidden on mobile)
+   * - Usage (hidden on mobile)
    * - Editors (hidden on mobile)
    * - Last Edited (hidden on mobile)
    * - Actions (always)
@@ -214,6 +231,7 @@ const getTableColumns = ({
     nameColumn,
     availabilityColumn,
     usedByColumn(onAgentClick, onUsedBySkillClick),
+    usageColumn,
     editorsColumn,
     lastEditedColumn,
     menuColumn,
@@ -275,6 +293,7 @@ export function SkillsTable({
         availability: skill.availability,
         editors: skill.relations.editors,
         usage: skill.relations.usage,
+        messageCount: skill.messageCount ?? 0,
         updatedAt: skill.updatedAt,
         createdAt: skill.createdAt,
         onClick: () => {

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -2495,6 +2495,102 @@ describe("SkillResource", () => {
     });
   });
 
+  describe("batchFetchMessageCounts", () => {
+    it("returns an empty map for empty input", async () => {
+      const messageCountMap = await SkillResource.batchFetchMessageCounts(
+        testContext.authenticator,
+        []
+      );
+
+      expect(messageCountMap.size).toBe(0);
+    });
+
+    it("counts distinct messages for custom and global skills", async () => {
+      const customSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "Custom Skill With Messages",
+      });
+      const globalSkill = await SkillResource.fetchById(
+        testContext.authenticator,
+        "frames"
+      );
+      if (!globalSkill) {
+        throw new Error("Expected frames global skill to exist.");
+      }
+
+      const agent = await AgentConfigurationFactory.createTestAgent(
+        testContext.authenticator,
+        { name: "Agent With Skill Messages" }
+      );
+      const conversation = await ConversationFactory.create(
+        testContext.authenticator,
+        { agentConfigurationId: agent.sId, messagesCreatedAt: [] }
+      );
+
+      await customSkill.enableForAgent(testContext.authenticator, {
+        agentConfiguration: agent,
+        conversation,
+      });
+      await globalSkill.enableForAgent(testContext.authenticator, {
+        agentConfiguration: agent,
+        conversation,
+      });
+
+      const firstMessage = await ConversationFactory.createAgentMessageWithRank(
+        {
+          workspace: testContext.workspace,
+          conversationId: conversation.id,
+          rank: 0,
+          agentConfigurationId: agent.sId,
+        }
+      );
+      const secondMessage =
+        await ConversationFactory.createAgentMessageWithRank({
+          workspace: testContext.workspace,
+          conversationId: conversation.id,
+          rank: 1,
+          agentConfigurationId: agent.sId,
+        });
+      if (!firstMessage.agentMessageId || !secondMessage.agentMessageId) {
+        throw new Error("Expected agent messages to exist.");
+      }
+
+      await SkillResource.snapshotConversationSkillsForMessage(
+        testContext.authenticator,
+        {
+          agentConfigurationId: agent.sId,
+          agentMessageId: firstMessage.agentMessageId,
+          conversationId: conversation.id,
+        }
+      );
+      // Simulate a finalization retry after the first snapshot insert succeeds.
+      await SkillResource.snapshotConversationSkillsForMessage(
+        testContext.authenticator,
+        {
+          agentConfigurationId: agent.sId,
+          agentMessageId: firstMessage.agentMessageId,
+          conversationId: conversation.id,
+        }
+      );
+      await SkillResource.snapshotConversationSkillsForMessage(
+        testContext.authenticator,
+        {
+          agentConfigurationId: agent.sId,
+          agentMessageId: secondMessage.agentMessageId,
+          conversationId: conversation.id,
+        }
+      );
+
+      const messageCountMap = await SkillResource.batchFetchMessageCounts(
+        testContext.authenticator,
+        [customSkill, globalSkill]
+      );
+
+      expect(messageCountMap.size).toBe(2);
+      expect(messageCountMap.get(customSkill.sId)).toBe(2);
+      expect(messageCountMap.get(globalSkill.sId)).toBe(2);
+    });
+  });
+
   describe("batchListEditors", () => {
     it("returns editors for skills with editor groups", async () => {
       const skill = await SkillFactory.create(testContext.authenticator, {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -95,7 +95,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { removeNulls } from "@app/types/shared/utils/general";
+import { isNumber, removeNulls } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
 import assert from "assert";
 import groupBy from "lodash/groupBy";
@@ -109,7 +109,7 @@ import type {
   Transaction,
   WhereOptions,
 } from "sequelize";
-import { Op } from "sequelize";
+import { col, fn, Op } from "sequelize";
 
 export type SkillMCPServerConfiguration = {
   view: MCPServerViewResource;
@@ -2575,6 +2575,66 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         }))
         .sort((a, b) => a.name.localeCompare(b.name));
       result.set(skill.sId, { count: agents.length, agents });
+    }
+
+    return result;
+  }
+
+  /**
+   * Count distinct agent messages using each skill, keyed by skill sId.
+   */
+  static async batchFetchMessageCounts(
+    auth: Authenticator,
+    skills: SkillResource[]
+  ): Promise<Map<string, number>> {
+    if (skills.length === 0) {
+      return new Map();
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const customSkillIdByModelId = new Map(
+      skills
+        .filter((skill) => !skill.globalSId)
+        .map((skill) => [skill.id, skill.sId])
+    );
+    const globalSkillIds = removeNulls(skills.map((skill) => skill.globalSId));
+
+    const rows = await AgentMessageSkillModel.findAll({
+      attributes: [
+        "customSkillId",
+        "globalSkillId",
+        [fn("COUNT", fn("DISTINCT", col("agentMessageId"))), "messageCount"],
+      ],
+      where: {
+        workspaceId: workspace.id,
+        [Op.or]: removeNulls([
+          customSkillIdByModelId.size > 0
+            ? {
+                customSkillId: {
+                  [Op.in]: [...customSkillIdByModelId.keys()],
+                },
+              }
+            : null,
+          globalSkillIds.length > 0
+            ? { globalSkillId: { [Op.in]: globalSkillIds } }
+            : null,
+        ]),
+      },
+      group: ["customSkillId", "globalSkillId"],
+    });
+
+    const result = new Map<string, number>();
+    for (const row of rows) {
+      const skillId =
+        row.customSkillId !== null
+          ? customSkillIdByModelId.get(row.customSkillId)
+          : (row.globalSkillId ?? undefined);
+      const messageCount = row.get("messageCount");
+
+      assert(isNumber(messageCount), "Expected message count to be a number");
+      if (skillId) {
+        result.set(skillId, messageCount);
+      }
     }
 
     return result;

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -95,7 +95,11 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { isNumber, removeNulls } from "@app/types/shared/utils/general";
+import {
+  isNumber,
+  isString,
+  removeNulls,
+} from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
 import assert from "assert";
 import groupBy from "lodash/groupBy";
@@ -109,7 +113,7 @@ import type {
   Transaction,
   WhereOptions,
 } from "sequelize";
-import { col, fn, Op } from "sequelize";
+import { Op } from "sequelize";
 
 export type SkillMCPServerConfiguration = {
   view: MCPServerViewResource;
@@ -2599,12 +2603,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
     const globalSkillIds = removeNulls(skills.map((skill) => skill.globalSId));
 
-    const rows = await AgentMessageSkillModel.findAll({
-      attributes: [
-        "customSkillId",
-        "globalSkillId",
-        [fn("COUNT", fn("DISTINCT", col("agentMessageId"))), "messageCount"],
-      ],
+    const counts = await AgentMessageSkillModel.count({
+      attributes: ["customSkillId", "globalSkillId"],
+      // Finalization activities can retry after the snapshot insert succeeds.
+      distinct: true,
+      col: "agentMessageId",
       where: {
         workspaceId: workspace.id,
         [Op.or]: removeNulls([
@@ -2624,16 +2627,15 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
 
     const result = new Map<string, number>();
-    for (const row of rows) {
-      const skillId =
-        row.customSkillId !== null
-          ? customSkillIdByModelId.get(row.customSkillId)
-          : (row.globalSkillId ?? undefined);
-      const messageCount = row.get("messageCount");
-
-      assert(isNumber(messageCount), "Expected message count to be a number");
+    for (const row of counts) {
+      let skillId: string | undefined;
+      if (isNumber(row.customSkillId)) {
+        skillId = customSkillIdByModelId.get(row.customSkillId);
+      } else if (isString(row.globalSkillId)) {
+        skillId = row.globalSkillId;
+      }
       if (skillId) {
-        result.set(skillId, messageCount);
+        result.set(skillId, row.count);
       }
     }
 

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -164,6 +164,7 @@ export function useSkillsWithRelations({
   status,
   onlyCustom,
   bypassEditorVisibility,
+  withMessageCount,
 }: {
   owner: LightWorkspaceType;
   disabled?: boolean;
@@ -172,6 +173,7 @@ export function useSkillsWithRelations({
   // Admin-only: bypass the editor-visibility rule and also list unpublished
   // (editors-only) skills the caller does not edit.
   bypassEditorVisibility?: boolean;
+  withMessageCount?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const skillsFetcher: Fetcher<GetSkillsWithRelationsResponseBody> = fetcher;
@@ -185,6 +187,9 @@ export function useSkillsWithRelations({
   }
   if (bypassEditorVisibility) {
     queryParams.set("bypassEditorVisibility", "true");
+  }
+  if (withMessageCount) {
+    queryParams.set("withMessageCount", "true");
   }
 
   const { data, isLoading, mutate, mutateRegardlessOfQueryParams } =

--- a/front/types/api/skills/index.ts
+++ b/front/types/api/skills/index.ts
@@ -14,6 +14,7 @@ export type GetSkillsResponseBody = {
 export type GetSkillsWithRelationsResponseBody = {
   skills: (SkillWithoutInstructionsAndToolsWithRelationsType & {
     isFavorite?: boolean;
+    messageCount?: number;
   })[];
 };
 


### PR DESCRIPTION
## Description

The Manage Skills table does not show how often each skill is used. This PR adds an all-time Usage column based on distinct messages recorded in `agent_message_skills`.

The list endpoint batches counts for custom and global skills. Manage Skills requests them explicitly, so other screens using the shared skill-list hook do not trigger the additional query.

<img width="2210" height="1124" alt="image" src="https://github.com/user-attachments/assets/8e649579-820c-46b1-a79b-e158ebc0249f" />

## Tests

- Added tests.

## Risk

- Low. Will need to monitor the impact of the query, but can be safely reverted.

## Deploy Plan

- Deploy front.
