### PR TITLE
Paginate the pending upgrade-requests queue

### DIFF
--- a/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
@@ -250,9 +250,10 @@ describe("/api/w/[wId]/credits/upgrade-requests", () => {
         upgradeRequestsUrl(workspace.sId)
       );
       expect(listResponse.status).toBe(200);
-      const { requests } = await listResponse.json();
+      const { requests, total } = await listResponse.json();
       expect(requests).toHaveLength(1);
       expect(requests[0].requester.sId).toBe(member.sId);
+      expect(total).toBe(1);
 
       const requestId = requests[0].sId;
       const patchResponse = await honoApp.request(
@@ -270,7 +271,92 @@ describe("/api/w/[wId]/credits/upgrade-requests", () => {
       const afterResponse = await honoApp.request(
         upgradeRequestsUrl(workspace.sId)
       );
-      expect((await afterResponse.json()).requests).toHaveLength(0);
+      const afterBody = await afterResponse.json();
+      expect(afterBody.requests).toHaveLength(0);
+      expect(afterBody.total).toBe(0);
+    });
+
+    it("paginates pending requests 100 per page", async () => {
+      const workspace = await creditPricedWorkspace();
+
+      const totalPendingRequests = 101;
+      for (let i = 0; i < totalPendingRequests; i++) {
+        const { user, auth: memberAuth } = await createPrivateApiMockRequest({
+          method: "POST",
+          role: "user",
+          workspace,
+        });
+        const created = await MembershipUpgradeRequestResource.createPending(
+          memberAuth,
+          { user, reason: null }
+        );
+        if (created.isErr()) {
+          throw created.error;
+        }
+      }
+
+      // Re-authenticate as an admin of the same workspace for the list calls.
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+
+      const firstPageResponse = await honoApp.request(
+        upgradeRequestsUrl(workspace.sId)
+      );
+      expect(firstPageResponse.status).toBe(200);
+      const firstPage = await firstPageResponse.json();
+      expect(firstPage.requests).toHaveLength(100);
+      expect(firstPage.total).toBe(totalPendingRequests);
+
+      const secondPageResponse = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}?offset=100`
+      );
+      expect(secondPageResponse.status).toBe(200);
+      const secondPage = await secondPageResponse.json();
+      expect(secondPage.requests).toHaveLength(1);
+      expect(secondPage.total).toBe(totalPendingRequests);
+
+      // The two pages are disjoint and together cover every pending request.
+      const firstPageIds = new Set(
+        firstPage.requests.map((r: { sId: string }) => r.sId)
+      );
+      const secondPageIds = new Set(
+        secondPage.requests.map((r: { sId: string }) => r.sId)
+      );
+      expect(firstPageIds.size).toBe(100);
+      for (const id of secondPageIds) {
+        expect(firstPageIds.has(id)).toBe(false);
+      }
+    });
+
+    it("filters pending requests by requester name/email search", async () => {
+      const workspace = await creditPricedWorkspace();
+      const { user: matchingMember } = await createMemberRequest(workspace);
+      const { user: otherMember } = await createMemberRequest(workspace);
+
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+
+      const searchResponse = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}?search=${encodeURIComponent(matchingMember.email ?? "")}`
+      );
+      expect(searchResponse.status).toBe(200);
+      const { requests: searchResults, total: searchTotal } =
+        await searchResponse.json();
+      expect(searchTotal).toBe(1);
+      expect(searchResults).toHaveLength(1);
+      expect(searchResults[0].requester.sId).toBe(matchingMember.sId);
+      expect(
+        searchResults.some(
+          (r: { requester: { sId: string } }) =>
+            r.requester.sId === otherMember.sId
+        )
+      ).toBe(false);
     });
 
     it("PATCH returns 404 for an unknown request id", async () => {

--- a/front-api/routes/w/[wId]/credits/upgrade-requests.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.ts
@@ -2,9 +2,8 @@ import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import type { ResolveUpgradeRequestError } from "@app/lib/api/credits/upgrade_requests";
 import {
   createUpgradeRequest,
-  listAllResolvedUpgradeRequests,
-  listPendingUpgradeRequests,
-  listResolvedUpgradeRequests,
+  listAllUpgradeRequests,
+  listUpgradeRequests,
   resolveUpgradeRequest,
 } from "@app/lib/api/credits/upgrade_requests";
 import { upgradeRequestsToCsv } from "@app/lib/api/credits/upgrade_requests_export";
@@ -121,11 +120,13 @@ app.get(
   async (ctx) => {
     const auth = ctx.get("auth");
     const { status, offset, decision, search, format } = ctx.req.valid("query");
+    const resolvedStatus = status ?? "pending";
 
     if (format === "csv") {
       // CSV export is only wired to the resolved-requests History tab; it
       // always covers the full history matching the current filters.
-      const requests = await listAllResolvedUpgradeRequests(auth, {
+      const requests = await listAllUpgradeRequests(auth, {
+        status: "resolved",
         decision,
         search,
       });
@@ -138,13 +139,12 @@ app.get(
       return ctx.body(upgradeRequestsToCsv(requests));
     }
 
-    const { requests, total } =
-      status === "resolved"
-        ? await listResolvedUpgradeRequests(auth, { offset, decision, search })
-        : {
-            requests: await listPendingUpgradeRequests(auth),
-            total: undefined,
-          };
+    const { requests, total } = await listUpgradeRequests(auth, {
+      status: resolvedStatus,
+      offset,
+      decision,
+      search,
+    });
 
     const body: GetUpgradeRequestsResponseBody = { requests, total };
     return ctx.json(body);

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -76,7 +76,7 @@ import {
 } from "@app/lib/swr/model_tiers";
 import type { UpgradeRequestDecisionFilter } from "@app/lib/swr/upgrade_requests";
 import {
-  UPGRADE_REQUESTS_HISTORY_PAGE_SIZE,
+  UPGRADE_REQUESTS_PAGE_SIZE,
   upgradeRequestsHistoryCsvUrl,
   useResolveUpgradeRequest,
   useUpgradeRequests,
@@ -227,10 +227,12 @@ export function UsagePage() {
     []
   );
 
-  // Name/email search is also applied server-side before pagination
+  // Name/email search feeds the Members table and both the Requests and
+  // History tabs, so all three paginations reset together.
   const handleSetSearchTerm = useCallback((next: string) => {
     setSearchTerm(next);
     setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    setRequestsPagination((prev) => ({ ...prev, pageIndex: 0 }));
     setHistoryPagination((prev) => ({ ...prev, pageIndex: 0 }));
   }, []);
 
@@ -283,13 +285,25 @@ export function UsagePage() {
   const [membersTab, setMembersTab] = useState<
     "members" | "requests" | "history"
   >("members");
-  const { upgradeRequests, isUpgradeRequestsLoading, isUpgradeRequestsError } =
-    useUpgradeRequests({
-      workspaceId: owner.sId,
-    });
+  const [requestsPagination, setRequestsPagination] = useState<PaginationState>(
+    {
+      pageIndex: 0,
+      pageSize: UPGRADE_REQUESTS_PAGE_SIZE,
+    }
+  );
+  const {
+    upgradeRequests,
+    totalUpgradeRequestsCount,
+    isUpgradeRequestsLoading,
+    isUpgradeRequestsError,
+  } = useUpgradeRequests({
+    workspaceId: owner.sId,
+    pageIndex: requestsPagination.pageIndex,
+    searchTerm,
+  });
   const [historyPagination, setHistoryPagination] = useState<PaginationState>({
     pageIndex: 0,
-    pageSize: UPGRADE_REQUESTS_HISTORY_PAGE_SIZE,
+    pageSize: UPGRADE_REQUESTS_PAGE_SIZE,
   });
   const {
     upgradeRequestsHistory,
@@ -313,22 +327,6 @@ export function UsagePage() {
       isUpgradeRequestsHistoryLoading || upgradeRequestsHistory.length === 0,
   });
 
-  const filteredUpgradeRequests = useMemo(() => {
-    const normalizedSearch = searchTerm.trim().toLowerCase();
-    return upgradeRequests.filter((request) => {
-      if (request.status !== "pending") {
-        return false;
-      }
-      if (!normalizedSearch) {
-        return true;
-      }
-      const { name, email } = request.requester;
-      return (
-        name.toLowerCase().includes(normalizedSearch) ||
-        (email?.toLowerCase().includes(normalizedSearch) ?? false)
-      );
-    });
-  }, [upgradeRequests, searchTerm]);
   const { doResolveUpgradeRequest } = useResolveUpgradeRequest({
     workspaceId: owner.sId,
   });
@@ -1225,8 +1223,8 @@ export function UsagePage() {
                       label="Requests"
                       isCounter
                       counterValue={
-                        filteredUpgradeRequests.length > 0
-                          ? String(filteredUpgradeRequests.length)
+                        totalUpgradeRequestsCount > 0
+                          ? String(totalUpgradeRequestsCount)
                           : undefined
                       }
                     />
@@ -1264,9 +1262,12 @@ export function UsagePage() {
                   )}
                   {membersTab === "requests" && (
                     <UpgradeRequestsTable
-                      requests={filteredUpgradeRequests}
+                      requests={upgradeRequests}
                       isLoading={isUpgradeRequestsLoading}
                       isError={isUpgradeRequestsError}
+                      totalRowCount={totalUpgradeRequestsCount}
+                      pagination={requestsPagination}
+                      setPagination={setRequestsPagination}
                       seatPlans={seatPlans}
                       isEnterprise={isEnterprise}
                       pendingRequestIds={resolvingRequestIds}

--- a/front/components/workspace/UpgradeRequestsTable.tsx
+++ b/front/components/workspace/UpgradeRequestsTable.tsx
@@ -15,7 +15,11 @@ import {
   Spinner,
   X,
 } from "@dust-tt/sparkle";
-import type { CellContext, ColumnDef } from "@tanstack/react-table";
+import type {
+  CellContext,
+  ColumnDef,
+  PaginationState,
+} from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 
 type RowData = {
@@ -144,6 +148,9 @@ interface UpgradeRequestsTableProps {
   requests: MembershipUpgradeRequestType[];
   isLoading: boolean;
   isError: boolean;
+  totalRowCount: number;
+  pagination: PaginationState;
+  setPagination: (pagination: PaginationState) => void;
   seatPlans: SeatPlanResponseBody;
   isEnterprise: boolean;
   pendingRequestIds: ReadonlySet<string>;
@@ -156,6 +163,9 @@ export function UpgradeRequestsTable({
   requests,
   isLoading,
   isError,
+  totalRowCount,
+  pagination,
+  setPagination,
   seatPlans,
   isEnterprise,
   pendingRequestIds,
@@ -234,7 +244,13 @@ export function UpgradeRequestsTable({
 
   return (
     <>
-      <DataTable<RowData> data={rows} columns={columns} />
+      <DataTable<RowData>
+        data={rows}
+        columns={columns}
+        pagination={pagination}
+        setPagination={setPagination}
+        totalRowCount={totalRowCount}
+      />
       <ManageUpgradeRequestModal
         request={manageRequest}
         onClose={() => setManageRequest(null)}

--- a/front/lib/api/credits/upgrade_requests.test.ts
+++ b/front/lib/api/credits/upgrade_requests.test.ts
@@ -1,6 +1,6 @@
 import {
-  listAllResolvedUpgradeRequests,
-  RESOLVED_UPGRADE_REQUESTS_HISTORY_PAGE_SIZE,
+  listAllUpgradeRequests,
+  UPGRADE_REQUESTS_PAGE_SIZE,
 } from "@app/lib/api/credits/upgrade_requests";
 import { Authenticator } from "@app/lib/auth";
 import { MembershipUpgradeRequestResource } from "@app/lib/resources/membership_upgrade_request_resource";
@@ -53,26 +53,25 @@ async function createResolvedRequest(
   return request;
 }
 
-describe("listAllResolvedUpgradeRequests", () => {
+describe("listAllUpgradeRequests", () => {
   it("does not duplicate or drop rows when a request is resolved between page fetches", async () => {
     const { adminAuth, memberUser } = await setupWorkspaceWithAdminAndMember();
 
     // More than one page's worth of pre-existing resolved requests, so the
     // export has to fetch at least two pages.
-    const preExistingCount = RESOLVED_UPGRADE_REQUESTS_HISTORY_PAGE_SIZE + 50;
+    const preExistingCount = UPGRADE_REQUESTS_PAGE_SIZE + 50;
     const preExistingIds: string[] = [];
     for (let i = 0; i < preExistingCount; i++) {
       const request = await createResolvedRequest(adminAuth, memberUser);
       preExistingIds.push(request.sId);
     }
 
-    const original =
-      MembershipUpgradeRequestResource.listResolvedByWorkspaceAfter.bind(
-        MembershipUpgradeRequestResource
-      );
+    const original = MembershipUpgradeRequestResource.listByWorkspaceAfter.bind(
+      MembershipUpgradeRequestResource
+    );
     const spy = vi.spyOn(
       MembershipUpgradeRequestResource,
-      "listResolvedByWorkspaceAfter"
+      "listByWorkspaceAfter"
     );
     let concurrentRequestId: string | null = null;
     spy.mockImplementation(async (auth, opts) => {
@@ -86,7 +85,9 @@ describe("listAllResolvedUpgradeRequests", () => {
       return page;
     });
 
-    const exported = await listAllResolvedUpgradeRequests(adminAuth);
+    const exported = await listAllUpgradeRequests(adminAuth, {
+      status: "resolved",
+    });
     const exportedIds = exported.map((r) => r.sId);
 
     expect(spy.mock.calls.length).toBeGreaterThan(1);

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -234,17 +234,8 @@ export async function getUpgradeRequestAvailabilityForUser(
   };
 }
 
-// Admin-only: list pending upgrade requests for the workspace.
-export async function listPendingUpgradeRequests(
-  auth: Authenticator
-): Promise<MembershipUpgradeRequestType[]> {
-  const requests =
-    await MembershipUpgradeRequestResource.listPendingByWorkspace(auth);
-  return requests.map((r) => r.toJSON());
-}
-
-// Admin-only: resolved requests, for the history view, paginated.
-export const RESOLVED_UPGRADE_REQUESTS_HISTORY_PAGE_SIZE = 100;
+// Admin-only: paginated upgrade requests for the workspace
+export const UPGRADE_REQUESTS_PAGE_SIZE = 100;
 
 // The requester isn't joined in SQL so a name/email search
 // resolves matching users via the user search index first, then restricts the
@@ -267,13 +258,15 @@ async function resolveSearchUserModelIds(
   return userModelIds.length === 0 ? null : userModelIds;
 }
 
-export async function listResolvedUpgradeRequests(
+export async function listUpgradeRequests(
   auth: Authenticator,
   {
+    status,
     offset,
     decision,
     search,
   }: {
+    status: "pending" | "resolved";
     offset: number;
     decision?: Exclude<MembershipUpgradeRequestStatus, "pending">;
     search?: string;
@@ -285,8 +278,9 @@ export async function listResolvedUpgradeRequests(
   }
 
   const { requests, total } =
-    await MembershipUpgradeRequestResource.listResolvedByWorkspace(auth, {
-      limit: RESOLVED_UPGRADE_REQUESTS_HISTORY_PAGE_SIZE,
+    await MembershipUpgradeRequestResource.listByWorkspace(auth, {
+      status,
+      limit: UPGRADE_REQUESTS_PAGE_SIZE,
       offset,
       decision,
       userModelIds,
@@ -294,18 +288,20 @@ export async function listResolvedUpgradeRequests(
   return { requests: requests.map((r) => r.toJSON()), total };
 }
 
-// Admin-only: every resolved request, keyset-paginated fetching. Keyset
-// (not offset) pagination so a request resolved concurrently mid-export
-// can't shift page boundaries and cause a duplicated or omitted row.
-export async function listAllResolvedUpgradeRequests(
+// Admin-only: every upgrade request matching the current filters. Keyset
+// (not offset) pagination so a request created/resolved concurrently
+// mid-export can't shift page boundaries and duplicate or drop a row.
+export async function listAllUpgradeRequests(
   auth: Authenticator,
   {
+    status,
     decision,
     search,
   }: {
+    status: "pending" | "resolved";
     decision?: Exclude<MembershipUpgradeRequestStatus, "pending">;
     search?: string;
-  } = {}
+  }
 ): Promise<MembershipUpgradeRequestType[]> {
   const userModelIds = await resolveSearchUserModelIds(auth, search);
   if (userModelIds === null) {
@@ -313,24 +309,24 @@ export async function listAllResolvedUpgradeRequests(
   }
 
   const allRequests: MembershipUpgradeRequestType[] = [];
-  let after: { resolvedAt: Date; id: ModelId } | null = null;
+  let after: { sortKey: Date; id: ModelId } | null = null;
   while (true) {
     const requests =
-      await MembershipUpgradeRequestResource.listResolvedByWorkspaceAfter(
-        auth,
-        {
-          limit: RESOLVED_UPGRADE_REQUESTS_HISTORY_PAGE_SIZE,
-          after,
-          decision,
-          userModelIds,
-        }
-      );
+      await MembershipUpgradeRequestResource.listByWorkspaceAfter(auth, {
+        status,
+        limit: UPGRADE_REQUESTS_PAGE_SIZE,
+        after,
+        decision,
+        userModelIds,
+      });
     allRequests.push(...requests.map((r) => r.toJSON()));
-    if (requests.length < RESOLVED_UPGRADE_REQUESTS_HISTORY_PAGE_SIZE) {
+    if (requests.length < UPGRADE_REQUESTS_PAGE_SIZE) {
       break;
     }
     const last = requests[requests.length - 1];
-    after = { resolvedAt: last.resolvedAt ?? new Date(0), id: last.id };
+    const sortKey =
+      status === "pending" ? last.createdAt : (last.resolvedAt ?? new Date(0));
+    after = { sortKey, id: last.id };
   }
   return allRequests;
 }

--- a/front/lib/resources/membership_upgrade_request_resource.ts
+++ b/front/lib/resources/membership_upgrade_request_resource.ts
@@ -190,27 +190,17 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
     return request ?? null;
   }
 
-  static async listPendingByWorkspace(
-    auth: Authenticator
-  ): Promise<MembershipUpgradeRequestResource[]> {
-    if (!auth.isManager()) {
-      return [];
-    }
-    return this.baseFetch(auth, {
-      where: { status: "pending" },
-      order: [["createdAt", "DESC"]],
-    });
-  }
-
-  // Resolved requests, most recent first.
-  static async listResolvedByWorkspace(
+  // Admin-only, offset-paginated: the pending queue or the resolved history
+  static async listByWorkspace(
     auth: Authenticator,
     {
+      status,
       limit,
       offset,
       decision,
       userModelIds,
     }: {
+      status: "pending" | "resolved";
       limit: number;
       offset: number;
       decision?: Exclude<MembershipUpgradeRequestStatus, "pending">;
@@ -221,15 +211,16 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
       return { requests: [], total: 0 };
     }
     const where = {
-      status: decision ?? { [Op.ne]: "pending" },
+      status:
+        status === "pending" ? "pending" : (decision ?? { [Op.ne]: "pending" }),
       ...(userModelIds ? { userId: { [Op.in]: userModelIds } } : {}),
     };
     const requests = await this.baseFetch(auth, {
       where,
-      // `id` breaks ties between requests resolved at the same timestamp, so
-      // offset pagination stays stable across pages.
+      // `id` breaks ties between requests created/resolved at the same
+      // timestamp, so offset pagination stays stable across pages.
       order: [
-        ["resolvedAt", "DESC"],
+        [status === "pending" ? "createdAt" : "resolvedAt", "DESC"],
         ["id", "DESC"],
       ],
       limit,
@@ -242,25 +233,21 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
     return { requests, total };
   }
 
-  // Resolved requests, most recent first, keyset-paginated on
-  // (resolvedAt, id) rather than offset. Offset pagination would shift
-  // under a concurrent resolution (a newly resolved request is inserted at
-  // the head, pushing every offset down), causing the caller to duplicate
-  // or skip rows across pages; keyset pagination is immune to that because
-  // each page is bounded by the last row actually returned. `decision` and
-  // `userModelIds` mirror the same filters as `listResolvedByWorkspace`, so
-  // the full-history export respects the History tab's decision filter and
-  // search bar.
-  static async listResolvedByWorkspaceAfter(
+  // Same view as `listByWorkspace`, keyset-paginated on (sort column, id)
+  // instead of offset so a concurrent create/resolve can't shift page
+  // boundaries and duplicate or drop a row.
+  static async listByWorkspaceAfter(
     auth: Authenticator,
     {
+      status,
       limit,
       after,
       decision,
       userModelIds,
     }: {
+      status: "pending" | "resolved";
       limit: number;
-      after: { resolvedAt: Date; id: ModelId } | null;
+      after: { sortKey: Date; id: ModelId } | null;
       decision?: Exclude<MembershipUpgradeRequestStatus, "pending">;
       userModelIds?: ModelId[];
     }
@@ -268,16 +255,18 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
     if (!auth.isManager()) {
       return [];
     }
+    const sortField = status === "pending" ? "createdAt" : "resolvedAt";
     const baseFilter = {
-      status: decision ?? { [Op.ne]: "pending" },
+      status:
+        status === "pending" ? "pending" : (decision ?? { [Op.ne]: "pending" }),
       ...(userModelIds ? { userId: { [Op.in]: userModelIds } } : {}),
     };
     const where = after
       ? {
           ...baseFilter,
           [Op.or]: [
-            { resolvedAt: { [Op.lt]: after.resolvedAt } },
-            { resolvedAt: after.resolvedAt, id: { [Op.lt]: after.id } },
+            { [sortField]: { [Op.lt]: after.sortKey } },
+            { [sortField]: after.sortKey, id: { [Op.lt]: after.id } },
           ],
         }
       : baseFilter;
@@ -285,7 +274,7 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
     return this.baseFetch(auth, {
       where,
       order: [
-        ["resolvedAt", "DESC"],
+        [sortField, "DESC"],
         ["id", "DESC"],
       ],
       limit,

--- a/front/lib/resources/storage/models/membership_upgrade_requests.ts
+++ b/front/lib/resources/storage/models/membership_upgrade_requests.ts
@@ -114,7 +114,7 @@ MembershipUpgradeRequestModel.init(
         name: "membership_upgrade_requests_resolved_by_user_idx",
       },
       // Admin history view: resolved requests for a workspace, newest first
-      // (see `listResolvedByWorkspace`).
+      // (see `listByWorkspace`).
       {
         fields: ["workspaceId", "resolvedAt"],
         name: "membership_upgrade_requests_workspace_resolved_at_idx",

--- a/front/lib/swr/upgrade_requests.ts
+++ b/front/lib/swr/upgrade_requests.ts
@@ -16,6 +16,7 @@ import type { MembershipUpgradeRequestStatus } from "@app/types/memberships";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { useCallback, useEffect, useState } from "react";
 import type { Fetcher } from "swr";
+import { mutate } from "swr";
 
 export type UpgradeRequestDecisionFilter = Exclude<
   MembershipUpgradeRequestStatus,
@@ -48,12 +49,22 @@ function usageStatusUrl(workspaceId: string): string {
   return `/api/w/${workspaceId}/usage-status`;
 }
 
+async function invalidateUpgradeRequests(workspaceId: string): Promise<void> {
+  await mutate(
+    (key) =>
+      typeof key === "string" && key.startsWith(upgradeRequestsUrl(workspaceId))
+  );
+}
+
 // Member-initiated: request a spend-limit upgrade for the current user. On
 // success the usage-status read is revalidated so the banner reflects the now
 // pending request.
 export function useRequestUpgrade({ workspaceId }: { workspaceId: string }) {
   const sendNotification = useSendNotification();
-  const { mutate } = useSWRWithDefaults(usageStatusUrl(workspaceId), null);
+  const { mutate: mutateUsageStatus } = useSWRWithDefaults(
+    usageStatusUrl(workspaceId),
+    null
+  );
 
   const doRequestUpgrade = useCallback(
     async ({ reason }: { reason?: string }): Promise<boolean> => {
@@ -73,7 +84,7 @@ export function useRequestUpgrade({ workspaceId }: { workspaceId: string }) {
         return false;
       }
 
-      await mutate();
+      await mutateUsageStatus();
       sendNotification({
         type: "success",
         title: "Upgrade requested",
@@ -81,64 +92,32 @@ export function useRequestUpgrade({ workspaceId }: { workspaceId: string }) {
       });
       return true;
     },
-    [workspaceId, sendNotification, mutate]
+    [workspaceId, sendNotification, mutateUsageStatus]
   );
 
   return { doRequestUpgrade };
 }
 
-// Admin-only: pending upgrade requests for the workspace. Fetched on the Usage
-// page both to render the Requests tab and to back its count badge, so it is
-// not gated behind tab visibility.
-export function useUpgradeRequests({
+// Server-enforced page size
+export const UPGRADE_REQUESTS_PAGE_SIZE = 100;
+
+function useUpgradeRequestsList({
   workspaceId,
-  disabled,
-}: {
-  workspaceId: string;
-  disabled?: boolean;
-}) {
-  const { fetcher } = useFetcher();
-  const upgradeRequestsFetcher: Fetcher<GetUpgradeRequestsResponseBody> =
-    fetcher;
-
-  const { data, error, mutate } = useSWRWithDefaults(
-    upgradeRequestsUrl(workspaceId),
-    upgradeRequestsFetcher,
-    { disabled }
-  );
-
-  const requests = data?.requests ?? emptyArray();
-
-  return {
-    upgradeRequests: requests,
-    isUpgradeRequestsLoading: !error && !data && !disabled,
-    isUpgradeRequestsError: !!error,
-    mutateUpgradeRequests: mutate,
-  };
-}
-
-// Server-enforced page size for the History tab — must match
-// `RESOLVED_UPGRADE_REQUESTS_HISTORY_PAGE_SIZE` in
-// `@app/lib/api/credits/upgrade_requests`.
-export const UPGRADE_REQUESTS_HISTORY_PAGE_SIZE = 100;
-
-// Admin-only: resolved (approved/denied) upgrade requests, for the History
-// tab. Disabled until that tab is visible.
-export function useUpgradeRequestsHistory({
-  workspaceId,
+  status,
   pageIndex,
   searchTerm = "",
   decision,
   disabled,
 }: {
   workspaceId: string;
+  status: "pending" | "resolved";
   pageIndex: number;
   searchTerm?: string;
   decision?: UpgradeRequestDecisionFilter;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
-  const upgradeRequestsHistoryFetcher: Fetcher<GetUpgradeRequestsResponseBody> =
+  const upgradeRequestsFetcher: Fetcher<GetUpgradeRequestsResponseBody> =
     fetcher;
 
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState(searchTerm);
@@ -148,10 +127,10 @@ export function useUpgradeRequestsHistory({
     return () => clearTimeout(id);
   }, [searchTerm]);
 
-  const offset = pageIndex * UPGRADE_REQUESTS_HISTORY_PAGE_SIZE;
+  const offset = pageIndex * UPGRADE_REQUESTS_PAGE_SIZE;
 
   const searchParams = new URLSearchParams({
-    status: "resolved",
+    status,
     offset: offset.toString(),
   });
   if (decision) {
@@ -161,18 +140,78 @@ export function useUpgradeRequestsHistory({
     searchParams.set("search", debouncedSearchTerm.trim());
   }
 
-  const { data, error, mutate } = useSWRWithDefaults(
+  const { data, error } = useSWRWithDefaults(
     `${upgradeRequestsUrl(workspaceId)}?${searchParams.toString()}`,
-    upgradeRequestsHistoryFetcher,
+    upgradeRequestsFetcher,
     { disabled, keepPreviousData: true }
   );
 
   return {
-    upgradeRequestsHistory: data?.requests ?? emptyArray(),
-    totalUpgradeRequestsHistoryCount: data?.total ?? 0,
-    isUpgradeRequestsHistoryLoading: !error && !data && !disabled,
-    isUpgradeRequestsHistoryError: !!error,
-    mutateUpgradeRequestsHistory: mutate,
+    requests: data?.requests ?? emptyArray(),
+    totalCount: data?.total ?? 0,
+    isLoading: !error && !data && !disabled,
+    isError: !!error,
+  };
+}
+
+// Admin-only: pending upgrade requests for the workspace, paginated. Fetched
+// on the Usage page both to render the Requests tab and to back its count
+// badge, so it is not gated behind tab visibility.
+export function useUpgradeRequests({
+  workspaceId,
+  pageIndex,
+  searchTerm,
+  disabled,
+}: {
+  workspaceId: string;
+  pageIndex: number;
+  searchTerm?: string;
+  disabled?: boolean;
+}) {
+  const { requests, totalCount, isLoading, isError } = useUpgradeRequestsList({
+    workspaceId,
+    status: "pending",
+    pageIndex,
+    searchTerm,
+    disabled,
+  });
+
+  return {
+    upgradeRequests: requests,
+    totalUpgradeRequestsCount: totalCount,
+    isUpgradeRequestsLoading: isLoading,
+    isUpgradeRequestsError: isError,
+  };
+}
+
+// Admin-only: resolved (approved/denied) upgrade requests, applies filtering
+export function useUpgradeRequestsHistory({
+  workspaceId,
+  pageIndex,
+  searchTerm,
+  decision,
+  disabled,
+}: {
+  workspaceId: string;
+  pageIndex: number;
+  searchTerm?: string;
+  decision?: UpgradeRequestDecisionFilter;
+  disabled?: boolean;
+}) {
+  const { requests, totalCount, isLoading, isError } = useUpgradeRequestsList({
+    workspaceId,
+    status: "resolved",
+    pageIndex,
+    searchTerm,
+    decision,
+    disabled,
+  });
+
+  return {
+    upgradeRequestsHistory: requests,
+    totalUpgradeRequestsHistoryCount: totalCount,
+    isUpgradeRequestsHistoryLoading: isLoading,
+    isUpgradeRequestsHistoryError: isError,
   };
 }
 
@@ -182,7 +221,6 @@ export function useResolveUpgradeRequest({
   workspaceId: string;
 }) {
   const sendNotification = useSendNotification();
-  const { mutate } = useSWRWithDefaults(upgradeRequestsUrl(workspaceId), null);
 
   const doResolveUpgradeRequest = useCallback(
     async ({
@@ -218,7 +256,7 @@ export function useResolveUpgradeRequest({
       // approval edits the member's seat / limit, so the members-usage surface
       // only needs refreshing on approve.
       await Promise.all([
-        mutate(),
+        invalidateUpgradeRequests(workspaceId),
         resolution.status === "approved"
           ? invalidateMembersUsage(workspaceId)
           : Promise.resolve(),
@@ -244,7 +282,7 @@ export function useResolveUpgradeRequest({
       }
       return true;
     },
-    [workspaceId, sendNotification, mutate]
+    [workspaceId, sendNotification]
   );
 
   return { doResolveUpgradeRequest };

--- a/front/types/api/credits/upgrade_requests.ts
+++ b/front/types/api/credits/upgrade_requests.ts
@@ -6,8 +6,6 @@ import type {
 
 export type GetUpgradeRequestsResponseBody = {
   requests: MembershipUpgradeRequestType[];
-  // Total resolved-request count, for the history view's pagination. Absent
-  // for the (unpaginated) pending-requests list.
   total?: number;
 };
 


### PR DESCRIPTION
## Description
- Add pagination to the pending upgrade request tab so a workspace with a large backlog doesn't load too much at once
- Paginate it the same way the resolved-history view already is: offset-based, 100 per page, with server-side requester name/email search.
- Now that both the pending queue and the resolved history share the same pagination shape, merge the two nearly-identical list paths into one

## Deploy plan
- deploy front