### PR TITLE
[front] fix: use correct logger type in backfill script

### DIFF
--- a/front/migrations/20260805_find_pod_manager_conversations.ts
+++ b/front/migrations/20260805_find_pod_manager_conversations.ts
@@ -6,10 +6,10 @@ import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { isTextContent } from "@app/types/assistant/generation";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
-import type { Logger } from "pino";
 import { Op } from "sequelize";
 import { z } from "zod";
 


### PR DESCRIPTION
## Description

Fixes lint on main.

The pod manager conversation migration fails Front typechecking because it expects a raw `pino` logger, while `makeScript` provides the narrowed Dust application logger.

## Tests

## Risk

## Deploy Plan

- No deploy.
