### PR TITLE
[front] fix: hide activation opening message

### DIFF
--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -145,6 +145,7 @@ export const HIDDEN_MESSAGE_ORIGINS: UserMessageOrigin[] = [
   "onboarding_conversation",
   "project_kickoff",
   "reinforced_skill_notification",
+  "system_activation",
   "wakeup",
 ];
 


### PR DESCRIPTION
## Summary
- hide the system-generated Activation nudge prompt from conversation surfaces
- preserve the agent's first reply as the visible opening message

## Testing
Local validation

## Risk
Low

## Deploy
- Deploy front