### PR TITLE
[front] feat: consumption analytics page skeleton

### DIFF
--- a/front-spa/src/app/routes/adminRoutes.tsx
+++ b/front-spa/src/app/routes/adminRoutes.tsx
@@ -8,6 +8,13 @@ const AnalyticsPage = withSuspense(
   () => import("@dust-tt/front/components/pages/workspace/AnalyticsPage"),
   "AnalyticsPage"
 );
+const AnalyticsConsumptionPage = withSuspense(
+  () =>
+    import(
+      "@dust-tt/front/components/pages/workspace/AnalyticsConsumptionPage"
+    ),
+  "AnalyticsConsumptionPage"
+);
 const APIKeysPage = withSuspense(
   () =>
     import("@dust-tt/front/components/pages/workspace/developers/APIKeysPage"),
@@ -104,6 +111,10 @@ export const adminRoutes: RouteObject[] = [
     children: [
       { path: "members", element: <MembersPage /> },
       { path: "analytics", element: <AnalyticsPage /> },
+      {
+        path: "analytics/consumption",
+        element: <AnalyticsConsumptionPage />,
+      },
       { path: "usage", element: <UsagePage /> },
       { path: "governance", element: <GovernancePage /> },
       // Legacy Workspace Settings page, merged into Settings & Governance.

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -97,6 +97,7 @@ type SubNavigationAdminId =
   | "dev_secrets"
   | "sandbox"
   | "analytics"
+  | "analytics_consumption"
   | "credits_usage"
   | "usage"
   | "self_improving_skills";
@@ -108,6 +109,7 @@ const ADMIN_ROUTE_PATTERNS: Record<SubNavigationAdminId, string[]> = {
   workspace_branding: ["/w/[wId]/brand"],
   model_providers: ["/w/[wId]/model-providers"],
   analytics: ["/w/[wId]/analytics"],
+  analytics_consumption: ["/w/[wId]/analytics/consumption"],
   subscription: ["/w/[wId]/subscription"],
   billing: ["/w/[wId]/billing"],
   api_keys: ["/w/[wId]/developers/api-keys"],
@@ -226,6 +228,7 @@ export const getTopNavigationTabs = (
           "/w/[wId]/subscription",
           "/w/[wId]/billing",
           "/w/[wId]/analytics",
+          "/w/[wId]/analytics/consumption",
           "/w/[wId]/actions",
           "/w/[wId]/developers/credits-usage",
           "/w/[wId]/developers/providers",
@@ -344,6 +347,20 @@ export const subNavigationAdmin = ({
         current: isCurrent("analytics"),
         disabled: !hasManagerRole,
       },
+      // Sits alongside the current Analytics entry while the consumption-backed
+      // dashboard is brought to parity; it replaces it at cut-over.
+      ...(featureFlags.includes("enable_analytics_consumption")
+        ? [
+            {
+              id: "analytics_consumption" as const,
+              label: "Analytics (new)",
+              icon: BarChart01,
+              href: `/w/${owner.sId}/analytics/consumption`,
+              current: isCurrent("analytics_consumption"),
+              disabled: !hasManagerRole,
+            },
+          ]
+        : []),
       isCreditPricedPlan(subscription.plan)
         ? {
             id: "billing",

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -347,8 +347,6 @@ export const subNavigationAdmin = ({
         current: isCurrent("analytics"),
         disabled: !hasManagerRole,
       },
-      // Sits alongside the current Analytics entry while the consumption-backed
-      // dashboard is brought to parity; it replaces it at cut-over.
       ...(featureFlags.includes("enable_analytics_consumption")
         ? [
             {

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -2,13 +2,31 @@ import { ConsumptionOverview } from "@app/components/workspace/analytics/consump
 import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
 import { BarChart01, cn, Page } from "@dust-tt/sparkle";
 
-/**
- * The consumption-backed Analytics dashboard, built alongside `AnalyticsPage`
- * behind `enable_analytics_consumption` until it reaches parity.
- */
 export function AnalyticsConsumptionPage() {
   const owner = useWorkspace();
   const { hasFeature } = useFeatureFlags();
+  const isEnabled = hasFeature("enable_analytics_consumption");
+
+  if (!isEnabled) {
+    return (
+      <Page.Vertical align="stretch" gap="xl">
+        <Page.Header
+          title={<Page.H variant="h3">Analytics</Page.H>}
+          icon={BarChart01}
+        />
+        <div
+          className={cn(
+            "flex flex-col gap-2 rounded-xl border p-6",
+            "border-border bg-muted"
+          )}
+        >
+          <p className="text-sm text-muted-foreground">
+            This page is not enabled for this workspace.
+          </p>
+        </div>
+      </Page.Vertical>
+    );
+  }
 
   return (
     <Page.Vertical align="stretch" gap="xl">
@@ -16,21 +34,7 @@ export function AnalyticsConsumptionPage() {
         title={<Page.H variant="h3">Analytics</Page.H>}
         icon={BarChart01}
       />
-      {hasFeature("enable_analytics_consumption") ? (
-        <ConsumptionOverview workspaceId={owner.sId} />
-      ) : (
-        <div
-          className={cn(
-            "flex flex-col gap-2 rounded-xl border p-6",
-            "border-border bg-muted"
-          )}
-        >
-          <p className="heading-lg text-foreground">Analytics</p>
-          <p className="text-sm text-muted-foreground">
-            This version of Analytics is not enabled for this workspace.
-          </p>
-        </div>
-      )}
+      <ConsumptionOverview workspaceId={owner.sId} />
     </Page.Vertical>
   );
 }

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -1,0 +1,36 @@
+import { ConsumptionOverview } from "@app/components/workspace/analytics/consumption/ConsumptionOverview";
+import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
+import { BarChart01, cn, Page } from "@dust-tt/sparkle";
+
+/**
+ * The consumption-backed Analytics dashboard, built alongside `AnalyticsPage`
+ * behind `enable_analytics_consumption` until it reaches parity.
+ */
+export function AnalyticsConsumptionPage() {
+  const owner = useWorkspace();
+  const { hasFeature } = useFeatureFlags();
+
+  return (
+    <Page.Vertical align="stretch" gap="xl">
+      <Page.Header
+        title={<Page.H variant="h3">Analytics</Page.H>}
+        icon={BarChart01}
+      />
+      {hasFeature("enable_analytics_consumption") ? (
+        <ConsumptionOverview workspaceId={owner.sId} />
+      ) : (
+        <div
+          className={cn(
+            "flex flex-col gap-2 rounded-xl border p-6",
+            "border-border bg-muted"
+          )}
+        >
+          <p className="heading-lg text-foreground">Analytics</p>
+          <p className="text-sm text-muted-foreground">
+            This version of Analytics is not enabled for this workspace.
+          </p>
+        </div>
+      )}
+    </Page.Vertical>
+  );
+}

--- a/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
@@ -1,18 +1,12 @@
 import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
-import type { ConsumptionPace } from "@app/lib/api/analytics/consumption/overview";
 import { timeAgoFrom } from "@app/lib/utils";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
-import { Button, Chip, cn, ValueCard } from "@dust-tt/sparkle";
-import { ExternalLinkIcon } from "lucide-react";
+import { cn, ValueCard } from "@dust-tt/sparkle";
 
 interface ConsumptionOverviewProps {
   workspaceId: string;
 }
 
-const EMPTY_VALUE = "—";
-
-// The period is resolved in UTC server-side, so it has to be rendered in UTC
-// too or a cycle boundary shifts by a day for anyone west of Greenwich.
+// The period is resolved in UTC server-side, so it has to be rendered in UTC here too.
 function formatPeriodBound(isoDate: string): string {
   return new Date(isoDate).toLocaleDateString("en-US", {
     month: "short",
@@ -23,38 +17,6 @@ function formatPeriodBound(isoDate: string): string {
 
 function formatCredits(credits: number): string {
   return Math.round(credits).toLocaleString();
-}
-
-function formatRatio(ratio: number): string {
-  return `${Math.round(ratio * 100)}%`;
-}
-
-function paceLabel(pace: ConsumptionPace): string {
-  switch (pace) {
-    case "under":
-      return "Under pace";
-    case "on_pace":
-      return "On pace";
-    case "over":
-      return "Over pace";
-    default:
-      assertNeverAndIgnore(pace);
-      return "On pace";
-  }
-}
-
-function paceColor(pace: ConsumptionPace) {
-  switch (pace) {
-    case "under":
-      return "success" as const;
-    case "on_pace":
-      return "info" as const;
-    case "over":
-      return "warning" as const;
-    default:
-      assertNeverAndIgnore(pace);
-      return "info" as const;
-  }
 }
 
 export function ConsumptionOverview({ workspaceId }: ConsumptionOverviewProps) {
@@ -90,7 +52,7 @@ export function ConsumptionOverview({ workspaceId }: ConsumptionOverviewProps) {
     );
   }
 
-  const { period, members, credits, projection, lastRecordAt } = overview;
+  const { period, members, credits, lastRecordAt } = overview;
 
   const metaParts = [
     `${formatPeriodBound(period.startDate)} to ${formatPeriodBound(period.endDate)}`,
@@ -104,36 +66,6 @@ export function ConsumptionOverview({ workspaceId }: ConsumptionOverviewProps) {
     <div className="flex flex-col gap-6">
       <p className="text-sm text-muted-foreground">{metaParts.join("  |  ")}</p>
 
-      {projection?.pace &&
-        credits.usedRatio !== null &&
-        projection.projectedRatio !== null && (
-          <div
-            className={cn(
-              "flex flex-row items-center justify-between gap-4",
-              "rounded-xl border border-border bg-muted px-4 py-3"
-            )}
-          >
-            <div className="flex flex-row items-center gap-3">
-              <Chip
-                size="xs"
-                color={paceColor(projection.pace)}
-                label={paceLabel(projection.pace)}
-              />
-              <span className="text-sm text-muted-foreground">
-                {formatRatio(credits.usedRatio)} of the cap used,{" "}
-                {formatRatio(projection.projectedRatio)} of the cycle elapsed
-              </span>
-            </div>
-            <Button
-              variant="ghost"
-              size="xs"
-              label="Manage in Usage"
-              icon={ExternalLinkIcon}
-              href={`/w/${workspaceId}/usage`}
-            />
-          </div>
-        )}
-
       <div className="grid grid-cols-2 gap-6">
         <ValueCard
           title="Used this period"
@@ -142,33 +74,6 @@ export function ConsumptionOverview({ workspaceId }: ConsumptionOverviewProps) {
             <div className="flex flex-col gap-1">
               <div className="truncate text-2xl text-foreground">
                 {formatCredits(credits.usedCredits)}
-              </div>
-              <div className="text-xs text-muted-foreground">
-                {credits.capCredits !== null && credits.usedRatio !== null
-                  ? `${formatRatio(credits.usedRatio)} of ${formatCredits(credits.capCredits)} cap`
-                  : "No credit cap on this workspace"}
-              </div>
-            </div>
-          }
-        />
-        <ValueCard
-          title="Projected end of cycle"
-          className="h-24"
-          content={
-            <div className="flex flex-col gap-1">
-              <div className="truncate text-2xl text-foreground">
-                {projection === null
-                  ? EMPTY_VALUE
-                  : projection.projectedRatio !== null
-                    ? formatRatio(projection.projectedRatio)
-                    : formatCredits(projection.projectedCredits)}
-              </div>
-              <div className="text-xs text-muted-foreground">
-                {projection === null
-                  ? "Too early in the cycle to project"
-                  : projection.pace !== null
-                    ? paceLabel(projection.pace)
-                    : "credits projected"}
               </div>
             </div>
           }

--- a/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
@@ -1,6 +1,5 @@
 import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
 import { timeAgoFrom } from "@app/lib/utils";
-import { cn, ValueCard } from "@dust-tt/sparkle";
 
 interface ConsumptionOverviewProps {
   workspaceId: string;
@@ -15,10 +14,6 @@ function formatPeriodBound(isoDate: string): string {
   });
 }
 
-function formatCredits(credits: number): string {
-  return Math.round(credits).toLocaleString();
-}
-
 export function ConsumptionOverview({ workspaceId }: ConsumptionOverviewProps) {
   const { overview, isOverviewLoading, isOverviewError } =
     useConsumptionOverview({ workspaceId });
@@ -27,34 +22,17 @@ export function ConsumptionOverview({ workspaceId }: ConsumptionOverviewProps) {
     return (
       <div className="flex flex-col gap-6">
         <div className="h-5 w-80 animate-pulse rounded bg-muted-background" />
-        <div className="h-12 w-full animate-pulse rounded-xl bg-muted-background" />
-        <div className="grid grid-cols-2 gap-6">
-          <div className="h-24 animate-pulse rounded-xl bg-muted-background" />
-          <div className="h-24 animate-pulse rounded-xl bg-muted-background" />
-        </div>
       </div>
     );
   }
 
   if (isOverviewError || !overview) {
-    return (
-      <div
-        className={cn(
-          "flex flex-col gap-2 rounded-xl border p-6",
-          "border-border bg-muted"
-        )}
-      >
-        <p className="heading-lg text-foreground">Analytics unavailable</p>
-        <p className="text-sm text-muted-foreground">
-          We could not load the consumption overview. Please try again later.
-        </p>
-      </div>
-    );
+    return null;
   }
 
-  const { period, members, credits, lastRecordAt } = overview;
+  const { period, members, lastRecordAt } = overview;
 
-  const metaParts = [
+  const header = [
     `${formatPeriodBound(period.startDate)} to ${formatPeriodBound(period.endDate)}`,
     `${members.active.toLocaleString()} of ${members.total.toLocaleString()} members active`,
     ...(lastRecordAt
@@ -63,22 +41,8 @@ export function ConsumptionOverview({ workspaceId }: ConsumptionOverviewProps) {
   ];
 
   return (
-    <div className="flex flex-col gap-6">
-      <p className="text-sm text-muted-foreground">{metaParts.join("  |  ")}</p>
-
-      <div className="grid grid-cols-2 gap-6">
-        <ValueCard
-          title="Used this period"
-          className="h-24"
-          content={
-            <div className="flex flex-col gap-1">
-              <div className="truncate text-2xl text-foreground">
-                {formatCredits(credits.usedCredits)}
-              </div>
-            </div>
-          }
-        />
-      </div>
+    <div className="flex">
+      <p className="text-sm text-muted-foreground">{header.join("  |  ")}</p>
     </div>
   );
 }

--- a/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
@@ -1,0 +1,179 @@
+import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
+import type { ConsumptionPace } from "@app/lib/api/analytics/consumption/overview";
+import { timeAgoFrom } from "@app/lib/utils";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { Button, Chip, cn, ValueCard } from "@dust-tt/sparkle";
+import { ExternalLinkIcon } from "lucide-react";
+
+interface ConsumptionOverviewProps {
+  workspaceId: string;
+}
+
+const EMPTY_VALUE = "—";
+
+// The period is resolved in UTC server-side, so it has to be rendered in UTC
+// too or a cycle boundary shifts by a day for anyone west of Greenwich.
+function formatPeriodBound(isoDate: string): string {
+  return new Date(isoDate).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function formatCredits(credits: number): string {
+  return Math.round(credits).toLocaleString();
+}
+
+function formatRatio(ratio: number): string {
+  return `${Math.round(ratio * 100)}%`;
+}
+
+function paceLabel(pace: ConsumptionPace): string {
+  switch (pace) {
+    case "under":
+      return "Under pace";
+    case "on_pace":
+      return "On pace";
+    case "over":
+      return "Over pace";
+    default:
+      assertNeverAndIgnore(pace);
+      return "On pace";
+  }
+}
+
+function paceColor(pace: ConsumptionPace) {
+  switch (pace) {
+    case "under":
+      return "success" as const;
+    case "on_pace":
+      return "info" as const;
+    case "over":
+      return "warning" as const;
+    default:
+      assertNeverAndIgnore(pace);
+      return "info" as const;
+  }
+}
+
+export function ConsumptionOverview({ workspaceId }: ConsumptionOverviewProps) {
+  const { overview, isOverviewLoading, isOverviewError } =
+    useConsumptionOverview({ workspaceId });
+
+  if (isOverviewLoading) {
+    return (
+      <div className="flex flex-col gap-6">
+        <div className="h-5 w-80 animate-pulse rounded bg-muted-background" />
+        <div className="h-12 w-full animate-pulse rounded-xl bg-muted-background" />
+        <div className="grid grid-cols-2 gap-6">
+          <div className="h-24 animate-pulse rounded-xl bg-muted-background" />
+          <div className="h-24 animate-pulse rounded-xl bg-muted-background" />
+        </div>
+      </div>
+    );
+  }
+
+  if (isOverviewError || !overview) {
+    return (
+      <div
+        className={cn(
+          "flex flex-col gap-2 rounded-xl border p-6",
+          "border-border bg-muted"
+        )}
+      >
+        <p className="heading-lg text-foreground">Analytics unavailable</p>
+        <p className="text-sm text-muted-foreground">
+          We could not load the consumption overview. Please try again later.
+        </p>
+      </div>
+    );
+  }
+
+  const { period, members, credits, projection, lastRecordAt } = overview;
+
+  const metaParts = [
+    `${formatPeriodBound(period.startDate)} to ${formatPeriodBound(period.endDate)}`,
+    `${members.active.toLocaleString()} of ${members.total.toLocaleString()} members active`,
+    ...(lastRecordAt
+      ? [`Updated ${timeAgoFrom(new Date(lastRecordAt).getTime())} ago`]
+      : []),
+  ];
+
+  return (
+    <div className="flex flex-col gap-6">
+      <p className="text-sm text-muted-foreground">{metaParts.join("  |  ")}</p>
+
+      {projection?.pace &&
+        credits.usedRatio !== null &&
+        projection.projectedRatio !== null && (
+          <div
+            className={cn(
+              "flex flex-row items-center justify-between gap-4",
+              "rounded-xl border border-border bg-muted px-4 py-3"
+            )}
+          >
+            <div className="flex flex-row items-center gap-3">
+              <Chip
+                size="xs"
+                color={paceColor(projection.pace)}
+                label={paceLabel(projection.pace)}
+              />
+              <span className="text-sm text-muted-foreground">
+                {formatRatio(credits.usedRatio)} of the cap used,{" "}
+                {formatRatio(projection.projectedRatio)} of the cycle elapsed
+              </span>
+            </div>
+            <Button
+              variant="ghost"
+              size="xs"
+              label="Manage in Usage"
+              icon={ExternalLinkIcon}
+              href={`/w/${workspaceId}/usage`}
+            />
+          </div>
+        )}
+
+      <div className="grid grid-cols-2 gap-6">
+        <ValueCard
+          title="Used this period"
+          className="h-24"
+          content={
+            <div className="flex flex-col gap-1">
+              <div className="truncate text-2xl text-foreground">
+                {formatCredits(credits.usedCredits)}
+              </div>
+              <div className="text-xs text-muted-foreground">
+                {credits.capCredits !== null && credits.usedRatio !== null
+                  ? `${formatRatio(credits.usedRatio)} of ${formatCredits(credits.capCredits)} cap`
+                  : "No credit cap on this workspace"}
+              </div>
+            </div>
+          }
+        />
+        <ValueCard
+          title="Projected end of cycle"
+          className="h-24"
+          content={
+            <div className="flex flex-col gap-1">
+              <div className="truncate text-2xl text-foreground">
+                {projection === null
+                  ? EMPTY_VALUE
+                  : projection.projectedRatio !== null
+                    ? formatRatio(projection.projectedRatio)
+                    : formatCredits(projection.projectedCredits)}
+              </div>
+              <div className="text-xs text-muted-foreground">
+                {projection === null
+                  ? "Too early in the cycle to project"
+                  : projection.pace !== null
+                    ? paceLabel(projection.pace)
+                    : "credits projected"}
+              </div>
+            </div>
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/front/hooks/useConsumptionOverview.ts
+++ b/front/hooks/useConsumptionOverview.ts
@@ -1,0 +1,27 @@
+import type { GetConsumptionOverviewResponse } from "@app/lib/api/analytics/consumption/overview";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { Fetcher } from "swr";
+
+export function useConsumptionOverview({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const overviewFetcher: Fetcher<GetConsumptionOverviewResponse> = fetcher;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/analytics/consumption/overview`,
+    overviewFetcher,
+    { disabled }
+  );
+
+  return {
+    overview: data ?? null,
+    isOverviewLoading: !error && !data && !disabled,
+    isOverviewError: error,
+    isOverviewValidating: isValidating,
+  };
+}

--- a/front/lib/api/analytics/consumption/overview.ts
+++ b/front/lib/api/analytics/consumption/overview.ts
@@ -52,7 +52,7 @@ export async function fetchConsumptionOverview(
   const period = await resolveConsumptionPeriod(auth, periodInput);
 
   const query = buildConsumptionScopeQuery({
-    workspaceId: workspace.sId,
+    auth: auth,
     startDate: period.startDate,
     endDate: period.endDate,
     filter,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -154,6 +154,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Allow legacy-contract workspaces to view the Usage page in read-only mode (analytics and member spend visible; all actions disabled).",
     stage: "on_demand",
   },
+  enable_analytics_consumption: {
+    description:
+      "Access to the new consumption-based Analytics dashboard, built alongside the current one while it is brought to parity.",
+    stage: "dust_only",
+  },
   xai_feature: {
     description: "Access to xAI models in the agent builder",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -794,6 +794,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "run_tools_from_prompt"
   | "usage_data_api"
   | "usage_page_read_only"
+  | "enable_analytics_consumption"
   | "pricing_groups"
   | "workspace_analytics"
   | "xai_feature"


### PR DESCRIPTION
## Description

The page shell for the new Analytics dashboard, behind `enable_analytics_consumption`
(dust-only).
Renders the overview from the endpoint below it in the stack and nothing else yet — chart, attribution table and filters follow.

- add `AnalyticsConsumptionPage` under `analytics/consumption`
- add `enable_analytics_consumption` feature flag.
- the page fetches the `analytics/consumption/overview` endpoint (from PR below) only


## Tests

Checked the new page renders locally:
<img width="1509" height="361" alt="Screenshot 2026-08-06 at 10 16 22" src="https://github.com/user-attachments/assets/06a51c2e-6636-402f-a4e5-95fc3a865d72" />


## Risk

Low. Safe to rollback.

## Deploy Plan

Front only.
