### PR TITLE
Skills: correctly save the skill editors when creating a skill

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -164,7 +164,9 @@ export default function SkillBuilder({ skill, onSaved }: SkillBuilderProps) {
       formData: data,
       owner,
       skillId: skill?.sId,
-      currentEditors: editors,
+      // A skill being created already has its creator as editor by the time the editors request
+      // runs, so that is the baseline to diff the picked editors against.
+      currentEditors: isCreatingNew ? [user] : editors,
     });
 
     if (result.isErr()) {
@@ -177,20 +179,33 @@ export default function SkillBuilder({ skill, onSaved }: SkillBuilderProps) {
       return;
     }
 
-    sendNotification({
-      title: isCreatingNew ? "Skill created" : "Skill updated",
-      description: isCreatingNew
-        ? "Your skill has been successfully created."
-        : "Your skill has been successfully updated.",
-      type: "success",
-    });
+    const { skill: savedSkill, editorsError } = result.value;
 
-    await mutateEditors({ editors: data.editors }, { revalidate: false });
+    if (editorsError) {
+      // The skill itself was saved, so we keep going: only the editors list is out of date.
+      sendNotification({
+        title: isCreatingNew
+          ? "Skill created, but its editors were not saved"
+          : "Skill updated, but its editors were not saved",
+        description: editorsError.message,
+        type: "error",
+      });
+      await mutateEditors();
+    } else {
+      sendNotification({
+        title: isCreatingNew ? "Skill created" : "Skill updated",
+        description: isCreatingNew
+          ? "Your skill has been successfully created."
+          : "Your skill has been successfully updated.",
+        type: "success",
+      });
+      await mutateEditors({ editors: data.editors }, { revalidate: false });
+    }
 
     onSaved();
 
-    if (isCreatingNew && result.value.sId) {
-      const newUrl = `/w/${owner.sId}/builder/skills/${result.value.sId}`;
+    if (isCreatingNew && savedSkill.sId) {
+      const newUrl = `/w/${owner.sId}/builder/skills/${savedSkill.sId}`;
       await router.replace(newUrl, undefined, { shallow: true });
     } else {
       form.reset(form.getValues(), { keepValues: true });

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -9,6 +9,19 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightUserType, WorkspaceType } from "@app/types/user";
 
+type SubmittedSkill =
+  | PostSkillResponseBody["skill"]
+  | PatchSkillResponseBody["skill"];
+
+export interface SubmitSkillBuilderFormResult {
+  skill: SubmittedSkill;
+  /**
+   * Set when the skill itself was saved but its editors could not be. Reported apart from the
+   * `Err` channel so callers do not present a saved skill as a failed save.
+   */
+  editorsError: Error | null;
+}
+
 export async function submitSkillBuilderForm({
   formData,
   owner,
@@ -18,13 +31,12 @@ export async function submitSkillBuilderForm({
   formData: SkillBuilderFormData;
   owner: Pick<WorkspaceType, "sId">;
   skillId?: string;
+  /**
+   * The editors the skill has before this save. On create the server seeds the editors group with
+   * the creator alone, so callers pass the creator rather than an empty list.
+   */
   currentEditors?: LightUserType[];
-}): Promise<
-  Result<
-    PostSkillResponseBody["skill"] | PatchSkillResponseBody["skill"],
-    Error
-  >
-> {
+}): Promise<Result<SubmitSkillBuilderFormResult, Error>> {
   try {
     const endpoint = skillId
       ? `/api/w/${owner.sId}/skills/${skillId}`
@@ -75,56 +87,48 @@ export async function submitSkillBuilderForm({
 
     const { skill } = result;
 
-    // Only sync editors for existing skills (updates), not for newly created skills
-    // When creating a skill, the backend automatically adds the creator to the editors group
-    if (skillId) {
-      const desiredEditorIds = new Set(formData.editors.map((e) => e.sId));
-      const currentEditorIds = new Set(currentEditors.map((e) => e.sId));
+    // Editors live behind their own endpoint, so they need a second request whether we just created
+    // the skill or updated it. `skill.sId` is used rather than `skillId` so this also addresses a
+    // skill that did not exist a moment ago.
+    const desiredEditorIds = new Set(formData.editors.map((e) => e.sId));
+    const currentEditorIds = new Set(currentEditors.map((e) => e.sId));
 
-      const addEditorIds: string[] = [];
-      const removeEditorIds: string[] = [];
+    const addEditorIds = formData.editors
+      .filter((editor) => !currentEditorIds.has(editor.sId))
+      .map((editor) => editor.sId);
+    const removeEditorIds = currentEditors
+      .filter((editor) => !desiredEditorIds.has(editor.sId))
+      .map((editor) => editor.sId);
 
-      // Add editors who are in desired but not in current
-      for (const editor of formData.editors) {
-        if (!currentEditorIds.has(editor.sId)) {
-          addEditorIds.push(editor.sId);
-        }
-      }
-
-      // Remove editors who are in current but not in desired
-      for (const editor of currentEditors) {
-        if (!desiredEditorIds.has(editor.sId)) {
-          removeEditorIds.push(editor.sId);
-        }
-      }
-
-      if (addEditorIds.length > 0 || removeEditorIds.length > 0) {
-        const editorsResponse = await clientFetch(
-          `/api/w/${owner.sId}/skills/${skill.sId}/editors`,
-          {
-            method: "PATCH",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              addEditorIds,
-              removeEditorIds,
-            }),
-          }
-        );
-
-        if (!editorsResponse.ok) {
-          const errorData = await editorsResponse.json();
-          return new Err(
-            new Error(
-              errorData.error?.message ?? "Failed to update skill editors"
-            )
-          );
-        }
-      }
+    if (addEditorIds.length === 0 && removeEditorIds.length === 0) {
+      return new Ok({ skill, editorsError: null });
     }
 
-    return new Ok(skill);
+    const editorsResponse = await clientFetch(
+      `/api/w/${owner.sId}/skills/${skill.sId}/editors`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          addEditorIds,
+          removeEditorIds,
+        }),
+      }
+    );
+
+    if (!editorsResponse.ok) {
+      const errorData = await editorsResponse.json();
+      return new Ok({
+        skill,
+        editorsError: new Error(
+          errorData.error?.message ?? "Failed to update skill editors"
+        ),
+      });
+    }
+
+    return new Ok({ skill, editorsError: null });
   } catch (error) {
     const normalizedError = normalizeError(error);
     return new Err(


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/9884

Editors are updated in a second call after the skill is actually updated.
However, this second call was not done for newly created skill, losing the editors

This PR always saves the editors + propagate an error on editors save to the end user as a toast

## Tests

tested locally

## Risk

low, purely UI and easy to revert

## Deploy Plan

deploy front
