### PR TITLE
Give credit usage a first-class spot in agent messages

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -880,7 +880,6 @@ export function AgentMessage({
           size="xs"
           label={formattedCredits}
           iconRight={CoinsStacked01}
-          isSelect
           className="gap-1 px-1 tracking-normal"
           aria-label={`${formattedCredits} credits used for this message. View credit breakdown`}
         />

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -63,6 +63,7 @@ import { isImageProgressOutput } from "@app/lib/actions/mcp_internal_actions/out
 import { CONTEXT_WINDOW_DOC_URL } from "@app/lib/api/assistant/errors";
 import config from "@app/lib/api/config";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { formatCredits } from "@app/lib/client/credits";
 import { clientFetch } from "@app/lib/egress/client";
 import type { DustError } from "@app/lib/error";
 import { FILE_ID_PATTERN } from "@app/lib/files";
@@ -102,11 +103,11 @@ import type {
 } from "@app/types/user";
 import {
   Button,
-  ButtonGroup,
   ButtonGroupDropdown,
   Chip,
   Clipboard,
   ClipboardCheck,
+  CoinsStacked01,
   ConversationMessageAvatar,
   ConversationMessageContainer,
   ConversationMessageContent,
@@ -274,7 +275,6 @@ export function AgentMessage({
     { index: number; document: MCPReferenceCitation }[]
   >([]);
   const [isCopied, copy] = useCopyToClipboard();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
   // Latches to true the first time the menu opens. We use this rather than
   // `isMenuOpen` to gate the cost fetch so the query stays enabled after the
   // menu closes: otherwise disabling it nulls the SWR key, dropping
@@ -714,7 +714,6 @@ export function AgentMessage({
   });
 
   const alwaysVisibleButtons: ReactElement[] = [];
-  const hoverButtons: ReactElement[] = [];
 
   const hasMultiAgents =
     getConversationGeneratingMessages(conversationId).length > 1;
@@ -891,7 +890,7 @@ export function AgentMessage({
     }
   }, [streamError, reloadMessage, conversationId, agentMessage.sId]);
 
-  // Add feedback buttons (always visible)
+  // Add feedback buttons.
   if (shouldShowFeedback) {
     alwaysVisibleButtons.push(
       <FeedbackSelector
@@ -905,7 +904,7 @@ export function AgentMessage({
     );
   }
 
-  // Add copy button or split button with dropdown (hover only)
+  // Add the remaining footer actions.
   if (shouldShowMessageActions) {
     const dropdownItems: DropdownMenuItemProps[] = [
       {
@@ -948,79 +947,101 @@ export function AgentMessage({
       });
     }
 
-    hoverButtons.push(
-      <ButtonGroup key="split-button-group">
-        <Button
-          tooltip={isCopied ? "Copied!" : "Copy to clipboard"}
-          variant="outline"
-          size="xs"
-          onClick={handleCopyToClipboard}
-          icon={isCopied ? ClipboardCheck : Clipboard}
-          className="text-muted-foreground"
+    alwaysVisibleButtons.push(
+      <Button
+        key="copy-message"
+        tooltip={isCopied ? "Copied!" : "Copy to clipboard"}
+        variant="ghost-secondary"
+        size="xs"
+        onClick={handleCopyToClipboard}
+        icon={isCopied ? ClipboardCheck : Clipboard}
+      />
+    );
+
+    if (agentMessage.costCredits !== null && agentMessage.costCredits > 0) {
+      const formattedCredits = formatCredits(agentMessage.costCredits);
+      alwaysVisibleButtons.push(
+        <Tooltip
+          key="message-credit-cost"
+          label="Credits used for this message"
+          tooltipTriggerAsChild
+          trigger={
+            <span
+              tabIndex={0}
+              aria-label={`${formattedCredits} credits used for this message`}
+              className="inline-flex h-6 items-center gap-1 rounded-lg px-1 text-sm font-medium leading-5 text-muted-foreground"
+            >
+              {formattedCredits}
+              <CoinsStacked01 className="h-4 w-4" />
+            </span>
+          }
         />
-        <DropdownMenu
-          onOpenChange={(open) => {
-            setIsMenuOpen(open);
-            if (open) {
-              setHasOpenedMenu(true);
-              // The streamed cost is stale after a live completion (computed
-              // post-event). Revalidate the authoritative value once per
-              // completion so the total (e.g. summed across an `ask_user`
-              // resume) is correct without a page refresh.
-              if (pendingCostRevalidationRef.current) {
-                pendingCostRevalidationRef.current = false;
-                void mutateMessage();
-              }
+      );
+    }
+
+    alwaysVisibleButtons.push(
+      <DropdownMenu
+        key="message-actions"
+        onOpenChange={(open) => {
+          if (open) {
+            setHasOpenedMenu(true);
+            // The streamed cost is stale after a live completion (computed
+            // post-event). Revalidate the authoritative value once per
+            // completion so the total (e.g. summed across an `ask_user`
+            // resume) is correct without a page refresh.
+            if (pendingCostRevalidationRef.current) {
+              pendingCostRevalidationRef.current = false;
+              void mutateMessage();
             }
-          }}
-        >
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="outline"
-              size="xs"
-              icon={DotsHorizontal}
-              className="text-muted-foreground"
-            />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {(creditCostItem || isCreditCostLoading) && (
-              <>
-                {hasConsumptionDetails ? (
-                  <CreditCostSubmenu
-                    credits={
-                      refreshedAgentMessage?.costCredits ??
-                      agentMessage.costCredits
-                    }
-                    subAgentCredits={
-                      refreshedAgentMessage?.subAgentCostCredits ??
-                      agentMessage.subAgentCostCredits
-                    }
-                    conversationId={conversationId}
-                    messageId={agentMessage.sId}
-                    workspaceId={owner.sId}
-                    isCostLoading={isCreditCostLoading}
-                  />
-                ) : creditCostItem ? (
-                  <DropdownMenuItem {...creditCostItem} />
-                ) : (
-                  <DropdownMenuItem
-                    label="Credit cost"
-                    endComponent={
-                      <div className="h-3 w-8 animate-pulse rounded bg-muted-foreground/20" />
-                    }
-                    className={CREDIT_COST_ITEM_CLASS_NAME}
-                    onSelect={(e) => e.preventDefault()}
-                  />
-                )}
-                <DropdownMenuSeparator />
-              </>
-            )}
-            {dropdownItems.map((item, index) => (
-              <DropdownMenuItem key={index} {...item} />
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </ButtonGroup>
+          }
+        }}
+      >
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost-secondary"
+            size="xs"
+            icon={DotsHorizontal}
+            aria-label="More message actions"
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {(creditCostItem || isCreditCostLoading) && (
+            <>
+              {hasConsumptionDetails ? (
+                <CreditCostSubmenu
+                  credits={
+                    refreshedAgentMessage?.costCredits ??
+                    agentMessage.costCredits
+                  }
+                  subAgentCredits={
+                    refreshedAgentMessage?.subAgentCostCredits ??
+                    agentMessage.subAgentCostCredits
+                  }
+                  conversationId={conversationId}
+                  messageId={agentMessage.sId}
+                  workspaceId={owner.sId}
+                  isCostLoading={isCreditCostLoading}
+                />
+              ) : creditCostItem ? (
+                <DropdownMenuItem {...creditCostItem} />
+              ) : (
+                <DropdownMenuItem
+                  label="Credit cost"
+                  endComponent={
+                    <div className="h-3 w-8 animate-pulse rounded bg-muted-foreground/20" />
+                  }
+                  className={CREDIT_COST_ITEM_CLASS_NAME}
+                  onSelect={(e) => e.preventDefault()}
+                />
+              )}
+              <DropdownMenuSeparator />
+            </>
+          )}
+          {dropdownItems.map((item, index) => (
+            <DropdownMenuItem key={index} {...item} />
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
     );
   }
 
@@ -1175,17 +1196,8 @@ export function AgentMessage({
 
   const footerButtons = !isDeleted &&
     !isGracefullyStopped &&
-    (alwaysVisibleButtons.length > 0 || hoverButtons.length > 0) && (
-      <div className="flex items-center gap-2">
-        {alwaysVisibleButtons}
-        {hoverButtons.length > 0 && (
-          <div
-            className={`flex gap-2 transition-opacity duration-150 ${isMenuOpen ? "opacity-100" : "@xs:opacity-0 @xs:group-hover:opacity-100"}`}
-          >
-            {hoverButtons}
-          </div>
-        )}
-      </div>
+    alwaysVisibleButtons.length > 0 && (
+      <div className="flex items-center gap-1">{alwaysVisibleButtons}</div>
     );
 
   const renderMessageContent = () => {

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -8,7 +8,7 @@ import { AttachmentCitation } from "@app/components/assistant/conversation/attac
 import { markdownCitationToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
 import { BlockedAction } from "@app/components/assistant/conversation/BlockedAction";
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
-import { CreditCostSubmenu } from "@app/components/assistant/conversation/CreditCostSubmenu";
+import { CreditCostPopover } from "@app/components/assistant/conversation/CreditCostPopover";
 import { DeletedMessage } from "@app/components/assistant/conversation/DeletedMessage";
 import { ErrorMessage } from "@app/components/assistant/conversation/ErrorMessage";
 import type { FeedbackSelectorBaseProps } from "@app/components/assistant/conversation/FeedbackSelector";
@@ -27,10 +27,6 @@ import {
   makeInitialMessageStreamState,
 } from "@app/components/assistant/conversation/types";
 import { useAutoOpenSidePanel } from "@app/components/assistant/conversation/useAutoOpenSidePanel";
-import {
-  CREDIT_COST_ITEM_CLASS_NAME,
-  useCreditCostMenuItem,
-} from "@app/components/assistant/conversation/useCreditCostMenuItem";
 import { ConfirmContext } from "@app/components/Confirm";
 import { getActionCardPlugin } from "@app/components/markdown/ActionCardDirective";
 import {
@@ -48,7 +44,6 @@ import { getModelWithReasoningEffortLabel } from "@app/components/model_picker/m
 import {
   useBranchConversation,
   useCancelMessage,
-  useConversationMessage,
   usePostOnboardingFollowUp,
 } from "@app/hooks/conversations";
 import { useConversationAttachments } from "@app/hooks/conversations/useConversationAttachments";
@@ -117,7 +112,6 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   type DropdownMenuItemProps,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
   GitBranch01,
   InfoCircle,
@@ -142,14 +136,11 @@ import {
   useContext,
   useEffect,
   useMemo,
-  useRef,
   useState,
 } from "react";
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
 import { mutate } from "swr";
-
-const RUN_AGENT_TOOL_NAME = "run_agent";
 
 // Popover (not Tooltip) so the "Learn more" link inside stays reachable.
 function PrunedContextChip() {
@@ -201,21 +192,6 @@ function PrunedContextChip() {
         </div>
       </PopoverContent>
     </PopoverRoot>
-  );
-}
-
-function hasMessageSpawnedSubAgent(
-  agentMessage: AgentMessageWithStreaming
-): boolean {
-  return (
-    agentMessage.actions.some(
-      (action) => action.internalMCPServerName === RUN_AGENT_TOOL_NAME
-    ) ||
-    agentMessage.activitySteps.some(
-      (step) =>
-        step.type === "action" &&
-        step.internalMCPServerName === RUN_AGENT_TOOL_NAME
-    )
   );
 }
 
@@ -275,62 +251,6 @@ export function AgentMessage({
     { index: number; document: MCPReferenceCitation }[]
   >([]);
   const [isCopied, copy] = useCopyToClipboard();
-  // Latches to true the first time the menu opens. We use this rather than
-  // `isMenuOpen` to gate the cost fetch so the query stays enabled after the
-  // menu closes: otherwise disabling it nulls the SWR key, dropping
-  // `refreshedMessage` back to the prop values (which never carry
-  // `subAgentCostCredits`) and flickering the displayed total during the close
-  // animation.
-  const [hasOpenedMenu, setHasOpenedMenu] = useState(false);
-  // Set once this message finishes a run live in this session (terminal stream
-  // event). Credits are computed in the finalize activity *after* the terminal
-  // event is published, so the streamed `costCredits` is never the authoritative
-  // total: it is `null` on a first run, and the *previous* run's total after an
-  // `ask_user` resume. So we keep the authoritative single-message fetch enabled
-  // and revalidate it when the menu opens (see below), rather than trusting the
-  // streamed value. Never reset: flipping `needsCostFetch` back to false would
-  // null the SWR key and revert the display to the stale streamed prop.
-  const [hasCompletedRunThisSession, setHasCompletedRunThisSession] =
-    useState(false);
-  // Owed revalidation, consumed on menu open: set on each terminal event,
-  // cleared once the mutate is fired, so reopening the menu with no new run in
-  // between does not refetch.
-  const pendingCostRevalidationRef = useRef(false);
-  // Re-fetch (on menu open) if a cost we want to show is still missing or may be
-  // stale:
-  // - Own cost: null until the agentic loop finishes; absent while streaming/listed.
-  // - Sub-agent cost: only aggregated by the single-message fetch, and only exists
-  //   when a `run_agent` action is present (it triggers both run_agent and handover).
-  // - Live completion: the streamed cost is pre-recompute (see above), so any
-  //   message that completed a run this session needs the authoritative fetch.
-  const needsCostFetch =
-    hasCompletedRunThisSession ||
-    agentMessage.costCredits == null ||
-    (hasMessageSpawnedSubAgent(agentMessage) &&
-      agentMessage.subAgentCostCredits == null);
-  const {
-    message: refreshedMessage,
-    isMessageLoading,
-    mutateMessage,
-  } = useConversationMessage({
-    conversationId,
-    workspaceId: owner.sId,
-    messageId: agentMessage.sId,
-    options: {
-      disabled: !hasOpenedMenu || !needsCostFetch,
-    },
-  });
-  const refreshedAgentMessage =
-    refreshedMessage?.type === "agent_message" ? refreshedMessage : null;
-  const creditCostItem = useCreditCostMenuItem({
-    credits: refreshedAgentMessage?.costCredits ?? agentMessage.costCredits,
-    subAgentCredits:
-      refreshedAgentMessage?.subAgentCostCredits ??
-      agentMessage.subAgentCostCredits,
-  });
-  // Keep the cost section visible while the fetch is in flight (showing a
-  // loader) rather than popping it in once it resolves.
-  const isCreditCostLoading = needsCostFetch && isMessageLoading;
   const sendNotification = useSendNotification();
   const confirm = useContext(ConfirmContext);
 
@@ -473,12 +393,6 @@ export function AgentMessage({
 
           case "agent_message_success":
           case "agent_message_gracefully_stopped":
-            // A run finished live: its terminal event carries a pre-recompute
-            // cost (credits are computed in the finalize activity after the event
-            // is published), so mark the cost for revalidation on the next menu
-            // open.
-            setHasCompletedRunThisSession(true);
-            pendingCostRevalidationRef.current = true;
             // We can remove all blocked actions for this message (especially useful to let other users see the message updates)
             void removeAllBlockedActionsForMessage({
               messageId: sId,
@@ -960,42 +874,45 @@ export function AgentMessage({
 
     if (agentMessage.costCredits !== null && agentMessage.costCredits > 0) {
       const formattedCredits = formatCredits(agentMessage.costCredits);
-      alwaysVisibleButtons.push(
-        <Tooltip
-          key="message-credit-cost"
-          label="Credits used for this message"
-          tooltipTriggerAsChild
-          trigger={
-            <span
-              tabIndex={0}
-              aria-label={`${formattedCredits} credits used for this message`}
-              className="inline-flex h-6 items-center gap-1 rounded-lg px-1 text-sm font-medium leading-5 text-muted-foreground"
-            >
-              {formattedCredits}
-              <CoinsStacked01 className="h-4 w-4" />
-            </span>
-          }
+      const creditCostTrigger = (
+        <Button
+          variant="ghost-secondary"
+          size="xs"
+          label={formattedCredits}
+          iconRight={CoinsStacked01}
+          isSelect
+          className="gap-1 px-1 tracking-normal"
+          aria-label={`${formattedCredits} credits used for this message. View credit breakdown`}
         />
+      );
+
+      alwaysVisibleButtons.push(
+        hasConsumptionDetails ? (
+          <CreditCostPopover
+            key="message-credit-cost"
+            credits={agentMessage.costCredits}
+            subAgentCredits={agentMessage.subAgentCostCredits}
+            conversationId={conversationId}
+            messageId={agentMessage.sId}
+            workspaceId={owner.sId}
+            trigger={creditCostTrigger}
+          />
+        ) : (
+          <span
+            key="message-credit-cost"
+            role="status"
+            aria-label={`${formattedCredits} credits used for this message`}
+            className="inline-flex h-6 items-center gap-1 rounded-lg px-1 text-sm font-medium leading-5 text-muted-foreground"
+          >
+            {formattedCredits}
+            <CoinsStacked01 className="h-4 w-4" />
+          </span>
+        )
       );
     }
 
     alwaysVisibleButtons.push(
-      <DropdownMenu
-        key="message-actions"
-        onOpenChange={(open) => {
-          if (open) {
-            setHasOpenedMenu(true);
-            // The streamed cost is stale after a live completion (computed
-            // post-event). Revalidate the authoritative value once per
-            // completion so the total (e.g. summed across an `ask_user`
-            // resume) is correct without a page refresh.
-            if (pendingCostRevalidationRef.current) {
-              pendingCostRevalidationRef.current = false;
-              void mutateMessage();
-            }
-          }
-        }}
-      >
+      <DropdownMenu key="message-actions">
         <DropdownMenuTrigger asChild>
           <Button
             variant="ghost-secondary"
@@ -1005,38 +922,6 @@ export function AgentMessage({
           />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          {(creditCostItem || isCreditCostLoading) && (
-            <>
-              {hasConsumptionDetails ? (
-                <CreditCostSubmenu
-                  credits={
-                    refreshedAgentMessage?.costCredits ??
-                    agentMessage.costCredits
-                  }
-                  subAgentCredits={
-                    refreshedAgentMessage?.subAgentCostCredits ??
-                    agentMessage.subAgentCostCredits
-                  }
-                  conversationId={conversationId}
-                  messageId={agentMessage.sId}
-                  workspaceId={owner.sId}
-                  isCostLoading={isCreditCostLoading}
-                />
-              ) : creditCostItem ? (
-                <DropdownMenuItem {...creditCostItem} />
-              ) : (
-                <DropdownMenuItem
-                  label="Credit cost"
-                  endComponent={
-                    <div className="h-3 w-8 animate-pulse rounded bg-muted-foreground/20" />
-                  }
-                  className={CREDIT_COST_ITEM_CLASS_NAME}
-                  onSelect={(e) => e.preventDefault()}
-                />
-              )}
-              <DropdownMenuSeparator />
-            </>
-          )}
           {dropdownItems.map((item, index) => (
             <DropdownMenuItem key={index} {...item} />
           ))}

--- a/front/components/assistant/conversation/CreditCostPopover.accessibility.test.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.accessibility.test.tsx
@@ -1,0 +1,80 @@
+import { CreditCostPopover } from "@app/components/assistant/conversation/CreditCostPopover";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockUseAgentMessageConsumption } = vi.hoisted(() => ({
+  mockUseAgentMessageConsumption: vi.fn(),
+}));
+
+vi.mock("@app/hooks/conversations/useAgentMessageConsumption", () => ({
+  useAgentMessageConsumption: mockUseAgentMessageConsumption,
+}));
+
+vi.mock("@app/components/assistant/conversation/actions/inline/utils", () => ({
+  getActionStepIcon: () => () => null,
+}));
+
+vi.mock("@app/components/resources/resources_icons", () => ({
+  InternalActionIcons: {
+    ActionBrainIcon: () => null,
+    ToolsIcon: () => null,
+  },
+}));
+
+describe("CreditCostPopover accessibility", () => {
+  beforeEach(() => {
+    mockUseAgentMessageConsumption.mockReturnValue({
+      consumption: {
+        billedCredits: 10,
+        details: {
+          attributionVersion: 3,
+          agentWorkCredits: 4,
+          tools: [],
+        },
+      },
+      isConsumptionLoading: false,
+      mutateConsumption: vi.fn(),
+    });
+  });
+
+  it("opens from the keyboard and restores focus when closed", async () => {
+    const user = userEvent.setup();
+    render(
+      <CreditCostPopover
+        credits={10}
+        subAgentCredits={0}
+        conversationId="conversation_test"
+        messageId="message_test"
+        workspaceId="workspace_test"
+        trigger={
+          <button type="button" aria-label="10 credits used. View breakdown">
+            10 credits
+          </button>
+        }
+      />
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: "10 credits used. View breakdown",
+    });
+    await user.tab();
+    expect(trigger).toHaveFocus();
+
+    await user.keyboard("{Enter}");
+
+    expect(
+      await screen.findByRole("dialog", { name: "Credit usage" })
+    ).toBeInTheDocument();
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Credit usage" })
+      ).not.toBeInTheDocument();
+      expect(trigger).toHaveFocus();
+    });
+  });
+});

--- a/front/components/assistant/conversation/CreditCostPopover.test.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.test.tsx
@@ -1,4 +1,4 @@
-import { CreditCostSubmenu } from "@app/components/assistant/conversation/CreditCostSubmenu";
+import { CreditCostPopover } from "@app/components/assistant/conversation/CreditCostPopover";
 import type { AgentMessageConsumptionToolDetails } from "@app/types/assistant/agent_message_consumption";
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ComponentProps, ReactNode } from "react";
@@ -23,29 +23,9 @@ vi.mock("@app/components/resources/resources_icons", () => ({
 }));
 
 vi.mock("@dust-tt/sparkle", () => ({
-  ChevronRight: () => null,
   ShapesPlus: () => null,
-  DropdownMenuItem: ({
-    label,
-    description,
-    endComponent,
-    disabled,
-  }: {
-    label: string;
-    description?: string;
-    endComponent?: ReactNode;
-    disabled?: boolean;
-  }) => (
-    <div data-disabled={disabled || undefined}>
-      <span>{label}</span>
-      {description && <span>{description}</span>}
-      {endComponent && <span>{endComponent}</span>}
-    </div>
-  ),
-  DropdownMenuLabel: ({ label }: { label: string }) => <div>{label}</div>,
-  DropdownMenuPortal: ({ children }: { children: ReactNode }) => children,
-  DropdownMenuSeparator: () => <hr />,
-  DropdownMenuSub: ({
+  Icon: () => null,
+  PopoverRoot: ({
     children,
     onOpenChange,
   }: {
@@ -59,12 +39,11 @@ vi.mock("@dust-tt/sparkle", () => ({
       {children}
     </div>
   ),
-  DropdownMenuSubContent: ({ children }: { children: ReactNode }) => (
+  PopoverContent: ({ children }: { children: ReactNode }) => (
     <div>{children}</div>
   ),
-  DropdownMenuSubTrigger: ({ children }: { children: ReactNode }) => (
-    <button type="button">{children}</button>
-  ),
+  PopoverTrigger: ({ children }: { children: ReactNode }) => children,
+  Tooltip: ({ trigger }: { trigger: ReactNode }) => trigger,
 }));
 
 const makeTool = (
@@ -83,16 +62,16 @@ const makeTool = (
   ...overrides,
 });
 
-const defaultProps: ComponentProps<typeof CreditCostSubmenu> = {
+const defaultProps: ComponentProps<typeof CreditCostPopover> = {
   credits: 10,
   subAgentCredits: 0,
   conversationId: "conversation_test",
   messageId: "message_test",
   workspaceId: "workspace_test",
-  isCostLoading: false,
+  trigger: <button type="button">Credit trigger</button>,
 };
 
-describe("CreditCostSubmenu", () => {
+describe("CreditCostPopover", () => {
   beforeEach(() => {
     mockUseAgentMessageConsumption.mockReset();
   });
@@ -117,7 +96,7 @@ describe("CreditCostSubmenu", () => {
       mutateConsumption: vi.fn(),
     });
 
-    render(<CreditCostSubmenu {...defaultProps} subAgentCredits={3} />);
+    render(<CreditCostPopover {...defaultProps} subAgentCredits={3} />);
 
     expect(screen.getByText("Calendar tool")).toBeInTheDocument();
     expect(screen.getByText("7.1 credits")).toBeInTheDocument();
@@ -134,10 +113,6 @@ describe("CreditCostSubmenu", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("This message")).toBeInTheDocument();
     expect(screen.getByText("Sub-agents")).toBeInTheDocument();
-    expect(screen.getByText("Calendar tool").parentElement).toHaveAttribute(
-      "data-disabled",
-      "true"
-    );
   });
 
   it("shows an additive breakdown without a separate savings adjustment", () => {
@@ -158,7 +133,7 @@ describe("CreditCostSubmenu", () => {
       mutateConsumption: vi.fn(),
     });
 
-    render(<CreditCostSubmenu {...defaultProps} />);
+    render(<CreditCostPopover {...defaultProps} />);
 
     expect(screen.getByText("Credit breakdown")).toBeInTheDocument();
     expect(screen.queryByText("Saved through reuse")).not.toBeInTheDocument();
@@ -173,7 +148,7 @@ describe("CreditCostSubmenu", () => {
       mutateConsumption: vi.fn(),
     });
 
-    render(<CreditCostSubmenu {...defaultProps} />);
+    render(<CreditCostPopover {...defaultProps} />);
 
     expect(screen.getByText("12 credits")).toBeInTheDocument();
     expect(
@@ -189,7 +164,7 @@ describe("CreditCostSubmenu", () => {
       mutateConsumption,
     });
 
-    render(<CreditCostSubmenu {...defaultProps} />);
+    render(<CreditCostPopover {...defaultProps} />);
 
     expect(mockUseAgentMessageConsumption).toHaveBeenLastCalledWith(
       expect.objectContaining({ disabled: true })

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -167,7 +167,7 @@ export function CreditCostPopover({
           </dl>
         </section>
 
-        <div role="separator" className="my-1 border-t border-border" />
+        <hr className="my-1 border-t border-border" />
 
         <section aria-labelledby={`${headingId}-breakdown`}>
           <h3

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -4,17 +4,14 @@ import { useAgentMessageConsumption } from "@app/hooks/conversations/useAgentMes
 import { formatCredits } from "@app/lib/client/credits";
 import type { AgentMessageConsumptionToolDetails } from "@app/types/assistant/agent_message_consumption";
 import {
-  ChevronRight,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuPortal,
-  DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
+  Icon,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+  Tooltip,
 } from "@dust-tt/sparkle";
-import type { ComponentType } from "react";
-import { useState } from "react";
+import type { ComponentType, ReactElement } from "react";
+import { useId, useState } from "react";
 
 const MAX_VISIBLE_TOOLS = 3;
 
@@ -34,67 +31,59 @@ function toolDescription(tool: AgentMessageConsumptionToolDetails): string {
   return descriptions.join(" · ");
 }
 
-interface ReadonlyCostItemProps {
+interface CreditDetailRowProps {
   description?: string;
   icon?: ComponentType<{ className?: string }>;
   label: string;
   value: string;
 }
 
-function ReadonlyCostItem({
+function CreditDetailRow({
   description,
   icon,
   label,
   value,
-}: ReadonlyCostItemProps) {
+}: CreditDetailRowProps) {
   return (
-    <DropdownMenuItem
-      aria-label={`${label}, ${description ? `${description}, ` : ""}${value}`}
-      disabled
-      label={label}
-      description={description}
-      icon={icon}
-      endComponent={value}
-      className="cursor-default font-normal text-foreground data-[disabled]:text-foreground"
-    />
+    <div className="grid min-h-9 grid-cols-[minmax(0,1fr)_auto] items-start gap-x-3 rounded-lg px-2 py-1.5 text-sm">
+      <dt className="flex min-w-0 items-start gap-2 font-medium text-foreground">
+        {icon && (
+          <Icon
+            visual={icon}
+            size="xs"
+            className="mt-0.5 shrink-0 text-muted-foreground"
+          />
+        )}
+        <span>{label}</span>
+      </dt>
+      <dd className="shrink-0 text-muted-foreground">{value}</dd>
+      {description && (
+        <dd className="col-start-1 text-xs text-muted-foreground">
+          {description}
+        </dd>
+      )}
+    </div>
   );
 }
 
-interface ReadonlyNoticeProps {
-  description: string;
-  label: string;
-}
-
-function ReadonlyNotice({ description, label }: ReadonlyNoticeProps) {
-  return (
-    <DropdownMenuItem
-      aria-label={`${label}. ${description}`}
-      disabled
-      label={label}
-      description={description}
-      className="cursor-default font-normal data-[disabled]:text-muted-foreground"
-    />
-  );
-}
-
-interface CreditCostSubmenuProps {
+interface CreditCostPopoverProps {
   conversationId: string;
   credits: number | null | undefined;
-  isCostLoading: boolean;
   messageId: string;
   subAgentCredits: number | null | undefined;
+  trigger: ReactElement;
   workspaceId: string;
 }
 
-// TODO(2026-08-03 OBSERVABILITY) Temporary component, design and implementation will be improved in the future.
-export function CreditCostSubmenu({
+export function CreditCostPopover({
   conversationId,
   credits,
-  isCostLoading,
   messageId,
   subAgentCredits,
+  trigger,
   workspaceId,
-}: CreditCostSubmenuProps) {
+}: CreditCostPopoverProps) {
+  const headingId = useId();
   const [hasOpened, setHasOpened] = useState(false);
   const { consumption, isConsumptionLoading, mutateConsumption } =
     useAgentMessageConsumption({
@@ -109,7 +98,7 @@ export function CreditCostSubmenu({
   const totalCredits = ownCredits + childCredits;
   const details = consumption?.details;
 
-  if (!isCostLoading && totalCredits <= 0) {
+  if (totalCredits <= 0) {
     return null;
   }
 
@@ -130,7 +119,7 @@ export function CreditCostSubmenu({
   );
 
   return (
-    <DropdownMenuSub
+    <PopoverRoot
       onOpenChange={(open) => {
         if (!open) {
           return;
@@ -142,36 +131,51 @@ export function CreditCostSubmenu({
         }
       }}
     >
-      <DropdownMenuSubTrigger>
-        <span className="flex min-w-44 flex-1 items-center gap-2">
-          <span className="flex-1">Credit cost</span>
-          {isCostLoading ? (
-            <span className="h-3 w-8 animate-pulse rounded bg-muted-foreground/20" />
-          ) : (
-            <span className="font-normal text-muted-foreground">
-              {formatCredits(totalCredits)}
-            </span>
-          )}
-          <ChevronRight className="h-3 w-3 text-muted-foreground" />
-        </span>
-      </DropdownMenuSubTrigger>
-      <DropdownMenuPortal>
-        <DropdownMenuSubContent className="w-80">
-          <DropdownMenuLabel label="Charged" />
-          <ReadonlyCostItem
-            label="This message"
-            value={isCostLoading ? "Updating" : formatCreditValue(ownCredits)}
-          />
-          {childCredits > 0 && (
-            <ReadonlyCostItem
-              label="Sub-agents"
-              value={
-                isCostLoading ? "Updating" : formatCreditValue(childCredits)
-              }
+      <Tooltip
+        label="View credit breakdown"
+        tooltipTriggerAsChild
+        trigger={<PopoverTrigger asChild>{trigger}</PopoverTrigger>}
+      />
+      <PopoverContent
+        role="dialog"
+        aria-labelledby={headingId}
+        align="start"
+        className="w-80 p-2"
+        preventAutoFocusOnClose={false}
+      >
+        <h2 id={headingId} className="px-2 py-1 text-sm font-semibold">
+          Credit usage
+        </h2>
+        <section aria-labelledby={`${headingId}-charged`}>
+          <h3
+            id={`${headingId}-charged`}
+            className="px-2 py-1 text-xs font-medium text-muted-foreground"
+          >
+            Charged
+          </h3>
+          <dl>
+            <CreditDetailRow
+              label="This message"
+              value={formatCreditValue(ownCredits)}
             />
-          )}
-          <DropdownMenuSeparator />
-          <DropdownMenuLabel label="Credit breakdown" />
+            {childCredits > 0 && (
+              <CreditDetailRow
+                label="Sub-agents"
+                value={formatCreditValue(childCredits)}
+              />
+            )}
+          </dl>
+        </section>
+
+        <div role="separator" className="my-1 border-t border-border" />
+
+        <section aria-labelledby={`${headingId}-breakdown`}>
+          <h3
+            id={`${headingId}-breakdown`}
+            className="px-2 py-1 text-xs font-medium text-muted-foreground"
+          >
+            Credit breakdown
+          </h3>
           {isConsumptionLoading && !consumption ? (
             <div
               aria-busy="true"
@@ -182,15 +186,15 @@ export function CreditCostSubmenu({
               <span className="h-3 w-8 animate-pulse rounded bg-muted-foreground/20" />
             </div>
           ) : details ? (
-            <>
-              <ReadonlyCostItem
+            <dl>
+              <CreditDetailRow
                 label="Agent work and context"
                 description="Longer conversations require more context to process"
                 value={formatCreditValue(details.agentWorkCredits)}
                 icon={InternalActionIcons.ActionBrainIcon}
               />
               {visibleTools.map((tool) => (
-                <ReadonlyCostItem
+                <CreditDetailRow
                   key={`${tool.internalMCPServerName ?? "external"}:${tool.toolName}:${tool.label}`}
                   label={tool.label}
                   description={toolDescription(tool)}
@@ -199,22 +203,26 @@ export function CreditCostSubmenu({
                 />
               ))}
               {remainingTools.length > 0 && (
-                <ReadonlyCostItem
+                <CreditDetailRow
                   label="Other tools"
                   description={`${remainingTools.length} ${remainingTools.length === 1 ? "tool" : "tools"}, ${remainingToolCallCount} ${remainingToolCallCount === 1 ? "use" : "uses"}`}
                   value={formatCreditValue(remainingToolCredits)}
                   icon={InternalActionIcons.ToolsIcon}
                 />
               )}
-            </>
+            </dl>
           ) : (
-            <ReadonlyNotice
-              label="Detailed explanation unavailable"
-              description="The exact charge above is authoritative."
-            />
+            <div className="px-2 py-1.5 text-sm">
+              <p className="font-medium text-foreground">
+                Detailed explanation unavailable
+              </p>
+              <p className="text-xs text-muted-foreground">
+                The exact charge above is authoritative.
+              </p>
+            </div>
           )}
-        </DropdownMenuSubContent>
-      </DropdownMenuPortal>
-    </DropdownMenuSub>
+        </section>
+      </PopoverContent>
+    </PopoverRoot>
   );
 }

--- a/front/components/assistant/conversation/FeedbackSelector.test.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.test.tsx
@@ -1,0 +1,141 @@
+import { FeedbackSelector } from "@app/components/assistant/conversation/FeedbackSelector";
+import type { LightWorkspaceType } from "@app/types/user";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock(
+  "@app/components/assistant/conversation/FeedbackSelectorPopoverContent",
+  () => ({
+    FeedbackSelectorPopoverContent: () => null,
+  })
+);
+
+const owner: LightWorkspaceType = {
+  id: 1,
+  sId: "w_1",
+  name: "Workspace",
+  role: "user",
+  segmentation: null,
+  whiteListedProviders: null,
+  defaultEmbeddingProvider: null,
+  regionalModelsOnly: false,
+  sharingPolicy: "workspace_only",
+  metronomeCustomerId: null,
+};
+
+const defaultProps: ComponentProps<typeof FeedbackSelector> = {
+  feedback: null,
+  onSubmitThumb: vi.fn().mockResolvedValue(undefined),
+  isSubmittingThumb: false,
+  owner,
+  agentConfigurationId: "agent_1",
+  agentName: "Helper",
+  isGlobalAgent: false,
+};
+
+beforeAll(() => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  );
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("FeedbackSelector", () => {
+  it("opens the feedback dialog with thumbs up preselected", async () => {
+    const user = userEvent.setup();
+    const onSubmitThumb = vi.fn().mockResolvedValue(undefined);
+    render(
+      <FeedbackSelector {...defaultProps} onSubmitThumb={onSubmitThumb} />
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "I found this helpful" })
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Provide feedback on @Helper" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Glad you liked it! Tell us more?")).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(onSubmitThumb).toHaveBeenCalledWith({
+        thumb: "up",
+        shouldRemoveExistingFeedback: false,
+        feedbackContent: null,
+        isConversationShared: true,
+      });
+    });
+  });
+
+  it("opens the feedback dialog with thumbs down preselected", async () => {
+    const user = userEvent.setup();
+    const onSubmitThumb = vi.fn().mockResolvedValue(undefined);
+    render(
+      <FeedbackSelector {...defaultProps} onSubmitThumb={onSubmitThumb} />
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Report an issue with this answer",
+      })
+    );
+
+    expect(screen.getByText("What was the issue?")).toBeVisible();
+    await user.type(
+      screen.getByPlaceholderText("Describe what went wrong"),
+      "The answer used outdated data."
+    );
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(onSubmitThumb).toHaveBeenCalledWith({
+        thumb: "down",
+        shouldRemoveExistingFeedback: false,
+        feedbackContent: "The answer used outdated data.",
+        isConversationShared: true,
+      });
+    });
+  });
+
+  it("removes feedback when clicking the selected thumb", async () => {
+    const user = userEvent.setup();
+    const onSubmitThumb = vi.fn().mockResolvedValue(undefined);
+    render(
+      <FeedbackSelector
+        {...defaultProps}
+        feedback={{
+          thumb: "up",
+          feedbackContent: null,
+          isConversationShared: true,
+        }}
+        onSubmitThumb={onSubmitThumb}
+      />
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "I found this helpful" })
+    );
+
+    expect(onSubmitThumb).toHaveBeenCalledWith({
+      thumb: "up",
+      shouldRemoveExistingFeedback: true,
+      feedbackContent: null,
+      isConversationShared: false,
+    });
+    expect(
+      screen.queryByRole("heading", { name: "Provide feedback on @Helper" })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -145,10 +145,13 @@ export function FeedbackSelector({
       return;
     }
 
-    form.reset({
-      ...DEFAULT_FEEDBACK_FORM_VALUES,
-      thumbDirection: direction,
-    });
+    form.reset(
+      {
+        ...DEFAULT_FEEDBACK_FORM_VALUES,
+        thumbDirection: direction,
+      },
+      { keepDefaultValues: true }
+    );
     setIsDialogOpen(true);
   };
 

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -11,7 +11,6 @@ import {
   DialogHeader,
   DialogTitle,
   Label,
-  MagicWand02,
   Spinner,
   TextArea,
   ThumbsDown,
@@ -89,6 +88,13 @@ function makeFeedbackSchema(showPredefinedAnswers: boolean) {
 
 type FeedbackFormValues = z.infer<ReturnType<typeof makeFeedbackSchema>>;
 
+const DEFAULT_FEEDBACK_FORM_VALUES: FeedbackFormValues = {
+  thumbDirection: null,
+  selectedAnswer: "",
+  feedbackContent: "",
+  isConversationShared: true,
+};
+
 export function FeedbackSelector({
   feedback,
   onSubmitThumb,
@@ -102,22 +108,11 @@ export function FeedbackSelector({
   // Predefined answers are not so relevant in the context of sidekick.
   const showPredefinedAnswers = !isSidekick;
 
-  const buttonLabel = feedback
-    ? "Clear feedback"
-    : isGlobalAgent
-      ? "Provide feedback"
-      : "Improve this agent";
-
   const [isDialogOpen, setIsDialogOpen] = React.useState(false);
 
   const form = useForm<FeedbackFormValues>({
     resolver: zodResolver(makeFeedbackSchema(showPredefinedAnswers)),
-    defaultValues: {
-      thumbDirection: null,
-      selectedAnswer: "",
-      feedbackContent: "",
-      isConversationShared: true,
-    },
+    defaultValues: DEFAULT_FEEDBACK_FORM_VALUES,
   });
 
   const thumbDirectionField = useController({
@@ -139,17 +134,22 @@ export function FeedbackSelector({
 
   const thumbDirection = thumbDirectionField.field.value;
 
-  const handleButtonClick = async () => {
-    if (feedback) {
+  const handleThumbClick = async (direction: ThumbReaction) => {
+    if (feedback?.thumb === direction) {
       await onSubmitThumb({
-        thumb: feedback.thumb,
+        thumb: direction,
         shouldRemoveExistingFeedback: true,
         feedbackContent: null,
         isConversationShared: false,
       });
-    } else {
-      setIsDialogOpen(true);
+      return;
     }
+
+    form.reset({
+      ...DEFAULT_FEEDBACK_FORM_VALUES,
+      thumbDirection: direction,
+    });
+    setIsDialogOpen(true);
   };
 
   const handleThumbSelect = (direction: ThumbReaction) => {
@@ -183,15 +183,22 @@ export function FeedbackSelector({
   });
 
   return (
-    <div className="flex items-center">
+    <div className="flex items-center gap-1">
       <Button
-        variant={feedback ? "primary" : "outline"}
+        variant={feedback?.thumb === "up" ? "primary" : "ghost-secondary"}
         size="xs"
         disabled={isSubmittingThumb}
-        onClick={handleButtonClick}
-        icon={MagicWand02}
-        label={buttonLabel}
-        className={feedback ? "" : "text-muted-foreground"}
+        onClick={() => void handleThumbClick("up")}
+        icon={ThumbsUp}
+        tooltip="I found this helpful"
+      />
+      <Button
+        variant={feedback?.thumb === "down" ? "primary" : "ghost-secondary"}
+        size="xs"
+        disabled={isSubmittingThumb}
+        onClick={() => void handleThumbClick("down")}
+        icon={ThumbsDown}
+        tooltip="Report an issue with this answer"
       />
 
       <Dialog

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsagePanel.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsagePanel.tsx
@@ -26,7 +26,7 @@ export function ConversationCreditUsagePanel({
   return (
     <div className="flex h-panel flex-col">
       <ConversationSidePanelHeader onClose={closePanel}>
-        <span className="text-sm font-semibold text-foreground">
+        <span className="text-sm font-medium text-foreground">
           Conversation credit usage
         </span>
       </ConversationSidePanelHeader>

--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -92,7 +92,7 @@ export function ConversationFileExplorer({
       <AppLayoutTitle>
         <div className="flex h-full items-center justify-between gap-2">
           <span className="text-sm text-foreground">
-            {isPod ? "Files" : "Conversation Files"}
+            {isPod ? "Files" : "Conversation files"}
           </span>
           <Button
             variant="ghost"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR implements the new agent message footer [design](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=13006-5011&m=dev), giving the credits consumed by each message a first-class spot alongside feedback and copy actions.

Clicking the credit count opens a detailed, accessible breakdown of the message’s consumption.

https://github.com/user-attachments/assets/1d721816-c378-4fcf-8aa0-419b102b6470

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
