### PR TITLE
[Activation] Notification depth logic fix

### DIFF
--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -1240,7 +1240,6 @@ export function createProjectManagerTools(
         // Get origin and timezone from the current conversation
         let origin: UserMessageOrigin = "web";
         let timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-        // Sub-conversations created on behalf of an agent are nested one level below their parent
         let originMessageId: string | null = null;
 
         if (isAgentLoopRunContext(toolContext?.runContext)) {
@@ -1286,8 +1285,6 @@ export function createProjectManagerTools(
           mentions = [{ configurationId: matchedAgentId }];
         }
 
-        // Create conversation in the project space, nested under the parent so it
-        // stays hidden from the pod's conversation list and notifications.
         const conversationResource = await createConversation(auth, {
           title: params.title,
           visibility: "unlisted",

--- a/front/lib/notifications/triggers/project-new-conversation.test.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.test.ts
@@ -333,22 +333,6 @@ describe("notifyActivationConversationAgentReplied", () => {
     expect(vi.mocked(getNovuClient)).toHaveBeenCalled();
   });
 
-  test("does not trigger the activation email for a nested sub-conversation", async () => {
-    const conversation = await ConversationFactory.create(auth, {
-      agentConfigurationId: agent.sId,
-      messagesCreatedAt: [],
-      spaceId: pod.id,
-      depth: 1,
-      triggerId: activationTrigger.id,
-    });
-
-    await notifyActivationConversationAgentReplied(auth, {
-      conversationId: conversation.sId,
-    });
-
-    expect(vi.mocked(getNovuClient)).not.toHaveBeenCalled();
-  });
-
   test("does not trigger the activation email for a conversation the user starts", async () => {
     const conversation = await ConversationFactory.create(auth, {
       agentConfigurationId: agent.sId,

--- a/front/lib/notifications/triggers/project-new-conversation.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.ts
@@ -256,11 +256,6 @@ export async function notifyActivationConversationAgentReplied(
     return;
   }
 
-  // Skip sub-conversations
-  if (conversationResource.depth > 0) {
-    return;
-  }
-
   const conversation = conversationResource.toJSON();
   if (!isPodConversation(conversation)) {
     return;


### PR DESCRIPTION
## Description
Revert all the unused activation notification logic and comments that used depth following this [incident](https://dust4ai.slack.com/archives/C050SM8NSPK/p1785932638562669).

Activation notifications now use `triggerId` to ensure sub-agent and user started activation conversations do not get notifications.
Note: `triggerId` will get removed with this [issue](https://github.com/dust-tt/tasks/issues/9943) and the current check will need to be updated.

## Tests
Removed notification test for "does not trigger the activation email for a nested sub-conversation" that checked depth.

## Risk


## Deploy Plan
Deploy front.
