### PR TITLE
[front] feat: consumption analytics attribution table

### DIFF
--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -1,3 +1,4 @@
+import { ConsumptionAttributionTable } from "@app/components/workspace/analytics/consumption/ConsumptionAttributionTable";
 import { ConsumptionOverview } from "@app/components/workspace/analytics/consumption/ConsumptionOverview";
 import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
@@ -69,6 +70,7 @@ export function AnalyticsConsumptionPage() {
         <SafeSuspense fallback={<ChartFallback />}>
           <ConsumptionChart workspaceId={owner.sId} period={period} />
         </SafeSuspense>
+        <ConsumptionAttributionTable workspaceId={owner.sId} period={period} />
       </div>
     </Page.Vertical>
   );

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -1,12 +1,11 @@
 import type { ConsumptionPeriodSelection } from "@app/components/workspace/analytics/consumption/consumptionPeriod";
 import { AvatarNameCell } from "@app/components/workspace/analytics/creditsTableCells";
-import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
-import { useDebounce } from "@app/hooks/useDebounce";
 import type {
   ConsumptionTopDimension,
   ConsumptionTopRow,
-  ConsumptionTopUnit,
-} from "@app/lib/api/analytics/consumption/top";
+} from "@app/hooks/useConsumptionTop";
+import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
+import { useDebounce } from "@app/hooks/useDebounce";
 import { formatCredits } from "@app/lib/client/credits";
 import {
   cn,
@@ -20,20 +19,53 @@ import {
 import type { ColumnDef } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 
-// The rankings this table can show. Skills are intentionally absent for now:
-// the top endpoint does not break down by skill yet (a tool call can be enabled
-// by several skills, which double-counts).
+// The rankings this table can show, one tab per `top-*` endpoint. Tools and
+// skills average their cost over invocations rather than messages: a single
+// message can call the same tool many times, so a per-message figure would say
+// nothing about the tool itself.
 const DIMENSION_TABS: {
   dimension: ConsumptionTopDimension;
   label: string;
   // Agents and users have a picture; the rest are labels only.
   hasAvatar: boolean;
+  avgLabel: string;
 }[] = [
-  { dimension: "agent", label: "Agents", hasAvatar: true },
-  { dimension: "user", label: "Members", hasAvatar: true },
-  { dimension: "model", label: "Models", hasAvatar: false },
-  { dimension: "tool", label: "Tools", hasAvatar: false },
-  { dimension: "source", label: "Sources", hasAvatar: false },
+  {
+    dimension: "agent",
+    label: "Agents",
+    hasAvatar: true,
+    avgLabel: "Cost / message",
+  },
+  {
+    dimension: "user",
+    label: "Members",
+    hasAvatar: true,
+    avgLabel: "Cost / message",
+  },
+  {
+    dimension: "model",
+    label: "Models",
+    hasAvatar: false,
+    avgLabel: "Cost / message",
+  },
+  {
+    dimension: "tool",
+    label: "Tools",
+    hasAvatar: false,
+    avgLabel: "Cost / invocation",
+  },
+  {
+    dimension: "skill",
+    label: "Skills",
+    hasAvatar: false,
+    avgLabel: "Cost / invocation",
+  },
+  {
+    dimension: "source",
+    label: "Sources",
+    hasAvatar: false,
+    avgLabel: "Cost / message",
+  },
 ];
 
 // Enough to make the per-tab search useful without paging; the table shows a
@@ -46,11 +78,6 @@ const TOP_LIMIT = 25;
 type AttributionRowData = ConsumptionTopRow & {
   onClick?: () => void;
   onDoubleClick?: () => void;
-};
-
-const UNIT_LABEL: Record<ConsumptionTopUnit, string> = {
-  message: "Cost / message",
-  tool_call: "Cost / tool call",
 };
 
 function CostShareCell({ share }: { share: number }) {
@@ -72,11 +99,11 @@ function CostShareCell({ share }: { share: number }) {
 
 function buildColumns({
   hasAvatar,
-  unit,
+  avgLabel,
   totalCredits,
 }: {
   hasAvatar: boolean;
-  unit: ConsumptionTopUnit;
+  avgLabel: string;
   totalCredits: number;
 }): ColumnDef<AttributionRowData>[] {
   return [
@@ -124,13 +151,13 @@ function buildColumns({
       ),
     },
     {
-      id: "avgCreditPerUnit",
-      accessorKey: "avgCreditPerUnit",
-      header: UNIT_LABEL[unit],
+      id: "avgCredits",
+      accessorKey: "avgCredits",
+      header: avgLabel,
       meta: { sizeRatio: 22 },
       cell: (info) => (
         <DataTable.BasicCellContent
-          label={formatCredits(info.row.original.avgCreditPerUnit)}
+          label={formatCredits(info.row.original.avgCredits)}
         />
       ),
     },
@@ -141,6 +168,7 @@ interface AttributionRowsProps {
   workspaceId: string;
   dimension: ConsumptionTopDimension;
   hasAvatar: boolean;
+  avgLabel: string;
   period: ConsumptionPeriodSelection;
   search: string;
 }
@@ -149,10 +177,16 @@ function AttributionRows({
   workspaceId,
   dimension,
   hasAvatar,
+  avgLabel,
   period,
   search,
 }: AttributionRowsProps) {
-  const { top, isTopLoading, isTopError } = useConsumptionTop({
+  const {
+    rows: allRows,
+    totalCredits,
+    isTopLoading,
+    isTopError,
+  } = useConsumptionTop({
     workspaceId,
     dimension,
     period,
@@ -162,21 +196,15 @@ function AttributionRows({
   // Client-side filter over the loaded ranking. A row outside the top
   // TOP_LIMIT will not appear — the endpoint has no server-side search yet.
   const rows = useMemo(() => {
-    const all = top?.rows ?? [];
     const needle = search.trim().toLowerCase();
     return needle
-      ? all.filter((row) => row.name.toLowerCase().includes(needle))
-      : all;
-  }, [top, search]);
+      ? allRows.filter((row) => row.name.toLowerCase().includes(needle))
+      : allRows;
+  }, [allRows, search]);
 
   const columns = useMemo(
-    () =>
-      buildColumns({
-        hasAvatar,
-        unit: top?.unit ?? "message",
-        totalCredits: top?.totalCredits ?? 0,
-      }),
-    [hasAvatar, top?.unit, top?.totalCredits]
+    () => buildColumns({ hasAvatar, avgLabel, totalCredits }),
+    [hasAvatar, avgLabel, totalCredits]
   );
 
   if (isTopLoading) {
@@ -267,6 +295,7 @@ export function ConsumptionAttributionTable({
           workspaceId={workspaceId}
           dimension={dimension}
           hasAvatar={activeTab?.hasAvatar ?? false}
+          avgLabel={activeTab?.avgLabel ?? "Cost / message"}
           period={period}
           search={debouncedValue}
         />

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -1,0 +1,276 @@
+import type { ConsumptionPeriodSelection } from "@app/components/workspace/analytics/consumption/consumptionPeriod";
+import { AvatarNameCell } from "@app/components/workspace/analytics/creditsTableCells";
+import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
+import { useDebounce } from "@app/hooks/useDebounce";
+import type {
+  ConsumptionTopDimension,
+  ConsumptionTopRow,
+  ConsumptionTopUnit,
+} from "@app/lib/api/analytics/consumption/top";
+import { formatCredits } from "@app/lib/client/credits";
+import {
+  cn,
+  DataTable,
+  SearchInput,
+  Spinner,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+} from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useMemo, useState } from "react";
+
+// The rankings this table can show. Skills are intentionally absent for now:
+// the top endpoint does not break down by skill yet (a tool call can be enabled
+// by several skills, which double-counts).
+const DIMENSION_TABS: {
+  dimension: ConsumptionTopDimension;
+  label: string;
+  // Agents and users have a picture; the rest are labels only.
+  hasAvatar: boolean;
+}[] = [
+  { dimension: "agent", label: "Agents", hasAvatar: true },
+  { dimension: "user", label: "Members", hasAvatar: true },
+  { dimension: "model", label: "Models", hasAvatar: false },
+  { dimension: "tool", label: "Tools", hasAvatar: false },
+  { dimension: "source", label: "Sources", hasAvatar: false },
+];
+
+// Enough to make the per-tab search useful without paging; the table shows a
+// ranking, not the full population.
+const TOP_LIMIT = 25;
+
+// DataTable requires its optional row-interaction fields on the row shape.
+// No row action here yet — expandable rows and the row-to-chart drilldown come
+// in later branches.
+type AttributionRowData = ConsumptionTopRow & {
+  onClick?: () => void;
+  onDoubleClick?: () => void;
+};
+
+const UNIT_LABEL: Record<ConsumptionTopUnit, string> = {
+  message: "Cost / message",
+  tool_call: "Cost / tool call",
+};
+
+function CostShareCell({ share }: { share: number }) {
+  const percent = Math.round(share * 100);
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-1.5 w-24 overflow-hidden rounded-full bg-muted">
+        <div
+          className="h-full rounded-full bg-primary"
+          style={{ width: `${Math.min(100, share * 100)}%` }}
+        />
+      </div>
+      <span className="w-8 text-right text-xs text-muted-foreground tabular-nums">
+        {percent}%
+      </span>
+    </div>
+  );
+}
+
+function buildColumns({
+  hasAvatar,
+  unit,
+  totalCredits,
+}: {
+  hasAvatar: boolean;
+  unit: ConsumptionTopUnit;
+  totalCredits: number;
+}): ColumnDef<AttributionRowData>[] {
+  return [
+    {
+      id: "name",
+      accessorKey: "name",
+      header: "Name",
+      meta: { sizeRatio: 34 },
+      cell: (info) => {
+        const { name, pictureUrl } = info.row.original;
+        return (
+          <DataTable.CellContent>
+            {hasAvatar ? (
+              <AvatarNameCell name={name} imageUrl={pictureUrl} />
+            ) : (
+              <span className="truncate text-sm">{name}</span>
+            )}
+          </DataTable.CellContent>
+        );
+      },
+    },
+    {
+      id: "costShare",
+      header: "Cost share",
+      meta: { sizeRatio: 22 },
+      cell: (info) => (
+        <DataTable.CellContent>
+          <CostShareCell
+            share={
+              totalCredits > 0 ? info.row.original.credits / totalCredits : 0
+            }
+          />
+        </DataTable.CellContent>
+      ),
+    },
+    {
+      id: "credits",
+      accessorKey: "credits",
+      header: "Total credits",
+      meta: { sizeRatio: 22 },
+      cell: (info) => (
+        <DataTable.BasicCellContent
+          label={formatCredits(info.row.original.credits)}
+        />
+      ),
+    },
+    {
+      id: "avgCreditPerUnit",
+      accessorKey: "avgCreditPerUnit",
+      header: UNIT_LABEL[unit],
+      meta: { sizeRatio: 22 },
+      cell: (info) => (
+        <DataTable.BasicCellContent
+          label={formatCredits(info.row.original.avgCreditPerUnit)}
+        />
+      ),
+    },
+  ];
+}
+
+interface AttributionRowsProps {
+  workspaceId: string;
+  dimension: ConsumptionTopDimension;
+  hasAvatar: boolean;
+  period: ConsumptionPeriodSelection;
+  search: string;
+}
+
+function AttributionRows({
+  workspaceId,
+  dimension,
+  hasAvatar,
+  period,
+  search,
+}: AttributionRowsProps) {
+  const { top, isTopLoading, isTopError } = useConsumptionTop({
+    workspaceId,
+    dimension,
+    period,
+    limit: TOP_LIMIT,
+  });
+
+  // Client-side filter over the loaded ranking. A row outside the top
+  // TOP_LIMIT will not appear — the endpoint has no server-side search yet.
+  const rows = useMemo(() => {
+    const all = top?.rows ?? [];
+    const needle = search.trim().toLowerCase();
+    return needle
+      ? all.filter((row) => row.name.toLowerCase().includes(needle))
+      : all;
+  }, [top, search]);
+
+  const columns = useMemo(
+    () =>
+      buildColumns({
+        hasAvatar,
+        unit: top?.unit ?? "message",
+        totalCredits: top?.totalCredits ?? 0,
+      }),
+    [hasAvatar, top?.unit, top?.totalCredits]
+  );
+
+  if (isTopLoading) {
+    return (
+      <div className="flex h-48 items-center justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+  if (isTopError) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        Failed to load attribution.
+      </div>
+    );
+  }
+  if (rows.length === 0) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        {search.trim()
+          ? `No match for "${search.trim()}".`
+          : "No consumption over this period."}
+      </div>
+    );
+  }
+
+  return (
+    <div className="[&_tbody_tr:last-child]:border-b-0">
+      <DataTable<AttributionRowData> data={rows} columns={columns} />
+    </div>
+  );
+}
+
+function isConsumptionTopDimension(
+  value: string
+): value is ConsumptionTopDimension {
+  return DIMENSION_TABS.some((tab) => tab.dimension === value);
+}
+
+interface ConsumptionAttributionTableProps {
+  workspaceId: string;
+  period: ConsumptionPeriodSelection;
+}
+
+export function ConsumptionAttributionTable({
+  workspaceId,
+  period,
+}: ConsumptionAttributionTableProps) {
+  const [dimension, setDimension] = useState<ConsumptionTopDimension>("agent");
+  const { inputValue, debouncedValue, setValue } = useDebounce("", {
+    delay: 300,
+  });
+
+  const activeTab = DIMENSION_TABS.find((tab) => tab.dimension === dimension);
+
+  return (
+    <div className={cn("rounded-lg border border-border bg-card p-4")}>
+      <div className="mb-3 flex items-center justify-between gap-4">
+        <h3 className="text-base font-medium text-foreground">Attribution</h3>
+        <SearchInput
+          name="consumption-attribution-search"
+          placeholder="Search…"
+          value={inputValue}
+          onChange={setValue}
+          className="w-64"
+        />
+      </div>
+      <Tabs
+        value={dimension}
+        onValueChange={(value) => {
+          if (isConsumptionTopDimension(value)) {
+            setDimension(value);
+          }
+        }}
+      >
+        <TabsList border>
+          {DIMENSION_TABS.map((tab) => (
+            <TabsTrigger
+              key={tab.dimension}
+              value={tab.dimension}
+              label={tab.label}
+            />
+          ))}
+        </TabsList>
+      </Tabs>
+      <div className="pt-3">
+        <AttributionRows
+          workspaceId={workspaceId}
+          dimension={dimension}
+          hasAvatar={activeTab?.hasAvatar ?? false}
+          period={period}
+          search={debouncedValue}
+        />
+      </div>
+    </div>
+  );
+}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -1,4 +1,3 @@
-import type { ConsumptionPeriodSelection } from "@app/components/workspace/analytics/consumption/consumptionPeriod";
 import { AvatarNameCell } from "@app/components/workspace/analytics/creditsTableCells";
 import type {
   ConsumptionTopDimension,
@@ -6,6 +5,7 @@ import type {
 } from "@app/hooks/useConsumptionTop";
 import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
 import { useDebounce } from "@app/hooks/useDebounce";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { formatCredits } from "@app/lib/client/credits";
 import {
   cn,
@@ -19,10 +19,8 @@ import {
 import type { ColumnDef } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 
-// The rankings this table can show, one tab per `top-*` endpoint. Tools and
-// skills average their cost over invocations rather than messages: a single
-// message can call the same tool many times, so a per-message figure would say
-// nothing about the tool itself.
+// The rankings this table can show, one tab per `top-*` endpoint.
+// Tools and Skills average their cost over invocations rather than messages.
 const DIMENSION_TABS: {
   dimension: ConsumptionTopDimension;
   label: string;
@@ -68,13 +66,16 @@ const DIMENSION_TABS: {
   },
 ];
 
-// Enough to make the per-tab search useful without paging; the table shows a
-// ranking, not the full population.
+function isConsumptionTopDimension(
+  value: string
+): value is ConsumptionTopDimension {
+  return DIMENSION_TABS.some((tab) => tab.dimension === value);
+}
+
 const TOP_LIMIT = 25;
 
-// DataTable requires its optional row-interaction fields on the row shape.
-// No row action here yet — expandable rows and the row-to-chart drilldown come
-// in later branches.
+const SEARCH_DEBOUNCE_DELAY_MS = 300;
+
 type AttributionRowData = ConsumptionTopRow & {
   onClick?: () => void;
   onDoubleClick?: () => void;
@@ -231,17 +232,7 @@ function AttributionRows({
     );
   }
 
-  return (
-    <div className="[&_tbody_tr:last-child]:border-b-0">
-      <DataTable<AttributionRowData> data={rows} columns={columns} />
-    </div>
-  );
-}
-
-function isConsumptionTopDimension(
-  value: string
-): value is ConsumptionTopDimension {
-  return DIMENSION_TABS.some((tab) => tab.dimension === value);
+  return <DataTable<AttributionRowData> data={rows} columns={columns} />;
 }
 
 interface ConsumptionAttributionTableProps {
@@ -255,7 +246,7 @@ export function ConsumptionAttributionTable({
 }: ConsumptionAttributionTableProps) {
   const [dimension, setDimension] = useState<ConsumptionTopDimension>("agent");
   const { inputValue, debouncedValue, setValue } = useDebounce("", {
-    delay: 300,
+    delay: SEARCH_DEBOUNCE_DELAY_MS,
   });
 
   const activeTab = DIMENSION_TABS.find((tab) => tab.dimension === dimension);

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -1,7 +1,9 @@
-import type { ConsumptionPeriodSelection } from "@app/components/workspace/analytics/consumption/consumptionPeriod";
-import { consumptionQueryString } from "@app/components/workspace/analytics/consumption/consumptionPeriod";
 // Type-only: importing a value from these modules would pull the Elasticsearch
 // client into the browser bundle (see the note in `series.ts`).
+import {
+  type ConsumptionPeriodSelection,
+  consumptionQueryString,
+} from "@app/lib/analytics/consumption_period";
 import type { GetConsumptionTopAgentsResponse } from "@app/lib/api/analytics/consumption/top_agents";
 import type { GetConsumptionTopModelsResponse } from "@app/lib/api/analytics/consumption/top_models";
 import type { GetConsumptionTopSkillsResponse } from "@app/lib/api/analytics/consumption/top_skills";

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -1,0 +1,44 @@
+import type { ConsumptionPeriodSelection } from "@app/components/workspace/analytics/consumption/consumptionPeriod";
+import { consumptionQueryString } from "@app/components/workspace/analytics/consumption/consumptionPeriod";
+// Type-only: importing a value from `top.ts` would pull the Elasticsearch
+// client into the browser bundle (see the note in `series.ts`).
+import type {
+  ConsumptionTopDimension,
+  GetConsumptionTopResponse,
+} from "@app/lib/api/analytics/consumption/top";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { Fetcher } from "swr";
+
+export function useConsumptionTop({
+  workspaceId,
+  dimension,
+  period,
+  limit,
+  disabled,
+}: {
+  workspaceId: string;
+  dimension: ConsumptionTopDimension;
+  period: ConsumptionPeriodSelection;
+  limit: number;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const topFetcher: Fetcher<GetConsumptionTopResponse> = fetcher;
+
+  const params = new URLSearchParams(consumptionQueryString(period));
+  params.set("dimension", dimension);
+  params.set("limit", String(limit));
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/analytics/consumption/top?${params.toString()}`,
+    topFetcher,
+    { disabled }
+  );
+
+  return {
+    top: data ?? null,
+    isTopLoading: !error && !data && !disabled,
+    isTopError: error,
+    isTopValidating: isValidating,
+  };
+}

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -1,13 +1,117 @@
 import type { ConsumptionPeriodSelection } from "@app/components/workspace/analytics/consumption/consumptionPeriod";
 import { consumptionQueryString } from "@app/components/workspace/analytics/consumption/consumptionPeriod";
-// Type-only: importing a value from `top.ts` would pull the Elasticsearch
+// Type-only: importing a value from these modules would pull the Elasticsearch
 // client into the browser bundle (see the note in `series.ts`).
-import type {
-  ConsumptionTopDimension,
-  GetConsumptionTopResponse,
-} from "@app/lib/api/analytics/consumption/top";
-import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetConsumptionTopAgentsResponse } from "@app/lib/api/analytics/consumption/top_agents";
+import type { GetConsumptionTopModelsResponse } from "@app/lib/api/analytics/consumption/top_models";
+import type { GetConsumptionTopSkillsResponse } from "@app/lib/api/analytics/consumption/top_skills";
+import type { GetConsumptionTopSourcesResponse } from "@app/lib/api/analytics/consumption/top_sources";
+import type { GetConsumptionTopToolsResponse } from "@app/lib/api/analytics/consumption/top_tools";
+import type { GetConsumptionTopUsersResponse } from "@app/lib/api/analytics/consumption/top_users";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { useMemo } from "react";
 import type { Fetcher } from "swr";
+
+/**
+ * One ranking of the period's consumption, along one dimension.
+ *
+ * Each dimension has its own endpoint because their averages are denominated
+ * differently — per message for the ones that consume whole messages, per
+ * invocation for tools and skills — and their rows differ with them. This hook
+ * flattens all six into the one shape a ranking table needs.
+ */
+
+export const CONSUMPTION_TOP_ENDPOINTS = {
+  agent: "top-agents",
+  user: "top-users",
+  model: "top-models",
+  tool: "top-tools",
+  skill: "top-skills",
+  source: "top-sources",
+} as const;
+
+export type ConsumptionTopDimension = keyof typeof CONSUMPTION_TOP_ENDPOINTS;
+
+export type ConsumptionTopRow = {
+  id: string;
+  name: string;
+  // Only agents and users have one.
+  pictureUrl: string | null;
+  credits: number;
+  // Per message, or per invocation, depending on the dimension.
+  avgCredits: number;
+};
+
+type ConsumptionTopResponse =
+  | GetConsumptionTopAgentsResponse
+  | GetConsumptionTopUsersResponse
+  | GetConsumptionTopModelsResponse
+  | GetConsumptionTopToolsResponse
+  | GetConsumptionTopSkillsResponse
+  | GetConsumptionTopSourcesResponse;
+
+// Narrowed on the collection each response carries rather than on the requested
+// dimension, so a row shape that drifts from its endpoint is a type error here
+// instead of a silently empty table.
+function toRows(data: ConsumptionTopResponse): ConsumptionTopRow[] {
+  if ("agents" in data) {
+    return data.agents.map((row) => ({
+      id: row.agentId,
+      name: row.name,
+      pictureUrl: row.pictureUrl,
+      credits: row.credits,
+      avgCredits: row.avgCreditsPerMessage,
+    }));
+  }
+  if ("users" in data) {
+    return data.users.map((row) => ({
+      id: row.userId,
+      name: row.name,
+      pictureUrl: row.pictureUrl,
+      credits: row.credits,
+      avgCredits: row.avgCreditsPerMessage,
+    }));
+  }
+  if ("models" in data) {
+    return data.models.map((row) => ({
+      id: row.modelId,
+      name: row.name,
+      pictureUrl: null,
+      credits: row.credits,
+      avgCredits: row.avgCreditsPerMessage,
+    }));
+  }
+  if ("tools" in data) {
+    return data.tools.map((row) => ({
+      id: row.serverName,
+      name: row.name,
+      pictureUrl: null,
+      credits: row.credits,
+      avgCredits: row.avgCreditsPerInvocation,
+    }));
+  }
+  if ("skills" in data) {
+    return data.skills.map((row) => ({
+      id: row.skillId,
+      name: row.name,
+      pictureUrl: null,
+      credits: row.credits,
+      avgCredits: row.avgCreditsPerInvocation,
+    }));
+  }
+  if ("sources" in data) {
+    return data.sources.map((row) => ({
+      id: row.source,
+      name: row.name,
+      pictureUrl: null,
+      credits: row.credits,
+      avgCredits: row.avgCreditsPerMessage,
+    }));
+  }
+  assertNeverAndIgnore(data);
+  return [];
+}
 
 export function useConsumptionTop({
   workspaceId,
@@ -23,20 +127,28 @@ export function useConsumptionTop({
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
-  const topFetcher: Fetcher<GetConsumptionTopResponse> = fetcher;
+  const topFetcher: Fetcher<ConsumptionTopResponse> = fetcher;
 
   const params = new URLSearchParams(consumptionQueryString(period));
-  params.set("dimension", dimension);
   params.set("limit", String(limit));
 
   const { data, error, isValidating } = useSWRWithDefaults(
-    `/api/w/${workspaceId}/analytics/consumption/top?${params.toString()}`,
+    `/api/w/${workspaceId}/analytics/consumption/` +
+      `${CONSUMPTION_TOP_ENDPOINTS[dimension]}?${params.toString()}`,
     topFetcher,
     { disabled }
   );
 
+  const rows = useMemo(
+    () => (data ? toRows(data) : emptyArray<ConsumptionTopRow>()),
+    [data]
+  );
+
   return {
-    top: data ?? null,
+    rows,
+    // Everything the workspace consumed over the period, so a row's share of it
+    // is `credits / totalCredits`.
+    totalCredits: data?.totalCredits ?? 0,
     isTopLoading: !error && !data && !disabled,
     isTopError: error,
     isTopValidating: isValidating,

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -1,9 +1,5 @@
-// Type-only: importing a value from these modules would pull the Elasticsearch
-// client into the browser bundle (see the note in `series.ts`).
-import {
-  type ConsumptionPeriodSelection,
-  consumptionQueryString,
-} from "@app/lib/analytics/consumption_period";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import { consumptionQueryString } from "@app/lib/analytics/consumption_period";
 import type { GetConsumptionTopAgentsResponse } from "@app/lib/api/analytics/consumption/top_agents";
 import type { GetConsumptionTopModelsResponse } from "@app/lib/api/analytics/consumption/top_models";
 import type { GetConsumptionTopSkillsResponse } from "@app/lib/api/analytics/consumption/top_skills";


### PR DESCRIPTION
## Description

Adds the Attribution table to the new Analytics page, consuming the top-*
endpoints from PR below.

## Tests

<img width="1148" height="799" alt="Screenshot 2026-08-06 at 10 33 47" src="https://github.com/user-attachments/assets/d007ce2c-e18e-4702-a8e9-0e9f39531f75" />


## Risk

Low. Safe to rollback.

## Deploy Plan

Front only.
