### PR TITLE
[front] enh: Max connection pool to 10

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -554,10 +554,6 @@ const config = {
   getTemporalFrontNamespace: () => {
     return EnvironmentConfig.getOptionalEnvVariable("TEMPORAL_NAMESPACE");
   },
-  // Deployment component name. Set via DD_SERVICE in helm values per deployment.
-  getServiceName: (): string | undefined => {
-    return EnvironmentConfig.getOptionalEnvVariable("DD_SERVICE");
-  },
   // Email.
   getEmailWebhookSecret: (): string => {
     return EnvironmentConfig.getEnvVariable("EMAIL_WEBHOOK_SECRET");

--- a/front/lib/resources/storage/index.ts
+++ b/front/lib/resources/storage/index.ts
@@ -1,4 +1,3 @@
-import config from "@app/lib/api/config";
 import { SequelizeWithComments } from "@app/lib/api/database";
 import { dbConfig } from "@app/lib/resources/storage/config";
 import { getStatsDClient } from "@app/lib/utils/statsd";
@@ -79,27 +78,16 @@ function reportPoolMetrics(
 
 const POOL_TAGS = ["pool:front_master"];
 
-// Web-serving deployments handle concurrent requests where the auth codepath
-// acquires multiple connections in parallel (Promise.all). They need a larger
-// pool than workers which process jobs sequentially.
-const WEB_SERVING_SERVICES = new Set(["front", "front-edge", "front-internal"]);
-
-function getPoolMaxForService(): number {
-  const service = config.getServiceName();
-
-  // DO NOT BLINDLY INCREASE THIS NUMBER (see comment below).
-  return service && WEB_SERVING_SERVICES.has(service) ? 40 : 25;
-}
+// DO NOT BLINDLY INCREASE THIS NUMBER. Each connection holds a PostgreSQL
+// backend via PgBouncer, so raising it shifts contention downstream. Prefer
+// reducing per-request connection usage (caching, shared connections).
+const POOL_MAX = 10;
 
 export const frontSequelize = new SequelizeWithComments(
   dbConfig.getRequiredFrontDatabaseURI(),
   {
-    // Pool size is intentionally conservative. Each connection holds a PostgreSQL
-    // backend via PgBouncer. Blindly increasing this shifts contention downstream.
-    // Prefer reducing per-request connection usage (caching, shared connections)
-    // over bumping pool size. See getPoolMax() for per-deployment values.
     pool: {
-      max: getPoolMaxForService(),
+      max: POOL_MAX,
       acquire: 30000,
     },
     logging: isDevelopment() && DB_LOGGING_ENABLED ? sequelizeLogger : false,


### PR DESCRIPTION
## Description

We gave 40 connections to our api and 25 to our workers, but that was a patch over a lot of problems we had. 10 should be the right number looking at current metrics, we might have to drop activity slots on agent-loop again from 40 to 20, but looking at how often we get cpu throttled, seems like the right direction anyway.


## Tests

N/A

## Risk
Low
Blast radius: Connection acquisition increasing, or even spiking.
Will revert the deploy if I see this.

## Deploy Plan

Deploy front