### PR TITLE
Skills/Agents: Message on empty search in manage page

### DIFF
--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -31,6 +31,7 @@ import {
   Button,
   Chip,
   ContactsRobot,
+  EmptyCTA,
   ListSelect,
   Page,
   Plus,
@@ -93,6 +94,8 @@ export function ManageAgentsPage() {
 
   const canCreateAgent = hasPermission("create", "agent");
   const isSearchActive = assistantSearch.trim() !== "";
+  const isFilterActive =
+    isSearchActive || selectedTags.length > 0 || selectedModels.length > 0;
 
   const activeTab = useMemo(() => {
     return selectedTab && isValidTab(selectedTab) ? selectedTab : "all_custom";
@@ -392,7 +395,14 @@ export function ManageAgentsPage() {
               <div className="mt-8 flex justify-center">
                 <Spinner size="lg" />
               </div>
-            ) : activeTab && agentsByTab[activeTab] ? (
+            ) : isFilterActive && agentsByTab[activeTab].length === 0 ? (
+              <div className="pt-2">
+                <EmptyCTA
+                  message="No agent matches your search or filters."
+                  action={null}
+                />
+              </div>
+            ) : agentsByTab[activeTab].length > 0 ? (
               <AssistantsTable
                 isBatchEdit={isBatchEdit}
                 selection={selection}
@@ -408,7 +418,6 @@ export function ManageAgentsPage() {
                 mutateAgentConfigurations={mutateAgentConfigurations}
               />
             ) : (
-              !assistantSearch &&
               canCreateAgent && (
                 <div className="pt-2">
                   <EmptyCallToAction

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -52,6 +52,8 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  EmptyCTA,
+  EmptyCTAButton,
   FolderOpen,
   InfoCircle,
   ListSelect,
@@ -118,6 +120,7 @@ export function ManageSkillsPage() {
   const { updateSkillFavorite } = useUpdateSkillFavorite({ owner });
 
   const isSearchActive = !isEmptyString(skillSearch);
+  const isFilterActive = isSearchActive || availabilityFilter !== "all";
 
   const activeTab = useMemo<SkillManagerTabType>(() => {
     if (
@@ -360,6 +363,35 @@ export function ManageSkillsPage() {
   useSetPageTitle("Dust - Manage Skills");
   useSetNavChildren(navChildren);
 
+  const isActiveTabEmpty = skillsByTab[activeTab].length === 0;
+
+  const renderEmptyTabState = () => {
+    if (isFilterActive) {
+      return (
+        <EmptyCTA
+          message="No skill matches your search or filters."
+          action={null}
+        />
+      );
+    }
+    // Nothing to create into from the archived tab.
+    if (activeTab === "archived" || !canCreateSkill) {
+      return null;
+    }
+    return (
+      <EmptyCTA
+        action={
+          <EmptyCTAButton
+            label="Create a skill"
+            icon={Plus}
+            variant="primary"
+            href={getSkillBuilderRoute(owner.sId, "new")}
+          />
+        }
+      />
+    );
+  };
+
   return (
     <>
       <SkillDetailsSheet
@@ -521,17 +553,21 @@ export function ManageSkillsPage() {
                       user={user}
                     />
                   )}
-                <SkillsTable
-                  owner={owner}
-                  skills={skillsByTab[activeTab]}
-                  onSkillClick={handleSkillSelect}
-                  onAgentClick={setAgentId}
-                  onUsedBySkillClick={handleUsedBySkillSelect}
-                  canMakeSkillAutoDiscoverable={canMakeSkillAutoDiscoverable}
-                  {...(isBatchEditionAvailable && isBatchEditing
-                    ? { rowSelection, setRowSelection }
-                    : {})}
-                />
+                {isActiveTabEmpty ? (
+                  <div className="pt-2">{renderEmptyTabState()}</div>
+                ) : (
+                  <SkillsTable
+                    owner={owner}
+                    skills={skillsByTab[activeTab]}
+                    onSkillClick={handleSkillSelect}
+                    onAgentClick={setAgentId}
+                    onUsedBySkillClick={handleUsedBySkillSelect}
+                    canMakeSkillAutoDiscoverable={canMakeSkillAutoDiscoverable}
+                    {...(isBatchEditionAvailable && isBatchEditing
+                      ? { rowSelection, setRowSelection }
+                      : {})}
+                  />
+                )}
               </>
             )}
           </div>


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/9888

 - Add a EmptyCTA with button to create skill when there is no "Editable by me" skills
 - Add a  message saying there is no result if the search lead to 0 agents/skills

<img width="1407" height="535" alt="Screenshot 2026-08-06 at 09 46 49" src="https://github.com/user-attachments/assets/f782a5be-d9e2-4d29-a30d-0f585dbef388" />

<img width="1401" height="636" alt="Screenshot 2026-08-06 at 09 47 01" src="https://github.com/user-attachments/assets/67203c1d-e0b4-4d3b-b032-f95e0b268168" />

<img width="1402" height="487" alt="Screenshot 2026-08-06 at 09 47 14" src="https://github.com/user-attachments/assets/70e0484b-5e96-4d07-95b1-27dc9d5d4663" />




## Tests

tested locally

## Risk
low

## Deploy Plan

deploy front
