### PR TITLE
Add: ability to put Frame as tabs in a pod.

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -9572,6 +9572,31 @@
                               "nullable": true,
                               "description": "Scoped path to the frame file pinned as the Pod banner."
                             },
+                            "frameTabs": {
+                              "type": "array",
+                              "description": "Frames promoted as custom Pod tabs.",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "title": {
+                                    "type": "string"
+                                  },
+                                  "icon": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "tabsOrder": {
+                              "type": "array",
+                              "description": "Interleaved system tab ids and frame paths before Settings.",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
                             "isAdminControlled": {
                               "type": "boolean",
                               "description": "Whether workspace admins control membership and connected data for this Pod."
@@ -11926,6 +11951,39 @@
                 "type": "string",
                 "nullable": true,
                 "description": "Scoped path to the frame file pinned as the Pod banner (e.g. project/banner.html)."
+              },
+              "frameTabs": {
+                "type": "array",
+                "description": "Frames promoted as custom Pod tabs (shared for all members).",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "path",
+                    "title",
+                    "icon"
+                  ],
+                  "properties": {
+                    "path": {
+                      "type": "string",
+                      "description": "Canonical scoped path to the frame file in the Pod filesystem."
+                    },
+                    "title": {
+                      "type": "string",
+                      "description": "Display title for the tab."
+                    },
+                    "icon": {
+                      "type": "string",
+                      "description": "Action icon name (e.g. ActionDashboardIcon)."
+                    }
+                  }
+                }
+              },
+              "tabsOrder": {
+                "type": "array",
+                "description": "Interleaved system tab ids and frame paths before Settings.",
+                "items": {
+                  "type": "string"
+                }
               },
               "isAdminControlled": {
                 "type": "boolean",

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -1100,6 +1100,30 @@
  *               type: string
  *               nullable: true
  *               description: Scoped path to the frame file pinned as the Pod banner (e.g. project/banner.html).
+ *             frameTabs:
+ *               type: array
+ *               description: Frames promoted as custom Pod tabs (shared for all members).
+ *               items:
+ *                 type: object
+ *                 required:
+ *                   - path
+ *                   - title
+ *                   - icon
+ *                 properties:
+ *                   path:
+ *                     type: string
+ *                     description: Canonical scoped path to the frame file in the Pod filesystem.
+ *                   title:
+ *                     type: string
+ *                     description: Display title for the tab.
+ *                   icon:
+ *                     type: string
+ *                     description: Action icon name (e.g. ActionDashboardIcon).
+ *             tabsOrder:
+ *               type: array
+ *               description: Interleaved system tab ids and frame paths before Settings.
+ *               items:
+ *                 type: string
  *             isAdminControlled:
  *               type: boolean
  *               description: Whether workspace admins control membership and connected data for this Pod.

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -120,6 +120,8 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_metadata", () => {
       isAdminControlled: false,
       lastTodoAnalysisAt: null,
       pinnedFramePath: null,
+      frameTabs: [],
+      tabsOrder: ["conversations", "tasks", "files", "connected_data"],
       sId: expect.anything(),
       spaceId: space.sId,
       todoGenerationEnabled: false,

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
@@ -18,6 +18,7 @@ import type {
   SpaceCategoryInfo,
 } from "@app/types/api/spaces";
 import { PatchSpaceRequestBodySchema } from "@app/types/api/spaces";
+import { normalizeTabsOrder, sortPodFrameTabs } from "@app/types/pod_frame_tab";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { SpaceUserType } from "@app/types/user";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -140,6 +141,23 @@ const app = workspaceApp();
  *                           type: string
  *                           nullable: true
  *                           description: Scoped path to the frame file pinned as the Pod banner.
+ *                         frameTabs:
+ *                           type: array
+ *                           description: Frames promoted as custom Pod tabs.
+ *                           items:
+ *                             type: object
+ *                             properties:
+ *                               path:
+ *                                 type: string
+ *                               title:
+ *                                 type: string
+ *                               icon:
+ *                                 type: string
+ *                         tabsOrder:
+ *                           type: array
+ *                           description: Interleaved system tab ids and frame paths before Settings.
+ *                           items:
+ *                             type: string
  *                         isAdminControlled:
  *                           type: boolean
  *                           description: Whether workspace admins control membership and connected data for this Pod.
@@ -339,6 +357,11 @@ app.get(
         todoGenerationEnabled: meta?.todoGenerationEnabled ?? false,
         lastTodoAnalysisAt: meta?.lastTodoAnalysisAt?.getTime() ?? null,
         pinnedFramePath: meta?.pinnedFramePath ?? null,
+        frameTabs: sortPodFrameTabs(meta?.frameTabs ?? []),
+        tabsOrder: normalizeTabsOrder(
+          meta?.tabsOrder ?? [],
+          (meta?.frameTabs ?? []).map((tab) => tab.path)
+        ),
         isAdminControlled: meta?.isAdminControlled ?? false,
       },
     });

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -1,4 +1,5 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { validatePodFrameTabs } from "@app/lib/api/projects/frame_tabs";
 import { validatePinnedFramePath } from "@app/lib/api/projects/pinned_frame";
 import { hasFeatureFlag } from "@app/lib/auth";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
@@ -131,6 +132,49 @@ app.patch(
       }
     }
 
+    let resolvedFrameTabs: {
+      frameTabs: NonNullable<typeof body.frameTabs>;
+      tabsOrder: string[];
+    } | null = null;
+    if (body.frameTabs !== undefined || body.tabsOrder !== undefined) {
+      if (body.frameTabs === undefined || body.tabsOrder === undefined) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "frameTabs and tabsOrder must be provided together.",
+          },
+        });
+      }
+
+      if (!(await hasFeatureFlag(auth, "pod_frame_tabs"))) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "feature_flag_not_found",
+            message: "Pod frame tabs are not enabled for this workspace.",
+          },
+        });
+      }
+
+      const validation = await validatePodFrameTabs(
+        auth,
+        space,
+        body.frameTabs,
+        body.tabsOrder
+      );
+      if (validation.isErr()) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: validation.error.message,
+          },
+        });
+      }
+      resolvedFrameTabs = validation.value;
+    }
+
     // Validate the default agent exists and is usable (handles both global agents like
     // "claude-4.5-sonnet" and workspace agents). A null value clears the default (@dust).
     if (body.defaultAgentId) {
@@ -228,6 +272,8 @@ app.patch(
         todoGenerationEnabled: body.todoGenerationEnabled ?? false,
         initialTodoAnalysisLookback: body.initialTodoAnalysisLookback ?? null,
         pinnedFramePath: body.pinnedFramePath ?? null,
+        frameTabs: resolvedFrameTabs?.frameTabs ?? [],
+        tabsOrder: resolvedFrameTabs?.tabsOrder ?? [],
         defaultAgentId: body.defaultAgentId ?? null,
         isAdminControlled: body.isAdminControlled ?? false,
       });
@@ -278,6 +324,12 @@ app.patch(
       }
       if (body.pinnedFramePath !== undefined) {
         await metadata.updatePinnedFramePath(body.pinnedFramePath);
+      }
+      if (resolvedFrameTabs) {
+        await metadata.updateFrameTabs(
+          resolvedFrameTabs.frameTabs,
+          resolvedFrameTabs.tabsOrder
+        );
       }
       if (body.defaultAgentId !== undefined) {
         await metadata.updateDefaultAgentId(body.defaultAgentId);

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -8,10 +8,11 @@ import { ShareFrameSheet } from "@app/components/assistant/conversation/interact
 import { ConfirmContext } from "@app/components/Confirm";
 import { useDesktopNavigation } from "@app/components/navigation/DesktopNavigationContext";
 import { PinPodBannerButton } from "@app/components/pod/files/PinPodBannerButton";
+import { PodFrameTabButton } from "@app/components/pod/files/PodFrameTabButton";
 import { useVisualizationRevert } from "@app/hooks/conversations";
 import { useHashParam } from "@app/hooks/useHashParams";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { useAuth } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useClientType } from "@app/lib/context/clientType";
 import { clientFetch } from "@app/lib/egress/client";
 import { useFileContent, useFileMetadata } from "@app/lib/swr/files";
@@ -64,6 +65,8 @@ export function FrameRenderer({
   contentHash,
 }: FrameRendererProps) {
   const { vizUrl } = useAuth();
+  const { hasFeature } = useFeatureFlags();
+  const hasFrameTabs = hasFeature("pod_frame_tabs");
   const isMobile = useIsMobile();
   const { isNavigationBarOpen, setIsNavigationBarOpen } =
     useDesktopNavigation();
@@ -393,6 +396,18 @@ export function FrameRenderer({
               fileName={fileMetadata?.fileName}
               hidden={!isFrameInPod}
             />
+            {hasFrameTabs && (
+              <PodFrameTabButton
+                owner={owner}
+                spaceId={projectId ?? ""}
+                frameTabs={projectInfo?.frameTabs ?? []}
+                tabsOrder={projectInfo?.tabsOrder ?? []}
+                isEditor={projectInfo?.isEditor ?? false}
+                framePath={framePath}
+                fileName={fileMetadata?.fileName}
+                hidden={!isFrameInPod}
+              />
+            )}
             {projectSaveState === "saved" && (
               <Button
                 icon={CheckCircle}

--- a/front/components/pages/pod/PodPage.tsx
+++ b/front/components/pages/pod/PodPage.tsx
@@ -1,16 +1,31 @@
+import { EditPodFrameTabDialog } from "@app/components/pod/files/EditPodFrameTabDialog";
 import { PodHeaderActions } from "@app/components/pod/PodHeaderActions";
 import { PodPageContent } from "@app/components/pod/PodPageContent";
+import { getIcon } from "@app/components/resources/resources_icons";
 import { useActivePodId } from "@app/hooks/useActivePodId";
 import { useScopedPodUiPreferences } from "@app/hooks/useScopedUIPreferences";
 import {
   DEFAULT_POD_UI_PREFERENCES,
-  type PodTab,
+  isValidPodTabValue,
   usePodTabs,
 } from "@app/hooks/useSpaceProjectTabs";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import {
+  useAuth,
+  useFeatureFlags,
+  useWorkspace,
+} from "@app/lib/auth/AuthContext";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { classNames } from "@app/lib/utils";
+import type { PodFrameTab } from "@app/types/pod_frame_tab";
+import {
+  buildPodNavItemsBeforeSettings,
+  makePodFrameTabValue,
+  normalizeTabsOrder,
+  parsePodFrameTabPath,
+  sortPodFrameTabs,
+} from "@app/types/pod_frame_tab";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import {
   CheckCircle,
   CloudArrowLeftRight,
@@ -22,11 +37,36 @@ import {
   Settings01,
   Spinner,
 } from "@dust-tt/sparkle";
+import { useEffect, useMemo, useState } from "react";
+
+const SYSTEM_TAB_TRIGGERS = {
+  conversations: {
+    label: "Conversations",
+    icon: MessageChatSquare,
+  },
+  tasks: {
+    label: "Tasks",
+    icon: CheckCircle,
+  },
+  files: {
+    label: "Files",
+    icon: Folder,
+  },
+  connected_data: {
+    label: "Connected Data",
+    icon: CloudArrowLeftRight,
+  },
+} as const;
 
 export function PodPage() {
   const owner = useWorkspace();
   const { user } = useAuth();
+  const { hasFeature } = useFeatureFlags();
   const podId = useActivePodId();
+  const hasFrameTabs = hasFeature("pod_frame_tabs");
+  const [editingFrameTab, setEditingFrameTab] = useState<PodFrameTab | null>(
+    null
+  );
 
   const {
     spaceInfo: podInfo,
@@ -54,6 +94,44 @@ export function PodPage() {
     setPodUiPreferences,
     isAdminControlled: podInfo?.isAdminControlled,
   });
+
+  const frameTabs = useMemo(
+    () => (hasFrameTabs ? sortPodFrameTabs(podInfo?.frameTabs ?? []) : []),
+    [hasFrameTabs, podInfo?.frameTabs]
+  );
+
+  const tabsOrder = useMemo(
+    () =>
+      hasFrameTabs
+        ? normalizeTabsOrder(
+            podInfo?.tabsOrder ?? [],
+            frameTabs.map((tab) => tab.path)
+          )
+        : [],
+    [frameTabs, hasFrameTabs, podInfo?.tabsOrder]
+  );
+
+  const includeConnectedData = !!podInfo?.isAdminControlled;
+
+  const navItemsBeforeSettings = useMemo(
+    () =>
+      buildPodNavItemsBeforeSettings(frameTabs, tabsOrder, {
+        includeConnectedData,
+      }),
+    [frameTabs, tabsOrder, includeConnectedData]
+  );
+
+  // Drop frame-tab selection when the flag is off or the tab was removed
+  // (including restored preference pointing at a deleted tab).
+  useEffect(() => {
+    const framePath = parsePodFrameTabPath(currentTab);
+    if (!framePath) {
+      return;
+    }
+    if (!hasFrameTabs || !frameTabs.some((tab) => tab.path === framePath)) {
+      handleTabChange("conversations");
+    }
+  }, [currentTab, frameTabs, handleTabChange, hasFrameTabs]);
 
   if (isPodsInfoLoading) {
     return (
@@ -83,7 +161,11 @@ export function PodPage() {
         className="pt-2 flex min-h-0 flex-1 flex-col overflow-hidden"
         defaultValue="conversations"
         value={currentTab}
-        onValueChange={(value) => handleTabChange(value as PodTab)}
+        onValueChange={(value) => {
+          if (isValidPodTabValue(value)) {
+            handleTabChange(value);
+          }
+        }}
       >
         <div
           className={classNames(
@@ -92,23 +174,44 @@ export function PodPage() {
           )}
         >
           <NavTabPillList>
-            <NavTabPillTrigger value="conversations" icon={MessageChatSquare}>
-              Conversations
-            </NavTabPillTrigger>
-            <NavTabPillTrigger value="tasks" icon={CheckCircle}>
-              Tasks
-            </NavTabPillTrigger>
-            <NavTabPillTrigger value="files" icon={Folder}>
-              Files
-            </NavTabPillTrigger>
-            {podInfo.isAdminControlled && (
-              <NavTabPillTrigger
-                value="connected_data"
-                icon={CloudArrowLeftRight}
-              >
-                Connected Data
-              </NavTabPillTrigger>
-            )}
+            {navItemsBeforeSettings.map((item) => {
+              const kind = item.kind;
+              switch (kind) {
+                case "system": {
+                  const trigger = SYSTEM_TAB_TRIGGERS[item.id];
+                  return (
+                    <NavTabPillTrigger
+                      key={item.id}
+                      value={item.id}
+                      icon={trigger.icon}
+                    >
+                      {trigger.label}
+                    </NavTabPillTrigger>
+                  );
+                }
+                case "frame": {
+                  const tabValue = makePodFrameTabValue(item.tab.path);
+                  return (
+                    <NavTabPillTrigger
+                      key={item.tab.path}
+                      value={tabValue}
+                      icon={getIcon(item.tab.icon)}
+                      onPointerDown={() => {
+                        // Re-click of the already-active tab opens the editor.
+                        if (podInfo.isEditor && currentTab === tabValue) {
+                          setEditingFrameTab(item.tab);
+                        }
+                      }}
+                    >
+                      {item.tab.title}
+                    </NavTabPillTrigger>
+                  );
+                }
+                default: {
+                  assertNever(kind);
+                }
+              }
+            })}
             <NavTabPillTrigger value="settings" icon={Settings01}>
               Settings
             </NavTabPillTrigger>
@@ -134,8 +237,24 @@ export function PodPage() {
           podUiPreferences={podUiPreferences}
           setPodUiPreferences={setPodUiPreferences}
           mutatePodInfo={mutatePodInfo}
+          frameTabs={frameTabs}
         />
       </NavTabPill>
+
+      {editingFrameTab && (
+        <EditPodFrameTabDialog
+          key={editingFrameTab.path}
+          owner={owner}
+          podId={podInfo.sId}
+          frameTabs={frameTabs}
+          tabsOrder={tabsOrder}
+          isEditor={podInfo.isEditor}
+          includeConnectedData={includeConnectedData}
+          tab={editingFrameTab}
+          isOpen
+          onClose={() => setEditingFrameTab(null)}
+        />
+      )}
     </div>
   );
 }

--- a/front/components/pod/PodFrameTabContent.tsx
+++ b/front/components/pod/PodFrameTabContent.tsx
@@ -1,0 +1,74 @@
+import { AuthenticatedVisualizationActionIframe } from "@app/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import {
+  getFilePathContentApiPath,
+  useFileContentByUrl,
+} from "@app/lib/swr/files";
+import type { RichSpaceType } from "@app/types/api/spaces";
+import type { PodFrameTab } from "@app/types/pod_frame_tab";
+import type { WorkspaceType } from "@app/types/user";
+import { Spinner } from "@dust-tt/sparkle";
+import { useMemo, useRef } from "react";
+
+interface PodFrameTabContentProps {
+  owner: WorkspaceType;
+  podInfo: RichSpaceType;
+  tab: PodFrameTab;
+}
+
+export function PodFrameTabContent({
+  owner,
+  podInfo,
+  tab,
+}: PodFrameTabContentProps) {
+  const { vizUrl } = useAuth();
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  const contentUrl = useMemo(
+    () => getFilePathContentApiPath(owner, tab.path),
+    [owner, tab.path]
+  );
+
+  const { fileContent, isNotFound, isFileContentLoading } = useFileContentByUrl(
+    {
+      url: contentUrl,
+    }
+  );
+
+  if (isFileContentLoading) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isNotFound || !fileContent || !vizUrl) {
+    return (
+      <div className="flex h-full w-full items-center justify-center p-8 text-center text-sm text-muted-foreground">
+        This frame is no longer available in the Pod files.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden p-2">
+      <div className="h-full overflow-hidden rounded-xl ring-1 ring-border/60">
+        <AuthenticatedVisualizationActionIframe
+          agentConfigurationId={null}
+          workspaceId={owner.sId}
+          vizUrl={vizUrl}
+          visualization={{
+            code: fileContent,
+            complete: true,
+            identifier: `viz-frame-tab-${tab.path}`,
+          }}
+          conversationId={null}
+          spaceId={podInfo.sId}
+          isInDrawer={true}
+          ref={iframeRef}
+        />
+      </div>
+    </div>
+  );
+}

--- a/front/components/pod/PodPageContent.tsx
+++ b/front/components/pod/PodPageContent.tsx
@@ -3,6 +3,7 @@ import { ManageUsersPanel } from "@app/components/assistant/conversation/space/M
 import { PodConnectedDataTab } from "@app/components/pod/connected_data/PodConnectedDataTab";
 import { PodConversationsTab } from "@app/components/pod/conversation/PodConversationsTab";
 import { PodFilesTab } from "@app/components/pod/files/PodFilesTab";
+import { PodFrameTabContent } from "@app/components/pod/PodFrameTabContent";
 import { PodSettingsTab } from "@app/components/pod/settings/PodSettingsTab";
 import { PodTasksTab } from "@app/components/pod/tasks/PodTasksTab";
 import {
@@ -22,6 +23,8 @@ import type { RichMention } from "@app/types/assistant/mentions";
 import { toMentionType } from "@app/types/assistant/mentions";
 import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
+import type { PodFrameTab } from "@app/types/pod_frame_tab";
+import { makePodFrameTabValue } from "@app/types/pod_frame_tab";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { NavTabPillContent } from "@dust-tt/sparkle";
@@ -36,6 +39,7 @@ interface PodPageContentProps {
   setPodUiPreferences: (value: PodUiScopedPreferences) => void;
   mutatePodInfo: () => Promise<unknown>;
   clientSideMCPServerIds?: string[];
+  frameTabs?: PodFrameTab[];
 }
 
 export function PodPageContent({
@@ -45,6 +49,7 @@ export function PodPageContent({
   setPodUiPreferences,
   mutatePodInfo,
   clientSideMCPServerIds,
+  frameTabs = [],
 }: PodPageContentProps) {
   const owner = useWorkspace();
   const { user } = useAuth();
@@ -207,6 +212,14 @@ export function PodPageContent({
           <PodConnectedDataTab owner={owner} pod={podInfo} />
         </NavTabPillContent>
       )}
+      {frameTabs.map((tab) => (
+        <NavTabPillContent
+          key={tab.path}
+          value={makePodFrameTabValue(tab.path)}
+        >
+          <PodFrameTabContent owner={owner} podInfo={podInfo} tab={tab} />
+        </NavTabPillContent>
+      ))}
       <NavTabPillContent value="settings">
         <PodSettingsTab
           key={podInfo.sId}

--- a/front/components/pod/files/EditPodFrameTabDialog.tsx
+++ b/front/components/pod/files/EditPodFrameTabDialog.tsx
@@ -1,0 +1,222 @@
+import { isCustomResourceIconType } from "@app/components/resources/resources_icon_names";
+import { getIcon } from "@app/components/resources/resources_icons";
+import { usePodFrameTabs } from "@app/hooks/usePodFrameTabs";
+import {
+  buildPodNavItemsBeforeSettings,
+  DEFAULT_POD_FRAME_TAB_ICON,
+  MAX_POD_FRAME_TAB_TITLE_LENGTH,
+  type PodFrameTab,
+} from "@app/types/pod_frame_tab";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  ActionIcons,
+  ArrowLeft,
+  ArrowRight,
+  Button,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  IconPicker,
+  Input,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+} from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
+
+interface EditPodFrameTabDialogProps {
+  owner: LightWorkspaceType;
+  podId: string;
+  frameTabs: PodFrameTab[];
+  tabsOrder?: string[];
+  isEditor: boolean;
+  includeConnectedData?: boolean;
+  tab: PodFrameTab;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function EditPodFrameTabDialog({
+  owner,
+  podId,
+  frameTabs,
+  tabsOrder,
+  isEditor,
+  includeConnectedData = false,
+  tab,
+  isOpen,
+  onClose,
+}: EditPodFrameTabDialogProps) {
+  const {
+    updateFrameTab,
+    removeFrameTab,
+    moveFrameTab,
+    tabsOrder: navOrder,
+  } = usePodFrameTabs({
+    owner,
+    podId,
+    frameTabs,
+    tabsOrder,
+    isEditor,
+  });
+
+  const [title, setTitle] = useState(tab.title);
+  const [icon, setIcon] = useState(tab.icon);
+  const [isIconPickerOpen, setIsIconPickerOpen] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isMoving, setIsMoving] = useState(false);
+
+  const navItems = useMemo(
+    () =>
+      buildPodNavItemsBeforeSettings(frameTabs, navOrder, {
+        includeConnectedData,
+      }),
+    [frameTabs, includeConnectedData, navOrder]
+  );
+  const tabIndex = navItems.findIndex(
+    (item) => item.kind === "frame" && item.tab.path === tab.path
+  );
+  const canMoveLeft = isEditor && tabIndex > 0;
+  const canMoveRight =
+    isEditor && tabIndex >= 0 && tabIndex < navItems.length - 1;
+
+  const selectedIcon = isCustomResourceIconType(icon)
+    ? icon
+    : DEFAULT_POD_FRAME_TAB_ICON;
+  const IconComponent = getIcon(selectedIcon);
+
+  const handleSave = async () => {
+    if (!isEditor) {
+      return;
+    }
+    setIsSaving(true);
+    const ok = await updateFrameTab(tab.path, {
+      title: title.trim() || tab.title,
+      icon: selectedIcon,
+    });
+    setIsSaving(false);
+    if (ok) {
+      onClose();
+    }
+  };
+
+  const handleRemove = async () => {
+    if (!isEditor) {
+      return;
+    }
+    setIsSaving(true);
+    const ok = await removeFrameTab(tab.path, { fileName: tab.title });
+    setIsSaving(false);
+    if (ok) {
+      onClose();
+    }
+  };
+
+  const handleMove = async (direction: "left" | "right") => {
+    if (!isEditor) {
+      return;
+    }
+    setIsMoving(true);
+    await moveFrameTab(tab.path, direction, { includeConnectedData });
+    setIsMoving(false);
+  };
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          setIsIconPickerOpen(false);
+          onClose();
+        }
+      }}
+    >
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>Edit frame tab</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          <div className="flex items-center gap-2">
+            <PopoverRoot
+              open={isIconPickerOpen}
+              onOpenChange={(open) => {
+                if (isEditor) {
+                  setIsIconPickerOpen(open);
+                }
+              }}
+            >
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  icon={IconComponent}
+                  disabled={!isEditor}
+                  tooltip="Change icon"
+                />
+              </PopoverTrigger>
+              <PopoverContent
+                className="w-fit p-0"
+                onOpenAutoFocus={(e) => e.preventDefault()}
+              >
+                <IconPicker
+                  icons={ActionIcons}
+                  selectedIcon={selectedIcon}
+                  onIconSelect={(iconName: string) => {
+                    if (isCustomResourceIconType(iconName)) {
+                      setIcon(iconName);
+                    }
+                    setIsIconPickerOpen(false);
+                  }}
+                />
+              </PopoverContent>
+            </PopoverRoot>
+            <Input
+              id="frame-tab-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              maxLength={MAX_POD_FRAME_TAB_TITLE_LENGTH}
+              disabled={!isEditor}
+              placeholder="Tab title"
+              containerClassName="flex-1"
+            />
+            {(canMoveLeft || canMoveRight) && (
+              <div className="flex shrink-0 items-center gap-0.5">
+                <Button
+                  variant="ghost"
+                  icon={ArrowLeft}
+                  tooltip="Move left"
+                  disabled={!canMoveLeft || isMoving || isSaving}
+                  onClick={() => void handleMove("left")}
+                />
+                <Button
+                  variant="ghost"
+                  icon={ArrowRight}
+                  tooltip="Move right"
+                  disabled={!canMoveRight || isMoving || isSaving}
+                  onClick={() => void handleMove("right")}
+                />
+              </div>
+            )}
+          </div>
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Remove tab",
+            variant: "warning",
+            onClick: () => void handleRemove(),
+            disabled: !isEditor || isSaving || isMoving,
+          }}
+          rightButtonProps={{
+            label: "Save",
+            variant: "primary",
+            onClick: () => void handleSave(),
+            disabled: !isEditor || isSaving || isMoving || !title.trim(),
+            isLoading: isSaving,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/pod/files/PinPodBannerButton.tsx
+++ b/front/components/pod/files/PinPodBannerButton.tsx
@@ -1,5 +1,4 @@
 import { usePinPodBanner } from "@app/hooks/usePinPodBanner";
-import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Button, Pin02 } from "@dust-tt/sparkle";
 
@@ -22,7 +21,6 @@ export function PinPodBannerButton({
   fileName,
   hidden,
 }: PinPodBannerButtonProps) {
-  const isMobile = useIsMobile();
   const { togglePin, isPinned } = usePinPodBanner({
     owner,
     podId: spaceId,
@@ -39,8 +37,8 @@ export function PinPodBannerButton({
   return (
     <Button
       icon={Pin02}
-      variant="ghost"
-      label={isMobile ? undefined : pinnedAsBanner ? "Pinned" : "Pin"}
+      variant={pinnedAsBanner ? "highlight-ghost" : "ghost"}
+      label={""}
       tooltip={pinnedAsBanner ? "Unpin from Pod banner" : "Pin as Pod banner"}
       onClick={() =>
         void togglePin(framePath, {

--- a/front/components/pod/files/PodFileExplorer.tsx
+++ b/front/components/pod/files/PodFileExplorer.tsx
@@ -21,7 +21,9 @@ import SpaceManagedDatasourcesViewsModal from "@app/components/spaces/SpaceManag
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useFolderPathUrlState } from "@app/hooks/useFolderPathUrlState";
 import { usePinPodBanner } from "@app/hooks/usePinPodBanner";
+import { usePodFrameTabs } from "@app/hooks/usePodFrameTabs";
 import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { downloadFile, getFilePathViewUrl } from "@app/lib/swr/files";
 import {
@@ -61,6 +63,7 @@ import {
   DropdownMenuTrigger,
   EmptyCTA,
   Folder,
+  LayoutAlt02,
   Pin02,
   Tooltip,
   UploadCloud02,
@@ -255,10 +258,19 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
 
   const isArchived = !!pod.archivedAt;
   const isEditor = pod.isEditor;
+  const { hasFeature } = useFeatureFlags();
+  const hasFrameTabs = hasFeature("pod_frame_tabs");
   const { togglePin, isPinned } = usePinPodBanner({
     owner,
     podId: pod.sId,
     pinnedFramePath: pod.pinnedFramePath ?? null,
+    isEditor,
+  });
+  const { toggleFrameTab, isFrameTab } = usePodFrameTabs({
+    owner,
+    podId: pod.sId,
+    frameTabs: pod.frameTabs ?? [],
+    tabsOrder: pod.tabsOrder ?? [],
     isEditor,
   });
 
@@ -274,7 +286,7 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
       }
 
       const pinned = isPinned(entry.path);
-      return [
+      const items: FileExplorerMenuAction[] = [
         {
           label: pinned ? "Unpin from banner" : "Pin as Pod banner",
           icon: Pin02,
@@ -284,8 +296,30 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
           },
         },
       ];
+
+      if (hasFrameTabs) {
+        const asTab = isFrameTab(entry.path);
+        items.push({
+          label: asTab ? "Remove from Pod tabs" : "Add as Pod tab",
+          icon: LayoutAlt02,
+          onClick: (e) => {
+            e.stopPropagation();
+            void toggleFrameTab(entry.path, { fileName: entry.fileName });
+          },
+        });
+      }
+
+      return items;
     },
-    [isArchived, isEditor, isPinned, togglePin]
+    [
+      hasFrameTabs,
+      isArchived,
+      isEditor,
+      isFrameTab,
+      isPinned,
+      toggleFrameTab,
+      togglePin,
+    ]
   );
 
   const canManuallyManagePodKnowledge =
@@ -703,6 +737,8 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
         fileName={framePreview?.fileName}
         podId={pod.sId}
         pinnedFramePath={pod.pinnedFramePath ?? null}
+        frameTabs={pod.frameTabs ?? []}
+        tabsOrder={pod.tabsOrder ?? []}
         isEditor={isEditor}
         isArchived={isArchived}
         isOpen={framePreview !== null}

--- a/front/components/pod/files/PodFrameSheet.tsx
+++ b/front/components/pod/files/PodFrameSheet.tsx
@@ -2,8 +2,10 @@ import { AuthenticatedVisualizationActionIframe } from "@app/components/assistan
 import { ExportContentDropdown } from "@app/components/assistant/conversation/interactive_content/ExportContentDropdown";
 import { ShareFrameSheet } from "@app/components/assistant/conversation/interactive_content/frame/ShareFrameSheet";
 import { PinPodBannerButton } from "@app/components/pod/files/PinPodBannerButton";
-import { useAuth } from "@app/lib/auth/AuthContext";
+import { PodFrameTabButton } from "@app/components/pod/files/PodFrameTabButton";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useFileContent, useFileMetadata } from "@app/lib/swr/files";
+import type { PodFrameTab } from "@app/types/pod_frame_tab";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -26,6 +28,8 @@ interface PodFrameSheetProps {
   fileName?: string;
   podId: string;
   pinnedFramePath: string | null;
+  frameTabs: PodFrameTab[];
+  tabsOrder?: string[];
   isEditor: boolean;
   isArchived: boolean;
   isOpen: boolean;
@@ -39,6 +43,8 @@ export function PodFrameSheet({
   fileName,
   podId,
   pinnedFramePath,
+  frameTabs,
+  tabsOrder,
   isEditor,
   isArchived,
   isOpen,
@@ -46,6 +52,8 @@ export function PodFrameSheet({
   owner,
 }: PodFrameSheetProps) {
   const { vizUrl } = useAuth();
+  const { hasFeature } = useFeatureFlags();
+  const hasFrameTabs = hasFeature("pod_frame_tabs");
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
 
@@ -79,12 +87,12 @@ export function PodFrameSheet({
         }}
       >
         <SheetHeader hideButton>
-          <div className="flex items-center gap-2">
-            <SheetTitle className="flex-1 truncate">
+          <div className="flex min-w-0 items-center gap-2">
+            <SheetTitle className="min-w-0 flex-1 truncate">
               {fileMetadata?.fileName}
             </SheetTitle>
             {fileId && (
-              <div className="flex shrink-0 items-center gap-1">
+              <div className="flex max-w-[60%] shrink-0 items-center justify-end gap-1 overflow-x-auto">
                 <ExportContentDropdown
                   iframeRef={iframeRef}
                   owner={owner}
@@ -102,6 +110,18 @@ export function PodFrameSheet({
                   fileName={fileName}
                   hidden={isArchived}
                 />
+                {hasFrameTabs && (
+                  <PodFrameTabButton
+                    owner={owner}
+                    spaceId={podId}
+                    frameTabs={frameTabs}
+                    tabsOrder={tabsOrder}
+                    isEditor={isEditor}
+                    framePath={framePath}
+                    fileName={fileName}
+                    hidden={isArchived}
+                  />
+                )}
                 <Button
                   icon={isFullscreen ? Minimize01 : Maximize01}
                   variant="ghost"

--- a/front/components/pod/files/PodFrameTabButton.tsx
+++ b/front/components/pod/files/PodFrameTabButton.tsx
@@ -1,0 +1,54 @@
+import { usePodFrameTabs } from "@app/hooks/usePodFrameTabs";
+import type { PodFrameTab } from "@app/types/pod_frame_tab";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Button, LayoutAlt02 } from "@dust-tt/sparkle";
+
+interface PodFrameTabButtonProps {
+  owner: LightWorkspaceType;
+  spaceId: string;
+  frameTabs: PodFrameTab[];
+  tabsOrder?: string[];
+  isEditor: boolean;
+  framePath: string | null;
+  fileName?: string;
+  hidden?: boolean;
+}
+
+export function PodFrameTabButton({
+  owner,
+  spaceId,
+  frameTabs,
+  tabsOrder,
+  isEditor,
+  framePath,
+  fileName,
+  hidden,
+}: PodFrameTabButtonProps) {
+  const { toggleFrameTab, isFrameTab } = usePodFrameTabs({
+    owner,
+    podId: spaceId,
+    frameTabs,
+    tabsOrder,
+    isEditor,
+  });
+
+  if (hidden || !isEditor || !framePath) {
+    return null;
+  }
+
+  const addedAsTab = isFrameTab(framePath);
+
+  return (
+    <Button
+      icon={LayoutAlt02}
+      variant={addedAsTab ? "highlight-ghost" : "ghost"}
+      size="sm"
+      tooltip={addedAsTab ? "Remove from Pod tabs" : "Add as Pod tab"}
+      onClick={() =>
+        void toggleFrameTab(framePath, {
+          fileName,
+        })
+      }
+    />
+  );
+}

--- a/front/hooks/usePodFrameTabs.ts
+++ b/front/hooks/usePodFrameTabs.ts
@@ -1,0 +1,234 @@
+import { ConfirmContext } from "@app/components/Confirm";
+import type { CustomResourceIconType } from "@app/components/resources/resources_icon_names";
+import { useSendNotification } from "@app/hooks/useNotification";
+import { useUpdatePodMetadata } from "@app/lib/swr/pods";
+import {
+  DEFAULT_POD_FRAME_TAB_ICON,
+  MAX_POD_FRAME_TAB_TITLE_LENGTH,
+  MAX_POD_FRAME_TABS,
+  moveFrameTabInTabsOrder,
+  normalizeTabsOrder,
+  type PodFrameTab,
+  podFrameTabBasename,
+  sortPodFrameTabs,
+} from "@app/types/pod_frame_tab";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useCallback, useContext, useMemo } from "react";
+
+type FrameTabOptions = {
+  fileName?: string;
+  title?: string;
+  icon?: CustomResourceIconType;
+};
+
+export function usePodFrameTabs({
+  owner,
+  podId,
+  frameTabs,
+  tabsOrder,
+  isEditor,
+}: {
+  owner: LightWorkspaceType;
+  podId: string;
+  frameTabs: PodFrameTab[];
+  tabsOrder?: string[];
+  isEditor: boolean;
+}) {
+  const confirm = useContext(ConfirmContext);
+  const sendNotification = useSendNotification();
+  const updatePodMetadata = useUpdatePodMetadata({
+    owner,
+    podId,
+  });
+
+  const sortedTabs = useMemo(() => sortPodFrameTabs(frameTabs), [frameTabs]);
+  const navOrder = useMemo(
+    () =>
+      normalizeTabsOrder(
+        tabsOrder ?? [],
+        sortedTabs.map((tab) => tab.path)
+      ),
+    [tabsOrder, sortedTabs]
+  );
+
+  const persist = useCallback(
+    async (nextTabs: PodFrameTab[], nextNavOrder: string[]) => {
+      const normalizedTabs = sortPodFrameTabs(nextTabs);
+      const normalizedNavOrder = normalizeTabsOrder(
+        nextNavOrder,
+        normalizedTabs.map((tab) => tab.path)
+      );
+      const result = await updatePodMetadata({
+        frameTabs: normalizedTabs,
+        tabsOrder: normalizedNavOrder,
+      });
+      return result !== null;
+    },
+    [updatePodMetadata]
+  );
+
+  const isFrameTab = useCallback(
+    (path: string) => sortedTabs.some((tab) => tab.path === path),
+    [sortedTabs]
+  );
+
+  const addFrameTab = useCallback(
+    async (path: string, options?: FrameTabOptions) => {
+      if (!isEditor) {
+        return false;
+      }
+
+      if (isFrameTab(path)) {
+        return true;
+      }
+
+      if (sortedTabs.length >= MAX_POD_FRAME_TABS) {
+        sendNotification({
+          type: "error",
+          title: "Frame tab limit reached",
+          description: `A pod can have at most ${MAX_POD_FRAME_TABS} frame tabs.`,
+        });
+        return false;
+      }
+
+      const label = podFrameTabBasename(
+        options?.title ?? options?.fileName ?? path
+      );
+
+      const confirmed = await confirm({
+        title: "Add as Pod tab?",
+        message: `"${label}" will appear as a tab in this Pod for all members.`,
+        validateLabel: "Add tab",
+        validateVariant: "primary",
+      });
+      if (!confirmed) {
+        return false;
+      }
+
+      const nextTabs: PodFrameTab[] = [
+        ...sortedTabs,
+        {
+          path,
+          title: label.slice(0, MAX_POD_FRAME_TAB_TITLE_LENGTH),
+          icon: options?.icon ?? DEFAULT_POD_FRAME_TAB_ICON,
+        },
+      ];
+
+      return persist(nextTabs, [...navOrder, path]);
+    },
+    [
+      confirm,
+      isEditor,
+      isFrameTab,
+      navOrder,
+      persist,
+      sendNotification,
+      sortedTabs,
+    ]
+  );
+
+  const removeFrameTab = useCallback(
+    async (path: string, options?: FrameTabOptions) => {
+      if (!isEditor) {
+        return false;
+      }
+
+      const existing = sortedTabs.find((tab) => tab.path === path);
+      if (!existing) {
+        return true;
+      }
+
+      const label = options?.fileName ?? existing.title;
+
+      const confirmed = await confirm({
+        title: "Remove Pod tab?",
+        message: `"${label}" will no longer appear as a tab in this Pod.`,
+        validateLabel: "Remove",
+        validateVariant: "warning",
+      });
+      if (!confirmed) {
+        return false;
+      }
+
+      return persist(
+        sortedTabs.filter((tab) => tab.path !== path),
+        navOrder.filter((entry) => entry !== path)
+      );
+    },
+    [confirm, isEditor, navOrder, persist, sortedTabs]
+  );
+
+  const toggleFrameTab = useCallback(
+    async (path: string, options?: FrameTabOptions) => {
+      if (!isEditor) {
+        return false;
+      }
+      if (isFrameTab(path)) {
+        return removeFrameTab(path, options);
+      }
+      return addFrameTab(path, options);
+    },
+    [addFrameTab, isEditor, isFrameTab, removeFrameTab]
+  );
+
+  const updateFrameTab = useCallback(
+    async (
+      path: string,
+      updates: {
+        title?: string;
+        icon?: CustomResourceIconType;
+      }
+    ) => {
+      if (!isEditor) {
+        return false;
+      }
+
+      const nextTabs = sortedTabs.map((tab) => {
+        if (tab.path !== path) {
+          return tab;
+        }
+        return {
+          ...tab,
+          title: updates.title?.trim() || tab.title,
+          icon: updates.icon ?? tab.icon,
+        };
+      });
+
+      return persist(nextTabs, navOrder);
+    },
+    [isEditor, navOrder, persist, sortedTabs]
+  );
+
+  const moveFrameTab = useCallback(
+    async (
+      path: string,
+      direction: "left" | "right",
+      { includeConnectedData }: { includeConnectedData: boolean }
+    ) => {
+      if (!isEditor) {
+        return false;
+      }
+
+      const nextNavOrder = moveFrameTabInTabsOrder(navOrder, path, direction, {
+        includeConnectedData,
+      });
+      if (!nextNavOrder) {
+        return false;
+      }
+
+      return persist(sortedTabs, nextNavOrder);
+    },
+    [isEditor, navOrder, persist, sortedTabs]
+  );
+
+  return {
+    frameTabs: sortedTabs,
+    tabsOrder: navOrder,
+    isFrameTab,
+    addFrameTab,
+    removeFrameTab,
+    toggleFrameTab,
+    updateFrameTab,
+    moveFrameTab,
+  };
+}

--- a/front/hooks/useScopedUIPreferences.ts
+++ b/front/hooks/useScopedUIPreferences.ts
@@ -4,15 +4,17 @@ import { z } from "zod";
 
 const SCOPED_UI_PREFERENCES_KEY_PREFIX = "scopedUIPreferences";
 
+const SYSTEM_POD_TABS = [
+  "conversations",
+  "tasks",
+  "files",
+  "connected_data",
+  "settings",
+] as const;
+
 const scopedUIPreferencesSchemaByScope = {
   podUi: z.object({
-    tab: z.enum([
-      "conversations",
-      "tasks",
-      "files",
-      "connected_data",
-      "settings",
-    ]),
+    tab: z.union([z.enum(SYSTEM_POD_TABS), z.string().regex(/^frame:.+/)]),
     conversationsFilter: z.enum(["all", "group", "with_me"]),
     tasksOwnerFilter: z
       .unknown()
@@ -21,7 +23,7 @@ const scopedUIPreferencesSchemaByScope = {
   podPinnedBanner: z.object({
     collapsed: z.boolean().default(false),
   }),
-} as const;
+};
 
 export type PodPinnedBannerScopedPreferences = z.infer<
   (typeof scopedUIPreferencesSchemaByScope)["podPinnedBanner"]

--- a/front/hooks/useSpaceProjectTabs.ts
+++ b/front/hooks/useSpaceProjectTabs.ts
@@ -1,6 +1,18 @@
 import { DEFAULT_TASK_OWNER_FILTER } from "@app/components/assistant/conversation/space/conversations/project_tasks/projectTasksListScope";
 import type { PodUiScopedPreferences } from "@app/hooks/useScopedUIPreferences";
+import {
+  isPodFrameTabValue,
+  makePodFrameTabValue,
+  parsePodFrameTabPath,
+} from "@app/types/pod_frame_tab";
 import { useCallback, useEffect, useRef } from "react";
+
+export type SystemPodTab =
+  | "conversations"
+  | "tasks"
+  | "files"
+  | "connected_data"
+  | "settings";
 
 export type PodTab = PodUiScopedPreferences["tab"];
 
@@ -12,20 +24,36 @@ export const DEFAULT_POD_UI_PREFERENCES: PodUiScopedPreferences = {
 
 const CONNECTED_DATA_QUERY_PARAMS = ["dsvId", "parentId", "q"] as const;
 
+const SYSTEM_POD_TAB_HASHES = new Set<string>([
+  "files",
+  "settings",
+  "conversations",
+  "tasks",
+  "connected_data",
+]);
+
+function isSystemPodTab(tab: string): tab is SystemPodTab {
+  return SYSTEM_POD_TAB_HASHES.has(tab);
+}
+
 /** Hash segment → tab when the user navigates with the hash (same pod). */
 function parsePodTabFromLocationHash(fallbackTab: PodTab): PodTab {
   if (typeof window === "undefined") {
     return fallbackTab;
   }
   const hash = window.location.hash.slice(1);
-  if (
-    hash === "files" ||
-    hash === "settings" ||
-    hash === "conversations" ||
-    hash === "tasks" ||
-    hash === "connected_data"
-  ) {
+  if (isSystemPodTab(hash)) {
     return hash;
+  }
+  if (hash.startsWith("frame/")) {
+    try {
+      const path = decodeURIComponent(hash.slice("frame/".length));
+      if (path.length > 0) {
+        return makePodFrameTabValue(path);
+      }
+    } catch {
+      return fallbackTab;
+    }
   }
   return fallbackTab;
 }
@@ -49,6 +77,11 @@ function hasConnectedDataQueryParams(): boolean {
   return CONNECTED_DATA_QUERY_PARAMS.some((key) => params.has(key));
 }
 
+function tabToHash(tab: PodTab): string {
+  const framePath = parsePodFrameTabPath(tab);
+  return framePath ? `frame/${encodeURIComponent(framePath)}` : tab;
+}
+
 function replaceUrlWithTab(tab: PodTab) {
   const url = new URL(window.location.href);
   if (tab !== "connected_data") {
@@ -56,7 +89,7 @@ function replaceUrlWithTab(tab: PodTab) {
       url.searchParams.delete(key);
     }
   }
-  url.hash = tab;
+  url.hash = tabToHash(tab);
   window.history.replaceState(null, "", url.pathname + url.search + url.hash);
 }
 
@@ -71,11 +104,7 @@ interface UsePodTabsParams {
 /**
  * Pod page tabs: URL hash mirrors `projectUIPreferences.tab` (per pod).
  *
- * One sync function runs on mount, `podId` change, and `hashchange`. If
- * the URL hash names a valid tab, state adopts it (so deep links like
- * `/pod/X#tasks` win over the persisted tab); otherwise the persisted
- * tab is written back into the URL asynchronously, so other layout hooks
- * (e.g. side panel) observe the previous hash first.
+ * System tabs use `#conversations` etc. Frame tabs use `#frame/<encoded-path>`.
  *
  * Tab clicks go through `handleTabChange`, which writes URL + state
  * synchronously and bypasses the sync function.
@@ -97,15 +126,16 @@ export function usePodTabs({
   onHashChangeRef.current = () => {
     const tabFromHash = parsePodTabFromLocationHash(podUiPreferences.tab);
     const resolved = resolvePodTab(tabFromHash, isAdminControlled);
+    const expectedHash = `#${tabToHash(podUiPreferences.tab)}`;
     if (resolved !== podUiPreferences.tab) {
       setPodUiPreferences({ ...podUiPreferences, tab: resolved });
       if (
-        window.location.hash !== `#${resolved}` ||
+        window.location.hash !== `#${tabToHash(resolved)}` ||
         (resolved !== "connected_data" && hasConnectedDataQueryParams())
       ) {
         replaceUrlWithTab(resolved);
       }
-    } else if (window.location.hash !== `#${podUiPreferences.tab}`) {
+    } else if (window.location.hash !== expectedHash) {
       const newTab = podUiPreferences.tab;
       window.setTimeout(() => replaceUrlWithTab(newTab), 0);
     } else if (resolved !== "connected_data" && hasConnectedDataQueryParams()) {
@@ -155,4 +185,8 @@ export function usePodTabs({
     currentTab: resolvePodTab(podUiPreferences.tab, isAdminControlled),
     handleTabChange,
   };
+}
+
+export function isValidPodTabValue(value: string): value is PodTab {
+  return isSystemPodTab(value) || isPodFrameTabValue(value);
 }

--- a/front/lib/api/projects/frame_tabs.ts
+++ b/front/lib/api/projects/frame_tabs.ts
@@ -1,0 +1,97 @@
+import { DustFileSystem } from "@app/lib/api/file_system";
+import { resolveCanonicalScopedPath } from "@app/lib/api/files/mount_path";
+import type { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { isInteractiveContentType } from "@app/types/files";
+import {
+  MAX_POD_FRAME_TABS,
+  normalizeTabsOrder,
+  POD_NAV_SYSTEM_TABS_BEFORE_SETTINGS,
+  type PodFrameTab,
+  type PodTabsOrder,
+  sortPodFrameTabs,
+} from "@app/types/pod_frame_tab";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+
+/**
+ * Validate frame tabs + nav order for a project space.
+ *
+ * Paths are canonicalized via resolveCanonicalScopedPath (same as pinned frames)
+ * so accepted aliases like `project/...` / `pod/...` become `pod-{spaceId}/...`.
+ */
+export async function validatePodFrameTabs(
+  auth: Authenticator,
+  space: SpaceResource,
+  frameTabs: PodFrameTab[],
+  tabsOrder: PodTabsOrder | undefined
+): Promise<Result<{ frameTabs: PodFrameTab[]; tabsOrder: string[] }, Error>> {
+  if (frameTabs.length > MAX_POD_FRAME_TABS) {
+    return new Err(
+      new Error(`A pod can have at most ${MAX_POD_FRAME_TABS} frame tabs.`)
+    );
+  }
+
+  const fsResult = await DustFileSystem.forPod(auth, space);
+  if (fsResult.isErr()) {
+    return new Err(new Error("Failed to initialize file system."));
+  }
+  const fs = fsResult.value;
+
+  const seenPaths = new Set<string>();
+  const normalized: PodFrameTab[] = [];
+  const pathRemap = new Map<string, string>();
+
+  for (const tab of frameTabs) {
+    const normalizedPath = resolveCanonicalScopedPath(tab.path, {
+      conversationId: null,
+      spaceId: space.sId,
+    });
+    if (!normalizedPath) {
+      return new Err(new Error(`Invalid frame tab path: ${tab.path}`));
+    }
+
+    if (seenPaths.has(normalizedPath)) {
+      return new Err(new Error(`Duplicate frame tab path: ${normalizedPath}`));
+    }
+    seenPaths.add(normalizedPath);
+    pathRemap.set(tab.path, normalizedPath);
+
+    const statResult = await fs.stat(normalizedPath);
+    if (statResult.isErr() || !statResult.value) {
+      return new Err(new Error(`Frame tab file not found: ${normalizedPath}`));
+    }
+
+    if (!isInteractiveContentType(statResult.value.contentType)) {
+      return new Err(
+        new Error(
+          `Frame tab path is not an interactive frame: ${normalizedPath}`
+        )
+      );
+    }
+
+    normalized.push({
+      path: normalizedPath,
+      title: tab.title.trim(),
+      icon: tab.icon,
+    });
+  }
+
+  const remappedTabsOrder = (tabsOrder ?? []).map(
+    (entry) => pathRemap.get(entry) ?? entry
+  );
+  const normalizedTabsOrder = normalizeTabsOrder(
+    remappedTabsOrder,
+    normalized.map((tab) => tab.path)
+  );
+
+  for (const id of POD_NAV_SYSTEM_TABS_BEFORE_SETTINGS) {
+    if (!normalizedTabsOrder.includes(id)) {
+      return new Err(new Error(`Nav order is missing system tab: ${id}`));
+    }
+  }
+
+  return new Ok({
+    frameTabs: sortPodFrameTabs(normalized),
+    tabsOrder: normalizedTabsOrder,
+  });
+}

--- a/front/lib/resources/project_metadata_resource.test.ts
+++ b/front/lib/resources/project_metadata_resource.test.ts
@@ -119,6 +119,13 @@ describe("ProjectMetadataResource", () => {
       expect(json.todoGenerationEnabled).toBe(false);
       expect(json.lastTodoAnalysisAt).toBeNull();
       expect(json.pinnedFramePath).toBeNull();
+      expect(json.frameTabs).toEqual([]);
+      expect(json.tabsOrder).toEqual([
+        "conversations",
+        "tasks",
+        "files",
+        "connected_data",
+      ]);
       expect(json.defaultSkillIds).toEqual([]);
       expect(json.isAdminControlled).toBe(false);
     });

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -5,6 +5,8 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { ProjectMetadataModel } from "@app/lib/resources/storage/models/project_metadata";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
+import type { PodFrameTab } from "@app/types/pod_frame_tab";
+import { normalizeTabsOrder, sortPodFrameTabs } from "@app/types/pod_frame_tab";
 import type { PodMetadataType } from "@app/types/project_metadata";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -223,6 +225,14 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
     await this.update({ pinnedFramePath }, transaction);
   }
 
+  async updateFrameTabs(
+    frameTabs: PodFrameTab[],
+    tabsOrder: string[],
+    transaction?: Transaction
+  ) {
+    await this.update({ frameTabs, tabsOrder }, transaction);
+  }
+
   async updateDefaultAgentId(
     defaultAgentId: string | null,
     transaction?: Transaction
@@ -276,6 +286,13 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
       todoGenerationEnabled: this.todoGenerationEnabled,
       lastTodoAnalysisAt: this.lastTodoAnalysisAt?.getTime() ?? null,
       pinnedFramePath: this.pinnedFramePath ?? null,
+      frameTabs: sortPodFrameTabs(this.frameTabs ?? []).map(
+        ({ path, title, icon }) => ({ path, title, icon })
+      ),
+      tabsOrder: normalizeTabsOrder(
+        this.tabsOrder ?? [],
+        (this.frameTabs ?? []).map((tab) => tab.path)
+      ),
       defaultAgentId: this.defaultAgentId ?? null,
       defaultSkillIds: this.defaultSkillIds,
       isAdminControlled: this.isAdminControlled,

--- a/front/lib/resources/storage/models/project_metadata.ts
+++ b/front/lib/resources/storage/models/project_metadata.ts
@@ -5,6 +5,7 @@ import {
 } from "@app/lib/resources/storage/data_types";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { PodFrameTab } from "@app/types/pod_frame_tab";
 import type { CreationOptional, ForeignKey } from "sequelize";
 
 export class ProjectMetadataModel extends WorkspaceAwareModel<ProjectMetadataModel> {
@@ -26,6 +27,13 @@ export class ProjectMetadataModel extends WorkspaceAwareModel<ProjectMetadataMod
   declare description: string | null;
   /** Scoped path to a project frame file, e.g. `project/banner.html`. */
   declare pinnedFramePath: CreationOptional<string | null>;
+  /** Frames promoted as custom pod tabs (shared). */
+  declare frameTabs: CreationOptional<PodFrameTab[]>;
+  /**
+   * Interleaved nav order before Settings: system tab ids + frame paths.
+   * Empty means default (system tabs then frame paths).
+   */
+  declare tabsOrder: CreationOptional<string[]>;
   /** sId of the agent pre-selected for new conversations in this pod. Null = @dust. */
   declare defaultAgentId: CreationOptional<string | null>;
   declare defaultSkillsIds: CreationOptional<string[] | null>;
@@ -72,6 +80,16 @@ ProjectMetadataModel.init(
     pinnedFramePath: {
       type: DataTypes.STRING,
       allowNull: true,
+    },
+    frameTabs: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: [],
+    },
+    tabsOrder: {
+      type: DataTypes.ARRAY(DataTypes.STRING),
+      allowNull: false,
+      defaultValue: [],
     },
     defaultAgentId: {
       type: DataTypes.STRING,

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -1133,23 +1133,27 @@ export function useUpdatePodMetadata({
     void mutateSpaceInfoRegardlessOfQueryParams();
 
     const title =
-      updates.pinnedFramePath !== undefined
-        ? updates.pinnedFramePath
-          ? "Frame pinned as Pod banner"
-          : "Banner unpinned"
-        : updates.archive !== undefined
-          ? updates.archive
-            ? "Pod archived"
-            : "Pod unarchived"
-          : updates.todoGenerationEnabled !== undefined
-            ? updates.todoGenerationEnabled
-              ? "Automatic task suggestions turned on"
-              : "Automatic task suggestions turned off"
-            : updates.isAdminControlled !== undefined
-              ? updates.isAdminControlled
-                ? "Pod is now admin-controlled"
-                : "Pod is now self-serve"
-              : "Pod updated";
+      updates.frameTabs !== undefined || updates.tabsOrder !== undefined
+        ? updates.frameTabs?.length === 0
+          ? "Frame tabs cleared"
+          : "Pod frame tabs updated"
+        : updates.pinnedFramePath !== undefined
+          ? updates.pinnedFramePath
+            ? "Frame pinned as Pod banner"
+            : "Banner unpinned"
+          : updates.archive !== undefined
+            ? updates.archive
+              ? "Pod archived"
+              : "Pod unarchived"
+            : updates.todoGenerationEnabled !== undefined
+              ? updates.todoGenerationEnabled
+                ? "Automatic task suggestions turned on"
+                : "Automatic task suggestions turned off"
+              : updates.isAdminControlled !== undefined
+                ? updates.isAdminControlled
+                  ? "Pod is now admin-controlled"
+                  : "Pod is now self-serve"
+                : "Pod updated";
 
     sendNotification({
       type: "success",

--- a/front/migrations/pre-deploy/20260804140545_add_frame_tabs_to_project_metadata.sql
+++ b/front/migrations/pre-deploy/20260804140545_add_frame_tabs_to_project_metadata.sql
@@ -1,0 +1,9 @@
+/*
+Add shared frame tabs (path, title, icon) to project_metadata. Empty array default;
+feature is gated by pod_frame_tabs so no backfill is required.
+
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."project_metadata" ADD COLUMN "frameTabs" jsonb DEFAULT '[]'::jsonb NOT NULL;

--- a/front/migrations/pre-deploy/20260804163500_add_tabs_order_to_project_metadata.sql
+++ b/front/migrations/pre-deploy/20260804163500_add_tabs_order_to_project_metadata.sql
@@ -1,0 +1,9 @@
+/*
+Add tabsOrder (system tab ids + frame paths) for interleaved pod nav.
+Settings stays last and is never stored here.
+
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."project_metadata" ADD COLUMN "tabsOrder" varchar(255)[] NOT NULL DEFAULT ARRAY[]::varchar(255)[];

--- a/front/types/api/spaces.ts
+++ b/front/types/api/spaces.ts
@@ -1,4 +1,9 @@
 import type { AgentsUsageType } from "@app/types/data_source";
+import {
+  type PodFrameTab,
+  PodFrameTabsSchema,
+  PodTabsOrderSchema,
+} from "@app/types/pod_frame_tab";
 import type { PodType, SpaceType } from "@app/types/space";
 import type { SpaceUserType } from "@app/types/user";
 import { z } from "zod";
@@ -40,6 +45,8 @@ export const PatchPodMetadataBodySchema = z.object({
   todoGenerationEnabled: z.boolean().optional(),
   initialTodoAnalysisLookback: z.enum(["now", "last_24h", "max"]).optional(),
   pinnedFramePath: z.string().nullable().optional(),
+  frameTabs: PodFrameTabsSchema.optional(),
+  tabsOrder: PodTabsOrderSchema.optional(),
   defaultAgentId: z.string().nullable().optional(),
   defaultSkillIds: z.array(z.string()).optional(),
   isAdminControlled: z.boolean().optional(),
@@ -98,6 +105,8 @@ export type RichSpaceType = SpaceType & {
   todoGenerationEnabled: boolean;
   lastTodoAnalysisAt: number | null;
   pinnedFramePath: string | null;
+  frameTabs: PodFrameTab[];
+  tabsOrder: string[];
   /** Workspace admins control membership and connected data (project spaces only). */
   isAdminControlled: boolean;
 };

--- a/front/types/pod_frame_tab.ts
+++ b/front/types/pod_frame_tab.ts
@@ -1,0 +1,184 @@
+import {
+  type CustomResourceIconType,
+  isCustomResourceIconType,
+} from "@app/components/resources/resources_icon_names";
+import { z } from "zod";
+
+export const MAX_POD_FRAME_TABS = 8;
+export const MAX_POD_FRAME_TAB_TITLE_LENGTH = 64;
+export const DEFAULT_POD_FRAME_TAB_ICON =
+  "ActionDashboardIcon" satisfies CustomResourceIconType;
+
+/** System tabs that participate in ordering (Settings is always last and excluded). */
+export const POD_NAV_SYSTEM_TABS_BEFORE_SETTINGS = [
+  "conversations",
+  "tasks",
+  "files",
+  "connected_data",
+] as const;
+
+export type PodNavSystemTabBeforeSettings =
+  (typeof POD_NAV_SYSTEM_TABS_BEFORE_SETTINGS)[number];
+
+const POD_NAV_SYSTEM_TAB_SET = new Set<string>(
+  POD_NAV_SYSTEM_TABS_BEFORE_SETTINGS
+);
+
+export function isPodNavSystemTabBeforeSettings(
+  value: string
+): value is PodNavSystemTabBeforeSettings {
+  return POD_NAV_SYSTEM_TAB_SET.has(value);
+}
+
+export const PodFrameTabSchema = z.object({
+  path: z.string().min(1),
+  title: z.string().min(1).max(MAX_POD_FRAME_TAB_TITLE_LENGTH),
+  icon: z.custom<CustomResourceIconType>(isCustomResourceIconType, {
+    message: "Invalid icon.",
+  }),
+});
+
+export type PodFrameTab = z.infer<typeof PodFrameTabSchema>;
+
+export const PodFrameTabsSchema = z
+  .array(PodFrameTabSchema)
+  .max(MAX_POD_FRAME_TABS);
+
+/** Mixed list of system tab ids and frame paths (Settings is never included). */
+export const PodTabsOrderSchema = z.array(z.string().min(1));
+
+export type PodTabsOrder = z.infer<typeof PodTabsOrderSchema>;
+
+export type PodNavItemBeforeSettings =
+  | { kind: "system"; id: PodNavSystemTabBeforeSettings }
+  | { kind: "frame"; tab: PodFrameTab };
+
+export function sortPodFrameTabs(tabs: PodFrameTab[]): PodFrameTab[] {
+  return [...tabs].sort((a, b) => a.path.localeCompare(b.path));
+}
+
+/**
+ * Ensure tabsOrder contains every system tab + every frame path exactly once.
+ * Unknown entries are dropped; missing ones are appended.
+ */
+export function normalizeTabsOrder(
+  tabsOrder: string[] | null | undefined,
+  framePaths: string[]
+): string[] {
+  const framePathSet = new Set(framePaths);
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const entry of tabsOrder ?? []) {
+    if (seen.has(entry)) {
+      continue;
+    }
+    if (isPodNavSystemTabBeforeSettings(entry) || framePathSet.has(entry)) {
+      result.push(entry);
+      seen.add(entry);
+    }
+  }
+
+  for (const id of POD_NAV_SYSTEM_TABS_BEFORE_SETTINGS) {
+    if (!seen.has(id)) {
+      result.push(id);
+      seen.add(id);
+    }
+  }
+
+  for (const path of framePaths) {
+    if (!seen.has(path)) {
+      result.push(path);
+      seen.add(path);
+    }
+  }
+
+  return result;
+}
+
+export function visibleTabsOrder(
+  tabsOrder: string[],
+  { includeConnectedData }: { includeConnectedData: boolean }
+): string[] {
+  return tabsOrder.filter(
+    (id) => id !== "connected_data" || includeConnectedData
+  );
+}
+
+export function buildPodNavItemsBeforeSettings(
+  frameTabs: PodFrameTab[],
+  tabsOrder: string[],
+  { includeConnectedData }: { includeConnectedData: boolean }
+): PodNavItemBeforeSettings[] {
+  const byPath = new Map(frameTabs.map((tab) => [tab.path, tab]));
+  const normalized = normalizeTabsOrder(
+    tabsOrder,
+    frameTabs.map((tab) => tab.path)
+  );
+  const visible = visibleTabsOrder(normalized, { includeConnectedData });
+
+  const items: PodNavItemBeforeSettings[] = [];
+  for (const entry of visible) {
+    if (isPodNavSystemTabBeforeSettings(entry)) {
+      items.push({ kind: "system", id: entry });
+      continue;
+    }
+    const tab = byPath.get(entry);
+    if (tab) {
+      items.push({ kind: "frame", tab });
+    }
+  }
+  return items;
+}
+
+/** Swap a frame with its visible neighbor (system or frame). */
+export function moveFrameTabInTabsOrder(
+  tabsOrder: string[],
+  path: string,
+  direction: "left" | "right",
+  { includeConnectedData }: { includeConnectedData: boolean }
+): string[] | null {
+  const visible = visibleTabsOrder(tabsOrder, { includeConnectedData });
+  const index = visible.indexOf(path);
+  if (index < 0) {
+    return null;
+  }
+
+  const swapWith = direction === "left" ? index - 1 : index + 1;
+  if (swapWith < 0 || swapWith >= visible.length) {
+    return null;
+  }
+
+  const a = visible[index];
+  const b = visible[swapWith];
+  const next = [...tabsOrder];
+  const ai = next.indexOf(a);
+  const bi = next.indexOf(b);
+  if (ai < 0 || bi < 0) {
+    return null;
+  }
+  next[ai] = b;
+  next[bi] = a;
+  return next;
+}
+
+export function podFrameTabBasename(path: string): string {
+  const base = path.split("/").pop() ?? path;
+  return base.replace(/\.(tsx?|jsx?)$/i, "") || base;
+}
+
+export function makePodFrameTabValue(path: string): string {
+  return `frame:${path}`;
+}
+
+export function parsePodFrameTabPath(tab: string): string | null {
+  if (!tab.startsWith("frame:")) {
+    return null;
+  }
+  const path = tab.slice("frame:".length);
+  return path.length > 0 ? path : null;
+}
+
+export function isPodFrameTabValue(tab: string): boolean {
+  return parsePodFrameTabPath(tab) !== null;
+}

--- a/front/types/project_metadata.ts
+++ b/front/types/project_metadata.ts
@@ -1,3 +1,5 @@
+import type { PodFrameTab } from "@app/types/pod_frame_tab";
+
 export interface PodMetadataType {
   sId: string;
   createdAt: number;
@@ -8,6 +10,9 @@ export interface PodMetadataType {
   todoGenerationEnabled: boolean;
   lastTodoAnalysisAt: number | null;
   pinnedFramePath: string | null;
+  frameTabs: PodFrameTab[];
+  /** System tab ids + frame paths before Settings. */
+  tabsOrder: string[];
   defaultAgentId: string | null;
   defaultSkillIds: string[];
   isAdminControlled: boolean;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -320,6 +320,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable admin-controlled Pods: admins manage membership and attach connected data (Space DataSourceViews) to the Pod itself.",
     stage: "dust_only",
   },
+  pod_frame_tabs: {
+    description:
+      "Allow adding frames from the pod file system as custom tabs (title, icon, order) on the pod.",
+    stage: "dust_only",
+  },
   group_permissions_shadow: {
     description:
       "Admin Governance: evaluate the new group_permissions checks alongside the legacy ones and log mismatches (shadow mode). Serves the legacy result; safe to toggle.",

--- a/front/types/space.ts
+++ b/front/types/space.ts
@@ -1,3 +1,5 @@
+import type { PodFrameTab } from "@app/types/pod_frame_tab";
+
 const UNIQUE_SPACE_KINDS = [
   "global", // Also known as "company data", by definition, this space is shared by all users in the workspace.
   "system", // Used for admins to configure the workspace datasources and other system-wide settings.
@@ -36,6 +38,9 @@ export type PodType = SpaceType & {
   isEditor: boolean;
   archivedAt: number | null;
   pinnedFramePath?: string | null;
+  frameTabs?: PodFrameTab[];
+  tabsOrder?: string[];
+  isAdminControlled?: boolean;
 };
 
 export type PodListItemType = PodType & {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -777,6 +777,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "self_improvement_beta_tester"
   | "legacy_billing"
   | "plan_mode"
+  | "pod_frame_tabs"
   | "skill_favorites"
   | "poke_mcp"
   | "restricted_spaces_in_input_bar"


### PR DESCRIPTION
## Description

Lets Pod editors promote any Frame file into a persistent Pod tab, visible to all members. Each tab stores a `path`, `title`, and `icon`; ordering is controlled by `frameTabsNavOrder`, an interleaved list of system tab ids and frame paths.

- `frameTabs` + `frameTabsNavOrder` JSONB columns on `project_metadata` (pre-deploy SQL migrations included). PATCH `project_metadata` validates both fields together via `validatePodFrameTabs()`, gated by the `pod_frame_tabs` FF.
- New `PodFrameTab` type module (`pod_frame_tab.ts`) with Zod schemas, nav-order helpers, URL encoding (`#frame/<encoded-path>`), and constants (`MAX_POD_FRAME_TABS`, `DEFAULT_POD_FRAME_TAB_ICON`).
- `PodFrameTabContent` renders the frame via `AuthenticatedVisualizationActionIframe`. `PodFrameTabButton` surfaces in `FrameRenderer` and `PodFrameSheet` toolbars. `PodFileExplorer` gains an "Add/Remove as Pod tab" context menu item for Frame files.
- `EditPodFrameTabDialog` lets editors rename, change icon (via `IconPicker`), reorder (left/right arrows), and remove a tab. Opens on re-click of the active frame tab in `PodPage`.
- `usePodTabs` / `useScopedUIPreferences` extended to accept `frame:<path>` tab values alongside system tabs.

<img width="1388" height="1372" alt="file-08714ce982fcf5ffb74ead30b5a9b088" src="https://github.com/user-attachments/assets/a6e2848c-5389-43b2-a436-2e68039515e7" />

<img width="531" height="229" alt="file-ab8ae0d7ed1a33c0573e89f6c93cd5cf" src="https://github.com/user-attachments/assets/5c380525-982e-4cb8-a2bf-a08540cbfecc" />

<img width="879" height="225" alt="file-76040b41b381e23f43ebddc0120349c8" src="https://github.com/user-attachments/assets/4dfab5bb-6482-4c9e-836f-97c9e9efc650" />


## Tests

- Updated `project_metadata.test.ts` and `project_metadata_resource.test.ts` to assert `frameTabs: []` and the default `frameTabsNavOrder` on fresh records.
- Updated `project_metadata.test.ts` GET snapshot to include both new fields.
- Tested locally: add/remove/reorder frame tabs, icon picker, tab navigation, flag-off fallback to conversations tab.

## Risk

Low. Both columns default to `[]` so no backfill is needed and existing rows are unaffected. The feature is fully gated by the `pod_frame_tabs` FF; no impact until the flag is enabled. `migrateLegacyFrameTabsNavOrder` handles forward compat for rows written before the nav-order column existed.

## Deploy Plan

1. Run pre-deploy
2. Deploy front
3. Enable `pod_frame_tabs` FF per workspace.
