### PR TITLE
Add: admin controlled toggle

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -9509,6 +9509,10 @@
                               "type": "string",
                               "nullable": true,
                               "description": "Scoped path to the frame file pinned as the Pod banner."
+                            },
+                            "isAdminControlled": {
+                              "type": "boolean",
+                              "description": "Whether workspace admins control membership and connected data for this Pod."
                             }
                           }
                         }
@@ -11718,6 +11722,10 @@
                 "type": "string",
                 "nullable": true,
                 "description": "Scoped path to the frame file pinned as the Pod banner (e.g. project/banner.html)."
+              },
+              "isAdminControlled": {
+                "type": "boolean",
+                "description": "Whether workspace admins control membership and connected data for this Pod."
               }
             }
           }

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -998,6 +998,9 @@
  *               type: string
  *               nullable: true
  *               description: Scoped path to the frame file pinned as the Pod banner (e.g. project/banner.html).
+ *             isAdminControlled:
+ *               type: boolean
+ *               description: Whether workspace admins control membership and connected data for this Pod.
  *     PrivateDataSourceView:
  *       type: object
  *       description: A view on a data source within a space.

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -117,6 +117,7 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_metadata", () => {
       defaultAgentId: null,
       defaultSkillIds: [],
       description: "Test project description",
+      isAdminControlled: false,
       lastTodoAnalysisAt: null,
       pinnedFramePath: null,
       sId: expect.anything(),

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
@@ -140,6 +140,9 @@ const app = workspaceApp();
  *                           type: string
  *                           nullable: true
  *                           description: Scoped path to the frame file pinned as the Pod banner.
+ *                         isAdminControlled:
+ *                           type: boolean
+ *                           description: Whether workspace admins control membership and connected data for this Pod.
  *       401:
  *         description: Unauthorized
  *   patch:
@@ -336,6 +339,7 @@ app.get(
         todoGenerationEnabled: meta?.todoGenerationEnabled ?? false,
         lastTodoAnalysisAt: meta?.lastTodoAnalysisAt?.getTime() ?? null,
         pinnedFramePath: meta?.pinnedFramePath ?? null,
+        isAdminControlled: meta?.isAdminControlled ?? false,
       },
     });
   }

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -1,5 +1,6 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { validatePinnedFramePath } from "@app/lib/api/projects/pinned_frame";
+import { hasFeatureFlag } from "@app/lib/auth";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import {
@@ -77,6 +78,42 @@ app.patch(
 
     const body = ctx.req.valid("json");
 
+    if (body.isAdminControlled !== undefined) {
+      if (!(await hasFeatureFlag(auth, "admin_controlled_pods"))) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "feature_flag_not_found",
+            message:
+              "Admin-controlled Pods are not enabled for this workspace.",
+          },
+        });
+      }
+
+      // biome-ignore lint/plugin/noDirectRoleCheck: endpoint can be called by any authenticated user.
+      if (!auth.isAdmin()) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message:
+              "Only workspace admins can change admin-controlled Pod mode.",
+          },
+        });
+      }
+
+      if (space.managementMode !== "manual") {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Admin-controlled mode requires manual membership management.",
+          },
+        });
+      }
+    }
+
     if (body.pinnedFramePath !== undefined) {
       const validation = await validatePinnedFramePath(
         auth,
@@ -139,6 +176,45 @@ app.patch(
 
     const priorLastTodoAnalysisAt = metadata?.lastTodoAnalysisAt ?? null;
     const priorTodoGenerationEnabled = metadata?.todoGenerationEnabled ?? false;
+    const priorIsAdminControlled = metadata?.isAdminControlled ?? false;
+
+    if (
+      body.isAdminControlled !== undefined &&
+      body.isAdminControlled !== priorIsAdminControlled
+    ) {
+      const membershipRes = await space.applyAdminControlledMembershipChange(
+        auth,
+        body.isAdminControlled
+      );
+      if (membershipRes.isErr()) {
+        switch (membershipRes.error.code) {
+          case "unauthorized":
+            return apiError(ctx, {
+              status_code: 403,
+              api_error: {
+                type: "workspace_auth_error",
+                message: membershipRes.error.message,
+              },
+            });
+          case "group_requirements_not_met":
+            return apiError(ctx, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: membershipRes.error.message,
+              },
+            });
+          default:
+            return apiError(ctx, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: membershipRes.error.message,
+              },
+            });
+        }
+      }
+    }
 
     const shouldTriggerFirstImmediateSync =
       body.todoGenerationEnabled === true &&
@@ -153,6 +229,7 @@ app.patch(
         initialTodoAnalysisLookback: body.initialTodoAnalysisLookback ?? null,
         pinnedFramePath: body.pinnedFramePath ?? null,
         defaultAgentId: body.defaultAgentId ?? null,
+        isAdminControlled: body.isAdminControlled ?? false,
       });
       if (resolvedDefaultSkills) {
         await metadata.setDefaultSkills(resolvedDefaultSkills);
@@ -204,6 +281,9 @@ app.patch(
       }
       if (body.defaultAgentId !== undefined) {
         await metadata.updateDefaultAgentId(body.defaultAgentId);
+      }
+      if (body.isAdminControlled !== undefined) {
+        await metadata.updateIsAdminControlled(body.isAdminControlled);
       }
       if (resolvedDefaultSkills) {
         await metadata.setDefaultSkills(resolvedDefaultSkills);

--- a/front/components/assistant/conversation/space/ManageUsersPanel.tsx
+++ b/front/components/assistant/conversation/space/ManageUsersPanel.tsx
@@ -5,7 +5,7 @@ import {
 } from "@app/components/members/MemberSelectionTable";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useUpdateSpace } from "@app/lib/swr/spaces";
-import type { SpaceType } from "@app/types/space";
+import type { RichSpaceType } from "@app/types/api/spaces";
 import type { LightWorkspaceType, SpaceUserType } from "@app/types/user";
 import {
   Button,
@@ -29,7 +29,7 @@ interface BaseManageUsersPanelProps {
 
 interface SpaceMembersMode extends BaseManageUsersPanelProps {
   mode: "space-members";
-  space: SpaceType;
+  space: RichSpaceType;
   currentProjectMembers: SpaceUserType[];
   onSuccess?: () => void | Promise<void>;
 }
@@ -54,17 +54,17 @@ export function ManageUsersPanel(props: ManageUsersPanelProps) {
   const [currentEditors, setCurrentEditors] = useState<Set<string>>(new Set());
   const [selectedUsers, setSelectedUsers] = useState<SearchMemberType[]>([]);
 
+  const isAdminControlled =
+    mode === "space-members" && props.space.isAdminControlled;
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: reset state when panel opens
   useEffect(() => {
     if (mode === "space-members") {
+      const editorIds = props.currentProjectMembers
+        .filter((m) => m.isEditor)
+        .map((m) => m.sId);
       setCurrentMembers(new Set(props.currentProjectMembers.map((m) => m.sId)));
-      setCurrentEditors(
-        new Set(
-          props.currentProjectMembers
-            .filter((m) => m.isEditor)
-            .map((m) => m.sId)
-        )
-      );
+      setCurrentEditors(new Set(editorIds));
     } else if (mode === "editors-only") {
       setCurrentMembers(new Set(props.editors.map((e) => e.sId)));
       setSelectedUsers(props.editors);
@@ -73,7 +73,7 @@ export function ManageUsersPanel(props: ManageUsersPanelProps) {
 
   const toggleEditor = useCallback(
     (userId: string) => {
-      if (!currentMembers.has(userId)) {
+      if (isAdminControlled || !currentMembers.has(userId)) {
         return;
       }
       setCurrentEditors((prev) => {
@@ -86,7 +86,7 @@ export function ManageUsersPanel(props: ManageUsersPanelProps) {
         return next;
       });
     },
-    [currentMembers]
+    [isAdminControlled, currentMembers]
   );
 
   const handleSave = async () => {
@@ -98,7 +98,7 @@ export function ManageUsersPanel(props: ManageUsersPanelProps) {
       );
       const editorIds = Array.from(currentEditors);
 
-      if (editorIds.length === 0) {
+      if (!isAdminControlled && editorIds.length === 0) {
         setIsOpen(false);
         sendNotification({
           title: "At least one editor is required.",
@@ -161,7 +161,7 @@ export function ManageUsersPanel(props: ManageUsersPanelProps) {
   };
 
   const editorColumn: ColumnDef<MemberRowData>[] = useMemo(() => {
-    if (mode !== "space-members") {
+    if (mode !== "space-members" || isAdminControlled) {
       return [];
     }
     return [
@@ -197,13 +197,14 @@ export function ManageUsersPanel(props: ManageUsersPanelProps) {
         },
       },
     ];
-  }, [mode, currentMembers, currentEditors, toggleEditor]);
+  }, [mode, isAdminControlled, currentMembers, currentEditors, toggleEditor]);
 
   const initialMembers =
     mode === "editors-only" ? props.editors : props.currentProjectMembers;
 
   const canSave =
-    !isSaving && (mode !== "space-members" || currentEditors.size > 0);
+    !isSaving &&
+    (mode !== "space-members" || isAdminControlled || currentEditors.size > 0);
 
   const sheetTitle =
     mode === "space-members"
@@ -238,7 +239,7 @@ export function ManageUsersPanel(props: ManageUsersPanelProps) {
             disabled: !canSave,
             isLoading: isSaving,
             tooltip:
-              !canSave && mode === "space-members"
+              !canSave && mode === "space-members" && !isAdminControlled
                 ? "Please select at least one editor to save."
                 : undefined,
           }}

--- a/front/components/pod/PodHeaderActions.tsx
+++ b/front/components/pod/PodHeaderActions.tsx
@@ -62,7 +62,7 @@ export function PodHeaderActions({
   const podEditors = members.filter((member) => member.isEditor);
   const isPodEditor = podEditors.some((member) => member.sId === user.sId);
   const canLeavePod =
-    (isMember && !isPodEditor) || // regular members can leave the pod
+    (isMember && !isPodEditor) || // regular members can leave
     (isPodEditor && podEditors.length > 1); // editors can leave if there's at least another editor
   return (
     <>

--- a/front/components/pod/PodMenu.tsx
+++ b/front/components/pod/PodMenu.tsx
@@ -204,15 +204,18 @@ export function PodMenu({
   // Determine permissions based on spaceInfo
   const isPod = pod?.kind === "project" || podInfo?.kind === "project";
   const isMember = podInfo?.isMember ?? false;
+  // podInfo.isEditor is canAdministrate (true for workspace admins on
+  // admin-controlled Pods; true for Pod editors otherwise).
+  const canAdministratePod = podInfo?.isEditor ?? false;
   const podEditors =
     podInfo?.members?.filter((member) => member.isEditor) ?? [];
   const isPodEditor = podEditors.some((member) => member.sId === user.sId);
   const canLeave =
-    ((isMember && !isPodEditor) || // regular members can leave the pod
-      (isPodEditor && podEditors.length > 1)) && // editors can leave if there's at least another editor
-    isPod;
+    isPod &&
+    ((isMember && !isPodEditor) || // regular members can leave
+      (isPodEditor && podEditors.length > 1)); // editors can leave if there's at least another editor
   // Must match PATCH /spaces/[spaceId] (canAdministrate). canWrite is true for pod members too.
-  const canRename = podInfo?.isEditor ?? false;
+  const canRename = canAdministratePod;
 
   return (
     <div
@@ -305,7 +308,7 @@ export function PodMenu({
               </DropdownMenuSubContent>
             </DropdownMenuPortal>
           </DropdownMenuSub>
-          {isPodEditor && (
+          {canAdministratePod && (
             <DropdownMenuItem
               label="Archive"
               onClick={archivePod}

--- a/front/components/pod/settings/AdminControlledPodTile.tsx
+++ b/front/components/pod/settings/AdminControlledPodTile.tsx
@@ -1,0 +1,120 @@
+import { ConfirmContext } from "@app/components/Confirm";
+import { PodSettingsOptionLabel } from "@app/components/pod/settings/PodSettingsOptionLabel";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import { useUpdatePodMetadata } from "@app/lib/swr/pods";
+import type { RichSpaceType } from "@app/types/api/spaces";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Lock01, SliderToggle, Tooltip } from "@dust-tt/sparkle";
+import { useCallback, useContext, useState } from "react";
+
+const ADMIN_CONTROLLED_DESCRIPTION =
+  "Workspace admins control membership and can attach connected data sources to this Pod.";
+
+const ADMIN_CONTROLLED_NON_ADMIN_TOOLTIP =
+  "Only workspace admins can change admin-controlled mode.";
+
+interface AdminControlledPodTileProps {
+  owner: LightWorkspaceType;
+  pod: RichSpaceType;
+}
+
+export function AdminControlledPodTile({
+  owner,
+  pod,
+}: AdminControlledPodTileProps) {
+  const confirm = useContext(ConfirmContext);
+  const { isAdmin } = useAuth();
+  const updatePodMetadata = useUpdatePodMetadata({
+    owner,
+    podId: pod.sId,
+  });
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const isPodArchived = !!pod.archivedAt;
+  const structurallyDisabled = isPodArchived || !isAdmin;
+  const sliderDisabled = structurallyDisabled || isUpdating;
+
+  const toggleTooltip = isPodArchived
+    ? "This Pod is archived; settings cannot be changed."
+    : !isAdmin
+      ? ADMIN_CONTROLLED_NON_ADMIN_TOOLTIP
+      : ADMIN_CONTROLLED_DESCRIPTION;
+
+  const handleToggle = useCallback(async () => {
+    if (structurallyDisabled) {
+      return;
+    }
+
+    if (pod.isAdminControlled) {
+      const confirmed = await confirm({
+        title: "Switch to self-serve Pod?",
+        message:
+          "The longest-standing member will become the Pod editor again. Connected data attached as Space data sources will remain until removed separately.",
+        validateVariant: "warning",
+        validateLabel: "Switch to self-serve",
+        cancelLabel: "Cancel",
+      });
+      if (!confirmed) {
+        return;
+      }
+      setIsUpdating(true);
+      try {
+        await updatePodMetadata({ isAdminControlled: false });
+      } finally {
+        setIsUpdating(false);
+      }
+      return;
+    }
+
+    const confirmed = await confirm({
+      title: "Make this Pod admin-controlled?",
+      message:
+        "Current editors will become regular members. Only workspace admins will manage membership and connected data for this Pod.",
+      validateVariant: "warning",
+      validateLabel: "Make admin-controlled",
+      cancelLabel: "Cancel",
+    });
+    if (!confirmed) {
+      return;
+    }
+
+    setIsUpdating(true);
+    try {
+      await updatePodMetadata({ isAdminControlled: true });
+    } finally {
+      setIsUpdating(false);
+    }
+  }, [confirm, pod.isAdminControlled, structurallyDisabled, updatePodMetadata]);
+
+  return (
+    <div className="flex items-center justify-between gap-4 py-4">
+      <PodSettingsOptionLabel
+        icon={Lock01}
+        title="Admin-controlled"
+        description={ADMIN_CONTROLLED_DESCRIPTION}
+      />
+      <div className="flex shrink-0 items-center gap-2">
+        {sliderDisabled && !isUpdating ? (
+          <Tooltip
+            label={toggleTooltip}
+            trigger={
+              <div>
+                <SliderToggle
+                  selected={pod.isAdminControlled}
+                  onClick={handleToggle}
+                  disabled
+                />
+              </div>
+            }
+          />
+        ) : (
+          <SliderToggle
+            selected={pod.isAdminControlled}
+            onClick={handleToggle}
+            disabled={sliderDisabled}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front/components/pod/settings/PodMembersTable.tsx
+++ b/front/components/pod/settings/PodMembersTable.tsx
@@ -1,7 +1,7 @@
 import { ConfirmContext } from "@app/components/Confirm";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useUpdateSpace } from "@app/lib/swr/spaces";
-import type { PodType } from "@app/types/space";
+import type { RichSpaceType } from "@app/types/api/spaces";
 import type { LightWorkspaceType, SpaceUserType } from "@app/types/user";
 import type { MenuItem } from "@dust-tt/sparkle";
 import {
@@ -17,7 +17,7 @@ import { useCallback, useContext, useMemo } from "react";
 
 interface PodMembersTableProps {
   owner: LightWorkspaceType;
-  pod: PodType;
+  pod: RichSpaceType;
   selectedMembers: SpaceUserType[];
   searchSelectedMembers: string;
   isEditor?: boolean;
@@ -63,7 +63,11 @@ export function PodMembersTable({
   const removeMember = useCallback(
     async (userId: string) => {
       const updatedMembers = selectedMembers.filter((m) => m.sId !== userId);
-      if (!updatedMembers.some((m) => m.isEditor)) {
+      if (
+        !pod.isAdminControlled &&
+        selectedMembers.some((m) => m.isEditor) &&
+        !updatedMembers.some((m) => m.isEditor)
+      ) {
         sendNotifications({
           title: "Pods must have at least one editor.",
           description: "You cannot remove the last editor.",
@@ -97,6 +101,9 @@ export function PodMembersTable({
 
   const toggleEditor = useCallback(
     async (userId: string) => {
+      if (pod.isAdminControlled) {
+        return;
+      }
       const toggledMember = selectedMembers.find((m) => m.sId === userId);
       if (!toggledMember) {
         return;
@@ -147,7 +154,7 @@ export function PodMembersTable({
         await mutatePodInfo();
       }
     },
-    [doUpdate, pod, selectedMembers, sendNotifications, mutatePodInfo]
+    [doUpdate, mutatePodInfo, pod, selectedMembers, sendNotifications]
   );
 
   const rows = useMemo(
@@ -239,80 +246,78 @@ export function PodMembersTable({
                 className: "w-12",
               },
               cell: (info: MemberRowInfo) => {
-                let editorSettingItem: MenuItem;
-                if (info.row.original.isEditor) {
-                  const editorLabel = "Remove from editors";
-                  editorSettingItem = {
-                    kind: "item",
-                    label: editorLabel,
-                    disabled: rows.filter((row) => row.isEditor).length <= 1, // disable the "remove" action if it's the last editor
-                    icon: XClose,
-                    variant: "default",
-                    onClick: async () => {
-                      const confirmed = await confirm({
-                        title: editorLabel,
-                        message: `Are you sure you want to remove "${info.row.original.name}" from editors?`,
-                        validateLabel: "Remove",
-                        validateVariant: "primary",
-                      });
+                const menuItems: MenuItem[] = [];
+                if (!pod.isAdminControlled) {
+                  let editorSettingItem: MenuItem;
+                  if (info.row.original.isEditor) {
+                    const editorLabel = "Remove from editors";
+                    editorSettingItem = {
+                      kind: "item",
+                      label: editorLabel,
+                      disabled: rows.filter((row) => row.isEditor).length <= 1,
+                      icon: XClose,
+                      variant: "default",
+                      onClick: async () => {
+                        const confirmed = await confirm({
+                          title: editorLabel,
+                          message: `Are you sure you want to remove "${info.row.original.name}" from editors?`,
+                          validateLabel: "Remove",
+                          validateVariant: "primary",
+                        });
 
-                      if (confirmed) {
-                        await toggleEditor(info.row.original.userId);
-                      }
-                    },
-                  };
-                } else {
-                  const editorLabel = "Set as editor";
-                  editorSettingItem = {
-                    kind: "item",
-                    label: editorLabel,
-                    icon: Check,
-                    variant: "default",
-                    onClick: async () => {
-                      const confirmed = await confirm({
-                        title: editorLabel,
-                        message: `Are you sure you want to add "${info.row.original.name}" as an editor?`,
-                        validateLabel: "Add",
-                        validateVariant: "primary",
-                      });
-
-                      if (confirmed) {
-                        await toggleEditor(info.row.original.userId);
-                      }
-                    },
-                  };
-                }
-                return (
-                  <DataTable.MoreButton
-                    menuItems={[
-                      editorSettingItem,
-                      {
-                        kind: "item",
-                        label: "Remove from Pod",
-                        icon: Trash01,
-                        variant: "warning",
-                        onClick: async () => {
-                          const confirmed = await confirm({
-                            title: "Remove member",
-                            message: `Are you sure you want to remove "${info.row.original.name}" from this Pod?`,
-                            validateLabel: "Remove",
-                            validateVariant: "warning",
-                          });
-
-                          if (confirmed) {
-                            await removeMember(info.row.original.userId);
-                          }
-                        },
+                        if (confirmed) {
+                          await toggleEditor(info.row.original.userId);
+                        }
                       },
-                    ]}
-                  />
-                );
+                    };
+                  } else {
+                    const editorLabel = "Set as editor";
+                    editorSettingItem = {
+                      kind: "item",
+                      label: editorLabel,
+                      icon: Check,
+                      variant: "default",
+                      onClick: async () => {
+                        const confirmed = await confirm({
+                          title: editorLabel,
+                          message: `Are you sure you want to add "${info.row.original.name}" as an editor?`,
+                          validateLabel: "Add",
+                          validateVariant: "primary",
+                        });
+
+                        if (confirmed) {
+                          await toggleEditor(info.row.original.userId);
+                        }
+                      },
+                    };
+                  }
+                  menuItems.push(editorSettingItem);
+                }
+                menuItems.push({
+                  kind: "item",
+                  label: "Remove from Pod",
+                  icon: Trash01,
+                  variant: "warning",
+                  onClick: async () => {
+                    const confirmed = await confirm({
+                      title: "Remove member",
+                      message: `Are you sure you want to remove "${info.row.original.name}" from this Pod?`,
+                      validateLabel: "Remove",
+                      validateVariant: "warning",
+                    });
+
+                    if (confirmed) {
+                      await removeMember(info.row.original.userId);
+                    }
+                  },
+                });
+                return <DataTable.MoreButton menuItems={menuItems} />;
               },
             },
           ]
         : []),
     ],
-    [isEditor, removeMember, confirm, toggleEditor, rows]
+    [isEditor, removeMember, confirm, toggleEditor, rows, pod.isAdminControlled]
   );
 
   return (

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -2,6 +2,7 @@ import { AgentPicker } from "@app/components/assistant/AgentPicker";
 import { CapabilitiesPickerItemsList } from "@app/components/assistant/CapabilitiesPicker";
 import { ConfirmContext } from "@app/components/Confirm";
 import { MarkdownFileEditor } from "@app/components/editor/MarkdownFileEditor";
+import { AdminControlledPodTile } from "@app/components/pod/settings/AdminControlledPodTile";
 import { DeletePodDialog } from "@app/components/pod/settings/DeletePodDialog";
 import { PodMembersTable } from "@app/components/pod/settings/PodMembersTable";
 import { PodNetworkSection } from "@app/components/pod/settings/PodNetworkSection";
@@ -98,6 +99,7 @@ export function PodSettingsTab({
   const { hasFeature } = useFeatureFlags();
   const { isAdmin } = useAuth();
   const hasWorkspaceDefaultAgentFeature = hasFeature("workspace_default_agent");
+  const hasAdminControlledPodsFeature = hasFeature("admin_controlled_pods");
   // The pod sandbox network allowlist is workspace-admin only (matching the
   // API) and part of the Sandbox Functions surface.
   // Mirrors the API gate (workspace-admin + sandbox_functions FF; pod
@@ -714,6 +716,12 @@ export function PodSettingsTab({
                 )}
               </div>
             </div>
+
+            {hasAdminControlledPodsFeature && (
+              <div className="border-t border-border">
+                <AdminControlledPodTile owner={owner} pod={pod} />
+              </div>
+            )}
 
             <div className="border-t border-border py-4">
               <SuggestedTasksGenerationTile owner={owner} pod={pod} />

--- a/front/lib/resources/group_space_editor_resource.ts
+++ b/front/lib/resources/group_space_editor_resource.ts
@@ -143,6 +143,10 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
   }
 
   async canAddMember(auth: Authenticator, _userId: string): Promise<boolean> {
+    if (await this.space.fetchIsAdminControlled()) {
+      // Editor group stays empty while admin-controlled.
+      return false;
+    }
     const requestedPermissions = await this.requestedPermissions();
     return auth.canWrite(requestedPermissions);
   }

--- a/front/lib/resources/project_metadata_resource.test.ts
+++ b/front/lib/resources/project_metadata_resource.test.ts
@@ -120,6 +120,7 @@ describe("ProjectMetadataResource", () => {
       expect(json.lastTodoAnalysisAt).toBeNull();
       expect(json.pinnedFramePath).toBeNull();
       expect(json.defaultSkillIds).toEqual([]);
+      expect(json.isAdminControlled).toBe(false);
     });
   });
 

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -202,6 +202,13 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
     await this.update({ todoGenerationEnabled }, transaction);
   }
 
+  async updateIsAdminControlled(
+    isAdminControlled: boolean,
+    transaction?: Transaction
+  ) {
+    await this.update({ isAdminControlled }, transaction);
+  }
+
   async updateInitialTodoAnalysisLookback(
     initialTodoAnalysisLookback: string | null,
     transaction?: Transaction
@@ -271,6 +278,7 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
       pinnedFramePath: this.pinnedFramePath ?? null,
       defaultAgentId: this.defaultAgentId ?? null,
       defaultSkillIds: this.defaultSkillIds,
+      isAdminControlled: this.isAdminControlled,
     };
   }
 }

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -6,6 +6,7 @@ import { ConversationSelectedSpaceModel } from "@app/lib/models/agent/conversati
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupSpaceEditorResource } from "@app/lib/resources/group_space_editor_resource";
 import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_member_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
@@ -983,6 +984,229 @@ describe("SpaceResource", () => {
               "group_requirements_not_met"
             );
           }
+        });
+      });
+
+      describe("admin-controlled Pods", () => {
+        beforeEach(async () => {
+          projectEditorGroup = await GroupResource.makeNew({
+            name: "Project Editors Group",
+            workspaceId: workspace.id,
+            kind: "space_editors",
+          });
+
+          projectSpace = await SpaceResource.makeNew(
+            {
+              name: "Admin Controlled Project",
+              kind: "project",
+              workspaceId: workspace.id,
+              managementMode: "manual",
+            },
+            { members: [projectMemberGroup] }
+          );
+
+          await GroupSpaceEditorResource.makeNew(adminAuth, {
+            group: projectEditorGroup,
+            space: projectSpace,
+          });
+
+          await ProjectMetadataResource.makeNew(adminAuth, projectSpace, {
+            description: "Admin controlled",
+            isAdminControlled: false,
+          });
+        });
+
+        it("demotes editors to members when enabling admin-controlled mode", async () => {
+          await projectEditorGroup.dangerouslyAddMember(adminAuth, {
+            user: editorUser.toJSON(),
+          });
+          await projectMemberGroup.dangerouslyAddMember(adminAuth, {
+            user: memberUser.toJSON(),
+          });
+
+          const reloadedSpace = await SpaceResource.fetchById(
+            adminAuth,
+            projectSpace.sId
+          );
+          const result =
+            await reloadedSpace!.applyAdminControlledMembershipChange(
+              adminAuth,
+              true
+            );
+          expect(result.isOk()).toBe(true);
+
+          const editorGroupMembers =
+            await projectEditorGroup.getActiveMembers(adminAuth);
+          expect(editorGroupMembers).toHaveLength(0);
+
+          const memberGroupMembers =
+            await projectMemberGroup.getActiveMembers(adminAuth);
+          expect(memberGroupMembers.some((m) => m.sId === editorUser.sId)).toBe(
+            true
+          );
+          expect(memberGroupMembers.some((m) => m.sId === memberUser.sId)).toBe(
+            true
+          );
+        });
+
+        it("promotes the oldest member to editor when disabling admin-controlled mode", async () => {
+          await projectMemberGroup.dangerouslyAddMember(adminAuth, {
+            user: memberUser.toJSON(),
+          });
+          // Add editorUser second so memberUser is oldest.
+          await projectMemberGroup.dangerouslyAddMember(adminAuth, {
+            user: editorUser.toJSON(),
+          });
+
+          const metadata = await ProjectMetadataResource.fetchBySpace(
+            adminAuth,
+            projectSpace
+          );
+          await metadata!.updateIsAdminControlled(true);
+
+          const reloadedSpace = await SpaceResource.fetchById(
+            adminAuth,
+            projectSpace.sId
+          );
+          const result =
+            await reloadedSpace!.applyAdminControlledMembershipChange(
+              adminAuth,
+              false
+            );
+          expect(result.isOk()).toBe(true);
+
+          const editorGroupMembers =
+            await projectEditorGroup.getActiveMembers(adminAuth);
+          expect(editorGroupMembers).toHaveLength(1);
+          expect(editorGroupMembers[0].sId).toBe(memberUser.sId);
+
+          const memberGroupMembers =
+            await projectMemberGroup.getActiveMembers(adminAuth);
+          expect(memberGroupMembers.some((m) => m.sId === memberUser.sId)).toBe(
+            false
+          );
+          expect(memberGroupMembers.some((m) => m.sId === editorUser.sId)).toBe(
+            true
+          );
+        });
+
+        it("lets workspace admins administrate without being in the editor group", async () => {
+          const metadata = await ProjectMetadataResource.fetchBySpace(
+            adminAuth,
+            projectSpace
+          );
+          await metadata!.updateIsAdminControlled(true);
+
+          const reloadedSpace = await SpaceResource.fetchById(
+            adminAuth,
+            projectSpace.sId
+          );
+
+          expect(await reloadedSpace!.fetchIsAdminControlled()).toBe(true);
+          expect(reloadedSpace!.canAdministrate(adminAuth)).toBe(true);
+        });
+
+        it("does not let managers administrate", async () => {
+          const metadata = await ProjectMetadataResource.fetchBySpace(
+            adminAuth,
+            projectSpace
+          );
+          await metadata!.updateIsAdminControlled(true);
+
+          const managerUser = await UserFactory.basic();
+          await MembershipFactory.associate(workspace, managerUser, {
+            role: "manager",
+          });
+          const managerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            managerUser.sId,
+            workspace.sId
+          );
+
+          const reloadedSpace = await SpaceResource.fetchById(
+            managerAuth,
+            projectSpace.sId
+          );
+
+          expect(reloadedSpace!.canAdministrate(managerAuth)).toBe(false);
+        });
+
+        it("blocks addEditors while admin-controlled", async () => {
+          const metadata = await ProjectMetadataResource.fetchBySpace(
+            adminAuth,
+            projectSpace
+          );
+          await metadata!.updateIsAdminControlled(true);
+          await projectMemberGroup.dangerouslyAddMember(adminAuth, {
+            user: memberUser.toJSON(),
+          });
+
+          const reloadedSpace = await SpaceResource.fetchById(
+            adminAuth,
+            projectSpace.sId
+          );
+
+          const addRes = await reloadedSpace!.addEditors(adminAuth, {
+            userIds: [memberUser.sId],
+          });
+          expect(addRes.isErr()).toBe(true);
+          if (addRes.isErr()) {
+            expect(addRes.error.code).toBe("unauthorized");
+          }
+        });
+
+        it("rejects setting editors via updatePermissions while admin-controlled", async () => {
+          const metadata = await ProjectMetadataResource.fetchBySpace(
+            adminAuth,
+            projectSpace
+          );
+          await metadata!.updateIsAdminControlled(true);
+          await projectMemberGroup.dangerouslyAddMember(adminAuth, {
+            user: memberUser.toJSON(),
+          });
+
+          const reloadedSpace = await SpaceResource.fetchById(
+            adminAuth,
+            projectSpace.sId
+          );
+
+          const result = await reloadedSpace!.updatePermissions(adminAuth, {
+            name: projectSpace.name,
+            isRestricted: true,
+            managementMode: "manual",
+            memberIds: [],
+            editorIds: [memberUser.sId],
+          });
+
+          expect(result.isErr()).toBe(true);
+          if (result.isErr()) {
+            expect(result.error.code).toBe("unauthorized");
+          }
+        });
+
+        it("allows updating members with an empty editor list while admin-controlled", async () => {
+          const metadata = await ProjectMetadataResource.fetchBySpace(
+            adminAuth,
+            projectSpace
+          );
+          await metadata!.updateIsAdminControlled(true);
+          await projectMemberGroup.dangerouslyAddMember(adminAuth, {
+            user: memberUser.toJSON(),
+          });
+
+          const reloadedSpace = await SpaceResource.fetchById(
+            adminAuth,
+            projectSpace.sId
+          );
+
+          const result = await reloadedSpace!.updatePermissions(adminAuth, {
+            name: projectSpace.name,
+            isRestricted: true,
+            managementMode: "manual",
+            memberIds: [memberUser.sId, editorUser.sId],
+            editorIds: [],
+          });
+
+          expect(result.isOk()).toBe(true);
         });
       });
 

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -10,6 +10,7 @@ import { GroupSpaceViewerResource } from "@app/lib/resources/group_space_viewer_
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
+import { ProjectMetadataModel } from "@app/lib/resources/storage/models/project_metadata";
 import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
 import { SandboxEnvVarModel } from "@app/lib/resources/storage/models/sandbox_env_var";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
@@ -116,6 +117,29 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       space.get(),
       space.groupSpaces.map(SpaceGroupReference.fromGroupSpaceModel)
     );
+  }
+
+  /**
+   * Project-only: when true, workspace admins are the only people with
+   * editor/admin powers. Enabling demotes editors to members; disabling
+   * promotes the oldest member back to editor.
+   *
+   * Fetched on demand from project_metadata (not joined on every space load).
+   */
+  async fetchIsAdminControlled(): Promise<boolean> {
+    if (!this.isProject()) {
+      return false;
+    }
+
+    const metadata = await ProjectMetadataModel.findOne({
+      attributes: ["isAdminControlled"],
+      where: {
+        spaceId: this.id,
+        workspaceId: this.workspaceId,
+      },
+    });
+
+    return metadata?.isAdminControlled ?? false;
   }
 
   static async makeNew(
@@ -999,6 +1023,21 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           "A user cannot be both a member and an editor of the same space."
         );
 
+        const isAdminControlled = await this.fetchIsAdminControlled();
+
+        // Admin-controlled Pods have an empty editor group; workspace admins
+        // administrate via role. Reject any attempt to set editors.
+        if (isAdminControlled && this.isProject()) {
+          if (editorIds.length > 0) {
+            return new Err(
+              new DustError(
+                "unauthorized",
+                "Editors cannot be set while this Pod is admin-controlled."
+              )
+            );
+          }
+        }
+
         // Handle member-based management
         const users = await UserResource.fetchByIds(memberIds);
 
@@ -1059,7 +1098,10 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
           // Set members of the editor group using the GroupSpaceEditorResource
           const editorUsers = await UserResource.fetchByIds(editorIds);
-          assert(editorUsers.length > 0, "Pods must have at least one editor.");
+          assert(
+            editorUsers.length > 0 || isAdminControlled,
+            "Pods must have at least one editor."
+          );
           const setEditorsRes = await editorGroupSpaces[0].setMembers(auth, {
             users: editorUsers.map((u) => u.toJSON()),
             transaction: t,
@@ -1175,6 +1217,139 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return editorGroupSpaces[0];
   }
 
+  /**
+   * When enabling admin-controlled mode: demote all editors to members.
+   * When disabling: promote the oldest member to editor.
+   * Caller must update project metadata separately; this only adjusts groups.
+   */
+  async applyAdminControlledMembershipChange(
+    auth: Authenticator,
+    isAdminControlled: boolean,
+    transaction?: Transaction
+  ): Promise<
+    Result<
+      undefined,
+      DustError<
+        | "unauthorized"
+        | "user_not_found"
+        | "user_not_member"
+        | "user_already_member"
+        | "group_requirements_not_met"
+        | "system_or_global_group"
+      >
+    >
+  > {
+    assert(this.isProject(), "Only projects support admin-controlled mode.");
+    assert(
+      this.managementMode === "manual",
+      "Admin-controlled mode requires manual membership management."
+    );
+
+    if (!auth.isAdmin()) {
+      return new Err(
+        new DustError(
+          "unauthorized",
+          "Only workspace admins can change admin-controlled Pod mode."
+        )
+      );
+    }
+
+    return withTransaction(async (t: Transaction) => {
+      const editorGroupSpace = await this.fetchManualEditorGroupSpace();
+      const memberGroupSpace = await this.fetchManualMemberGroupSpace();
+      const editorGroup = editorGroupSpace.group;
+      const memberGroup = memberGroupSpace.group;
+
+      if (isAdminControlled) {
+        const editors = await editorGroup.getActiveMembers(auth, {
+          transaction: t,
+        });
+        if (editors.length === 0) {
+          return new Ok(undefined);
+        }
+
+        const members = await memberGroup.getActiveMembers(auth, {
+          transaction: t,
+        });
+        const existingMemberSIds = new Set(members.map((m) => m.sId));
+        const editorsToAdd = editors.filter(
+          (e) => !existingMemberSIds.has(e.sId)
+        );
+
+        if (editorsToAdd.length > 0) {
+          const addRes = await memberGroup.dangerouslyAddMembers(auth, {
+            users: editorsToAdd.map((u) => u.toJSON()),
+            transaction: t,
+          });
+          if (addRes.isErr()) {
+            return addRes;
+          }
+        }
+
+        const clearEditorsRes = await editorGroup.dangerouslySetMembers(auth, {
+          users: [],
+          transaction: t,
+        });
+        if (clearEditorsRes.isErr()) {
+          return clearEditorsRes;
+        }
+
+        return new Ok(undefined);
+      }
+
+      // Disabling: promote the oldest member (by join date) to editor.
+      const now = new Date();
+      const memberMemberships = await GroupMembershipModel.findAll({
+        where: {
+          workspaceId: this.workspaceId,
+          groupId: memberGroup.id,
+          status: "active" as const,
+          startAt: { [Op.lte]: now },
+          [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
+        },
+        order: [["startAt", "ASC"]],
+        transaction: t,
+      });
+      if (memberMemberships.length === 0) {
+        return new Err(
+          new DustError(
+            "group_requirements_not_met",
+            "Cannot disable admin-controlled mode: this Pod has no members."
+          )
+        );
+      }
+
+      const oldestUsers = await UserResource.fetchByModelIds([
+        memberMemberships[0].userId,
+      ]);
+      const oldestMember = oldestUsers[0];
+      if (!oldestMember) {
+        return new Err(new DustError("user_not_found", "User not found"));
+      }
+
+      const removeFromMembersRes = await memberGroup.dangerouslyRemoveMembers(
+        auth,
+        {
+          users: [oldestMember.toJSON()],
+          transaction: t,
+        }
+      );
+      if (removeFromMembersRes.isErr()) {
+        return removeFromMembersRes;
+      }
+
+      const setEditorRes = await editorGroup.dangerouslySetMembers(auth, {
+        users: [oldestMember.toJSON()],
+        transaction: t,
+      });
+      if (setEditorRes.isErr()) {
+        return setEditorRes;
+      }
+
+      return new Ok(undefined);
+    }, transaction);
+  }
+
   async fetchActiveEditorUsers(auth: Authenticator): Promise<UserResource[]> {
     if (!this.isProject()) {
       return [];
@@ -1288,6 +1463,15 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       );
     }
 
+    if (await this.fetchIsAdminControlled()) {
+      return new Err(
+        new DustError(
+          "unauthorized",
+          "Editors cannot be changed while this Pod is admin-controlled."
+        )
+      );
+    }
+
     assert(this.isProject(), "Only projects can have editors.");
     assert(
       this.managementMode === "manual",
@@ -1368,6 +1552,15 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         new DustError(
           "unauthorized",
           "You do not have permission to remove editors from this space."
+        )
+      );
+    }
+
+    if (await this.fetchIsAdminControlled()) {
+      return new Err(
+        new DustError(
+          "unauthorized",
+          "Editors cannot be changed while this Pod is admin-controlled."
         )
       );
     }
@@ -1625,7 +1818,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           groups: this.groups.reduce((acc, group) => {
             if (groupFilter(group)) {
               if (group.groupSpaceKind === "project_editor") {
-                // Project editors get admin permissions
                 acc.push({
                   id: group.groupId,
                   permissions: ["admin", "read", "write"],

--- a/front/lib/resources/storage/models/project_metadata.ts
+++ b/front/lib/resources/storage/models/project_metadata.ts
@@ -19,6 +19,11 @@ export class ProjectMetadataModel extends WorkspaceAwareModel<ProjectMetadataMod
   declare todoGenerationEnabled: CreationOptional<boolean>;
   /** First-run window only; cleared after first successful analysis. Internal / workflow. */
   declare initialTodoAnalysisLookback: CreationOptional<string | null>;
+  /**
+   * When true, workspace admins control membership and can attach connected data
+   * (Space DataSourceViews) to this Pod. Opt-in; gated by `admin_controlled_pods`.
+   */
+  declare isAdminControlled: CreationOptional<boolean>;
   declare spaceId: ForeignKey<SpaceModel["id"]>;
 
   declare description: string | null;
@@ -55,6 +60,11 @@ ProjectMetadataModel.init(
       allowNull: true,
     },
     todoGenerationEnabled: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    isAdminControlled: {
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -1145,7 +1145,11 @@ export function useUpdatePodMetadata({
             ? updates.todoGenerationEnabled
               ? "Automatic task suggestions turned on"
               : "Automatic task suggestions turned off"
-            : "Pod updated";
+            : updates.isAdminControlled !== undefined
+              ? updates.isAdminControlled
+                ? "Pod is now admin-controlled"
+                : "Pod is now self-serve"
+              : "Pod updated";
 
     sendNotification({
       type: "success",

--- a/front/migrations/pre-deploy/20260804094318_add_is_admin_controlled_to_project_metadata.sql
+++ b/front/migrations/pre-deploy/20260804094318_add_is_admin_controlled_to_project_metadata.sql
@@ -1,0 +1,9 @@
+/*
+Add isAdminControlled to project_metadata for opt-in admin-controlled Pods
+(membership + connected data managed by workspace admins). Default false.
+
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."project_metadata" ADD COLUMN "isAdminControlled" BOOLEAN NOT NULL DEFAULT false;

--- a/front/types/api/spaces.ts
+++ b/front/types/api/spaces.ts
@@ -42,6 +42,7 @@ export const PatchPodMetadataBodySchema = z.object({
   pinnedFramePath: z.string().nullable().optional(),
   defaultAgentId: z.string().nullable().optional(),
   defaultSkillIds: z.array(z.string()).optional(),
+  isAdminControlled: z.boolean().optional(),
 });
 
 export type PatchPodMetadataBodyType = z.infer<
@@ -97,6 +98,8 @@ export type RichSpaceType = SpaceType & {
   todoGenerationEnabled: boolean;
   lastTodoAnalysisAt: number | null;
   pinnedFramePath: string | null;
+  /** Workspace admins control membership and connected data (project spaces only). */
+  isAdminControlled: boolean;
 };
 
 export type GetSpaceResponseBody = {

--- a/front/types/project_metadata.ts
+++ b/front/types/project_metadata.ts
@@ -10,4 +10,5 @@ export interface PodMetadataType {
   pinnedFramePath: string | null;
   defaultAgentId: string | null;
   defaultSkillIds: string[];
+  isAdminControlled: boolean;
 }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -305,6 +305,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable the per-workspace Activation scheduler workflow",
     stage: "dust_only",
   },
+  admin_controlled_pods: {
+    description:
+      "Enable admin-controlled Pods: admins manage membership and attach connected data (Space DataSourceViews) to the Pod itself.",
+    stage: "dust_only",
+  },
   group_permissions_shadow: {
     description:
       "Admin Governance: evaluate the new group_permissions checks alongside the legacy ones and log mismatches (shadow mode). Serves the legacy result; safe to toggle.",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -732,6 +732,7 @@ export type RetrievalDocumentPublicType = z.infer<
 const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "activation_scheduler"
   | "activation_skill"
+  | "admin_controlled_pods"
   | "advanced_notion_management"
   | "allow_scim"
   | "allow_sso"


### PR DESCRIPTION
## Description

Adds an `isAdminControlled` mode to Pods, gated by the `admin_controlled_pods` feature flag (dust_only). When enabled, workspace admins take exclusive control of membership and connected data for a Pod:

- The `space_editors` group is **frozen**: existing editors retain read/write but lose admin powers. Editor promotions are blocked; removals from the Pod still drop users from the frozen group.
- Members (including frozen editors) can always leave the Pod.
- `canAdministrate` is re-routed to workspace admins only via role-based ACL in `GroupSpaceEditorResource.requestedPermissions` and `GroupSpaceMemberResource`.

Backend: `PATCH /spaces/[spaceId]/project_metadata` accepts `isAdminControlled`, enforced with a FF check + `auth.isAdmin()` guard. `SpaceResource.fromModel` LEFT JOINs `ProjectMetadataModel` to hydrate `isAdminControlled` on every space fetch. New `updateIsAdminControlled` on `ProjectMetadataResource`.

Frontend: New `AdminControlledPodTile` in Pod settings with a `SliderToggle` and confirmation dialogs. `ManageUsersPanel` and `PodMembersTable` suppress the editor column and block role changes when admin-controlled. `PodHeaderActions` and `PodMenu` update `canLeavePod` and gate rename/archive via `canAdministratePod`.

Pre-deploy SQL: adds `isAdminControlled BOOLEAN NOT NULL DEFAULT false` to `project_metadata`.

<img width="973" height="95" alt="image" src="https://github.com/user-attachments/assets/9c55a46a-402a-4caa-a5f2-698acb00157e" />


## Tests

- Added integration tests in `space_resource.test.ts` covering: frozen-editor read/write-but-not-admin, workspace-admin-only administrate, manager blocked, `addEditors`/`removeEditors` returning `unauthorized`, `updatePermissions` blocking promotions and allowing removals, frozen editors blocked from managing members.
- Updated `project_metadata_resource.test.ts` and `project_metadata.test.ts` snapshots with `isAdminControlled: false`.
- Tested locally.

## Risk

Low. The feature is fully gated behind `admin_controlled_pods` (dust_only), so no live user impact on deploy. The SQL migration adds a nullable-safe `BOOLEAN NOT NULL DEFAULT false` column — online, no locking risk. The `SpaceResource.fromModel` LEFT JOIN on `ProjectMetadataModel` is a minor query overhead on all space fetches; existing rows default to `false` with no behavioral change.

## Deploy Plan

1. Run pre-deploy SQL migration: `front/migrations/pre-deploy/20260804094318_add_is_admin_controlled_to_project_metadata.sql`
2. Deploy front + front-api.
3. Enable `admin_controlled_pods` FF per workspace to activate.
