### PR TITLE
fix: reject log payload statuses Datadog would misread as severity

### DIFF
--- a/connectors/migrations/20250128_github_backfill_folders_bis.ts
+++ b/connectors/migrations/20250128_github_backfill_folders_bis.ts
@@ -6,7 +6,7 @@ import {
 } from "@connectors/connectors/github/temporal/activities";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
-import type { Logger } from "pino";
+import type { Logger } from "@connectors/logger/logger";
 import { makeScript } from "scripts/helpers";
 
 makeScript(
@@ -49,7 +49,7 @@ async function backfillMissingFolders(
     repos = await getRepositories(connectorId);
   } catch (error) {
     logger.error(
-      error,
+      { error },
       "Error getting repositories for connector, skipping this connector"
     );
     return;

--- a/connectors/migrations/20250304_add_notion_workspace_id_to_connector_state.ts
+++ b/connectors/migrations/20250304_add_notion_workspace_id_to_connector_state.ts
@@ -2,7 +2,7 @@ import { workspaceIdFromConnectionId } from "@connectors/connectors/notion";
 import { NotionConnectorStateModel } from "@connectors/lib/models/notion";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { concurrentExecutor } from "@connectors/types";
-import type { Logger } from "pino";
+import type { Logger } from "@connectors/logger/logger";
 import { makeScript } from "scripts/helpers";
 
 async function updateConnector(

--- a/connectors/migrations/20250710_cleanup_duplicate_zendesk_tickets.ts
+++ b/connectors/migrations/20250710_cleanup_duplicate_zendesk_tickets.ts
@@ -8,7 +8,7 @@ import { ZendeskTicketModel } from "@connectors/lib/models/zendesk";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
 import _ from "lodash";
-import type { Logger } from "pino";
+import type { Logger } from "@connectors/logger/logger";
 import { makeScript } from "scripts/helpers";
 import { Op } from "sequelize";
 

--- a/connectors/migrations/20250806_backfill_confluence_parent_type.ts
+++ b/connectors/migrations/20250806_backfill_confluence_parent_type.ts
@@ -2,7 +2,7 @@ import { ConfluencePageModel } from "@connectors/lib/models/confluence";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types/shared/model_id";
 import { concurrentExecutor } from "@connectors/types/shared/utils/async_utils";
-import type { Logger } from "pino";
+import type { Logger } from "@connectors/logger/logger";
 import { makeScript } from "scripts/helpers";
 import { Op } from "sequelize";
 

--- a/connectors/migrations/20260218_delete_private_gong_transcripts.ts
+++ b/connectors/migrations/20260218_delete_private_gong_transcripts.ts
@@ -10,7 +10,7 @@ import { GongTranscriptModel } from "@connectors/lib/models/gong";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { makeScript } from "scripts/helpers";
 import { Op } from "sequelize";
-import type { Logger } from "pino";
+import type { Logger } from "@connectors/logger/logger";
 
 const BATCH_SIZE = 100;
 const CORE_DELETION_CONCURRENCY = 10;

--- a/connectors/scripts/mark_rate_limited_slack_connectors.ts
+++ b/connectors/scripts/mark_rate_limited_slack_connectors.ts
@@ -4,10 +4,10 @@ import {
   withSlackErrorHandling,
 } from "@connectors/connectors/slack/lib/slack_client";
 import { ProviderRateLimitError } from "@connectors/lib/error";
+import type { Logger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 import { concurrentExecutor } from "@connectors/types";
-import type { Logger } from "pino";
 
 import { makeScript } from "./helpers";
 

--- a/connectors/src/api/webhooks/discord/bot.ts
+++ b/connectors/src/api/webhooks/discord/bot.ts
@@ -376,7 +376,7 @@ async function sendDiscordFollowUpMessage(
     const errorText = await response.text();
     logger.error(
       {
-        status: response.status,
+        statusCode: response.status,
         statusText: response.statusText,
         error: errorText,
       },
@@ -408,7 +408,7 @@ async function updateDiscordMessage(
     const errorText = await response.text();
     logger.error(
       {
-        status: response.status,
+        statusCode: response.status,
         statusText: response.statusText,
         error: errorText,
       },

--- a/connectors/src/api/webhooks/discord/content_fragments.ts
+++ b/connectors/src/api/webhooks/discord/content_fragments.ts
@@ -56,7 +56,7 @@ export async function makeDiscordContentFragments({
     const errorText = await channelResponse.text();
     logger.error(
       {
-        status: channelResponse.status,
+        statusCode: channelResponse.status,
         statusText: channelResponse.statusText,
         error: errorText,
         channelId,
@@ -106,7 +106,7 @@ export async function makeDiscordContentFragments({
       const errorText = await response.text();
       logger.error(
         {
-          status: response.status,
+          statusCode: response.status,
           statusText: response.statusText,
           error: errorText,
           channelId,

--- a/connectors/src/api/webhooks/slack/deprecated_bot.ts
+++ b/connectors/src/api/webhooks/slack/deprecated_bot.ts
@@ -1,11 +1,11 @@
 import { makeMarkdownBlock } from "@connectors/connectors/slack/chat/blocks";
 import { getBotUserIdResponse } from "@connectors/connectors/slack/lib/bot_user_helpers";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
+import type { Logger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 import { removeNulls } from "@connectors/types/shared/utils/general";
 import type { WebClient } from "@slack/web-api";
-import type { Logger } from "pino";
 
 async function sendSlackMessage(
   slackClient: WebClient,

--- a/connectors/src/api/webhooks/webhook_discord_app.ts
+++ b/connectors/src/api/webhooks/webhook_discord_app.ts
@@ -465,7 +465,7 @@ async function sendDiscordFollowUp(
       const errorText = await response.text();
       logger.error(
         {
-          status: response.status,
+          statusCode: response.status,
           statusText: response.statusText,
           error: errorText,
         },

--- a/connectors/src/connectors/bigquery/lib/bigquery_api.ts
+++ b/connectors/src/connectors/bigquery/lib/bigquery_api.ts
@@ -116,7 +116,7 @@ export const fetchDatabases = async ({
         .map((project) => project.projectId!),
     ];
   } catch (error) {
-    logger?.error(error, "Error listing accessible projects");
+    logger?.error({ error }, "Error listing accessible projects");
   }
 
   return Array.from(new Set(projectIds)).map((projectId) => ({

--- a/connectors/src/connectors/github/lib/code/garbage_collect.ts
+++ b/connectors/src/connectors/github/lib/code/garbage_collect.ts
@@ -7,10 +7,10 @@ import {
   GithubCodeFileModel,
 } from "@connectors/lib/models/github";
 import { heartbeat } from "@connectors/lib/temporal";
+import type { Logger } from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig } from "@connectors/types";
 import { concurrentExecutor } from "@connectors/types";
-import type { Logger } from "pino";
 import { Op } from "sequelize";
 
 const MAX_CONCURRENCY_DELETE = 10;

--- a/connectors/src/connectors/gong/lib/oauth.ts
+++ b/connectors/src/connectors/gong/lib/oauth.ts
@@ -1,11 +1,11 @@
 import { apiConfig } from "@connectors/lib/api/config";
+import type { Logger } from "@connectors/logger/logger";
 import logger from "@connectors/logger/logger";
 import { getOAuthConnectionAccessToken } from "@connectors/types";
 import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
-import type { Logger } from "pino";
 
 // Define the type codec for the Gong OAuth response
 const GongOAuthResponse = t.type({

--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -27,6 +27,7 @@ import {
   GoogleDriveFoldersModel,
   GoogleDriveSheetModel,
 } from "@connectors/lib/models/google_drive";
+import type { Logger } from "@connectors/logger/logger";
 import { getLoggerArgs } from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type {
@@ -44,7 +45,6 @@ import {
 } from "@connectors/types";
 import { withTransaction } from "@connectors/types/shared/utils/sql_utils";
 import { removeNulls } from "@dust-tt/client";
-import type { Logger } from "pino";
 import type { InferAttributes, WhereOptions } from "sequelize";
 
 const SHEET_PARENT_UPDATES_CONCURRENCY = 8;

--- a/connectors/src/connectors/google_drive/lib/cli.ts
+++ b/connectors/src/connectors/google_drive/lib/cli.ts
@@ -480,7 +480,7 @@ export const google_drive = async ({
 
           if (res.status !== 200 || !res.data.files) {
             logger.warn(
-              { folderId, status: res.status },
+              { folderId, statusCode: res.status },
               "Error listing files in folder"
             );
             break;

--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -97,7 +97,7 @@ async function queryIntercomAPI({
       );
     }
     logger.info(
-      { path, response: text, status: rawResponse.status },
+      { path, response: text, statusCode: rawResponse.status },
       "Failed to parse Intercom JSON response."
     );
     throw e;

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -330,7 +330,7 @@ export async function syncOneFile({
     if (axios.isAxiosError(error) && error.response?.status === 403) {
       localLogger.info(
         {
-          status: 403,
+          statusCode: 403,
           fileName: file.name,
           internalId: documentId,
           webUrl: file.webUrl,
@@ -365,7 +365,7 @@ export async function syncOneFile({
     if (axios.isAxiosError(error) && error.response?.status === 423) {
       localLogger.info(
         {
-          status: 423,
+          statusCode: 423,
           fileName: file.name,
           internalId: documentId,
           webUrl: file.webUrl,
@@ -606,7 +606,7 @@ export async function syncOneFile({
           ) {
             localLogger.info(
               {
-                status: 413,
+                statusCode: 413,
                 fileName: file.name,
                 internalId: documentId,
                 webUrl: file.webUrl,

--- a/connectors/src/connectors/notion/lib/cli.ts
+++ b/connectors/src/connectors/notion/lib/cli.ts
@@ -736,7 +736,7 @@ export const notion = async ({
         {
           url,
           method,
-          status: response.status,
+          statusCode: response.status,
           connectorId: connector.id,
         },
         "[Admin] Notion API request completed"

--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -1,5 +1,6 @@
 import { cacheGet, cacheSet } from "@connectors/lib/cache";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
+import type { Logger } from "@connectors/logger/logger";
 import mainLogger from "@connectors/logger/logger";
 import type {
   PageObjectProperties,
@@ -31,7 +32,6 @@ import type {
   SearchResponse,
 } from "@notionhq/client/build/src/api-endpoints";
 import { stringify } from "csv-stringify";
-import type { Logger } from "pino";
 
 const logger = mainLogger.child({ provider: "notion" });
 const NOTION_SEARCH_PAGE_SIZE = 90;

--- a/connectors/src/connectors/notion/lib/utils.ts
+++ b/connectors/src/connectors/notion/lib/utils.ts
@@ -4,11 +4,11 @@ import {
   NotionDatabaseModel,
   NotionPageModel,
 } from "@connectors/lib/models/notion";
+import type { Logger } from "@connectors/logger/logger";
 import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
-import type { Logger } from "pino";
 
 // Define the type codec for the Notion OAuth response
 export const NotionOAuthResponse = t.type({

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -68,6 +68,7 @@ import {
 } from "@connectors/lib/models/notion";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import { heartbeat } from "@connectors/lib/temporal";
+import type { Logger } from "@connectors/logger/logger";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type {
@@ -96,7 +97,6 @@ import {
 import type { PageObjectResponse } from "@notionhq/client/build/src/api-endpoints";
 import { Context } from "@temporalio/activity";
 import chunk from "lodash/chunk";
-import type { Logger } from "pino";
 import { Op } from "sequelize";
 
 const logger = mainLogger.child({ provider: "notion" });

--- a/connectors/src/connectors/slack/feedback_api.ts
+++ b/connectors/src/connectors/slack/feedback_api.ts
@@ -105,7 +105,7 @@ export async function submitFeedbackToAPI({
           connectorWId,
           metadataWorkspaceId: workspaceId,
           slackUserId,
-          status: response.status,
+          statusCode: response.status,
           error: errorData,
         },
         "Failed to submit feedback to API"

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -28,6 +28,7 @@ import {
   syncStarted,
   syncSucceeded,
 } from "@connectors/lib/sync_status";
+import type { Logger } from "@connectors/logger/logger";
 import logger from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -50,7 +51,6 @@ import { FirecrawlError } from "@mendable/firecrawl-js";
 import { Context } from "@temporalio/activity";
 import { createHash, randomUUID } from "crypto";
 import path from "path";
-import type { Logger } from "pino";
 import { Op } from "sequelize";
 
 export async function markAsCrawled(connectorId: ModelId) {
@@ -521,7 +521,7 @@ export async function firecrawlCrawlPage(
 
   if (res.status !== 200) {
     localLogger.error(
-      { status: res.status, scrapeId },
+      { statusCode: res.status, scrapeId },
       "Failed to fetch Firecrawl scrape details"
     );
     return;

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -20,6 +20,7 @@ import {
   launchZendeskTicketReSyncWorkflow,
 } from "@connectors/connectors/zendesk/temporal/client";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import type { Logger } from "@connectors/logger/logger";
 import { default as topLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import {
@@ -40,7 +41,6 @@ import type {
 } from "@connectors/types";
 import { normalizeError } from "@connectors/types";
 import { removeNulls } from "@connectors/types/shared/utils/general";
-import type { Logger } from "pino";
 
 function getTagsArgs(args: ZendeskCommandType["args"]) {
   const tag = args.tag;
@@ -398,7 +398,7 @@ export const zendesk = async ({
 
       if (!shouldSyncTicket) {
         logger.info(
-          { ticketId, brandId, status: ticket.status },
+          { ticketId, brandId, ticketStatus: ticket.status },
           "Ticket should not be synced based on status and configuration."
         );
         return { success: true };

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -226,7 +226,7 @@ async function _upsertDataSourceDocument({
         );
         localLogger.error(
           {
-            status: dustRequestResult.status,
+            statusCode: dustRequestResult.status,
             elapsed,
           },
           "Error uploading document to Dust."
@@ -351,7 +351,7 @@ export async function deleteDataSourceDocument(
   } else {
     localLogger.error(
       {
-        status: dustRequestResult.status,
+        statusCode: dustRequestResult.status,
       },
       "Error deleting document from Dust."
     );
@@ -456,7 +456,7 @@ async function _updateDocumentOrTableParentsField({
   } else {
     localLogger.error(
       {
-        status: dustRequestResult.status,
+        statusCode: dustRequestResult.status,
         data: dustRequestResult.data,
       },
       `Error updating ${tableOrDocument} parents field.`
@@ -974,7 +974,7 @@ export async function upsertDataSourceRemoteTable({
     );
     localLogger.error(
       {
-        status: dustRequestResult.status,
+        statusCode: dustRequestResult.status,
         elapsed,
       },
       "Error upserting table to Dust."
@@ -1207,7 +1207,7 @@ export async function upsertDataSourceTableFromCsv({
     );
     localLogger.error(
       {
-        status: dustRequestResult.status,
+        statusCode: dustRequestResult.status,
         elapsed,
       },
       "Error uploading table to Dust."
@@ -1326,7 +1326,7 @@ export async function deleteDataSourceTableRow({
     );
     localLogger.error(
       {
-        status: dustRequestResult.status,
+        statusCode: dustRequestResult.status,
         elapsed,
       },
       "Error deleting table from Dust."
@@ -1465,7 +1465,7 @@ export async function deleteDataSourceTable({
     );
     localLogger.error(
       {
-        status: dustRequestResult.status,
+        statusCode: dustRequestResult.status,
         elapsed,
       },
       "Error deleting table from Dust."
@@ -1623,7 +1623,7 @@ export async function checkDataSourceUpsertQueueStatus({
     } else {
       localLogger.error(
         {
-          status: dustRequestResult.status,
+          statusCode: dustRequestResult.status,
         },
         "Error checking upsert queue for data source."
       );

--- a/connectors/src/logger/logger.ts
+++ b/connectors/src/logger/logger.ts
@@ -26,6 +26,47 @@ function sanitizeError(error: Error) {
   return pino.stdSerializers.err(error);
 }
 
+// Datadog reads a top-level `status` as the log severity, prefix-matched on its value, so
+// `status: "completed"` reads as critical and `status: "succeeded"` as ok. Only real
+// severities may be logged as `status`; use another key for anything else.
+export const DATADOG_LOG_STATUSES = [
+  "emergency",
+  "alert",
+  "critical",
+  "error",
+  "warning",
+  "notice",
+  "info",
+  "debug",
+  "ok",
+] as const;
+
+export type DatadogLogStatus = (typeof DATADOG_LOG_STATUSES)[number];
+
+interface CheckedLogFn {
+  (msg: string, ...args: unknown[]): void;
+  (obj: Error, msg?: string, ...args: unknown[]): void;
+  (
+    obj: { status?: DatadogLogStatus } & Record<string, unknown>,
+    msg?: string,
+    ...args: unknown[]
+  ): void;
+}
+
+// pino's own log methods accept any `status`; ours reject the values Datadog would misread.
+export type Logger = Omit<
+  pino.Logger,
+  "trace" | "debug" | "info" | "warn" | "error" | "fatal" | "child"
+> & {
+  trace: CheckedLogFn;
+  debug: CheckedLogFn;
+  info: CheckedLogFn;
+  warn: CheckedLogFn;
+  error: CheckedLogFn;
+  fatal: CheckedLogFn;
+  child: (bindings: pino.Bindings, options?: pino.ChildLoggerOptions) => Logger;
+};
+
 const NODE_ENV = process.env.NODE_ENV;
 const LOG_LEVEL = process.env.LOG_LEVEL || "info";
 const defaultPinoOptions: LoggerOptions = {
@@ -71,10 +112,9 @@ if (NODE_ENV === "development") {
   pinoOptions = { ...defaultPinoOptions, ...devOptions };
 }
 
-const logger = pino(pinoOptions);
+const logger: Logger = pino(pinoOptions);
 
 export default logger;
-export type { Logger } from "pino";
 
 export function getLoggerArgs(
   connector: ConnectorResource,

--- a/connectors/src/start_worker.ts
+++ b/connectors/src/start_worker.ts
@@ -16,7 +16,7 @@ import logger from "./logger/logger";
 setupGlobalErrorHandler(logger);
 
 const pinoAdapter: Logger = {
-  log: (level: LogLevel, msg: string, meta: object) =>
+  log: (level: LogLevel, msg: string, meta: Record<string, unknown>) =>
     ({
       TRACE: logger.trace,
       DEBUG: logger.debug,
@@ -24,11 +24,16 @@ const pinoAdapter: Logger = {
       WARN: logger.warn,
       ERROR: logger.error,
     })[level](meta ?? {}, msg),
-  info: (msg: string, meta: object) => logger.info(meta ?? {}, msg),
-  warn: (msg: string, meta: object) => logger.warn(meta ?? {}, msg),
-  error: (msg: string, meta: object) => logger.error(meta ?? {}, msg),
-  debug: (msg: string, meta: object) => logger.debug(meta ?? {}, msg),
-  trace: (msg: string, meta: object) => logger.trace(meta ?? {}, msg),
+  info: (msg: string, meta: Record<string, unknown>) =>
+    logger.info(meta ?? {}, msg),
+  warn: (msg: string, meta: Record<string, unknown>) =>
+    logger.warn(meta ?? {}, msg),
+  error: (msg: string, meta: Record<string, unknown>) =>
+    logger.error(meta ?? {}, msg),
+  debug: (msg: string, meta: Record<string, unknown>) =>
+    logger.debug(meta ?? {}, msg),
+  trace: (msg: string, meta: Record<string, unknown>) =>
+    logger.trace(meta ?? {}, msg),
 };
 
 // Install once per process — before creating Worker/Client

--- a/extension/shared/lib/fetcher.ts
+++ b/extension/shared/lib/fetcher.ts
@@ -41,7 +41,7 @@ export const resHandler = async (res: Response) => {
   }
 
   logger.error(
-    { status: res.status, errorMessage },
+    { statusCode: res.status, errorMessage },
     "Error returned by the front API."
   );
   throw new APIError(errorType, errorMessage);

--- a/front-api/routes/w/[wId]/labs/transcripts/[tId].ts
+++ b/front-api/routes/w/[wId]/labs/transcripts/[tId].ts
@@ -114,7 +114,7 @@ app.patch(
       logger.info(
         {
           transcriptsConfigurationId: transcriptsConfiguration.sId,
-          status: newStatus,
+          configurationStatus: newStatus,
         },
         "Setting transcript configuration status."
       );

--- a/front/admin/check_transcripts_connections.ts
+++ b/front/admin/check_transcripts_connections.ts
@@ -159,7 +159,7 @@ async function main() {
         configId: configuration.sId,
         userEmail: userEmail,
         provider: configuration.provider,
-        status: configuration.status,
+        configurationStatus: configuration.status,
         dataSourceViewId: configuration.dataSourceViewId,
         agentConfigurationId: configuration.agentConfigurationId,
         connectionId: configuration.connectionId,

--- a/front/admin/check_transcripts_pending.ts
+++ b/front/admin/check_transcripts_pending.ts
@@ -77,7 +77,7 @@ async function main() {
       {
         configId: configuration.sId,
         userEmail,
-        status: configuration.status,
+        configurationStatus: configuration.status,
         pendingCount,
         pendingFileIds: res.value,
       },

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -28,6 +28,7 @@ import { processAndStoreFromUrl } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { Logger } from "@app/logger/logger";
 import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
 import {
   extensionsForContentType,
@@ -42,7 +43,6 @@ import {
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
 import { extname } from "path";
-import type { Logger } from "pino";
 
 /**
  * Recursively sanitizes all string values in an object by removing null bytes and lone surrogates.

--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -444,7 +444,7 @@ export async function handleSubscriptionActivationSuccess({
       {
         workspaceId: workspace.sId,
         contractId,
-        status: checkoutPayment.status,
+        paymentStatus: checkoutPayment.status,
       },
       "[Business Activation] payment_gate success: unexpected Redis status, skipping"
     );
@@ -646,7 +646,7 @@ export async function handleSubscriptionActivationSuccess({
         );
       } else {
         logger.info(
-          { workspaceId: workspace.sId, status: syncResult.value.status },
+          { workspaceId: workspace.sId, syncStatus: syncResult.value.status },
           "[Business Activation] Immediate seat sync completed"
         );
       }

--- a/front/lib/api/hubspot/hubspot.ts
+++ b/front/lib/api/hubspot/hubspot.ts
@@ -96,7 +96,7 @@ export async function submitToHubSpotForm(params: {
     if (!response.ok) {
       const errorText = await response.text();
       logger.error(
-        { status: response.status, error: errorText, fields },
+        { statusCode: response.status, error: errorText, fields },
         "HubSpot form submission failed"
       );
       return new Err(
@@ -198,7 +198,7 @@ export async function submitToHubSpotPartnerForm(params: {
     if (!response.ok) {
       const errorText = await response.text();
       logger.error(
-        { status: response.status, error: errorText, fields },
+        { statusCode: response.status, error: errorText, fields },
         "HubSpot partner form submission failed"
       );
       return new Err(
@@ -278,7 +278,7 @@ export async function submitToHubSpotEbookForm(params: {
     if (!response.ok) {
       const errorText = await response.text();
       logger.error(
-        { status: response.status, error: errorText, fields },
+        { statusCode: response.status, error: errorText, fields },
         "HubSpot ebook form submission failed"
       );
       return new Err(

--- a/front/lib/api/poke/coupons.ts
+++ b/front/lib/api/poke/coupons.ts
@@ -69,7 +69,7 @@ export async function pushCouponToOtherRegion(
 
   if (!response.ok) {
     logger.error(
-      { status: response.status, couponId: coupon.sId },
+      { statusCode: response.status, couponId: coupon.sId },
       "[CouponSync] Failed to push coupon to other region"
     );
     return new Err("other_region_push_failed");

--- a/front/lib/api/stripe/webhook_handler.ts
+++ b/front/lib/api/stripe/webhook_handler.ts
@@ -1464,7 +1464,7 @@ export async function processStripeWebhookEvent({
           {
             event,
             stripeSubscriptionId: stripeSubscription.id,
-            status: stripeSubscription.status,
+            subscriptionStatus: stripeSubscription.status,
             stripeError: true,
           },
           `[Stripe Webhook] Received customer.subscription.deleted with unknown status = ${stripeSubscription.status}. Expected status = canceled.`

--- a/front/lib/api/workspace_verification/turnstile/verify.ts
+++ b/front/lib/api/workspace_verification/turnstile/verify.ts
@@ -53,7 +53,7 @@ export async function verifyTurnstileToken({
 
   if (!response.ok) {
     logger.error(
-      { status: response.status },
+      { statusCode: response.status },
       "Turnstile siteverify returned non-200."
     );
     return new Err(new CaptchaError("network"));

--- a/front/lib/geo/country-detection.ts
+++ b/front/lib/geo/country-detection.ts
@@ -30,7 +30,7 @@ export async function resolveCountryCode(ip: string): Promise<string> {
   if (!response.ok) {
     logger.error(
       {
-        status: response.status,
+        statusCode: response.status,
         statusText: response.statusText,
         ip,
       },

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1993,7 +1993,11 @@ export async function cleanAndFinalizeMetronomeDraftInvoice({
 
     if (invoice.status !== "draft") {
       logger.info(
-        { stripeInvoiceId: invoiceId, workspaceId, status: invoice.status },
+        {
+          stripeInvoiceId: invoiceId,
+          workspaceId,
+          invoiceStatus: invoice.status,
+        },
         "[Stripe] Skipping invoice clean: invoice is no longer a draft"
       );
       return new Ok({ outcome: "skipped" });

--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -5,6 +5,7 @@ import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getTemporalClientForConnectorsNamespace } from "@app/lib/temporal";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
+import type { Logger } from "@app/logger/logger";
 import { getNotionWorkflowId } from "@app/types/connectors/workflows";
 import type { ActionLink, CheckFunction } from "@app/types/production_checks";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -12,7 +13,6 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { Client, WorkflowExecutionDescription } from "@temporalio/client";
 import { WorkflowNotFoundError } from "@temporalio/client";
-import type { Logger } from "pino";
 import { QueryTypes } from "sequelize";
 
 const TEMPORAL_WORKFLOW_STALLED_THRESHOLD_MS = 12 * 60 * 60 * 1000; // 12 hours.

--- a/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
+++ b/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
@@ -6,12 +6,12 @@ import {
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { getTemporalClientForConnectorsNamespace } from "@app/lib/temporal";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { Logger } from "@app/logger/logger";
 import { googleDriveGarbageCollectorWorkflowId } from "@app/types/connectors/workflows";
 import type { ActionLink, CheckFunction } from "@app/types/production_checks";
 import { withRetries } from "@app/types/shared/retries";
 import type { Client } from "@temporalio/client";
 import { WorkflowNotFoundError } from "@temporalio/client";
-import type { Logger } from "pino";
 import { QueryTypes } from "sequelize";
 
 // Below this share of a data source's documents, a non-empty GC backlog is treated as

--- a/front/lib/project_task/analyze_document/index.ts
+++ b/front/lib/project_task/analyze_document/index.ts
@@ -18,10 +18,10 @@ import {
   TakeawaysResource,
 } from "@app/lib/resources/takeaways_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import type { Logger } from "@app/logger/logger";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { startActiveObservation, updateActiveTrace } from "@langfuse/tracing";
-import type { Logger } from "pino";
 import { buildPromptForSourceType } from "./prompts";
 
 async function buildPromptProjectMembers(

--- a/front/lib/project_task/deduplicate_candidates.ts
+++ b/front/lib/project_task/deduplicate_candidates.ts
@@ -32,11 +32,11 @@ import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { Authenticator } from "@app/lib/auth";
 import type { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
+import type { Logger } from "@app/logger/logger";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { ModelId } from "@app/types/shared/model_id";
 import { startActiveObservation, updateActiveTrace } from "@langfuse/tracing";
-import type { Logger } from "pino";
 import { z } from "zod";
 
 // ── Public types ──────────────────────────────────────────────────────────────

--- a/front/lib/project_task/merge_into_project.test.ts
+++ b/front/lib/project_task/merge_into_project.test.ts
@@ -9,11 +9,11 @@ import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
 import type { TakeawaysWithSource } from "@app/lib/resources/takeaways_resource";
 import { TakeawaysResource } from "@app/lib/resources/takeaways_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import type { Logger } from "@app/logger/logger";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { PodTaskSourceInfo } from "@app/types/project_task";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { TaskVersionedActionItem } from "@app/types/takeaways";
-import type { Logger } from "pino";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ── Shared fixtures ───────────────────────────────────────────────────────────

--- a/front/lib/project_task/merge_into_project.ts
+++ b/front/lib/project_task/merge_into_project.ts
@@ -43,11 +43,11 @@ import {
 } from "@app/lib/resources/takeaways_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { Logger } from "@app/logger/logger";
 import type { PodTaskSourceInfo } from "@app/types/project_task";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import type { TaskVersionedActionItem } from "@app/types/takeaways";
-import type { Logger } from "pino";
 
 // Stable identifier used when recording the creating actor for butler-created
 // project tasks. This is not an actual agent configuration sId but a sentinel

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -449,7 +449,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
           workspaceId: auth.getNonNullableWorkspace().sId,
           sandboxFunctionId: this.sandboxFunction.sId,
           invocationId: this.sId,
-          status: this.status,
+          invocationStatus: this.status,
         },
         "Skipping execution of a terminal Pod function invocation"
       );

--- a/front/lib/utils/webbrowse.ts
+++ b/front/lib/utils/webbrowse.ts
@@ -504,7 +504,7 @@ const browseUrlSpider = async (
       {
         error,
         url,
-        status: res.status,
+        statusCode: res.status,
       },
       "[Spider] Failed to parse JSON response"
     );
@@ -521,7 +521,7 @@ const browseUrlSpider = async (
     logger.error(
       {
         url,
-        status: res.status,
+        statusCode: res.status,
       },
       "[Spider] Empty scrape response"
     );
@@ -540,7 +540,7 @@ const browseUrlSpider = async (
     logger.error(
       {
         url,
-        status: effectiveStatus,
+        statusCode: effectiveStatus,
         error,
       },
       "[Spider] Scrape request failed"
@@ -556,7 +556,7 @@ const browseUrlSpider = async (
     logger.error(
       {
         url,
-        status: effectiveStatus,
+        statusCode: effectiveStatus,
       },
       "[Spider] No content field in scrape response"
     );

--- a/front/lib/utils/websearch.ts
+++ b/front/lib/utils/websearch.ts
@@ -97,7 +97,7 @@ const serpapiSearch = async (
     }
   );
 
-  logger.debug({ ok: res.ok, status: res.status }, "get serpapi");
+  logger.debug({ ok: res.ok, statusCode: res.status }, "get serpapi");
 
   if (res.ok) {
     const json = await res.json();
@@ -125,7 +125,7 @@ const serpapiSearch = async (
 
   // TODO: Remove once we have a proper error handling.
   logger.error(
-    { status: res.status, statusText: res.statusText },
+    { statusCode: res.status, statusText: res.statusText },
     "Bad request on SerpAPI"
   );
 
@@ -156,7 +156,7 @@ const serperSearch = async (
 
   // TODO: Remove once we have a proper error handling.
   logger.error(
-    { status: res.status, statusText: res.statusText },
+    { statusCode: res.status, statusText: res.statusText },
     "Bad request on Serper"
   );
 

--- a/front/logger/logger.test.ts
+++ b/front/logger/logger.test.ts
@@ -1,0 +1,22 @@
+import logger from "@app/logger/logger";
+import { describe, expectTypeOf, it } from "vitest";
+
+describe("logger status typing", () => {
+  it("accepts a real Datadog severity as status", () => {
+    expectTypeOf(logger.info).toBeCallableWith(
+      { status: "critical" },
+      "message"
+    );
+  });
+
+  it("accepts payloads without a status", () => {
+    expectTypeOf(logger.info).toBeCallableWith({ itemId: "1" }, "message");
+    expectTypeOf(logger.error).toBeCallableWith(new Error("boom"), "message");
+    expectTypeOf(logger.info).toBeCallableWith("message");
+  });
+
+  it("rejects a status Datadog would misread as a severity", () => {
+    // @ts-expect-error - "completed" is prefix-matched to critical by Datadog.
+    expectTypeOf(logger.info).toBeCallableWith({ status: "completed" }, "msg");
+  });
+});

--- a/front/logger/logger.ts
+++ b/front/logger/logger.ts
@@ -5,6 +5,47 @@ import pino from "pino";
 const NODE_ENV = process.env.NODE_ENV;
 const LOG_LEVEL = process.env.LOG_LEVEL ?? "info";
 
+// Datadog reads a top-level `status` as the log severity, prefix-matched on its value, so
+// `status: "completed"` reads as critical and `status: "succeeded"` as ok. Only real
+// severities may be logged as `status`; use another key for anything else.
+export const DATADOG_LOG_STATUSES = [
+  "emergency",
+  "alert",
+  "critical",
+  "error",
+  "warning",
+  "notice",
+  "info",
+  "debug",
+  "ok",
+] as const;
+
+export type DatadogLogStatus = (typeof DATADOG_LOG_STATUSES)[number];
+
+interface CheckedLogFn {
+  (msg: string, ...args: unknown[]): void;
+  (obj: Error, msg?: string, ...args: unknown[]): void;
+  (
+    obj: { status?: DatadogLogStatus } & Record<string, unknown>,
+    msg?: string,
+    ...args: unknown[]
+  ): void;
+}
+
+// pino's own log methods accept any `status`; ours reject the values Datadog would misread.
+export type Logger = Omit<
+  pino.Logger,
+  "trace" | "debug" | "info" | "warn" | "error" | "fatal" | "child"
+> & {
+  trace: CheckedLogFn;
+  debug: CheckedLogFn;
+  info: CheckedLogFn;
+  warn: CheckedLogFn;
+  error: CheckedLogFn;
+  fatal: CheckedLogFn;
+  child: (bindings: pino.Bindings, options?: pino.ChildLoggerOptions) => Logger;
+};
+
 const defaultPinoOptions: LoggerOptions = {
   serializers: {
     error: pino.stdSerializers.err,
@@ -47,10 +88,9 @@ if (NODE_ENV === "development") {
   pinoOptions = { ...defaultPinoOptions, ...devOptions };
 }
 
-const logger = pino(pinoOptions);
+const logger: Logger = pino(pinoOptions);
 
 export default logger;
-export type { Logger } from "pino";
 
 export function auditLog(
   data: { author: UserType | "no-author" } & Record<string, unknown>,

--- a/front/migrations/20240910_app_data_sources.ts
+++ b/front/migrations/20240910_app_data_sources.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 
 import { Authenticator } from "@app/lib/auth";
 import { AppResource } from "@app/lib/resources/app_resource";

--- a/front/migrations/20241211_parents_front_migrator.ts
+++ b/front/migrations/20241211_parents_front_migrator.ts
@@ -1,6 +1,6 @@
 /* Commented out as we don't use this anymore and a refactor broke it.
 import _ from "lodash";
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 import { Op } from "sequelize";
 
 import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";

--- a/front/migrations/20250321_startstop_relocated_transcripts_workflows.ts
+++ b/front/migrations/20250321_startstop_relocated_transcripts_workflows.ts
@@ -1,4 +1,4 @@
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 
 import {
   pauseAllLabsWorkflows,

--- a/front/migrations/20250428_backfill_editor_groups.ts
+++ b/front/migrations/20250428_backfill_editor_groups.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import _ from "lodash";
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 import { Op } from "sequelize";
 
 import { Authenticator } from "@app/lib/auth";

--- a/front/migrations/20250429_update_agent_scopes.ts
+++ b/front/migrations/20250429_update_agent_scopes.ts
@@ -1,4 +1,4 @@
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { Authenticator } from "@app/lib/auth";

--- a/front/migrations/20250626_move_process_actions_to_mcp.ts
+++ b/front/migrations/20250626_move_process_actions_to_mcp.ts
@@ -1,6 +1,6 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import assert from "assert";
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 import type { CreationAttributes } from "sequelize";
 import { Op } from "sequelize";
 

--- a/front/migrations/20250729_cleanup_zendesk_delta.ts
+++ b/front/migrations/20250729_cleanup_zendesk_delta.ts
@@ -1,4 +1,4 @@
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 import { QueryTypes } from "sequelize";
 
 import config from "@app/lib/api/config";

--- a/front/migrations/20250729_cleanup_zendesk_old_format.ts
+++ b/front/migrations/20250729_cleanup_zendesk_old_format.ts
@@ -1,4 +1,4 @@
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 import { QueryTypes } from "sequelize";
 
 import config from "@app/lib/api/config";

--- a/front/migrations/20251009_update_frame_content_type.ts
+++ b/front/migrations/20251009_update_frame_content_type.ts
@@ -1,5 +1,5 @@
 import chunk from "lodash/chunk";
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 
 import {
   FileModel,

--- a/front/migrations/20251011_replace_viz_by_frame.ts
+++ b/front/migrations/20251011_replace_viz_by_frame.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import chunk from "lodash/chunk";
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";

--- a/front/migrations/20251013_suspend_group_mode_members.ts
+++ b/front/migrations/20251013_suspend_group_mode_members.ts
@@ -1,5 +1,5 @@
 import { Op } from "sequelize";
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";

--- a/front/migrations/20251117_backfill_missing_agent_editor_groups.ts
+++ b/front/migrations/20251117_backfill_missing_agent_editor_groups.ts
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 import { Op } from "sequelize";
 
 import { Authenticator } from "@app/lib/auth";

--- a/front/migrations/20251229_add_global_skill_to_agents_with_tool.ts
+++ b/front/migrations/20251229_add_global_skill_to_agents_with_tool.ts
@@ -1,6 +1,6 @@
 import chunk from "lodash/chunk";
 import fs from "fs";
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 import { Op } from "sequelize";
 
 import {

--- a/front/migrations/20251229_check_tool_migration_blockers.ts
+++ b/front/migrations/20251229_check_tool_migration_blockers.ts
@@ -1,4 +1,4 @@
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 
 import {
   isAutoInternalMCPServerName,

--- a/front/migrations/20260112_migrate_skill_editor_groups.ts
+++ b/front/migrations/20260112_migrate_skill_editor_groups.ts
@@ -1,4 +1,4 @@
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 import { Op } from "sequelize";
 
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";

--- a/front/migrations/20260114_backfill_project_metadata.ts
+++ b/front/migrations/20260114_backfill_project_metadata.ts
@@ -1,4 +1,4 @@
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 import { Op } from "sequelize";
 
 import { ProjectMetadataModel } from "@app/lib/resources/storage/models/project_metadata";

--- a/front/migrations/20260129_backfill_frames_skill_for_interactive_content.ts
+++ b/front/migrations/20260129_backfill_frames_skill_for_interactive_content.ts
@@ -1,4 +1,4 @@
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 import { Op } from "sequelize";
 
 import { Authenticator } from "@app/lib/auth";

--- a/front/migrations/20260209_disable_transcripts_on_connected_datasources.ts
+++ b/front/migrations/20260209_disable_transcripts_on_connected_datasources.ts
@@ -59,7 +59,7 @@ async function disableTranscriptsOnConnectedDataSources({
         configId: config.id,
         workspaceId: config.workspaceId,
         provider: config.provider,
-        status: config.status,
+        configurationStatus: config.status,
         dataSourceViewId: config.dataSourceViewId,
       },
       "Disabling transcript configuration on connected data source"

--- a/front/migrations/20260219_delete_disabled_workos_memberships.ts
+++ b/front/migrations/20260219_delete_disabled_workos_memberships.ts
@@ -64,7 +64,7 @@ async function deleteDisabledMembershipsForWorkspace(
       {
         membershipId: membership.id,
         userId: membership.userId,
-        status: membership.status,
+        membershipStatus: membership.status,
       },
       execute
         ? "Deleting disabled WorkOS membership"

--- a/front/migrations/20260402_backfill_project_content_fragments.ts
+++ b/front/migrations/20260402_backfill_project_content_fragments.ts
@@ -1,4 +1,4 @@
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 import { QueryTypes } from "sequelize";
 
 import { Authenticator } from "@app/lib/auth";

--- a/front/migrations/20260413_backfill_projects_skill_from_project_conversation.ts
+++ b/front/migrations/20260413_backfill_projects_skill_from_project_conversation.ts
@@ -1,7 +1,7 @@
 /*
 import chunk from "lodash/chunk";
 import fs from "fs";
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 import { Op } from "sequelize";
 
 import {

--- a/front/migrations/20260602_backfill_skill_tool_references.ts
+++ b/front/migrations/20260602_backfill_skill_tool_references.ts
@@ -16,7 +16,7 @@ import {
 } from "@app/lib/tools/format";
 import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
 import * as cheerio from "cheerio";
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 
 const ASSOCIATED_TOOLS_LABEL = "Tools associated with this skill:";
 const TOOLS_SECTION_SEPARATOR = "----";

--- a/front/migrations/20260606_backfill_frame_authorized_file_access.ts
+++ b/front/migrations/20260606_backfill_frame_authorized_file_access.ts
@@ -1,5 +1,5 @@
 /*
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 import { Op, QueryTypes } from "sequelize";
 
 import { readFrameFileContent } from "@app/lib/api/viz/authorized_file_access";

--- a/front/migrations/20260624_sunset_slideshow_mcp_server.ts
+++ b/front/migrations/20260624_sunset_slideshow_mcp_server.ts
@@ -1,4 +1,4 @@
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 
 import { Authenticator } from "@app/lib/auth";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";

--- a/front/migrations/20260710_deduplicate_user_tool_approvals.ts
+++ b/front/migrations/20260710_deduplicate_user_tool_approvals.ts
@@ -1,4 +1,4 @@
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 import { Op } from "sequelize";
 import { chunk } from "lodash";
 

--- a/front/migrations/20260731_backfill_user_memory.ts
+++ b/front/migrations/20260731_backfill_user_memory.ts
@@ -1,6 +1,6 @@
 import { getUserMemory, setUserMemory } from "@app/lib/api/user_memory";
 import { Authenticator } from "@app/lib/auth";
-import type { Logger } from "pino";
+import type { Logger } from "@app/logger/logger";
 import { AgentMemoryModel } from "@app/lib/resources/storage/models/agent_memories";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { makeScript } from "@app/scripts/helpers";

--- a/front/scripts/debug/profile_k8s_pods.ts
+++ b/front/scripts/debug/profile_k8s_pods.ts
@@ -78,7 +78,7 @@ makeScript(
         "  Chrome DevTools → Performance → Load Profile → select files"
       );
     } catch (err) {
-      logger.error(err);
+      logger.error({ err }, "Failed to profile pods");
       throw err;
     }
   }

--- a/front/scripts/dev/seed_conversations.ts
+++ b/front/scripts/dev/seed_conversations.ts
@@ -353,7 +353,7 @@ async function seedConversations(
     throw new Error("This script can only be run in development.");
   }
 
-  logger.info(config, "Starting seed conversations script");
+  logger.info({ ...config }, "Starting seed conversations script");
 
   const { workspace, user, auth } = await fetchWorkspaceAndUser(
     config.workspaceId

--- a/front/scripts/dev/seed_project_tasks.ts
+++ b/front/scripts/dev/seed_project_tasks.ts
@@ -225,7 +225,7 @@ makeScript(
         {
           text: todo.text,
           assignedTo: user.sId,
-          status: todo.deleted ? "deleted" : (todo.status ?? "todo"),
+          taskStatus: todo.deleted ? "deleted" : (todo.status ?? "todo"),
           isAgentSuggestion: todo.isAgentSuggestion,
         },
         "Created todo."

--- a/front/scripts/dev/voices_elevenlabs.ts
+++ b/front/scripts/dev/voices_elevenlabs.ts
@@ -3,9 +3,9 @@ import type {
   VoiceGender,
   VoiceUseCase,
 } from "@app/lib/api/actions/servers/speech_generator/metadata";
+import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import type { Voice } from "@elevenlabs/elevenlabs-js/api/types";
-import type { Logger } from "pino";
 
 interface CandidateVoice {
   voiceId: string;

--- a/front/scripts/fix_zero_amount_recurring_free_credits.ts
+++ b/front/scripts/fix_zero_amount_recurring_free_credits.ts
@@ -125,7 +125,7 @@ async function fixSegment({
   if (!finding.contractId) {
     finding.fixError = "no contract id on credit, cannot patch segment";
     logger.warn(
-      finding,
+      { ...finding },
       "[ZeroAmountFreeCredits] Skipping fix: no contract id"
     );
     return;
@@ -142,7 +142,7 @@ async function fixSegment({
     // human can investigate (zero eligible users? misconfigured override?).
     finding.fixError = "computed amount is 0, refusing to patch";
     logger.warn(
-      finding,
+      { ...finding },
       "[ZeroAmountFreeCredits] Computed amount is 0 — leaving segment as-is for manual review"
     );
     return;
@@ -150,7 +150,7 @@ async function fixSegment({
 
   if (!execute) {
     logger.info(
-      finding,
+      { ...finding },
       "[ZeroAmountFreeCredits] [DRY RUN] Would update segment amount and ensure DB credit"
     );
     return;
@@ -283,7 +283,7 @@ async function findZeroAmountSegments(
     };
     findings.push(finding);
     logger.warn(
-      finding,
+      { ...finding },
       execute
         ? "[ZeroAmountFreeCredits] Active segment has amount=0 — fixing"
         : "[ZeroAmountFreeCredits] Active segment has amount=0 (dry run)"

--- a/front/scripts/merge_mapped_identities.ts
+++ b/front/scripts/merge_mapped_identities.ts
@@ -362,7 +362,7 @@ makeScript(
       }
       await verifyRevoked(auth, [currentPair]);
       logger.info(
-        currentPair,
+        { ...currentPair },
         "Successfully merged old identity into primary user"
       );
     }

--- a/front/scripts/migrate_legacy_manual_internal_mcp_server_ids_to_auto.ts
+++ b/front/scripts/migrate_legacy_manual_internal_mcp_server_ids_to_auto.ts
@@ -42,11 +42,11 @@ import {
 } from "@app/lib/resources/string_ids";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
+import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { LightWorkspaceType } from "@app/types/user";
-import type { Logger } from "pino";
 import { Op } from "sequelize";
 import Sqids from "sqids";
 

--- a/front/scripts/migrate_skill_instructions_html.ts
+++ b/front/scripts/migrate_skill_instructions_html.ts
@@ -14,6 +14,7 @@ import { buildSkillInstructionsExtensions } from "@app/lib/editor/build_skill_in
 import { postProcessMarkdown } from "@app/lib/editor/skill_instructions_preprocessing";
 import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instructions_html";
+import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -136,7 +137,7 @@ type WorkspaceStats = {
 async function processSkillsForWorkspace(
   workspace: LightWorkspaceType,
   execute: boolean,
-  logger: { info: (obj: object, msg: string) => void }
+  logger: Logger
 ): Promise<WorkspaceStats> {
   const skills = await SkillConfigurationModel.findAll({
     where: {

--- a/front/scripts/relocation/read_front_table_chunk.ts
+++ b/front/scripts/relocation/read_front_table_chunk.ts
@@ -78,7 +78,7 @@ makeScript(
         });
         logger.info(res, "readFrontTableChunk");
       } catch (err) {
-        logger.error(err);
+        logger.error({ err }, "readFrontTableChunk failed");
       }
     } else {
       logger.info("Nothing will be executed");

--- a/front/scripts/scrub_agent.ts
+++ b/front/scripts/scrub_agent.ts
@@ -50,7 +50,7 @@ makeScript(
           agentId,
           name: latest.name,
           scope: latest.scope,
-          status: latest.status,
+          agentStatus: latest.status,
           versionCount: versions.length,
           versions: versions.map((v) => v.version),
         },

--- a/front/start_worker.ts
+++ b/front/start_worker.ts
@@ -14,7 +14,7 @@ import { hideBin } from "yargs/helpers";
 setupGlobalErrorHandler(logger);
 
 const pinoAdapter: Logger = {
-  log: (level: LogLevel, msg: string, meta: object) =>
+  log: (level: LogLevel, msg: string, meta: Record<string, unknown>) =>
     ({
       TRACE: logger.trace,
       DEBUG: logger.debug,
@@ -22,11 +22,16 @@ const pinoAdapter: Logger = {
       WARN: logger.warn,
       ERROR: logger.error,
     })[level](meta ?? {}, msg),
-  info: (msg: string, meta: object) => logger.info(meta ?? {}, msg),
-  warn: (msg: string, meta: object) => logger.warn(meta ?? {}, msg),
-  error: (msg: string, meta: object) => logger.error(meta ?? {}, msg),
-  debug: (msg: string, meta: object) => logger.debug(meta ?? {}, msg),
-  trace: (msg: string, meta: object) => logger.trace(meta ?? {}, msg),
+  info: (msg: string, meta: Record<string, unknown>) =>
+    logger.info(meta ?? {}, msg),
+  warn: (msg: string, meta: Record<string, unknown>) =>
+    logger.warn(meta ?? {}, msg),
+  error: (msg: string, meta: Record<string, unknown>) =>
+    logger.error(meta ?? {}, msg),
+  debug: (msg: string, meta: Record<string, unknown>) =>
+    logger.debug(meta ?? {}, msg),
+  trace: (msg: string, meta: Record<string, unknown>) =>
+    logger.trace(meta ?? {}, msg),
 };
 
 // Install once per process — before creating Worker/Client.

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -736,7 +736,7 @@ export async function finalizeInterruption(
       {
         agentMessageId: agentMessage.sId,
         conversationId: conversation.sId,
-        status: agentMessage.status,
+        messageStatus: agentMessage.status,
       },
       "finalizeInterruption: message already finalized, skipping"
     );

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -390,7 +390,7 @@ export async function runCompaction(
           sourceConversationId: sourceConversation?.conversationId,
           compactionMessageId,
           historyFilePath: historyFileRes.value.path,
-          status,
+          generationStatus: status,
         },
         "Compaction generation succeeded"
       );

--- a/front/temporal/labs/transcripts/utils/gong.ts
+++ b/front/temporal/labs/transcripts/utils/gong.ts
@@ -130,7 +130,7 @@ export async function retrieveGongTranscripts(
 
   if (!newTranscripts.ok) {
     localLogger.error(
-      { status: newTranscripts.status },
+      { statusCode: newTranscripts.status },
       "[retrieveNewTranscripts] Error fetching new transcripts from Gong. Stopping."
     );
     return [];
@@ -232,7 +232,7 @@ export async function retrieveGongTranscriptContent(
         localLogger.error(
           {
             fileId,
-            status: response.status,
+            statusCode: response.status,
           },
           "[retrieveGongTranscripts] Error fetching Gong users. Skipping."
         );
@@ -298,7 +298,7 @@ export async function retrieveGongTranscriptContent(
     localLogger.error(
       {
         fileId,
-        status: call.status,
+        statusCode: call.status,
         statusText: call.statusText,
         errorText,
       },

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -418,7 +418,7 @@ export async function runWakeUpActivity({
 
   if (wakeUp.status !== "scheduled") {
     logger.info(
-      { status: wakeUp.status, wakeUpId, workspaceId },
+      { wakeUpStatus: wakeUp.status, wakeUpId, workspaceId },
       "Skipping wake-up: wake-up is not scheduled."
     );
     return;
@@ -429,7 +429,7 @@ export async function runWakeUpActivity({
   ]);
   if (!c) {
     logger.info(
-      { status: wakeUp.status, wakeUpId, workspaceId },
+      { wakeUpStatus: wakeUp.status, wakeUpId, workspaceId },
       "Cancelling wake-up: conversation not found."
     );
     await cancelWakeUpAndCleanupSchedule(auth, wakeUp);
@@ -443,7 +443,7 @@ export async function runWakeUpActivity({
   if (!conversationResource) {
     logger.info(
       {
-        status: wakeUp.status,
+        wakeUpStatus: wakeUp.status,
         wakeUpId,
         workspaceId,
         error: "Conversation not found",

--- a/front/types/production_checks.ts
+++ b/front/types/production_checks.ts
@@ -1,4 +1,4 @@
-import type pino from "pino";
+import type { Logger } from "@app/logger/logger";
 import { z } from "zod";
 
 // Action links for check results
@@ -20,7 +20,7 @@ export type CheckSuccessPayload = Record<string, unknown>;
 
 export type CheckFunction = (
   checkName: string,
-  logger: pino.Logger,
+  logger: Logger,
   reportSuccess: (payload?: CheckSuccessPayload) => void,
   reportFailure: (payload: CheckFailurePayload, message: string) => void,
   heartbeat: () => void

--- a/marketing/lib/api/hubspot/hubspot.ts
+++ b/marketing/lib/api/hubspot/hubspot.ts
@@ -96,7 +96,7 @@ export async function submitToHubSpotForm(params: {
     if (!response.ok) {
       const errorText = await response.text();
       logger.error(
-        { status: response.status, error: errorText, fields },
+        { statusCode: response.status, error: errorText, fields },
         "HubSpot form submission failed"
       );
       return new Err(
@@ -198,7 +198,7 @@ export async function submitToHubSpotPartnerForm(params: {
     if (!response.ok) {
       const errorText = await response.text();
       logger.error(
-        { status: response.status, error: errorText, fields },
+        { statusCode: response.status, error: errorText, fields },
         "HubSpot partner form submission failed"
       );
       return new Err(
@@ -278,7 +278,7 @@ export async function submitToHubSpotEbookForm(params: {
     if (!response.ok) {
       const errorText = await response.text();
       logger.error(
-        { status: response.status, error: errorText, fields },
+        { statusCode: response.status, error: errorText, fields },
         "HubSpot ebook form submission failed"
       );
       return new Err(

--- a/marketing/lib/geo/country-detection.ts
+++ b/marketing/lib/geo/country-detection.ts
@@ -28,7 +28,7 @@ export async function resolveCountryCode(ip: string): Promise<string> {
   if (!response.ok) {
     logger.error(
       {
-        status: response.status,
+        statusCode: response.status,
         statusText: response.statusText,
         ip,
       },

--- a/marketing/logger/logger.ts
+++ b/marketing/logger/logger.ts
@@ -4,6 +4,47 @@ import pino from "pino";
 const NODE_ENV = process.env.NODE_ENV;
 const LOG_LEVEL = process.env.LOG_LEVEL ?? "info";
 
+// Datadog reads a top-level `status` as the log severity, prefix-matched on its value, so
+// `status: "completed"` reads as critical and `status: "succeeded"` as ok. Only real
+// severities may be logged as `status`; use another key for anything else.
+export const DATADOG_LOG_STATUSES = [
+  "emergency",
+  "alert",
+  "critical",
+  "error",
+  "warning",
+  "notice",
+  "info",
+  "debug",
+  "ok",
+] as const;
+
+export type DatadogLogStatus = (typeof DATADOG_LOG_STATUSES)[number];
+
+interface CheckedLogFn {
+  (msg: string, ...args: unknown[]): void;
+  (obj: Error, msg?: string, ...args: unknown[]): void;
+  (
+    obj: { status?: DatadogLogStatus } & Record<string, unknown>,
+    msg?: string,
+    ...args: unknown[]
+  ): void;
+}
+
+// pino's own log methods accept any `status`; ours reject the values Datadog would misread.
+export type Logger = Omit<
+  pino.Logger,
+  "trace" | "debug" | "info" | "warn" | "error" | "fatal" | "child"
+> & {
+  trace: CheckedLogFn;
+  debug: CheckedLogFn;
+  info: CheckedLogFn;
+  warn: CheckedLogFn;
+  error: CheckedLogFn;
+  fatal: CheckedLogFn;
+  child: (bindings: pino.Bindings, options?: pino.ChildLoggerOptions) => Logger;
+};
+
 const defaultPinoOptions: LoggerOptions = {
   serializers: {
     error: pino.stdSerializers.err,
@@ -45,7 +86,6 @@ if (NODE_ENV === "development") {
   pinoOptions = { ...defaultPinoOptions, ...devOptions };
 }
 
-const logger = pino(pinoOptions);
+const logger: Logger = pino(pinoOptions);
 
 export default logger;
-export type { Logger } from "pino";

--- a/marketing/types/shared/logger.ts
+++ b/marketing/types/shared/logger.ts
@@ -1,5 +1,10 @@
-// Structural interface compatible with pino Logger.
-type LogFn = (obj: unknown, msg?: string, ...args: unknown[]) => void;
+// Structural interface compatible with our pino Logger, whose log methods reject a `status`
+// that Datadog would misread as the log severity.
+type LogFn = (
+  obj: Record<string, unknown>,
+  msg?: string,
+  ...args: unknown[]
+) => void;
 
 export interface LoggerInterface {
   trace: LogFn;

--- a/viz/app/content/ServerVisualizationWrapper.tsx
+++ b/viz/app/content/ServerVisualizationWrapper.tsx
@@ -54,7 +54,7 @@ async function fetchFileRefsRecursively(
 
         if (!fileResponse.ok) {
           logger.warn(
-            { key, status: fileResponse.status },
+            { key, statusCode: fileResponse.status },
             "Failed to fetch file ref"
           );
           return;
@@ -154,7 +154,7 @@ export async function ServerSideVisualizationWrapper({
       );
     } else {
       logger.warn(
-        { identifier, status: codeResponse.status },
+        { identifier, statusCode: codeResponse.status },
         "Failed to fetch code"
       );
     }

--- a/viz/app/lib/logger.ts
+++ b/viz/app/lib/logger.ts
@@ -3,6 +3,47 @@ import pino from "pino";
 
 const LOG_LEVEL = process.env.LOG_LEVEL ?? "info";
 
+// Datadog reads a top-level `status` as the log severity, prefix-matched on its value, so
+// `status: "completed"` reads as critical and `status: "succeeded"` as ok. Only real
+// severities may be logged as `status`; use another key for anything else.
+export const DATADOG_LOG_STATUSES = [
+  "emergency",
+  "alert",
+  "critical",
+  "error",
+  "warning",
+  "notice",
+  "info",
+  "debug",
+  "ok",
+] as const;
+
+export type DatadogLogStatus = (typeof DATADOG_LOG_STATUSES)[number];
+
+interface CheckedLogFn {
+  (msg: string, ...args: unknown[]): void;
+  (obj: Error, msg?: string, ...args: unknown[]): void;
+  (
+    obj: { status?: DatadogLogStatus } & Record<string, unknown>,
+    msg?: string,
+    ...args: unknown[]
+  ): void;
+}
+
+// pino's own log methods accept any `status`; ours reject the values Datadog would misread.
+export type Logger = Omit<
+  pino.Logger,
+  "trace" | "debug" | "info" | "warn" | "error" | "fatal" | "child"
+> & {
+  trace: CheckedLogFn;
+  debug: CheckedLogFn;
+  info: CheckedLogFn;
+  warn: CheckedLogFn;
+  error: CheckedLogFn;
+  fatal: CheckedLogFn;
+  child: (bindings: pino.Bindings, options?: pino.ChildLoggerOptions) => Logger;
+};
+
 const defaultPinoOptions: LoggerOptions = {
   serializers: {
     error: pino.stdSerializers.err,
@@ -24,7 +65,6 @@ const defaultPinoOptions: LoggerOptions = {
   level: LOG_LEVEL,
 };
 
-const logger = pino(defaultPinoOptions);
+const logger: Logger = pino(defaultPinoOptions);
 
 export default logger;
-export type { Logger } from "pino";


### PR DESCRIPTION
## Description

Follow-up to #30021. Datadog reads a top-level `status` as the log severity and prefix-matches its value: a value starting with `c` becomes `critical`, one starting with `s` becomes `ok`. A payload `status` from any other vocabulary rewrites the severity of the log. Prod over the last 3h:

| DD status | message | payload `status` |
|---|---|---|
| critical | OpenAI tool search query/results | `completed` |
| critical | Skipping wake-up: wake-up is not scheduled. | `cancelled` |
| ok | Compaction generation succeeded | `succeeded` |
| ok | Cancelling wake-up: conversation not found. | `scheduled` |

The log methods now accept only a real severity as `status`. Anything else is a compile error and the author picks another key.

The type check surfaced the offenders already in the code, which I renamed: HTTP statuses to `statusCode`, domain statuses to a descriptive name (`wakeUpStatus`, `subscriptionStatus`). Most of the file count is `Logger` type imports moving from pino to our own logger, which is what carries the checked signature. Applied in front, connectors, marketing and viz, the four places we build a pino logger.

One gap remains. A payload typed `Record<string, unknown>` still passes unchecked. The OpenAI logs escaped that way, with `status` set three functions upstream inside a `details: Record<string, unknown>`. Fixing that residue belongs in the Datadog pipeline: point the status remapper at `level` only, which also covers reserved attributes like `message` and `host`.

## Tests

`front/logger/logger.test.ts` pins the signature with `expectTypeOf`: a valid severity is accepted, so are `Error` and status-less payloads, and `"completed"` is rejected under `@ts-expect-error`. Type-checked front, front-api, front-spa, connectors, extension, marketing, viz and sparkle, all clean apart from errors that pre-exist on main (1 in front-api, 2 in viz). No runtime change, only types and key renames.

## Risk

Low. The renames change log field names, so anything querying `@status` on the messages above needs `@statusCode` or the new key. No monitors reference them today.

## Deploy Plan

Normal deploy.