### PR TITLE
[front] enh: add search aliases for global skills in search dropdown

### DIFF
--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -241,7 +241,7 @@ describe("searchCapabilityIndex ranking", () => {
     expect(result.map((item) => item.id)).toEqual(["favorite", "non-favorite"]);
   });
 
-  it("uses the best matching name or alias for ranking", () => {
+  it("allows exact aliases to rank normally", () => {
     const result = searchCapabilityIndex({
       items: [
         {
@@ -258,6 +258,47 @@ describe("searchCapabilityIndex ranking", () => {
     });
 
     expect(result.map((item) => item.id)).toEqual(["alias", "prefix"]);
+  });
+
+  it("does not let a partial alias outrank a canonical prefix", () => {
+    const result = searchCapabilityIndex({
+      items: [
+        {
+          id: "frames",
+          searchAliases: ["Frames"],
+          sortName: "Create Frames",
+        },
+        {
+          id: "canonical-prefix",
+          sortName: "Fraud Analysis",
+        },
+      ],
+      query: "fra",
+    });
+
+    expect(result.map((item) => item.id)).toEqual([
+      "canonical-prefix",
+      "frames",
+    ]);
+  });
+
+  it("ranks partial alias matches below canonical name matches", () => {
+    const result = searchCapabilityIndex({
+      items: [
+        {
+          id: "canonical-fuzzy",
+          sortName: "Search And Navigate Data",
+        },
+        {
+          id: "alias",
+          searchAliases: ["Sandbox"],
+          sortName: "Computer",
+        },
+      ],
+      query: "sand",
+    });
+
+    expect(result.map((item) => item.id)).toEqual(["canonical-fuzzy", "alias"]);
   });
 });
 

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -10,6 +10,7 @@ import {
   type SlashCommandToolSuggestion,
   searchCapabilityIndex,
 } from "./SlashCommandCapabilitiesItems";
+import { buildCapabilitySlashCommandItems } from "./slash_suggestion/buildSlashCommandItems";
 
 function toolSuggestion({
   description = "Search data.",
@@ -239,6 +240,25 @@ describe("searchCapabilityIndex ranking", () => {
 
     expect(result.map((item) => item.id)).toEqual(["favorite", "non-favorite"]);
   });
+
+  it("uses the best matching name or alias for ranking", () => {
+    const result = searchCapabilityIndex({
+      items: [
+        {
+          id: "prefix",
+          sortName: "Deep Dive Assistant",
+        },
+        {
+          id: "alias",
+          searchAliases: ["Detailed Research", "Deep Dive"],
+          sortName: "Go Deep",
+        },
+      ],
+      query: "deep dive",
+    });
+
+    expect(result.map((item) => item.id)).toEqual(["alias", "prefix"]);
+  });
 });
 
 describe("searchCapabilityIndex", () => {
@@ -336,5 +356,29 @@ describe("getToolSlashCommandItem", () => {
       id: "mcp_server_view_linear",
       label: "Create ticket (Product)",
     });
+  });
+});
+
+describe("buildCapabilitySlashCommandItems", () => {
+  it("matches a global skill by its configured search aliases", () => {
+    const goDeep = skillSuggestion({
+      name: "Go Deep",
+      sId: "go-deep",
+    });
+    const deepDiveAssistant = skillSuggestion({
+      name: "Deep Dive Assistant",
+      sId: "skl_deep_dive_assistant",
+    });
+
+    const result = buildCapabilitySlashCommandItems({
+      query: "Deep Dive",
+      skills: [deepDiveAssistant, goDeep],
+      tools: [],
+    });
+
+    expect(result.map((item) => item.id)).toEqual([
+      "go-deep",
+      "skl_deep_dive_assistant",
+    ]);
   });
 });

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -260,29 +260,7 @@ describe("searchCapabilityIndex ranking", () => {
     expect(result.map((item) => item.id)).toEqual(["alias", "prefix"]);
   });
 
-  it("does not let a partial alias outrank a canonical prefix", () => {
-    const result = searchCapabilityIndex({
-      items: [
-        {
-          id: "frames",
-          searchAliases: ["Frames"],
-          sortName: "Create Frames",
-        },
-        {
-          id: "canonical-prefix",
-          sortName: "Fraud Analysis",
-        },
-      ],
-      query: "fra",
-    });
-
-    expect(result.map((item) => item.id)).toEqual([
-      "canonical-prefix",
-      "frames",
-    ]);
-  });
-
-  it("ranks partial alias matches below canonical name matches", () => {
+  it("ranks partial alias matches below canonical names when favorite", () => {
     const result = searchCapabilityIndex({
       items: [
         {
@@ -291,6 +269,7 @@ describe("searchCapabilityIndex ranking", () => {
         },
         {
           id: "alias",
+          isFavorite: true,
           searchAliases: ["Sandbox"],
           sortName: "Computer",
         },

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -24,29 +24,44 @@ export interface CapabilitySearchIndexItem {
   sortName: string;
 }
 
+interface CapabilityNameMatch {
+  isLowPriorityAlias: boolean;
+  name: string;
+}
+
 function getBestMatchingName({
   item,
   normalizedQuery,
 }: {
   item: CapabilitySearchIndexItem;
   normalizedQuery: string;
-}): string | null {
-  let bestMatch: string | null = null;
+}): CapabilityNameMatch | null {
+  const aliases = item.searchAliases ?? [];
+  const exactAlias = aliases.find(
+    (alias) => alias.toLowerCase() === normalizedQuery
+  );
+  if (exactAlias) {
+    return { isLowPriorityAlias: false, name: exactAlias };
+  }
 
-  for (const candidate of [item.sortName, ...(item.searchAliases ?? [])]) {
-    if (!subFilter(normalizedQuery, candidate.toLowerCase())) {
+  if (subFilter(normalizedQuery, item.sortName.toLowerCase())) {
+    return { isLowPriorityAlias: false, name: item.sortName };
+  }
+
+  let bestAlias: string | null = null;
+  for (const alias of aliases) {
+    if (!subFilter(normalizedQuery, alias.toLowerCase())) {
       continue;
     }
-
     if (
-      bestMatch === null ||
-      compareForAutocompleteSort(normalizedQuery, candidate, bestMatch) < 0
+      bestAlias === null ||
+      compareForAutocompleteSort(normalizedQuery, alias, bestAlias) < 0
     ) {
-      bestMatch = candidate;
+      bestAlias = alias;
     }
   }
 
-  return bestMatch;
+  return bestAlias ? { isLowPriorityAlias: true, name: bestAlias } : null;
 }
 
 export function searchCapabilityIndex<T extends CapabilitySearchIndexItem>({
@@ -59,12 +74,12 @@ export function searchCapabilityIndex<T extends CapabilitySearchIndexItem>({
   limit?: number;
 }): T[] {
   const normalizedQuery = query.trim().toLowerCase();
-  const matches: { item: T; matchedName: string | null }[] = [];
+  const matches: { item: T; matchedName: CapabilityNameMatch | null }[] = [];
 
   for (const item of items) {
     const matchedName =
       normalizedQuery.length === 0
-        ? item.sortName
+        ? { isLowPriorityAlias: false, name: item.sortName }
         : getBestMatchingName({ item, normalizedQuery });
     const descriptionMatches =
       normalizedQuery.length > 0 &&
@@ -102,10 +117,12 @@ export function searchCapabilityIndex<T extends CapabilitySearchIndexItem>({
     if (a.matchedName !== null && b.matchedName !== null) {
       return (
         favoriteComparison ||
+        Number(a.matchedName.isLowPriorityAlias) -
+          Number(b.matchedName.isLowPriorityAlias) ||
         compareForAutocompleteSort(
           normalizedQuery,
-          a.matchedName,
-          b.matchedName
+          a.matchedName.name,
+          b.matchedName.name
         ) ||
         a.item.sortName.localeCompare(b.item.sortName)
       );

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -116,9 +116,9 @@ export function searchCapabilityIndex<T extends CapabilitySearchIndexItem>({
 
     if (a.matchedName !== null && b.matchedName !== null) {
       return (
-        favoriteComparison ||
         Number(a.matchedName.isLowPriorityAlias) -
           Number(b.matchedName.isLowPriorityAlias) ||
+        favoriteComparison ||
         compareForAutocompleteSort(
           normalizedQuery,
           a.matchedName.name,

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -19,8 +19,34 @@ export const MAX_RENDERED_CAPABILITY_ITEMS = 50;
 export interface CapabilitySearchIndexItem {
   isFavorite?: boolean;
   normalizedDescription?: string;
+  searchAliases?: readonly string[];
   sortGroup?: number;
   sortName: string;
+}
+
+function getBestMatchingName({
+  item,
+  normalizedQuery,
+}: {
+  item: CapabilitySearchIndexItem;
+  normalizedQuery: string;
+}): string | null {
+  let bestMatch: string | null = null;
+
+  for (const candidate of [item.sortName, ...(item.searchAliases ?? [])]) {
+    if (!subFilter(normalizedQuery, candidate.toLowerCase())) {
+      continue;
+    }
+
+    if (
+      bestMatch === null ||
+      compareForAutocompleteSort(normalizedQuery, candidate, bestMatch) < 0
+    ) {
+      bestMatch = candidate;
+    }
+  }
+
+  return bestMatch;
 }
 
 export function searchCapabilityIndex<T extends CapabilitySearchIndexItem>({
@@ -33,18 +59,20 @@ export function searchCapabilityIndex<T extends CapabilitySearchIndexItem>({
   limit?: number;
 }): T[] {
   const normalizedQuery = query.trim().toLowerCase();
-  const matches: { item: T; titleMatches: boolean }[] = [];
+  const matches: { item: T; matchedName: string | null }[] = [];
 
   for (const item of items) {
-    const titleMatches =
-      normalizedQuery.length === 0 || subFilter(normalizedQuery, item.sortName);
+    const matchedName =
+      normalizedQuery.length === 0
+        ? item.sortName
+        : getBestMatchingName({ item, normalizedQuery });
     const descriptionMatches =
       normalizedQuery.length > 0 &&
       item.normalizedDescription !== undefined &&
       subFilter(normalizedQuery, item.normalizedDescription);
 
-    if (titleMatches || descriptionMatches) {
-      matches.push({ item, titleMatches });
+    if (matchedName !== null || descriptionMatches) {
+      matches.push({ item, matchedName });
     }
   }
 
@@ -65,18 +93,21 @@ export function searchCapabilityIndex<T extends CapabilitySearchIndexItem>({
       );
     }
 
-    if (a.titleMatches !== b.titleMatches) {
-      return a.titleMatches ? -1 : 1;
+    const aNameMatches = a.matchedName !== null;
+    const bNameMatches = b.matchedName !== null;
+    if (aNameMatches !== bNameMatches) {
+      return aNameMatches ? -1 : 1;
     }
 
-    if (a.titleMatches) {
+    if (a.matchedName !== null && b.matchedName !== null) {
       return (
         favoriteComparison ||
         compareForAutocompleteSort(
           normalizedQuery,
-          a.item.sortName,
-          b.item.sortName
-        )
+          a.matchedName,
+          b.matchedName
+        ) ||
+        a.item.sortName.localeCompare(b.item.sortName)
       );
     }
 

--- a/front/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems.ts
@@ -47,10 +47,8 @@ export function buildCapabilitySlashCommandItems<
   toolFilter?: (tool: SlashCommandToolSuggestion<V>) => boolean;
   tools: SlashCommandToolSuggestion<V>[];
 }): SlashCommand[] {
-  const normalizedQuery = query.trim().toLowerCase();
-
   const matches = searchCapabilityIndex({
-    query: normalizedQuery,
+    query,
     items: [
       ...skills
         .filter((skill) => skill.sId !== excludeSkillId)
@@ -61,7 +59,7 @@ export function buildCapabilitySlashCommandItems<
           normalizedDescription: skill.userFacingDescription?.toLowerCase(),
           searchAliases: GLOBAL_SKILL_SEARCH_ALIASES[skill.sId],
           skill,
-          sortName: skill.name.toLowerCase(),
+          sortName: skill.name,
         })),
       ...tools
         .filter((tool) => toolFilter?.(tool) ?? true)
@@ -70,7 +68,7 @@ export function buildCapabilitySlashCommandItems<
           normalizedDescription:
             getMcpServerViewDescription(tool)?.toLowerCase(),
           tool,
-          sortName: getToolSlashCommandLabel(tool).toLowerCase(),
+          sortName: getToolSlashCommandLabel(tool),
         })),
     ],
   });

--- a/front/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems.ts
@@ -9,7 +9,7 @@ import {
 import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
 import { getMcpServerViewDescription } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewLightType } from "@app/lib/api/mcp";
-import { GLOBAL_SKILL_SEARCH_ALIASES } from "@app/lib/resources/skill/code_defined/global/search_aliases";
+import { GLOBAL_SKILL_SEARCH_ALIASES } from "@app/lib/skills/global_search_aliases";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export function filterSlashCommandItems(

--- a/front/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems.ts
@@ -9,6 +9,7 @@ import {
 import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
 import { getMcpServerViewDescription } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewLightType } from "@app/lib/api/mcp";
+import { GLOBAL_SKILL_SEARCH_ALIASES } from "@app/lib/resources/skill/code_defined/global/search_aliases";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export function filterSlashCommandItems(
@@ -58,6 +59,7 @@ export function buildCapabilitySlashCommandItems<
           isFavorite: skill.isFavorite ?? false,
           kind: "skill" as const,
           normalizedDescription: skill.userFacingDescription?.toLowerCase(),
+          searchAliases: GLOBAL_SKILL_SEARCH_ALIASES[skill.sId],
           skill,
           sortName: skill.name.toLowerCase(),
         })),

--- a/front/lib/resources/skill/code_defined/global/search_aliases.test.ts
+++ b/front/lib/resources/skill/code_defined/global/search_aliases.test.ts
@@ -1,0 +1,17 @@
+import { GLOBAL_SKILLS_ARRAY } from "@app/lib/resources/skill/code_defined/global";
+import { GLOBAL_SKILL_SEARCH_ALIASES } from "@app/lib/skills/global_search_aliases";
+import { describe, expect, it } from "vitest";
+
+describe("GLOBAL_SKILL_SEARCH_ALIASES", () => {
+  it("only defines aliases for global skills", () => {
+    const globalSkillIds = new Set<string>(
+      GLOBAL_SKILLS_ARRAY.map((skill) => skill.sId)
+    );
+
+    expect(
+      Object.keys(GLOBAL_SKILL_SEARCH_ALIASES).filter(
+        (skillId) => !globalSkillIds.has(skillId)
+      )
+    ).toEqual([]);
+  });
+});

--- a/front/lib/resources/skill/code_defined/global/search_aliases.ts
+++ b/front/lib/resources/skill/code_defined/global/search_aliases.ts
@@ -4,4 +4,5 @@ export const GLOBAL_SKILL_SEARCH_ALIASES: Readonly<
   Record<string, readonly string[]>
 > = {
   "go-deep": ["Deep Dive"],
+  "frames": ["Frames"],
 } satisfies Partial<Record<GlobalSkillId, readonly string[]>>;

--- a/front/lib/resources/skill/code_defined/global/search_aliases.ts
+++ b/front/lib/resources/skill/code_defined/global/search_aliases.ts
@@ -4,6 +4,6 @@ export const GLOBAL_SKILL_SEARCH_ALIASES: Readonly<
   Record<string, readonly string[]>
 > = {
   "go-deep": ["Deep Dive"],
-  "frames": ["Frames"],
-  "sandbox": ["Sandbox"],  // Currently called "Computer", but makes sense to think of it as a sandbox.
+  frames: ["Frames"],
+  sandbox: ["Sandbox"], // Currently called "Computer", but makes sense to think of it as a sandbox.
 } satisfies Partial<Record<GlobalSkillId, readonly string[]>>;

--- a/front/lib/resources/skill/code_defined/global/search_aliases.ts
+++ b/front/lib/resources/skill/code_defined/global/search_aliases.ts
@@ -5,4 +5,5 @@ export const GLOBAL_SKILL_SEARCH_ALIASES: Readonly<
 > = {
   "go-deep": ["Deep Dive"],
   "frames": ["Frames"],
+  "sandbox": ["Sandbox"],  // Currently called "Computer", but makes sense to think of it as a sandbox.
 } satisfies Partial<Record<GlobalSkillId, readonly string[]>>;

--- a/front/lib/resources/skill/code_defined/global/search_aliases.ts
+++ b/front/lib/resources/skill/code_defined/global/search_aliases.ts
@@ -1,0 +1,7 @@
+import type { GlobalSkillId } from "@app/lib/resources/skill/code_defined/global_registry";
+
+export const GLOBAL_SKILL_SEARCH_ALIASES: Readonly<
+  Record<string, readonly string[]>
+> = {
+  "go-deep": ["Deep Dive"],
+} satisfies Partial<Record<GlobalSkillId, readonly string[]>>;

--- a/front/lib/skills/global_search_aliases.ts
+++ b/front/lib/skills/global_search_aliases.ts
@@ -1,9 +1,7 @@
-import type { GlobalSkillId } from "@app/lib/resources/skill/code_defined/global_registry";
-
 export const GLOBAL_SKILL_SEARCH_ALIASES: Readonly<
   Record<string, readonly string[]>
 > = {
   "go-deep": ["Deep Dive"],
   frames: ["Frames"],
   sandbox: ["Sandbox"], // Currently called "Computer", but makes sense to think of it as a sandbox.
-} satisfies Partial<Record<GlobalSkillId, readonly string[]>>;
+};


### PR DESCRIPTION
## Description

Certain global skills can be hard to find from the slash menu when people still think of one with another name (e.g. old name, shortened name).

This adds an alias map for global skills and lets slash search match aliases without changing the displayed skill name. Exact aliases rank normally, while partial alias matches stay below canonical-name matches. Deep Dive now finds Go Deep for instance.

## Tests

- Added an entire test suite.

## Risk

- Low. Only changes the order of results in the slash command.

## Deploy Plan

- Deploy front.