### PR TITLE
feat: bring back the triggers list in personal settings

### DIFF
--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -10,6 +10,7 @@ import {
   useSoundNotificationPreferencesForm,
 } from "@app/components/me/SoundNotificationPreferences";
 import { UserToolsTable } from "@app/components/me/UserToolsTable";
+import { UserTriggersTable } from "@app/components/me/UserTriggersTable";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { MyAwuUsageFromAnalyticsChart } from "@app/components/workspace/AwuUsageFromAnalyticsChart";
@@ -765,9 +766,7 @@ function ToolsSection({ owner }: { owner: WorkspaceType }) {
           <UserToolsTable owner={owner} />
         </TabsContent>
         <TabsContent value="triggers">
-          <p className="py-8 text-center text-sm text-muted-foreground">
-            Coming soon
-          </p>
+          <UserTriggersTable owner={owner} />
         </TabsContent>
       </Tabs>
     </SectionContent>

--- a/front/components/agent_builder/triggers/TriggerCard.tsx
+++ b/front/components/agent_builder/triggers/TriggerCard.tsx
@@ -63,12 +63,10 @@ export function TriggerCard({
   const isEditor = trigger.editor === user?.id;
   const description = useMemo(() => {
     switch (trigger.kind) {
-      case "schedule":
-        try {
-          return `Runs ${describeScheduleConfig(trigger.configuration)}.`;
-        } catch {
-          return "";
-        }
+      case "schedule": {
+        const schedule = describeScheduleConfig(trigger.configuration);
+        return schedule ? `Runs ${schedule}.` : "";
+      }
       case "webhook":
         return getWebhookCardDescription({
           webhookTrigger: trigger,

--- a/front/components/assistant/details/tabs/AgentTriggersTab.tsx
+++ b/front/components/assistant/details/tabs/AgentTriggersTab.tsx
@@ -3,7 +3,7 @@ import {
   useAgentTriggers,
   useDeleteTrigger,
 } from "@app/lib/swr/agent_triggers";
-import { describeScheduleConfig } from "@app/lib/utils/schedule_description";
+import { getTriggerDescription } from "@app/lib/utils/trigger_description";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { TriggerType } from "@app/types/assistant/triggers";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -25,23 +25,6 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
-
-function getTriggerDescription(trigger: TriggerType): string {
-  switch (trigger.kind) {
-    case "schedule":
-      try {
-        return `Runs ${describeScheduleConfig(trigger.configuration)}.`;
-      } catch {
-        return "";
-      }
-    case "webhook":
-      return trigger.configuration.event
-        ? `Triggered by ${trigger.configuration.event} events.`
-        : "Triggered by webhook events.";
-    default:
-      assertNever(trigger);
-  }
-}
 
 function getTriggerIcon(trigger: TriggerType) {
   switch (trigger.kind) {

--- a/front/components/me/UserTriggersTable.tsx
+++ b/front/components/me/UserTriggersTable.tsx
@@ -1,0 +1,269 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { useDeleteTrigger, useUserTriggers } from "@app/lib/swr/agent_triggers";
+import { getAgentBuilderRoute } from "@app/lib/utils/router";
+import { getTriggerDescription } from "@app/lib/utils/trigger_description";
+import type { GetUserTriggersResponseBody } from "@app/types/api/assistant/configuration/triggers";
+import { isGlobalAgentId } from "@app/types/assistant/assistant";
+import type { TriggerStatus } from "@app/types/assistant/triggers";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Avatar,
+  Button,
+  Chip,
+  DataTable,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  SearchInput,
+  Spinner,
+  Trash01,
+} from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useCallback, useMemo, useState } from "react";
+
+// `onClick` satisfies DataTable's row shape, which is otherwise a weak type.
+type UserTriggerRow = GetUserTriggersResponseBody["triggers"][number] & {
+  onClick?: () => void;
+};
+
+type ChipColor = React.ComponentProps<typeof Chip>["color"];
+
+function statusChipColor(status: TriggerStatus): ChipColor {
+  switch (status) {
+    case "enabled":
+      return "success";
+    case "disabled":
+      return "primary";
+    case "relocating":
+      return "info";
+    case "downgraded":
+      return "warning";
+    default:
+      assertNeverAndIgnore(status);
+      return "primary";
+  }
+}
+
+interface UserTriggersTableProps {
+  owner: LightWorkspaceType;
+}
+
+export function UserTriggersTable({ owner }: UserTriggersTableProps) {
+  const { triggers, isTriggersLoading, mutateTriggers } = useUserTriggers({
+    workspaceId: owner.sId,
+  });
+
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const getEditionURL = useCallback(
+    (agentConfigurationId: string) => {
+      return getAgentBuilderRoute(owner.sId, agentConfigurationId);
+    },
+    [owner.sId]
+  );
+
+  const [triggerToDelete, setTriggerToDelete] = useState<UserTriggerRow | null>(
+    null
+  );
+  const [isDeleting, setIsDeleting] = useState(false);
+  const sendNotification = useSendNotification();
+
+  const deleteTrigger = useDeleteTrigger({
+    workspaceId: owner.sId,
+    agentConfigurationId: triggerToDelete?.agentConfigurationId ?? "",
+  });
+
+  const handleDeleteTrigger = async () => {
+    if (!triggerToDelete) {
+      return;
+    }
+    setIsDeleting(true);
+    const success = await deleteTrigger(triggerToDelete.sId);
+    setIsDeleting(false);
+    setTriggerToDelete(null);
+
+    if (success) {
+      void mutateTriggers();
+      sendNotification({
+        type: "success",
+        title: "Trigger deleted",
+        description: `The trigger "${triggerToDelete.name}" has been deleted.`,
+      });
+    } else {
+      sendNotification({
+        type: "error",
+        title: "Failed to delete trigger",
+        description: "An error occurred while deleting the trigger.",
+      });
+    }
+  };
+
+  const filteredTriggers: UserTriggerRow[] = useMemo(() => {
+    return triggers.filter(
+      (trigger) =>
+        trigger.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        trigger.agentName.toLowerCase().includes(searchQuery.toLowerCase())
+    );
+  }, [triggers, searchQuery]);
+
+  const triggerColumns = useMemo<ColumnDef<UserTriggerRow>[]>(
+    () => [
+      {
+        accessorKey: "agentName",
+        header: "Agent",
+        sortingFn: (rowA, rowB) => {
+          return rowA.original.agentName.localeCompare(rowB.original.agentName);
+        },
+        cell: ({ row }) => (
+          <DataTable.CellContent>
+            <div className="flex min-w-0 items-center gap-2">
+              <Avatar size="xs" visual={row.original.agentPictureUrl} />
+              <div className="truncate text-sm text-foreground dark:text-foreground-night">
+                {row.original.agentName}
+              </div>
+            </div>
+          </DataTable.CellContent>
+        ),
+        meta: {
+          className: "w-40",
+        },
+      },
+      {
+        accessorKey: "name",
+        header: "Trigger",
+        sortingFn: (rowA, rowB) => {
+          return rowA.original.name.localeCompare(rowB.original.name);
+        },
+        cell: ({ row }) => (
+          <DataTable.CellContent grow>
+            <div className="flex min-w-0 flex-col py-3">
+              <div className="truncate text-sm font-semibold text-foreground dark:text-foreground-night">
+                {row.original.name}
+              </div>
+              <div className="truncate text-sm text-muted-foreground dark:text-muted-foreground-night">
+                {getTriggerDescription(row.original)}
+              </div>
+            </div>
+          </DataTable.CellContent>
+        ),
+        meta: {
+          className: "w-full",
+        },
+      },
+      {
+        accessorKey: "status",
+        header: "Status",
+        cell: ({ row }) => (
+          <DataTable.CellContent>
+            <Chip size="xs" color={statusChipColor(row.original.status)}>
+              {row.original.status.charAt(0).toUpperCase() +
+                row.original.status.slice(1)}
+            </Chip>
+          </DataTable.CellContent>
+        ),
+        meta: {
+          className: "w-28",
+        },
+      },
+      {
+        header: "",
+        accessorKey: "actions",
+        cell: ({ row }) => {
+          const buttonProps = isGlobalAgentId(row.original.agentConfigurationId)
+            ? {
+                onClick: () => setTriggerToDelete(row.original),
+                icon: Trash01,
+                tooltip: "Delete trigger",
+              }
+            : {
+                href: getEditionURL(row.original.agentConfigurationId),
+                label: "Manage",
+              };
+
+          return (
+            <DataTable.CellContent>
+              <Button variant="outline" size="xs" {...buttonProps} />
+            </DataTable.CellContent>
+          );
+        },
+        meta: {
+          className: "w-24",
+        },
+      },
+    ],
+    [getEditionURL]
+  );
+
+  return (
+    <>
+      <div className="relative my-4">
+        <SearchInput
+          name="search"
+          placeholder="Search triggers and agents"
+          value={searchQuery}
+          onChange={setSearchQuery}
+        />
+      </div>
+
+      {isTriggersLoading ? (
+        <div className="flex justify-center p-6">
+          <Spinner />
+        </div>
+      ) : filteredTriggers.length > 0 ? (
+        <DataTable
+          data={filteredTriggers}
+          columns={triggerColumns}
+          sorting={[{ id: "agentName", desc: false }]}
+        />
+      ) : (
+        <p className="py-10 text-center text-sm text-muted-foreground">
+          {searchQuery
+            ? "No triggers match your search criteria."
+            : "You haven't created any triggers yet."}
+        </p>
+      )}
+
+      <Dialog
+        open={triggerToDelete !== null}
+        onOpenChange={(open) => !open && setTriggerToDelete(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete trigger</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete the trigger "
+              {triggerToDelete?.name}"?
+            </DialogDescription>
+          </DialogHeader>
+          {isDeleting ? (
+            <div className="flex justify-center py-8">
+              <Spinner variant="dark" size="md" />
+            </div>
+          ) : (
+            <>
+              <DialogContainer>
+                <b>This action cannot be undone.</b>
+              </DialogContainer>
+              <DialogFooter
+                leftButtonProps={{
+                  label: "Cancel",
+                  variant: "outline",
+                }}
+                rightButtonProps={{
+                  label: "Delete",
+                  variant: "warning",
+                  onClick: handleDeleteTrigger,
+                }}
+              />
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/front/components/me/UserTriggersTable.tsx
+++ b/front/components/me/UserTriggersTable.tsx
@@ -5,7 +5,6 @@ import { getTriggerDescription } from "@app/lib/utils/trigger_description";
 import type { GetUserTriggersResponseBody } from "@app/types/api/assistant/configuration/triggers";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { TriggerStatus } from "@app/types/assistant/triggers";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Avatar,
@@ -33,21 +32,12 @@ type UserTriggerRow = GetUserTriggersResponseBody["triggers"][number] & {
 
 type ChipColor = React.ComponentProps<typeof Chip>["color"];
 
-function statusChipColor(status: TriggerStatus): ChipColor {
-  switch (status) {
-    case "enabled":
-      return "success";
-    case "disabled":
-      return "primary";
-    case "relocating":
-      return "info";
-    case "downgraded":
-      return "warning";
-    default:
-      assertNeverAndIgnore(status);
-      return "primary";
-  }
-}
+const STATUS_CHIP_COLORS: Record<TriggerStatus, ChipColor> = {
+  enabled: "success",
+  disabled: "primary",
+  relocating: "info",
+  downgraded: "warning",
+};
 
 interface UserTriggersTableProps {
   owner: LightWorkspaceType;
@@ -160,7 +150,7 @@ export function UserTriggersTable({ owner }: UserTriggersTableProps) {
         header: "Status",
         cell: ({ row }) => (
           <DataTable.CellContent>
-            <Chip size="xs" color={statusChipColor(row.original.status)}>
+            <Chip size="xs" color={STATUS_CHIP_COLORS[row.original.status]}>
               {row.original.status.charAt(0).toUpperCase() +
                 row.original.status.slice(1)}
             </Chip>

--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -10,6 +10,7 @@ import {
 import type { GetTriggerEstimationResponseBody } from "@app/lib/triggers/trigger_usage_estimation";
 import type {
   GetTriggersResponseBody,
+  GetUserTriggersResponseBody,
   PatchTriggersRequestBody,
   PostTextAsCronRuleRequestBody,
   PostTextAsCronRuleResponseBody,
@@ -50,6 +51,31 @@ export function useAgentTriggers({
   return {
     triggers: data?.triggers ?? emptyArray(),
     isTriggersLoading: !!agentConfigurationId && !error && !data && !disabled,
+    isTriggersError: error,
+    isTriggersValidating: isValidating,
+    mutateTriggers: mutate,
+  };
+}
+
+export function useUserTriggers({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const userTriggersFetcher: Fetcher<GetUserTriggersResponseBody> = fetcher;
+
+  const { data, error, mutate, isValidating } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/me/triggers`,
+    userTriggersFetcher,
+    { disabled }
+  );
+
+  return {
+    triggers: data?.triggers ?? emptyArray(),
+    isTriggersLoading: !error && !data && !disabled,
     isTriggersError: error,
     isTriggersValidating: isValidating,
     mutateTriggers: mutate,

--- a/front/lib/utils/schedule_description.ts
+++ b/front/lib/utils/schedule_description.ts
@@ -13,9 +13,14 @@ const DAY_NAMES = [
   "Saturday",
 ];
 
+// Returns an empty string for cron expressions cronstrue cannot parse.
 export function describeScheduleConfig(config: ScheduleConfig): string {
   if (isCronScheduleConfig(config)) {
-    return cronstrue.toString(config.cron);
+    try {
+      return cronstrue.toString(config.cron);
+    } catch {
+      return "";
+    }
   }
 
   const time = `${config.hour}:${String(config.minute).padStart(2, "0")}`;

--- a/front/lib/utils/trigger_description.ts
+++ b/front/lib/utils/trigger_description.ts
@@ -4,13 +4,10 @@ import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 
 export function getTriggerDescription(trigger: TriggerType): string {
   switch (trigger.kind) {
-    case "schedule":
-      try {
-        // cronstrue throws on expressions it cannot parse.
-        return `Runs ${describeScheduleConfig(trigger.configuration)}.`;
-      } catch {
-        return "";
-      }
+    case "schedule": {
+      const schedule = describeScheduleConfig(trigger.configuration);
+      return schedule ? `Runs ${schedule}.` : "";
+    }
     case "webhook":
       return trigger.configuration.event
         ? `Triggered by ${trigger.configuration.event} events.`

--- a/front/lib/utils/trigger_description.ts
+++ b/front/lib/utils/trigger_description.ts
@@ -1,0 +1,22 @@
+import { describeScheduleConfig } from "@app/lib/utils/schedule_description";
+import type { TriggerType } from "@app/types/assistant/triggers";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+
+export function getTriggerDescription(trigger: TriggerType): string {
+  switch (trigger.kind) {
+    case "schedule":
+      try {
+        // cronstrue throws on expressions it cannot parse.
+        return `Runs ${describeScheduleConfig(trigger.configuration)}.`;
+      } catch {
+        return "";
+      }
+    case "webhook":
+      return trigger.configuration.event
+        ? `Triggered by ${trigger.configuration.event} events.`
+        : "Triggered by webhook events.";
+    default:
+      assertNeverAndIgnore(trigger);
+      return "";
+  }
+}


### PR DESCRIPTION
## Description

The Triggers tab in personal settings has been showing "Coming soon" since #27414 removed the `/me` profile page. This puts the list back.

Also moves `getTriggerDescription` out of `AgentTriggersTab` into `lib/utils/trigger_description.ts` so both surfaces share it.

<img width="1920" height="1080" alt="Capture d’écran 2026-08-04 à 16 12 32" src="https://github.com/user-attachments/assets/2752cb8d-4dc2-479e-9ba3-9fc4bccdfb3c" />

## Tests

Manual, no tests added.

## Risk

Low, UI only. The `/api/w/:wId/me/triggers` endpoint already exists and is unchanged. Follow-up: the delete dialog is still duplicated with `AgentTriggersTab`.

## Deploy Plan

Ship it.