### PR TITLE
perf: index spaces by id in baseFetchWithAuthorization

### DIFF
--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -119,10 +119,14 @@ export abstract class ResourceWithSpace<
       dangerouslyBypassWorkspaceIsolationSecurity: true,
     });
 
+    // Resolve each blob's space through an index: `spaces` can hold thousands of rows and every
+    // Sequelize attribute read allocates, so the per-blob lookup has to stay O(1).
+    const spacesById = new Map(spaces.map((space) => [space.id, space]));
+
     return (
       blobs
         .map((b) => {
-          const space = spaces.find((space) => space.id === b.vaultId);
+          const space = spacesById.get(b.vaultId);
           if (!space) {
             throw new Error("Unreachable: space not found.");
           }


### PR DESCRIPTION
## Description

`baseFetchWithAuthorization` resolved each blob's space with `spaces.find(...)`, so the cost was O(blobs × spaces). Both sides of the comparison are Sequelize attribute reads, which allocate per call, so wide fetches spent a lot of time and memory there. Swapped in a Map lookup.

## Tests

No behaviour change, space ids are unique in the fetched set, so `find` and `Map.get` should be aligned, also, both return `undefined` on a miss.

## Risk

Low. Single expression, no signature or query change.

## Deploy Plan

Normal deploy.