### PR TITLE
Hide user_memory from other participants in multi-user conversations

### DIFF
--- a/front-api/lib/api/sse/message_events.ts
+++ b/front-api/lib/api/sse/message_events.ts
@@ -1,8 +1,12 @@
 import { getConversationMessageType } from "@app/lib/api/assistant/conversation";
+import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
+import { getRunOwnerUserId } from "@app/lib/api/assistant/conversation/messages";
 import type { MessageStreamEvent } from "@app/lib/api/assistant/pubsub";
 import { getMessagesEvents } from "@app/lib/api/assistant/pubsub";
+import { redactUserMemoryFromMessageStreamEvent } from "@app/lib/api/assistant/user_memory_redaction";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
 import { ConversationError } from "@app/types/assistant/conversation";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { streamEvents } from "@front-api/lib/api/sse/stream_events";
@@ -67,11 +71,30 @@ export async function streamMessageEventsForRoute(
     });
   }
 
+  const runOwnerRes = await getRunOwnerUserId(auth, { messageId });
+  if (runOwnerRes.isErr()) {
+    logger.warn(
+      { conversationId, messageId, err: runOwnerRes.error },
+      "Could not resolve run owner; redacting user_memory from the stream."
+    );
+  }
+  const canViewUserMemory =
+    runOwnerRes.isOk() &&
+    canCurrentUserRespondToParentUserMessage({
+      parentUserId: runOwnerRes.value,
+      currentUserId: auth.user()?.id,
+    });
+
   return streamEvents({
     ctx,
     iterator: (signal) =>
       getMessagesEvents(auth, { messageId, lastEventId, signal }),
-    transform: (event) => opts.transformEvent(auth, event),
+    transform: (event) => {
+      const redacted = canViewUserMemory
+        ? event
+        : redactUserMemoryFromMessageStreamEvent(event);
+      return opts.transformEvent(auth, redacted);
+    },
     writeDoneSentinel: true,
   });
 }

--- a/front-api/routes/sse/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.test.ts
+++ b/front-api/routes/sse/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.test.ts
@@ -1,8 +1,11 @@
 import { fetchConversationMessages } from "@app/lib/api/assistant/messages";
 import type { MessageStreamEvent } from "@app/lib/api/assistant/pubsub";
-import type { Authenticator } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { honoApp } from "@front-api/app";
 import {
@@ -110,5 +113,72 @@ describe("GET /api/sse/w/[wId]/assistant/conversations/[cId]/messages/[mId]/even
     expect(response.status).toBe(200);
     const payloads = parseSseDataPayloads(await response.text());
     expect(payloads.map((p) => JSON.parse(p).data.text)).toEqual(["hello"]);
+  });
+
+  it("redacts user_memory tool output for a non-owner participant", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest();
+
+    const owner = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, owner, { role: "user" });
+    const ownerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      owner.sId,
+      workspace.sId
+    );
+
+    const conversation = await ConversationFactory.create(ownerAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+    const agentMessageSId = await getMessageSIdByRank(
+      auth,
+      conversation.sId,
+      1
+    );
+
+    const MEMORY_TEXT = "SECRET: user lives in Paris";
+    const action = {
+      id: 1,
+      sId: "act_1",
+      createdAt: 0,
+      updatedAt: 0,
+      agentMessageId: 1,
+      internalMCPServerName: "user_memory",
+      toolName: "read",
+      mcpServerId: "srv",
+      functionCallName: "read",
+      functionCallId: "call_1",
+      params: {},
+      citationsAllocated: 0,
+      status: "succeeded",
+      step: 0,
+      executionDurationMs: null,
+      displayLabels: null,
+      generatedFiles: [],
+      output: [{ type: "text", text: MEMORY_TEXT }],
+      citations: null,
+    } satisfies AgentMCPActionWithOutputType;
+
+    const event: MessageStreamEvent = {
+      eventId: "evt",
+      data: {
+        type: "agent_action_success",
+        created: 0,
+        configurationId: "dust",
+        messageId: "msg",
+        action,
+        step: 0,
+      },
+    };
+    vi.mocked(getMessagesEvents).mockImplementation(asyncIteratorFrom([event]));
+
+    const response = await getMessageEvents(
+      workspace.sId,
+      conversation.sId,
+      agentMessageSId
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).not.toContain(MEMORY_TEXT);
   });
 });

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -36,6 +36,8 @@ import type {
   ResolvedRequestedModel,
 } from "@app/types/assistant/models/types";
 import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -742,6 +744,43 @@ export async function getUserMessageIdFromMessageId(
     userMessageUserId: parentMessage.userMessage.userId,
     userMessageOrigin: parentMessage.userMessage.userContextOrigin,
   };
+}
+
+export async function getRunOwnerUserId(
+  auth: Authenticator,
+  { messageId }: { messageId: string }
+): Promise<Result<number | null, Error>> {
+  const workspaceId = auth.getNonNullableWorkspace().id;
+
+  const agentMessage = await MessageModel.findOne({
+    where: {
+      workspaceId,
+      sId: messageId,
+      agentMessageId: { [Op.ne]: null },
+    },
+    attributes: ["parentId"],
+  });
+  if (!agentMessage?.parentId) {
+    return new Err(new Error("Agent message has no parent."));
+  }
+
+  const parentMessage = await MessageModel.findOne({
+    where: { id: agentMessage.parentId, workspaceId },
+    attributes: ["id"],
+    include: [
+      {
+        model: UserMessageModel,
+        as: "userMessage",
+        required: false,
+        attributes: ["userId"],
+      },
+    ],
+  });
+  if (!parentMessage?.userMessage) {
+    return new Err(new Error("Agent message parent is not a user message."));
+  }
+
+  return new Ok(parentMessage.userMessage.userId);
 }
 
 export async function createCompactionMessage(

--- a/front/lib/api/assistant/messages.test.ts
+++ b/front/lib/api/assistant/messages.test.ts
@@ -1,5 +1,6 @@
+import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import { batchRenderMessages } from "@app/lib/api/assistant/messages";
-import type { Authenticator } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import {
   AgentMessageModel,
   MentionModel,
@@ -12,6 +13,7 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -1102,6 +1104,130 @@ describe("batchRenderMessages", () => {
           }
         }
       }
+    });
+  });
+
+  describe("user memory redaction", () => {
+    // Leaks through the tool output (the `read` tool result).
+    const MEMORY_OUTPUT_TEXT = "SECRET: user lives in Paris and loves sushi";
+    // Leaks through the function-call arguments (the `edit` tool params).
+    const MEMORY_ARGS_TEXT = "SECRET: user moved to Paris last year";
+
+    async function setupConversationWithUserMemoryAction() {
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [new Date()],
+      });
+
+      const agentMessageModel = await MessageModel.findOne({
+        where: { conversationId: conversation.id, workspaceId: workspace.id },
+        include: [
+          { model: AgentMessageModel, as: "agentMessage", required: true },
+        ],
+        order: [["rank", "DESC"]],
+      });
+      expect(agentMessageModel).not.toBeNull();
+
+      await AgentMCPActionFactory.create(auth, {
+        workspace,
+        conversationModelId: conversation.id,
+        agentMessageModelId: agentMessageModel!.agentMessageId!,
+        status: "succeeded",
+        step: 0,
+        output: [{ type: "text", text: MEMORY_OUTPUT_TEXT }],
+        functionCallArguments: JSON.stringify({
+          oldStr: MEMORY_ARGS_TEXT,
+          newStr: "SECRET: user now lives in Lyon",
+        }),
+        toolServerId: internalMCPServerNameToSId({
+          name: "user_memory",
+          workspaceId: workspace.id,
+          prefix: 0,
+        }),
+      });
+
+      return { conversation, agentMessageModel: agentMessageModel! };
+    }
+
+    async function renderAsUser(
+      renderAuth: Authenticator,
+      conversationId: string,
+      agentMessageModel: MessageModel
+    ): Promise<AgentMessageType> {
+      const conversationResource = await ConversationResource.fetchById(
+        renderAuth,
+        conversationId
+      );
+
+      const result = await batchRenderMessages(
+        renderAuth,
+        conversationResource!,
+        [agentMessageModel],
+        "full"
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      const rendered = result.value.find((m) => m.type === "agent_message") as
+        | AgentMessageType
+        | undefined;
+      expect(rendered).toBeDefined();
+      return rendered!;
+    }
+
+    it("returns the memory content to the owner of the run", async () => {
+      const { conversation, agentMessageModel } =
+        await setupConversationWithUserMemoryAction();
+
+      const rendered = await renderAsUser(
+        auth,
+        conversation.sId,
+        agentMessageModel
+      );
+
+      const outputText = JSON.stringify(
+        rendered.actions.find((a) => a.internalMCPServerName === "user_memory")
+          ?.output ?? []
+      );
+      expect(outputText).toContain(MEMORY_OUTPUT_TEXT);
+      expect(JSON.stringify(rendered.contents)).toContain(MEMORY_ARGS_TEXT);
+    });
+
+    it("hides the memory content from a non-owner participant", async () => {
+      const { conversation, agentMessageModel } =
+        await setupConversationWithUserMemoryAction();
+
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherUser, {
+        role: "user",
+      });
+      const otherUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        workspace.sId
+      );
+
+      const rendered = await renderAsUser(
+        otherUserAuth,
+        conversation.sId,
+        agentMessageModel
+      );
+
+      const action = rendered.actions.find(
+        (a) => a.internalMCPServerName === "user_memory"
+      );
+      expect(action).toBeDefined();
+      // The tool output is redacted.
+      expect(JSON.stringify(action?.output ?? [])).not.toContain(
+        MEMORY_OUTPUT_TEXT
+      );
+      // The tool params (both on the action and in the function-call step
+      // content) are redacted.
+      expect(JSON.stringify(action?.params ?? {})).not.toContain(
+        MEMORY_ARGS_TEXT
+      );
+      expect(JSON.stringify(rendered.contents)).not.toContain(MEMORY_ARGS_TEXT);
     });
   });
 });

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -1,11 +1,17 @@
 import { renderAgentMessageContentView } from "@app/lib/api/assistant/activity_steps";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import {
   resolvedModelFromAgentMessageRow,
   resolvedModelFromUserMessageRow,
 } from "@app/lib/api/assistant/models";
 import { getMessagesReactions } from "@app/lib/api/assistant/reaction";
+import {
+  getUserMemoryFunctionCallIds,
+  redactUserMemoryActions,
+  redactUserMemoryStepContent,
+} from "@app/lib/api/assistant/user_memory_redaction";
 import type { Authenticator } from "@app/lib/auth";
 import {
   MentionModel,
@@ -703,9 +709,24 @@ async function renderSingleAgentMessage(
   }
   const agentMessage = message.agentMessage;
 
-  const actions = (actionsByAgentMessageId[agentMessage.id] ?? []).sort(
+  const rawActions = (actionsByAgentMessageId[agentMessage.id] ?? []).sort(
     (a, b) => a.step - b.step
   );
+
+  const actingUserId =
+    message.parentId !== null
+      ? (allMessagesById.get(message.parentId)?.userMessage?.userId ?? null)
+      : null;
+  const isMemoryOwner = canCurrentUserRespondToParentUserMessage({
+    parentUserId: actingUserId,
+    currentUserId: auth.user()?.id,
+  });
+  const actions = isMemoryOwner
+    ? rawActions
+    : redactUserMemoryActions(rawActions);
+  const redactedUserMemoryCallIds = isMemoryOwner
+    ? new Set<string>()
+    : getUserMemoryFunctionCallIds(rawActions);
 
   const agentConfiguration = agentConfigurationsById.get(
     agentMessage.agentConfigurationId
@@ -746,7 +767,10 @@ async function renderSingleAgentMessage(
       ?.sort((a, b) => a.step - b.step || a.index - b.index)
       .map((sc) => ({
         step: sc.step,
-        content: sc.value,
+        content: redactUserMemoryStepContent(
+          sc.value,
+          redactedUserMemoryCallIds
+        ),
       })) ?? [];
 
   // Single source of truth for the body, chain of thought, and activity steps:

--- a/front/lib/api/assistant/user_memory_redaction.test.ts
+++ b/front/lib/api/assistant/user_memory_redaction.test.ts
@@ -1,0 +1,106 @@
+import { redactUserMemoryFromMessageStreamEvent } from "@app/lib/api/assistant/user_memory_redaction";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import { describe, expect, it } from "vitest";
+
+const MEMORY_TEXT = "SECRET: user lives in Paris";
+
+function makeAction(
+  overrides: Partial<AgentMCPActionWithOutputType> = {}
+): AgentMCPActionWithOutputType {
+  return {
+    id: 1,
+    sId: "act_1",
+    createdAt: 0,
+    updatedAt: 0,
+    agentMessageId: 1,
+    internalMCPServerName: "user_memory",
+    toolName: "read",
+    mcpServerId: "srv",
+    functionCallName: "read",
+    functionCallId: "call_1",
+    params: { oldStr: MEMORY_TEXT },
+    citationsAllocated: 0,
+    status: "succeeded",
+    step: 0,
+    executionDurationMs: null,
+    displayLabels: null,
+    generatedFiles: [],
+    output: [{ type: "text", text: MEMORY_TEXT }],
+    citations: null,
+    ...overrides,
+  };
+}
+
+describe("redactUserMemoryFromMessageStreamEvent", () => {
+  it("redacts params and output of a user_memory agent_action_success event", () => {
+    const redacted = redactUserMemoryFromMessageStreamEvent({
+      eventId: "evt",
+      data: {
+        type: "agent_action_success",
+        created: 0,
+        configurationId: "dust",
+        messageId: "msg",
+        action: makeAction(),
+        step: 0,
+      },
+    });
+
+    expect(JSON.stringify(redacted)).not.toContain(MEMORY_TEXT);
+    if ("action" in redacted.data) {
+      expect(redacted.data.action.params).toEqual({});
+    }
+  });
+
+  it("redacts params of a user_memory tool_params event", () => {
+    const redacted = redactUserMemoryFromMessageStreamEvent({
+      eventId: "evt",
+      data: {
+        type: "tool_params",
+        created: 0,
+        configurationId: "dust",
+        messageId: "msg",
+        action: makeAction({ toolName: "edit", output: null }),
+        step: 0,
+      },
+    });
+
+    expect(JSON.stringify(redacted)).not.toContain(MEMORY_TEXT);
+  });
+
+  it("leaves a non-user_memory action event untouched", () => {
+    const event = {
+      eventId: "evt",
+      data: {
+        type: "agent_action_success" as const,
+        created: 0,
+        configurationId: "dust",
+        messageId: "msg",
+        action: makeAction({ internalMCPServerName: "search" }),
+        step: 0,
+      },
+    };
+
+    const redacted = redactUserMemoryFromMessageStreamEvent(event);
+
+    expect(JSON.stringify(redacted)).toContain(MEMORY_TEXT);
+  });
+
+  it("leaves an event without an action untouched", () => {
+    const event = {
+      eventId: "evt",
+      data: {
+        type: "generation_tokens" as const,
+        created: 0,
+        configurationId: "dust",
+        messageId: "msg",
+        text: MEMORY_TEXT,
+        classification: "tokens" as const,
+        step: 0,
+      },
+    };
+
+    const redacted = redactUserMemoryFromMessageStreamEvent(event);
+
+    expect(JSON.stringify(redacted)).toContain(MEMORY_TEXT);
+  });
+});

--- a/front/lib/api/assistant/user_memory_redaction.ts
+++ b/front/lib/api/assistant/user_memory_redaction.ts
@@ -1,0 +1,73 @@
+import { USER_MEMORY_SERVER_NAME } from "@app/lib/api/actions/servers/user_memory/metadata";
+import type { MessageStreamEvent } from "@app/lib/api/assistant/pubsub";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import type { AgentContentItemType } from "@app/types/assistant/agent_message_content";
+import { isAgentFunctionCallContent } from "@app/types/assistant/agent_message_content";
+
+export const REDACTED_USER_MEMORY_TEXT =
+  "Personal memory is hidden from other conversation participants.";
+
+function isUserMemoryAction(action: AgentMCPActionWithOutputType): boolean {
+  return action.internalMCPServerName === USER_MEMORY_SERVER_NAME;
+}
+
+export function redactUserMemoryAction(
+  action: AgentMCPActionWithOutputType
+): AgentMCPActionWithOutputType {
+  if (!isUserMemoryAction(action)) {
+    return action;
+  }
+
+  return {
+    ...action,
+    params: {},
+    output: [{ type: "text" as const, text: REDACTED_USER_MEMORY_TEXT }],
+    generatedFiles: [],
+    citations: null,
+  };
+}
+
+export function redactUserMemoryActions(
+  actions: AgentMCPActionWithOutputType[]
+): AgentMCPActionWithOutputType[] {
+  return actions.map(redactUserMemoryAction);
+}
+
+export function getUserMemoryFunctionCallIds(
+  actions: AgentMCPActionWithOutputType[]
+): Set<string> {
+  return new Set(
+    actions.filter(isUserMemoryAction).map((a) => a.functionCallId)
+  );
+}
+
+export function redactUserMemoryStepContent(
+  content: AgentContentItemType,
+  redactedFunctionCallIds: Set<string>
+): AgentContentItemType {
+  if (
+    !isAgentFunctionCallContent(content) ||
+    !redactedFunctionCallIds.has(content.value.id)
+  ) {
+    return content;
+  }
+
+  return {
+    ...content,
+    value: { ...content.value, arguments: "{}" },
+  };
+}
+
+export function redactUserMemoryFromMessageStreamEvent(
+  event: MessageStreamEvent
+): MessageStreamEvent {
+  const { data } = event;
+  if (!("action" in data) || !isUserMemoryAction(data.action)) {
+    return event;
+  }
+
+  return {
+    ...event,
+    data: { ...data, action: redactUserMemoryAction(data.action) },
+  };
+}

--- a/front/tests/utils/AgentMCPActionFactory.ts
+++ b/front/tests/utils/AgentMCPActionFactory.ts
@@ -45,6 +45,7 @@ export class AgentMCPActionFactory {
       toolName = "test_tool",
       mcpServerName = "test_server",
       toolServerId = "test-server",
+      functionCallArguments = "{}",
       sandboxChildActionInfo,
       parentAction,
     }: {
@@ -60,6 +61,7 @@ export class AgentMCPActionFactory {
       toolName?: string;
       mcpServerName?: string;
       toolServerId?: string;
+      functionCallArguments?: string;
       sandboxChildActionInfo?: SandboxChildActionInfo;
       parentAction?: AgentMCPActionResource;
     }
@@ -84,7 +86,7 @@ export class AgentMCPActionFactory {
           value: {
             id: functionCallId,
             name: functionCallName,
-            arguments: "{}",
+            arguments: functionCallArguments,
           },
         },
       }));


### PR DESCRIPTION
## Description

An issue with user memory was that in multi-user conversations when the agent used the memory tool then all participants of the conversation could read the user's entire memory. 
To avoid this we hide the content of the Reading Memory to all participants who aren't the user who sent the message. 

## Tests

Can't test locally since only one user on DevWorkspace. Can test by deploying front-edge maybe 

## Risk

Low

## Deploy Plan

Deploy front and front-api
