### PR TITLE
Poke: fix the has opus access flag to latest rule

### DIFF
--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -16,12 +16,7 @@ import type { SeatPlanResponseBody } from "@app/lib/api/credits/seat_plan";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
 import { getMetronomeContractUrl } from "@app/lib/metronome/urls";
-import {
-  FREE_NO_PLAN_CODE,
-  isDustCompanyPlan,
-  isEnterprisePlanPrefix,
-  isProPlanPrefix,
-} from "@app/lib/plans/plan_codes";
+import { FREE_NO_PLAN_CODE, isProPlanPrefix } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
 import { usePokeCancelPendingContract, usePokePlans } from "@app/lib/swr/poke";
 import type { PlanType, SubscriptionType } from "@app/types/plan";
@@ -546,12 +541,11 @@ export function PlanLimitationsTable({
               </PokeTableRow>
 
               <PokeTableRow>
-                <PokeTableCell>Is Opus enabled?</PokeTableCell>
                 <PokeTableCell>
-                  {isDustCompanyPlan(activePlan.code) ||
-                  isEnterprisePlanPrefix(activePlan.code)
-                    ? "✅"
-                    : "❌"}
+                  Has advanced model access (Opus...)
+                </PokeTableCell>
+                <PokeTableCell>
+                  {activePlan.hasAdvancedModelAccess ? "✅" : "❌"}
                 </PokeTableCell>
               </PokeTableRow>
 


### PR DESCRIPTION
## Description

Current access to advanced models is determined by a flag on the plan ( +some feature flags).
Correctly use the new plan flag instead of old rule in the poke plan description

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low, only poke

## Deploy Plan

deploy front
