### PR TITLE
Fix: bogus tooltip for default agent

### DIFF
--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -343,7 +343,11 @@ const getTableColumns = ({
       cell: (info: CellContext<RowData, number>) => (
         <DataTable.BasicCellContent
           disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
-          tooltip={formatTimestampToFriendlyDate(info.getValue(), "long")}
+          tooltip={
+            info.getValue()
+              ? formatTimestampToFriendlyDate(info.getValue(), "long")
+              : undefined
+          }
           label={
             info.getValue()
               ? formatTimestampToFriendlyDate(info.getValue(), "compact")


### PR DESCRIPTION
## Description

In `AssistantsTable`, the "last used" column's `tooltip` prop was unconditionally calling `formatTimestampToFriendlyDate(info.getValue(), "long")` even when the value is falsy (default agents with no usage timestamp). This produced a bogus tooltip. Added a guard so `tooltip` is `undefined` when the value is absent — matching the existing `label` conditional already in place.

> 📸 UI fix — please attach a screenshot or GIF showing the corrected tooltip state on a default agent row.

## Tests

Tested manually in the Assistants manager table against a default agent with no usage timestamp.

## Risk

Low. Single conditional guard on a tooltip prop. No logic or data change, no other component affected. Safe to rollback.

## Deploy Plan

Deploy front.
