### PR TITLE
[front] feat: consumption analytics query scaffolding

### DIFF
--- a/front/lib/api/analytics/consumption/period.test.ts
+++ b/front/lib/api/analytics/consumption/period.test.ts
@@ -1,0 +1,50 @@
+import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import { Authenticator } from "@app/lib/auth";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Jul 13 2026 09:30 UTC.
+const NOW_MS = Date.UTC(2026, 6, 13, 9, 30);
+
+async function setup() {
+  const workspace = await WorkspaceFactory.basic();
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  return { auth };
+}
+
+describe("resolveConsumptionPeriod", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW_MS));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves a days window to [start-of-day (days-1 ago), now]", async () => {
+    const { auth } = await setup();
+
+    const period = await resolveConsumptionPeriod(auth, {
+      kind: "days",
+      days: 7,
+    });
+
+    expect(period).toEqual({
+      // 6 days before Jul 13, floored to midnight.
+      startDate: "2026-07-07T00:00:00.000Z",
+      endDate: "2026-07-13T09:30:00.000Z",
+    });
+  });
+
+  it("resolves the cycle to the current UTC calendar month for a workspace with no billing cycle", async () => {
+    const { auth } = await setup();
+
+    const period = await resolveConsumptionPeriod(auth, { kind: "cycle" });
+
+    expect(period).toEqual({
+      startDate: "2026-07-01T00:00:00.000Z",
+      endDate: "2026-08-01T00:00:00.000Z",
+    });
+  });
+});

--- a/front/lib/api/analytics/consumption/period.ts
+++ b/front/lib/api/analytics/consumption/period.ts
@@ -1,0 +1,93 @@
+import type { Authenticator } from "@app/lib/auth";
+import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
+import logger from "@app/logger/logger";
+import { isCreditPricedPlan } from "@app/types/plan";
+import moment from "moment-timezone";
+
+/**
+ * Period resolution for the consumption analytics endpoints: turns a requested
+ * period into the [startDate, endDate) window the queries are scoped to.
+ *
+ * "this cycle" is the workspace's current billing cycle; "last N days" is a
+ * relative window.
+ */
+
+export type ConsumptionPeriodInput =
+  | { kind: "cycle" }
+  | { kind: "days"; days: number };
+
+export type ConsumptionPeriod = {
+  startDate: string;
+  endDate: string;
+};
+
+// Workspaces that are not on credit-based pricing have no billing cycle to
+// speak of, so "this cycle" is the current UTC calendar month for them.
+function calendarMonthBounds(now: Date): {
+  cycleStart: Date;
+  cycleEnd: Date;
+} {
+  const startOfMonth = moment.utc(now).startOf("month");
+  return {
+    cycleStart: startOfMonth.toDate(),
+    cycleEnd: startOfMonth.clone().add(1, "month").toDate(),
+  };
+}
+
+// Returns the bounds of the current billing cycle for the workspace, or the
+// current calendar month if the workspace is not on a credit-based plan.
+// If the billing cycle cannot be resolved, returns the current calendar month.
+async function resolveCycleBounds(
+  auth: Authenticator,
+  now: Date
+): Promise<{ cycleStart: Date; cycleEnd: Date }> {
+  const plan = auth.plan();
+  if (!plan || !isCreditPricedPlan(plan)) {
+    return calendarMonthBounds(now);
+  }
+
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+  const periodResult =
+    await getCachedMetronomeCurrentBillingPeriod(workspaceId);
+  if (periodResult.isErr()) {
+    logger.warn(
+      { workspaceId, err: periodResult.error },
+      "[ConsumptionAnalytics] Failed to resolve billing period, " +
+        "falling back to the calendar month."
+    );
+    return calendarMonthBounds(now);
+  }
+  if (!periodResult.value) {
+    return calendarMonthBounds(now);
+  }
+
+  return {
+    cycleStart: periodResult.value.cycleStart,
+    cycleEnd: periodResult.value.cycleEnd,
+  };
+}
+
+export async function resolveConsumptionPeriod(
+  auth: Authenticator,
+  input: ConsumptionPeriodInput
+): Promise<ConsumptionPeriod> {
+  const now = new Date();
+
+  if (input.kind === "days") {
+    const startMs = moment
+      .utc(now)
+      .subtract(input.days - 1, "days")
+      .startOf("day")
+      .valueOf();
+    return {
+      startDate: new Date(startMs).toISOString(),
+      endDate: now.toISOString(),
+    };
+  }
+
+  const { cycleStart, cycleEnd } = await resolveCycleBounds(auth, now);
+  return {
+    startDate: cycleStart.toISOString(),
+    endDate: cycleEnd.toISOString(),
+  };
+}

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -1,0 +1,51 @@
+import type { ConsumptionPeriodInput } from "@app/lib/api/analytics/consumption/period";
+import { CONSUMPTION_SCOPE_DIMENSIONS } from "@app/lib/api/analytics/consumption/scope";
+import { z } from "zod";
+
+/**
+ * Query-string contract shared by the consumption analytics endpoints, so the
+ * period and the Explore filters are parsed the same way everywhere.
+ */
+
+export const DEFAULT_CONSUMPTION_PERIOD_DAYS = 30;
+
+const ConsumptionFilterSchema = z.record(
+  z.enum(CONSUMPTION_SCOPE_DIMENSIONS),
+  z.string().array()
+);
+
+export const ConsumptionQuerySchema = z.object({
+  period: z.enum(["cycle", "days"]).optional().default("cycle"),
+  days: z.coerce
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .default(DEFAULT_CONSUMPTION_PERIOD_DAYS),
+  // JSON-encoded, mirroring the existing analytics filter query param: the
+  // filter is a map of dimension to selected ids and does not flatten well
+  // into repeated query params.
+  filter: z
+    .string()
+    .optional()
+    .transform((value) => {
+      if (!value) {
+        return undefined;
+      }
+      try {
+        return JSON.parse(value);
+      } catch {
+        return value; // Return the original so validation fails below.
+      }
+    })
+    .pipe(ConsumptionFilterSchema.optional()),
+});
+
+export type ConsumptionQuery = z.infer<typeof ConsumptionQuerySchema>;
+
+export function toConsumptionPeriodInput({
+  period,
+  days,
+}: Pick<ConsumptionQuery, "period" | "days">): ConsumptionPeriodInput {
+  return period === "cycle" ? { kind: "cycle" } : { kind: "days", days };
+}

--- a/front/lib/api/analytics/consumption/scope.test.ts
+++ b/front/lib/api/analytics/consumption/scope.test.ts
@@ -1,7 +1,4 @@
-import {
-  buildConsumptionScopeQuery,
-  creditsFromMicroCredits,
-} from "@app/lib/api/analytics/consumption/scope";
+import { buildConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/scope";
 import { describe, expect, it } from "vitest";
 
 const WINDOW = {
@@ -61,12 +58,5 @@ describe("buildConsumptionScopeQuery", () => {
     });
 
     expect(query.bool?.filter).toHaveLength(2);
-  });
-});
-
-describe("creditsFromMicroCredits", () => {
-  it("converts micro-credits without rounding", () => {
-    expect(creditsFromMicroCredits(1_570_588)).toBeCloseTo(1.570588);
-    expect(creditsFromMicroCredits(0)).toBe(0);
   });
 });

--- a/front/lib/api/analytics/consumption/scope.test.ts
+++ b/front/lib/api/analytics/consumption/scope.test.ts
@@ -1,0 +1,72 @@
+import {
+  buildConsumptionScopeQuery,
+  creditsFromMicroCredits,
+} from "@app/lib/api/analytics/consumption/scope";
+import { describe, expect, it } from "vitest";
+
+const WINDOW = {
+  startDate: "2026-07-01T00:00:00.000Z",
+  endDate: "2026-07-13T00:00:00.000Z",
+};
+
+describe("buildConsumptionScopeQuery", () => {
+  it("scopes to the workspace over a half-open window", () => {
+    expect(
+      buildConsumptionScopeQuery({ workspaceId: "w1", ...WINDOW })
+    ).toEqual({
+      bool: {
+        filter: [
+          { term: { workspace_id: "w1" } },
+          {
+            range: {
+              completed_at: { gte: WINDOW.startDate, lt: WINDOW.endDate },
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it("maps each dimension to its index field, single value as a term", () => {
+    const query = buildConsumptionScopeQuery({
+      workspaceId: "w1",
+      ...WINDOW,
+      filter: {
+        agent: ["a1"],
+        member: ["u1", "u2"],
+        model: ["gpt-5.6-luna"],
+        tool: ["web_search_&_browse"],
+        skill: ["s1"],
+        source: ["web"],
+      },
+    });
+
+    expect(query.bool?.filter).toEqual([
+      { term: { workspace_id: "w1" } },
+      expect.objectContaining({ range: expect.anything() }),
+      { term: { "agent.id": "a1" } },
+      { terms: { "user.id": ["u1", "u2"] } },
+      { term: { "model.model_id": "gpt-5.6-luna" } },
+      { term: { "tool.server_name": "web_search_&_browse" } },
+      { term: { "tool.attributed_skill_ids": "s1" } },
+      { term: { context_origin: "web" } },
+    ]);
+  });
+
+  it("ignores empty selections", () => {
+    const query = buildConsumptionScopeQuery({
+      workspaceId: "w1",
+      ...WINDOW,
+      filter: { agent: [], member: [""] },
+    });
+
+    expect(query.bool?.filter).toHaveLength(2);
+  });
+});
+
+describe("creditsFromMicroCredits", () => {
+  it("converts micro-credits without rounding", () => {
+    expect(creditsFromMicroCredits(1_570_588)).toBeCloseTo(1.570588);
+    expect(creditsFromMicroCredits(0)).toBe(0);
+  });
+});

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -1,10 +1,6 @@
 import type { estypes } from "@elastic/elasticsearch";
 
-const MICRO_CREDITS_PER_CREDIT = 1_000_000;
-
-export const CREDIT_MICRO_FIELD = "credit_micro";
 export const COMPLETED_AT_FIELD = "completed_at";
-export const AGENT_MESSAGE_ID_FIELD = "agent_message_id";
 
 // Dimensions a consumption query can be filtered by. Every one of them maps to
 // a single keyword field, so filtering is always a term/terms clause.
@@ -35,10 +31,6 @@ export const CONSUMPTION_DIMENSION_FIELDS: Record<
 export type ConsumptionScopeFilter = Partial<
   Record<ConsumptionScopeDimension, string[]>
 >;
-
-export function creditsFromMicroCredits(microCredits: number): number {
-  return microCredits / MICRO_CREDITS_PER_CREDIT;
-}
 
 function termFilter(
   field: string,

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -1,0 +1,89 @@
+import type { estypes } from "@elastic/elasticsearch";
+
+const MICRO_CREDITS_PER_CREDIT = 1_000_000;
+
+export const CREDIT_MICRO_FIELD = "credit_micro";
+export const COMPLETED_AT_FIELD = "completed_at";
+export const AGENT_MESSAGE_ID_FIELD = "agent_message_id";
+
+// Dimensions a consumption query can be filtered by. Every one of them maps to
+// a single keyword field, so filtering is always a term/terms clause.
+export const CONSUMPTION_SCOPE_DIMENSIONS = [
+  "agent",
+  "member",
+  "model",
+  "tool",
+  "skill",
+  "source",
+] as const;
+
+export type ConsumptionScopeDimension =
+  (typeof CONSUMPTION_SCOPE_DIMENSIONS)[number];
+
+export const CONSUMPTION_DIMENSION_FIELDS: Record<
+  ConsumptionScopeDimension,
+  string
+> = {
+  agent: "agent.id",
+  member: "user.id",
+  model: "model.model_id",
+  tool: "tool.server_name",
+  skill: "tool.attributed_skill_ids",
+  source: "context_origin",
+};
+
+export type ConsumptionScopeFilter = Partial<
+  Record<ConsumptionScopeDimension, string[]>
+>;
+
+export function creditsFromMicroCredits(microCredits: number): number {
+  return microCredits / MICRO_CREDITS_PER_CREDIT;
+}
+
+function termFilter(
+  field: string,
+  values: string[] | undefined
+): estypes.QueryDslQueryContainer[] {
+  if (!values) {
+    return [];
+  }
+  const nonEmpty = values.filter((value) => value.length > 0);
+  if (nonEmpty.length === 0) {
+    return [];
+  }
+  return [
+    nonEmpty.length === 1
+      ? { term: { [field]: nonEmpty[0] } }
+      : { terms: { [field]: nonEmpty } },
+  ];
+}
+
+/**
+ * Workspace-scoped query over a half-open [startDate, endDate) window.
+ */
+export function buildConsumptionScopeQuery({
+  workspaceId,
+  startDate,
+  endDate,
+  filter = {},
+  extraFilters = [],
+}: {
+  workspaceId: string;
+  startDate: string;
+  endDate: string;
+  filter?: ConsumptionScopeFilter;
+  extraFilters?: estypes.QueryDslQueryContainer[];
+}): estypes.QueryDslQueryContainer {
+  const filters: estypes.QueryDslQueryContainer[] = [
+    { term: { workspace_id: workspaceId } },
+    { range: { [COMPLETED_AT_FIELD]: { gte: startDate, lt: endDate } } },
+  ];
+
+  for (const dimension of CONSUMPTION_SCOPE_DIMENSIONS) {
+    filters.push(
+      ...termFilter(CONSUMPTION_DIMENSION_FIELDS[dimension], filter[dimension])
+    );
+  }
+
+  return { bool: { filter: [...filters, ...extraFilters] } };
+}

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -247,3 +247,34 @@ export async function searchAnalytics<
     search_after: options?.search_after,
   });
 }
+
+/**
+ * High-level consumption  analytics-specific interface.
+ * This interface enforces proper usage and makes it harder to accidentally
+ * query other Elasticsearch indexes from the front service.
+ */
+export async function searchConsumptionAnalytics<
+  TDocument extends ElasticsearchBaseDocument | never,
+  TAggregations = unknown,
+>(
+  query: estypes.QueryDslQueryContainer,
+  options?: {
+    aggregations?: Record<string, estypes.AggregationsAggregationContainer>;
+    size?: number;
+    from?: number;
+    sort?: estypes.Sort;
+    search_after?: estypes.SortResults;
+  }
+): Promise<
+  Result<estypes.SearchResponse<TDocument, TAggregations>, ElasticsearchError>
+> {
+  return esSearch<TDocument, TAggregations>({
+    index: CONSUMPTION_ANALYTICS_ALIAS_NAME,
+    query,
+    aggs: options?.aggregations,
+    size: options?.size,
+    from: options?.from,
+    sort: options?.sort,
+    search_after: options?.search_after,
+  });
+}


### PR DESCRIPTION
## Description

Foundation for the new consumption-index-backed analytics dashboard. No
endpoint and no UI yet — this is the shared query layer every following
branch builds on.

- `searchConsumptionAnalytics`: same contract as `searchAnalytics`, bound to
  `front.agent_message_consumption_analytics`.
- `period.ts`: resolves "this cycle" / "last N days".
  Workspaces not on credit-based pricing have no billing cycle, so they
  resolve to the current UTC calendar month.
- `scope.ts`: the filter dimensions and their index fields, plus the
  workspace-scoped query builder.
- `schema.ts`: shared zod contract for the period and filter query params.

## Tests

uts

## Risk

Low. Safe to rollback.

## Deploy Plan

Front only
