### PR TITLE
[front] Add script to backfill `pod_manager` conversation depths

### DIFF
--- a/front/migrations/20260805_find_pod_manager_conversations.ts
+++ b/front/migrations/20260805_find_pod_manager_conversations.ts
@@ -107,9 +107,13 @@ async function updateConversationDepthsToZero(
     logger,
   }: { actionCount: number; execute: boolean; logger: Logger }
 ): Promise<void> {
-  const conversations = await ConversationResource.fetchByIds(auth, [
-    ...actionByConversationId.keys(),
-  ]);
+  const conversations = await ConversationResource.fetchByIds(
+    auth,
+    [...actionByConversationId.keys()],
+    {
+      dangerouslySkipPermissionFiltering: true,
+    }
+  );
   const conversationById = new Map(
     conversations.map((conversation) => [conversation.sId, conversation])
   );

--- a/front/migrations/20260805_find_pod_manager_conversations.ts
+++ b/front/migrations/20260805_find_pod_manager_conversations.ts
@@ -102,7 +102,6 @@ makeScript(
   {
     workspaceId: {
       alias: "w",
-      describe: "Workspace sId to search",
       demandOption: true,
       type: "string" as const,
     },
@@ -152,8 +151,9 @@ makeScript(
     }
 
     const conversationsToUpdate = conversations.filter(
-      (conversation) => conversation.depth !== 0
+      (conversation) => conversation.depth === 1
     );
+
     let updatedConversationCount = 0;
     if (execute && conversationsToUpdate.length > 0) {
       [updatedConversationCount] = await ConversationModel.update(
@@ -163,6 +163,7 @@ makeScript(
             workspaceId: auth.getNonNullableWorkspace().id,
             id: { [Op.in]: conversationsToUpdate.map(({ id }) => id) },
           },
+          // Silent to not update the updatedAt of Sequelize.
           silent: true,
         }
       );

--- a/front/migrations/20260805_find_pod_manager_conversations.ts
+++ b/front/migrations/20260805_find_pod_manager_conversations.ts
@@ -98,6 +98,29 @@ async function fetchConversationIds(
   return actionByConversationId;
 }
 
+async function updateConversationDepthsToZero(
+  auth: Authenticator,
+  conversations: ConversationResource[]
+): Promise<number> {
+  if (conversations.length === 0) {
+    return 0;
+  }
+
+  const [updatedConversationCount] = await ConversationModel.update(
+    { depth: 0 },
+    {
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        id: { [Op.in]: conversations.map(({ id }) => id) },
+      },
+      // Silent to not update the updatedAt of Sequelize.
+      silent: true,
+    }
+  );
+
+  return updatedConversationCount;
+}
+
 makeScript(
   {
     workspaceId: {
@@ -155,20 +178,9 @@ makeScript(
       (conversation) => conversation.depth === 1
     );
 
-    let updatedConversationCount = 0;
-    if (execute && conversationsToUpdate.length > 0) {
-      [updatedConversationCount] = await ConversationModel.update(
-        { depth: 0 },
-        {
-          where: {
-            workspaceId: auth.getNonNullableWorkspace().id,
-            id: { [Op.in]: conversationsToUpdate.map(({ id }) => id) },
-          },
-          // Silent to not update the updatedAt of Sequelize.
-          silent: true,
-        }
-      );
-    }
+    const updatedConversationCount = execute
+      ? await updateConversationDepthsToZero(auth, conversationsToUpdate)
+      : 0;
 
     logger.info(
       {

--- a/front/migrations/20260805_find_pod_manager_conversations.ts
+++ b/front/migrations/20260805_find_pod_manager_conversations.ts
@@ -3,6 +3,7 @@ import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/gu
 import { POD_MANAGER_SERVER_NAME } from "@app/lib/api/actions/servers/pod_manager/metadata";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
+import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { makeScript } from "@app/scripts/helpers";
@@ -97,62 +98,6 @@ async function mapConversationIdsToActions(
   return actionByConversationId;
 }
 
-async function processWorkspace(
-  workspaceId: string,
-  logger: Logger
-): Promise<void> {
-  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
-
-  const actions = await listPodManagerCreateConversationActions(auth);
-  if (actions.length === 0) {
-    return;
-  }
-
-  const actionByConversationId = await mapConversationIdsToActions(
-    auth,
-    actions
-  );
-
-  const conversations = await ConversationResource.fetchByIds(auth, [
-    ...actionByConversationId.keys(),
-  ]);
-  const conversationById = new Map(
-    conversations.map((conversation) => [conversation.sId, conversation])
-  );
-
-  for (const [conversationId, action] of actionByConversationId) {
-    const conversation = conversationById.get(conversationId);
-    if (!conversation) {
-      logger.warn(
-        {
-          actionId: action.id,
-          conversationId,
-        },
-        "Conversation from pod_manager output not found"
-      );
-      continue;
-    }
-
-    logger.info(
-      {
-        actionId: action.id,
-        conversationId: conversation.sId,
-        conversationCreatedAt: conversation.createdAt,
-      },
-      "Found conversation created via pod_manager.create_conversation"
-    );
-  }
-
-  logger.info(
-    {
-      actionCount: actions.length,
-      actionWithConversationOutputCount: actionByConversationId.size,
-      conversationCount: conversations.length,
-    },
-    "Done finding pod_manager conversations"
-  );
-}
-
 makeScript(
   {
     workspaceId: {
@@ -162,7 +107,85 @@ makeScript(
       type: "string" as const,
     },
   },
-  async ({ workspaceId }, logger) => {
-    await processWorkspace(workspaceId, logger.child({ workspaceId }));
+  async ({ workspaceId, execute }, logger) => {
+    const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+
+    const actions = await listPodManagerCreateConversationActions(auth);
+    if (actions.length === 0) {
+      return;
+    }
+
+    const actionByConversationId = await mapConversationIdsToActions(
+      auth,
+      actions
+    );
+
+    const conversations = await ConversationResource.fetchByIds(auth, [
+      ...actionByConversationId.keys(),
+    ]);
+    const conversationById = new Map(
+      conversations.map((conversation) => [conversation.sId, conversation])
+    );
+
+    for (const [conversationId, action] of actionByConversationId) {
+      const conversation = conversationById.get(conversationId);
+      if (!conversation) {
+        logger.warn(
+          {
+            actionId: action.id,
+            conversationId,
+          },
+          "Conversation from pod_manager output not found"
+        );
+        continue;
+      }
+
+      logger.info(
+        {
+          actionId: action.id,
+          conversationId: conversation.sId,
+          conversationCreatedAt: conversation.createdAt,
+          depth: conversation.depth,
+        },
+        "Found conversation created via pod_manager.create_conversation"
+      );
+    }
+
+    const conversationsToUpdate = conversations.filter(
+      (conversation) => conversation.depth !== 0
+    );
+    let updatedConversationCount = 0;
+    if (execute && conversationsToUpdate.length > 0) {
+      [updatedConversationCount] = await ConversationModel.update(
+        { depth: 0 },
+        {
+          where: {
+            workspaceId: auth.getNonNullableWorkspace().id,
+            id: { [Op.in]: conversationsToUpdate.map(({ id }) => id) },
+          },
+          silent: true,
+        }
+      );
+    }
+
+    logger.info(
+      {
+        execute,
+        conversationToUpdateCount: conversationsToUpdate.length,
+        updatedConversationCount,
+      },
+      execute
+        ? "Updated pod_manager conversation depths to 0"
+        : "Would update pod_manager conversation depths to 0"
+    );
+
+    logger.info(
+      {
+        actionCount: actions.length,
+        actionWithConversationOutputCount: actionByConversationId.size,
+        conversationCount: conversations.length,
+      },
+      "Done finding pod_manager conversations"
+    );
   }
 );

--- a/front/migrations/20260805_find_pod_manager_conversations.ts
+++ b/front/migrations/20260805_find_pod_manager_conversations.ts
@@ -1,0 +1,168 @@
+import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
+import { POD_MANAGER_SERVER_NAME } from "@app/lib/api/actions/servers/pod_manager/metadata";
+import { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { makeScript } from "@app/scripts/helpers";
+import { isTextContent } from "@app/types/assistant/generation";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
+import type { Logger } from "pino";
+import { Op } from "sequelize";
+import { z } from "zod";
+
+const CreateConversationOutputSchema = z
+  .object({
+    success: z.literal(true),
+    conversationId: z.string(),
+  })
+  .passthrough();
+
+const CREATED_AT_START = new Date("2026-08-04T09:30:00+02:00");
+const CREATED_AT_END = new Date("2026-08-05T16:00:00+02:00");
+
+async function listPodManagerCreateConversationActions(
+  auth: Authenticator
+): Promise<AgentMCPActionModel[]> {
+  const workspaceId = auth.getNonNullableWorkspace().id;
+
+  const podManagerServerId = autoInternalMCPServerNameToSId({
+    name: POD_MANAGER_SERVER_NAME,
+    workspaceId,
+  });
+
+  const actionModels = await AgentMCPActionModel.findAll({
+    attributes: ["id", "createdAt", "toolConfiguration"],
+    where: {
+      workspaceId,
+      createdAt: {
+        [Op.gte]: CREATED_AT_START,
+        [Op.lte]: CREATED_AT_END,
+      },
+    },
+  });
+  const podManagerActions = actionModels.filter(
+    (action) =>
+      isLightServerSideMCPToolConfiguration(action.toolConfiguration) &&
+      action.toolConfiguration.internalMCPServerId === podManagerServerId &&
+      action.toolConfiguration.originalName === "create_conversation"
+  );
+
+  return podManagerActions.sort(
+    (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
+  );
+}
+
+async function mapConversationIdsToActions(
+  auth: Authenticator,
+  actions: AgentMCPActionModel[]
+): Promise<Map<string, AgentMCPActionModel>> {
+  if (actions.length === 0) {
+    return new Map();
+  }
+
+  const outputItemsByActionId =
+    await AgentMCPActionResource.fetchOutputItemsByActionIds(auth, {
+      actionIds: actions.map((action) => action.id),
+      ignoreContent: false,
+    });
+  const actionByConversationId = new Map<string, AgentMCPActionModel>();
+
+  for (const action of actions) {
+    const outputItems = outputItemsByActionId.get(action.id) ?? [];
+
+    for (const outputItem of outputItems) {
+      if (!isTextContent(outputItem.content)) {
+        continue;
+      }
+
+      const parsedJson = safeParseJSON(outputItem.content.text);
+      if (parsedJson.isErr()) {
+        continue;
+      }
+
+      const parsedOutput = CreateConversationOutputSchema.safeParse(
+        parsedJson.value
+      );
+      if (!parsedOutput.success) {
+        continue;
+      }
+
+      actionByConversationId.set(parsedOutput.data.conversationId, action);
+      break;
+    }
+  }
+
+  return actionByConversationId;
+}
+
+async function processWorkspace(
+  workspaceId: string,
+  logger: Logger
+): Promise<void> {
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+
+  const actions = await listPodManagerCreateConversationActions(auth);
+  if (actions.length === 0) {
+    return;
+  }
+
+  const actionByConversationId = await mapConversationIdsToActions(
+    auth,
+    actions
+  );
+
+  const conversations = await ConversationResource.fetchByIds(auth, [
+    ...actionByConversationId.keys(),
+  ]);
+  const conversationById = new Map(
+    conversations.map((conversation) => [conversation.sId, conversation])
+  );
+
+  for (const [conversationId, action] of actionByConversationId) {
+    const conversation = conversationById.get(conversationId);
+    if (!conversation) {
+      logger.warn(
+        {
+          actionId: action.id,
+          conversationId,
+        },
+        "Conversation from pod_manager output not found"
+      );
+      continue;
+    }
+
+    logger.info(
+      {
+        actionId: action.id,
+        conversationId: conversation.sId,
+        conversationCreatedAt: conversation.createdAt,
+      },
+      "Found conversation created via pod_manager.create_conversation"
+    );
+  }
+
+  logger.info(
+    {
+      actionCount: actions.length,
+      actionWithConversationOutputCount: actionByConversationId.size,
+      conversationCount: conversations.length,
+    },
+    "Done finding pod_manager conversations"
+  );
+}
+
+makeScript(
+  {
+    workspaceId: {
+      alias: "w",
+      describe: "Workspace sId to search",
+      demandOption: true,
+      type: "string" as const,
+    },
+  },
+  async ({ workspaceId }, logger) => {
+    await processWorkspace(workspaceId, logger.child({ workspaceId }));
+  }
+);

--- a/front/migrations/20260805_find_pod_manager_conversations.ts
+++ b/front/migrations/20260805_find_pod_manager_conversations.ts
@@ -55,7 +55,7 @@ async function listPodManagerCreateConversationActions(
   );
 }
 
-async function mapConversationIdsToActions(
+async function fetchConversationIDs(
   auth: Authenticator,
   actions: AgentMCPActionModel[]
 ): Promise<Map<string, AgentMCPActionModel>> {
@@ -114,7 +114,7 @@ makeScript(
       return;
     }
 
-    const actionByConversationId = await mapConversationIdsToActions(
+    const actionByConversationId = await fetchConversationIDs(
       auth,
       actions
     );

--- a/front/migrations/20260805_find_pod_manager_conversations.ts
+++ b/front/migrations/20260805_find_pod_manager_conversations.ts
@@ -55,7 +55,7 @@ async function listPodManagerCreateConversationActions(
   );
 }
 
-async function fetchConversationIDs(
+async function fetchConversationIds(
   auth: Authenticator,
   actions: AgentMCPActionModel[]
 ): Promise<Map<string, AgentMCPActionModel>> {
@@ -114,7 +114,7 @@ makeScript(
       return;
     }
 
-    const actionByConversationId = await fetchConversationIDs(
+    const actionByConversationId = await fetchConversationIds(
       auth,
       actions
     );

--- a/front/migrations/20260805_find_pod_manager_conversations.ts
+++ b/front/migrations/20260805_find_pod_manager_conversations.ts
@@ -132,15 +132,14 @@ makeScript(
   async ({ workspaceId, execute }, logger) => {
     const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
 
+    // Fetch all actions for the server pod_manager and tool create_conversation.
     const actions = await listPodManagerCreateConversationActions(auth);
     if (actions.length === 0) {
       return;
     }
 
-    const actionByConversationId = await fetchConversationIds(
-      auth,
-      actions
-    );
+    // Fetch the outputs, extract the conversation IDs and map with the actions.
+    const actionByConversationId = await fetchConversationIds(auth, actions);
 
     const conversations = await ConversationResource.fetchByIds(auth, [
       ...actionByConversationId.keys(),

--- a/front/migrations/20260805_find_pod_manager_conversations.ts
+++ b/front/migrations/20260805_find_pod_manager_conversations.ts
@@ -151,6 +151,7 @@ makeScript(
     }
 
     const conversationsToUpdate = conversations.filter(
+      // We only take the ones with depth 1, the other ones have been created with sub agents so should remain hidden.
       (conversation) => conversation.depth === 1
     );
 

--- a/front/migrations/20260805_find_pod_manager_conversations.ts
+++ b/front/migrations/20260805_find_pod_manager_conversations.ts
@@ -100,25 +100,82 @@ async function fetchConversationIds(
 
 async function updateConversationDepthsToZero(
   auth: Authenticator,
-  conversations: ConversationResource[]
-): Promise<number> {
-  if (conversations.length === 0) {
-    return 0;
-  }
-
-  const [updatedConversationCount] = await ConversationModel.update(
-    { depth: 0 },
-    {
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        id: { [Op.in]: conversations.map(({ id }) => id) },
-      },
-      // Silent to not update the updatedAt of Sequelize.
-      silent: true,
-    }
+  actionByConversationId: Map<string, AgentMCPActionModel>,
+  {
+    actionCount,
+    execute,
+    logger,
+  }: { actionCount: number; execute: boolean; logger: Logger }
+): Promise<void> {
+  const conversations = await ConversationResource.fetchByIds(auth, [
+    ...actionByConversationId.keys(),
+  ]);
+  const conversationById = new Map(
+    conversations.map((conversation) => [conversation.sId, conversation])
   );
 
-  return updatedConversationCount;
+  for (const [conversationId, action] of actionByConversationId) {
+    const conversation = conversationById.get(conversationId);
+    if (!conversation) {
+      logger.warn(
+        {
+          actionId: action.id,
+          conversationId,
+        },
+        "Conversation from pod_manager output not found"
+      );
+      continue;
+    }
+
+    logger.info(
+      {
+        actionId: action.id,
+        conversationId: conversation.sId,
+        conversationCreatedAt: conversation.createdAt,
+        depth: conversation.depth,
+      },
+      "Found conversation created via pod_manager.create_conversation"
+    );
+  }
+
+  const conversationsToUpdate = conversations.filter(
+    // We only take the ones with depth 1, the other ones have been created with sub agents so should remain hidden.
+    (conversation) => conversation.depth === 1
+  );
+  let updatedConversationCount = 0;
+  if (execute && conversationsToUpdate.length > 0) {
+    [updatedConversationCount] = await ConversationModel.update(
+      { depth: 0 },
+      {
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          id: { [Op.in]: conversationsToUpdate.map(({ id }) => id) },
+        },
+        // Silent to not update the updatedAt of Sequelize.
+        silent: true,
+      }
+    );
+  }
+
+  logger.info(
+    {
+      execute,
+      conversationToUpdateCount: conversationsToUpdate.length,
+      updatedConversationCount,
+    },
+    execute
+      ? "Updated pod_manager conversation depths to 0"
+      : "Would update pod_manager conversation depths to 0"
+  );
+
+  logger.info(
+    {
+      actionCount,
+      actionWithConversationOutputCount: actionByConversationId.size,
+      conversationCount: conversations.length,
+    },
+    "Done finding pod_manager conversations"
+  );
 }
 
 makeScript(
@@ -141,64 +198,11 @@ makeScript(
     // Fetch the outputs, extract the conversation IDs and map with the actions.
     const actionByConversationId = await fetchConversationIds(auth, actions);
 
-    const conversations = await ConversationResource.fetchByIds(auth, [
-      ...actionByConversationId.keys(),
-    ]);
-    const conversationById = new Map(
-      conversations.map((conversation) => [conversation.sId, conversation])
-    );
-
-    for (const [conversationId, action] of actionByConversationId) {
-      const conversation = conversationById.get(conversationId);
-      if (!conversation) {
-        logger.warn(
-          {
-            actionId: action.id,
-            conversationId,
-          },
-          "Conversation from pod_manager output not found"
-        );
-        continue;
-      }
-
-      logger.info(
-        {
-          actionId: action.id,
-          conversationId: conversation.sId,
-          conversationCreatedAt: conversation.createdAt,
-          depth: conversation.depth,
-        },
-        "Found conversation created via pod_manager.create_conversation"
-      );
-    }
-
-    const conversationsToUpdate = conversations.filter(
-      // We only take the ones with depth 1, the other ones have been created with sub agents so should remain hidden.
-      (conversation) => conversation.depth === 1
-    );
-
-    const updatedConversationCount = execute
-      ? await updateConversationDepthsToZero(auth, conversationsToUpdate)
-      : 0;
-
-    logger.info(
-      {
-        execute,
-        conversationToUpdateCount: conversationsToUpdate.length,
-        updatedConversationCount,
-      },
-      execute
-        ? "Updated pod_manager conversation depths to 0"
-        : "Would update pod_manager conversation depths to 0"
-    );
-
-    logger.info(
-      {
-        actionCount: actions.length,
-        actionWithConversationOutputCount: actionByConversationId.size,
-        conversationCount: conversations.length,
-      },
-      "Done finding pod_manager conversations"
-    );
+    // Update the depth for those conversations.
+    await updateConversationDepthsToZero(auth, actionByConversationId, {
+      actionCount: actions.length,
+      execute,
+      logger,
+    });
   }
 );


### PR DESCRIPTION
## Description

Context in [thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1785932638562669).
This PR adds a script to backfill the depth of the conversations that were incorrectly created with a depth > 0 via the `pod_manager` `create_conversation` tool.

## Tests

## Risk

- N/A.

## Deploy Plan

- No deploy.
