### PR TITLE
[dust-hive] enh: infer current hive for dh aliases

### DIFF
--- a/x/henry/dust-hive/README.md
+++ b/x/henry/dust-hive/README.md
@@ -212,8 +212,8 @@ When you source the shell completion script, it also defines shorthand commands:
 | `dhw` | `dust-hive warm` |
 | `dhc` | `dust-hive cool` |
 | `dhx` | `dust-hive spawn -C -c "codex"` |
-| `dhb <query>` | Open the matched environment app URL in your browser |
-| `dhdb <query> [database] [psql-args...]` | Open `psql` on the matched environment database. Defaults to `dust_front`; `front`, `connectors`, and `core` complete to `dust_front`, `dust_connectors`, and `dust_api`. |
+| `dhb [query]` | Open the matched environment app URL in your browser. Defaults to the current hive when run from its worktree. |
+| `dhdb [query] [database] [psql-args...]` | Open `psql` on the matched environment database. Defaults to the current hive when run from its worktree and to `dust_front`; `front`, `connectors`, and `core` complete to `dust_front`, `dust_connectors`, and `dust_api`. |
 | `dhcd` | Change directory into the environment worktree |
 
 > **Tip**: When `NAME` is omitted, you'll get an interactive picker to select an environment.

--- a/x/henry/dust-hive/completions/dust-hive.bash
+++ b/x/henry/dust-hive/completions/dust-hive.bash
@@ -562,9 +562,17 @@ _dust_hive_base_port() {
 }
 
 dhb() {
-  local query="${1:?usage: dhb <worktree-name-query>}"
+  local query="${1:-}"
   local offset="${DHB_PORT_OFFSET:-11}"
   local base port url
+
+  if (( $# == 0 )); then
+    query="$(_dust_hive_current_env_from_metadata)"
+  fi
+  if [[ -z "$query" ]]; then
+    echo "usage: dhb <worktree-name-query>" >&2
+    return 1
+  fi
 
   base="$(_dust_hive_base_port "$query")" || return
   port=$((base + offset))
@@ -576,11 +584,20 @@ dhb() {
 
 dhdb() {
   local usage="usage: dhdb <worktree-name-query> [front|connectors|core|dust_front|dust_connectors|dust_api|dust_oauth] [psql-args...]"
-  local query="${1:?$usage}"
-  shift
+  local query="${1:-}"
   local db="dust_front"
   local offset="${DHDB_PORT_OFFSET:-432}"
   local base port
+
+  if (( $# == 0 )); then
+    query="$(_dust_hive_current_env_from_metadata)"
+  else
+    shift
+  fi
+  if [[ -z "$query" ]]; then
+    echo "$usage" >&2
+    return 1
+  fi
 
   if (( $# > 0 )); then
     case "$1" in

--- a/x/henry/dust-hive/completions/dust-hive.zsh
+++ b/x/henry/dust-hive/completions/dust-hive.zsh
@@ -533,9 +533,17 @@ function _dust_hive_base_port {
 }
 
 function dhb {
-  local query="${1:?usage: dhb <worktree-name-query>}"
+  local query="${1:-}"
   local offset="${DHB_PORT_OFFSET:-11}"
   local base port url
+
+  if (( $# == 0 )); then
+    query="$(_dust_hive_current_env_from_metadata)"
+  fi
+  if [[ -z "$query" ]]; then
+    echo "usage: dhb <worktree-name-query>" >&2
+    return 1
+  fi
 
   base="$(_dust_hive_base_port "$query")" || return
   port=$((base + offset))
@@ -547,11 +555,20 @@ function dhb {
 
 function dhdb {
   local usage="usage: dhdb <worktree-name-query> [front|connectors|core|dust_front|dust_connectors|dust_api|dust_oauth] [psql-args...]"
-  local query="${1:?$usage}"
-  shift
+  local query="${1:-}"
   local db="dust_front"
   local offset="${DHDB_PORT_OFFSET:-432}"
   local base port
+
+  if (( $# == 0 )); then
+    query="$(_dust_hive_current_env_from_metadata)"
+  else
+    shift
+  fi
+  if [[ -z "$query" ]]; then
+    echo "$usage" >&2
+    return 1
+  fi
 
   if (( $# > 0 )); then
     case "$1" in


### PR DESCRIPTION
## Description

Running `dhb` or `dhdb` from a hive currently still requires repeating the hive name. These aliases now infer the registered hive from the current worktree when called without arguments, opening the app or connecting to `dust_front` for that hive.

Explicit hive queries, database selection, and psql arguments remain unchanged. Calls without arguments outside a registered hive still show usage.

## Tests

- Tested locally in Bash and Zsh.

## Risk

- Low.

## Deploy Plan

- No deploy.