### PR TITLE
[front] fix: create conversation in `pod_manager` with same depth

### DIFF
--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -1293,7 +1293,11 @@ export function createProjectManagerTools(
         const conversationResource = await createConversation(auth, {
           title: params.title,
           visibility: "unlisted",
-          depth: parentConversationDepth + 1,
+          // We keep the same depth here to prevent sub agent conversations from flooding the pod list view (fine for
+          // them to use the pod, but they have no right to add something visible there).
+          // We must not increment the depth here (i.e. do parentConversationDepth + 1), otherwise this would hide any
+          // conversation created this way.
+          depth: parentConversationDepth,
           spaceId: pod.id,
         });
 


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/9929.

This PR fixes how we create conversations in the `pod_manager` MCP tools.
They are currently created with depth equal to the main conversation's depth + 1, making them all invisible in the pod conversation list.

Whether to always put 0 is debatable, here we choose to prevent sub agent from creating listable conversations. Can definitely be revisited in the future, this PR is more of a quick fix.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
