### PR TITLE
[front] feat: consumption analytics ES schema (parent agents/servers)

### DIFF
--- a/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
+++ b/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
@@ -42,7 +42,13 @@
         "tag_ids": {
           "type": "keyword"
         },
-        "root_agent_id": {
+        "parent_ids": {
+          "type": "keyword"
+        },
+        "direct_parent_id": {
+          "type": "keyword"
+        },
+        "root_id": {
           "type": "keyword"
         },
         "depth": {
@@ -93,10 +99,13 @@
         "server_name": {
           "type": "keyword"
         },
+        "parent_server_name": {
+          "type": "keyword"
+        },
         "action_id": {
           "type": "keyword"
         },
-        "enabled_by_skill_ids": {
+        "attributed_skill_ids": {
           "type": "keyword"
         }
       }

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -117,8 +117,12 @@ export interface AgentMessageConsumptionAnalyticsAgent {
   id: string;
   version: string;
   tag_ids: string[];
-  // Agent that started the run; equals `id` for a top-level agent.
-  root_agent_id: string;
+  // IDs of the agent's ancestors, from the top-level agent down to the immediate parent. Empty for a top-level agent.
+  parent_ids: string[];
+  // The immediate parent of the agent. Null for a top-level agent.
+  direct_parent_id: string | null;
+  // The top-level agent of the run. Equals `id` when this agent is itself the root.
+  root_id: string;
   // 0 for a top-level agent, incremented once per level of sub-agent nesting.
   depth: number;
 }
@@ -130,9 +134,13 @@ export interface AgentMessageConsumptionAnalyticsUser {
 export interface AgentMessageConsumptionAnalyticsTool {
   name: string;
   server_name: string;
+  // Server that called this tool. Empty when the agent called this tool directly.
+  parent_server_name: string;
   action_id: string;
-  // Skills that made this tool available to the agent.
-  enabled_by_skill_ids: string[];
+  // Every skill that can be held responsible, directly or indirectly, for this
+  // tool call being made.
+  // When a tool call enables a skill, that skill is also reflected here.
+  attributed_skill_ids: string[];
 }
 
 export interface AgentMessageConsumptionAnalyticsTokens {


### PR DESCRIPTION
## Description

Modify schema of `agent_message_consumption_analytics_1` in place:
- add `agent.parent_ids` to capture an agent's entire lineage. Useful to answer queries like "what's the cost of this agent, taking into account all its descendant"
- add `agent.direct_parent_id` to link to the direct parent of that sub agent. 
- rename `agent.root_agent_id` into `agent.root_id` to be consistent
- add `tool.parent_server_name`: because the computer tool can itself be responsible for triggering other calls (singular as we don't expect more than one parent)
- rename `enabled_by_skills_ids` to `attributed_skills_ids` to make it clear this lists all the skills we can attribute to this action (either a tool call or a tool call that enables this skill)

## Tests

Recreated the index locally.

## Risk

None. This index is not yet written to.

## Deploy Plan

Will recreate the index mapping from scratch.
