### PR TITLE
Admin governance for skill: add warning for inconsistencies in governance settings page

### DIFF
--- a/front/components/pages/workspace/governance/GovernancePage.tsx
+++ b/front/components/pages/workspace/governance/GovernancePage.tsx
@@ -2,6 +2,7 @@ import { GovernancePageLayout } from "@app/components/pages/workspace/governance
 import { GovernancePageSkeleton } from "@app/components/pages/workspace/governance/GovernancePageSkeleton";
 import { GovernanceSettingRow } from "@app/components/pages/workspace/governance/GovernanceSettingRow";
 import { GovernanceSettingSection } from "@app/components/pages/workspace/governance/GovernanceSettingSection";
+import { SkillDiscoverabilityWarning } from "@app/components/pages/workspace/governance/SkillDiscoverabilityWarning";
 import { ExtensionMcpToolsSection } from "@app/components/workspace/ExtensionMcpToolsSection";
 import { LinkedSectionNotice } from "@app/components/workspace/LinkedSectionNotice";
 import { AuditLogsGovernanceSection } from "@app/components/workspace/settings/AuditLogsToggle";
@@ -196,31 +197,45 @@ export const GovernancePage = () => {
         onLinkClick={handleNavigateToGroups}
       />
       <div className="flex w-full flex-col gap-8">
-        {sections.map(({ id, label, icon, governancePermissions }) => (
-          <GovernanceSettingSection key={id} label={label} icon={icon}>
-            {id === "frame" && isAdmin && (
-              <InteractiveContentSharing
-                sharingPolicy={sharingPolicy}
-                doUpdateSharingPolicy={doUpdateSharingPolicy}
-                isChanging={isChanging}
-              />
-            )}
-            {governancePermissions.map((governancePermission) => (
-              <GovernanceSettingRow
-                key={capabilityKey(governancePermission)}
-                governancePermission={governancePermission}
-                groups={groups}
-                onChange={(newConfiguration) =>
-                  onPermissionChange({
-                    grantType: governancePermission.grantType,
-                    resourceType: governancePermission.resourceType,
-                    configuration: newConfiguration,
-                  })
-                }
-              />
-            ))}
-          </GovernanceSettingSection>
-        ))}
+        {sections.map(
+          ({ id, label, icon, governancePermissions: sectionPermissions }) => (
+            <GovernanceSettingSection
+              key={id}
+              label={label}
+              icon={icon}
+              footer={
+                id === "skills" ? (
+                  <SkillDiscoverabilityWarning
+                    governancePermissions={governancePermissions}
+                    groups={groups}
+                  />
+                ) : undefined
+              }
+            >
+              {id === "frame" && isAdmin && (
+                <InteractiveContentSharing
+                  sharingPolicy={sharingPolicy}
+                  doUpdateSharingPolicy={doUpdateSharingPolicy}
+                  isChanging={isChanging}
+                />
+              )}
+              {sectionPermissions.map((governancePermission) => (
+                <GovernanceSettingRow
+                  key={capabilityKey(governancePermission)}
+                  governancePermission={governancePermission}
+                  groups={groups}
+                  onChange={(newConfiguration) =>
+                    onPermissionChange({
+                      grantType: governancePermission.grantType,
+                      resourceType: governancePermission.resourceType,
+                      configuration: newConfiguration,
+                    })
+                  }
+                />
+              ))}
+            </GovernanceSettingSection>
+          )
+        )}
 
         {isAdmin && (
           <>

--- a/front/components/pages/workspace/governance/GovernanceSettingSection.tsx
+++ b/front/components/pages/workspace/governance/GovernanceSettingSection.tsx
@@ -5,12 +5,15 @@ interface GovernanceSettingSectionProps {
   label: string;
   icon: ComponentType;
   children: ReactNode;
+  // Rendered inside the section card, below the rows and without a divider above it.
+  footer?: ReactNode;
 }
 
 export const GovernanceSettingSection = ({
   label,
   icon,
   children,
+  footer,
 }: GovernanceSettingSectionProps) => {
   return (
     <div className="flex w-full flex-col gap-4">
@@ -20,8 +23,9 @@ export const GovernanceSettingSection = ({
           <Page.H variant="h5">{label}</Page.H>
         </div>
       </div>
-      <div className="w-full rounded-xl border border-border divide-y divide-border">
-        {children}
+      <div className="w-full rounded-xl border border-border">
+        <div className="divide-y divide-border">{children}</div>
+        {footer}
       </div>
     </div>
   );

--- a/front/components/pages/workspace/governance/SkillDiscoverabilityWarning.tsx
+++ b/front/components/pages/workspace/governance/SkillDiscoverabilityWarning.tsx
@@ -1,0 +1,79 @@
+import type { GovernancePermissionsByKey } from "@app/types/api/governance";
+import { capabilityKey } from "@app/types/group_permissions";
+import type { GroupType } from "@app/types/groups";
+import { removeNulls } from "@app/types/shared/utils/general";
+import { ContentMessage } from "@dust-tt/sparkle";
+
+// Making a skill discoverable is useless without also being able to pick its availability: whoever
+// can do the former should be able to do the latter. Returns who can make skills discoverable but
+// not manage availability, or null when the configuration is consistent.
+function getDiscoverabilityWarningSubject(
+  governancePermissions: GovernancePermissionsByKey,
+  groups: GroupType[]
+): string | null {
+  const availability =
+    governancePermissions[
+      capabilityKey({ grantType: "publish", resourceType: "skill" })
+    ]?.configuration;
+  const discoverability =
+    governancePermissions[
+      capabilityKey({ grantType: "make_discoverable", resourceType: "skill" })
+    ]?.configuration;
+
+  if (!availability || !discoverability) {
+    return null;
+  }
+
+  // "Everyone" covers any discoverability scope, and admins can always manage availability.
+  if (availability.scope === "everyone") {
+    return null;
+  }
+  if (discoverability.scope !== "groups") {
+    return discoverability.scope === "everyone" ? "Everyone" : null;
+  }
+
+  const availabilityGroupIds = new Set(
+    availability.scope === "groups" ? availability.groupIds : []
+  );
+  const groupsById = new Map(groups.map((g) => [g.sId, g]));
+  const missingGroupNames = removeNulls(
+    discoverability.groupIds
+      .filter((groupId) => !availabilityGroupIds.has(groupId))
+      .map((groupId) => groupsById.get(groupId)?.name ?? null)
+  );
+
+  if (missingGroupNames.length === 0) {
+    return null;
+  }
+
+  return `The groups ${missingGroupNames.join(", ")}`;
+}
+
+interface SkillDiscoverabilityWarningProps {
+  governancePermissions: GovernancePermissionsByKey;
+  groups: GroupType[];
+}
+
+export const SkillDiscoverabilityWarning = ({
+  governancePermissions,
+  groups,
+}: SkillDiscoverabilityWarningProps) => {
+  const subject = getDiscoverabilityWarningSubject(
+    governancePermissions,
+    groups
+  );
+
+  if (!subject) {
+    return null;
+  }
+
+  return (
+    <div className="w-full p-4">
+      <ContentMessage variant="golden" size="lg">
+        {subject} can make skills discoverable, but only people who can manage
+        skill availability can act on it. Consider granting them "Manage skill
+        availability" to make this permission usable.
+      </ContentMessage>
+    </div>
+  );
+};

--- a/front/components/pages/workspace/governance/SkillDiscoverabilityWarning.tsx
+++ b/front/components/pages/workspace/governance/SkillDiscoverabilityWarning.tsx
@@ -2,6 +2,7 @@ import type { GovernancePermissionsByKey } from "@app/types/api/governance";
 import { capabilityKey } from "@app/types/group_permissions";
 import type { GroupType } from "@app/types/groups";
 import { removeNulls } from "@app/types/shared/utils/general";
+import { pluralize } from "@app/types/shared/utils/string_utils";
 import { ContentMessage } from "@dust-tt/sparkle";
 
 // Making a skill discoverable is useless without also being able to pick its availability: whoever
@@ -46,7 +47,7 @@ function getDiscoverabilityWarningSubject(
     return null;
   }
 
-  return `The groups ${missingGroupNames.join(", ")}`;
+  return `The group${pluralize(missingGroupNames.length)} ${missingGroupNames.join(", ")}`;
 }
 
 interface SkillDiscoverabilityWarningProps {

--- a/front/scripts/seed/governance/seed.ts
+++ b/front/scripts/seed/governance/seed.ts
@@ -1,3 +1,4 @@
+import { setWorkspaceGovernancePermission } from "@app/lib/api/permissions/governance";
 import { makeScript } from "@app/scripts/helpers";
 import type {
   AgentAsset,
@@ -68,7 +69,20 @@ makeScript({}, async ({ execute }, logger) => {
     members: bob ? [bob] : [],
   });
 
-  // 3. Create skills. The current user's skill requires the restricted space and has both Bob and
+  // 3. Open skill creation to everyone
+  logger.info("Opening skill creation to everyone...");
+  if (execute) {
+    const res = await setWorkspaceGovernancePermission(ctx.auth, {
+      grantType: "create",
+      resourceType: "skill",
+      configuration: { scope: "everyone" },
+    });
+    if (res.isErr()) {
+      throw res.error;
+    }
+  }
+
+  // 4. Create skills. The current user's skill requires the restricted space and has both Bob and
   // Alfred as editors. Bob is a member of the space, Alfred is not, so the skill builder shows the
   // warning for Alfred only.
   logger.info("Seeding Alfred's unpublished skill...");
@@ -81,7 +95,7 @@ makeScript({}, async ({ execute }, logger) => {
     spaces: restrictedSpace ? [restrictedSpace] : [],
   });
 
-  // 4. Create an agent edited by the current user that uses Alfred's unpublished skill.
+  // 5. Create an agent edited by the current user that uses Alfred's unpublished skill.
   logger.info("Seeding agents...");
   await seedAgents(ctx, agents, {
     skills: alfredSkill ? [alfredSkill] : [],


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/9889

When the permissions is given to make skill discoverable but cannot change the availability of skills then you cannot do anything.
This PR adds a a warning to don't leave user in a useless state

<img width="2292" height="820" alt="image" src="https://github.com/user-attachments/assets/ef019c0d-8009-49dc-bb69-24fe24115887" />

<img width="2290" height="888" alt="image" src="https://github.com/user-attachments/assets/6e7110b2-6729-4a51-93de-0d6e6ff27d90" />


## Tests

tested locally

## Risk

low, purely UI

## Deploy Plan

deploy front
