### PR TITLE
[front] fix: hide usage for system skills in Manage Skills

### DIFF
--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -805,8 +805,13 @@ describe("GET /api/w/:wId/skills?withRelations=true", () => {
     const skillResult = responseBody.skills.find(
       (listedSkill) => listedSkill.sId === skill.sId
     );
+    const systemSkillResult = responseBody.skills.find(
+      (listedSkill) => listedSkill.sId === "discover_tools"
+    );
 
     expect(skillResult?.messageCount).toBe(2);
+    expect(systemSkillResult).toBeDefined();
+    expect(systemSkillResult?.messageCount).toBeNull();
   });
 
   it("should return skills with usage when linked to agents", async () => {

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -221,7 +221,7 @@ app.get(
       if (withMessageCount) {
         messageCountMap = await SkillResource.batchFetchMessageCounts(
           auth,
-          skills
+          skills.filter((skill) => !skill.isSystemSkill)
         );
       }
       const editorsMap = await SkillResource.batchListEditors(auth, skills);
@@ -262,7 +262,11 @@ app.get(
         return {
           ...skillWithoutInstructionsAndTools,
           ...(messageCountMap
-            ? { messageCount: messageCountMap.get(sc.sId) ?? 0 }
+            ? {
+                messageCount: sc.isSystemSkill
+                  ? null
+                  : (messageCountMap.get(sc.sId) ?? 0),
+              }
             : {}),
           relations: {
             usage: usageWithSkills,

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -39,7 +39,7 @@ type RowData = {
   availability: SkillAvailability;
   editors: UserType[] | null;
   usage: SkillUsageType;
-  messageCount: number;
+  messageCount: number | null;
   updatedAt: number | null;
   createdAt: number | null;
   onClick: () => void;
@@ -164,15 +164,24 @@ const usedByColumn = (
   },
 });
 
-const usageColumn: ColumnDef<RowData, number> = {
+const usageColumn: ColumnDef<RowData, number | null> = {
   header: "Usage",
   accessorKey: "messageCount",
-  cell: (info: CellContext<RowData, number>) => (
-    <DataTable.BasicCellContent
-      className="font-mono"
-      label={info.getValue().toLocaleString()}
-    />
-  ),
+  cell: (info: CellContext<RowData, number | null>) => {
+    const messageCount = info.getValue();
+
+    return (
+      <DataTable.BasicCellContent
+        className="font-mono"
+        label={messageCount === null ? "—" : messageCount.toLocaleString()}
+        tooltip={
+          messageCount === null
+            ? "System skills are always active, so message usage does not apply."
+            : undefined
+        }
+      />
+    );
+  },
   meta: {
     className: "hidden @sm:w-20 @sm:table-cell",
     tooltip: "All-time messages",
@@ -293,7 +302,7 @@ export function SkillsTable({
         availability: skill.availability,
         editors: skill.relations.editors,
         usage: skill.relations.usage,
-        messageCount: skill.messageCount ?? 0,
+        messageCount: skill.messageCount === undefined ? 0 : skill.messageCount,
         updatedAt: skill.updatedAt,
         createdAt: skill.createdAt,
         onClick: () => {

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -173,7 +173,7 @@ const usageColumn: ColumnDef<RowData, number | null> = {
     return (
       <DataTable.BasicCellContent
         className="font-mono"
-        label={messageCount === null ? "—" : messageCount.toLocaleString()}
+        label={messageCount === null ? "-" : messageCount.toLocaleString()}
         tooltip={
           messageCount === null
             ? "System skills are always active, so message usage does not apply."

--- a/front/types/api/skills/index.ts
+++ b/front/types/api/skills/index.ts
@@ -14,7 +14,7 @@ export type GetSkillsResponseBody = {
 export type GetSkillsWithRelationsResponseBody = {
   skills: (SkillWithoutInstructionsAndToolsWithRelationsType & {
     isFavorite?: boolean;
-    messageCount?: number;
+    messageCount?: number | null;
   })[];
 };
 


### PR DESCRIPTION
## Description

System skills are always active, so we don't register them in `agent_message_skills` (was originally used to track which skills were enabled for a given message). The usage therefore is not populated, and would not mean much.

This PR bypasses this by just hiding the usage in this case (replacing with a -).
Not ideal but backfilling would be quite costly here.

## Tests

- Updated endpoint coverage for system skill usage.

## Risk

- Low.

## Deploy Plan

- Deploy front and front-api.
