### PR TITLE
fix: index skill_file_attachments.fileId

### DIFF
--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -379,6 +379,14 @@ SkillFileAttachmentModel.init(
         name: "idx_skill_file_attachment_workspace_file",
         unique: true,
       },
+      // The `fileId` foreign key is ON DELETE RESTRICT, so Postgres checks this table on every
+      // `files` row deletion. That check filters on `fileId` alone, which the composite index
+      // above cannot serve.
+      {
+        fields: ["fileId"],
+        name: "idx_skill_file_attachment_file",
+        concurrently: true,
+      },
     ],
   }
 );

--- a/front/migrations/pre-deploy/20260805092806_add_file_id_index_to_skill_file_attachments.sql
+++ b/front/migrations/pre-deploy/20260805092806_add_file_id_index_to_skill_file_attachments.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY idx_skill_file_attachment_file ON public.skill_file_attachments USING btree ("fileId");


### PR DESCRIPTION
## Description

`skill_file_attachments.fileId` has an `ON DELETE RESTRICT` foreign key to `files.id`, so Postgres runs `SELECT 1 FROM ONLY skill_file_attachments WHERE $1 = "fileId" FOR KEY SHARE` for every `files` row that gets deleted. The only index covering that column is the `(workspaceId, fileId)` composite, which can't serve a lookup that doesn't constrain the leading column, so each check falls back to a sequential scan.

Came out of looking at #30005: during a workspace hard delete, `DELETE FROM files WHERE
"workspaceId" = ?` kept hitting the 300s statement timeout. Batching there keeps each statement short; this makes the per-row FK check cheap. The other four FK columns referencing `files.id` already have `fileId` as their leading column.

## Tests

Applied locally and confirmed the planner picks it up for the FK check shape:

```
Bitmap Index Scan on idx_skill_file_attachment_file
  Index Cond: ("fileId" = 42)
```

## Risk

Low

## Deploy Plan

Pre-deploy migration, then deploy