### PR TITLE
Increase memory size limit to 8k

### DIFF
--- a/front/types/api/me/memory.ts
+++ b/front/types/api/me/memory.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 // User-facing limit, counted as visible characters (markdown formatting syntax
 // does not count against it).
-export const MAX_USER_MEMORY_CHARS = 2_000;
+export const MAX_USER_MEMORY_CHARS = 8_000;
 
 // Server-side cap on the raw stored markdown. Formatting syntax (**bold**,
 // headings, ...) inflates the raw length beyond the visible character count, so


### PR DESCRIPTION
## Description

After looking at results from the backfill of agent-memory to user-memory several users had memory sizes much bigger than 2k chars so increasing the memory size seems necessary. 8k size seemed to be the best compromise. 

## Tests
Locally 

## Risk

Low 

## Deploy Plan

Deploy front
