### PR TITLE
Fix: icon picker mousewheel support in pods.

### DIFF
--- a/front/components/pod/files/EditPodFrameTabDialog.tsx
+++ b/front/components/pod/files/EditPodFrameTabDialog.tsx
@@ -141,6 +141,7 @@ export function EditPodFrameTabDialog({
         <DialogContainer>
           <div className="flex items-center gap-2">
             <PopoverRoot
+              modal
               open={isIconPickerOpen}
               onOpenChange={(open) => {
                 if (isEditor) {


### PR DESCRIPTION
## Description

Adds `modal` to `PopoverRoot` in `EditPodFrameTabDialog` so the icon picker captures scroll events correctly. Without this prop, mousewheel input inside the popover is swallowed by the underlying dialog, making it impossible to scroll through the icon list in Pods.

## Tests

Tested locally by opening the icon picker in a Pod frame tab dialog and scrolling through icons with the mousewheel.

## Risk

Low. Single-prop addition to a Radix `PopoverRoot`; no logic change, no data model change. Rollback is trivial.

## Deploy Plan

Deploy front.
