### PR TITLE
[front] fix: align Skill Builder settings spacing and headings

### DIFF
--- a/front/components/shared/BaseFormFieldSection.tsx
+++ b/front/components/shared/BaseFormFieldSection.tsx
@@ -6,6 +6,7 @@ import { useController, useFormContext } from "react-hook-form";
 interface BaseFormFieldSectionProps<
   E extends HTMLInputElement | HTMLTextAreaElement,
 > {
+  className?: string;
   title?: string;
   titleClassName?: string;
   description?: string;
@@ -31,6 +32,7 @@ interface BaseFormFieldSectionProps<
 export function BaseFormFieldSection<
   E extends HTMLInputElement | HTMLTextAreaElement,
 >({
+  className,
   title,
   titleClassName,
   description,
@@ -51,7 +53,7 @@ export function BaseFormFieldSection<
   };
 
   return (
-    <div className="space-y-4">
+    <div className={cn("space-y-4", className)}>
       {(!!title || !!description || !!headerActions) && (
         <div className="flex flex-col items-start justify-between gap-2 sm:flex-row sm:items-end">
           <div>

--- a/front/components/skill_builder/SkillBuilderNameSection.tsx
+++ b/front/components/skill_builder/SkillBuilderNameSection.tsx
@@ -6,6 +6,7 @@ const NAME_FIELD_NAME = "name";
 export function SkillBuilderNameSection() {
   return (
     <BaseFormFieldSection
+      className="space-y-2"
       title="Name"
       fieldName={NAME_FIELD_NAME}
       triggerValidationOnChange={false}

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -231,7 +231,7 @@ export function SkillBuilderSettingsSection({
       )}
 
       {hasSelfImprovingSkills && (
-        <div className="space-y-3">
+        <div className="space-y-4">
           <Label className="text-base font-semibold text-foreground">
             Self Improvement
           </Label>

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -24,7 +24,6 @@ import {
   Hoverable,
   Icon,
   InfoCircle,
-  Label,
   LinkExternal01,
   LinkWrapper,
 } from "@dust-tt/sparkle";
@@ -115,7 +114,9 @@ export function SkillBuilderSettingsSection({
   return (
     <div className="space-y-4">
       <div className="space-y-1">
-        <h2 className="heading-lg text-foreground">Skill settings</h2>
+        <h2 className="heading-lg font-semibold text-foreground">
+          Skill settings
+        </h2>
         {githubSkillFolderUrl && (
           <div className="flex items-center gap-1 text-sm text-muted-foreground">
             <span>This skill was originally imported from</span>
@@ -232,9 +233,9 @@ export function SkillBuilderSettingsSection({
 
       {hasSelfImprovingSkills && (
         <div className="space-y-4">
-          <Label className="text-base font-semibold text-foreground">
+          <h3 className="text-base font-semibold text-foreground">
             Self Improvement
-          </Label>
+          </h3>
           <SkillBuilderEnableSuggestionsSection
             selfImprovementLock={skill?.selfImprovementLock ?? false}
           />

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -140,99 +140,95 @@ export function SkillBuilderSettingsSection({
         <SkillBuilderIconSection />
       </div>
       <SkillBuilderUserFacingDescriptionSection />
-      <div className="flex flex-col gap-5">
-        <div className="flex flex-col">
-          <h3 className="text-base font-semibold text-foreground mb-2">
-            Editors
-          </h3>
-          <div className="flex w-full flex-row flex-wrap items-center gap-2">
-            <SkillEditorsSheetWithButton
-              isEditorGateVisible={isEditorGateVisible}
-              isAddingSelfAsEditor={isAddingSelfAsEditor}
-              onAddSelfAsEditor={onAddSelfAsEditor}
-            />
-          </div>
-          {editorsWithoutSpaceAccess.length > 0 && (
-            <div className="mt-3">
-              <SkillEditorsAccessWarning
-                editorsWithoutSpaceAccess={editorsWithoutSpaceAccess}
-                owner={owner}
-              />
-            </div>
-          )}
+      <div className="space-y-2">
+        <h3 className="text-base font-semibold text-foreground">Editors</h3>
+        <div className="flex w-full flex-row flex-wrap items-center gap-2">
+          <SkillEditorsSheetWithButton
+            isEditorGateVisible={isEditorGateVisible}
+            isAddingSelfAsEditor={isAddingSelfAsEditor}
+            onAddSelfAsEditor={onAddSelfAsEditor}
+          />
         </div>
-        <div>
-          <h3 className="text-base font-semibold text-foreground mb-2">
-            Availability
-          </h3>
-          <DropdownMenu>
-            <DropdownMenuTrigger>
-              <Button
-                label={currentOption?.label}
-                variant="outline"
-                isSelect
-                disabled={!canUpdateAvailability || isAvailabilityLocked}
-                tooltip={availabilityTooltip}
-              />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start">
-              {AVAILABILITY_OPTIONS.map((option) => {
-                const isOptionDisabled =
-                  option.value === "users_and_agents" &&
-                  !canMakeSkillAutoDiscoverable;
-                return (
-                  <DropdownMenuItem
-                    key={option.label}
-                    label={option.label}
-                    onClick={() => {
-                      onChange(option.value);
-                    }}
-                    description={option.description}
-                    disabled={isOptionDisabled}
-                    tooltip={
-                      isOptionDisabled
-                        ? "You don’t have permission to make skills auto-discoverable"
-                        : undefined
-                    }
-                  />
-                );
-              })}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
+        {editorsWithoutSpaceAccess.length > 0 && (
+          <SkillEditorsAccessWarning
+            editorsWithoutSpaceAccess={editorsWithoutSpaceAccess}
+            owner={owner}
+          />
+        )}
       </div>
-      {showWorkspaceWideEffectsMessage ? (
-        <ContentMessage
-          icon={InfoCircle}
-          title="This skill has workspace-wide effects"
-          size="lg"
-        >
-          <ul className="list-disc space-y-1 pl-5">
-            <li>All members can find it via the input bar and agent builder</li>
-            <li>
-              Any agent with Discover Skills, including Dust, can use it
-              automatically. See other skills available to agents in{" "}
-              <Hoverable
-                href={`/w/${owner.sId}/builder/skills?availability=users_and_agents`}
-                target="_blank"
-                className="inline-flex items-center gap-1 underline"
-              >
-                Manage Skills
-                <Icon visual={LinkExternal01} size="xs" />
-              </Hoverable>
-            </li>
-          </ul>
-        </ContentMessage>
-      ) : (
-        <SkillBuilderAvailabilityMessage
-          availability={availability}
-          owner={owner}
-          restrictedSpaces={nonGlobalSpacesWithRestrictions}
-        />
-      )}
+      <div className="space-y-2">
+        <h3 className="text-base font-semibold text-foreground">
+          Availability
+        </h3>
+        <DropdownMenu>
+          <DropdownMenuTrigger>
+            <Button
+              label={currentOption?.label}
+              variant="outline"
+              isSelect
+              disabled={!canUpdateAvailability || isAvailabilityLocked}
+              tooltip={availabilityTooltip}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start">
+            {AVAILABILITY_OPTIONS.map((option) => {
+              const isOptionDisabled =
+                option.value === "users_and_agents" &&
+                !canMakeSkillAutoDiscoverable;
+              return (
+                <DropdownMenuItem
+                  key={option.label}
+                  label={option.label}
+                  onClick={() => {
+                    onChange(option.value);
+                  }}
+                  description={option.description}
+                  disabled={isOptionDisabled}
+                  tooltip={
+                    isOptionDisabled
+                      ? "You don’t have permission to make skills auto-discoverable"
+                      : undefined
+                  }
+                />
+              );
+            })}
+          </DropdownMenuContent>
+        </DropdownMenu>
+        {showWorkspaceWideEffectsMessage ? (
+          <ContentMessage
+            icon={InfoCircle}
+            title="This skill has workspace-wide effects"
+            size="lg"
+          >
+            <ul className="list-disc space-y-1 pl-5">
+              <li>
+                All members can find it via the input bar and agent builder
+              </li>
+              <li>
+                Any agent with Discover Skills, including Dust, can use it
+                automatically. See other skills available to agents in{" "}
+                <Hoverable
+                  href={`/w/${owner.sId}/builder/skills?availability=users_and_agents`}
+                  target="_blank"
+                  className="inline-flex items-center gap-1 underline"
+                >
+                  Manage Skills
+                  <Icon visual={LinkExternal01} size="xs" />
+                </Hoverable>
+              </li>
+            </ul>
+          </ContentMessage>
+        ) : (
+          <SkillBuilderAvailabilityMessage
+            availability={availability}
+            owner={owner}
+            restrictedSpaces={nonGlobalSpacesWithRestrictions}
+          />
+        )}
+      </div>
 
       {hasSelfImprovingSkills && (
-        <div className="space-y-4">
+        <div className="space-y-2">
           <h3 className="text-base font-semibold text-foreground">
             Self Improvement
           </h3>

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -113,7 +113,7 @@ export function SkillBuilderSettingsSection({
 
   return (
     <div className="space-y-4">
-      <div className="space-y-1">
+      <div className="space-y-1 pb-1">
         <h2 className="heading-lg font-semibold text-foreground">
           Skill settings
         </h2>

--- a/front/components/skill_builder/SkillBuilderUserFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderUserFacingDescriptionSection.tsx
@@ -108,6 +108,7 @@ export function SkillBuilderUserFacingDescriptionSection() {
 
   return (
     <BaseFormFieldSection
+      className="space-y-2"
       title="Description"
       fieldName={USER_FACING_DESCRIPTION_FIELD_NAME}
       triggerValidationOnChange={false}


### PR DESCRIPTION
## Description

The Skill settings section used inconsistent spacing, which made the visual grouping between titles and controls slightly awkward and hard to get at a glance.

This PR applies a consistent proximity rule: related elements use an 8px gap, separate settings use a 16px gap, and the main Skill settings heading gets slightly more breathing room. The availability message is now grouped within the Availability section, therefore also benefitting from the smaller gap (closer to the other stuff under Availability).

Before:
<img width="917" height="508" alt="image" src="https://github.com/user-attachments/assets/6fc499c7-c304-43b7-94ec-1b2341602c30" />

After:
<img width="1034" height="601" alt="image" src="https://github.com/user-attachments/assets/2f8f7fd8-10d4-4381-8597-d89dd832bf96" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
