### PR TITLE
feat: allow to view manage agents and skills page based on permissions

### DIFF
--- a/front/components/assistant/CreateDropdown.tsx
+++ b/front/components/assistant/CreateDropdown.tsx
@@ -41,7 +41,17 @@ export const CreateDropdown = ({
   });
   const { hasPermission } = useWorkspacePermissions();
 
+  const canCreateAgent = hasPermission("create", "agent");
   const canCreateSkill = hasPermission("create", "skill");
+
+  // The section labels only disambiguate when both groups are listed.
+  const showSectionLabels = canCreateAgent && canCreateSkill;
+
+  // Each group is gated on its own permission, so the button itself is only
+  // worth showing when there is at least one thing the user can create.
+  if (!canCreateAgent && !canCreateSkill) {
+    return null;
+  }
 
   return (
     <DropdownMenu>
@@ -60,40 +70,44 @@ export const CreateDropdown = ({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">
-        {canCreateSkill && <DropdownMenuLabel label="Agents" />}
-        <DropdownMenuItem
-          label="agent from scratch"
-          icon={File02}
-          onClick={withTracking(
-            TRACKING_AREAS.BUILDER,
-            "create_from_scratch",
-            () => {
-              setIsLoading(true);
-              void router.push(getAgentBuilderRoute(owner.sId, "new"));
-            }
-          )}
-        />
-        <DropdownMenuItem
-          label="agent from template"
-          icon={MagicWand02}
-          onClick={withTracking(
-            TRACKING_AREAS.BUILDER,
-            "create_from_template",
-            () => {
-              setIsLoading(true);
-              void router.push(getAgentBuilderRoute(owner.sId, "create"));
-            }
-          )}
-        />
-        <DropdownMenuItem
-          label={isUploadingYAML ? "Uploading..." : "agent from YAML"}
-          icon={isUploadingYAML ? <Spinner size="xs" /> : FolderOpen}
-          disabled={isUploadingYAML}
-          onClick={triggerYAMLUpload}
-        />
+        {canCreateAgent && (
+          <>
+            {showSectionLabels && <DropdownMenuLabel label="Agents" />}
+            <DropdownMenuItem
+              label="agent from scratch"
+              icon={File02}
+              onClick={withTracking(
+                TRACKING_AREAS.BUILDER,
+                "create_from_scratch",
+                () => {
+                  setIsLoading(true);
+                  void router.push(getAgentBuilderRoute(owner.sId, "new"));
+                }
+              )}
+            />
+            <DropdownMenuItem
+              label="agent from template"
+              icon={MagicWand02}
+              onClick={withTracking(
+                TRACKING_AREAS.BUILDER,
+                "create_from_template",
+                () => {
+                  setIsLoading(true);
+                  void router.push(getAgentBuilderRoute(owner.sId, "create"));
+                }
+              )}
+            />
+            <DropdownMenuItem
+              label={isUploadingYAML ? "Uploading..." : "agent from YAML"}
+              icon={isUploadingYAML ? <Spinner size="xs" /> : FolderOpen}
+              disabled={isUploadingYAML}
+              onClick={triggerYAMLUpload}
+            />
+          </>
+        )}
         {canCreateSkill && (
           <>
-            <DropdownMenuLabel label="Skills" />
+            {showSectionLabels && <DropdownMenuLabel label="Skills" />}
             <DropdownMenuItem
               label="skill from scratch"
               icon={PuzzlePiece01}

--- a/front/components/assistant/ManageDropdownMenu.tsx
+++ b/front/components/assistant/ManageDropdownMenu.tsx
@@ -1,5 +1,8 @@
 import { useAppRouter } from "@app/lib/platform";
 import { SKILL_ICON } from "@app/lib/skill";
+import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import {
   getAgentBuilderRoute,
   getSkillBuilderRoute,
@@ -23,6 +26,53 @@ interface ManageDropdownMenuProps {
 export const ManageDropdownMenu = ({ owner }: ManageDropdownMenuProps) => {
   const router = useAppRouter();
   const [isLoading, setIsLoading] = useState(false);
+  const { hasPermission } = useWorkspacePermissions();
+  const { agentConfigurations } = useUnifiedAgentConfigurations({
+    workspaceId: owner.sId,
+  });
+
+  const canManageAgents =
+    hasPermission("create", "agent") ||
+    hasPermission("publish", "agent") ||
+    agentConfigurations.some((agent) => agent.canEdit);
+  const canManageSkills =
+    hasPermission("create", "skill") ||
+    hasPermission("publish", "skill") ||
+    hasPermission("make_discoverable", "skill");
+
+  if (!canManageAgents && !canManageSkills) {
+    return null;
+  }
+
+  // With a single destination the dropdown would only add a click: link
+  // straight to it instead.
+  if (!canManageSkills) {
+    return (
+      <Button
+        href={getAgentBuilderRoute(owner.sId, "manage")}
+        variant="primary"
+        icon={ContactsRobot}
+        label="Manage agents"
+        data-gtm-label="assistantManagementButton"
+        data-gtm-location="homepage"
+        size="sm"
+        onClick={withTracking(TRACKING_AREAS.BUILDER, "manage_agents")}
+      />
+    );
+  }
+
+  if (!canManageAgents) {
+    return (
+      <Button
+        href={getSkillBuilderRoute(owner.sId, "manage")}
+        variant="primary"
+        icon={SKILL_ICON}
+        label="Manage skills"
+        size="sm"
+        onClick={withTracking(TRACKING_AREAS.BUILDER, "manage_skills")}
+      />
+    );
+  }
 
   return (
     <DropdownMenu>

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -41,11 +41,12 @@ import { useYAMLUpload } from "@app/hooks/useYAMLUpload";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { CONVERSATIONS_UPDATED_EVENT } from "@app/lib/notifications/events";
 import { useAppRouter } from "@app/lib/platform";
-import { SKILL_ICON } from "@app/lib/skill";
+import { getSkillAvatarIcon, SKILL_ICON } from "@app/lib/skill";
 import { getSpaceIcon } from "@app/lib/spaces";
 import { useActivationRecommendations } from "@app/lib/swr/activation";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
+import { useSkills } from "@app/lib/swr/skill_configurations";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { getConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
 import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
@@ -434,7 +435,9 @@ export function AgentSidebarMenu({
   const noHealthyProviders = !hasHealthyProviders(providersHealth);
 
   const agentsSearchInputRef = useRef<HTMLInputElement>(null);
-  const [searchText, setSearchText] = useState("");
+  const [agentSearchText, setAgentSearchText] = useState("");
+  const [skillSearchText, setSkillSearchText] = useState("");
+  const [hasOpenedActionsMenu, setHasOpenedActionsMenu] = useState(false);
   const { agentConfigurations } = useUnifiedAgentConfigurations({
     workspaceId: owner.sId,
   });
@@ -446,10 +449,33 @@ export function AgentSidebarMenu({
     () =>
       editableAgents
         .filter((agent) =>
-          agent.name.toLowerCase().includes(searchText.toLowerCase().trim())
+          agent.name
+            .toLowerCase()
+            .includes(agentSearchText.toLowerCase().trim())
         )
         .sort((a, b) => a.name.localeCompare(b.name)),
-    [editableAgents, searchText]
+    [editableAgents, agentSearchText]
+  );
+
+  const { skills } = useSkills({
+    owner,
+    status: "active",
+    disabled: !hasOpenedActionsMenu,
+  });
+  const editableSkills = useMemo(
+    () => skills.filter((skill) => skill.canAdministrate),
+    [skills]
+  );
+  const filteredSkills = useMemo(
+    () =>
+      editableSkills
+        .filter((skill) =>
+          skill.name
+            .toLowerCase()
+            .includes(skillSearchText.toLowerCase().trim())
+        )
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [editableSkills, skillSearchText]
   );
 
   const { setSidebarOpen } = useContext(SidebarContext);
@@ -504,11 +530,20 @@ export function AgentSidebarMenu({
     useStarredPodsSectionCollapsed();
 
   const canCreateAgent = hasPermission("create", "agent");
-  const canPublishAgent = hasPermission("publish", "agent");
-  // Users who can publish agents can reach the manage agents page to discover
-  // existing agents and edit the ones they can, even without create permission.
-  const canManageAgents = canCreateAgent || canPublishAgent;
   const canCreateSkill = hasPermission("create", "skill");
+
+  // The manage pages themselves are open to every member, but linking to them
+  // from the sidebar is only useful to users who have something to do there:
+  // a workspace-level permission, or at least one resource they edit.
+  const canManageAgents =
+    canCreateAgent ||
+    hasPermission("publish", "agent") ||
+    editableAgents.length > 0;
+  const canManageSkills =
+    canCreateSkill ||
+    hasPermission("publish", "skill") ||
+    hasPermission("make_discoverable", "skill") ||
+    editableSkills.length > 0;
 
   const [showDeleteDialog, setShowDeleteDialog] = useState<
     "all" | "selection" | null
@@ -1013,7 +1048,14 @@ export function AgentSidebarMenu({
                     onClick={handleNewClick}
                   />
                   {!hideActions && (
-                    <DropdownMenu modal={false}>
+                    <DropdownMenu
+                      modal={false}
+                      onOpenChange={(open) => {
+                        if (open) {
+                          setHasOpenedActionsMenu(true);
+                        }
+                      }}
+                    >
                       <DropdownMenuTrigger asChild>
                         <Button
                           size="sm"
@@ -1096,8 +1138,8 @@ export function AgentSidebarMenu({
                                     <DropdownMenuSearchbar
                                       ref={agentsSearchInputRef}
                                       name="search"
-                                      value={searchText}
-                                      onChange={setSearchText}
+                                      value={agentSearchText}
+                                      onChange={setAgentSearchText}
                                       placeholder="Search"
                                     />
                                     <div className="max-h-150 overflow-y-auto">
@@ -1136,29 +1178,66 @@ export function AgentSidebarMenu({
                             />
                           </>
                         )}
-                        {canCreateSkill && (
+                        {canManageSkills && (
                           <>
                             <DropdownMenuLabel>Skills</DropdownMenuLabel>
-                            <DropdownMenuSub>
-                              <DropdownMenuSubTrigger
-                                icon={Plus}
-                                label="New skill"
-                              />
-                              <DropdownMenuSubContent>
-                                <DropdownMenuItem
-                                  href={getSkillBuilderRoute(owner.sId, "new")}
-                                  icon={SKILL_ICON}
-                                  label="From scratch"
+                            {canCreateSkill && (
+                              <DropdownMenuSub>
+                                <DropdownMenuSubTrigger
+                                  icon={Plus}
+                                  label="New skill"
                                 />
-                                <DropdownMenuItem
-                                  icon={FolderOpen}
-                                  label="From existing"
-                                  onClick={() =>
-                                    setIsImportSkillDialogOpen(true)
-                                  }
+                                <DropdownMenuSubContent>
+                                  <DropdownMenuItem
+                                    href={getSkillBuilderRoute(
+                                      owner.sId,
+                                      "new"
+                                    )}
+                                    icon={SKILL_ICON}
+                                    label="From scratch"
+                                  />
+                                  <DropdownMenuItem
+                                    icon={FolderOpen}
+                                    label="From existing"
+                                    onClick={() =>
+                                      setIsImportSkillDialogOpen(true)
+                                    }
+                                  />
+                                </DropdownMenuSubContent>
+                              </DropdownMenuSub>
+                            )}
+                            {editableSkills.length > 0 && (
+                              <DropdownMenuSub>
+                                <DropdownMenuSubTrigger
+                                  icon={Edit04}
+                                  label="Edit skill"
                                 />
-                              </DropdownMenuSubContent>
-                            </DropdownMenuSub>
+                                <DropdownMenuPortal>
+                                  <DropdownMenuSubContent className="pointer-events-auto">
+                                    <DropdownMenuSearchbar
+                                      name="search"
+                                      value={skillSearchText}
+                                      onChange={setSkillSearchText}
+                                      placeholder="Search"
+                                    />
+                                    <div className="max-h-150 overflow-y-auto">
+                                      {filteredSkills.map((skill) => (
+                                        <DropdownMenuItem
+                                          key={skill.sId}
+                                          href={getSkillBuilderRoute(
+                                            owner.sId,
+                                            skill.sId
+                                          )}
+                                          truncateText
+                                          label={skill.name}
+                                          icon={getSkillAvatarIcon(skill.icon)}
+                                        />
+                                      ))}
+                                    </div>
+                                  </DropdownMenuSubContent>
+                                </DropdownMenuPortal>
+                              </DropdownMenuSub>
+                            )}
                             <DropdownMenuItem
                               href={getSkillBuilderRoute(owner.sId, "manage")}
                               icon={SKILL_ICON}

--- a/front/components/assistant/conversation/agent_browser/WebAgentBrowser.tsx
+++ b/front/components/assistant/conversation/agent_browser/WebAgentBrowser.tsx
@@ -2,17 +2,10 @@ import { CreateDropdown } from "@app/components/assistant/CreateDropdown";
 import { ManageDropdownMenu } from "@app/components/assistant/ManageDropdownMenu";
 import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
 import { useAppRouter } from "@app/lib/platform";
-import { SKILL_ICON } from "@app/lib/skill";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
-import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
-import {
-  getAgentBuilderRoute,
-  getSkillBuilderRoute,
-  setQueryParam,
-} from "@app/lib/utils/router";
+import { setQueryParam } from "@app/lib/utils/router";
 import {
   Button,
-  ContactsRobot,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -57,12 +50,8 @@ export function WebAgentBrowser({
   const { createAgentButtonRef } = useWelcomeTourGuide();
   const { hasPermission } = useWorkspacePermissions();
 
-  const canCreateAgent = hasPermission("create", "agent");
-  const canPublishAgent = hasPermission("publish", "agent");
-  // Users who can publish agents can reach the manage agents page to discover
-  // existing agents and edit the ones they can, even without create permission.
-  const canManageAgents = canCreateAgent || canPublishAgent;
-  const canCreateSkill = hasPermission("create", "skill");
+  const canCreate =
+    hasPermission("create", "agent") || hasPermission("create", "skill");
 
   const sortTypeLabel = useMemo(() => {
     switch (sortType) {
@@ -107,33 +96,12 @@ export function WebAgentBrowser({
 
         <div className="hidden sm:block">
           <div className="flex gap-2">
-            {canCreateAgent && (
+            {canCreate && (
               <div ref={createAgentButtonRef}>
                 <CreateDropdown owner={owner} dataGtmLocation="homepage" />
               </div>
             )}
-            {canManageAgents && canCreateSkill ? (
-              <ManageDropdownMenu owner={owner} />
-            ) : canManageAgents ? (
-              <Button
-                href={getAgentBuilderRoute(owner.sId, "manage")}
-                variant="primary"
-                icon={ContactsRobot}
-                label="Manage agents"
-                data-gtm-label="assistantManagementButton"
-                data-gtm-location="homepage"
-                size="sm"
-                onClick={withTracking(TRACKING_AREAS.BUILDER, "manage_agents")}
-              />
-            ) : canCreateSkill ? (
-              <Button
-                href={getSkillBuilderRoute(owner.sId, "manage")}
-                variant="primary"
-                icon={SKILL_ICON}
-                label="Manage skills"
-                size="sm"
-              />
-            ) : null}
+            <ManageDropdownMenu owner={owner} />
           </div>
         </div>
       </div>

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -9,6 +9,7 @@ import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { useAppRouter } from "@app/lib/platform";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { useTags } from "@app/lib/swr/tags";
 import {
   classNames,
@@ -62,6 +63,7 @@ type RowData = {
   agentTagsAsString: string;
   action?: ReactNode;
   canArchive: boolean;
+  canEdit: boolean;
 };
 
 // Global agents (canArchive: false) cannot be edited, so we disable them in batch edit.
@@ -267,13 +269,15 @@ const getTableColumns = ({
                 trigger={<span>{info.getValue()}</span>}
               />
             </div>
-            <TableTagSelector
-              tags={tags}
-              agentTags={info.row.original.agentTags}
-              agentConfigurationId={info.row.original.sId}
-              owner={owner}
-              onChange={mutateAgentConfigurations}
-            />
+            {info.row.original.canEdit && (
+              <TableTagSelector
+                tags={tags}
+                agentTags={info.row.original.agentTags}
+                agentConfigurationId={info.row.original.sId}
+                owner={owner}
+                onChange={mutateAgentConfigurations}
+              />
+            )}
           </div>
         </DataTable.CellContent>
       ),
@@ -422,6 +426,9 @@ export function AssistantsTable({
   const { providersHealth } = useAuth();
   const noHealthyProviders = !hasHealthyProviders(providersHealth);
 
+  const { hasPermission } = useWorkspacePermissions();
+  const canCreateAgent = hasPermission("create", "agent");
+
   const [showDeleteDialog, setShowDeleteDialog] = useState<{
     open: boolean;
     agentConfiguration: LightAgentConfigurationType | undefined;
@@ -443,8 +450,11 @@ export function AssistantsTable({
   const rows: RowData[] = useMemo(
     () =>
       agents.map((agentConfiguration) => {
+        // Editing an agent (settings, tags, archive) is reserved to its
+        // editors and to workspace admins.
+        const canEdit = agentConfiguration.canEdit || isAdmin(owner);
         const canArchive =
-          (agentConfiguration.canEdit || isAdmin(owner)) &&
+          canEdit &&
           agentConfiguration.status !== "archived" &&
           agentConfiguration.scope !== "global";
 
@@ -475,6 +485,7 @@ export function AssistantsTable({
               ? agentConfiguration.tags.map((t) => t.name).join(", ")
               : "",
           canArchive,
+          canEdit,
           action:
             agentConfiguration.scope === "global" ? (
               <GlobalAgentAction
@@ -503,9 +514,7 @@ export function AssistantsTable({
                     "data-gtm-label": "assistantEditButton",
                     "data-gtm-location": "assistantDetails",
                     icon: Edit04,
-                    disabled:
-                      (!agentConfiguration.canEdit && !isAdmin(owner)) ||
-                      noHealthyProviders,
+                    disabled: !canEdit || noHealthyProviders,
                     onClick: (e: React.MouseEvent) => {
                       e.stopPropagation();
                       void router.push(
@@ -554,14 +563,14 @@ export function AssistantsTable({
                       );
                     },
                     kind: "item" as const,
-                    disabled: noHealthyProviders,
+                    disabled: !canCreateAgent || noHealthyProviders,
                   },
                   {
                     label: "Archive",
                     "data-gtm-label": "assistantDeletionButton",
                     "data-gtm-location": "assistantDetails",
                     icon: Trash01,
-                    disabled: !agentConfiguration.canEdit && !isAdmin(owner),
+                    disabled: !canEdit,
                     variant: "warning" as const,
                     onClick: (e: React.MouseEvent) => {
                       e.stopPropagation();
@@ -582,6 +591,7 @@ export function AssistantsTable({
       showDisabledFreeWorkspacePopup,
       isBatchEdit,
       isDark,
+      canCreateAgent,
     ]
   );
 

--- a/front/components/pages/builder/agents/CreateAgentPage.tsx
+++ b/front/components/pages/builder/agents/CreateAgentPage.tsx
@@ -1,5 +1,6 @@
 import { AgentTemplateGrid } from "@app/components/agent_builder/AgentTemplateGrid";
 import { getUniqueTemplateTags } from "@app/components/agent_builder/utils";
+import Custom404 from "@app/components/pages/Custom404";
 import {
   useSetContentWidth,
   useSetHideSidebar,
@@ -9,6 +10,7 @@ import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitl
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useAssistantTemplates } from "@app/lib/swr/assistants";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import {
   getAgentBuilderRoute,
   getConversationRoute,
@@ -26,6 +28,9 @@ export function CreateAgentPage() {
   const router = useAppRouter();
   const owner = useWorkspace();
   const templateTagsMapping = TEMPLATES_TAGS_CONFIG;
+
+  const { hasPermission } = useWorkspacePermissions();
+  const canCreateAgent = hasPermission("create", "agent");
 
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedTags, setSelectedTags] = useState<TemplateTagCodeType[]>([]);
@@ -90,6 +95,10 @@ export function CreateAgentPage() {
   useSetContentWidth("centered");
   useSetHideSidebar(true);
   useSetTitle(title);
+
+  if (!canCreateAgent) {
+    return <Custom404 />;
+  }
 
   return (
     <div id="pageContent">

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -7,7 +7,6 @@ import { ModelsFilterMenu } from "@app/components/assistant/ModelsFilterMenu";
 import { AssistantsTable } from "@app/components/assistant/manager/AssistantsTable";
 import { TagsFilterMenu } from "@app/components/assistant/TagsFilterMenu";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
-import Custom404 from "@app/components/pages/Custom404";
 import { getModelLogoByModelId } from "@app/components/providers/types";
 import {
   useSetContentWidth,
@@ -93,11 +92,6 @@ export function ManageAgentsPage() {
   const { hasPermission } = useWorkspacePermissions();
 
   const canCreateAgent = hasPermission("create", "agent");
-  const canPublishAgent = hasPermission("publish", "agent");
-  // Users who can publish agents can view the page to discover existing agents
-  // and identify the ones they can edit, even without create permission.
-  const canManageAgents = canCreateAgent || canPublishAgent;
-  const shouldDisableAgentFetching = !canManageAgents;
   const isSearchActive = assistantSearch.trim() !== "";
 
   const activeTab = useMemo(() => {
@@ -114,7 +108,6 @@ export function ManageAgentsPage() {
     workspaceId: owner.sId,
     agentsGetView: "manage",
     includes: ["authors", "usage", "feedbacks", "editors"],
-    disabled: shouldDisableAgentFetching,
   });
 
   const selectedAgents = agentConfigurations.filter((a) =>
@@ -128,7 +121,7 @@ export function ManageAgentsPage() {
     workspaceId: owner.sId,
     agentsGetView: "archived",
     includes: ["usage", "feedbacks", "editors"],
-    disabled: shouldDisableAgentFetching || selectedTab !== "archived",
+    disabled: selectedTab !== "archived",
   });
 
   const agentsByTab = useMemo(() => {
@@ -256,9 +249,6 @@ export function ManageAgentsPage() {
   }, []);
 
   useEffect(() => {
-    if (!canManageAgents) {
-      return;
-    }
     const handleKeyPress = (event: KeyboardEvent) => {
       if (event.key === "/") {
         event.preventDefault();
@@ -270,7 +260,7 @@ export function ManageAgentsPage() {
     return () => {
       window.removeEventListener("keydown", handleKeyPress);
     };
-  }, [canManageAgents]);
+  }, []);
 
   const navChildren = useMemo(
     () => <AgentSidebarMenu owner={owner} />,
@@ -282,169 +272,158 @@ export function ManageAgentsPage() {
 
   return (
     <>
-      {!canManageAgents ? (
-        <Custom404 />
-      ) : (
-        <>
-          <AgentDetailsSheet
-            owner={owner}
-            user={user}
-            agentId={detailedAgentId}
-            onClose={() => setDetailedAgentId(null)}
-          />
-          <div className="flex w-full flex-col gap-8 pb-4">
-            <Page.Header title="Manage Agents" icon={ContactsRobot} />
-            <Page.Vertical gap="md" align="stretch">
-              <div className="flex flex-row gap-2">
-                <SearchInput
-                  ref={searchBarRef}
-                  className="flex-grow"
-                  name="search"
-                  placeholder="Search (Name, Editors)"
-                  value={assistantSearch}
-                  onChange={(s: string) => {
-                    setAssistantSearch(s);
-                  }}
-                />
-                {!isBatchEdit && (
-                  <div className="flex gap-2">
-                    {isAdmin(owner) && (
-                      <Button
-                        variant="outline"
-                        icon={ListSelect}
-                        label="Batch edit"
-                        onClick={() => {
-                          setIsBatchEdit(true);
-                        }}
-                      />
-                    )}
-
-                    <ModelsFilterMenu
-                      models={uniqueModels}
-                      selectedModels={selectedModels}
-                      setSelectedModels={setSelectedModels}
-                    />
-                    <TagsFilterMenu
-                      tags={uniqueTags}
-                      selectedTags={selectedTags}
-                      setSelectedTags={setSelectedTags}
-                      owner={owner}
-                    />
-                    {canCreateAgent && (
-                      <CreateDropdown
-                        owner={owner}
-                        dataGtmLocation="assistantsWorkspace"
-                      />
-                    )}
-                  </div>
-                )}
-              </div>
-              {(selectedModels.length > 0 || selectedTags.length > 0) && (
-                <div className="flex flex-row flex-wrap gap-2">
-                  {selectedModels.map((model) => (
-                    <Chip
-                      key={model.modelId}
-                      label={model.displayName}
-                      size="xs"
-                      color="primary"
-                      icon={getModelLogoByModelId(model.modelId, isDark)}
-                      onRemove={() =>
-                        setSelectedModels(
-                          selectedModels.filter(
-                            (m) => m.modelId !== model.modelId
-                          )
-                        )
-                      }
-                    />
-                  ))}
-                  {selectedTags.map((tag) => (
-                    <Chip
-                      key={tag.sId}
-                      label={tag.name}
-                      size="xs"
-                      color="info"
-                      onRemove={() =>
-                        setSelectedTags(selectedTags.filter((t) => t !== tag))
-                      }
-                    />
-                  ))}
-                </div>
-              )}
-              <div className="flex flex-col pt-3">
-                {isBatchEdit ? (
-                  <AgentEditBar
-                    onClose={() => {
-                      setIsBatchEdit(false);
-                      setSelection([]);
+      <AgentDetailsSheet
+        owner={owner}
+        user={user}
+        agentId={detailedAgentId}
+        onClose={() => setDetailedAgentId(null)}
+      />
+      <div className="flex w-full flex-col gap-8 pb-4">
+        <Page.Header title="Manage Agents" icon={ContactsRobot} />
+        <Page.Vertical gap="md" align="stretch">
+          <div className="flex flex-row gap-2">
+            <SearchInput
+              ref={searchBarRef}
+              className="flex-grow"
+              name="search"
+              placeholder="Search (Name, Editors)"
+              value={assistantSearch}
+              onChange={(s: string) => {
+                setAssistantSearch(s);
+              }}
+            />
+            {!isBatchEdit && (
+              <div className="flex gap-2">
+                {isAdmin(owner) && (
+                  <Button
+                    variant="outline"
+                    icon={ListSelect}
+                    label="Batch edit"
+                    onClick={() => {
+                      setIsBatchEdit(true);
                     }}
-                    owner={owner}
-                    selectedAgents={selectedAgents}
-                    tags={uniqueTags}
-                    mutateAgentConfigurations={mutateAgentConfigurations}
                   />
-                ) : (
-                  <Tabs value={activeTab}>
-                    <TabsList>
-                      {AGENT_MANAGER_TABS.map((tab) => (
-                        <TabsTrigger
-                          key={tab.id}
-                          value={tab.id}
-                          label={tab.label}
-                          onClick={() => {
-                            setSelectedTab(tab.id);
-                          }}
-                          tooltip={
-                            AGENT_MANAGER_TABS.find((t) => t.id === tab.id)
-                              ?.description
-                          }
-                          isCounter={tab.id !== "archived"}
-                          counterValue={`${agentsByTab[tab.id].length}`}
-                        />
-                      ))}
-                    </TabsList>
-                  </Tabs>
                 )}
-                {isAgentConfigurationsLoading ||
-                isArchivedAgentConfigurationsLoading ? (
-                  <div className="mt-8 flex justify-center">
-                    <Spinner size="lg" />
-                  </div>
-                ) : activeTab && agentsByTab[activeTab] ? (
-                  <AssistantsTable
-                    isBatchEdit={isBatchEdit}
-                    selection={selection}
-                    setSelection={setSelection}
+                <ModelsFilterMenu
+                  models={uniqueModels}
+                  selectedModels={selectedModels}
+                  setSelectedModels={setSelectedModels}
+                />
+                <TagsFilterMenu
+                  tags={uniqueTags}
+                  selectedTags={selectedTags}
+                  setSelectedTags={setSelectedTags}
+                  owner={owner}
+                />
+                {canCreateAgent && (
+                  <CreateDropdown
                     owner={owner}
-                    agents={agentsByTab[activeTab]}
-                    setDetailedAgentId={setDetailedAgentId}
-                    handleToggleAgentStatus={handleToggleAgentStatus}
-                    showDisabledFreeWorkspacePopup={
-                      showDisabledFreeWorkspacePopup
-                    }
-                    setShowDisabledFreeWorkspacePopup={
-                      setShowDisabledFreeWorkspacePopup
-                    }
-                    mutateAgentConfigurations={mutateAgentConfigurations}
+                    dataGtmLocation="assistantsWorkspace"
                   />
-                ) : (
-                  !assistantSearch &&
-                  canCreateAgent && (
-                    <div className="pt-2">
-                      <EmptyCallToAction
-                        href={`/w/${owner.sId}/builder/agents/create`}
-                        label="Create an agent"
-                        icon={Plus}
-                        data-gtm-label="assistantCreationButton"
-                        data-gtm-location="assistantsWorkspace"
-                      />
-                    </div>
-                  )
                 )}
               </div>
-            </Page.Vertical>
+            )}
           </div>
-        </>
-      )}
+          {(selectedModels.length > 0 || selectedTags.length > 0) && (
+            <div className="flex flex-row flex-wrap gap-2">
+              {selectedModels.map((model) => (
+                <Chip
+                  key={model.modelId}
+                  label={model.displayName}
+                  size="xs"
+                  color="primary"
+                  icon={getModelLogoByModelId(model.modelId, isDark)}
+                  onRemove={() =>
+                    setSelectedModels(
+                      selectedModels.filter((m) => m.modelId !== model.modelId)
+                    )
+                  }
+                />
+              ))}
+              {selectedTags.map((tag) => (
+                <Chip
+                  key={tag.sId}
+                  label={tag.name}
+                  size="xs"
+                  color="info"
+                  onRemove={() =>
+                    setSelectedTags(selectedTags.filter((t) => t !== tag))
+                  }
+                />
+              ))}
+            </div>
+          )}
+          <div className="flex flex-col pt-3">
+            {isBatchEdit ? (
+              <AgentEditBar
+                onClose={() => {
+                  setIsBatchEdit(false);
+                  setSelection([]);
+                }}
+                owner={owner}
+                selectedAgents={selectedAgents}
+                tags={uniqueTags}
+                mutateAgentConfigurations={mutateAgentConfigurations}
+              />
+            ) : (
+              <Tabs value={activeTab}>
+                <TabsList>
+                  {AGENT_MANAGER_TABS.map((tab) => (
+                    <TabsTrigger
+                      key={tab.id}
+                      value={tab.id}
+                      label={tab.label}
+                      onClick={() => {
+                        setSelectedTab(tab.id);
+                      }}
+                      tooltip={
+                        AGENT_MANAGER_TABS.find((t) => t.id === tab.id)
+                          ?.description
+                      }
+                      isCounter={tab.id !== "archived"}
+                      counterValue={`${agentsByTab[tab.id].length}`}
+                    />
+                  ))}
+                </TabsList>
+              </Tabs>
+            )}
+            {isAgentConfigurationsLoading ||
+            isArchivedAgentConfigurationsLoading ? (
+              <div className="mt-8 flex justify-center">
+                <Spinner size="lg" />
+              </div>
+            ) : activeTab && agentsByTab[activeTab] ? (
+              <AssistantsTable
+                isBatchEdit={isBatchEdit}
+                selection={selection}
+                setSelection={setSelection}
+                owner={owner}
+                agents={agentsByTab[activeTab]}
+                setDetailedAgentId={setDetailedAgentId}
+                handleToggleAgentStatus={handleToggleAgentStatus}
+                showDisabledFreeWorkspacePopup={showDisabledFreeWorkspacePopup}
+                setShowDisabledFreeWorkspacePopup={
+                  setShowDisabledFreeWorkspacePopup
+                }
+                mutateAgentConfigurations={mutateAgentConfigurations}
+              />
+            ) : (
+              !assistantSearch &&
+              canCreateAgent && (
+                <div className="pt-2">
+                  <EmptyCallToAction
+                    href={`/w/${owner.sId}/builder/agents/create`}
+                    label="Create an agent"
+                    icon={Plus}
+                    data-gtm-label="assistantCreationButton"
+                    data-gtm-location="assistantsWorkspace"
+                  />
+                </div>
+              )
+            )}
+          </div>
+        </Page.Vertical>
+      </div>
     </>
   );
 }

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -130,6 +130,8 @@ export function ManageSkillsPage() {
     return "active";
   }, [selectedTab, skillManagerTabs]);
 
+  const canCreateSkill = hasPermission("create", "skill");
+
   const canBypassEditorVisibility = isAdmin;
   const isBypassEditorVisibilityEnabled =
     canBypassEditorVisibility && bypassEditorVisibility;
@@ -161,7 +163,9 @@ export function ManageSkillsPage() {
   } = useSkillsWithRelations({
     owner,
     status: "suggested",
-    disabled: activeTab !== "active",
+    // Suggestions are only ever listed to users who can create skills, since
+    // adopting one means becoming its editor.
+    disabled: activeTab !== "active" || !canCreateSkill,
   });
 
   const sortedActiveSkills = useMemo(
@@ -415,23 +419,25 @@ export function ManageSkillsPage() {
                 onClick={() => setIsBatchEditing(true)}
               />
             )}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button label="Create skill" icon={Plus} isSelect />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent>
-                <DropdownMenuItem
-                  label="From scratch"
-                  icon={SKILL_ICON}
-                  href={getSkillBuilderRoute(owner.sId, "new")}
-                />
-                <DropdownMenuItem
-                  label="From existing"
-                  icon={FolderOpen}
-                  onClick={() => setIsImportDialogOpen(true)}
-                />
-              </DropdownMenuContent>
-            </DropdownMenu>
+            {canCreateSkill && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button label="Create skill" icon={Plus} isSelect />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  <DropdownMenuItem
+                    label="From scratch"
+                    icon={SKILL_ICON}
+                    href={getSkillBuilderRoute(owner.sId, "new")}
+                  />
+                  <DropdownMenuItem
+                    label="From existing"
+                    icon={FolderOpen}
+                    onClick={() => setIsImportDialogOpen(true)}
+                  />
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
           </div>
           {isBatchEditionAvailable && isBatchEditing && (
             <SkillsBatchEditBar


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9886

This PR gates access to the "Manage agents" and "Manage skills" UI entry points (sidebar menu, create dropdown, manage dropdown) based on workspace permissions.

- Users should see the manage agents page in the sidebar when they can either create, publish an agent or are editors of an agent.
- Users should see the manage skills page in the sidebar when they can create, publish or make skills discoverable or they are editors of a skill.

## Tests

Manually.

## Risks

Low. Changes are purely UI-side permission checks.

## Deploy Plan

Standard deployment.