### PR TITLE
perf: skip attachment derivation in GET sandbox/actions

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
@@ -103,13 +103,29 @@ app.post(
     });
 
     if (result.isErr()) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: result.error.message,
+      logger.error(
+        {
+          err: result.error,
+          conversationId: claims.cId,
+          agentMessageId: claims.mId,
+          parentActionId: claims.actionId,
+          serverViewId,
+          toolName,
         },
-      });
+        "Failed to create sandbox child action"
+      );
+
+      return apiError(
+        ctx,
+        {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: result.error.message,
+          },
+        },
+        result.error
+      );
     }
 
     const { actionId, pauseSandbox } = result.value;

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
@@ -2,7 +2,6 @@ import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guard
 import { SANDBOX_TOOL_NAME } from "@app/lib/api/actions/servers/sandbox/metadata";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
-import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { resolveSkillMCPServers } from "@app/lib/api/assistant/skill_actions";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
@@ -142,13 +141,13 @@ app.get("/", async (ctx): HandlerResult<GetSandboxToolsResponseType> => {
   }
   const conversation = conversationResource.toJSON();
 
-  const attachments = await listAttachments(auth, {
-    conversation: conversationResource,
-  });
+  // No attachments: matches `createSandboxChildAction`, so the tools listed here are exactly
+  // the ones `/call` can resolve. Deriving them would also mean recomputing the conversation's
+  // attachment set on every poll.
   const jitServers = await getJITServers(auth, {
     agentConfiguration: agentConfig,
     conversation,
-    attachments,
+    attachments: [],
   });
   const { systemSkillServers, skillServers } = await resolveSkillMCPServers(
     auth,

--- a/front/lib/api/sandbox/create_child_action.test.ts
+++ b/front/lib/api/sandbox/create_child_action.test.ts
@@ -402,9 +402,7 @@ describe("createSandboxChildAction", () => {
     if (result.isOk()) {
       throw new Error("Expected the disabled tool call to fail.");
     }
-    expect(result.error.message).toBe(
-      "Tool is not available to this agent or conversation."
-    );
+    expect(result.error.message).toBe("Tool is disabled on this server.");
     expect(vi.mocked(launchSandboxChildToolWorkflow)).not.toHaveBeenCalled();
   });
 

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -178,7 +178,7 @@ export async function createSandboxChildAction(
 
   if (!serverSideConfig) {
     return new Err(
-      new Error("Tool is not available to this agent or conversation.")
+      new Error("Server is not available to this agent or conversation.")
     );
   }
 
@@ -199,9 +199,7 @@ export async function createSandboxChildAction(
   const [toolConfiguration] = toolConfigurationsRes.value;
 
   if (!toolConfiguration) {
-    return new Err(
-      new Error("Tool is not available to this agent or conversation.")
-    );
+    return new Err(new Error("Tool is disabled on this server."));
   }
 
   // User tool approvals ("low"/"medium" stakes) are keyed on the prefixed


### PR DESCRIPTION
## Description

`GET /api/v1/w/:wId/sandbox/actions` was calling `listAttachments` on every request to feed `getJITServers`. That's four serial queries, one of which is a wide `IN` over `agent_mcp_action_output_items`. It showed up during a burst of polls from one workspace: pool exhaustion, and that query at 113s.

`createSandboxChildAction` (the `/call` path) already passes `attachments: []`, so the attachment-gated servers (`conversation_files`, `query_tables_v2`, folder `search`) were already listed by the GET but rejected by `/call`.

Also, this PR splits the two identical `"Tool is not available to this agent or conversation."` errors in `create_child_action.ts` and added a log line with `serverViewId` / `toolName` / `conversationId` on the failure path. ~1.4k of these in the last 30 days and no way to tell which was which, or for which tool.

## Tests

- `front-api` route tests pass (`sandbox/actions/index.test.ts`, `sandbox/actions/call.test.ts`).
- Updated the assertion in `create_child_action.test.ts` that pinned the old message.

## Risk

Low, but notable behaviour change: sandboxes no longer see `conversation_files`, `query_tables_v2` or folder `search` in the tool list. Nothing that worked before stops working, since `/call` already refused them.

Rollback is a revert.

## Deploy Plan

Nothing special, no migration.