### PR TITLE
[Front] Sidebar fixes

### DIFF
--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -151,12 +151,11 @@ export const NavigationSidebar = React.forwardRef<
               </div>
             </NavTabPillList>
             {navs.map((tab) => (
-              <NavTabPillContent
-                key={tab.id}
-                value={tab.id}
-                className="mx-sidebar-side-spacing"
-              >
-                <NavigationList>
+              // NavTabPillContent is display:contents, so it generates no box
+              // and margins set on it do nothing — the side spacing has to go
+              // on the list itself, as the other tabs' menus already do.
+              <NavTabPillContent key={tab.id} value={tab.id}>
+                <NavigationList className="mx-sidebar-side-spacing">
                   {subNavigation &&
                     tab.isCurrent(activePath) &&
                     subNavigation.map((nav) => (

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -23,8 +23,8 @@ import {
   cn,
   LayoutLeft,
   NavigationList,
+  NavigationListCompactLabel,
   NavigationListItem,
-  NavigationListLabel,
   NavTabPill,
   NavTabPillContent,
   NavTabPillList,
@@ -160,7 +160,9 @@ export const NavigationSidebar = React.forwardRef<
                     tab.isCurrent(activePath) &&
                     subNavigation.map((nav) => (
                       <React.Fragment key={`nav-${nav.label}`}>
-                        {nav.label && <NavigationListLabel label={nav.label} />}
+                        {nav.label && (
+                          <NavigationListCompactLabel label={nav.label} />
+                        )}
                         {nav.menus
                           .filter(
                             (menu) =>

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -5,6 +5,7 @@ import type {
 import { getAvatarFromIcon } from "@app/components/resources/resources_icons";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { usePersistedNavigationSelection } from "@app/hooks/usePersistedNavigationSelection";
+import { useSidebarSectionCollapsed } from "@app/hooks/useSidebarSectionCollapsed";
 import { useSpaceSidebarItemFocus } from "@app/hooks/useSpaceSidebarItemFocus";
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
@@ -51,8 +52,8 @@ import {
   Button,
   CloudArrowLeftRight,
   NavigationList,
+  NavigationListCollapsibleSection,
   NavigationListItem,
-  NavigationListLabel,
   Plus,
   ShapesPlus,
   Terminal,
@@ -61,7 +62,7 @@ import {
 } from "@dust-tt/sparkle";
 import sortBy from "lodash/sortBy";
 import uniqBy from "lodash/uniqBy";
-import type { ComponentType, ReactElement } from "react";
+import type { ComponentType, ReactElement, ReactNode } from "react";
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 
 interface SpaceSideBarMenuProps {
@@ -159,35 +160,19 @@ export default function SpaceSideBarMenu({
               return null;
             }
 
-            const sectionDetails = getSpaceSectionDetails(section);
-
             return (
-              <Fragment key={`space-section-${index}`}>
-                <div className="flex items-center justify-between pr-1">
-                  <NavigationListLabel label={sectionDetails.label} />
-                  {sectionDetails.displayCreateSpaceButton &&
-                    isAdmin &&
-                    openSpaceCreationModal && (
-                      <Button
-                        className="mt-1"
-                        size="xs"
-                        variant="ghost"
-                        label="New"
-                        icon={Plus}
-                        onClick={() =>
-                          openSpaceCreationModal({
-                            defaultRestricted: sectionDetails.defaultRestricted,
-                          })
-                        }
-                      />
-                    )}
-                </div>
+              <SpaceSection
+                key={`space-section-${index}`}
+                section={section}
+                isAdmin={isAdmin}
+                openSpaceCreationModal={openSpaceCreationModal}
+              >
                 {renderSpaceItems(
                   spaces.toSorted(compareSpaces),
                   spacesAsUser,
                   owner
                 )}
-              </Fragment>
+              </SpaceSection>
             );
           })}
         </div>
@@ -203,7 +188,8 @@ type SpaceSectionStructureType =
       defaultRestricted: boolean;
     }
   | {
-      label: string;
+      // A null label renders the spaces on their own, with no section header.
+      label: string | null;
       displayCreateSpaceButton: false;
     };
 
@@ -226,13 +212,71 @@ const getSpaceSectionDetails = (
       };
 
     case "system":
-      return { label: "Administration", displayCreateSpaceButton: false };
+      return { label: null, displayCreateSpaceButton: false };
 
     default:
       assertNeverAndIgnore(kind);
       return { label: kind, displayCreateSpaceButton: false };
   }
 };
+
+interface SpaceSectionProps {
+  section: SpaceSectionGroupType;
+  isAdmin: boolean;
+  openSpaceCreationModal?: ({
+    defaultRestricted,
+  }: {
+    defaultRestricted: boolean;
+  }) => void;
+  children: ReactNode;
+}
+
+function SpaceSection({
+  section,
+  isAdmin,
+  openSpaceCreationModal,
+  children,
+}: SpaceSectionProps) {
+  const { isCollapsed, setCollapsed } = useSidebarSectionCollapsed(
+    `spacesSectionCollapsed:${section}`
+  );
+
+  const sectionDetails = getSpaceSectionDetails(section);
+
+  // The Administration section has no header, so there is nothing to collapse
+  // from — render its spaces directly.
+  if (sectionDetails.label === null) {
+    return <>{children}</>;
+  }
+
+  const defaultRestricted = sectionDetails.displayCreateSpaceButton
+    ? sectionDetails.defaultRestricted
+    : null;
+  const canCreateSpace =
+    defaultRestricted !== null && isAdmin && openSpaceCreationModal;
+
+  return (
+    <NavigationListCollapsibleSection
+      label={sectionDetails.label}
+      type="collapse"
+      open={!isCollapsed}
+      onOpenChange={(open) => setCollapsed(!open)}
+      action={
+        canCreateSpace ? (
+          <Button
+            size="xs"
+            variant="ghost-secondary"
+            label="New"
+            icon={Plus}
+            onClick={() => openSpaceCreationModal({ defaultRestricted })}
+          />
+        ) : null
+      }
+    >
+      {children}
+    </NavigationListCollapsibleSection>
+  );
+}
 
 // System space.
 

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -154,7 +154,9 @@ export default function SpaceSideBarMenu({
   return (
     <div className="flex h-0 min-h-full w-full overflow-y-auto">
       <NavigationList className="w-full">
-        <div className="mx-sidebar-side-spacing">
+        {/* pt-3 because the first section (Administration) has no header to
+         * space it off the top of the sidebar. */}
+        <div className="mx-sidebar-side-spacing pt-3">
           {sortedGroupedSpaces.map(({ section, spaces }, index) => {
             if (section === "restricted" && !spaces.length && !isAdmin) {
               return null;

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -157,14 +157,14 @@ export default function SpaceSideBarMenu({
         {/* pt-3 because the first section (Administration) has no header to
          * space it off the top of the sidebar. */}
         <div className="mx-sidebar-side-spacing pt-3">
-          {sortedGroupedSpaces.map(({ section, spaces }, index) => {
+          {sortedGroupedSpaces.map(({ section, spaces }) => {
             if (section === "restricted" && !spaces.length && !isAdmin) {
               return null;
             }
 
             return (
               <SpaceSection
-                key={`space-section-${index}`}
+                key={`space-section-${section}`}
                 section={section}
                 isAdmin={isAdmin}
                 openSpaceCreationModal={openSpaceCreationModal}


### PR DESCRIPTION
## Description

Two sidebar fixes:

1. **Collapsible space sections**: Open Spaces and Restricted Spaces sections in the spaces sidebar are now `NavigationListCollapsibleSection` headers (with a chevron), matching the conversations sidebar pattern. The "New" button moves into the section's action slot. Collapsed state persists per section via `useSidebarSectionCollapsed`. The Administration section loses its label entirely (its system space is self-describing), expressed as `label: null` meaning "render spaces with no section header". A `SpaceSection` component is extracted so each section can own its collapsed state independently (hooks can't be called inside a `map`).

2. **Restore Admin tab side padding**: A previous commit made `NavTabPillContent` `display:contents`, which caused margins set on it to have no effect — the Admin tab's sub-navigation rendered flush against the sidebar edge. The fix moves `mx-sidebar-side-spacing` from `NavTabPillContent` onto the inner `NavigationList`, consistent with how the Conversations and Knowledge tabs already handle it.

## Tests

Manually verified: space sections collapse/expand and persist state; Admin tab sub-navigation has correct side spacing; pod scrollability fix is unaffected.

## Risk

Low — UI-only changes, no data or API changes.

## Deploy Plan

Deploy front.