### PR TITLE
Return Pod function results in the invocation response when they settle in time

### DIFF
--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -16,7 +16,10 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SandboxFunctionMCPActionFactory } from "@app/tests/utils/SandboxFunctionMCPActionFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import type { SandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
+import type {
+  SandboxFunctionInvocationEvent,
+  SandboxFunctionUserIdentityPolicy,
+} from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
@@ -31,6 +34,9 @@ vi.mock("@app/lib/api/sandbox_functions/events", async (importOriginal) => {
   return {
     ...mod,
     publishSandboxFunctionInvocationEvent: vi.fn(),
+    // Defaults to a stream that ends without settling, which is what an invocation still running
+    // when the request returns looks like.
+    getSandboxFunctionInvocationEvents: vi.fn(async function* () {}),
   };
 });
 
@@ -58,7 +64,10 @@ vi.mock("@app/lib/actions/tool_status", async (importOriginal) => {
 });
 
 import { setUserAlwaysApprovedTool } from "@app/lib/actions/tool_status";
-import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
+import {
+  getSandboxFunctionInvocationEvents,
+  publishSandboxFunctionInvocationEvent,
+} from "@app/lib/api/sandbox_functions/events";
 import {
   launchSandboxFunctionInvocationWorkflow,
   launchSandboxFunctionToolWorkflow,
@@ -89,10 +98,12 @@ afterEach(() => {
 async function setupSandboxFunction({
   addCallerToSpace = true,
   withSandboxFunctionsFeatureFlag = true,
+  withFastExecutionFeatureFlag = false,
   userIdentity = "optional",
 }: {
   addCallerToSpace?: boolean;
   withSandboxFunctionsFeatureFlag?: boolean;
+  withFastExecutionFeatureFlag?: boolean;
   userIdentity?: SandboxFunctionUserIdentityPolicy;
 } = {}) {
   const { workspace, auth: adminAuth } = await createPrivateApiMockRequest({
@@ -100,6 +111,12 @@ async function setupSandboxFunction({
   });
   if (withSandboxFunctionsFeatureFlag) {
     await FeatureFlagFactory.basic(adminAuth, "sandbox_functions");
+  }
+  if (withFastExecutionFeatureFlag) {
+    await FeatureFlagFactory.basic(
+      adminAuth,
+      "sandbox_function_fast_execution"
+    );
   }
 
   const space = await SpaceFactory.project(workspace);
@@ -277,6 +294,38 @@ function postInvocation({
   );
 }
 
+function mockInvocationEventStream(events: SandboxFunctionInvocationEvent[]) {
+  vi.mocked(getSandboxFunctionInvocationEvents).mockImplementation(
+    async function* () {
+      for (const [index, data] of events.entries()) {
+        yield { eventId: `event-${index}`, data };
+      }
+    }
+  );
+}
+
+function toolApprovalEvent({
+  invocationId,
+  sandboxFunctionId,
+}: {
+  invocationId: string;
+  sandboxFunctionId: string;
+}): SandboxFunctionInvocationEvent {
+  return {
+    type: "tool_approve_execution",
+    actionId: "act_blocked",
+    created: Date.now(),
+    invocationId,
+    sandboxFunctionId,
+    inputs: {},
+    metadata: {
+      toolName: "send_email",
+      mcpServerName: "gmail",
+      agentName: "agent",
+    },
+  };
+}
+
 describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () => {
   it("creates an invocation and starts its workflow", async () => {
     const { workspace, sandboxFunction } = await setupSandboxFunction();
@@ -320,6 +369,101 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
       },
       { invocationId: invocation.sId }
     );
+  });
+
+  it("returns the result inline when the invocation succeeds before the response", async () => {
+    const { workspace, sandboxFunction } = await setupSandboxFunction({
+      withFastExecutionFeatureFlag: true,
+    });
+    mockInvocationEventStream([
+      {
+        type: "sandbox_function_invocation_result",
+        created: Date.now(),
+        invocationId: "sfi_ignored",
+        functionId: sandboxFunction.sId,
+        result: { ok: true },
+      },
+    ]);
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+    });
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.outcome).toEqual({ status: "succeeded", result: { ok: true } });
+  });
+
+  it("returns the error inline when the invocation fails before the response", async () => {
+    const { workspace, sandboxFunction } = await setupSandboxFunction({
+      withFastExecutionFeatureFlag: true,
+    });
+    mockInvocationEventStream([
+      {
+        type: "sandbox_function_invocation_error",
+        created: Date.now(),
+        invocationId: "sfi_ignored",
+        functionId: sandboxFunction.sId,
+        error: { code: "threw", message: "boom" },
+      },
+    ]);
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+    });
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.outcome).toEqual({
+      status: "errored",
+      error: { code: "threw", message: "boom" },
+    });
+  });
+
+  // Holding the response until an invocation blocked on user input settles would deadlock: the
+  // approval card only renders once the client holds the invocation.
+  it("returns no outcome when the invocation blocks on a tool approval", async () => {
+    const { workspace, sandboxFunction } = await setupSandboxFunction({
+      withFastExecutionFeatureFlag: true,
+    });
+    mockInvocationEventStream([
+      toolApprovalEvent({
+        invocationId: "sfi_ignored",
+        sandboxFunctionId: sandboxFunction.sId,
+      }),
+      {
+        type: "sandbox_function_invocation_result",
+        created: Date.now(),
+        invocationId: "sfi_ignored",
+        functionId: sandboxFunction.sId,
+        result: { ok: true },
+      },
+    ]);
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+    });
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.outcome).toBeUndefined();
+  });
+
+  it("does not wait for an outcome when fast execution is disabled", async () => {
+    const { workspace, sandboxFunction } = await setupSandboxFunction();
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+    });
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.outcome).toBeUndefined();
+    expect(getSandboxFunctionInvocationEvents).not.toHaveBeenCalled();
   });
 
   it("allows a workspace member to invoke a workspace-user-required function", async () => {

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -1,7 +1,9 @@
 import { MCP_VALIDATION_OUTPUTS } from "@app/lib/actions/constants";
+import { awaitSandboxFunctionInvocationOutcome } from "@app/lib/api/sandbox_functions/await_invocation";
 import { isSandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
 import { resolveSandboxFunctionActionAuthentication } from "@app/lib/api/sandbox_functions/resolve_authentication";
 import { validateSandboxFunctionAction } from "@app/lib/api/sandbox_functions/validate_action";
+import { hasFeatureFlag } from "@app/lib/auth";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type {
   PostSandboxFunctionInvocationRequestBody,
@@ -120,6 +122,11 @@ app.post(
       });
     }
 
+    const fastExecution = await hasFeatureFlag(
+      auth,
+      "sandbox_function_fast_execution"
+    );
+
     const invocationResult = await sandboxFunction.invoke(auth, body, {
       origin:
         auth.authMethod() === "session" ? "interactive_session" : "delegated",
@@ -147,9 +154,17 @@ app.post(
       );
     }
 
+    const invocation = invocationResult.value;
+    const outcome = fastExecution
+      ? await awaitSandboxFunctionInvocationOutcome({
+          invocationId: invocation.sId,
+        })
+      : null;
+
     return ctx.json(
       {
-        invocation: invocationResult.value.toJSON(),
+        invocation: invocation.toJSON(),
+        ...(outcome ? { outcome } : {}),
       },
       201
     );

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -15,7 +15,7 @@ import type {
   PostSandboxFunctionInvocationResponseBody,
   SandboxFunctionCallError,
   SandboxFunctionInvocationEvent,
-  SandboxFunctionInvocationType,
+  SandboxFunctionInvocationOutcome,
 } from "@app/types/api/sandbox_functions";
 import type {
   CallFunctionRequest,
@@ -150,6 +150,23 @@ const sendErrorToIframe = (
     },
     { targetOrigin: "*" }
   );
+};
+
+const resultFromInvocationOutcome = (
+  outcome: SandboxFunctionInvocationOutcome
+): Result<unknown, SandboxFunctionCallError> => {
+  switch (outcome.status) {
+    case "succeeded":
+      return new Ok(outcome.result);
+    case "errored":
+      return new Err(outcome.error);
+    default:
+      assertNeverAndIgnore(outcome);
+      return new Err({
+        code: "transport_error",
+        message: "Unsupported function invocation outcome.",
+      });
+  }
 };
 
 const getExtensionFromBlob = (blob: Blob): string => {
@@ -374,7 +391,9 @@ function useVisualizationDataHandler({
   createSandboxFunctionInvocation: (
     functionIdOrSlug: string,
     input?: unknown
-  ) => Promise<Result<SandboxFunctionInvocationType, SandboxFunctionCallError>>;
+  ) => Promise<
+    Result<PostSandboxFunctionInvocationResponseBody, SandboxFunctionCallError>
+  >;
   getFileBlob: (fileId: string) => Promise<Blob | null>;
   onEditText?: EditTextFn;
   setCodeDrawerOpened: (v: SetStateAction<boolean>) => void;
@@ -458,10 +477,16 @@ function useVisualizationDataHandler({
             break;
           }
 
-          const result = await waitForSandboxFunctionInvocationResult({
-            functionId: invocationRes.value.functionId,
-            invocationId: invocationRes.value.sId,
-          });
+          const { invocation, outcome } = invocationRes.value;
+          // An invocation that settled before the response was sent needs no stream: the outcome
+          // is the whole result. Anything still running, including one blocked on user input,
+          // comes back with no outcome and settles over its event stream.
+          const result = outcome
+            ? resultFromInvocationOutcome(outcome)
+            : await waitForSandboxFunctionInvocationResult({
+                functionId: invocation.functionId,
+                invocationId: invocation.sId,
+              });
 
           if (result.isErr()) {
             sendErrorToIframe(data, result.error, event.source, {
@@ -789,7 +814,10 @@ export const VisualizationActionIframe = forwardRef<
       functionIdOrSlug: string,
       input?: unknown
     ): Promise<
-      Result<SandboxFunctionInvocationType, SandboxFunctionCallError>
+      Result<
+        PostSandboxFunctionInvocationResponseBody,
+        SandboxFunctionCallError
+      >
     > => {
       try {
         if (!runtimeAccess.canInvokeFunctions) {
@@ -833,7 +861,7 @@ export const VisualizationActionIframe = forwardRef<
         const result: PostSandboxFunctionInvocationResponseBody =
           await response.json();
 
-        return new Ok(result.invocation);
+        return new Ok(result);
       } catch (error) {
         return new Err({
           code: "transport_error",

--- a/front/lib/api/sandbox_functions/await_invocation.ts
+++ b/front/lib/api/sandbox_functions/await_invocation.ts
@@ -1,0 +1,72 @@
+import { getSandboxFunctionInvocationEvents } from "@app/lib/api/sandbox_functions/events";
+import logger from "@app/logger/logger";
+import type { SandboxFunctionInvocationOutcome } from "@app/types/api/sandbox_functions";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+// How long an invocation request waits for an outcome before handing the client back to the
+// invocation event stream. This bounds how long a request is held open, not how long a Pod
+// function may run: an invocation that outlives the wait keeps running and settles on the stream.
+export const SYNCHRONOUS_INVOCATION_WAIT_TIMEOUT_MS = 10_000;
+
+/**
+ * Wait for an invocation to settle, up to a short ceiling.
+ *
+ * Returns null when the invocation is still running, which happens in two cases:
+ *
+ * - It blocked on user input (tool approval or personal authentication). Waiting further would
+ *   deadlock: the approval card only renders once the client holds the invocation and subscribes
+ *   to its stream, which it cannot do while the request that returns the invocation is pending.
+ * - The ceiling elapsed.
+ *
+ * In both cases the caller returns the invocation without an outcome and the client subscribes to
+ * the event stream, which replays from history everything already published.
+ */
+export async function awaitSandboxFunctionInvocationOutcome({
+  invocationId,
+  timeoutMs = SYNCHRONOUS_INVOCATION_WAIT_TIMEOUT_MS,
+}: {
+  invocationId: string;
+  timeoutMs?: number;
+}): Promise<SandboxFunctionInvocationOutcome | null> {
+  try {
+    for await (const { data } of getSandboxFunctionInvocationEvents({
+      invocationId,
+      lastEventId: null,
+      signal: AbortSignal.timeout(timeoutMs),
+    })) {
+      switch (data.type) {
+        case "sandbox_function_invocation_result":
+          return { status: "succeeded", result: data.result };
+        case "sandbox_function_invocation_error":
+          return { status: "errored", error: data.error };
+        case "tool_approve_execution":
+        case "tool_personal_auth_required":
+          return null;
+        case "sandbox_function_invocation_created":
+          break;
+        default:
+          // A deploy rolling out a new event type must not fail invocations served by older
+          // instances: ignore what this instance does not know and keep waiting.
+          assertNeverAndIgnore(data);
+      }
+    }
+  } catch (error) {
+    // The invocation itself is unaffected, only this wait failed. Fall back to the stream.
+    logger.error(
+      { invocationId, error: normalizeError(error).message },
+      "Failed to wait for Pod function invocation outcome"
+    );
+    return null;
+  }
+
+  // Reaching here means the stream ended without an outcome and without the invocation blocking
+  // on user input: it is simply still running past the ceiling. That should be rare, since a Pod
+  // function settling this slowly is the case the wait cannot help with.
+  logger.info(
+    { invocationId, timeoutMs },
+    "Pod function invocation outlived the synchronous wait"
+  );
+
+  return null;
+}

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -144,6 +144,16 @@ export type PostSandboxFunctionInvocationRequestBody = {
   context?: SandboxFunctionInvocationContext;
 };
 
+// The terminal state of an invocation, as returned by the invocation endpoint when the invocation
+// settled while the request was still open.
+export type SandboxFunctionInvocationOutcome =
+  | { status: "succeeded"; result: unknown }
+  | { status: "errored"; error: SandboxFunctionCallError };
+
 export type PostSandboxFunctionInvocationResponseBody = {
   invocation: SandboxFunctionInvocationType;
+  // Set when the invocation settled before the response was sent. Callers that get an outcome are
+  // done; callers that do not must subscribe to the invocation event stream, which replays
+  // everything published so far.
+  outcome?: SandboxFunctionInvocationOutcome;
 };

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -211,6 +211,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Return Pod function results through the worker dsbx stdout channel instead of the in-sandbox HTTP callback",
     stage: "dust_only",
   },
+  sandbox_function_fast_execution: {
+    description:
+      "Return Pod function results in the invocation response when the invocation settles before it returns",
+    stage: "dust_only",
+  },
   run_tools_from_prompt: {
     description: "Enable /run command to directly call tools without LLM",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -782,6 +782,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "restricted_spaces_in_input_bar"
   | "salesforce_synced_queries"
   | "salesforce_tool"
+  | "sandbox_function_fast_execution"
   | "sandbox_function_stdout_result"
   | "sandbox_functions"
   | "self_created_slack_app_connector_rollout"


### PR DESCRIPTION
## Description

The invocation endpoint returns as soon as the workflow is launched, so a Frame calling a Pod function pays a second round trip to the event stream for a result that was usually ready in under a second.

Behind `sandbox_function_fast_execution`, the endpoint waits a short while for the invocation to settle and returns its outcome inline, as a new optional `outcome` field on the response.

The wait stops as soon as the invocation blocks on a tool approval or on personal authentication. Holding the response there would deadlock: the approval card only renders once the client holds the invocation and subscribes to its stream, which is why execution moved into a workflow in the first place. Clients that get no outcome subscribe as before, and the stream replays from history everything already published.

## Tests

Added endpoint tests for the four cases: settles with a result, settles with an error, blocks on a tool approval (no outcome, so the card can render), and flag off.

Not exercised against a live pod, the flag is off everywhere.

## Risk

Low. Gated on `sandbox_function_fast_execution` (dust_only), and the response field is optional and additive, so an un-updated client keeps using the stream. Rollback is turning the flag off.

## Deploy Plan

None, ship and flip the flag on the Dust workspace when the rest of the stack is in.
