### PR TITLE
Fix: scrollability of Pod pages

### DIFF
--- a/front/components/pages/pod/PodPage.tsx
+++ b/front/components/pages/pod/PodPage.tsx
@@ -78,7 +78,7 @@ export function PodPage() {
   return (
     <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden">
       <NavTabPill
-        className="pt-2"
+        className="pt-2 flex min-h-0 flex-1 flex-col overflow-hidden"
         defaultValue="conversations"
         value={currentTab}
         onValueChange={(value) => handleTabChange(value as PodTab)}

--- a/sparkle/src/components/NavTabPill.tsx
+++ b/sparkle/src/components/NavTabPill.tsx
@@ -138,7 +138,7 @@ const NavTabPillContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "contents focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
       className
     )}
     {...props}


### PR DESCRIPTION
## Description

Pod pages weren't scrollable because the flex chain was broken at two points: `NavTabPill` didn't propagate `flex-1 min-h-0 overflow-hidden` down, and `NavTabPillContent` (`TabsPrimitive.Content`) was an opaque block element interrupting the flex layout. Fixed by adding the flex constraints to `NavTabPill` in `PodPage` and setting `display: contents` on `NavTabPillContent` in sparkle so the tab content wrapper is transparent to the flex tree.

## Tests

Tested locally on Pod pages — conversations and tasks tabs now scroll correctly.

## Risk

Low. Tailwind-only changes to two components. `contents` on `NavTabPillContent` is intentional: it only affects how the wrapper participates in layout, not the content itself. Any non-Pod usage of `NavTabPill` that relied on the wrapper being a block element could be affected — worth a visual sanity check.

## Deploy Plan

Deploy front.
