### PR TITLE
Prevent Agent to create message in the same conversation.

### DIFF
--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -557,9 +557,8 @@ export const POD_MANAGER_TOOLS_METADATA = [
     schema: {
       conversationId: z
         .string()
-        .optional()
         .describe(
-          "Conversation id to post to; defaults to the conversation this agent run is in when omitted"
+          "Conversation id to post to, cannot be the same as the current conversation"
         ),
       message: z
         .string()

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -1518,17 +1518,21 @@ export function createProjectManagerTools(
         const user = auth.user();
         const owner = auth.getNonNullableWorkspace();
 
-        const conversationId =
-          params.conversationId ??
-          (isAgentLoopRunContext(toolContext?.runContext)
-            ? toolContext.runContext.conversation.sId
-            : null);
+        const conversationId = params.conversationId;
 
-        if (!conversationId) {
+        const currentConversationId = isAgentLoopRunContext(
+          toolContext?.runContext
+        )
+          ? toolContext.runContext.conversation.sId
+          : null;
+
+        if (conversationId === currentConversationId) {
           return new Err(
             new MCPError(
-              "No conversationId provided and no conversation in agent context; pass conversationId explicitly.",
-              { tracked: false }
+              "ConversationId cannot be the same as the current conversation",
+              {
+                tracked: false,
+              }
             )
           );
         }


### PR DESCRIPTION
## Description

Removes the default-to-current-conversation fallback from the `create_conversation_message` Pod Manager tool, and adds an explicit guard that returns an `MCPError` when `conversationId` matches the running conversation's `sId`. `conversationId` is now required in the Zod schema (`.optional()` dropped). This prevents agents from posting messages back into their own conversation, which would trigger recursive agent loops.

## Tests

Tested manually.

## Risk

Low. The schema change makes `conversationId` required — any agent call that previously omitted it to self-post will now receive a clear error instead of silently looping. No DB changes, no API surface changes outside the MCP tool schema.

## Deploy Plan

Deploy front.
