### PR TITLE
Fix cost attribution for tools called through the sandbox

### DIFF
--- a/front/lib/api/assistant/agent_message_consumption_attribution/attribution_builder.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/attribution_builder.ts
@@ -11,8 +11,10 @@ import assert from "assert";
 // Version 1 attributed the model token buckets only. Version 2 added per-tool rows and netted the
 // tool-call emission out of the assistant output bucket. Version 3 expands an enabled skill's tool
 // input footprint with the instructions and tool definitions that the action adds to later model
-// requests. Each version remains a separate, self-consistent set of rows.
-export const AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION = 3;
+// requests. Version 4 keeps sandbox-child actions as direct-charge-only rows because their calls
+// and results reach the outer model through their parent Computer action. Each version remains a
+// separate, self-consistent set of rows.
+export const AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION = 4;
 
 const CREDIT_AMOUNT_MICRO_PER_CREDIT = 1_000_000;
 

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
@@ -1,3 +1,4 @@
+import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import { makeEnableSkillResultOutput } from "@app/lib/api/actions/servers/skill_management/rendering";
 import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
 import { computeAndStoreAgentMessageConsumptionAttribution } from "@app/lib/api/assistant/agent_message_consumption_attribution/store";
@@ -208,6 +209,109 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
     expect(
       (outputItem?.outputTokensCount ?? 0) + (toolItem?.outputTokensCount ?? 0)
     ).toBe(OUTPUT_TOKENS_COUNT - REASONING_TOKENS_COUNT);
+  });
+
+  it("stores a sandbox child Frame call as direct-charge-only", async () => {
+    const {
+      auth,
+      workspace,
+      conversation,
+      run,
+      conversationId,
+      agentMessageId,
+      agentMessageModelId,
+    } = await setupSettledMessageWithUsage();
+
+    const { action: computerAction } = await AgentMCPActionFactory.create(
+      auth,
+      {
+        workspace,
+        conversationModelId: conversation.id,
+        agentMessageModelId,
+        status: "succeeded",
+        dustRunId: run.dustRunId,
+        functionCallName: "sandbox__bash",
+        toolName: "bash",
+        mcpServerName: "sandbox",
+        toolServerId: autoInternalMCPServerNameToSId({
+          name: "sandbox",
+          workspaceId: workspace.id,
+        }),
+      }
+    );
+    const { action: frameAction } = await AgentMCPActionFactory.create(auth, {
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId,
+      status: "succeeded",
+      dustRunId: run.dustRunId,
+      functionCallName: "interactive_content__create_interactive_content_file",
+      toolName: "create_interactive_content_file",
+      mcpServerName: "interactive_content",
+      toolServerId: autoInternalMCPServerNameToSId({
+        name: "interactive_content",
+        workspaceId: workspace.id,
+      }),
+      inputs: {
+        file_name: "dashboard.tsx",
+        mode: "inline",
+        source: "export default function Dashboard() { return null; }",
+      },
+      sandboxChildActionInfo: { parentActionId: computerAction.sId },
+      // Production sandbox children reuse the parent's function-call step content. Their own CLI
+      // inputs are persisted on augmentedInputs, but functionCallArguments still resolves to the
+      // parent's sandbox arguments.
+      parentAction: computerAction,
+    });
+
+    await computeAndStoreAgentMessageConsumptionAttribution(auth, {
+      agentMessageId,
+      conversationId,
+    });
+
+    const [callTexts] = vi.mocked(tokenCountForTexts).mock.calls[0];
+    const [inputTexts] = vi.mocked(tokenCountForTexts).mock.calls[1];
+    expect(callTexts).toHaveLength(1);
+    expect(callTexts[0]).toContain("sandbox__bash");
+    expect(frameAction.augmentedInputs).toMatchObject({
+      file_name: "dashboard.tsx",
+      mode: "inline",
+    });
+    // Only the parent Computer call/result is model-visible. The child inputs are issued by dsbx,
+    // and the child result reaches the model inside the Computer output.
+    expect(inputTexts).toHaveLength(1);
+
+    const items =
+      await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
+        auth,
+        {
+          agentMessageModelIds: [agentMessageModelId],
+          attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+        }
+      );
+    const toolItemByActionId = new Map(
+      items
+        .filter((item) => item.itemType === "tool")
+        .map((item) => [item.agentMCPActionId, item])
+    );
+
+    expect(toolItemByActionId.get(computerAction.id)).toMatchObject({
+      outputTokensCount: TOKENS_PER_FOOTPRINT,
+      inputTokensCount: TOKENS_PER_FOOTPRINT,
+      directCreditAmountMicro: 0,
+    });
+    expect(toolItemByActionId.get(frameAction.id)).toMatchObject({
+      outputTokensCount: 0,
+      inputTokensCount: 0,
+      directCreditAmountMicro: 3_000_000,
+      grossAttributedCreditAmountMicro: 3_000_000,
+    });
+
+    // Only the parent call is carved from the outer model's output budget.
+    const outputItem = items.find((item) => item.itemType === "output");
+    expect(outputItem?.outputTokensCount).toBe(
+      OUTPUT_TOKENS_COUNT - REASONING_TOKENS_COUNT - TOKENS_PER_FOOTPRINT
+    );
   });
 
   it("attributes enabled skill instructions and tool definitions to the tool input", async () => {

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
@@ -1,4 +1,5 @@
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
+import { isSandboxChildActionInfo } from "@app/lib/actions/types";
 import {
   AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
   buildRunUsageAttribution,
@@ -18,7 +19,6 @@ import { RunResource } from "@app/lib/resources/run_resource";
 import logger from "@app/logger/logger";
 import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { removeNulls } from "@app/types/shared/utils/general";
 import assert from "assert";
 
 // AWU (the credit unit tool charges are denominated in) expressed in micro-credits, matching how the
@@ -30,9 +30,11 @@ const CREDIT_AMOUNT_MICRO_PER_CREDIT = 1_000_000;
  *
  * This is analytics, not billing: the authoritative charge is computed and stored separately by the
  * credit pipeline. Here we explain the relative composition of that cost by writing, per run usage,
- * one row per model token bucket (input, output, reasoning) and one row per tool call. A tool row
- * carries the output tokens the model spent emitting the call, the input tokens its result would
- * occupy if carried into a later prompt, and the tool's direct credit charge.
+ * one row per model token bucket (input, output, reasoning) and one row per tool call. A directly
+ * model-visible tool row carries the output tokens the model spent emitting the call, the input
+ * tokens its result would occupy if carried into a later prompt, and the tool's direct credit
+ * charge. Sandbox-child calls are direct-charge-only: the outer model emits only the parent
+ * Computer call and receives the child's result through the Computer output.
  *
  * Runs once the message has settled, launched from the analytics queue by the finalize activities.
  * It is idempotent by (agent message, attribution version, run usage, item type) for model rows and
@@ -141,24 +143,35 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
   for (const usage of usages) {
     const dustRunId = dustRunIdByRunModelId.get(usage.runModelId);
     const runActions = (dustRunId && actionsByDustRunId.get(dustRunId)) || [];
-    const enrichedRunActions = removeNulls(
-      runActions.map((action) => enrichedActionById.get(action.id))
+    const runActionPairs = runActions.map((action) => {
+      const enrichedAction = enrichedActionById.get(action.id);
+      assert(enrichedAction, "Every action must have an enriched counterpart");
+      return { action, enrichedAction };
+    });
+    // Sandbox-child actions are invoked by the in-sandbox dsbx CLI, not by the outer model. They
+    // reuse their parent's function-call step content, so measuring them here would tokenize the
+    // parent Computer call a second time and separately count a result already carried in the
+    // Computer output.
+    const modelVisibleRunActionPairs = runActionPairs.filter(
+      ({ action }) =>
+        !isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)
     );
-    assert(
-      enrichedRunActions.length === runActions.length,
-      "Every action must have an enriched counterpart"
+    const sandboxChildRunActionPairs = runActionPairs.filter(({ action }) =>
+      isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)
     );
 
-    // Token footprints of this run's tool calls: the output the model spent emitting each call and
-    // the input its result occupied. Everything is priced against this one usage below.
+    // Token footprints of this run's model-visible tool calls: the output the model spent emitting
+    // each call and the input its result occupied. Everything is priced against this one usage below.
     const footprintsRes = await measureToolCallFootprints(auth, {
       modelId: usage.modelId,
       // TODO(2026-07-31 FLAV) Refactor `enrichActionsWithOutputItems` so it still returns the
       // resource.
-      toolCalls: runActions.map((action, index) => ({
-        action: enrichedRunActions[index],
-        functionCallArguments: action.functionCallArguments,
-      })),
+      toolCalls: modelVisibleRunActionPairs.map(
+        ({ action, enrichedAction }) => ({
+          action: enrichedAction,
+          functionCallArguments: action.functionCallArguments,
+        })
+      ),
     });
     if (footprintsRes.isErr()) {
       throw new Error(
@@ -169,14 +182,16 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
 
     // Pair each tool call with its enriched form and measured footprint once, here. This is the only
     // place alignment is assumed: measureToolCallFootprints returns counts positioned by the actions
-    // it received, and enrichedRunActions is aligned with runActions (the length assert above proves
-    // removeNulls dropped nothing), so index i is the same tool call across all three. From here each
-    // call carries its own data through the builder, so nothing downstream re-derives the position.
-    const measuredToolCalls = runActions.map((action, index) => ({
-      action,
-      enrichedAction: enrichedRunActions[index],
-      footprint: footprints[index],
-    }));
+    // it received, and modelVisibleRunActionPairs is aligned with the measured footprints, so index
+    // i is the same tool call across both. From here each call carries its own data through the
+    // builder, so nothing downstream re-derives the position.
+    const measuredToolCalls = modelVisibleRunActionPairs.map(
+      ({ action, enrichedAction }, index) => ({
+        action,
+        enrichedAction,
+        footprint: footprints[index],
+      })
+    );
 
     // A single partition of the usage: the tool calls take their share of the output budget, and the
     // model buckets take the rest (so the output row here is net of tool emission).
@@ -263,6 +278,41 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
           toolAttribution.grossAttributedCreditAmountMicro,
       });
     });
+
+    for (const { action, enrichedAction } of sandboxChildRunActionPairs) {
+      // A blocked child has not reached the nested tool yet. Unlike a directly model-emitted call,
+      // it contributes no output footprint while pending.
+      if (!isToolExecutionStatusFinal(action.status)) {
+        pendingToolItems.push({
+          action,
+          runUsageModelId: usage.runUsageModelId,
+          outputTokensCount: 0,
+          grossAttributedCreditAmountMicro: 0,
+        });
+        continue;
+      }
+
+      const directCreditAmountMicro = Math.round(
+        toolAwuFromAction(
+          {
+            toolName: enrichedAction.toolName,
+            internalMCPServerName: enrichedAction.internalMCPServerName,
+            status: action.status,
+          },
+          triggeringUserMessageOrigin
+        ) * CREDIT_AMOUNT_MICRO_PER_CREDIT
+      );
+
+      records.push({
+        itemType: "tool",
+        runUsageModelId: usage.runUsageModelId,
+        action,
+        inputTokensCount: 0,
+        outputTokensCount: 0,
+        directCreditAmountMicro,
+        grossAttributedCreditAmountMicro: directCreditAmountMicro,
+      });
+    }
   }
 
   // One atomic write for the whole pass. The resource inserts the model buckets and the final tools,

--- a/front/tests/utils/AgentMCPActionFactory.ts
+++ b/front/tests/utils/AgentMCPActionFactory.ts
@@ -1,5 +1,6 @@
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
+import type { SandboxChildActionInfo } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
 import {
@@ -39,6 +40,13 @@ export class AgentMCPActionFactory {
       step = 1,
       dustRunId = null,
       output = [],
+      inputs = {},
+      functionCallName = "test_tool",
+      toolName = "test_tool",
+      mcpServerName = "test_server",
+      toolServerId = "test-server",
+      sandboxChildActionInfo,
+      parentAction,
     }: {
       workspace: WorkspaceType;
       conversationModelId: ModelId;
@@ -47,6 +55,13 @@ export class AgentMCPActionFactory {
       step?: number;
       dustRunId?: string | null;
       output?: CallToolResult["content"];
+      inputs?: Record<string, unknown>;
+      functionCallName?: string;
+      toolName?: string;
+      mcpServerName?: string;
+      toolServerId?: string;
+      sandboxChildActionInfo?: SandboxChildActionInfo;
+      parentAction?: AgentMCPActionResource;
     }
   ): Promise<{
     action: AgentMCPActionResource;
@@ -54,29 +69,31 @@ export class AgentMCPActionFactory {
     const functionCallId = generateRandomModelSId();
     const currentIndex = this.stepContentIndex++;
 
-    const stepContent = await AgentStepContentModel.create({
-      workspaceId: workspace.id,
-      agentMessageId: agentMessageModelId,
-      step,
-      index: currentIndex,
-      version: 0,
-      dustRunId,
-      type: "function_call",
-      value: {
+    const stepContent =
+      parentAction?.stepContent ??
+      (await AgentStepContentModel.create({
+        workspaceId: workspace.id,
+        agentMessageId: agentMessageModelId,
+        step,
+        index: currentIndex,
+        version: 0,
+        dustRunId,
         type: "function_call",
         value: {
-          id: functionCallId,
-          name: "test_tool",
-          arguments: "{}",
+          type: "function_call",
+          value: {
+            id: functionCallId,
+            name: functionCallName,
+            arguments: "{}",
+          },
         },
-      },
-    });
+      }));
 
     const toolConfiguration: LightMCPToolConfigurationType = {
       id: 1,
       sId: generateRandomModelSId(),
       type: "mcp_configuration",
-      name: "test_tool",
+      name: functionCallName,
       dataSources: null,
       tables: null,
       childAgentId: null,
@@ -90,10 +107,10 @@ export class AgentMCPActionFactory {
       internalMCPServerId: null,
       availability: "auto",
       permission: "low",
-      toolServerId: "test-server",
+      toolServerId,
       retryPolicy: "no_retry",
-      originalName: "test_tool",
-      mcpServerName: "test_server",
+      originalName: toolName,
+      mcpServerName,
     };
 
     // TODO(Adrien): Drop column if not used anymore.
@@ -106,7 +123,7 @@ export class AgentMCPActionFactory {
       mcpServerConfigurationId: generateRandomModelSId(),
       status,
       citationsAllocated: 0,
-      augmentedInputs: {},
+      augmentedInputs: inputs,
       toolConfiguration,
       stepContext: {
         citationsCount: 0,
@@ -114,6 +131,7 @@ export class AgentMCPActionFactory {
         resumeState: null,
         retrievalTopK: 10,
         websearchResultCount: 5,
+        ...(sandboxChildActionInfo ? { sandboxChildActionInfo } : {}),
       },
     });
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When the model uses Computer to run a command, that command can call another tool through the sandbox (using the `dsbx` CLI). For example, Computer may run a CLI command that creates a Frame.

Today, the nested Frame action reuses the Computer action’s model input and output. As a result, the same model work can be attributed twice: once to Computer and once to Frame. The Frame action may also appear to contain the Computer command instead of only its real sandbox arguments.

This PR applies an interim attribution rule. Computer owns the model input and output because it is the action the model directly called. Nested sandbox actions only receive their direct credit charge.

For example, if Computer creates a Frame, Computer carries the model token cost and the Frame row carries the 3-credits creation charge. We no longer copy the Computer token footprint onto the Frame row.

This keeps the tool breakdown useful without double-counting (or even more) model work. A later improvement could distribute model tokens across nested actions more precisely, but the data available today does not support doing that reliably (cc @adrsimon).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
