### PR TITLE
Preempt sandbox cleanup for capacity reaping

### DIFF
--- a/front/temporal/sandbox_reaper/workflows.test.ts
+++ b/front/temporal/sandbox_reaper/workflows.test.ts
@@ -110,4 +110,53 @@ describe("sandboxReaperWorkflow", () => {
       { cursor: null, phase: "sleeping" },
     ]);
   });
+
+  it("stops maintenance when capacity work reaches its batch limit", async () => {
+    const maintenanceCursor: ReaperCursor = {
+      sandboxModelId: 30,
+      timestampMs: 3_000,
+    };
+    const capacityCursor: ReaperCursor = {
+      sandboxModelId: 40,
+      timestampMs: 4_000,
+    };
+    let killRequestedSleepingCalls = 0;
+
+    mockReapSandboxPhaseActivity.mockImplementation(
+      async ({
+        phase,
+      }: {
+        cursor: ReaperCursor | null;
+        phase: ReaperPhase;
+      }) => {
+        if (phase === "kill_requested") {
+          return makeResult(
+            killRequestedSleepingCalls > 0 ? capacityCursor : null
+          );
+        }
+        if (phase === "kill_requested_sleeping") {
+          killRequestedSleepingCalls += 1;
+          return makeResult(maintenanceCursor);
+        }
+        return makeResult(null);
+      }
+    );
+
+    await sandboxReaperWorkflow();
+
+    expect(killRequestedSleepingCalls).toBe(1);
+    expect(
+      mockReapSandboxPhaseActivity.mock.calls.some(
+        ([{ phase }]) => phase === "sleeping"
+      )
+    ).toBe(false);
+    expect(mockLogWarn).toHaveBeenCalledWith(
+      "Reaper phase reached its batch limit.",
+      expect.objectContaining({
+        phase: "kill_requested",
+        sandboxModelId: capacityCursor.sandboxModelId,
+        timestampMs: capacityCursor.timestampMs,
+      })
+    );
+  });
 });

--- a/front/temporal/sandbox_reaper/workflows.test.ts
+++ b/front/temporal/sandbox_reaper/workflows.test.ts
@@ -7,17 +7,13 @@ import { BATCH_SIZE } from "@app/temporal/sandbox_reaper/config";
 import { sandboxReaperWorkflow } from "@app/temporal/sandbox_reaper/workflows";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockLogWarn, mockPatched, mockReapSandboxPhaseActivity } = vi.hoisted(
-  () => ({
-    mockLogWarn: vi.fn(),
-    mockPatched: vi.fn(),
-    mockReapSandboxPhaseActivity: vi.fn(),
-  })
-);
+const { mockLogWarn, mockReapSandboxPhaseActivity } = vi.hoisted(() => ({
+  mockLogWarn: vi.fn(),
+  mockReapSandboxPhaseActivity: vi.fn(),
+}));
 
 vi.mock("@temporalio/workflow", () => ({
   log: { warn: mockLogWarn },
-  patched: mockPatched,
   proxyActivities: () => ({
     reapSandboxPhaseActivity: mockReapSandboxPhaseActivity,
   }),
@@ -38,7 +34,6 @@ function makeResult(
 describe("sandboxReaperWorkflow", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockPatched.mockReturnValue(true);
     mockReapSandboxPhaseActivity.mockResolvedValue(makeResult(null));
   });
 
@@ -92,22 +87,6 @@ describe("sandboxReaperWorkflow", () => {
       { cursor: maintenanceCursor, phase: "kill_requested_sleeping" },
       { cursor: null, phase: "running" },
       { cursor: null, phase: "running" },
-    ]);
-  });
-
-  it("keeps the legacy phase loop for in-flight workflows", async () => {
-    mockPatched.mockReturnValue(false);
-
-    await sandboxReaperWorkflow();
-
-    expect(
-      mockReapSandboxPhaseActivity.mock.calls.map(([input]) => input)
-    ).toEqual([
-      { cursor: null, phase: "kill_requested" },
-      { cursor: null, phase: "running" },
-      { cursor: null, phase: "pending_approval" },
-      { cursor: null, phase: "kill_requested_sleeping" },
-      { cursor: null, phase: "sleeping" },
     ]);
   });
 

--- a/front/temporal/sandbox_reaper/workflows.test.ts
+++ b/front/temporal/sandbox_reaper/workflows.test.ts
@@ -1,0 +1,113 @@
+import type {
+  ReaperCursor,
+  ReaperPhase,
+  ReapSandboxPhaseActivityResult,
+} from "@app/temporal/sandbox_reaper/activities";
+import { BATCH_SIZE } from "@app/temporal/sandbox_reaper/config";
+import { sandboxReaperWorkflow } from "@app/temporal/sandbox_reaper/workflows";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockLogWarn, mockPatched, mockReapSandboxPhaseActivity } = vi.hoisted(
+  () => ({
+    mockLogWarn: vi.fn(),
+    mockPatched: vi.fn(),
+    mockReapSandboxPhaseActivity: vi.fn(),
+  })
+);
+
+vi.mock("@temporalio/workflow", () => ({
+  log: { warn: mockLogWarn },
+  patched: mockPatched,
+  proxyActivities: () => ({
+    reapSandboxPhaseActivity: mockReapSandboxPhaseActivity,
+  }),
+}));
+
+function makeResult(
+  nextCursor: ReaperCursor | null
+): ReapSandboxPhaseActivityResult {
+  return {
+    failedCount: 0,
+    nextCursor,
+    processedCount: nextCursor ? BATCH_SIZE : 0,
+    skippedCount: 0,
+    succeededCount: nextCursor ? BATCH_SIZE : 0,
+  };
+}
+
+describe("sandboxReaperWorkflow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPatched.mockReturnValue(true);
+    mockReapSandboxPhaseActivity.mockResolvedValue(makeResult(null));
+  });
+
+  it("rechecks capacity work between maintenance batches", async () => {
+    const maintenanceCursor: ReaperCursor = {
+      sandboxModelId: 10,
+      timestampMs: 1_000,
+    };
+    const runningCursor: ReaperCursor = {
+      sandboxModelId: 20,
+      timestampMs: 2_000,
+    };
+    let runningCalls = 0;
+    let killRequestedSleepingCalls = 0;
+
+    mockReapSandboxPhaseActivity.mockImplementation(
+      async ({
+        phase,
+      }: {
+        cursor: ReaperCursor | null;
+        phase: ReaperPhase;
+      }) => {
+        if (phase === "running") {
+          runningCalls += 1;
+          return makeResult(runningCalls === 3 ? runningCursor : null);
+        }
+        if (phase === "kill_requested_sleeping") {
+          killRequestedSleepingCalls += 1;
+          return makeResult(
+            killRequestedSleepingCalls === 1 ? maintenanceCursor : null
+          );
+        }
+        return makeResult(null);
+      }
+    );
+
+    await sandboxReaperWorkflow();
+
+    const capacityAndMaintenanceCalls = mockReapSandboxPhaseActivity.mock.calls
+      .map(([input]) => input)
+      .filter(
+        ({ phase }) =>
+          phase === "running" || phase === "kill_requested_sleeping"
+      );
+    expect(capacityAndMaintenanceCalls).toEqual([
+      { cursor: null, phase: "running" },
+      { cursor: null, phase: "running" },
+      { cursor: null, phase: "kill_requested_sleeping" },
+      { cursor: null, phase: "running" },
+      { cursor: runningCursor, phase: "running" },
+      { cursor: maintenanceCursor, phase: "kill_requested_sleeping" },
+      { cursor: null, phase: "running" },
+      { cursor: null, phase: "running" },
+    ]);
+  });
+
+  it("keeps the legacy phase loop for in-flight workflows", async () => {
+    mockPatched.mockReturnValue(false);
+
+    await sandboxReaperWorkflow();
+
+    expect(
+      mockReapSandboxPhaseActivity.mock.calls.map(([input]) => input)
+    ).toEqual([
+      { cursor: null, phase: "kill_requested" },
+      { cursor: null, phase: "running" },
+      { cursor: null, phase: "pending_approval" },
+      { cursor: null, phase: "kill_requested_sleeping" },
+      { cursor: null, phase: "sleeping" },
+    ]);
+  });
+});

--- a/front/temporal/sandbox_reaper/workflows.ts
+++ b/front/temporal/sandbox_reaper/workflows.ts
@@ -3,7 +3,7 @@ import type {
   ReaperCursor,
   ReaperPhase,
 } from "@app/temporal/sandbox_reaper/activities";
-import { log, patched, proxyActivities } from "@temporalio/workflow";
+import { log, proxyActivities } from "@temporalio/workflow";
 
 const { reapSandboxPhaseActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
@@ -12,16 +12,6 @@ const { reapSandboxPhaseActivity } = proxyActivities<typeof activities>({
     maximumAttempts: 3,
   },
 });
-
-// Legacy phase order, kept for replay of workflows that started before the
-// preemptible maintenance patch.
-const LEGACY_REAPER_PHASES = [
-  "kill_requested",
-  "running",
-  "pending_approval",
-  "kill_requested_sleeping",
-  "sleeping",
-] satisfies ReaperPhase[];
 
 // These phases free E2B concurrency and must preempt maintenance work.
 const CAPACITY_PHASES = ["kill_requested", "running"] satisfies ReaperPhase[];
@@ -83,13 +73,7 @@ async function drainCapacityPhases(): Promise<boolean> {
   return true;
 }
 
-async function runLegacyReaperWorkflow(): Promise<void> {
-  for (const phase of LEGACY_REAPER_PHASES) {
-    await drainPhase(phase);
-  }
-}
-
-async function runPreemptibleReaperWorkflow(): Promise<void> {
+export async function sandboxReaperWorkflow(): Promise<void> {
   const capacityFullyDrained = await drainCapacityPhases();
   if (!capacityFullyDrained) {
     return;
@@ -121,22 +105,6 @@ async function runPreemptibleReaperWorkflow(): Promise<void> {
       logPhaseBatchLimit(phase, cursor, MAX_BATCHES_PER_PHASE);
     }
   }
-}
-
-export async function sandboxReaperWorkflow(): Promise<void> {
-  // Patch lifecycle for preemptible maintenance:
-  // 1. Now: in-flight executions replay the legacy phase loop.
-  // 2. Once every history produced without this marker has left retention and
-  //    every worker runs this version, replace patched() with deprecatePatch()
-  //    and remove runLegacyReaperWorkflow and LEGACY_REAPER_PHASES.
-  // 3. Once every live run was produced by the deprecatePatch() version,
-  //    remove deprecatePatch() and the patch marker.
-  if (!patched("sandbox-reaper-preemptible-maintenance")) {
-    await runLegacyReaperWorkflow();
-    return;
-  }
-
-  await runPreemptibleReaperWorkflow();
 }
 
 export { sandboxKillRequesterWorkflow } from "./kill_requester/workflows";

--- a/front/temporal/sandbox_reaper/workflows.ts
+++ b/front/temporal/sandbox_reaper/workflows.ts
@@ -3,7 +3,7 @@ import type {
   ReaperCursor,
   ReaperPhase,
 } from "@app/temporal/sandbox_reaper/activities";
-import { log, proxyActivities } from "@temporalio/workflow";
+import { log, patched, proxyActivities } from "@temporalio/workflow";
 
 const { reapSandboxPhaseActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
@@ -13,15 +13,9 @@ const { reapSandboxPhaseActivity } = proxyActivities<typeof activities>({
   },
 });
 
-// Priority order: concurrency-freeing work first, then storage cleanup.
-// Awake kill-requested sandboxes burn E2B capacity and sit on the user
-// recreate path, so they are destroyed first. Stale running sandboxes are
-// paused next (same concurrency win, non-destructive). pending_approval is
-// cheap DB-only bookkeeping (already paused). Kill-requested sleepers are
-// storage/rollout cleanup ahead of cold sleeping destroy - they free no
-// concurrency, but taking the provider destroy off ensureActive is hotter
-// than 4-day-stale sleepers.
-const REAPER_PHASES = [
+// Legacy phase order, kept for replay of workflows that started before the
+// preemptible maintenance patch.
+const LEGACY_REAPER_PHASES = [
   "kill_requested",
   "running",
   "pending_approval",
@@ -29,34 +23,118 @@ const REAPER_PHASES = [
   "sleeping",
 ] satisfies ReaperPhase[];
 
+// These phases free E2B concurrency and must preempt maintenance work.
+const CAPACITY_PHASES = ["kill_requested", "running"] satisfies ReaperPhase[];
+
+// These phases operate on sandboxes that are already paused. Process one batch
+// at a time so newly stale running sandboxes never wait behind a full cleanup
+// sweep.
+const MAINTENANCE_PHASES = [
+  "pending_approval",
+  "kill_requested_sleeping",
+  "sleeping",
+] satisfies ReaperPhase[];
+
 const MAX_BATCHES_PER_PHASE = 200;
 
-export async function sandboxReaperWorkflow(): Promise<void> {
-  for (const phase of REAPER_PHASES) {
-    let cursor: ReaperCursor | null = null;
-    let processedBatches = 0;
+function logPhaseBatchLimit(
+  phase: ReaperPhase,
+  cursor: ReaperCursor,
+  processedBatches: number
+): void {
+  log.warn("Reaper phase reached its batch limit.", {
+    phase,
+    processedBatches,
+    sandboxModelId: cursor.sandboxModelId,
+    timestampMs: cursor.timestampMs,
+  });
+}
 
-    while (processedBatches < MAX_BATCHES_PER_PHASE) {
+async function drainPhase(phase: ReaperPhase): Promise<boolean> {
+  let cursor: ReaperCursor | null = null;
+
+  for (
+    let processedBatches = 0;
+    processedBatches < MAX_BATCHES_PER_PHASE;
+    processedBatches += 1
+  ) {
+    const result: activities.ReapSandboxPhaseActivityResult =
+      await reapSandboxPhaseActivity({ cursor, phase });
+
+    if (!result.nextCursor) {
+      return true;
+    }
+    cursor = result.nextCursor;
+  }
+
+  if (cursor) {
+    logPhaseBatchLimit(phase, cursor, MAX_BATCHES_PER_PHASE);
+  }
+  return false;
+}
+
+async function drainCapacityPhases(): Promise<boolean> {
+  for (const phase of CAPACITY_PHASES) {
+    const fullyDrained = await drainPhase(phase);
+    if (!fullyDrained) {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function runLegacyReaperWorkflow(): Promise<void> {
+  for (const phase of LEGACY_REAPER_PHASES) {
+    await drainPhase(phase);
+  }
+}
+
+async function runPreemptibleReaperWorkflow(): Promise<void> {
+  const capacityFullyDrained = await drainCapacityPhases();
+  if (!capacityFullyDrained) {
+    return;
+  }
+
+  for (const phase of MAINTENANCE_PHASES) {
+    let cursor: ReaperCursor | null = null;
+
+    for (
+      let processedBatches = 0;
+      processedBatches < MAX_BATCHES_PER_PHASE;
+      processedBatches += 1
+    ) {
       const result: activities.ReapSandboxPhaseActivityResult =
         await reapSandboxPhaseActivity({ cursor, phase });
-      processedBatches += 1;
+      cursor = result.nextCursor;
 
-      if (!result.nextCursor) {
-        cursor = null;
+      const capacityFullyDrained = await drainCapacityPhases();
+      if (!capacityFullyDrained) {
+        return;
+      }
+
+      if (!cursor) {
         break;
       }
-      cursor = result.nextCursor;
     }
 
     if (cursor) {
-      log.warn("Reaper phase reached its batch limit.", {
-        phase,
-        processedBatches,
-        sandboxModelId: cursor.sandboxModelId,
-        timestampMs: cursor.timestampMs,
-      });
+      logPhaseBatchLimit(phase, cursor, MAX_BATCHES_PER_PHASE);
     }
   }
+}
+
+export async function sandboxReaperWorkflow(): Promise<void> {
+  // Patch lifecycle for preemptible maintenance:
+  // 1. Now: in-flight executions replay the legacy phase loop.
+  // 2. After 2026-08-18: replace patched() with deprecatePatch() and remove
+  //    runLegacyReaperWorkflow and LEGACY_REAPER_PHASES.
+  // 3. After 2026-09-01: remove deprecatePatch() and the patch marker.
+  if (!patched("sandbox-reaper-preemptible-maintenance")) {
+    await runLegacyReaperWorkflow();
+    return;
+  }
+
+  await runPreemptibleReaperWorkflow();
 }
 
 export { sandboxKillRequesterWorkflow } from "./kill_requester/workflows";

--- a/front/temporal/sandbox_reaper/workflows.ts
+++ b/front/temporal/sandbox_reaper/workflows.ts
@@ -126,9 +126,11 @@ async function runPreemptibleReaperWorkflow(): Promise<void> {
 export async function sandboxReaperWorkflow(): Promise<void> {
   // Patch lifecycle for preemptible maintenance:
   // 1. Now: in-flight executions replay the legacy phase loop.
-  // 2. After 2026-08-18: replace patched() with deprecatePatch() and remove
-  //    runLegacyReaperWorkflow and LEGACY_REAPER_PHASES.
-  // 3. After 2026-09-01: remove deprecatePatch() and the patch marker.
+  // 2. Once every history produced without this marker has left retention and
+  //    every worker runs this version, replace patched() with deprecatePatch()
+  //    and remove runLegacyReaperWorkflow and LEGACY_REAPER_PHASES.
+  // 3. Once every live run was produced by the deprecatePatch() version,
+  //    remove deprecatePatch() and the patch marker.
   if (!patched("sandbox-reaper-preemptible-maintenance")) {
     await runLegacyReaperWorkflow();
     return;


### PR DESCRIPTION
## Description

Large image cleanup sweeps kept the serial sandbox reaper in paused-sandbox maintenance for about 40 minutes. Scheduled overlaps were skipped, so newly stale running sandboxes accumulated until the sweep finished.

Recheck and fully drain awake kill requests and stale running sandboxes after every maintenance batch. Preserve maintenance cursors across those priority checks. The workflow intentionally has no replay compatibility path because the open executions will be terminated during deployment.

## Tests

Added workflow coverage for priority preemption, cursor preservation, and priority batch-cap handling. Ran the sandbox reaper workflow and activity test suites locally.

## Risk

The runtime behavior change is low risk, but the Temporal deployment requires a coordinated cutover in both clusters. Existing sandbox reaper histories are incompatible with the new command sequence and must not continue on new workers.

## Deploy Plan

1. Pause the sandbox reaper schedules in both US and EU.
2. Before rolling out the new workers, terminate every open sandbox reaper workflow in both clusters.
3. Deploy the new workers.
4. Immediately start one sandbox reaper workflow in each cluster and verify that capacity phases run between maintenance batches.
5. Resume both schedules and verify that concurrency continues to drain.

For rollback, pause both schedules and terminate every open reaper started on the new code before deploying the previous worker version, then start fresh reapers and resume the schedules.