### PR TITLE
[front] feat: switch analytics chart by dimensions

### DIFF
--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -1,11 +1,16 @@
 import { ConsumptionAttributionTable } from "@app/components/workspace/analytics/consumption/ConsumptionAttributionTable";
 import { ConsumptionOverview } from "@app/components/workspace/analytics/consumption/ConsumptionOverview";
 import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
-import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
-import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
+import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
+import { DEFAULT_CONSUMPTION_DIMENSION } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
+import {
+  type ConsumptionPeriodSelection,
+  DEFAULT_CONSUMPTION_PERIOD,
+} from "@app/lib/analytics/consumption_period";
 import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
 import { isNavigationLocked } from "@app/lib/navigation-lock";
 import { BarChart01, cn, Page, SafeSuspense, safeLazy } from "@dust-tt/sparkle";
+
 import { useState } from "react";
 
 const canReload = () => !isNavigationLocked();
@@ -28,6 +33,11 @@ export function AnalyticsConsumptionPage() {
   const isEnabled = hasFeature("enable_analytics_consumption");
   const [period, setPeriod] = useState<ConsumptionPeriodSelection>(
     DEFAULT_CONSUMPTION_PERIOD
+  );
+  // Shared by the chart and the attribution table.
+  // Changing attribution table dimension switches the chart's dimension too.
+  const [dimension, setDimension] = useState<ConsumptionDimension>(
+    DEFAULT_CONSUMPTION_DIMENSION
   );
 
   if (!isEnabled) {
@@ -68,9 +78,18 @@ export function AnalyticsConsumptionPage() {
       <div className="flex flex-col gap-8 pb-8">
         <ConsumptionOverview workspaceId={owner.sId} period={period} />
         <SafeSuspense fallback={<ChartFallback />}>
-          <ConsumptionChart workspaceId={owner.sId} period={period} />
+          <ConsumptionChart
+            workspaceId={owner.sId}
+            period={period}
+            dimension={dimension}
+          />
         </SafeSuspense>
-        <ConsumptionAttributionTable workspaceId={owner.sId} period={period} />
+        <ConsumptionAttributionTable
+          workspaceId={owner.sId}
+          period={period}
+          dimension={dimension}
+          onDimensionChange={setDimension}
+        />
       </div>
     </Page.Vertical>
   );

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -3,10 +3,8 @@ import { ConsumptionOverview } from "@app/components/workspace/analytics/consump
 import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
 import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
 import { DEFAULT_CONSUMPTION_DIMENSION } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
-import {
-  type ConsumptionPeriodSelection,
-  DEFAULT_CONSUMPTION_PERIOD,
-} from "@app/lib/analytics/consumption_period";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
 import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
 import { isNavigationLocked } from "@app/lib/navigation-lock";
 import { BarChart01, cn, Page, SafeSuspense, safeLazy } from "@dust-tt/sparkle";

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -15,10 +15,10 @@ import {
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useMemo } from "react";
+import type { ConsumptionDimension } from "./consumptionDimensions";
 import {
   CONSUMPTION_DIMENSION_CONFIG,
   CONSUMPTION_DIMENSIONS,
-  type ConsumptionDimension,
   isConsumptionDimension,
 } from "./consumptionDimensions";
 

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -1,8 +1,5 @@
 import { AvatarNameCell } from "@app/components/workspace/analytics/creditsTableCells";
-import type {
-  ConsumptionTopDimension,
-  ConsumptionTopRow,
-} from "@app/hooks/useConsumptionTop";
+import type { ConsumptionTopRow } from "@app/hooks/useConsumptionTop";
 import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
 import { useDebounce } from "@app/hooks/useDebounce";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
@@ -17,60 +14,13 @@ import {
   TabsTrigger,
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
-import { useMemo, useState } from "react";
-
-// The rankings this table can show, one tab per `top-*` endpoint.
-// Tools and Skills average their cost over invocations rather than messages.
-const DIMENSION_TABS: {
-  dimension: ConsumptionTopDimension;
-  label: string;
-  // Agents and users have a picture; the rest are labels only.
-  hasAvatar: boolean;
-  avgLabel: string;
-}[] = [
-  {
-    dimension: "agent",
-    label: "Agents",
-    hasAvatar: true,
-    avgLabel: "Cost / message",
-  },
-  {
-    dimension: "user",
-    label: "Members",
-    hasAvatar: true,
-    avgLabel: "Cost / message",
-  },
-  {
-    dimension: "model",
-    label: "Models",
-    hasAvatar: false,
-    avgLabel: "Cost / message",
-  },
-  {
-    dimension: "tool",
-    label: "Tools",
-    hasAvatar: false,
-    avgLabel: "Cost / invocation",
-  },
-  {
-    dimension: "skill",
-    label: "Skills",
-    hasAvatar: false,
-    avgLabel: "Cost / invocation",
-  },
-  {
-    dimension: "source",
-    label: "Sources",
-    hasAvatar: false,
-    avgLabel: "Cost / message",
-  },
-];
-
-function isConsumptionTopDimension(
-  value: string
-): value is ConsumptionTopDimension {
-  return DIMENSION_TABS.some((tab) => tab.dimension === value);
-}
+import { useMemo } from "react";
+import {
+  CONSUMPTION_DIMENSION_CONFIG,
+  CONSUMPTION_DIMENSIONS,
+  type ConsumptionDimension,
+  isConsumptionDimension,
+} from "./consumptionDimensions";
 
 const TOP_LIMIT = 25;
 
@@ -167,9 +117,7 @@ function buildColumns({
 
 interface AttributionRowsProps {
   workspaceId: string;
-  dimension: ConsumptionTopDimension;
-  hasAvatar: boolean;
-  avgLabel: string;
+  dimension: ConsumptionDimension;
   period: ConsumptionPeriodSelection;
   search: string;
 }
@@ -177,11 +125,11 @@ interface AttributionRowsProps {
 function AttributionRows({
   workspaceId,
   dimension,
-  hasAvatar,
-  avgLabel,
   period,
   search,
 }: AttributionRowsProps) {
+  const { hasAvatar, avgLabel } = CONSUMPTION_DIMENSION_CONFIG[dimension];
+
   const {
     rows: allRows,
     totalCredits,
@@ -238,18 +186,19 @@ function AttributionRows({
 interface ConsumptionAttributionTableProps {
   workspaceId: string;
   period: ConsumptionPeriodSelection;
+  dimension: ConsumptionDimension;
+  onDimensionChange: (dimension: ConsumptionDimension) => void;
 }
 
 export function ConsumptionAttributionTable({
   workspaceId,
   period,
+  dimension,
+  onDimensionChange,
 }: ConsumptionAttributionTableProps) {
-  const [dimension, setDimension] = useState<ConsumptionTopDimension>("agent");
   const { inputValue, debouncedValue, setValue } = useDebounce("", {
     delay: SEARCH_DEBOUNCE_DELAY_MS,
   });
-
-  const activeTab = DIMENSION_TABS.find((tab) => tab.dimension === dimension);
 
   return (
     <div className={cn("rounded-lg border border-border bg-card p-4")}>
@@ -266,17 +215,17 @@ export function ConsumptionAttributionTable({
       <Tabs
         value={dimension}
         onValueChange={(value) => {
-          if (isConsumptionTopDimension(value)) {
-            setDimension(value);
+          if (isConsumptionDimension(value)) {
+            onDimensionChange(value);
           }
         }}
       >
         <TabsList border>
-          {DIMENSION_TABS.map((tab) => (
+          {CONSUMPTION_DIMENSIONS.map((tabDimension) => (
             <TabsTrigger
-              key={tab.dimension}
-              value={tab.dimension}
-              label={tab.label}
+              key={tabDimension}
+              value={tabDimension}
+              label={CONSUMPTION_DIMENSION_CONFIG[tabDimension].label}
             />
           ))}
         </TabsList>
@@ -285,8 +234,6 @@ export function ConsumptionAttributionTable({
         <AttributionRows
           workspaceId={workspaceId}
           dimension={dimension}
-          hasAvatar={activeTab?.hasAvatar ?? false}
-          avgLabel={activeTab?.avgLabel ?? "Cost / message"}
           period={period}
           search={debouncedValue}
         />

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -24,10 +24,8 @@ import {
   YAxis,
 } from "recharts";
 import type { TooltipContentProps } from "recharts/types/component/Tooltip";
-import {
-  CONSUMPTION_DIMENSION_CONFIG,
-  type ConsumptionDimension,
-} from "./consumptionDimensions";
+import type { ConsumptionDimension } from "./consumptionDimensions";
+import { CONSUMPTION_DIMENSION_CONFIG } from "./consumptionDimensions";
 
 // The bucket in progress (if mapped to today) is drawn faded across every series.
 const PARTIAL_BAR_OPACITY = "opacity-40";

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -24,6 +24,10 @@ import {
   YAxis,
 } from "recharts";
 import type { TooltipContentProps } from "recharts/types/component/Tooltip";
+import {
+  CONSUMPTION_DIMENSION_CONFIG,
+  type ConsumptionDimension,
+} from "./consumptionDimensions";
 
 // The bucket in progress (if mapped to today) is drawn faded across every series.
 const PARTIAL_BAR_OPACITY = "opacity-40";
@@ -113,18 +117,20 @@ function ConsumptionChartTooltip({
 interface ConsumptionChartProps {
   workspaceId: string;
   period: ConsumptionPeriodSelection;
+  dimension: ConsumptionDimension;
 }
 
 export function ConsumptionChart({
   workspaceId,
   period,
+  dimension,
 }: ConsumptionChartProps) {
   const { timeseries, isTimeseriesLoading, isTimeseriesError } =
     useConsumptionTimeseries({
       workspaceId,
       period,
       mode: "daily",
-      breakdownBy: "agent",
+      breakdownBy: dimension,
     });
 
   const groups = useMemo(() => timeseries?.groups ?? [], [timeseries]);
@@ -172,7 +178,7 @@ export function ConsumptionChart({
 
   return (
     <ChartContainer
-      title="Daily credits"
+      title={`Daily credits by ${CONSUMPTION_DIMENSION_CONFIG[dimension].breakdownLabel}`}
       isLoading={isTimeseriesLoading}
       errorMessage={
         isTimeseriesError ? "Failed to load consumption." : undefined

--- a/front/components/workspace/analytics/consumption/consumptionDimensions.ts
+++ b/front/components/workspace/analytics/consumption/consumptionDimensions.ts
@@ -1,0 +1,73 @@
+import type { ConsumptionBreakdownDimension } from "@app/lib/api/analytics/consumption/timeseries";
+
+export type ConsumptionDimension = ConsumptionBreakdownDimension;
+
+export const DEFAULT_CONSUMPTION_DIMENSION: ConsumptionDimension = "agent";
+
+// Tab order, left to right.
+export const CONSUMPTION_DIMENSIONS: ConsumptionDimension[] = [
+  "agent",
+  "user",
+  "model",
+  "tool",
+  "skill",
+  "source",
+];
+
+interface ConsumptionDimensionConfig {
+  label: string;
+  breakdownLabel: string;
+  hasAvatar: boolean;
+  avgLabel: string;
+}
+
+const MESSAGE_AVG_LABEL = "Cost / message";
+const INVOCATION_AVG_LABEL = "Cost / invocation";
+
+export const CONSUMPTION_DIMENSION_CONFIG: Record<
+  ConsumptionDimension,
+  ConsumptionDimensionConfig
+> = {
+  agent: {
+    label: "Agents",
+    breakdownLabel: "agent",
+    hasAvatar: true,
+    avgLabel: MESSAGE_AVG_LABEL,
+  },
+  user: {
+    label: "Members",
+    breakdownLabel: "member",
+    hasAvatar: true,
+    avgLabel: MESSAGE_AVG_LABEL,
+  },
+  model: {
+    label: "Models",
+    breakdownLabel: "model",
+    hasAvatar: false,
+    avgLabel: MESSAGE_AVG_LABEL,
+  },
+  tool: {
+    label: "Tools",
+    breakdownLabel: "tool",
+    hasAvatar: false,
+    avgLabel: INVOCATION_AVG_LABEL,
+  },
+  skill: {
+    label: "Skills",
+    breakdownLabel: "skill",
+    hasAvatar: false,
+    avgLabel: INVOCATION_AVG_LABEL,
+  },
+  source: {
+    label: "Sources",
+    breakdownLabel: "source",
+    hasAvatar: false,
+    avgLabel: MESSAGE_AVG_LABEL,
+  },
+};
+
+export function isConsumptionDimension(
+  value: string
+): value is ConsumptionDimension {
+  return CONSUMPTION_DIMENSIONS.some((dimension) => dimension === value);
+}

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -1,3 +1,4 @@
+import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { consumptionQueryString } from "@app/lib/analytics/consumption_period";
 import type { GetConsumptionTopAgentsResponse } from "@app/lib/api/analytics/consumption/top_agents";
@@ -11,33 +12,20 @@ import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
-/**
- * One ranking of the period's consumption, along one dimension.
- *
- * Each dimension has its own endpoint because their averages are denominated
- * differently — per message for the ones that consume whole messages, per
- * invocation for tools and skills — and their rows differ with them. This hook
- * flattens all six into the one shape a ranking table needs.
- */
-
-export const CONSUMPTION_TOP_ENDPOINTS = {
+const CONSUMPTION_TOP_ENDPOINTS = {
   agent: "top-agents",
   user: "top-users",
   model: "top-models",
   tool: "top-tools",
   skill: "top-skills",
   source: "top-sources",
-} as const;
-
-export type ConsumptionTopDimension = keyof typeof CONSUMPTION_TOP_ENDPOINTS;
+} as const satisfies Record<ConsumptionDimension, string>;
 
 export type ConsumptionTopRow = {
   id: string;
   name: string;
-  // Only agents and users have one.
   pictureUrl: string | null;
   credits: number;
-  // Per message, or per invocation, depending on the dimension.
   avgCredits: number;
 };
 
@@ -119,7 +107,7 @@ export function useConsumptionTop({
   disabled,
 }: {
   workspaceId: string;
-  dimension: ConsumptionTopDimension;
+  dimension: ConsumptionDimension;
   period: ConsumptionPeriodSelection;
   limit: number;
   disabled?: boolean;


### PR DESCRIPTION
## Description

Switch the analytics consumption timeseries dimension based on what attribution table is selected.
E.g when viewing the attribution per agents, the graph displays the credits per agents per day.
when viewing the attribution per models, the graph displays the credits per models per day.

## Tests

https://github.com/user-attachments/assets/7c95477e-8ad2-499a-96d2-8f4414bab4c7


## Risk

Low. Safe to rollback.

## Deploy Plan

Front only.
