### PR TITLE
Admin governance for skills: rename 'All members' into 'Members'

### DIFF
--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -40,7 +40,7 @@ const AVAILABILITY_OPTIONS: {
     value: "editors",
   },
   {
-    label: "All members",
+    label: "Members",
     value: "workspace_users",
   },
   {

--- a/front/components/skills/SkillsBatchEdit.tsx
+++ b/front/components/skills/SkillsBatchEdit.tsx
@@ -36,7 +36,7 @@ const BATCH_AVAILABILITY_ACTIONS: BatchAvailabilityAction[] = [
     },
   },
   {
-    label: "All members",
+    label: "Members",
     availability: "workspace_users",
     getDialogTitle: (count) =>
       `Make ${count} skill${pluralize(count)} available to all members`,
@@ -46,7 +46,7 @@ const BATCH_AVAILABILITY_ACTIONS: BatchAvailabilityAction[] = [
     },
   },
   {
-    label: "All members and agents",
+    label: "Members and agents",
     description: "Available to all members and agents with Discover Skills",
     availability: "users_and_agents",
     getDialogTitle: () => `This affects your entire workspace`,

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -56,7 +56,7 @@ export const SKILL_AVAILABILITY_DISPLAY: Record<
     tooltip: "Only editors can find it via the input bar and agent builder",
   },
   workspace_users: {
-    label: "All members",
+    label: "Members",
     color: "success",
     tooltip: "All members can find it via the input bar and agent builder",
   },


### PR DESCRIPTION
## Description

Simple renaming from "All members" to "Members" to be more consistent with "Editors" and "Members and Agents"

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low, purely UI and easy to revert

## Deploy Plan
deploy front
