### PR TITLE
admin governance for skills: add pop up to confirm unpublished skill removal

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -276,6 +276,8 @@ function AgentBuilderForm({
       name: skill.name,
       description: skill.userFacingDescription,
       icon: skill.icon,
+      availability: skill.availability,
+      canWrite: skill.canWrite,
     }));
   }, [skills]);
 

--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -4,6 +4,7 @@ import {
   generationSettingsSchema,
 } from "@app/components/shared/tools_picker/types";
 import type { ProjectConfiguration } from "@app/lib/api/assistant/configuration/types";
+import { SKILL_AVAILABILITIES } from "@app/types/assistant/skill_configuration";
 import { TRIGGER_STATUSES } from "@app/types/assistant/triggers";
 import { editorUserSchema } from "@app/types/editors";
 import { WEBHOOK_PROVIDERS } from "@app/types/triggers/webhooks";
@@ -107,6 +108,9 @@ const skillsSchema = z.object({
   name: z.string(),
   description: z.string(),
   icon: z.string().nullable(),
+  availability: z.enum(SKILL_AVAILABILITIES),
+  // Whether the current user is an editor of the skill.
+  canWrite: z.boolean(),
 });
 
 // Additional space IDs selected by the user for global skills

--- a/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
@@ -85,6 +85,8 @@ export const useSkillSelection = ({
           name: skill.name,
           description: skill.userFacingDescription,
           icon: skill.icon,
+          availability: skill.availability,
+          canWrite: skill.canWrite,
         },
       ]);
     },

--- a/front/components/agent_builder/skills/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderCapabilitiesBlock.tsx
@@ -18,6 +18,7 @@ import type {
 } from "@app/components/agent_builder/skills/types";
 import { isCapabilitiesSheetOpen } from "@app/components/agent_builder/skills/types";
 import { getDefaultMCPAction } from "@app/components/agent_builder/types";
+import { ConfirmContext } from "@app/components/Confirm";
 import { useSkillsContext } from "@app/components/shared/skills/SkillsContext";
 import { BuilderToolCard } from "@app/components/shared/tools_picker/BuilderToolCard";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
@@ -41,7 +42,7 @@ import {
   ShapesPlus,
   Spinner,
 } from "@dust-tt/sparkle";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useContext, useRef, useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 
 interface SkillCardProps {
@@ -103,6 +104,7 @@ export function AgentBuilderCapabilitiesBlock({
   initialRequestedSpaceIds,
 }: AgentBuilderCapabilitiesBlockProps) {
   const sendNotification = useSendNotification();
+  const confirm = useContext(ConfirmContext);
   const { owner } = useAgentBuilderContext();
 
   const { getValues } = useFormContext<AgentBuilderFormData>();
@@ -237,6 +239,31 @@ export function AgentBuilderCapabilitiesBlock({
     [appendSkills, appendActions, sendNotification]
   );
 
+  // Unpublished (editors-only) skills are only listed to their editors: a non-editor who removes
+  // one will not find it in the capabilities picker anymore, so make the removal explicit.
+  const handleRemoveSkill = useCallback(
+    async (index: number, skill: AgentBuilderSkillsType) => {
+      if (skill.availability === "editors" && !skill.canWrite) {
+        const confirmed = await confirm({
+          title: `Remove ${skill.name}?`,
+          message:
+            "You will not be able to add this skill back because it is only " +
+            "accessible to the skill editors and you are not an editor.",
+          validateLabel: "Remove",
+          validateVariant: "warning",
+          cancelLabel: "Cancel",
+        });
+
+        if (!confirmed) {
+          return;
+        }
+      }
+
+      removeSkill(index);
+    },
+    [confirm, removeSkill]
+  );
+
   const handleClickKnowledge = () => {
     // We don't know which action will be selected so we will create a generic MCP action.
     const action = getDefaultMCPAction();
@@ -306,7 +333,7 @@ export function AgentBuilderCapabilitiesBlock({
               <SkillCard
                 key={field.id}
                 skill={field}
-                onRemove={() => removeSkill(index)}
+                onRemove={() => void handleRemoveSkill(index, field)}
                 onClick={() => {
                   void fetchSkillWithRelations(field.sId);
                 }}

--- a/front/components/markdown/suggestion/SidekickSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/SidekickSuggestionCard.tsx
@@ -359,6 +359,8 @@ function SkillSuggestionCard({ agentSuggestion }: SkillSuggestionCardProps) {
             name: skill.name,
             description: skill.userFacingDescription,
             icon: skill.icon,
+            availability: skill.availability,
+            canWrite: skill.canWrite,
           };
           setValue("skills", [...currentSkills, newSkill], {
             shouldDirty: true,

--- a/front/lib/api/assistant/configuration/yaml_export.ts
+++ b/front/lib/api/assistant/configuration/yaml_export.ts
@@ -115,6 +115,8 @@ export async function getAgentConfigurationAsYAMLConfig(
         name: json.name,
         description: json.userFacingDescription,
         icon: json.icon,
+        availability: json.availability,
+        canWrite: json.canWrite,
       };
     }),
     agentSettings: {


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/9735

When removing a skill from the agent builder, if the skill is unpublished ("editors" availability) and the user is not an editor, then the skill cannot be added back.
To prevent unwanted situation we warn the user that it cannot be added back

<img width="1710" height="873" alt="Screenshot 2026-08-04 at 13 46 58" src="https://github.com/user-attachments/assets/b3912514-6261-4d2c-80e8-59a45b9bb3a8" />


## Tests

tested locally

## Risk

low, purely UI and easy to revert

## Deploy Plan

deploy front
