### PR TITLE
Pricing/poke: allow to sort the poke usage by more columns + filter by seat/creditState

### DIFF
--- a/front/components/poke/credits/PokeMembersUsageTable.tsx
+++ b/front/components/poke/credits/PokeMembersUsageTable.tsx
@@ -8,13 +8,13 @@ import { formatCredits } from "@app/lib/client/credits";
 import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
 import { getMetronomeAlertUrl } from "@app/lib/metronome/urls";
 import { usePokeMembersUsage } from "@app/poke/swr/credits";
-import {
-  MEMBERSHIP_SEAT_TYPES,
-  USER_CREDIT_STATES,
-} from "@app/types/memberships";
 import type {
   MembershipSeatType,
   UserCreditState,
+} from "@app/types/memberships";
+import {
+  MEMBERSHIP_SEAT_TYPES,
+  USER_CREDIT_STATES,
 } from "@app/types/memberships";
 import type { WorkspaceType } from "@app/types/user";
 import {

--- a/front/components/poke/credits/PokeMembersUsageTable.tsx
+++ b/front/components/poke/credits/PokeMembersUsageTable.tsx
@@ -8,6 +8,10 @@ import { formatCredits } from "@app/lib/client/credits";
 import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
 import { getMetronomeAlertUrl } from "@app/lib/metronome/urls";
 import { usePokeMembersUsage } from "@app/poke/swr/credits";
+import {
+  MEMBERSHIP_SEAT_TYPES,
+  USER_CREDIT_STATES,
+} from "@app/types/memberships";
 import type {
   MembershipSeatType,
   UserCreditState,
@@ -17,8 +21,13 @@ import {
   AlertCircle,
   ArrowDown,
   ArrowUp,
+  Button,
   Chip,
   ContentMessage,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   Icon,
   LinkWrapper,
 } from "@dust-tt/sparkle";
@@ -27,24 +36,85 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 type SortDirection = "asc" | "desc";
 
-// Explicit, server-driven sort header for the Member (name) column. Toggling
-// updates the parent sort state directly (no reliance on react-table's
-// manual-sorting toggle), which re-queries the server.
-interface MemberSortHeaderProps {
+type OrderColumn = "name" | "seatType" | "consumedAwuCredits" | "creditState";
+
+// Explicit, server-driven sort header. Toggling updates the parent sort state
+// directly (no reliance on react-table's manual-sorting toggle), which
+// re-queries the server. Clicking a non-active column switches to it
+// (ascending); clicking the active column flips its direction.
+interface SortableHeaderProps {
+  label: string;
+  column: OrderColumn;
+  activeColumn: OrderColumn;
   direction: SortDirection;
-  onToggle: () => void;
+  onToggle: (column: OrderColumn) => void;
 }
 
-function MemberSortHeader({ direction, onToggle }: MemberSortHeaderProps) {
+function SortableHeader({
+  label,
+  column,
+  activeColumn,
+  direction,
+  onToggle,
+}: SortableHeaderProps) {
+  const isActive = column === activeColumn;
   return (
     <button
       type="button"
-      onClick={onToggle}
+      onClick={() => onToggle(column)}
       className="flex items-center gap-1 hover:text-foreground"
     >
-      Member
-      <Icon visual={direction === "desc" ? ArrowDown : ArrowUp} size="xs" />
+      {label}
+      {isActive && (
+        <Icon visual={direction === "desc" ? ArrowDown : ArrowUp} size="xs" />
+      )}
     </button>
+  );
+}
+
+interface EnumFilterDropdownProps<T extends string> {
+  label: string;
+  value: T | undefined;
+  options: readonly T[];
+  onChange: (value: T | undefined) => void;
+}
+
+// Single-value filter dropdown, mirroring the backend's single-value
+// `seatType`/`creditState` query params (not a multi-select facet).
+function EnumFilterDropdown<T extends string>({
+  label,
+  value,
+  options,
+  onChange,
+}: EnumFilterDropdownProps<T>) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="xs"
+          isSelect
+          label={value ? `${label}: ${value}` : label}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <DropdownMenuItem
+          onClick={() => onChange(undefined)}
+          disabled={value === undefined}
+        >
+          All
+        </DropdownMenuItem>
+        {options.map((option) => (
+          <DropdownMenuItem
+            key={option}
+            onClick={() => onChange(option)}
+            disabled={value === option}
+          >
+            {option}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -95,22 +165,27 @@ interface PokeMembersUsageTableProps {
 function makeColumns({
   owner,
   onReconciled,
-  nameSortDirection,
-  onToggleNameSort,
+  orderColumn,
+  orderDirection,
+  onToggleSort,
 }: {
   owner: WorkspaceType;
   onReconciled: () => void;
-  nameSortDirection: SortDirection;
-  onToggleNameSort: () => void;
+  orderColumn: OrderColumn;
+  orderDirection: SortDirection;
+  onToggleSort: (column: OrderColumn) => void;
 }): ColumnDef<MemberUsageType>[] {
   return [
     {
       accessorKey: "name",
       enableSorting: false,
       header: () => (
-        <MemberSortHeader
-          direction={nameSortDirection}
-          onToggle={onToggleNameSort}
+        <SortableHeader
+          label="Member"
+          column="name"
+          activeColumn={orderColumn}
+          direction={orderDirection}
+          onToggle={onToggleSort}
         />
       ),
       cell: ({ row }) => {
@@ -127,7 +202,15 @@ function makeColumns({
     },
     {
       accessorKey: "seatType",
-      header: "Seat type",
+      header: () => (
+        <SortableHeader
+          label="Seat type"
+          column="seatType"
+          activeColumn={orderColumn}
+          direction={orderDirection}
+          onToggle={onToggleSort}
+        />
+      ),
       enableSorting: false,
       cell: ({ row }) => <span>{row.original.seatType ?? "-"}</span>,
     },
@@ -135,7 +218,16 @@ function makeColumns({
       accessorKey: "consumedAwuCredits",
       // ES = Elasticsearch, RL = Redis rate-limiter counter, MT = Metronome.
       // The three should agree; divergence points at a counter/metric issue.
-      header: "Consumed (ES / RL / MT)",
+      // Sorting is driven by the ES figure (see resolveMembersUsagePageUsers).
+      header: () => (
+        <SortableHeader
+          label="Consumed (ES / RL / MT)"
+          column="consumedAwuCredits"
+          activeColumn={orderColumn}
+          direction={orderDirection}
+          onToggle={onToggleSort}
+        />
+      ),
       enableSorting: false,
       cell: ({ row }) => {
         const {
@@ -237,7 +329,15 @@ function makeColumns({
     },
     {
       accessorKey: "creditState",
-      header: "Credit state",
+      header: () => (
+        <SortableHeader
+          label="Credit state"
+          column="creditState"
+          activeColumn={orderColumn}
+          direction={orderDirection}
+          onToggle={onToggleSort}
+        />
+      ),
       enableSorting: false,
       cell: ({ row }) => {
         const { creditState, nearLimit, sId } = row.original;
@@ -289,8 +389,15 @@ export function PokeMembersUsageTable({ owner }: PokeMembersUsageTableProps) {
     pageIndex: 0,
     pageSize: DEFAULT_PAGE_SIZE,
   });
-  // Only name sorting is supported (server-side). Default: name ascending.
+  // Sorting is server-side and single-column. Default: name ascending.
+  const [orderColumn, setOrderColumn] = useState<OrderColumn>("name");
   const [orderDirection, setOrderDirection] = useState<SortDirection>("asc");
+  const [seatTypeFilter, setSeatTypeFilter] = useState<
+    MembershipSeatType | undefined
+  >(undefined);
+  const [creditStateFilter, setCreditStateFilter] = useState<
+    UserCreditState | undefined
+  >(undefined);
   const [searchInput, setSearchInput] = useState("");
   const [search, setSearch] = useState("");
 
@@ -314,26 +421,55 @@ export function PokeMembersUsageTable({ owner }: PokeMembersUsageTableProps) {
     pageIndex: pagination.pageIndex,
     pageSize: pagination.pageSize,
     search,
-    orderColumn: "name",
+    orderColumn,
     orderDirection,
+    seatType: seatTypeFilter,
+    creditState: creditStateFilter,
   });
 
-  // Toggle name sort direction and jump back to the first page. Stable across
-  // renders (only uses functional setters), so it's safe in the columns memo.
-  const toggleNameSort = useCallback(() => {
-    setOrderDirection((prev) => (prev === "asc" ? "desc" : "asc"));
-    setPagination((prev) => ({ ...prev, pageIndex: 0 }));
-  }, []);
+  // Switching to a new sort column resets to ascending; clicking the already-
+  // active column flips its direction. Jumps back to the first page either
+  // way. Depends on `orderColumn` (read to detect the "same column" case), so
+  // it's recreated when the active column changes.
+  const toggleSort = useCallback(
+    (column: OrderColumn) => {
+      if (column === orderColumn) {
+        setOrderDirection((prev) => (prev === "asc" ? "desc" : "asc"));
+      } else {
+        setOrderColumn(column);
+        setOrderDirection("asc");
+      }
+      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    },
+    [orderColumn]
+  );
+
+  const handleSeatTypeFilterChange = useCallback(
+    (value: MembershipSeatType | undefined) => {
+      setSeatTypeFilter(value);
+      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    },
+    []
+  );
+
+  const handleCreditStateFilterChange = useCallback(
+    (value: UserCreditState | undefined) => {
+      setCreditStateFilter(value);
+      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    },
+    []
+  );
 
   const columns = useMemo(
     () =>
       makeColumns({
         owner,
         onReconciled: () => void mutateMembersUsage(),
-        nameSortDirection: orderDirection,
-        onToggleNameSort: toggleNameSort,
+        orderColumn,
+        orderDirection,
+        onToggleSort: toggleSort,
       }),
-    [owner, mutateMembersUsage, orderDirection, toggleNameSort]
+    [owner, mutateMembersUsage, orderColumn, orderDirection, toggleSort]
   );
 
   if (isMembersUsageError) {
@@ -354,6 +490,20 @@ export function PokeMembersUsageTable({ owner }: PokeMembersUsageTableProps) {
       <span className="text-sm font-medium text-foreground">
         Members credit states
       </span>
+      <div className="flex items-center gap-2">
+        <EnumFilterDropdown
+          label="Seat type"
+          value={seatTypeFilter}
+          options={MEMBERSHIP_SEAT_TYPES}
+          onChange={handleSeatTypeFilterChange}
+        />
+        <EnumFilterDropdown
+          label="Credit state"
+          value={creditStateFilter}
+          options={USER_CREDIT_STATES}
+          onChange={handleCreditStateFilterChange}
+        />
+      </div>
       <PokeDataTable
         columns={columns}
         data={members}

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1433,20 +1433,23 @@ async function resolveMembersUsagePageUsers({
   }
   const { users: allUsers, total } = allUsersResult.value;
 
+  // Every remaining sort column derives its key from the active membership
+  // (seat type, credit state, or the seat-type split for consumed credits).
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace,
+    users: allUsers,
+  });
+  const membershipByUserModelId = new Map(
+    memberships.map((m) => [m.userId, m])
+  );
+
   const sortKeyByUserId = new Map<string, number | string>();
   switch (orderColumn) {
     case "consumedAwuCredits": {
       // Split consumed credits on seat type so free-seat users sort by their
       // free-seat usage and everyone else by their paid-seat usage.
-      const { memberships } = await MembershipResource.getActiveMemberships({
-        workspace,
-        users: allUsers,
-      });
-      const seatTypeByUserModelId = new Map(
-        memberships.map((m) => [m.userId, m.seatType])
-      );
       const freeSeatUserIds = allUsers.flatMap((u) =>
-        seatTypeByUserModelId.get(u.id) === "free" ? [u.sId] : []
+        membershipByUserModelId.get(u.id)?.seatType === "free" ? [u.sId] : []
       );
       const creditsByUserId = await fetchConsumedAwuCreditsByUserId({
         workspace,
@@ -1459,28 +1462,20 @@ async function resolveMembersUsagePageUsers({
       break;
     }
     case "seatType": {
-      const { memberships } = await MembershipResource.getActiveMemberships({
-        workspace,
-        users: allUsers,
-      });
-      const seatTypeByUserModelId = new Map(
-        memberships.map((m) => [m.userId, m.seatType ?? "none"])
-      );
       for (const u of allUsers) {
-        sortKeyByUserId.set(u.sId, seatTypeByUserModelId.get(u.id) ?? "none");
+        sortKeyByUserId.set(
+          u.sId,
+          membershipByUserModelId.get(u.id)?.seatType ?? "none"
+        );
       }
       break;
     }
     case "creditState": {
-      const { memberships } = await MembershipResource.getActiveMemberships({
-        workspace,
-        users: allUsers,
-      });
-      const creditStateByUserModelId = new Map(
-        memberships.map((m) => [m.userId, m.creditState])
-      );
       for (const u of allUsers) {
-        sortKeyByUserId.set(u.sId, creditStateByUserModelId.get(u.id) ?? "");
+        sortKeyByUserId.set(
+          u.sId,
+          membershipByUserModelId.get(u.id)?.creditState ?? ""
+        );
       }
       break;
     }

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -70,6 +70,7 @@ import {
   NORMALIZED_POOL_LIMIT_SEAT_TYPES,
   normalizeToPoolLimitSeatType,
   toBaseSeatType,
+  USER_CREDIT_STATES,
 } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -192,15 +193,20 @@ export const MembersUsagePaginationSchema = z.object({
   search: z.string().optional().catch(undefined),
   // Members are ordered by name (ascending) by default, giving a stable order
   // for pagination instead of relevance ranking. "name"/"email" are sorted by
-  // the search index; "consumedAwuCredits" is sorted in-app over the full
+  // the search index; every other column is sorted in-app over the full
   // matching set (see resolveMembersUsagePageUsers).
-  orderColumn: z.enum(["name", "email", "consumedAwuCredits"]).catch("name"),
+  orderColumn: z
+    .enum(["name", "email", "consumedAwuCredits", "seatType", "creditState"])
+    .catch("name"),
   orderDirection: z.enum(["asc", "desc"]).catch("asc"),
   // Optional seat-type filter. A base seat type (e.g. "pro") matches its
   // monthly and yearly variants; "none" matches members with no seat.
   seatType: z.enum(MEMBERSHIP_SEAT_TYPES).optional().catch(undefined),
+  // Optional credit-state filter (the per-user credit state machine state).
+  creditState: z.enum(USER_CREDIT_STATES).optional().catch(undefined),
   // Optional group filter (group sId). Restricts the table to the active
-  // members of that group. Combined with `seatType` as an intersection.
+  // members of that group. Combined with `seatType`/`creditState` as an
+  // intersection.
   groupId: z.string().optional().catch(undefined),
 });
 
@@ -1297,16 +1303,37 @@ async function resolveGroupFilterUserIds({
   return members.map((u) => u.sId);
 }
 
+// Resolve the member user sIds matching a credit-state filter. `creditState`
+// isn't a DB-indexed or search-indexed field, so — like the seat-type filter —
+// we fetch every active membership and filter in JS to build an allowlist.
+async function resolveCreditStateFilterUserIds({
+  workspace,
+  creditState,
+}: {
+  workspace: LightWorkspaceType;
+  creditState: UserCreditState;
+}): Promise<string[]> {
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace,
+  });
+  return memberships
+    .filter((m) => m.creditState === creditState)
+    .map((m) => m.user?.sId)
+    .filter((sId): sId is string => Boolean(sId));
+}
+
 async function resolveSeatAndGroupRestriction({
   auth,
   workspace,
   seatType,
   groupId,
+  creditState,
 }: {
   auth: Authenticator;
   workspace: LightWorkspaceType;
   seatType?: MembershipSeatType;
   groupId?: string;
+  creditState?: UserCreditState;
 }): Promise<string[] | undefined> {
   const restrictionSets: string[][] = [];
   if (seatType) {
@@ -1316,6 +1343,11 @@ async function resolveSeatAndGroupRestriction({
   }
   if (groupId) {
     restrictionSets.push(await resolveGroupFilterUserIds({ auth, groupId }));
+  }
+  if (creditState) {
+    restrictionSets.push(
+      await resolveCreditStateFilterUserIds({ workspace, creditState })
+    );
   }
   if (restrictionSets.length === 0) {
     return undefined;
@@ -1332,7 +1364,12 @@ export async function resolveMatchingMemberUserIds({
   filter,
 }: {
   auth: Authenticator;
-  filter: { seatType?: MembershipSeatType; groupId?: string; search?: string };
+  filter: {
+    seatType?: MembershipSeatType;
+    groupId?: string;
+    search?: string;
+    creditState?: UserCreditState;
+  };
 }): Promise<Result<string[], Error>> {
   const workspace = auth.getNonNullableWorkspace();
   const restrictToUserIds = await resolveSeatAndGroupRestriction({
@@ -1340,6 +1377,7 @@ export async function resolveMatchingMemberUserIds({
     workspace,
     seatType: filter.seatType,
     groupId: filter.groupId,
+    creditState: filter.creditState,
   });
   if (restrictToUserIds !== undefined && restrictToUserIds.length === 0) {
     return new Ok([]);
@@ -1358,10 +1396,9 @@ export async function resolveMatchingMemberUserIds({
 }
 
 // "name"/"email" live in the user search index, which owns sort + pagination
-// for those columns. "consumedAwuCredits" is not indexed, so to sort by it we
+// for those columns. Every other column is not indexed, so to sort by it we
 // fetch the full matching set with Elasticsearch `search_after`, rank it by
-// consumed AWU (the same analytics-index signal the table displays, see
-// fetchConsumedAwuCreditsByUserId), sort in-app, then slice the requested page.
+// the relevant signal, sort in-app, then slice the requested page.
 async function resolveMembersUsagePageUsers({
   auth,
   workspace,
@@ -1396,7 +1433,7 @@ async function resolveMembersUsagePageUsers({
   }
   const { users: allUsers, total } = allUsersResult.value;
 
-  const sortKeyByUserId = new Map<string, number>();
+  const sortKeyByUserId = new Map<string, number | string>();
   switch (orderColumn) {
     case "consumedAwuCredits": {
       // Split consumed credits on seat type so free-seat users sort by their
@@ -1421,6 +1458,32 @@ async function resolveMembersUsagePageUsers({
       }
       break;
     }
+    case "seatType": {
+      const { memberships } = await MembershipResource.getActiveMemberships({
+        workspace,
+        users: allUsers,
+      });
+      const seatTypeByUserModelId = new Map(
+        memberships.map((m) => [m.userId, m.seatType ?? "none"])
+      );
+      for (const u of allUsers) {
+        sortKeyByUserId.set(u.sId, seatTypeByUserModelId.get(u.id) ?? "none");
+      }
+      break;
+    }
+    case "creditState": {
+      const { memberships } = await MembershipResource.getActiveMemberships({
+        workspace,
+        users: allUsers,
+      });
+      const creditStateByUserModelId = new Map(
+        memberships.map((m) => [m.userId, m.creditState])
+      );
+      for (const u of allUsers) {
+        sortKeyByUserId.set(u.sId, creditStateByUserModelId.get(u.id) ?? "");
+      }
+      break;
+    }
     default:
       assertNever(orderColumn);
   }
@@ -1429,8 +1492,12 @@ async function resolveMembersUsagePageUsers({
   const sortedUsers = [...allUsers].sort((a, b) => {
     const keyA = sortKeyByUserId.get(a.sId) ?? 0;
     const keyB = sortKeyByUserId.get(b.sId) ?? 0;
-    if (keyA !== keyB) {
-      return (keyA - keyB) * directionFactor;
+    const cmp =
+      typeof keyA === "number" && typeof keyB === "number"
+        ? keyA - keyB
+        : String(keyA).localeCompare(String(keyB));
+    if (cmp !== 0) {
+      return cmp * directionFactor;
     }
     // Stable, direction-independent tiebreaker so pages don't reshuffle.
     const nameA = (a.fullName() || a.name).toLowerCase();
@@ -1475,6 +1542,7 @@ export async function getMembersUsage({
     workspace,
     seatType: paginationParams.seatType,
     groupId: paginationParams.groupId,
+    creditState: paginationParams.creditState,
   });
   if (restrictToUserIds !== undefined && restrictToUserIds.length === 0) {
     return { members: [], total: 0, creditsResetAt };

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -11,7 +11,10 @@ import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { AwuPoolSummaryResponseBody } from "@app/types/api/credits/awu_pool_summary";
 import type { PokeListCreditsResponseBody } from "@app/types/api/poke/credits";
-import type { MembershipSeatType, UserCreditState } from "@app/types/memberships";
+import type {
+  MembershipSeatType,
+  UserCreditState,
+} from "@app/types/memberships";
 import type { Fetcher } from "swr";
 
 export type PokeCreditsData = {

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -11,6 +11,7 @@ import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { AwuPoolSummaryResponseBody } from "@app/types/api/credits/awu_pool_summary";
 import type { PokeListCreditsResponseBody } from "@app/types/api/poke/credits";
+import type { MembershipSeatType, UserCreditState } from "@app/types/memberships";
 import type { Fetcher } from "swr";
 
 export type PokeCreditsData = {
@@ -170,12 +171,21 @@ export function usePokeMembersUsage({
   search,
   orderColumn,
   orderDirection,
+  seatType,
+  creditState,
 }: PokeConditionalFetchProps & {
   pageIndex: number;
   pageSize: number;
   search?: string;
-  orderColumn?: "name" | "email";
+  orderColumn?:
+    | "name"
+    | "email"
+    | "consumedAwuCredits"
+    | "seatType"
+    | "creditState";
   orderDirection?: "asc" | "desc";
+  seatType?: MembershipSeatType;
+  creditState?: UserCreditState;
 }) {
   const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetMembersUsageResponseBody> = fetcher;
@@ -189,6 +199,12 @@ export function usePokeMembersUsage({
   }
   if (orderColumn) {
     params.set("orderColumn", orderColumn);
+  }
+  if (seatType) {
+    params.set("seatType", seatType);
+  }
+  if (creditState) {
+    params.set("creditState", creditState);
   }
   if (orderDirection) {
     params.set("orderDirection", orderDirection);


### PR DESCRIPTION
## Description

Add 3 new column to order by: 
 - consumedAwuCredits
 - seat type
 - credit state 

Allow to filter by seat and credit state (to identify for instance the blocked user or the user on the pool)

## Tests

tested locally

<img width="1621" height="290" alt="Screenshot 2026-08-05 at 11 07 20" src="https://github.com/user-attachments/assets/e6392b0c-3b14-41c3-88a1-80d27f77d56e" />


## Risk

low, it's poke

## Deploy Plan

deploy front
