### PR TITLE
admin governance: add a dust hive seed to test skill governance

### DIFF
--- a/front/scripts/seed/README.md
+++ b/front/scripts/seed/README.md
@@ -18,6 +18,7 @@ DEV_WORKSPACE_SID=MyWorkspace npx tsx scripts/seed/<folder>/seed.ts --execute
 
 - `basics/` - Creates a custom agent with skills and sample conversations
 - `byok/` - Setup workspace to test Bring your own key
+- `governance/` - Creates users and skills for testing admin governance
 - `mcp_tools/` - Creates data-source-backed agents with internal MCP tools
 - `reinforcement/` - Creates skills with conversations, feedbacks, Dust conversations with JIT skills for testing reinforcement
 - `sidekick/` - Creates agents and conversations for testing the agent builder sidekick feature

--- a/front/scripts/seed/factories/seedSkill.ts
+++ b/front/scripts/seed/factories/seedSkill.ts
@@ -1,13 +1,22 @@
+import { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 
 import type { SeedContext, SkillAsset } from "./types";
 
+interface SeedSkillOptions {
+  // Create the skill on behalf of this user, making them its only editor. Defaults to the
+  // context user.
+  owner?: UserResource;
+}
+
 export async function seedSkill(
   ctx: SeedContext,
-  skillAsset: SkillAsset
+  skillAsset: SkillAsset,
+  { owner }: SeedSkillOptions = {}
 ): Promise<SkillResource | null> {
-  const { auth, execute, logger } = ctx;
+  const { auth, workspace, execute, logger } = ctx;
 
   const existingSkills = await SkillResource.listByWorkspace(auth, {
     status: "active",
@@ -23,15 +32,23 @@ export async function seedSkill(
   }
 
   if (execute) {
-    const skill = await SkillFactory.create(auth, {
+    const ownerAuth = owner
+      ? await Authenticator.fromUserIdAndWorkspaceId(owner.sId, workspace.sId)
+      : auth;
+
+    const skill = await SkillFactory.create(ownerAuth, {
       name: skillAsset.name,
       agentFacingDescription: skillAsset.agentFacingDescription,
       userFacingDescription: skillAsset.userFacingDescription,
       instructions: skillAsset.instructions,
       instructionsHtml: skillAsset.instructionsHtml,
       status: "active",
+      availability: skillAsset.availability,
     });
-    logger.info({ sId: skill.sId }, "Skill created");
+    logger.info(
+      { sId: skill.sId, ownerId: owner?.sId ?? auth.getNonNullableUser().sId },
+      "Skill created"
+    );
     return skill;
   }
 

--- a/front/scripts/seed/factories/types.ts
+++ b/front/scripts/seed/factories/types.ts
@@ -1,6 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import type { Logger } from "@app/logger/logger";
+import type { SkillAvailability } from "@app/types/assistant/skill_configuration";
 import type { TemplateTagCodeType } from "@app/types/assistant/templates";
 import type { AgentSuggestionData } from "@app/types/suggestions/agent_suggestion";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -37,6 +38,8 @@ export interface SkillAsset {
   userFacingDescription: string;
   instructions: string;
   instructionsHtml: string;
+  // Defaults to DEFAULT_SKILL_AVAILABILITY ("editors", i.e. unpublished).
+  availability?: SkillAvailability;
 }
 
 export interface SkillSuggestionAsset {

--- a/front/scripts/seed/governance/README.md
+++ b/front/scripts/seed/governance/README.md
@@ -1,0 +1,17 @@
+# Governance Seed
+
+Seeds data for testing admin governance, in particular the skill governance.
+
+## How to use
+
+Run:
+
+```bash
+npx tsx scripts/seed/governance/seed.ts --execute
+```
+
+To target a different workspace:
+
+```bash
+DEV_WORKSPACE_SID=MyWorkspace npx tsx scripts/seed/governance/seed.ts --execute
+```

--- a/front/scripts/seed/governance/assets/agents.json
+++ b/front/scripts/seed/governance/assets/agents.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "IncidentReporter",
+    "description": "Writes incident postmortems from raw notes.",
+    "instructions": "You help engineers turn their raw incident notes into a clean postmortem. Follow the Incident Postmortem skill for the structure of the document.",
+    "pictureUrl": "https://dust.tt/static/systemavatar/claude_avatar_full.png"
+  }
+]

--- a/front/scripts/seed/governance/assets/skills.json
+++ b/front/scripts/seed/governance/assets/skills.json
@@ -1,0 +1,18 @@
+{
+  "alfredSkill": {
+    "name": "Incident Postmortem",
+    "agentFacingDescription": "Guidelines to write an incident postmortem: timeline, impact, root cause and follow-up actions.",
+    "userFacingDescription": "Write incident postmortems following the internal template.",
+    "instructions": "# Incident Postmortem\n\nWhen writing a postmortem, always produce the following sections:\n\n## Summary\nOne paragraph describing what broke, for whom, and for how long.\n\n## Timeline\nA bulleted, timestamped list of events, from the first symptom to the resolution.\n\n## Impact\nQuantify the impact: number of affected users, failed requests, revenue at risk.\n\n## Root cause\nExplain the technical root cause, and the reason it was not caught earlier.\n\n## Follow-up actions\nList concrete, owned action items. Never write \"be more careful\".",
+    "instructionsHtml": "<div data-type=\"instructions-root\" data-block-id=\"instructions-root\"><h1 data-block-id=\"ip01titl\">Incident Postmortem</h1><p data-block-id=\"ip02intr\">When writing a postmortem, always produce the following sections:</p><h2 data-block-id=\"ip03summ\">Summary</h2><p data-block-id=\"ip04summ\">One paragraph describing what broke, for whom, and for how long.</p><h2 data-block-id=\"ip05time\">Timeline</h2><p data-block-id=\"ip06time\">A bulleted, timestamped list of events, from the first symptom to the resolution.</p><h2 data-block-id=\"ip07impa\">Impact</h2><p data-block-id=\"ip08impa\">Quantify the impact: number of affected users, failed requests, revenue at risk.</p><h2 data-block-id=\"ip09root\">Root cause</h2><p data-block-id=\"ip10root\">Explain the technical root cause, and the reason it was not caught earlier.</p><h2 data-block-id=\"ip11foll\">Follow-up actions</h2><p data-block-id=\"ip12foll\">List concrete, owned action items. Never write \"be more careful\".</p></div>",
+    "availability": "editors"
+  },
+  "currentUserSkill": {
+    "name": "Release Notes Writer",
+    "agentFacingDescription": "Guidelines to turn a list of merged pull requests into user-facing release notes.",
+    "userFacingDescription": "Turn merged pull requests into readable release notes.",
+    "instructions": "# Release Notes\n\nGroup changes under three headings: **New**, **Improved**, **Fixed**.\n\n- One line per change, written from the user's point of view.\n- No internal ticket numbers, no commit hashes.\n- Skip purely internal refactors.",
+    "instructionsHtml": "<div data-type=\"instructions-root\" data-block-id=\"instructions-root\"><h1 data-block-id=\"rn01titl\">Release Notes</h1><p data-block-id=\"rn02intr\">Group changes under three headings: <strong>New</strong>, <strong>Improved</strong>, <strong>Fixed</strong>.</p><ul data-block-id=\"rn03rul\"><li>One line per change, written from the user's point of view.</li><li>No internal ticket numbers, no commit hashes.</li><li>Skip purely internal refactors.</li></ul></div>",
+    "availability": "workspace_users"
+  }
+}

--- a/front/scripts/seed/governance/assets/users.json
+++ b/front/scripts/seed/governance/assets/users.json
@@ -1,0 +1,16 @@
+[
+  {
+    "sId": "SeedUserAlfred",
+    "username": "alfred",
+    "email": "alfred@example.com",
+    "firstName": "Alfred",
+    "lastName": "Pennyworth"
+  },
+  {
+    "sId": "SeedUserBob",
+    "username": "bob",
+    "email": "bob@example.com",
+    "firstName": "Bob",
+    "lastName": "Kane"
+  }
+]

--- a/front/scripts/seed/governance/seed.test.ts
+++ b/front/scripts/seed/governance/seed.test.ts
@@ -1,0 +1,91 @@
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import logger from "@app/logger/logger";
+import type { SeedContext } from "@app/scripts/seed/factories";
+import { seedAgents, seedSkill, seedUsers } from "@app/scripts/seed/factories";
+import type { Assets } from "@app/scripts/seed/governance/seed";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import * as fs from "fs";
+import * as path from "path";
+import { describe, expect, it } from "vitest";
+
+const ALFRED_USER_ID = "SeedUserAlfred";
+
+// Load assets from JSON files (same as seed.ts)
+function loadAssets(): Assets {
+  const assetsDir = path.join(__dirname, "assets");
+  const agents = JSON.parse(
+    fs.readFileSync(path.join(assetsDir, "agents.json"), "utf-8")
+  );
+  const users = JSON.parse(
+    fs.readFileSync(path.join(assetsDir, "users.json"), "utf-8")
+  );
+  const skills = JSON.parse(
+    fs.readFileSync(path.join(assetsDir, "skills.json"), "utf-8")
+  );
+  return { agents, users, skills };
+}
+
+describe("governance seed script integration test", () => {
+  const assets = loadAssets();
+
+  it("should create the users, skills and agent", async () => {
+    const { workspace, user, authenticator } = await createResourceTest({
+      role: "admin",
+    });
+
+    const ctx: SeedContext = {
+      auth: authenticator,
+      workspace,
+      user,
+      execute: true,
+      logger,
+    };
+
+    // Run the seed flow (same order as seed.ts).
+    const createdUsers = await seedUsers(ctx, assets.users);
+    const alfred = createdUsers.get(ALFRED_USER_ID);
+    expect(createdUsers.size).toBe(assets.users.length);
+    expect(alfred).toBeDefined();
+
+    const alfredSkill = await seedSkill(ctx, assets.skills.alfredSkill, {
+      owner: alfred,
+    });
+    const currentUserSkill = await seedSkill(
+      ctx,
+      assets.skills.currentUserSkill
+    );
+    const createdAgents = await seedAgents(ctx, assets.agents, {
+      skills: alfredSkill ? [alfredSkill] : [],
+    });
+
+    // Both skills are created with the availability from the assets.
+    expect(alfredSkill).toBeDefined();
+    expect(alfredSkill!.name).toBe(assets.skills.alfredSkill.name);
+    expect(alfredSkill!.availability).toBe(
+      assets.skills.alfredSkill.availability
+    );
+
+    expect(currentUserSkill).toBeDefined();
+    expect(currentUserSkill!.name).toBe(assets.skills.currentUserSkill.name);
+    expect(currentUserSkill!.availability).toBe(
+      assets.skills.currentUserSkill.availability
+    );
+
+    // The agent is created and uses Alfred's skill.
+    expect(createdAgents.size).toBe(assets.agents.length);
+    const agent = createdAgents.get(assets.agents[0].name);
+    expect(agent).toBeDefined();
+
+    const agentConfiguration = await getAgentConfiguration(authenticator, {
+      agentId: agent!.sId,
+      variant: "full",
+    });
+    expect(agentConfiguration).toBeDefined();
+    const agentSkills = await SkillResource.listByAgentConfiguration(
+      authenticator,
+      agentConfiguration!
+    );
+    expect(agentSkills.map((s) => s.sId)).toEqual([alfredSkill!.sId]);
+  });
+});

--- a/front/scripts/seed/governance/seed.ts
+++ b/front/scripts/seed/governance/seed.ts
@@ -1,0 +1,70 @@
+import { makeScript } from "@app/scripts/helpers";
+import type {
+  AgentAsset,
+  SkillAsset,
+  UserAsset,
+} from "@app/scripts/seed/factories";
+import {
+  createSeedContext,
+  seedAgents,
+  seedSkill,
+  seedUsers,
+} from "@app/scripts/seed/factories";
+import * as fs from "fs";
+import * as path from "path";
+
+export interface Assets {
+  agents: AgentAsset[];
+  users: UserAsset[];
+  skills: {
+    alfredSkill: SkillAsset;
+    currentUserSkill: SkillAsset;
+  };
+}
+
+// Load assets from JSON files
+function loadAssets(): Assets {
+  const assetsDir = path.join(__dirname, "assets");
+  const agents = JSON.parse(
+    fs.readFileSync(path.join(assetsDir, "agents.json"), "utf-8")
+  );
+  const users = JSON.parse(
+    fs.readFileSync(path.join(assetsDir, "users.json"), "utf-8")
+  );
+  const skills = JSON.parse(
+    fs.readFileSync(path.join(assetsDir, "skills.json"), "utf-8")
+  );
+  return { agents, users, skills };
+}
+
+const ALFRED_USER_ID = "SeedUserAlfred";
+
+makeScript({}, async ({ execute }, logger) => {
+  const { agents, users, skills } = loadAssets();
+
+  const ctx = await createSeedContext({ execute, logger });
+
+  // 1. Create Alfred and Bob as regular workspace members.
+  logger.info("Seeding users...");
+  const createdUsers = await seedUsers(ctx, users);
+  const alfred = createdUsers.get(ALFRED_USER_ID);
+  if (execute && !alfred) {
+    throw new Error(`User ${ALFRED_USER_ID} was not created`);
+  }
+
+  // 2. Create skills
+  logger.info("Seeding Alfred's unpublished skill...");
+  const alfredSkill = await seedSkill(ctx, skills.alfredSkill, {
+    owner: alfred,
+  });
+  logger.info("Seeding the current user's skill...");
+  await seedSkill(ctx, skills.currentUserSkill);
+
+  // 2. Create an agent edited by the current user that uses Alfred's unpublished skill.
+  logger.info("Seeding agents...");
+  await seedAgents(ctx, agents, {
+    skills: alfredSkill ? [alfredSkill] : [],
+  });
+
+  logger.info("Governance seed completed");
+});


### PR DESCRIPTION
## Description

Add a new seed for testing admin governance in a dust hive environment
It creates:
 - 2 users
 - A skill owned by alfred unpublished
 - an agent using this skill
 - Another skill owner by the current user

## Tests
added unit tests + tested lcoally that it correctly feeds the workspace

## Risk

low, only a script 

## Deploy Plan

none
