### PR TITLE
[front] fix: capture conversations from sub agents in pod manager backfill script

### DIFF
--- a/front/migrations/20260805_find_pod_manager_conversations.ts
+++ b/front/migrations/20260805_find_pod_manager_conversations.ts
@@ -142,18 +142,14 @@ async function updateConversationDepthsToZero(
     );
   }
 
-  const conversationsToUpdate = conversations.filter(
-    // We only take the ones with depth 1, the other ones have been created with sub agents so should remain hidden.
-    (conversation) => conversation.depth === 1
-  );
   let updatedConversationCount = 0;
-  if (execute && conversationsToUpdate.length > 0) {
+  if (execute && conversations.length > 0) {
     [updatedConversationCount] = await ConversationModel.update(
       { depth: 0 },
       {
         where: {
           workspaceId: auth.getNonNullableWorkspace().id,
-          id: { [Op.in]: conversationsToUpdate.map(({ id }) => id) },
+          id: { [Op.in]: conversations.map(({ id }) => id) },
         },
         // Silent to not update the updatedAt of Sequelize.
         silent: true,
@@ -164,7 +160,7 @@ async function updateConversationDepthsToZero(
   logger.info(
     {
       execute,
-      conversationToUpdateCount: conversationsToUpdate.length,
+      conversationCount: conversations.length,
       updatedConversationCount,
     },
     execute


### PR DESCRIPTION
## Description

Context in this [thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1785951045202809?thread_ts=1785932638.562669&cid=C050SM8NSPK).
This PR tweaks the script introduced in https://github.com/dust-tt/dust/pull/30044 to include all conversations, regardless of their depths.
This will bring conversations created by sub agents back in the pod list view.

## Tests

## Risk

- N/A

## Deploy Plan

- No deploy
