### PR TITLE
[front] feat: consumption analytics chart, broken down by agent

### DIFF
--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -3,9 +3,28 @@ import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/c
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
 import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
-import { BarChart01, cn, Page } from "@dust-tt/sparkle";
+import { isNavigationLocked } from "@app/lib/navigation-lock";
+import { BarChart01, cn, Page, SafeSuspense, safeLazy } from "@dust-tt/sparkle";
 import { useState } from "react";
 
+const canReload = () => !isNavigationLocked();
+
+const ConsumptionChart = safeLazy(
+  () =>
+    import(
+      "@app/components/workspace/analytics/consumption/ConsumptionChart"
+    ).then((mod) => ({ default: mod.ConsumptionChart })),
+  { canReload }
+);
+
+function ChartFallback() {
+  return <div className="h-64 animate-pulse rounded-lg bg-muted-background" />;
+}
+
+/**
+ * The consumption-backed Analytics dashboard, built alongside `AnalyticsPage`
+ * behind `enable_analytics_consumption` until it reaches parity.
+ */
 export function AnalyticsConsumptionPage() {
   const owner = useWorkspace();
   const { hasFeature } = useFeatureFlags();
@@ -49,7 +68,12 @@ export function AnalyticsConsumptionPage() {
         }
         icon={BarChart01}
       />
-      <ConsumptionOverview workspaceId={owner.sId} period={period} />
+      <div className="flex flex-col gap-8 pb-8">
+        <ConsumptionOverview workspaceId={owner.sId} period={period} />
+        <SafeSuspense fallback={<ChartFallback />}>
+          <ConsumptionChart workspaceId={owner.sId} period={period} />
+        </SafeSuspense>
+      </div>
     </Page.Vertical>
   );
 }

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -21,10 +21,6 @@ function ChartFallback() {
   return <div className="h-64 animate-pulse rounded-lg bg-muted-background" />;
 }
 
-/**
- * The consumption-backed Analytics dashboard, built alongside `AnalyticsPage`
- * behind `enable_analytics_consumption` until it reaches parity.
- */
 export function AnalyticsConsumptionPage() {
   const owner = useWorkspace();
   const { hasFeature } = useFeatureFlags();

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -26,8 +26,7 @@ import {
 } from "recharts";
 import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 
-// The bucket in progress is drawn faded across every series: its total is still
-// growing, and at full strength it reads as a real drop in consumption.
+// The bucket in progress (if mapped to today) is drawn faded across every series.
 const PARTIAL_BAR_OPACITY = "opacity-40";
 
 // Recharts hands the tooltip its datum as `unknown`; the points go into the
@@ -39,15 +38,25 @@ function isConsumptionTimeseriesPoint(
     typeof data === "object" &&
     data !== null &&
     "timestamp" in data &&
-    "isPartial" in data &&
     "values" in data
   );
+}
+
+// The endpoint buckets the whole period, so the tail of the series is the part
+// of the cycle still to come. The bucket holding the present is the last one
+// that has started, which is all it takes to tell the two apart.
+function findPartialTimestamp(
+  points: ConsumptionTimeseriesPoint[]
+): number | undefined {
+  const nowMs = Date.now();
+  return points.findLast((point) => point.timestamp <= nowMs)?.timestamp;
 }
 
 interface ConsumptionChartTooltipProps
   extends TooltipContentProps<number, string> {
   groups: ConsumptionTimeseriesGroup[];
   colorByGroupKey: Map<string, string>;
+  partialTimestamp: number | undefined;
 }
 
 function ConsumptionChartTooltip({
@@ -55,14 +64,22 @@ function ConsumptionChartTooltip({
   payload,
   groups,
   colorByGroupKey,
+  partialTimestamp,
 }: ConsumptionChartTooltipProps) {
   const datum = payload?.[0]?.payload;
   if (!active || !isConsumptionTimeseriesPoint(datum)) {
     return null;
   }
 
+  // The partialTimestamp points to the bucket in progress (if mapped to today).
+  // So every buckets after that are in the future, and are expected to be empty,
+  // hence nothing to show.
+  if (partialTimestamp !== undefined && datum.timestamp > partialTimestamp) {
+    return null;
+  }
+
   // Only the series that actually consumed something on this day, largest
-  // first: with ten agents, listing the zeroes buries the ones that matter.
+  // first.
   const rows = groups
     .map((group) => ({
       key: group.groupKey,
@@ -74,6 +91,7 @@ function ConsumptionChartTooltip({
     .sort((a, b) => b.credits - a.credits);
 
   const totalCredits = rows.reduce((sum, row) => sum + row.credits, 0);
+  const isPartial = datum.timestamp === partialTimestamp;
 
   return (
     <ChartTooltipCard
@@ -85,7 +103,7 @@ function ConsumptionChartTooltip({
         colorClassName: row.colorClassName,
       }))}
       footer={
-        datum.isPartial
+        isPartial
           ? `${formatCredits(totalCredits)} so far today`
           : `${formatCredits(totalCredits)} total`
       }
@@ -127,15 +145,21 @@ export function ConsumptionChart({
 
   const chartData = useMemo(() => timeseries?.points ?? [], [timeseries]);
 
+  const partialTimestamp = useMemo(
+    () => findPartialTimestamp(chartData),
+    [chartData]
+  );
+
   const renderTooltip = useCallback(
     (props: TooltipContentProps<number, string>) => (
       <ConsumptionChartTooltip
         {...props}
         groups={groups}
         colorByGroupKey={colorByGroupKey}
+        partialTimestamp={partialTimestamp}
       />
     ),
-    [groups, colorByGroupKey]
+    [groups, colorByGroupKey, partialTimestamp]
   );
 
   const legendItems: LegendItem[] = groups.map((group) => ({
@@ -144,9 +168,6 @@ export function ConsumptionChart({
     colorClassName: colorByGroupKey.get(group.groupKey) ?? "",
   }));
 
-  const partialTimestamp = chartData.find(
-    (datum) => datum.isPartial
-  )?.timestamp;
   const hasConsumption = chartData.some((datum) =>
     Object.values(datum.values).some((credits) => credits > 0)
   );
@@ -219,7 +240,7 @@ export function ConsumptionChart({
                 fill="currentColor"
                 className={cn(
                   colorByGroupKey.get(group.groupKey),
-                  datum.isPartial && PARTIAL_BAR_OPACITY
+                  datum.timestamp === partialTimestamp && PARTIAL_BAR_OPACITY
                 )}
               />
             ))}

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -3,14 +3,15 @@ import { getIndexedColor } from "@app/components/agent_builder/observability/uti
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
-import type { ConsumptionPeriodSelection } from "@app/components/workspace/analytics/consumption/consumptionPeriod";
-import { formatConsumptionDate } from "@app/components/workspace/analytics/consumption/consumptionPeriod";
 import { useConsumptionTimeseries } from "@app/hooks/useConsumptionTimeseries";
+import {
+  type ConsumptionPeriodSelection,
+  formatConsumptionDate,
+} from "@app/lib/analytics/consumption_period";
 import type {
   ConsumptionTimeseriesGroup,
   ConsumptionTimeseriesPoint,
-} from "@app/lib/api/analytics/consumption/series";
-import { DEFAULT_CONSUMPTION_BREAKDOWN_COUNT } from "@app/lib/api/analytics/consumption/series";
+} from "@app/lib/api/analytics/consumption/timeseries";
 import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
 import { cn } from "@dust-tt/sparkle";
 import { useCallback, useMemo } from "react";
@@ -126,7 +127,6 @@ export function ConsumptionChart({
       period,
       mode: "daily",
       breakdownBy: "agent",
-      breakdownCount: DEFAULT_CONSUMPTION_BREAKDOWN_COUNT,
     });
 
   const groups = useMemo(() => timeseries?.groups ?? [], [timeseries]);

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -6,8 +6,12 @@ import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
 import type { ConsumptionPeriodSelection } from "@app/components/workspace/analytics/consumption/consumptionPeriod";
 import { formatConsumptionDate } from "@app/components/workspace/analytics/consumption/consumptionPeriod";
 import { useConsumptionTimeseries } from "@app/hooks/useConsumptionTimeseries";
-import type { ConsumptionTimeseriesGroup } from "@app/lib/api/analytics/consumption/series";
+import type {
+  ConsumptionTimeseriesGroup,
+  ConsumptionTimeseriesPoint,
+} from "@app/lib/api/analytics/consumption/series";
 import { DEFAULT_CONSUMPTION_BREAKDOWN_COUNT } from "@app/lib/api/analytics/consumption/series";
+import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
 import { cn } from "@dust-tt/sparkle";
 import { useCallback, useMemo } from "react";
 import {
@@ -26,13 +30,11 @@ import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 // growing, and at full strength it reads as a real drop in consumption.
 const PARTIAL_BAR_OPACITY = "opacity-40";
 
-interface ConsumptionChartDatum {
-  timestamp: number;
-  isPartial: boolean;
-  values: Record<string, number>;
-}
-
-function isConsumptionChartDatum(data: unknown): data is ConsumptionChartDatum {
+// Recharts hands the tooltip its datum as `unknown`; the points go into the
+// chart unchanged, so this narrows back to what the endpoint returned.
+function isConsumptionTimeseriesPoint(
+  data: unknown
+): data is ConsumptionTimeseriesPoint {
   return (
     typeof data === "object" &&
     data !== null &&
@@ -40,10 +42,6 @@ function isConsumptionChartDatum(data: unknown): data is ConsumptionChartDatum {
     "isPartial" in data &&
     "values" in data
   );
-}
-
-function formatCredits(credits: number): string {
-  return credits.toLocaleString(undefined, { maximumFractionDigits: 1 });
 }
 
 interface ConsumptionChartTooltipProps
@@ -59,7 +57,7 @@ function ConsumptionChartTooltip({
   colorByGroupKey,
 }: ConsumptionChartTooltipProps) {
   const datum = payload?.[0]?.payload;
-  if (!active || !isConsumptionChartDatum(datum)) {
+  if (!active || !isConsumptionTimeseriesPoint(datum)) {
     return null;
   }
 
@@ -109,13 +107,11 @@ export function ConsumptionChart({
       workspaceId,
       period,
       mode: "daily",
-      // Per-agent is the view that answers "where are the credits going".
-      // Becomes selectable once the attribution table can drive the chart.
       breakdownBy: "agent",
       breakdownCount: DEFAULT_CONSUMPTION_BREAKDOWN_COUNT,
     });
 
-  const groups = timeseries?.groups ?? [];
+  const groups = useMemo(() => timeseries?.groups ?? [], [timeseries]);
 
   // Colors are assigned by rank, so the biggest consumer keeps its color as
   // long as it stays on top. "Others" is special-cased by getIndexedColor.
@@ -129,15 +125,7 @@ export function ConsumptionChart({
     );
   }, [groups]);
 
-  const chartData = useMemo<ConsumptionChartDatum[]>(
-    () =>
-      (timeseries?.points ?? []).map((point) => ({
-        timestamp: point.timestamp,
-        isPartial: point.isPartial,
-        values: point.values,
-      })),
-    [timeseries]
-  );
+  const chartData = useMemo(() => timeseries?.points ?? [], [timeseries]);
 
   const renderTooltip = useCallback(
     (props: TooltipContentProps<number, string>) => (
@@ -165,7 +153,7 @@ export function ConsumptionChart({
 
   return (
     <ChartContainer
-      title="Daily credits by agent"
+      title="Daily credits"
       isLoading={isTimeseriesLoading}
       errorMessage={
         isTimeseriesError ? "Failed to load consumption." : undefined
@@ -189,8 +177,6 @@ export function ConsumptionChart({
           tickLine={false}
           axisLine={false}
           tickMargin={8}
-          // Buckets run to the end of the cycle, so a cycle-length axis would
-          // label every empty future day without this.
           minTickGap={24}
           tickFormatter={(timestamp: number) =>
             formatConsumptionDate(timestamp)
@@ -201,6 +187,7 @@ export function ConsumptionChart({
           tickLine={false}
           axisLine={false}
           tickMargin={8}
+          tickFormatter={formatCreditsCompact}
         />
         <Tooltip
           cursor={false}
@@ -219,9 +206,7 @@ export function ConsumptionChart({
         {groups.map((group) => (
           <Bar
             key={group.groupKey}
-            // The endpoint zero-fills every group on every point, so this
-            // accessor never has to cope with a missing series.
-            dataKey={(datum: ConsumptionChartDatum) =>
+            dataKey={(datum: ConsumptionTimeseriesPoint) =>
               datum.values[group.groupKey] ?? 0
             }
             name={group.name}

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -1,0 +1,246 @@
+import { CHART_HEIGHT } from "@app/components/agent_builder/observability/constants";
+import { getIndexedColor } from "@app/components/agent_builder/observability/utils";
+import { ChartContainer } from "@app/components/charts/ChartContainer";
+import type { LegendItem } from "@app/components/charts/ChartLegend";
+import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import type { ConsumptionPeriodSelection } from "@app/components/workspace/analytics/consumption/consumptionPeriod";
+import { formatConsumptionDate } from "@app/components/workspace/analytics/consumption/consumptionPeriod";
+import { useConsumptionTimeseries } from "@app/hooks/useConsumptionTimeseries";
+import type { ConsumptionTimeseriesGroup } from "@app/lib/api/analytics/consumption/series";
+import { DEFAULT_CONSUMPTION_BREAKDOWN_COUNT } from "@app/lib/api/analytics/consumption/series";
+import { cn } from "@dust-tt/sparkle";
+import { useCallback, useMemo } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ReferenceLine,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { TooltipContentProps } from "recharts/types/component/Tooltip";
+
+// The bucket in progress is drawn faded across every series: its total is still
+// growing, and at full strength it reads as a real drop in consumption.
+const PARTIAL_BAR_OPACITY = "opacity-40";
+
+interface ConsumptionChartDatum {
+  timestamp: number;
+  isPartial: boolean;
+  values: Record<string, number>;
+}
+
+function isConsumptionChartDatum(data: unknown): data is ConsumptionChartDatum {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "timestamp" in data &&
+    "isPartial" in data &&
+    "values" in data
+  );
+}
+
+function formatCredits(credits: number): string {
+  return credits.toLocaleString(undefined, { maximumFractionDigits: 1 });
+}
+
+interface ConsumptionChartTooltipProps
+  extends TooltipContentProps<number, string> {
+  groups: ConsumptionTimeseriesGroup[];
+  colorByGroupKey: Map<string, string>;
+}
+
+function ConsumptionChartTooltip({
+  active,
+  payload,
+  groups,
+  colorByGroupKey,
+}: ConsumptionChartTooltipProps) {
+  const datum = payload?.[0]?.payload;
+  if (!active || !isConsumptionChartDatum(datum)) {
+    return null;
+  }
+
+  // Only the series that actually consumed something on this day, largest
+  // first: with ten agents, listing the zeroes buries the ones that matter.
+  const rows = groups
+    .map((group) => ({
+      key: group.groupKey,
+      label: group.name,
+      credits: datum.values[group.groupKey] ?? 0,
+      colorClassName: colorByGroupKey.get(group.groupKey),
+    }))
+    .filter((row) => row.credits > 0)
+    .sort((a, b) => b.credits - a.credits);
+
+  const totalCredits = rows.reduce((sum, row) => sum + row.credits, 0);
+
+  return (
+    <ChartTooltipCard
+      title={formatConsumptionDate(datum.timestamp)}
+      rows={rows.map((row) => ({
+        key: row.key,
+        label: row.label,
+        value: formatCredits(row.credits),
+        colorClassName: row.colorClassName,
+      }))}
+      footer={
+        datum.isPartial
+          ? `${formatCredits(totalCredits)} so far today`
+          : `${formatCredits(totalCredits)} total`
+      }
+    />
+  );
+}
+
+interface ConsumptionChartProps {
+  workspaceId: string;
+  period: ConsumptionPeriodSelection;
+}
+
+export function ConsumptionChart({
+  workspaceId,
+  period,
+}: ConsumptionChartProps) {
+  const { timeseries, isTimeseriesLoading, isTimeseriesError } =
+    useConsumptionTimeseries({
+      workspaceId,
+      period,
+      mode: "daily",
+      // Per-agent is the view that answers "where are the credits going".
+      // Becomes selectable once the attribution table can drive the chart.
+      breakdownBy: "agent",
+      breakdownCount: DEFAULT_CONSUMPTION_BREAKDOWN_COUNT,
+    });
+
+  const groups = timeseries?.groups ?? [];
+
+  // Colors are assigned by rank, so the biggest consumer keeps its color as
+  // long as it stays on top. "Others" is special-cased by getIndexedColor.
+  const colorByGroupKey = useMemo(() => {
+    const names = groups.map((group) => group.name);
+    return new Map(
+      groups.map((group) => [
+        group.groupKey,
+        getIndexedColor(group.name, names),
+      ])
+    );
+  }, [groups]);
+
+  const chartData = useMemo<ConsumptionChartDatum[]>(
+    () =>
+      (timeseries?.points ?? []).map((point) => ({
+        timestamp: point.timestamp,
+        isPartial: point.isPartial,
+        values: point.values,
+      })),
+    [timeseries]
+  );
+
+  const renderTooltip = useCallback(
+    (props: TooltipContentProps<number, string>) => (
+      <ConsumptionChartTooltip
+        {...props}
+        groups={groups}
+        colorByGroupKey={colorByGroupKey}
+      />
+    ),
+    [groups, colorByGroupKey]
+  );
+
+  const legendItems: LegendItem[] = groups.map((group) => ({
+    key: group.groupKey,
+    label: group.name,
+    colorClassName: colorByGroupKey.get(group.groupKey) ?? "",
+  }));
+
+  const partialTimestamp = chartData.find(
+    (datum) => datum.isPartial
+  )?.timestamp;
+  const hasConsumption = chartData.some((datum) =>
+    Object.values(datum.values).some((credits) => credits > 0)
+  );
+
+  return (
+    <ChartContainer
+      title="Daily credits by agent"
+      isLoading={isTimeseriesLoading}
+      errorMessage={
+        isTimeseriesError ? "Failed to load consumption." : undefined
+      }
+      emptyMessage={
+        !isTimeseriesLoading && !hasConsumption
+          ? "No consumption over this period."
+          : undefined
+      }
+      height={CHART_HEIGHT}
+      legendItems={legendItems}
+    >
+      <BarChart
+        data={chartData}
+        margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
+      >
+        <CartesianGrid vertical={false} className="stroke-border" />
+        <XAxis
+          dataKey="timestamp"
+          className="text-xs text-muted-foreground"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          // Buckets run to the end of the cycle, so a cycle-length axis would
+          // label every empty future day without this.
+          minTickGap={24}
+          tickFormatter={(timestamp: number) =>
+            formatConsumptionDate(timestamp)
+          }
+        />
+        <YAxis
+          className="text-xs text-muted-foreground"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+        />
+        <Tooltip
+          cursor={false}
+          content={renderTooltip}
+          wrapperStyle={{ outline: "none", zIndex: 50 }}
+        />
+        {partialTimestamp !== undefined && (
+          <ReferenceLine
+            x={partialTimestamp}
+            stroke="hsl(var(--primary))"
+            strokeDasharray="5 5"
+            label={{ value: "Today (partial)", position: "top", fontSize: 11 }}
+            ifOverflow="extendDomain"
+          />
+        )}
+        {groups.map((group) => (
+          <Bar
+            key={group.groupKey}
+            // The endpoint zero-fills every group on every point, so this
+            // accessor never has to cope with a missing series.
+            dataKey={(datum: ConsumptionChartDatum) =>
+              datum.values[group.groupKey] ?? 0
+            }
+            name={group.name}
+            stackId="credits"
+            isAnimationActive={false}
+          >
+            {chartData.map((datum) => (
+              <Cell
+                key={datum.timestamp}
+                fill="currentColor"
+                className={cn(
+                  colorByGroupKey.get(group.groupKey),
+                  datum.isPartial && PARTIAL_BAR_OPACITY
+                )}
+              />
+            ))}
+          </Bar>
+        ))}
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
@@ -1,19 +1,11 @@
 import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import { formatConsumptionDate } from "@app/lib/analytics/consumption_period";
 import { timeAgoFrom } from "@app/lib/utils";
 
 interface ConsumptionOverviewProps {
   workspaceId: string;
   period: ConsumptionPeriodSelection;
-}
-
-// The period is resolved in UTC server-side, so it has to be rendered in UTC here too.
-function formatPeriodBound(isoDate: string): string {
-  return new Date(isoDate).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    timeZone: "UTC",
-  });
 }
 
 export function ConsumptionOverview({
@@ -38,7 +30,7 @@ export function ConsumptionOverview({
   const { period, members, lastRecordAt } = overview;
 
   const header = [
-    `${formatPeriodBound(period.startDate)} to ${formatPeriodBound(period.endDate)}`,
+    `${formatConsumptionDate(period.startDate)} to ${formatConsumptionDate(period.endDate)}`,
     `${members.active.toLocaleString()} of ${members.total.toLocaleString()} members active`,
     ...(lastRecordAt
       ? [`Updated ${timeAgoFrom(new Date(lastRecordAt).getTime())} ago`]

--- a/front/hooks/useConsumptionTimeseries.ts
+++ b/front/hooks/useConsumptionTimeseries.ts
@@ -1,10 +1,12 @@
-import type { ConsumptionPeriodSelection } from "@app/components/workspace/analytics/consumption/consumptionPeriod";
-import { consumptionQueryString } from "@app/components/workspace/analytics/consumption/consumptionPeriod";
+import {
+  type ConsumptionPeriodSelection,
+  consumptionQueryString,
+} from "@app/lib/analytics/consumption_period";
 import type {
   ConsumptionBreakdownDimension,
   ConsumptionTimeseriesMode,
-} from "@app/lib/api/analytics/consumption/series";
-import type { GetConsumptionTimeseriesResponse } from "@app/lib/api/analytics/consumption/timeseries";
+  GetConsumptionTimeseriesResponse,
+} from "@app/lib/api/analytics/consumption/timeseries";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { Fetcher } from "swr";
 

--- a/front/hooks/useConsumptionTimeseries.ts
+++ b/front/hooks/useConsumptionTimeseries.ts
@@ -1,0 +1,51 @@
+import type { ConsumptionPeriodSelection } from "@app/components/workspace/analytics/consumption/consumptionPeriod";
+import { consumptionQueryString } from "@app/components/workspace/analytics/consumption/consumptionPeriod";
+import type {
+  ConsumptionBreakdownDimension,
+  ConsumptionTimeseriesMode,
+} from "@app/lib/api/analytics/consumption/series";
+import type { GetConsumptionTimeseriesResponse } from "@app/lib/api/analytics/consumption/timeseries";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { Fetcher } from "swr";
+
+export function useConsumptionTimeseries({
+  workspaceId,
+  period,
+  mode,
+  breakdownBy,
+  breakdownCount,
+  disabled,
+}: {
+  workspaceId: string;
+  period: ConsumptionPeriodSelection;
+  mode: ConsumptionTimeseriesMode;
+  // Omit for a single total series.
+  breakdownBy?: ConsumptionBreakdownDimension;
+  breakdownCount?: number;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const timeseriesFetcher: Fetcher<GetConsumptionTimeseriesResponse> = fetcher;
+
+  const params = new URLSearchParams(consumptionQueryString(period));
+  params.set("mode", mode);
+  if (breakdownBy) {
+    params.set("breakdownBy", breakdownBy);
+  }
+  if (breakdownCount !== undefined) {
+    params.set("breakdownCount", String(breakdownCount));
+  }
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/analytics/consumption/timeseries?${params.toString()}`,
+    timeseriesFetcher,
+    { disabled }
+  );
+
+  return {
+    timeseries: data ?? null,
+    isTimeseriesLoading: !error && !data && !disabled,
+    isTimeseriesError: error,
+    isTimeseriesValidating: isValidating,
+  };
+}

--- a/front/lib/analytics/consumption_period.ts
+++ b/front/lib/analytics/consumption_period.ts
@@ -19,6 +19,20 @@ export const CONSUMPTION_PERIOD_OPTIONS: ConsumptionPeriodSelection[] = [
   })),
 ];
 
+/**
+ * Periods and chart buckets are both resolved in UTC server-side, so they have
+ * to be rendered in UTC too. Formatting a UTC midnight boundary in the viewer's
+ * zone shifts the label by a day for anyone west of Greenwich — the chart would
+ * attribute a day's consumption to the day before.
+ */
+export function formatConsumptionDate(date: string | number): string {
+  return new Date(date).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
 export function consumptionPeriodLabel(
   selection: ConsumptionPeriodSelection
 ): string {

--- a/front/lib/analytics/consumption_period.ts
+++ b/front/lib/analytics/consumption_period.ts
@@ -19,12 +19,6 @@ export const CONSUMPTION_PERIOD_OPTIONS: ConsumptionPeriodSelection[] = [
   })),
 ];
 
-/**
- * Periods and chart buckets are both resolved in UTC server-side, so they have
- * to be rendered in UTC too. Formatting a UTC midnight boundary in the viewer's
- * zone shifts the label by a day for anyone west of Greenwich — the chart would
- * attribute a day's consumption to the day before.
- */
 export function formatConsumptionDate(date: string | number): string {
   return new Date(date).toLocaleDateString("en-US", {
     month: "short",


### PR DESCRIPTION
## Description

Adds the daily-credits chart to the new Analytics page.
It defaults to a per-agent dimension: top 10 by consumption plus an "others" series for the rest.

The breakdown dimension is fixed to agent for now; it will change based on the selected attribution table in a follow up PR.

## Tests

<img width="1159" height="521" alt="Screenshot 2026-08-06 at 10 26 18" src="https://github.com/user-attachments/assets/87b3455a-3f57-413a-8b4c-b9d9844a06f7" />


## Risk

Low. Safe to rollback.

## Deploy Plan

Front only.

