### PR TITLE
Bump max concurrent activities to 24 for Pods sync worker.

### DIFF
--- a/connectors/src/connectors/dust_project/temporal/worker.ts
+++ b/connectors/src/connectors/dust_project/temporal/worker.ts
@@ -21,7 +21,7 @@ export async function runDustProjectWorker() {
     }),
     activities: { ...activities, ...sync_status },
     taskQueue: QUEUE_NAME,
-    maxConcurrentActivityTaskExecutions: 12,
+    maxConcurrentActivityTaskExecutions: 24,
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
     connection,
     reuseV8Context: true,


### PR DESCRIPTION
## Description

Doubles `maxConcurrentActivityTaskExecutions` from 12 to 24 in the `dust_project` Temporal worker to increase sync throughput for the Pods sync worker. The previous bump (12, from 5) was introduced alongside the on-demand incremental sync — this raises the ceiling further to handle higher concurrency demands.

## Tests

Tested by observing worker behavior under load in staging.

## Risk

Low. This is a Temporal worker concurrency setting — raising it increases throughput but does not change activity logic. If the worker becomes resource-constrained, Temporal will queue excess tasks gracefully. Rollback by reverting to 12.

## Deploy Plan

Deploy connectors.
