### PR TITLE
[front] enh: read user memory for non-trivial requests

### DIFF
--- a/front/lib/resources/skill/code_defined/system/user_memory.ts
+++ b/front/lib/resources/skill/code_defined/system/user_memory.ts
@@ -22,11 +22,13 @@ const USER_MEMORY_INSTRUCTIONS = `<memory_guidelines>
 You have a persistent, user-scoped memory kept in a single \`MEMORY.md\` file, shared across all of this user's conversations and agents.
 
 <critical_behavior>
-Call the \`${READ_TOOL_NAME}\` tool directly with no arguments to recall the user's memory before answering anything whose answer could depend on who they are: their work, projects, team, location, timezone, preferences, or past decisions; anything you write on their behalf or in their voice (emails, messages, documents); and any advice, recommendation, or plan for them. This tool is always available, so you do not need to search for or enable it. You cannot tell whether memory is relevant until you read it, so when unsure, read.
+Call the \`${READ_TOOL_NAME}\` tool directly with no arguments to recall the user's memory before handling any non-trivial request. Treat a request as non-trivial if it requires reasoning, judgment, planning, recommendations, drafting, analysis, or multiple steps, even when it does not explicitly mention the user.
+
+Always read memory for anything that could depend on who the user is: their work, projects, team, location, timezone, preferences, or past decisions; anything you write on their behalf or in their voice (emails, messages, documents); and any advice, recommendation, or plan for them. This tool is always available, so you do not need to search for or enable it. You cannot tell whether memory is relevant until you read it, so when unsure, read.
 
 Watch for requests about the user themselves ("me", "my", "I"). If you are about to give a generic "it depends" answer because you lack a personal detail (where they live, their role, their team), read memory first: it may already be there. For example, "how long would it take me to fly to New York" depends on where the user lives, which may be in memory.
 
-Skip reading only for self-contained requests whose answer cannot depend on the user, such as "who is the president of Spain", "translate this to French", or "what is 15% of 240".
+Skip reading only for simple, fully self-contained requests whose answer cannot depend on the user, such as "who is the president of Spain", "translate this to French", or "what is 15% of 240".
 
 You do not need to provide a query or specify what to retrieve: a single read returns the whole memory. Read it once per conversation. Read again only if the memory may have changed since.
 


### PR DESCRIPTION
## Description

Memory can improve more than explicitly personal requests, but agents can currently skip it when a request merely appears generic. This follow-up to #30002 makes memory recall the default before any non-trivial request, including reasoning, planning, recommendations, drafting, analysis, and multi-step work.

Reading remains skippable for simple, fully self-contained requests that cannot depend on the user.

## Tests

- Tested locally.

## Risk

- Low. Safe to revert.

## Deploy Plan

- Deploy front.
