### PR TITLE
Pricing/Poke: add the topup history of the pool in poke

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/credits/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/index.ts
@@ -5,6 +5,7 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 
 import awuPoolSummary from "./awu-pool-summary";
 import membersUsage from "./members-usage";
+import topUps from "./top-ups";
 
 // Mounted at /api/poke/workspaces/:wId/credits.
 const app = pokeApp();
@@ -35,5 +36,6 @@ app.get("/", async (ctx): HandlerResult<PokeListCreditsResponseBody> => {
 
 app.route("/awu-pool-summary", awuPoolSummary);
 app.route("/members-usage", membersUsage);
+app.route("/top-ups", topUps);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/credits/top-ups.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/top-ups.ts
@@ -1,0 +1,49 @@
+import type { AwuTopUpsHistoryError } from "@app/lib/api/credits/top_ups_history";
+import { getAwuTopUpsHistory } from "@app/lib/api/credits/top_ups_history";
+import type { GetAwuTopUpsHistoryResponseBody } from "@app/types/api/credits/top_ups_history";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import type { Context } from "hono";
+
+export type { GetAwuTopUpsHistoryResponseBody };
+
+function topUpsErrorToApi(ctx: Context, err: AwuTopUpsHistoryError) {
+  switch (err.type) {
+    case "not_configured":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      });
+    case "balances_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}
+
+// Mounted at /api/poke/workspaces/:wId/credits/top-ups.
+const app = pokeApp();
+
+/** @ignoreswagger */
+app.get("/", async (ctx): HandlerResult<GetAwuTopUpsHistoryResponseBody> => {
+  const auth = ctx.get("auth");
+
+  const result = await getAwuTopUpsHistory(auth);
+  if (result.isErr()) {
+    return topUpsErrorToApi(ctx, result.error);
+  }
+  return ctx.json(result.value);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/credits/top-ups.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/top-ups.ts
@@ -1,36 +1,10 @@
-import type { AwuTopUpsHistoryError } from "@app/lib/api/credits/top_ups_history";
 import { getAwuTopUpsHistory } from "@app/lib/api/credits/top_ups_history";
 import type { GetAwuTopUpsHistoryResponseBody } from "@app/types/api/credits/top_ups_history";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-import { apiError } from "@front-api/middlewares/utils";
-import type { Context } from "hono";
+import { topUpsErrorToApi } from "@front-api/routes/w/[wId]/credits/top-ups";
 
 export type { GetAwuTopUpsHistoryResponseBody };
-
-function topUpsErrorToApi(ctx: Context, err: AwuTopUpsHistoryError) {
-  switch (err.type) {
-    case "not_configured":
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Workspace is not configured for Metronome billing.",
-        },
-      });
-    case "balances_fetch_failed":
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
-        },
-      });
-    default:
-      assertNever(err.type);
-  }
-}
 
 // Mounted at /api/poke/workspaces/:wId/credits/top-ups.
 const app = pokeApp();

--- a/front-api/routes/w/[wId]/credits/top-ups.ts
+++ b/front-api/routes/w/[wId]/credits/top-ups.ts
@@ -8,7 +8,7 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import type { Context } from "hono";
 
-function topUpsErrorToApi(ctx: Context, err: AwuTopUpsHistoryError) {
+export function topUpsErrorToApi(ctx: Context, err: AwuTopUpsHistoryError) {
   switch (err.type) {
     case "not_configured":
       return apiError(ctx, {

--- a/front/components/poke/credits/PokeTopUpsHistoryTable.tsx
+++ b/front/components/poke/credits/PokeTopUpsHistoryTable.tsx
@@ -1,0 +1,85 @@
+import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import { formatCredits } from "@app/lib/client/credits";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import { usePokeTopUpsHistory } from "@app/poke/swr/credits";
+import type { WorkspaceType } from "@app/types/user";
+import { AlertCircle, ContentMessage } from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useMemo } from "react";
+
+interface PokeTopUpsHistoryTableProps {
+  owner: WorkspaceType;
+}
+
+type TopUpRowData = {
+  date: string;
+  name: string;
+  credits: string;
+  expiration: string;
+};
+
+const COLUMNS: ColumnDef<TopUpRowData>[] = [
+  {
+    accessorKey: "date",
+    header: "Date",
+    enableSorting: false,
+  },
+  {
+    accessorKey: "name",
+    header: "Top-up",
+    enableSorting: false,
+  },
+  {
+    accessorKey: "credits",
+    header: "Credits",
+    enableSorting: false,
+  },
+  {
+    accessorKey: "expiration",
+    header: "Expiration",
+    enableSorting: false,
+  },
+];
+
+export function PokeTopUpsHistoryTable({ owner }: PokeTopUpsHistoryTableProps) {
+  const { topUps, isTopUpsHistoryLoading, isTopUpsHistoryError } =
+    usePokeTopUpsHistory({ owner });
+
+  const rows: TopUpRowData[] = useMemo(() => {
+    const nowMs = Date.now();
+    return topUps.map((topUp) => ({
+      date: formatTimestampToFriendlyDate(topUp.grantedAtMs, "compactWithDay"),
+      name: topUp.name,
+      credits: formatCredits(topUp.amountCredits),
+      expiration:
+        topUp.expiresAtMs <= nowMs
+          ? `Expired ${formatTimestampToFriendlyDate(topUp.expiresAtMs, "compactWithDay")}`
+          : formatTimestampToFriendlyDate(topUp.expiresAtMs, "compactWithDay"),
+    }));
+  }, [topUps]);
+
+  if (isTopUpsHistoryError) {
+    return (
+      <ContentMessage
+        title="Failed to load top-ups history"
+        icon={AlertCircle}
+        variant="warning"
+      >
+        Could not load the top-ups history for this workspace.
+      </ContentMessage>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-border p-4">
+      <span className="text-sm font-medium text-foreground">
+        Top-ups history
+      </span>
+      <PokeDataTable
+        columns={COLUMNS}
+        data={rows}
+        isLoading={isTopUpsHistoryLoading}
+      />
+    </div>
+  );
+}

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -2,6 +2,7 @@ import { AlertChip } from "@app/components/poke/credits/AlertChip";
 import { CreditStateLogsLink } from "@app/components/poke/credits/CreditStateLogsLink";
 import { PokeAwuUsageFromAnalyticsChart } from "@app/components/poke/credits/PokeAwuUsageFromAnalyticsChart";
 import { PokeMembersUsageTable } from "@app/components/poke/credits/PokeMembersUsageTable";
+import { PokeTopUpsHistoryTable } from "@app/components/poke/credits/PokeTopUpsHistoryTable";
 import { ReconcileCreditStateButton } from "@app/components/poke/credits/ReconcileCreditStateButton";
 import type {
   PokeCreditUsageConfig,
@@ -309,6 +310,7 @@ export function PokeUsageTab({
       />
       <PokeDefaultAlertsCard defaultAlerts={defaultAlerts} />
       <PokeCreditPoolCard owner={owner} />
+      <PokeTopUpsHistoryTable owner={owner} />
       <PokeMembersUsageTable owner={owner} />
       {billingCycleStartDay && (
         <PokeAwuUsageFromAnalyticsChart

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -10,6 +10,7 @@ import type { GetMembersUsageResponseBody } from "@app/lib/api/credits/members_u
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { AwuPoolSummaryResponseBody } from "@app/types/api/credits/awu_pool_summary";
+import type { GetAwuTopUpsHistoryResponseBody } from "@app/types/api/credits/top_ups_history";
 import type { PokeListCreditsResponseBody } from "@app/types/api/poke/credits";
 import type { Fetcher } from "swr";
 
@@ -159,6 +160,27 @@ export function usePokeAwuPoolSummary({
     isAwuPoolSummaryError: error,
     isAwuPoolSummaryValidating: isValidating,
     mutateAwuPoolSummary: mutate,
+  };
+}
+
+export function usePokeTopUpsHistory({
+  owner,
+  disabled,
+}: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
+  const fetcherFn: Fetcher<GetAwuTopUpsHistoryResponseBody> = fetcher;
+
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
+    disabled ? null : `/api/poke/workspaces/${owner.sId}/credits/top-ups`,
+    fetcherFn
+  );
+
+  return {
+    topUps: data?.topUps ?? emptyArray(),
+    isTopUpsHistoryLoading: !error && !data && !disabled,
+    isTopUpsHistoryError: error,
+    isTopUpsHistoryValidating: isValidating,
+    mutateTopUpsHistory: mutate,
   };
 }
 


### PR DESCRIPTION
## Description

Add the same topup history from admin page into poke

<img width="3192" height="738" alt="image" src="https://github.com/user-attachments/assets/dd2b6eed-a468-46ae-a8da-ffd4bd18c796" />


## Tests
tested locally

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
