### PR TITLE
fix(front): always create conversation forks at depth 0

### DIFF
--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -482,6 +482,7 @@ describe("createConversationFork", () => {
     const parentConversation = await createConversation(auth, {
       title: "Parent conversation",
       visibility: "unlisted",
+      depth: 1,
       spaceId: null,
     });
 
@@ -514,9 +515,8 @@ describe("createConversationFork", () => {
 
     expect(childConversation.title).toBeNull();
     expect(childConversation.spaceId).toBe(null);
-    // Forks keep the parent's depth: depth > 0 marks run_agent sub-conversations,
-    // which are hidden from space conversation lists.
-    expect(childConversation.depth).toBe(parentConversation.depth);
+    // Forks are root conversations even when created from a sub-agent conversation.
+    expect(childConversation.depth).toBe(0);
     expect(childConversation.forkingData).toEqual({
       forkedFrom: {
         parentConversationId: parentConversation.sId,

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -609,7 +609,9 @@ export async function createConversationFork(
         sId: generateRandomModelSId(),
         title: null,
         visibility: parentConversation.visibility,
-        // Forks are user-facing conversations, not run_agent sub-conversations.
+        // Forking is an explicit user operation, so users expect to find the
+        // conversation they created alongside their other root conversations.
+        // Forks are not run_agent sub-conversations, even when their source is.
         depth: 0,
         triggerId: null,
         spaceId: parentConversation.space?.id ?? null,

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -609,10 +609,8 @@ export async function createConversationFork(
         sId: generateRandomModelSId(),
         title: null,
         visibility: parentConversation.visibility,
-        // Forks are user-facing conversations, not run_agent sub-conversations:
-        // they must keep the parent's depth so depth-based behaviors (space
-        // listing, notifications, action limits) treat them as such.
-        depth: parentConversation.depth,
+        // Forks are user-facing conversations, not run_agent sub-conversations.
+        depth: 0,
         triggerId: null,
         spaceId: parentConversation.space?.id ?? null,
         requestedSpaceIds: [...parentConversation.requestedSpaceIds],


### PR DESCRIPTION
## Description

Follow up on #28931 by creating every new conversation fork at depth 0, regardless of the parent conversation's depth. This keeps forks from sub-agent conversations visible as root conversations while preserving their parent and fork lineage.

## Tests

Updated `front/lib/api/assistant/conversation/forks.test.ts` to fork a depth-1 conversation and assert that the child has depth 0. `git diff --check` passed. The focused Vitest test was not run locally because the shallow clone does not have dependencies installed in the Computer.

## Risk

Low. The change only affects the depth assigned to newly created forks. Parent relationships, requested spaces, and other fork metadata remain unchanged. No data migration is required.

## Deploy Plan

Deploy through the standard front-end rollout. PR CI should run the focused test and the repository's normal validation checks.