### PR TITLE
Preserve previous cost attribution breakdowns

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -7067,7 +7067,7 @@
                     "details": {
                       "type": "object",
                       "nullable": true,
-                      "description": "Additive attribution reconciled to the bill through model input rows. Null when the active attribution version is unavailable or incomplete.",
+                      "description": "Additive attribution reconciled to the bill through model input rows, using the newest complete stored attribution version. Null when no stored version is complete.",
                       "required": [
                         "attributionVersion",
                         "agentWorkCredits",
@@ -7075,7 +7075,8 @@
                       ],
                       "properties": {
                         "attributionVersion": {
-                          "type": "integer"
+                          "type": "integer",
+                          "description": "Attribution version used for this breakdown."
                         },
                         "agentWorkCredits": {
                           "type": "number",
@@ -10512,18 +10513,14 @@
       },
       "PrivateConversationConsumptionDetails": {
         "type": "object",
-        "description": "Additive attribution reconciled to the authoritative bill exclusively through model input rows. Null when any billed message lacks complete attribution for the active version.",
+        "description": "Additive attribution reconciled to the authoritative bill exclusively through model input rows. Each message uses its newest complete stored attribution version. Null when any billed message has no complete stored attribution.",
         "required": [
-          "attributionVersion",
           "agentWorkCredits",
           "tools",
           "models",
           "agents"
         ],
         "properties": {
-          "attributionVersion": {
-            "type": "integer"
-          },
           "agentWorkCredits": {
             "type": "number",
             "description": "Agent work after assigning billing reconciliation exclusively to model input rows."

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -178,16 +178,13 @@
  *             $ref: '#/components/schemas/PrivateConversationConsumptionModelDetails'
  *     PrivateConversationConsumptionDetails:
  *       type: object
- *       description: Additive attribution reconciled to the authoritative bill exclusively through model input rows. Null when any billed message lacks complete attribution for the active version.
+ *       description: Additive attribution reconciled to the authoritative bill exclusively through model input rows. Each message uses its newest complete stored attribution version. Null when any billed message has no complete stored attribution.
  *       required:
- *         - attributionVersion
  *         - agentWorkCredits
  *         - tools
  *         - models
  *         - agents
  *       properties:
- *         attributionVersion:
- *           type: integer
  *         agentWorkCredits:
  *           type: number
  *           description: Agent work after assigning billing reconciliation exclusively to model input rows.

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/consumption.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/consumption.test.ts
@@ -10,6 +10,8 @@ import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
 const BILLED_CREDITS = 7;
+const PREVIOUS_ATTRIBUTION_VERSION =
+  AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION - 1;
 
 async function setupConversation() {
   const { auth, workspace } = await createPrivateApiMockRequest({
@@ -91,7 +93,7 @@ describe("GET /api/w/:wId/assistant/conversations/:cId/consumption", () => {
     await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
       conversation,
       agentMessageModelId: agentMessage.agentMessageId,
-      attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+      attributionVersion: PREVIOUS_ATTRIBUTION_VERSION,
       records: [
         {
           itemType: "input",

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/consumption.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/consumption.test.ts
@@ -10,6 +10,8 @@ import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
 const BILLED_CREDITS = 7;
+const PREVIOUS_ATTRIBUTION_VERSION =
+  AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION - 1;
 
 async function setupMessage() {
   const { auth, workspace } = await createPrivateApiMockRequest({
@@ -90,7 +92,7 @@ describe("GET /api/w/:wId/assistant/conversations/:cId/messages/:mId/consumption
     await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
       conversation,
       agentMessageModelId: agentMessage.agentMessageId,
-      attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+      attributionVersion: PREVIOUS_ATTRIBUTION_VERSION,
       records: [
         {
           itemType: "input",
@@ -124,6 +126,7 @@ describe("GET /api/w/:wId/assistant/conversations/:cId/messages/:mId/consumption
     await expect(response.json()).resolves.toMatchObject({
       billedCredits: BILLED_CREDITS,
       details: {
+        attributionVersion: PREVIOUS_ATTRIBUTION_VERSION,
         agentWorkCredits: BILLED_CREDITS,
       },
     });

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/consumption.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/consumption.ts
@@ -61,7 +61,7 @@ app.use(withFeatureFlag("conversation_consumption_details"));
  *                 details:
  *                   type: object
  *                   nullable: true
- *                   description: Additive attribution reconciled to the bill through model input rows. Null when the active attribution version is unavailable or incomplete.
+ *                   description: Additive attribution reconciled to the bill through model input rows, using the newest complete stored attribution version. Null when no stored version is complete.
  *                   required:
  *                     - attributionVersion
  *                     - agentWorkCredits
@@ -69,6 +69,7 @@ app.use(withFeatureFlag("conversation_consumption_details"));
  *                   properties:
  *                     attributionVersion:
  *                       type: integer
+ *                       description: Attribution version used for this breakdown.
  *                     agentWorkCredits:
  *                       type: number
  *                       description: Agent work after assigning billing reconciliation exclusively to model input rows.

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.test.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.test.tsx
@@ -29,7 +29,6 @@ function makeTool(
 describe("ConversationCreditUsageBreakdown", () => {
   it("shows the largest tools and groups the rest", () => {
     const details: ConversationConsumptionDetails = {
-      attributionVersion: 3,
       agentWorkCredits: 4.5,
       tools: [
         makeTool("files", "File tool", 2),
@@ -86,7 +85,6 @@ describe("ConversationCreditUsageBreakdown", () => {
       models: [],
     };
     const details: ConversationConsumptionDetails = {
-      attributionVersion: 3,
       agentWorkCredits: 20,
       tools: [],
       models: [],

--- a/front/lib/api/assistant/agent_message_consumption_attribution/conversation_read.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/conversation_read.test.ts
@@ -12,6 +12,8 @@ import type { ModelId } from "@app/types/shared/model_id";
 import { describe, expect, it } from "vitest";
 
 const BILLED_CREDITS = 10;
+const PREVIOUS_ATTRIBUTION_VERSION =
+  AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION - 1;
 
 async function setupMessage() {
   const { authenticator: auth, workspace } = await createResourceTest({});
@@ -129,7 +131,6 @@ describe("getConversationConsumption", () => {
     expect(consumption).toMatchObject({
       billedCredits: BILLED_CREDITS,
       details: {
-        attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
         agentWorkCredits: 5,
         tools: [
           {
@@ -153,6 +154,75 @@ describe("getConversationConsumption", () => {
           expect.objectContaining({
             billedCredits: BILLED_CREDITS,
             agentWorkCredits: 5,
+          }),
+        ],
+      },
+    });
+  });
+
+  it("aggregates messages using their newest complete attribution", async () => {
+    const {
+      auth,
+      workspace,
+      conversation,
+      runUsageModelId,
+      agentMessage,
+      agentConfiguration,
+    } = await setupMessage();
+    const { run: previousRun, runUsageModelId: previousRunUsageModelId } =
+      await RunFactory.createWithUsage(auth, {
+        inputTokens: 100,
+        outputTokens: 20,
+        reasoningTokens: 5,
+      });
+    const previousMessage =
+      await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conversation.id,
+        rank: 1,
+        agentConfigurationId: agentConfiguration.sId,
+        runIds: [previousRun.dustRunId],
+      });
+    if (!previousMessage.agentMessageId) {
+      throw new Error("Previous-version agent message was not created.");
+    }
+    await ConversationResource.updateAgentMessageCostCredits(auth, {
+      agentMessageModelId: previousMessage.agentMessageId,
+      costCredits: BILLED_CREDITS,
+    });
+    await ConversationFactory.setAgentMessageStatus({
+      workspace,
+      agentMessageModelId: previousMessage.agentMessageId,
+      status: "succeeded",
+    });
+
+    await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+      conversation,
+      agentMessageModelId: agentMessage.agentMessageId,
+      attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+      records: modelRecords(runUsageModelId),
+      pendingToolItems: [],
+    });
+    await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+      conversation,
+      agentMessageModelId: previousMessage.agentMessageId,
+      attributionVersion: PREVIOUS_ATTRIBUTION_VERSION,
+      records: modelRecords(previousRunUsageModelId),
+      pendingToolItems: [],
+    });
+
+    const consumption = await getConversationConsumption(auth, {
+      conversation,
+    });
+
+    expect(consumption).toMatchObject({
+      billedCredits: BILLED_CREDITS * 2,
+      details: {
+        agentWorkCredits: BILLED_CREDITS * 2,
+        agents: [
+          expect.objectContaining({
+            billedCredits: BILLED_CREDITS * 2,
+            agentWorkCredits: BILLED_CREDITS * 2,
           }),
         ],
       },

--- a/front/lib/api/assistant/agent_message_consumption_attribution/conversation_read.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/conversation_read.ts
@@ -1,6 +1,6 @@
 import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
 import {
-  buildMessageConsumptionDetails,
+  buildLatestAvailableMessageConsumptionDetails,
   type MessageConsumptionDetails,
 } from "@app/lib/api/assistant/agent_message_consumption_attribution/message_details";
 import { resolveAnalyticsAgentLabels } from "@app/lib/api/assistant/observability/agent_labels";
@@ -78,7 +78,6 @@ function aggregateMessageDetails(
   details: MessageConsumptionDetails[]
 ): Omit<ConversationConsumptionDetails, "agents"> {
   return {
-    attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
     agentWorkCredits: details.reduce(
       (total, detail) => total + detail.agentWorkCredits,
       0
@@ -89,10 +88,10 @@ function aggregateMessageDetails(
 }
 
 /**
- * Aggregates the latest stable bill and active-version attribution for messages belonging directly
- * to a conversation. In-progress messages are ignored until they reach a terminal state. If any
- * completed billed message lacks a complete attribution, the stable total remains available while
- * the detailed breakdown is withheld.
+ * Aggregates the latest stable bill and newest complete attribution available for each message
+ * belonging directly to a conversation. In-progress messages are ignored until they reach a
+ * terminal state. If any completed billed message lacks a complete attribution, the stable total
+ * remains available while the detailed breakdown is withheld.
  */
 export async function getConversationConsumption(
   auth: Authenticator,
@@ -106,7 +105,7 @@ export async function getConversationConsumption(
     auth,
     {
       conversation,
-      attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+      maxAttributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
     }
   );
   const completedMessages = facts.messages.filter((message) =>
@@ -132,7 +131,7 @@ export async function getConversationConsumption(
   const messageDetails: MessageDetailsEntry[] = billedMessages.map(
     (message) => ({
       message,
-      details: buildMessageConsumptionDetails({
+      details: buildLatestAvailableMessageConsumptionDetails({
         actions: message.actions,
         billedCredits: message.billedCredits,
         dustRunIds: message.dustRunIds,

--- a/front/lib/api/assistant/agent_message_consumption_attribution/message_details.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/message_details.ts
@@ -1,6 +1,5 @@
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import { getToolAggregateDisplayLabel } from "@app/lib/actions/tool_display_labels";
-import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
@@ -16,6 +15,7 @@ import type {
 import type { ModelId } from "@app/types/shared/model_id";
 
 const MICRO_CREDITS_PER_CREDIT = 1_000_000;
+const FIRST_ATTRIBUTION_VERSION_WITH_TOOL_ROWS = 2;
 
 export type MessageConsumptionDetails = AgentMessageConsumptionDetails & {
   models: AgentMessageConsumptionModelDetails[];
@@ -353,8 +353,9 @@ function buildModelDetails({
   );
 }
 
-export function buildMessageConsumptionDetails({
+function buildMessageConsumptionDetails({
   actions,
+  attributionVersion,
   billedCredits,
   dustRunIds,
   items,
@@ -362,6 +363,7 @@ export function buildMessageConsumptionDetails({
   usages,
 }: {
   actions: AgentMCPActionResource[];
+  attributionVersion: number;
   billedCredits: number | null;
   dustRunIds: string[];
   items: AgentMessageConsumptionItemResource[];
@@ -395,11 +397,12 @@ export function buildMessageConsumptionDetails({
 
   if (
     !hasCompleteModelAttribution(items, messageUsages) ||
-    !hasCompleteToolAttribution({
-      actions,
-      items,
-      dustRunIdsWithUsage,
-    })
+    (attributionVersion >= FIRST_ATTRIBUTION_VERSION_WITH_TOOL_ROWS &&
+      !hasCompleteToolAttribution({
+        actions,
+        items,
+        dustRunIdsWithUsage,
+      }))
   ) {
     return null;
   }
@@ -422,7 +425,7 @@ export function buildMessageConsumptionDetails({
   }
 
   return {
-    attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+    attributionVersion,
     ...buildConsumptionTotals({
       items,
       reconciledCreditAmounts,
@@ -434,4 +437,52 @@ export function buildMessageConsumptionDetails({
       reconciledCreditAmounts,
     }),
   };
+}
+
+/** Selects the newest self-consistent attribution stored for a message. */
+export function buildLatestAvailableMessageConsumptionDetails({
+  actions,
+  billedCredits,
+  dustRunIds,
+  items,
+  runs,
+  usages,
+}: {
+  actions: AgentMCPActionResource[];
+  billedCredits: number | null;
+  dustRunIds: string[];
+  items: AgentMessageConsumptionItemResource[];
+  runs: RunResource[];
+  usages: RunUsageWithRunKeyType[];
+}): MessageConsumptionDetails | null {
+  const itemsByAttributionVersion = new Map<
+    number,
+    AgentMessageConsumptionItemResource[]
+  >();
+  for (const item of items) {
+    const versionItems =
+      itemsByAttributionVersion.get(item.attributionVersion) ?? [];
+    versionItems.push(item);
+    itemsByAttributionVersion.set(item.attributionVersion, versionItems);
+  }
+
+  const attributionVersions = [...itemsByAttributionVersion.keys()].sort(
+    (left, right) => right - left
+  );
+  for (const attributionVersion of attributionVersions) {
+    const details = buildMessageConsumptionDetails({
+      actions,
+      attributionVersion,
+      billedCredits,
+      dustRunIds,
+      items: itemsByAttributionVersion.get(attributionVersion) ?? [],
+      runs,
+      usages,
+    });
+    if (details) {
+      return details;
+    }
+  }
+
+  return null;
 }

--- a/front/lib/api/assistant/agent_message_consumption_attribution/read.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/read.test.ts
@@ -12,6 +12,8 @@ import type { ModelId } from "@app/types/shared/model_id";
 import { describe, expect, it } from "vitest";
 
 const BILLED_CREDITS = 10;
+const PREVIOUS_ATTRIBUTION_VERSION =
+  AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION - 1;
 const INPUT_GROSS_CREDITS_MICRO = 2_000_000;
 const OUTPUT_GROSS_CREDITS_MICRO = 1_000_000;
 const REASONING_GROSS_CREDITS_MICRO = 1_000_000;
@@ -256,7 +258,40 @@ describe("getAgentMessageConsumption", () => {
     ).resolves.toEqual({ billedCredits: BILLED_CREDITS, details: null });
   });
 
-  it("withholds details when the active rows do not cover every current run bucket", async () => {
+  it("falls back to the newest complete previous attribution", async () => {
+    const { auth, conversation, runUsageModelId, agentMessage } =
+      await setupMessage();
+
+    await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+      conversation,
+      agentMessageModelId: agentMessage.agentMessageId,
+      attributionVersion: PREVIOUS_ATTRIBUTION_VERSION,
+      records: modelRecords(runUsageModelId),
+      pendingToolItems: [],
+    });
+    await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+      conversation,
+      agentMessageModelId: agentMessage.agentMessageId,
+      attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+      records: modelRecords(runUsageModelId).filter(
+        (record) => record.itemType !== "output"
+      ),
+      pendingToolItems: [],
+    });
+
+    const consumption = await getAgentMessageConsumption(auth, {
+      conversation,
+      agentMessageId: agentMessage.sId,
+    });
+
+    expect(consumption?.details).toMatchObject({
+      attributionVersion: PREVIOUS_ATTRIBUTION_VERSION,
+      agentWorkCredits: BILLED_CREDITS,
+      tools: [],
+    });
+  });
+
+  it("withholds details when no version covers every current run bucket", async () => {
     const { auth, conversation, runUsageModelId, agentMessage } =
       await setupMessage();
 

--- a/front/lib/api/assistant/agent_message_consumption_attribution/read.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/read.ts
@@ -1,5 +1,5 @@
 import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
-import { buildMessageConsumptionDetails } from "@app/lib/api/assistant/agent_message_consumption_attribution/message_details";
+import { buildLatestAvailableMessageConsumptionDetails } from "@app/lib/api/assistant/agent_message_consumption_attribution/message_details";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMessageConsumptionItemResource as ConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -8,8 +8,9 @@ import type { AgentMessageConsumptionResponse } from "@app/types/assistant/agent
 
 /**
  * Builds the end-user explanation for one agent message. Provider and token facts stay behind this
- * interface. If the active attribution version does not cover the message's current runs and tools,
- * the exact bill remains available while details are withheld.
+ * interface. It uses the newest complete attribution version stored for the message. If no version
+ * covers the message's current runs and tools, the exact bill remains available while details are
+ * withheld.
  */
 export async function getAgentMessageConsumption(
   auth: Authenticator,
@@ -26,7 +27,7 @@ export async function getAgentMessageConsumption(
     {
       conversation,
       agentMessageId,
-      attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+      maxAttributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
     }
   );
   if (!facts) {
@@ -49,7 +50,7 @@ export async function getAgentMessageConsumption(
     return unavailableResponse;
   }
 
-  const details = buildMessageConsumptionDetails({
+  const details = buildLatestAvailableMessageConsumptionDetails({
     actions: facts.actions,
     billedCredits: facts.billedCredits,
     dustRunIds: facts.dustRunIds,

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
@@ -96,7 +96,7 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
         auth,
         {
           agentMessageModelIds: [agentMessageModelId],
-          attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+          maxAttributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
         }
       );
 
@@ -145,7 +145,7 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
         auth,
         {
           agentMessageModelIds: [agentMessageModelId],
-          attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+          maxAttributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
         }
       );
 
@@ -187,7 +187,7 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
         auth,
         {
           agentMessageModelIds: [agentMessageModelId],
-          attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+          maxAttributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
         }
       );
 
@@ -286,7 +286,7 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
         auth,
         {
           agentMessageModelIds: [agentMessageModelId],
-          attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+          maxAttributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
         }
       );
     const toolItemByActionId = new Map(
@@ -382,7 +382,7 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
         auth,
         {
           agentMessageModelIds: [agentMessageModelId],
-          attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+          maxAttributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
         }
       );
     const toolItem = items.find((item) => item.itemType === "tool");
@@ -419,7 +419,7 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
         auth,
         {
           agentMessageModelIds: [agentMessageModelId],
-          attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+          maxAttributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
         }
       );
 
@@ -482,7 +482,7 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
         auth,
         {
           agentMessageModelIds: [agentMessageModelId],
-          attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+          maxAttributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
         }
       )
     ).filter((item) => item.itemType === "tool");
@@ -538,7 +538,7 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
         auth,
         {
           agentMessageModelIds: [agentMessageModelId],
-          attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+          maxAttributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
         }
       )
     ).filter((item) => item.itemType === "tool");
@@ -598,7 +598,7 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
         auth,
         {
           agentMessageModelIds: [agentMessageModelId],
-          attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+          maxAttributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
         }
       )
     ).filter((item) => item.itemType === "tool");
@@ -643,7 +643,7 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
         auth,
         {
           agentMessageModelIds: [agentMessage.agentMessageId],
-          attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+          maxAttributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
         }
       );
 

--- a/front/lib/resources/agent_message_consumption_item_resource.test.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.test.ts
@@ -97,7 +97,7 @@ async function listTools(
   const items =
     await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(auth, {
       agentMessageModelIds: [agentMessageModelId],
-      attributionVersion: ATTRIBUTION_VERSION,
+      maxAttributionVersion: ATTRIBUTION_VERSION,
     });
   return items.filter((item) => item.itemType === "tool");
 }
@@ -178,7 +178,7 @@ describe("AgentMessageConsumptionItemResource", () => {
         auth,
         {
           agentMessageModelIds: [context.agentMessageModelId],
-          attributionVersion: ATTRIBUTION_VERSION,
+          maxAttributionVersion: ATTRIBUTION_VERSION,
         }
       );
     expect(items).toHaveLength(1);
@@ -399,13 +399,13 @@ describe("AgentMessageConsumptionItemResource", () => {
     await expect(
       AgentMessageConsumptionItemResource.listByAgentMessageModelIds(auth, {
         agentMessageModelIds: [first.agentMessageModelId],
-        attributionVersion: ATTRIBUTION_VERSION,
+        maxAttributionVersion: ATTRIBUTION_VERSION,
       })
     ).resolves.toHaveLength(0);
     await expect(
       AgentMessageConsumptionItemResource.listByAgentMessageModelIds(auth, {
         agentMessageModelIds: [second.agentMessageModelId],
-        attributionVersion: ATTRIBUTION_VERSION,
+        maxAttributionVersion: ATTRIBUTION_VERSION,
       })
     ).resolves.toHaveLength(1);
   });

--- a/front/lib/resources/agent_message_consumption_item_resource.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.ts
@@ -446,11 +446,11 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
     auth: Authenticator,
     {
       agentMessageModelIds,
-      attributionVersion,
+      maxAttributionVersion,
       transaction,
     }: {
       agentMessageModelIds: ModelId[];
-      attributionVersion: number;
+      maxAttributionVersion: number;
       transaction?: Transaction;
     }
   ): Promise<AgentMessageConsumptionItemResource[]> {
@@ -462,7 +462,7 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         agentMessageId: { [Op.in]: agentMessageModelIds },
-        attributionVersion,
+        attributionVersion: { [Op.lte]: maxAttributionVersion },
       },
       order: [
         ["agentMessageId", "ASC"],
@@ -486,10 +486,10 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
     auth: Authenticator,
     {
       conversation,
-      attributionVersion,
+      maxAttributionVersion,
     }: {
       conversation: ConversationResource;
-      attributionVersion: number;
+      maxAttributionVersion: number;
     }
   ): Promise<{
     messages: ConversationConsumptionMessageFacts[];
@@ -527,7 +527,7 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
         where: {
           workspaceId,
           conversationId: conversation.id,
-          attributionVersion,
+          attributionVersion: { [Op.lte]: maxAttributionVersion },
         },
         order: [
           ["agentMessageId", "ASC"],
@@ -584,11 +584,11 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
     {
       conversation,
       agentMessageId,
-      attributionVersion,
+      maxAttributionVersion,
     }: {
       conversation: ConversationResource;
       agentMessageId: string;
-      attributionVersion: number;
+      maxAttributionVersion: number;
     }
   ): Promise<{
     billedCredits: number | null;
@@ -605,7 +605,7 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
     const [items, actions] = await Promise.all([
       this.listByAgentMessageModelIds(auth, {
         agentMessageModelIds: [agentMessage.id],
-        attributionVersion,
+        maxAttributionVersion,
       }),
       AgentMCPActionResource.listByAgentMessageIds(auth, [agentMessage.id]),
     ]);

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -855,7 +855,7 @@ describe("destroyConversation", () => {
     await expect(
       AgentMessageConsumptionItemResource.listByAgentMessageModelIds(auth, {
         agentMessageModelIds: [agentMessageId],
-        attributionVersion: 1,
+        maxAttributionVersion: 1,
       })
     ).resolves.toHaveLength(0);
   });

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -381,6 +381,7 @@ export class ConversationFactory {
     version = 0,
     resolvedModel = null,
     modelResolutionMethod = null,
+    runIds = null,
   }: {
     workspace: WorkspaceType;
     conversationId: ModelId;
@@ -391,6 +392,7 @@ export class ConversationFactory {
     version?: number;
     resolvedModel?: ResolvedRequestedModel | null;
     modelResolutionMethod?: ModelResolutionMethodType | null;
+    runIds?: string[] | null;
   }): Promise<MessageModel> {
     const agentMessageRow = await AgentMessageModel.create({
       status: "created",
@@ -403,6 +405,7 @@ export class ConversationFactory {
       resolvedModelId: resolvedModel?.modelId ?? null,
       resolvedReasoningEffort: resolvedModel?.reasoningEffort ?? null,
       modelResolutionMethod,
+      runIds,
     });
 
     return MessageModel.create({

--- a/front/types/assistant/conversation_consumption.ts
+++ b/front/types/assistant/conversation_consumption.ts
@@ -32,7 +32,6 @@ export type ConversationConsumptionAgentDetails = {
  * @swaggerschema PrivateConversationConsumptionDetails (swagger_private_schemas.ts)
  */
 export type ConversationConsumptionDetails = {
-  attributionVersion: number;
   agentWorkCredits: number;
   tools: ConversationConsumptionToolDetails[];
   models: ConversationConsumptionModelDetails[];


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When we bump the cost attribution version, existing messages still have rows from the previous version. Readers were only looking for the current version, so historical messages kept their billed credits but lost their detailed breakdown until a backfill was performed (except that we are not into backfills 😅).

This change fetches attribution rows up to the current version and selects the newest complete version for each message. For example, if version 4 is missing or incomplete but version 3 is complete, the version 3 breakdown remains available.

The same rule applies independently to every message in a conversation, so a conversation can safely aggregate both version 3 and version 4 messages. The conversation response does not expose a single version because a mixed aggregate cannot be described by one value. Message responses still expose the version they use.

No migration or backfill is required.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
