### PR TITLE
Fix Academy quiz prompt rendering the literal `{contentType}` placeholder

### DIFF
--- a/marketing/components/academy/AcademyQuiz.tsx
+++ b/marketing/components/academy/AcademyQuiz.tsx
@@ -195,9 +195,11 @@ export function AcademyQuiz({
     [resetQuiz, contentType, correctAnswers, totalQuestions]
   );
 
-  const greeting = userName
-    ? quizSettings.quizGreetingUser.replace("{name}", userName)
-    : quizSettings.quizGreetingGeneric;
+  const greeting = (
+    userName
+      ? quizSettings.quizGreetingUser.replace("{name}", userName)
+      : quizSettings.quizGreetingGeneric
+  ).replace("{contentType}", contentType);
 
   return (
     <div className="mt-12 rounded-xl border border-highlight/20 bg-highlight/5">


### PR DESCRIPTION
## Description

Fix the Academy quiz prompt rendering the literal `{contentType}` placeholder for all academy course chapters.

The quiz greeting came from the Contentful `quizSettings` entry, whose English `quizGreetingGeneric` is authored as `"Ready to test your understanding of this {contentType}?"`. `AcademyQuiz` substituted the other placeholders it knows about (`{name}`, `{passing}`, `{total}`) but never `{contentType}`, so it rendered verbatim on every Academy quiz.

Bug: <img width="1676" height="698" alt="image" src="https://github.com/user-attachments/assets/550e2ec3-48ee-41d4-9cdd-8a1b50524363" />

The quiz now uses the existing `contentType` prop (already passed correctly by all three quiz pages as `"course"`, `"lesson"`, `"chapter"`) instead of displaying the unresolved template variable.

Fixed with one file edit: marketing/components/academy/AcademyQuiz.tsx 
1. <img width="1678" height="485" alt="image" src="https://github.com/user-attachments/assets/a6d49294-1c84-4825-90b1-bacd0dbf13a4" />
2. <img width="1691" height="620" alt="image" src="https://github.com/user-attachments/assets/1a1efc14-a9f1-48c5-85ed-1c5aafdca9a3" />



## Tests

- Confirmed in the browser on an Academy chapter quiz - before: "Ready to test your understanding of this `{contentType}`?"; after: "Ready to test your understanding of this chapter?"
- Confirmed in the browser on an Academy lesson quiz - renders "Ready to test your understanding of this lesson?"
- Ran `npm run tsgo` - clean
- Ran formatting checks (`biome check`, plus the pre-commit biome hook) - clean
- Ran `git diff --check` - clean
- Ran `npm run build` for `marketing` - succeeded

_Note: The `fr` copy spells the word out and carries no placeholder, so French output is unchanged_

Not done:

- Mobile layout check

Note:
Manually verified for chapter and lesson quizzes. The course variant was verified by tracing the existing prop path, but cannot currently be exercised because published courses have chapters.

No regression test is included: the `marketing` workspace has no test runner (no `test` script, no config, no test files), and adding one would mean new infrastructure and undeclared dependencies.

## Risk

Low. This is a scoped rendering fix in the Academy quiz prompt. Quiz questions, scoring, navigation, progress tracking, and data loading are unchanged.

Exactly one user-visible string changes, on the English locale - `String.replace` returns the input unchanged when the placeholder is absent, so French copy and the built-in fallback copy are byte-identical.

## Deploy Plan

Standard deployment with the marketing application. No migration or special deployment step required.


