### PR TITLE
[Activation] Remove provisioningSource column and model

### DIFF
--- a/front/lib/resources/storage/models/project_metadata.ts
+++ b/front/lib/resources/storage/models/project_metadata.ts
@@ -6,9 +6,6 @@ import {
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { Op } from "sequelize";
-
-type ProvisioningSource = "activation";
 
 export class ProjectMetadataModel extends WorkspaceAwareModel<ProjectMetadataModel> {
   declare id: CreationOptional<number>;
@@ -27,7 +24,6 @@ export class ProjectMetadataModel extends WorkspaceAwareModel<ProjectMetadataMod
   /** sId of the agent pre-selected for new conversations in this pod. Null = @dust. */
   declare defaultAgentId: CreationOptional<string | null>;
   declare defaultSkillsIds: CreationOptional<string[] | null>;
-  declare provisioningSource: CreationOptional<ProvisioningSource | null>;
 }
 
 ProjectMetadataModel.init(
@@ -79,11 +75,6 @@ ProjectMetadataModel.init(
       defaultValue: null,
       field: "defaultSkillsIds",
     },
-    provisioningSource: {
-      type: DataTypes.STRING,
-      allowNull: true,
-      defaultValue: null,
-    },
   },
   {
     modelName: "project_metadata",
@@ -91,11 +82,6 @@ ProjectMetadataModel.init(
     indexes: [
       { unique: true, fields: ["spaceId"], concurrently: true },
       { fields: ["workspaceId"], concurrently: true },
-      {
-        fields: ["provisioningSource"],
-        where: { provisioningSource: { [Op.ne]: null } },
-        concurrently: true,
-      },
     ],
   }
 );

--- a/front/migrations/post-deploy/20260804180000_drop_provisioning_source_from_project_metadata.sql
+++ b/front/migrations/post-deploy/20260804180000_drop_provisioning_source_from_project_metadata.sql
@@ -1,0 +1,15 @@
+/*
+Statement 0
+  - INDEX_DROPPED: Dropping this index means queries that use this index might perform worse because they will no longer will be able to leverage it.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+DROP INDEX CONCURRENTLY "public"."project_metadata_provisioning_source";
+
+/*
+Statement 1
+  - DELETES_DATA: Deletes all values in the column
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."project_metadata" DROP COLUMN "provisioningSource";

--- a/front/migrations/post-deploy/20260804180000_drop_provisioning_source_from_project_metadata.sql
+++ b/front/migrations/post-deploy/20260804180000_drop_provisioning_source_from_project_metadata.sql
@@ -1,6 +1,6 @@
 /*
 Statement 0
-  - INDEX_DROPPED: Dropping this index means queries that use this index might perform worse because they will no longer will be able to leverage it.
+  - INDEX_DROPPED: Drops the index on the column
 */
 SET SESSION statement_timeout = 1200000;
 SET SESSION lock_timeout = 3000;


### PR DESCRIPTION
## Description
All activation pod related data has been moved to the `activation_pods` table. The `provisioningSource` column of `project_metadata` is no longer used by anything and can be removed.

## Tests


## Risk
Low- nothing depends on `provisioningSource`

## Deploy Plan
Follow post-deploy migration steps.
