### PR TITLE
[front] feat: add generated webhook filter validation

### DIFF
--- a/front/lib/api/assistant/configuration/triggers/webhook_filter.test.ts
+++ b/front/lib/api/assistant/configuration/triggers/webhook_filter.test.ts
@@ -2,6 +2,7 @@ import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { getWebhookFilterGeneration } from "@app/lib/api/assistant/configuration/triggers/webhook_filter";
 import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { Ok } from "@app/types/shared/result";
 import type { WebhookEvent } from "@app/types/triggers/webhooks_source_preset";
@@ -78,6 +79,7 @@ describe("getWebhookFilterGeneration", () => {
   });
 
   it("repairs an invalid generated filter once", async () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
     mockFilterGeneration('(has-any "status" ("open" "closed"))');
     mockFilterGeneration('(or (eq "status" "open") (eq "status" "closed"))');
 
@@ -98,6 +100,18 @@ describe("getWebhookFilterGeneration", () => {
     expect(JSON.stringify(repairInput.conversation)).toContain(
       'Operator \\"has-any\\" requires an array field'
     );
+    expect(warnSpy).toHaveBeenCalledWith(
+      {
+        workspaceId: authenticator.getNonNullableWorkspace().sId,
+        webhookEvent: event.value,
+        error: expect.objectContaining({
+          message:
+            'Operator "has-any" requires an array field, but "status" is string.',
+        }),
+      },
+      "Generated webhook filter failed validation, retrying"
+    );
+    warnSpy.mockRestore();
   });
 
   it("returns the repaired filter without validating it again", async () => {

--- a/front/lib/api/assistant/configuration/triggers/webhook_filter.test.ts
+++ b/front/lib/api/assistant/configuration/triggers/webhook_filter.test.ts
@@ -1,0 +1,121 @@
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import { getWebhookFilterGeneration } from "@app/lib/api/assistant/configuration/triggers/webhook_filter";
+import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
+import type { Authenticator } from "@app/lib/auth";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { Ok } from "@app/types/shared/result";
+import type { WebhookEvent } from "@app/types/triggers/webhooks_source_preset";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/assistant/call_llm", () => ({
+  runMultiActionsAgent: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/assistant/models", () => ({
+  getLargeWhitelistedModel: vi.fn(),
+}));
+
+const mockRunMultiActionsAgent = vi.mocked(runMultiActionsAgent);
+const mockGetLargeWhitelistedModel = vi.mocked(getLargeWhitelistedModel);
+
+const event: WebhookEvent = {
+  name: "test.event",
+  value: "test.event",
+  description: "A test event",
+  schema: {
+    type: "object",
+    properties: {
+      status: { type: "string" },
+      count: { type: "integer" },
+    },
+  },
+  sample: {
+    status: "open",
+    count: 1,
+  },
+};
+
+function mockFilterGeneration(filter: string): void {
+  mockRunMultiActionsAgent.mockResolvedValueOnce(
+    new Ok({
+      actions: [
+        {
+          name: "set_filter",
+          arguments: { filter },
+        },
+      ],
+    }) as never
+  );
+}
+
+describe("getWebhookFilterGeneration", () => {
+  let authenticator: Authenticator;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockGetLargeWhitelistedModel.mockReturnValue({
+      modelId: "test-model",
+      providerId: "openai",
+    } as never);
+    const testResources = await createResourceTest({ role: "admin" });
+    authenticator = testResources.authenticator;
+  });
+
+  it("returns a valid filter without retrying", async () => {
+    mockFilterGeneration('(eq "status" "open")');
+
+    const result = await getWebhookFilterGeneration(authenticator, {
+      naturalDescription: "Status is open",
+      event,
+      providerSpecificInstructions: null,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.filter).toBe('(eq "status" "open")');
+    }
+    expect(mockRunMultiActionsAgent).toHaveBeenCalledOnce();
+  });
+
+  it("repairs an invalid generated filter once", async () => {
+    mockFilterGeneration('(has-any "status" ("open" "closed"))');
+    mockFilterGeneration('(or (eq "status" "open") (eq "status" "closed"))');
+
+    const result = await getWebhookFilterGeneration(authenticator, {
+      naturalDescription: "Status is open or closed",
+      event,
+      providerSpecificInstructions: null,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.filter).toBe(
+        '(or (eq "status" "open") (eq "status" "closed"))'
+      );
+    }
+    expect(mockRunMultiActionsAgent).toHaveBeenCalledTimes(2);
+    const repairInput = mockRunMultiActionsAgent.mock.calls[1][2];
+    expect(JSON.stringify(repairInput.conversation)).toContain(
+      'Operator \\"has-any\\" requires an array field'
+    );
+  });
+
+  it("returns an error when the repaired filter is still invalid", async () => {
+    mockFilterGeneration('(has-any "status" ("open" "closed"))');
+    mockFilterGeneration('(contains "count" "1")');
+
+    const result = await getWebhookFilterGeneration(authenticator, {
+      naturalDescription: "Status is open or closed",
+      event,
+      providerSpecificInstructions: null,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe(
+        'Unable to generate a valid filter: Operator "contains" requires a string field, but "count" is integer.'
+      );
+    }
+    expect(mockRunMultiActionsAgent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/front/lib/api/assistant/configuration/triggers/webhook_filter.test.ts
+++ b/front/lib/api/assistant/configuration/triggers/webhook_filter.test.ts
@@ -100,7 +100,7 @@ describe("getWebhookFilterGeneration", () => {
     );
   });
 
-  it("returns an error when the repaired filter is still invalid", async () => {
+  it("returns the repaired filter without validating it again", async () => {
     mockFilterGeneration('(has-any "status" ("open" "closed"))');
     mockFilterGeneration('(contains "count" "1")');
 
@@ -110,11 +110,9 @@ describe("getWebhookFilterGeneration", () => {
       providerSpecificInstructions: null,
     });
 
-    expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
-      expect(result.error.message).toBe(
-        'Unable to generate a valid filter: Operator "contains" requires a string field, but "count" is integer.'
-      );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.filter).toBe('(contains "count" "1")');
     }
     expect(mockRunMultiActionsAgent).toHaveBeenCalledTimes(2);
   });

--- a/front/lib/api/assistant/configuration/triggers/webhook_filter.ts
+++ b/front/lib/api/assistant/configuration/triggers/webhook_filter.ts
@@ -402,17 +402,5 @@ The previous filter is invalid. Generate a corrected filter that resolves the va
     return new Err(repairResult.error);
   }
 
-  const repairValidationResult = validateWebhookFilter(
-    repairResult.value,
-    event.schema
-  );
-  if (repairValidationResult.isErr()) {
-    return new Err(
-      new Error(
-        `Unable to generate a valid filter: ${repairValidationResult.error.message}`
-      )
-    );
-  }
-
   return new Ok({ filter: repairResult.value });
 }

--- a/front/lib/api/assistant/configuration/triggers/webhook_filter.ts
+++ b/front/lib/api/assistant/configuration/triggers/webhook_filter.ts
@@ -1,5 +1,6 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import { validateWebhookFilter } from "@app/lib/api/assistant/configuration/triggers/webhook_filter_validation";
 import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
@@ -304,57 +305,97 @@ export async function getWebhookFilterGeneration(
     .filter((part) => part !== null)
     .join("\n\n");
 
-  const res = await runMultiActionsAgent(
-    auth,
-    {
-      functionCall: SET_FILTER_FUNCTION_NAME,
-      modelId: model.modelId,
-      providerId: model.providerId,
-      temperature: 0.7,
-      useCache: false,
-    },
-    {
-      conversation: {
-        messages: [
-          {
-            role: "user",
-            content: [{ type: "text", text: userContent }],
-            name: "",
-          },
-        ],
+  const generateFilter = async (
+    content: string
+  ): Promise<Result<string, Error>> => {
+    const generationResult = await runMultiActionsAgent(
+      auth,
+      {
+        functionCall: SET_FILTER_FUNCTION_NAME,
+        modelId: model.modelId,
+        providerId: model.providerId,
+        temperature: 0.7,
+        useCache: false,
       },
-      prompt: getInstructions(providerSpecificInstructions),
-      specifications,
-      forceToolCall: SET_FILTER_FUNCTION_NAME,
-    },
-    {
-      context: {
-        operationType: "trigger_webhook_filter_generator",
-        userId: auth.user()?.sId,
-        workspaceId: owner.sId,
+      {
+        conversation: {
+          messages: [
+            {
+              role: "user",
+              content: [{ type: "text", text: content }],
+              name: "",
+            },
+          ],
+        },
+        prompt: getInstructions(providerSpecificInstructions),
+        specifications,
+        forceToolCall: SET_FILTER_FUNCTION_NAME,
       },
+      {
+        context: {
+          operationType: "trigger_webhook_filter_generator",
+          userId: auth.user()?.sId,
+          workspaceId: owner.sId,
+        },
+      }
+    );
+
+    if (generationResult.isErr()) {
+      return new Err(generationResult.error);
     }
-  );
 
-  if (res.isErr()) {
-    return new Err(res.error);
-  }
-
-  let filter: string | null = null;
-
-  if (res.value.actions) {
-    for (const action of res.value.actions) {
+    for (const action of generationResult.value.actions ?? []) {
       if (action.name === SET_FILTER_FUNCTION_NAME) {
-        filter = action.arguments.filter;
+        return new Ok(action.arguments.filter);
       }
     }
-  }
 
-  if (!filter) {
     return new Err(
       new Error("Unable to generate a filter. Please try rephrasing.")
     );
+  };
+
+  const generationResult = await generateFilter(userContent);
+  if (generationResult.isErr()) {
+    return new Err(generationResult.error);
   }
 
-  return new Ok({ filter });
+  const validationResult = validateWebhookFilter(
+    generationResult.value,
+    event.schema
+  );
+  if (validationResult.isOk()) {
+    return new Ok({ filter: generationResult.value });
+  }
+
+  const repairContent = `${userContent}
+
+<invalid_filter>
+${generationResult.value}
+</invalid_filter>
+
+<validation_error>
+${validationResult.error.message}
+</validation_error>
+
+The previous filter is invalid. Generate a corrected filter that resolves the validation error.`;
+
+  const repairResult = await generateFilter(repairContent);
+  if (repairResult.isErr()) {
+    return new Err(repairResult.error);
+  }
+
+  const repairValidationResult = validateWebhookFilter(
+    repairResult.value,
+    event.schema
+  );
+  if (repairValidationResult.isErr()) {
+    return new Err(
+      new Error(
+        `Unable to generate a valid filter: ${repairValidationResult.error.message}`
+      )
+    );
+  }
+
+  return new Ok({ filter: repairResult.value });
 }

--- a/front/lib/api/assistant/configuration/triggers/webhook_filter.ts
+++ b/front/lib/api/assistant/configuration/triggers/webhook_filter.ts
@@ -3,6 +3,7 @@ import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { validateWebhookFilter } from "@app/lib/api/assistant/configuration/triggers/webhook_filter_validation";
 import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -380,6 +381,15 @@ export async function getWebhookFilterGeneration(
   if (validationResult.isOk()) {
     return new Ok({ filter: generationResult.value });
   }
+
+  logger.warn(
+    {
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      webhookEvent: event.value,
+      error: validationResult.error,
+    },
+    "Generated webhook filter failed validation, retrying"
+  );
 
   const repairContent = `${userContent}
 

--- a/front/lib/api/assistant/configuration/triggers/webhook_filter.ts
+++ b/front/lib/api/assistant/configuration/triggers/webhook_filter.ts
@@ -3,6 +3,7 @@ import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { validateWebhookFilter } from "@app/lib/api/assistant/configuration/triggers/webhook_filter_validation";
 import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { WebhookEvent } from "@app/types/triggers/webhooks_source_preset";
@@ -273,6 +274,66 @@ In addition to the exhaustive JSON Schema of the payload, you will be provided a
 ${providerInstructionsSection}`;
 }
 
+async function generateFilter(
+  auth: Authenticator,
+  {
+    content,
+    model,
+    providerSpecificInstructions,
+  }: {
+    content: string;
+    model: ModelConfigurationType;
+    providerSpecificInstructions: string | null;
+  }
+): Promise<Result<string, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+  const generationResult = await runMultiActionsAgent(
+    auth,
+    {
+      functionCall: SET_FILTER_FUNCTION_NAME,
+      modelId: model.modelId,
+      providerId: model.providerId,
+      temperature: 0.7,
+      useCache: false,
+    },
+    {
+      conversation: {
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: content }],
+            name: "",
+          },
+        ],
+      },
+      prompt: getInstructions(providerSpecificInstructions),
+      specifications,
+      forceToolCall: SET_FILTER_FUNCTION_NAME,
+    },
+    {
+      context: {
+        operationType: "trigger_webhook_filter_generator",
+        userId: auth.user()?.sId,
+        workspaceId: owner.sId,
+      },
+    }
+  );
+
+  if (generationResult.isErr()) {
+    return new Err(generationResult.error);
+  }
+
+  for (const action of generationResult.value.actions ?? []) {
+    if (action.name === SET_FILTER_FUNCTION_NAME) {
+      return new Ok(action.arguments.filter);
+    }
+  }
+
+  return new Err(
+    new Error("Unable to generate a filter. Please try rephrasing.")
+  );
+}
+
 export async function getWebhookFilterGeneration(
   auth: Authenticator,
   {
@@ -285,8 +346,6 @@ export async function getWebhookFilterGeneration(
     providerSpecificInstructions: string | null;
   }
 ): Promise<Result<{ filter: string }, Error>> {
-  const owner = auth.getNonNullableWorkspace();
-
   const model = await getLargeWhitelistedModel(auth);
   if (!model) {
     return new Err(
@@ -305,57 +364,11 @@ export async function getWebhookFilterGeneration(
     .filter((part) => part !== null)
     .join("\n\n");
 
-  const generateFilter = async (
-    content: string
-  ): Promise<Result<string, Error>> => {
-    const generationResult = await runMultiActionsAgent(
-      auth,
-      {
-        functionCall: SET_FILTER_FUNCTION_NAME,
-        modelId: model.modelId,
-        providerId: model.providerId,
-        temperature: 0.7,
-        useCache: false,
-      },
-      {
-        conversation: {
-          messages: [
-            {
-              role: "user",
-              content: [{ type: "text", text: content }],
-              name: "",
-            },
-          ],
-        },
-        prompt: getInstructions(providerSpecificInstructions),
-        specifications,
-        forceToolCall: SET_FILTER_FUNCTION_NAME,
-      },
-      {
-        context: {
-          operationType: "trigger_webhook_filter_generator",
-          userId: auth.user()?.sId,
-          workspaceId: owner.sId,
-        },
-      }
-    );
-
-    if (generationResult.isErr()) {
-      return new Err(generationResult.error);
-    }
-
-    for (const action of generationResult.value.actions ?? []) {
-      if (action.name === SET_FILTER_FUNCTION_NAME) {
-        return new Ok(action.arguments.filter);
-      }
-    }
-
-    return new Err(
-      new Error("Unable to generate a filter. Please try rephrasing.")
-    );
-  };
-
-  const generationResult = await generateFilter(userContent);
+  const generationResult = await generateFilter(auth, {
+    content: userContent,
+    model,
+    providerSpecificInstructions,
+  });
   if (generationResult.isErr()) {
     return new Err(generationResult.error);
   }
@@ -380,7 +393,11 @@ ${validationResult.error.message}
 
 The previous filter is invalid. Generate a corrected filter that resolves the validation error.`;
 
-  const repairResult = await generateFilter(repairContent);
+  const repairResult = await generateFilter(auth, {
+    content: repairContent,
+    model,
+    providerSpecificInstructions,
+  });
   if (repairResult.isErr()) {
     return new Err(repairResult.error);
   }

--- a/front/lib/api/assistant/configuration/triggers/webhook_filter_validation.test.ts
+++ b/front/lib/api/assistant/configuration/triggers/webhook_filter_validation.test.ts
@@ -1,0 +1,89 @@
+import { validateWebhookFilter } from "@app/lib/api/assistant/configuration/triggers/webhook_filter_validation";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { describe, expect, it } from "vitest";
+
+const schema: JSONSchema = {
+  type: "object",
+  properties: {
+    status: { type: "string" },
+    nullableStatus: { type: ["string", "null"] },
+    count: { type: "integer" },
+    active: { type: "boolean" },
+    tags: {
+      type: "array",
+      items: { type: "string" },
+    },
+    labels: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          score: { type: "number" },
+        },
+      },
+    },
+  },
+};
+
+function expectValid(filter: string): void {
+  const result = validateWebhookFilter(filter, schema);
+  expect(result.isOk()).toBe(true);
+}
+
+function expectInvalid(filter: string, message: string): void {
+  const result = validateWebhookFilter(filter, schema);
+  expect(result.isErr()).toBe(true);
+  if (result.isErr()) {
+    expect(result.error.message).toBe(message);
+  }
+}
+
+describe("validateWebhookFilter", () => {
+  it.each([
+    '(eq "status" "open")',
+    '(contains "nullableStatus" "open")',
+    '(gt "count" 10)',
+    '(eq "active" true)',
+    '(has-any "tags" ("urgent" "vip"))',
+    '(has "labels.*.name" "urgent")',
+    '(has "labels.*.score" 0.8)',
+    '(and (eq "status" "open") (exists "active"))',
+  ])("accepts a type-compatible filter: %s", (filter) => {
+    expectValid(filter);
+  });
+
+  it.each([
+    {
+      filter: '(has-any "status" ("open" "closed"))',
+      message:
+        'Operator "has-any" requires an array field, but "status" is string.',
+    },
+    {
+      filter: '(contains "count" "1")',
+      message:
+        'Operator "contains" requires a string field, but "count" is integer.',
+    },
+    {
+      filter: '(eq "count" "1")',
+      message: 'Value for "count" must be integer, but received string.',
+    },
+    {
+      filter: '(has "tags" 1)',
+      message: 'Value for "tags" must be string, but received integer.',
+    },
+    {
+      filter: '(eq "missing" "value")',
+      message: 'Field "missing" does not exist in the event schema.',
+    },
+  ])("rejects an incompatible filter: $filter", ({ filter, message }) => {
+    expectInvalid(filter, message);
+  });
+
+  it("rejects invalid syntax", () => {
+    expectInvalid(
+      '(eq "status" "open"',
+      "Invalid filter syntax: Unbalanced parentheses"
+    );
+  });
+});

--- a/front/lib/api/assistant/configuration/triggers/webhook_filter_validation.ts
+++ b/front/lib/api/assistant/configuration/triggers/webhook_filter_validation.ts
@@ -1,0 +1,322 @@
+import type { MatcherExpression, OperationExpression } from "@app/lib/matcher";
+import { isLogicalExpression, parseMatcherExpression } from "@app/lib/matcher";
+import { isJSONSchemaObject } from "@app/lib/utils/json_schemas";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import type {
+  JSONSchema7 as JSONSchema,
+  JSONSchema7TypeName as JSONSchemaTypeName,
+} from "json-schema";
+
+type ResolvedFieldSchema = {
+  fieldTypes: Set<JSONSchemaTypeName>;
+  valueSchema: JSONSchema | null;
+};
+
+function getSchemaTypes(schema: JSONSchema | null): Set<JSONSchemaTypeName> {
+  if (!schema) {
+    return new Set();
+  }
+  if (Array.isArray(schema.type)) {
+    return new Set(schema.type);
+  }
+  if (schema.type) {
+    return new Set([schema.type]);
+  }
+  if (schema.properties) {
+    return new Set(["object"]);
+  }
+  if (schema.items) {
+    return new Set(["array"]);
+  }
+  return new Set();
+}
+
+function resolveFieldSchema(
+  rootSchema: JSONSchema,
+  field: string
+): Result<ResolvedFieldSchema, Error> {
+  const path = field.split(".");
+  const wildcardCount = path.filter((segment) => segment === "*").length;
+  if (wildcardCount > 1) {
+    return new Err(new Error(`Field "${field}" uses more than one wildcard.`));
+  }
+  if (path.at(-1) === "*") {
+    return new Err(
+      new Error(`Field "${field}" must select a property after its wildcard.`)
+    );
+  }
+
+  let currentSchema = rootSchema;
+  let usesWildcard = false;
+
+  for (const segment of path) {
+    if (segment === "*") {
+      const items = currentSchema.items;
+      if (
+        !getSchemaTypes(currentSchema).has("array") ||
+        Array.isArray(items) ||
+        !isJSONSchemaObject(items)
+      ) {
+        return new Err(
+          new Error(`Field "${field}" does not exist in the event schema.`)
+        );
+      }
+      currentSchema = items;
+      usesWildcard = true;
+      continue;
+    }
+
+    const property = currentSchema.properties?.[segment];
+    if (!isJSONSchemaObject(property)) {
+      return new Err(
+        new Error(`Field "${field}" does not exist in the event schema.`)
+      );
+    }
+    currentSchema = property;
+  }
+
+  if (usesWildcard) {
+    return new Ok({
+      fieldTypes: new Set(["array"]),
+      valueSchema: currentSchema,
+    });
+  }
+
+  const fieldTypes = getSchemaTypes(currentSchema);
+  const items = currentSchema.items;
+  let valueSchema: JSONSchema | null = currentSchema;
+  if (fieldTypes.has("array")) {
+    valueSchema =
+      !Array.isArray(items) && isJSONSchemaObject(items) ? items : null;
+  }
+
+  return new Ok({ fieldTypes, valueSchema });
+}
+
+function getValueType(value: unknown): JSONSchemaTypeName {
+  if (value === null) {
+    return "null";
+  }
+  if (Array.isArray(value)) {
+    return "array";
+  }
+  switch (typeof value) {
+    case "boolean":
+      return "boolean";
+    case "number":
+      return Number.isInteger(value) ? "integer" : "number";
+    case "object":
+      return "object";
+    case "string":
+      return "string";
+    default:
+      return "null";
+  }
+}
+
+function typesInclude(
+  types: Set<JSONSchemaTypeName>,
+  expectedType: JSONSchemaTypeName
+): boolean {
+  if (expectedType === "number") {
+    return types.has("number") || types.has("integer");
+  }
+  return types.has(expectedType);
+}
+
+function typesAcceptValue(
+  types: Set<JSONSchemaTypeName>,
+  value: unknown
+): boolean {
+  const valueType = getValueType(value);
+  if (valueType === "integer") {
+    return types.has("integer") || types.has("number");
+  }
+  return types.has(valueType);
+}
+
+function formatTypes(types: Set<JSONSchemaTypeName>): string {
+  return [...types].sort().join(" or ") || "an unknown type";
+}
+
+function validateFieldType({
+  expression,
+  fieldTypes,
+  expectedType,
+}: {
+  expression: OperationExpression;
+  fieldTypes: Set<JSONSchemaTypeName>;
+  expectedType: JSONSchemaTypeName;
+}): Result<void, Error> {
+  if (fieldTypes.size === 0 || typesInclude(fieldTypes, expectedType)) {
+    return new Ok(undefined);
+  }
+
+  const article = expectedType === "array" ? "an" : "a";
+  return new Err(
+    new Error(
+      `Operator "${expression.op}" requires ${article} ${expectedType} field, but "${expression.field}" is ${formatTypes(fieldTypes)}.`
+    )
+  );
+}
+
+function validateValues(
+  expression: OperationExpression,
+  valueSchema: JSONSchema | null,
+  values: unknown[]
+): Result<void, Error> {
+  const expectedTypes = getSchemaTypes(valueSchema);
+  if (expectedTypes.size === 0) {
+    return new Ok(undefined);
+  }
+
+  for (const value of values) {
+    if (!typesAcceptValue(expectedTypes, value)) {
+      return new Err(
+        new Error(
+          `Value for "${expression.field}" must be ${formatTypes(expectedTypes)}, but received ${getValueType(value)}.`
+        )
+      );
+    }
+  }
+  return new Ok(undefined);
+}
+
+function validateOperationExpression(
+  expression: OperationExpression,
+  schema: JSONSchema
+): Result<void, Error> {
+  const fieldSchemaResult = resolveFieldSchema(schema, expression.field);
+  if (fieldSchemaResult.isErr()) {
+    return fieldSchemaResult;
+  }
+  const { fieldTypes, valueSchema } = fieldSchemaResult.value;
+
+  switch (expression.op) {
+    case "exists":
+      return new Ok(undefined);
+    case "eq": {
+      const valueType = getValueType(expression.value);
+      if (valueType === "array" || valueType === "object") {
+        return new Err(
+          new Error('Operator "eq" only supports scalar comparison values.')
+        );
+      }
+      if (
+        fieldTypes.size > 0 &&
+        !typesAcceptValue(fieldTypes, expression.value)
+      ) {
+        return new Err(
+          new Error(
+            `Value for "${expression.field}" must be ${formatTypes(fieldTypes)}, but received ${valueType}.`
+          )
+        );
+      }
+      return new Ok(undefined);
+    }
+    case "starts-with":
+    case "contains": {
+      const fieldTypeResult = validateFieldType({
+        expression,
+        fieldTypes,
+        expectedType: "string",
+      });
+      if (fieldTypeResult.isErr()) {
+        return fieldTypeResult;
+      }
+      if (typeof expression.value !== "string") {
+        return new Err(
+          new Error(`Operator "${expression.op}" requires a string value.`)
+        );
+      }
+      return new Ok(undefined);
+    }
+    case "gt":
+    case "gte":
+    case "lt":
+    case "lte": {
+      const fieldTypeResult = validateFieldType({
+        expression,
+        fieldTypes,
+        expectedType: "number",
+      });
+      if (fieldTypeResult.isErr()) {
+        return fieldTypeResult;
+      }
+      if (typeof expression.value !== "number") {
+        return new Err(
+          new Error(`Operator "${expression.op}" requires a number value.`)
+        );
+      }
+      return new Ok(undefined);
+    }
+    case "has": {
+      const fieldTypeResult = validateFieldType({
+        expression,
+        fieldTypes,
+        expectedType: "array",
+      });
+      if (fieldTypeResult.isErr()) {
+        return fieldTypeResult;
+      }
+      return validateValues(expression, valueSchema, [expression.value]);
+    }
+    case "has-all":
+    case "has-any": {
+      const fieldTypeResult = validateFieldType({
+        expression,
+        fieldTypes,
+        expectedType: "array",
+      });
+      if (fieldTypeResult.isErr()) {
+        return fieldTypeResult;
+      }
+      if (!expression.values?.length) {
+        return new Err(
+          new Error(`Operator "${expression.op}" requires a non-empty list.`)
+        );
+      }
+      return validateValues(expression, valueSchema, expression.values);
+    }
+    default:
+      return assertNever(expression.op);
+  }
+}
+
+function validateExpression(
+  expression: MatcherExpression,
+  schema: JSONSchema
+): Result<void, Error> {
+  if (isLogicalExpression(expression)) {
+    if (expression.expressions.length === 0) {
+      return new Err(
+        new Error(`Operator "${expression.op}" requires an expression.`)
+      );
+    }
+    for (const childExpression of expression.expressions) {
+      const childResult = validateExpression(childExpression, schema);
+      if (childResult.isErr()) {
+        return childResult;
+      }
+    }
+    return new Ok(undefined);
+  }
+
+  return validateOperationExpression(expression, schema);
+}
+
+export function validateWebhookFilter(
+  filter: string,
+  schema: JSONSchema
+): Result<void, Error> {
+  const parseResult = parseMatcherExpression(filter);
+  if (parseResult.isErr()) {
+    return new Err(
+      new Error(`Invalid filter syntax: ${parseResult.error.message}`)
+    );
+  }
+
+  return validateExpression(parseResult.value, schema);
+}


### PR DESCRIPTION
## Description

Generated webhook filters can be syntactically valid but never match when an operator is incompatible with the selected event schema, such as `has-any` on a string field.

This PR adds a validation step on the generated expressions. Checks the expression against the event JSON Schema to flag filters that will never match (assumes the JSON schemas are valid). Invalid filters get one retry with the validation error.

## Tests

- Added tests.

## Risk

Low. At worst we do a few more LLM calls.

## Deploy Plan

Deploy front.