### PR TITLE
Increase max activities for the dust project worker. Increase incremental sync delay for pod. Add endpoint and workflow for on demand sync.

### DIFF
--- a/connectors/src/api/sync_connector_incremental.ts
+++ b/connectors/src/api/sync_connector_incremental.ts
@@ -1,0 +1,69 @@
+import { getConnectorManager } from "@connectors/connectors";
+import { withLogging } from "@connectors/logger/withlogging";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import type { WithConnectorsAPIErrorReponse } from "@connectors/types";
+import type { Request, Response } from "express";
+
+type RequestIncrementalSyncRes = WithConnectorsAPIErrorReponse<{
+  workflowId: string;
+}>;
+
+const _syncConnectorIncrementalAPIHandler = async (
+  req: Request<{ connector_id: string }, RequestIncrementalSyncRes, undefined>,
+  res: Response<RequestIncrementalSyncRes>
+) => {
+  if (!req.params.connector_id) {
+    res.status(400).send({
+      error: {
+        type: "invalid_request_error",
+        message: `Missing required parameters. Required : connector_id`,
+      },
+    });
+
+    return;
+  }
+
+  const connector = await ConnectorResource.fetchById(req.params.connector_id);
+  if (!connector) {
+    res.status(404).send({
+      error: {
+        type: "connector_not_found",
+        message: `Connector with id ${req.params.connector_id} not found`,
+      },
+    });
+    return;
+  }
+
+  if (connector.type !== "dust_project") {
+    res.status(400).send({
+      error: {
+        type: "invalid_request_error",
+        message: `Incremental sync on demand is only supported for dust_project connectors (got ${connector.type})`,
+      },
+    });
+    return;
+  }
+
+  const launchRes = await getConnectorManager({
+    connectorProvider: connector.type,
+    connectorId: connector.id,
+  }).requestIncrementalSync();
+
+  if (launchRes.isErr()) {
+    res.status(500).send({
+      error: {
+        type: "internal_server_error",
+        message: launchRes.error.message,
+      },
+    });
+    return;
+  }
+
+  return res.status(200).send({
+    workflowId: launchRes.value,
+  });
+};
+
+export const syncConnectorIncrementalAPIHandler = withLogging(
+  _syncConnectorIncrementalAPIHandler
+);

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -15,6 +15,7 @@ import {
   patchSlackChannelsLinkedWithAgentHandler,
 } from "@connectors/api/slack_channels_linked_with_agent";
 import { syncConnectorAPIHandler } from "@connectors/api/sync_connector";
+import { syncConnectorIncrementalAPIHandler } from "@connectors/api/sync_connector_incremental";
 import { unpauseConnectorAPIHandler } from "@connectors/api/unpause_connector";
 import { postConnectorUpdateAPIHandler } from "@connectors/api/update_connector";
 import { webhookDiscordAppHandler } from "@connectors/api/webhooks/webhook_discord_app";
@@ -112,6 +113,10 @@ export function startServer(port: number) {
   app.get("/connectors/:connector_id", getConnectorAPIHandler);
   app.get("/connectors", getConnectorsAPIHandler);
   app.post("/connectors/sync/:connector_id", syncConnectorAPIHandler);
+  app.post(
+    "/connectors/sync/:connector_id/incremental",
+    syncConnectorIncrementalAPIHandler
+  );
   app.get(
     "/connectors/:connector_id/permissions",
     getConnectorPermissionsAPIHandler

--- a/connectors/src/connectors/dust_project/index.ts
+++ b/connectors/src/connectors/dust_project/index.ts
@@ -1,6 +1,7 @@
 import {
   launchDustProjectFullSyncWorkflow,
   launchDustProjectIncrementalSyncWorkflow,
+  signalDustProjectIncrementalSync,
   stopDustProjectSyncWorkflow,
 } from "@connectors/connectors/dust_project/temporal/client";
 import type {
@@ -154,12 +155,16 @@ export class DustProjectConnectorManager extends BaseConnectorManager<null> {
   }: {
     fromTs: number | null;
   }): Promise<Result<string, Error>> {
-    // Launch full sync if fromTs is null, otherwise incremental sync
+    // Launch full sync if fromTs is null, otherwise (re)schedule hourly incremental cron
     if (fromTs === null) {
       return launchDustProjectFullSyncWorkflow(this.connectorId);
     } else {
       return launchDustProjectIncrementalSyncWorkflow(this.connectorId);
     }
+  }
+
+  async requestIncrementalSync(): Promise<Result<string, Error>> {
+    return signalDustProjectIncrementalSync(this.connectorId);
   }
 
   async retrievePermissions({

--- a/connectors/src/connectors/dust_project/temporal/client.ts
+++ b/connectors/src/connectors/dust_project/temporal/client.ts
@@ -1,7 +1,10 @@
 import { QUEUE_NAME } from "@connectors/connectors/dust_project/temporal/config";
+import { dustProjectSyncSignal } from "@connectors/connectors/dust_project/temporal/signals";
 import {
   dustProjectFullSyncWorkflow,
   dustProjectFullSyncWorkflowId,
+  dustProjectIncrementalSyncNowWorkflow,
+  dustProjectIncrementalSyncNowWorkflowId,
   dustProjectIncrementalSyncWorkflow,
   dustProjectIncrementalSyncWorkflowId,
 } from "@connectors/connectors/dust_project/temporal/workflows";
@@ -71,10 +74,9 @@ export async function launchDustProjectIncrementalSyncWorkflow(
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const workflowId = dustProjectIncrementalSyncWorkflowId(connectorId);
 
-  // minuteOffset ensures jobs are distributed across the 10-minute intervals based on connector ID
-  // Run incremental sync every 10 minutes
-  const minuteOffset = connector.id % 10;
-  const cronSchedule = `${minuteOffset},${minuteOffset + 10},${minuteOffset + 20},${minuteOffset + 30},${minuteOffset + 40},${minuteOffset + 50} * * * *`;
+  // Spread hourly jobs across the hour by connector ID.
+  const minuteOffset = connector.id % 60;
+  const cronSchedule = `${minuteOffset} * * * *`;
 
   try {
     // Check if workflow already exists
@@ -106,7 +108,6 @@ export async function launchDustProjectIncrementalSyncWorkflow(
       memo: {
         connectorId,
       },
-      // Every 30 minutes, with minute offset based on connector ID
       cronSchedule,
     });
     logger.info(
@@ -131,6 +132,68 @@ export async function launchDustProjectIncrementalSyncWorkflow(
   }
 }
 
+/**
+ * Signal (or start) a debounced on-demand incremental sync.
+ * Does not touch the hourly cron workflow.
+ */
+export async function signalDustProjectIncrementalSync(
+  connectorId: ModelId
+): Promise<Result<string, Error>> {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    return new Err(new Error(`Connector ${connectorId} not found`));
+  }
+
+  if (connector.isPaused()) {
+    logger.info(
+      { connectorId },
+      "Skipping dust_project incremental sync signal because connector is paused."
+    );
+    return new Ok(dustProjectIncrementalSyncNowWorkflowId(connectorId));
+  }
+
+  const client = await getTemporalClient();
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const workflowId = dustProjectIncrementalSyncNowWorkflowId(connectorId);
+
+  try {
+    await client.workflow.signalWithStart(
+      dustProjectIncrementalSyncNowWorkflow,
+      {
+        args: [{ connectorId }],
+        taskQueue: QUEUE_NAME,
+        workflowId,
+        searchAttributes: {
+          connectorId: [connectorId],
+        },
+        memo: {
+          connectorId,
+        },
+        signal: dustProjectSyncSignal,
+        signalArgs: undefined,
+      }
+    );
+    logger.info(
+      {
+        workspaceId: dataSourceConfig.workspaceId,
+        workflowId,
+      },
+      `Signaled dust_project incremental sync now workflow.`
+    );
+    return new Ok(workflowId);
+  } catch (e) {
+    logger.error(
+      {
+        workspaceId: dataSourceConfig.workspaceId,
+        workflowId,
+        error: e,
+      },
+      `Failed signaling dust_project incremental sync now workflow.`
+    );
+    return new Err(normalizeError(e));
+  }
+}
+
 export async function stopDustProjectSyncWorkflow({
   connectorId,
   stopReason,
@@ -144,31 +207,21 @@ export async function stopDustProjectSyncWorkflow({
     return new Err(new Error(`Connector ${connectorId} not found`));
   }
 
-  const fullSyncWorkflowId = dustProjectFullSyncWorkflowId(connectorId);
-  const incrementalSyncWorkflowId =
-    dustProjectIncrementalSyncWorkflowId(connectorId);
+  const workflowIds = [
+    dustProjectFullSyncWorkflowId(connectorId),
+    dustProjectIncrementalSyncWorkflowId(connectorId),
+    dustProjectIncrementalSyncNowWorkflowId(connectorId),
+  ];
 
   try {
-    // Terminate full sync workflow if running
-    try {
-      const fullSyncHandle: WorkflowHandle<typeof dustProjectFullSyncWorkflow> =
-        client.workflow.getHandle(fullSyncWorkflowId);
-      await fullSyncHandle.terminate(stopReason);
-    } catch (e) {
-      if (!(e instanceof WorkflowNotFoundError)) {
-        throw e;
-      }
-    }
-
-    // Terminate incremental sync workflow if running
-    try {
-      const incrementalSyncHandle: WorkflowHandle<
-        typeof dustProjectIncrementalSyncWorkflow
-      > = client.workflow.getHandle(incrementalSyncWorkflowId);
-      await incrementalSyncHandle.terminate(stopReason);
-    } catch (e) {
-      if (!(e instanceof WorkflowNotFoundError)) {
-        throw e;
+    for (const workflowId of workflowIds) {
+      try {
+        const handle = client.workflow.getHandle(workflowId);
+        await handle.terminate(stopReason);
+      } catch (e) {
+        if (!(e instanceof WorkflowNotFoundError)) {
+          throw e;
+        }
       }
     }
 

--- a/connectors/src/connectors/dust_project/temporal/signals.ts
+++ b/connectors/src/connectors/dust_project/temporal/signals.ts
@@ -1,0 +1,5 @@
+import { defineSignal } from "@temporalio/workflow";
+
+export const dustProjectSyncSignal = defineSignal<[void]>(
+  "dust_project_sync_signal"
+);

--- a/connectors/src/connectors/dust_project/temporal/worker.ts
+++ b/connectors/src/connectors/dust_project/temporal/worker.ts
@@ -21,7 +21,7 @@ export async function runDustProjectWorker() {
     }),
     activities: { ...activities, ...sync_status },
     taskQueue: QUEUE_NAME,
-    maxConcurrentActivityTaskExecutions: 5,
+    maxConcurrentActivityTaskExecutions: 12,
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
     connection,
     reuseV8Context: true,

--- a/connectors/src/connectors/dust_project/temporal/workflows.ts
+++ b/connectors/src/connectors/dust_project/temporal/workflows.ts
@@ -1,6 +1,14 @@
 import type * as activities from "@connectors/connectors/dust_project/temporal/activities";
+import { dustProjectSyncSignal } from "@connectors/connectors/dust_project/temporal/signals";
 import type { ModelId } from "@connectors/types";
-import { proxyActivities } from "@temporalio/workflow";
+import {
+  allHandlersFinished,
+  condition,
+  continueAsNew,
+  proxyActivities,
+  setHandler,
+  sleep,
+} from "@temporalio/workflow";
 
 const {
   dustProjectConversationsFullSyncActivity,
@@ -13,6 +21,11 @@ const {
   startToCloseTimeout: "60 minutes",
 });
 
+/** Debounce window before running an on-demand incremental sync. */
+const INCREMENTAL_SYNC_DEBOUNCE_MS = 30_000;
+/** Cap debounce loops before continueAsNew to bound workflow history size. */
+const MAX_DEBOUNCE_COUNT = 100;
+
 /**
  * Generate workflow IDs for dust_project workflows
  */
@@ -24,6 +37,12 @@ export function dustProjectIncrementalSyncWorkflowId(
   connectorId: ModelId
 ): string {
   return `dust-project-incremental-sync-${connectorId}`;
+}
+
+export function dustProjectIncrementalSyncNowWorkflowId(
+  connectorId: ModelId
+): string {
+  return `dust-project-incremental-sync-now-${connectorId}`;
 }
 
 type DustProjectSyncActivity = (input: {
@@ -40,6 +59,20 @@ async function dustProjectSyncActivitiesCompleted(
     }
   }
   return true;
+}
+
+async function runDustProjectIncrementalSync(
+  connectorId: ModelId
+): Promise<void> {
+  if (
+    await dustProjectSyncActivitiesCompleted(connectorId, [
+      dustProjectConversationsIncrementalSyncActivity,
+      dustProjectMountFilesIncrementalSyncActivity,
+      dustProjectSyncMetadataActivity,
+    ])
+  ) {
+    await dustProjectMarkSyncedActivity({ connectorId });
+  }
 }
 
 /**
@@ -63,21 +96,49 @@ export async function dustProjectFullSyncWorkflow({
 }
 
 /**
- * Incremental sync workflow for dust_project connector.
- * Syncs only conversations that have been updated since the last sync.
+ * Cron-driven incremental sync for dust_project (hourly catch-up / GC).
  */
 export async function dustProjectIncrementalSyncWorkflow({
   connectorId,
 }: {
   connectorId: ModelId;
 }): Promise<void> {
-  if (
-    await dustProjectSyncActivitiesCompleted(connectorId, [
-      dustProjectConversationsIncrementalSyncActivity,
-      dustProjectMountFilesIncrementalSyncActivity,
-      dustProjectSyncMetadataActivity,
-    ])
-  ) {
-    await dustProjectMarkSyncedActivity({ connectorId });
+  await runDustProjectIncrementalSync(connectorId);
+}
+
+/**
+ * On-demand incremental sync, coalesced via Temporal signals.
+ * Front notifies on file/conversation changes; bursts debounce into one sync.
+ */
+export async function dustProjectIncrementalSyncNowWorkflow({
+  connectorId,
+}: {
+  connectorId: ModelId;
+}): Promise<void> {
+  let signaled = false;
+  let debounceCount = 0;
+
+  setHandler(dustProjectSyncSignal, () => {
+    signaled = true;
+  });
+
+  while (signaled && debounceCount < MAX_DEBOUNCE_COUNT) {
+    signaled = false;
+    await sleep(INCREMENTAL_SYNC_DEBOUNCE_MS);
+    if (signaled) {
+      debounceCount++;
+      continue;
+    }
+
+    await runDustProjectIncrementalSync(connectorId);
   }
+
+  if (debounceCount >= MAX_DEBOUNCE_COUNT) {
+    setHandler(dustProjectSyncSignal, undefined);
+    await condition(allHandlersFinished);
+    await continueAsNew({ connectorId });
+  }
+
+  // /!\ Any signal received outside of the while loop will be lost, so don't make any async
+  // call here, which will allow the signal handler to be executed by the nodejs event loop. /!\
 }

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -8,6 +8,7 @@ import type {
   ModelId,
 } from "@connectors/types";
 import type { ConnectorProvider, Result } from "@dust-tt/client";
+import { Err } from "@dust-tt/client";
 
 export type CreateConnectorErrorCode = "INVALID_CONFIGURATION";
 
@@ -71,6 +72,18 @@ export abstract class BaseConnectorManager<T extends ConnectorConfiguration> {
   abstract sync(params: {
     fromTs: number | null;
   }): Promise<Result<string, Error>>;
+
+  /**
+   * Request a debounced on-demand incremental sync (e.g. after content changes).
+   * Default: not supported for this connector type.
+   */
+  async requestIncrementalSync(): Promise<Result<string, Error>> {
+    return new Err(
+      new Error(
+        `requestIncrementalSync is not implemented for connector provider ${this.provider}`
+      )
+    );
+  }
 
   abstract retrievePermissions(params: {
     parentInternalId: string | null;

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -340,6 +340,7 @@ export const batch = async ({
         "snowflake",
         "zendesk",
         "bigquery",
+        "dust_project",
       ];
       if (!PROVIDERS_ALLOWING_RESTART.includes(args.provider)) {
         throw new Error(


### PR DESCRIPTION
## Description

**NEXT PR IN THE STACK : uses the new endpoint to request a sync when files are added to the Pod**

Three related changes to `dust_project` connector sync:

- Bumps `maxConcurrentActivityTaskExecutions` from 5 → 12 in `runDustProjectWorker`.
- Slows the background cron from every 10 minutes to hourly, offset per connector (`connector.id % 60`) to spread load.
- Adds an on-demand incremental sync path: `dustProjectIncrementalSyncNowWorkflow` uses Temporal `signalWithStart` + a 30 s debounce to coalesce bursts into a single sync. Exposed via `POST /connectors/sync/:connector_id/incremental` and `requestIncrementalSync()` on `DustProjectConnectorManager`. `stopDustProjectSyncWorkflow` now terminates all three workflow IDs. `dust_project` is also added to the CLI batch restart allowlist.

## Tests

Tested locally.

## Risk

- **Cron slowdown**: existing `dustProjectIncrementalSyncWorkflow` instances already running at the 10-minute schedule will keep that cadence until terminated; the new hourly schedule only applies on next `launchDustProjectIncrementalSyncWorkflow` call. The new on-demand path compensates for the wider catch-up window.
- **Concurrency bump** (5 → 12): may increase CPU/memory on the connectors worker; still conservative relative to typical Temporal limits.
- **Debounce workflow**: bounded by `MAX_DEBOUNCE_COUNT = 100` before `continueAsNew` to cap history size. Any signal received after the while-loop exits is lost (noted inline).
- Rollback is safe: revert the cron schedule line and the concurrency constant; terminate the new workflow type if needed.

## Deploy Plan

1. Deploy `connectors`.
2. Existing incremental cron workflows retain their old 10-minute schedule. To migrate to hourly immediately, run the CLI batch restart for `dust_project` (now in `PROVIDERS_ALLOWING_RESTART`).
