### PR TITLE
Deny tool calls to Pod functions published as fast

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/actions/call.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/call.test.ts
@@ -48,9 +48,9 @@ function callSandboxTool(
   });
 }
 
-async function setupWithView() {
+async function setupWithView({ noTools = false }: { noTools?: boolean } = {}) {
   const context =
-    await createPersistedSandboxFunctionInvocationTokenTestContext();
+    await createPersistedSandboxFunctionInvocationTokenTestContext({ noTools });
   const commonUtilities = await InternalMCPServerInMemoryResource.makeNew(
     context.auth,
     { name: "common_utilities", useCase: null }
@@ -99,6 +99,21 @@ describe("POST /api/v1/w/[wId]/sandbox/actions/call (function invocation)", () =
     expect(
       vi.mocked(publishSandboxFunctionInvocationEvent)
     ).not.toHaveBeenCalled();
+  });
+
+  it("refuses a tool call from a function published as fast", async () => {
+    const { token, workspace, view } = await setupWithView({ noTools: true });
+
+    const response = await callSandboxTool(workspace, token, {
+      serverViewId: view.sId,
+      toolName: "generate_random_number",
+      arguments: { max: 10 },
+    });
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error.message).toContain("published as fast");
+    expect(vi.mocked(launchSandboxFunctionToolWorkflow)).not.toHaveBeenCalled();
   });
 
   it("returns 404 for an unknown server view", async () => {

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
@@ -41,6 +41,26 @@ app.post(
     // scoped to the invocation. The sandbox is never paused (function invocations are blocking
     // execs), so the response can be returned directly.
     if (isSandboxFunctionInvocationTokenPayload(claims)) {
+      // A fast function is published on the promise that it does not call tools, and its
+      // invocation cannot survive the wait a tool call can turn into. Refusing on the token
+      // rather than in the sandbox makes this hold however the function is invoked.
+      //
+      // This is a guardrail against a mislabelled function, not a sandbox boundary: every
+      // invocation execs as the same user, so a fast function running alongside a durable one
+      // could read that invocation's token out of /proc. That grants nothing the pod owner could
+      // not get by publishing as durable, and the tool call still needs its usual approval.
+      if (claims.noTools) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "This Pod function is published as fast and cannot call tools. Publish it with " +
+              "executionMode `durable` to let it call tools.",
+          },
+        });
+      }
+
       const result = await createSandboxFunctionMCPAction(auth, {
         sandboxFunctionId: claims.sandboxFunctionId,
         invocationId: claims.invocationId,

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.test.ts
@@ -75,6 +75,7 @@ describe("POST /api/v1/w/[wId]/sandbox/sandbox-functions/result", () => {
       })
     ).resolves.toBeNull();
     const token = await generateSandboxFunctionInvocationToken(callbackAuth, {
+      noTools: false,
       sandbox,
       sandboxFunction,
       invocationId: invocation.sId,

--- a/front/lib/api/sandbox/access_tokens.test.ts
+++ b/front/lib/api/sandbox/access_tokens.test.ts
@@ -210,6 +210,7 @@ describe("sandbox access tokens", () => {
     const pod = await SpaceFactory.project(auth.getNonNullableWorkspace());
 
     const token = await generateSandboxFunctionInvocationToken(auth, {
+      noTools: false,
       sandbox,
       sandboxFunction: {
         sId: "sfn_test",

--- a/front/lib/api/sandbox/access_tokens.ts
+++ b/front/lib/api/sandbox/access_tokens.ts
@@ -36,6 +36,10 @@ const SandboxTokenPayloadSchema = z
     spaceId: z.string().optional(),
     sandboxFunctionId: z.string().optional(),
     invocationId: z.string().optional(),
+    // Set for a fast Pod function, published on the promise that it does not call tools. A tool
+    // call can wait on the user for as long as they take, which a fast invocation has no way to
+    // survive, so the token it runs under cannot make one.
+    noTools: z.literal(true).optional(),
   })
   .superRefine((payload, ctx) => {
     const actionClaims = [payload.aId, payload.mId, payload.actionId];
@@ -281,6 +285,7 @@ export async function generateSandboxFunctionInvocationToken(
     sandboxFunction,
     invocationId,
     execId,
+    noTools,
     expiryMs = 2 * 60 * 1000, // Default to 2 minutes
   }: {
     conversationId?: string;
@@ -288,6 +293,9 @@ export async function generateSandboxFunctionInvocationToken(
     sandboxFunction: { sId: string; space: { sId: string } };
     invocationId: string;
     execId: string;
+    // Required rather than defaulted: a minting site that forgets it would silently hand out tool
+    // access.
+    noTools: boolean;
     expiryMs?: number;
   }
 ): Promise<string> {
@@ -300,6 +308,7 @@ export async function generateSandboxFunctionInvocationToken(
     spaceId: sandboxFunction.space.sId,
     sandboxFunctionId: sandboxFunction.sId,
     invocationId,
+    ...(noTools ? { noTools: true as const } : {}),
   };
 
   await registerExecToken(payload);

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -702,6 +702,7 @@ describe("SandboxFunctionInvocationResource", () => {
         sandboxFunction,
         invocationId: invocation.sId,
         execId: expect.any(String),
+        noTools: false,
       }
     );
     expect(execSpy).toHaveBeenCalledTimes(1);
@@ -1146,6 +1147,32 @@ describe("SandboxFunctionInvocationResource.createAndStartExecution", () => {
     // the workflow's.
     const [, , execOptions] = execSpy.mock.calls[0]!;
     expect(execOptions?.timeoutMs).toBe(10 * 1000);
+    // A fast function runs under a token that cannot call tools.
+    expect(generateSandboxFunctionInvocationToken).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ noTools: true })
+    );
+  });
+
+  it("runs a durable function under a token that can call tools", async () => {
+    const { authenticator, sandboxFunction } = await setupInlineTest("durable");
+    enableFlags(["sandbox_function_stdout_result"]);
+
+    const result =
+      await SandboxFunctionInvocationResource.createAndStartExecution(
+        authenticator,
+        { sandboxFunction, body: {} }
+      );
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    const executionResult = await result.value.execute(authenticator);
+    expect(executionResult.isOk()).toBe(true);
+    expect(generateSandboxFunctionInvocationToken).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ noTools: false })
+    );
   });
 
   it("starts the workflow for a durable function", async () => {

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -549,11 +549,17 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       );
 
       const execId = generateExecId();
+      // The mode, not the transport, decides this: a fast function is denied tools however it
+      // ends up running, so it behaves the same whether it ran inline or through the workflow.
+      // Read from the persisted row rather than the in-memory copy, which may predate a
+      // re-publish, since this one gates tool access.
+      const noTools = persistedFunction.executionMode === "fast";
       const token = await generateSandboxFunctionInvocationToken(auth, {
         sandbox,
         sandboxFunction,
         invocationId: this.sId,
         execId,
+        noTools,
       });
 
       const command = buildSandboxFunctionRunCommand(sandboxFunction.slug, {

--- a/front/tests/utils/SandboxTokenFactory.ts
+++ b/front/tests/utils/SandboxTokenFactory.ts
@@ -158,6 +158,7 @@ export async function createSandboxFunctionInvocationTokenTestContext({
     disableComputerFeature,
   });
   const token = await generateSandboxFunctionInvocationToken(context.auth, {
+    noTools: false,
     sandbox: context.sandbox,
     sandboxFunction: {
       sId: "sfn_test",
@@ -175,7 +176,11 @@ export async function createSandboxFunctionInvocationTokenTestContext({
 
 // Same as above but with a real sandbox function and invocation persisted, for flows that fetch
 // them back (calling MCP tools from a function invocation).
-export async function createPersistedSandboxFunctionInvocationTokenTestContext() {
+export async function createPersistedSandboxFunctionInvocationTokenTestContext({
+  noTools = false,
+}: {
+  noTools?: boolean;
+} = {}) {
   const context = await createSandboxTokenTestContext();
   const { workspace } = context;
 
@@ -226,6 +231,7 @@ export async function createPersistedSandboxFunctionInvocationTokenTestContext()
     },
     invocationId: invocation.sId,
     execId: `test-function-exec-${context.sandbox.sId}`,
+    noTools,
   });
 
   return {


### PR DESCRIPTION
## Description

Stacked on #30039.

A fast function is published on the promise that it does not call Dust tools through `dsbx tools`, and fast execution depends on that promise: a tool call can block on approval or authentication for as long as the user takes, which an invocation running inside a request cannot survive. Local binaries and outbound HTTP are not the problem and stay allowed, since neither waits on a person. Nothing enforced the promise, so a mislabelled function would hold a request for as long as the tool call polls, up to the 10 minute cap in `dsbx tools`.

Mint the invocation token without tool access for a fast function, and refuse the tool-call endpoint when it is presented. The mode decides this, not the transport, so a fast function behaves the same whether it ran inline or through the workflow. The mode is read from the persisted row, next to the user identity policy, not from the in-memory copy that may predate a re-publish.

`noTools` is required rather than defaulted, since a minting site that forgets it would silently grant tool access. The claim has to be declared on the token payload schema to survive verification, which strips what it does not know.

Scope: this is a guardrail against a mislabelled function, not a sandbox boundary. Every invocation execs as the same user, so a fast function running alongside a durable one could read that invocation's token out of `/proc`. That grants nothing the pod owner could not get by publishing as durable, and the tool call still needs its usual approval.

There is no static check that a `fast` bundle avoids tools: tools are reached by shelling out to `dsbx tools`, not by importing an SDK, so a bundle scan would be guesswork.

## Tests

Added an endpoint test that a tool call presented with a fast function's token is refused with 403 and launches no tool workflow, plus resource tests that the token is minted without tool access for fast and with it for durable.

Making `noTools` required surfaced three call sites that were omitting it.

## Risk

Low. Only reachable for functions published `fast`, of which there are none yet. Durable functions are untouched.

## Deploy Plan

None.

