### PR TITLE
[front] enh: add CSV mode to domain identity merge script

### DIFF
--- a/front/scripts/merge_domain_user_identities.ts
+++ b/front/scripts/merge_domain_user_identities.ts
@@ -3,8 +3,34 @@ import { Authenticator } from "@app/lib/auth";
 import { mergeUserIdentities } from "@app/lib/iam/users";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { parse } from "csv-parse/sync";
+import { promises as fs } from "fs";
+import { z } from "zod";
 
 import { makeScript } from "./helpers";
+
+const EmailSchema = z
+  .string()
+  .email()
+  .transform((email) => email.toLowerCase());
+const CsvMappingSchema = z.array(
+  z.object({
+    "From address": EmailSchema,
+    "To address": EmailSchema,
+  })
+);
+
+async function loadEmailMappings(filePath: string) {
+  const content = await fs.readFile(filePath, "utf-8");
+  return CsvMappingSchema.parse(
+    parse(content, {
+      bom: true,
+      columns: true,
+      skip_empty_lines: true,
+      trim: true,
+    })
+  );
+}
 
 makeScript(
   {
@@ -17,21 +43,40 @@ makeScript(
     oldDomain: {
       describe: "Old email domain (e.g. old.com) — secondary accounts",
       type: "string" as const,
-      demandOption: true,
     },
     newDomain: {
       describe: "New email domain (e.g. new.com) — primary accounts",
       type: "string" as const,
-      demandOption: true,
+    },
+    file: {
+      alias: "f",
+      describe: "CSV mapping From address to To address",
+      type: "string" as const,
     },
     userId: {
-      describe:
-        "Optional sId of a single old-domain (secondary) user to process",
+      describe: "Optional sId of a single secondary user to process",
       type: "string" as const,
     },
   },
-  async ({ workspaceId, oldDomain, newDomain, userId, execute }, logger) => {
-    if (oldDomain === newDomain) {
+  async (
+    { workspaceId, oldDomain, newDomain, file, userId, execute },
+    logger
+  ) => {
+    if (file && (oldDomain || newDomain)) {
+      logger.error(
+        { file, oldDomain, newDomain },
+        "Pass either --file or both --oldDomain and --newDomain"
+      );
+      return;
+    }
+    if (!file && (!oldDomain || !newDomain)) {
+      logger.error(
+        { oldDomain, newDomain },
+        "Pass either --file or both --oldDomain and --newDomain"
+      );
+      return;
+    }
+    if (oldDomain && newDomain && oldDomain === newDomain) {
       logger.error({ oldDomain, newDomain }, "Old and new domains must differ");
       return;
     }
@@ -50,6 +95,11 @@ makeScript(
 
     logger.info({ memberCount: members.length }, "Fetched workspace members");
 
+    const mappings = file ? await loadEmailMappings(file) : null;
+    const memberByEmail = new Map(
+      members.map((member) => [member.email.toLowerCase(), member])
+    );
+
     // Build a map local -> member for new-domain members (primary accounts).
     const primaryByLocal = new Map(
       members
@@ -63,23 +113,48 @@ makeScript(
         })
     );
 
-    // Secondary users have an email on the old domain.
-    let oldDomainMembers = members.filter((m) => {
-      const [, domain] = m.email.split("@");
-      return domain === oldDomain;
-    });
+    let targetEmailBySourceEmail: Map<string, string> | null = null;
+    let oldDomainMembers: typeof members;
+    if (mappings) {
+      targetEmailBySourceEmail = new Map(
+        mappings.map((mapping) => [
+          mapping["From address"],
+          mapping["To address"],
+        ])
+      );
+      oldDomainMembers = mappings.map((mapping) => {
+        const fromEmail = mapping["From address"];
+        const member = memberByEmail.get(fromEmail);
+        if (!member) {
+          throw new Error(
+            `No active workspace member found with email: ${fromEmail}`
+          );
+        }
+        return member;
+      });
+      logger.info(
+        { mappingCount: mappings.length },
+        "Loaded CSV identity mappings"
+      );
+    } else {
+      // Secondary users have an email on the old domain.
+      oldDomainMembers = members.filter((m) => {
+        const [, domain] = m.email.split("@");
+        return domain === oldDomain;
+      });
 
-    logger.info(
-      { oldDomainMemberCount: oldDomainMembers.length },
-      "Found old-domain members"
-    );
+      logger.info(
+        { oldDomainMemberCount: oldDomainMembers.length },
+        "Found old-domain members"
+      );
+    }
 
     if (userId) {
       oldDomainMembers = oldDomainMembers.filter((m) => m.sId === userId);
       if (oldDomainMembers.length === 0) {
         logger.error(
-          { userId, oldDomain },
-          "No old-domain member found with the provided userId"
+          { userId },
+          "No secondary member found with the provided userId"
         );
         return;
       }
@@ -98,8 +173,13 @@ makeScript(
 
     for (const secondaryMember of oldDomainMembers) {
       const [local] = secondaryMember.email.split("@");
-      const newEmail = `${local}@${newDomain}`;
-      const primaryMember = primaryByLocal.get(local);
+      const mappedEmail = targetEmailBySourceEmail?.get(
+        secondaryMember.email.toLowerCase()
+      );
+      const newEmail = mappedEmail ?? `${local}@${newDomain}`;
+      const primaryMember = mappedEmail
+        ? memberByEmail.get(mappedEmail)
+        : primaryByLocal.get(local);
 
       if (!primaryMember) {
         logger.info(
@@ -108,7 +188,7 @@ makeScript(
         );
         results.skipped.push({
           email: secondaryMember.email,
-          reason: `No primary member found for new-domain email ${newEmail}`,
+          reason: `No primary member found for target email ${newEmail}`,
         });
         continue;
       }

--- a/front/scripts/merge_mapped_identities.ts
+++ b/front/scripts/merge_mapped_identities.ts
@@ -5,9 +5,7 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { parse } from "csv-parse/sync";
 import { promises as fs } from "fs";
-import { extname } from "path";
 import { z } from "zod";
 
 import { makeScript } from "./helpers";
@@ -16,17 +14,11 @@ const EmailSchema = z
   .string()
   .email()
   .transform((email) => email.toLowerCase());
-const JsonMergeFileSchema = z.array(
+const MergeFileSchema = z.array(
   z.object({
     _comment: z.string().min(1),
     email: EmailSchema,
     sIdToKeep: z.string().min(1),
-  })
-);
-const CsvMergeFileSchema = z.array(
-  z.object({
-    "From address": EmailSchema,
-    "To address": EmailSchema,
   })
 );
 const MIN_ADMINS_FOR_REVOCATION = 2;
@@ -67,82 +59,34 @@ function parseComment(comment: string) {
     .parse({ oldEmail, primaryEmail });
 }
 
-async function loadRecords(filePath: string): Promise<MergeRecord[]> {
+async function loadRecords(filePath: string) {
   const content = await fs.readFile(filePath, "utf-8");
-  let records: MergeRecord[];
-
-  if (extname(filePath).toLowerCase() === ".csv") {
-    const inputRecords = CsvMergeFileSchema.parse(
-      parse(content, {
-        bom: true,
-        columns: true,
-        skip_empty_lines: true,
-        trim: true,
-      })
-    );
-    const oldUsers = await UserResource.fetchByEmails(
-      inputRecords.map((record) => record["From address"])
-    );
-    const oldUserByEmail = new Map<string, UserResource>();
-    const duplicateOldEmails = new Set<string>();
-    for (const oldUser of oldUsers) {
-      const email = oldUser.email.toLowerCase();
-      if (oldUserByEmail.has(email)) {
-        duplicateOldEmails.add(email);
-        continue;
-      }
-      oldUserByEmail.set(email, oldUser);
-    }
-
-    records = inputRecords.map((record) => {
-      const oldEmail = record["From address"];
-      if (duplicateOldEmails.has(oldEmail)) {
-        throw new Error(`Multiple users found with email: ${oldEmail}`);
-      }
-      const oldUser = oldUserByEmail.get(oldEmail);
-      if (!oldUser) {
-        throw new Error(`No user found with email: ${oldEmail}`);
-      }
-
-      return {
-        primaryEmail: record["To address"],
-        expectedOldEmail: oldEmail,
-        oldUserId: oldUser.sId,
-      };
-    });
-  } else {
-    const inputRecords = JsonMergeFileSchema.parse(JSON.parse(content));
-    records = inputRecords.map(({ _comment, email, sIdToKeep }) => {
-      const { oldEmail, primaryEmail } = parseComment(_comment);
-      if (primaryEmail !== email) {
-        throw new Error(`Comment primary email does not match: ${email}`);
-      }
-
-      // The issue mapping names this field sIdToKeep, but its comment identifies it as the old
-      // account whose data must move to the newly provisioned account at `email`.
-      return {
-        primaryEmail: email,
-        expectedOldEmail: oldEmail,
-        oldUserId: sIdToKeep,
-      };
-    });
-  }
-
+  const inputRecords = MergeFileSchema.parse(JSON.parse(content));
   const primaryEmails = new Set<string>();
   const oldUserIds = new Set<string>();
 
-  for (const record of records) {
-    if (primaryEmails.has(record.primaryEmail)) {
-      throw new Error(`Duplicate primary email: ${record.primaryEmail}`);
+  return inputRecords.map(({ _comment, email, sIdToKeep }) => {
+    const { oldEmail, primaryEmail } = parseComment(_comment);
+    if (primaryEmail !== email) {
+      throw new Error(`Comment primary email does not match: ${email}`);
     }
-    if (oldUserIds.has(record.oldUserId)) {
-      throw new Error(`Duplicate old user ID: ${record.oldUserId}`);
+    if (primaryEmails.has(email)) {
+      throw new Error(`Duplicate primary email: ${email}`);
     }
-    primaryEmails.add(record.primaryEmail);
-    oldUserIds.add(record.oldUserId);
-  }
+    if (oldUserIds.has(sIdToKeep)) {
+      throw new Error(`Duplicate old user ID: ${sIdToKeep}`);
+    }
+    primaryEmails.add(email);
+    oldUserIds.add(sIdToKeep);
 
-  return records;
+    // The issue mapping names this field sIdToKeep, but its comment identifies it as the old
+    // account whose data must move to the newly provisioned account at `email`.
+    return {
+      primaryEmail: email,
+      expectedOldEmail: oldEmail,
+      oldUserId: sIdToKeep,
+    };
+  });
 }
 
 function indexMembers(members: Member[]) {
@@ -162,12 +106,11 @@ function indexMembers(members: Member[]) {
     if (memberWorkspace.role === "admin") {
       activeAdminCount += 1;
     }
-    const email = member.email.toLowerCase();
-    if (primaryByEmail.has(email)) {
-      duplicateEmails.add(email);
+    if (primaryByEmail.has(member.email)) {
+      duplicateEmails.add(member.email);
       continue;
     }
-    primaryByEmail.set(email, member);
+    primaryByEmail.set(member.email, member);
   }
 
   return { memberById, primaryByEmail, duplicateEmails, activeAdminCount };
@@ -338,8 +281,7 @@ makeScript(
     },
     file: {
       alias: "f",
-      describe:
-        "CSV mapping From address to To address, or issue JSON mapping primary emails to old user IDs",
+      describe: "Issue JSON mapping primary emails to old user IDs",
       type: "string" as const,
       demandOption: true,
     },

--- a/front/scripts/merge_mapped_identities.ts
+++ b/front/scripts/merge_mapped_identities.ts
@@ -5,7 +5,9 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { parse } from "csv-parse/sync";
 import { promises as fs } from "fs";
+import { extname } from "path";
 import { z } from "zod";
 
 import { makeScript } from "./helpers";
@@ -14,11 +16,17 @@ const EmailSchema = z
   .string()
   .email()
   .transform((email) => email.toLowerCase());
-const MergeFileSchema = z.array(
+const JsonMergeFileSchema = z.array(
   z.object({
     _comment: z.string().min(1),
     email: EmailSchema,
     sIdToKeep: z.string().min(1),
+  })
+);
+const CsvMergeFileSchema = z.array(
+  z.object({
+    "From address": EmailSchema,
+    "To address": EmailSchema,
   })
 );
 const MIN_ADMINS_FOR_REVOCATION = 2;
@@ -59,34 +67,82 @@ function parseComment(comment: string) {
     .parse({ oldEmail, primaryEmail });
 }
 
-async function loadRecords(filePath: string) {
+async function loadRecords(filePath: string): Promise<MergeRecord[]> {
   const content = await fs.readFile(filePath, "utf-8");
-  const inputRecords = MergeFileSchema.parse(JSON.parse(content));
+  let records: MergeRecord[];
+
+  if (extname(filePath).toLowerCase() === ".csv") {
+    const inputRecords = CsvMergeFileSchema.parse(
+      parse(content, {
+        bom: true,
+        columns: true,
+        skip_empty_lines: true,
+        trim: true,
+      })
+    );
+    const oldUsers = await UserResource.fetchByEmails(
+      inputRecords.map((record) => record["From address"])
+    );
+    const oldUserByEmail = new Map<string, UserResource>();
+    const duplicateOldEmails = new Set<string>();
+    for (const oldUser of oldUsers) {
+      const email = oldUser.email.toLowerCase();
+      if (oldUserByEmail.has(email)) {
+        duplicateOldEmails.add(email);
+        continue;
+      }
+      oldUserByEmail.set(email, oldUser);
+    }
+
+    records = inputRecords.map((record) => {
+      const oldEmail = record["From address"];
+      if (duplicateOldEmails.has(oldEmail)) {
+        throw new Error(`Multiple users found with email: ${oldEmail}`);
+      }
+      const oldUser = oldUserByEmail.get(oldEmail);
+      if (!oldUser) {
+        throw new Error(`No user found with email: ${oldEmail}`);
+      }
+
+      return {
+        primaryEmail: record["To address"],
+        expectedOldEmail: oldEmail,
+        oldUserId: oldUser.sId,
+      };
+    });
+  } else {
+    const inputRecords = JsonMergeFileSchema.parse(JSON.parse(content));
+    records = inputRecords.map(({ _comment, email, sIdToKeep }) => {
+      const { oldEmail, primaryEmail } = parseComment(_comment);
+      if (primaryEmail !== email) {
+        throw new Error(`Comment primary email does not match: ${email}`);
+      }
+
+      // The issue mapping names this field sIdToKeep, but its comment identifies it as the old
+      // account whose data must move to the newly provisioned account at `email`.
+      return {
+        primaryEmail: email,
+        expectedOldEmail: oldEmail,
+        oldUserId: sIdToKeep,
+      };
+    });
+  }
+
   const primaryEmails = new Set<string>();
   const oldUserIds = new Set<string>();
 
-  return inputRecords.map(({ _comment, email, sIdToKeep }) => {
-    const { oldEmail, primaryEmail } = parseComment(_comment);
-    if (primaryEmail !== email) {
-      throw new Error(`Comment primary email does not match: ${email}`);
+  for (const record of records) {
+    if (primaryEmails.has(record.primaryEmail)) {
+      throw new Error(`Duplicate primary email: ${record.primaryEmail}`);
     }
-    if (primaryEmails.has(email)) {
-      throw new Error(`Duplicate primary email: ${email}`);
+    if (oldUserIds.has(record.oldUserId)) {
+      throw new Error(`Duplicate old user ID: ${record.oldUserId}`);
     }
-    if (oldUserIds.has(sIdToKeep)) {
-      throw new Error(`Duplicate old user ID: ${sIdToKeep}`);
-    }
-    primaryEmails.add(email);
-    oldUserIds.add(sIdToKeep);
+    primaryEmails.add(record.primaryEmail);
+    oldUserIds.add(record.oldUserId);
+  }
 
-    // The issue mapping names this field sIdToKeep, but its comment identifies it as the old
-    // account whose data must move to the newly provisioned account at `email`.
-    return {
-      primaryEmail: email,
-      expectedOldEmail: oldEmail,
-      oldUserId: sIdToKeep,
-    };
-  });
+  return records;
 }
 
 function indexMembers(members: Member[]) {
@@ -106,11 +162,12 @@ function indexMembers(members: Member[]) {
     if (memberWorkspace.role === "admin") {
       activeAdminCount += 1;
     }
-    if (primaryByEmail.has(member.email)) {
-      duplicateEmails.add(member.email);
+    const email = member.email.toLowerCase();
+    if (primaryByEmail.has(email)) {
+      duplicateEmails.add(email);
       continue;
     }
-    primaryByEmail.set(member.email, member);
+    primaryByEmail.set(email, member);
   }
 
   return { memberById, primaryByEmail, duplicateEmails, activeAdminCount };
@@ -281,7 +338,8 @@ makeScript(
     },
     file: {
       alias: "f",
-      describe: "Issue JSON mapping primary emails to old user IDs",
+      describe:
+        "CSV mapping From address to To address, or issue JSON mapping primary emails to old user IDs",
       type: "string" as const,
       demandOption: true,
     },


### PR DESCRIPTION
## Description

Allow the domain identity merge script to merge a list of explicit email pairs from a CSV, rather than requiring every user to follow the same old-domain/new-domain mapping.

The script accepts a file with From address and To address columns, validates and normalizes the addresses, and looks up active workspace members by email before running the existing merge flow. CSV mode processes every mapping by default, remains a dry run unless --execute is passed, and can still be narrowed with --userId. The existing domain-based invocation remains supported.

## Tests

- Tested locally.

## Risk

- Low. Internal script only.

## Deploy Plan

- No deploy.