### PR TITLE
[front] enh: retry all same-server actions on personal authentication connection

### DIFF
--- a/front/lib/api/assistant/conversation/resolve_authentication.ts
+++ b/front/lib/api/assistant/conversation/resolve_authentication.ts
@@ -132,7 +132,8 @@ export async function resolveAuthentication(
   const { sandboxChildActionInfo } = action.stepContext;
   const isSandboxChildAction = isSandboxChildActionInfo(sandboxChildActionInfo);
 
-  let resolvedActions: AgentMCPActionResource[];
+  let actionWasResolved: boolean;
+  let actionIdsToClearFromRedis: string[];
   let remainingBlockedActionsForAgentMessage: AgentMCPActionResource[] | null =
     null;
   if (
@@ -142,19 +143,21 @@ export async function resolveAuthentication(
   ) {
     const result =
       await action.markSameMCPServerAuthenticationActionsReady(auth);
-    resolvedActions = result.resolvedActions;
+    actionWasResolved = true;
+    actionIdsToClearFromRedis = result.resolvedActions.map(
+      (resolvedAction) => resolvedAction.sId
+    );
     remainingBlockedActionsForAgentMessage = result.remainingBlockedActions;
   } else {
     const [updatedCount] = await action.updateStatusFromExpected(auth, {
       status: outcome === "completed" ? "ready_allowed_explicitly" : "denied",
       expectedStatus: blockedStatus,
     });
-    resolvedActions = updatedCount > 0 ? [action] : [];
+    actionWasResolved = updatedCount > 0;
+    actionIdsToClearFromRedis = [action.sId];
   }
 
-  if (
-    !resolvedActions.some((resolvedAction) => resolvedAction.id === action.id)
-  ) {
+  if (!actionWasResolved) {
     logger.info(
       {
         actionId,
@@ -168,9 +171,7 @@ export async function resolveAuthentication(
     return new Ok(undefined);
   }
 
-  const resolvedActionIds = new Set(
-    resolvedActions.map((resolvedAction) => resolvedAction.sId)
-  );
+  const resolvedActionIds = new Set(actionIdsToClearFromRedis);
   await getRedisHybridManager().removeEvent((event) => {
     const payload = JSON.parse(event.message["payload"]);
     return (

--- a/front/lib/api/assistant/conversation/resolve_authentication.ts
+++ b/front/lib/api/assistant/conversation/resolve_authentication.ts
@@ -133,7 +133,8 @@ export async function resolveAuthentication(
   const isSandboxChildAction = isSandboxChildActionInfo(sandboxChildActionInfo);
 
   let resolvedActions: AgentMCPActionResource[];
-  let blockedActionsForAgentMessage: AgentMCPActionResource[] | null = null;
+  let remainingBlockedActionsForAgentMessage: AgentMCPActionResource[] | null =
+    null;
   if (
     kind === "authentication" &&
     outcome === "completed" &&
@@ -141,7 +142,7 @@ export async function resolveAuthentication(
   ) {
     const result = await action.markMatchingAuthenticationActionsReady(auth);
     resolvedActions = result.resolvedActions;
-    blockedActionsForAgentMessage = result.blockedActions;
+    remainingBlockedActionsForAgentMessage = result.remainingBlockedActions;
   } else {
     const [updatedCount] = await action.updateStatusFromExpected(auth, {
       status: outcome === "completed" ? "ready_allowed_explicitly" : "denied",
@@ -198,10 +199,8 @@ export async function resolveAuthentication(
     return new Ok(undefined);
   }
 
-  const blockedActions = blockedActionsForAgentMessage
-    ? blockedActionsForAgentMessage.filter(
-        (blockedAction) => !resolvedActionIds.has(blockedAction.sId)
-      )
+  const blockedActions = remainingBlockedActionsForAgentMessage
+    ? remainingBlockedActionsForAgentMessage
     : (
         await AgentMCPActionResource.listBlockedActionsForConversation(
           auth,

--- a/front/lib/api/assistant/conversation/resolve_authentication.ts
+++ b/front/lib/api/assistant/conversation/resolve_authentication.ts
@@ -140,7 +140,8 @@ export async function resolveAuthentication(
     outcome === "completed" &&
     !isSandboxChildAction
   ) {
-    const result = await action.markMatchingAuthenticationActionsReady(auth);
+    const result =
+      await action.markSameMCPServerAuthenticationActionsReady(auth);
     resolvedActions = result.resolvedActions;
     remainingBlockedActionsForAgentMessage = result.remainingBlockedActions;
   } else {

--- a/front/lib/api/assistant/conversation/resolve_authentication.ts
+++ b/front/lib/api/assistant/conversation/resolve_authentication.ts
@@ -1,4 +1,5 @@
 import {
+  type AgentLoopBlockedToolExecution,
   isToolFileAuthRequiredEvent,
   isToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp";
@@ -136,6 +137,7 @@ export async function resolveAuthentication(
   let actionIdsToClearFromRedis: string[];
   let remainingBlockedActionsForAgentMessage: AgentMCPActionResource[] | null =
     null;
+
   if (
     kind === "authentication" &&
     outcome === "completed" &&
@@ -201,14 +203,21 @@ export async function resolveAuthentication(
     return new Ok(undefined);
   }
 
-  const blockedActions = remainingBlockedActionsForAgentMessage
-    ? remainingBlockedActionsForAgentMessage
-    : (
-        await AgentMCPActionResource.listBlockedActionsForConversation(
-          auth,
-          conversation
-        )
-      ).filter((blockedAction) => blockedAction.messageId === messageId);
+  let blockedActions:
+    | AgentMCPActionResource[]
+    | AgentLoopBlockedToolExecution[];
+  if (remainingBlockedActionsForAgentMessage !== null) {
+    blockedActions = remainingBlockedActionsForAgentMessage;
+  } else {
+    const blockedActionsForConversation =
+      await AgentMCPActionResource.listBlockedActionsForConversation(
+        auth,
+        conversation
+      );
+    blockedActions = blockedActionsForConversation.filter(
+      (blockedAction) => blockedAction.messageId === messageId
+    );
+  }
 
   if (blockedActions.length > 0) {
     logger.info(

--- a/front/lib/api/assistant/conversation/resolve_authentication.ts
+++ b/front/lib/api/assistant/conversation/resolve_authentication.ts
@@ -133,12 +133,15 @@ export async function resolveAuthentication(
   const isSandboxChildAction = isSandboxChildActionInfo(sandboxChildActionInfo);
 
   let resolvedActions: AgentMCPActionResource[];
+  let blockedActionsForAgentMessage: AgentMCPActionResource[] | null = null;
   if (
     kind === "authentication" &&
     outcome === "completed" &&
     !isSandboxChildAction
   ) {
-    resolvedActions = await action.markMatchingAuthenticationActionsReady(auth);
+    const result = await action.markMatchingAuthenticationActionsReady(auth);
+    resolvedActions = result.resolvedActions;
+    blockedActionsForAgentMessage = result.blockedActions;
   } else {
     const [updatedCount] = await action.updateStatusFromExpected(auth, {
       status: outcome === "completed" ? "ready_allowed_explicitly" : "denied",
@@ -195,13 +198,18 @@ export async function resolveAuthentication(
     return new Ok(undefined);
   }
 
-  const blockedActions =
-    await AgentMCPActionResource.listBlockedActionsForConversation(
-      auth,
-      conversation
-    );
+  const blockedActions = blockedActionsForAgentMessage
+    ? blockedActionsForAgentMessage.filter(
+        (blockedAction) => !resolvedActionIds.has(blockedAction.sId)
+      )
+    : (
+        await AgentMCPActionResource.listBlockedActionsForConversation(
+          auth,
+          conversation
+        )
+      ).filter((blockedAction) => blockedAction.messageId === messageId);
 
-  if (blockedActions.some((a) => a.messageId === messageId)) {
+  if (blockedActions.length > 0) {
     logger.info(
       { blockedActions },
       "Skipping agent loop launch because there are remaining blocked actions"

--- a/front/lib/api/assistant/conversation/resolve_authentication.ts
+++ b/front/lib/api/assistant/conversation/resolve_authentication.ts
@@ -129,12 +129,27 @@ export async function resolveAuthentication(
     );
   }
 
-  const [updatedCount] = await action.updateStatusFromExpected(auth, {
-    status: outcome === "completed" ? "ready_allowed_explicitly" : "denied",
-    expectedStatus: blockedStatus,
-  });
+  const { sandboxChildActionInfo } = action.stepContext;
+  const isSandboxChildAction = isSandboxChildActionInfo(sandboxChildActionInfo);
 
-  if (updatedCount === 0) {
+  let resolvedActions: AgentMCPActionResource[];
+  if (
+    kind === "authentication" &&
+    outcome === "completed" &&
+    !isSandboxChildAction
+  ) {
+    resolvedActions = await action.markMatchingAuthenticationActionsReady(auth);
+  } else {
+    const [updatedCount] = await action.updateStatusFromExpected(auth, {
+      status: outcome === "completed" ? "ready_allowed_explicitly" : "denied",
+      expectedStatus: blockedStatus,
+    });
+    resolvedActions = updatedCount > 0 ? [action] : [];
+  }
+
+  if (
+    !resolvedActions.some((resolvedAction) => resolvedAction.id === action.id)
+  ) {
     logger.info(
       {
         actionId,
@@ -148,16 +163,18 @@ export async function resolveAuthentication(
     return new Ok(undefined);
   }
 
+  const resolvedActionIds = new Set(
+    resolvedActions.map((resolvedAction) => resolvedAction.sId)
+  );
   await getRedisHybridManager().removeEvent((event) => {
     const payload = JSON.parse(event.message["payload"]);
     return (
       isMatchingEvent(payload) &&
-      (payload as { actionId: string }).actionId === actionId
+      resolvedActionIds.has((payload as { actionId: string }).actionId)
     );
   }, getMessageChannelId(messageId));
 
-  const { sandboxChildActionInfo } = action.stepContext;
-  if (isSandboxChildActionInfo(sandboxChildActionInfo)) {
+  if (isSandboxChildAction) {
     // Sandbox-child resolution always relaunches the parent bash (the
     // frozen sandbox must be thawed regardless of auth outcome — the
     // relaunched bash sees the failure in its tool-call response).

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -44,6 +44,7 @@ import {
   publishAgentMessagesEvents,
   publishMessageEventsOnMessagePostOrEdit,
 } from "@app/lib/api/assistant/streaming/events";
+import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import { Authenticator } from "@app/lib/auth";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
 import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
@@ -815,6 +816,7 @@ describe("validateAction", () => {
     permission = "low",
     argumentsRequiringApproval,
     augmentedInputs = {},
+    toolServerId = "test-server",
   }: {
     agentMessageId: number;
     status?: ToolExecutionStatus;
@@ -823,6 +825,7 @@ describe("validateAction", () => {
     permission?: MCPToolStakeLevelType;
     argumentsRequiringApproval?: string[];
     augmentedInputs?: Record<string, unknown>;
+    toolServerId?: string;
   }) {
     const functionCallId = generateRandomModelSId();
     const currentIndex = stepContentIndex++;
@@ -864,7 +867,7 @@ describe("validateAction", () => {
       internalMCPServerId: null,
       availability: "auto",
       permission,
-      toolServerId: "test-server",
+      toolServerId,
       retryPolicy: "no_retry",
       originalName: configurationName,
       mcpServerName: "test_server",
@@ -904,6 +907,36 @@ describe("validateAction", () => {
     });
 
     return { action, actionId, stepContent };
+  }
+
+  async function createAgentMessageForResolution() {
+    const userMessage = await ConversationFactory.createUserMessageWithRank({
+      auth,
+      workspace,
+      conversationId: conversation.id,
+      rank: 0,
+      content: "Test message",
+    });
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+    });
+
+    const agentMessage = await ConversationFactory.createAgentMessageWithRank({
+      workspace,
+      conversationId: conversation.id,
+      rank: 1,
+      agentConfigurationId: agentConfig.sId,
+      agentConfigurationVersion: agentConfig.version,
+      parentId: userMessage.id,
+    });
+    if (!agentMessage.agentMessageId) {
+      throw new Error("Just-created agent message is missing its model ID.");
+    }
+
+    return {
+      agentMessage,
+      agentMessageModelId: agentMessage.agentMessageId,
+    };
   }
 
   async function createAgentMessageWithNullUserParent() {
@@ -1724,6 +1757,109 @@ describe("validateAction", () => {
   });
 
   describe("agent loop launching", () => {
+    it("resolves parallel authentication blocks for the same MCP server", async () => {
+      const { agentMessage, agentMessageModelId } =
+        await createAgentMessageForResolution();
+      const { action: firstAction, actionId: firstActionId } =
+        await createBlockedAction({
+          agentMessageId: agentMessageModelId,
+          status: "blocked_authentication_required",
+        });
+      const { action: secondAction, actionId: secondActionId } =
+        await createBlockedAction({
+          agentMessageId: agentMessageModelId,
+          status: "blocked_authentication_required",
+        });
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      expect(conversationResource).not.toBeNull();
+
+      const result = await resolveAuthentication(auth, conversationResource!, {
+        actionId: firstActionId,
+        messageId: agentMessage.sId,
+        outcome: "completed",
+      });
+
+      expect(result.isOk()).toBe(true);
+      await firstAction.reload();
+      await secondAction.reload();
+      expect(firstAction.status).toBe("ready_allowed_explicitly");
+      expect(secondAction.status).toBe("ready_allowed_explicitly");
+      expect(vi.mocked(launchAgentLoopWorkflow)).toHaveBeenCalledTimes(1);
+
+      const removeEventMock = vi.mocked(getRedisHybridManager().removeEvent);
+      expect(removeEventMock).toHaveBeenCalledTimes(1);
+      const [removeEventPredicate] = removeEventMock.mock.calls[0];
+      const makeAuthenticationEvent = (actionId: string) => ({
+        id: generateRandomModelSId(),
+        message: {
+          payload: JSON.stringify({
+            type: "tool_personal_auth_required",
+            actionId,
+          }),
+        },
+      });
+      expect(removeEventPredicate(makeAuthenticationEvent(firstActionId))).toBe(
+        true
+      );
+      expect(
+        removeEventPredicate(makeAuthenticationEvent(secondActionId))
+      ).toBe(true);
+    });
+
+    it("does not resolve authentication blocks for another MCP server", async () => {
+      const { agentMessage, agentMessageModelId } =
+        await createAgentMessageForResolution();
+      const { actionId: firstActionId } = await createBlockedAction({
+        agentMessageId: agentMessageModelId,
+        status: "blocked_authentication_required",
+      });
+      const { action: otherServerAction, actionId: otherServerActionId } =
+        await createBlockedAction({
+          agentMessageId: agentMessageModelId,
+          status: "blocked_authentication_required",
+          toolServerId: "other-test-server",
+        });
+      // Keep a serializable blocked action in the test conversation: auth actions whose fake MCP
+      // server has no corresponding view are intentionally omitted from the UI response.
+      await createBlockedAction({
+        agentMessageId: agentMessageModelId,
+        status: "blocked_validation_required",
+      });
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      expect(conversationResource).not.toBeNull();
+
+      const result = await resolveAuthentication(auth, conversationResource!, {
+        actionId: firstActionId,
+        messageId: agentMessage.sId,
+        outcome: "completed",
+      });
+
+      expect(result.isOk()).toBe(true);
+      await otherServerAction.reload();
+      expect(otherServerAction.status).toBe("blocked_authentication_required");
+      expect(vi.mocked(launchAgentLoopWorkflow)).not.toHaveBeenCalled();
+
+      const removeEventMock = vi.mocked(getRedisHybridManager().removeEvent);
+      const [removeEventPredicate] = removeEventMock.mock.calls[0];
+      expect(
+        removeEventPredicate({
+          id: generateRandomModelSId(),
+          message: {
+            payload: JSON.stringify({
+              type: "tool_personal_auth_required",
+              actionId: otherServerActionId,
+            }),
+          },
+        })
+      ).toBe(false);
+    });
+
     it("should not launch agent loop when there are remaining blocked actions", async () => {
       // Create a user message and agent message
       const { messageRow } = await ConversationFactory.createUserMessage({

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1535,8 +1535,8 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   }
 
   /**
-   * Marks every direct authentication-blocked action from the same agent-message step and MCP
-   * server as ready. A personal connection is scoped to the MCP server, so one completed
+   * Marks every direct authentication-blocked action from the same agent message and MCP server
+   * as ready. A personal connection is scoped to the MCP server, so one completed
    * authentication can unblock parallel calls to any of its tools. Sandbox-child actions are
    * excluded because each one must thaw and relaunch its own parent bash.
    */

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1540,7 +1540,9 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
    * authentication can unblock parallel calls to any of its tools. Sandbox-child actions are
    * excluded because each one must thaw and relaunch its own parent bash.
    */
-  async markMatchingAuthenticationActionsReady(auth: Authenticator): Promise<{
+  async markSameMCPServerAuthenticationActionsReady(
+    auth: Authenticator
+  ): Promise<{
     remainingBlockedActions: AgentMCPActionResource[];
     resolvedActions: AgentMCPActionResource[];
   }> {
@@ -1553,6 +1555,8 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       ? blockedActions.filter(
           (action) =>
             action.status === "blocked_authentication_required" &&
+            // Sharing an MCP server is our proxy for the completed personal authentication being
+            // reusable by this action.
             action.metadata.mcpServerId === mcpServerId &&
             !isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)
         )

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1543,7 +1543,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   async markMatchingAuthenticationActionsReady(
     auth: Authenticator
   ): Promise<AgentMCPActionResource[]> {
-    const mcpServerId = this.metadata.mcpServerId;
+    const { mcpServerId } = this.metadata;
     const blockedActions = mcpServerId
       ? await AgentMCPActionResource.listBlockedActionsForAgentMessage(auth, {
           agentMessageId: this.agentMessageId,

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1541,7 +1541,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
    * excluded because each one must thaw and relaunch its own parent bash.
    */
   async markMatchingAuthenticationActionsReady(auth: Authenticator): Promise<{
-    blockedActions: AgentMCPActionResource[];
+    remainingBlockedActions: AgentMCPActionResource[];
     resolvedActions: AgentMCPActionResource[];
   }> {
     const { mcpServerId } = this.metadata;
@@ -1569,7 +1569,14 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       }
     );
 
-    return { blockedActions, resolvedActions };
+    const resolvedActionIds = new Set(
+      resolvedActions.map((action) => action.id)
+    );
+    const remainingBlockedActions = blockedActions.filter(
+      (action) => !resolvedActionIds.has(action.id)
+    );
+
+    return { remainingBlockedActions, resolvedActions };
   }
 
   /**

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1540,34 +1540,36 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
    * authentication can unblock parallel calls to any of its tools. Sandbox-child actions are
    * excluded because each one must thaw and relaunch its own parent bash.
    */
-  async markMatchingAuthenticationActionsReady(
-    auth: Authenticator
-  ): Promise<AgentMCPActionResource[]> {
+  async markMatchingAuthenticationActionsReady(auth: Authenticator): Promise<{
+    blockedActions: AgentMCPActionResource[];
+    resolvedActions: AgentMCPActionResource[];
+  }> {
     const { mcpServerId } = this.metadata;
-    const blockedActions = mcpServerId
-      ? await AgentMCPActionResource.listBlockedActionsForAgentMessage(auth, {
-          agentMessageId: this.agentMessageId,
-        })
+    const blockedActions =
+      await AgentMCPActionResource.listBlockedActionsForAgentMessage(auth, {
+        agentMessageId: this.agentMessageId,
+      });
+    const resolvedActions = mcpServerId
+      ? blockedActions.filter(
+          (action) =>
+            action.status === "blocked_authentication_required" &&
+            action.metadata.mcpServerId === mcpServerId &&
+            !isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)
+        )
       : [this];
-    const matchingActions = blockedActions.filter(
-      (action) =>
-        action.status === "blocked_authentication_required" &&
-        action.metadata.mcpServerId === mcpServerId &&
-        !isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)
-    );
 
     await AgentMCPActionModel.update(
       { status: "ready_allowed_explicitly" },
       {
         where: {
-          id: { [Op.in]: matchingActions.map((action) => action.id) },
+          id: { [Op.in]: resolvedActions.map((action) => action.id) },
           workspaceId: auth.getNonNullableWorkspace().id,
           status: "blocked_authentication_required",
         },
       }
     );
 
-    return matchingActions;
+    return { blockedActions, resolvedActions };
   }
 
   /**

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1535,6 +1535,50 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   }
 
   /**
+   * Marks every direct authentication-blocked action from the same agent-message step and MCP
+   * server as ready. A personal connection is scoped to the MCP server, so one completed
+   * authentication can unblock parallel calls to any of its tools. The update is batched and
+   * compare-and-swapped so concurrent resolutions have a single winner. Sandbox-child actions are
+   * excluded because each one must thaw and relaunch its own parent bash.
+   */
+  async markMatchingAuthenticationActionsReady(
+    auth: Authenticator
+  ): Promise<AgentMCPActionResource[]> {
+    const mcpServerId = this.metadata.mcpServerId;
+    const blockedActions = mcpServerId
+      ? await AgentMCPActionResource.listBlockedActionsForAgentMessage(auth, {
+          agentMessageId: this.agentMessageId,
+        })
+      : [this];
+    const matchingActions = blockedActions.filter(
+      (action) =>
+        action.status === "blocked_authentication_required" &&
+        action.metadata.mcpServerId === mcpServerId &&
+        !isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)
+    );
+
+    // Do not let an idempotent request for an action resolved elsewhere claim its siblings.
+    if (!matchingActions.some((action) => action.id === this.id)) {
+      return [];
+    }
+
+    const [, affectedRows] = await AgentMCPActionModel.update(
+      { status: "ready_allowed_explicitly" },
+      {
+        where: {
+          id: { [Op.in]: matchingActions.map((action) => action.id) },
+          workspaceId: auth.getNonNullableWorkspace().id,
+          status: "blocked_authentication_required",
+        },
+        returning: true,
+      }
+    );
+    const affectedActionIds = new Set(affectedRows.map((action) => action.id));
+
+    return matchingActions.filter((action) => affectedActionIds.has(action.id));
+  }
+
+  /**
    * Resolves the (light) agent configuration that owns this action, via the
    * action's agent message. Returns null if the agent message can't be found.
    * Keeps the agent-message model lookup inside the resource layer.

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1537,8 +1537,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   /**
    * Marks every direct authentication-blocked action from the same agent-message step and MCP
    * server as ready. A personal connection is scoped to the MCP server, so one completed
-   * authentication can unblock parallel calls to any of its tools. The update is batched and
-   * compare-and-swapped so concurrent resolutions have a single winner. Sandbox-child actions are
+   * authentication can unblock parallel calls to any of its tools. Sandbox-child actions are
    * excluded because each one must thaw and relaunch its own parent bash.
    */
   async markMatchingAuthenticationActionsReady(
@@ -1557,12 +1556,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         !isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)
     );
 
-    // Do not let an idempotent request for an action resolved elsewhere claim its siblings.
-    if (!matchingActions.some((action) => action.id === this.id)) {
-      return [];
-    }
-
-    const [, affectedRows] = await AgentMCPActionModel.update(
+    await AgentMCPActionModel.update(
       { status: "ready_allowed_explicitly" },
       {
         where: {
@@ -1570,12 +1564,10 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
           workspaceId: auth.getNonNullableWorkspace().id,
           status: "blocked_authentication_required",
         },
-        returning: true,
       }
     );
-    const affectedActionIds = new Set(affectedRows.map((action) => action.id));
 
-    return matchingActions.filter((action) => affectedActionIds.has(action.id));
+    return matchingActions;
   }
 
   /**

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1558,7 +1558,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         )
       : [this];
 
-    await AgentMCPActionModel.update(
+    await this.model.update(
       { status: "ready_allowed_explicitly" },
       {
         where: {


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/9921.

When the model outputs several parallel tool calls for a server that requires authentication (seems to happen often for certain MCP servers like Slack) the user needs to authenticate for all of them, even if the connection we get the first time could be used for all of them.

This PR updates the personal auth flow to look for blocked actions from the same MCP server and retrying them all. Since it's personal authentication it's fine to retry even if the tool execution fails .

## Tests

- Added tests for both the happy path and the path where we have other actions.

## Risk

- Low.

## Deploy Plan

- Deploy front.
