### PR TITLE
fix: ship prestop.sh in the front-api image

### DIFF
--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -253,6 +253,8 @@ COPY --from=base-deps /app/scripts/db /app/scripts/db
 COPY --from=front-api-build /app/front-api ./front-api
 # Copy migration SQL files (migrations live in front/ but the pre-deploy hook runs from /app/front-api).
 COPY --from=base-deps /app/front/migrations ./front-api/migrations
+# Copy prestop.sh (it lives in front/ but the preStop hook runs from /app/front-api).
+COPY --from=base-deps /app/front/admin/prestop.sh ./front-api/admin/prestop.sh
 
 # Sibling workspaces resolved via @app aliases or transitive imports.
 COPY --from=base-deps /app/sdks/js ./sdks/js


### PR DESCRIPTION
## Description

`preStop` hook is `/bin/sh -c admin/prestop.sh`. The front-api stage sets `WORKDIR /app/front-api`, but the script only lands at `/app/front/admin/prestop.sh`, so the hook exits 127 and `FailedPreStopHook` fires on every terminating pod.

Means `runPreStop()` never runs. Copies the single file (not all of `front/admin`, which is mostly dev scripts) next to the existing migrations COPY that works around the same WORKDIR mismatch.

## Tests

Reproduced in a prod pod: `sh -c "admin/prestop.sh"` → `127, not found`.

## Risk

Low, one COPY. Worst case it stays broken as today. Rollback is a revert.

Note it *enables* a code path that's been dead, so first deploy after this is the first time pods actually drain: ~70s minimum termination (10s LB + 60s draining), up to 130s.

## Deploy Plan

Normal deploy.