### PR TITLE
[front] enh: move agent and skill actions to sidebar

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1086,7 +1086,7 @@ export function AgentSidebarMenu({
               </NavigationList>
             )}
             {!isMultiSelect && !hideActions && (
-              <NavigationList className="mx-sidebar-side-spacing flex-shrink-0">
+              <NavigationList className="mx-sidebar-side-spacing mb-4 flex-shrink-0">
                 <NavigationListItem
                   href={getAgentBuilderRoute(owner.sId, "manage")}
                   icon={Robot}

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1123,9 +1123,8 @@ export function AgentSidebarMenu({
                             />
                           </DropdownMenuTrigger>
                           <DropdownMenuContent
-                            side="right"
-                            align="start"
-                            alignOffset={-8}
+                            side="bottom"
+                            align="end"
                             onClick={(e) => e.stopPropagation()}
                           >
                             <DropdownMenuLabel label="New agent" />
@@ -1205,9 +1204,8 @@ export function AgentSidebarMenu({
                             />
                           </DropdownMenuTrigger>
                           <DropdownMenuContent
-                            side="right"
-                            align="start"
-                            alignOffset={-8}
+                            side="bottom"
+                            align="end"
                             onClick={(e) => e.stopPropagation()}
                           >
                             <DropdownMenuLabel label="New skill" />

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1105,7 +1105,7 @@ export function AgentSidebarMenu({
                     canCreateAgent ? (
                       <div
                         ref={createAgentButtonRef}
-                        className="absolute right-2 top-1.5"
+                        className="absolute right-2 top-1.5 transition-opacity [@media(hover:hover)_and_(pointer:fine)]:opacity-0 group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 has-[[data-state=open]]:opacity-100"
                       >
                         <DropdownMenu modal={false}>
                           <DropdownMenuTrigger asChild>
@@ -1189,7 +1189,7 @@ export function AgentSidebarMenu({
                   )}
                   moreMenu={
                     canCreateSkill ? (
-                      <div className="absolute right-2 top-1.5">
+                      <div className="absolute right-2 top-1.5 transition-opacity [@media(hover:hover)_and_(pointer:fine)]:opacity-0 group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 has-[[data-state=open]]:opacity-100">
                         <DropdownMenu modal={false}>
                           <DropdownMenuTrigger asChild>
                             <Button

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1124,7 +1124,7 @@ export function AgentSidebarMenu({
                           </DropdownMenuTrigger>
                           <DropdownMenuContent
                             side="bottom"
-                            align="end"
+                            align="center"
                             onClick={(e) => e.stopPropagation()}
                           >
                             <DropdownMenuLabel label="New agent" />
@@ -1205,7 +1205,7 @@ export function AgentSidebarMenu({
                           </DropdownMenuTrigger>
                           <DropdownMenuContent
                             side="bottom"
-                            align="end"
+                            align="center"
                             onClick={(e) => e.stopPropagation()}
                           >
                             <DropdownMenuLabel label="New skill" />

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1166,7 +1166,18 @@ export function AgentSidebarMenu({
                           </DropdownMenuContent>
                         </DropdownMenu>
                       </div>
-                    ) : undefined
+                    ) : (
+                      <div className="absolute right-2 top-1.5 transition-opacity [@media(hover:hover)_and_(pointer:fine)]:opacity-0 group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100">
+                        <Button
+                          size="xs"
+                          icon={Plus}
+                          label="New"
+                          variant="ghost-secondary"
+                          disabled
+                          tooltip="Ask an admin for permission to create agents."
+                        />
+                      </div>
+                    )
                   }
                 />
                 <NavigationListItem
@@ -1218,7 +1229,18 @@ export function AgentSidebarMenu({
                           </DropdownMenuContent>
                         </DropdownMenu>
                       </div>
-                    ) : undefined
+                    ) : (
+                      <div className="absolute right-2 top-1.5 transition-opacity [@media(hover:hover)_and_(pointer:fine)]:opacity-0 group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100">
+                        <Button
+                          size="xs"
+                          icon={Plus}
+                          label="New"
+                          variant="ghost-secondary"
+                          disabled
+                          tooltip="Ask an admin for permission to create skills."
+                        />
+                      </div>
+                    )
                   }
                 />
               </NavigationList>

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1158,7 +1158,15 @@ export function AgentSidebarMenu({
                   )}
                   moreMenu={
                     canCreateAgent ? (
-                      <div className="absolute right-2 top-1.5 transition-opacity [@media(hover:hover)_and_(pointer:fine)]:opacity-0 group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 has-[[data-state=open]]:opacity-100">
+                      <div
+                        className={cn(
+                          "absolute right-2 top-1.5",
+                          "transition-opacity",
+                          "[@media(hover:hover)_and_(pointer:fine)]:opacity-0",
+                          "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100",
+                          "has-[[data-state=open]]:opacity-100"
+                        )}
+                      >
                         <DropdownMenu modal={false}>
                           <DropdownMenuTrigger asChild>
                             <Button
@@ -1242,7 +1250,15 @@ export function AgentSidebarMenu({
                   )}
                   moreMenu={
                     canCreateSkill ? (
-                      <div className="absolute right-2 top-1.5 transition-opacity [@media(hover:hover)_and_(pointer:fine)]:opacity-0 group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 has-[[data-state=open]]:opacity-100">
+                      <div
+                        className={cn(
+                          "absolute right-2 top-1.5",
+                          "transition-opacity",
+                          "[@media(hover:hover)_and_(pointer:fine)]:opacity-0",
+                          "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100",
+                          "has-[[data-state=open]]:opacity-100"
+                        )}
+                      >
                         <DropdownMenu modal={false}>
                           <DropdownMenuTrigger asChild>
                             <Button

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1086,7 +1086,7 @@ export function AgentSidebarMenu({
               </NavigationList>
             )}
             {!isMultiSelect && !hideActions && (
-              <NavigationList className="mx-sidebar-side-spacing mb-4 flex-shrink-0">
+              <NavigationList className="mx-sidebar-side-spacing mb-4 flex-shrink-0 pt-1">
                 <NavigationListItem
                   href={getAgentBuilderRoute(owner.sId, "manage")}
                   icon={Robot}

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -48,7 +48,9 @@ import {
   useActivationPod,
   useActivationRecommendations,
 } from "@app/lib/swr/activation";
+import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
+import { useSkills } from "@app/lib/swr/skill_configurations";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { getConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
 import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
@@ -101,6 +103,7 @@ import {
   Robot,
   ScrollArea,
   Spinner,
+  Tooltip,
   Trash01,
   XClose,
   Zap,
@@ -108,6 +111,7 @@ import {
 } from "@dust-tt/sparkle";
 import { AnimatePresence, motion } from "framer-motion";
 import {
+  type ComponentProps,
   memo,
   useCallback,
   useContext,
@@ -125,6 +129,41 @@ interface AgentSidebarMenuProps {
   owner: WorkspaceType;
   hideActions?: boolean;
   hideInAppBanner?: boolean;
+}
+
+type PermissionedNavigationListItemProps = Omit<
+  ComponentProps<typeof NavigationListItem>,
+  "disabled"
+> & {
+  canAccess: boolean;
+  permissionTooltip: string;
+};
+
+function PermissionedNavigationListItem({
+  canAccess,
+  permissionTooltip,
+  moreMenu,
+  onClick,
+  ...props
+}: PermissionedNavigationListItemProps) {
+  const item = (
+    <NavigationListItem
+      {...props}
+      aria-disabled={!canAccess || undefined}
+      disabled={!canAccess}
+      moreMenu={canAccess ? moreMenu : undefined}
+      onClick={canAccess ? onClick : undefined}
+      tabIndex={canAccess ? props.tabIndex : 0}
+    />
+  );
+
+  if (canAccess) {
+    return item;
+  }
+
+  return (
+    <Tooltip label={permissionTooltip} trigger={item} tooltipTriggerAsChild />
+  );
 }
 
 type GroupLabel =
@@ -446,6 +485,13 @@ export function AgentSidebarMenu({
       workspaceId: owner.sId,
       disabled: !showGetStarted,
     });
+  const { agentConfigurations } = useUnifiedAgentConfigurations({
+    workspaceId: owner.sId,
+  });
+  const { skills } = useSkills({
+    owner,
+    status: "active",
+  });
 
   const [podSearchText, setPodSearchText] = useState("");
   const { setSidebarOpen } = useContext(SidebarContext);
@@ -501,6 +547,15 @@ export function AgentSidebarMenu({
 
   const canCreateAgent = hasPermission("create", "agent");
   const canCreateSkill = hasPermission("create", "skill");
+  const canManageAgents =
+    canCreateAgent ||
+    hasPermission("publish", "agent") ||
+    agentConfigurations.some((agent) => agent.canEdit);
+  const canManageSkills =
+    canCreateSkill ||
+    hasPermission("publish", "skill") ||
+    hasPermission("make_discoverable", "skill") ||
+    skills.some((skill) => skill.canAdministrate);
 
   const [showDeleteDialog, setShowDeleteDialog] = useState<
     "all" | "selection" | null
@@ -1085,7 +1140,9 @@ export function AgentSidebarMenu({
             )}
             {!isMultiSelect && !hideActions && (
               <NavigationList className="mx-sidebar-side-spacing mb-4 flex-shrink-0 pt-1">
-                <NavigationListItem
+                <PermissionedNavigationListItem
+                  canAccess={canManageAgents}
+                  permissionTooltip="Ask an admin for permission to manage agents."
                   href={getAgentBuilderRoute(owner.sId, "manage")}
                   icon={Robot}
                   label="Agents"
@@ -1166,21 +1223,12 @@ export function AgentSidebarMenu({
                           </DropdownMenuContent>
                         </DropdownMenu>
                       </div>
-                    ) : (
-                      <div className="absolute right-2 top-1.5 transition-opacity [@media(hover:hover)_and_(pointer:fine)]:opacity-0 group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100">
-                        <Button
-                          size="xs"
-                          icon={Plus}
-                          label="New"
-                          variant="ghost-secondary"
-                          disabled
-                          tooltip="Ask an admin for permission to create agents."
-                        />
-                      </div>
-                    )
+                    ) : undefined
                   }
                 />
-                <NavigationListItem
+                <PermissionedNavigationListItem
+                  canAccess={canManageSkills}
+                  permissionTooltip="Ask an admin for permission to manage skills."
                   href={getSkillBuilderRoute(owner.sId, "manage")}
                   icon={SKILL_ICON}
                   label="Skills"
@@ -1229,18 +1277,7 @@ export function AgentSidebarMenu({
                           </DropdownMenuContent>
                         </DropdownMenu>
                       </div>
-                    ) : (
-                      <div className="absolute right-2 top-1.5 transition-opacity [@media(hover:hover)_and_(pointer:fine)]:opacity-0 group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100">
-                        <Button
-                          size="xs"
-                          icon={Plus}
-                          label="New"
-                          variant="ghost-secondary"
-                          disabled
-                          tooltip="Ask an admin for permission to create skills."
-                        />
-                      </div>
-                    )
+                    ) : undefined
                   }
                 />
               </NavigationList>

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -15,7 +15,6 @@ import {
   getGroupConversationsByUnreadAndActionRequired,
   groupUnreadConversations,
 } from "@app/components/assistant/conversation/utils";
-import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
 import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { ImportSkillsDialog } from "@app/components/skills/import/ImportSkillsDialog";
 import { SidebarContext } from "@app/components/sparkle/SidebarContext";
@@ -450,7 +449,6 @@ export function AgentSidebarMenu({
 
   const [podSearchText, setPodSearchText] = useState("");
   const { setSidebarOpen } = useContext(SidebarContext);
-  const { createAgentButtonRef } = useWelcomeTourGuide();
 
   const {
     conversations,
@@ -1103,10 +1101,7 @@ export function AgentSidebarMenu({
                   )}
                   moreMenu={
                     canCreateAgent ? (
-                      <div
-                        ref={createAgentButtonRef}
-                        className="absolute right-2 top-1.5 transition-opacity [@media(hover:hover)_and_(pointer:fine)]:opacity-0 group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 has-[[data-state=open]]:opacity-100"
-                      >
+                      <div className="absolute right-2 top-1.5 transition-opacity [@media(hover:hover)_and_(pointer:fine)]:opacity-0 group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 has-[[data-state=open]]:opacity-100">
                         <DropdownMenu modal={false}>
                           <DropdownMenuTrigger asChild>
                             <Button

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -15,6 +15,7 @@ import {
   getGroupConversationsByUnreadAndActionRequired,
   groupUnreadConversations,
 } from "@app/components/assistant/conversation/utils";
+import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
 import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { ImportSkillsDialog } from "@app/components/skills/import/ImportSkillsDialog";
 import { SidebarContext } from "@app/components/sparkle/SidebarContext";
@@ -42,15 +43,13 @@ import { useYAMLUpload } from "@app/hooks/useYAMLUpload";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { CONVERSATIONS_UPDATED_EVENT } from "@app/lib/notifications/events";
 import { useAppRouter } from "@app/lib/platform";
-import { getSkillAvatarIcon, SKILL_ICON } from "@app/lib/skill";
+import { SKILL_ICON } from "@app/lib/skill";
 import { getSpaceIcon } from "@app/lib/spaces";
 import {
   useActivationPod,
   useActivationRecommendations,
 } from "@app/lib/swr/activation";
-import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
-import { useSkills } from "@app/lib/swr/skill_configurations";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { getConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
 import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
@@ -72,7 +71,6 @@ import type { PodListItemType, PodType, SpaceType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
 import {
   ArrowRight,
-  Avatar,
   Brackets,
   Button,
   Checkbox,
@@ -85,14 +83,9 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
-  DropdownMenuPortal,
   DropdownMenuSearchbar,
   DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
-  Edit04,
   File02,
   FolderOpen,
   Icon,
@@ -455,52 +448,9 @@ export function AgentSidebarMenu({
       disabled: !showGetStarted,
     });
 
-  const agentsSearchInputRef = useRef<HTMLInputElement>(null);
-  const [agentSearchText, setAgentSearchText] = useState("");
-  const [skillSearchText, setSkillSearchText] = useState("");
   const [podSearchText, setPodSearchText] = useState("");
-  const [hasOpenedActionsMenu, setHasOpenedActionsMenu] = useState(false);
-  const { agentConfigurations } = useUnifiedAgentConfigurations({
-    workspaceId: owner.sId,
-  });
-  const editableAgents = useMemo(
-    () => agentConfigurations.filter((agent) => agent.canEdit),
-    [agentConfigurations]
-  );
-  const filteredAgents = useMemo(
-    () =>
-      editableAgents
-        .filter((agent) =>
-          agent.name
-            .toLowerCase()
-            .includes(agentSearchText.toLowerCase().trim())
-        )
-        .sort((a, b) => a.name.localeCompare(b.name)),
-    [editableAgents, agentSearchText]
-  );
-
-  const { skills } = useSkills({
-    owner,
-    status: "active",
-    disabled: !hasOpenedActionsMenu,
-  });
-  const editableSkills = useMemo(
-    () => skills.filter((skill) => skill.canAdministrate),
-    [skills]
-  );
-  const filteredSkills = useMemo(
-    () =>
-      editableSkills
-        .filter((skill) =>
-          skill.name
-            .toLowerCase()
-            .includes(skillSearchText.toLowerCase().trim())
-        )
-        .sort((a, b) => a.name.localeCompare(b.name)),
-    [editableSkills, skillSearchText]
-  );
-
   const { setSidebarOpen } = useContext(SidebarContext);
+  const { createAgentButtonRef } = useWelcomeTourGuide();
 
   const {
     conversations,
@@ -553,19 +503,6 @@ export function AgentSidebarMenu({
 
   const canCreateAgent = hasPermission("create", "agent");
   const canCreateSkill = hasPermission("create", "skill");
-
-  // The manage pages themselves are open to every member, but linking to them
-  // from the sidebar is only useful to users who have something to do there:
-  // a workspace-level permission, or at least one resource they edit.
-  const canManageAgents =
-    canCreateAgent ||
-    hasPermission("publish", "agent") ||
-    editableAgents.length > 0;
-  const canManageSkills =
-    canCreateSkill ||
-    hasPermission("publish", "skill") ||
-    hasPermission("make_discoverable", "skill") ||
-    editableSkills.length > 0;
 
   const [showDeleteDialog, setShowDeleteDialog] = useState<
     "all" | "selection" | null
@@ -1087,203 +1024,16 @@ export function AgentSidebarMenu({
                     onClick={handleNewClick}
                   />
                   {!hideActions && (
-                    <DropdownMenu
-                      modal={false}
-                      onOpenChange={(open) => {
-                        if (open) {
-                          setHasOpenedActionsMenu(true);
-                        }
-                      }}
-                    >
+                    <DropdownMenu modal={false}>
                       <DropdownMenuTrigger asChild>
                         <Button
                           size="sm"
                           icon={DotsHorizontal}
                           variant="outline"
+                          aria-label="Conversation options"
                         />
                       </DropdownMenuTrigger>
                       <DropdownMenuContent>
-                        {canManageAgents && (
-                          <>
-                            <DropdownMenuLabel>Agents</DropdownMenuLabel>
-                            {canCreateAgent && (
-                              <DropdownMenuSub>
-                                <DropdownMenuSubTrigger
-                                  icon={Plus}
-                                  label="New agent"
-                                  disabled={noHealthyProviders}
-                                />
-                                <DropdownMenuPortal>
-                                  <DropdownMenuSubContent className="pointer-events-auto">
-                                    <DropdownMenuItem
-                                      href={getAgentBuilderRoute(
-                                        owner.sId,
-                                        "new"
-                                      )}
-                                      icon={File02}
-                                      label="From scratch"
-                                      data-gtm-label="assistantCreationButton"
-                                      data-gtm-location="sidebarMenu"
-                                      onClick={withTracking(
-                                        TRACKING_AREAS.BUILDER,
-                                        "create_from_scratch"
-                                      )}
-                                    />
-                                    <DropdownMenuItem
-                                      href={getAgentBuilderRoute(
-                                        owner.sId,
-                                        "create"
-                                      )}
-                                      icon={MagicWand02}
-                                      label="From template"
-                                      data-gtm-label="assistantCreationButton"
-                                      data-gtm-location="sidebarMenu"
-                                      onClick={withTracking(
-                                        TRACKING_AREAS.BUILDER,
-                                        "create_from_template"
-                                      )}
-                                    />
-                                    <DropdownMenuItem
-                                      icon={
-                                        isUploadingYAML ? (
-                                          <Spinner size="xs" />
-                                        ) : (
-                                          Brackets
-                                        )
-                                      }
-                                      label={
-                                        isUploadingYAML
-                                          ? "Uploading..."
-                                          : "From YAML"
-                                      }
-                                      disabled={isUploadingYAML}
-                                      onClick={triggerYAMLUpload}
-                                      data-gtm-label="yamlUploadButton"
-                                      data-gtm-location="sidebarMenu"
-                                    />
-                                  </DropdownMenuSubContent>
-                                </DropdownMenuPortal>
-                              </DropdownMenuSub>
-                            )}
-                            {editableAgents.length > 0 && (
-                              <DropdownMenuSub>
-                                <DropdownMenuSubTrigger
-                                  icon={Edit04}
-                                  label="Edit agent"
-                                  disabled={noHealthyProviders}
-                                />
-                                <DropdownMenuPortal>
-                                  <DropdownMenuSubContent className="pointer-events-auto">
-                                    <DropdownMenuSearchbar
-                                      ref={agentsSearchInputRef}
-                                      name="search"
-                                      value={agentSearchText}
-                                      onChange={setAgentSearchText}
-                                      placeholder="Search"
-                                    />
-                                    <div className="max-h-150 overflow-y-auto">
-                                      {filteredAgents.map((agent) => (
-                                        <DropdownMenuItem
-                                          key={agent.sId}
-                                          href={getAgentBuilderRoute(
-                                            owner.sId,
-                                            agent.sId
-                                          )}
-                                          truncateText
-                                          label={agent.name}
-                                          icon={() => (
-                                            <Avatar
-                                              size="xs"
-                                              visual={agent.pictureUrl}
-                                            />
-                                          )}
-                                        />
-                                      ))}
-                                    </div>
-                                  </DropdownMenuSubContent>
-                                </DropdownMenuPortal>
-                              </DropdownMenuSub>
-                            )}
-                            <DropdownMenuItem
-                              href={getAgentBuilderRoute(owner.sId, "manage")}
-                              icon={Robot}
-                              label="Manage agents"
-                              data-gtm-label="assistantManagementButton"
-                              data-gtm-location="sidebarMenu"
-                              onClick={withTracking(
-                                TRACKING_AREAS.BUILDER,
-                                "manage_agents"
-                              )}
-                            />
-                          </>
-                        )}
-                        {canManageSkills && (
-                          <>
-                            <DropdownMenuLabel>Skills</DropdownMenuLabel>
-                            {canCreateSkill && (
-                              <DropdownMenuSub>
-                                <DropdownMenuSubTrigger
-                                  icon={Plus}
-                                  label="New skill"
-                                />
-                                <DropdownMenuSubContent>
-                                  <DropdownMenuItem
-                                    href={getSkillBuilderRoute(
-                                      owner.sId,
-                                      "new"
-                                    )}
-                                    icon={SKILL_ICON}
-                                    label="From scratch"
-                                  />
-                                  <DropdownMenuItem
-                                    icon={FolderOpen}
-                                    label="From existing"
-                                    onClick={() =>
-                                      setIsImportSkillDialogOpen(true)
-                                    }
-                                  />
-                                </DropdownMenuSubContent>
-                              </DropdownMenuSub>
-                            )}
-                            {editableSkills.length > 0 && (
-                              <DropdownMenuSub>
-                                <DropdownMenuSubTrigger
-                                  icon={Edit04}
-                                  label="Edit skill"
-                                />
-                                <DropdownMenuPortal>
-                                  <DropdownMenuSubContent className="pointer-events-auto">
-                                    <DropdownMenuSearchbar
-                                      name="search"
-                                      value={skillSearchText}
-                                      onChange={setSkillSearchText}
-                                      placeholder="Search"
-                                    />
-                                    <div className="max-h-150 overflow-y-auto">
-                                      {filteredSkills.map((skill) => (
-                                        <DropdownMenuItem
-                                          key={skill.sId}
-                                          href={getSkillBuilderRoute(
-                                            owner.sId,
-                                            skill.sId
-                                          )}
-                                          truncateText
-                                          label={skill.name}
-                                          icon={getSkillAvatarIcon(skill.icon)}
-                                        />
-                                      ))}
-                                    </div>
-                                  </DropdownMenuSubContent>
-                                </DropdownMenuPortal>
-                              </DropdownMenuSub>
-                            )}
-                            <DropdownMenuItem
-                              href={getSkillBuilderRoute(owner.sId, "manage")}
-                              icon={SKILL_ICON}
-                              label="Manage skills"
-                            />
-                          </>
-                        )}
                         <DropdownMenuLabel>Conversations</DropdownMenuLabel>
                         <DropdownMenuItem
                           label={
@@ -1331,6 +1081,151 @@ export function AgentSidebarMenu({
                     activationRecsForBadge.length > 0
                       ? activationRecsForBadge.length
                       : undefined
+                  }
+                />
+              </NavigationList>
+            )}
+            {!isMultiSelect && !hideActions && (
+              <NavigationList className="mx-sidebar-side-spacing flex-shrink-0">
+                <NavigationListItem
+                  href={getAgentBuilderRoute(owner.sId, "manage")}
+                  icon={Robot}
+                  label="Agents"
+                  selected={router.asPath.startsWith(
+                    `/w/${owner.sId}/builder/agents`
+                  )}
+                  data-gtm-label="assistantManagementButton"
+                  data-gtm-location="sidebarMenu"
+                  onClick={withTracking(
+                    TRACKING_AREAS.BUILDER,
+                    "manage_agents",
+                    () => setSidebarOpen(false)
+                  )}
+                  moreMenu={
+                    canCreateAgent ? (
+                      <div
+                        ref={createAgentButtonRef}
+                        className="absolute right-2 top-1.5"
+                      >
+                        <DropdownMenu modal={false}>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              size="xs"
+                              icon={Plus}
+                              label="New"
+                              variant="ghost-secondary"
+                              className="data-[state=open]:bg-hover"
+                              disabled={noHealthyProviders}
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                              }}
+                            />
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent
+                            side="right"
+                            align="start"
+                            alignOffset={-8}
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <DropdownMenuLabel label="New agent" />
+                            <DropdownMenuItem
+                              href={getAgentBuilderRoute(owner.sId, "new")}
+                              icon={File02}
+                              label="From scratch"
+                              data-gtm-label="assistantCreationButton"
+                              data-gtm-location="sidebarMenu"
+                              onClick={withTracking(
+                                TRACKING_AREAS.BUILDER,
+                                "create_from_scratch",
+                                () => setSidebarOpen(false)
+                              )}
+                            />
+                            <DropdownMenuItem
+                              href={getAgentBuilderRoute(owner.sId, "create")}
+                              icon={MagicWand02}
+                              label="From template"
+                              data-gtm-label="assistantCreationButton"
+                              data-gtm-location="sidebarMenu"
+                              onClick={withTracking(
+                                TRACKING_AREAS.BUILDER,
+                                "create_from_template",
+                                () => setSidebarOpen(false)
+                              )}
+                            />
+                            <DropdownMenuItem
+                              icon={
+                                isUploadingYAML ? (
+                                  <Spinner size="xs" />
+                                ) : (
+                                  Brackets
+                                )
+                              }
+                              label={
+                                isUploadingYAML ? "Uploading..." : "From YAML"
+                              }
+                              disabled={isUploadingYAML}
+                              onClick={triggerYAMLUpload}
+                              data-gtm-label="yamlUploadButton"
+                              data-gtm-location="sidebarMenu"
+                            />
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </div>
+                    ) : undefined
+                  }
+                />
+                <NavigationListItem
+                  href={getSkillBuilderRoute(owner.sId, "manage")}
+                  icon={SKILL_ICON}
+                  label="Skills"
+                  selected={router.asPath.startsWith(
+                    `/w/${owner.sId}/builder/skills`
+                  )}
+                  onClick={withTracking(
+                    TRACKING_AREAS.BUILDER,
+                    "manage_skills",
+                    () => setSidebarOpen(false)
+                  )}
+                  moreMenu={
+                    canCreateSkill ? (
+                      <div className="absolute right-2 top-1.5">
+                        <DropdownMenu modal={false}>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              size="xs"
+                              icon={Plus}
+                              label="New"
+                              variant="ghost-secondary"
+                              className="data-[state=open]:bg-hover"
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                              }}
+                            />
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent
+                            side="right"
+                            align="start"
+                            alignOffset={-8}
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <DropdownMenuLabel label="New skill" />
+                            <DropdownMenuItem
+                              href={getSkillBuilderRoute(owner.sId, "new")}
+                              icon={SKILL_ICON}
+                              label="From scratch"
+                              onClick={() => setSidebarOpen(false)}
+                            />
+                            <DropdownMenuItem
+                              icon={FolderOpen}
+                              label="From existing"
+                              onClick={() => setIsImportSkillDialogOpen(true)}
+                            />
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </div>
+                    ) : undefined
                   }
                 />
               </NavigationList>

--- a/front/components/assistant/conversation/agent_browser/WebAgentBrowser.tsx
+++ b/front/components/assistant/conversation/agent_browser/WebAgentBrowser.tsx
@@ -1,8 +1,4 @@
-import { CreateDropdown } from "@app/components/assistant/CreateDropdown";
-import { ManageDropdownMenu } from "@app/components/assistant/ManageDropdownMenu";
-import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
 import { useAppRouter } from "@app/lib/platform";
-import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { setQueryParam } from "@app/lib/utils/router";
 import {
   Button,
@@ -47,11 +43,6 @@ export function WebAgentBrowser({
   setSortType,
 }: WebAgentBrowserProps) {
   const router = useAppRouter();
-  const { createAgentButtonRef } = useWelcomeTourGuide();
-  const { hasPermission } = useWorkspacePermissions();
-
-  const canCreate =
-    hasPermission("create", "agent") || hasPermission("create", "skill");
 
   const sortTypeLabel = useMemo(() => {
     switch (sortType) {
@@ -93,17 +84,6 @@ export function WebAgentBrowser({
           }
           trackAgentBrowserEvents
         />
-
-        <div className="hidden sm:block">
-          <div className="flex gap-2">
-            {canCreate && (
-              <div ref={createAgentButtonRef}>
-                <CreateDropdown owner={owner} dataGtmLocation="homepage" />
-              </div>
-            )}
-            <ManageDropdownMenu owner={owner} />
-          </div>
-        </div>
       </div>
 
       {/* Agent tabs */}

--- a/front/components/assistant/conversation/agent_browser/WebAgentBrowser.tsx
+++ b/front/components/assistant/conversation/agent_browser/WebAgentBrowser.tsx
@@ -1,4 +1,8 @@
+import { CreateDropdown } from "@app/components/assistant/CreateDropdown";
+import { ManageDropdownMenu } from "@app/components/assistant/ManageDropdownMenu";
+import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
 import { useAppRouter } from "@app/lib/platform";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { setQueryParam } from "@app/lib/utils/router";
 import {
   Button,
@@ -43,6 +47,11 @@ export function WebAgentBrowser({
   setSortType,
 }: WebAgentBrowserProps) {
   const router = useAppRouter();
+  const { createAgentButtonRef } = useWelcomeTourGuide();
+  const { hasPermission } = useWorkspacePermissions();
+
+  const canCreate =
+    hasPermission("create", "agent") || hasPermission("create", "skill");
 
   const sortTypeLabel = useMemo(() => {
     switch (sortType) {
@@ -84,6 +93,17 @@ export function WebAgentBrowser({
           }
           trackAgentBrowserEvents
         />
+
+        <div className="hidden sm:block">
+          <div className="flex gap-2">
+            {canCreate && (
+              <div ref={createAgentButtonRef}>
+                <CreateDropdown owner={owner} dataGtmLocation="homepage" />
+              </div>
+            )}
+            <ManageDropdownMenu owner={owner} />
+          </div>
+        </div>
       </div>
 
       {/* Agent tabs */}


### PR DESCRIPTION
## Description

Figma [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=13223-38023&t=rD2DeClA7TjYpMRp-0).
Context [here](https://dust4ai.slack.com/archives/C0A04EWRV0E/p1785954047171149).

This PR moves around the sidebar buttons: the agent and skill actions are brought to the foreground instead of being hidden away in the `...` menu. 

<img width="336" height="400" alt="image" src="https://github.com/user-attachments/assets/abce8f0b-2018-4ea0-92f0-677fc325b66a" />

Disabled state
<img width="302" height="324" alt="image" src="https://github.com/user-attachments/assets/c30c0732-fb65-4922-8c01-d29621405485" />

They are moved into dedicated Agents and Skills sidebar rows. Each row links to its Manage page, while its New button opens the existing creation options in a dropdown.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
