### PR TITLE
Skills: clicking on skill in conv open details in side panel

### DIFF
--- a/front/components/assistant/UserMessageMarkdown.integration.test.tsx
+++ b/front/components/assistant/UserMessageMarkdown.integration.test.tsx
@@ -1,6 +1,7 @@
 import { FilePreviewProvider } from "@app/components/assistant/conversation/FilePreviewContext";
 import { getFilePreviewMarkdownDirective } from "@app/lib/markdown/file_preview";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type React from "react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -43,15 +44,35 @@ vi.mock("@app/lib/utils/router", () => ({
   setQueryParam: (...args: any[]) => setQueryParamMock(...args),
 }));
 
-// Mock workspace permissions so skill chips can be rendered without a
-// FetcherProvider / live permissions endpoint. Tests toggle the return value to
-// simulate whether the current user can create skills.
+// Mock workspace permissions so mention/directive components can be rendered
+// without a FetcherProvider / live permissions endpoint.
 const hasPermissionMock = vi.fn(() => false);
 vi.mock("@app/lib/swr/permissions", () => ({
   useWorkspacePermissions: () => ({
     hasPermission: hasPermissionMock,
   }),
 }));
+
+// Skill chips open the conversation side panel; the provider is not mounted here.
+const togglePanelMock = vi.fn();
+vi.mock(
+  import("@app/components/assistant/conversation/ConversationSidePanelContext"),
+  async (importOriginal) => ({
+    ...(await importOriginal()),
+    useConversationSidePanelContext: () => ({
+      currentPanel: undefined,
+      openPanel: vi.fn(),
+      togglePanel: togglePanelMock,
+      closePanel: vi.fn(),
+      onPanelClosed: vi.fn(),
+      setPanelRef: vi.fn(),
+      panelRef: { current: null },
+      setVirtuosoMsg: vi.fn(),
+      virtuosoMsg: null,
+      data: undefined,
+    }),
+  })
+);
 
 const mockOwner = {
   id: 1,
@@ -229,7 +250,6 @@ Quote text
     });
 
     it("renders inline skill tags as chips", () => {
-      hasPermissionMock.mockReturnValue(false);
       const content =
         'Please use <skill id="skill_123" name="commit" icon="book_open" />';
       const message = { ...mockMessage, content };
@@ -246,12 +266,12 @@ Quote text
       expect(container.textContent).not.toContain("<skill");
     });
 
-    it("links inline skill tags when the user can create skills", () => {
-      hasPermissionMock.mockReturnValue(true);
+    it("opens the skill side panel when an inline skill tag is clicked", async () => {
+      togglePanelMock.mockClear();
       const content =
         'Please use <skill id="skill_123" name="commit" icon="book_open" />';
       const message = { ...mockMessage, content };
-      const { container } = render(
+      render(
         <UserMessageMarkdown
           owner={mockOwner}
           message={message}
@@ -259,11 +279,12 @@ Quote text
         />
       );
 
-      const skillLink = container.querySelector("a[href]");
-      expect(skillLink).toHaveAttribute(
-        "href",
-        "/w/test-workspace/builder/skills#?skillId=skill_123"
-      );
+      await userEvent.click(screen.getByText("commit"));
+
+      expect(togglePanelMock).toHaveBeenCalledWith({
+        type: "skill",
+        skillId: "skill_123",
+      });
     });
 
     it("renders content node mentions", () => {

--- a/front/components/assistant/UserMessageMarkdown.tsx
+++ b/front/components/assistant/UserMessageMarkdown.tsx
@@ -59,7 +59,6 @@ export const UserMessageMarkdown = ({
       file_preview: getFilePreviewPlugin(),
       skill: ({ skillIcon, skillId, skillName }: SkillDirectiveProps) => (
         <SkillBlock
-          owner={owner}
           skillIcon={skillIcon ?? null}
           skillId={skillId}
           skillName={skillName}

--- a/front/components/assistant/conversation/ConversationSidePanelContent.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContent.tsx
@@ -4,6 +4,7 @@ import { ConversationFilesPanel } from "@app/components/assistant/conversation/f
 import { FilePreviewPanel } from "@app/components/assistant/conversation/files_panel/FilePreviewPanel";
 import { InteractiveContentContainer } from "@app/components/assistant/conversation/interactive_content/InteractiveContentContainer";
 import { ConversationPlanModePanel } from "@app/components/assistant/conversation/plan_mode/ConversationPlanModePanel";
+import { ConversationSkillPanel } from "@app/components/assistant/conversation/skill_panel/ConversationSkillPanel";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { ConversationSidePanelType } from "@app/types/conversation_side_panel";
 import {
@@ -13,6 +14,7 @@ import {
   FILES_SIDE_PANEL_TYPE,
   INTERACTIVE_CONTENT_SIDE_PANEL_TYPE,
   PLAN_SIDE_PANEL_TYPE,
+  SKILL_SIDE_PANEL_TYPE,
 } from "@app/types/conversation_side_panel";
 import type { LightWorkspaceType } from "@app/types/user";
 
@@ -59,6 +61,9 @@ export default function ConversationSidePanelContent({
       return (
         <ConversationPlanModePanel conversation={conversation} owner={owner} />
       );
+
+    case SKILL_SIDE_PANEL_TYPE:
+      return <ConversationSkillPanel owner={owner} />;
 
     default:
       return null;

--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -13,6 +13,7 @@ import {
   PLAN_SIDE_PANEL_TYPE,
   SIDE_PANEL_HASH_PARAM,
   SIDE_PANEL_TYPE_HASH_PARAM,
+  SKILL_SIDE_PANEL_TYPE,
 } from "@app/types/conversation_side_panel";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import React, { useCallback, useEffect, useMemo } from "react";
@@ -41,6 +42,10 @@ type OpenPanelParams =
     }
   | {
       type: "plan";
+    }
+  | {
+      type: "skill";
+      skillId: string;
     };
 
 const isSupportedPanelType = (
@@ -51,7 +56,8 @@ const isSupportedPanelType = (
   type === "interactive_content" ||
   type === "file_preview" ||
   type === "files" ||
-  type === "plan";
+  type === "plan" ||
+  type === "skill";
 
 interface ConversationSidePanelContextType {
   currentPanel: ConversationSidePanelType;
@@ -192,6 +198,15 @@ export function ConversationSidePanelProvider({
             return;
           }
           setData("plan");
+          break;
+
+        case SKILL_SIDE_PANEL_TYPE:
+          // A different skill switches content; only the same skill toggles closed.
+          if (toggle && params.skillId === data) {
+            closePanel();
+            return;
+          }
+          setData(params.skillId);
           break;
 
         default:

--- a/front/components/assistant/conversation/skill_panel/ConversationSkillPanel.tsx
+++ b/front/components/assistant/conversation/skill_panel/ConversationSkillPanel.tsx
@@ -32,7 +32,7 @@ export function ConversationSkillPanel({ owner }: ConversationSkillPanelProps) {
       <ConversationSidePanelHeader onClose={closePanel}>
         <span className="text-sm font-medium text-foreground">Skill</span>
       </ConversationSidePanelHeader>
-      <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-4">
+      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-4 pb-4">
         {isSkillError ? (
           <SkillLoadError onRetry={mutateSkill} />
         ) : !skill || !user ? (
@@ -46,9 +46,7 @@ export function ConversationSkillPanel({ owner }: ConversationSkillPanelProps) {
               owner={owner}
               onClose={closePanel}
             />
-            <div className="mt-4">
-              <SkillDetailsContent skill={skill} owner={owner} user={user} />
-            </div>
+            <SkillDetailsContent skill={skill} owner={owner} user={user} />
           </>
         )}
       </div>

--- a/front/components/assistant/conversation/skill_panel/ConversationSkillPanel.tsx
+++ b/front/components/assistant/conversation/skill_panel/ConversationSkillPanel.tsx
@@ -1,0 +1,57 @@
+import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import { ConversationSidePanelHeader } from "@app/components/assistant/conversation/ConversationSidePanelHeader";
+import {
+  SkillDetailsContent,
+  SkillDetailsHeader,
+  SkillLoadError,
+} from "@app/components/skills/SkillDetailsBody";
+import { useSkill } from "@app/lib/swr/skill_configurations";
+import { useUser } from "@app/lib/swr/user";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Spinner } from "@dust-tt/sparkle";
+
+interface ConversationSkillPanelProps {
+  owner: LightWorkspaceType;
+}
+
+export function ConversationSkillPanel({ owner }: ConversationSkillPanelProps) {
+  const { closePanel, data: skillId } = useConversationSidePanelContext();
+  const { user } = useUser();
+
+  // Fetching by id (rather than resolving from a list) is what lets non-editors
+  // and unpublished skills render here at all.
+  const { skill, isSkillError, mutateSkill } = useSkill({
+    workspaceId: owner.sId,
+    skillId: skillId ?? null,
+    withRelations: true,
+    disabled: !skillId,
+  });
+
+  return (
+    <div className="flex h-panel flex-col bg-panel-background">
+      <ConversationSidePanelHeader onClose={closePanel}>
+        <span className="text-sm font-medium text-foreground">Skill</span>
+      </ConversationSidePanelHeader>
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-4">
+        {isSkillError ? (
+          <SkillLoadError onRetry={mutateSkill} />
+        ) : !skill || !user ? (
+          <div className="flex h-full items-center justify-center">
+            <Spinner size="lg" />
+          </div>
+        ) : (
+          <>
+            <SkillDetailsHeader
+              skill={skill}
+              owner={owner}
+              onClose={closePanel}
+            />
+            <div className="mt-4">
+              <SkillDetailsContent skill={skill} owner={owner} user={user} />
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front/components/markdown/SkillBlock.tsx
+++ b/front/components/markdown/SkillBlock.tsx
@@ -1,7 +1,6 @@
+import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { getSkillIcon } from "@app/lib/skill";
-import { useWorkspacePermissions } from "@app/lib/swr/permissions";
-import { getManageSkillsRoute } from "@app/lib/utils/router";
-import type { WorkspaceType } from "@app/types/user";
+import { SKILL_SIDE_PANEL_TYPE } from "@app/types/conversation_side_panel";
 import { AttachmentChip } from "@dust-tt/sparkle";
 import { visit } from "unist-util-visit";
 
@@ -11,29 +10,18 @@ export interface SkillDirectiveProps {
   skillName: string;
 }
 
-interface SkillBlockProps extends SkillDirectiveProps {
-  owner: WorkspaceType;
-}
-
 export function SkillBlock({
-  owner,
   skillId,
   skillIcon,
   skillName,
-}: SkillBlockProps) {
-  const { hasPermission } = useWorkspacePermissions();
-  const canCreateSkill = hasPermission("create", "skill");
-
-  const href = canCreateSkill
-    ? getManageSkillsRoute(owner.sId, skillId)
-    : undefined;
+}: SkillDirectiveProps) {
+  const { togglePanel } = useConversationSidePanelContext();
 
   return (
     <AttachmentChip
       label={skillName}
       icon={{ visual: getSkillIcon(skillIcon), size: "xs" }}
-      href={href}
-      target={href ? "_blank" : undefined}
+      onClick={() => togglePanel({ type: SKILL_SIDE_PANEL_TYPE, skillId })}
       color="primary"
       size="xs"
     />

--- a/front/components/skills/SkillDetailsBody.tsx
+++ b/front/components/skills/SkillDetailsBody.tsx
@@ -1,0 +1,210 @@
+import { RestoreSkillDialog } from "@app/components/skills/RestoreSkillDialog";
+import { SkillDetailsButtonBar } from "@app/components/skills/SkillDetailsButtonBar";
+import { SkillEditorsTab } from "@app/components/skills/SkillEditorsTab";
+import { SkillInfoTab } from "@app/components/skills/SkillInfoTab";
+import {
+  getSkillAvatarIcon,
+  hasRelations,
+  isDustProvidedSkill,
+} from "@app/lib/skill";
+import type { GetSkillsWithRelationsResponseBody } from "@app/types/api/skills";
+import type {
+  SkillRelations,
+  SkillType,
+} from "@app/types/assistant/skill_configuration";
+import type { UserType, WorkspaceType } from "@app/types/user";
+import {
+  Button,
+  ContentMessage,
+  ContentMessageAction,
+  InfoCircle,
+  RefreshCw02,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  Users01,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+// Skill details rendering shared by the surfaces that display a skill: the
+// `SkillDetailsSheet` and the conversation skill side panel.
+
+interface SkillLoadErrorProps {
+  onRetry?: () => void;
+}
+
+export function SkillLoadError({ onRetry }: SkillLoadErrorProps) {
+  return (
+    <div className="flex h-full w-full items-center justify-center p-4">
+      <ContentMessage
+        title="Unable to load skill"
+        variant="warning"
+        icon={InfoCircle}
+        size="lg"
+        action={
+          onRetry ? (
+            <ContentMessageAction
+              icon={RefreshCw02}
+              label="Retry"
+              variant="warning"
+              onClick={onRetry}
+            />
+          ) : undefined
+        }
+      >
+        The skill could not be loaded. Please try again.
+      </ContentMessage>
+    </div>
+  );
+}
+
+interface SkillDetailsContentProps {
+  skill: SkillType & { relations?: SkillRelations };
+  owner: WorkspaceType;
+  user: UserType;
+}
+
+export function SkillDetailsContent({
+  skill,
+  owner,
+  user,
+}: SkillDetailsContentProps) {
+  const [selectedTab, setSelectedTab] = useState<"info" | "editors">("info");
+
+  // The editors tab is shown to everyone (non-editors get a read-only list,
+  // SkillEditorsTab hides the remove column for them), except for global
+  // skills which have no editor group.
+  const showEditorsTabs =
+    skill.status !== "suggested" && !isDustProvidedSkill(skill);
+
+  if (showEditorsTabs) {
+    return (
+      <Tabs value={selectedTab}>
+        <TabsList border={false}>
+          <TabsTrigger
+            value="info"
+            label="Info"
+            icon={InfoCircle}
+            onClick={() => setSelectedTab("info")}
+          />
+          <TabsTrigger
+            value="editors"
+            label="Editors"
+            icon={Users01}
+            onClick={() => setSelectedTab("editors")}
+          />
+        </TabsList>
+        <div className="mt-4">
+          <TabsContent value="info">
+            <SkillInfoTab skill={skill} owner={owner} />
+          </TabsContent>
+          <TabsContent value="editors">
+            {hasRelations(skill) && (
+              <SkillEditorsTab skill={skill} owner={owner} user={user} />
+            )}
+          </TabsContent>
+        </div>
+      </Tabs>
+    );
+  }
+
+  return <SkillInfoTab skill={skill} owner={owner} />;
+}
+
+interface SkillDetailsHeaderProps {
+  skill: GetSkillsWithRelationsResponseBody["skills"][number];
+  owner: WorkspaceType;
+  onClose: () => void;
+  replaceOnEdit?: boolean;
+  onFavoriteChange?: (
+    skill: GetSkillsWithRelationsResponseBody["skills"][number],
+    isFavorite: boolean
+  ) => Promise<void>;
+}
+
+export function SkillDetailsHeader({
+  skill,
+  owner,
+  onClose,
+  replaceOnEdit,
+  onFavoriteChange,
+}: SkillDetailsHeaderProps) {
+  const [showRestoreModal, setShowRestoreModal] = useState(false);
+  const { editedByUser } = skill.relations;
+  const editedDate =
+    skill.updatedAt &&
+    new Date(skill.updatedAt).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+
+  const SkillAvatar = getSkillAvatarIcon(skill);
+
+  return (
+    <div className="flex flex-col items-center gap-4 pt-4">
+      <div className="relative flex items-center justify-center">
+        {/* eslint-disable-next-line react-hooks/static-components */}
+        <SkillAvatar name="Skill avatar" size="xl" />
+      </div>
+
+      {/* Title and edit info */}
+      <div className="flex flex-col items-center gap-1">
+        <h2 className="text-xl font-semibold text-foreground">{skill.name}</h2>
+
+        {editedDate && (
+          <p className="text-sm text-muted-foreground">
+            Last edited: {editedDate}
+            {editedByUser && ` by ${editedByUser.fullName}`}
+          </p>
+        )}
+      </div>
+
+      {skill.status === "active" && (
+        <SkillDetailsButtonBar
+          owner={owner}
+          skill={skill}
+          onClose={onClose}
+          replaceOnEdit={replaceOnEdit}
+          onFavoriteChange={onFavoriteChange}
+        />
+      )}
+
+      {skill.status === "archived" && (
+        <>
+          <ContentMessage
+            title="This skill has been archived."
+            variant="warning"
+            icon={InfoCircle}
+            size="sm"
+          >
+            It is no longer active and cannot be used.
+            {skill.canAdministrate && (
+              <div className="mt-2">
+                <Button
+                  variant="outline"
+                  label="Restore"
+                  onClick={() => {
+                    setShowRestoreModal(true);
+                  }}
+                  icon={RefreshCw02}
+                />
+              </div>
+            )}
+          </ContentMessage>
+
+          <RestoreSkillDialog
+            owner={owner}
+            isOpen={showRestoreModal}
+            skill={skill}
+            onClose={() => {
+              setShowRestoreModal(false);
+              onClose();
+            }}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -1,39 +1,20 @@
-import { RestoreSkillDialog } from "@app/components/skills/RestoreSkillDialog";
-import { SkillDetailsButtonBar } from "@app/components/skills/SkillDetailsButtonBar";
-import { SkillEditorsTab } from "@app/components/skills/SkillEditorsTab";
-import { SkillInfoTab } from "@app/components/skills/SkillInfoTab";
 import {
-  getSkillAvatarIcon,
-  hasRelations,
-  isDustProvidedSkill,
-} from "@app/lib/skill";
+  SkillDetailsContent,
+  SkillDetailsHeader,
+  SkillLoadError,
+} from "@app/components/skills/SkillDetailsBody";
 import { useSkill } from "@app/lib/swr/skill_configurations";
 import type { GetSkillsWithRelationsResponseBody } from "@app/types/api/skills";
-import type {
-  SkillRelations,
-  SkillType,
-} from "@app/types/assistant/skill_configuration";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import {
-  Button,
-  ContentMessage,
-  ContentMessageAction,
-  InfoCircle,
-  RefreshCw02,
   Sheet,
   SheetContainer,
   SheetContent,
   SheetHeader,
   SheetTitle,
   Spinner,
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-  Users01,
 } from "@dust-tt/sparkle";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
-import { useState } from "react";
 
 type SkillDetailsProps = {
   skill: GetSkillsWithRelationsResponseBody["skills"][number] | null;
@@ -85,7 +66,7 @@ export function SkillDetailsSheet({
         {skill ? (
           <>
             <SheetHeader>
-              <DescriptionSection
+              <SkillDetailsHeader
                 skill={skill}
                 owner={owner}
                 onClose={onClose}
@@ -101,7 +82,7 @@ export function SkillDetailsSheet({
                   <Spinner size="lg" />
                 </div>
               ) : (
-                <SkillDetailsSheetContent
+                <SkillDetailsContent
                   skill={{ ...fullSkill, relations: skill.relations }}
                   user={user}
                   owner={owner}
@@ -120,178 +101,3 @@ export function SkillDetailsSheet({
     </Sheet>
   );
 }
-
-function SkillLoadError({ onRetry }: { onRetry?: () => void }) {
-  return (
-    <div className="flex h-full w-full items-center justify-center p-4">
-      <ContentMessage
-        title="Unable to load skill"
-        variant="warning"
-        icon={InfoCircle}
-        size="lg"
-        action={
-          onRetry ? (
-            <ContentMessageAction
-              icon={RefreshCw02}
-              label="Retry"
-              variant="warning"
-              onClick={onRetry}
-            />
-          ) : undefined
-        }
-      >
-        The skill could not be loaded. Please try again.
-      </ContentMessage>
-    </div>
-  );
-}
-
-type SkillDetailsSheetContentProps = {
-  skill: SkillType & { relations?: SkillRelations };
-  owner: WorkspaceType;
-  user: UserType;
-};
-
-function SkillDetailsSheetContent({
-  skill,
-  owner,
-  user,
-}: SkillDetailsSheetContentProps) {
-  const [selectedTab, setSelectedTab] = useState<"info" | "editors">("info");
-
-  // The editors tab is shown to everyone (non-editors get a read-only list,
-  // SkillEditorsTab hides the remove column for them), except for global
-  // skills which have no editor group.
-  const showEditorsTabs =
-    skill.status !== "suggested" && !isDustProvidedSkill(skill);
-
-  if (showEditorsTabs) {
-    return (
-      <Tabs value={selectedTab}>
-        <TabsList border={false}>
-          <TabsTrigger
-            value="info"
-            label="Info"
-            icon={InfoCircle}
-            onClick={() => setSelectedTab("info")}
-          />
-          <TabsTrigger
-            value="editors"
-            label="Editors"
-            icon={Users01}
-            onClick={() => setSelectedTab("editors")}
-          />
-        </TabsList>
-        <div className="mt-4">
-          <TabsContent value="info">
-            <SkillInfoTab skill={skill} owner={owner} />
-          </TabsContent>
-          <TabsContent value="editors">
-            {hasRelations(skill) && (
-              <SkillEditorsTab skill={skill} owner={owner} user={user} />
-            )}
-          </TabsContent>
-        </div>
-      </Tabs>
-    );
-  }
-
-  return <SkillInfoTab skill={skill} owner={owner} />;
-}
-
-type DescriptionSectionProps = {
-  skill: GetSkillsWithRelationsResponseBody["skills"][number];
-  owner: WorkspaceType;
-  onClose: () => void;
-  replaceOnEdit?: boolean;
-  onFavoriteChange?: (
-    skill: GetSkillsWithRelationsResponseBody["skills"][number],
-    isFavorite: boolean
-  ) => Promise<void>;
-};
-
-const DescriptionSection = ({
-  skill,
-  owner,
-  onClose,
-  replaceOnEdit,
-  onFavoriteChange,
-}: DescriptionSectionProps) => {
-  const [showRestoreModal, setShowRestoreModal] = useState(false);
-  const { editedByUser } = skill.relations;
-  const editedDate =
-    skill.updatedAt &&
-    new Date(skill.updatedAt).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-    });
-
-  const SkillAvatar = getSkillAvatarIcon(skill);
-
-  return (
-    <div className="flex flex-col items-center gap-4 pt-4">
-      <div className="relative flex items-center justify-center">
-        {/* eslint-disable-next-line react-hooks/static-components */}
-        <SkillAvatar name="Skill avatar" size="xl" />
-      </div>
-
-      {/* Title and edit info */}
-      <div className="flex flex-col items-center gap-1">
-        <h2 className="text-xl font-semibold text-foreground">{skill.name}</h2>
-
-        {editedDate && (
-          <p className="text-sm text-muted-foreground">
-            Last edited: {editedDate}
-            {editedByUser && ` by ${editedByUser.fullName}`}
-          </p>
-        )}
-      </div>
-
-      {skill.status === "active" && (
-        <SkillDetailsButtonBar
-          owner={owner}
-          skill={skill}
-          onClose={onClose}
-          replaceOnEdit={replaceOnEdit}
-          onFavoriteChange={onFavoriteChange}
-        />
-      )}
-
-      {skill.status === "archived" && (
-        <>
-          <ContentMessage
-            title="This skill has been archived."
-            variant="warning"
-            icon={InfoCircle}
-            size="sm"
-          >
-            It is no longer active and cannot be used.
-            {skill.canAdministrate && (
-              <div className="mt-2">
-                <Button
-                  variant="outline"
-                  label="Restore"
-                  onClick={() => {
-                    setShowRestoreModal(true);
-                  }}
-                  icon={RefreshCw02}
-                />
-              </div>
-            )}
-          </ContentMessage>
-
-          <RestoreSkillDialog
-            owner={owner}
-            isOpen={showRestoreModal}
-            skill={skill}
-            onClose={() => {
-              setShowRestoreModal(false);
-              onClose();
-            }}
-          />
-        </>
-      )}
-    </div>
-  );
-};

--- a/front/types/conversation_side_panel.ts
+++ b/front/types/conversation_side_panel.ts
@@ -8,6 +8,7 @@ export const FILE_PREVIEW_SIDE_PANEL_TYPE = "file_preview";
 export const FILES_SIDE_PANEL_TYPE = "files";
 export const CREDITS_SIDE_PANEL_TYPE = "credits";
 export const PLAN_SIDE_PANEL_TYPE = "plan";
+export const SKILL_SIDE_PANEL_TYPE = "skill";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const SIDE_PANEL_TYPES = [
   AGENT_ACTIONS_SIDE_PANEL_TYPE,
@@ -16,6 +17,7 @@ const SIDE_PANEL_TYPES = [
   FILES_SIDE_PANEL_TYPE,
   CREDITS_SIDE_PANEL_TYPE,
   PLAN_SIDE_PANEL_TYPE,
+  SKILL_SIDE_PANEL_TYPE,
 ] as const;
 
 export type ConversationSidePanelType =


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/9890

Instead of opening the manage skills page with the side panel open, open the skill details in the conv side panel directly.
This is a double benefits:
 - we can see the skill details in context of the conv
 - people without access to the manage skills page can still see the detail 

<img width="1721" height="851" alt="Screenshot 2026-08-06 at 13 29 21" src="https://github.com/user-attachments/assets/ef5e4e0f-e33c-4025-9778-c491131d8984" />

Can be reviewed commit by commit for simplicity

## Tests

 - tested locally

https://github.com/user-attachments/assets/f55ac336-e5b5-4dd3-9861-c66a8112f5e3

 - manage skill side panel is still working 

## Risk

low, purely UI

## Deploy Plan

deploy front.
