### PR TITLE
[front] enh: add hint on user memory read tool usage

### DIFF
--- a/front/lib/resources/skill/code_defined/system/user_memory.ts
+++ b/front/lib/resources/skill/code_defined/system/user_memory.ts
@@ -22,7 +22,7 @@ const USER_MEMORY_INSTRUCTIONS = `<memory_guidelines>
 You have a persistent, user-scoped memory kept in a single \`MEMORY.md\` file, shared across all of this user's conversations and agents.
 
 <critical_behavior>
-Call the \`${READ_TOOL_NAME}\` tool to recall the user's memory before answering anything whose answer could depend on who they are: their work, projects, team, location, timezone, preferences, or past decisions; anything you write on their behalf or in their voice (emails, messages, documents); and any advice, recommendation, or plan for them. You cannot tell whether memory is relevant until you read it, so when unsure, read.
+Call the \`${READ_TOOL_NAME}\` tool directly with no arguments to recall the user's memory before answering anything whose answer could depend on who they are: their work, projects, team, location, timezone, preferences, or past decisions; anything you write on their behalf or in their voice (emails, messages, documents); and any advice, recommendation, or plan for them. You cannot tell whether memory is relevant until you read it, so when unsure, read.
 
 Watch for requests about the user themselves ("me", "my", "I"). If you are about to give a generic "it depends" answer because you lack a personal detail (where they live, their role, their team), read memory first: it may already be there. For example, "how long would it take me to fly to New York" depends on where the user lives, which may be in memory.
 

--- a/front/lib/resources/skill/code_defined/system/user_memory.ts
+++ b/front/lib/resources/skill/code_defined/system/user_memory.ts
@@ -22,7 +22,7 @@ const USER_MEMORY_INSTRUCTIONS = `<memory_guidelines>
 You have a persistent, user-scoped memory kept in a single \`MEMORY.md\` file, shared across all of this user's conversations and agents.
 
 <critical_behavior>
-Call the \`${READ_TOOL_NAME}\` tool directly with no arguments to recall the user's memory before answering anything whose answer could depend on who they are: their work, projects, team, location, timezone, preferences, or past decisions; anything you write on their behalf or in their voice (emails, messages, documents); and any advice, recommendation, or plan for them. You cannot tell whether memory is relevant until you read it, so when unsure, read.
+Call the \`${READ_TOOL_NAME}\` tool directly with no arguments to recall the user's memory before answering anything whose answer could depend on who they are: their work, projects, team, location, timezone, preferences, or past decisions; anything you write on their behalf or in their voice (emails, messages, documents); and any advice, recommendation, or plan for them. This tool is always available in every conversation, so you do not need to search for or enable it. You cannot tell whether memory is relevant until you read it, so when unsure, read.
 
 Watch for requests about the user themselves ("me", "my", "I"). If you are about to give a generic "it depends" answer because you lack a personal detail (where they live, their role, their team), read memory first: it may already be there. For example, "how long would it take me to fly to New York" depends on where the user lives, which may be in memory.
 

--- a/front/lib/resources/skill/code_defined/system/user_memory.ts
+++ b/front/lib/resources/skill/code_defined/system/user_memory.ts
@@ -28,7 +28,7 @@ Watch for requests about the user themselves ("me", "my", "I"). If you are about
 
 Skip reading only for self-contained requests whose answer cannot depend on the user, such as "who is the president of Spain", "translate this to French", or "what is 15% of 240".
 
-A single read returns the whole memory, so read it once per conversation. Read again only if the memory may have changed since.
+A single read returns the whole memory, so you do not need to provide a query or specify what to retrieve. Read it once per conversation. Read again only if the memory may have changed since.
 
 Add, edit, or remove memories with the \`${EDIT_TOOL_NAME}\` tool, which replaces an exact snippet of \`MEMORY.md\`:
 - To change existing memory, pass the exact current text as \`oldStr\` and the replacement as \`newStr\`.

--- a/front/lib/resources/skill/code_defined/system/user_memory.ts
+++ b/front/lib/resources/skill/code_defined/system/user_memory.ts
@@ -28,7 +28,7 @@ Watch for requests about the user themselves ("me", "my", "I"). If you are about
 
 Skip reading only for self-contained requests whose answer cannot depend on the user, such as "who is the president of Spain", "translate this to French", or "what is 15% of 240".
 
-A single read returns the whole memory, so you do not need to provide a query or specify what to retrieve. Read it once per conversation. Read again only if the memory may have changed since.
+You do not need to provide a query or specify what to retrieve: a single read returns the whole memory. Read it once per conversation. Read again only if the memory may have changed since.
 
 Add, edit, or remove memories with the \`${EDIT_TOOL_NAME}\` tool, which replaces an exact snippet of \`MEMORY.md\`:
 - To change existing memory, pass the exact current text as \`oldStr\` and the replacement as \`newStr\`.

--- a/front/lib/resources/skill/code_defined/system/user_memory.ts
+++ b/front/lib/resources/skill/code_defined/system/user_memory.ts
@@ -22,7 +22,7 @@ const USER_MEMORY_INSTRUCTIONS = `<memory_guidelines>
 You have a persistent, user-scoped memory kept in a single \`MEMORY.md\` file, shared across all of this user's conversations and agents.
 
 <critical_behavior>
-Call the \`${READ_TOOL_NAME}\` tool directly with no arguments to recall the user's memory before answering anything whose answer could depend on who they are: their work, projects, team, location, timezone, preferences, or past decisions; anything you write on their behalf or in their voice (emails, messages, documents); and any advice, recommendation, or plan for them. This tool is always available in every conversation, so you do not need to search for or enable it. You cannot tell whether memory is relevant until you read it, so when unsure, read.
+Call the \`${READ_TOOL_NAME}\` tool directly with no arguments to recall the user's memory before answering anything whose answer could depend on who they are: their work, projects, team, location, timezone, preferences, or past decisions; anything you write on their behalf or in their voice (emails, messages, documents); and any advice, recommendation, or plan for them. This tool is always available, so you do not need to search for or enable it. You cannot tell whether memory is relevant until you read it, so when unsure, read.
 
 Watch for requests about the user themselves ("me", "my", "I"). If you are about to give a generic "it depends" answer because you lack a personal detail (where they live, their role, their team), read memory first: it may already be there. For example, "how long would it take me to fly to New York" depends on where the user lives, which may be in memory.
 


### PR DESCRIPTION
## Description

Agents may not realize the user memory read tool can be invoked without constructing an input. This PR updates the User Memory system skill instructions to tell agents to call the read tool directly with no arguments when prior user context could change the answer.

This is a hack to bypass tool search for this specific case: we expect many conversations to require reading memories, less to require writing. Yet we'd have to eagerly load both tools for the sake of the conversations that only read them. This PR hopes to allow not requiring the agent to run a tool search for them, keeping the cost to a minimum.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
