### PR TITLE
Fix: internal notion MCP use the correct flow for databases / datasources

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -1588,7 +1588,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": false,
       "toolCostCategory": "advanced",
     },
-    "query_database": {
+    "query_datasource": {
       "freeUsage": false,
       "toolCostCategory": "advanced",
     },
@@ -1600,11 +1600,15 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": false,
       "toolCostCategory": "advanced",
     },
-    "retrieve_database_content": {
+    "retrieve_database": {
       "freeUsage": false,
       "toolCostCategory": "advanced",
     },
-    "retrieve_database_schema": {
+    "retrieve_datasource_content": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "retrieve_datasource_schema": {
       "freeUsage": false,
       "toolCostCategory": "advanced",
     },
@@ -1624,7 +1628,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": false,
       "toolCostCategory": "advanced",
     },
-    "update_schema_database": {
+    "update_schema_datasource": {
       "freeUsage": false,
       "toolCostCategory": "advanced",
     },
@@ -3080,16 +3084,17 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_about_user": "never_ask",
     "insert_row_into_database": "low",
     "list_users": "never_ask",
-    "query_database": "never_ask",
+    "query_datasource": "never_ask",
     "retrieve_block": "never_ask",
     "retrieve_block_children": "never_ask",
-    "retrieve_database_content": "never_ask",
-    "retrieve_database_schema": "never_ask",
+    "retrieve_database": "never_ask",
+    "retrieve_datasource_content": "never_ask",
+    "retrieve_datasource_schema": "never_ask",
     "retrieve_page": "never_ask",
     "search": "never_ask",
     "update_page": "low",
     "update_row_database": "low",
-    "update_schema_database": "low",
+    "update_schema_datasource": "low",
   },
   "openai_usage": {
     "get_completions_usage": "low",

--- a/front/lib/api/actions/servers/notion/metadata.ts
+++ b/front/lib/api/actions/servers/notion/metadata.ts
@@ -258,26 +258,40 @@ export const NOTION_TOOLS_METADATA = [
     freeUsage: false,
   },
   {
-    name: "retrieve_database_schema",
-    description:
-      "Retrieve the schema of a Notion database by its ID: the list of columns and property definitions and their types. Use to inspect a database's structure.",
+    name: "retrieve_database",
+    description: "Retrieve a Notion database by its ID.",
     schema: {
       databaseId: z.string().describe("The Notion database ID."),
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving Notion database schema",
-      done: "Retrieve Notion database schema",
+      running: "Retrieving Notion database",
+      done: "Retrieve Notion database",
     },
     toolCostCategory: "advanced",
     freeUsage: false,
   },
   {
-    name: "retrieve_database_content",
+    name: "retrieve_datasource_schema",
     description:
-      "List all entries (the rows and pages) contained in a Notion database by its ID, with optional filtering and sorting. Returns every page in the database.",
+      "Retrieve the schema of a Notion datasource by its ID: the list of columns and property definitions and their types. Use to inspect a datasource's structure.",
     schema: {
-      databaseId: z.string().describe("The Notion database ID."),
+      datasourceId: z.string().describe("The Notion datasource ID."),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving Notion datasource schema",
+      done: "Retrieve Notion datasource schema",
+    },
+    toolCostCategory: "advanced",
+    freeUsage: false,
+  },
+  {
+    name: "retrieve_datasource_content",
+    description:
+      "List all entries (the rows and pages) contained in a Notion datasource by its ID, with optional filtering and sorting. Returns every page in the datasource.",
+    schema: {
+      datasourceId: z.string().describe("The Notion datasource ID."),
       filter: dbFilterSchema.optional(),
       sorts: dbSortsArraySchema.optional(),
       start_cursor: z
@@ -288,17 +302,17 @@ export const NOTION_TOOLS_METADATA = [
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving Notion database content",
-      done: "Retrieve Notion database content",
+      running: "Retrieving Notion datasource content",
+      done: "Retrieve Notion datasource content",
     },
     toolCostCategory: "advanced",
     freeUsage: false,
   },
   {
-    name: "query_database",
-    description: "Query a Notion database.",
+    name: "query_datasource",
+    description: "Query a Notion datasource.",
     schema: {
-      databaseId: z.string().describe("The Notion database ID."),
+      datasourceId: z.string().describe("The Notion datasource ID."),
       filter: dbFilterSchema.optional(),
       sorts: dbSortsArraySchema.optional(),
       start_cursor: z
@@ -309,8 +323,8 @@ export const NOTION_TOOLS_METADATA = [
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Querying Notion database",
-      done: "Query Notion database",
+      running: "Querying Notion datasource",
+      done: "Query Notion datasource",
     },
     toolCostCategory: "advanced",
     freeUsage: false,
@@ -539,17 +553,17 @@ export const NOTION_TOOLS_METADATA = [
     freeUsage: false,
   },
   {
-    name: "update_schema_database",
+    name: "update_schema_datasource",
     description:
-      "Update the schema (columns/properties) of an existing Notion database.",
+      "Update the schema (columns/properties) of an existing Notion datasource.",
     schema: {
-      databaseId: z.string().describe("The Notion database ID."),
+      datasourceId: z.string().describe("The Notion datasource ID."),
       properties: propertiesSchema,
     },
     stake: "low",
     displayLabels: {
-      running: "Updating Notion database schema",
-      done: "Update Notion database schema",
+      running: "Updating Notion datasource schema",
+      done: "Update Notion datasource schema",
     },
     toolCostCategory: "advanced",
     freeUsage: false,
@@ -586,7 +600,7 @@ export const NOTION_SERVER = {
   serverInfo: {
     name: "notion",
     version: "1.0.0",
-    description: "Access workspace pages and databases.",
+    description: "Access workspace pages, databases and datasources.",
     authorization: {
       provider: "notion",
       supported_use_cases: ["platform_actions", "personal_actions"],

--- a/front/lib/api/actions/servers/notion/tools/index.ts
+++ b/front/lib/api/actions/servers/notion/tools/index.ts
@@ -32,8 +32,8 @@ import type {
 import { APIResponseError } from "@notionhq/client/build/src/errors";
 import { parseISO } from "date-fns";
 
-async function withNotionClient<T>(
-  fn: (notion: Client) => Promise<T>,
+async function withNotionClient<T, S extends string>(
+  fn: (notion: Client) => Promise<[T, S]>,
   authInfo?: AuthInfo
 ): Promise<ToolHandlerResult> {
   const accessToken = authInfo?.token;
@@ -44,11 +44,13 @@ async function withNotionClient<T>(
   try {
     const notion = new Client({ auth: accessToken });
 
-    const result = await fn(notion);
+    const [result, successMessage] = await fn(notion);
 
     return new Ok([
-      { type: "text" as const, text: "Success" },
-      { type: "text" as const, text: JSON.stringify(result, null, 2) },
+      {
+        type: "text" as const,
+        text: successMessage + "\n\n" + JSON.stringify(result, null, 2),
+      },
     ]);
   } catch (e) {
     const tracked =
@@ -213,55 +215,80 @@ export function createNotionTools(toolContext?: ToolContext): ToolDefinition[] {
 
     retrieve_page: async ({ pageId }, { authInfo }) => {
       return withNotionClient(
-        (notion) => notion.pages.retrieve({ page_id: pageId }),
+        async (notion) => [
+          await notion.pages.retrieve({ page_id: pageId }),
+          "Page retrieved.",
+        ],
         authInfo
       );
     },
 
-    retrieve_database_schema: async ({ databaseId }, { authInfo }) => {
+    retrieve_database: async ({ databaseId }, { authInfo }) => {
       return withNotionClient(
-        (notion) => notion.dataSources.retrieve({ data_source_id: databaseId }),
+        async (notion) => [
+          await notion.databases.retrieve({
+            database_id: databaseId,
+          }),
+          "Tables in the database are listed as datasources. Use the datasources id to retrieve the schema, content or query the datasource.",
+        ],
         authInfo
       );
     },
 
-    retrieve_database_content: async (
-      { databaseId, filter, sorts, start_cursor, page_size },
+    retrieve_datasource_schema: async ({ datasourceId }, { authInfo }) => {
+      return withNotionClient(
+        async (notion) => [
+          await notion.dataSources.retrieve({ data_source_id: datasourceId }),
+          "Schema of the datasource retrieved.",
+        ],
+        authInfo
+      );
+    },
+
+    retrieve_datasource_content: async (
+      { datasourceId, filter, sorts, start_cursor, page_size },
       { authInfo }
     ) => {
       return withNotionClient(
-        (notion) =>
-          notion.dataSources.query({
-            data_source_id: databaseId,
+        async (notion) => [
+          await notion.dataSources.query({
+            data_source_id: datasourceId,
             filter: filter as QueryDataSourceParameters["filter"],
             sorts,
             start_cursor,
             page_size,
           }),
+          "Content of the datasource retrieved.",
+        ],
         authInfo
       );
     },
 
-    query_database: async (
-      { databaseId, filter, sorts, start_cursor, page_size },
+    query_datasource: async (
+      { datasourceId, filter, sorts, start_cursor, page_size },
       { authInfo }
     ) => {
       return withNotionClient(
-        (notion) =>
-          notion.dataSources.query({
-            data_source_id: databaseId,
+        async (notion) => [
+          await notion.dataSources.query({
+            data_source_id: datasourceId,
             filter: filter as QueryDataSourceParameters["filter"],
             sorts,
             start_cursor,
             page_size,
           }),
+          "Results of the query.",
+        ],
         authInfo
       );
     },
 
     create_page: async ({ parent, properties, icon, cover }, { authInfo }) => {
       return withNotionClient(
-        (notion) => notion.pages.create({ parent, properties, icon, cover }),
+        async (notion) => [
+          await notion.pages.create({ parent, properties, icon, cover }),
+          "Page created.",
+        ],
         authInfo
       );
     },
@@ -271,13 +298,15 @@ export function createNotionTools(toolContext?: ToolContext): ToolDefinition[] {
       { authInfo }
     ) => {
       return withNotionClient(
-        (notion) =>
-          notion.pages.create({
+        async (notion) => [
+          await notion.pages.create({
             parent: { database_id: databaseId, type: "database_id" },
             properties,
             icon,
             cover,
           }),
+          "Row inserted into the database.",
+        ],
         authInfo
       );
     },
@@ -287,28 +316,36 @@ export function createNotionTools(toolContext?: ToolContext): ToolDefinition[] {
       { authInfo }
     ) => {
       return withNotionClient(
-        (notion) =>
-          notion.databases.create({
+        async (notion) => [
+          await notion.databases.create({
             parent,
             title,
             initial_data_source: { properties },
             icon,
             cover,
           }),
+          "Database created.",
+        ],
         authInfo
       );
     },
 
     update_page: async ({ pageId, properties }, { authInfo }) => {
       return withNotionClient(
-        (notion) => notion.pages.update({ page_id: pageId, properties }),
+        async (notion) => [
+          await notion.pages.update({ page_id: pageId, properties }),
+          "Page updated.",
+        ],
         authInfo
       );
     },
 
     retrieve_block: async ({ blockId }, { authInfo }) => {
       return withNotionClient(
-        (notion) => notion.blocks.retrieve({ block_id: blockId }),
+        async (notion) => [
+          await notion.blocks.retrieve({ block_id: blockId }),
+          "Block retrieved.",
+        ],
         authInfo
       );
     },
@@ -318,24 +355,28 @@ export function createNotionTools(toolContext?: ToolContext): ToolDefinition[] {
       { authInfo }
     ) => {
       return withNotionClient(
-        (notion) =>
-          notion.blocks.children.list({
+        async (notion) => [
+          await notion.blocks.children.list({
             block_id: blockId,
             start_cursor,
             page_size,
           }),
+          "Children of the block retrieved.",
+        ],
         authInfo
       );
     },
 
     add_page_content: async ({ after, blockId, children }, { authInfo }) => {
       return withNotionClient(
-        (notion) =>
-          notion.blocks.children.append({
+        async (notion) => [
+          await notion.blocks.children.append({
             after,
             block_id: blockId,
             children,
           }),
+          "Children of the block added.",
+        ],
         authInfo
       );
     },
@@ -344,7 +385,7 @@ export function createNotionTools(toolContext?: ToolContext): ToolDefinition[] {
       { parent_page_id, discussion_id, comment },
       { authInfo }
     ) => {
-      return withNotionClient((notion) => {
+      return withNotionClient(async (notion) => {
         if (!parent_page_id && !discussion_id) {
           throw new Error(
             "Either parent_page_id or discussion_id must be provided."
@@ -362,59 +403,79 @@ export function createNotionTools(toolContext?: ToolContext): ToolDefinition[] {
             rich_text: [{ type: "text", text: { content: comment } }],
           };
         }
-        return notion.comments.create(params);
+        return [await notion.comments.create(params), "Comment created."];
       }, authInfo);
     },
 
     delete_block: async ({ blockId }, { authInfo }) => {
       return withNotionClient(
-        (notion) => notion.blocks.update({ block_id: blockId, archived: true }),
+        async (notion) => [
+          await notion.blocks.update({ block_id: blockId, archived: true }),
+          "Block deleted.",
+        ],
         authInfo
       );
     },
 
     delete_page: async ({ pageId }, { authInfo }) => {
       return withNotionClient(
-        (notion) => notion.pages.update({ page_id: pageId, in_trash: true }),
+        async (notion) => [
+          await notion.pages.update({ page_id: pageId, in_trash: true }),
+          "Page deleted.",
+        ],
         authInfo
       );
     },
 
     fetch_comments: async ({ blockId }, { authInfo }) => {
       return withNotionClient(
-        (notion) => notion.comments.list({ block_id: blockId }),
+        async (notion) => [
+          await notion.comments.list({ block_id: blockId }),
+          "Comments retrieved.",
+        ],
         authInfo
       );
     },
 
     update_row_database: async ({ pageId, properties }, { authInfo }) => {
       return withNotionClient(
-        (notion) => notion.pages.update({ page_id: pageId, properties }),
+        async (notion) => [
+          await notion.pages.update({ page_id: pageId, properties }),
+          "Row updated.",
+        ],
         authInfo
       );
     },
 
-    update_schema_database: async (
-      { databaseId, properties },
+    update_schema_datasource: async (
+      { datasourceId, properties },
       { authInfo }
     ) => {
       return withNotionClient(
-        (notion) =>
-          notion.dataSources.update({
-            data_source_id: databaseId,
+        async (notion) => [
+          await notion.dataSources.update({
+            data_source_id: datasourceId,
             properties,
           }),
+          "Datasource schema updated.",
+        ],
         authInfo
       );
     },
 
     list_users: async (_params, { authInfo }) => {
-      return withNotionClient((notion) => notion.users.list({}), authInfo);
+      return withNotionClient(
+        async (notion) => [await notion.users.list({}), "Users retrieved."],
+        authInfo
+      );
     },
 
     get_about_user: async ({ userId }, { authInfo }) => {
       return withNotionClient(
-        (notion) => notion.users.retrieve({ user_id: userId }),
+        async (notion) => [
+          await notion.users.retrieve({ user_id: userId }),
+          "User retrieved.",
+        ],
         authInfo
       );
     },


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9933
[4K logs in the past 2 weeks](https://app.datadoghq.eu/logs?query=%22Could%20not%20find%20data_source%20with%20ID%22%20%40conversationId%3A%2A&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1784707070564&to_ts=1786003070564&live=true)

The internal Notion MCP server conflated "databases" and "datasources" — `retrieve_database_schema` was calling `notion.dataSources.retrieve()` when it should have called `notion.databases.retrieve()`, and `databaseId` was passed where a `datasourceId` was expected.

Fix introduces a proper two-step flow:
- `retrieve_database` (new) calls `notion.databases.retrieve()` and tells the model to use the returned datasource IDs for subsequent operations.
- `retrieve_datasource_schema`, `retrieve_datasource_content`, `query_datasource`, and `update_schema_datasource` now correctly accept a `datasourceId` and call the `dataSources.*` APIs.

Also refactors `withNotionClient` to return `[result, successMessage]` tuples, replacing the generic `"Success"` prefix with a meaningful per-tool message.

## Tests

Snapshot tests updated to reflect renamed tools. Tested manually against the Notion MCP server with a real database to verify the corrected query flow.

![Uploading file-35326a8720dbf28d526edadd42a29e81.png…]()


## Risk

Low. Front-only change, no DB. The tool renames are breaking for any agent that had cached the old tool names, but since this is the internal MCP server the agent will rediscover tools on next invocation.

## Deploy Plan

Deploy front.
