### PR TITLE
[front] fix: load favorite skills' effective spaces in agent loops

### DIFF
--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -294,20 +294,43 @@ describe("getJITServers", () => {
           agentConfigurationId: agentConfig.id,
         });
 
-        const skill = await SkillFactory.create(auth, {
-          name: "Discoverable Favorite Skill",
-          availability: "users_and_agents",
-        });
+        const [skill] = await SkillResource.fetchByIds(auth, ["mention_users"]);
+        if (!skill) {
+          throw new Error("Expected Mention Users skill to be available");
+        }
         const favoriteResult = await skill.setFavorite(auth, true);
         expect(favoriteResult.isOk()).toBe(true);
 
+        const { userMessage } = await ConversationFactory.createUserMessage({
+          auth,
+          workspace,
+          conversation,
+          content: "Mention someone.",
+          rank: -1,
+        });
+        const { agentMessage } = await ConversationFactory.createAgentMessage(
+          auth,
+          {
+            workspace,
+            conversation,
+            agentConfig,
+          }
+        );
+        const { model: agentModel, ...agentConfiguration } = agentConfig;
+
         const { equippedSkills, favoriteSkills } =
           await SkillResource.listForAgentLoop(auth, {
-            agentConfiguration: agentConfig,
+            agentConfiguration,
+            modelInfo: {
+              endpoint: getTestStreamEndpoint(agentModel.modelId),
+              ...agentModel,
+            },
+            agentMessage,
             conversation: {
               ...conversation,
               spaceId: conversationsSpace.sId,
             },
+            userMessage,
           });
 
         expect(equippedSkills.map((s) => s.sId)).toContain(skill.sId);

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1225,8 +1225,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     auth: Authenticator,
     {
       agentLoopData,
+      effectiveSpaceIds,
     }: {
       agentLoopData?: AgentLoopExecutionData;
+      effectiveSpaceIds?: string[];
     } = {}
   ): Promise<SkillResource[]> {
     const user = auth.user();
@@ -1249,6 +1251,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     return this.fetchByIds(auth, favorites.skillIds, {
       agentLoopData,
+      effectiveSpaceIds,
       onlyActive: true,
     });
   }
@@ -1797,6 +1800,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       if (hasSkillFavorites) {
         favoriteSkills = await this.listFavoritesForCurrentUser(auth, {
           agentLoopData,
+          effectiveSpaceIds,
         });
       }
     }


### PR DESCRIPTION
## Description

Posting a message with a favorited code-defined skill fails with `effectiveSpaceIds must be provided with agentLoopData`.

Propagate the already-resolved effective space IDs through the favorites lookup so global favorites are loaded with the same context as the rest of the agent loop skills.

## Tests

- Updated the existing favorites test to cover a code-defined skill with full agent-loop data.

## Risk

- Low.

## Deploy Plan

- Deploy front.