### PR TITLE
Request immediate (debounced) sync when file is added / remove from pod.

### DIFF
--- a/connectors/src/api/sync_connector_incremental.ts
+++ b/connectors/src/api/sync_connector_incremental.ts
@@ -1,0 +1,69 @@
+import { getConnectorManager } from "@connectors/connectors";
+import { withLogging } from "@connectors/logger/withlogging";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import type { WithConnectorsAPIErrorReponse } from "@connectors/types";
+import type { Request, Response } from "express";
+
+type RequestIncrementalSyncRes = WithConnectorsAPIErrorReponse<{
+  workflowId: string;
+}>;
+
+const _syncConnectorIncrementalAPIHandler = async (
+  req: Request<{ connector_id: string }, RequestIncrementalSyncRes, undefined>,
+  res: Response<RequestIncrementalSyncRes>
+) => {
+  if (!req.params.connector_id) {
+    res.status(400).send({
+      error: {
+        type: "invalid_request_error",
+        message: `Missing required parameters. Required : connector_id`,
+      },
+    });
+
+    return;
+  }
+
+  const connector = await ConnectorResource.fetchById(req.params.connector_id);
+  if (!connector) {
+    res.status(404).send({
+      error: {
+        type: "connector_not_found",
+        message: `Connector with id ${req.params.connector_id} not found`,
+      },
+    });
+    return;
+  }
+
+  if (connector.type !== "dust_project") {
+    res.status(400).send({
+      error: {
+        type: "invalid_request_error",
+        message: `Incremental sync on demand is only supported for dust_project connectors (got ${connector.type})`,
+      },
+    });
+    return;
+  }
+
+  const launchRes = await getConnectorManager({
+    connectorProvider: connector.type,
+    connectorId: connector.id,
+  }).requestIncrementalSync();
+
+  if (launchRes.isErr()) {
+    res.status(500).send({
+      error: {
+        type: "internal_server_error",
+        message: launchRes.error.message,
+      },
+    });
+    return;
+  }
+
+  return res.status(200).send({
+    workflowId: launchRes.value,
+  });
+};
+
+export const syncConnectorIncrementalAPIHandler = withLogging(
+  _syncConnectorIncrementalAPIHandler
+);

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -15,6 +15,7 @@ import {
   patchSlackChannelsLinkedWithAgentHandler,
 } from "@connectors/api/slack_channels_linked_with_agent";
 import { syncConnectorAPIHandler } from "@connectors/api/sync_connector";
+import { syncConnectorIncrementalAPIHandler } from "@connectors/api/sync_connector_incremental";
 import { unpauseConnectorAPIHandler } from "@connectors/api/unpause_connector";
 import { postConnectorUpdateAPIHandler } from "@connectors/api/update_connector";
 import { webhookDiscordAppHandler } from "@connectors/api/webhooks/webhook_discord_app";
@@ -112,6 +113,10 @@ export function startServer(port: number) {
   app.get("/connectors/:connector_id", getConnectorAPIHandler);
   app.get("/connectors", getConnectorsAPIHandler);
   app.post("/connectors/sync/:connector_id", syncConnectorAPIHandler);
+  app.post(
+    "/connectors/sync/:connector_id/incremental",
+    syncConnectorIncrementalAPIHandler
+  );
   app.get(
     "/connectors/:connector_id/permissions",
     getConnectorPermissionsAPIHandler

--- a/connectors/src/connectors/dust_project/index.ts
+++ b/connectors/src/connectors/dust_project/index.ts
@@ -1,6 +1,7 @@
 import {
   launchDustProjectFullSyncWorkflow,
   launchDustProjectIncrementalSyncWorkflow,
+  signalDustProjectIncrementalSync,
   stopDustProjectSyncWorkflow,
 } from "@connectors/connectors/dust_project/temporal/client";
 import type {
@@ -154,12 +155,16 @@ export class DustProjectConnectorManager extends BaseConnectorManager<null> {
   }: {
     fromTs: number | null;
   }): Promise<Result<string, Error>> {
-    // Launch full sync if fromTs is null, otherwise incremental sync
+    // Launch full sync if fromTs is null, otherwise (re)schedule hourly incremental cron
     if (fromTs === null) {
       return launchDustProjectFullSyncWorkflow(this.connectorId);
     } else {
       return launchDustProjectIncrementalSyncWorkflow(this.connectorId);
     }
+  }
+
+  async requestIncrementalSync(): Promise<Result<string, Error>> {
+    return signalDustProjectIncrementalSync(this.connectorId);
   }
 
   async retrievePermissions({

--- a/connectors/src/connectors/dust_project/temporal/client.ts
+++ b/connectors/src/connectors/dust_project/temporal/client.ts
@@ -1,7 +1,10 @@
 import { QUEUE_NAME } from "@connectors/connectors/dust_project/temporal/config";
+import { dustProjectSyncSignal } from "@connectors/connectors/dust_project/temporal/signals";
 import {
   dustProjectFullSyncWorkflow,
   dustProjectFullSyncWorkflowId,
+  dustProjectIncrementalSyncNowWorkflow,
+  dustProjectIncrementalSyncNowWorkflowId,
   dustProjectIncrementalSyncWorkflow,
   dustProjectIncrementalSyncWorkflowId,
 } from "@connectors/connectors/dust_project/temporal/workflows";
@@ -71,10 +74,9 @@ export async function launchDustProjectIncrementalSyncWorkflow(
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const workflowId = dustProjectIncrementalSyncWorkflowId(connectorId);
 
-  // minuteOffset ensures jobs are distributed across the 10-minute intervals based on connector ID
-  // Run incremental sync every 10 minutes
-  const minuteOffset = connector.id % 10;
-  const cronSchedule = `${minuteOffset},${minuteOffset + 10},${minuteOffset + 20},${minuteOffset + 30},${minuteOffset + 40},${minuteOffset + 50} * * * *`;
+  // Spread hourly jobs across the hour by connector ID.
+  const minuteOffset = connector.id % 60;
+  const cronSchedule = `${minuteOffset} * * * *`;
 
   try {
     // Check if workflow already exists
@@ -106,7 +108,6 @@ export async function launchDustProjectIncrementalSyncWorkflow(
       memo: {
         connectorId,
       },
-      // Every 30 minutes, with minute offset based on connector ID
       cronSchedule,
     });
     logger.info(
@@ -131,6 +132,68 @@ export async function launchDustProjectIncrementalSyncWorkflow(
   }
 }
 
+/**
+ * Signal (or start) a debounced on-demand incremental sync.
+ * Does not touch the hourly cron workflow.
+ */
+export async function signalDustProjectIncrementalSync(
+  connectorId: ModelId
+): Promise<Result<string, Error>> {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    return new Err(new Error(`Connector ${connectorId} not found`));
+  }
+
+  if (connector.isPaused()) {
+    logger.info(
+      { connectorId },
+      "Skipping dust_project incremental sync signal because connector is paused."
+    );
+    return new Ok(dustProjectIncrementalSyncNowWorkflowId(connectorId));
+  }
+
+  const client = await getTemporalClient();
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const workflowId = dustProjectIncrementalSyncNowWorkflowId(connectorId);
+
+  try {
+    await client.workflow.signalWithStart(
+      dustProjectIncrementalSyncNowWorkflow,
+      {
+        args: [{ connectorId }],
+        taskQueue: QUEUE_NAME,
+        workflowId,
+        searchAttributes: {
+          connectorId: [connectorId],
+        },
+        memo: {
+          connectorId,
+        },
+        signal: dustProjectSyncSignal,
+        signalArgs: undefined,
+      }
+    );
+    logger.info(
+      {
+        workspaceId: dataSourceConfig.workspaceId,
+        workflowId,
+      },
+      `Signaled dust_project incremental sync now workflow.`
+    );
+    return new Ok(workflowId);
+  } catch (e) {
+    logger.error(
+      {
+        workspaceId: dataSourceConfig.workspaceId,
+        workflowId,
+        error: e,
+      },
+      `Failed signaling dust_project incremental sync now workflow.`
+    );
+    return new Err(normalizeError(e));
+  }
+}
+
 export async function stopDustProjectSyncWorkflow({
   connectorId,
   stopReason,
@@ -144,31 +207,21 @@ export async function stopDustProjectSyncWorkflow({
     return new Err(new Error(`Connector ${connectorId} not found`));
   }
 
-  const fullSyncWorkflowId = dustProjectFullSyncWorkflowId(connectorId);
-  const incrementalSyncWorkflowId =
-    dustProjectIncrementalSyncWorkflowId(connectorId);
+  const workflowIds = [
+    dustProjectFullSyncWorkflowId(connectorId),
+    dustProjectIncrementalSyncWorkflowId(connectorId),
+    dustProjectIncrementalSyncNowWorkflowId(connectorId),
+  ];
 
   try {
-    // Terminate full sync workflow if running
-    try {
-      const fullSyncHandle: WorkflowHandle<typeof dustProjectFullSyncWorkflow> =
-        client.workflow.getHandle(fullSyncWorkflowId);
-      await fullSyncHandle.terminate(stopReason);
-    } catch (e) {
-      if (!(e instanceof WorkflowNotFoundError)) {
-        throw e;
-      }
-    }
-
-    // Terminate incremental sync workflow if running
-    try {
-      const incrementalSyncHandle: WorkflowHandle<
-        typeof dustProjectIncrementalSyncWorkflow
-      > = client.workflow.getHandle(incrementalSyncWorkflowId);
-      await incrementalSyncHandle.terminate(stopReason);
-    } catch (e) {
-      if (!(e instanceof WorkflowNotFoundError)) {
-        throw e;
+    for (const workflowId of workflowIds) {
+      try {
+        const handle = client.workflow.getHandle(workflowId);
+        await handle.terminate(stopReason);
+      } catch (e) {
+        if (!(e instanceof WorkflowNotFoundError)) {
+          throw e;
+        }
       }
     }
 

--- a/connectors/src/connectors/dust_project/temporal/signals.ts
+++ b/connectors/src/connectors/dust_project/temporal/signals.ts
@@ -1,0 +1,5 @@
+import { defineSignal } from "@temporalio/workflow";
+
+export const dustProjectSyncSignal = defineSignal<[void]>(
+  "dust_project_sync_signal"
+);

--- a/connectors/src/connectors/dust_project/temporal/worker.ts
+++ b/connectors/src/connectors/dust_project/temporal/worker.ts
@@ -21,7 +21,7 @@ export async function runDustProjectWorker() {
     }),
     activities: { ...activities, ...sync_status },
     taskQueue: QUEUE_NAME,
-    maxConcurrentActivityTaskExecutions: 5,
+    maxConcurrentActivityTaskExecutions: 12,
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
     connection,
     reuseV8Context: true,

--- a/connectors/src/connectors/dust_project/temporal/workflows.ts
+++ b/connectors/src/connectors/dust_project/temporal/workflows.ts
@@ -1,6 +1,14 @@
 import type * as activities from "@connectors/connectors/dust_project/temporal/activities";
+import { dustProjectSyncSignal } from "@connectors/connectors/dust_project/temporal/signals";
 import type { ModelId } from "@connectors/types";
-import { proxyActivities } from "@temporalio/workflow";
+import {
+  allHandlersFinished,
+  condition,
+  continueAsNew,
+  proxyActivities,
+  setHandler,
+  sleep,
+} from "@temporalio/workflow";
 
 const {
   dustProjectConversationsFullSyncActivity,
@@ -13,6 +21,11 @@ const {
   startToCloseTimeout: "60 minutes",
 });
 
+/** Debounce window before running an on-demand incremental sync. */
+const INCREMENTAL_SYNC_DEBOUNCE_MS = 30_000;
+/** Cap debounce loops before continueAsNew to bound workflow history size. */
+const MAX_DEBOUNCE_COUNT = 100;
+
 /**
  * Generate workflow IDs for dust_project workflows
  */
@@ -24,6 +37,12 @@ export function dustProjectIncrementalSyncWorkflowId(
   connectorId: ModelId
 ): string {
   return `dust-project-incremental-sync-${connectorId}`;
+}
+
+export function dustProjectIncrementalSyncNowWorkflowId(
+  connectorId: ModelId
+): string {
+  return `dust-project-incremental-sync-now-${connectorId}`;
 }
 
 type DustProjectSyncActivity = (input: {
@@ -40,6 +59,20 @@ async function dustProjectSyncActivitiesCompleted(
     }
   }
   return true;
+}
+
+async function runDustProjectIncrementalSync(
+  connectorId: ModelId
+): Promise<void> {
+  if (
+    await dustProjectSyncActivitiesCompleted(connectorId, [
+      dustProjectConversationsIncrementalSyncActivity,
+      dustProjectMountFilesIncrementalSyncActivity,
+      dustProjectSyncMetadataActivity,
+    ])
+  ) {
+    await dustProjectMarkSyncedActivity({ connectorId });
+  }
 }
 
 /**
@@ -63,21 +96,49 @@ export async function dustProjectFullSyncWorkflow({
 }
 
 /**
- * Incremental sync workflow for dust_project connector.
- * Syncs only conversations that have been updated since the last sync.
+ * Cron-driven incremental sync for dust_project (hourly catch-up / GC).
  */
 export async function dustProjectIncrementalSyncWorkflow({
   connectorId,
 }: {
   connectorId: ModelId;
 }): Promise<void> {
-  if (
-    await dustProjectSyncActivitiesCompleted(connectorId, [
-      dustProjectConversationsIncrementalSyncActivity,
-      dustProjectMountFilesIncrementalSyncActivity,
-      dustProjectSyncMetadataActivity,
-    ])
-  ) {
-    await dustProjectMarkSyncedActivity({ connectorId });
+  await runDustProjectIncrementalSync(connectorId);
+}
+
+/**
+ * On-demand incremental sync, coalesced via Temporal signals.
+ * Front notifies on file/conversation changes; bursts debounce into one sync.
+ */
+export async function dustProjectIncrementalSyncNowWorkflow({
+  connectorId,
+}: {
+  connectorId: ModelId;
+}): Promise<void> {
+  let signaled = false;
+  let debounceCount = 0;
+
+  setHandler(dustProjectSyncSignal, () => {
+    signaled = true;
+  });
+
+  while (signaled && debounceCount < MAX_DEBOUNCE_COUNT) {
+    signaled = false;
+    await sleep(INCREMENTAL_SYNC_DEBOUNCE_MS);
+    if (signaled) {
+      debounceCount++;
+      continue;
+    }
+
+    await runDustProjectIncrementalSync(connectorId);
   }
+
+  if (debounceCount >= MAX_DEBOUNCE_COUNT) {
+    setHandler(dustProjectSyncSignal, undefined);
+    await condition(allHandlersFinished);
+    await continueAsNew({ connectorId });
+  }
+
+  // /!\ Any signal received outside of the while loop will be lost, so don't make any async
+  // call here, which will allow the signal handler to be executed by the nodejs event loop. /!\
 }

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -8,6 +8,7 @@ import type {
   ModelId,
 } from "@connectors/types";
 import type { ConnectorProvider, Result } from "@dust-tt/client";
+import { Err } from "@dust-tt/client";
 
 export type CreateConnectorErrorCode = "INVALID_CONFIGURATION";
 
@@ -71,6 +72,18 @@ export abstract class BaseConnectorManager<T extends ConnectorConfiguration> {
   abstract sync(params: {
     fromTs: number | null;
   }): Promise<Result<string, Error>>;
+
+  /**
+   * Request a debounced on-demand incremental sync (e.g. after content changes).
+   * Default: not supported for this connector type.
+   */
+  async requestIncrementalSync(): Promise<Result<string, Error>> {
+    return new Err(
+      new Error(
+        `requestIncrementalSync is not implemented for connector provider ${this.provider}`
+      )
+    );
+  }
 
   abstract retrievePermissions(params: {
     parentInternalId: string | null;

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -340,6 +340,7 @@ export const batch = async ({
         "snowflake",
         "zendesk",
         "bigquery",
+        "dust_project",
       ];
       if (!PROVIDERS_ALLOWING_RESTART.includes(args.provider)) {
         throw new Error(

--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
@@ -12,6 +12,7 @@ import {
   WriteCanonicalFileContentError,
   writeCanonicalFileContent,
 } from "@app/lib/api/files/file_system_ops";
+import { requestDustProjectIncrementalSyncForScopedPath } from "@app/lib/api/projects/request_incremental_sync";
 import {
   DUST_FILE_ID_HEADER,
   getFileFormat,
@@ -516,6 +517,8 @@ app.delete(
     if (deleteResult.isErr()) {
       return apiError(ctx, mapDustFsError(deleteResult.error));
     }
+
+    requestDustProjectIncrementalSyncForScopedPath(auth, canonicalPath);
 
     return new Response(null, { status: 204 });
   }

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -23,6 +23,7 @@ import {
   normalizeMountParentRelativePath,
   validateMountFolderName,
 } from "@app/lib/api/files/mount_path";
+import { requestDustProjectIncrementalSync } from "@app/lib/api/projects/request_incremental_sync";
 import type { Authenticator } from "@app/lib/auth";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import type { DustError } from "@app/lib/error";
@@ -422,6 +423,8 @@ export async function addFileToProject(
     });
   }
 
+  requestDustProjectIncrementalSync(auth, space);
+
   return new Ok(fragmentRes.value);
 }
 
@@ -574,6 +577,8 @@ export async function removeFileFromProject(
   if (deleteRes.isErr()) {
     return new Err(deleteRes.error);
   }
+
+  requestDustProjectIncrementalSync(auth, space);
 
   return new Ok(undefined);
 }
@@ -837,11 +842,15 @@ export async function deleteProjectFile(
     });
   }
 
-  return deleteGCSMountFile(
+  const deleteRes = await deleteGCSMountFile(
     auth,
     { useCase: "pod", podId: space.sId },
     { relativeFilePath: normalized }
   );
+  if (deleteRes.isOk()) {
+    requestDustProjectIncrementalSync(auth, space);
+  }
+  return deleteRes;
 }
 
 /**

--- a/front/lib/api/projects/request_incremental_sync.ts
+++ b/front/lib/api/projects/request_incremental_sync.ts
@@ -1,0 +1,118 @@
+import { default as config } from "@app/lib/api/config";
+import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
+import { fetchProjectDataSource } from "@app/lib/api/projects/data_sources";
+import type { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
+import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
+
+/**
+ * Fire-and-forget request for a debounced dust_project incremental sync.
+ * Failures are logged and never thrown to callers.
+ */
+export function requestDustProjectIncrementalSync(
+  auth: Authenticator,
+  space: SpaceResource
+): void {
+  void (async () => {
+    const workspaceId = auth.getNonNullableWorkspace().sId;
+    const localLogger = logger.child({
+      workspaceId,
+      spaceId: space.sId,
+    });
+
+    if (!space.isProject()) {
+      return;
+    }
+
+    const dsRes = await fetchProjectDataSource(auth, space);
+    if (dsRes.isErr()) {
+      localLogger.warn(
+        { error: dsRes.error },
+        "Skipping dust_project incremental sync request: data source not found"
+      );
+      return;
+    }
+
+    const connectorId = dsRes.value.connectorId;
+    if (!connectorId) {
+      localLogger.warn(
+        "Skipping dust_project incremental sync request: connectorId missing"
+      );
+      return;
+    }
+
+    const connectorsAPI = new ConnectorsAPI(
+      config.getConnectorsAPIConfig(),
+      logger
+    );
+    const syncRes = await connectorsAPI.requestIncrementalSync(connectorId);
+    if (syncRes.isErr()) {
+      localLogger.warn(
+        { connectorId, error: syncRes.error },
+        "Failed to request dust_project incremental sync"
+      );
+      return;
+    }
+
+    localLogger.info(
+      { connectorId, workflowId: syncRes.value.workflowId },
+      "Requested dust_project incremental sync"
+    );
+  })().catch((error) => {
+    logger.warn(
+      {
+        workspaceId: auth.workspace()?.sId,
+        spaceId: space.sId,
+        error,
+      },
+      "Unexpected error requesting dust_project incremental sync"
+    );
+  });
+}
+
+/**
+ * If `scopedPath` is under a pod mount (`pod-{spaceId}/...`), request incremental sync.
+ * No-op for conversation/user paths.
+ */
+export function requestDustProjectIncrementalSyncForScopedPath(
+  auth: Authenticator,
+  scopedPath: string
+): void {
+  if (!scopedPath.startsWith(SCOPED_PREFIX_POD)) {
+    return;
+  }
+
+  const rest = scopedPath.slice(SCOPED_PREFIX_POD.length);
+  const slash = rest.indexOf("/");
+  const spaceId = slash < 0 ? rest : rest.slice(0, slash);
+  if (!spaceId) {
+    return;
+  }
+
+  void (async () => {
+    const space = await SpaceResource.fetchById(auth, spaceId);
+    if (!space) {
+      logger.warn(
+        {
+          workspaceId: auth.workspace()?.sId,
+          spaceId,
+          scopedPath,
+        },
+        "Skipping dust_project incremental sync request: space not found for scoped path"
+      );
+      return;
+    }
+    requestDustProjectIncrementalSync(auth, space);
+  })().catch((error) => {
+    logger.warn(
+      {
+        workspaceId: auth.workspace()?.sId,
+        spaceId,
+        scopedPath,
+        error,
+      },
+      "Unexpected error requesting dust_project incremental sync for scoped path"
+    );
+  });
+}

--- a/front/types/connectors/connectors_api.ts
+++ b/front/types/connectors/connectors_api.ts
@@ -279,6 +279,20 @@ export class ConnectorsAPI {
     return this._resultFromResponse(res);
   }
 
+  async requestIncrementalSync(
+    connectorId: string
+  ): Promise<ConnectorsAPIResponse<{ workflowId: string }>> {
+    const res = await this._fetchWithError(
+      `${this._url}/connectors/sync/${encodeURIComponent(connectorId)}/incremental`,
+      {
+        method: "POST",
+        headers: this.getDefaultHeaders(),
+      }
+    );
+
+    return this._resultFromResponse(res);
+  }
+
   async deleteConnector(
     connectorId: string,
     force = false


### PR DESCRIPTION
## Description

After a file is added to or removed from a Pod, trigger a debounced `dust_project` incremental sync so the connector picks up the change without waiting for the hourly cron. New `request_incremental_sync.ts` module exposes two fire-and-forget helpers — `requestDustProjectIncrementalSync(auth, space)` and `requestDustProjectIncrementalSyncForScopedPath(auth, scopedPath)` — that resolve the connector ID and call `POST /connectors/sync/:connectorId/incremental` on the connectors service. Call sites are `addFileToProject`, `removeFileFromProject`, `deleteProjectFile` in `context.ts`, and the `DELETE` handler in the canonical path route. `ConnectorsAPI.requestIncrementalSync()` is added as the underlying HTTP call.

## Tests

Tested locally by adding/removing files from a Pod and verifying the incremental sync workflow is triggered. Failures are logged and never surfaced to callers, so error paths were verified through log output.

## Risk

Low. Fire-and-forget with full error handling — failures log a warning and are never thrown. The `space.isProject()` guard ensures this only fires for pod spaces. Debounce logic lives in the connectors service (introduced in PR #30042). Safe to roll back: the connectors endpoint simply won't be called on file operations, falling back to the hourly cron.

## Deploy Plan

Deploy front + front-api. The connectors-side endpoint (`POST /connectors/sync/:connectorId/incremental`) is already live.
