### PR TITLE
Admin governance for skills: deny saving skills if editors and spaces are incompatible

### DIFF
--- a/front-api/routes/w/[wId]/skills/[sId]/editors.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/editors.test.ts
@@ -3,12 +3,13 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
 async function setup() {
-  const { workspace, user } = await createPrivateApiMockRequest({
+  const { workspace, user, globalSpace } = await createPrivateApiMockRequest({
     method: "PATCH",
     role: "admin",
   });
@@ -21,7 +22,7 @@ async function setup() {
     subscription: null,
     authMethod: "internal",
   });
-  return { workspace, user, auth };
+  return { workspace, user, auth, globalSpace };
 }
 
 function patch(workspace: { sId: string }, sId: string, body: unknown) {
@@ -162,6 +163,79 @@ describe("PATCH /api/w/:wId/skills/:sId/editors", () => {
     expect(response.status).toBe(200);
     const data = await response.json();
     expect(data.editors).toHaveLength(0);
+  });
+
+  it("rejects adding an editor that cannot access a restricted space the skill requires", async () => {
+    const { workspace, user, auth } = await setup();
+
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const space = await SpaceFactory.regular(workspace);
+    await space.addMembers(adminAuth, { userIds: [user.sId] });
+
+    const skill = await SkillFactory.create(auth, {
+      requestedSpaceIds: [space.id],
+    });
+
+    const outsider = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, outsider, { role: "builder" });
+
+    const response = await patch(workspace, skill.sId, {
+      addEditorIds: [outsider.sId],
+    });
+
+    expect(response.status).toBe(400);
+    const { error } = await response.json();
+    expect(error.type).toBe("invalid_request_error");
+    expect(error.message).toContain("do not have access");
+
+    // The editor list is unchanged.
+    const editorsResponse = await get(workspace, skill.sId);
+    const data = await editorsResponse.json();
+    expect(data.editors.map((e: { sId: string }) => e.sId)).toEqual([user.sId]);
+  });
+
+  it("allows adding an editor that is a member of the restricted space", async () => {
+    const { workspace, user, auth } = await setup();
+
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const space = await SpaceFactory.regular(workspace);
+
+    const peer = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, peer, { role: "builder" });
+    await space.addMembers(adminAuth, { userIds: [user.sId, peer.sId] });
+
+    const skill = await SkillFactory.create(auth, {
+      requestedSpaceIds: [space.id],
+    });
+
+    const response = await patch(workspace, skill.sId, {
+      addEditorIds: [peer.sId],
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.editors.map((e: { sId: string }) => e.sId)).toContain(peer.sId);
+  });
+
+  it("allows adding an editor when the skill only requires an open space", async () => {
+    const { workspace, auth, globalSpace } = await setup();
+
+    const skill = await SkillFactory.create(auth, {
+      requestedSpaceIds: [globalSpace.id],
+    });
+
+    const outsider = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, outsider, { role: "builder" });
+
+    const response = await patch(workspace, skill.sId, {
+      addEditorIds: [outsider.sId],
+    });
+
+    expect(response.status).toBe(200);
   });
 
   it("GET endpoint returns all editors", async () => {

--- a/front-api/routes/w/[wId]/skills/[sId]/editors.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/editors.ts
@@ -1,3 +1,4 @@
+import { findSkillEditorsWithoutSpaceAccess } from "@app/lib/api/skills/space_requirements";
 import type { GroupResource } from "@app/lib/resources/group_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -135,6 +136,22 @@ app.patch(
           },
         });
       }
+    }
+
+    // Only the editors being added need checking: the ones already there were validated when they
+    // were added or when the skill's spaces last changed.
+    const editorsAccessError = await findSkillEditorsWithoutSpaceAccess(auth, {
+      editors: usersToAddResources,
+      requestedSpaceModelIds: skillRes.requestedSpaceIds,
+    });
+    if (editorsAccessError) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: editorsAccessError,
+        },
+      });
     }
 
     // Check authorization for modifying group members.

--- a/front-api/routes/w/[wId]/skills/[sId]/editors.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/editors.ts
@@ -1,6 +1,7 @@
 import { findSkillEditorsWithoutSpaceAccess } from "@app/lib/api/skills/space_requirements";
 import type { GroupResource } from "@app/lib/resources/group_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type {
   PatchSkillEditorsRequestBody,
@@ -140,9 +141,12 @@ app.patch(
 
     // Only the editors being added need checking: the ones already there were validated when they
     // were added or when the skill's spaces last changed.
+    const requestedSpaces = await SpaceResource.fetchByModelIds(auth, [
+      ...skillRes.requestedSpaceIds,
+    ]);
     const editorsAccessError = await findSkillEditorsWithoutSpaceAccess(auth, {
       editors: usersToAddResources,
-      requestedSpaceModelIds: skillRes.requestedSpaceIds,
+      requestedSpaces,
     });
     if (editorsAccessError) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -762,6 +762,97 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
     expect(updatedSkill?.requestedSpaceIds).toContain(openSpace.id);
   });
 
+  it("rejects a restricted space that an existing editor cannot access", async () => {
+    const { workspace, skill, requestUser, requestUserAuth } = await setupTest({
+      requestUserRole: "admin",
+    });
+
+    // Restricted: no global group is associated with it.
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await restrictedSpace.addMembers(adminAuth, {
+      userIds: [requestUser.sId],
+    });
+
+    const coEditor = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, coEditor, { role: "builder" });
+    const addRes = await skill.editorGroup?.dangerouslyAddMembers(
+      requestUserAuth,
+      { users: [coEditor.toJSON()] }
+    );
+    if (!addRes || addRes.isErr()) {
+      throw new Error("Failed to add the co-editor");
+    }
+
+    const response = await patchSkill(workspace, skill.sId, {
+      name: skill.name,
+      agentFacingDescription: skill.agentFacingDescription,
+      userFacingDescription: skill.userFacingDescription,
+      instructions: skill.instructions,
+      icon: null,
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+      additionalRequestedSpaceIds: [restrictedSpace.sId],
+    });
+
+    expect(response.status).toBe(400);
+    const { error } = await response.json();
+    expect(error.message).toContain("do not have access");
+    expect(error.message).toContain(restrictedSpace.name);
+
+    // The skill was not updated.
+    const unchangedSkill = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(unchangedSkill?.requestedSpaceIds).not.toContain(restrictedSpace.id);
+  });
+
+  it("accepts a restricted space that every editor can access", async () => {
+    const { workspace, skill, requestUser, requestUserAuth } = await setupTest({
+      requestUserRole: "admin",
+    });
+
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+
+    const coEditor = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, coEditor, { role: "builder" });
+    await restrictedSpace.addMembers(adminAuth, {
+      userIds: [requestUser.sId, coEditor.sId],
+    });
+
+    const addRes = await skill.editorGroup?.dangerouslyAddMembers(
+      requestUserAuth,
+      { users: [coEditor.toJSON()] }
+    );
+    if (!addRes || addRes.isErr()) {
+      throw new Error("Failed to add the co-editor");
+    }
+
+    const response = await patchSkill(workspace, skill.sId, {
+      name: skill.name,
+      agentFacingDescription: skill.agentFacingDescription,
+      userFacingDescription: skill.userFacingDescription,
+      instructions: skill.instructions,
+      icon: null,
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+      additionalRequestedSpaceIds: [restrictedSpace.sId],
+    });
+
+    const data = await response.json();
+    expect(data).not.toHaveProperty("error");
+    expect(response.status).toBe(200);
+    expect(data.skill.requestedSpaceIds).toContain(restrictedSpace.sId);
+  });
+
   it("should preserve existing additional requested spaces when omitted", async () => {
     const { workspace, skill, requestUserAuth, globalGroup } = await setupTest({
       requestUserRole: "admin",

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -1,5 +1,6 @@
 import { AttachedKnowledgeSchema } from "@app/lib/api/skills/schemas";
 import {
+  findSkillEditorsWithoutSpaceAccess,
   getReferencedSkillSpaceModelIds,
   resolveAdditionalRequestedSpaceModelIds,
 } from "@app/lib/api/skills/space_requirements";
@@ -30,6 +31,7 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { Context, TypedResponse } from "hono";
 import uniq from "lodash/uniq";
+import uniqBy from "lodash/uniqBy";
 import { z } from "zod";
 
 import editors from "./editors";
@@ -405,6 +407,25 @@ app.patch(
       ...referencedSkillSpaceIds,
       ...additionalRequestedSpaceIds,
     ]);
+
+    // Adding a restricted space can lock out editors that are already on the skill. `updateSkill`
+    // also makes the caller an editor, so they are part of the set to validate.
+    const editors = skill.editorGroup
+      ? await skill.editorGroup.getActiveMembers(auth)
+      : [];
+    const editorsAccessError = await findSkillEditorsWithoutSpaceAccess(auth, {
+      editors: uniqBy([...editors, auth.getNonNullableUser()], "id"),
+      requestedSpaceModelIds: requestedSpaceIds,
+    });
+    if (editorsAccessError) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: editorsAccessError,
+        },
+      });
+    }
 
     // Validate file attachments if provided.
     let files: FileResource[] | undefined;

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -10,6 +10,7 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { isResourceSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import type {
@@ -413,9 +414,13 @@ app.patch(
     const editors = skill.editorGroup
       ? await skill.editorGroup.getActiveMembers(auth)
       : [];
+    const requestedSpaces = await SpaceResource.fetchByModelIds(
+      auth,
+      requestedSpaceIds
+    );
     const editorsAccessError = await findSkillEditorsWithoutSpaceAccess(auth, {
       editors: uniqBy([...editors, auth.getNonNullableUser()], "id"),
-      requestedSpaceModelIds: requestedSpaceIds,
+      requestedSpaces,
     });
     if (editorsAccessError) {
       return apiError(ctx, {

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -20,7 +20,10 @@ import {
   SkillVersionComparisonProvider,
   useSkillVersionComparisonContext,
 } from "@app/components/skill_builder/SkillBuilderVersionContext";
-import { SkillSpaceRestrictionsProvider } from "@app/components/skill_builder/SkillSpaceRestrictionsContext";
+import {
+  SkillSpaceRestrictionsProvider,
+  useSkillSpaceRestrictionsContext,
+} from "@app/components/skill_builder/SkillSpaceRestrictionsContext";
 import {
   getDefaultSkillFormData,
   transformSkillTypeToFormData,
@@ -323,25 +326,11 @@ export default function SkillBuilder({ skill, onSaved }: SkillBuilderProps) {
           />
         </div>
       </ScrollArea>
-      <BarFooter
-        variant="default"
-        className="mx-4 justify-between"
-        leftActions={
-          <Button
-            variant="outline"
-            label="Cancel"
-            onClick={handleCancel}
-            type="button"
-          />
-        }
-        rightActions={
-          <Button
-            variant="highlight"
-            label={isSaving ? "Saving..." : "Save"}
-            onClick={handleSave}
-            disabled={isSaving || isEditorLocked}
-          />
-        }
+      <SkillBuilderFooter
+        isEditorLocked={isEditorLocked}
+        isSaving={isSaving}
+        onCancel={handleCancel}
+        onSave={handleSave}
       />
     </div>
   );
@@ -390,6 +379,57 @@ export default function SkillBuilder({ skill, onSaved }: SkillBuilderProps) {
         </SkillVersionComparisonProvider>
       </FormProvider>
     </SkillBuilderFormContext.Provider>
+  );
+}
+
+interface SkillBuilderFooterProps {
+  isEditorLocked: boolean;
+  isSaving: boolean;
+  onCancel: () => void;
+  onSave: () => void;
+}
+
+/**
+ * Rendered inside `SkillSpaceRestrictionsProvider` so it can gate saving on the editors' space
+ * access — the server rejects that combination, so the button explains it up front instead.
+ */
+function SkillBuilderFooter({
+  isEditorLocked,
+  isSaving,
+  onCancel,
+  onSave,
+}: SkillBuilderFooterProps) {
+  const { editorsWithoutSpaceAccess } = useSkillSpaceRestrictionsContext();
+
+  const hasEditorsWithoutSpaceAccess = editorsWithoutSpaceAccess.length > 0;
+  // The warning in the editors section names who and offers the fixes; the tooltip only has to say
+  // why the button is off.
+  const saveTooltip = hasEditorsWithoutSpaceAccess
+    ? "Some skill editors cannot access some of the restricted spaces"
+    : undefined;
+
+  return (
+    <BarFooter
+      variant="default"
+      className="mx-4 justify-between"
+      leftActions={
+        <Button
+          variant="outline"
+          label="Cancel"
+          onClick={onCancel}
+          type="button"
+        />
+      }
+      rightActions={
+        <Button
+          variant="highlight"
+          label={isSaving ? "Saving..." : "Save"}
+          onClick={onSave}
+          disabled={isSaving || isEditorLocked || hasEditorsWithoutSpaceAccess}
+          tooltip={saveTooltip}
+        />
+      }
+    />
   );
 }
 

--- a/front/lib/api/skills/space_requirements.ts
+++ b/front/lib/api/skills/space_requirements.ts
@@ -65,18 +65,14 @@ export async function findSkillEditorsWithoutSpaceAccess(
   auth: Authenticator,
   {
     editors,
-    requestedSpaceModelIds,
-  }: { editors: UserResource[]; requestedSpaceModelIds: ModelId[] }
+    requestedSpaces,
+  }: { editors: UserResource[]; requestedSpaces: SpaceResource[] }
 ): Promise<string | null> {
-  if (editors.length === 0 || requestedSpaceModelIds.length === 0) {
+  if (editors.length === 0 || requestedSpaces.length === 0) {
     return null;
   }
 
-  const spaces = await SpaceResource.fetchByModelIds(
-    auth,
-    requestedSpaceModelIds
-  );
-  const restrictedSpaces = spaces.filter(
+  const restrictedSpaces = requestedSpaces.filter(
     (space) => space.isRegularAndRestricted() || space.isProjectAndRestricted()
   );
 

--- a/front/lib/api/skills/space_requirements.ts
+++ b/front/lib/api/skills/space_requirements.ts
@@ -1,6 +1,8 @@
+import { listUsersWithoutAccessToSpaceResources } from "@app/lib/api/spaces/access";
 import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
 import { extractUniqueSkillReferenceIds } from "@app/lib/skills/format";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -45,6 +47,59 @@ export async function resolveAdditionalRequestedSpaceModelIds(
   }
 
   return new Ok(additionalRequestedSpaceModelIds);
+}
+
+/**
+ * Checks that every editor can read every restricted space the skill requires, and describes the
+ * ones that cannot.
+ *
+ * A skill is only usable by someone who can read all of its requested spaces, so an editor without
+ * that access cannot open the skill they are supposed to maintain. Both sides can drift into that
+ * state — adding a restricted space to the skill, or adding an editor — so both write paths call
+ * this. Non-restricted spaces are readable workspace-wide and never constrain anyone.
+ *
+ * Returns `null` when every editor is fine, or a human-readable explanation naming who is missing
+ * what. Callers turn that into their own error shape.
+ */
+export async function findSkillEditorsWithoutSpaceAccess(
+  auth: Authenticator,
+  {
+    editors,
+    requestedSpaceModelIds,
+  }: { editors: UserResource[]; requestedSpaceModelIds: ModelId[] }
+): Promise<string | null> {
+  if (editors.length === 0 || requestedSpaceModelIds.length === 0) {
+    return null;
+  }
+
+  const spaces = await SpaceResource.fetchByModelIds(
+    auth,
+    requestedSpaceModelIds
+  );
+  const restrictedSpaces = spaces.filter(
+    (space) => space.isRegularAndRestricted() || space.isProjectAndRestricted()
+  );
+
+  const editorsWithoutAccess = await listUsersWithoutAccessToSpaceResources(
+    auth,
+    { spaces: restrictedSpaces, users: editors }
+  );
+
+  if (editorsWithoutAccess.length === 0) {
+    return null;
+  }
+
+  const details = editorsWithoutAccess
+    .map(
+      ({ user, spaces: missingSpaces }) =>
+        `${user.fullName()} (${missingSpaces.map((space) => space.name).join(", ")})`
+    )
+    .join("; ");
+
+  return (
+    `Some editors do not have access to the spaces this skill requires: ${details}. ` +
+    `Add them to those spaces, remove the spaces from the skill, or remove them from the editors.`
+  );
 }
 
 export async function getReferencedSkillSpaceModelIds(

--- a/front/lib/api/spaces/access.ts
+++ b/front/lib/api/spaces/access.ts
@@ -24,6 +24,60 @@ export class SpaceAccessCheckError extends Error {
 const NO_GROUPS: ReadonlySet<ModelId> = new Set();
 
 /**
+ * For each user, the groups they are an active member of among the ones that make `spaces`
+ * readable. One query, whatever the number of users and spaces.
+ */
+async function listSpaceGroupsByUser(
+  auth: Authenticator,
+  { spaces, users }: { spaces: SpaceResource[]; users: UserResource[] }
+): Promise<Map<ModelId, Set<ModelId>>> {
+  const groupModelIds = [
+    ...new Set(spaces.flatMap((space) => space.groups.map((g) => g.groupId))),
+  ];
+
+  return GroupResource.listGroupModelIdsByUserModelIdInWorkspace({
+    workspace: auth.getNonNullableWorkspace(),
+    userModelIds: users.map((user) => user.id),
+    groupModelIds,
+  });
+}
+
+export interface UserWithoutSpaceAccess {
+  user: UserResource;
+  spaces: SpaceResource[];
+}
+
+/**
+ * For each of `users`, the spaces among `spaces` they cannot read.
+ *
+ * Unlike {@link listUsersWithoutAccessToSpaces} this takes already-fetched resources and performs
+ * no permission check of its own: it is meant for callers that hold the spaces because they are
+ * about to write them (skill requirements, editor lists), and that have established their own
+ * access separately. Users are assumed to be active workspace members.
+ */
+export async function listUsersWithoutAccessToSpaceResources(
+  auth: Authenticator,
+  { spaces, users }: { spaces: SpaceResource[]; users: UserResource[] }
+): Promise<UserWithoutSpaceAccess[]> {
+  if (spaces.length === 0 || users.length === 0) {
+    return [];
+  }
+
+  const groupsByUser = await listSpaceGroupsByUser(auth, { spaces, users });
+
+  return users.flatMap((user) => {
+    const groupModelIds = groupsByUser.get(user.id) ?? NO_GROUPS;
+    const unreadableSpaces = spaces.filter(
+      (space) => !space.isMemberByGroupModelIds(groupModelIds)
+    );
+
+    return unreadableSpaces.length > 0
+      ? [{ user, spaces: unreadableSpaces }]
+      : [];
+  });
+}
+
+/**
  * For each requested space, the requested users that are not members of it.
  *
  * Membership is the ground truth for read access on restricted spaces: their
@@ -77,15 +131,10 @@ export async function listUsersWithoutAccessToSpaces(
     (userId) => !workspaceUserIds.has(userId)
   );
 
-  const groupModelIds = [
-    ...new Set(spaces.flatMap((space) => space.groups.map((g) => g.groupId))),
-  ];
-  const groupModelIdsByUserModelId =
-    await GroupResource.listGroupModelIdsByUserModelIdInWorkspace({
-      workspace,
-      userModelIds: workspaceUsers.map((user) => user.id),
-      groupModelIds,
-    });
+  const groupModelIdsByUserModelId = await listSpaceGroupsByUser(auth, {
+    spaces,
+    users: workspaceUsers,
+  });
 
   // A user belong to multiple groups
   // A space has multiple group of readers


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/9740

 - disable save button when editors and spaces are incompatible
 - add utility to check incomaptibility
 - check in PATCH endpoint to edit skill and endpoint to PATCH skill editors
 - endpoint to create skill does not need check as it does not carry the editors (it's suppose to be done it 2 steps and does not really work, but UI will be disable anyway)

## Tests


tested locally + unit tests for endpoint

<img width="2764" height="920" alt="image" src="https://github.com/user-attachments/assets/d3c59b9d-060c-4396-9e5d-9e941619ec3e" />




## Risk

This will prevent the skills in an existing broken state from being edited.
This is desirable but will cause a bit of friction at first edit as people will have to handle removing editors or changing restricted spaces.

## Deploy Plan

deploy front
