### PR TITLE
[front-api] fix: reject the Activation webhook source on the public hooks route

### DIFF
--- a/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
@@ -1,3 +1,4 @@
+import { ACTIVATION_WEBHOOK_SOURCE_NAME } from "@app/lib/api/activation/trigger";
 import { Authenticator } from "@app/lib/auth";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -163,6 +164,29 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
     expect(response.status).toBe(404);
     const data = await response.json();
     expect(data.error.type).toBe("webhook_source_not_found");
+  });
+
+  it("returns 404 for the Activation source even with a valid url secret", async () => {
+    const { workspace } = await createPublicApiMockRequest();
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await SpaceFactory.defaults(auth);
+
+    const webhookSource = await new WebhookSourceFactory(workspace).create({
+      name: ACTIVATION_WEBHOOK_SOURCE_NAME,
+    });
+
+    const response = await postWebhook(
+      workspace,
+      webhookSource.sId,
+      webhookSource.urlSecret,
+      { any: "payload" }
+    );
+
+    expect(response.status).toBe(404);
+    const data = await response.json();
+    expect(data.error.type).toBe("webhook_source_not_found");
+    expect(launchTriggersWorkflowsMock).not.toHaveBeenCalled();
   });
 
   it("returns 401 on non-POST methods", async () => {

--- a/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
@@ -1,5 +1,6 @@
 import { timingSafeEqual } from "node:crypto";
 
+import { ACTIVATION_WEBHOOK_SOURCE_NAME } from "@app/lib/api/activation/trigger";
 import { Authenticator } from "@app/lib/auth";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
@@ -132,6 +133,20 @@ app.post(
     );
 
     if (!webhookSource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "webhook_source_not_found",
+          message: `Webhook source ${webhookSourceId} not found in workspace ${wId}.`,
+        },
+      });
+    }
+
+    // Activation nudges are emitted in-process and have no external sender, so
+    // an HTTP fire can only be a forgery: it would post a message under the
+    // agent's identity, with a body the sender wrote, to whichever pod the
+    // payload names.
+    if (webhookSource.name === ACTIVATION_WEBHOOK_SOURCE_NAME) {
       return apiError(ctx, {
         status_code: 404,
         api_error: {


### PR DESCRIPTION


## Description

Small security gap: you can forge a webhook with a free origin (activation).
Introduced on Tuesday this week, fixing in this PR.
The rest of the stack is focused on removing the need to send a webhook altogether.


## Tests

Added a new test

## Risk

Low

## Deploy Plan

Deploy front