### PR TITLE
Support Clojure files in GitHub code sync

### DIFF
--- a/connectors/src/connectors/github/lib/code/supported_files.test.ts
+++ b/connectors/src/connectors/github/lib/code/supported_files.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { isSupportedFile } from "./supported_files";
+
+describe("isSupportedFile", () => {
+  it("supports Clojure source files", () => {
+    for (const extension of [".clj", ".cljc", ".cljs"]) {
+      expect(isSupportedFile(`source${extension}`)).toBe(true);
+    }
+  });
+});

--- a/connectors/src/connectors/github/lib/code/supported_files.ts
+++ b/connectors/src/connectors/github/lib/code/supported_files.ts
@@ -20,6 +20,9 @@ const EXTENSION_WHITELIST = [
   ".hpp",
   ".php",
   ".scala",
+  ".clj", // Clojure
+  ".cljc", // Clojure cross-platform source
+  ".cljs", // ClojureScript
   ".kt", // Kotlin
   ".neon", // PHP configuration
   ".phtml", // PHP template


### PR DESCRIPTION
Adds `.clj`, `.cljc`, and `.cljs` to the GitHub code sync extension allowlist, with a focused regression test.

Fixes dust-tt/tasks#9872