### PR TITLE
Tell agents how to choose a Pod function execution mode, and make them choose

### DIFF
--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -74,16 +74,14 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
         ),
       executionMode: z
         .enum(SANDBOX_FUNCTION_EXECUTION_MODES)
-        .optional()
         .describe(
           "`fast` runs synchronously and returns in a fraction of the time, but cannot call Dust " +
             "tools through `dsbx tools`. It can still read and write pod state, run local " +
             "binaries and make outbound HTTP calls, though those count against its execution " +
-            "ceiling. `durable` (the default) is for a function that calls `dsbx tools`, which " +
-            "may wait on the user for approval or authentication. Keep the functions a Frame " +
-            "calls on user interaction or on a poll `fast`, and isolate `dsbx tools` calls in " +
-            "their own `durable` functions. Restate this on every publish: a re-publish that " +
-            "omits it goes back to `durable`."
+            "ceiling. `durable` is for a function that calls `dsbx tools`, which may wait on the " +
+            "user for approval or authentication. Keep the functions a Frame calls on user " +
+            "interaction or on a poll `fast`, and isolate `dsbx tools` calls in their own " +
+            "`durable` functions."
         ),
     },
     stake: "low",

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
@@ -18,7 +18,7 @@ export async function publishHandler(
     slug,
   }: {
     description: string;
-    executionMode?: SandboxFunctionExecutionMode;
+    executionMode: SandboxFunctionExecutionMode;
     path: string;
     slug: string;
   },

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -141,15 +141,48 @@ are available under the same substitution rules as the Computer.
 Computer: shell out to \`dsbx tools --json [SERVER_NAME] [TOOL_NAME] [ARGS]...\` and parse its
 stdout (\`{ content, isError }\`) for the result.
 Run \`dsbx tools --help\` from the Computer to explore available
-servers and tools before writing the function.
+servers and tools before writing the function. A function that calls \`dsbx tools\` must be
+published as \`durable\`, see below.
+
+#### Fast and durable functions
+
+Every function is published in one of two execution modes, and which one it needs shapes how you
+split functions up.
+
+- \`fast\`: runs synchronously and returns several times quicker, but **cannot call Dust tools**:
+  \`dsbx tools\` is refused inside it. Everything else still works, including Pod state, local
+  binaries and outbound HTTP calls, but those count against the invocation's execution ceiling, so
+  a fast function that waits on a slow endpoint will fail rather than return late.
+- \`durable\`: required for any function that calls \`dsbx tools\`. A tool call can wait on the user
+  for approval or authentication, for as long as they take, so the invocation runs in the
+  background and its result reaches the caller when it is ready.
+
+So the shape of your functions is the real decision:
+
+- The mode follows one question: does the function call \`dsbx tools\`? If it does it is \`durable\`,
+  if it does not it is \`fast\`. You do not get to choose that, but you do choose how to arrange
+  functions, and the aim is that the paths a Frame polls land on the fast side.
+- When a path the Frame polls needs data from an external system, do not fetch it inline and make
+  the whole path \`durable\`. Split it: a \`durable\` function calls \`dsbx tools\` and writes what it
+  gets into a database, and a \`fast\` function serves that database to the Frame. The Frame keeps
+  polling at full speed and the data refreshes on its own schedule, or on an explicit user action.
+- Some paths are \`durable\` and that is correct: a read that must be live on every call, or an
+  interaction that *is* a tool call, like sending a message to a teammate. Reach for the split
+  above when the data can tolerate being a little stale, not when it cannot.
+- Publishing a function that calls \`dsbx tools\` as \`fast\` is a bug: its tool call is refused at
+  run time and the invocation fails.
+
+The Frame API is identical for both, but a \`durable\` call takes visibly longer, so give it a
+loading state.
 
 #### Publishing, discovering, and invoking
 
-Once the source is on the Pod, use \`${toolName("publish")}\` to build it. Publishing bundles and
-type-checks the source on the Computer and extracts the input and output JSON schemas from the
-\`schema\` export. Publishing again under the same name replaces the previous version. The stored
-bundle is owned by the platform and runs from a read-only mount, so a published function can be
-executed but never overwritten from within the Computer.
+Once the source is on the Pod, use \`${toolName("publish")}\` to build it. It requires you to state
+\`executionMode\` on every publish. Publishing bundles and type-checks the source on the Computer
+and extracts the input and output JSON schemas from the \`schema\` export. Publishing again under
+the same name replaces the previous version. The stored bundle is owned by the platform and runs
+from a read-only mount, so a published function can be executed but never overwritten from within
+the Computer.
 
 Use \`${toolName("list")}\` and \`${toolName("get")}\` to see what the Pod has already
 published and to inspect a function's contract before relying on it or publishing a near-duplicate.


### PR DESCRIPTION
## Description

The execution mode is the publisher's call and it shapes how functions are split up, rather than being a flag set at the end. The publish tool now **requires** it: a mode the model has to state on every publish is a decision it has to make, and it removes the trap where omitting the field on a re-publish quietly moved a fast function back to `durable`. That also makes the prose telling agents to "pass it every time" unnecessary, so it is gone.

The skill leads with what actually decides the mode, which is one question: does the function call `dsbx tools`? That is not a choice, so the real decision is how functions are arranged, with the aim of keeping the paths a Frame polls on the fast side. When such a path needs data from an external system, the fix is not to fetch inline and make the whole path `durable`: split it, with a `durable` function calling `dsbx tools` and writing what it returns into a database, and a `fast` function serving that database. Some paths are legitimately `durable`, whether a read that must be live on every call or an interaction that is itself a tool call, and the skill says so rather than pretending otherwise.

That replaces an earlier draft that said never to put a tool call in a read path, which was wrong: plenty of read paths legitimately need a tool, and the guidance has to tell you how to keep them fast rather than forbid them.

It also spells out what `fast` forbids, which is narrower than it sounds: only `dsbx tools`. Pod state, local binaries and outbound HTTP all still work, though they count against the invocation's execution ceiling, so a fast function waiting on a slow endpoint fails rather than returning late.

The skill deliberately does not mention the self-healing from #30104. It is an operational safety net, not something the author should plan around, and "publishing a tool-calling function as fast is a bug" is stronger on its own.

## Tests

Prose and one tool schema field.

## Risk

Low. Requiring `executionMode` changes the publish tool's contract, but tool schemas are read fresh on every call so there is no stale-client concern, and the field has existed since #30038.

## Deploy Plan

None.

