### PR TITLE
Record a Pod function as durable when it calls a Dust tool as fast

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/actions/call.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/call.test.ts
@@ -1,5 +1,6 @@
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { createPersistedSandboxFunctionInvocationTokenTestContext } from "@app/tests/utils/SandboxTokenFactory";
@@ -114,6 +115,48 @@ describe("POST /api/v1/w/[wId]/sandbox/actions/call (function invocation)", () =
     const body = await response.json();
     expect(body.error.message).toContain("published as fast");
     expect(vi.mocked(launchSandboxFunctionToolWorkflow)).not.toHaveBeenCalled();
+  });
+
+  // The refusal is the only evidence that the published mode is wrong, so it is also what fixes
+  // it: this invocation still fails, the next one runs durably.
+  it("records the function as durable after refusing its tool call", async () => {
+    const { auth, token, workspace, view, sandboxFunction } =
+      await setupWithView({ noTools: true });
+    expect(sandboxFunction.executionMode).toBe("fast");
+
+    const response = await callSandboxTool(workspace, token, {
+      serverViewId: view.sId,
+      toolName: "generate_random_number",
+      arguments: { max: 10 },
+    });
+    expect(response.status).toBe(403);
+
+    // The write is deliberately not awaited by the request, so let it settle.
+    await vi.waitFor(async () => {
+      const refetched = await SandboxFunctionResource.fetchById(
+        auth,
+        sandboxFunction.sId
+      );
+      expect(refetched?.executionMode).toBe("durable");
+    });
+  });
+
+  it("leaves a durable function's mode alone when its tool call succeeds", async () => {
+    const { auth, token, workspace, view, sandboxFunction } =
+      await setupWithView();
+
+    const response = await callSandboxTool(workspace, token, {
+      serverViewId: view.sId,
+      toolName: "generate_random_number",
+      arguments: { max: 10 },
+    });
+    expect(response.status).toBe(202);
+
+    const refetched = await SandboxFunctionResource.fetchById(
+      auth,
+      sandboxFunction.sId
+    );
+    expect(refetched?.executionMode).toBe("durable");
   });
 
   it("returns 404 for an unknown server view", async () => {

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
@@ -4,6 +4,7 @@ import {
 } from "@app/lib/api/sandbox/access_tokens";
 import { createSandboxChildAction } from "@app/lib/api/sandbox/create_child_action";
 import { createSandboxFunctionMCPAction } from "@app/lib/api/sandbox_functions/create_sandbox_function_mcp_action";
+import { selfHealSandboxFunctionExecutionMode } from "@app/lib/api/sandbox_functions/self_heal_execution_mode";
 import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { CallMCPToolRequestBodySchema } from "@dust-tt/client";
@@ -50,6 +51,22 @@ app.post(
       // could read that invocation's token out of /proc. That grants nothing the pod owner could
       // not get by publishing as durable, and the tool call still needs its usual approval.
       if (claims.noTools) {
+        // The declaration was wrong, and only this refusal reveals it. Record the function as
+        // durable so the next invocation works, without holding up the refusal this one gets.
+        void selfHealSandboxFunctionExecutionMode(auth, {
+          sandboxFunctionId: claims.sandboxFunctionId,
+          invocationId: claims.invocationId,
+        }).catch((err) =>
+          logger.error(
+            {
+              err,
+              sandboxFunctionId: claims.sandboxFunctionId,
+              invocationId: claims.invocationId,
+            },
+            "Failed to record a Pod function as durable"
+          )
+        );
+
         return apiError(ctx, {
           status_code: 403,
           api_error: {

--- a/front/lib/api/sandbox_functions/self_heal_execution_mode.ts
+++ b/front/lib/api/sandbox_functions/self_heal_execution_mode.ts
@@ -1,0 +1,52 @@
+import type { Authenticator } from "@app/lib/auth";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import logger from "@app/logger/logger";
+
+/**
+ * Record a fast Pod function as durable after it tried to call a Dust tool.
+ *
+ * The attempt is refused, so the invocation that triggered this still fails: what it buys is that
+ * the next one does not. A function reaching this point is mislabelled by definition, since the
+ * refusal is the only way to get here, so there is nothing to weigh up.
+ *
+ * Never awaited by the request that refuses the tool call: the caller has already decided its
+ * response, and a slow or failing write here must not hold it up or change what it returns.
+ */
+export async function selfHealSandboxFunctionExecutionMode(
+  auth: Authenticator,
+  {
+    sandboxFunctionId,
+    invocationId,
+  }: {
+    sandboxFunctionId: string;
+    invocationId: string;
+  }
+): Promise<void> {
+  const sandboxFunction = await SandboxFunctionResource.fetchById(
+    auth,
+    sandboxFunctionId
+  );
+  if (!sandboxFunction) {
+    logger.error(
+      { sandboxFunctionId, invocationId },
+      "Could not find the Pod function to record as durable"
+    );
+    return;
+  }
+
+  const madeDurable = await sandboxFunction.makeDurable(auth);
+  if (!madeDurable) {
+    // Another invocation got there first, or the publisher already moved it.
+    return;
+  }
+
+  logger.info(
+    {
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      sandboxFunctionId,
+      invocationId,
+      slug: sandboxFunction.slug,
+    },
+    "Recorded a Pod function as durable after it called a Dust tool as fast"
+  );
+}

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -605,6 +605,24 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         user: "agent-proxied",
       });
       if (execResult.isErr()) {
+        if (inline) {
+          // An inline exec that fails is usually one that ran past its ceiling, but nothing in the
+          // provider result says so: the timeout is handed to the sandbox provider and comes back
+          // as an ordinary failure. Log the whole class rather than guess, so we can see how often
+          // a fast function is simply too slow before deciding whether that should move it to
+          // durable the way a refused tool call does.
+          logger.info(
+            {
+              workspaceId: auth.getNonNullableWorkspace().sId,
+              sandboxFunctionId: sandboxFunction.sId,
+              slug: sandboxFunction.slug,
+              invocationId: this.sId,
+              timeoutMs: SANDBOX_FUNCTION_INLINE_EXEC_TIMEOUT_MS,
+              error: execResult.error.message,
+            },
+            "Inline Pod function execution failed"
+          );
+        }
         return execResult;
       }
 

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -434,6 +434,46 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     return new Ok(sandboxFunctions.length);
   }
 
+  /**
+   * Make a fast function durable, after it did something only a durable function can do.
+   *
+   * A fast function is published on the promise that it does not call Dust tools. When it breaks
+   * that promise the invocation fails, and without this the next one fails the same way: the
+   * publisher's declaration is wrong and nothing on the platform knows it. Recording durable here
+   * costs that function its fast path and makes every later invocation work.
+   *
+   * The update is guarded on the mode still being fast, so concurrent invocations that each break
+   * the promise converge on one write, and a function whose publisher has already moved it is left
+   * alone. Returns whether this call is the one that moved it.
+   *
+   * A re-publish restates the mode, so this is an override the publisher can clear rather than a
+   * permanent verdict. If the republished bundle still calls tools, it is simply made durable
+   * again.
+   */
+  async makeDurable(auth: Authenticator): Promise<boolean> {
+    const [affectedCount, rows] = await this.model.update(
+      { executionMode: "durable" },
+      {
+        where: {
+          id: this.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+          executionMode: "fast",
+        },
+        returning: true,
+      }
+    );
+    if (affectedCount === 0) {
+      return false;
+    }
+
+    const row = rows[0];
+    if (row) {
+      Object.assign(this, row.get());
+    }
+
+    return true;
+  }
+
   async invoke(
     auth: Authenticator,
     body: PostSandboxFunctionInvocationRequestBody,

--- a/front/tests/utils/SandboxTokenFactory.ts
+++ b/front/tests/utils/SandboxTokenFactory.ts
@@ -207,6 +207,8 @@ export async function createPersistedSandboxFunctionInvocationTokenTestContext({
     file,
     slug: "greet",
     description: "Greet someone.",
+    // A token that denies tools only ever belongs to a function published as fast.
+    executionMode: noTools ? "fast" : "durable",
     inputSchema: {
       type: "object",
       properties: { message: { type: "string" } },


### PR DESCRIPTION
## Description

A fast function is published on the promise that it does not call Dust tools through `dsbx tools`, and #30040 refuses the call when it breaks that promise. That refusal is also the only evidence the declaration was wrong, and today the evidence goes nowhere: the invocation fails, and the next one fails identically, because the declaration that caused it is still sitting on the function.

This records the function as `durable` from the refusal path. The invocation that triggered it still fails, since the tool call was already refused, but every later one runs durably and works. A mislabelled function starts behaving without the publisher having to notice anything.

The write is guarded on the mode still being `fast`, so concurrent invocations that each break the promise converge on a single write, and a function whose publisher has already moved it is left alone. It is never awaited by the request: the refusal is already decided, and a slow or failing write must not delay it or change what it returns.

Because a publish restates the mode (#30038), this is an override the publisher clears rather than a permanent verdict. A republished bundle that still calls tools is simply recorded again.

This also logs inline execution failures. The other case worth healing is a fast function that runs past its ceiling, but a timeout currently arrives as an ordinary provider failure with nothing marking it as a timeout, and one slow run is far weaker evidence than a refused tool call: a slow upstream or a loaded sandbox looks identical to a genuinely long function. Logging the whole class first means the decision can be made from numbers rather than from a guess.

## Tests

Added an endpoint test that the function is recorded as `durable` after its tool call is refused, and one that a durable function whose tool call succeeds keeps its mode.

The token test factory now publishes as `fast` when it mints a no-tools token, since that is the only combination that occurs.

Not exercised against a live pod.

## Risk

Low. The only path that reaches it is the 403 that #30040 already returns, which no function hits today since none is published `fast`. Worst case is a function losing its fast path, which costs latency and nothing else, and a republish restores it.

## Deploy Plan

None.
