### PR TITLE
Add: can customize the title & icon when add a Frame to pod tabs

### DIFF
--- a/front/components/pod/files/EditPodFrameTabDialog.tsx
+++ b/front/components/pod/files/EditPodFrameTabDialog.tsx
@@ -35,6 +35,7 @@ interface EditPodFrameTabDialogProps {
   isEditor: boolean;
   includeConnectedData?: boolean;
   tab: PodFrameTab;
+  mode?: "create" | "edit";
   isOpen: boolean;
   onClose: () => void;
 }
@@ -47,10 +48,13 @@ export function EditPodFrameTabDialog({
   isEditor,
   includeConnectedData = false,
   tab,
+  mode = "edit",
   isOpen,
   onClose,
 }: EditPodFrameTabDialogProps) {
+  const isCreate = mode === "create";
   const {
+    addFrameTab,
     updateFrameTab,
     removeFrameTab,
     moveFrameTab,
@@ -79,9 +83,9 @@ export function EditPodFrameTabDialog({
   const tabIndex = navItems.findIndex(
     (item) => item.kind === "frame" && item.tab.path === tab.path
   );
-  const canMoveLeft = isEditor && tabIndex > 0;
+  const canMoveLeft = !isCreate && isEditor && tabIndex > 0;
   const canMoveRight =
-    isEditor && tabIndex >= 0 && tabIndex < navItems.length - 1;
+    !isCreate && isEditor && tabIndex >= 0 && tabIndex < navItems.length - 1;
 
   const selectedIcon = isCustomResourceIconType(icon)
     ? icon
@@ -93,10 +97,17 @@ export function EditPodFrameTabDialog({
       return;
     }
     setIsSaving(true);
-    const ok = await updateFrameTab(tab.path, {
-      title: title.trim() || tab.title,
-      icon: selectedIcon,
-    });
+    const nextTitle = title.trim() || tab.title;
+    const ok = isCreate
+      ? await addFrameTab(tab.path, {
+          title: nextTitle,
+          icon: selectedIcon,
+          skipConfirm: true,
+        })
+      : await updateFrameTab(tab.path, {
+          title: nextTitle,
+          icon: selectedIcon,
+        });
     setIsSaving(false);
     if (ok) {
       onClose();
@@ -104,11 +115,14 @@ export function EditPodFrameTabDialog({
   };
 
   const handleRemove = async () => {
-    if (!isEditor) {
+    if (!isEditor || isCreate) {
       return;
     }
     setIsSaving(true);
-    const ok = await removeFrameTab(tab.path, { fileName: tab.title });
+    const ok = await removeFrameTab(tab.path, {
+      fileName: tab.title,
+      skipConfirm: true,
+    });
     setIsSaving(false);
     if (ok) {
       onClose();
@@ -116,7 +130,7 @@ export function EditPodFrameTabDialog({
   };
 
   const handleMove = async (direction: "left" | "right") => {
-    if (!isEditor) {
+    if (!isEditor || isCreate) {
       return;
     }
     setIsMoving(true);
@@ -136,7 +150,9 @@ export function EditPodFrameTabDialog({
     >
       <DialogContent size="md">
         <DialogHeader>
-          <DialogTitle>Edit frame tab</DialogTitle>
+          <DialogTitle>
+            {isCreate ? "Add frame tab" : "Edit frame tab"}
+          </DialogTitle>
         </DialogHeader>
         <DialogContainer>
           <div className="flex items-center gap-2">
@@ -159,6 +175,9 @@ export function EditPodFrameTabDialog({
               </PopoverTrigger>
               <PopoverContent
                 className="w-fit p-0"
+                mountPortalContainer={
+                  typeof document !== "undefined" ? document.body : undefined
+                }
                 onOpenAutoFocus={(e) => e.preventDefault()}
               >
                 <IconPicker
@@ -203,14 +222,18 @@ export function EditPodFrameTabDialog({
           </div>
         </DialogContainer>
         <DialogFooter
-          leftButtonProps={{
-            label: "Remove tab",
-            variant: "warning",
-            onClick: () => void handleRemove(),
-            disabled: !isEditor || isSaving || isMoving,
-          }}
+          leftButtonProps={
+            isCreate
+              ? undefined
+              : {
+                  label: "Remove tab",
+                  variant: "warning",
+                  onClick: () => void handleRemove(),
+                  disabled: !isEditor || isSaving || isMoving,
+                }
+          }
           rightButtonProps={{
-            label: "Save",
+            label: isCreate ? "Add tab" : "Save",
             variant: "primary",
             onClick: () => void handleSave(),
             disabled: !isEditor || isSaving || isMoving || !title.trim(),

--- a/front/components/pod/files/PodFileExplorer.tsx
+++ b/front/components/pod/files/PodFileExplorer.tsx
@@ -15,6 +15,7 @@ import { useFileDownload } from "@app/components/file_explorer/useFileDownload";
 import { joinMountRelativePath } from "@app/components/file_explorer/utils";
 import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
 import { CreateFolderDialog } from "@app/components/pod/files/CreateFolderDialog";
+import { EditPodFrameTabDialog } from "@app/components/pod/files/EditPodFrameTabDialog";
 import { PodFrameSheet } from "@app/components/pod/files/PodFrameSheet";
 import { RenameFileDialog } from "@app/components/pod/files/RenameFileDialog";
 import SpaceManagedDatasourcesViewsModal from "@app/components/spaces/SpaceManagedDatasourcesViewsModal";
@@ -46,6 +47,12 @@ import {
   getSupportedFileExtensions,
   isInteractiveContentType,
 } from "@app/types/files";
+import {
+  DEFAULT_POD_FRAME_TAB_ICON,
+  MAX_POD_FRAME_TAB_TITLE_LENGTH,
+  type PodFrameTab,
+  podFrameTabBasename,
+} from "@app/types/pod_frame_tab";
 import type { PodType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -266,13 +273,15 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
     pinnedFramePath: pod.pinnedFramePath ?? null,
     isEditor,
   });
-  const { toggleFrameTab, isFrameTab } = usePodFrameTabs({
+  const { removeFrameTab, isFrameTab } = usePodFrameTabs({
     owner,
     podId: pod.sId,
     frameTabs: pod.frameTabs ?? [],
     tabsOrder: pod.tabsOrder ?? [],
     isEditor,
   });
+  const [createFrameTabDraft, setCreateFrameTabDraft] =
+    useState<PodFrameTab | null>(null);
 
   const getExtraFileMenuItems = useCallback(
     (entry: FileExplorerEntry): FileExplorerMenuAction[] => {
@@ -304,7 +313,18 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
           icon: LayoutAlt02,
           onClick: (e) => {
             e.stopPropagation();
-            void toggleFrameTab(entry.path, { fileName: entry.fileName });
+            if (asTab) {
+              void removeFrameTab(entry.path, { fileName: entry.fileName });
+              return;
+            }
+            setCreateFrameTabDraft({
+              path: entry.path,
+              title: podFrameTabBasename(entry.fileName).slice(
+                0,
+                MAX_POD_FRAME_TAB_TITLE_LENGTH
+              ),
+              icon: DEFAULT_POD_FRAME_TAB_ICON,
+            });
           },
         });
       }
@@ -317,7 +337,7 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
       isEditor,
       isFrameTab,
       isPinned,
-      toggleFrameTab,
+      removeFrameTab,
       togglePin,
     ]
   );
@@ -744,6 +764,21 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
         isOpen={framePreview !== null}
         onClose={() => setFramePreview(null)}
       />
+
+      {createFrameTabDraft && (
+        <EditPodFrameTabDialog
+          key={createFrameTabDraft.path}
+          owner={owner}
+          podId={pod.sId}
+          frameTabs={pod.frameTabs ?? []}
+          tabsOrder={pod.tabsOrder ?? []}
+          isEditor={isEditor}
+          tab={createFrameTabDraft}
+          mode="create"
+          isOpen
+          onClose={() => setCreateFrameTabDraft(null)}
+        />
+      )}
 
       <RenameFileDialog
         isOpen={showRenameDialog}

--- a/front/components/pod/files/PodFrameTabButton.tsx
+++ b/front/components/pod/files/PodFrameTabButton.tsx
@@ -1,7 +1,14 @@
+import { EditPodFrameTabDialog } from "@app/components/pod/files/EditPodFrameTabDialog";
 import { usePodFrameTabs } from "@app/hooks/usePodFrameTabs";
-import type { PodFrameTab } from "@app/types/pod_frame_tab";
+import {
+  DEFAULT_POD_FRAME_TAB_ICON,
+  MAX_POD_FRAME_TAB_TITLE_LENGTH,
+  type PodFrameTab,
+  podFrameTabBasename,
+} from "@app/types/pod_frame_tab";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Button, LayoutAlt02 } from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
 
 interface PodFrameTabButtonProps {
   owner: LightWorkspaceType;
@@ -24,31 +31,64 @@ export function PodFrameTabButton({
   fileName,
   hidden,
 }: PodFrameTabButtonProps) {
-  const { toggleFrameTab, isFrameTab } = usePodFrameTabs({
+  const { removeFrameTab, isFrameTab } = usePodFrameTabs({
     owner,
     podId: spaceId,
     frameTabs,
     tabsOrder,
     isEditor,
   });
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
 
-  if (hidden || !isEditor || !framePath) {
+  const draftTab = useMemo((): PodFrameTab | null => {
+    if (!framePath) {
+      return null;
+    }
+    return {
+      path: framePath,
+      title: podFrameTabBasename(fileName ?? framePath).slice(
+        0,
+        MAX_POD_FRAME_TAB_TITLE_LENGTH
+      ),
+      icon: DEFAULT_POD_FRAME_TAB_ICON,
+    };
+  }, [fileName, framePath]);
+
+  if (hidden || !isEditor || !framePath || !draftTab) {
     return null;
   }
 
   const addedAsTab = isFrameTab(framePath);
 
   return (
-    <Button
-      icon={LayoutAlt02}
-      variant={addedAsTab ? "highlight-ghost" : "ghost"}
-      size="sm"
-      tooltip={addedAsTab ? "Remove from Pod tabs" : "Add as Pod tab"}
-      onClick={() =>
-        void toggleFrameTab(framePath, {
-          fileName,
-        })
-      }
-    />
+    <>
+      <Button
+        icon={LayoutAlt02}
+        variant={addedAsTab ? "highlight-ghost" : "ghost"}
+        size="sm"
+        tooltip={addedAsTab ? "Remove from Pod tabs" : "Add as Pod tab"}
+        onClick={() => {
+          if (addedAsTab) {
+            void removeFrameTab(framePath, { fileName });
+            return;
+          }
+          setIsCreateDialogOpen(true);
+        }}
+      />
+      {isCreateDialogOpen && (
+        <EditPodFrameTabDialog
+          key={draftTab.path}
+          owner={owner}
+          podId={spaceId}
+          frameTabs={frameTabs}
+          tabsOrder={tabsOrder}
+          isEditor={isEditor}
+          tab={draftTab}
+          mode="create"
+          isOpen
+          onClose={() => setIsCreateDialogOpen(false)}
+        />
+      )}
+    </>
   );
 }

--- a/front/hooks/usePodFrameTabs.ts
+++ b/front/hooks/usePodFrameTabs.ts
@@ -19,6 +19,7 @@ type FrameTabOptions = {
   fileName?: string;
   title?: string;
   icon?: CustomResourceIconType;
+  skipConfirm?: boolean;
 };
 
 export function usePodFrameTabs({
@@ -91,25 +92,27 @@ export function usePodFrameTabs({
         return false;
       }
 
-      const label = podFrameTabBasename(
-        options?.title ?? options?.fileName ?? path
-      );
+      const label = (
+        options?.title?.trim() || podFrameTabBasename(options?.fileName ?? path)
+      ).slice(0, MAX_POD_FRAME_TAB_TITLE_LENGTH);
 
-      const confirmed = await confirm({
-        title: "Add as Pod tab?",
-        message: `"${label}" will appear as a tab in this Pod for all members.`,
-        validateLabel: "Add tab",
-        validateVariant: "primary",
-      });
-      if (!confirmed) {
-        return false;
+      if (!options?.skipConfirm) {
+        const confirmed = await confirm({
+          title: "Add as Pod tab?",
+          message: `"${label}" will appear as a tab in this Pod for all members.`,
+          validateLabel: "Add tab",
+          validateVariant: "primary",
+        });
+        if (!confirmed) {
+          return false;
+        }
       }
 
       const nextTabs: PodFrameTab[] = [
         ...sortedTabs,
         {
           path,
-          title: label.slice(0, MAX_POD_FRAME_TAB_TITLE_LENGTH),
+          title: label,
           icon: options?.icon ?? DEFAULT_POD_FRAME_TAB_ICON,
         },
       ];
@@ -140,14 +143,16 @@ export function usePodFrameTabs({
 
       const label = options?.fileName ?? existing.title;
 
-      const confirmed = await confirm({
-        title: "Remove Pod tab?",
-        message: `"${label}" will no longer appear as a tab in this Pod.`,
-        validateLabel: "Remove",
-        validateVariant: "warning",
-      });
-      if (!confirmed) {
-        return false;
+      if (!options?.skipConfirm) {
+        const confirmed = await confirm({
+          title: "Remove Pod tab?",
+          message: `"${label}" will no longer appear as a tab in this Pod.`,
+          validateLabel: "Remove",
+          validateVariant: "warning",
+        });
+        if (!confirmed) {
+          return false;
+        }
       }
 
       return persist(


### PR DESCRIPTION
## Description

When adding a Frame as a Pod tab, the old flow showed a plain confirmation dialog with no customization. Now, clicking "Add as Pod tab" (from both `PodFrameTabButton` and `PodFileExplorer`'s file menu) opens `EditPodFrameTabDialog` in `"create"` mode, letting the user set a custom title and icon before the tab is created.

Key changes:
- `EditPodFrameTabDialog` gains a `mode?: "create" | "edit"` prop; in create mode, move/remove actions are disabled and the footer shows "Add tab" instead of "Save"/"Remove tab".
- `toggleFrameTab` is replaced by separate `removeFrameTab` (direct) and `addFrameTab` (via dialog with `skipConfirm: true`) call paths in `usePodFrameTabs`.
- `FrameTabOptions` gains `skipConfirm` to bypass the old confirm dialog when the new dialog handles confirmation itself.
- `PopoverContent` inside the dialog gets `mountPortalContainer={document.body}` to fix icon-picker popover stacking.

## Tests

Tested locally — added a Frame as a Pod tab via both the file explorer menu and the `PodFrameTabButton`, verified the dialog opens with pre-filled title/icon, allows customization, and correctly adds the tab on confirm.

## Risk

Low. Front-only, no DB changes. The `skipConfirm` flag is only passed from within the new dialog, so existing non-dialog paths are unaffected. Rollback: redeploy front.

## Deploy Plan

Deploy `front`.
