### PR TITLE
[front] fix: show exact free credit renewal date

### DIFF
--- a/front-api/routes/w/[wId]/credits/index.test.ts
+++ b/front-api/routes/w/[wId]/credits/index.test.ts
@@ -1,0 +1,120 @@
+import type { Authenticator } from "@app/lib/auth";
+import { upsertCreditPricedPlans } from "@app/lib/plans/credit_priced_plans";
+import { CREDIT_PRICED_BUSINESS_PLAN_CODE } from "@app/lib/plans/plan_codes";
+import { CreditResource } from "@app/lib/resources/credit_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import type { GetCreditsResponseBody } from "@app/types/credits";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function creditsUrl(workspaceId: string) {
+  return `/api/w/${workspaceId}/credits`;
+}
+
+async function createFreeCredit({
+  auth,
+  invoiceOrLineItemId,
+  startDate,
+  expirationDate,
+}: {
+  auth: Authenticator;
+  invoiceOrLineItemId: string;
+  startDate: Date;
+  expirationDate: Date;
+}) {
+  const credit = await CreditResource.makeNew(auth, {
+    type: "free",
+    initialAmountMicroUsd: 100_000_000,
+    consumedAmountMicroUsd: 0,
+    discount: null,
+    invoiceOrLineItemId,
+  });
+  const result = await credit.start(auth, { startDate, expirationDate });
+  if (result.isErr()) {
+    throw result.error;
+  }
+}
+
+describe("GET /api/w/[wId]/credits", () => {
+  it("uses the recurring grant expiration rather than a one-off free credit", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+    const nowMs = Date.now();
+    const recurringExpirationDate = new Date(nowMs + 10 * 24 * 60 * 60 * 1000);
+
+    await createFreeCredit({
+      auth,
+      invoiceOrLineItemId: `free-poke-${workspace.sId}-${nowMs}`,
+      startDate: new Date(nowMs - 24 * 60 * 60 * 1000),
+      expirationDate: new Date(nowMs + 24 * 60 * 60 * 1000),
+    });
+    await createFreeCredit({
+      auth,
+      invoiceOrLineItemId: `free-renewal-sub_test-${nowMs}`,
+      startDate: new Date(nowMs - 2 * 24 * 60 * 60 * 1000),
+      expirationDate: recurringExpirationDate,
+    });
+
+    const response = await honoApp.request(creditsUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    const body: GetCreditsResponseBody = await response.json();
+    expect(body.freeCreditRenewalDateMs).toBe(
+      recurringExpirationDate.getTime()
+    );
+  });
+
+  it("omits the renewal date when there is no active recurring grant", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+    const nowMs = Date.now();
+
+    await createFreeCredit({
+      auth,
+      invoiceOrLineItemId: `free-poke-${workspace.sId}-${nowMs}`,
+      startDate: new Date(nowMs - 24 * 60 * 60 * 1000),
+      expirationDate: new Date(nowMs + 24 * 60 * 60 * 1000),
+    });
+
+    const response = await honoApp.request(creditsUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    const body: GetCreditsResponseBody = await response.json();
+    expect(body.freeCreditRenewalDateMs).toBeUndefined();
+  });
+
+  it("omits legacy recurring grant dates for credit-priced plans", async () => {
+    await upsertCreditPricedPlans(CREDIT_PRICED_BUSINESS_PLAN_CODE);
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+    const nowMs = Date.now();
+
+    await createFreeCredit({
+      auth,
+      invoiceOrLineItemId: `free-renewal-sub_legacy-${nowMs}`,
+      startDate: new Date(nowMs - 24 * 60 * 60 * 1000),
+      expirationDate: new Date(nowMs + 10 * 24 * 60 * 60 * 1000),
+    });
+    await auth.getNonNullableSubscriptionResource().swapMetronomeContract({
+      metronomeContractId: `contract_credit_priced_${workspace.sId}`,
+      planCode: CREDIT_PRICED_BUSINESS_PLAN_CODE,
+    });
+    await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+      workspace,
+    });
+
+    const response = await honoApp.request(creditsUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    const body: GetCreditsResponseBody = await response.json();
+    expect(body.freeCreditRenewalDateMs).toBeUndefined();
+  });
+});

--- a/front-api/routes/w/[wId]/credits/index.ts
+++ b/front-api/routes/w/[wId]/credits/index.ts
@@ -1,3 +1,4 @@
+import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
 import { getInvoicePaymentUrl } from "@app/lib/plans/stripe";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -46,6 +47,38 @@ app.get("/", ensureIsAdmin(), async (ctx) => {
     .filter((credit) => credit.startDate !== null && credit.type !== "excess")
     .map((credit) => credit.toJSON());
 
+  const nowMs = Date.now();
+  const recurringFreeCreditRenewalDateMs = credits.reduce<number | null>(
+    (earliestExpirationDateMs, credit) => {
+      if (
+        credit.type !== "free" ||
+        !credit.invoiceOrLineItemId?.startsWith("free-renewal-") ||
+        !credit.startDate ||
+        credit.startDate.getTime() > nowMs ||
+        !credit.expirationDate ||
+        credit.expirationDate.getTime() <= nowMs
+      ) {
+        return earliestExpirationDateMs;
+      }
+
+      const expirationDateMs = credit.expirationDate.getTime();
+      return earliestExpirationDateMs === null ||
+        expirationDateMs < earliestExpirationDateMs
+        ? expirationDateMs
+        : earliestExpirationDateMs;
+    },
+    null
+  );
+
+  // Credit-priced plans renew AWU allocations, not legacy USD free credits.
+  // Migrated workspaces can retain active `free-renewal-*` rows, so only use
+  // those rows as the renewal source while the workspace is on a legacy plan.
+  const freeCreditRenewalDateMs = isCreditPricedPlanPrefix(
+    auth.getNonNullablePlan().code
+  )
+    ? null
+    : recurringFreeCreditRenewalDateMs;
+
   const pendingCommittedCredits = credits.filter(
     (credit) =>
       credit.startDate === null &&
@@ -74,6 +107,7 @@ app.get("/", ensureIsAdmin(), async (ctx) => {
     credits: creditsData,
     pendingCredits:
       pendingCreditsData.length > 0 ? pendingCreditsData : undefined,
+    freeCreditRenewalDateMs: freeCreditRenewalDateMs ?? undefined,
   };
   return ctx.json(body);
 });

--- a/front/components/pages/workspace/developers/CreditsUsagePage.tsx
+++ b/front/components/pages/workspace/developers/CreditsUsagePage.tsx
@@ -88,6 +88,7 @@ interface UsageSectionProps {
   >;
   totalConsumed: number;
   totalCredits: number;
+  freeCreditRenewalDateMs: number | null;
   isLoading: boolean;
   setShowBuyCreditDialog: (show: boolean) => void;
 }
@@ -122,6 +123,7 @@ function UsageSection({
   creditsByType,
   totalConsumed,
   totalCredits,
+  freeCreditRenewalDateMs,
   isLoading,
   setShowBuyCreditDialog,
 }: UsageSectionProps) {
@@ -181,7 +183,7 @@ function UsageSection({
           consumed={creditsByType.free.consumed}
           total={creditsByType.free.total}
           renewalDate={formatRenewalDate(
-            billingCycle?.cycleEnd.getTime() ?? null
+            freeCreditRenewalDateMs ?? billingCycle?.cycleEnd.getTime() ?? null
           )}
         />
         <CreditCategoryBar
@@ -220,9 +222,8 @@ export function CreditsUsagePage() {
   const owner = useWorkspace();
   const { subscription } = useAuth();
   const [showBuyCreditDialog, setShowBuyCreditDialog] = useState(false);
-  const { credits, pendingCredits, isCreditsLoading } = useCredits({
-    workspaceId: owner.sId,
-  });
+  const { credits, pendingCredits, freeCreditRenewalDateMs, isCreditsLoading } =
+    useCredits({ workspaceId: owner.sId });
   const {
     isEnterprise,
     currency,
@@ -426,6 +427,7 @@ export function CreditsUsagePage() {
           creditsByType={creditsByType}
           totalConsumed={totalConsumed}
           totalCredits={totalCredits}
+          freeCreditRenewalDateMs={freeCreditRenewalDateMs}
           isLoading={isCreditsLoading || isCreditPurchaseInfoLoading}
           setShowBuyCreditDialog={setShowBuyCreditDialog}
         />

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -88,6 +88,7 @@ export function useCredits({
   return {
     credits: data?.credits ?? emptyArray(),
     pendingCredits,
+    freeCreditRenewalDateMs: data?.freeCreditRenewalDateMs ?? null,
     isCreditsLoading: !error && !data && !disabled,
     isCreditsValidating: isValidating,
     isCreditsError: error,

--- a/front/types/credits.ts
+++ b/front/types/credits.ts
@@ -105,4 +105,5 @@ export type PendingCreditData = {
 export type GetCreditsResponseBody = {
   credits: CreditDisplayData[];
   pendingCredits?: PendingCreditData[];
+  freeCreditRenewalDateMs?: number;
 };


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#9917.

Legacy programmatic-usage non-credit workspaces can receive recurring free credits on a different schedule from their subscription billing cycle.
In the example in the card, the UI showed the date for the billing cycle (based on the subscription start date) even though the active free-credit expired on a different day (confirmed in poke). IIUC the user has no way of actually knowing when the credits will be refilled, and they will randomly get back to full on one day that is different from the one in the UI.

This PR fixes that to show the appropriate date for non-credit based plans, keeping the same behavior for the ones that are on credits.

## Tests

- Tested locally with various plans.

## Risk

- Low.

## Deploy Plan

- Deploy front.
