### PR TITLE
[front] feat: surface the sandbox connect command in Poke

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/config.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/config.test.ts
@@ -1,0 +1,59 @@
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+async function setup() {
+  const { workspace, auth } = await createPrivateApiMockRequest({
+    isSuperUser: true,
+    role: "admin",
+  });
+
+  const agentConfiguration =
+    await AgentConfigurationFactory.createTestAgent(auth);
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: agentConfiguration.sId,
+    messagesCreatedAt: [new Date()],
+  });
+
+  return { auth, conversation, workspace };
+}
+
+function configUrl(workspaceId: string, conversationId: string) {
+  return `/api/poke/workspaces/${workspaceId}/conversations/${conversationId}/config`;
+}
+
+describe("GET /api/poke/workspaces/:wId/conversations/:cId/config", () => {
+  it("returns the sandbox provider id and status when the conversation owns one", async () => {
+    const { auth, conversation, workspace } = await setup();
+
+    const sandbox = await SandboxFactory.create(auth, conversation, {
+      status: "sleeping",
+    });
+
+    const response = await honoApp.request(
+      configUrl(workspace.sId, conversation.sId)
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.sandbox).toEqual({
+      providerId: sandbox.providerId,
+      status: "sleeping",
+    });
+  });
+
+  it("returns a null sandbox when the conversation owns none", async () => {
+    const { conversation, workspace } = await setup();
+
+    const response = await honoApp.request(
+      configUrl(workspace.sId, conversation.sId)
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.sandbox).toBeNull();
+  });
+});

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/config.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/config.ts
@@ -1,6 +1,7 @@
 import config from "@app/lib/api/config";
 import type { PokeGetConversationConfig } from "@app/lib/api/poke/conversations";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -40,9 +41,15 @@ app.get(
       conversation
     );
 
+    const sandbox = await ConversationSandboxAdapter.fetchSandbox(
+      auth,
+      conversation
+    );
+
     return ctx.json({
       conversationDataSourceId: conversationDataSource?.sId ?? null,
       langfuseUiBaseUrl: config.getLangfuseUiBaseUrl() ?? null,
+      sandbox: sandbox ? sandbox.toPokeJSON() : null,
       temporalWorkspace: config.getTemporalAgentNamespace() ?? "",
     });
   }

--- a/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.test.ts
@@ -1,0 +1,62 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function detailsUrl(workspaceId: string, spaceId: string) {
+  return `/api/poke/workspaces/${workspaceId}/spaces/${spaceId}/details`;
+}
+
+describe("GET /api/poke/workspaces/:wId/spaces/:spaceId/details", () => {
+  it("returns the sandbox provider id and status when the pod owns one", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const pod = await SpaceFactory.project(workspace);
+    const sandbox = await SandboxFactory.createForPod(auth, pod);
+
+    const response = await honoApp.request(detailsUrl(workspace.sId, pod.sId));
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.sandbox).toEqual({
+      providerId: sandbox.providerId,
+      status: "running",
+    });
+  });
+
+  it("returns a null sandbox when the pod owns none", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const pod = await SpaceFactory.project(workspace);
+
+    const response = await honoApp.request(detailsUrl(workspace.sId, pod.sId));
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.sandbox).toBeNull();
+  });
+
+  it("returns a null sandbox for a regular space", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const space = await SpaceFactory.regular(workspace);
+
+    const response = await honoApp.request(
+      detailsUrl(workspace.sId, space.sId)
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.sandbox).toBeNull();
+  });
+});

--- a/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
@@ -1,6 +1,7 @@
 import type { PokeGetSpaceDetails } from "@app/lib/api/poke/spaces";
 import { getMembers } from "@app/lib/api/workspace";
 import { spaceToPokeJSON } from "@app/lib/poke/utils";
+import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { UserTypeWithWorkspaces } from "@app/types/user";
@@ -59,9 +60,14 @@ app.get(
       ? await ProjectMetadataResource.fetchBySpace(auth, space)
       : null;
 
+    const sandbox = space.isProject()
+      ? await PodSandboxAdapter.fetchSandbox(auth, space)
+      : null;
+
     return ctx.json({
       members,
       metadata: metadata ? metadata.toJSON() : null,
+      sandbox: sandbox ? sandbox.toPokeJSON() : null,
       space: await spaceToPokeJSON(auth, space),
     });
   }

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -4,6 +4,7 @@ import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { formatCredits } from "@app/lib/client/credits";
 import { clientFetch } from "@app/lib/egress/client";
 import { useRequiredPathParam } from "@app/lib/platform";
+import { makeSandboxConnectCommand } from "@app/lib/poke/sandbox";
 import { usePokeConversation } from "@app/poke/swr";
 import { usePokeAgentConfigurations } from "@app/poke/swr/agent_configurations";
 import { usePokeConversationConfig } from "@app/poke/swr/conversation_config";
@@ -915,6 +916,7 @@ export function ConversationPage() {
   }>(null);
   const [showRenderControls, setShowRenderControls] = useState(false);
   const [isCopiedJSON, copyJSON] = useCopyToClipboard();
+  const [isCopiedSandboxCommand, copySandboxCommand] = useCopyToClipboard();
 
   const { copyTestCase, isLoading: isTestCaseLoading } =
     useCopyReinforcementTestCase({ owner, conversationId });
@@ -977,8 +979,16 @@ export function ConversationPage() {
     );
   }
 
-  const { conversationDataSourceId, langfuseUiBaseUrl, temporalWorkspace } =
-    conversationConfig;
+  const {
+    conversationDataSourceId,
+    langfuseUiBaseUrl,
+    sandbox,
+    temporalWorkspace,
+  } = conversationConfig;
+
+  const sandboxConnect = sandbox
+    ? { command: makeSandboxConnectCommand(sandbox), status: sandbox.status }
+    : null;
 
   const allMessages = conversation?.content.flat() ?? [];
   const pendingUserCount = allMessages.filter(
@@ -1048,6 +1058,23 @@ export function ConversationPage() {
                 variant="primary"
                 size="xs"
                 target="_blank"
+              />
+              <Button
+                label={isCopiedSandboxCommand ? "Copied" : "Sandbox Cmd"}
+                variant="primary"
+                size="xs"
+                icon={isCopiedSandboxCommand ? ClipboardCheck : Clipboard}
+                disabled={!sandboxConnect}
+                tooltip={
+                  sandboxConnect
+                    ? `${sandboxConnect.command} (${sandboxConnect.status})`
+                    : "No sandbox for this conversation"
+                }
+                onClick={() => {
+                  if (sandboxConnect) {
+                    void copySandboxCommand(sandboxConnect.command);
+                  }
+                }}
               />
               <Button
                 href={`/poke/${owner.sId}/data_sources/${conversationDataSourceId}`}

--- a/front/components/poke/pages/ProjectPage.tsx
+++ b/front/components/poke/pages/ProjectPage.tsx
@@ -17,7 +17,7 @@ interface ProjectPageProps {
 export function ProjectPage({ details }: ProjectPageProps) {
   const owner = useWorkspace();
 
-  const { members, metadata, space } = details;
+  const { members, metadata, sandbox, space } = details;
 
   return (
     <>
@@ -33,7 +33,7 @@ export function ProjectPage({ details }: ProjectPageProps) {
         </p>
       )}
       <div className="flex flex-row gap-x-6">
-        <ViewSpaceViewTable space={space} />
+        <ViewSpaceViewTable sandbox={sandbox} space={space} />
         <div className="mt-4 flex grow flex-col">
           {Object.entries(members).map(([groupName, groupMembers]) => (
             <MembersDataTable

--- a/front/components/poke/pages/SpacePage.tsx
+++ b/front/components/poke/pages/SpacePage.tsx
@@ -46,7 +46,7 @@ export function SpacePage() {
     );
   }
 
-  const { members, space } = spaceDetails;
+  const { members, sandbox, space } = spaceDetails;
 
   if (spaceDetails.space.kind === "project") {
     return <ProjectPage details={spaceDetails} />;
@@ -61,7 +61,7 @@ export function SpacePage() {
         </LinkWrapper>
       </h3>
       <div className="flex flex-row gap-x-6">
-        <ViewSpaceViewTable space={space} />
+        <ViewSpaceViewTable sandbox={sandbox} space={space} />
         <div className="mt-4 flex grow flex-col">
           {Object.entries(members).map(([groupName, groupMembers]) => (
             <MembersDataTable

--- a/front/components/poke/spaces/view.tsx
+++ b/front/components/poke/spaces/view.tsx
@@ -78,11 +78,10 @@ export function ViewSpaceViewTable({ sandbox, space }: ViewSpaceTableProps) {
                   </PokeTableRow>
                   <PokeTableRow>
                     <PokeTableHead>Sandbox Connect</PokeTableHead>
-                    {/* The full `e2b sandbox connect` command is too wide for
-                        the Overview, so show the sandbox id and copy the
-                        command. */}
+                    {/* The `e2b sandbox connect` command is too wide for the
+                        Overview; the copy button is what matters here. */}
                     <PokeTableCellWithCopy
-                      label={sandbox.providerId}
+                      label="Copy command"
                       textToCopy={makeSandboxConnectCommand(sandbox)}
                     />
                   </PokeTableRow>

--- a/front/components/poke/spaces/view.tsx
+++ b/front/components/poke/spaces/view.tsx
@@ -6,14 +6,16 @@ import {
   PokeTableHead,
   PokeTableRow,
 } from "@app/components/poke/shadcn/ui/table";
+import { makeSandboxConnectCommand } from "@app/lib/poke/sandbox";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import type { PokeSpaceType } from "@app/types/poke";
+import type { PokeSandboxType, PokeSpaceType } from "@app/types/poke";
 
 interface ViewSpaceTableProps {
+  sandbox: PokeSandboxType | null;
   space: PokeSpaceType;
 }
 
-export function ViewSpaceViewTable({ space }: ViewSpaceTableProps) {
+export function ViewSpaceViewTable({ sandbox, space }: ViewSpaceTableProps) {
   return (
     <div className="flex flex-col space-y-8">
       <div className="flex justify-between gap-3">
@@ -67,6 +69,24 @@ export function ViewSpaceViewTable({ space }: ViewSpaceTableProps) {
                       .join(", ")}
                   </PokeTableCell>
                 </PokeTableRow>
+              )}
+              {sandbox && (
+                <>
+                  <PokeTableRow>
+                    <PokeTableHead>Sandbox Status</PokeTableHead>
+                    <PokeTableCell>{sandbox.status}</PokeTableCell>
+                  </PokeTableRow>
+                  <PokeTableRow>
+                    <PokeTableHead>Sandbox Connect</PokeTableHead>
+                    {/* The full `e2b sandbox connect` command is too wide for
+                        the Overview, so show the sandbox id and copy the
+                        command. */}
+                    <PokeTableCellWithCopy
+                      label={sandbox.providerId}
+                      textToCopy={makeSandboxConnectCommand(sandbox)}
+                    />
+                  </PokeTableRow>
+                </>
               )}
               <PokeTableRow>
                 <PokeTableHead>Created At</PokeTableHead>

--- a/front/lib/api/poke/conversations.ts
+++ b/front/lib/api/poke/conversations.ts
@@ -3,6 +3,7 @@ import type {
   ConversationVisibility,
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
+import type { PokeSandboxType } from "@app/types/poke";
 
 export type PokeListConversationItem = ConversationWithoutContentType & {
   visibility?: ConversationVisibility;
@@ -15,6 +16,7 @@ export type PokeListConversations = {
 export type PokeGetConversationConfig = {
   conversationDataSourceId: string | null;
   langfuseUiBaseUrl: string | null;
+  sandbox: PokeSandboxType | null;
   temporalWorkspace: string;
 };
 

--- a/front/lib/api/poke/plugins/conversations/index.ts
+++ b/front/lib/api/poke/plugins/conversations/index.ts
@@ -1,1 +1,2 @@
 export * from "./unstick";
+export * from "./wake_sandbox";

--- a/front/lib/api/poke/plugins/conversations/wake_sandbox.ts
+++ b/front/lib/api/poke/plugins/conversations/wake_sandbox.ts
@@ -21,9 +21,7 @@ export const wakeConversationSandboxPlugin = createPlugin({
   manifest: {
     id: "wake-conversation-sandbox",
     name: "Wake Sandbox",
-    description:
-      "Resume this conversation's sleeping sandbox so it can be connected to with " +
-      "`e2b sandbox connect`.",
+    description: "Resume this conversation's sleeping sandbox.",
     resourceTypes: ["conversations"],
     args: {},
     requiredRoles: ["support"],

--- a/front/lib/api/poke/plugins/conversations/wake_sandbox.ts
+++ b/front/lib/api/poke/plugins/conversations/wake_sandbox.ts
@@ -1,0 +1,40 @@
+import {
+  isSandboxSleeping,
+  wakeSleepingSandbox,
+} from "@app/lib/api/poke/sandboxes";
+import { createPlugin } from "@app/lib/api/poke/types";
+import { ensureConversationSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import { Err } from "@app/types/shared/result";
+
+function sandboxTarget(auth: Authenticator, conversation: ConversationType) {
+  return {
+    ensureReady: () => ensureConversationSandboxReady(auth, conversation),
+    fetchSandbox: () =>
+      ConversationSandboxAdapter.fetchSandbox(auth, conversation),
+  };
+}
+
+export const wakeConversationSandboxPlugin = createPlugin({
+  manifest: {
+    id: "wake-conversation-sandbox",
+    name: "Wake Sandbox",
+    description:
+      "Resume this conversation's sleeping sandbox so it can be connected to with " +
+      "`e2b sandbox connect`.",
+    resourceTypes: ["conversations"],
+    args: {},
+    requiredRoles: ["support"],
+  },
+  isApplicableTo: async (auth, conversation) =>
+    conversation ? isSandboxSleeping(sandboxTarget(auth, conversation)) : false,
+  execute: async (auth, conversation) => {
+    if (!conversation) {
+      return new Err(new Error("Conversation not found."));
+    }
+
+    return wakeSleepingSandbox(sandboxTarget(auth, conversation));
+  },
+});

--- a/front/lib/api/poke/plugins/spaces/index.ts
+++ b/front/lib/api/poke/plugins/spaces/index.ts
@@ -2,3 +2,4 @@ export * from "./activation_management";
 export * from "./force_run_task_generation";
 export * from "./import_app";
 export * from "./update_pod_members";
+export * from "./wake_sandbox";

--- a/front/lib/api/poke/plugins/spaces/wake_sandbox.test.ts
+++ b/front/lib/api/poke/plugins/spaces/wake_sandbox.test.ts
@@ -1,0 +1,74 @@
+import { wakePodSandboxPlugin } from "@app/lib/api/poke/plugins/spaces/wake_sandbox";
+import { Authenticator } from "@app/lib/auth";
+import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { describe, expect, it } from "vitest";
+
+async function setup() {
+  const workspace = await WorkspaceFactory.basic();
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  const pod = await SpaceFactory.project(workspace);
+
+  return { auth, pod, workspace };
+}
+
+describe("wakePodSandboxPlugin", () => {
+  it("is applicable when the pod sandbox is sleeping", async () => {
+    const { auth, pod } = await setup();
+    await SandboxFactory.createForPod(auth, pod, { status: "sleeping" });
+
+    await expect(wakePodSandboxPlugin.isApplicableTo(auth, pod)).resolves.toBe(
+      true
+    );
+  });
+
+  it("is not applicable when the pod sandbox is already running", async () => {
+    const { auth, pod } = await setup();
+    await SandboxFactory.createForPod(auth, pod, { status: "running" });
+
+    await expect(wakePodSandboxPlugin.isApplicableTo(auth, pod)).resolves.toBe(
+      false
+    );
+  });
+
+  it("is not applicable when the pod has no sandbox", async () => {
+    const { auth, pod } = await setup();
+
+    await expect(wakePodSandboxPlugin.isApplicableTo(auth, pod)).resolves.toBe(
+      false
+    );
+  });
+
+  it("is not applicable to a regular space", async () => {
+    const { workspace, auth } = await setup();
+    const space = await SpaceFactory.regular(workspace);
+
+    await expect(
+      wakePodSandboxPlugin.isApplicableTo(auth, space)
+    ).resolves.toBe(false);
+  });
+
+  // Waking provisions nothing: a sandbox in any other status is refused before
+  // the ready helper (and therefore the provider) is ever reached.
+  it("refuses to wake a sandbox that is not sleeping", async () => {
+    const { auth, pod } = await setup();
+    await SandboxFactory.createForPod(auth, pod, { status: "deleted" });
+
+    const result = await wakePodSandboxPlugin.execute(auth, pod, {});
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() && result.error.message).toContain("not sleeping");
+  });
+
+  it("errors when the pod has no sandbox", async () => {
+    const { auth, pod } = await setup();
+
+    const result = await wakePodSandboxPlugin.execute(auth, pod, {});
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() && result.error.message).toContain(
+      "No sandbox to wake"
+    );
+  });
+});

--- a/front/lib/api/poke/plugins/spaces/wake_sandbox.ts
+++ b/front/lib/api/poke/plugins/spaces/wake_sandbox.ts
@@ -20,9 +20,7 @@ export const wakePodSandboxPlugin = createPlugin({
   manifest: {
     id: "wake-pod-sandbox",
     name: "Wake Sandbox",
-    description:
-      "Resume this pod's sleeping sandbox so it can be connected to with " +
-      "`e2b sandbox connect`.",
+    description: "Resume this pod's sleeping sandbox.",
     resourceTypes: ["spaces"],
     args: {},
     requiredRoles: ["support"],

--- a/front/lib/api/poke/plugins/spaces/wake_sandbox.ts
+++ b/front/lib/api/poke/plugins/spaces/wake_sandbox.ts
@@ -1,0 +1,39 @@
+import {
+  isSandboxSleeping,
+  wakeSleepingSandbox,
+} from "@app/lib/api/poke/sandboxes";
+import { createPlugin } from "@app/lib/api/poke/types";
+import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import type { Authenticator } from "@app/lib/auth";
+import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { Err } from "@app/types/shared/result";
+
+function sandboxTarget(auth: Authenticator, pod: SpaceResource) {
+  return {
+    ensureReady: () => ensurePodSandboxReady(auth, pod),
+    fetchSandbox: () => PodSandboxAdapter.fetchSandbox(auth, pod),
+  };
+}
+
+export const wakePodSandboxPlugin = createPlugin({
+  manifest: {
+    id: "wake-pod-sandbox",
+    name: "Wake Sandbox",
+    description:
+      "Resume this pod's sleeping sandbox so it can be connected to with " +
+      "`e2b sandbox connect`.",
+    resourceTypes: ["spaces"],
+    args: {},
+    requiredRoles: ["support"],
+  },
+  isApplicableTo: async (auth, space) =>
+    space?.isProject() ? isSandboxSleeping(sandboxTarget(auth, space)) : false,
+  execute: async (auth, space) => {
+    if (!space?.isProject()) {
+      return new Err(new Error("Pod not found."));
+    }
+
+    return wakeSleepingSandbox(sandboxTarget(auth, space));
+  },
+});

--- a/front/lib/api/poke/sandboxes.ts
+++ b/front/lib/api/poke/sandboxes.ts
@@ -1,0 +1,54 @@
+import type { PluginResponse } from "@app/lib/api/poke/types";
+import type { EnsureSandboxReadyResult } from "@app/lib/api/sandbox/lifecycle";
+import { makeSandboxConnectCommand } from "@app/lib/poke/sandbox";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+type SandboxWakeTarget = {
+  // Must go through the owner-specific ready helper, not the owner adapter:
+  // waking through the adapter skips the GCS mount and egress bring-up.
+  ensureReady: () => Promise<Result<EnsureSandboxReadyResult, Error>>;
+  fetchSandbox: () => Promise<SandboxResource | null>;
+};
+
+export async function isSandboxSleeping({
+  fetchSandbox,
+}: Pick<SandboxWakeTarget, "fetchSandbox">): Promise<boolean> {
+  const sandbox = await fetchSandbox();
+
+  return sandbox?.status === "sleeping";
+}
+
+export async function wakeSleepingSandbox({
+  ensureReady,
+  fetchSandbox,
+}: SandboxWakeTarget): Promise<Result<PluginResponse, Error>> {
+  const sandbox = await fetchSandbox();
+  if (!sandbox) {
+    return new Err(new Error("No sandbox to wake."));
+  }
+
+  // The ready helper would create a sandbox from scratch if there were none, and
+  // resume anything that is merely paused. Waking is only meaningful for a
+  // sleeping one, so refuse every other status rather than provisioning.
+  if (sandbox.status !== "sleeping") {
+    return new Err(
+      new Error(`Sandbox is ${sandbox.status}, not sleeping — nothing to wake.`)
+    );
+  }
+
+  const readyResult = await ensureReady();
+  if (readyResult.isErr()) {
+    return new Err(readyResult.error);
+  }
+
+  const woken = readyResult.value.sandbox;
+
+  return new Ok({
+    display: "text",
+    value:
+      `Sandbox is now ${woken.status}. Connect with: ` +
+      makeSandboxConnectCommand(woken.toPokeJSON()),
+  });
+}

--- a/front/lib/api/poke/spaces.ts
+++ b/front/lib/api/poke/spaces.ts
@@ -1,4 +1,4 @@
-import type { PokeSpaceType } from "@app/types/poke";
+import type { PokeSandboxType, PokeSpaceType } from "@app/types/poke";
 import type { PodMetadataType } from "@app/types/project_metadata";
 import type { SpaceType } from "@app/types/space";
 import type { UserTypeWithWorkspaces } from "@app/types/user";
@@ -10,5 +10,7 @@ export type PokeListSpaces = {
 export type PokeGetSpaceDetails = {
   members: Record<string, UserTypeWithWorkspaces[]>;
   metadata: PodMetadataType | null;
+  // Only pods own a sandbox; always null for other space kinds.
+  sandbox: PokeSandboxType | null;
   space: PokeSpaceType;
 };

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -26,7 +26,7 @@ import { Ok, type Result } from "@app/types/shared/result";
 
 const SANDBOX_RUNTIME_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 
-interface EnsureSandboxReadyResult {
+export interface EnsureSandboxReadyResult {
   sandbox: SandboxResource;
   freshlyCreated: boolean;
 }

--- a/front/lib/poke/sandbox.ts
+++ b/front/lib/poke/sandbox.ts
@@ -1,0 +1,6 @@
+import type { PokeSandboxType } from "@app/types/poke";
+
+// E2B is the only sandbox provider, so its CLI is what operators attach with.
+export function makeSandboxConnectCommand(sandbox: PokeSandboxType): string {
+  return `e2b sandbox connect ${sandbox.providerId}`;
+}

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -31,6 +31,7 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
+import type { PokeSandboxType } from "@app/types/poke";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -1257,6 +1258,15 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     }
 
     return result;
+  }
+
+  // The provider id is the handle the `e2b sandbox connect` CLI takes, so Poke
+  // surfaces it to let operators attach to a live sandbox.
+  toPokeJSON(): PokeSandboxType {
+    return {
+      providerId: this.providerId,
+      status: this.status,
+    };
   }
 
   toLogJSON() {

--- a/front/tests/utils/SandboxFactory.ts
+++ b/front/tests/utils/SandboxFactory.ts
@@ -1,6 +1,8 @@
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
+import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
 import {
   SandboxModel,
@@ -61,6 +63,31 @@ export class SandboxFactory {
     );
     if (!result) {
       throw new Error("Sandbox not found after creation");
+    }
+    return result;
+  }
+
+  static async createForPod(
+    auth: Authenticator,
+    pod: SpaceResource,
+    opts?: { status?: SandboxStatus }
+  ): Promise<SandboxResource> {
+    const sandbox = await SandboxResource.makeNew(auth, {
+      providerId: `test-provider-${Date.now()}`,
+      status: opts?.status ?? "running",
+      baseImage: "dust-base",
+      version: "0.0.0-test",
+    });
+
+    await SandboxOwnerModel.create({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      spaceId: pod.id,
+      sandboxId: sandbox.id,
+    });
+
+    const result = await PodSandboxAdapter.fetchSandbox(auth, pod);
+    if (!result) {
+      throw new Error("Pod sandbox not found after creation");
     }
     return result;
   }

--- a/front/types/poke/index.ts
+++ b/front/types/poke/index.ts
@@ -1,6 +1,7 @@
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
 import type { AgentMessageCreditsBreakdown } from "@app/lib/api/assistant/credit_cost";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
 import type { RegionType } from "@app/types/region";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
@@ -35,6 +36,11 @@ export interface PokeItemBase {
 export type PokeSpaceType = SpaceType & {
   id: ModelId;
   groups: GroupType[];
+};
+
+export type PokeSandboxType = {
+  providerId: string;
+  status: SandboxStatus;
 };
 
 export type PokeDataSourceType = DataSourceType &


### PR DESCRIPTION
## Description

Both conversations and pods can own a sandbox, but Poke gave no way to get the
`e2b sandbox connect <id>` command needed to attach to one — the provider id
only lived in the `sandboxes` table.

The provider id is now exposed on the two responses each page already loads (the
conversation config and the space details) as a `sandbox` field built by a new
`SandboxResource.toPokeJSON`. The lookup is a single indexed owner-link query,
so — unlike the pod databases listing — neither page wakes a sandbox just by
loading.

- **Pod page**: `Sandbox Status` and `Sandbox Connect` rows in the Overview. The
  connect cell is a `Copy command` button rather than the command text, which
  was far too wide for the table.
- **Conversation page**: no Overview table there, so a toolbar copy button next
  to `Sandbox Logs`, carrying the command and status in its tooltip. Disabled,
  with an explanatory tooltip, when the conversation has no sandbox.
- **Wake Sandbox plugin** for both resource types, applicable only while the
  sandbox is sleeping. It routes through `ensure{Conversation,Pod}SandboxReady`
  rather than the owner adapters, per the `/!\` warning in `lifecycle.ts`, so the
  GCS mount and egress forwarder come back up with it and the sandbox is
  actually usable once you connect. Any other status is refused rather than
  provisioned, since the ready helper would otherwise create a sandbox from
  nothing.

A plugin was chosen over a bespoke button + endpoint because it is the
established Poke path for state-changing actions: role-gated via
`requiredRoles: ["support"]`, recorded in `PluginRun` history, auto-registered
by the barrel exports, and `isApplicableTo` expresses the only-when-sleeping
rule declaratively.

## Tests

New functional tests on both modified endpoints (sandbox present, absent, and a
non-pod space) and on the wake plugin's guard logic — its applicability across
sleeping / running / absent / non-pod, and its refusal to wake a non-sleeping
sandbox, which is the path that keeps it from provisioning through the ready
helper. `SandboxFactory` gained a `createForPod` variant; it previously only
created conversation-owned sandboxes.

- 5 new endpoint tests + 6 new plugin tests pass
- the 62-test poke endpoint suite passes
- the 49 existing `sandbox_resource` + `lifecycle` tests pass
- `tsgo --noEmit` clean on `front`, `front-api` and `front-spa`

## Risk

Low. Read-only additive fields on two internal Poke endpoints, plus one new
opt-in plugin. The only behavior reachable by accident is the plugin, which is
super-user + `support`-role gated and refuses anything other than a sleeping
sandbox. Safe to roll back: no migration, no schema change.

One pre-existing export was widened — `EnsureSandboxReadyResult` in
`lifecycle.ts` is now exported so the shared wake helper can type its callback.
No behavior change.

## Deploy Plan

Standard deploy, no ordering constraints. `front` and `front-api` ship together;
the new `sandbox` response field is additive, so an older client simply ignores
it.