### PR TITLE
fix: batch file deletion on workspace hard delete

### DIFF
--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -1623,4 +1623,50 @@ describe("FileResource", () => {
       );
     });
   });
+
+  describe("deleteAllForWorkspace", () => {
+    const makeFile = (auth: Authenticator, fileName: string) =>
+      FileFactory.create(auth, null, {
+        contentType: "text/plain",
+        fileName,
+        fileSize: 10,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: "conv-delete-all" },
+      });
+
+    it("should delete every file of the workspace", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      for (const fileName of ["a.txt", "b.txt", "c.txt"]) {
+        await makeFile(auth, fileName);
+      }
+
+      const deletedCount = await FileResource.deleteAllForWorkspace(auth);
+
+      expect(deletedCount).toBe(3);
+      expect(
+        await FileModel.count({ where: { workspaceId: workspace.id } })
+      ).toBe(0);
+    });
+
+    it("should leave the files of other workspaces untouched", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+      const { authenticator: otherAuth, workspace: otherWorkspace } =
+        await createResourceTest({ role: "admin" });
+
+      await makeFile(auth, "mine.txt");
+      await makeFile(otherAuth, "theirs.txt");
+
+      await FileResource.deleteAllForWorkspace(auth);
+
+      expect(
+        await FileModel.count({ where: { workspaceId: otherWorkspace.id } })
+      ).toBe(1);
+    });
+  });
 });

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -464,21 +464,22 @@ export class FileResource extends BaseResource<FileModel> {
       where: { workspaceId },
     });
 
-    return this.batchDestroyAllForWorkspace(workspaceId);
+    return this.batchDestroyAllForWorkspace(auth);
   }
 
   // A workspace can hold millions of files. Deleting them in a single statement exceeds the
   // Postgres statement timeout, and the aborted transaction rolls back after having written
   // gigabytes of WAL, which stalls every other query on the instance. Batching keeps each
   // statement short and lets the deletion make forward progress across retries.
-  private static async batchDestroyAllForWorkspace(workspaceId: ModelId) {
-    const localLogger = logger.child({ workspaceId });
+  private static async batchDestroyAllForWorkspace(auth: Authenticator) {
+    const owner = auth.getNonNullableWorkspace();
+    const localLogger = logger.child({ workspaceId: owner.id });
     let deletedCount = 0;
 
     for (;;) {
       const batch = await this.model.findAll({
         attributes: ["id"],
-        where: { workspaceId },
+        where: { workspaceId: owner.id },
         limit: BATCH_DESTROY_SIZE,
       });
 
@@ -488,7 +489,7 @@ export class FileResource extends BaseResource<FileModel> {
 
       deletedCount += await this.model.destroy({
         where: {
-          workspaceId,
+          workspaceId: owner.id,
           id: batch.map((file) => file.id),
         },
       });

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -118,6 +118,8 @@ const FRAME_CONTENT_TYPES = new Set([
   frameSlideshowContentType,
 ]);
 
+const BATCH_DESTROY_SIZE = 10_000;
+
 export interface FileUploadedRequestResponseBody {
   file: FileType & {
     /** Scoped mount path when the file is on GCS (same shape as `GCSMountEntryBase.path`). */
@@ -462,9 +464,43 @@ export class FileResource extends BaseResource<FileModel> {
       where: { workspaceId },
     });
 
-    return this.model.destroy({
-      where: { workspaceId },
-    });
+    return this.batchDestroyAllForWorkspace(workspaceId);
+  }
+
+  // A workspace can hold millions of files. Deleting them in a single statement exceeds the
+  // Postgres statement timeout, and the aborted transaction rolls back after having written
+  // gigabytes of WAL, which stalls every other query on the instance. Batching keeps each
+  // statement short and lets the deletion make forward progress across retries.
+  private static async batchDestroyAllForWorkspace(workspaceId: ModelId) {
+    const localLogger = logger.child({ workspaceId });
+    let deletedCount = 0;
+
+    for (;;) {
+      const batch = await this.model.findAll({
+        attributes: ["id"],
+        where: { workspaceId },
+        limit: BATCH_DESTROY_SIZE,
+      });
+
+      if (batch.length === 0) {
+        break;
+      }
+
+      deletedCount += await this.model.destroy({
+        where: {
+          workspaceId,
+          id: batch.map((file) => file.id),
+        },
+      });
+
+      localLogger.info({ deletedCount }, "Deleted a batch of workspace files");
+
+      if (batch.length < BATCH_DESTROY_SIZE) {
+        break;
+      }
+    }
+
+    return deletedCount;
   }
 
   static async deleteAllForUser(


### PR DESCRIPTION
## Description

`FileResource.deleteAllForWorkspace` deleted every file of a workspace in one unbounded `DELETE FROM files WHERE "workspaceId" = ?`. On a big enough workspace that never completes: it runs for the full 300s statement timeout, and Temporal retries it about every 7 minutes forever.

Deletes in batches of 10k now, so each statement is short and progress survives a retry.

## Tests

Added coverage for `deleteAllForWorkspace`, which had none: deletes all files of the workspace and returns the count, and leaves other workspaces alone. Full `file_resource.test.ts` suite passes (52).

## Risk

Low. Same end state, more statements. No longer atomic, but a partial delete just resumes on the next run, which is strictly better than the current behaviour.

## Deploy Plan

Nothing special. Once workers pick this up, the retry runs the batched version.