### PR TITLE
Admin governance for skills: Add warning if any editor will lose access to the skill

### DIFF
--- a/front-api/routes/w/[wId]/spaces/access-check.test.ts
+++ b/front-api/routes/w/[wId]/spaces/access-check.test.ts
@@ -1,0 +1,185 @@
+import { Authenticator } from "@app/lib/auth";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+function accessCheck(
+  workspace: { sId: string },
+  { spaceIds = [], userIds = [] }: { spaceIds?: string[]; userIds?: string[] }
+) {
+  const params = new URLSearchParams();
+  for (const spaceId of spaceIds) {
+    params.append("spaceIds", spaceId);
+  }
+  for (const userId of userIds) {
+    params.append("userIds", userId);
+  }
+
+  return honoApp.request(
+    `/api/w/${workspace.sId}/spaces/access-check?${params.toString()}`
+  );
+}
+
+describe("GET /api/w/:wId/spaces/access-check", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Parameter Validation", () => {
+    it("returns 400 when spaceIds is missing", async () => {
+      const { workspace, user } = await createPrivateApiMockRequest();
+
+      const response = await accessCheck(workspace, { userIds: [user.sId] });
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error.type).toBe("invalid_request_error");
+    });
+
+    it("returns 400 when userIds is missing", async () => {
+      const { workspace } = await createPrivateApiMockRequest();
+      const space = await SpaceFactory.regular(workspace);
+
+      const response = await accessCheck(workspace, { spaceIds: [space.sId] });
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error.type).toBe("invalid_request_error");
+    });
+
+    it("returns 400 when more than 100 space ids are provided", async () => {
+      const { workspace, user } = await createPrivateApiMockRequest();
+
+      const response = await accessCheck(workspace, {
+        spaceIds: Array.from({ length: 101 }, (_, i) => `spc_${i}`),
+        userIds: [user.sId],
+      });
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error.message).toContain("Too many ids");
+    });
+  });
+
+  describe("Authorization", () => {
+    it("returns 404 when a requested space does not exist", async () => {
+      const { workspace, user } = await createPrivateApiMockRequest();
+
+      const response = await accessCheck(workspace, {
+        spaceIds: ["spc_doesnotexist"],
+        userIds: [user.sId],
+      });
+
+      expect(response.status).toBe(404);
+      expect((await response.json()).error.type).toBe("space_not_found");
+    });
+
+    it("returns 403 when the caller cannot read a requested space", async () => {
+      const { workspace, user } = await createPrivateApiMockRequest();
+
+      // The caller is not a member of this restricted space.
+      const space = await SpaceFactory.regular(workspace);
+
+      const response = await accessCheck(workspace, {
+        spaceIds: [space.sId],
+        userIds: [user.sId],
+      });
+
+      expect(response.status).toBe(403);
+      expect((await response.json()).error.type).toBe("workspace_auth_error");
+    });
+  });
+
+  describe("Happy Path", () => {
+    it("reports only the users that are not members of the space", async () => {
+      const { workspace, user } = await createPrivateApiMockRequest();
+
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+
+      const space = await SpaceFactory.regular(workspace);
+      const addRes = await space.addMembers(adminAuth, { userIds: [user.sId] });
+      if (addRes.isErr()) {
+        throw new Error("Failed to add the caller to the space");
+      }
+
+      const outsider = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, outsider, { role: "user" });
+
+      const response = await accessCheck(workspace, {
+        spaceIds: [space.sId],
+        userIds: [user.sId, outsider.sId],
+      });
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.spacesAccess).toHaveLength(1);
+      expect(data.spacesAccess[0].spaceId).toBe(space.sId);
+      expect(data.spacesAccess[0].userIdsWithoutAccess).toEqual([outsider.sId]);
+    });
+
+    it("reports every space when several are requested", async () => {
+      const { workspace, user } = await createPrivateApiMockRequest();
+
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+
+      const spaceWithBoth = await SpaceFactory.regular(workspace);
+      const spaceWithCallerOnly = await SpaceFactory.regular(workspace);
+
+      const peer = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, peer, { role: "user" });
+
+      await spaceWithBoth.addMembers(adminAuth, {
+        userIds: [user.sId, peer.sId],
+      });
+      await spaceWithCallerOnly.addMembers(adminAuth, { userIds: [user.sId] });
+
+      const response = await accessCheck(workspace, {
+        spaceIds: [spaceWithBoth.sId, spaceWithCallerOnly.sId],
+        userIds: [user.sId, peer.sId],
+      });
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+
+      const bySpaceId = new Map<string, string[]>(
+        data.spacesAccess.map(
+          (entry: { spaceId: string; userIdsWithoutAccess: string[] }) => [
+            entry.spaceId,
+            entry.userIdsWithoutAccess,
+          ]
+        )
+      );
+      expect(bySpaceId.get(spaceWithBoth.sId)).toEqual([]);
+      expect(bySpaceId.get(spaceWithCallerOnly.sId)).toEqual([peer.sId]);
+    });
+
+    it("reports users that are not members of the workspace", async () => {
+      const { workspace, user } = await createPrivateApiMockRequest();
+
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+
+      const space = await SpaceFactory.regular(workspace);
+      await space.addMembers(adminAuth, { userIds: [user.sId] });
+
+      // A user of another workspace, and an id that matches nobody.
+      const stranger = await UserFactory.basic();
+
+      const response = await accessCheck(workspace, {
+        spaceIds: [space.sId],
+        userIds: [user.sId, stranger.sId, "usr_doesnotexist"],
+      });
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(new Set(data.spacesAccess[0].userIdsWithoutAccess)).toEqual(
+        new Set([stranger.sId, "usr_doesnotexist"])
+      );
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/spaces/access-check.ts
+++ b/front-api/routes/w/[wId]/spaces/access-check.ts
@@ -1,0 +1,91 @@
+import { listUsersWithoutAccessToSpaces } from "@app/lib/api/spaces/access";
+import type { GetSpacesAccessCheckResponseBody } from "@app/types/api/spaces";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+// Mounted under /api/w/:wId/spaces/access-check.
+const app = workspaceApp();
+
+const MAX_IDS = 100;
+
+const idsSchema = z.union([z.string(), z.array(z.string())]);
+
+const GetSpacesAccessCheckQuerySchema = z.object({
+  spaceIds: idsSchema,
+  userIds: idsSchema,
+});
+
+function toUniqueIds(ids: string | string[]): string[] {
+  return [...new Set(Array.isArray(ids) ? ids : [ids])].filter(Boolean);
+}
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  validate("query", GetSpacesAccessCheckQuerySchema),
+  async (ctx): HandlerResult<GetSpacesAccessCheckResponseBody> => {
+    const auth = ctx.get("auth");
+    const query = ctx.req.valid("query");
+
+    const spaceIds = toUniqueIds(query.spaceIds);
+    const userIds = toUniqueIds(query.userIds);
+
+    if (spaceIds.length === 0 || userIds.length === 0) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "The query parameters `spaceIds` and `userIds` must each hold at least one id.",
+        },
+      });
+    }
+
+    if (spaceIds.length > MAX_IDS || userIds.length > MAX_IDS) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Too many ids provided. Maximum is ${MAX_IDS} per parameter.`,
+        },
+      });
+    }
+
+    const result = await listUsersWithoutAccessToSpaces(auth, {
+      spaceIds,
+      userIds,
+    });
+
+    if (result.isErr()) {
+      const { type, spaceIds: erroredSpaceIds } = result.error;
+      switch (type) {
+        case "space_not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "space_not_found",
+              message: `Space not found: ${erroredSpaceIds.join(", ")}.`,
+            },
+          });
+        case "space_unauthorized":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message: `You do not have access to the requested space: ${erroredSpaceIds.join(", ")}.`,
+            },
+          });
+        default:
+          assertNever(type);
+      }
+    }
+
+    return ctx.json({ spacesAccess: result.value });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/spaces/index.ts
+++ b/front-api/routes/w/[wId]/spaces/index.ts
@@ -21,6 +21,7 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 import spaceId from "./[spaceId]";
+import accessCheck from "./access-check";
 import checkName from "./check-name";
 import projectsLookup from "./projects-lookup";
 import searchProjects from "./search_projects";
@@ -282,6 +283,7 @@ app.post(
 
 // Register static paths BEFORE `/:spaceId` so the param route does not
 // swallow these names as ids.
+app.route("/access-check", accessCheck);
 app.route("/check-name", checkName);
 app.route("/projects-lookup", projectsLookup);
 app.route("/search_projects", searchProjects);

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -4,6 +4,7 @@ import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBu
 import { SkillBuilderIconSection } from "@app/components/skill_builder/SkillBuilderIconSection";
 import { SkillBuilderNameSection } from "@app/components/skill_builder/SkillBuilderNameSection";
 import { SkillBuilderUserFacingDescriptionSection } from "@app/components/skill_builder/SkillBuilderUserFacingDescriptionSection";
+import { SkillEditorsAccessWarning } from "@app/components/skill_builder/SkillEditorsAccessWarning";
 import { SkillEditorsSheetWithButton } from "@app/components/skill_builder/SkillEditorsSheetWithButton";
 import { useSkillSpaceRestrictionsContext } from "@app/components/skill_builder/SkillSpaceRestrictionsContext";
 import { parseGitHubRepoUrl } from "@app/lib/skill_detection";
@@ -83,7 +84,7 @@ export function SkillBuilderSettingsSection({
   );
   const githubSkillFolderUrl = getGitHubSkillFolderUrl(skill);
 
-  const { nonGlobalSpacesWithRestrictions } =
+  const { editorsWithoutSpaceAccess, nonGlobalSpacesWithRestrictions } =
     useSkillSpaceRestrictionsContext();
 
   const currentOption = AVAILABILITY_OPTIONS.find(
@@ -150,6 +151,14 @@ export function SkillBuilderSettingsSection({
               onAddSelfAsEditor={onAddSelfAsEditor}
             />
           </div>
+          {editorsWithoutSpaceAccess.length > 0 && (
+            <div className="mt-3">
+              <SkillEditorsAccessWarning
+                editorsWithoutSpaceAccess={editorsWithoutSpaceAccess}
+                owner={owner}
+              />
+            </div>
+          )}
         </div>
         <div>
           <h3 className="text-base font-semibold text-foreground mb-2">

--- a/front/components/skill_builder/SkillEditorsAccessWarning.tsx
+++ b/front/components/skill_builder/SkillEditorsAccessWarning.tsx
@@ -1,0 +1,62 @@
+import { SpaceLinks } from "@app/components/shared/SpaceLinks";
+import type { EditorWithoutSpaceAccess } from "@app/components/skill_builder/SkillSpaceRestrictionsContext";
+import type { LightWorkspaceType } from "@app/types/user";
+import { AlertCircle, ContentMessage } from "@dust-tt/sparkle";
+
+interface SkillEditorsAccessWarningProps {
+  editorsWithoutSpaceAccess: EditorWithoutSpaceAccess[];
+  owner: LightWorkspaceType;
+}
+
+export function SkillEditorsAccessWarning({
+  editorsWithoutSpaceAccess,
+  owner,
+}: SkillEditorsAccessWarningProps) {
+  if (editorsWithoutSpaceAccess.length === 0) {
+    return null;
+  }
+
+  const isSingle = editorsWithoutSpaceAccess.length === 1;
+
+  return (
+    <ContentMessage
+      variant="warning"
+      icon={AlertCircle}
+      size="lg"
+      title={
+        isSingle
+          ? "An editor doesn't have access to this skill"
+          : "Some editors don't have access to this skill"
+      }
+    >
+      {isSingle ? (
+        <p>
+          <strong>{editorsWithoutSpaceAccess[0].editor.fullName}</strong> is not
+          a member of{" "}
+          <SpaceLinks
+            owner={owner}
+            spaces={editorsWithoutSpaceAccess[0].spaces}
+          />
+          , so they cannot view or use this skill. Add them to the space, or
+          remove them from the editors.
+        </p>
+      ) : (
+        <>
+          <p className="mb-1">
+            These editors are not members of the restricted spaces this skill
+            uses, so they cannot view or use it. Add them to the spaces, or
+            remove them from the editors.
+          </p>
+          <ul className="list-disc space-y-1 pl-5">
+            {editorsWithoutSpaceAccess.map(({ editor, spaces }) => (
+              <li key={editor.sId}>
+                <strong>{editor.fullName}</strong> is missing{" "}
+                <SpaceLinks owner={owner} spaces={spaces} />
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </ContentMessage>
+  );
+}

--- a/front/components/skill_builder/SkillSpaceRestrictionsContext.tsx
+++ b/front/components/skill_builder/SkillSpaceRestrictionsContext.tsx
@@ -6,16 +6,26 @@ import type {
   ReferencedSkillFormData,
   SkillBuilderFormData,
 } from "@app/components/skill_builder/SkillBuilderFormContext";
-import { useSpaceProjectsLookup } from "@app/lib/swr/spaces";
+import {
+  useSpaceProjectsLookup,
+  useSpacesAccessCheck,
+} from "@app/lib/swr/spaces";
 import type { SpaceType } from "@app/types/space";
 import type { ReactNode } from "react";
 import { createContext, useContext, useMemo } from "react";
 import { useWatch } from "react-hook-form";
 
+/** An editor of the skill, with the restricted spaces they cannot read. */
+export interface EditorWithoutSpaceAccess {
+  editor: SkillBuilderFormData["editors"][number];
+  spaces: SpaceType[];
+}
+
 interface SkillSpaceRestrictionsContextType {
   actionsBySpaceId: ReturnType<typeof getSpaceIdToActionsMap>;
   allSpaces: SpaceType[];
   areSpaceRequirementsReady: boolean;
+  editorsWithoutSpaceAccess: EditorWithoutSpaceAccess[];
   globalSpace: SpaceType | undefined;
   initialAdditionalSpaces: string[];
   initialRequestedSpaceIds?: string[];
@@ -50,6 +60,9 @@ export function SkillSpaceRestrictionsProvider({
   });
   const additionalSpaces = useWatch<SkillBuilderFormData, "additionalSpaces">({
     name: "additionalSpaces",
+  });
+  const editors = useWatch<SkillBuilderFormData, "editors">({
+    name: "editors",
   });
 
   const { mcpServerViews, isMCPServerViewsLoading } =
@@ -164,11 +177,56 @@ export function SkillSpaceRestrictionsProvider({
     return allSpaces.find((s) => s.kind === "global");
   }, [allSpaces]);
 
+  // `allSpaces` only holds spaces the current user can read, so the access check
+  // never gets asked about a space it would reject.
+  const restrictedSpaceIds = useMemo(() => {
+    return nonGlobalSpacesWithRestrictions.map((space) => space.sId);
+  }, [nonGlobalSpacesWithRestrictions]);
+
+  const editorIds = useMemo(() => {
+    return (editors ?? []).map((editor) => editor.sId);
+  }, [editors]);
+
+  const { spacesAccess } = useSpacesAccessCheck({
+    workspaceId: owner.sId,
+    spaceIds: restrictedSpaceIds,
+    userIds: editorIds,
+  });
+
+  const editorsWithoutSpaceAccess: EditorWithoutSpaceAccess[] = useMemo(() => {
+    const spaceById = new Map(
+      nonGlobalSpacesWithRestrictions.map((space) => [space.sId, space])
+    );
+    const spacesByEditorId = new Map<string, SpaceType[]>();
+
+    for (const { spaceId, userIdsWithoutAccess } of spacesAccess) {
+      const space = spaceById.get(spaceId);
+      if (!space) {
+        continue;
+      }
+
+      for (const userId of userIdsWithoutAccess) {
+        const existing = spacesByEditorId.get(userId);
+        if (existing) {
+          existing.push(space);
+        } else {
+          spacesByEditorId.set(userId, [space]);
+        }
+      }
+    }
+
+    return (editors ?? []).flatMap((editor) => {
+      const spaces = spacesByEditorId.get(editor.sId);
+      return spaces ? [{ editor, spaces }] : [];
+    });
+  }, [editors, nonGlobalSpacesWithRestrictions, spacesAccess]);
+
   const value = useMemo(
     () => ({
       actionsBySpaceId,
       allSpaces,
       areSpaceRequirementsReady,
+      editorsWithoutSpaceAccess,
       globalSpace,
       initialAdditionalSpaces,
       initialRequestedSpaceIds,
@@ -183,6 +241,7 @@ export function SkillSpaceRestrictionsProvider({
       actionsBySpaceId,
       allSpaces,
       areSpaceRequirementsReady,
+      editorsWithoutSpaceAccess,
       globalSpace,
       initialAdditionalSpaces,
       initialRequestedSpaceIds,

--- a/front/lib/api/spaces/access.ts
+++ b/front/lib/api/spaces/access.ts
@@ -1,0 +1,109 @@
+import type { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import type { SpaceUsersWithoutAccess } from "@app/types/api/spaces";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export type SpaceAccessCheckErrorType =
+  | "space_not_found"
+  | "space_unauthorized";
+
+export class SpaceAccessCheckError extends Error {
+  constructor(
+    readonly type: SpaceAccessCheckErrorType,
+    readonly spaceIds: string[]
+  ) {
+    super(`${type}: ${spaceIds.join(", ")}`);
+  }
+}
+
+const NO_GROUPS: ReadonlySet<ModelId> = new Set();
+
+/**
+ * For each requested space, the requested users that are not members of it.
+ *
+ * Membership is the ground truth for read access on restricted spaces: their
+ * `requestedPermissions()` grant `read` to group members only, so a user who is
+ * not a member cannot see the space's data — not even a workspace admin, who
+ * gets `admin` without `read`.
+ *
+ * Errors out on any space the caller cannot read or administrate, rather than
+ * silently dropping it: a partial answer would read as "everyone has access".
+ */
+export async function listUsersWithoutAccessToSpaces(
+  auth: Authenticator,
+  { spaceIds, userIds }: { spaceIds: string[]; userIds: string[] }
+): Promise<Result<SpaceUsersWithoutAccess[], SpaceAccessCheckError>> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const spaces = await SpaceResource.fetchByIds(auth, spaceIds);
+
+  const fetchedSpaceIds = new Set(spaces.map((space) => space.sId));
+  const notFoundSpaceIds = spaceIds.filter((id) => !fetchedSpaceIds.has(id));
+  if (notFoundSpaceIds.length > 0) {
+    return new Err(
+      new SpaceAccessCheckError("space_not_found", notFoundSpaceIds)
+    );
+  }
+
+  const unauthorizedSpaceIds = spaces
+    .filter((space) => !space.canReadOrAdministrate(auth))
+    .map((space) => space.sId);
+  if (unauthorizedSpaceIds.length > 0) {
+    return new Err(
+      new SpaceAccessCheckError("space_unauthorized", unauthorizedSpaceIds)
+    );
+  }
+
+  // Users without an active membership in the workspace have no access to any of
+  // its spaces, and neither do unknown user ids. Both fall through to the
+  // `usersWithoutMembership` bucket below.
+  const users = await UserResource.fetchByIds(userIds);
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    users,
+    workspace,
+  });
+  const activeUserModelIds = new Set(memberships.map((m) => m.userId));
+  const workspaceUsers = users.filter((user) =>
+    activeUserModelIds.has(user.id)
+  );
+
+  const workspaceUserIds = new Set(workspaceUsers.map((user) => user.sId));
+  const usersWithoutMembership = userIds.filter(
+    (userId) => !workspaceUserIds.has(userId)
+  );
+
+  const groupModelIds = [
+    ...new Set(spaces.flatMap((space) => space.groups.map((g) => g.groupId))),
+  ];
+  const groupModelIdsByUserModelId =
+    await GroupResource.listGroupModelIdsByUserModelIdInWorkspace({
+      workspace,
+      userModelIds: workspaceUsers.map((user) => user.id),
+      groupModelIds,
+    });
+
+  // A user belong to multiple groups
+  // A space has multiple group of readers
+  // We must check if they intercept or not to know if a user has access.
+  return new Ok(
+    spaces.map((space) => ({
+      spaceId: space.sId,
+      userIdsWithoutAccess: [
+        ...usersWithoutMembership,
+        ...workspaceUsers
+          .filter(
+            (user) =>
+              !space.isMemberByGroupModelIds(
+                groupModelIdsByUserModelId.get(user.id) ?? NO_GROUPS
+              )
+          )
+          .map((user) => user.sId),
+      ],
+    }))
+  );
+}

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1315,6 +1315,51 @@ export class GroupResource extends BaseResource<GroupModel> {
     return result;
   }
 
+  /**
+   * For each user, the subset of `groupModelIds` they are an active member of.
+   * Users with no matching membership are absent from the map. Restricting the
+   * query to the caller's group ids keeps this to a single row-bounded query
+   * regardless of how many groups the workspace has.
+   */
+  static async listGroupModelIdsByUserModelIdInWorkspace({
+    workspace,
+    userModelIds,
+    groupModelIds,
+  }: {
+    workspace: LightWorkspaceType;
+    userModelIds: ModelId[];
+    groupModelIds: ModelId[];
+  }): Promise<Map<ModelId, Set<ModelId>>> {
+    const result = new Map<ModelId, Set<ModelId>>();
+    if (userModelIds.length === 0 || groupModelIds.length === 0) {
+      return result;
+    }
+
+    const now = new Date();
+    const memberships = await GroupMembershipModel.findAll({
+      attributes: ["userId", "groupId"],
+      where: {
+        workspaceId: workspace.id,
+        userId: userModelIds,
+        groupId: groupModelIds,
+        status: "active",
+        startAt: { [Op.lte]: now },
+        [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
+      },
+    });
+
+    for (const membership of memberships) {
+      const existing = result.get(membership.userId);
+      if (existing) {
+        existing.add(membership.groupId);
+      } else {
+        result.set(membership.userId, new Set([membership.groupId]));
+      }
+    }
+
+    return result;
+  }
+
   // For each user, the highest per-group pool cap (excluding seat allowance)
   // among the cap-eligible (provisioned) groups they belong to. Users with no
   // capped group are absent from the map (the caller falls back to the workspace

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1487,6 +1487,26 @@ export class SpaceResource extends BaseResource<SpaceModel> {
    */
 
   isMember(auth: Authenticator): boolean {
+    return this.isMemberByGroupPredicate((groupModelId) =>
+      auth.hasGroupByModelId(groupModelId)
+    );
+  }
+
+  /**
+   * Same membership rule as {@link SpaceResource.isMember}, evaluated against a
+   * precomputed set of group model ids instead of an `Authenticator`. Lets
+   * callers check many users at once without building one `Authenticator` per
+   * user.
+   */
+  isMemberByGroupModelIds(groupModelIds: ReadonlySet<ModelId>): boolean {
+    return this.isMemberByGroupPredicate((groupModelId) =>
+      groupModelIds.has(groupModelId)
+    );
+  }
+
+  private isMemberByGroupPredicate(
+    hasGroup: (groupModelId: ModelId) => boolean
+  ): boolean {
     // TODO(projects): update this method to check groups whose group_vaults relationship is
     // to remove the complexity of checking the global group based on the space type.
     switch (this.kind) {
@@ -1496,7 +1516,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           if (group.isGlobal()) {
             return true;
           }
-          if (auth.hasGroupByModelId(group.groupId)) {
+          if (hasGroup(group.groupId)) {
             return true;
           }
         }
@@ -1507,7 +1527,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           if (group.isGlobal()) {
             continue;
           }
-          if (auth.hasGroupByModelId(group.groupId)) {
+          if (hasGroup(group.groupId)) {
             return true;
           }
         }

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -26,10 +26,12 @@ import type {
 } from "@app/types/api/search";
 import type {
   GetSpaceResponseBody,
+  GetSpacesAccessCheckResponseBody,
   GetSpacesResponseBody,
   PatchSpaceResponseBody,
   PostSpaceRequestBodyType,
   PostSpacesResponseBody,
+  SpaceUsersWithoutAccess,
 } from "@app/types/api/spaces";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
 import type { SearchWarningCode } from "@app/types/core/core_api";
@@ -122,6 +124,47 @@ export function useSpaceProjectsLookup({
     isSpacesLookupLoading: !error && !data && !!query && !disabled,
     isSpacesLookupError: !!error,
     mutate,
+  };
+}
+
+/**
+ * For each of `spaceIds`, which of `userIds` are not members of it — i.e. cannot
+ * read what the space holds. The endpoint errors out on any space the current
+ * user cannot read, so callers should only pass spaces they already display.
+ */
+export function useSpacesAccessCheck({
+  workspaceId,
+  spaceIds,
+  userIds,
+  disabled,
+}: {
+  workspaceId: string;
+  spaceIds: string[];
+  userIds: string[];
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const accessCheckFetcher: Fetcher<GetSpacesAccessCheckResponseBody> = fetcher;
+
+  const isEmpty = spaceIds.length === 0 || userIds.length === 0;
+  const params = new URLSearchParams();
+  for (const spaceId of spaceIds) {
+    params.append("spaceIds", spaceId);
+  }
+  for (const userId of userIds) {
+    params.append("userIds", userId);
+  }
+
+  const { data, error } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/spaces/access-check?${params.toString()}`,
+    accessCheckFetcher,
+    { disabled: disabled || isEmpty }
+  );
+
+  return {
+    spacesAccess: data?.spacesAccess ?? emptyArray<SpaceUsersWithoutAccess>(),
+    isSpacesAccessLoading: !error && !data && !disabled && !isEmpty,
+    isSpacesAccessError: !!error,
   };
 }
 

--- a/front/scripts/seed/factories/seedSkill.ts
+++ b/front/scripts/seed/factories/seedSkill.ts
@@ -1,5 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 
@@ -9,12 +10,17 @@ interface SeedSkillOptions {
   // Create the skill on behalf of this user, making them its only editor. Defaults to the
   // context user.
   owner?: UserResource;
+  // Users added to the skill's editor group on top of the owner.
+  editors?: UserResource[];
+  // Spaces the skill requires access to. Members of the skill that are not members of
+  // these spaces cannot view or use it.
+  spaces?: SpaceResource[];
 }
 
 export async function seedSkill(
   ctx: SeedContext,
   skillAsset: SkillAsset,
-  { owner }: SeedSkillOptions = {}
+  { owner, editors = [], spaces = [] }: SeedSkillOptions = {}
 ): Promise<SkillResource | null> {
   const { auth, workspace, execute, logger } = ctx;
 
@@ -44,13 +50,52 @@ export async function seedSkill(
       instructionsHtml: skillAsset.instructionsHtml,
       status: "active",
       availability: skillAsset.availability,
+      requestedSpaceIds: spaces.map((space) => space.id),
     });
     logger.info(
       { sId: skill.sId, ownerId: owner?.sId ?? auth.getNonNullableUser().sId },
       "Skill created"
     );
+
+    if (editors.length > 0) {
+      await addSkillEditors(ownerAuth, skill, editors);
+      logger.info(
+        { sId: skill.sId, editorIds: editors.map((editor) => editor.sId) },
+        "Skill editors added"
+      );
+    }
+
     return skill;
   }
 
   return null;
+}
+
+async function addSkillEditors(
+  auth: Authenticator,
+  skill: SkillResource,
+  editors: UserResource[]
+): Promise<void> {
+  const { editorGroup } = skill;
+  if (!editorGroup) {
+    throw new Error(`Skill ${skill.sId} has no editor group`);
+  }
+
+  // The owner is already in the group, and adding an existing member is an error.
+  const activeMemberIds = new Set(
+    (await editorGroup.getActiveMembers(auth)).map((member) => member.sId)
+  );
+  const usersToAdd = editors.filter(
+    (editor) => !activeMemberIds.has(editor.sId)
+  );
+  if (usersToAdd.length === 0) {
+    return;
+  }
+
+  const addResult = await editorGroup.dangerouslyAddMembers(auth, {
+    users: usersToAdd.map((editor) => editor.toJSON()),
+  });
+  if (addResult.isErr()) {
+    throw new Error(`Failed to add skill editors: ${addResult.error.message}`);
+  }
 }

--- a/front/scripts/seed/factories/seedSpace.ts
+++ b/front/scripts/seed/factories/seedSpace.ts
@@ -1,23 +1,29 @@
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
 
 import type { SeedContext } from "./types";
 
 const RESTRICTED_SPACE_NAME = "Restricted Space";
 
+interface SeedSpaceOptions {
+  name?: string;
+  // Members to add on top of the context user, who is always a member.
+  members?: UserResource[];
+}
+
 export async function seedSpace(
-  ctx: SeedContext
+  ctx: SeedContext,
+  { name = RESTRICTED_SPACE_NAME, members = [] }: SeedSpaceOptions = {}
 ): Promise<SpaceResource | undefined> {
   const { auth, workspace, user, execute, logger } = ctx;
 
   const existingSpaces = await SpaceResource.listWorkspaceSpaces(auth);
-  const existingRestrictedSpace = existingSpaces.find(
-    (s) => s.name === RESTRICTED_SPACE_NAME
-  );
+  const existingRestrictedSpace = existingSpaces.find((s) => s.name === name);
 
   if (existingRestrictedSpace) {
     logger.info(
-      { sId: existingRestrictedSpace.sId, name: RESTRICTED_SPACE_NAME },
+      { sId: existingRestrictedSpace.sId, name },
       "Restricted space already exists, skipping"
     );
     return existingRestrictedSpace;
@@ -26,7 +32,7 @@ export async function seedSpace(
   if (execute) {
     // Create a group for the restricted space
     const group = await GroupResource.makeNew({
-      name: `Group for ${RESTRICTED_SPACE_NAME}`,
+      name: `Group for ${name}`,
       workspaceId: workspace.id,
       kind: "regular_auto",
     });
@@ -34,7 +40,7 @@ export async function seedSpace(
     // Create the restricted space
     const restrictedSpace = await SpaceResource.makeNew(
       {
-        name: RESTRICTED_SPACE_NAME,
+        name,
         kind: "regular",
         workspaceId: workspace.id,
       },
@@ -44,17 +50,17 @@ export async function seedSpace(
     if (!group.canWrite(auth)) {
       throw new Error("Only admins or group editors can change group members");
     }
-    // Add the user to the group so they can access the space
-    const addMemberResult = await group.dangerouslyAddMember(auth, {
-      user: user.toJSON(),
+    // Add the users to the group so they can access the space
+    const addMemberResult = await group.dangerouslyAddMembers(auth, {
+      users: [user, ...members].map((u) => u.toJSON()),
     });
     if (addMemberResult.isErr()) {
       throw new Error(
-        `Failed to add user to group: ${addMemberResult.error.message}`
+        `Failed to add users to group: ${addMemberResult.error.message}`
       );
     }
 
-    logger.info({ sId: restrictedSpace.sId }, "Restricted space created");
+    logger.info({ sId: restrictedSpace.sId, name }, "Restricted space created");
     return restrictedSpace;
   }
 

--- a/front/scripts/seed/governance/assets/users.json
+++ b/front/scripts/seed/governance/assets/users.json
@@ -12,5 +12,12 @@
     "email": "bob@example.com",
     "firstName": "Bob",
     "lastName": "Kane"
+  },
+  {
+    "sId": "SeedUserCharly",
+    "username": "charly",
+    "email": "charly@example.com",
+    "firstName": "Charly",
+    "lastName": "Gordon"
   }
 ]

--- a/front/scripts/seed/governance/seed.test.ts
+++ b/front/scripts/seed/governance/seed.test.ts
@@ -2,7 +2,12 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agen
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import logger from "@app/logger/logger";
 import type { SeedContext } from "@app/scripts/seed/factories";
-import { seedAgents, seedSkill, seedUsers } from "@app/scripts/seed/factories";
+import {
+  seedAgents,
+  seedSkill,
+  seedSpace,
+  seedUsers,
+} from "@app/scripts/seed/factories";
 import type { Assets } from "@app/scripts/seed/governance/seed";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import * as fs from "fs";
@@ -10,6 +15,8 @@ import * as path from "path";
 import { describe, expect, it } from "vitest";
 
 const ALFRED_USER_ID = "SeedUserAlfred";
+const BOB_USER_ID = "SeedUserBob";
+const RESTRICTED_SPACE_NAME = "Governance Restricted Space";
 
 // Load assets from JSON files (same as seed.ts)
 function loadAssets(): Assets {
@@ -48,16 +55,49 @@ describe("governance seed script integration test", () => {
     expect(createdUsers.size).toBe(assets.users.length);
     expect(alfred).toBeDefined();
 
+    const bob = createdUsers.get(BOB_USER_ID);
+    expect(bob).toBeDefined();
+
+    const restrictedSpace = await seedSpace(ctx, {
+      name: RESTRICTED_SPACE_NAME,
+      members: [bob!],
+    });
+
     const alfredSkill = await seedSkill(ctx, assets.skills.alfredSkill, {
       owner: alfred,
     });
     const currentUserSkill = await seedSkill(
       ctx,
-      assets.skills.currentUserSkill
+      assets.skills.currentUserSkill,
+      {
+        editors: [bob!, alfred!],
+        spaces: restrictedSpace ? [restrictedSpace] : [],
+      }
     );
     const createdAgents = await seedAgents(ctx, assets.agents, {
       skills: alfredSkill ? [alfredSkill] : [],
     });
+
+    // The restricted space holds the current user and Bob.
+    expect(restrictedSpace).toBeDefined();
+    expect(restrictedSpace!.isRegularAndRestricted()).toBe(true);
+    const spaceMembers =
+      await restrictedSpace!.fetchDistinctActiveManualGroupMembers(
+        authenticator
+      );
+    expect(new Set(spaceMembers.map((m) => m.sId))).toEqual(
+      new Set([user.sId, bob!.sId])
+    );
+
+    // The current user's skill requires the restricted space and has Bob and Alfred as editors.
+    // Alfred is not a member of the space, which is what the skill builder warns about.
+    expect(currentUserSkill!.requestedSpaceIds).toEqual([restrictedSpace!.id]);
+    const skillEditors =
+      await currentUserSkill!.editorGroup!.getActiveMembers(authenticator);
+    expect(new Set(skillEditors.map((e) => e.sId))).toEqual(
+      new Set([user.sId, bob!.sId, alfred!.sId])
+    );
+    expect(spaceMembers.map((m) => m.sId)).not.toContain(alfred!.sId);
 
     // Both skills are created with the availability from the assets.
     expect(alfredSkill).toBeDefined();

--- a/front/scripts/seed/governance/seed.ts
+++ b/front/scripts/seed/governance/seed.ts
@@ -8,8 +8,10 @@ import {
   createSeedContext,
   seedAgents,
   seedSkill,
+  seedSpace,
   seedUsers,
 } from "@app/scripts/seed/factories";
+import { removeNulls } from "@app/types/shared/utils/general";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -38,13 +40,15 @@ function loadAssets(): Assets {
 }
 
 const ALFRED_USER_ID = "SeedUserAlfred";
+const BOB_USER_ID = "SeedUserBob";
+const RESTRICTED_SPACE_NAME = "Governance Restricted Space";
 
 makeScript({}, async ({ execute }, logger) => {
   const { agents, users, skills } = loadAssets();
 
   const ctx = await createSeedContext({ execute, logger });
 
-  // 1. Create Alfred and Bob as regular workspace members.
+  // 1. Create Alfred, Bob and Charly as regular workspace members.
   logger.info("Seeding users...");
   const createdUsers = await seedUsers(ctx, users);
   const alfred = createdUsers.get(ALFRED_USER_ID);
@@ -52,15 +56,32 @@ makeScript({}, async ({ execute }, logger) => {
     throw new Error(`User ${ALFRED_USER_ID} was not created`);
   }
 
-  // 2. Create skills
+  const bob = createdUsers.get(BOB_USER_ID);
+  if (execute && !bob) {
+    throw new Error(`User ${BOB_USER_ID} was not created`);
+  }
+
+  // 2. Create a restricted space holding the current user and Bob.
+  logger.info("Seeding the restricted space...");
+  const restrictedSpace = await seedSpace(ctx, {
+    name: RESTRICTED_SPACE_NAME,
+    members: bob ? [bob] : [],
+  });
+
+  // 3. Create skills. The current user's skill requires the restricted space and has both Bob and
+  // Alfred as editors. Bob is a member of the space, Alfred is not, so the skill builder shows the
+  // warning for Alfred only.
   logger.info("Seeding Alfred's unpublished skill...");
   const alfredSkill = await seedSkill(ctx, skills.alfredSkill, {
     owner: alfred,
   });
   logger.info("Seeding the current user's skill...");
-  await seedSkill(ctx, skills.currentUserSkill);
+  await seedSkill(ctx, skills.currentUserSkill, {
+    editors: removeNulls([bob, alfred]),
+    spaces: restrictedSpace ? [restrictedSpace] : [],
+  });
 
-  // 2. Create an agent edited by the current user that uses Alfred's unpublished skill.
+  // 4. Create an agent edited by the current user that uses Alfred's unpublished skill.
   logger.info("Seeding agents...");
   await seedAgents(ctx, agents, {
     skills: alfredSkill ? [alfredSkill] : [],

--- a/front/types/api/spaces.ts
+++ b/front/types/api/spaces.ts
@@ -107,6 +107,19 @@ export type PatchSpaceResponseBody = {
   space: SpaceType;
 };
 
+/**
+ * For one space, the requested users that are not members of it — i.e. that
+ * cannot read the data it holds.
+ */
+export type SpaceUsersWithoutAccess = {
+  spaceId: string;
+  userIdsWithoutAccess: string[];
+};
+
+export type GetSpacesAccessCheckResponseBody = {
+  spacesAccess: SpaceUsersWithoutAccess[];
+};
+
 export type CheckNameResponseBody = {
   available: boolean;
 };


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/9736

 - Add a enw endpoint to check if all the users have access to a set of spaces. Only work if you are a member of the endpoint.
 - Display a warning if any of the admin does not have access to the skill due to a space restriction. the check is run at every change of editors or spaces.
 - does NOT prevent saving the skill so far.

## Tests

 - unit tests for endpoint
 - manual tests

<img width="1003" height="191" alt="Screenshot 2026-08-04 at 15 44 25" src="https://github.com/user-attachments/assets/ec0283b4-ad4c-42fb-a538-a3380112c5ea" />
<img width="999" height="245" alt="Screenshot 2026-08-04 at 15 44 16" src="https://github.com/user-attachments/assets/6286f236-1262-4d05-a7fe-80796b3aa94a" />


## Risk

low.
We are exposing the members of a space but I think it is OK.

## Deploy Plan

deploy front
