### PR TITLE
[front] Tell Frames not to use <form> elements

### DIFF
--- a/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
@@ -15,7 +15,7 @@ Before declaring a frame done, mentally check both the default panel width and f
 - \`React.createElement\` is not supported.
 - Outbound network requests (fetch, XHR, WebSocket) are blocked. connect-src is restricted to the Dust service only. External images can be rendered via <img src="https://..."> tags.
 - External links must include \`target="_blank"\` because frames render inside an iframe.
-- Do not use \`<form>\` elements. The iframe sandbox blocks form submission, so submitting one fails with "Blocked form submission ... the 'allow-forms' permission is not set". Use a \`<div>\` with inputs and an \`onClick\` handler on the button instead.
+- Do not use \`<form>\` elements, as the iframe sandbox blocks form submission. Use a \`<div>\` with inputs and an \`onClick\` handler on the button instead.
 - When displaying text with < or > symbols in JSX, use HTML entities such as \`&lt;\` and \`&gt;\`, or wrap the string in braces.
 
 ### Layout Rules

--- a/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
@@ -15,6 +15,7 @@ Before declaring a frame done, mentally check both the default panel width and f
 - \`React.createElement\` is not supported.
 - Outbound network requests (fetch, XHR, WebSocket) are blocked. connect-src is restricted to the Dust service only. External images can be rendered via <img src="https://..."> tags.
 - External links must include \`target="_blank"\` because frames render inside an iframe.
+- Do not use \`<form>\` elements. The iframe sandbox blocks form submission, so submitting one fails with "Blocked form submission ... the 'allow-forms' permission is not set". Use a \`<div>\` with inputs and an \`onClick\` handler on the button instead.
 - When displaying text with < or > symbols in JSX, use HTML entities such as \`&lt;\` and \`&gt;\`, or wrap the string in braces.
 
 ### Layout Rules


### PR DESCRIPTION
Frames render in an iframe with `sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"` (`VisualizationActionIframe.tsx:983`) — no `allow-forms`. When a generated Frame wraps its inputs in a `<form>`, submitting it dies with `Blocked form submission to '' because the form's frame is sandboxed and the 'allow-forms' permission is not set`. Models figure this out once the error is handed back to them, but that costs the user a round trip every time.

This adds one bullet to the shared Frame authoring prose, in "React Component Rules" next to the existing `target="_blank"` bullet since both come from the same sandbox. `INTERACTIVE_CONTENT_AUTHORING_PROSE_V2` is used by all three instruction variants (legacy, files-first, computer-first), so the rule reaches every Frame flow.

The alternative fix would be adding `allow-forms` to the iframe sandbox, which widens the sandbox for a capability Frames don't otherwise need. Prompting seemed like the cheaper trade.