### PR TITLE
[front] enh: list pod conversations in Poke

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/conversations.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/conversations.test.ts
@@ -1,0 +1,97 @@
+import { Authenticator } from "@app/lib/auth";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function projectConversationsUrl(workspaceId: string, projectId: string) {
+  return `/api/poke/workspaces/${workspaceId}/projects/${projectId}/conversations`;
+}
+
+describe("GET /api/poke/workspaces/:wId/projects/:projectId/conversations", () => {
+  it("lists the pod conversations with cursor pagination", async () => {
+    const {
+      auth: initialAuth,
+      user,
+      workspace,
+    } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+    const project = await SpaceFactory.project(workspace, user.id);
+    const otherProject = await SpaceFactory.project(workspace, user.id);
+    await project.addMembers(initialAuth, { userIds: [user.sId] });
+    await otherProject.addMembers(initialAuth, { userIds: [user.sId] });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const olderConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "unused",
+      messagesCreatedAt: [],
+      requestedSpaceIds: [project.id],
+      spaceId: project.id,
+    });
+    const newerConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "unused",
+      messagesCreatedAt: [],
+      requestedSpaceIds: [project.id],
+      spaceId: project.id,
+    });
+    const testConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "unused",
+      messagesCreatedAt: [],
+      requestedSpaceIds: [project.id],
+      spaceId: project.id,
+      visibility: "test",
+    });
+    const otherProjectConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "unused",
+      messagesCreatedAt: [],
+      requestedSpaceIds: [otherProject.id],
+      spaceId: otherProject.id,
+    });
+
+    await ConversationFactory.setUpdatedAtForTest(
+      auth,
+      olderConversation.id,
+      new Date("2026-01-01T00:00:00.000Z")
+    );
+    await ConversationFactory.setUpdatedAtForTest(
+      auth,
+      newerConversation.id,
+      new Date("2026-01-02T00:00:00.000Z")
+    );
+
+    const url = projectConversationsUrl(workspace.sId, project.sId);
+    const firstResponse = await honoApp.request(`${url}?limit=1`);
+
+    expect(firstResponse.status).toBe(200);
+    const firstPage = await firstResponse.json();
+    expect(firstPage.conversations).toEqual([
+      expect.objectContaining({ id: newerConversation.sId }),
+    ]);
+    expect(firstPage.hasMore).toBe(true);
+    expect(firstPage.lastValue).not.toBeNull();
+
+    const secondResponse = await honoApp.request(
+      `${url}?limit=1&lastValue=${firstPage.lastValue}`
+    );
+
+    expect(secondResponse.status).toBe(200);
+    const secondPage = await secondResponse.json();
+    expect(secondPage.conversations).toEqual([
+      expect.objectContaining({ id: olderConversation.sId }),
+    ]);
+    expect(secondPage.hasMore).toBe(false);
+
+    const returnedConversationIds = [
+      ...firstPage.conversations,
+      ...secondPage.conversations,
+    ].map((conversation: { id: string }) => conversation.id);
+    expect(returnedConversationIds).not.toContain(testConversation.sId);
+    expect(returnedConversationIds).not.toContain(otherProjectConversation.sId);
+  });
+});

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/conversations.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/conversations.ts
@@ -1,0 +1,60 @@
+import { getPaginationParams } from "@app/lib/api/pagination";
+import { toPodConversationListItem } from "@app/lib/api/projects/conversations";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { GetSpaceConversationsResponseBody } from "@app/types/api/assistant/conversation/spaces";
+import { pokeProjectApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+
+// Mounted at /api/poke/workspaces/:wId/projects/:projectId/conversations.
+const app = pokeProjectApp();
+
+/** @ignoreswagger */
+app.get("/", async (ctx): HandlerResult<GetSpaceConversationsResponseBody> => {
+  const auth = ctx.get("auth");
+  const space = ctx.get("space");
+
+  const paginationRes = getPaginationParams(ctx.req.query(), {
+    defaultLimit: 20,
+    defaultOrderColumn: "updatedAt",
+    defaultOrderDirection: "desc",
+    supportedOrderColumn: ["updatedAt"],
+  });
+
+  if (paginationRes.isErr()) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: paginationRes.error.reason,
+      },
+    });
+  }
+
+  const pagination = paginationRes.value;
+  const {
+    conversations: conversationResources,
+    hasMore,
+    lastValue,
+  } = await ConversationResource.listConversationsInSpacePaginated(auth, {
+    spaceId: space.sId,
+    options: { excludeTest: true },
+    pagination: {
+      limit: pagination.limit,
+      lastValue: pagination.lastValue,
+      orderDirection: pagination.orderDirection,
+    },
+  });
+
+  const conversations = await toPodConversationListItem(auth, {
+    conversations: conversationResources,
+  });
+
+  return ctx.json({
+    conversations,
+    hasMore,
+    lastValue,
+    isEmpty: !pagination.lastValue && conversations.length === 0,
+  });
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/index.ts
@@ -2,6 +2,7 @@ import { pokeProjectApp } from "@front-api/middlewares/ctx";
 import { withProject } from "@front-api/middlewares/with_projects";
 
 import connectorKnowledge from "./connector-knowledge";
+import conversations from "./conversations";
 import podDatabases from "./pod-databases";
 import podFunctions from "./pod-functions";
 import tasks from "./tasks";
@@ -12,6 +13,7 @@ const app = pokeProjectApp();
 app.use("*", withProject());
 
 app.route("/connector-knowledge", connectorKnowledge);
+app.route("/conversations", conversations);
 app.route("/tasks-workflow", tasksWorkflow);
 app.route("/tasks", tasks);
 app.route("/pod-functions", podFunctions);

--- a/front/components/poke/pages/ProjectPage.tsx
+++ b/front/components/poke/pages/ProjectPage.tsx
@@ -46,7 +46,6 @@ export function ProjectPage({ details }: ProjectPageProps) {
               readonly
             />
           ))}
-          <ProjectConversationDataTable owner={owner} projectId={space.sId} />
           <PluginList
             pluginResourceTarget={{
               resourceId: space.sId,
@@ -54,6 +53,7 @@ export function ProjectPage({ details }: ProjectPageProps) {
               workspace: owner,
             }}
           />
+          <ProjectConversationDataTable owner={owner} projectId={space.sId} />
           <ViewProjectWorkflowTable owner={owner} projectId={space.sId} />
           <ProjectConnectorKnowledgeDataTable
             owner={owner}

--- a/front/components/poke/pages/ProjectPage.tsx
+++ b/front/components/poke/pages/ProjectPage.tsx
@@ -2,6 +2,7 @@ import { DataSourceViewsDataTable } from "@app/components/poke/data_source_views
 import { MembersDataTable } from "@app/components/poke/members/table";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
 import { ProjectConnectorKnowledgeDataTable } from "@app/components/poke/projects/connector_knowledge/table";
+import { ProjectConversationDataTable } from "@app/components/poke/projects/conversations/table";
 import { ProjectPodDatabaseDataTable } from "@app/components/poke/projects/pod_databases/table";
 import { ProjectPodFunctionDataTable } from "@app/components/poke/projects/pod_functions/table";
 import { ProjectTasksDataTable } from "@app/components/poke/projects/tasks/table";
@@ -45,6 +46,7 @@ export function ProjectPage({ details }: ProjectPageProps) {
               readonly
             />
           ))}
+          <ProjectConversationDataTable owner={owner} projectId={space.sId} />
           <PluginList
             pluginResourceTarget={{
               resourceId: space.sId,

--- a/front/components/poke/projects/conversations/columns.tsx
+++ b/front/components/poke/projects/conversations/columns.tsx
@@ -1,0 +1,53 @@
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type { PodConversationListItemType } from "@app/types/api/assistant/conversation/spaces";
+import type { LightWorkspaceType } from "@app/types/user";
+import { LinkWrapper } from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+
+export function makeColumnsForProjectConversations(
+  owner: LightWorkspaceType
+): ColumnDef<PodConversationListItemType>[] {
+  return [
+    {
+      accessorKey: "id",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="sId" />
+      ),
+      cell: ({ row }) => (
+        <LinkWrapper
+          href={`/poke/${owner.sId}/conversation/${row.original.id}`}
+        >
+          {row.original.id}
+        </LinkWrapper>
+      ),
+    },
+    {
+      accessorKey: "updated",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Updated at" />
+      ),
+      cell: ({ row }) => formatTimestampToFriendlyDate(row.original.updated),
+    },
+    {
+      accessorKey: "title",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Title" />
+      ),
+    },
+    {
+      id: "creator",
+      accessorFn: (conversation) => conversation.creator?.name ?? "",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Creator" />
+      ),
+      cell: ({ row }) => row.original.creator?.name ?? "—",
+    },
+    {
+      accessorKey: "replyCount",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Replies" />
+      ),
+    },
+  ];
+}

--- a/front/components/poke/projects/conversations/table.tsx
+++ b/front/components/poke/projects/conversations/table.tsx
@@ -1,0 +1,53 @@
+import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
+import { makeColumnsForProjectConversations } from "@app/components/poke/projects/conversations/columns";
+import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import { usePokeProjectConversations } from "@app/poke/swr/project_conversations";
+import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Button } from "@dust-tt/sparkle";
+import { useState } from "react";
+
+const PAGE_SIZE = 20;
+
+interface ProjectConversationDataTableProps {
+  owner: LightWorkspaceType;
+  projectId: string;
+}
+
+export function ProjectConversationDataTable({
+  owner,
+  projectId,
+}: ProjectConversationDataTableProps) {
+  const [limit, setLimit] = useState(PAGE_SIZE);
+  const useConversationsForProject = (props: PokeConditionalFetchProps) =>
+    usePokeProjectConversations({ ...props, limit, projectId });
+
+  return (
+    <PokeDataTableConditionalFetch
+      header="Conversations"
+      owner={owner}
+      showSensitiveDataWarning={true}
+      useSWRHook={useConversationsForProject}
+    >
+      {({ conversations, hasMore, isLoadingMore }) => (
+        <div className="flex flex-col gap-3">
+          <PokeDataTable
+            columns={makeColumnsForProjectConversations(owner)}
+            data={conversations}
+            pageSize={PAGE_SIZE}
+          />
+          {hasMore && (
+            <div className="flex justify-center">
+              <Button
+                variant="outline"
+                label="Load more"
+                isLoading={isLoadingMore}
+                onClick={() => setLimit((current) => current + PAGE_SIZE)}
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </PokeDataTableConditionalFetch>
+  );
+}

--- a/front/poke/swr/project_conversations.ts
+++ b/front/poke/swr/project_conversations.ts
@@ -1,0 +1,48 @@
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type {
+  GetSpaceConversationsResponseBody,
+  PodConversationListItemType,
+} from "@app/types/api/assistant/conversation/spaces";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { Fetcher } from "swr";
+
+interface UsePokeProjectConversationsProps {
+  disabled?: boolean;
+  limit: number;
+  owner: LightWorkspaceType;
+  projectId: string;
+}
+
+export interface PokeProjectConversationsData {
+  conversations: PodConversationListItemType[];
+  hasMore: boolean;
+  isLoadingMore: boolean;
+}
+
+export function usePokeProjectConversations({
+  disabled,
+  limit,
+  owner,
+  projectId,
+}: UsePokeProjectConversationsProps) {
+  const { fetcher } = useFetcher();
+  const conversationsFetcher: Fetcher<GetSpaceConversationsResponseBody> =
+    fetcher;
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/projects/${projectId}/conversations?limit=${limit}`,
+    conversationsFetcher,
+    { disabled, keepPreviousData: true }
+  );
+
+  return {
+    data: {
+      conversations:
+        data?.conversations ?? emptyArray<PodConversationListItemType>(),
+      hasMore: data?.hasMore ?? false,
+      isLoadingMore: isValidating && !!data,
+    },
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}


### PR DESCRIPTION
## Description

This PR adds a conversation table to the Poke pod page.
Can be used to see what conversations are listed for users.

It uses the same paginated conversation query and list-item serialization as the user-facing pod view, excludes test conversations, and links each result to its Poke conversation page.

<img width="1507" height="519" alt="image" src="https://github.com/user-attachments/assets/b2e2a9c5-10d3-4104-abc5-d3982ec0491b" />

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
