### PR TITLE
[front] chore: remove MCP usage outdated retro-compatibility path

### DIFF
--- a/front-api/routes/w/[wId]/mcp/usage.ts
+++ b/front-api/routes/w/[wId]/mcp/usage.ts
@@ -1,41 +1,17 @@
 import { getToolsUsage } from "@app/lib/api/agent_actions";
-import type {
-  GetMCPServersUsageResponseBody,
-  GetMCPServersUsageWithSkillsResponseBody,
-} from "@app/lib/api/mcp";
+import type { GetMCPServersUsageResponseBody } from "@app/lib/api/mcp";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-import { validate } from "@front-api/middlewares/validator";
-import { z } from "zod";
-
-const QuerySchema = z.object({
-  withSkills: z.enum(["true", "false"]).optional(),
-});
 
 // Mounted at /api/w/:wId/mcp/usage.
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
-  "/",
-  validate("query", QuerySchema),
-  async (
-    ctx
-  ): HandlerResult<
-    GetMCPServersUsageResponseBody | GetMCPServersUsageWithSkillsResponseBody
-  > => {
-    const auth = ctx.get("auth");
-    const { withSkills } = ctx.req.valid("query");
+app.get("/", async (ctx): HandlerResult<GetMCPServersUsageResponseBody> => {
+  const auth = ctx.get("auth");
 
-    // TODO(2024-08-04 aubin): Remove the withSkills compatibility path once legacy frontend traffic has drained.
-    if (withSkills === "true") {
-      const usage = await getToolsUsage(auth, { withSkills: true });
-      return ctx.json({ usage });
-    }
-
-    const usage = await getToolsUsage(auth);
-    return ctx.json({ usage });
-  }
-);
+  const usage = await getToolsUsage(auth);
+  return ctx.json({ usage });
+});
 
 export default app;

--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -28,7 +28,6 @@ import {
 import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { SkillUsageType } from "@app/types/assistant/skill_configuration";
-import type { AgentsUsageType } from "@app/types/data_source";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
@@ -39,7 +38,7 @@ import { useMemo, useState } from "react";
 type RowData = {
   mcpServer: MCPServerType;
   mcpServerView?: MCPServerViewType;
-  usage: AgentsUsageType | SkillUsageType | null;
+  usage: SkillUsageType | null;
   isConnected: boolean;
   account: string;
   spaces: SpaceType[];

--- a/front/lib/api/agent_actions.test.ts
+++ b/front/lib/api/agent_actions.test.ts
@@ -71,14 +71,7 @@ describe("getToolsUsage", () => {
       mcpServerViews: [firstView],
     });
 
-    const legacyUsage = await getToolsUsage(testContext.authenticator);
-
-    expect(legacyUsage[server.sId]?.count).toBe(2);
-    expect(legacyUsage[server.sId]).not.toHaveProperty("skills");
-
-    const adminUsage = await getToolsUsage(testContext.authenticator, {
-      withSkills: true,
-    });
+    const adminUsage = await getToolsUsage(testContext.authenticator);
 
     expect(adminUsage[server.sId]?.count).toBe(4);
     expect(adminUsage[server.sId]?.agents.map((agent) => agent.sId)).toEqual([
@@ -99,7 +92,7 @@ describe("getToolsUsage", () => {
       testContext.workspace.sId
     );
 
-    const memberUsage = await getToolsUsage(auth, { withSkills: true });
+    const memberUsage = await getToolsUsage(auth);
 
     expect(memberUsage[server.sId]?.count).toBe(2);
     expect(memberUsage[server.sId]?.agents.map((agent) => agent.sId)).toEqual([

--- a/front/lib/api/agent_actions.ts
+++ b/front/lib/api/agent_actions.ts
@@ -7,7 +7,6 @@ import type {
   SkillUsageType,
   UsedBySkillType,
 } from "@app/types/assistant/skill_configuration";
-import type { AgentsUsageType } from "@app/types/data_source";
 import type { ModelId } from "@app/types/shared/model_id";
 import { QueryTypes } from "sequelize";
 
@@ -15,7 +14,6 @@ import { QueryTypes } from "sequelize";
 // If it is a problem, let's add caching
 const DISABLE_QUERIES = false;
 
-export type MCPServersUsageByAgent = Record<string, AgentsUsageType>;
 export type MCPServersUsage = Record<string, SkillUsageType>;
 
 interface MCPServerUsageRow {
@@ -71,7 +69,7 @@ async function buildVisibilityFilter(auth: Authenticator): Promise<{
 function rowToUsageEntry(
   row: MCPServerUsageRow,
   workspaceId: ModelId
-): { key: string; usage: AgentsUsageType } {
+): { key: string; usage: SkillUsageType } {
   const key =
     row.internalMCPServerId ||
     remoteMCPServerNameToSId({
@@ -88,6 +86,7 @@ function rowToUsageEntry(
         name: row.names[index],
         pictureUrl: row.pictureUrls[index],
       })),
+      skills: [],
     },
   };
 }
@@ -130,17 +129,9 @@ async function fetchSkillsByMCPServer(
   return skillsByMCPServer;
 }
 
-export function getToolsUsage(
-  auth: Authenticator
-): Promise<MCPServersUsageByAgent>;
-export function getToolsUsage(
-  auth: Authenticator,
-  options: { withSkills: true }
-): Promise<MCPServersUsage>;
 export async function getToolsUsage(
-  auth: Authenticator,
-  options?: { withSkills: true }
-): Promise<MCPServersUsageByAgent | MCPServersUsage> {
+  auth: Authenticator
+): Promise<MCPServersUsage> {
   const owner = auth.workspace();
 
   if (!owner || !auth.isUser()) {
@@ -174,33 +165,20 @@ export async function getToolsUsage(
     `,
     { replacements: params, type: QueryTypes.SELECT }
   );
-  const result: MCPServersUsageByAgent = {};
+  const result: MCPServersUsage = {};
   for (const row of rows) {
     const { key, usage } = rowToUsageEntry(row, owner.id);
     result[key] = usage;
   }
 
-  if (!options?.withSkills) {
-    return result;
-  }
-
   const skillsByMCPServer = await fetchSkillsByMCPServer(auth);
-  const resultWithSkills: MCPServersUsage = {};
-  for (const [mcpServerId, usage] of Object.entries(result)) {
-    resultWithSkills[mcpServerId] = {
-      count: usage.count,
-      agents: usage.agents,
-      skills: [],
-    };
-  }
-
   for (const [mcpServerId, skills] of skillsByMCPServer) {
-    const usage = resultWithSkills[mcpServerId];
+    const usage = result[mcpServerId];
     if (usage) {
       usage.skills = skills;
       usage.count += skills.length;
     } else {
-      resultWithSkills[mcpServerId] = {
+      result[mcpServerId] = {
         count: skills.length,
         agents: [],
         skills,
@@ -208,5 +186,5 @@ export async function getToolsUsage(
     }
   }
 
-  return resultWithSkills;
+  return result;
 }

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -17,10 +17,7 @@ import {
   isLightServerSideMCPToolConfiguration,
   isServerSideMCPToolConfiguration,
 } from "@app/lib/actions/types/guards";
-import type {
-  MCPServersUsage,
-  MCPServersUsageByAgent,
-} from "@app/lib/api/agent_actions";
+import type { MCPServersUsage } from "@app/lib/api/agent_actions";
 import type {
   PatchMCPServerBodySchema,
   PostRequestActionsAccessBodySchema,
@@ -240,10 +237,6 @@ export type DeleteMCPServerResponseBody = {
 };
 
 export type GetMCPServersUsageResponseBody = {
-  usage: MCPServersUsageByAgent;
-};
-
-export type GetMCPServersUsageWithSkillsResponseBody = {
   usage: MCPServersUsage;
 };
 

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -13,7 +13,6 @@ import type {
   GetMCPServerResponseBody,
   GetMCPServersResponseBody,
   GetMCPServersUsageResponseBody,
-  GetMCPServersUsageWithSkillsResponseBody,
   GetMCPServerViewsListResponseBody,
   GetMCPServerViewsNotActivatedResponseBody,
   MCPServerType,
@@ -971,11 +970,9 @@ export function useMCPServersUsage({
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
-  const configFetcher: Fetcher<
-    GetMCPServersUsageResponseBody | GetMCPServersUsageWithSkillsResponseBody
-  > = fetcher;
+  const configFetcher: Fetcher<GetMCPServersUsageResponseBody> = fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/mcp/usage?withSkills=true`,
+    `/api/w/${owner.sId}/mcp/usage`,
     configFetcher,
     {
       disabled,


### PR DESCRIPTION
## Description

Follow-up to #29819. The frontend rollout that consumes skill usage from the MCP usage endpoint is complete, so this removes the temporary `withSkills` opt-in and the legacy agent-only response contract.

The endpoint now always returns agent and skill usage, and the frontend uses the canonical usage URL again.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
