### PR TITLE
[front] fix: make agents clickable from user's top agents list

### DIFF
--- a/front/components/workspace/analytics/WorkspaceUserCreditsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceUserCreditsTable.tsx
@@ -1,4 +1,5 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
+import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
 import type { AnalyticsEntityFilter } from "@app/components/workspace/analytics/analyticsFilter";
 import { CreditsTableCard } from "@app/components/workspace/analytics/CreditsTableCard";
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
@@ -13,23 +14,31 @@ import type {
   UserCreditAgent,
   UserCreditRow,
 } from "@app/lib/api/assistant/observability/user_credits";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { useWorkspaceUserCredits } from "@app/lib/swr/workspaces";
-import { Avatar, DataTable, Tooltip } from "@dust-tt/sparkle";
+import { Avatar, DataTable, Hoverable, Tooltip } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
+import { useState } from "react";
 
 interface UserCreditRowData extends UserCreditRow {
   onClick?: () => void;
   onDoubleClick?: () => void;
+  onAgentClick?: (agentId: string) => void;
 }
 
 type UserCreditInfo = CellContext<UserCreditRowData, unknown>;
 
-function TopAgentsCell({ agents }: { agents: UserCreditAgent[] }) {
+interface TopAgentsCellProps {
+  agents: UserCreditAgent[];
+  onAgentClick?: (agentId: string) => void;
+}
+
+function TopAgentsCell({ agents, onAgentClick }: TopAgentsCellProps) {
   return (
     <EntityList
       items={agents}
       renderItem={(agent) => {
-        const row = (
+        const label = (
           <div className="flex items-center gap-1.5">
             <Avatar
               name={agent.name}
@@ -44,6 +53,20 @@ function TopAgentsCell({ agents }: { agents: UserCreditAgent[] }) {
               </span>
             </span>
           </div>
+        );
+        const row = onAgentClick ? (
+          <Hoverable
+            variant="primary"
+            className="flex min-w-0 items-center text-left"
+            onClick={(e) => {
+              e.stopPropagation();
+              onAgentClick(agent.agentId);
+            }}
+          >
+            {label}
+          </Hoverable>
+        ) : (
+          label
         );
         return agent.description ? (
           <Tooltip
@@ -106,7 +129,10 @@ const columns: ColumnDef<UserCreditRowData>[] = [
     meta: { sizeRatio: 44 },
     cell: (info: UserCreditInfo) => (
       <DataTable.CellContent>
-        <TopAgentsCell agents={info.row.original.topAgents} />
+        <TopAgentsCell
+          agents={info.row.original.topAgents}
+          onAgentClick={info.row.original.onAgentClick}
+        />
       </DataTable.CellContent>
     ),
   },
@@ -123,6 +149,9 @@ export function WorkspaceUserCreditsTable({
   period,
   onSelectUser,
 }: WorkspaceUserCreditsTableProps) {
+  const { user, workspace } = useAuth();
+  const [detailedAgentId, setDetailedAgentId] = useState<string | null>(null);
+
   const { inputValue, debouncedValue, setValue } = useDebounce("", {
     delay: 300,
   });
@@ -136,12 +165,13 @@ export function WorkspaceUserCreditsTable({
       disabled: !workspaceId,
     });
 
-  const rows: UserCreditRowData[] = onSelectUser
-    ? userCredits.map((row) => ({
-        ...row,
-        onClick: () => onSelectUser({ id: row.userId, name: row.name }),
-      }))
-    : userCredits;
+  const rows: UserCreditRowData[] = userCredits.map((row) => ({
+    ...row,
+    onAgentClick: (agentId) => setDetailedAgentId(agentId),
+    ...(onSelectUser
+      ? { onClick: () => onSelectUser({ id: row.userId, name: row.name }) }
+      : {}),
+  }));
 
   const exportParams = new URLSearchParams({
     days: period.toString(),
@@ -161,24 +191,32 @@ export function WorkspaceUserCreditsTable({
   });
 
   return (
-    <CreditsTableCard<UserCreditRowData>
-      actions={<CsvDownloadButton {...csvDownload} />}
-      title="Users by credits"
-      description={`Top 100 users by credits over the last ${period} days, with their most-used agents.`}
-      searchName="user-credits-search"
-      searchPlaceholder="Search a user…"
-      searchValue={inputValue}
-      onSearchChange={setValue}
-      isLoading={isUserCreditsLoading}
-      isError={Boolean(isUserCreditsError)}
-      errorMessage="Failed to load user credits."
-      emptyMessage={
-        debouncedValue
-          ? `No user matches "${inputValue}".`
-          : "No user activity for this selection."
-      }
-      columns={columns}
-      data={rows}
-    />
+    <>
+      <AgentDetailsSheet
+        owner={workspace}
+        user={user}
+        agentId={detailedAgentId}
+        onClose={() => setDetailedAgentId(null)}
+      />
+      <CreditsTableCard<UserCreditRowData>
+        actions={<CsvDownloadButton {...csvDownload} />}
+        title="Users by credits"
+        description={`Top 100 users by credits over the last ${period} days, with their most-used agents.`}
+        searchName="user-credits-search"
+        searchPlaceholder="Search a user…"
+        searchValue={inputValue}
+        onSearchChange={setValue}
+        isLoading={isUserCreditsLoading}
+        isError={Boolean(isUserCreditsError)}
+        errorMessage="Failed to load user credits."
+        emptyMessage={
+          debouncedValue
+            ? `No user matches "${inputValue}".`
+            : "No user activity for this selection."
+        }
+        columns={columns}
+        data={rows}
+      />
+    </>
   );
 }

--- a/front/components/workspace/analytics/WorkspaceUserCreditsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceUserCreditsTable.tsx
@@ -16,6 +16,7 @@ import type {
 } from "@app/lib/api/assistant/observability/user_credits";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useWorkspaceUserCredits } from "@app/lib/swr/workspaces";
+import { isAdmin } from "@app/types/user";
 import { Avatar, DataTable, Hoverable, Tooltip } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useState } from "react";
@@ -151,6 +152,7 @@ export function WorkspaceUserCreditsTable({
 }: WorkspaceUserCreditsTableProps) {
   const { user, workspace } = useAuth();
   const [detailedAgentId, setDetailedAgentId] = useState<string | null>(null);
+  const canOpenAgentDetails = isAdmin(workspace);
 
   const { inputValue, debouncedValue, setValue } = useDebounce("", {
     delay: 300,
@@ -167,7 +169,9 @@ export function WorkspaceUserCreditsTable({
 
   const rows: UserCreditRowData[] = userCredits.map((row) => ({
     ...row,
-    onAgentClick: (agentId) => setDetailedAgentId(agentId),
+    ...(canOpenAgentDetails
+      ? { onAgentClick: (agentId: string) => setDetailedAgentId(agentId) }
+      : {}),
     ...(onSelectUser
       ? { onClick: () => onSelectUser({ id: row.userId, name: row.name }) }
       : {}),
@@ -192,12 +196,14 @@ export function WorkspaceUserCreditsTable({
 
   return (
     <>
-      <AgentDetailsSheet
-        owner={workspace}
-        user={user}
-        agentId={detailedAgentId}
-        onClose={() => setDetailedAgentId(null)}
-      />
+      {canOpenAgentDetails && (
+        <AgentDetailsSheet
+          owner={workspace}
+          user={user}
+          agentId={detailedAgentId}
+          onClose={() => setDetailedAgentId(null)}
+        />
+      )}
       <CreditsTableCard<UserCreditRowData>
         actions={<CsvDownloadButton {...csvDownload} />}
         title="Users by credits"


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/9926

Workspace admins could open an agent from "Agents by credits" but not the same agent from a user's top agents, even though admins are allowed to read private agent details.

This PR fixes that by making the top-agent entries clickable to open the existing agent details sheet.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
