### PR TITLE
Normalize credit attribution through model input

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -6943,7 +6943,7 @@
     "/api/w/{wId}/assistant/conversations/{cId}/messages/{mId}/consumption": {
       "get": {
         "summary": "Get an agent message credit attribution",
-        "description": "Returns the exact billed credits and, when available, an estimated cache-naive attribution grouped into agent work and tools.",
+        "description": "Returns exact billed credits and an additive attribution reconciled exclusively through model input rows.",
         "tags": [
           "Private Messages"
         ],
@@ -6998,11 +6998,9 @@
                     "details": {
                       "type": "object",
                       "nullable": true,
-                      "description": "Cache-naive estimated attribution. Null when the active attribution version is unavailable or incomplete.",
+                      "description": "Additive attribution reconciled to the bill through model input rows. Null when the active attribution version is unavailable or incomplete.",
                       "required": [
                         "attributionVersion",
-                        "grossAttributedCredits",
-                        "estimatedCacheSavingsCredits",
                         "agentWorkCredits",
                         "tools"
                       ],
@@ -7010,15 +7008,9 @@
                         "attributionVersion": {
                           "type": "integer"
                         },
-                        "grossAttributedCredits": {
-                          "type": "number"
-                        },
-                        "estimatedCacheSavingsCredits": {
-                          "type": "number",
-                          "nullable": true
-                        },
                         "agentWorkCredits": {
-                          "type": "number"
+                          "type": "number",
+                          "description": "Agent work after assigning billing reconciliation exclusively to model input rows."
                         },
                         "tools": {
                           "type": "array",
@@ -7029,7 +7021,7 @@
                               "internalMCPServerName",
                               "toolName",
                               "callCount",
-                              "grossAttributedCredits",
+                              "attributedCredits",
                               "directCredits",
                               "pending"
                             ],
@@ -7047,8 +7039,9 @@
                               "callCount": {
                                 "type": "integer"
                               },
-                              "grossAttributedCredits": {
-                                "type": "number"
+                              "attributedCredits": {
+                                "type": "number",
+                                "description": "Share of billed credits after input-only reconciliation."
                               },
                               "directCredits": {
                                 "type": "number"

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/consumption.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/consumption.test.ts
@@ -1,8 +1,11 @@
+import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
+import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { RunFactory } from "@app/tests/utils/RunFactory";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
@@ -17,21 +20,34 @@ async function setupMessage() {
     auth,
     { name: "Consumption endpoint" }
   );
-  const conversation = await ConversationFactory.create(auth, {
+  const createdConversation = await ConversationFactory.create(auth, {
     agentConfigurationId: agentConfiguration.sId,
     messagesCreatedAt: [],
+  });
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    createdConversation.sId
+  );
+  if (!conversation) {
+    throw new Error("Just-created conversation not found.");
+  }
+  const { run, runUsageModelId } = await RunFactory.createWithUsage(auth, {
+    inputTokens: 100,
+    outputTokens: 20,
+    reasoningTokens: 5,
   });
   const { agentMessage } = await ConversationFactory.createAgentMessage(auth, {
     workspace,
     conversation,
     agentConfig: agentConfiguration,
+    runIds: [run.dustRunId],
   });
   await ConversationResource.updateAgentMessageCostCredits(auth, {
     agentMessageModelId: agentMessage.agentMessageId,
     costCredits: BILLED_CREDITS,
   });
 
-  return { auth, workspace, conversation, agentMessage };
+  return { auth, workspace, conversation, agentMessage, runUsageModelId };
 }
 
 function getConsumption({
@@ -64,6 +80,52 @@ describe("GET /api/w/:wId/assistant/conversations/:cId/messages/:mId/consumption
     await expect(response.json()).resolves.toEqual({
       billedCredits: BILLED_CREDITS,
       details: null,
+    });
+  });
+
+  it("returns a breakdown reconciled exclusively through model input", async () => {
+    const { auth, workspace, conversation, agentMessage, runUsageModelId } =
+      await setupMessage();
+    await FeatureFlagFactory.basic(auth, "conversation_consumption_details");
+    await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+      conversation,
+      agentMessageModelId: agentMessage.agentMessageId,
+      attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+      records: [
+        {
+          itemType: "input",
+          runUsageModelId,
+          inputTokensCount: 100,
+          grossAttributedCreditAmountMicro: 8_000_000,
+        },
+        {
+          itemType: "output",
+          runUsageModelId,
+          outputTokensCount: 15,
+          grossAttributedCreditAmountMicro: 1_000_000,
+        },
+        {
+          itemType: "reasoning",
+          runUsageModelId,
+          outputTokensCount: 5,
+          grossAttributedCreditAmountMicro: 1_000_000,
+        },
+      ],
+      pendingToolItems: [],
+    });
+
+    const response = await getConsumption({
+      workspaceId: workspace.sId,
+      conversationId: conversation.sId,
+      messageId: agentMessage.sId,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      billedCredits: BILLED_CREDITS,
+      details: {
+        agentWorkCredits: BILLED_CREDITS,
+      },
     });
   });
 

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/consumption.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/consumption.ts
@@ -22,7 +22,7 @@ app.use(withFeatureFlag("conversation_consumption_details"));
  * /api/w/{wId}/assistant/conversations/{cId}/messages/{mId}/consumption:
  *   get:
  *     summary: Get an agent message credit attribution
- *     description: Returns the exact billed credits and, when available, an estimated cache-naive attribution grouped into agent work and tools.
+ *     description: Returns exact billed credits and an additive attribution reconciled exclusively through model input rows.
  *     tags:
  *       - Private Messages
  *     parameters:
@@ -61,23 +61,17 @@ app.use(withFeatureFlag("conversation_consumption_details"));
  *                 details:
  *                   type: object
  *                   nullable: true
- *                   description: Cache-naive estimated attribution. Null when the active attribution version is unavailable or incomplete.
+ *                   description: Additive attribution reconciled to the bill through model input rows. Null when the active attribution version is unavailable or incomplete.
  *                   required:
  *                     - attributionVersion
- *                     - grossAttributedCredits
- *                     - estimatedCacheSavingsCredits
  *                     - agentWorkCredits
  *                     - tools
  *                   properties:
  *                     attributionVersion:
  *                       type: integer
- *                     grossAttributedCredits:
- *                       type: number
- *                     estimatedCacheSavingsCredits:
- *                       type: number
- *                       nullable: true
  *                     agentWorkCredits:
  *                       type: number
+ *                       description: Agent work after assigning billing reconciliation exclusively to model input rows.
  *                     tools:
  *                       type: array
  *                       items:
@@ -87,7 +81,7 @@ app.use(withFeatureFlag("conversation_consumption_details"));
  *                           - internalMCPServerName
  *                           - toolName
  *                           - callCount
- *                           - grossAttributedCredits
+ *                           - attributedCredits
  *                           - directCredits
  *                           - pending
  *                         properties:
@@ -100,8 +94,9 @@ app.use(withFeatureFlag("conversation_consumption_details"));
  *                             type: string
  *                           callCount:
  *                             type: integer
- *                           grossAttributedCredits:
+ *                           attributedCredits:
  *                             type: number
+ *                             description: Share of billed credits after input-only reconciliation.
  *                           directCredits:
  *                             type: number
  *                           pending:

--- a/front-api/routes/w/[wId]/auth-context.ts
+++ b/front-api/routes/w/[wId]/auth-context.ts
@@ -1,4 +1,3 @@
-import config from "@app/lib/api/config";
 import { getWorkspaceRegionRedirect } from "@app/lib/api/regions/lookup";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { isWorkspaceEligibleForTrial } from "@app/lib/plans/trial";
@@ -79,7 +78,7 @@ app.get(
       isManager: auth.isManager(),
       featureFlags,
       ...(isEligibleForTrial !== undefined && { isEligibleForTrial }),
-      vizUrl: config.getVizPublicUrl(),
+      vizUrl: "http://localhost:3007", // config.getVizPublicUrl(),
       providersHealth: auth.providersHealth(),
       workspacePermissions,
     });

--- a/front-api/routes/w/[wId]/auth-context.ts
+++ b/front-api/routes/w/[wId]/auth-context.ts
@@ -78,7 +78,7 @@ app.get(
       isManager: auth.isManager(),
       featureFlags,
       ...(isEligibleForTrial !== undefined && { isEligibleForTrial }),
-      vizUrl: "http://localhost:3007", // config.getVizPublicUrl(),
+      vizUrl: config.getVizPublicUrl(),
       providersHealth: auth.providersHealth(),
       workspacePermissions,
     });

--- a/front/components/assistant/conversation/CreditCostSubmenu.test.tsx
+++ b/front/components/assistant/conversation/CreditCostSubmenu.test.tsx
@@ -70,14 +70,14 @@ vi.mock("@dust-tt/sparkle", () => ({
 const makeTool = (
   toolName: string,
   label: string,
-  grossAttributedCredits: number,
+  attributedCredits: number,
   overrides: Partial<AgentMessageConsumptionToolDetails> = {}
 ): AgentMessageConsumptionToolDetails => ({
   label,
   internalMCPServerName: null,
   toolName,
   callCount: 1,
-  grossAttributedCredits,
+  attributedCredits,
   directCredits: 0,
   pending: false,
   ...overrides,
@@ -103,8 +103,6 @@ describe("CreditCostSubmenu", () => {
         billedCredits: 12,
         details: {
           attributionVersion: 2,
-          grossAttributedCredits: 22,
-          estimatedCacheSavingsCredits: 2,
           agentWorkCredits: 4,
           tools: [
             makeTool("files", "File tool", 2),
@@ -129,7 +127,7 @@ describe("CreditCostSubmenu", () => {
     expect(screen.queryByText("Title tool")).not.toBeInTheDocument();
     expect(screen.getByText("Other tools")).toBeInTheDocument();
     expect(screen.getByText("2 tools, 2 uses")).toBeInTheDocument();
-    expect(screen.getByText("Saved through reuse")).toBeInTheDocument();
+    expect(screen.getByText("Credit breakdown")).toBeInTheDocument();
     expect(screen.getByText("Agent work and context")).toBeInTheDocument();
     expect(
       screen.getByText("Longer conversations require more context to process")
@@ -140,6 +138,32 @@ describe("CreditCostSubmenu", () => {
       "data-disabled",
       "true"
     );
+  });
+
+  it("shows an additive breakdown without a separate savings adjustment", () => {
+    mockUseAgentMessageConsumption.mockReturnValue({
+      consumption: {
+        billedCredits: 10,
+        details: {
+          attributionVersion: 3,
+          agentWorkCredits: 3,
+          tools: [
+            makeTool("search", "Semantic Search", 7, {
+              directCredits: 3,
+            }),
+          ],
+        },
+      },
+      isConsumptionLoading: false,
+      mutateConsumption: vi.fn(),
+    });
+
+    render(<CreditCostSubmenu {...defaultProps} />);
+
+    expect(screen.getByText("Credit breakdown")).toBeInTheDocument();
+    expect(screen.queryByText("Saved through reuse")).not.toBeInTheDocument();
+    expect(screen.getByText("3 credits")).toBeInTheDocument();
+    expect(screen.getByText("7 credits")).toBeInTheDocument();
   });
 
   it("keeps the exact charge visible when attribution details are unavailable", () => {

--- a/front/components/assistant/conversation/CreditCostSubmenu.tsx
+++ b/front/components/assistant/conversation/CreditCostSubmenu.tsx
@@ -116,14 +116,13 @@ export function CreditCostSubmenu({
 
   const rankedTools = details
     ? [...details.tools].sort(
-        (left, right) =>
-          right.grossAttributedCredits - left.grossAttributedCredits
+        (left, right) => right.attributedCredits - left.attributedCredits
       )
     : [];
   const visibleTools = rankedTools.slice(0, MAX_VISIBLE_TOOLS);
   const remainingTools = rankedTools.slice(MAX_VISIBLE_TOOLS);
   const remainingToolCredits = remainingTools.reduce(
-    (total, tool) => total + tool.grossAttributedCredits,
+    (total, tool) => total + tool.attributedCredits,
     0
   );
   const remainingToolCallCount = remainingTools.reduce(
@@ -173,7 +172,7 @@ export function CreditCostSubmenu({
             />
           )}
           <DropdownMenuSeparator />
-          <DropdownMenuLabel label="Estimated work before savings" />
+          <DropdownMenuLabel label="Credit breakdown" />
           {isConsumptionLoading && !consumption ? (
             <div
               aria-busy="true"
@@ -196,7 +195,7 @@ export function CreditCostSubmenu({
                   key={`${tool.internalMCPServerName ?? "external"}:${tool.toolName}:${tool.label}`}
                   label={tool.label}
                   description={toolDescription(tool)}
-                  value={formatCreditValue(tool.grossAttributedCredits)}
+                  value={formatCreditValue(tool.attributedCredits)}
                   icon={getActionStepIcon(tool)}
                 />
               ))}
@@ -208,13 +207,6 @@ export function CreditCostSubmenu({
                   icon={ShapesPlus}
                 />
               )}
-              {details.estimatedCacheSavingsCredits !== null &&
-                details.estimatedCacheSavingsCredits > 0 && (
-                  <ReadonlyCostItem
-                    label="Saved through reuse"
-                    value={`−${formatCreditValue(details.estimatedCacheSavingsCredits)}`}
-                  />
-                )}
             </>
           ) : (
             <ReadonlyNotice

--- a/front/lib/api/assistant/agent_message_consumption_attribution/message_details.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/message_details.ts
@@ -1,0 +1,437 @@
+import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
+import { getToolAggregateDisplayLabel } from "@app/lib/actions/tool_display_labels";
+import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
+import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
+import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import type { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
+import type { RunResource } from "@app/lib/resources/run_resource";
+import type { AgentMCPActionType } from "@app/types/actions";
+import type {
+  AgentMessageConsumptionDetails,
+  AgentMessageConsumptionModelDetails,
+} from "@app/types/assistant/agent_message_consumption";
+import type { ModelId } from "@app/types/shared/model_id";
+
+const MICRO_CREDITS_PER_CREDIT = 1_000_000;
+
+type RunUsages = Awaited<ReturnType<typeof RunResource.listRunUsagesForRuns>>;
+
+export type MessageConsumptionDetails = AgentMessageConsumptionDetails & {
+  models: AgentMessageConsumptionModelDetails[];
+};
+
+function creditsFromMicroCredits(microCredits: number): number {
+  return microCredits / MICRO_CREDITS_PER_CREDIT;
+}
+
+type ReconciledCreditAmounts = {
+  byItem: ReadonlyMap<AgentMessageConsumptionItemResource, number>;
+};
+
+/**
+ * Makes the attribution additive with the authoritative bill without changing stored evidence.
+ *
+ * Tool rows already represent the causal first-use cost of emitting a tool call and carrying its
+ * new result into the next model input. We keep every non-input attribution unchanged. The model's
+ * ordinary `input` bucket contains reused conversation context, so it is the single explicit
+ * reconciliation seam.
+ *
+ * Multiple input rows share the reconciled input total in proportion to their cache-naive cost.
+ * Allocation happens in integer micro-credits and assigns rounding remainders deterministically in
+ * input order. If the non-input evidence alone exceeds the bill, no input-only reconciliation is
+ * possible and the detailed breakdown is withheld.
+ */
+function reconcileInputCredits({
+  items,
+  billedCredits,
+}: {
+  items: AgentMessageConsumptionItemResource[];
+  billedCredits: number;
+}): ReconciledCreditAmounts | null {
+  const billedCreditAmountMicro = Math.round(
+    billedCredits * MICRO_CREDITS_PER_CREDIT
+  );
+  const inputItems = items.filter((item) => item.itemType === "input");
+  const nonInputCreditAmountMicro = items.reduce(
+    (total, item) =>
+      item.itemType === "input"
+        ? total
+        : total + item.grossAttributedCreditAmountMicro,
+    0
+  );
+  // Non-input rows stay fixed, so input absorbs the difference from the bill.
+  const reconciledInputCreditAmountMicro =
+    billedCreditAmountMicro - nonInputCreditAmountMicro;
+  if (reconciledInputCreditAmountMicro < 0) {
+    return null;
+  }
+
+  const grossInputCreditAmountMicro = inputItems.reduce(
+    (total, item) => total + item.grossAttributedCreditAmountMicro,
+    0
+  );
+  // A positive input total cannot be allocated without any input weight.
+  if (grossInputCreditAmountMicro === 0) {
+    return reconciledInputCreditAmountMicro === 0
+      ? {
+          byItem: new Map(
+            items.map((item) => [item, item.grossAttributedCreditAmountMicro])
+          ),
+        }
+      : null;
+  }
+
+  // Preserve the relative weight of the cache-naive input rows.
+  const inputAllocations = inputItems.map((item, index) => {
+    const exactMicro =
+      (item.grossAttributedCreditAmountMicro *
+        reconciledInputCreditAmountMicro) /
+      grossInputCreditAmountMicro;
+    const floorMicro = Math.floor(exactMicro);
+
+    return {
+      item,
+      index,
+      floorMicro,
+      fractionalMicro: exactMicro - floorMicro,
+    };
+  });
+  const allocatedFloorMicro = inputAllocations.reduce(
+    (total, allocation) => total + allocation.floorMicro,
+    0
+  );
+  const remainderMicro = reconciledInputCreditAmountMicro - allocatedFloorMicro;
+
+  // Largest remainders and then source order make integer allocation deterministic.
+  const allocationsReceivingRemainder = new Set(
+    [...inputAllocations]
+      .sort(
+        (left, right) =>
+          right.fractionalMicro - left.fractionalMicro ||
+          left.index - right.index
+      )
+      .slice(0, remainderMicro)
+      .map(({ item }) => item)
+  );
+  const reconciledInputCreditAmountByItem = new Map(
+    inputAllocations.map(({ item, floorMicro }) => [
+      item,
+      floorMicro + (allocationsReceivingRemainder.has(item) ? 1 : 0),
+    ])
+  );
+
+  return {
+    byItem: new Map(
+      items.map((item) => [
+        item,
+        item.itemType === "input"
+          ? (reconciledInputCreditAmountByItem.get(item) ?? 0)
+          : item.grossAttributedCreditAmountMicro,
+      ])
+    ),
+  };
+}
+
+function buildConsumptionTotals({
+  items,
+  reconciledCreditAmounts,
+}: {
+  items: AgentMessageConsumptionItemResource[];
+  reconciledCreditAmounts: ReconciledCreditAmounts;
+}): {
+  agentWorkCredits: number;
+} {
+  const reconciledAgentWorkCreditAmountMicro = items.reduce(
+    (total, item) =>
+      item.itemType === "tool"
+        ? total
+        : total + (reconciledCreditAmounts.byItem.get(item) ?? 0),
+    0
+  );
+  return {
+    agentWorkCredits: creditsFromMicroCredits(
+      reconciledAgentWorkCreditAmountMicro
+    ),
+  };
+}
+
+/** Ensures every provider-reported model bucket has a row for the active attribution version. */
+function hasCompleteModelAttribution(
+  items: AgentMessageConsumptionItemResource[],
+  usages: RunUsages
+): boolean {
+  const itemTypesByRunUsageModelId = new Map<ModelId, Set<string>>();
+
+  for (const item of items) {
+    if (item.itemType === "tool" || item.runUsageId === null) {
+      continue;
+    }
+
+    const itemTypes =
+      itemTypesByRunUsageModelId.get(item.runUsageId) ?? new Set();
+    itemTypes.add(item.itemType);
+    itemTypesByRunUsageModelId.set(item.runUsageId, itemTypes);
+  }
+
+  return usages.every((usage) => {
+    const itemTypes = itemTypesByRunUsageModelId.get(usage.runUsageModelId);
+    return (
+      itemTypes?.has("input") === true &&
+      itemTypes.has("output") &&
+      (usage.reasoningTokens === null || itemTypes.has("reasoning"))
+    );
+  });
+}
+
+/** Ensures every attributable action has a row and every settled action has final evidence. */
+function hasCompleteToolAttribution({
+  actions,
+  items,
+  dustRunIdsWithUsage,
+}: {
+  actions: AgentMCPActionResource[];
+  items: AgentMessageConsumptionItemResource[];
+  dustRunIdsWithUsage: Set<string>;
+}): boolean {
+  const toolItemByActionModelId = new Map<
+    ModelId,
+    AgentMessageConsumptionItemResource
+  >();
+  for (const item of items) {
+    if (item.itemType === "tool" && item.agentMCPActionId !== null) {
+      toolItemByActionModelId.set(item.agentMCPActionId, item);
+    }
+  }
+  const actionModelIds = new Set(actions.map((action) => action.id));
+
+  for (const actionModelId of toolItemByActionModelId.keys()) {
+    if (!actionModelIds.has(actionModelId)) {
+      return false;
+    }
+  }
+
+  for (const action of actions) {
+    const dustRunId = action.stepContent.dustRunId;
+    if (!dustRunId || !dustRunIdsWithUsage.has(dustRunId)) {
+      continue;
+    }
+
+    const item = toolItemByActionModelId.get(action.id);
+    if (!item) {
+      return false;
+    }
+    if (
+      isToolExecutionStatusFinal(action.status) &&
+      item.completedAt === null
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function toolIdentity(action: AgentMCPActionType): string {
+  const serverIdentity =
+    action.mcpServerId ??
+    action.internalMCPServerName ??
+    action.functionCallName;
+
+  return `${serverIdentity}:${action.toolName}`;
+}
+
+/** Groups repeated executions by tool identity while preserving first-use display order. */
+function buildToolDetails({
+  actions,
+  items,
+  reconciledCreditAmounts,
+}: {
+  actions: AgentMCPActionResource[];
+  items: AgentMessageConsumptionItemResource[];
+  reconciledCreditAmounts: ReconciledCreditAmounts;
+}): MessageConsumptionDetails["tools"] | null {
+  const actionByModelId = new Map(actions.map((action) => [action.id, action]));
+  const groupedTools = new Map<
+    string,
+    MessageConsumptionDetails["tools"][number] & { firstStep: number }
+  >();
+
+  for (const item of items) {
+    if (item.itemType !== "tool" || item.agentMCPActionId === null) {
+      continue;
+    }
+
+    const action = actionByModelId.get(item.agentMCPActionId);
+    if (!action) {
+      return null;
+    }
+
+    const serialized = action.toJSON();
+    const identity = toolIdentity(serialized);
+    const current = groupedTools.get(identity);
+    const attributedCredits = creditsFromMicroCredits(
+      reconciledCreditAmounts.byItem.get(item) ?? 0
+    );
+    const directCredits = creditsFromMicroCredits(
+      item.directCreditAmountMicro ?? 0
+    );
+
+    if (current) {
+      groupedTools.set(identity, {
+        ...current,
+        callCount: current.callCount + 1,
+        attributedCredits: current.attributedCredits + attributedCredits,
+        directCredits: current.directCredits + directCredits,
+        pending: current.pending || item.completedAt === null,
+        firstStep: Math.min(current.firstStep, serialized.step),
+      });
+      continue;
+    }
+
+    groupedTools.set(identity, {
+      label: getToolAggregateDisplayLabel(serialized),
+      internalMCPServerName: serialized.internalMCPServerName,
+      toolName: serialized.toolName,
+      callCount: 1,
+      attributedCredits,
+      directCredits,
+      pending: item.completedAt === null,
+      firstStep: serialized.step,
+    });
+  }
+
+  return [...groupedTools.values()]
+    .sort((left, right) => left.firstStep - right.firstStep)
+    .map(({ firstStep: _firstStep, ...tool }) => tool);
+}
+
+function buildModelDetails({
+  items,
+  usages,
+  reconciledCreditAmounts,
+}: {
+  items: AgentMessageConsumptionItemResource[];
+  usages: RunUsages;
+  reconciledCreditAmounts: ReconciledCreditAmounts;
+}): MessageConsumptionDetails["models"] {
+  const usageByModelId = new Map(
+    usages.map((usage) => [usage.runUsageModelId, usage])
+  );
+  const models = new Map<string, MessageConsumptionDetails["models"][number]>();
+
+  for (const item of items) {
+    if (item.runUsageId === null) {
+      continue;
+    }
+
+    const usage = usageByModelId.get(item.runUsageId);
+    if (!usage) {
+      continue;
+    }
+
+    const key = `${usage.providerId}:${usage.modelId}`;
+    const attributedCredits = creditsFromMicroCredits(
+      reconciledCreditAmounts.byItem.get(item) ?? 0
+    );
+    const existing = models.get(key);
+    if (existing) {
+      existing.attributedCredits += attributedCredits;
+      continue;
+    }
+
+    models.set(key, {
+      providerId: usage.providerId,
+      modelId: usage.modelId,
+      displayName:
+        getModelConfigByModelId(usage.modelId)?.displayName ?? usage.modelId,
+      attributedCredits,
+    });
+  }
+
+  return [...models.values()].sort(
+    (left, right) => right.attributedCredits - left.attributedCredits
+  );
+}
+
+export function buildMessageConsumptionDetails({
+  actions,
+  billedCredits,
+  dustRunIds,
+  items,
+  runs,
+  usages,
+}: {
+  actions: AgentMCPActionResource[];
+  billedCredits: number | null;
+  dustRunIds: string[];
+  items: AgentMessageConsumptionItemResource[];
+  runs: RunResource[];
+  usages: RunUsages;
+}): MessageConsumptionDetails | null {
+  if (billedCredits === null || items.length === 0 || dustRunIds.length === 0) {
+    return null;
+  }
+
+  const dustRunIdSet = new Set(dustRunIds);
+  const messageRunModelIds = new Set(
+    runs.filter((run) => dustRunIdSet.has(run.dustRunId)).map((run) => run.id)
+  );
+  const messageUsages = usages.filter((usage) =>
+    messageRunModelIds.has(usage.runModelId)
+  );
+  if (messageUsages.length === 0) {
+    return null;
+  }
+
+  const dustRunIdByRunModelId = new Map(
+    runs.map((run) => [run.id, run.dustRunId])
+  );
+  const dustRunIdsWithUsage = new Set(
+    messageUsages.flatMap((usage) => {
+      const dustRunId = dustRunIdByRunModelId.get(usage.runModelId);
+      return dustRunId ? [dustRunId] : [];
+    })
+  );
+
+  if (
+    !hasCompleteModelAttribution(items, messageUsages) ||
+    !hasCompleteToolAttribution({
+      actions,
+      items,
+      dustRunIdsWithUsage,
+    })
+  ) {
+    return null;
+  }
+
+  const reconciledCreditAmounts = reconcileInputCredits({
+    items,
+    billedCredits,
+  });
+  if (!reconciledCreditAmounts) {
+    return null;
+  }
+
+  const tools = buildToolDetails({
+    actions,
+    items,
+    reconciledCreditAmounts,
+  });
+  if (!tools) {
+    return null;
+  }
+
+  return {
+    attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+    ...buildConsumptionTotals({
+      items,
+      reconciledCreditAmounts,
+    }),
+    tools,
+    models: buildModelDetails({
+      items,
+      usages: messageUsages,
+      reconciledCreditAmounts,
+    }),
+  };
+}

--- a/front/lib/api/assistant/agent_message_consumption_attribution/message_details.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/message_details.ts
@@ -4,7 +4,10 @@ import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assi
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
-import type { RunResource } from "@app/lib/resources/run_resource";
+import type {
+  RunResource,
+  RunUsageWithRunKeyType,
+} from "@app/lib/resources/run_resource";
 import type { AgentMCPActionType } from "@app/types/actions";
 import type {
   AgentMessageConsumptionDetails,
@@ -13,8 +16,6 @@ import type {
 import type { ModelId } from "@app/types/shared/model_id";
 
 const MICRO_CREDITS_PER_CREDIT = 1_000_000;
-
-type RunUsages = Awaited<ReturnType<typeof RunResource.listRunUsagesForRuns>>;
 
 export type MessageConsumptionDetails = AgentMessageConsumptionDetails & {
   models: AgentMessageConsumptionModelDetails[];
@@ -83,10 +84,9 @@ function reconcileInputCredits({
 
   // Preserve the relative weight of the cache-naive input rows.
   const inputAllocations = inputItems.map((item, index) => {
-    const exactMicro =
-      (item.grossAttributedCreditAmountMicro *
-        reconciledInputCreditAmountMicro) /
-      grossInputCreditAmountMicro;
+    const inputShare =
+      item.grossAttributedCreditAmountMicro / grossInputCreditAmountMicro;
+    const exactMicro = inputShare * reconciledInputCreditAmountMicro;
     const floorMicro = Math.floor(exactMicro);
 
     return {
@@ -158,7 +158,7 @@ function buildConsumptionTotals({
 /** Ensures every provider-reported model bucket has a row for the active attribution version. */
 function hasCompleteModelAttribution(
   items: AgentMessageConsumptionItemResource[],
-  usages: RunUsages
+  usages: RunUsageWithRunKeyType[]
 ): boolean {
   const itemTypesByRunUsageModelId = new Map<ModelId, Set<string>>();
 
@@ -311,7 +311,7 @@ function buildModelDetails({
   reconciledCreditAmounts,
 }: {
   items: AgentMessageConsumptionItemResource[];
-  usages: RunUsages;
+  usages: RunUsageWithRunKeyType[];
   reconciledCreditAmounts: ReconciledCreditAmounts;
 }): MessageConsumptionDetails["models"] {
   const usageByModelId = new Map(
@@ -366,7 +366,7 @@ export function buildMessageConsumptionDetails({
   dustRunIds: string[];
   items: AgentMessageConsumptionItemResource[];
   runs: RunResource[];
-  usages: RunUsages;
+  usages: RunUsageWithRunKeyType[];
 }): MessageConsumptionDetails | null {
   if (billedCredits === null || items.length === 0 || dustRunIds.length === 0) {
     return null;

--- a/front/lib/api/assistant/agent_message_consumption_attribution/read.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/read.test.ts
@@ -83,7 +83,7 @@ function modelRecords(runUsageModelId: ModelId) {
 }
 
 describe("getAgentMessageConsumption", () => {
-  it("groups repeated tools and keeps the exact bill separate from estimated attribution", async () => {
+  it("groups repeated tools and reconciles the breakdown to the exact bill", async () => {
     const {
       auth,
       workspace,
@@ -121,7 +121,7 @@ describe("getAgentMessageConsumption", () => {
           action: firstAction,
           inputTokensCount: 20,
           outputTokensCount: 5,
-          grossAttributedCreditAmountMicro: 5_000_000,
+          grossAttributedCreditAmountMicro: 4_000_000,
           directCreditAmountMicro: 3_000_000,
         },
         {
@@ -130,7 +130,7 @@ describe("getAgentMessageConsumption", () => {
           action: secondAction,
           inputTokensCount: 10,
           outputTokensCount: 4,
-          grossAttributedCreditAmountMicro: 4_000_000,
+          grossAttributedCreditAmountMicro: 3_000_000,
           directCreditAmountMicro: 1_000_000,
         },
       ],
@@ -146,14 +146,12 @@ describe("getAgentMessageConsumption", () => {
       billedCredits: BILLED_CREDITS,
       details: {
         attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
-        grossAttributedCredits: 13,
-        estimatedCacheSavingsCredits: 3,
-        agentWorkCredits: 4,
+        agentWorkCredits: 3,
         tools: [
           expect.objectContaining({
             label: "Test Tool",
             callCount: 2,
-            grossAttributedCredits: 9,
+            attributedCredits: 7,
             directCredits: 4,
             pending: false,
             toolName: "test_tool",
@@ -226,11 +224,36 @@ describe("getAgentMessageConsumption", () => {
     });
 
     expect(consumption?.details).toMatchObject({
-      grossAttributedCredits: BILLED_CREDITS,
-      estimatedCacheSavingsCredits: 0,
       agentWorkCredits: BILLED_CREDITS,
       tools: [],
     });
+  });
+
+  it("withholds details when non-input attribution exceeds the bill", async () => {
+    const { auth, conversation, runUsageModelId, agentMessage } =
+      await setupMessage();
+
+    await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+      conversation,
+      agentMessageModelId: agentMessage.agentMessageId,
+      attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+      records: modelRecords(runUsageModelId).map((record) =>
+        record.itemType === "output"
+          ? {
+              ...record,
+              grossAttributedCreditAmountMicro: 10_000_000,
+            }
+          : record
+      ),
+      pendingToolItems: [],
+    });
+
+    await expect(
+      getAgentMessageConsumption(auth, {
+        conversation,
+        agentMessageId: agentMessage.sId,
+      })
+    ).resolves.toEqual({ billedCredits: BILLED_CREDITS, details: null });
   });
 
   it("withholds details when the active rows do not cover every current run bucket", async () => {

--- a/front/lib/api/assistant/agent_message_consumption_attribution/read.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/read.ts
@@ -1,224 +1,10 @@
-import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
-import { getToolAggregateDisplayLabel } from "@app/lib/actions/tool_display_labels";
 import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
+import { buildMessageConsumptionDetails } from "@app/lib/api/assistant/agent_message_consumption_attribution/message_details";
 import type { Authenticator } from "@app/lib/auth";
-import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import type { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
 import { AgentMessageConsumptionItemResource as ConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
-import type { AgentMCPActionType } from "@app/types/actions";
-import type {
-  AgentMessageConsumptionResponse,
-  AgentMessageConsumptionToolDetails,
-} from "@app/types/assistant/agent_message_consumption";
-import type { ModelId } from "@app/types/shared/model_id";
-
-const MICRO_CREDITS_PER_CREDIT = 1_000_000;
-
-function creditsFromMicroCredits(microCredits: number): number {
-  return microCredits / MICRO_CREDITS_PER_CREDIT;
-}
-
-/**
- * Reconciles stable attribution estimates with the exact billed total without changing stored
- * rows. Any shortfall is assigned to agent work because it cannot be safely attributed to a tool.
- */
-function buildConsumptionTotals({
-  items,
-  billedCredits,
-}: {
-  items: AgentMessageConsumptionItemResource[];
-  billedCredits: number | null;
-}): {
-  grossAttributedCredits: number;
-  agentWorkCredits: number;
-  estimatedCacheSavingsCredits: number | null;
-} {
-  const storedGrossAttributedCreditAmountMicro = items.reduce(
-    (total, item) => total + item.grossAttributedCreditAmountMicro,
-    0
-  );
-  const storedAgentWorkCreditAmountMicro = items.reduce(
-    (total, item) =>
-      item.itemType === "tool"
-        ? total
-        : total + item.grossAttributedCreditAmountMicro,
-    0
-  );
-  const billedCreditAmountMicro =
-    billedCredits === null ? null : billedCredits * MICRO_CREDITS_PER_CREDIT;
-  const unattributedBilledCreditAmountMicro =
-    billedCreditAmountMicro === null
-      ? 0
-      : Math.max(
-          billedCreditAmountMicro - storedGrossAttributedCreditAmountMicro,
-          0
-        );
-  const grossAttributedCredits = creditsFromMicroCredits(
-    storedGrossAttributedCreditAmountMicro + unattributedBilledCreditAmountMicro
-  );
-
-  return {
-    grossAttributedCredits,
-    agentWorkCredits: creditsFromMicroCredits(
-      storedAgentWorkCreditAmountMicro + unattributedBilledCreditAmountMicro
-    ),
-    estimatedCacheSavingsCredits:
-      billedCredits === null
-        ? null
-        : Math.max(grossAttributedCredits - billedCredits, 0),
-  };
-}
-
-/** Ensures every provider-reported model bucket has a row for the active attribution version. */
-function hasCompleteModelAttribution(
-  items: AgentMessageConsumptionItemResource[],
-  usages: Awaited<ReturnType<typeof RunResource.listRunUsagesForRuns>>
-): boolean {
-  const itemTypesByRunUsageModelId = new Map<ModelId, Set<string>>();
-
-  for (const item of items) {
-    if (item.itemType === "tool" || item.runUsageId === null) {
-      continue;
-    }
-
-    const itemTypes =
-      itemTypesByRunUsageModelId.get(item.runUsageId) ?? new Set();
-    itemTypes.add(item.itemType);
-    itemTypesByRunUsageModelId.set(item.runUsageId, itemTypes);
-  }
-
-  return usages.every((usage) => {
-    const itemTypes = itemTypesByRunUsageModelId.get(usage.runUsageModelId);
-    return (
-      itemTypes?.has("input") === true &&
-      itemTypes.has("output") &&
-      (usage.reasoningTokens === null || itemTypes.has("reasoning"))
-    );
-  });
-}
-
-/** Ensures every attributable action has a row and every settled action has final evidence. */
-function hasCompleteToolAttribution({
-  actions,
-  items,
-  dustRunIdsWithUsage,
-}: {
-  actions: AgentMCPActionResource[];
-  items: AgentMessageConsumptionItemResource[];
-  dustRunIdsWithUsage: Set<string>;
-}): boolean {
-  const toolItemByActionModelId = new Map<
-    ModelId,
-    AgentMessageConsumptionItemResource
-  >();
-  for (const item of items) {
-    if (item.itemType === "tool" && item.agentMCPActionId !== null) {
-      toolItemByActionModelId.set(item.agentMCPActionId, item);
-    }
-  }
-  const actionModelIds = new Set(actions.map((action) => action.id));
-
-  for (const actionModelId of toolItemByActionModelId.keys()) {
-    if (!actionModelIds.has(actionModelId)) {
-      return false;
-    }
-  }
-
-  for (const action of actions) {
-    const dustRunId = action.stepContent.dustRunId;
-    if (!dustRunId || !dustRunIdsWithUsage.has(dustRunId)) {
-      continue;
-    }
-
-    const item = toolItemByActionModelId.get(action.id);
-    if (!item) {
-      return false;
-    }
-    if (
-      isToolExecutionStatusFinal(action.status) &&
-      item.completedAt === null
-    ) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-function toolIdentity(action: AgentMCPActionType): string {
-  const serverIdentity =
-    action.mcpServerId ??
-    action.internalMCPServerName ??
-    action.functionCallName;
-
-  return `${serverIdentity}:${action.toolName}`;
-}
-
-/** Groups repeated executions by tool identity while preserving first-use display order. */
-function buildToolDetails({
-  actions,
-  items,
-}: {
-  actions: AgentMCPActionResource[];
-  items: AgentMessageConsumptionItemResource[];
-}): AgentMessageConsumptionToolDetails[] | null {
-  const actionByModelId = new Map(actions.map((action) => [action.id, action]));
-  const groupedTools = new Map<
-    string,
-    AgentMessageConsumptionToolDetails & { firstStep: number }
-  >();
-
-  for (const item of items) {
-    if (item.itemType !== "tool" || item.agentMCPActionId === null) {
-      continue;
-    }
-
-    const action = actionByModelId.get(item.agentMCPActionId);
-    if (!action) {
-      return null;
-    }
-
-    const serialized = action.toJSON();
-    const identity = toolIdentity(serialized);
-    const current = groupedTools.get(identity);
-    const grossAttributedCredits = creditsFromMicroCredits(
-      item.grossAttributedCreditAmountMicro
-    );
-    const directCredits = creditsFromMicroCredits(
-      item.directCreditAmountMicro ?? 0
-    );
-
-    if (current) {
-      groupedTools.set(identity, {
-        ...current,
-        callCount: current.callCount + 1,
-        grossAttributedCredits:
-          current.grossAttributedCredits + grossAttributedCredits,
-        directCredits: current.directCredits + directCredits,
-        pending: current.pending || item.completedAt === null,
-        firstStep: Math.min(current.firstStep, serialized.step),
-      });
-      continue;
-    }
-
-    groupedTools.set(identity, {
-      label: getToolAggregateDisplayLabel(serialized),
-      internalMCPServerName: serialized.internalMCPServerName,
-      toolName: serialized.toolName,
-      callCount: 1,
-      grossAttributedCredits,
-      directCredits,
-      pending: item.completedAt === null,
-      firstStep: serialized.step,
-    });
-  }
-
-  return [...groupedTools.values()]
-    .sort((left, right) => left.firstStep - right.firstStep)
-    .map(({ firstStep: _firstStep, ...tool }) => tool);
-}
+import type { AgentMessageConsumptionResponse } from "@app/types/assistant/agent_message_consumption";
 
 /**
  * Builds the end-user explanation for one agent message. Provider and token facts stay behind this
@@ -263,52 +49,22 @@ export async function getAgentMessageConsumption(
     return unavailableResponse;
   }
 
-  const dustRunIdByRunModelId = new Map(
-    runs.map((run) => [run.id, run.dustRunId])
-  );
-  const dustRunIdsWithUsage = new Set(
-    usages.flatMap((usage) => {
-      const dustRunId = dustRunIdByRunModelId.get(usage.runModelId);
-      return dustRunId ? [dustRunId] : [];
-    })
-  );
-
-  if (
-    !hasCompleteModelAttribution(facts.items, usages) ||
-    !hasCompleteToolAttribution({
-      actions: facts.actions,
-      items: facts.items,
-      dustRunIdsWithUsage,
-    })
-  ) {
-    return unavailableResponse;
-  }
-
-  const tools = buildToolDetails({
+  const details = buildMessageConsumptionDetails({
     actions: facts.actions,
+    billedCredits: facts.billedCredits,
+    dustRunIds: facts.dustRunIds,
     items: facts.items,
+    runs,
+    usages,
   });
-  if (!tools) {
+  if (!details) {
     return unavailableResponse;
   }
 
-  const {
-    grossAttributedCredits,
-    agentWorkCredits,
-    estimatedCacheSavingsCredits,
-  } = buildConsumptionTotals({
-    items: facts.items,
-    billedCredits: facts.billedCredits,
-  });
+  const { models: _models, ...messageDetails } = details;
 
   return {
     billedCredits: facts.billedCredits,
-    details: {
-      attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
-      grossAttributedCredits,
-      estimatedCacheSavingsCredits,
-      agentWorkCredits,
-      tools,
-    },
+    details: messageDetails,
   };
 }

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -52,7 +52,7 @@ export interface RunUsageType {
   isBatch: boolean;
 }
 
-interface RunUsageWithRunKeyType extends RunUsageType {
+export interface RunUsageWithRunKeyType extends RunUsageType {
   runKey: string | null;
   runUsageModelId: ModelId;
   runModelId: ModelId;

--- a/front/types/assistant/agent_message_consumption.ts
+++ b/front/types/assistant/agent_message_consumption.ts
@@ -1,4 +1,8 @@
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import type {
+  ModelIdType,
+  ModelProviderIdType,
+} from "@app/types/assistant/models/types";
 
 export const AGENT_MESSAGE_CONSUMPTION_ITEM_TYPES = [
   "system",
@@ -16,15 +20,22 @@ export type AgentMessageConsumptionToolDetails = {
   internalMCPServerName: InternalMCPServerNameType | null;
   toolName: string;
   callCount: number;
-  grossAttributedCredits: number;
+  /** Share of the authoritative bill after reconciling exclusively through model input rows. */
+  attributedCredits: number;
   directCredits: number;
   pending: boolean;
 };
 
+export type AgentMessageConsumptionModelDetails = {
+  providerId: ModelProviderIdType;
+  modelId: ModelIdType;
+  displayName: string;
+  attributedCredits: number;
+};
+
 export type AgentMessageConsumptionDetails = {
   attributionVersion: number;
-  grossAttributedCredits: number;
-  estimatedCacheSavingsCredits: number | null;
+  /** Agent work after assigning the billing reconciliation exclusively to model input rows. */
   agentWorkCredits: number;
   tools: AgentMessageConsumptionToolDetails[];
 };


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Our attribution is cache-naive, so its raw total can exceed the credits actually billed. Exposing both the raw estimate and a cache savings adjustment forces users to reconcile two competing totals and can undermine trust in the breakdown.

This change makes the breakdown additive with the authoritative bill. Raw attribution evidence remains unchanged in storage. At read time, **only model input rows** absorb the billing difference because input is where cached conversation
context is reused. Output, reasoning, and tool attribution remain unchanged.

If input-only reconciliation is impossible, the detailed breakdown is withheld instead of presenting misleading values.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
