### PR TITLE
[front] add rich fields to activation_recommendations model

### DIFF
--- a/front/lib/models/activation/activation_recommendation.ts
+++ b/front/lib/models/activation/activation_recommendation.ts
@@ -75,7 +75,7 @@ ActivationRecommendationModel.init(
       allowNull: false,
     },
     body: {
-      type: DataTypes.STRING(2048),
+      type: DataTypes.STRING(1024),
       allowNull: true,
     },
     steps: {

--- a/front/lib/models/activation/activation_recommendation.ts
+++ b/front/lib/models/activation/activation_recommendation.ts
@@ -27,6 +27,11 @@ export class ActivationRecommendationModel extends WorkspaceAwareModel<Activatio
   declare status: ActivationRecommendationStatus;
   declare title: string;
   declare content: string;
+  declare body: string | null;
+  declare steps: string[] | null;
+  declare ctaLabel: string | null;
+  declare sourceIcon: string | null;
+  declare sourceLabel: string | null;
 
   // The conversation in which the recommendation was (originally) made
   declare conversationId: ForeignKey<ConversationModel["id"]> | null;
@@ -68,6 +73,26 @@ ActivationRecommendationModel.init(
     content: {
       type: DataTypes.STRING(4096),
       allowNull: false,
+    },
+    body: {
+      type: DataTypes.STRING(2048),
+      allowNull: true,
+    },
+    steps: {
+      type: DataTypes.ARRAY(DataTypes.STRING),
+      allowNull: true,
+    },
+    ctaLabel: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    sourceIcon: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    sourceLabel: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
     conversationId: {
       type: DataTypes.BIGINT,

--- a/front/migrations/pre-deploy/20260805100000_add_rich_fields_activation_recommendations.sql
+++ b/front/migrations/pre-deploy/20260805100000_add_rich_fields_activation_recommendations.sql
@@ -5,7 +5,7 @@ SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
 
 ALTER TABLE "public"."activation_recommendations"
-  ADD COLUMN IF NOT EXISTS "body" character varying(2048),
+  ADD COLUMN IF NOT EXISTS "body" character varying(1024),
   ADD COLUMN IF NOT EXISTS "steps" character varying(255)[],
   ADD COLUMN IF NOT EXISTS "ctaLabel" character varying(255),
   ADD COLUMN IF NOT EXISTS "sourceIcon" character varying(255),

--- a/front/migrations/pre-deploy/20260805100000_add_rich_fields_activation_recommendations.sql
+++ b/front/migrations/pre-deploy/20260805100000_add_rich_fields_activation_recommendations.sql
@@ -1,0 +1,12 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+
+ALTER TABLE "public"."activation_recommendations"
+  ADD COLUMN IF NOT EXISTS "body" character varying(2048),
+  ADD COLUMN IF NOT EXISTS "steps" character varying(255)[],
+  ADD COLUMN IF NOT EXISTS "ctaLabel" character varying(255),
+  ADD COLUMN IF NOT EXISTS "sourceIcon" character varying(255),
+  ADD COLUMN IF NOT EXISTS "sourceLabel" character varying(255);


### PR DESCRIPTION
## Summary
Adds five nullable columns to the `activation_recommendations` table and the matching Sequelize model fields, to back the richer recommendation cards on the new Get Started page:

- `body` — `varchar(2048)`: fuller explanation shown when a card is expanded.
- `steps` — `varchar(255)[]`: ordered, user-facing steps the recommendation performs.
- `ctaLabel` — `varchar(255)`: accept-button label (e.g. "Create this agent").
- `sourceIcon` — `varchar(255)`: connector provider (e.g. `slack`) or Sparkle icon name.
- `sourceLabel` — `varchar(255)`: short source label (e.g. "From your #design Slack channel").

All columns are nullable and additive — existing rows and code paths are unaffected, and no backfill is required. Column sizes follow existing conventions (bare `DataTypes.STRING` → `varchar(255)`, `ARRAY(DataTypes.STRING)`, and `2048` for the longer `body`).

This PR is intentionally scoped to **just the model + migration**. The resource, API, MCP tool schema, prompt, and UI that consume these fields land in a follow-up.

## Testing
- Ran migration locally

## Risk
Low - not customer facing yet

## Deploy
1. pre-deploy migration
2. deploy front