### PR TITLE
[front] feat: audit pod function publishes

### DIFF
--- a/front/admin/audit_log_schemas/pod_function.published.json
+++ b/front/admin/audit_log_schemas/pod_function.published.json
@@ -1,0 +1,21 @@
+{
+  "action": "pod_function.published",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "space"
+    },
+    {
+      "type": "pod_function"
+    }
+  ],
+  "metadata": {
+    "operation": "string",
+    "pod_function_slug": "string",
+    "user_identity": "string",
+    "previous_user_identity": "string",
+    "file_id": "string"
+  }
+}

--- a/front/admin/audit_log_schemas/pod_function.published.json
+++ b/front/admin/audit_log_schemas/pod_function.published.json
@@ -16,6 +16,7 @@
     "pod_function_slug": "string",
     "user_identity": "string",
     "previous_user_identity": "string",
-    "file_id": "string"
+    "file_id": "string",
+    "actor_type": "string"
   }
 }

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -58,6 +58,7 @@
   "oauth.authorized": 3,
   "oauth.initiated": 3,
   "oauth.revoked": 2,
+  "pod_function.published": 1,
   "project.joined": 3,
   "project.left": 3,
   "sandbox_egress_policy.agent_requests_setting_updated": 1,

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -58,7 +58,7 @@
   "oauth.authorized": 3,
   "oauth.initiated": 3,
   "oauth.revoked": 2,
-  "pod_function.published": 1,
+  "pod_function.published": 2,
   "project.joined": 3,
   "project.left": 3,
   "sandbox_egress_policy.agent_requests_setting_updated": 1,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -84,6 +84,7 @@ export const AUDIT_ACTIONS = [
   "self_improvement.batch_mode_updated",
   "skill.self_improvement_updated",
   // Sandbox.
+  "pod_function.published",
   "sandbox_egress_policy.agent_requests_setting_updated",
   "sandbox_egress_policy.sandbox_updated",
   "sandbox_egress_policy.updated",
@@ -415,6 +416,7 @@ type AuditTargetType =
   | "credential"
   | "mcp_connection"
   | "sandbox_env_var"
+  | "pod_function"
   | "frame";
 
 /**

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
@@ -15,6 +15,17 @@ import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const { emitAuditLogEventMock } = vi.hoisted(() => ({
+  emitAuditLogEventMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/audit/workos_audit")>();
+
+  return { ...actual, emitAuditLogEvent: emitAuditLogEventMock };
+});
+
 vi.mock(
   "@app/lib/api/sandbox_functions/build_on_sandbox",
   async (importOriginal) => {
@@ -121,6 +132,26 @@ describe("publishSandboxFunction", () => {
 
     const listed = await SandboxFunctionResource.listBySpace(auth, space);
     expect(listed.map(({ id }) => id)).toEqual([fn.id]);
+
+    // A first publish has no prior policy, so `previous_user_identity` is absent rather than
+    // reported as the default.
+    expect(emitAuditLogEventMock).toHaveBeenCalledTimes(1);
+    expect(emitAuditLogEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "pod_function.published",
+        targets: [
+          { type: "workspace", id: workspace.sId, name: workspace.name },
+          { type: "space", id: space.sId, name: space.name },
+          { type: "pod_function", id: fn.sId, name: "greet" },
+        ],
+        metadata: {
+          operation: "created",
+          pod_function_slug: "greet",
+          user_identity: "interactive_workspace_user_required",
+          file_id: fn.file.sId,
+        },
+      })
+    );
   });
 
   it("overwrites the bundle in place on re-publish, keeping one row and the same file", async () => {
@@ -192,6 +223,23 @@ describe("publishSandboxFunction", () => {
       `w/${workspace.sId}/pods/${space.sId}/sandbox-functions/greet.ts`
     );
     expect(files[0].version).toBeGreaterThan(firstVersion ?? 0);
+
+    // The re-publish widened who may call the function. `previous_user_identity` must be the policy
+    // in force before the update, which only holds because it is captured before `updateContent`
+    // assigns the new values onto the resource instance.
+    expect(emitAuditLogEventMock).toHaveBeenCalledTimes(2);
+    expect(emitAuditLogEventMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: "pod_function.published",
+        metadata: {
+          operation: "updated",
+          pod_function_slug: "greet",
+          user_identity: "optional",
+          previous_user_identity: "workspace_user_required",
+          file_id: second.value.file.sId,
+        },
+      })
+    );
   });
 
   it("rejects a path that escapes the pod mount", async () => {

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.ts
@@ -1,3 +1,7 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+} from "@app/lib/api/audit/workos_audit";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
@@ -5,6 +9,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { SandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -66,6 +71,10 @@ export async function publishSandboxFunction(
     slug
   );
   if (existing) {
+    // Read before updateContent: BaseResource.update assigns the new values onto the instance, so
+    // reading afterwards would report the incoming policy as the previous one.
+    const previousUserIdentity = existing.userIdentity ?? "optional";
+
     const updateResult = await existing.updateContent(auth, {
       bundleCode,
       description,
@@ -78,6 +87,13 @@ export async function publishSandboxFunction(
         new SandboxFunctionError("internal", updateResult.error.message)
       );
     }
+
+    emitPodFunctionPublishedAuditEvent(auth, {
+      space,
+      sandboxFunction: existing,
+      operation: "updated",
+      previousUserIdentity,
+    });
 
     return new Ok(existing);
   }
@@ -97,7 +113,57 @@ export async function publishSandboxFunction(
     outputSchema,
   });
 
+  emitPodFunctionPublishedAuditEvent(auth, {
+    space,
+    sandboxFunction: created,
+    operation: "created",
+    previousUserIdentity: null,
+  });
+
   return new Ok(created);
+}
+
+/**
+ * Publishing puts executable code behind a callable endpoint on a Pod's shared runtime, so it is
+ * audited even though functions are not a user-facing concept. `user_identity` is declared in the
+ * function source rather than passed in, which means a re-publish can widen who is allowed to call
+ * an existing function: both the new and previous policy are recorded so that change is visible.
+ */
+function emitPodFunctionPublishedAuditEvent(
+  auth: Authenticator,
+  {
+    space,
+    sandboxFunction,
+    operation,
+    previousUserIdentity,
+  }: {
+    space: SpaceResource;
+    sandboxFunction: SandboxFunctionResource;
+    operation: "created" | "updated";
+    previousUserIdentity: SandboxFunctionUserIdentityPolicy | null;
+  }
+): void {
+  void emitAuditLogEvent({
+    auth,
+    action: "pod_function.published",
+    targets: [
+      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+      buildAuditLogTarget("space", space),
+      buildAuditLogTarget("pod_function", {
+        sId: sandboxFunction.sId,
+        name: sandboxFunction.slug,
+      }),
+    ],
+    metadata: {
+      operation,
+      pod_function_slug: sandboxFunction.slug,
+      user_identity: sandboxFunction.userIdentity ?? "optional",
+      ...(previousUserIdentity
+        ? { previous_user_identity: previousUserIdentity }
+        : {}),
+      file_id: sandboxFunction.file.sId,
+    },
+  });
 }
 
 async function createBundleFile(


### PR DESCRIPTION
## Problem

Publishing a pod function puts executable code behind a callable endpoint on a Pod's shared runtime — authored by an agent, under a user's identity, reachable by anyone the function's identity policy allows. It was the most security-relevant mutation on the function path with no audit trail at all.

Follow-up to #29970, which covered tool calls made *by* functions.

## Approach

Unlike tool calls, this has no existing namespace to fold into, so it adds `pod_function.published` and a `pod_function` target type. Emitted from `publishSandboxFunction` (rather than the MCP tool handler) so it covers every caller and sits with the mutation it records.

Targets are `[workspace, space, pod_function]` — the pod as `space` so an admin can filter to everything published in one Pod.

## The identity-policy transition

`userIdentity` is declared in the function *source* and extracted at build time, not passed in by the caller. A re-publish can therefore **widen** who may call an existing function, and `updateContent` only pre-commits the policy when it *strengthens* (`sandbox_function_resource.ts`) — weakening lands with the new bundle. Going from `interactive_workspace_user_required` to `optional` turns a function that required a logged-in interactive user into one callable by any delegated caller.

So the event records both `user_identity` and `previous_user_identity` rather than just the new value.

That previous value is captured **before** `updateContent`, because `BaseResource.update` does `Object.assign(this, affectedRows[0].get())` — reading afterwards would report the incoming policy as the previous one. The existing re-publish test already exercised `workspace_user_required` → `optional`, so the assertion went there. Verified it fails on the regression: moving the capture below `updateContent` yields `previous_user_identity: "optional"` instead of `"workspace_user_required"`.

## Event shape

```json
{
  "actor": { "id": "IvcQRUlbYw", "name": "David Ebbo", "type": "user" },
  "action": "pod_function.published",
  "targets": [
    { "id": "BHWrN3HaUa", "name": "david", "type": "workspace" },
    { "id": "spc_a1b2c3", "name": "Team Weekly", "type": "space" },
    { "id": "sbxfn_d4e5f6", "name": "add-comment", "type": "pod_function" }
  ],
  "metadata": {
    "operation": "updated",
    "pod_function_slug": "add-comment",
    "user_identity": "optional",
    "previous_user_identity": "workspace_user_required",
    "file_id": "fil_g7h8i9"
  }
}
```

`previous_user_identity` is absent on a first publish rather than reported as the default — also asserted.

## Notes for review

- **Actor is the human, not the agent** (`[AUDIT2]`). Publishing always runs through the `publish` MCP tool under the user's `auth`. The authoring agent and conversation are *not* recorded — threading `runContext` into the business layer purely for audit metadata seemed like the wrong trade, but say the word if traceability back to the conversation is worth it.
- **`pod_function` naming** follows the `pod_*` metadata keys shipped in #29970. Worth noting the codebase is now inconsistent with itself: `project.joined` / `project.left` use "project" for the same underlying space that this calls a "pod".
- **Deletion is not audited.** There's no delete tool; functions only disappear via space deletion cascade (`deleteAllForSpace`), so the lifecycle event would fire during workspace scrubbing rather than on a user action. Left out deliberately.

## Registration

`pod_function.published` v1 is registered in the **test** WorkOS environment; `schema_versions.json` is committed. Production needs the same registration before deploy, as with #29970:

```
npx tsx admin/register_audit_log_schemas.ts --execute pod_function.published
```

Note `--changed` does **not** pick this up — it diffs via `git diff`, so a newly added (untracked) schema file is invisible to it. Register by action name.

## Testing

- `npx tsgo --noEmit` clean
- `lib/api/sandbox_functions` + `lib/api/audit` — 54/54, including the emit/schema drift scan
- Regression-verified the `previous_user_identity` assertion fails when the capture is moved after `updateContent`
