### PR TITLE
[sparkle,front] Sidebar section titles as list rows

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1477,10 +1477,12 @@ function UnreadConversationsSection({
 const ConversationList = ({
   conversations,
   dateLabel,
+  isFirstGroup,
   ...props
 }: {
   conversations: ConversationListItemType[];
   dateLabel: string;
+  isFirstGroup: boolean;
   isMultiSelect: boolean;
   selectedConversations: ConversationListItemType[];
   toggleConversationSelection: (c: ConversationListItemType) => void;
@@ -1494,11 +1496,13 @@ const ConversationList = ({
   return (
     <ConversationListContainer>
       {/* Compact overline so date groups read as a level below the
-       * (semibold) section titles rather than competing with them. */}
+       * (semibold) section titles rather than competing with them. The top
+       * padding separates a group from the one above it, so the first group
+       * — which follows the section header — does without it. */}
       <NavigationListCompactLabel
         label={dateLabel}
         isSticky
-        className="bg-app-background"
+        className={cn("bg-app-background", isFirstGroup && "pt-1")}
       />
 
       {conversations.map((conversation) => (
@@ -1756,13 +1760,20 @@ function NavigationListWithInbox({
       })
     : ({} as Record<GroupLabel, ConversationListItemType[]>);
 
+  // Empty groups render nothing, so the first non-empty one is the first the
+  // user actually sees — that's the one that skips the top padding.
+  const nonEmptyDateLabels = Object.keys(conversationsByDate).filter(
+    (dateLabel) => conversationsByDate[dateLabel as GroupLabel].length > 0
+  );
+
   const conversationsContent = (
     <>
-      {Object.keys(conversationsByDate).map((dateLabel) => (
+      {nonEmptyDateLabels.map((dateLabel, index) => (
         <ConversationList
           key={dateLabel}
           conversations={conversationsByDate[dateLabel as GroupLabel]}
           dateLabel={dateLabel}
+          isFirstGroup={index === 0}
           isMultiSelect={isMultiSelect}
           selectedConversations={selectedConversations}
           toggleConversationSelection={toggleConversationSelection}

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -773,9 +773,6 @@ export function AgentSidebarMenu({
       return null;
     }
 
-    const showCount =
-      isStarredPodsSectionCollapsed && starredCountInSummary > 0;
-
     const VISIBLE_STARRED = 5;
     const hiddenStarredSummary = starredSummary.slice(VISIBLE_STARRED);
     const hiddenOverflowCount = hiddenStarredSummary.reduce(
@@ -791,7 +788,7 @@ export function AgentSidebarMenu({
     return (
       <NavigationList className="mx-sidebar-side-spacing">
         <NavigationListCollapsibleSection
-          label={showCount ? `Starred (${starredCountInSummary})` : "Starred"}
+          label="Starred"
           type="collapse"
           visibleItems={VISIBLE_STARRED}
           overflowCount={hiddenOverflowCount}
@@ -820,8 +817,6 @@ export function AgentSidebarMenu({
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   const podsSection = useMemo(() => {
     const nonStarredSummary = summary.filter((pod) => !pod.space.isStarred);
-    const podCountInSummary = nonStarredSummary.length;
-    const showCount = isPodsSectionCollapsed && podCountInSummary > 0;
 
     const VISIBLE_PODS = 4;
     const hiddenSummary = nonStarredSummary.slice(VISIBLE_PODS);
@@ -838,7 +833,7 @@ export function AgentSidebarMenu({
     return (
       <NavigationList className="mx-sidebar-side-spacing flex-shrink-0">
         <NavigationListCollapsibleSection
-          label={showCount ? `Pods (${podCountInSummary})` : "Pods"}
+          label="Pods"
           type="collapse"
           visibleItems={VISIBLE_PODS}
           overflowCount={hiddenOverflowCount}

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1502,7 +1502,7 @@ const ConversationList = ({
       <NavigationListCompactLabel
         label={dateLabel}
         isSticky
-        className={cn("bg-app-background", isFirstGroup && "pt-1")}
+        className={cn("bg-app-background", isFirstGroup && "pt-2")}
       />
 
       {conversations.map((conversation) => (

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -26,6 +26,7 @@ import {
 } from "@app/hooks/conversations";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useActivePodId } from "@app/hooks/useActivePodId";
+import { useConversationsSectionCollapsed } from "@app/hooks/useConversationsSectionCollapsed";
 import { useDeleteConversation } from "@app/hooks/useDeleteConversation";
 import { useHideTriggeredConversations } from "@app/hooks/useHideTriggeredConversations";
 import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversationsAsRead";
@@ -97,6 +98,7 @@ import {
   MessagePlusCircle,
   NavigationList,
   NavigationListCollapsibleSection,
+  NavigationListCompactLabel,
   NavigationListItem,
   NavigationListItemAction,
   NavigationListLabel,
@@ -104,7 +106,6 @@ import {
   Robot,
   ScrollArea,
   Spinner,
-  Star01,
   Trash01,
   XClose,
   Zap,
@@ -226,6 +227,8 @@ function SearchResults({
   toggleConversationSelection,
 }: SearchResultsProps) {
   const [podsSectionOpen, setPodsSectionOpen] = useState(true);
+  const [conversationsSectionOpen, setConversationsSectionOpen] =
+    useState(true);
 
   const allConversations = useMemo(() => {
     const seen = new Set<string>();
@@ -344,6 +347,9 @@ function SearchResults({
       <NavigationList className="mx-sidebar-side-spacing">
         <NavigationListCollapsibleSection
           label="Conversations"
+          type="collapse"
+          open={conversationsSectionOpen}
+          onOpenChange={setConversationsSectionOpen}
           action={
             <>
               <DropdownMenu modal={false}>
@@ -786,7 +792,6 @@ export function AgentSidebarMenu({
       <NavigationList className="mx-sidebar-side-spacing">
         <NavigationListCollapsibleSection
           label={showCount ? `Starred (${starredCountInSummary})` : "Starred"}
-          icon={Star01}
           type="collapse"
           visibleItems={VISIBLE_STARRED}
           overflowCount={hiddenOverflowCount}
@@ -1494,7 +1499,13 @@ const ConversationList = ({
   return (
     <ConversationListContainer>
       {dateLabel !== "Today" && (
-        <NavigationListLabel label={dateLabel} isSticky />
+        // Compact overline so date groups read as a level below the
+        // (semibold) section titles rather than competing with them.
+        <NavigationListCompactLabel
+          label={dateLabel}
+          isSticky
+          className="bg-app-background"
+        />
       )}
 
       {conversations.map((conversation) => (
@@ -1703,6 +1714,8 @@ function NavigationListWithInbox({
   const [scrollViewport, setScrollViewport] = useState<HTMLDivElement | null>(
     null
   );
+  const { isConversationsSectionCollapsed, setConversationsSectionCollapsed } =
+    useConversationsSectionCollapsed();
   // Conversations opened from an activation recommendation are pinned into
   // their own highlighted "Recommendations for you" section at the top and
   // pulled out of the other sections so they only appear once. The recs are
@@ -1908,6 +1921,9 @@ function NavigationListWithInbox({
         <NavigationList className="mx-sidebar-side-spacing">
           <NavigationListCollapsibleSection
             label="Conversations"
+            type="collapse"
+            open={!isConversationsSectionCollapsed}
+            onOpenChange={(open) => setConversationsSectionCollapsed(!open)}
             action={
               <>
                 <DropdownMenu modal={false}>

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1498,15 +1498,13 @@ const ConversationList = ({
 
   return (
     <ConversationListContainer>
-      {dateLabel !== "Today" && (
-        // Compact overline so date groups read as a level below the
-        // (semibold) section titles rather than competing with them.
-        <NavigationListCompactLabel
-          label={dateLabel}
-          isSticky
-          className="bg-app-background"
-        />
-      )}
+      {/* Compact overline so date groups read as a level below the
+       * (semibold) section titles rather than competing with them. */}
+      <NavigationListCompactLabel
+        label={dateLabel}
+        isSticky
+        className="bg-app-background"
+      />
 
       {conversations.map((conversation) => (
         <ConversationListItem

--- a/front/hooks/useConversationsSectionCollapsed.ts
+++ b/front/hooks/useConversationsSectionCollapsed.ts
@@ -1,0 +1,13 @@
+import { useSidebarSectionCollapsed } from "@app/hooks/useSidebarSectionCollapsed";
+
+const LOCAL_STORAGE_KEY = "conversationsSectionCollapsed";
+
+export const useConversationsSectionCollapsed = () => {
+  const { isCollapsed, setCollapsed } =
+    useSidebarSectionCollapsed(LOCAL_STORAGE_KEY);
+
+  return {
+    isConversationsSectionCollapsed: isCollapsed,
+    setConversationsSectionCollapsed: setCollapsed,
+  };
+};

--- a/front/hooks/usePodsSectionCollapsed.ts
+++ b/front/hooks/usePodsSectionCollapsed.ts
@@ -1,30 +1,14 @@
-import { useCallback, useState } from "react";
+import { useSidebarSectionCollapsed } from "@app/hooks/useSidebarSectionCollapsed";
 
+// Legacy key: the section was named "Projects" before it became "Pods".
 const LOCAL_STORAGE_KEY = "projectsSectionCollapsed";
 
 export const usePodsSectionCollapsed = () => {
-  const [isPodsSectionCollapsed, setCollapsedState] = useState<boolean>(() => {
-    if (typeof window === "undefined") {
-      return false;
-    }
-    try {
-      return localStorage.getItem(LOCAL_STORAGE_KEY) === "true";
-    } catch {
-      return false;
-    }
-  });
-
-  const setPodsSectionCollapsed = useCallback((collapsed: boolean) => {
-    setCollapsedState(collapsed);
-    try {
-      localStorage.setItem(LOCAL_STORAGE_KEY, collapsed ? "true" : "false");
-    } catch {
-      // localStorage may be full or unavailable — silently ignore.
-    }
-  }, []);
+  const { isCollapsed, setCollapsed } =
+    useSidebarSectionCollapsed(LOCAL_STORAGE_KEY);
 
   return {
-    isPodsSectionCollapsed,
-    setPodsSectionCollapsed,
+    isPodsSectionCollapsed: isCollapsed,
+    setPodsSectionCollapsed: setCollapsed,
   };
 };

--- a/front/hooks/useSidebarSectionCollapsed.ts
+++ b/front/hooks/useSidebarSectionCollapsed.ts
@@ -1,0 +1,34 @@
+import { useCallback, useState } from "react";
+
+/**
+ * Collapsed state for a sidebar section, persisted in localStorage.
+ *
+ * `storageKey` is part of the persisted contract: changing it resets the
+ * collapsed state for every user.
+ */
+export const useSidebarSectionCollapsed = (storageKey: string) => {
+  const [isCollapsed, setCollapsedState] = useState<boolean>(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+    try {
+      return localStorage.getItem(storageKey) === "true";
+    } catch {
+      return false;
+    }
+  });
+
+  const setCollapsed = useCallback(
+    (collapsed: boolean) => {
+      setCollapsedState(collapsed);
+      try {
+        localStorage.setItem(storageKey, collapsed ? "true" : "false");
+      } catch {
+        // localStorage may be full or unavailable — silently ignore.
+      }
+    },
+    [storageKey]
+  );
+
+  return { isCollapsed, setCollapsed };
+};

--- a/front/hooks/useStarredPodsSectionCollapsed.ts
+++ b/front/hooks/useStarredPodsSectionCollapsed.ts
@@ -1,32 +1,13 @@
-import { useCallback, useState } from "react";
+import { useSidebarSectionCollapsed } from "@app/hooks/useSidebarSectionCollapsed";
 
 const LOCAL_STORAGE_KEY = "starredPodsSectionCollapsed";
 
 export const useStarredPodsSectionCollapsed = () => {
-  const [isStarredPodsSectionCollapsed, setCollapsedState] = useState<boolean>(
-    () => {
-      if (typeof window === "undefined") {
-        return false;
-      }
-      try {
-        return localStorage.getItem(LOCAL_STORAGE_KEY) === "true";
-      } catch {
-        return false;
-      }
-    }
-  );
-
-  const setStarredPodsSectionCollapsed = useCallback((collapsed: boolean) => {
-    setCollapsedState(collapsed);
-    try {
-      localStorage.setItem(LOCAL_STORAGE_KEY, collapsed ? "true" : "false");
-    } catch {
-      // localStorage may be full or unavailable — silently ignore.
-    }
-  }, []);
+  const { isCollapsed, setCollapsed } =
+    useSidebarSectionCollapsed(LOCAL_STORAGE_KEY);
 
   return {
-    isStarredPodsSectionCollapsed,
-    setStarredPodsSectionCollapsed,
+    isStarredPodsSectionCollapsed: isCollapsed,
+    setStarredPodsSectionCollapsed: setCollapsed,
   };
 };

--- a/sparkle/src/components/Collapsible.tsx
+++ b/sparkle/src/components/Collapsible.tsx
@@ -133,19 +133,28 @@ const contentVariants = cva("overflow-hidden transition-all", {
 
 export interface CollapsibleContentProps
   extends React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Content>,
-    VariantProps<typeof contentVariants> {}
+    VariantProps<typeof contentVariants> {
+  /**
+   * Set to false to open and close instantly. Worth doing for high-frequency
+   * toggles, where the height animation reads as lag rather than motion.
+   * Note that no animation means no animationend event.
+   */
+  animated?: boolean;
+}
 
 const CollapsibleContent = React.forwardRef<
   React.ElementRef<typeof CollapsiblePrimitive.Content>,
   CollapsibleContentProps
->(({ children, className, variant, ...props }, ref) => (
+>(({ children, className, variant, animated = true, ...props }, ref) => (
   <CollapsiblePrimitive.Content
     ref={ref}
     className={cn(
       contentVariants({ variant }),
-      "data-[state=closed]:animate-collapse-up data-[state=open]:animate-collapse-down",
-      // Open/close still works, it just snaps instead of sliding.
-      "motion-reduce:animate-none",
+      animated && [
+        "data-[state=closed]:animate-collapse-up data-[state=open]:animate-collapse-down",
+        // Open/close still works, it just snaps instead of sliding.
+        "motion-reduce:animate-none",
+      ],
       className
     )}
     {...props}

--- a/sparkle/src/components/Collapsible.tsx
+++ b/sparkle/src/components/Collapsible.tsx
@@ -144,6 +144,8 @@ const CollapsibleContent = React.forwardRef<
     className={cn(
       contentVariants({ variant }),
       "data-[state=closed]:animate-collapse-up data-[state=open]:animate-collapse-down",
+      // Open/close still works, it just snaps instead of sliding.
+      "motion-reduce:animate-none",
       className
     )}
     {...props}

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -384,6 +384,10 @@ const NavigationListCollapsibleSection = React.forwardRef<
     ref
   ) => {
     const [isShowingAll, setIsShowingAll] = React.useState(false);
+    // The collapse animates height, so the content has to clip while it runs
+    // or children spill outside the growing/shrinking box. Once it settles we
+    // stop clipping again so sticky children can pin to the scroll viewport.
+    const [isHeightAnimating, setIsHeightAnimating] = React.useState(false);
 
     const childArray = React.Children.toArray(children);
     const hasPartialCollapse =
@@ -447,6 +451,9 @@ const NavigationListCollapsibleSection = React.forwardRef<
       if (!newOpen) {
         setIsShowingAll(false);
       }
+      // Set synchronously, before Radix flips data-state, so the content is
+      // already clipping on the first frame of the height animation.
+      setIsHeightAnimating(true);
       onOpenChange?.(newOpen);
     };
 
@@ -545,9 +552,19 @@ const NavigationListCollapsibleSection = React.forwardRef<
           </CollapsibleTrigger>
           {actionElement}
         </div>
-        {/* Sticky children (e.g. date labels) need a non-clipping ancestor
-         * once the section is open; the clip only matters while animating. */}
-        <CollapsibleContent className="data-[state=open]:overflow-visible">
+        {/* Sticky children (e.g. date labels) need a non-clipping ancestor,
+         * but only once the height animation has finished — see above. */}
+        <CollapsibleContent
+          className={cn(
+            !isHeightAnimating && "data-[state=open]:overflow-visible"
+          )}
+          onAnimationEnd={(e) => {
+            // Ignore animations bubbling up from children.
+            if (e.target === e.currentTarget) {
+              setIsHeightAnimating(false);
+            }
+          }}
+        >
           {renderedContent}
         </CollapsibleContent>
       </Collapsible>

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -294,8 +294,9 @@ const NavigationListCompactLabel = React.forwardRef<
     ref={ref}
     className={cn(
       // px-2 matches NavigationListItem's p-2 so the label's text aligns with
-      // the item labels underneath it.
-      "flex px-2 py-1 text-xs font-semibold text-faint pt-3 uppercase whitespace-nowrap overflow-hidden text-ellipsis",
+      // the item labels underneath it. The lopsided pt-5/pb-1 groups the label
+      // with the items it heads, and breaks it away from the group above.
+      "flex px-2 py-1 text-xs font-semibold text-faint pt-5 uppercase whitespace-nowrap overflow-hidden text-ellipsis",
       isSticky && "sticky top-0 z-10 bg-muted-background border-border",
       className
     )}

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -421,10 +421,18 @@ const NavigationListCollapsibleSection = React.forwardRef<
 
     const actionElement = action && (
       <div
+        // Lets the header row keep its active styling while a menu opened from
+        // one of these actions is still open (see the collapse header below).
+        data-nav="section-action"
         className={cn(
           "flex gap-1 transition-opacity",
           actionOnHover
-            ? "[@media(hover:hover)_and_(pointer:fine)]:opacity-0 hover:opacity-100 group-has-[:focus-visible]/menu-item:opacity-100 group-hover/menu-item:opacity-100"
+            ? cn(
+                "[@media(hover:hover)_and_(pointer:fine)]:opacity-0 hover:opacity-100 group-has-[:focus-visible]/menu-item:opacity-100 group-hover/menu-item:opacity-100",
+                // The pointer leaves the row to navigate the menu it just
+                // opened; keep the action visible until the menu closes.
+                "has-[[data-state=open]]:opacity-100"
+              )
             : "opacity-100"
         )}
         onClick={(e) => {
@@ -508,7 +516,11 @@ const NavigationListCollapsibleSection = React.forwardRef<
             "text-muted-foreground font-semibold",
             "box-border flex items-center w-full gap-1.5 cursor-pointer select-none",
             "items-center outline-hidden rounded-lg text-sm p-2 transition-colors duration-150 motion-reduce:transition-none",
-            "hover:bg-hover hover:text-primary"
+            "hover:bg-hover hover:text-primary",
+            // Hold the hover styling while a menu opened from one of the row's
+            // actions is still open. Scoped to the action slot so the
+            // CollapsibleTrigger's own data-state=open never matches.
+            "has-[[data-nav=section-action]_[data-state=open]]:bg-hover has-[[data-nav=section-action]_[data-state=open]]:text-primary"
           )}
         >
           <CollapsibleTrigger hideChevron>

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -514,8 +514,13 @@ const NavigationListCollapsibleSection = React.forwardRef<
           className={cn(
             "group/menu-item relative",
             "text-muted-foreground font-semibold",
-            "box-border flex items-center w-full gap-1.5 cursor-pointer select-none",
-            "items-center outline-hidden rounded-lg text-sm p-2 transition-colors duration-150 motion-reduce:transition-none",
+            // No gap: it would be dead space between the trigger and the
+            // action slot. The trigger's own pr-2 does the separating.
+            "box-border flex items-center w-full select-none",
+            // The row's own padding lives on the trigger below, so the whole
+            // row height is clickable rather than just the label's line box.
+            // pr-2 keeps the action slot off the right edge.
+            "items-center outline-hidden rounded-lg text-sm pr-2 transition-colors duration-150 motion-reduce:transition-none",
             "hover:bg-hover hover:text-primary",
             // Hold the hover styling while a menu opened from one of the row's
             // actions is still open. Scoped to the action slot so the
@@ -523,7 +528,7 @@ const NavigationListCollapsibleSection = React.forwardRef<
             "has-[[data-nav=section-action]_[data-state=open]]:bg-hover has-[[data-nav=section-action]_[data-state=open]]:text-primary"
           )}
         >
-          <CollapsibleTrigger hideChevron>
+          <CollapsibleTrigger hideChevron className="p-2">
             <span className="flex min-w-0 items-center gap-1">
               {labelElement}
               <Icon

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -17,6 +17,7 @@ import { TypingAnimation } from "@sparkle/components/TypingAnimation";
 import { Lock01 } from "@sparkle/icons";
 import {
   ChevronDown,
+  ChevronRight,
   ChevronUp,
   DotsHorizontal,
 } from "@sparkle/icons/v2-stroke";
@@ -329,7 +330,7 @@ interface NavigationListCollapsibleSectionProps
 
 const collapseableStyles = cva(
   cn(
-    "w-full flex-1 text-left w-full",
+    "text-left",
     "text-muted-foreground",
     "text-sm whitespace-nowrap overflow-hidden text-ellipsis",
     "select-none",
@@ -339,15 +340,19 @@ const collapseableStyles = cva(
   {
     variants: {
       isCollapsible: {
-        true: cn(
-          "cursor-pointer mb-0.5"
-          // "hover:bg-primary-100"
-        ),
+        true: "cursor-pointer",
         false: "",
+      },
+      // Static headers fill the row; collapsible ones shrink-wrap so the
+      // chevron sits right next to the label instead of at the row's edge.
+      grow: {
+        true: "w-full flex-1",
+        false: "min-w-0",
       },
     },
     defaultVariants: {
       isCollapsible: false,
+      grow: true,
     },
   }
 );
@@ -393,7 +398,15 @@ const NavigationListCollapsibleSection = React.forwardRef<
     const isCollapsible = type !== "static";
     const counterValue = count && count > 0 ? count : undefined;
     const labelElement = (
-      <div className={cn("notranslate", collapseableStyles({ isCollapsible }))}>
+      <div
+        className={cn(
+          "notranslate",
+          collapseableStyles({ isCollapsible, grow: !isCollapsible }),
+          // The collapsible header row owns the text color (including its
+          // hover state), so the label inherits it instead of forcing its own.
+          isCollapsible && "text-inherit"
+        )}
+      >
         <span className="flex items-center gap-1.5">
           {icon && <Icon visual={icon} size="xs" />}
           <span className="overflow-hidden text-ellipsis">{label}</span>
@@ -485,11 +498,39 @@ const NavigationListCollapsibleSection = React.forwardRef<
 
     return (
       <Collapsible ref={ref} className={className} {...collapsibleProps}>
-        <div className="group/menu-item relative flex flex-1 items-center text-sm font-medium justify-start gap-2 pl-2 py-1.5 text-muted-foreground">
-          <CollapsibleTrigger hideChevron>{label}</CollapsibleTrigger>
+        {/* Mirrors the NavigationListItem row, in semibold, so section titles
+         * sit in the same rhythm as the items they contain. */}
+        <div
+          className={cn(
+            "group/menu-item relative",
+            "text-muted-foreground font-semibold",
+            "box-border flex items-center w-full gap-1.5 cursor-pointer select-none",
+            "items-center outline-hidden rounded-lg text-sm p-2 transition-colors duration-150 motion-reduce:transition-none",
+            "hover:bg-hover hover:text-primary"
+          )}
+        >
+          <CollapsibleTrigger hideChevron>
+            <span className="flex min-w-0 items-center gap-1">
+              {labelElement}
+              <Icon
+                visual={ChevronRight}
+                size="xs"
+                className="block shrink-0 group-data-[state=open]/col:hidden"
+              />
+              <Icon
+                visual={ChevronDown}
+                size="xs"
+                className="hidden shrink-0 group-data-[state=open]/col:block"
+              />
+            </span>
+          </CollapsibleTrigger>
           {actionElement}
         </div>
-        <CollapsibleContent>{renderedContent}</CollapsibleContent>
+        {/* Sticky children (e.g. date labels) need a non-clipping ancestor
+         * once the section is open; the clip only matters while animating. */}
+        <CollapsibleContent className="data-[state=open]:overflow-visible">
+          {renderedContent}
+        </CollapsibleContent>
       </Collapsible>
     );
   }

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -294,9 +294,9 @@ const NavigationListCompactLabel = React.forwardRef<
     ref={ref}
     className={cn(
       // px-2 matches NavigationListItem's p-2 so the label's text aligns with
-      // the item labels underneath it. The lopsided pt-5/pb-1 groups the label
+      // the item labels underneath it. The lopsided pt-4/pb-1 groups the label
       // with the items it heads, and breaks it away from the group above.
-      "flex px-2 py-1 text-xs font-semibold text-faint pt-5 uppercase whitespace-nowrap overflow-hidden text-ellipsis",
+      "flex px-2 py-1 text-xs font-semibold text-faint pt-4 uppercase whitespace-nowrap overflow-hidden text-ellipsis",
       isSticky && "sticky top-0 z-10 bg-muted-background border-border",
       className
     )}

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -293,7 +293,9 @@ const NavigationListCompactLabel = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "flex px-2 py-1 pl-3 text-[10px] font-semibold text-faint pt-3 uppercase whitespace-nowrap overflow-hidden text-ellipsis",
+      // px-2 matches NavigationListItem's p-2 so the label's text aligns with
+      // the item labels underneath it.
+      "flex px-2 py-1 text-[10px] font-semibold text-faint pt-3 uppercase whitespace-nowrap overflow-hidden text-ellipsis",
       isSticky && "sticky top-0 z-10 bg-muted-background border-border",
       className
     )}

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -543,10 +543,18 @@ const NavigationListCollapsibleSection = React.forwardRef<
                 size="xs"
                 className="block shrink-0 group-data-[state=open]/col:hidden"
               />
+              {/* An expanded section shows its own contents, so the chevron
+               * only appears on hover. It keeps its slot (opacity, not
+               * display) so the label doesn't shift, and stays visible where
+               * there is no hover to rely on: touch and keyboard focus. */}
               <Icon
                 visual={ChevronDown}
                 size="xs"
-                className="hidden shrink-0 group-data-[state=open]/col:block"
+                className={cn(
+                  "hidden shrink-0 transition-opacity group-data-[state=open]/col:block",
+                  "[@media(hover:hover)_and_(pointer:fine)]:opacity-0",
+                  "group-hover/menu-item:opacity-100 group-has-[:focus-visible]/menu-item:opacity-100"
+                )}
               />
             </span>
           </CollapsibleTrigger>

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -452,8 +452,12 @@ const NavigationListCollapsibleSection = React.forwardRef<
         setIsShowingAll(false);
       }
       // Set synchronously, before Radix flips data-state, so the content is
-      // already clipping on the first frame of the height animation.
-      setIsHeightAnimating(true);
+      // already clipping on the first frame of the height animation. Under
+      // reduced motion there is no animation, so no animationend would ever
+      // arrive to clear this again — stay unclipped instead.
+      setIsHeightAnimating(
+        !window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      );
       onOpenChange?.(newOpen);
     };
 

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -295,7 +295,7 @@ const NavigationListCompactLabel = React.forwardRef<
     className={cn(
       // px-2 matches NavigationListItem's p-2 so the label's text aligns with
       // the item labels underneath it.
-      "flex px-2 py-1 text-[10px] font-semibold text-faint pt-3 uppercase whitespace-nowrap overflow-hidden text-ellipsis",
+      "flex px-2 py-1 text-xs font-semibold text-faint pt-3 uppercase whitespace-nowrap overflow-hidden text-ellipsis",
       isSticky && "sticky top-0 z-10 bg-muted-background border-border",
       className
     )}

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -385,10 +385,6 @@ const NavigationListCollapsibleSection = React.forwardRef<
     ref
   ) => {
     const [isShowingAll, setIsShowingAll] = React.useState(false);
-    // The collapse animates height, so the content has to clip while it runs
-    // or children spill outside the growing/shrinking box. Once it settles we
-    // stop clipping again so sticky children can pin to the scroll viewport.
-    const [isHeightAnimating, setIsHeightAnimating] = React.useState(false);
 
     const childArray = React.Children.toArray(children);
     const hasPartialCollapse =
@@ -452,13 +448,6 @@ const NavigationListCollapsibleSection = React.forwardRef<
       if (!newOpen) {
         setIsShowingAll(false);
       }
-      // Set synchronously, before Radix flips data-state, so the content is
-      // already clipping on the first frame of the height animation. Under
-      // reduced motion there is no animation, so no animationend would ever
-      // arrive to clear this again — stay unclipped instead.
-      setIsHeightAnimating(
-        !window.matchMedia("(prefers-reduced-motion: reduce)").matches
-      );
       onOpenChange?.(newOpen);
     };
 
@@ -565,18 +554,14 @@ const NavigationListCollapsibleSection = React.forwardRef<
           </CollapsibleTrigger>
           {actionElement}
         </div>
-        {/* Sticky children (e.g. date labels) need a non-clipping ancestor,
-         * but only once the height animation has finished — see above. */}
+        {/* Toggling a sidebar section is a high-frequency action, and the
+         * shared height animation is layout-bound — on a long list it reads
+         * as lag rather than motion. Open/close instantly instead.
+         * With no animation to spill out of, the content can also stop
+         * clipping outright, so sticky children pin to the scroll viewport. */}
         <CollapsibleContent
-          className={cn(
-            !isHeightAnimating && "data-[state=open]:overflow-visible"
-          )}
-          onAnimationEnd={(e) => {
-            // Ignore animations bubbling up from children.
-            if (e.target === e.currentTarget) {
-              setIsHeightAnimating(false);
-            }
-          }}
+          animated={false}
+          className="data-[state=open]:overflow-visible"
         >
           {renderedContent}
         </CollapsibleContent>


### PR DESCRIPTION
## Description

Sidebar section titles in the conversation sidebar previously used a one-off header style that didn't visually match the list items beneath them, and the Pods/Starred sections had no collapse affordance. This PR makes `NavigationListCollapsibleSection` with `type="collapse"` mirror the `NavigationListItem` row styling (padding, rounded corners, hover, semibold, chevron), so all collapsible section headers look consistent. The Conversations section is now collapsible in both the normal and search sidebars, with state persisted in `localStorage`. Date group labels are demoted to `NavigationListCompactLabel` so they read as visually subordinate to section titles. The three copy-pasted collapse hooks (`usePodsSectionCollapsed`, `useStarredPodsSectionCollapsed`, and the new `useConversationsSectionCollapsed`) are consolidated onto a shared `useSidebarSectionCollapsed` primitive; existing `localStorage` keys are preserved.

## Tests

Manually tested: collapsing/expanding Conversations, Pods, and Starred sections; verifying persistence across page reloads; verifying date group label styling.

## Risk

Low. UI-only change in the conversations sidebar. Existing `localStorage` keys are unchanged so no user state is reset.

## Deploy Plan

Deploy front.