### PR TITLE
List pod databases in Poke

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/index.ts
@@ -2,6 +2,7 @@ import { pokeProjectApp } from "@front-api/middlewares/ctx";
 import { withProject } from "@front-api/middlewares/with_projects";
 
 import connectorKnowledge from "./connector-knowledge";
+import podDatabases from "./pod-databases";
 import podFunctions from "./pod-functions";
 import tasks from "./tasks";
 import tasksWorkflow from "./tasks-workflow";
@@ -14,5 +15,6 @@ app.route("/connector-knowledge", connectorKnowledge);
 app.route("/tasks-workflow", tasksWorkflow);
 app.route("/tasks", tasks);
 app.route("/pod-functions", podFunctions);
+app.route("/pod-databases", podDatabases);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/pod-databases.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/pod-databases.test.ts
@@ -1,0 +1,71 @@
+import { listDatabasesOnSandbox } from "@app/lib/api/sandbox_functions/dsbx_db";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { Err, Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it, vi } from "vitest";
+
+// Listing databases runs `dsbx db list` inside the pod sandbox.
+vi.mock(import("@app/lib/api/sandbox_functions/dsbx_db"), async (orig) => {
+  const mod = await orig();
+  return {
+    ...mod,
+    listDatabasesOnSandbox: vi.fn(),
+  };
+});
+
+async function setup() {
+  const { workspace } = await createPrivateApiMockRequest({
+    isSuperUser: true,
+    role: "admin",
+  });
+
+  const space = await SpaceFactory.project(workspace);
+
+  return { space, workspace };
+}
+
+function podDatabasesUrl(workspaceId: string, spaceId: string) {
+  return `/api/poke/workspaces/${workspaceId}/projects/${spaceId}/pod-databases`;
+}
+
+describe("GET /api/poke/workspaces/:wId/projects/:projectId/pod-databases", () => {
+  it("returns the live databases of the pod", async () => {
+    const { workspace, space } = await setup();
+
+    vi.mocked(listDatabasesOnSandbox).mockResolvedValue(
+      new Ok([
+        { name: "chat", sizeBytes: 8192 },
+        { name: "notes", sizeBytes: 4096 },
+      ])
+    );
+
+    const response = await honoApp.request(
+      podDatabasesUrl(workspace.sId, space.sId)
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.items).toEqual([
+      { name: "chat", sizeBytes: 8192 },
+      { name: "notes", sizeBytes: 4096 },
+    ]);
+  });
+
+  it("returns 500 when the pod sandbox is unavailable", async () => {
+    const { workspace, space } = await setup();
+
+    vi.mocked(listDatabasesOnSandbox).mockResolvedValue(
+      new Err(new SandboxFunctionError("sandbox_unavailable", "no sandbox"))
+    );
+
+    const response = await honoApp.request(
+      podDatabasesUrl(workspace.sId, space.sId)
+    );
+
+    expect(response.status).toBe(500);
+    const data = await response.json();
+    expect(data.error.type).toBe("internal_server_error");
+  });
+});

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/pod-databases.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/pod-databases.ts
@@ -1,0 +1,31 @@
+import type { PokeListProjectPodDatabases } from "@app/lib/api/poke/projects";
+import { listDatabasesOnSandbox } from "@app/lib/api/sandbox_functions/dsbx_db";
+import { pokeProjectApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+
+// Mounted at /api/poke/workspaces/:wId/projects/:projectId/pod-databases.
+const app = pokeProjectApp();
+
+/** @ignoreswagger */
+app.get("/", async (ctx): HandlerResult<PokeListProjectPodDatabases> => {
+  const auth = ctx.get("auth");
+  const space = ctx.get("space");
+
+  // There is no database-backed record of pod databases: the only source of truth is the live
+  // `{db}.db` files in the pod, so this runs `dsbx db list` and wakes (or cold starts) the pod
+  // sandbox. Poke fetches it on demand only.
+  const result = await listDatabasesOnSandbox(auth, { space });
+  if (result.isErr()) {
+    return apiError(ctx, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to list pod databases: ${result.error.message}`,
+      },
+    });
+  }
+
+  return ctx.json({ items: result.value });
+});
+
+export default app;

--- a/front/components/poke/pages/ProjectPage.tsx
+++ b/front/components/poke/pages/ProjectPage.tsx
@@ -2,6 +2,7 @@ import { DataSourceViewsDataTable } from "@app/components/poke/data_source_views
 import { MembersDataTable } from "@app/components/poke/members/table";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
 import { ProjectConnectorKnowledgeDataTable } from "@app/components/poke/projects/connector_knowledge/table";
+import { ProjectPodDatabaseDataTable } from "@app/components/poke/projects/pod_databases/table";
 import { ProjectPodFunctionDataTable } from "@app/components/poke/projects/pod_functions/table";
 import { ProjectTasksDataTable } from "@app/components/poke/projects/tasks/table";
 import { ViewProjectWorkflowTable } from "@app/components/poke/projects/workflow/view";
@@ -59,6 +60,7 @@ export function ProjectPage({ details }: ProjectPageProps) {
           <ProjectTasksDataTable owner={owner} projectId={space.sId} />
           <DataSourceViewsDataTable owner={owner} spaceId={space.sId} />
           <ProjectPodFunctionDataTable owner={owner} projectId={space.sId} />
+          <ProjectPodDatabaseDataTable owner={owner} projectId={space.sId} />
         </div>
       </div>
     </>

--- a/front/components/poke/projects/pod_databases/columns.tsx
+++ b/front/components/poke/projects/pod_databases/columns.tsx
@@ -1,0 +1,22 @@
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
+import type { PokePodDatabase } from "@app/lib/api/poke/projects";
+import type { ColumnDef } from "@tanstack/react-table";
+
+export function makeColumnsForProjectPodDatabase(): ColumnDef<PokePodDatabase>[] {
+  return [
+    {
+      accessorKey: "name",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Name" />
+      ),
+      cell: ({ row }) => row.original.name,
+    },
+    {
+      accessorKey: "sizeBytes",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Size (bytes)" />
+      ),
+      cell: ({ row }) => row.original.sizeBytes.toLocaleString(),
+    },
+  ];
+}

--- a/front/components/poke/projects/pod_databases/table.tsx
+++ b/front/components/poke/projects/pod_databases/table.tsx
@@ -1,0 +1,36 @@
+import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
+import { makeColumnsForProjectPodDatabase } from "@app/components/poke/projects/pod_databases/columns";
+import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import { usePokeProjectPodDatabases } from "@app/poke/swr/project_pod_databases";
+import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
+import type { LightWorkspaceType } from "@app/types/user";
+
+interface ProjectPodDatabaseDataTableProps {
+  owner: LightWorkspaceType;
+  projectId: string;
+}
+
+export function ProjectPodDatabaseDataTable({
+  owner,
+  projectId,
+}: ProjectPodDatabaseDataTableProps) {
+  const usePodDatabasesForProject = (props: PokeConditionalFetchProps) =>
+    usePokeProjectPodDatabases({ ...props, projectId });
+
+  return (
+    <PokeDataTableConditionalFetch
+      // Listing databases runs in the pod itself, which starts the sandbox if it is asleep.
+      buttonText="Load Data (starts the pod sandbox)"
+      header="Pod Databases"
+      owner={owner}
+      useSWRHook={usePodDatabasesForProject}
+    >
+      {(items) => (
+        <PokeDataTable
+          columns={makeColumnsForProjectPodDatabase()}
+          data={items}
+        />
+      )}
+    </PokeDataTableConditionalFetch>
+  );
+}

--- a/front/lib/api/poke/projects.ts
+++ b/front/lib/api/poke/projects.ts
@@ -44,6 +44,15 @@ export type PokeGetProjectWorkflow = {
   latestWorkflow: PokeProjectWorkflowInfo | null;
 };
 
+export type PokePodDatabase = {
+  name: string;
+  sizeBytes: number;
+};
+
+export type PokeListProjectPodDatabases = {
+  items: PokePodDatabase[];
+};
+
 export type PokePodFunction = {
   sId: string;
   slug: string;

--- a/front/poke/swr/project_pod_databases.ts
+++ b/front/poke/swr/project_pod_databases.ts
@@ -1,0 +1,34 @@
+import type {
+  PokeListProjectPodDatabases,
+  PokePodDatabase,
+} from "@app/lib/api/poke/projects";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { Fetcher } from "swr";
+
+interface UsePokeProjectPodDatabasesProps {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+  projectId: string;
+}
+
+export function usePokeProjectPodDatabases({
+  disabled,
+  owner,
+  projectId,
+}: UsePokeProjectPodDatabasesProps) {
+  const { fetcher } = useFetcher();
+  const podDatabasesFetcher: Fetcher<PokeListProjectPodDatabases> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/projects/${projectId}/pod-databases`,
+    podDatabasesFetcher,
+    { disabled }
+  );
+
+  return {
+    data: data?.items ?? emptyArray<PokePodDatabase>(),
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}


### PR DESCRIPTION
### Description

Poke's Pod page could list Pod Functions but not the pod's databases. This adds a **Pod Databases** table right below Pod Functions, listing each live database with its size.

Kept deliberately simple for now: a flat list, no per-database page (schema / query views can come later if useful).

### Implementation

- `PokePodDatabase` / `PokeListProjectPodDatabases` wire types in `lib/api/poke/projects.ts`.
- `GET /api/poke/workspaces/:wId/projects/:projectId/pod-databases`, reusing the existing `listDatabasesOnSandbox`.
- SWR hook + data table mirroring the Pod Functions ones.

Unlike functions, pod databases have no database-backed record — the only source of truth is the live `{db}.db` files in the pod. So the endpoint runs `dsbx db list` in the sandbox (the same call behind the agent's `db_list` tool), which **wakes or cold starts the pod**. No other Poke endpoint currently starts a sandbox, so it stays behind Poke's existing explicit load-on-click fetch, and the button is labelled accordingly.

An alternative that never touches the sandbox would be enumerating the litestream replica prefixes in GCS (`getPodStateBasePath`) — free and read-only, but it reports replicated DBs and replica sizes rather than live ones. Happy to switch if the wake-up is unwelcome.

### Tests

`pod-databases.test.ts` covers the success list and the sandbox-unavailable 500. `tsgo --noEmit` clean in `front` and `front-api`.
