### PR TITLE
Run fast Pod function invocations without the invocation workflow

### DIFF
--- a/front/lib/api/sandbox/errors.ts
+++ b/front/lib/api/sandbox/errors.ts
@@ -1,0 +1,19 @@
+/**
+ * The sandbox was not running when a caller asked to use it without creating, waking, or
+ * recreating it.
+ *
+ * Raised before any work is dispatched to the sandbox, so the caller is free to retry through a
+ * path that can afford to wait for one.
+ */
+export class SandboxNotRunningError extends Error {
+  constructor() {
+    super("The sandbox is not running.");
+    this.name = "SandboxNotRunningError";
+  }
+}
+
+export function isSandboxNotRunningError(
+  error: Error
+): error is SandboxNotRunningError {
+  return error instanceof SandboxNotRunningError;
+}

--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -347,7 +347,9 @@ describe("ensureConversationSandboxReady", () => {
     const result = await ensurePodSandboxReady(auth as never, pod as never);
 
     expect(result.isOk()).toBe(true);
-    expect(mockEnsurePodSandboxActive).toHaveBeenCalledWith(auth, pod);
+    expect(mockEnsurePodSandboxActive).toHaveBeenCalledWith(auth, pod, {
+      requireRunning: false,
+    });
     expect(mockEnsureSandboxActive).not.toHaveBeenCalled();
     // The pod's published bundles are mounted read-only under a pod-scoped
     // path; the litestream replica prefix is mounted rw for the in-sandbox

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -223,10 +223,12 @@ export async function ensureConversationSandboxReady(
 
 export async function ensurePodSandboxReady(
   auth: Authenticator,
-  pod: SpaceResource
+  pod: SpaceResource,
+  { requireRunning = false }: { requireRunning?: boolean } = {}
 ): Promise<Result<EnsureSandboxReadyResult, Error>> {
   return ensureOwnerSandboxReady(auth, {
-    ensureActive: () => PodSandboxAdapter.ensureSandboxActive(auth, pod),
+    ensureActive: () =>
+      PodSandboxAdapter.ensureSandboxActive(auth, pod, { requireRunning }),
     getFileSystem: () =>
       DustFileSystem.forPod(auth, pod, {
         sandboxOnlyMounts: podSandboxOnlyMounts(pod),

--- a/front/lib/resources/pod_sandbox_adapter.ts
+++ b/front/lib/resources/pod_sandbox_adapter.ts
@@ -149,7 +149,8 @@ export class PodSandboxAdapter {
 
   static async ensureSandboxActive(
     auth: Authenticator,
-    pod: SpaceResource
+    pod: SpaceResource,
+    { requireRunning = false }: { requireRunning?: boolean } = {}
   ): Promise<Result<EnsureSandboxResult, Error>> {
     this.assertPod(pod);
 
@@ -162,7 +163,7 @@ export class PodSandboxAdapter {
         createSandbox: (blob) =>
           this.createSandboxRecordForPod(auth, pod, blob),
       },
-      { beforeSleep: this.podPreSleepCheck(auth, pod) }
+      { beforeSleep: this.podPreSleepCheck(auth, pod), requireRunning }
     );
   }
 

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -1,5 +1,6 @@
 import { formatSandboxFunctionInvocations } from "@app/lib/api/actions/servers/sandbox_functions/tools/inspect_invocations";
 import { generateSandboxFunctionInvocationToken } from "@app/lib/api/sandbox/access_tokens";
+import { SandboxNotRunningError } from "@app/lib/api/sandbox/errors";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
 import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
@@ -9,6 +10,7 @@ import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_fu
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { launchSandboxFunctionInvocationWorkflow } from "@app/temporal/sandbox_functions/client";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -16,11 +18,13 @@ import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type {
+  SandboxFunctionExecutionMode,
   SandboxFunctionInvocationOrigin,
   SandboxFunctionUserIdentityPolicy,
 } from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
-import { Ok } from "@app/types/shared/result";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import { Err, Ok } from "@app/types/shared/result";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -47,6 +51,19 @@ vi.mock("@app/lib/api/sandbox_functions/events", async (importOriginal) => {
   return {
     ...actual,
     publishSandboxFunctionInvocationEvent: vi.fn(),
+  };
+});
+
+vi.mock("@app/temporal/sandbox_functions/client", async (importOriginal) => {
+  const mod =
+    await importOriginal<
+      typeof import("@app/temporal/sandbox_functions/client")
+    >();
+  return {
+    ...mod,
+    launchSandboxFunctionInvocationWorkflow: vi.fn(
+      async () => new Ok(undefined)
+    ),
   };
 });
 
@@ -82,7 +99,8 @@ beforeEach(() => {
 
 async function setupExecutionTest(
   userIdentity: SandboxFunctionUserIdentityPolicy = "optional",
-  origin: SandboxFunctionInvocationOrigin = "delegated"
+  origin: SandboxFunctionInvocationOrigin = "delegated",
+  executionMode: SandboxFunctionExecutionMode = "durable"
 ) {
   const { authenticator, workspace } = await createResourceTest({
     role: "admin",
@@ -102,6 +120,7 @@ async function setupExecutionTest(
     slug: "add-comment",
     description: "Add a comment.",
     userIdentity,
+    executionMode,
     inputSchema,
     outputSchema,
   });
@@ -673,7 +692,9 @@ describe("SandboxFunctionInvocationResource", () => {
       });
     expect(refetchedInvocation?.status).toBe("created");
     expect(updateLastActivityAtSpy).toHaveBeenCalledOnce();
-    expect(ensurePodSandboxReady).toHaveBeenCalledWith(authenticator, space);
+    expect(ensurePodSandboxReady).toHaveBeenCalledWith(authenticator, space, {
+      requireRunning: false,
+    });
     expect(generateSandboxFunctionInvocationToken).toHaveBeenCalledWith(
       authenticator,
       {
@@ -1055,5 +1076,157 @@ describe("SandboxFunctionInvocationResource", () => {
       code: "invocation_failed",
       message: "function produced no output",
     });
+  });
+});
+
+describe("SandboxFunctionInvocationResource.createAndStartExecution", () => {
+  // Fast execution rides on stdout delivery, so both flags are on together in practice.
+  function enableFlags(flags: WhitelistableFeature[]) {
+    vi.mocked(hasFeatureFlag).mockImplementation(async (_auth, flag) =>
+      flags.includes(flag)
+    );
+  }
+
+  async function setupInlineTest(
+    executionMode: SandboxFunctionExecutionMode = "fast"
+  ) {
+    const setup = await setupExecutionTest(
+      "optional",
+      "delegated",
+      executionMode
+    );
+    // Stand in for the lifecycle, which refuses rather than creating, waking, or recreating a
+    // sandbox when the caller cannot wait for one.
+    vi.mocked(ensurePodSandboxReady).mockImplementation(
+      async (_auth, _pod, opts) => {
+        if (opts?.requireRunning && setup.sandbox.status !== "running") {
+          return new Err(new SandboxNotRunningError());
+        }
+        return new Ok({ sandbox: setup.sandbox, freshlyCreated: false });
+      }
+    );
+    const execSpy = vi.spyOn(setup.sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout:
+          JSON.stringify({
+            protocolVersion: 3,
+            delivery: "stdout",
+            outcome: { ok: true, output: { commentId: "inline" } },
+          }) + "\n",
+        stderr: "",
+      })
+    );
+
+    return { ...setup, execSpy };
+  }
+
+  it("runs a fast invocation inline instead of starting the workflow", async () => {
+    const { authenticator, sandboxFunction, execSpy } = await setupInlineTest();
+    enableFlags([
+      "sandbox_function_fast_execution",
+      "sandbox_function_stdout_result",
+    ]);
+
+    const result =
+      await SandboxFunctionInvocationResource.createAndStartExecution(
+        authenticator,
+        { sandboxFunction, body: { input: { message: "hello" } } }
+      );
+
+    expect(result.isOk()).toBe(true);
+    expect(execSpy).toHaveBeenCalledOnce();
+    expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value.status).toBe("succeeded");
+    expect(result.value.result).toEqual({ commentId: "inline" });
+    // An inline invocation holds a request while it runs, so it gets a far shorter ceiling than
+    // the workflow's.
+    const [, , execOptions] = execSpy.mock.calls[0]!;
+    expect(execOptions?.timeoutMs).toBe(10 * 1000);
+  });
+
+  it("starts the workflow for a durable function", async () => {
+    const { authenticator, sandboxFunction, execSpy } =
+      await setupInlineTest("durable");
+    enableFlags([
+      "sandbox_function_fast_execution",
+      "sandbox_function_stdout_result",
+    ]);
+
+    const result =
+      await SandboxFunctionInvocationResource.createAndStartExecution(
+        authenticator,
+        { sandboxFunction, body: {} }
+      );
+
+    expect(result.isOk()).toBe(true);
+    expect(execSpy).not.toHaveBeenCalled();
+    expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledOnce();
+  });
+
+  it("starts the workflow when fast execution is disabled", async () => {
+    const { authenticator, sandboxFunction, execSpy } = await setupInlineTest();
+    enableFlags(["sandbox_function_stdout_result"]);
+
+    const result =
+      await SandboxFunctionInvocationResource.createAndStartExecution(
+        authenticator,
+        { sandboxFunction, body: {} }
+      );
+
+    expect(result.isOk()).toBe(true);
+    expect(execSpy).not.toHaveBeenCalled();
+    expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledOnce();
+  });
+
+  // Resuming a sandbox takes far longer than a request can be held, and nothing has executed at
+  // that point, so the workflow takes the invocation over.
+  it("starts the workflow when the sandbox is not running", async () => {
+    const { authenticator, sandboxFunction, sandbox, execSpy } =
+      await setupInlineTest();
+    enableFlags([
+      "sandbox_function_fast_execution",
+      "sandbox_function_stdout_result",
+    ]);
+    await sandbox.updateStatus("sleeping");
+
+    const result =
+      await SandboxFunctionInvocationResource.createAndStartExecution(
+        authenticator,
+        { sandboxFunction, body: {} }
+      );
+
+    expect(result.isOk()).toBe(true);
+    expect(execSpy).not.toHaveBeenCalled();
+    expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledOnce();
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value.status).toBe("created");
+  });
+
+  it("records the failure of a fast invocation that errors inline", async () => {
+    const { authenticator, sandboxFunction, execSpy } = await setupInlineTest();
+    enableFlags(["sandbox_function_fast_execution"]);
+    execSpy.mockResolvedValue(
+      new Ok({ exitCode: 1, stdout: "", stderr: "boom" })
+    );
+
+    const result =
+      await SandboxFunctionInvocationResource.createAndStartExecution(
+        authenticator,
+        { sandboxFunction, body: {} }
+      );
+
+    expect(result.isOk()).toBe(true);
+    expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value.status).toBe("errored");
+    expect(result.value.error?.message).toContain("boom");
   });
 });

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -12,6 +12,7 @@ import {
   generateExecId,
   generateSandboxFunctionInvocationToken,
 } from "@app/lib/api/sandbox/access_tokens";
+import { isSandboxNotRunningError } from "@app/lib/api/sandbox/errors";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import { SandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
@@ -65,6 +66,11 @@ import { fromError } from "zod-validation-error";
 
 const SANDBOX_FUNCTION_WORKING_DIRECTORY = "/home/agent";
 const SANDBOX_FUNCTION_EXEC_TIMEOUT_MS = 2 * 60 * 1000;
+// A fast function is contractually short, and an inline invocation holds a request for as long as
+// it runs. Bound it well below the workflow's ceiling: past this the invocation is failed rather
+// than handed to the workflow, since by then the function may already have written to pod state
+// and re-running it would repeat those writes.
+const SANDBOX_FUNCTION_INLINE_EXEC_TIMEOUT_MS = 10 * 1000;
 const DSBX_BIN_PATH = "/opt/bin/dsbx";
 // Caps on runner output surfaced on failure: a small head for the error forwarded to the agent,
 // a larger one for the log fields.
@@ -208,6 +214,25 @@ function buildSandboxFunctionRunCommand(
     return `${DSBX_BIN_PATH} function run --result-delivery stdout -- ${shellEscape(slug)}`;
   }
   return `${DSBX_BIN_PATH} function run ${shellEscape(slug)}`;
+}
+
+/**
+ * Whether an invocation runs inline, in the request that creates it, instead of through the
+ * invocation workflow.
+ *
+ * Only a fast function qualifies. A durable one may call a tool that waits on the user for
+ * approval or authentication, and holding the request there would deadlock: the approval card
+ * only renders once the client holds the invocation.
+ */
+async function shouldExecuteInline(
+  auth: Authenticator,
+  sandboxFunction: SandboxFunctionResource
+): Promise<boolean> {
+  if (sandboxFunction.executionMode !== "fast") {
+    return false;
+  }
+
+  return hasFeatureFlag(auth, "sandbox_function_fast_execution");
 }
 
 function getSandboxFunctionUserIdentity(
@@ -442,7 +467,20 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     );
     return true;
   }
-  async execute(auth: Authenticator): Promise<Result<undefined, Error>> {
+  /**
+   * Run the invocation on the pod sandbox and record its outcome.
+   *
+   * `inline` marks an invocation running inside the request that created it, which constrains it
+   * twice. The sandbox is used only if it is already running, never created, woken, or recreated,
+   * all of which take seconds to minutes, which the lifecycle enforces under its own lock and
+   * reports as `SandboxNotRunningError`. Nothing has executed when that happens, so the caller is
+   * free to restart the invocation durably. And execution is bounded by a much shorter timeout, so
+   * a function that never returns cannot hold the request open for the workflow's ceiling.
+   */
+  async execute(
+    auth: Authenticator,
+    { inline = false }: { inline?: boolean } = {}
+  ): Promise<Result<undefined, Error>> {
     if (this.status !== "created") {
       logger.info(
         {
@@ -486,7 +524,8 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
 
       const ensureResult = await ensurePodSandboxReady(
         auth,
-        sandboxFunction.space
+        sandboxFunction.space,
+        { requireRunning: inline }
       );
       if (ensureResult.isErr()) {
         return ensureResult;
@@ -545,7 +584,9 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
             : "",
         },
         stdin: JSON.stringify(inputEnvelope),
-        timeoutMs: SANDBOX_FUNCTION_EXEC_TIMEOUT_MS,
+        timeoutMs: inline
+          ? SANDBOX_FUNCTION_INLINE_EXEC_TIMEOUT_MS
+          : SANDBOX_FUNCTION_EXEC_TIMEOUT_MS,
         user: "agent-proxied",
       });
       if (execResult.isErr()) {
@@ -777,6 +818,30 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       },
       { invocationId: invocation.sId }
     );
+
+    if (await shouldExecuteInline(auth, sandboxFunction)) {
+      const executionResult = await invocation.execute(auth, { inline: true });
+      if (executionResult.isOk()) {
+        return new Ok(invocation);
+      }
+      if (!isSandboxNotRunningError(executionResult.error)) {
+        // The invocation ran and failed. Record the outcome here, as the invocation workflow's
+        // activity does, so listeners settle instead of waiting for a workflow that never ran.
+        await invocation.fail(executionResult.error);
+        return new Ok(invocation);
+      }
+      // The sandbox has to be resumed first. Nothing has executed, so hand the invocation to the
+      // workflow, which owns waits that outlive a request.
+      logger.info(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          sandboxFunctionId: sandboxFunction.sId,
+          invocationId: invocation.sId,
+          reason: "sandbox_not_running",
+        },
+        "Escalating a fast Pod function invocation to the invocation workflow"
+      );
+    }
 
     const launchResult = await launchSandboxFunctionInvocationWorkflow(auth, {
       sandboxFunction,

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -54,6 +54,7 @@ vi.mock("@app/lib/lock", () => ({
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
+import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import {
   SandboxModel,
@@ -64,6 +65,7 @@ import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFa
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { Ok } from "@app/types/shared/result";
 import { encrypt } from "@app/types/shared/utils/encryption";
@@ -1021,6 +1023,86 @@ describe("SandboxResource.ensureActive", () => {
       conversation
     );
     expect(persisted?.lastRuntimeRefreshAt).toBeNull();
+  });
+
+  // requireRunning is what lets a caller running inside a request use a sandbox without ever
+  // waiting on one being made ready. It is enforced under the lifecycle lock rather than by the
+  // caller, because a kill-requested sandbox reports itself as running right up until it is
+  // destroyed and recreated.
+  describe("with requireRunning", () => {
+    it("refuses a running sandbox that has a kill requested", async () => {
+      const pod = await SpaceFactory.project(
+        authenticator.getNonNullableWorkspace()
+      );
+      await SandboxFactory.createForPod(authenticator, pod, {
+        status: "running",
+        killRequestedAt: new Date(),
+      });
+
+      const result = await PodSandboxAdapter.ensureSandboxActive(
+        authenticator,
+        pod,
+        { requireRunning: true }
+      );
+
+      expect(result.isErr()).toBe(true);
+      expect(mockProviderDestroy).not.toHaveBeenCalled();
+      expect(mockProviderCreate).not.toHaveBeenCalled();
+    });
+
+    it("refuses a sleeping sandbox instead of waking it", async () => {
+      const pod = await SpaceFactory.project(
+        authenticator.getNonNullableWorkspace()
+      );
+      await SandboxFactory.createForPod(authenticator, pod, {
+        status: "sleeping",
+      });
+
+      const result = await PodSandboxAdapter.ensureSandboxActive(
+        authenticator,
+        pod,
+        { requireRunning: true }
+      );
+
+      expect(result.isErr()).toBe(true);
+      expect(mockProviderWake).not.toHaveBeenCalled();
+    });
+
+    it("refuses to create a sandbox when the pod has none", async () => {
+      const pod = await SpaceFactory.project(
+        authenticator.getNonNullableWorkspace()
+      );
+
+      const result = await PodSandboxAdapter.ensureSandboxActive(
+        authenticator,
+        pod,
+        { requireRunning: true }
+      );
+
+      expect(result.isErr()).toBe(true);
+      expect(mockProviderCreate).not.toHaveBeenCalled();
+    });
+
+    it("uses a running sandbox", async () => {
+      const pod = await SpaceFactory.project(
+        authenticator.getNonNullableWorkspace()
+      );
+      const running = await SandboxFactory.createForPod(authenticator, pod, {
+        status: "running",
+      });
+
+      const result = await PodSandboxAdapter.ensureSandboxActive(
+        authenticator,
+        pod,
+        { requireRunning: true }
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        return;
+      }
+      expect(result.value.sandbox.sId).toBe(running.sId);
+    });
   });
 
   it("destroys and recreates when killRequestedAt is set on the existing row", async () => {

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -1,6 +1,7 @@
 import { getSandboxProvider } from "@app/lib/api/sandbox";
 import { revokeAllExecTokensForSandbox } from "@app/lib/api/sandbox/access_tokens";
 import { deleteLegacySandboxPolicy } from "@app/lib/api/sandbox/egress_policy";
+import { SandboxNotRunningError } from "@app/lib/api/sandbox/errors";
 import { getSandboxImage } from "@app/lib/api/sandbox/image";
 import {
   recordLifecycleOperation,
@@ -497,7 +498,13 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   static async ensureActive(
     auth: Authenticator,
     owner: SandboxCreateOwner,
-    opts: { beforeSleep?: SandboxPreSleepCheck } = {}
+    opts: {
+      beforeSleep?: SandboxPreSleepCheck;
+      // Use the sandbox only if it is already running: do not create, wake, or recreate one.
+      // Creating and waking take seconds to minutes, which a caller running inside a request
+      // cannot wait for.
+      requireRunning?: boolean;
+    } = {}
   ): Promise<Result<EnsureSandboxResult, Error>> {
     assert(
       auth.getNonNullableWorkspace().id !== undefined,
@@ -507,6 +514,19 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     return this.withLifecycleLock(owner.lockKey, async (provider) => {
       const tracingOpts = { workspaceId: auth.getNonNullableWorkspace().sId };
       const existing = await owner.fetchSandbox();
+
+      // Decided here rather than by the caller: only under the lifecycle lock are the status and
+      // the kill marker stable, and a kill-requested sandbox is recreated below however it is
+      // reported, so a caller checking `status === "running"` beforehand would still get a cold
+      // start during an image rollout.
+      if (
+        opts.requireRunning &&
+        (!existing ||
+          existing.killRequestedAt !== null ||
+          existing.status !== "running")
+      ) {
+        return new Err(new SandboxNotRunningError());
+      }
 
       if (!existing) {
         const imageResult = getSandboxImage(auth);

--- a/front/tests/utils/SandboxFactory.ts
+++ b/front/tests/utils/SandboxFactory.ts
@@ -70,7 +70,7 @@ export class SandboxFactory {
   static async createForPod(
     auth: Authenticator,
     pod: SpaceResource,
-    opts?: { status?: SandboxStatus }
+    opts?: { status?: SandboxStatus; killRequestedAt?: Date }
   ): Promise<SandboxResource> {
     const sandbox = await SandboxResource.makeNew(auth, {
       providerId: `test-provider-${Date.now()}`,
@@ -78,6 +78,12 @@ export class SandboxFactory {
       baseImage: "dust-base",
       version: "0.0.0-test",
     });
+    if (opts?.killRequestedAt) {
+      await SandboxModel.update(
+        { killRequestedAt: opts.killRequestedAt } as Partial<SandboxModel>,
+        { where: { id: sandbox.id } }
+      );
+    }
 
     await SandboxOwnerModel.create({
       workspaceId: auth.getNonNullableWorkspace().id,


### PR DESCRIPTION
## Description

Stacked on #30038.

A fast function cannot call Dust tools through `dsbx tools`, which is the one thing that can wait on a person. It can still read and write pod state, run local binaries and make outbound HTTP calls, but none of those block on approval or authentication, so its invocation has nothing to survive. Routing it through a Temporal workflow costs a workflow start and an activity dispatch for durability it never uses.

Behind `sandbox_function_fast_execution`, a fast invocation executes in the request that creates it. The workflow still owns durable functions, and fast invocations whose sandbox is not already running.

`execute()` gains an `inline` mode for that, which constrains it twice:

- The sandbox is used only if it is already running, never created, woken or recreated. This is enforced by `SandboxResource.ensureActive` under the lifecycle lock, not by a check in the caller. A caller-side check is not enough: `ensureActive` destroys and recreates any sandbox with `killRequestedAt` set regardless of status, and `dangerouslyRequestKillForBaseImage` marks running sandboxes on every image rollout, so a full cold start (create, GCS mount, database restore) could still land inside the request. Nothing has executed when the refusal fires, so the invocation goes to the workflow and returns no outcome, which #30037 already handles.
- Execution is bounded at 10s instead of the workflow's 2 minutes. A fast function is not guaranteed to be quick, only unable to wait on a person: an outbound HTTP call to a slow endpoint still takes as long as it takes, and past the ceiling the invocation is failed rather than retried durably, since it may already have written to pod state.

An inline invocation that fails records its own outcome, as the workflow's activity does, so listeners settle instead of waiting for a workflow that never ran.

For scale, from production measurements taken before the change: the legs this removes are ~215ms of invocation POST plus ~200-300ms of Temporal dispatch, against a ~870ms worker-side p50.

## Tests

Added `ensureActive` tests for all four `requireRunning` cases, including the one that motivated moving the check: a `running` sandbox with `killRequestedAt` is refused and neither destroyed nor recreated.

Added invocation tests for: fast runs inline and skips the workflow, durable uses the workflow, flag off uses the workflow, a sandbox that is not running escalates without executing, an inline failure is recorded, and the inline exec ceiling is applied.

Not exercised against a live pod, the flag is off everywhere.

## Risk

Medium, this is the behaviour change. Gated on `sandbox_function_fast_execution` (dust_only) and only reachable for functions published `fast`, of which there are none yet. Worst case for a fast function is a request held up to 10s before the invocation is failed. Rollback is turning the flag off, which sends everything back through the workflow.

Worth watching after the flag goes on: how often invocations escalate (logged with a reason) and how close inline execs run to the 10s ceiling. There is no metric for the latter yet.

## Deploy Plan

None beyond #30038's migration.


