### PR TITLE
Admin governance: Add button for action in skill builder warning

### DIFF
--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -1,11 +1,9 @@
 import { SpaceSelectionSheet } from "@app/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage";
-import { useBlockedSkillSpaceRemovalConfirm } from "@app/components/shared/RemoveSpaceDialog";
 import { SpaceChips } from "@app/components/shared/SpaceChips";
-import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { useSkillSpaceRestrictionsContext } from "@app/components/skill_builder/SkillSpaceRestrictionsContext";
+import { useRemoveSkillSpace } from "@app/components/skill_builder/useRemoveSkillSpace";
 import { removeNulls } from "@app/types/shared/utils/general";
-import type { SpaceType } from "@app/types/space";
 import { Button, Planet } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useState } from "react";
 import { useController, useFormContext } from "react-hook-form";
@@ -22,21 +20,15 @@ export function SkillBuilderRequestedSpacesSection() {
   const isReadOnly = additionalSpacesField.disabled ?? false;
   const selectedAdditionalSpaces = additionalSpacesField.value ?? [];
 
-  const { mcpServerViews } = useMCPServerViewsContext();
-  const confirmBlockedSpaceRemoval = useBlockedSkillSpaceRemovalConfirm({
-    mcpServerViews,
-  });
+  const { removeSpace } = useRemoveSkillSpace();
 
   const {
-    actionsBySpaceId,
     areSpaceRequirementsReady,
     globalSpace,
     initialAdditionalSpaces,
     initialRequestedSpaceIds,
-    knowledgeBySpaceId,
     missingSpaceIds,
     nonGlobalSpacesUsedBySkill,
-    skillsBySpaceId,
     spaceIdsUsedBySkill,
   } = useSkillSpaceRestrictionsContext();
 
@@ -62,30 +54,6 @@ export function SkillBuilderRequestedSpacesSection() {
     initialRequestedSpaceIds,
     resetField,
   ]);
-
-  const handleRemoveSpace = async (space: SpaceType) => {
-    if (!areSpaceRequirementsReady) {
-      return;
-    }
-
-    if (spaceIdsUsedBySkill.has(space.sId)) {
-      await confirmBlockedSpaceRemoval({
-        space,
-        actions: actionsBySpaceId[space.sId] ?? [],
-        knowledge: knowledgeBySpaceId[space.sId] ?? [],
-        skills: (skillsBySpaceId[space.sId] ?? []).map((skill) => ({
-          sId: skill.id,
-          name: skill.name,
-          icon: skill.icon,
-        })),
-      });
-      return;
-    }
-
-    additionalSpacesField.onChange(
-      selectedAdditionalSpaces.filter((spaceId) => spaceId !== space.sId)
-    );
-  };
 
   const handleOpenSheet = () => {
     if (!areSpaceRequirementsReady) {
@@ -137,7 +105,7 @@ export function SkillBuilderRequestedSpacesSection() {
       </div>
       <SpaceChips
         spaces={spacesToDisplay}
-        onRemoveSpace={isReadOnly ? undefined : handleRemoveSpace}
+        onRemoveSpace={isReadOnly ? undefined : removeSpace}
       />
 
       <SpaceSelectionSheet

--- a/front/components/skill_builder/SkillEditorsAccessWarning.tsx
+++ b/front/components/skill_builder/SkillEditorsAccessWarning.tsx
@@ -1,62 +1,104 @@
 import { SpaceLinks } from "@app/components/shared/SpaceLinks";
+import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import type { EditorWithoutSpaceAccess } from "@app/components/skill_builder/SkillSpaceRestrictionsContext";
+import { useRemoveSkillSpace } from "@app/components/skill_builder/useRemoveSkillSpace";
+import { getSpaceName } from "@app/lib/spaces";
 import type { LightWorkspaceType } from "@app/types/user";
-import { AlertCircle, ContentMessage } from "@dust-tt/sparkle";
+import { AlertCircle, Button, ContentMessage } from "@dust-tt/sparkle";
+import { useController } from "react-hook-form";
 
 interface SkillEditorsAccessWarningProps {
   editorsWithoutSpaceAccess: EditorWithoutSpaceAccess[];
   owner: LightWorkspaceType;
 }
 
+/**
+ * One message per editor that cannot read a restricted space the skill uses. Dropping the space or
+ * the editor can be done from here; adding them to the space happens in the space itself, which the
+ * message links to.
+ */
 export function SkillEditorsAccessWarning({
   editorsWithoutSpaceAccess,
   owner,
 }: SkillEditorsAccessWarningProps) {
-  if (editorsWithoutSpaceAccess.length === 0) {
-    return null;
-  }
+  return (
+    <div className="flex flex-col gap-2">
+      {editorsWithoutSpaceAccess.map((editorWithoutAccess) => (
+        <EditorAccessWarning
+          key={editorWithoutAccess.editor.sId}
+          editorWithoutAccess={editorWithoutAccess}
+          owner={owner}
+        />
+      ))}
+    </div>
+  );
+}
 
-  const isSingle = editorsWithoutSpaceAccess.length === 1;
+interface EditorAccessWarningProps {
+  editorWithoutAccess: EditorWithoutSpaceAccess;
+  owner: LightWorkspaceType;
+}
+
+function EditorAccessWarning({
+  editorWithoutAccess,
+  owner,
+}: EditorAccessWarningProps) {
+  const { editor, missingSpaces } = editorWithoutAccess;
+
+  const { field: editorsField } = useController<
+    SkillBuilderFormData,
+    "editors"
+  >({
+    name: "editors",
+  });
+  const { removeSpace, isRemovalDisabled } = useRemoveSkillSpace();
+
+  const handleRemoveEditor = () => {
+    editorsField.onChange(
+      (editorsField.value ?? []).filter(
+        (currentEditor) => currentEditor.sId !== editor.sId
+      )
+    );
+  };
+
+  const isSingleSpace = missingSpaces.length === 1;
 
   return (
     <ContentMessage
-      variant="warning"
+      title="Invalid editors"
+      variant="golden"
       icon={AlertCircle}
       size="lg"
-      title={
-        isSingle
-          ? "An editor doesn't have access to this skill"
-          : "Some editors don't have access to this skill"
-      }
     >
-      {isSingle ? (
-        <p>
-          <strong>{editorsWithoutSpaceAccess[0].editor.fullName}</strong> is not
-          a member of{" "}
-          <SpaceLinks
-            owner={owner}
-            spaces={editorsWithoutSpaceAccess[0].spaces}
+      <p>
+        <strong>{editor.fullName}</strong> is an editor of this skill but is not
+        a member of <SpaceLinks owner={owner} spaces={missingSpaces} />, so they
+        cannot view or use it. Add them{" "}
+        {isSingleSpace ? "to that space" : "to those spaces"}, remove{" "}
+        {isSingleSpace ? "that space" : "those spaces"} restriction or remove
+        them from editors:
+      </p>
+      <div className="mt-2 flex flex-row flex-wrap items-center gap-2">
+        {missingSpaces.map((space) => (
+          <Button
+            key={space.sId}
+            size="xs"
+            variant="outline"
+            label={`Remove ${getSpaceName(space)}`}
+            disabled={isRemovalDisabled}
+            onClick={() => {
+              void removeSpace(space);
+            }}
           />
-          , so they cannot view or use this skill. Add them to the space, or
-          remove them from the editors.
-        </p>
-      ) : (
-        <>
-          <p className="mb-1">
-            These editors are not members of the restricted spaces this skill
-            uses, so they cannot view or use it. Add them to the spaces, or
-            remove them from the editors.
-          </p>
-          <ul className="list-disc space-y-1 pl-5">
-            {editorsWithoutSpaceAccess.map(({ editor, spaces }) => (
-              <li key={editor.sId}>
-                <strong>{editor.fullName}</strong> is missing{" "}
-                <SpaceLinks owner={owner} spaces={spaces} />
-              </li>
-            ))}
-          </ul>
-        </>
-      )}
+        ))}
+        <Button
+          size="xs"
+          variant="outline"
+          label="Remove editor"
+          disabled={editorsField.disabled}
+          onClick={handleRemoveEditor}
+        />
+      </div>
     </ContentMessage>
   );
 }

--- a/front/components/skill_builder/SkillSpaceRestrictionsContext.tsx
+++ b/front/components/skill_builder/SkillSpaceRestrictionsContext.tsx
@@ -18,7 +18,7 @@ import { useWatch } from "react-hook-form";
 /** An editor of the skill, with the restricted spaces they cannot read. */
 export interface EditorWithoutSpaceAccess {
   editor: SkillBuilderFormData["editors"][number];
-  spaces: SpaceType[];
+  missingSpaces: SpaceType[];
 }
 
 interface SkillSpaceRestrictionsContextType {
@@ -197,7 +197,7 @@ export function SkillSpaceRestrictionsProvider({
     const spaceById = new Map(
       nonGlobalSpacesWithRestrictions.map((space) => [space.sId, space])
     );
-    const spacesByEditorId = new Map<string, SpaceType[]>();
+    const missingSpacesByEditorId = new Map<string, SpaceType[]>();
 
     for (const { spaceId, userIdsWithoutAccess } of spacesAccess) {
       const space = spaceById.get(spaceId);
@@ -206,18 +206,18 @@ export function SkillSpaceRestrictionsProvider({
       }
 
       for (const userId of userIdsWithoutAccess) {
-        const existing = spacesByEditorId.get(userId);
+        const existing = missingSpacesByEditorId.get(userId);
         if (existing) {
           existing.push(space);
         } else {
-          spacesByEditorId.set(userId, [space]);
+          missingSpacesByEditorId.set(userId, [space]);
         }
       }
     }
 
     return (editors ?? []).flatMap((editor) => {
-      const spaces = spacesByEditorId.get(editor.sId);
-      return spaces ? [{ editor, spaces }] : [];
+      const missingSpaces = missingSpacesByEditorId.get(editor.sId);
+      return missingSpaces ? [{ editor, missingSpaces }] : [];
     });
   }, [editors, nonGlobalSpacesWithRestrictions, spacesAccess]);
 

--- a/front/components/skill_builder/useRemoveSkillSpace.ts
+++ b/front/components/skill_builder/useRemoveSkillSpace.ts
@@ -1,0 +1,80 @@
+import { useBlockedSkillSpaceRemovalConfirm } from "@app/components/shared/RemoveSpaceDialog";
+import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import { useSkillSpaceRestrictionsContext } from "@app/components/skill_builder/SkillSpaceRestrictionsContext";
+import type { SpaceType } from "@app/types/space";
+import { useCallback } from "react";
+import { useController } from "react-hook-form";
+
+/**
+ * Removes a space from the skill, or explains why it cannot be removed.
+ *
+ * A space that a tool, an attached knowledge or a nested skill depends on is not in
+ * `additionalSpaces` at all, so it cannot be dropped without first editing whatever pulls it in.
+ * For those, `removeSpace` opens the blocking dialog that lists the culprits instead.
+ */
+export function useRemoveSkillSpace() {
+  const { field: additionalSpacesField } = useController<
+    SkillBuilderFormData,
+    "additionalSpaces"
+  >({
+    name: "additionalSpaces",
+  });
+
+  const { mcpServerViews } = useMCPServerViewsContext();
+  const confirmBlockedSpaceRemoval = useBlockedSkillSpaceRemovalConfirm({
+    mcpServerViews,
+  });
+
+  const {
+    actionsBySpaceId,
+    areSpaceRequirementsReady,
+    knowledgeBySpaceId,
+    skillsBySpaceId,
+    spaceIdsUsedBySkill,
+  } = useSkillSpaceRestrictionsContext();
+
+  const selectedAdditionalSpaces = additionalSpacesField.value ?? [];
+  const isReadOnly = additionalSpacesField.disabled ?? false;
+
+  const removeSpace = useCallback(
+    async (space: SpaceType) => {
+      if (!areSpaceRequirementsReady) {
+        return;
+      }
+
+      if (spaceIdsUsedBySkill.has(space.sId)) {
+        await confirmBlockedSpaceRemoval({
+          space,
+          actions: actionsBySpaceId[space.sId] ?? [],
+          knowledge: knowledgeBySpaceId[space.sId] ?? [],
+          skills: (skillsBySpaceId[space.sId] ?? []).map((skill) => ({
+            sId: skill.id,
+            name: skill.name,
+            icon: skill.icon,
+          })),
+        });
+        return;
+      }
+
+      additionalSpacesField.onChange(
+        selectedAdditionalSpaces.filter((spaceId) => spaceId !== space.sId)
+      );
+    },
+    [
+      actionsBySpaceId,
+      additionalSpacesField,
+      areSpaceRequirementsReady,
+      confirmBlockedSpaceRemoval,
+      knowledgeBySpaceId,
+      selectedAdditionalSpaces,
+      skillsBySpaceId,
+      spaceIdsUsedBySkill,
+    ]
+  );
+
+  return {
+    removeSpace,
+    isRemovalDisabled: isReadOnly || !areSpaceRequirementsReady,
+  };
+}

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -148,10 +148,11 @@ export function useSpacesAccessCheck({
 
   const isEmpty = spaceIds.length === 0 || userIds.length === 0;
   const params = new URLSearchParams();
-  for (const spaceId of spaceIds) {
+  // Sorted so that the same sets always produce the same key, whatever the caller's order.
+  for (const spaceId of [...spaceIds].sort()) {
     params.append("spaceIds", spaceId);
   }
-  for (const userId of userIds) {
+  for (const userId of [...userIds].sort()) {
     params.append("userIds", userId);
   }
 


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9736

 - change color to be less aggressive than red (red is for very dangerous issues)
 - one warning per editor
 - action button to act on the issue: remove editor, remove space. Remove space is gated behind the check of whether the space can be removed or not.

<img width="2030" height="450" alt="image" src="https://github.com/user-attachments/assets/1a5b4e57-51d6-49e9-8481-eec8d64945b7" />


<img width="1964" height="702" alt="image" src="https://github.com/user-attachments/assets/3a989ff5-aa4c-47aa-be73-8daeaebaf734" />

<img width="2032" height="762" alt="image" src="https://github.com/user-attachments/assets/aeff9700-e4b5-4f67-b49d-68657980f1d5" />


## Tests
tested locally

## Risk

low, purely UI 

## Deploy Plan

deploy front
