### PR TITLE
[front] Allow sandbox bash commands up to 10 minutes

### DIFF
--- a/front/lib/actions/constants.test.ts
+++ b/front/lib/actions/constants.test.ts
@@ -4,7 +4,6 @@ import {
   SANDBOX_MAX_COMMAND_TIMEOUT_MS,
   SANDBOX_MCP_REQUEST_TIMEOUT_MS,
   TOOL_ACTIVITY_START_TO_CLOSE_TIMEOUT_MS,
-  TOOL_RESULT_PROCESSING_BUDGET_MS,
 } from "@app/lib/actions/constants";
 import { describe, expect, it } from "vitest";
 
@@ -21,9 +20,9 @@ describe("tool timeouts", () => {
     ).toBeLessThan(SANDBOX_MCP_REQUEST_TIMEOUT_MS);
   });
 
-  it("leaves room to process tool results within the tool activity", () => {
-    expect(
-      SANDBOX_MCP_REQUEST_TIMEOUT_MS + TOOL_RESULT_PROCESSING_BUDGET_MS
-    ).toBeLessThanOrEqual(TOOL_ACTIVITY_START_TO_CLOSE_TIMEOUT_MS);
+  it("aborts the MCP call before the tool activity times out", () => {
+    expect(SANDBOX_MCP_REQUEST_TIMEOUT_MS).toBeLessThan(
+      TOOL_ACTIVITY_START_TO_CLOSE_TIMEOUT_MS
+    );
   });
 });

--- a/front/lib/actions/constants.test.ts
+++ b/front/lib/actions/constants.test.ts
@@ -1,0 +1,29 @@
+import {
+  SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS,
+  SANDBOX_EXEC_TIMEOUT_BUFFER_MS,
+  SANDBOX_MAX_COMMAND_TIMEOUT_MS,
+  SANDBOX_MCP_REQUEST_TIMEOUT_MS,
+  TOOL_ACTIVITY_START_TO_CLOSE_TIMEOUT_MS,
+  TOOL_RESULT_PROCESSING_BUDGET_MS,
+} from "@app/lib/actions/constants";
+import { describe, expect, it } from "vitest";
+
+describe("tool timeouts", () => {
+  it("lets the sandbox default fit within the max the model can request", () => {
+    expect(SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS).toBeLessThanOrEqual(
+      SANDBOX_MAX_COMMAND_TIMEOUT_MS
+    );
+  });
+
+  it("stops a sandbox command in-container before the provider gives up", () => {
+    expect(
+      SANDBOX_MAX_COMMAND_TIMEOUT_MS + SANDBOX_EXEC_TIMEOUT_BUFFER_MS
+    ).toBeLessThan(SANDBOX_MCP_REQUEST_TIMEOUT_MS);
+  });
+
+  it("leaves room to process tool results within the tool activity", () => {
+    expect(
+      SANDBOX_MCP_REQUEST_TIMEOUT_MS + TOOL_RESULT_PROCESSING_BUDGET_MS
+    ).toBeLessThanOrEqual(TOOL_ACTIVITY_START_TO_CLOSE_TIMEOUT_MS);
+  });
+});

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -7,6 +7,44 @@ export const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes.
 
 export const RUN_AGENT_CALL_TOOL_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes.
 
+// Default and maximum timeout the model can request for a single sandbox bash
+// command. The value is enforced in-container by the `timeout` wrapper (see
+// `wrapCommandWithCapture`), which kills the command and returns the captured
+// output when it overruns.
+export const SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS = 60 * 1000;
+export const SANDBOX_MAX_COMMAND_TIMEOUT_MS = 10 * 60 * 1000;
+
+// Extra time we add on top of a command's in-container timeout to set the
+// timeout we give the sandbox provider. The in-container `timeout` wrapper
+// stops the command and returns whatever output it has; this extra time lets
+// that finish and reach us before the provider gives up. A few seconds is
+// plenty (it only covers stopping the command and sending its output back).
+export const SANDBOX_EXEC_TIMEOUT_BUFFER_MS = 10 * 1000;
+
+// Outer MCP request deadline for the sandbox server. It must be strictly
+// greater than the max in-container command timeout so the graceful
+// in-container timeout (which returns partial output) always fires before the
+// MCP layer hard-aborts the call. The buffer covers process teardown, output
+// flushing, and the host round-trip.
+const SANDBOX_MCP_TIMEOUT_BUFFER_MS = 30 * 1000;
+export const SANDBOX_MCP_REQUEST_TIMEOUT_MS =
+  SANDBOX_MAX_COMMAND_TIMEOUT_MS + SANDBOX_MCP_TIMEOUT_BUFFER_MS;
+
+// Time reserved inside the tool activity for the work surrounding the MCP call:
+// action setup and tool result processing, which can take minutes on large
+// outputs (see `processToolResults`).
+export const TOOL_RESULT_PROCESSING_BUDGET_MS = 5 * 60 * 1000;
+
+// Start-to-close for the Temporal tool activities: the longest MCP deadline any
+// tool can hold, plus the processing budget. Tool activities are not retried, so
+// blowing this budget loses the tool call instead of returning partial output.
+export const TOOL_ACTIVITY_START_TO_CLOSE_TIMEOUT_MS =
+  Math.max(
+    RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
+    DEFAULT_MCP_REQUEST_TIMEOUT_MS,
+    SANDBOX_MCP_REQUEST_TIMEOUT_MS
+  ) + TOOL_RESULT_PROCESSING_BUDGET_MS;
+
 export const RETRY_ON_INTERRUPT_MAX_ATTEMPTS = 15;
 
 // Stored in a separate file to prevent a circular dependency issue.

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -30,20 +30,18 @@ const SANDBOX_MCP_TIMEOUT_BUFFER_MS = 30 * 1000;
 export const SANDBOX_MCP_REQUEST_TIMEOUT_MS =
   SANDBOX_MAX_COMMAND_TIMEOUT_MS + SANDBOX_MCP_TIMEOUT_BUFFER_MS;
 
-// Time reserved inside the tool activity for the work surrounding the MCP call:
-// action setup and tool result processing, which can take minutes on large
-// outputs (see `processToolResults`).
-export const TOOL_RESULT_PROCESSING_BUDGET_MS = 5 * 60 * 1000;
-
 // Start-to-close for the Temporal tool activities: the longest MCP deadline any
-// tool can hold, plus the processing budget. Tool activities are not retried, so
-// blowing this budget loses the tool call instead of returning partial output.
+// tool can hold, plus a short buffer for the work surrounding the MCP call
+// (action setup, tool result processing) and to detect worker restarts
+// promptly. The MCP deadlines above are inputs so the activity always outlives
+// the tool call it wraps.
+const TOOL_ACTIVITY_TIMEOUT_BUFFER_MS = 60 * 1000;
 export const TOOL_ACTIVITY_START_TO_CLOSE_TIMEOUT_MS =
   Math.max(
     RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
     DEFAULT_MCP_REQUEST_TIMEOUT_MS,
     SANDBOX_MCP_REQUEST_TIMEOUT_MS
-  ) + TOOL_RESULT_PROCESSING_BUDGET_MS;
+  ) + TOOL_ACTIVITY_TIMEOUT_BUFFER_MS;
 
 export const RETRY_ON_INTERRUPT_MAX_ATTEMPTS = 15;
 

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -2,6 +2,7 @@ import type { InternalAllowedIconType } from "@app/components/resources/resource
 import {
   type MCPToolStakeLevelType,
   RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
+  SANDBOX_MCP_REQUEST_TIMEOUT_MS,
 } from "@app/lib/actions/constants";
 import type {
   ServerMetadata,
@@ -69,10 +70,7 @@ import { RUN_AGENT_SERVER } from "@app/lib/api/actions/servers/run_agent/metadat
 import { RUN_DUST_APP_SERVER } from "@app/lib/api/actions/servers/run_dust_app/metadata";
 import { SALESFORCE_SERVER } from "@app/lib/api/actions/servers/salesforce/metadata";
 import { SALESLOFT_SERVER } from "@app/lib/api/actions/servers/salesloft/metadata";
-import {
-  SANDBOX_MCP_REQUEST_TIMEOUT_MS,
-  SANDBOX_SERVER,
-} from "@app/lib/api/actions/servers/sandbox/metadata";
+import { SANDBOX_SERVER } from "@app/lib/api/actions/servers/sandbox/metadata";
 import { SANDBOX_FUNCTIONS_SERVER } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 import { SCHEDULES_MANAGEMENT_SERVER } from "@app/lib/api/actions/servers/schedules_management/metadata";
 import { SEARCH_SERVER } from "@app/lib/api/actions/servers/search/metadata";

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -8,7 +8,7 @@ export const SANDBOX_TOOL_NAME = "sandbox" as const;
 // `wrapCommandWithCapture`), which kills the command and returns the captured
 // output when it overruns.
 export const SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS = 60000;
-const SANDBOX_MAX_COMMAND_TIMEOUT_MS = 120000;
+const SANDBOX_MAX_COMMAND_TIMEOUT_MS = 10 * 60 * 1000;
 
 // Extra time we add on top of a command's in-container timeout to set the
 // timeout we give the sandbox provider. The in-container `timeout`
@@ -23,7 +23,10 @@ export const SANDBOX_EXEC_TIMEOUT_BUFFER_MS = 10000;
 // greater than the max in-container command timeout so the graceful
 // in-container timeout (which returns partial output) always fires before the
 // MCP layer hard-aborts the call. The buffer covers process teardown, output
-// flushing, and the host round-trip.
+// flushing, and the host round-trip. It must also stay small enough that the
+// resulting deadline stays under the tool activity `startToCloseTimeout` in
+// `temporal/agent_loop/workflows.ts`, which Temporal derives from
+// RUN_AGENT_CALL_TOOL_TIMEOUT_MS plus a minute.
 const SANDBOX_MCP_TIMEOUT_BUFFER_MS = 30000;
 export const SANDBOX_MCP_REQUEST_TIMEOUT_MS =
   SANDBOX_MAX_COMMAND_TIMEOUT_MS + SANDBOX_MCP_TIMEOUT_BUFFER_MS;

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -1,35 +1,11 @@
+import {
+  SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS,
+  SANDBOX_MAX_COMMAND_TIMEOUT_MS,
+} from "@app/lib/actions/constants";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
 export const SANDBOX_TOOL_NAME = "sandbox" as const;
-
-// Default and maximum timeout the model can request for a single bash command.
-// The value is enforced in-container by the `timeout` wrapper (see
-// `wrapCommandWithCapture`), which kills the command and returns the captured
-// output when it overruns.
-export const SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS = 60000;
-const SANDBOX_MAX_COMMAND_TIMEOUT_MS = 10 * 60 * 1000;
-
-// Extra time we add on top of a command's in-container timeout to set the
-// timeout we give the sandbox provider. The in-container `timeout`
-// wrapper stops the command and returns whatever output it has; this extra
-// time lets that finish and reach us before the provider gives up. A few
-// seconds is plenty (it only covers stopping the command and sending its
-// output back). It must stay small enough that the provider timeout
-// (max command timeout + this) stays under SANDBOX_MCP_REQUEST_TIMEOUT_MS.
-export const SANDBOX_EXEC_TIMEOUT_BUFFER_MS = 10000;
-
-// Outer MCP request deadline for the sandbox server. It must be strictly
-// greater than the max in-container command timeout so the graceful
-// in-container timeout (which returns partial output) always fires before the
-// MCP layer hard-aborts the call. The buffer covers process teardown, output
-// flushing, and the host round-trip. It must also stay small enough that the
-// resulting deadline stays under the tool activity `startToCloseTimeout` in
-// `temporal/agent_loop/workflows.ts`, which Temporal derives from
-// RUN_AGENT_CALL_TOOL_TIMEOUT_MS plus a minute.
-const SANDBOX_MCP_TIMEOUT_BUFFER_MS = 30000;
-export const SANDBOX_MCP_REQUEST_TIMEOUT_MS =
-  SANDBOX_MAX_COMMAND_TIMEOUT_MS + SANDBOX_MCP_TIMEOUT_BUFFER_MS;
 
 export const SANDBOX_TOOLS_METADATA = [
   {
@@ -57,6 +33,7 @@ export const SANDBOX_TOOLS_METADATA = [
         .describe("Working directory for command execution. Defaults to /tmp."),
       timeoutMs: z
         .number()
+        .min(1000)
         .max(SANDBOX_MAX_COMMAND_TIMEOUT_MS)
         .optional()
         .describe(

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -1,3 +1,7 @@
+import {
+  SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS,
+  SANDBOX_EXEC_TIMEOUT_BUFFER_MS,
+} from "@app/lib/actions/constants";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { BlockedAwaitingInputOutputResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type {
@@ -12,11 +16,7 @@ import {
   isAgentLoopRunContext,
   isSandboxResumeState,
 } from "@app/lib/actions/types";
-import {
-  SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS,
-  SANDBOX_EXEC_TIMEOUT_BUFFER_MS,
-  SANDBOX_TOOLS_METADATA,
-} from "@app/lib/api/actions/servers/sandbox/metadata";
+import { SANDBOX_TOOLS_METADATA } from "@app/lib/api/actions/servers/sandbox/metadata";
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -1,7 +1,6 @@
 import {
-  DEFAULT_MCP_REQUEST_TIMEOUT_MS,
   RETRY_ON_INTERRUPT_MAX_ATTEMPTS,
-  RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
+  TOOL_ACTIVITY_START_TO_CLOSE_TIMEOUT_MS,
 } from "@app/lib/actions/constants";
 import type { AuthenticatorType } from "@app/lib/auth";
 import type * as compactionActivities from "@app/temporal/agent_loop/activities/compaction";
@@ -35,6 +34,11 @@ import type {
 import type { CompactionSourceConversation } from "@app/types/assistant/compaction";
 import type { SupportedModel } from "@app/types/assistant/models/types";
 import { WorkflowExecutionAlreadyStartedError } from "@temporalio/common";
+import {
+  OpenTelemetryInboundInterceptor,
+  OpenTelemetryInternalsInterceptor,
+  OpenTelemetryOutboundInterceptor,
+} from "@temporalio/interceptors-opentelemetry/lib/workflow";
 import type {
   ChildWorkflowHandle,
   WorkflowInterceptorsFactory,
@@ -47,16 +51,6 @@ import {
   startChild,
   workflowInfo,
 } from "@temporalio/workflow";
-
-const toolActivityStartToCloseTimeoutMs =
-  Math.max(RUN_AGENT_CALL_TOOL_TIMEOUT_MS, DEFAULT_MCP_REQUEST_TIMEOUT_MS) +
-  60 * 1000;
-
-import {
-  OpenTelemetryInboundInterceptor,
-  OpenTelemetryInternalsInterceptor,
-  OpenTelemetryOutboundInterceptor,
-} from "@temporalio/interceptors-opentelemetry/lib/workflow";
 
 // Export an interceptors variable to add OpenTelemetry interceptors to the workflow.
 export const interceptors: WorkflowInterceptorsFactory = () => ({
@@ -77,8 +71,7 @@ const { runModelAndCreateActionsActivity } = proxyActivities<
 });
 
 const { runToolActivity } = proxyActivities<typeof runToolActivities>({
-  // Activity timeout keeps a short buffer above the tool timeout to detect worker restarts promptly.
-  startToCloseTimeout: toolActivityStartToCloseTimeoutMs,
+  startToCloseTimeout: TOOL_ACTIVITY_START_TO_CLOSE_TIMEOUT_MS,
   heartbeatTimeout: TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
   retry: {
     // Do not retry tool activities. Those are not idempotent.
@@ -89,7 +82,7 @@ const { runToolActivity } = proxyActivities<typeof runToolActivities>({
 const { runToolActivity: runRetryableToolActivity } = proxyActivities<
   typeof runToolActivities
 >({
-  startToCloseTimeout: toolActivityStartToCloseTimeoutMs,
+  startToCloseTimeout: TOOL_ACTIVITY_START_TO_CLOSE_TIMEOUT_MS,
   heartbeatTimeout: TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
   retry: {
     maximumAttempts: RETRY_ON_INTERRUPT_MAX_ATTEMPTS,

--- a/front/temporal/sandbox_functions/workflows.ts
+++ b/front/temporal/sandbox_functions/workflows.ts
@@ -1,7 +1,4 @@
-import {
-  DEFAULT_MCP_REQUEST_TIMEOUT_MS,
-  RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
-} from "@app/lib/actions/constants";
+import { TOOL_ACTIVITY_START_TO_CLOSE_TIMEOUT_MS } from "@app/lib/actions/constants";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS } from "@app/temporal/agent_loop/config";
 import type * as markSandboxFunctionInvocationFailedActivities from "@app/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed";
@@ -9,14 +6,10 @@ import type * as runSandboxFunctionInvocationActivities from "@app/temporal/sand
 import type * as runSandboxFunctionToolActivities from "@app/temporal/sandbox_functions/activities/run_sandbox_function_tool";
 import { proxyActivities } from "@temporalio/workflow";
 
-const toolActivityStartToCloseTimeoutMs =
-  Math.max(RUN_AGENT_CALL_TOOL_TIMEOUT_MS, DEFAULT_MCP_REQUEST_TIMEOUT_MS) +
-  60 * 1000;
-
 const { runSandboxFunctionToolActivity } = proxyActivities<
   typeof runSandboxFunctionToolActivities
 >({
-  startToCloseTimeout: toolActivityStartToCloseTimeoutMs,
+  startToCloseTimeout: TOOL_ACTIVITY_START_TO_CLOSE_TIMEOUT_MS,
   heartbeatTimeout: TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
   retry: {
     // Do not retry tool activities. Those are not idempotent.


### PR DESCRIPTION
## Description

The sandbox `bash` tool capped `timeoutMs` at 2 minutes, too short for installs, builds or long data crunching. Max is now 10 minutes, default stays 60s.

The timeout chain stays ordered: in-container `timeout` kills the command at 600s and returns partial output, provider exec at 610s, sandbox MCP deadline at 630s, tool activity `startToCloseTimeout` above that. The activity timeout used to be `max(RUN_AGENT, DEFAULT_MCP) + 60s` = 660s, which covered 630s only because `RUN_AGENT` happens to be 600s. The sandbox timeouts moved next to the other tool timeouts in `lib/actions/constants.ts` (the workflow bundle cannot import the zod-heavy server metadata) and the sandbox deadline is now an input to the `Math.max`, so the activity timeout goes to 690s and stays correct by construction.

Also added a `.min(1000)` on `timeoutMs`: a sub-second value used to pass schema validation and then fail inside the container.

## Tests

Added `lib/actions/constants.test.ts` pinning the ordering invariants (in-container timeout fires before the provider gives up, MCP deadline before the activity timeout), since so far these only lived in comments.

Not verified live: a real ~10 minute command against E2B. The SDK holds one stream for the whole command, so if anything between front and envd has an idle cap below 610s it would surface as a stream error rather than the graceful in-container timeout.

## Risk

Low. A single bash call can now hold a tool activity slot for 10 minutes, and the tool activity `startToCloseTimeout` moves 660s to 690s. The 60s heartbeat timeout still catches dead workers.

## Deploy Plan

Standard deploy.