### PR TITLE
[front] fix: keep approval-gated tools out of authorless runs

### DIFF
--- a/front/lib/actions/approval_tools_listing.test.ts
+++ b/front/lib/actions/approval_tools_listing.test.ts
@@ -1,0 +1,93 @@
+import { buildServerSideMCPServerConfiguration } from "@app/lib/actions/configuration/helpers";
+import { tryListMCPTools } from "@app/lib/actions/mcp_actions";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { describe, expect, it } from "vitest";
+
+// Lists the tools an agent sees when answering `content`, from a server that mixes tools running
+// without approval with tools that ask for one.
+async function listedToolNames({
+  authorless,
+}: {
+  authorless: boolean;
+}): Promise<string[]> {
+  const { authenticator, globalSpace, workspace } = await createResourceTest({
+    role: "admin",
+  });
+
+  const agentConfiguration = await AgentConfigurationFactory.createTestAgent(
+    authenticator,
+    { name: "Test Agent", description: "Test Agent" }
+  );
+
+  // schedules_management lists `list_schedules` at `never_ask` and `create_schedule` behind an
+  // approval.
+  const internalServer = await InternalMCPServerInMemoryResource.makeNew(
+    authenticator,
+    { name: "schedules_management", useCase: null }
+  );
+  const view = await MCPServerViewFactory.create(
+    workspace,
+    internalServer.id,
+    globalSpace
+  );
+
+  const conversation = await ConversationFactory.create(authenticator, {
+    agentConfigurationId: agentConfiguration.sId,
+    messagesCreatedAt: [],
+  });
+  const { agentMessage } = await ConversationFactory.createAgentMessage(
+    authenticator,
+    { workspace, conversation, agentConfig: agentConfiguration }
+  );
+  const { userMessage } = await ConversationFactory.createUserMessage({
+    auth: authenticator,
+    workspace,
+    conversation,
+    content: "Hello",
+    // The agent message factory sits at rank 0.
+    rank: 1,
+    authorless,
+  });
+
+  const serverToolsAndInstructions = await tryListMCPTools(
+    authenticator,
+    {
+      agentConfiguration,
+      agentMessage,
+      userMessage,
+      clientSideActionConfigurations: [],
+      conversation,
+    },
+    {
+      jitServers: [
+        buildServerSideMCPServerConfiguration({ mcpServerView: view }),
+      ],
+      skillServers: [],
+      systemSkillServers: [],
+    }
+  );
+
+  return serverToolsAndInstructions.flatMap(({ tools }) =>
+    tools.map(({ originalName }) => originalName)
+  );
+}
+
+describe("tryListMCPTools approval-requiring tools", () => {
+  it("lists them when a person wrote the message", async () => {
+    const toolNames = await listedToolNames({ authorless: false });
+
+    expect(toolNames).toContain("list_schedules");
+    expect(toolNames).toContain("create_schedule");
+  });
+
+  it("leaves them out for a message nobody wrote", async () => {
+    const toolNames = await listedToolNames({ authorless: true });
+
+    expect(toolNames).toContain("list_schedules");
+    expect(toolNames).not.toContain("create_schedule");
+  });
+});

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -1079,14 +1079,16 @@ export async function tryListMCPTools(
     preFetchedViews.map((view) => [view.sId, view])
   );
 
+  const isSystemAuthored = isSystemAuthoredUserMessage(
+    agentLoopListToolsContext.userMessage
+  );
+
   // An admin scoping a server to `personal_actions` decided it runs on each
   // person's own credentials. A message nobody wrote (posted by Dust on the
   // user's behalf) has no person to run as, so those servers are left out of the
   // tool list entirely: running them on the workspace connection instead would
   // quietly override that decision.
-  const listableActionsWithOrigin = isSystemAuthoredUserMessage(
-    agentLoopListToolsContext.userMessage
-  )
+  const listableActionsWithOrigin = isSystemAuthored
     ? mcpServerActionsWithOrigin.filter(({ action }) => {
         if (!isServerSideMCPServerConfiguration(action)) {
           return true;
@@ -1164,6 +1166,13 @@ export async function tryListMCPTools(
       const processedTools: MCPToolConfigurationType[] = [];
 
       for (const toolConfig of rawToolsFromServer) {
+        // Nobody wrote this message, so nobody is waiting on its answer: an approval prompt would
+        // be addressed to a person who never asked anything, and the run would sit blocked until
+        // they happen to open the conversation. Only `never_ask` tools run without one.
+        if (isSystemAuthored && toolConfig.permission !== "never_ask") {
+          continue;
+        }
+
         // Fix the tool name to be valid for the model.
         const toolNameRes = tryGetPrefixedToolName(
           action.name,

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -97,7 +97,7 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { fromEvent } from "@app/lib/utils/events";
 import logger from "@app/logger/logger";
-import { isSystemAuthoredUserMessage } from "@app/types/assistant/conversation";
+import { isUserMessageWithoutConcreteUser } from "@app/types/assistant/conversation";
 import type { OAuthProvider } from "@app/types/oauth/lib";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -1079,7 +1079,7 @@ export async function tryListMCPTools(
     preFetchedViews.map((view) => [view.sId, view])
   );
 
-  const isSystemAuthored = isSystemAuthoredUserMessage(
+  const isWithoutConcreteUser = isUserMessageWithoutConcreteUser(
     agentLoopListToolsContext.userMessage
   );
 
@@ -1088,7 +1088,7 @@ export async function tryListMCPTools(
   // user's behalf) has no person to run as, so those servers are left out of the
   // tool list entirely: running them on the workspace connection instead would
   // quietly override that decision.
-  const listableActionsWithOrigin = isSystemAuthored
+  const listableActionsWithOrigin = isWithoutConcreteUser
     ? mcpServerActionsWithOrigin.filter(({ action }) => {
         if (!isServerSideMCPServerConfiguration(action)) {
           return true;
@@ -1169,7 +1169,7 @@ export async function tryListMCPTools(
         // Nobody wrote this message, so nobody is waiting on its answer: an approval prompt would
         // be addressed to a person who never asked anything, and the run would sit blocked until
         // they happen to open the conversation. Only `never_ask` tools run without one.
-        if (isSystemAuthored && toolConfig.permission !== "never_ask") {
+        if (isWithoutConcreteUser && toolConfig.permission !== "never_ask") {
           continue;
         }
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -158,8 +158,8 @@ import {
   ConversationError,
   isAgentMessageType,
   isPodConversation,
-  isSystemAuthoredUserMessage,
   isUserMessageType,
+  isUserMessageWithoutConcreteUser,
   UNRESUMABLE_AGENT_MESSAGE_STATUSES,
 } from "@app/types/assistant/conversation";
 import type { MentionType } from "@app/types/assistant/mentions";
@@ -1084,14 +1084,14 @@ function canAccessAgent(
 
 class UserMessageError extends Error {}
 
-// A system-authored message has no author to be, so nobody passes this. Testing
-// that first also stops an API key, which has no `auth.user()` either, from
-// matching null against null.
+// A message with no concrete user has no author to be, so nobody passes this.
+// Testing that first also stops an API key, which has no `auth.user()` either,
+// from matching null against null.
 function isUserMessageAuthor(
   auth: Authenticator,
   message: UserMessageType
 ): boolean {
-  if (isSystemAuthoredUserMessage(message)) {
+  if (isUserMessageWithoutConcreteUser(message)) {
     return false;
   }
 
@@ -1770,7 +1770,7 @@ export async function retryAgentMessage(
 
   // Retrying would replay the parent's server-set origin, which can carry free
   // usage.
-  if (isSystemAuthoredUserMessage(parentUserMessage)) {
+  if (isUserMessageWithoutConcreteUser(parentUserMessage)) {
     return new Err({
       status_code: 403,
       api_error: {

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -246,7 +246,7 @@ export function isUserMessageTypeWithContentFragments(
  * `doNotAssociateUser`). Such a message is nobody's to edit, its answer nobody's
  * to retry, and it never runs on anyone's personal tool credentials.
  */
-export function isSystemAuthoredUserMessage(
+export function isUserMessageWithoutConcreteUser(
   message: Pick<UserMessageType, "user">
 ): boolean {
   return message.user === null;


### PR DESCRIPTION


## Description

Filter-out stakes > never_ask tools when a loop was started by a system message (i.e activation at time of writting)


## Tests

Added tests

## Risk

Low

## Deploy Plan

Deploy front