### PR TITLE
Avoid approval when creating Pod conversations

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -3126,7 +3126,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   "pod_manager": {
     "add_content_node": "never_ask",
     "add_message_to_conversation": "medium",
-    "create_conversation": "medium",
+    "create_conversation": "never_ask",
     "create_pod": "low",
     "edit_information": "low",
     "get_information": "never_ask",

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -442,7 +442,7 @@ export const POD_MANAGER_TOOLS_METADATA = [
           INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD
         ].optional(),
     },
-    stake: "medium",
+    stake: "never_ask",
     displayLabels: {
       running: "Creating conversation",
       done: "Create conversation",


### PR DESCRIPTION
## Description

* Making create_conversation in a pod low stakes
* This is low blast radius and we make run_agent never_ask which is the same thing
* It helps to make this never_ask for activation so we can create conversations without blocking users

## Tests

* Local

## Risk

* Low

## Deploy Plan

* Deploy front