### PR TITLE
[front] feat: add activation-pod API route and Learning Space SWR hooks

### DIFF
--- a/front-api/routes/w/[wId]/activation-pod/index.test.ts
+++ b/front-api/routes/w/[wId]/activation-pod/index.test.ts
@@ -1,0 +1,41 @@
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function getActivationPod(wId: string) {
+  return honoApp.request(`/api/w/${wId}/activation-pod`);
+}
+
+describe("GET /api/w/:wId/activation-pod", () => {
+  it("returns null when the user has no activation pod", async () => {
+    const { workspace } = await createPrivateApiMockRequest();
+
+    const response = await getActivationPod(workspace.sId);
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body).toEqual({ podId: null });
+  });
+
+  it("returns the pod space sId when the user has an activation pod", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest();
+
+    const user = auth.getNonNullableUser();
+    const [userResource] = await UserResource.fetchByModelIds([user.id]);
+    const podSpace = await SpaceFactory.regular(workspace);
+
+    await ActivationPodResource.makeNew(auth, {
+      pod: podSpace,
+      user: userResource,
+    });
+
+    const response = await getActivationPod(workspace.sId);
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body).toEqual({ podId: podSpace.sId });
+  });
+});

--- a/front-api/routes/w/[wId]/activation-pod/index.ts
+++ b/front-api/routes/w/[wId]/activation-pod/index.ts
@@ -1,0 +1,21 @@
+import type { GetActivationPodResponseBody } from "@app/lib/api/activation/recommendations";
+import { getActivationPodSpaceSIdForUser } from "@app/lib/api/activation/recommendations";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { type HandlerResult } from "@front-api/middlewares/utils";
+
+// Mounted at /api/w/:wId/activation-pod.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  async (ctx): HandlerResult<GetActivationPodResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const podId = await getActivationPodSpaceSIdForUser(auth);
+
+    return ctx.json({ podId });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/activation-pod/index.ts
+++ b/front-api/routes/w/[wId]/activation-pod/index.ts
@@ -1,21 +1,18 @@
 import type { GetActivationPodResponseBody } from "@app/lib/api/activation/recommendations";
 import { getActivationPodSpaceSIdForUser } from "@app/lib/api/activation/recommendations";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { type HandlerResult } from "@front-api/middlewares/utils";
+import type { HandlerResult } from "@front-api/middlewares/utils";
 
 // Mounted at /api/w/:wId/activation-pod.
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
-  "/",
-  async (ctx): HandlerResult<GetActivationPodResponseBody> => {
-    const auth = ctx.get("auth");
+app.get("/", async (ctx): HandlerResult<GetActivationPodResponseBody> => {
+  const auth = ctx.get("auth");
 
-    const podId = await getActivationPodSpaceSIdForUser(auth);
+  const podId = await getActivationPodSpaceSIdForUser(auth);
 
-    return ctx.json({ podId });
-  }
-);
+  return ctx.json({ podId });
+});
 
 export default app;

--- a/front-api/routes/w/[wId]/activation-pod/index.ts
+++ b/front-api/routes/w/[wId]/activation-pod/index.ts
@@ -1,5 +1,5 @@
 import type { GetActivationPodResponseBody } from "@app/lib/api/activation/recommendations";
-import { getActivationPodSId } from "@app/lib/api/activation/recommendations";
+import { getActivationPodId } from "@app/lib/api/activation/recommendations";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
@@ -10,7 +10,7 @@ const app = workspaceApp();
 app.get("/", async (ctx): HandlerResult<GetActivationPodResponseBody> => {
   const auth = ctx.get("auth");
 
-  const podId = await getActivationPodSId(auth);
+  const podId = await getActivationPodId(auth);
 
   return ctx.json({ podId });
 });

--- a/front-api/routes/w/[wId]/activation-pod/index.ts
+++ b/front-api/routes/w/[wId]/activation-pod/index.ts
@@ -1,5 +1,5 @@
 import type { GetActivationPodResponseBody } from "@app/lib/api/activation/recommendations";
-import { getActivationPodSpaceSIdForUser } from "@app/lib/api/activation/recommendations";
+import { getActivationPodSId } from "@app/lib/api/activation/recommendations";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
@@ -10,7 +10,7 @@ const app = workspaceApp();
 app.get("/", async (ctx): HandlerResult<GetActivationPodResponseBody> => {
   const auth = ctx.get("auth");
 
-  const podId = await getActivationPodSpaceSIdForUser(auth);
+  const podId = await getActivationPodSId(auth);
 
   return ctx.json({ podId });
 });

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -27,6 +27,7 @@ import { validate } from "@front-api/middlewares/validator";
 import { workspaceAuth } from "@front-api/middlewares/workspace_auth";
 import { escape } from "html-escaper";
 import { z } from "zod";
+import activationPod from "./activation-pod";
 import actionRecommendations from "./activation-recommendations";
 import analytics from "./analytics";
 import assistant from "./assistant";
@@ -953,6 +954,7 @@ app.post(
 // Sub-apps using the catch-all default + the partial-subtree exception
 // targets declared above.
 app.route("/activation-recommendations", actionRecommendations);
+app.route("/activation-pod", activationPod);
 app.route("/analytics", analytics);
 app.route("/model_tiers", modelTiers);
 app.route("/assistant", assistant);

--- a/front/lib/api/activation/recommendations.ts
+++ b/front/lib/api/activation/recommendations.ts
@@ -28,7 +28,7 @@ export interface GetActivationPodResponseBody {
   podId: string | null;
 }
 
-export async function getActivationPodSId(
+export async function getActivationPodId(
   auth: Authenticator
 ): Promise<string | null> {
   const activationPod = await ActivationPodResource.fetchByUser(auth);

--- a/front/lib/api/activation/recommendations.ts
+++ b/front/lib/api/activation/recommendations.ts
@@ -1,5 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import type { ActivationRecommendationStatus } from "@app/lib/models/activation/activation_recommendation";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { ActivationRecommendationResource } from "@app/lib/resources/activation_recommendation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 
@@ -21,6 +22,29 @@ export interface ActivationRecommendationForUserType {
 
 export interface GetActivationRecommendationsResponseBody {
   recommendations: ActivationRecommendationForUserType[];
+}
+
+export interface GetActivationPodResponseBody {
+  // The sId of the space backing the user's activation Pod, or null if they
+  // don't have one. Used to scope the Learning Space page (recommendations +
+  // recent conversations) to that Pod.
+  podId: string | null;
+}
+
+// Resolves the space sId of the calling user's activation Pod.
+export async function getActivationPodSpaceSIdForUser(
+  auth: Authenticator
+): Promise<string | null> {
+  const activationPod = await ActivationPodResource.fetchByUser(auth);
+  if (!activationPod) {
+    return null;
+  }
+
+  const [space] = await SpaceResource.fetchByModelIds(auth, [
+    activationPod.spaceId,
+  ]);
+
+  return space?.sId ?? null;
 }
 
 export interface UpdateActivationRecommendationResponseBody {

--- a/front/lib/api/activation/recommendations.ts
+++ b/front/lib/api/activation/recommendations.ts
@@ -25,14 +25,10 @@ export interface GetActivationRecommendationsResponseBody {
 }
 
 export interface GetActivationPodResponseBody {
-  // The sId of the space backing the user's activation Pod, or null if they
-  // don't have one. Used to scope the Learning Space page (recommendations +
-  // recent conversations) to that Pod.
   podId: string | null;
 }
 
-// Resolves the space sId of the calling user's activation Pod.
-export async function getActivationPodSpaceSIdForUser(
+export async function getActivationPodSId(
   auth: Authenticator
 ): Promise<string | null> {
   const activationPod = await ActivationPodResource.fetchByUser(auth);

--- a/front/lib/resources/activation_pod_resource.ts
+++ b/front/lib/resources/activation_pod_resource.ts
@@ -78,6 +78,24 @@ export class ActivationPodResource extends BaseResource<ActivationPodModel> {
     return activationPod ?? null;
   }
 
+  // Fetches the calling user's activation Pod. A user can technically have more
+  // than one over time; we return the most recent, treated as "their" learning
+  // space for surfaces like the Get Started page.
+  static async fetchByUser(
+    auth: Authenticator
+  ): Promise<ActivationPodResource | null> {
+    const user = auth.getNonNullableUser();
+    const activationPod = await this.model.findOne({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        userId: user.id,
+      },
+      order: [["createdAt", "DESC"]],
+    });
+
+    return activationPod ? new this(this.model, activationPod.get()) : null;
+  }
+
   // Batch variant of fetchBySpace, avoiding one query per pod (e.g. when the
   // scheduler processes many pods at once).
   static async fetchBySpaceModelIds(

--- a/front/lib/swr/activation.ts
+++ b/front/lib/swr/activation.ts
@@ -1,5 +1,8 @@
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { GetActivationRecommendationsResponseBody } from "@app/lib/api/activation/recommendations";
+import type {
+  GetActivationPodResponseBody,
+  GetActivationRecommendationsResponseBody,
+} from "@app/lib/api/activation/recommendations";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
@@ -13,24 +16,34 @@ import type { Fetcher } from "swr";
 export function useActivationRecommendations({
   workspaceId,
   podId,
+  status,
   disabled,
 }: {
   workspaceId: string;
   podId?: string;
+  status?: "suggested" | "executed";
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const recommendationsFetcher: Fetcher<GetActivationRecommendationsResponseBody> =
     fetcher;
 
-  const url = podId
-    ? `/api/w/${workspaceId}/activation-recommendations?podId=${podId}`
+  const params = new URLSearchParams();
+  if (podId) {
+    params.set("podId", podId);
+  }
+  if (status) {
+    params.set("status", status);
+  }
+  const queryString = params.toString();
+  const url = queryString
+    ? `/api/w/${workspaceId}/activation-recommendations?${queryString}`
     : `/api/w/${workspaceId}/activation-recommendations`;
 
   const { data, error, mutate, isLoading } = useSWRWithDefaults(
     url,
     recommendationsFetcher,
-    { disabled }
+    { disabled, revalidateOnFocus: false }
   );
 
   return {
@@ -38,6 +51,29 @@ export function useActivationRecommendations({
     isRecommendationsLoading: disabled ? false : isLoading,
     isRecommendationsError: !!error,
     mutateRecommendations: mutate,
+  };
+}
+
+export function useActivationPod({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const podFetcher: Fetcher<GetActivationPodResponseBody> = fetcher;
+
+  const { data, error, isLoading } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/activation-pod`,
+    podFetcher,
+    { disabled, revalidateOnFocus: false }
+  );
+
+  return {
+    activationPodId: data?.podId ?? null,
+    isActivationPodLoading: disabled ? false : isLoading,
+    isActivationPodError: !!error,
   };
 }
 


### PR DESCRIPTION
## Summary
- Adds activation-pod API that will be used to fetch the pod ID for the calling user
- Adds `useActivationPod` SWR hook for client-side pod resolution
- Extends `useActivationRecommendations` with a `status` param and URLSearchParams-based URL building; disables `revalidateOnFocus` on both hooks

## Testing

- Unit test

## Risk

Low - not user facing yet

## Deploy
1. Deploy front