### PR TITLE
[front] fix: use grey variant for skill availability message

### DIFF
--- a/front/components/skill_builder/SkillBuilderAvailabilityMessage.tsx
+++ b/front/components/skill_builder/SkillBuilderAvailabilityMessage.tsx
@@ -64,6 +64,7 @@ export function SkillBuilderAvailabilityMessage({
   return (
     <ContentMessage
       size="lg"
+      variant="primary"
       title="Who is this skill available for?"
       icon={Users01}
     >


### PR DESCRIPTION
## Summary
- The "Who is this skill available for?" `ContentMessage` in the skill builder used the default `info` variant, whose `bg-info-100`/`text-info-900` tokens resolve to golden/orange.
- Switch to the `primary` variant, which maps to `muted-background`/`muted-foreground` (grey).


from: 
<img width="986" height="120" alt="image" src="https://github.com/user-attachments/assets/07cfc250-f509-4168-8886-9f267552f37d" />


to: 
<img width="983" height="121" alt="image" src="https://github.com/user-attachments/assets/09d74c29-1a5a-4712-97a2-fe3060212f43" />


## Test plan
- [ ] Open the skill builder and confirm the availability message now renders in grey instead of orange, in both light and dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)