### PR TITLE
[front] fix: handle WorkOS domain deleted event

### DIFF
--- a/front/temporal/workos_events_queue/activities.test.ts
+++ b/front/temporal/workos_events_queue/activities.test.ts
@@ -1,0 +1,76 @@
+import * as workosAudit from "@app/lib/api/audit/workos_audit";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { processWorkOSEventActivity } from "@app/temporal/workos_events_queue/activities";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { OrganizationDomainDeletedEvent } from "@workos-inc/node";
+import {
+  OrganizationDomainState,
+  OrganizationDomainVerificationStrategy,
+} from "@workos-inc/node";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/audit/workos_audit", async () => {
+  const actual = await vi.importActual("@app/lib/api/audit/workos_audit");
+  return { ...actual, emitAuditLogEventDirect: vi.fn() };
+});
+
+vi.mock("@app/lib/api/workos/organization_primitives", async () => {
+  const actual = await vi.importActual(
+    "@app/lib/api/workos/organization_primitives"
+  );
+  return {
+    ...actual,
+    listWorkOSOrganizationsWithDomain: vi.fn().mockResolvedValue([]),
+  };
+});
+
+describe("processWorkOSEventActivity", () => {
+  it("idempotently deletes the workspace domain when WorkOS deletes it", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+    if (!workspaceResource || !workspace.workOSOrganizationId) {
+      throw new Error("Expected a workspace with a WorkOS organization");
+    }
+
+    const domain = "deleted.example.com";
+    const upsertResult = await workspaceResource.upsertWorkspaceDomain({
+      domain,
+    });
+    expect(upsertResult.isOk()).toBe(true);
+
+    const now = new Date().toISOString();
+    const event: OrganizationDomainDeletedEvent = {
+      id: "evt_domain_deleted",
+      event: "organization_domain.deleted",
+      context: undefined,
+      createdAt: now,
+      data: {
+        object: "organization_domain",
+        id: "org_domain_deleted",
+        organizationId: workspace.workOSOrganizationId,
+        domain,
+        state: OrganizationDomainState.Verified,
+        verificationStrategy: OrganizationDomainVerificationStrategy.Manual,
+        createdAt: now,
+        updatedAt: now,
+      },
+    };
+
+    await processWorkOSEventActivity({ eventPayload: event });
+    await processWorkOSEventActivity({ eventPayload: event });
+
+    await expect(workspaceResource.getVerifiedDomains()).resolves.toEqual([]);
+    expect(workosAudit.emitAuditLogEventDirect).toHaveBeenCalledTimes(1);
+    expect(workosAudit.emitAuditLogEventDirect).toHaveBeenCalledWith({
+      workspace: expect.objectContaining({
+        sId: workspace.sId,
+        name: workspace.name,
+      }),
+      action: "domain.removed",
+      actor: { type: "system", id: "workos", name: "WorkOS" },
+      targets: [{ type: "workspace", id: workspace.sId, name: workspace.name }],
+      context: { location: "system" },
+      metadata: { domain },
+    });
+  });
+});

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -60,6 +60,7 @@ import type {
   DsyncUserUpdatedEvent,
   Event,
   OrganizationDomain,
+  OrganizationDomainDeletedEvent,
   OrganizationDomainVerificationFailedEvent,
   OrganizationDomainVerifiedEvent,
   OrganizationUpdatedEvent,
@@ -370,6 +371,14 @@ export async function processWorkOSEventActivity({
       );
       break;
 
+    case "organization_domain.deleted":
+      await verifyWorkOSWorkspace(
+        eventPayload.data.organizationId,
+        eventPayload,
+        handleOrganizationDomainDeleted
+      );
+      break;
+
     case "organization.updated":
       await verifyWorkOSWorkspace(
         eventPayload.data.id,
@@ -444,22 +453,32 @@ export async function processWorkOSEventActivity({
 async function handleOrganizationDomainEvent(
   workspace: LightWorkspaceType,
   eventData: OrganizationDomain,
-  expectedState: "verified" | "failed"
+  eventType: "verified" | "failed" | "deleted"
 ) {
   const { domain, state } = eventData;
 
-  assert(
-    state === expectedState,
-    `Domain state is not ${expectedState} -- expected ${expectedState} but got ${state}`
-  );
+  if (eventType !== "deleted") {
+    assert(
+      state === eventType,
+      `Domain state is not ${eventType} -- expected ${eventType} but got ${state}`
+    );
+  }
 
   const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
   if (!workspaceResource) {
     throw new Error(`Workspace not found: ${workspace.sId}`);
   }
 
+  if (eventType === "deleted") {
+    const existingDomains = await workspaceResource.getVerifiedDomains();
+    if (!existingDomains.some((existing) => existing.domain === domain)) {
+      logger.info({ domain }, "Domain already deleted");
+      return false;
+    }
+  }
+
   let domainResult: Result<any, Error>;
-  if (expectedState === "verified") {
+  if (eventType === "verified") {
     domainResult = await workspaceResource.upsertWorkspaceDomain({
       domain,
       // If a workspace has a verified domain, it means that they went through the DNS
@@ -480,6 +499,7 @@ async function handleOrganizationDomainEvent(
   }
 
   logger.info({ domain }, "Domain updated/deleted");
+  return true;
 }
 
 async function handleOrganizationDomainVerified(
@@ -509,6 +529,30 @@ async function handleOrganizationDomainVerificationFailed(
   void emitAuditLogEventDirect({
     workspace,
     action: "domain.verification_failed",
+    actor: { type: "system", id: "workos", name: "WorkOS" },
+    targets: [{ type: "workspace", id: workspace.sId, name: workspace.name }],
+    context: { location: "system" },
+    metadata: { domain: eventData.domain },
+  });
+}
+
+async function handleOrganizationDomainDeleted(
+  workspace: LightWorkspaceType,
+  event: OrganizationDomainDeletedEvent
+) {
+  const { data: eventData } = event;
+  const domainWasDeleted = await handleOrganizationDomainEvent(
+    workspace,
+    eventData,
+    "deleted"
+  );
+  if (!domainWasDeleted) {
+    return;
+  }
+
+  void emitAuditLogEventDirect({
+    workspace,
+    action: "domain.removed",
     actor: { type: "system", id: "workos", name: "WorkOS" },
     targets: [{ type: "workspace", id: workspace.sId, name: workspace.name }],
     context: { location: "system" },

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -460,7 +460,7 @@ async function handleOrganizationDomainEvent(
   if (eventType !== "deleted") {
     assert(
       state === eventType,
-      `Domain state is not ${eventType} -- expected ${eventType} but got ${state}`
+      `Domain state mismatch: expected ${eventType} but got ${state}`
     );
   }
 


### PR DESCRIPTION
## Description

WorkOS `organization_domain.deleted` webhooks were not handled at all (not register in WorkOS' config and not handled in our code).

This PR adds handling for the event. Replays are treated as no-ops, and successful deletions emit the existing `domain.removed` audit log. No change on the other events.

## Tests

- Added testst.

## Risk

- Low.

## Deploy Plan

- Event already added in WorkOS.
- Deploy front.
