### PR TITLE
Centralize agent message billing calculations

### DIFF
--- a/front/lib/api/assistant/agent_message_consumption_attribution/attribution_builder.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/attribution_builder.ts
@@ -4,6 +4,7 @@
 // expected to sum to the billed amount. Their job is to rank what drove the cost, not to
 // reconcile euros.
 import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
+import { MICRO_CREDITS_PER_CREDIT } from "@app/lib/credits/units";
 import { MODEL_COST_MICRO_USD_PER_AWU_CREDIT } from "@app/lib/metronome/constants";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import assert from "assert";
@@ -15,8 +16,6 @@ import assert from "assert";
 // and results reach the outer model through their parent Computer action. Each version remains a
 // separate, self-consistent set of rows.
 export const AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION = 4;
-
-const CREDIT_AMOUNT_MICRO_PER_CREDIT = 1_000_000;
 
 export type RunUsageForAttribution = Pick<
   RunUsageType,
@@ -93,7 +92,7 @@ function assertValidRunUsage(usage: RunUsageForAttribution): void {
 /** Converts provider cost into millionths of a Dust credit. */
 function creditAmountMicroFromCostMicroUsd(costMicroUsd: number): number {
   return Math.round(
-    (costMicroUsd * CREDIT_AMOUNT_MICRO_PER_CREDIT) /
+    (costMicroUsd * MICRO_CREDITS_PER_CREDIT) /
       MODEL_COST_MICRO_USD_PER_AWU_CREDIT
   );
 }

--- a/front/lib/api/assistant/agent_message_consumption_attribution/message_details.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/message_details.ts
@@ -1,8 +1,8 @@
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import { getToolAggregateDisplayLabel } from "@app/lib/actions/tool_display_labels";
 import {
-  creditsToMicroCredits,
   microCreditsToCredits,
+  roundCreditsToMicroCredits,
 } from "@app/lib/credits/units";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -47,7 +47,7 @@ function reconcileInputCredits({
   items: AgentMessageConsumptionItemResource[];
   billedCredits: number;
 }): ReconciledCreditAmounts | null {
-  const billedCreditAmountMicro = creditsToMicroCredits(billedCredits);
+  const billedCreditAmountMicro = roundCreditsToMicroCredits(billedCredits);
   const inputItems = items.filter((item) => item.itemType === "input");
   const nonInputCreditAmountMicro = items.reduce(
     (total, item) =>

--- a/front/lib/api/assistant/agent_message_consumption_attribution/message_details.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/message_details.ts
@@ -1,5 +1,9 @@
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import { getToolAggregateDisplayLabel } from "@app/lib/actions/tool_display_labels";
+import {
+  creditsToMicroCredits,
+  microCreditsToCredits,
+} from "@app/lib/credits/units";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
@@ -14,16 +18,10 @@ import type {
 } from "@app/types/assistant/agent_message_consumption";
 import type { ModelId } from "@app/types/shared/model_id";
 
-const MICRO_CREDITS_PER_CREDIT = 1_000_000;
 const FIRST_ATTRIBUTION_VERSION_WITH_TOOL_ROWS = 2;
-
 export type MessageConsumptionDetails = AgentMessageConsumptionDetails & {
   models: AgentMessageConsumptionModelDetails[];
 };
-
-function creditsFromMicroCredits(microCredits: number): number {
-  return microCredits / MICRO_CREDITS_PER_CREDIT;
-}
 
 type ReconciledCreditAmounts = {
   byItem: ReadonlyMap<AgentMessageConsumptionItemResource, number>;
@@ -49,9 +47,7 @@ function reconcileInputCredits({
   items: AgentMessageConsumptionItemResource[];
   billedCredits: number;
 }): ReconciledCreditAmounts | null {
-  const billedCreditAmountMicro = Math.round(
-    billedCredits * MICRO_CREDITS_PER_CREDIT
-  );
+  const billedCreditAmountMicro = creditsToMicroCredits(billedCredits);
   const inputItems = items.filter((item) => item.itemType === "input");
   const nonInputCreditAmountMicro = items.reduce(
     (total, item) =>
@@ -149,7 +145,7 @@ function buildConsumptionTotals({
     0
   );
   return {
-    agentWorkCredits: creditsFromMicroCredits(
+    agentWorkCredits: microCreditsToCredits(
       reconciledAgentWorkCreditAmountMicro
     ),
   };
@@ -269,10 +265,10 @@ function buildToolDetails({
     const serialized = action.toJSON();
     const identity = toolIdentity(serialized);
     const current = groupedTools.get(identity);
-    const attributedCredits = creditsFromMicroCredits(
+    const attributedCredits = microCreditsToCredits(
       reconciledCreditAmounts.byItem.get(item) ?? 0
     );
-    const directCredits = creditsFromMicroCredits(
+    const directCredits = microCreditsToCredits(
       item.directCreditAmountMicro ?? 0
     );
 
@@ -330,7 +326,7 @@ function buildModelDetails({
     }
 
     const key = `${usage.providerId}:${usage.modelId}`;
-    const attributedCredits = creditsFromMicroCredits(
+    const attributedCredits = microCreditsToCredits(
       reconciledCreditAmounts.byItem.get(item) ?? 0
     );
     const existing = models.get(key);

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
@@ -7,7 +7,7 @@ import {
 } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
 import { measureToolCallFootprints } from "@app/lib/api/assistant/agent_message_consumption_attribution/tool_footprint";
 import type { Authenticator } from "@app/lib/auth";
-import { creditsToMicroCredits } from "@app/lib/credits/units";
+import { roundCreditsToMicroCredits } from "@app/lib/credits/units";
 import { toolAwuFromAction } from "@app/lib/metronome/events";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type {
@@ -246,7 +246,7 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
 
       // Zero for a denied call, which billing does not charge. Its emitted output tokens stay
       // attributed here.
-      const directCreditAmountMicro = creditsToMicroCredits(
+      const directCreditAmountMicro = roundCreditsToMicroCredits(
         toolAwuFromAction(
           {
             toolName: enrichedAction.toolName,
@@ -289,7 +289,7 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
         continue;
       }
 
-      const directCreditAmountMicro = creditsToMicroCredits(
+      const directCreditAmountMicro = roundCreditsToMicroCredits(
         toolAwuFromAction(
           {
             toolName: enrichedAction.toolName,

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
@@ -7,6 +7,7 @@ import {
 } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
 import { measureToolCallFootprints } from "@app/lib/api/assistant/agent_message_consumption_attribution/tool_footprint";
 import type { Authenticator } from "@app/lib/auth";
+import { creditsToMicroCredits } from "@app/lib/credits/units";
 import { toolAwuFromAction } from "@app/lib/metronome/events";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type {
@@ -20,10 +21,6 @@ import logger from "@app/logger/logger";
 import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import assert from "assert";
-
-// AWU (the credit unit tool charges are denominated in) expressed in micro-credits, matching how the
-// model token buckets store their attributed credits.
-const CREDIT_AMOUNT_MICRO_PER_CREDIT = 1_000_000;
 
 /**
  * Records the per-run consumption attribution breakdown for one settled agent message.
@@ -249,7 +246,7 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
 
       // Zero for a denied call, which billing does not charge. Its emitted output tokens stay
       // attributed here.
-      const directCreditAmountMicro = Math.round(
+      const directCreditAmountMicro = creditsToMicroCredits(
         toolAwuFromAction(
           {
             toolName: enrichedAction.toolName,
@@ -257,7 +254,7 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
             status: action.status,
           },
           triggeringUserMessageOrigin
-        ) * CREDIT_AMOUNT_MICRO_PER_CREDIT
+        )
       );
 
       const toolAttribution = buildToolAttribution({
@@ -292,7 +289,7 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
         continue;
       }
 
-      const directCreditAmountMicro = Math.round(
+      const directCreditAmountMicro = creditsToMicroCredits(
         toolAwuFromAction(
           {
             toolName: enrichedAction.toolName,
@@ -300,7 +297,7 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
             status: action.status,
           },
           triggeringUserMessageOrigin
-        ) * CREDIT_AMOUNT_MICRO_PER_CREDIT
+        )
       );
 
       records.push({

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -184,6 +184,8 @@ export function computeAgentMessageCredits({
     ({ disposition }) => disposition !== "unbillable_status"
   );
 
+  // A free tool or free-origin action is still tracked with a zero charge. Only
+  // actions that never reached execution are treated as no billable activity.
   if (runUsages.length === 0 && !hasBillableAction) {
     return null;
   }

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -181,7 +181,7 @@ export function computeAgentMessageCredits({
     runUsages,
   });
   const hasBillableAction = billingPlan.tools.some(
-    ({ disposition }) => disposition !== "unbillable_status"
+    ({ billingDisposition }) => billingDisposition !== "unbillable_status"
   );
 
   // A free tool or free-origin action is still tracked with a zero charge. Only

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -10,12 +10,11 @@ import { recordUserSpendLimitUsage } from "@app/lib/api/users/spend_limit";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import {
+  buildAgentMessageBillingPlan,
   computeRunKey,
   getToolBillingInfo,
-  getUsageType,
-  intelligenceAwuFromRunUsagesGroupedByRunKey,
-  toolAwuFromActions,
-} from "@app/lib/metronome/events";
+} from "@app/lib/credits/agent_message_billing";
+import { getUsageType } from "@app/lib/metronome/events";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
@@ -176,23 +175,20 @@ export function computeAgentMessageCredits({
   actions: CreditActionMinimalInput[];
   contextOrigin: UserMessageOrigin | null;
 }): number | null {
-  // Unbillable actions already price at 0 through toolAwuFromAction. Filtering them here settles
-  // the other question, whether the message has anything to bill at all.
-  const billableActions = actions.filter((a) =>
-    isToolExecutionStatusBillable(a.status)
+  const billingPlan = buildAgentMessageBillingPlan({
+    actions,
+    contextOrigin,
+    runUsages,
+  });
+  const hasBillableAction = billingPlan.tools.some(
+    ({ disposition }) => disposition !== "unbillable_status"
   );
 
-  if (runUsages.length === 0 && billableActions.length === 0) {
+  if (runUsages.length === 0 && !hasBillableAction) {
     return null;
   }
 
-  // Intelligence cost is ceiled per agent-loop execution (runKey) to match the
-  // per-execution Metronome events. Tool cost has no ceiling (fixed 1/3 per
-  // action), so it is grouping-invariant and stays message-level.
-  return (
-    intelligenceAwuFromRunUsagesGroupedByRunKey(runUsages, contextOrigin) +
-    toolAwuFromActions(billableActions, contextOrigin)
-  );
+  return billingPlan.totals.billedCredits;
 }
 
 /**

--- a/front/lib/credits/agent_message_billing.test.ts
+++ b/front/lib/credits/agent_message_billing.test.ts
@@ -1,0 +1,221 @@
+import {
+  type AgentMessageBillingRunUsage,
+  buildAgentMessageBillingPlan,
+} from "@app/lib/credits/agent_message_billing";
+import { describe, expect, it } from "vitest";
+
+function usage(
+  overrides: Partial<AgentMessageBillingRunUsage>
+): AgentMessageBillingRunUsage {
+  return {
+    completionTokens: 0,
+    reasoningTokens: null,
+    promptTokens: 0,
+    cachedTokens: 0,
+    cacheCreationTokens: 0,
+    costMicroUsd: 0,
+    modelId: "gpt-4o",
+    providerId: "openai",
+    isBatch: false,
+    runKey: null,
+    ...overrides,
+  };
+}
+
+describe("buildAgentMessageBillingPlan", () => {
+  it("groups LLM usage by execution and model and exposes deterministic allocations", () => {
+    const smallerUsage = usage({ costMicroUsd: 1, runKey: "exec1" });
+    const largerUsage = usage({ costMicroUsd: 2, runKey: "exec1" });
+    const otherExecutionUsage = usage({ costMicroUsd: 1, runKey: "exec2" });
+    const otherModelUsage = usage({
+      costMicroUsd: 1,
+      modelId: "claude-opus-4-8",
+      providerId: "anthropic",
+      runKey: "exec1",
+    });
+
+    const plan = buildAgentMessageBillingPlan({
+      actions: [],
+      contextOrigin: "api",
+      getUsageAllocationKey: (runUsage) =>
+        runUsage === smallerUsage ? "smaller" : "larger",
+      runUsages: [
+        smallerUsage,
+        largerUsage,
+        otherExecutionUsage,
+        otherModelUsage,
+      ],
+    });
+
+    expect(plan.totals).toEqual({
+      llmBilledCredits: 3,
+      toolBilledCredits: 0,
+      billedCredits: 3,
+    });
+    expect(plan.llm).toHaveLength(3);
+    expect(plan.llm[0]?.usageAllocations).toEqual([
+      { usage: smallerUsage, allocatedBilledCreditMicro: 333_333 },
+      { usage: largerUsage, allocatedBilledCreditMicro: 666_667 },
+    ]);
+  });
+
+  it("allocates rounding remainders by stable key instead of input order", () => {
+    const usages = [
+      { ...usage({ costMicroUsd: 1, runKey: "exec1" }), allocationKey: "b" },
+      { ...usage({ costMicroUsd: 1, runKey: "exec1" }), allocationKey: "a" },
+      { ...usage({ costMicroUsd: 1, runKey: "exec1" }), allocationKey: "c" },
+    ];
+    const allocations = (input: typeof usages) => {
+      const plan = buildAgentMessageBillingPlan({
+        actions: [],
+        contextOrigin: "api",
+        getUsageAllocationKey: (runUsage) => runUsage.allocationKey,
+        runUsages: input,
+      });
+
+      return new Map(
+        plan.llm[0]?.usageAllocations?.map(
+          ({ usage: runUsage, allocatedBilledCreditMicro }) => [
+            runUsage.allocationKey,
+            allocatedBilledCreditMicro,
+          ]
+        )
+      );
+    };
+
+    expect(allocations(usages)).toEqual(
+      new Map([
+        ["a", 333_334],
+        ["b", 333_333],
+        ["c", 333_333],
+      ])
+    );
+    expect(allocations([...usages].reverse())).toEqual(allocations(usages));
+  });
+
+  it("rejects duplicate allocation keys", () => {
+    const repeatedUsage = usage({ costMicroUsd: 1, runKey: "exec1" });
+
+    expect(() =>
+      buildAgentMessageBillingPlan({
+        actions: [],
+        contextOrigin: "api",
+        getUsageAllocationKey: () => "same",
+        runUsages: [repeatedUsage, repeatedUsage, repeatedUsage],
+      })
+    ).toThrow("Usage allocation keys must be unique within a billing group.");
+  });
+
+  it.each([
+    { costMicroUsd: 8_499, expectedCredits: 1 },
+    { costMicroUsd: 8_500, expectedCredits: 1 },
+    { costMicroUsd: 8_501, expectedCredits: 2 },
+  ])("rounds $costMicroUsd micro-dollars to $expectedCredits credit(s)", ({
+    costMicroUsd,
+    expectedCredits,
+  }) => {
+    const plan = buildAgentMessageBillingPlan({
+      actions: [],
+      contextOrigin: "api",
+      runUsages: [usage({ costMicroUsd, runKey: "exec1" })],
+    });
+
+    expect(plan.totals.llmBilledCredits).toBe(expectedCredits);
+  });
+
+  it("prices tools and returns one total across LLM and tools", () => {
+    const plan = buildAgentMessageBillingPlan({
+      actions: [
+        {
+          toolName: "websearch",
+          internalMCPServerName: "web_search_&_browse",
+          status: "succeeded",
+        },
+        {
+          toolName: "custom_tool",
+          internalMCPServerName: null,
+          status: "succeeded",
+        },
+        {
+          toolName: "custom_tool",
+          internalMCPServerName: null,
+          status: "denied",
+        },
+      ],
+      contextOrigin: "web",
+      runUsages: [usage({ costMicroUsd: 1, runKey: "exec1" })],
+    });
+
+    expect(plan.tools.map(({ billedCredits }) => billedCredits)).toEqual([
+      1, 3, 0,
+    ]);
+    expect(plan.tools.map(({ disposition }) => disposition)).toEqual([
+      "billed",
+      "billed",
+      "unbillable_status",
+    ]);
+    expect(plan.totals).toEqual({
+      llmBilledCredits: 1,
+      toolBilledCredits: 4,
+      billedCredits: 5,
+    });
+  });
+
+  it("keeps metered usage while making free-origin billing zero", () => {
+    const plan = buildAgentMessageBillingPlan({
+      actions: [
+        {
+          toolName: "custom_tool",
+          internalMCPServerName: null,
+          status: "succeeded",
+        },
+      ],
+      contextOrigin: "agent_sidekick",
+      runUsages: [usage({ costMicroUsd: 1, runKey: "exec1" })],
+    });
+
+    expect(plan.llm[0]).toMatchObject({
+      ratedCredits: 1,
+      billedCredits: 0,
+      disposition: "free_origin",
+    });
+    expect(plan.tools[0]).toMatchObject({
+      ratedCredits: 3,
+      billedCredits: 0,
+      disposition: "free_origin",
+    });
+    expect(plan.totals.billedCredits).toBe(0);
+  });
+
+  it("distinguishes free tools from unbillable statuses", () => {
+    const plan = buildAgentMessageBillingPlan({
+      actions: [
+        {
+          toolName: "create_recommendation",
+          internalMCPServerName: "activation_recommendations",
+          status: "succeeded",
+        },
+        {
+          toolName: "custom_tool",
+          internalMCPServerName: null,
+          status: "denied",
+        },
+      ],
+      contextOrigin: "web",
+      runUsages: [],
+    });
+
+    expect(plan.tools).toEqual([
+      expect.objectContaining({
+        ratedCredits: 1,
+        billedCredits: 0,
+        disposition: "free_tool",
+      }),
+      expect.objectContaining({
+        ratedCredits: 3,
+        billedCredits: 0,
+        disposition: "unbillable_status",
+      }),
+    ]);
+  });
+});

--- a/front/lib/credits/agent_message_billing.test.ts
+++ b/front/lib/credits/agent_message_billing.test.ts
@@ -149,11 +149,9 @@ describe("buildAgentMessageBillingPlan", () => {
     expect(plan.tools.map(({ billedCredits }) => billedCredits)).toEqual([
       1, 3, 0,
     ]);
-    expect(plan.tools.map(({ disposition }) => disposition)).toEqual([
-      "billed",
-      "billed",
-      "unbillable_status",
-    ]);
+    expect(
+      plan.tools.map(({ billingDisposition }) => billingDisposition)
+    ).toEqual(["billed", "billed", "unbillable_status"]);
     expect(plan.totals).toEqual({
       llmBilledCredits: 1,
       toolBilledCredits: 4,
@@ -177,12 +175,12 @@ describe("buildAgentMessageBillingPlan", () => {
     expect(plan.llm[0]).toMatchObject({
       ratedCredits: 1,
       billedCredits: 0,
-      disposition: "free_origin",
+      billingDisposition: "free_origin",
     });
     expect(plan.tools[0]).toMatchObject({
       ratedCredits: 3,
       billedCredits: 0,
-      disposition: "free_origin",
+      billingDisposition: "free_origin",
     });
     expect(plan.totals.billedCredits).toBe(0);
   });
@@ -209,12 +207,12 @@ describe("buildAgentMessageBillingPlan", () => {
       expect.objectContaining({
         ratedCredits: 1,
         billedCredits: 0,
-        disposition: "free_tool",
+        billingDisposition: "free_tool",
       }),
       expect.objectContaining({
         ratedCredits: 3,
         billedCredits: 0,
-        disposition: "unbillable_status",
+        billingDisposition: "unbillable_status",
       }),
     ]);
   });

--- a/front/lib/credits/agent_message_billing.ts
+++ b/front/lib/credits/agent_message_billing.ts
@@ -8,14 +8,13 @@ import {
   type ToolExecutionStatus,
 } from "@app/lib/actions/statuses";
 import { TOOL_COST_CATEGORIES, type ToolCostCategory } from "@app/lib/api/mcp";
+import { creditsToMicroCredits } from "@app/lib/credits/units";
 import { MODEL_COST_MICRO_USD_PER_AWU_CREDIT } from "@app/lib/metronome/constants";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { createHash } from "crypto";
 
 export { TOOL_COST_CATEGORIES, type ToolCostCategory } from "@app/lib/api/mcp";
-
-const MICRO_CREDITS_PER_CREDIT = 1_000_000;
 
 // Historical and non-agent-loop usages may not have a run key. Keep them in one
 // group to preserve the former message-level rounding behavior for those rows.
@@ -160,7 +159,7 @@ function allocateBilledCreditMicro<TUsage extends AgentMessageBillingRunUsage>({
   providerCostMicroUsd: number;
   usages: TUsage[];
 }): AgentMessageLlmBillingLine<TUsage>["usageAllocations"] {
-  const billedCreditMicro = billedCredits * MICRO_CREDITS_PER_CREDIT;
+  const billedCreditMicro = creditsToMicroCredits(billedCredits);
   if (providerCostMicroUsd === 0) {
     return usages.map((usage) => ({
       usage,

--- a/front/lib/credits/agent_message_billing.ts
+++ b/front/lib/credits/agent_message_billing.ts
@@ -49,10 +49,17 @@ export type AgentMessageBillingAction = {
   toolName: string;
 };
 
+/** Explains how the rated credits were treated by the billing rules. */
+export type AgentMessageLlmBillingDisposition = "billed" | "free_origin";
+
+export type AgentMessageToolBillingDisposition =
+  | AgentMessageLlmBillingDisposition
+  | "free_tool"
+  | "unbillable_status";
+
 export type AgentMessageLlmBillingLine<
   TUsage extends AgentMessageBillingRunUsage,
 > = {
-  billingGroupKey: string;
   runKey: string;
   providerId: TUsage["providerId"];
   modelId: TUsage["modelId"];
@@ -63,7 +70,7 @@ export type AgentMessageLlmBillingLine<
   providerCostMicroUsd: number;
   ratedCredits: number;
   billedCredits: number;
-  disposition: "billed" | "free_origin";
+  billingDisposition: AgentMessageLlmBillingDisposition;
   usageAllocations: Array<{
     usage: TUsage;
     allocatedBilledCreditMicro: number;
@@ -75,10 +82,9 @@ export type AgentMessageToolBillingLine<
 > = {
   action: TAction;
   toolCostCategory: ToolCostCategory;
-  freeUsage: boolean;
   ratedCredits: number;
   billedCredits: number;
-  disposition: "billed" | "free_origin" | "free_tool" | "unbillable_status";
+  billingDisposition: AgentMessageToolBillingDisposition;
 };
 
 export type AgentMessageBillingPlan<
@@ -236,7 +242,6 @@ export function buildAgentMessageBillingPlan<
   const usagesByBillingGroup = new Map<
     string,
     {
-      billingGroupKey: string;
       runKey: string;
       providerId: TUsage["providerId"];
       modelId: TUsage["modelId"];
@@ -252,7 +257,6 @@ export function buildAgentMessageBillingPlan<
       group.usages.push(usage);
     } else {
       usagesByBillingGroup.set(billingGroupKey, {
-        billingGroupKey,
         runKey,
         providerId: usage.providerId,
         modelId: usage.modelId,
@@ -262,7 +266,7 @@ export function buildAgentMessageBillingPlan<
   }
 
   const llm = [...usagesByBillingGroup.values()].map(
-    ({ billingGroupKey, runKey, providerId, modelId, usages }) => {
+    ({ runKey, providerId, modelId, usages }) => {
       const promptTokensCount = usages.reduce(
         (total, usage) => total + usage.promptTokens,
         0
@@ -285,11 +289,10 @@ export function buildAgentMessageBillingPlan<
       );
       const ratedCredits = awuFromMicroUsd(providerCostMicroUsd);
       const billedCredits = isMessageFree ? 0 : ratedCredits;
-      const disposition: AgentMessageLlmBillingLine<TUsage>["disposition"] =
+      const billingDisposition: AgentMessageLlmBillingDisposition =
         isMessageFree ? "free_origin" : "billed";
 
       return {
-        billingGroupKey,
         runKey,
         providerId,
         modelId,
@@ -300,7 +303,7 @@ export function buildAgentMessageBillingPlan<
         providerCostMicroUsd,
         ratedCredits,
         billedCredits,
-        disposition,
+        billingDisposition,
         usageAllocations: getUsageAllocationKey
           ? allocateBilledCreditMicro({
               billedCredits,
@@ -318,7 +321,7 @@ export function buildAgentMessageBillingPlan<
       action.internalMCPServerName,
       action.toolName
     );
-    const disposition: AgentMessageToolBillingLine<TAction>["disposition"] =
+    const billingDisposition: AgentMessageToolBillingDisposition =
       !isToolExecutionStatusBillable(action.status)
         ? "unbillable_status"
         : isMessageFree
@@ -327,15 +330,14 @@ export function buildAgentMessageBillingPlan<
             ? "free_tool"
             : "billed";
     const ratedCredits = TOOL_COST_CATEGORY_AWU_WEIGHTS[toolCostCategory];
-    const billedCredits = disposition === "billed" ? ratedCredits : 0;
+    const billedCredits = billingDisposition === "billed" ? ratedCredits : 0;
 
     return {
       action,
       toolCostCategory,
-      freeUsage,
       ratedCredits,
       billedCredits,
-      disposition,
+      billingDisposition,
     };
   });
 

--- a/front/lib/credits/agent_message_billing.ts
+++ b/front/lib/credits/agent_message_billing.ts
@@ -248,9 +248,6 @@ export function buildAgentMessageBillingPlan<
     }
   >();
 
-  // This key is the billing and rounding boundary, not merely an aggregation
-  // convenience. Removing runKey would round at the message level; removing
-  // provider/model would round unlike Metronome's separately priced events.
   for (const usage of runUsages) {
     const runKey = usage.runKey ?? LEGACY_RUN_KEY;
     const billingGroupKey = `${runKey}|${usage.providerId}|${usage.modelId}`;
@@ -323,8 +320,6 @@ export function buildAgentMessageBillingPlan<
       action.internalMCPServerName,
       action.toolName
     );
-    // Status has precedence so an action that never became billable is omitted
-    // from Metronome even when its origin or tool would otherwise be free.
     const billingDisposition: AgentMessageToolBillingDisposition =
       !isToolExecutionStatusBillable(action.status)
         ? "unbillable_status"

--- a/front/lib/credits/agent_message_billing.ts
+++ b/front/lib/credits/agent_message_billing.ts
@@ -8,7 +8,7 @@ import {
   type ToolExecutionStatus,
 } from "@app/lib/actions/statuses";
 import { TOOL_COST_CATEGORIES, type ToolCostCategory } from "@app/lib/api/mcp";
-import { creditsToMicroCredits } from "@app/lib/credits/units";
+import { roundCreditsToMicroCredits } from "@app/lib/credits/units";
 import { MODEL_COST_MICRO_USD_PER_AWU_CREDIT } from "@app/lib/metronome/constants";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
@@ -159,7 +159,7 @@ function allocateBilledCreditMicro<TUsage extends AgentMessageBillingRunUsage>({
   providerCostMicroUsd: number;
   usages: TUsage[];
 }): AgentMessageLlmBillingLine<TUsage>["usageAllocations"] {
-  const billedCreditMicro = creditsToMicroCredits(billedCredits);
+  const billedCreditMicro = roundCreditsToMicroCredits(billedCredits);
   if (providerCostMicroUsd === 0) {
     return usages.map((usage) => ({
       usage,
@@ -210,6 +210,27 @@ function allocateBilledCreditMicro<TUsage extends AgentMessageBillingRunUsage>({
       floorCreditMicro +
       (allocationKeysReceivingRemainder.has(allocationKey) ? 1 : 0),
   }));
+}
+
+function resolveToolBillingDisposition({
+  freeUsage,
+  isMessageFree,
+  status,
+}: {
+  freeUsage: boolean;
+  isMessageFree: boolean;
+  status: ToolExecutionStatus;
+}): AgentMessageToolBillingDisposition {
+  if (!isToolExecutionStatusBillable(status)) {
+    return "unbillable_status";
+  }
+  if (isMessageFree) {
+    return "free_origin";
+  }
+  if (freeUsage) {
+    return "free_tool";
+  }
+  return "billed";
 }
 
 /**
@@ -320,14 +341,11 @@ export function buildAgentMessageBillingPlan<
       action.internalMCPServerName,
       action.toolName
     );
-    const billingDisposition: AgentMessageToolBillingDisposition =
-      !isToolExecutionStatusBillable(action.status)
-        ? "unbillable_status"
-        : isMessageFree
-          ? "free_origin"
-          : freeUsage
-            ? "free_tool"
-            : "billed";
+    const billingDisposition = resolveToolBillingDisposition({
+      freeUsage,
+      isMessageFree,
+      status: action.status,
+    });
     const ratedCredits = TOOL_COST_CATEGORY_AWU_WEIGHTS[toolCostCategory];
     const billedCredits = billingDisposition === "billed" ? ratedCredits : 0;
 

--- a/front/lib/credits/agent_message_billing.ts
+++ b/front/lib/credits/agent_message_billing.ts
@@ -1,0 +1,340 @@
+import {
+  getInternalMCPServerMetadata,
+  type InternalMCPServerNameType,
+  isInternalMCPServerName,
+} from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  isToolExecutionStatusBillable,
+  type ToolExecutionStatus,
+} from "@app/lib/actions/statuses";
+import { TOOL_COST_CATEGORIES, type ToolCostCategory } from "@app/lib/api/mcp";
+import { MODEL_COST_MICRO_USD_PER_AWU_CREDIT } from "@app/lib/metronome/constants";
+import type { RunUsageType } from "@app/lib/resources/run_resource";
+import type { UserMessageOrigin } from "@app/types/assistant/conversation";
+import { createHash } from "crypto";
+
+export { TOOL_COST_CATEGORIES, type ToolCostCategory } from "@app/lib/api/mcp";
+
+const MICRO_CREDITS_PER_CREDIT = 1_000_000;
+
+export const LEGACY_RUN_KEY = "__legacy__";
+
+export const FREE_ORIGINS: ReadonlySet<UserMessageOrigin> =
+  new Set<UserMessageOrigin>([
+    "agent_sidekick",
+    // Only the Activation Pod nudge ever carries this origin: it is server-only,
+    // and the nudge has no author so it can neither be edited nor retried. User
+    // replies come back as `web` and bill normally.
+    "system_activation",
+  ]);
+
+export const TOOL_COST_CATEGORY_AWU_WEIGHTS: Record<ToolCostCategory, number> =
+  {
+    basic: 1,
+    advanced: 3,
+  };
+
+export type AgentMessageBillingRunUsage = RunUsageType & {
+  runKey: string | null;
+};
+
+export type AgentMessageBillingAction = {
+  internalMCPServerName: InternalMCPServerNameType | null;
+  status: ToolExecutionStatus;
+  toolName: string;
+};
+
+export type AgentMessageLlmBillingLine<
+  TUsage extends AgentMessageBillingRunUsage,
+> = {
+  billingGroupKey: string;
+  runKey: string;
+  providerId: TUsage["providerId"];
+  modelId: TUsage["modelId"];
+  promptTokensCount: number;
+  completionTokensCount: number;
+  cachedTokensCount: number;
+  cacheCreationTokensCount: number;
+  providerCostMicroUsd: number;
+  ratedCredits: number;
+  billedCredits: number;
+  disposition: "billed" | "free_origin";
+  usageAllocations: Array<{
+    usage: TUsage;
+    allocatedBilledCreditMicro: number;
+  }> | null;
+};
+
+export type AgentMessageToolBillingLine<
+  TAction extends AgentMessageBillingAction,
+> = {
+  action: TAction;
+  toolCostCategory: ToolCostCategory;
+  freeUsage: boolean;
+  ratedCredits: number;
+  billedCredits: number;
+  disposition: "billed" | "free_origin" | "free_tool" | "unbillable_status";
+};
+
+export type AgentMessageBillingPlan<
+  TUsage extends AgentMessageBillingRunUsage,
+  TAction extends AgentMessageBillingAction,
+> = {
+  llm: AgentMessageLlmBillingLine<TUsage>[];
+  tools: AgentMessageToolBillingLine<TAction>[];
+  totals: {
+    llmBilledCredits: number;
+    toolBilledCredits: number;
+    billedCredits: number;
+  };
+};
+
+export function isFreeOrigin(origin: UserMessageOrigin | null): boolean {
+  return origin !== null && FREE_ORIGINS.has(origin);
+}
+
+export function computeRunKey(dustRunIds: string[]): string {
+  return createHash("sha256")
+    .update([...dustRunIds].sort().join(","))
+    .digest("hex")
+    .slice(0, 8);
+}
+
+export function awuFromMicroUsd(microUsd: number): number {
+  return Math.ceil(microUsd / MODEL_COST_MICRO_USD_PER_AWU_CREDIT);
+}
+
+export function isToolCostCategory(value: string): value is ToolCostCategory {
+  return TOOL_COST_CATEGORIES.some((category) => category === value);
+}
+
+export function getToolBillingInfo(
+  serverName: string | null,
+  toolName: string
+): { toolCostCategory: ToolCostCategory; freeUsage: boolean } {
+  if (!serverName || !isInternalMCPServerName(serverName)) {
+    return { toolCostCategory: "advanced", freeUsage: false };
+  }
+
+  const metadata = getInternalMCPServerMetadata(serverName);
+  const tool = metadata.tools.find((candidate) => candidate.name === toolName);
+  if (!tool) {
+    return { toolCostCategory: "advanced", freeUsage: false };
+  }
+
+  return {
+    toolCostCategory: tool.toolCostCategory,
+    freeUsage: tool.freeUsage,
+  };
+}
+
+function allocateBilledCreditMicro<TUsage extends AgentMessageBillingRunUsage>({
+  billedCredits,
+  getUsageAllocationKey,
+  providerCostMicroUsd,
+  usages,
+}: {
+  billedCredits: number;
+  getUsageAllocationKey: (usage: TUsage) => string;
+  providerCostMicroUsd: number;
+  usages: TUsage[];
+}): AgentMessageLlmBillingLine<TUsage>["usageAllocations"] {
+  const billedCreditMicro = billedCredits * MICRO_CREDITS_PER_CREDIT;
+  if (providerCostMicroUsd === 0) {
+    return usages.map((usage) => ({
+      usage,
+      allocatedBilledCreditMicro: 0,
+    }));
+  }
+
+  const allocations = usages.map((usage) => {
+    const allocationKey = getUsageAllocationKey(usage);
+    const exactCreditMicro =
+      (usage.costMicroUsd / providerCostMicroUsd) * billedCreditMicro;
+    const floorCreditMicro = Math.floor(exactCreditMicro);
+
+    return {
+      usage,
+      allocationKey,
+      floorCreditMicro,
+      fractionalCreditMicro: exactCreditMicro - floorCreditMicro,
+    };
+  });
+  if (
+    new Set(allocations.map(({ allocationKey }) => allocationKey)).size !==
+    allocations.length
+  ) {
+    throw new Error(
+      "Usage allocation keys must be unique within a billing group."
+    );
+  }
+  const allocatedFloorCreditMicro = allocations.reduce(
+    (total, allocation) => total + allocation.floorCreditMicro,
+    0
+  );
+  const remainderCreditMicro = billedCreditMicro - allocatedFloorCreditMicro;
+  const allocationKeysReceivingRemainder = new Set(
+    [...allocations]
+      .sort(
+        (left, right) =>
+          right.fractionalCreditMicro - left.fractionalCreditMicro ||
+          (left.allocationKey < right.allocationKey ? -1 : 1)
+      )
+      .slice(0, remainderCreditMicro)
+      .map(({ allocationKey }) => allocationKey)
+  );
+
+  return allocations.map(({ usage, allocationKey, floorCreditMicro }) => ({
+    usage,
+    allocatedBilledCreditMicro:
+      floorCreditMicro +
+      (allocationKeysReceivingRemainder.has(allocationKey) ? 1 : 0),
+  }));
+}
+
+/**
+ * Produces the canonical billing plan for one agent message.
+ *
+ * LLM usage is billed once per (execution, provider, model). Tool actions are billed independently.
+ * Callers should project this plan instead of rebuilding grouping, free-usage, rounding, or tool-pricing rules.
+ */
+export function buildAgentMessageBillingPlan<
+  TUsage extends AgentMessageBillingRunUsage,
+  TAction extends AgentMessageBillingAction,
+>({
+  actions,
+  contextOrigin,
+  getUsageAllocationKey,
+  runUsages,
+}: {
+  actions: TAction[];
+  contextOrigin: UserMessageOrigin | null;
+  getUsageAllocationKey?: (usage: TUsage) => string;
+  runUsages: TUsage[];
+}): AgentMessageBillingPlan<TUsage, TAction> {
+  const isMessageFree = isFreeOrigin(contextOrigin);
+  const usagesByBillingGroup = new Map<
+    string,
+    {
+      billingGroupKey: string;
+      runKey: string;
+      providerId: TUsage["providerId"];
+      modelId: TUsage["modelId"];
+      usages: TUsage[];
+    }
+  >();
+
+  for (const usage of runUsages) {
+    const runKey = usage.runKey ?? LEGACY_RUN_KEY;
+    const billingGroupKey = `${runKey}|${usage.providerId}|${usage.modelId}`;
+    const group = usagesByBillingGroup.get(billingGroupKey);
+    if (group) {
+      group.usages.push(usage);
+    } else {
+      usagesByBillingGroup.set(billingGroupKey, {
+        billingGroupKey,
+        runKey,
+        providerId: usage.providerId,
+        modelId: usage.modelId,
+        usages: [usage],
+      });
+    }
+  }
+
+  const llm = [...usagesByBillingGroup.values()].map(
+    ({ billingGroupKey, runKey, providerId, modelId, usages }) => {
+      const promptTokensCount = usages.reduce(
+        (total, usage) => total + usage.promptTokens,
+        0
+      );
+      const completionTokensCount = usages.reduce(
+        (total, usage) => total + usage.completionTokens,
+        0
+      );
+      const cachedTokensCount = usages.reduce(
+        (total, usage) => total + (usage.cachedTokens ?? 0),
+        0
+      );
+      const cacheCreationTokensCount = usages.reduce(
+        (total, usage) => total + (usage.cacheCreationTokens ?? 0),
+        0
+      );
+      const providerCostMicroUsd = usages.reduce(
+        (total, usage) => total + usage.costMicroUsd,
+        0
+      );
+      const ratedCredits = awuFromMicroUsd(providerCostMicroUsd);
+      const billedCredits = isMessageFree ? 0 : ratedCredits;
+      const disposition: AgentMessageLlmBillingLine<TUsage>["disposition"] =
+        isMessageFree ? "free_origin" : "billed";
+
+      return {
+        billingGroupKey,
+        runKey,
+        providerId,
+        modelId,
+        promptTokensCount,
+        completionTokensCount,
+        cachedTokensCount,
+        cacheCreationTokensCount,
+        providerCostMicroUsd,
+        ratedCredits,
+        billedCredits,
+        disposition,
+        usageAllocations: getUsageAllocationKey
+          ? allocateBilledCreditMicro({
+              billedCredits,
+              getUsageAllocationKey,
+              providerCostMicroUsd,
+              usages,
+            })
+          : null,
+      };
+    }
+  );
+
+  const tools = actions.map((action) => {
+    const { toolCostCategory, freeUsage } = getToolBillingInfo(
+      action.internalMCPServerName,
+      action.toolName
+    );
+    const disposition: AgentMessageToolBillingLine<TAction>["disposition"] =
+      !isToolExecutionStatusBillable(action.status)
+        ? "unbillable_status"
+        : isMessageFree
+          ? "free_origin"
+          : freeUsage
+            ? "free_tool"
+            : "billed";
+    const ratedCredits = TOOL_COST_CATEGORY_AWU_WEIGHTS[toolCostCategory];
+    const billedCredits = disposition === "billed" ? ratedCredits : 0;
+
+    return {
+      action,
+      toolCostCategory,
+      freeUsage,
+      ratedCredits,
+      billedCredits,
+      disposition,
+    };
+  });
+
+  const llmBilledCredits = llm.reduce(
+    (total, line) => total + line.billedCredits,
+    0
+  );
+  const toolBilledCredits = tools.reduce(
+    (total, line) => total + line.billedCredits,
+    0
+  );
+
+  return {
+    llm,
+    tools,
+    totals: {
+      llmBilledCredits,
+      toolBilledCredits,
+      billedCredits: llmBilledCredits + toolBilledCredits,
+    },
+  };
+}

--- a/front/lib/credits/agent_message_billing.ts
+++ b/front/lib/credits/agent_message_billing.ts
@@ -17,8 +17,11 @@ export { TOOL_COST_CATEGORIES, type ToolCostCategory } from "@app/lib/api/mcp";
 
 const MICRO_CREDITS_PER_CREDIT = 1_000_000;
 
+// Historical and non-agent-loop usages may not have a run key. Keep them in one
+// group to preserve the former message-level rounding behavior for those rows.
 export const LEGACY_RUN_KEY = "__legacy__";
 
+// Platform-assistive messages are metered for observability but not billed.
 export const FREE_ORIGINS: ReadonlySet<UserMessageOrigin> =
   new Set<UserMessageOrigin>([
     "agent_sidekick",
@@ -28,6 +31,8 @@ export const FREE_ORIGINS: ReadonlySet<UserMessageOrigin> =
     "system_activation",
   ]);
 
+// Canonical tool prices used by runtime billing and Metronome rate-card setup.
+// A tool's `freeUsage` metadata can waive this rated price.
 export const TOOL_COST_CATEGORY_AWU_WEIGHTS: Record<ToolCostCategory, number> =
   {
     basic: 1,
@@ -93,6 +98,9 @@ export function isFreeOrigin(origin: UserMessageOrigin | null): boolean {
   return origin !== null && FREE_ORIGINS.has(origin);
 }
 
+// A run key identifies one agent-loop execution. Retries with the same run IDs
+// deduplicate in Metronome, while interrupt/resume executions receive distinct
+// keys and are consequently rounded and billed independently.
 export function computeRunKey(dustRunIds: string[]): string {
   return createHash("sha256")
     .update([...dustRunIds].sort().join(","))
@@ -100,6 +108,8 @@ export function computeRunKey(dustRunIds: string[]): string {
     .slice(0, 8);
 }
 
+// Convert provider cost in micro-USD to credits, rounding up exactly as the
+// Metronome event does (1 credit = $0.0085).
 export function awuFromMicroUsd(microUsd: number): number {
   return Math.ceil(microUsd / MODEL_COST_MICRO_USD_PER_AWU_CREDIT);
 }
@@ -112,12 +122,14 @@ export function getToolBillingInfo(
   serverName: string | null,
   toolName: string
 ): { toolCostCategory: ToolCostCategory; freeUsage: boolean } {
+  // External servers default to the paid advanced category.
   if (!serverName || !isInternalMCPServerName(serverName)) {
     return { toolCostCategory: "advanced", freeUsage: false };
   }
 
   const metadata = getInternalMCPServerMetadata(serverName);
   const tool = metadata.tools.find((candidate) => candidate.name === toolName);
+  // Missing metadata must never make an unknown internal tool free by accident.
   if (!tool) {
     return { toolCostCategory: "advanced", freeUsage: false };
   }
@@ -128,6 +140,9 @@ export function getToolBillingInfo(
   };
 }
 
+// Split a rounded billing line across its raw usage rows with the largest
+// remainder method. Stable, unique keys make the result independent of DB
+// query order, and the allocated microcredits always reconcile to the line.
 function allocateBilledCreditMicro<TUsage extends AgentMessageBillingRunUsage>({
   billedCredits,
   getUsageAllocationKey,
@@ -195,8 +210,13 @@ function allocateBilledCreditMicro<TUsage extends AgentMessageBillingRunUsage>({
 /**
  * Produces the canonical billing plan for one agent message.
  *
- * LLM usage is billed once per (execution, provider, model). Tool actions are billed independently.
- * Callers should project this plan instead of rebuilding grouping, free-usage, rounding, or tool-pricing rules.
+ * LLM provider cost is grouped and rounded once per (execution, provider,
+ * model), then those groups are summed for the message. Tool actions are priced
+ * independently at their category's fixed rate.
+ *
+ * `ratedCredits` is the price before free-origin/tool waivers;
+ * `billedCredits` is the authoritative charge after those rules. Callers should
+ * project this plan instead of rebuilding grouping, rounding, or pricing rules.
  */
 export function buildAgentMessageBillingPlan<
   TUsage extends AgentMessageBillingRunUsage,

--- a/front/lib/credits/agent_message_billing.ts
+++ b/front/lib/credits/agent_message_billing.ts
@@ -248,6 +248,9 @@ export function buildAgentMessageBillingPlan<
     }
   >();
 
+  // This key is the billing and rounding boundary, not merely an aggregation
+  // convenience. Removing runKey would round at the message level; removing
+  // provider/model would round unlike Metronome's separately priced events.
   for (const usage of runUsages) {
     const runKey = usage.runKey ?? LEGACY_RUN_KEY;
     const billingGroupKey = `${runKey}|${usage.providerId}|${usage.modelId}`;
@@ -320,6 +323,8 @@ export function buildAgentMessageBillingPlan<
       action.internalMCPServerName,
       action.toolName
     );
+    // Status has precedence so an action that never became billable is omitted
+    // from Metronome even when its origin or tool would otherwise be free.
     const billingDisposition: AgentMessageToolBillingDisposition =
       !isToolExecutionStatusBillable(action.status)
         ? "unbillable_status"

--- a/front/lib/credits/agent_message_billing.ts
+++ b/front/lib/credits/agent_message_billing.ts
@@ -67,7 +67,9 @@ export type AgentMessageLlmBillingLine<
   cachedTokensCount: number;
   cacheCreationTokensCount: number;
   providerCostMicroUsd: number;
+  // Rated credits are the computed price.
   ratedCredits: number;
+  // Billed credits are the actual charge after billing rules.
   billedCredits: number;
   billingDisposition: AgentMessageLlmBillingDisposition;
   usageAllocations: Array<{
@@ -81,7 +83,9 @@ export type AgentMessageToolBillingLine<
 > = {
   action: TAction;
   toolCostCategory: ToolCostCategory;
+  // Rated credits are the computed price.
   ratedCredits: number;
+  // Billed credits are the actual charge after billing rules.
   billedCredits: number;
   billingDisposition: AgentMessageToolBillingDisposition;
 };
@@ -224,12 +228,15 @@ function resolveToolBillingDisposition({
   if (!isToolExecutionStatusBillable(status)) {
     return "unbillable_status";
   }
+
   if (isMessageFree) {
     return "free_origin";
   }
+
   if (freeUsage) {
     return "free_tool";
   }
+
   return "billed";
 }
 

--- a/front/lib/credits/units.test.ts
+++ b/front/lib/credits/units.test.ts
@@ -7,7 +7,8 @@ import { describe, expect, it } from "vitest";
 describe("credit units", () => {
   it("converts credits to integer microcredits with one rounding rule", () => {
     expect(roundCreditsToMicroCredits(1)).toBe(1_000_000);
-    expect(roundCreditsToMicroCredits(0.1234567)).toBe(123_457);
+    expect(roundCreditsToMicroCredits(0.1234564)).toBe(123_456);
+    expect(roundCreditsToMicroCredits(0.1234565)).toBe(123_457);
   });
 
   it("converts persisted microcredits back to credits", () => {

--- a/front/lib/credits/units.test.ts
+++ b/front/lib/credits/units.test.ts
@@ -1,13 +1,13 @@
 import {
-  creditsToMicroCredits,
   microCreditsToCredits,
+  roundCreditsToMicroCredits,
 } from "@app/lib/credits/units";
 import { describe, expect, it } from "vitest";
 
 describe("credit units", () => {
   it("converts credits to integer microcredits with one rounding rule", () => {
-    expect(creditsToMicroCredits(1)).toBe(1_000_000);
-    expect(creditsToMicroCredits(0.1234567)).toBe(123_457);
+    expect(roundCreditsToMicroCredits(1)).toBe(1_000_000);
+    expect(roundCreditsToMicroCredits(0.1234567)).toBe(123_457);
   });
 
   it("converts persisted microcredits back to credits", () => {

--- a/front/lib/credits/units.test.ts
+++ b/front/lib/credits/units.test.ts
@@ -1,0 +1,17 @@
+import {
+  creditsToMicroCredits,
+  microCreditsToCredits,
+} from "@app/lib/credits/units";
+import { describe, expect, it } from "vitest";
+
+describe("credit units", () => {
+  it("converts credits to integer microcredits with one rounding rule", () => {
+    expect(creditsToMicroCredits(1)).toBe(1_000_000);
+    expect(creditsToMicroCredits(0.1234567)).toBe(123_457);
+  });
+
+  it("converts persisted microcredits back to credits", () => {
+    expect(microCreditsToCredits(1)).toBe(0.000001);
+    expect(microCreditsToCredits(1_250_000)).toBe(1.25);
+  });
+});

--- a/front/lib/credits/units.ts
+++ b/front/lib/credits/units.ts
@@ -7,7 +7,7 @@
  */
 export const MICRO_CREDITS_PER_CREDIT = 1_000_000;
 
-export function creditsToMicroCredits(credits: number): number {
+export function roundCreditsToMicroCredits(credits: number): number {
   return Math.round(credits * MICRO_CREDITS_PER_CREDIT);
 }
 

--- a/front/lib/credits/units.ts
+++ b/front/lib/credits/units.ts
@@ -1,0 +1,16 @@
+/**
+ * Dust credits use fixed-point millionths when persisted or allocated.
+ *
+ * Microcredits are not micro-USD: they share the same scale but represent a
+ * different unit. Keep conversions here so callers cannot silently disagree on
+ * rounding when credits become fractional.
+ */
+export const MICRO_CREDITS_PER_CREDIT = 1_000_000;
+
+export function creditsToMicroCredits(credits: number): number {
+  return Math.round(credits * MICRO_CREDITS_PER_CREDIT);
+}
+
+export function microCreditsToCredits(microCredits: number): number {
+  return microCredits / MICRO_CREDITS_PER_CREDIT;
+}

--- a/front/lib/metronome/events.test.ts
+++ b/front/lib/metronome/events.test.ts
@@ -1,0 +1,123 @@
+import {
+  buildLlmUsageEvents,
+  buildToolUseEvents,
+} from "@app/lib/metronome/events";
+import type { RunUsageType } from "@app/lib/resources/run_resource";
+import { describe, expect, it } from "vitest";
+
+function usage(overrides: Partial<RunUsageType>): RunUsageType {
+  return {
+    completionTokens: 0,
+    reasoningTokens: null,
+    promptTokens: 0,
+    cachedTokens: 0,
+    cacheCreationTokens: 0,
+    costMicroUsd: 0,
+    modelId: "gpt-4o",
+    providerId: "openai",
+    isBatch: false,
+    ...overrides,
+  };
+}
+
+const commonEventInput = {
+  workspaceId: "workspace",
+  conversationId: "conversation",
+  userId: "user",
+  isFreeSeatedUser: false,
+  agentMessageId: "message",
+  agentId: "agent",
+  subAgentId: null,
+  parentAgentMessageId: null,
+  runKey: "execution",
+  origin: "web" as const,
+  usageType: "user" as const,
+  authMethod: "session",
+  apiKeyName: null,
+  messageStatus: "succeeded",
+  isSubAgentMessage: false,
+  timestamp: "2026-08-05T12:00:00.000Z",
+};
+
+describe("Metronome billing event adapters", () => {
+  it("emits the canonical LLM billing groups and credit amounts", () => {
+    const events = buildLlmUsageEvents({
+      ...commonEventInput,
+      isByok: false,
+      runUsages: [
+        usage({ costMicroUsd: 1, promptTokens: 2 }),
+        usage({ costMicroUsd: 2, promptTokens: 3 }),
+        usage({
+          costMicroUsd: 1,
+          modelId: "claude-opus-4-8",
+          providerId: "anthropic",
+        }),
+      ],
+    });
+
+    expect(events).toHaveLength(2);
+    expect(events.map(({ properties }) => properties)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          provider_id: "openai",
+          model_id: "gpt-4o",
+          prompt_tokens: 5,
+          cost_micro_usd: 3,
+          cost_awu: 1,
+        }),
+        expect.objectContaining({
+          provider_id: "anthropic",
+          model_id: "claude-opus-4-8",
+          cost_awu: 1,
+        }),
+      ])
+    );
+  });
+
+  it("emits canonical tool categories and free-usage overrides", () => {
+    const events = buildToolUseEvents({
+      ...commonEventInput,
+      actions: [
+        {
+          toolName: "websearch",
+          mcpServerId: null,
+          internalMCPServerName: "web_search_&_browse",
+          status: "succeeded",
+          executionDurationMs: 10,
+        },
+        {
+          toolName: "websearch",
+          mcpServerId: null,
+          internalMCPServerName: "web_search_&_browse",
+          status: "succeeded",
+          executionDurationMs: 20,
+        },
+      ],
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.properties).toMatchObject({
+      tool_category: "basic",
+      count: 2,
+      total_execution_duration_ms: 30,
+      usage_type: "user",
+    });
+  });
+
+  it("does not emit events for unbillable tool statuses", () => {
+    const events = buildToolUseEvents({
+      ...commonEventInput,
+      actions: [
+        {
+          toolName: "custom_tool",
+          mcpServerId: null,
+          internalMCPServerName: null,
+          status: "denied",
+          executionDurationMs: null,
+        },
+      ],
+    });
+
+    expect(events).toEqual([]);
+  });
+});

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -1,18 +1,15 @@
-import {
-  getInternalMCPServerMetadata,
-  type InternalMCPServerNameType,
-  isInternalMCPServerName,
-} from "@app/lib/actions/mcp_internal_actions/constants";
+import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
-import { isToolExecutionStatusBillable } from "@app/lib/actions/statuses";
-import { TOOL_COST_CATEGORIES, type ToolCostCategory } from "@app/lib/api/mcp";
+import {
+  buildAgentMessageBillingPlan,
+  isFreeOrigin,
+} from "@app/lib/credits/agent_message_billing";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { createHash } from "crypto";
 
 import { getMetronomeIngestAlias } from "./client";
 import {
-  MODEL_COST_MICRO_USD_PER_AWU_CREDIT,
   toFreeMetronomeUserId,
   USAGE_TYPE_FREE,
   USAGE_TYPE_GROUP_KEY,
@@ -20,6 +17,17 @@ import {
   USAGE_TYPE_USER,
 } from "./constants";
 import type { MetronomeEvent, UsageType } from "./types";
+
+export { TOOL_COST_CATEGORIES, type ToolCostCategory } from "@app/lib/api/mcp";
+export {
+  awuFromMicroUsd,
+  computeRunKey,
+  FREE_ORIGINS,
+  getToolBillingInfo,
+  isFreeOrigin,
+  isToolCostCategory,
+  TOOL_COST_CATEGORY_AWU_WEIGHTS,
+} from "@app/lib/credits/agent_message_billing";
 
 const MAX_TRANSACTION_ID_LENGTH = 128;
 const MAX_PROPERTY_VALUE_BYTES = 128;
@@ -53,66 +61,8 @@ function truncatePropertyValue(value: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Tool category and billing info
-// ---------------------------------------------------------------------------
-// basic: 1 AWU, advanced: 3 AWU; freeUsage overrides to 0 AWU regardless of category
-
-// Re-export from mcp so consumers can import from one place.
-export { TOOL_COST_CATEGORIES, type ToolCostCategory } from "@app/lib/api/mcp";
-
-// AWU price per tool invocation by category (1 AWU = $0.01). Canonical source
-// for both the Tool Usage rate-card prices (scripts/metronome_setup.ts) and the
-// runtime per-user AWU spend computation (per_user_usage.ts) — keep both in
-// sync by importing from here rather than redefining.
-export const TOOL_COST_CATEGORY_AWU_WEIGHTS: Record<ToolCostCategory, number> =
-  {
-    basic: 1,
-    advanced: 3,
-  };
-
-export function isToolCostCategory(value: string): value is ToolCostCategory {
-  return TOOL_COST_CATEGORIES.includes(value as ToolCostCategory);
-}
-
-export function getToolBillingInfo(
-  serverName: string | null,
-  toolName: string
-): { toolCostCategory: ToolCostCategory; freeUsage: boolean } {
-  if (!serverName || !isInternalMCPServerName(serverName)) {
-    // External MCP servers (user-configured remote servers) are always advanced.
-    return { toolCostCategory: "advanced", freeUsage: false };
-  }
-  const metadata = getInternalMCPServerMetadata(serverName);
-  const tool = metadata.tools.find((t) => t.name === toolName);
-  // Unknown tool on a known internal server — default to advanced, not free.
-  if (!tool) {
-    return { toolCostCategory: "advanced", freeUsage: false };
-  }
-  return { toolCostCategory: tool.toolCostCategory, freeUsage: tool.freeUsage };
-}
-
-// ---------------------------------------------------------------------------
 // Usage type helpers
 // ---------------------------------------------------------------------------
-
-// Origins whose entire conversation is free (platform-assistive, not
-// user-requested output).
-export const FREE_ORIGINS: ReadonlySet<UserMessageOrigin> =
-  new Set<UserMessageOrigin>([
-    "agent_sidekick",
-    // Only the Activation Pod nudge ever carries this origin: it is server-only,
-    // and the nudge has no author so it can neither be edited nor retried. User
-    // replies come back as `web` and bill normally.
-    "system_activation",
-  ]);
-
-export function isFreeOrigin(origin: UserMessageOrigin | null): boolean {
-  if (origin == null) {
-    return false;
-  }
-
-  return FREE_ORIGINS.has(origin);
-}
 
 export function getUsageType(
   isProgrammaticUsage: boolean,
@@ -131,37 +81,6 @@ function getToolUsageType(
   return freeUsage ? USAGE_TYPE_FREE : baseUsageType;
 }
 
-// ---------------------------------------------------------------------------
-// Run key
-// ---------------------------------------------------------------------------
-
-// Identifies a single agent-loop execution by the set of dustRunIds it
-// produced. Same runIds → same key (so Metronome deduplicates retries and the
-// credit-cost recompute groups runs the same way); a new execution
-// (interrupt/resume) has different runIds → different key → additive billing.
-// The credit-cost flow ceils intelligence cost per key, exactly matching the
-// per-execution Metronome events.
-export function computeRunKey(dustRunIds: string[]): string {
-  return createHash("sha256")
-    .update([...dustRunIds].sort().join(","))
-    .digest("hex")
-    .slice(0, 8);
-}
-
-// ---------------------------------------------------------------------------
-// AWU credit conversion helpers
-// ---------------------------------------------------------------------------
-// These are the single source of truth for converting raw usage into AWU
-// credits. They are used both when emitting Metronome billing events (below)
-// and when surfacing the cost of a message/conversation to the frontend, so
-// the displayed credits always match what is billed.
-
-// Convert a raw model-compute cost in microUSD into AWU credits.
-// Rounded up, matching the Metronome event conversion.
-export function awuFromMicroUsd(microUsd: number): number {
-  return Math.ceil(microUsd / MODEL_COST_MICRO_USD_PER_AWU_CREDIT);
-}
-
 // Intelligence (AI compute) credits for a *single execution's* run usages.
 // Usages are grouped by (providerId, modelId) and converted per group before
 // summing — this mirrors the per-execution `buildLlmUsageEvents` event so the
@@ -173,28 +92,12 @@ export function intelligenceAwuFromRunUsages(
   runUsages: RunUsageType[],
   contextOrigin: UserMessageOrigin | null
 ): number {
-  if (isFreeOrigin(contextOrigin)) {
-    return 0;
-  }
-
-  const costByModel = new Map<string, number>();
-  for (const usage of runUsages) {
-    // Need this grouping to rightfully apply the Math.ceil in awuFromMicroUsd
-    const key = `${usage.providerId}|${usage.modelId}`;
-    costByModel.set(key, (costByModel.get(key) ?? 0) + usage.costMicroUsd);
-  }
-
-  let total = 0;
-  for (const costMicroUsd of costByModel.values()) {
-    total += awuFromMicroUsd(costMicroUsd);
-  }
-  return total;
+  return buildAgentMessageBillingPlan({
+    actions: [],
+    contextOrigin,
+    runUsages: runUsages.map((usage) => ({ ...usage, runKey: null })),
+  }).totals.llmBilledCredits;
 }
-
-// Synthetic group for run usages whose run has no runKey yet (legacy rows, or
-// non-agent-loop runs). They are summed together so behavior matches the old
-// single-ceil computation for them.
-export const LEGACY_RUN_KEY = "__legacy__";
 
 // Intelligence credits for an agent message, ceiling per agent-loop execution
 // (runKey) to exactly match the per-execution Metronome events. Metronome emits
@@ -206,23 +109,11 @@ export function intelligenceAwuFromRunUsagesGroupedByRunKey(
   runUsages: (RunUsageType & { runKey: string | null })[],
   contextOrigin: UserMessageOrigin | null
 ): number {
-  if (isFreeOrigin(contextOrigin)) {
-    return 0;
-  }
-
-  const byRunKey = new Map<string, RunUsageType[]>();
-  for (const usage of runUsages) {
-    const key = usage.runKey ?? LEGACY_RUN_KEY;
-    const group = byRunKey.get(key) ?? [];
-    group.push(usage);
-    byRunKey.set(key, group);
-  }
-
-  let total = 0;
-  for (const group of byRunKey.values()) {
-    total += intelligenceAwuFromRunUsages(group, contextOrigin);
-  }
-  return total;
+  return buildAgentMessageBillingPlan({
+    actions: [],
+    contextOrigin,
+    runUsages,
+  }).totals.llmBilledCredits;
 }
 
 // Tool (platform action) credits for a set of actions. Each action costs a
@@ -236,9 +127,11 @@ export function toolAwuFromActions(
   }[],
   contextOrigin: UserMessageOrigin | null
 ): number {
-  return actions.reduce((total, action) => {
-    return total + toolAwuFromAction(action, contextOrigin);
-  }, 0);
+  return buildAgentMessageBillingPlan({
+    actions,
+    contextOrigin,
+    runUsages: [],
+  }).totals.toolBilledCredits;
 }
 
 export function toolAwuFromAction(
@@ -249,21 +142,11 @@ export function toolAwuFromAction(
   },
   contextOrigin: UserMessageOrigin | null
 ): number {
-  if (isFreeOrigin(contextOrigin)) {
-    return 0;
-  }
-  // The single gate on billable status. Every surface that prices a tool call goes through here.
-  if (!isToolExecutionStatusBillable(action.status)) {
-    return 0;
-  }
-  const { toolCostCategory, freeUsage } = getToolBillingInfo(
-    action.internalMCPServerName,
-    action.toolName
-  );
-  if (freeUsage) {
-    return 0;
-  }
-  return TOOL_COST_CATEGORY_AWU_WEIGHTS[toolCostCategory];
+  return buildAgentMessageBillingPlan({
+    actions: [action],
+    contextOrigin,
+    runUsages: [],
+  }).totals.toolBilledCredits;
 }
 
 // ---------------------------------------------------------------------------
@@ -316,44 +199,13 @@ export function buildLlmUsageEvents({
   isSubAgentMessage: boolean;
   timestamp: string;
 }): MetronomeEvent[] {
-  // Group by (providerId, modelId).
-  const groups = new Map<
-    string,
-    {
-      providerId: string;
-      modelId: string;
-      promptTokens: number;
-      completionTokens: number;
-      cachedTokens: number;
-      cacheCreationTokens: number;
-      costMicroUsd: number;
-    }
-  >();
+  const billingPlan = buildAgentMessageBillingPlan({
+    actions: [],
+    contextOrigin: origin,
+    runUsages: runUsages.map((usage) => ({ ...usage, runKey })),
+  });
 
-  for (const usage of runUsages) {
-    const key = `${usage.providerId}|${usage.modelId}`;
-    const existing = groups.get(key);
-
-    if (existing) {
-      existing.promptTokens += usage.promptTokens;
-      existing.completionTokens += usage.completionTokens;
-      existing.cachedTokens += usage.cachedTokens ?? 0;
-      existing.cacheCreationTokens += usage.cacheCreationTokens ?? 0;
-      existing.costMicroUsd += usage.costMicroUsd;
-    } else {
-      groups.set(key, {
-        providerId: usage.providerId,
-        modelId: usage.modelId,
-        promptTokens: usage.promptTokens,
-        completionTokens: usage.completionTokens,
-        cachedTokens: usage.cachedTokens ?? 0,
-        cacheCreationTokens: usage.cacheCreationTokens ?? 0,
-        costMicroUsd: usage.costMicroUsd,
-      });
-    }
-  }
-
-  return [...groups.values()].map((group) => ({
+  return billingPlan.llm.map((group) => ({
     transaction_id: `llm3-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}-${group.providerId}-${group.modelId}`,
     customer_id: getMetronomeIngestAlias(workspaceId),
     event_type: "llm_usage_v3",
@@ -373,14 +225,14 @@ export function buildLlmUsageEvents({
       parent_agent_message_id: parentAgentMessageId ?? "none",
       provider_id: group.providerId,
       model_id: group.modelId,
-      prompt_tokens: group.promptTokens,
-      completion_tokens: group.completionTokens,
-      cached_tokens: group.cachedTokens,
-      cache_creation_tokens: group.cacheCreationTokens,
+      prompt_tokens: group.promptTokensCount,
+      completion_tokens: group.completionTokensCount,
+      cached_tokens: group.cachedTokensCount,
+      cache_creation_tokens: group.cacheCreationTokensCount,
       // Provider cost without markup — markup is applied in Metronome rate card. Only used for legacy rates.
-      cost_micro_usd: group.costMicroUsd,
+      cost_micro_usd: group.providerCostMicroUsd,
       // 1 AWU credit = $0.0085
-      cost_awu: awuFromMicroUsd(group.costMicroUsd),
+      cost_awu: group.ratedCredits,
       // TODO: Remove is_programmatic_usage & is_free_usage, this is replaced by single property "usage type"
       is_programmatic_usage:
         usageType === USAGE_TYPE_PROGRAMMATIC ? "true" : "false",
@@ -452,12 +304,26 @@ export function buildToolUseEvents({
   isSubAgentMessage: boolean;
   timestamp: string;
 }): MetronomeEvent[] {
+  const billingPlan = buildAgentMessageBillingPlan({
+    actions,
+    contextOrigin: origin,
+    runUsages: [],
+  });
+
   // Group actions by (toolName, internalMCPServerName, mcpServerId, status).
   const groups = new Map<
     string,
-    { action: ToolAction; count: number; totalDurationMs: number }
+    {
+      billingLine: (typeof billingPlan.tools)[number];
+      count: number;
+      totalDurationMs: number;
+    }
   >();
-  for (const action of actions) {
+  for (const billingLine of billingPlan.tools) {
+    if (billingLine.disposition === "unbillable_status") {
+      continue;
+    }
+    const { action } = billingLine;
     const key = `${action.toolName}|${action.internalMCPServerName ?? ""}|${action.mcpServerId ?? ""}|${action.status}`;
     const existing = groups.get(key);
     if (existing) {
@@ -465,18 +331,15 @@ export function buildToolUseEvents({
       existing.totalDurationMs += action.executionDurationMs ?? 0;
     } else {
       groups.set(key, {
-        action,
+        billingLine,
         count: 1,
         totalDurationMs: action.executionDurationMs ?? 0,
       });
     }
   }
 
-  return [...groups.values()].map(({ action, count, totalDurationMs }) => {
-    const { toolCostCategory, freeUsage } = getToolBillingInfo(
-      action.internalMCPServerName,
-      action.toolName
-    );
+  return [...groups.values()].map(({ billingLine, count, totalDurationMs }) => {
+    const { action, toolCostCategory, freeUsage } = billingLine;
     const effectiveUsageType = getToolUsageType(usageType, freeUsage);
     return {
       transaction_id: truncateTransactionId(

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -320,6 +320,8 @@ export function buildToolUseEvents({
     }
   >();
   for (const billingLine of billingPlan.tools) {
+    // Metronome prices every emitted tool event. Actions that never reached the
+    // tool must therefore be omitted rather than represented as zero-cost.
     if (billingLine.disposition === "unbillable_status") {
       continue;
     }

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -76,9 +76,9 @@ export function getUsageType(
 
 function getToolUsageType(
   baseUsageType: UsageType,
-  freeUsage: boolean
+  isFreeTool: boolean
 ): UsageType {
-  return freeUsage ? USAGE_TYPE_FREE : baseUsageType;
+  return isFreeTool ? USAGE_TYPE_FREE : baseUsageType;
 }
 
 // Intelligence (AI compute) credits for a *single execution's* run usages.
@@ -322,7 +322,7 @@ export function buildToolUseEvents({
   for (const billingLine of billingPlan.tools) {
     // Metronome prices every emitted tool event. Actions that never reached the
     // tool must therefore be omitted rather than represented as zero-cost.
-    if (billingLine.disposition === "unbillable_status") {
+    if (billingLine.billingDisposition === "unbillable_status") {
       continue;
     }
     const { action } = billingLine;
@@ -341,8 +341,11 @@ export function buildToolUseEvents({
   }
 
   return [...groups.values()].map(({ billingLine, count, totalDurationMs }) => {
-    const { action, toolCostCategory, freeUsage } = billingLine;
-    const effectiveUsageType = getToolUsageType(usageType, freeUsage);
+    const { action, billingDisposition, toolCostCategory } = billingLine;
+    const effectiveUsageType = getToolUsageType(
+      usageType,
+      billingDisposition === "free_tool"
+    );
     return {
       transaction_id: truncateTransactionId(
         `tool3-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}-${action.toolName}-${action.mcpServerId ?? ""}-${action.status}`

--- a/front/lib/metronome/setup_new_pricing.ts
+++ b/front/lib/metronome/setup_new_pricing.ts
@@ -13,6 +13,10 @@ import {
   CP_PRO_SEAT_COST_YEARLY,
 } from "@app/lib/client/subscription";
 import {
+  TOOL_COST_CATEGORIES,
+  TOOL_COST_CATEGORY_AWU_WEIGHTS,
+} from "@app/lib/credits/agent_message_billing";
+import {
   AWU_PRIORITY_SEAT_ALLOCATION,
   CREDIT_TYPE_EUR_ID,
   CREDIT_TYPE_GBP_ID,
@@ -25,7 +29,6 @@ import {
   USAGE_TYPE_PROGRAMMATIC,
   USAGE_TYPE_USER,
 } from "@app/lib/metronome/constants";
-import { TOOL_COST_CATEGORIES } from "@app/lib/metronome/events";
 import {
   BILLING_CYCLE_CONFIG,
   BILLING_CYCLE_CONFIG_FIRST_OF_MONTH,
@@ -207,15 +210,6 @@ export const NEW_METRICS: MetricDef[] = [
   },
 ];
 
-// Per-tier AWU price for Tool Usage rates. Shared across all AWU-priced rate cards
-const TOOL_COST_CATEGORY_PRICES_AWU: Record<
-  (typeof TOOL_COST_CATEGORIES)[number],
-  number
-> = {
-  basic: 1,
-  advanced: 3,
-};
-
 // usage_type splits each AWU usage rate: "user" and "programmatic" use the
 // nominal price, "free" is priced at 0 (covers free-tagged events, replacing
 // the prior recurring-credit mechanism).
@@ -229,7 +223,7 @@ function buildAwuToolUsageRates(): RateDef[] {
         starting_at: "2026-04-01T00:00:00.000Z",
         entitled: true,
         rate_type: "FLAT",
-        price: TOOL_COST_CATEGORY_PRICES_AWU[category],
+        price: TOOL_COST_CATEGORY_AWU_WEIGHTS[category],
         credit_type_id: getCreditTypeAwuId(),
         pricing_group_values: {
           tool_category: category,

--- a/front/temporal/analytics_queue/activities/agent_analytics.ts
+++ b/front/temporal/analytics_queue/activities/agent_analytics.ts
@@ -1,4 +1,3 @@
-import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
 import {
   getInternalMCPServerNameFromSId,
   type InternalMCPServerNameType,
@@ -6,6 +5,7 @@ import {
   SEARCH_TOOL_NAME,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { isSearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { getToolNameFromFunctionCallName } from "@app/lib/actions/tool_display_labels";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import { updateAnalyticsFeedback } from "@app/lib/analytics/feedback";
 import { resolvedModelFromAgentMessageRow } from "@app/lib/api/assistant/models";
@@ -19,10 +19,11 @@ import { isLLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import {
+  type AgentMessageBillingAction,
+  type AgentMessageToolBillingLine,
+  buildAgentMessageBillingPlan,
   computeRunKey,
-  intelligenceAwuFromRunUsagesGroupedByRunKey,
-  toolAwuFromAction,
-} from "@app/lib/metronome/events";
+} from "@app/lib/credits/agent_message_billing";
 import type { AgentMessageFeedbackModel } from "@app/lib/models/agent/conversation";
 import {
   AgentMessageModel,
@@ -232,12 +233,25 @@ export async function storeAgentAnalytics(
     agentAgentMessageRow.id
   );
 
-  // Collect tool usage data (with per-tool credit cost).
-  const toolsUsed = await collectToolUsageFromMessage(
-    auth,
-    actions,
-    contextOrigin
-  );
+  const billingPlan = buildAgentMessageBillingPlan({
+    actions: actions.map((actionResource) => {
+      const action = actionResource.toJSON();
+
+      return {
+        actionResource,
+        internalMCPServerName: action.internalMCPServerName,
+        status: action.status,
+        toolName: getToolNameFromFunctionCallName(
+          actionResource.functionCallName
+        ),
+      };
+    }),
+    contextOrigin,
+    runUsages,
+  });
+
+  // Collect tool usage data from the same billing lines used for the totals.
+  const toolsUsed = await collectToolUsageFromMessage(auth, billingPlan.tools);
 
   // Collect the agent's tag ids at message time.
   // NOTE: may not be stable over time, see `collectAgentTagIds` for details.
@@ -246,11 +260,8 @@ export async function storeAgentAnalytics(
   // Model that actually ran the message (resolved at message creation).
   const model = collectResolvedModel(agentAgentMessageRow);
 
-  const llmAwu = intelligenceAwuFromRunUsagesGroupedByRunKey(
-    runUsages,
-    contextOrigin
-  );
-  const toolAwu = toolsUsed.reduce((sum, tool) => sum + tool.cost_awu, 0);
+  const llmAwu = billingPlan.totals.llmBilledCredits;
+  const toolAwu = billingPlan.totals.toolBilledCredits;
 
   const isBillable = AGENT_MESSAGE_STATUSES_TO_TRACK.includes(
     agentAgentMessageRow.status
@@ -397,11 +408,17 @@ function aggregateTokenUsage(
 /**
  * Collect tool usage data from agent message actions.
  */
+type AnalyticsBillingAction = AgentMessageBillingAction & {
+  actionResource: AgentMCPActionResource;
+};
+
 async function collectToolUsageFromMessage(
   auth: Authenticator,
-  actionResources: AgentMCPActionResource[],
-  contextOrigin: UserMessageOrigin | null
+  billingLines: AgentMessageToolBillingLine<AnalyticsBillingAction>[]
 ): Promise<AgentMessageAnalyticsToolUsed[]> {
+  const actionResources = billingLines.map(
+    ({ action }) => action.actionResource
+  );
   const uniqueConfigIds = Array.from(
     new Set(actionResources.map((a) => a.mcpServerConfigurationId))
   );
@@ -435,22 +452,14 @@ async function collectToolUsageFromMessage(
     mcpServerIds
   );
 
-  return actionResources.map((actionResource) => {
+  return billingLines.map(({ action, billedCredits }) => {
+    const { actionResource, toolName } = action;
     const { internalMCPServerName, mcpServerId } = actionResource.metadata;
     const serverName =
       internalMCPServerName ??
       (mcpServerId && remoteServerNameMap.get(mcpServerId)) ??
       mcpServerId ??
       "unknown";
-
-    const toolName =
-      actionResource.functionCallName.split(TOOL_NAME_SEPARATOR).pop() ??
-      actionResource.functionCallName;
-    // Same pricing gate as the billing pipeline, so this snapshot matches what was emitted.
-    const cost_awu = toolAwuFromAction(
-      { toolName, internalMCPServerName, status: actionResource.status },
-      contextOrigin
-    );
 
     return {
       step_index: actionResource.stepContent.step,
@@ -460,7 +469,7 @@ async function collectToolUsageFromMessage(
         configIdToSId.get(actionResource.mcpServerConfigurationId) ?? undefined,
       execution_time_ms: actionResource.executionDurationMs,
       status: actionResource.status,
-      cost_awu,
+      cost_awu: billedCredits,
     };
   });
 }

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -1,4 +1,3 @@
-import { isToolExecutionStatusBillable } from "@app/lib/actions/statuses";
 import { reconcileApiKey } from "@app/lib/api/metronome/reconcile_credit_state";
 import { syncMetronomeSeatCountForWorkspace } from "@app/lib/api/metronome/seat_sync";
 import {
@@ -359,18 +358,14 @@ export async function emitMetronomeUsageEventsActivity(
   });
   const runUsages = await RunResource.listRunUsagesForRuns(auth, { runs });
 
-  // Get MCP actions, filtered to this execution's steps if startStep is available, and to the
-  // actions that reached the tool. The Metronome rate card prices every tool_use_v3 event it
-  // receives, so an unbillable call has to be dropped here rather than flagged on the event.
+  // Get MCP actions, filtered to this execution's steps if startStep is available. The event
+  // adapter applies the canonical billing-status gate before producing Metronome events.
   const allMcpActions = await AgentMCPActionResource.listByAgentMessageIds(
     auth,
     [agentMessage.id]
   );
   const mcpActions = allMcpActions.filter((a) => {
     const json = a.toJSON();
-    if (!isToolExecutionStatusBillable(json.status)) {
-      return false;
-    }
     if (
       agentLoopArgs.startStep !== undefined &&
       json.step < agentLoopArgs.startStep


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
As we build the new analytics stack, billing logic is currently spread across several places, with no guarantee that they will remain consistent over time.

This PR creates one shared place for agent message billing. It preserves the existing rounding per execution and model, free-usage rules, and tool prices of 0, 1, or 3 credits. Message costs, Metronome events, legacy analytics, and pricing setup now all use the same calculation.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
