### PR TITLE
feat: add front.agent_message_consumption_analytics index

### DIFF
--- a/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
+++ b/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
@@ -1,6 +1,6 @@
 {
   "properties": {
-    "timestamp": {
+    "completed_at": {
       "type": "date"
     },
     "workspace_id": {

--- a/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
+++ b/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
@@ -81,13 +81,8 @@
     "context_origin": {
       "type": "keyword"
     },
-    "api_key_name": {
-      "type": "text",
-      "fields": {
-        "keyword": {
-          "type": "keyword"
-        }
-      }
+    "api_key_id": {
+      "type": "keyword"
     },
     "tool": {
       "type": "object",

--- a/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
+++ b/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
@@ -75,6 +75,9 @@
         }
       }
     },
+    "trigger_id": {
+      "type": "keyword"
+    },
     "source": {
       "type": "keyword"
     },

--- a/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
+++ b/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
@@ -78,7 +78,7 @@
     "trigger_id": {
       "type": "keyword"
     },
-    "source": {
+    "context_origin": {
       "type": "keyword"
     },
     "api_key_name": {
@@ -155,8 +155,8 @@
     "credit_micro": {
       "type": "long"
     },
-    "is_billed": {
-      "type": "boolean"
+    "usage_type": {
+      "type": "keyword"
     },
     "status": {
       "type": "keyword"

--- a/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
+++ b/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
@@ -81,7 +81,7 @@
     "context_origin": {
       "type": "keyword"
     },
-    "api_key_id": {
+    "api_key_name": {
       "type": "keyword"
     },
     "tool": {

--- a/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
+++ b/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
@@ -1,0 +1,168 @@
+{
+  "properties": {
+    "timestamp": {
+      "type": "date"
+    },
+    "workspace_id": {
+      "type": "keyword"
+    },
+    "conversation_id": {
+      "type": "keyword"
+    },
+    "space_id": {
+      "type": "keyword"
+    },
+    "agent_message_id": {
+      "type": "keyword"
+    },
+    "message_version": {
+      "type": "keyword"
+    },
+    "consumption_key": {
+      "type": "keyword"
+    },
+    "consumption_type": {
+      "type": "keyword"
+    },
+    "attribution_version": {
+      "type": "short"
+    },
+    "run_usage_id": {
+      "type": "keyword"
+    },
+    "agent": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "keyword"
+        },
+        "version": {
+          "type": "keyword"
+        },
+        "tag_ids": {
+          "type": "keyword"
+        },
+        "root_agent_id": {
+          "type": "keyword"
+        },
+        "depth": {
+          "type": "short"
+        }
+      }
+    },
+    "model": {
+      "type": "object",
+      "properties": {
+        "provider_id": {
+          "type": "keyword"
+        },
+        "model_id": {
+          "type": "keyword"
+        },
+        "reasoning_effort": {
+          "type": "keyword"
+        },
+        "resolution_method": {
+          "type": "keyword"
+        }
+      }
+    },
+    "user": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "keyword"
+        }
+      }
+    },
+    "source": {
+      "type": "keyword"
+    },
+    "api_key_name": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword"
+        }
+      }
+    },
+    "tool": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "keyword"
+        },
+        "server_name": {
+          "type": "keyword"
+        },
+        "action_id": {
+          "type": "keyword"
+        },
+        "enabled_by_skill_ids": {
+          "type": "keyword"
+        }
+      }
+    },
+    "tokens": {
+      "type": "object",
+      "properties": {
+        "system": {
+          "type": "integer"
+        },
+        "input": {
+          "type": "integer"
+        },
+        "result_footprint": {
+          "type": "integer"
+        },
+        "output": {
+          "type": "integer"
+        },
+        "reasoning": {
+          "type": "integer"
+        }
+      }
+    },
+    "gross_credit_micro": {
+      "type": "object",
+      "properties": {
+        "system": {
+          "type": "long"
+        },
+        "input": {
+          "type": "long"
+        },
+        "result_footprint": {
+          "type": "long"
+        },
+        "output": {
+          "type": "long"
+        },
+        "reasoning": {
+          "type": "long"
+        },
+        "direct": {
+          "type": "long"
+        },
+        "total": {
+          "type": "long"
+        }
+      }
+    },
+    "credit_micro": {
+      "type": "long"
+    },
+    "is_billed": {
+      "type": "boolean"
+    },
+    "status": {
+      "type": "keyword"
+    },
+    "step_index": {
+      "type": "short"
+    },
+    "execution_time_ms": {
+      "type": "integer"
+    }
+  }
+}

--- a/front/lib/analytics/indices/agent_message_consumption_analytics_1.settings.europe-west1.json
+++ b/front/lib/analytics/indices/agent_message_consumption_analytics_1.settings.europe-west1.json
@@ -1,0 +1,5 @@
+{
+  "number_of_shards": 3,
+  "number_of_replicas": 1,
+  "refresh_interval": "30s"
+}

--- a/front/lib/analytics/indices/agent_message_consumption_analytics_1.settings.local.json
+++ b/front/lib/analytics/indices/agent_message_consumption_analytics_1.settings.local.json
@@ -1,0 +1,5 @@
+{
+  "number_of_shards": 1,
+  "number_of_replicas": 0,
+  "refresh_interval": "30s"
+}

--- a/front/lib/analytics/indices/agent_message_consumption_analytics_1.settings.us-central1.json
+++ b/front/lib/analytics/indices/agent_message_consumption_analytics_1.settings.us-central1.json
@@ -1,0 +1,5 @@
+{
+  "number_of_shards": 3,
+  "number_of_replicas": 1,
+  "refresh_interval": "30s"
+}

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -9,6 +9,8 @@ import moment from "moment-timezone";
 let esClient: Client | null = null;
 
 export const ANALYTICS_ALIAS_NAME = "front.agent_message_analytics";
+export const CONSUMPTION_ANALYTICS_ALIAS_NAME =
+  "front.agent_message_consumption_analytics";
 export const USER_SEARCH_ALIAS_NAME = "front.user_search";
 export const AGENT_DOCUMENT_OUTPUTS_ALIAS_NAME = "front.agent_document_outputs";
 export const CONVERSATION_SEARCH_ALIAS_NAME = "front.conversation_search";
@@ -20,6 +22,7 @@ export const CONVERSATION_SEARCH_ALIAS_NAME = "front.conversation_search";
 export const INDEX_DIRECTORIES: Record<string, string> = {
   agent_document_outputs: "lib/analytics/indices",
   agent_message_analytics: "lib/analytics/indices",
+  agent_message_consumption_analytics: "lib/analytics/indices",
   conversation_search: "lib/conversation_search/indices",
   user_search: "lib/user_search/indices",
 };

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -180,6 +180,7 @@ export interface AgentMessageConsumptionAnalyticsData
   step_index: number;
   tokens: AgentMessageConsumptionAnalyticsTokens;
   tool: AgentMessageConsumptionAnalyticsTool | null;
+  trigger_id: string | null;
   user: AgentMessageConsumptionAnalyticsUser | null;
   workspace_id: string;
 }

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -103,6 +103,15 @@ export interface AgentMessageAnalyticsData extends ElasticsearchBaseDocument {
 // "llm" document whose buckets are carried by `tokens` and `gross_credit_micro`.
 export type AgentMessageConsumptionAnalyticsType = "llm" | "tool";
 
+// Coarse bucket of what caused the consumption, derived at index time from the
+// user message origin (UserMessageOrigin). Deliberately coarser than
+// AgentMessageAnalyticsData.context_origin.
+export type AgentMessageConsumptionAnalyticsSource =
+  | "web"
+  | "api"
+  | "trigger"
+  | "wakeup";
+
 export interface AgentMessageConsumptionAnalyticsAgent {
   id: string;
   version: string;
@@ -164,7 +173,7 @@ export interface AgentMessageConsumptionAnalyticsData
   message_version: string;
   model: AgentMessageAnalyticsModel | null;
   run_usage_id: string;
-  source: string;
+  source: AgentMessageConsumptionAnalyticsSource;
   space_id: string | null;
   status: string;
   step_index: number;

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -160,7 +160,7 @@ export interface AgentMessageConsumptionAnalyticsData
   extends ElasticsearchBaseDocument {
   agent: AgentMessageConsumptionAnalyticsAgent;
   agent_message_id: string;
-  api_key_name: string | null;
+  api_key_id: string | null;
   // Version of the attribution logic that produced this document.
   attribution_version: number;
   completed_at: string; // ISO date string.

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -162,6 +162,7 @@ export interface AgentMessageConsumptionAnalyticsData
   api_key_name: string | null;
   // Version of the attribution logic that produced this document.
   attribution_version: number;
+  completed_at: string; // ISO date string.
   // Idempotency key.
   consumption_key: string;
   consumption_type: AgentMessageConsumptionAnalyticsType;
@@ -177,7 +178,6 @@ export interface AgentMessageConsumptionAnalyticsData
   space_id: string | null;
   status: string;
   step_index: number;
-  timestamp: string; // ISO date string.
   tokens: AgentMessageConsumptionAnalyticsTokens;
   tool: AgentMessageConsumptionAnalyticsTool | null;
   user: AgentMessageConsumptionAnalyticsUser | null;

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -1,5 +1,9 @@
 import type { ThumbReaction } from "@app/components/assistant/conversation/FeedbackSelector";
 import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
+import type {
+  USAGE_TYPE_PROGRAMMATIC,
+  USAGE_TYPE_USER,
+} from "@app/lib/metronome/constants";
 
 import type { AgentMessageStatus, UserMessageOrigin } from "./conversation";
 import type { ConversationSkillOrigin } from "./conversation_skills";
@@ -103,14 +107,11 @@ export interface AgentMessageAnalyticsData extends ElasticsearchBaseDocument {
 // "llm" document whose buckets are carried by `tokens` and `gross_credit_micro`.
 export type AgentMessageConsumptionAnalyticsType = "llm" | "tool";
 
-// Coarse bucket of what caused the consumption, derived at index time from the
-// user message origin (UserMessageOrigin). Deliberately coarser than
-// AgentMessageAnalyticsData.context_origin.
-export type AgentMessageConsumptionAnalyticsSource =
-  | "web"
-  | "api"
-  | "trigger"
-  | "wakeup";
+// Billing slice of the consumption unit. USAGE_TYPE_FREE is deliberately absent:
+// the index holds billed consumption only, so free calls are never indexed.
+export type AgentMessageConsumptionAnalyticsUsageType =
+  | typeof USAGE_TYPE_USER
+  | typeof USAGE_TYPE_PROGRAMMATIC;
 
 export interface AgentMessageConsumptionAnalyticsAgent {
   id: string;
@@ -166,21 +167,21 @@ export interface AgentMessageConsumptionAnalyticsData
   // Idempotency key.
   consumption_key: string;
   consumption_type: AgentMessageConsumptionAnalyticsType;
+  context_origin: UserMessageOrigin | null;
   conversation_id: string;
   credit_micro: number;
   execution_time_ms: number | null;
   gross_credit_micro: AgentMessageConsumptionAnalyticsGrossCreditMicro;
-  is_billed: boolean;
   message_version: string;
   model: AgentMessageAnalyticsModel | null;
   run_usage_id: string;
-  source: AgentMessageConsumptionAnalyticsSource;
   space_id: string | null;
   status: string;
   step_index: number;
   tokens: AgentMessageConsumptionAnalyticsTokens;
   tool: AgentMessageConsumptionAnalyticsTool | null;
   trigger_id: string | null;
+  usage_type: AgentMessageConsumptionAnalyticsUsageType;
   user: AgentMessageConsumptionAnalyticsUser | null;
   workspace_id: string;
 }

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -160,7 +160,7 @@ export interface AgentMessageConsumptionAnalyticsData
   extends ElasticsearchBaseDocument {
   agent: AgentMessageConsumptionAnalyticsAgent;
   agent_message_id: string;
-  api_key_id: string | null;
+  api_key_name: string | null;
   // Version of the attribution logic that produced this document.
   attribution_version: number;
   completed_at: string; // ISO date string.

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -91,6 +91,90 @@ export interface AgentMessageAnalyticsData extends ElasticsearchBaseDocument {
   workspace_id: string;
 }
 
+/**
+ * Types for consumption documents stored in Elasticsearch. One document per unit
+ * of credit consumption attributed to an agent message (an LLM call for one step,
+ * or a single tool call), as opposed to AgentMessageAnalyticsData which holds
+ * one aggregated document per message.
+ */
+
+// The 5 item types of the agent_message_consumption_items table collapse to 2
+// here: the model token buckets (system, input, output, reasoning) become one
+// "llm" document whose buckets are carried by `tokens` and `gross_credit_micro`.
+export type AgentMessageConsumptionAnalyticsType = "llm" | "tool";
+
+export interface AgentMessageConsumptionAnalyticsAgent {
+  id: string;
+  version: string;
+  tag_ids: string[];
+  // Agent that started the run; equals `id` for a top-level agent.
+  root_agent_id: string;
+  // 0 for a top-level agent, incremented once per level of sub-agent nesting.
+  depth: number;
+}
+
+export interface AgentMessageConsumptionAnalyticsUser {
+  id: string;
+}
+
+export interface AgentMessageConsumptionAnalyticsTool {
+  name: string;
+  server_name: string;
+  action_id: string;
+  // Skills that made this tool available to the agent.
+  enabled_by_skill_ids: string[];
+}
+
+export interface AgentMessageConsumptionAnalyticsTokens {
+  system: number;
+  input: number;
+  // Tool documents only: tokens the tool result adds to the conversation. Cannot
+  // be summed with `input`, which counts the tokens the LLM consumed itself.
+  result_footprint: number | null;
+  output: number;
+  reasoning: number;
+}
+
+export interface AgentMessageConsumptionAnalyticsGrossCreditMicro {
+  system: number;
+  input: number;
+  // Tool documents only, see AgentMessageConsumptionAnalyticsTokens.result_footprint.
+  result_footprint: number | null;
+  output: number;
+  reasoning: number;
+  direct: number;
+  total: number;
+}
+
+export interface AgentMessageConsumptionAnalyticsData
+  extends ElasticsearchBaseDocument {
+  agent: AgentMessageConsumptionAnalyticsAgent;
+  agent_message_id: string;
+  api_key_name: string | null;
+  // Version of the attribution logic that produced this document.
+  attribution_version: number;
+  // Idempotency key.
+  consumption_key: string;
+  consumption_type: AgentMessageConsumptionAnalyticsType;
+  conversation_id: string;
+  credit_micro: number;
+  execution_time_ms: number | null;
+  gross_credit_micro: AgentMessageConsumptionAnalyticsGrossCreditMicro;
+  is_billed: boolean;
+  message_version: string;
+  model: AgentMessageAnalyticsModel | null;
+  run_usage_id: string;
+  source: string;
+  space_id: string | null;
+  status: string;
+  step_index: number;
+  timestamp: string; // ISO date string.
+  tokens: AgentMessageConsumptionAnalyticsTokens;
+  tool: AgentMessageConsumptionAnalyticsTool | null;
+  user: AgentMessageConsumptionAnalyticsUser | null;
+  workspace_id: string;
+}
+
 export interface AgentRetrievalOutputAnalyticsData
   extends ElasticsearchBaseDocument {
   message_id: string;


### PR DESCRIPTION
## Description

Add ES index `front.agent_message_consumption_analytics` to capture usage per model call and tool call.
See https://app.notion.com/p/dust-tt/Analytics-Data-Model-for-Cost-Attribution-3b128599d94180cba49bcde500e24481

This index is meant to replace `front.agent_message_analytics` to power the Analytics, allowing both message level metrics (e.g: "get cost breakdown per agent or user") and to deep dive into skills and tools usage ("get skills or tools ranked by credit consumption").

This index contains one document per llm call and tool call. Multiple documents represent the breakdown of a single `agent_message`.

This index will mostly be fed from table `agent_message_consumption_items`. The main difference between this pg table and this index is this index collapses the item types `system` + `input` + `output` + `reasoning` into a single document.

## Tests

```
$ NODE_ENV=development npx tsx scripts/create_elasticsearch_index.ts --index-name agent_message_consumption_analytics --index-version 1 --execute 
[14:26:25.626] INFO (91681): Configuration: {"execute":true}
[14:26:25.626] INFO (91681):   Index name: front.agent_message_consumption_analytics_1 {"execute":true}
[14:26:25.626] INFO (91681):   Alias: front.agent_message_consumption_analytics {"execute":true}
[14:26:25.626] INFO (91681):   Region: local {"execute":true}
[14:26:25.626] INFO (91681):   Remove previous alias: false {"execute":true}
[14:26:25.644] INFO (91681): CHECK: Create index 'front.agent_message_consumption_analytics_1' with alias 'front.agent_message_consumption_analytics' in region 'local' (remove previous alias: false)? (y to confirm) {"execute":true}
y
[14:26:27.922] INFO (91681): Creating index front.agent_message_consumption_analytics_1... {"execute":true}
[14:26:28.035] INFO (91681): ✅ Index created: front.agent_message_consumption_analytics_1 {"execute":true}
[14:26:28.035] INFO (91681): Creating alias front.agent_message_consumption_analytics... {"execute":true}
[14:26:28.053] INFO (91681): ✅ Alias created: front.agent_message_consumption_analytics {"execute":true}
[14:26:28.053] INFO (91681): 🎉 Index creation complete! {"execute":true}
```
## Risk

Low. Safe to rollback until we actually start writing and reading from this index.

## Deploy Plan

Front only. Need to run script above to create the index in production.