### PR TITLE
[front] enh: suggest customizing remote MCP view name on conflict

### DIFF
--- a/front-api/routes/w/[wId]/mcp/index.test.ts
+++ b/front-api/routes/w/[wId]/mcp/index.test.ts
@@ -10,6 +10,7 @@ import {
 import { fetchRemoteServerMetaDataByURL } from "@app/lib/actions/mcp_metadata";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
@@ -331,7 +332,7 @@ describe("POST /api/w/:wId/mcp/ — name conflict", () => {
       serverType: "remote",
       url: "https://new-server.example.com",
       includeGlobal: true,
-      viewName: customName,
+      viewName: ` ${customName} `,
     });
 
     expect(retryResponse.status).toBe(201);
@@ -352,6 +353,66 @@ describe("POST /api/w/:wId/mcp/ — name conflict", () => {
       globalViews.find((view) => view.mcpServerId === retryBody.server.sId)
         ?.name
     ).toBe(customName);
+  });
+
+  it("normalizes custom view names before checking exact conflicts", async () => {
+    const { workspace, auth } = await setup();
+    const existingName = "existing-name";
+    const existingServer = await RemoteMCPServerFactory.create(workspace, {
+      name: existingName,
+      url: "https://existing.example.com",
+      tools: [],
+    });
+    const systemView =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        auth,
+        existingServer.sId
+      );
+    expect(systemView).toBeDefined();
+
+    await MCPServerViewResource.create(auth, {
+      systemView: systemView!,
+      space: await SpaceResource.fetchWorkspaceGlobalSpace(auth),
+    });
+
+    vi.mocked(fetchRemoteServerMetaDataByURL).mockResolvedValueOnce(
+      new Ok({
+        name: "candidate-name",
+        version: DEFAULT_MCP_ACTION_VERSION,
+        description: "Test description",
+        icon: DEFAULT_MCP_SERVER_ICON,
+        authorization: null,
+        tools: [],
+        availability: "manual",
+        allowMultipleInstances: true,
+        documentationUrl: null,
+      })
+    );
+
+    const response = await postMcp(workspace, {
+      serverType: "remote",
+      url: "https://new-server.example.com",
+      includeGlobal: true,
+      viewName: ` ${existingName} `,
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.message).toContain(existingName);
+  });
+
+  it("rejects custom view names longer than the database column", async () => {
+    const { workspace, auth } = await setup();
+
+    const response = await postMcp(workspace, {
+      serverType: "remote",
+      url: "https://new-server.example.com",
+      includeGlobal: true,
+      viewName: "a".repeat(256),
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.message).toContain("255");
+    expect(await RemoteMCPServerResource.listByWorkspace(auth)).toHaveLength(0);
   });
 
   it("succeeds when creating a remote server with includeGlobal and no name conflict", async () => {

--- a/front-api/routes/w/[wId]/mcp/index.test.ts
+++ b/front-api/routes/w/[wId]/mcp/index.test.ts
@@ -312,6 +312,7 @@ describe("POST /api/w/:wId/mcp/ — name conflict", () => {
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.error.message).toContain(candidateName);
+    expect(body.nameConflict).toEqual({ name: candidateName });
 
     vi.mocked(fetchRemoteServerMetaDataByURL).mockResolvedValueOnce(
       new Ok({
@@ -397,7 +398,9 @@ describe("POST /api/w/:wId/mcp/ — name conflict", () => {
     });
 
     expect(response.status).toBe(400);
-    expect((await response.json()).error.message).toContain(existingName);
+    const body = await response.json();
+    expect(body.error.message).toContain(existingName);
+    expect(body.nameConflict).toEqual({ name: existingName });
   });
 
   it("rejects custom view names longer than the database column", async () => {

--- a/front-api/routes/w/[wId]/mcp/index.test.ts
+++ b/front-api/routes/w/[wId]/mcp/index.test.ts
@@ -257,7 +257,7 @@ describe("POST /api/w/:wId/mcp/ — creation", () => {
 });
 
 describe("POST /api/w/:wId/mcp/ — name conflict", () => {
-  it("returns 400 when distinct names generate the same cropped tool name", async () => {
+  it("allows a custom view name to resolve a cropped tool name conflict", async () => {
     const { workspace, auth } = await setup();
     const sharedPrefix = "a".repeat(80);
     const existingName = `${sharedPrefix}-existing`;
@@ -311,6 +311,47 @@ describe("POST /api/w/:wId/mcp/ — name conflict", () => {
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.error.message).toContain(candidateName);
+
+    vi.mocked(fetchRemoteServerMetaDataByURL).mockResolvedValueOnce(
+      new Ok({
+        name: candidateName,
+        version: DEFAULT_MCP_ACTION_VERSION,
+        description: "Test description",
+        icon: DEFAULT_MCP_SERVER_ICON,
+        authorization: null,
+        tools,
+        availability: "manual",
+        allowMultipleInstances: true,
+        documentationUrl: null,
+      })
+    );
+
+    const customName = "custom-view-name";
+    const retryResponse = await postMcp(workspace, {
+      serverType: "remote",
+      url: "https://new-server.example.com",
+      includeGlobal: true,
+      viewName: customName,
+    });
+
+    expect(retryResponse.status).toBe(201);
+    const retryBody = await retryResponse.json();
+    expect(retryBody.server.name).toBe(candidateName);
+    const createdSystemView =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        auth,
+        retryBody.server.sId
+      );
+    expect(createdSystemView?.name).toBe(customName);
+
+    const globalViews = await MCPServerViewResource.listBySpace(
+      auth,
+      globalSpace
+    );
+    expect(
+      globalViews.find((view) => view.mcpServerId === retryBody.server.sId)
+        ?.name
+    ).toBe(customName);
   });
 
   it("succeeds when creating a remote server with includeGlobal and no name conflict", async () => {

--- a/front-api/routes/w/[wId]/mcp/index.ts
+++ b/front-api/routes/w/[wId]/mcp/index.ts
@@ -3,6 +3,7 @@ import type { GetMCPServersResponseBody } from "@app/lib/api/mcp";
 import {
   createInternalMCPServer,
   createRemoteMCPServer,
+  isMCPServerViewNameConflictError,
   listMCPServersWithViews,
 } from "@app/lib/api/mcp/servers";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -79,6 +80,18 @@ app.post("/", validate("json", PostBodySchema), async (ctx) => {
 
   if (result.isErr()) {
     const message = result.error.message;
+    if (
+      body.serverType === "remote" &&
+      isMCPServerViewNameConflictError(result.error)
+    ) {
+      return ctx.json(
+        {
+          error: { type: "invalid_request_error", message },
+          nameConflict: { name: result.error.viewName },
+        },
+        400
+      );
+    }
     if (isRemoteMCPServerError(result.error)) {
       // Non-standard envelope: callers rely on the `isRemoteServerError` flag.
       return ctx.json(

--- a/front-api/routes/w/[wId]/mcp/index.ts
+++ b/front-api/routes/w/[wId]/mcp/index.ts
@@ -3,7 +3,6 @@ import type { GetMCPServersResponseBody } from "@app/lib/api/mcp";
 import {
   createInternalMCPServer,
   createRemoteMCPServer,
-  isMCPServerViewNameConflictError,
   listMCPServersWithViews,
 } from "@app/lib/api/mcp/servers";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -79,19 +78,21 @@ app.post("/", validate("json", PostBodySchema), async (ctx) => {
       : await createInternalMCPServer(auth, body);
 
   if (result.isErr()) {
-    const message = result.error.message;
-    if (
-      body.serverType === "remote" &&
-      isMCPServerViewNameConflictError(result.error)
-    ) {
+    if ("nameConflict" in result.error) {
+      const { nameConflict } = result.error;
       return ctx.json(
         {
-          error: { type: "invalid_request_error", message },
-          nameConflict: { name: result.error.viewName },
+          error: {
+            type: "invalid_request_error",
+            message: `An existing Tool is already using the name "${nameConflict}"`,
+          },
+          nameConflict: { name: nameConflict },
         },
         400
       );
     }
+
+    const message = result.error.message;
     if (isRemoteMCPServerError(result.error)) {
       // Non-standard envelope: callers rely on the `isRemoteServerError` flag.
       return ctx.json(

--- a/front-api/routes/w/[wId]/mcp/index.ts
+++ b/front-api/routes/w/[wId]/mcp/index.ts
@@ -1,5 +1,8 @@
 import { isRemoteMCPServerError } from "@app/lib/actions/mcp_errors";
-import type { GetMCPServersResponseBody } from "@app/lib/api/mcp";
+import {
+  type GetMCPServersResponseBody,
+  isMCPServerViewNameConflict,
+} from "@app/lib/api/mcp";
 import {
   createInternalMCPServer,
   createRemoteMCPServer,
@@ -78,7 +81,7 @@ app.post("/", validate("json", PostBodySchema), async (ctx) => {
       : await createInternalMCPServer(auth, body);
 
   if (result.isErr()) {
-    if ("nameConflict" in result.error) {
+    if (isMCPServerViewNameConflict(result.error)) {
       const { nameConflict } = result.error;
       return ctx.json(
         {

--- a/front-api/routes/w/[wId]/mcp/index.ts
+++ b/front-api/routes/w/[wId]/mcp/index.ts
@@ -42,6 +42,7 @@ const PostBodySchema = z.discriminatedUnion("serverType", [
     useCase: UseCaseSchema,
     connectionId: z.string().optional(),
     customHeaders: CustomHeadersSchema,
+    viewName: z.string().optional(),
   }),
   z.object({
     serverType: z.literal("internal"),

--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -28,10 +28,7 @@ import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/mcp_icons";
 import type { DefaultRemoteMCPServerConfig } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import { getTokenFieldLabel } from "@app/lib/actions/mcp_internal_actions/server_token_labels";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
-import {
-  MAX_MCP_SERVER_VIEW_NAME_LENGTH,
-  type MCPServerType,
-} from "@app/lib/api/mcp";
+import type { MCPServerType } from "@app/lib/api/mcp";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import {
   useCreateInternalMCPServer,
@@ -202,9 +199,6 @@ export function CreateMCPServerDialog({
       if (trimmed === nameConflict.name) {
         return "This name conflicts with an existing Tool. Enter a different name.";
       }
-    }
-    if (trimmed.length > MAX_MCP_SERVER_VIEW_NAME_LENGTH) {
-      return `Name must be ${MAX_MCP_SERVER_VIEW_NAME_LENGTH} characters or fewer.`;
     }
     if (trimmed.length > 0 && existingViewNames.includes(trimmed)) {
       return "This name is already in use.";

--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -28,7 +28,10 @@ import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/mcp_icons";
 import type { DefaultRemoteMCPServerConfig } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import { getTokenFieldLabel } from "@app/lib/actions/mcp_internal_actions/server_token_labels";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
-import type { MCPServerType } from "@app/lib/api/mcp";
+import {
+  MAX_MCP_SERVER_VIEW_NAME_LENGTH,
+  type MCPServerType,
+} from "@app/lib/api/mcp";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import {
   useCreateInternalMCPServer,
@@ -76,10 +79,14 @@ function generateUniqueViewName(
 function getSubmitButtonLabel(
   isLoading: boolean,
   authorization: AuthorizationInfo | null,
-  defaultServerConfig?: DefaultRemoteMCPServerConfig
+  defaultServerConfig: DefaultRemoteMCPServerConfig | undefined,
+  oauthConnectionId: string | null
 ): string {
   if (isLoading) {
     return "Loading...";
+  }
+  if (oauthConnectionId) {
+    return "Save";
   }
   if (authorization) {
     return "Setup connection";
@@ -140,7 +147,7 @@ export function CreateMCPServerDialog({
   const defaultValues = useMemo<CreateMCPServerDialogFormValues>(() => {
     return {
       ...getCreateMCPServerDialogDefaultValues(defaultServerConfig),
-      viewName: suggestedViewName,
+      viewName: suggestedViewName ?? "",
       // Pre-fill headers and store their keys so the form can lock them as non-removable.
       ...(predefinedHeaders && {
         useCustomHeaders: true,
@@ -177,17 +184,36 @@ export function CreateMCPServerDialog({
     name: "selectedScopes",
   });
 
+  const [remoteMCPServerViewNameConflict, setRemoteMCPServerViewNameConflict] =
+    useState<string | null>(null);
+
   // Client-side validation for the view name field.
   const viewNameError = useMemo(() => {
     const trimmed = (viewName ?? "").trim();
-    if (needsCustomName && trimmed.length === 0) {
+    if (needsCustomName && !trimmed) {
       return "Name is required.";
+    }
+    if (remoteMCPServerViewNameConflict) {
+      if (!trimmed) {
+        return `The default name "${remoteMCPServerViewNameConflict}" conflicts with an existing Tool. Enter a different name.`;
+      }
+      if (trimmed === remoteMCPServerViewNameConflict) {
+        return "This name conflicts with an existing Tool. Enter a different name.";
+      }
+    }
+    if (trimmed.length > MAX_MCP_SERVER_VIEW_NAME_LENGTH) {
+      return `Name must be ${MAX_MCP_SERVER_VIEW_NAME_LENGTH} characters or fewer.`;
     }
     if (trimmed.length > 0 && existingViewNames.includes(trimmed)) {
       return "This name is already in use.";
     }
     return null;
-  }, [needsCustomName, viewName, existingViewNames]);
+  }, [
+    needsCustomName,
+    remoteMCPServerViewNameConflict,
+    viewName,
+    existingViewNames,
+  ]);
 
   const [isLoading, setIsLoading] = useState(false);
   const [serverError, setServerError] = useState<{
@@ -206,6 +232,10 @@ export function CreateMCPServerDialog({
     remoteMCPServerOAuthDiscoveryDone,
     setRemoteMCPServerOAuthDiscoveryDone,
   ] = useState(false);
+  const [
+    remoteMCPServerOAuthConnectionId,
+    setRemoteMCPServerOAuthConnectionId,
+  ] = useState<string | null>(null);
 
   const { discoverOAuthMetadata } = useDiscoverOAuthMetadata(owner);
   const { createWithURL } = useCreateRemoteMCPServer(owner);
@@ -264,6 +294,8 @@ export function CreateMCPServerDialog({
     // Reset workflow state (useState).
     setAuthorization(null);
     setRemoteMCPServerOAuthDiscoveryDone(false);
+    setRemoteMCPServerOAuthConnectionId(null);
+    setRemoteMCPServerViewNameConflict(null);
     setIsStaticFormValid(false);
     setServerError(null);
     // Reset form state.
@@ -287,6 +319,7 @@ export function CreateMCPServerDialog({
       // Pass workflow state as separate params (not from form).
       authorization,
       remoteMCPServerOAuthDiscoveryDone,
+      remoteMCPServerOAuthConnectionId,
       discoverOAuthMetadata,
       createWithURL,
       createInternalMCPServer,
@@ -297,16 +330,22 @@ export function CreateMCPServerDialog({
     if (submitRes.isErr()) {
       const err = submitRes.error;
       if (isCreateServerError(err)) {
-        setServerError({
-          message: err.message,
-          domain: new URL(values.remoteServerUrl).hostname,
-          isRemoteServerError: err.isRemoteServerError,
-        });
         setIsLoading(false);
         setExternalIsLoading(false);
         setRemoteMCPServerOAuthDiscoveryDone(
           err.remoteMCPServerOAuthDiscoveryDone
         );
+        if (err.nameConflict) {
+          setRemoteMCPServerViewNameConflict(err.nameConflict);
+          setRemoteMCPServerOAuthConnectionId(err.oauthConnectionId);
+          setServerError(null);
+          return;
+        }
+        setServerError({
+          message: err.message,
+          domain: new URL(values.remoteServerUrl).hostname,
+          isRemoteServerError: err.isRemoteServerError,
+        });
         return;
       }
       handleCreateMCPServerDialogSubmitError({
@@ -550,7 +589,7 @@ export function CreateMCPServerDialog({
                   {serverError.message}
                 </ContentMessage>
               )}
-              {(needsCustomName || !internalMCPServer) && (
+              {(needsCustomName || remoteMCPServerViewNameConflict) && (
                 <div className="space-y-2">
                   <Label htmlFor="viewName">Tool name</Label>
                   <Input
@@ -558,7 +597,7 @@ export function CreateMCPServerDialog({
                     placeholder={
                       needsCustomName
                         ? "Enter a name for this instance"
-                        : "Enter a custom name"
+                        : "Enter a different name"
                     }
                     {...form.register("viewName")}
                     isError={!!viewNameError}
@@ -566,7 +605,7 @@ export function CreateMCPServerDialog({
                       viewNameError ??
                       (needsCustomName
                         ? `${toolName} is already installed. This name tells them apart.`
-                        : "Optional. Defaults to the name provided by the MCP server.")
+                        : "Choose a name that distinguishes this Tool.")
                     }
                     messageStatus={viewNameError ? "error" : "info"}
                   />
@@ -629,7 +668,8 @@ export function CreateMCPServerDialog({
                 : getSubmitButtonLabel(
                     isLoading,
                     authorization,
-                    defaultServerConfig
+                    defaultServerConfig,
+                    remoteMCPServerOAuthConnectionId
                   ),
               variant: "primary",
               disabled: isSubmitDisabled,

--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -178,14 +178,11 @@ export function CreateMCPServerDialog({
 
   // Client-side validation for the view name field.
   const viewNameError = useMemo(() => {
-    if (!needsCustomName) {
-      return null;
-    }
     const trimmed = (viewName ?? "").trim();
-    if (trimmed.length === 0) {
+    if (needsCustomName && trimmed.length === 0) {
       return "Name is required.";
     }
-    if (existingViewNames.includes(trimmed)) {
+    if (trimmed.length > 0 && existingViewNames.includes(trimmed)) {
       return "This name is already in use.";
     }
     return null;
@@ -552,16 +549,22 @@ export function CreateMCPServerDialog({
                   {serverError.message}
                 </ContentMessage>
               )}
-              {needsCustomName && (
+              {(needsCustomName || !internalMCPServer) && (
                 <div className="space-y-4">
                   <div className="heading-lg text-foreground">Tool name</div>
                   <Input
-                    placeholder="Enter a name for this instance"
+                    placeholder={
+                      needsCustomName
+                        ? "Enter a name for this instance"
+                        : "Enter a custom name"
+                    }
                     {...form.register("viewName")}
                     isError={!!viewNameError}
                     message={
                       viewNameError ??
-                      `${toolName} is already installed. This name tells them apart.`
+                      (needsCustomName
+                        ? `${toolName} is already installed. This name tells them apart.`
+                        : "Optional. Defaults to the name provided by the MCP server.")
                     }
                     messageStatus={viewNameError ? "error" : "info"}
                   />

--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -184,8 +184,10 @@ export function CreateMCPServerDialog({
     name: "selectedScopes",
   });
 
-  const [remoteMCPServerViewNameConflict, setRemoteMCPServerViewNameConflict] =
-    useState<string | null>(null);
+  const [nameConflict, setNameConflict] = useState<{
+    name: string;
+    oauthConnectionId: string | null;
+  } | null>(null);
 
   // Client-side validation for the view name field.
   const viewNameError = useMemo(() => {
@@ -193,11 +195,11 @@ export function CreateMCPServerDialog({
     if (needsCustomName && !trimmed) {
       return "Name is required.";
     }
-    if (remoteMCPServerViewNameConflict) {
+    if (nameConflict) {
       if (!trimmed) {
-        return `The default name "${remoteMCPServerViewNameConflict}" conflicts with an existing Tool. Enter a different name.`;
+        return `The default name "${nameConflict.name}" conflicts with an existing Tool. Enter a different name.`;
       }
-      if (trimmed === remoteMCPServerViewNameConflict) {
+      if (trimmed === nameConflict.name) {
         return "This name conflicts with an existing Tool. Enter a different name.";
       }
     }
@@ -208,12 +210,7 @@ export function CreateMCPServerDialog({
       return "This name is already in use.";
     }
     return null;
-  }, [
-    needsCustomName,
-    remoteMCPServerViewNameConflict,
-    viewName,
-    existingViewNames,
-  ]);
+  }, [needsCustomName, nameConflict, viewName, existingViewNames]);
 
   const [isLoading, setIsLoading] = useState(false);
   const [serverError, setServerError] = useState<{
@@ -232,11 +229,6 @@ export function CreateMCPServerDialog({
     remoteMCPServerOAuthDiscoveryDone,
     setRemoteMCPServerOAuthDiscoveryDone,
   ] = useState(false);
-  const [
-    remoteMCPServerOAuthConnectionId,
-    setRemoteMCPServerOAuthConnectionId,
-  ] = useState<string | null>(null);
-
   const { discoverOAuthMetadata } = useDiscoverOAuthMetadata(owner);
   const { createWithURL } = useCreateRemoteMCPServer(owner);
   const { createInternalMCPServer } = useCreateInternalMCPServer(owner);
@@ -294,8 +286,7 @@ export function CreateMCPServerDialog({
     // Reset workflow state (useState).
     setAuthorization(null);
     setRemoteMCPServerOAuthDiscoveryDone(false);
-    setRemoteMCPServerOAuthConnectionId(null);
-    setRemoteMCPServerViewNameConflict(null);
+    setNameConflict(null);
     setIsStaticFormValid(false);
     setServerError(null);
     // Reset form state.
@@ -319,7 +310,7 @@ export function CreateMCPServerDialog({
       // Pass workflow state as separate params (not from form).
       authorization,
       remoteMCPServerOAuthDiscoveryDone,
-      remoteMCPServerOAuthConnectionId,
+      oauthConnectionId: nameConflict?.oauthConnectionId ?? null,
       discoverOAuthMetadata,
       createWithURL,
       createInternalMCPServer,
@@ -335,12 +326,6 @@ export function CreateMCPServerDialog({
         setRemoteMCPServerOAuthDiscoveryDone(
           err.remoteMCPServerOAuthDiscoveryDone
         );
-        if (err.nameConflict) {
-          setRemoteMCPServerViewNameConflict(err.nameConflict);
-          setRemoteMCPServerOAuthConnectionId(err.oauthConnectionId);
-          setServerError(null);
-          return;
-        }
         setServerError({
           message: err.message,
           domain: new URL(values.remoteServerUrl).hostname,
@@ -374,6 +359,16 @@ export function CreateMCPServerDialog({
       setAuthorization(submitRes.value.authorization);
       form.setValue("authCredentials", submitRes.value.authCredentials);
       // Returning here as now the user must select the use case.
+      setIsLoading(false);
+      return;
+    }
+
+    if (submitRes.value.type === "name_conflict") {
+      setNameConflict({
+        name: submitRes.value.name,
+        oauthConnectionId: submitRes.value.oauthConnectionId,
+      });
+      setExternalIsLoading(false);
       setIsLoading(false);
       return;
     }
@@ -589,7 +584,7 @@ export function CreateMCPServerDialog({
                   {serverError.message}
                 </ContentMessage>
               )}
-              {(needsCustomName || remoteMCPServerViewNameConflict) && (
+              {(needsCustomName || nameConflict) && (
                 <div className="space-y-2">
                   <Label htmlFor="viewName">Tool name</Label>
                   <Input
@@ -669,7 +664,7 @@ export function CreateMCPServerDialog({
                     isLoading,
                     authorization,
                     defaultServerConfig,
-                    remoteMCPServerOAuthConnectionId
+                    nameConflict?.oauthConnectionId ?? null
                   ),
               variant: "primary",
               disabled: isSubmitDisabled,

--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -49,6 +49,7 @@ import {
   DialogHeader,
   DialogTitle,
   Input,
+  Label,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -550,9 +551,10 @@ export function CreateMCPServerDialog({
                 </ContentMessage>
               )}
               {(needsCustomName || !internalMCPServer) && (
-                <div className="space-y-4">
-                  <div className="heading-lg text-foreground">Tool name</div>
+                <div className="space-y-2">
+                  <Label htmlFor="viewName">Tool name</Label>
                   <Input
+                    id="viewName"
                     placeholder={
                       needsCustomName
                         ? "Enter a name for this instance"

--- a/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.test.ts
+++ b/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.test.ts
@@ -1,0 +1,130 @@
+import {
+  CreateMCPServerDialogSubmitError,
+  submitCreateMCPServerDialogForm,
+} from "@app/components/actions/mcp/forms/submitCreateMCPServerDialogForm";
+import type { CreateMCPServerDialogFormValues } from "@app/components/actions/mcp/forms/types";
+import {
+  DEFAULT_MCP_ACTION_VERSION,
+  DEFAULT_MCP_SERVER_ICON,
+} from "@app/lib/actions/constants";
+import type { MCPServerType } from "@app/lib/api/mcp";
+import { MCPCreateServerError } from "@app/lib/swr/mcp_servers";
+import { setupOAuthConnection } from "@app/types/oauth/client/setup";
+import { Err, Ok } from "@app/types/shared/result";
+import type { WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@app/types/oauth/client/setup"), () => ({
+  setupOAuthConnection: vi.fn(),
+}));
+
+const owner = {
+  id: 0,
+  sId: "wId",
+  name: "Workspace",
+  role: "admin",
+  segmentation: null,
+  whiteListedProviders: null,
+  defaultEmbeddingProvider: null,
+  metadata: null,
+  metronomeCustomerId: null,
+  sharingPolicy: "all_scopes",
+  regionalModelsOnly: false,
+} satisfies WorkspaceType;
+
+const server = {
+  name: "Candidate",
+  version: DEFAULT_MCP_ACTION_VERSION,
+  description: "",
+  sId: "remote-id",
+  icon: DEFAULT_MCP_SERVER_ICON,
+  authorization: null,
+  tools: [],
+  availability: "manual",
+  allowMultipleInstances: true,
+  documentationUrl: null,
+} satisfies MCPServerType;
+
+const values = {
+  useCase: "platform_actions",
+  authCredentials: null,
+  remoteServerUrl: "https://example.com/mcp",
+  authMethod: "oauth-dynamic",
+  useCustomHeaders: false,
+  customHeaders: [],
+  viewName: "",
+} satisfies CreateMCPServerDialogFormValues;
+
+describe("submitCreateMCPServerDialogForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reuses the OAuth connection when retrying a view name conflict", async () => {
+    vi.mocked(setupOAuthConnection).mockResolvedValue(
+      new Ok({
+        connection_id: "connection-id",
+        created: 0,
+        metadata: {},
+        provider: "mcp",
+        status: "finalized",
+      })
+    );
+
+    const createWithURL = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Err(new MCPCreateServerError("Name conflict", false, "Candidate"))
+      )
+      .mockResolvedValueOnce(new Ok({ success: true, server }));
+
+    const submit = (
+      submittedValues: CreateMCPServerDialogFormValues,
+      remoteMCPServerOAuthConnectionId: string | null
+    ) =>
+      submitCreateMCPServerDialogForm({
+        owner,
+        values: submittedValues,
+        authorization: {
+          provider: "mcp",
+          supported_use_cases: ["platform_actions", "personal_actions"],
+        },
+        remoteMCPServerOAuthDiscoveryDone: true,
+        remoteMCPServerOAuthConnectionId,
+        discoverOAuthMetadata: vi.fn(),
+        createWithURL,
+        createInternalMCPServer: vi.fn(),
+        onBeforeCreateServer: vi.fn(),
+        regionInfo: null,
+      });
+
+    const firstResult = await submit(values, null);
+    expect(firstResult.isErr()).toBe(true);
+    if (
+      firstResult.isOk() ||
+      !(firstResult.error instanceof CreateMCPServerDialogSubmitError)
+    ) {
+      throw new Error("Expected a create server error");
+    }
+    expect(firstResult.error.nameConflict).toBe("Candidate");
+    expect(firstResult.error.oauthConnectionId).toBe("connection-id");
+
+    const retryResult = await submit(
+      { ...values, viewName: "Custom name" },
+      firstResult.error.oauthConnectionId
+    );
+
+    expect(retryResult.isOk()).toBe(true);
+    expect(setupOAuthConnection).toHaveBeenCalledTimes(1);
+    expect(createWithURL).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        viewName: "Custom name",
+        oauthConnection: {
+          connectionId: "connection-id",
+          useCase: "platform_actions",
+        },
+      })
+    );
+  });
+});

--- a/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.test.ts
+++ b/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.test.ts
@@ -1,14 +1,10 @@
-import {
-  CreateMCPServerDialogSubmitError,
-  submitCreateMCPServerDialogForm,
-} from "@app/components/actions/mcp/forms/submitCreateMCPServerDialogForm";
+import { submitCreateMCPServerDialogForm } from "@app/components/actions/mcp/forms/submitCreateMCPServerDialogForm";
 import type { CreateMCPServerDialogFormValues } from "@app/components/actions/mcp/forms/types";
 import {
   DEFAULT_MCP_ACTION_VERSION,
   DEFAULT_MCP_SERVER_ICON,
 } from "@app/lib/actions/constants";
 import type { MCPServerType } from "@app/lib/api/mcp";
-import { MCPCreateServerError } from "@app/lib/swr/mcp_servers";
 import { setupOAuthConnection } from "@app/types/oauth/client/setup";
 import { Err, Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
@@ -73,14 +69,12 @@ describe("submitCreateMCPServerDialogForm", () => {
 
     const createWithURL = vi
       .fn()
-      .mockResolvedValueOnce(
-        new Err(new MCPCreateServerError("Name conflict", false, "Candidate"))
-      )
+      .mockResolvedValueOnce(new Err({ nameConflict: "Candidate" }))
       .mockResolvedValueOnce(new Ok({ success: true, server }));
 
     const submit = (
       submittedValues: CreateMCPServerDialogFormValues,
-      remoteMCPServerOAuthConnectionId: string | null
+      oauthConnectionId: string | null
     ) =>
       submitCreateMCPServerDialogForm({
         owner,
@@ -90,7 +84,7 @@ describe("submitCreateMCPServerDialogForm", () => {
           supported_use_cases: ["platform_actions", "personal_actions"],
         },
         remoteMCPServerOAuthDiscoveryDone: true,
-        remoteMCPServerOAuthConnectionId,
+        oauthConnectionId,
         discoverOAuthMetadata: vi.fn(),
         createWithURL,
         createInternalMCPServer: vi.fn(),
@@ -99,19 +93,16 @@ describe("submitCreateMCPServerDialogForm", () => {
       });
 
     const firstResult = await submit(values, null);
-    expect(firstResult.isErr()).toBe(true);
-    if (
-      firstResult.isOk() ||
-      !(firstResult.error instanceof CreateMCPServerDialogSubmitError)
-    ) {
-      throw new Error("Expected a create server error");
+    expect(firstResult.isOk()).toBe(true);
+    if (firstResult.isErr() || firstResult.value.type !== "name_conflict") {
+      throw new Error("Expected a name conflict");
     }
-    expect(firstResult.error.nameConflict).toBe("Candidate");
-    expect(firstResult.error.oauthConnectionId).toBe("connection-id");
+    expect(firstResult.value.name).toBe("Candidate");
+    expect(firstResult.value.oauthConnectionId).toBe("connection-id");
 
     const retryResult = await submit(
       { ...values, viewName: "Custom name" },
-      firstResult.error.oauthConnectionId
+      firstResult.value.oauthConnectionId
     );
 
     expect(retryResult.isOk()).toBe(true);

--- a/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
+++ b/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
@@ -1,10 +1,11 @@
 import type { CreateMCPServerDialogFormValues } from "@app/components/actions/mcp/forms/types";
 import { requiresBearerTokenConfiguration } from "@app/lib/actions/mcp_helper";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
-import type {
-  CreateMCPServerResponseBody,
-  MCPServerType,
-  MCPServerViewNameConflict,
+import {
+  type CreateMCPServerResponseBody,
+  isMCPServerViewNameConflict,
+  type MCPServerType,
+  type MCPServerViewNameConflict,
 } from "@app/lib/api/mcp";
 import {
   isMCPCreateServerError,
@@ -330,7 +331,7 @@ export async function submitCreateMCPServerDialogForm({
 
     if (createRes.isErr()) {
       const err = createRes.error;
-      if ("nameConflict" in err) {
+      if (isMCPServerViewNameConflict(err)) {
         return new Ok({
           type: "name_conflict",
           name: err.nameConflict,

--- a/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
+++ b/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
@@ -81,6 +81,7 @@ type CreateRemoteMCPServerFn = (args: {
   sharedSecret?: string;
   oauthConnection?: MCPConnectionType;
   customHeaders?: { key: string; value: string }[];
+  viewName?: string;
 }) => Promise<Result<CreateMCPServerResponseBody, Error>>;
 
 type CreateInternalMCPServerFn = (
@@ -295,10 +296,12 @@ export async function submitCreateMCPServerDialogForm({
   }
 
   if (values.remoteServerUrl) {
+    const viewName = values.viewName?.trim();
     const createRes = await createWithURL({
       url: values.remoteServerUrl,
       defaultServerId,
       includeGlobal: true,
+      ...(viewName ? { viewName } : {}),
       sharedSecret:
         values.authMethod === "bearer" ? values.sharedSecret : undefined,
       oauthConnection,

--- a/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
+++ b/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
@@ -41,22 +41,30 @@ export class CreateMCPServerDialogSubmitError extends Error {
   readonly kind: CreateMCPServerDialogSubmitErrorKind;
   readonly remoteMCPServerOAuthDiscoveryDone: boolean;
   readonly isRemoteServerError: boolean;
+  readonly nameConflict: string | null;
+  readonly oauthConnectionId: string | null;
 
   constructor({
     kind,
     message,
     remoteMCPServerOAuthDiscoveryDone,
     isRemoteServerError = false,
+    nameConflict = null,
+    oauthConnectionId = null,
   }: {
     kind: CreateMCPServerDialogSubmitErrorKind;
     message: string;
     remoteMCPServerOAuthDiscoveryDone: boolean;
     isRemoteServerError?: boolean;
+    nameConflict?: string | null;
+    oauthConnectionId?: string | null;
   }) {
     super(message);
     this.kind = kind;
     this.remoteMCPServerOAuthDiscoveryDone = remoteMCPServerOAuthDiscoveryDone;
     this.isRemoteServerError = isRemoteServerError;
+    this.nameConflict = nameConflict;
+    this.oauthConnectionId = oauthConnectionId;
   }
 }
 
@@ -108,6 +116,7 @@ interface SubmitCreateMCPServerDialogFormParams {
   // These are server-derived values, not user input.
   authorization: AuthorizationInfo | null;
   remoteMCPServerOAuthDiscoveryDone: boolean;
+  remoteMCPServerOAuthConnectionId: string | null;
   discoverOAuthMetadata: DiscoverOAuthMetadataFn;
   createWithURL: CreateRemoteMCPServerFn;
   createInternalMCPServer: CreateInternalMCPServerFn;
@@ -122,6 +131,7 @@ export async function submitCreateMCPServerDialogForm({
   values,
   authorization,
   remoteMCPServerOAuthDiscoveryDone,
+  remoteMCPServerOAuthConnectionId,
   discoverOAuthMetadata,
   createWithURL,
   createInternalMCPServer,
@@ -208,33 +218,40 @@ export async function submitCreateMCPServerDialogForm({
       : authorization?.scope;
 
   if (authorization && oauthUseCase) {
-    const cRes = await setupOAuthConnection({
-      owner,
-      provider: authorization.provider,
-      // During setup, the use case is always "platform_actions".
-      useCase: "platform_actions",
-      extraConfig: {
-        ...(values.authCredentials ?? {}),
-        ...(effectiveScope ? { scope: effectiveScope } : {}),
-      },
-      regionInfo,
-    });
+    if (remoteMCPServerOAuthConnectionId) {
+      oauthConnection = {
+        useCase: oauthUseCase,
+        connectionId: remoteMCPServerOAuthConnectionId,
+      };
+    } else {
+      const cRes = await setupOAuthConnection({
+        owner,
+        provider: authorization.provider,
+        // During setup, the use case is always "platform_actions".
+        useCase: "platform_actions",
+        extraConfig: {
+          ...(values.authCredentials ?? {}),
+          ...(effectiveScope ? { scope: effectiveScope } : {}),
+        },
+        regionInfo,
+      });
 
-    if (cRes.isErr()) {
-      return new Err(
-        new CreateMCPServerDialogSubmitError({
-          kind: "oauth_connection",
-          message: cRes.error.message,
-          remoteMCPServerOAuthDiscoveryDone:
-            nextRemoteMCPServerOAuthDiscoveryDone,
-        })
-      );
+      if (cRes.isErr()) {
+        return new Err(
+          new CreateMCPServerDialogSubmitError({
+            kind: "oauth_connection",
+            message: cRes.error.message,
+            remoteMCPServerOAuthDiscoveryDone:
+              nextRemoteMCPServerOAuthDiscoveryDone,
+          })
+        );
+      }
+
+      oauthConnection = {
+        useCase: oauthUseCase,
+        connectionId: cRes.value.connection_id,
+      };
     }
-
-    oauthConnection = {
-      useCase: oauthUseCase,
-      connectionId: cRes.value.connection_id,
-    };
   }
 
   onBeforeCreateServer();
@@ -312,6 +329,7 @@ export async function submitCreateMCPServerDialogForm({
 
     if (createRes.isErr()) {
       const err = createRes.error;
+      const mcpCreateServerError = isMCPCreateServerError(err) ? err : null;
       return new Err(
         new CreateMCPServerDialogSubmitError({
           kind: "create_server",
@@ -319,7 +337,11 @@ export async function submitCreateMCPServerDialogForm({
           remoteMCPServerOAuthDiscoveryDone:
             nextRemoteMCPServerOAuthDiscoveryDone,
           isRemoteServerError:
-            isMCPCreateServerError(err) && err.isRemoteServerError,
+            mcpCreateServerError?.isRemoteServerError ?? false,
+          nameConflict: mcpCreateServerError?.nameConflict,
+          oauthConnectionId: mcpCreateServerError?.nameConflict
+            ? (oauthConnection?.connectionId ?? null)
+            : null,
         })
       );
     }

--- a/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
+++ b/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
@@ -4,6 +4,7 @@ import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction
 import type {
   CreateMCPServerResponseBody,
   MCPServerType,
+  MCPServerViewNameConflict,
 } from "@app/lib/api/mcp";
 import {
   isMCPCreateServerError,
@@ -29,6 +30,12 @@ type CreateMCPServerDialogSubmitResult =
       type: "server_created";
       server: MCPServerType;
       remoteMCPServerOAuthDiscoveryDone: boolean;
+    }
+  | {
+      type: "name_conflict";
+      name: string;
+      oauthConnectionId: string | null;
+      remoteMCPServerOAuthDiscoveryDone: boolean;
     };
 
 type CreateMCPServerDialogSubmitErrorKind =
@@ -41,30 +48,22 @@ export class CreateMCPServerDialogSubmitError extends Error {
   readonly kind: CreateMCPServerDialogSubmitErrorKind;
   readonly remoteMCPServerOAuthDiscoveryDone: boolean;
   readonly isRemoteServerError: boolean;
-  readonly nameConflict: string | null;
-  readonly oauthConnectionId: string | null;
 
   constructor({
     kind,
     message,
     remoteMCPServerOAuthDiscoveryDone,
     isRemoteServerError = false,
-    nameConflict = null,
-    oauthConnectionId = null,
   }: {
     kind: CreateMCPServerDialogSubmitErrorKind;
     message: string;
     remoteMCPServerOAuthDiscoveryDone: boolean;
     isRemoteServerError?: boolean;
-    nameConflict?: string | null;
-    oauthConnectionId?: string | null;
   }) {
     super(message);
     this.kind = kind;
     this.remoteMCPServerOAuthDiscoveryDone = remoteMCPServerOAuthDiscoveryDone;
     this.isRemoteServerError = isRemoteServerError;
-    this.nameConflict = nameConflict;
-    this.oauthConnectionId = oauthConnectionId;
   }
 }
 
@@ -90,7 +89,9 @@ type CreateRemoteMCPServerFn = (args: {
   oauthConnection?: MCPConnectionType;
   customHeaders?: { key: string; value: string }[];
   viewName?: string;
-}) => Promise<Result<CreateMCPServerResponseBody, Error>>;
+}) => Promise<
+  Result<CreateMCPServerResponseBody, Error | MCPServerViewNameConflict>
+>;
 
 type CreateInternalMCPServerFn = (
   args: {
@@ -116,7 +117,7 @@ interface SubmitCreateMCPServerDialogFormParams {
   // These are server-derived values, not user input.
   authorization: AuthorizationInfo | null;
   remoteMCPServerOAuthDiscoveryDone: boolean;
-  remoteMCPServerOAuthConnectionId: string | null;
+  oauthConnectionId: string | null;
   discoverOAuthMetadata: DiscoverOAuthMetadataFn;
   createWithURL: CreateRemoteMCPServerFn;
   createInternalMCPServer: CreateInternalMCPServerFn;
@@ -131,7 +132,7 @@ export async function submitCreateMCPServerDialogForm({
   values,
   authorization,
   remoteMCPServerOAuthDiscoveryDone,
-  remoteMCPServerOAuthConnectionId,
+  oauthConnectionId,
   discoverOAuthMetadata,
   createWithURL,
   createInternalMCPServer,
@@ -218,10 +219,10 @@ export async function submitCreateMCPServerDialogForm({
       : authorization?.scope;
 
   if (authorization && oauthUseCase) {
-    if (remoteMCPServerOAuthConnectionId) {
+    if (oauthConnectionId) {
       oauthConnection = {
         useCase: oauthUseCase,
-        connectionId: remoteMCPServerOAuthConnectionId,
+        connectionId: oauthConnectionId,
       };
     } else {
       const cRes = await setupOAuthConnection({
@@ -329,7 +330,15 @@ export async function submitCreateMCPServerDialogForm({
 
     if (createRes.isErr()) {
       const err = createRes.error;
-      const mcpCreateServerError = isMCPCreateServerError(err) ? err : null;
+      if ("nameConflict" in err) {
+        return new Ok({
+          type: "name_conflict",
+          name: err.nameConflict,
+          oauthConnectionId: oauthConnection?.connectionId ?? null,
+          remoteMCPServerOAuthDiscoveryDone:
+            nextRemoteMCPServerOAuthDiscoveryDone,
+        });
+      }
       return new Err(
         new CreateMCPServerDialogSubmitError({
           kind: "create_server",
@@ -337,11 +346,7 @@ export async function submitCreateMCPServerDialogForm({
           remoteMCPServerOAuthDiscoveryDone:
             nextRemoteMCPServerOAuthDiscoveryDone,
           isRemoteServerError:
-            mcpCreateServerError?.isRemoteServerError ?? false,
-          nameConflict: mcpCreateServerError?.nameConflict,
-          oauthConnectionId: mcpCreateServerError?.nameConflict
-            ? (oauthConnection?.connectionId ?? null)
-            : null,
+            isMCPCreateServerError(err) && err.isRemoteServerError,
         })
       );
     }

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -41,6 +41,8 @@ export type MCPToolRetryPolicyType =
 export const DEFAULT_MCP_TOOL_RETRY_POLICY =
   "no_retry" as const satisfies MCPToolRetryPolicyType;
 
+export const MAX_MCP_SERVER_VIEW_NAME_LENGTH = 255;
+
 export function getRetryPolicyFromToolConfiguration(
   toolConfiguration: MCPToolConfigurationType | LightMCPToolConfigurationType
 ): MCPToolRetryPolicyType {

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -42,6 +42,7 @@ export const DEFAULT_MCP_TOOL_RETRY_POLICY =
   "no_retry" as const satisfies MCPToolRetryPolicyType;
 
 export const MAX_MCP_SERVER_VIEW_NAME_LENGTH = 255;
+export type MCPServerViewNameConflict = { nameConflict: string };
 
 export function getRetryPolicyFromToolConfiguration(
   toolConfiguration: MCPToolConfigurationType | LightMCPToolConfigurationType

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -43,6 +43,12 @@ export const DEFAULT_MCP_TOOL_RETRY_POLICY =
 
 export type MCPServerViewNameConflict = { nameConflict: string };
 
+export function isMCPServerViewNameConflict(
+  input: Error | MCPServerViewNameConflict
+): input is MCPServerViewNameConflict {
+  return !(input instanceof Error) && typeof input.nameConflict === "string";
+}
+
 export function getRetryPolicyFromToolConfiguration(
   toolConfiguration: MCPToolConfigurationType | LightMCPToolConfigurationType
 ): MCPToolRetryPolicyType {

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -41,7 +41,6 @@ export type MCPToolRetryPolicyType =
 export const DEFAULT_MCP_TOOL_RETRY_POLICY =
   "no_retry" as const satisfies MCPToolRetryPolicyType;
 
-export const MAX_MCP_SERVER_VIEW_NAME_LENGTH = 255;
 export type MCPServerViewNameConflict = { nameConflict: string };
 
 export function getRetryPolicyFromToolConfiguration(

--- a/front/lib/api/mcp/servers.ts
+++ b/front/lib/api/mcp/servers.ts
@@ -92,14 +92,21 @@ interface CreateRemoteMCPServerInput {
   useCase?: MCPOAuthUseCase;
   connectionId?: string;
   customHeaders?: CustomHeader[];
+  viewName?: string;
 }
 
 export async function createRemoteMCPServer(
   auth: Authenticator,
   input: CreateRemoteMCPServerInput
 ): Promise<Result<MCPServerType, Error>> {
-  const { url, sharedSecret, customHeaders, connectionId, includeGlobal } =
-    input;
+  const {
+    url,
+    sharedSecret,
+    customHeaders,
+    connectionId,
+    includeGlobal,
+    viewName,
+  } = input;
 
   if (!url) {
     return new Err(new Error("URL is required"));
@@ -110,6 +117,12 @@ export async function createRemoteMCPServer(
         `MCP server URL exceeds maximum length (${MAX_URL_LENGTH} characters).`
       )
     );
+  }
+  if (viewName !== undefined) {
+    const trimmed = viewName.trim();
+    if (trimmed.length === 0 || trimmed.length > MAX_NAME_LENGTH) {
+      return new Err(new Error("viewName must be a non-empty string."));
+    }
   }
 
   // Default to the shared secret if it exists.
@@ -168,7 +181,7 @@ export async function createRemoteMCPServer(
   if (includeGlobal) {
     const conflict = await checkNameConflictInGlobalSpace(
       auth,
-      name,
+      viewName ?? name,
       metadata.tools
     );
     if (conflict.isErr()) {
@@ -193,6 +206,7 @@ export async function createRemoteMCPServer(
     customHeaders: headersArrayToRecord(customHeaders),
     authorization,
     oAuthUseCase: input.useCase ?? null,
+    viewName,
   });
 
   if (connectionId) {

--- a/front/lib/api/mcp/servers.ts
+++ b/front/lib/api/mcp/servers.ts
@@ -12,13 +12,12 @@ import { DEFAULT_REMOTE_MCP_SERVERS } from "@app/lib/actions/mcp_internal_action
 import { fetchRemoteServerMetaDataByURL } from "@app/lib/actions/mcp_metadata";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
 import { getMCPConnectionAccessToken } from "@app/lib/actions/mcp_oauth_access_token";
-import {
-  MAX_MCP_SERVER_VIEW_NAME_LENGTH,
-  type MCPServerType,
-  type MCPServerTypeWithViews,
-  type MCPServerViewNameConflict,
-  type MCPServerViewType,
-  type MCPToolType,
+import type {
+  MCPServerType,
+  MCPServerTypeWithViews,
+  MCPServerViewNameConflict,
+  MCPServerViewType,
+  MCPToolType,
 } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
@@ -35,6 +34,7 @@ import { headersArrayToRecord } from "@app/types/shared/utils/http_headers";
 
 const MAX_URL_LENGTH = 2048;
 const MAX_NAME_LENGTH = 2048;
+const MAX_VIEW_NAME_LENGTH = 255;
 
 type CustomHeader = { key: string; value: string };
 
@@ -124,11 +124,11 @@ export async function createRemoteMCPServer(
   if (viewName !== undefined) {
     if (
       !normalizedViewName ||
-      normalizedViewName.length > MAX_MCP_SERVER_VIEW_NAME_LENGTH
+      normalizedViewName.length > MAX_VIEW_NAME_LENGTH
     ) {
       return new Err(
         new Error(
-          `viewName must be a non-empty string of at most ${MAX_MCP_SERVER_VIEW_NAME_LENGTH} characters.`
+          `viewName must be a non-empty string of at most ${MAX_VIEW_NAME_LENGTH} characters.`
         )
       );
     }

--- a/front/lib/api/mcp/servers.ts
+++ b/front/lib/api/mcp/servers.ts
@@ -12,11 +12,12 @@ import { DEFAULT_REMOTE_MCP_SERVERS } from "@app/lib/actions/mcp_internal_action
 import { fetchRemoteServerMetaDataByURL } from "@app/lib/actions/mcp_metadata";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
 import { getMCPConnectionAccessToken } from "@app/lib/actions/mcp_oauth_access_token";
-import type {
-  MCPServerType,
-  MCPServerTypeWithViews,
-  MCPServerViewType,
-  MCPToolType,
+import {
+  MAX_MCP_SERVER_VIEW_NAME_LENGTH,
+  type MCPServerType,
+  type MCPServerTypeWithViews,
+  type MCPServerViewType,
+  type MCPToolType,
 } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
@@ -33,9 +34,20 @@ import { headersArrayToRecord } from "@app/types/shared/utils/http_headers";
 
 const MAX_URL_LENGTH = 2048;
 const MAX_NAME_LENGTH = 2048;
-const MAX_VIEW_NAME_LENGTH = 255;
 
 type CustomHeader = { key: string; value: string };
+
+export class MCPServerViewNameConflictError extends Error {
+  constructor(readonly viewName: string) {
+    super(`An existing Tool is already using the name "${viewName}"`);
+  }
+}
+
+export function isMCPServerViewNameConflictError(
+  error: Error
+): error is MCPServerViewNameConflictError {
+  return error instanceof MCPServerViewNameConflictError;
+}
 
 export async function listMCPServersWithViews(
   auth: Authenticator
@@ -123,11 +135,11 @@ export async function createRemoteMCPServer(
   if (viewName !== undefined) {
     if (
       !normalizedViewName ||
-      normalizedViewName.length > MAX_VIEW_NAME_LENGTH
+      normalizedViewName.length > MAX_MCP_SERVER_VIEW_NAME_LENGTH
     ) {
       return new Err(
         new Error(
-          `viewName must be a non-empty string of at most ${MAX_VIEW_NAME_LENGTH} characters.`
+          `viewName must be a non-empty string of at most ${MAX_MCP_SERVER_VIEW_NAME_LENGTH} characters.`
         )
       );
     }
@@ -401,9 +413,7 @@ async function checkNameConflictInGlobalSpace(
       tools
     );
   if (hasConflict) {
-    return new Err(
-      new Error(`An existing Tool is already using the name "${name}"`)
-    );
+    return new Err(new MCPServerViewNameConflictError(name));
   }
   return new Ok(undefined);
 }

--- a/front/lib/api/mcp/servers.ts
+++ b/front/lib/api/mcp/servers.ts
@@ -188,7 +188,7 @@ export async function createRemoteMCPServer(
   }
 
   if (includeGlobal) {
-    const nameConflict = await getNameConflictInGlobalSpace(
+    const nameConflict = await checkNameConflictInGlobalSpace(
       auth,
       normalizedViewName ?? name,
       metadata.tools
@@ -308,7 +308,7 @@ export async function createInternalMCPServer(
   // otherwise fall back to the internal server name.
   const nameForConflictCheck = viewName ?? name;
   if (includeGlobal) {
-    const nameConflict = await getNameConflictInGlobalSpace(
+    const nameConflict = await checkNameConflictInGlobalSpace(
       auth,
       nameForConflictCheck,
       getInternalMCPServerMetadata(name).tools
@@ -392,7 +392,7 @@ export async function createInternalMCPServer(
   return new Ok(newInternalMCPServer.toJSON());
 }
 
-async function getNameConflictInGlobalSpace(
+async function checkNameConflictInGlobalSpace(
   auth: Authenticator,
   name: string,
   tools: readonly MCPToolType[]

--- a/front/lib/api/mcp/servers.ts
+++ b/front/lib/api/mcp/servers.ts
@@ -16,6 +16,7 @@ import {
   MAX_MCP_SERVER_VIEW_NAME_LENGTH,
   type MCPServerType,
   type MCPServerTypeWithViews,
+  type MCPServerViewNameConflict,
   type MCPServerViewType,
   type MCPToolType,
 } from "@app/lib/api/mcp";
@@ -36,18 +37,6 @@ const MAX_URL_LENGTH = 2048;
 const MAX_NAME_LENGTH = 2048;
 
 type CustomHeader = { key: string; value: string };
-
-export class MCPServerViewNameConflictError extends Error {
-  constructor(readonly viewName: string) {
-    super(`An existing Tool is already using the name "${viewName}"`);
-  }
-}
-
-export function isMCPServerViewNameConflictError(
-  error: Error
-): error is MCPServerViewNameConflictError {
-  return error instanceof MCPServerViewNameConflictError;
-}
 
 export async function listMCPServersWithViews(
   auth: Authenticator
@@ -111,7 +100,7 @@ interface CreateRemoteMCPServerInput {
 export async function createRemoteMCPServer(
   auth: Authenticator,
   input: CreateRemoteMCPServerInput
-): Promise<Result<MCPServerType, Error>> {
+): Promise<Result<MCPServerType, Error | MCPServerViewNameConflict>> {
   const {
     url,
     sharedSecret,
@@ -199,13 +188,13 @@ export async function createRemoteMCPServer(
   }
 
   if (includeGlobal) {
-    const conflict = await checkNameConflictInGlobalSpace(
+    const nameConflict = await getNameConflictInGlobalSpace(
       auth,
       normalizedViewName ?? name,
       metadata.tools
     );
-    if (conflict.isErr()) {
-      return conflict;
+    if (nameConflict) {
+      return new Err({ nameConflict });
     }
   }
 
@@ -319,13 +308,17 @@ export async function createInternalMCPServer(
   // otherwise fall back to the internal server name.
   const nameForConflictCheck = viewName ?? name;
   if (includeGlobal) {
-    const conflict = await checkNameConflictInGlobalSpace(
+    const nameConflict = await getNameConflictInGlobalSpace(
       auth,
       nameForConflictCheck,
       getInternalMCPServerMetadata(name).tools
     );
-    if (conflict.isErr()) {
-      return conflict;
+    if (nameConflict) {
+      return new Err(
+        new Error(
+          `An existing Tool is already using the name "${nameConflict}"`
+        )
+      );
     }
   }
 
@@ -399,11 +392,11 @@ export async function createInternalMCPServer(
   return new Ok(newInternalMCPServer.toJSON());
 }
 
-async function checkNameConflictInGlobalSpace(
+async function getNameConflictInGlobalSpace(
   auth: Authenticator,
   name: string,
   tools: readonly MCPToolType[]
-): Promise<Result<void, Error>> {
+): Promise<string | null> {
   const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
   const { hasConflict } =
     await MCPServerViewResource.hasNameConflictInSpaceByName(
@@ -412,10 +405,7 @@ async function checkNameConflictInGlobalSpace(
       globalSpace,
       tools
     );
-  if (hasConflict) {
-    return new Err(new MCPServerViewNameConflictError(name));
-  }
-  return new Ok(undefined);
+  return hasConflict ? name : null;
 }
 
 async function createGlobalSpaceView(

--- a/front/lib/api/mcp/servers.ts
+++ b/front/lib/api/mcp/servers.ts
@@ -33,6 +33,7 @@ import { headersArrayToRecord } from "@app/types/shared/utils/http_headers";
 
 const MAX_URL_LENGTH = 2048;
 const MAX_NAME_LENGTH = 2048;
+const MAX_VIEW_NAME_LENGTH = 255;
 
 type CustomHeader = { key: string; value: string };
 
@@ -107,6 +108,7 @@ export async function createRemoteMCPServer(
     includeGlobal,
     viewName,
   } = input;
+  const normalizedViewName = viewName?.trim();
 
   if (!url) {
     return new Err(new Error("URL is required"));
@@ -119,9 +121,15 @@ export async function createRemoteMCPServer(
     );
   }
   if (viewName !== undefined) {
-    const trimmed = viewName.trim();
-    if (trimmed.length === 0 || trimmed.length > MAX_NAME_LENGTH) {
-      return new Err(new Error("viewName must be a non-empty string."));
+    if (
+      !normalizedViewName ||
+      normalizedViewName.length > MAX_VIEW_NAME_LENGTH
+    ) {
+      return new Err(
+        new Error(
+          `viewName must be a non-empty string of at most ${MAX_VIEW_NAME_LENGTH} characters.`
+        )
+      );
     }
   }
 
@@ -181,7 +189,7 @@ export async function createRemoteMCPServer(
   if (includeGlobal) {
     const conflict = await checkNameConflictInGlobalSpace(
       auth,
-      viewName ?? name,
+      normalizedViewName ?? name,
       metadata.tools
     );
     if (conflict.isErr()) {
@@ -206,7 +214,7 @@ export async function createRemoteMCPServer(
     customHeaders: headersArrayToRecord(customHeaders),
     authorization,
     oAuthUseCase: input.useCase ?? null,
-    viewName,
+    viewName: normalizedViewName,
   });
 
   if (connectionId) {

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -228,6 +228,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       | "cachedToolsRequireConfiguration"
     > & {
       oAuthUseCase: MCPOAuthUseCase | null;
+      viewName?: string;
     },
     transaction?: Transaction
   ) {
@@ -238,13 +239,14 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       "The user is not authorized to create a remote MCP server"
     );
 
+    const { oAuthUseCase, viewName, ...serverBlob } = blob;
     const serverData: CreationAttributes<RemoteMCPServerModel> = {
-      ...blob,
-      sharedSecret: blob.sharedSecret,
+      ...serverBlob,
+      sharedSecret: serverBlob.sharedSecret,
       lastSyncAt: new Date(),
-      authorization: blob.authorization,
+      authorization: serverBlob.authorization,
       cachedToolsRequireConfiguration: mcpToolsRequireConfiguration(
-        blob.cachedTools
+        serverBlob.cachedTools
       ),
     };
 
@@ -263,8 +265,9 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
         vaultId: systemSpace.id,
         editedAt: new Date(),
         editedByUserId: auth.user()?.id,
-        oAuthUseCase: blob.oAuthUseCase,
+        oAuthUseCase,
         isRestrictedToSkills: false,
+        ...(viewName ? { name: viewName } : {}),
       },
       {
         transaction,

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -364,13 +364,25 @@ export function useDiscoverOAuthMetadata(owner: LightWorkspaceType) {
   return { discoverOAuthMetadata };
 }
 
-class MCPCreateServerError extends Error {
+export class MCPCreateServerError extends Error {
   readonly isRemoteServerError: boolean;
-  constructor(message: string, isRemoteServerError: boolean) {
+  readonly nameConflict: string | null;
+  constructor(
+    message: string,
+    isRemoteServerError: boolean,
+    nameConflict: string | null
+  ) {
     super(message);
     this.isRemoteServerError = isRemoteServerError;
+    this.nameConflict = nameConflict;
   }
 }
+
+type MCPCreateServerErrorResponse = {
+  error?: { message?: string };
+  isRemoteServerError?: boolean;
+  nameConflict?: { name: string };
+};
 
 export function isMCPCreateServerError(
   error: Error
@@ -433,12 +445,13 @@ export function useCreateRemoteMCPServer(owner: LightWorkspaceType) {
       });
 
       if (!response.ok) {
-        const body = await response.json();
+        const body: MCPCreateServerErrorResponse = await response.json();
         return new Err(
           new MCPCreateServerError(
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             body.error?.message || "Failed to create server",
-            body.isRemoteServerError === true
+            body.isRemoteServerError === true,
+            body.nameConflict?.name ?? null
           )
         );
       }

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -398,6 +398,7 @@ export function useCreateRemoteMCPServer(owner: LightWorkspaceType) {
       sharedSecret,
       oauthConnection,
       customHeaders,
+      viewName,
     }: {
       url: string;
       defaultServerId?: number;
@@ -405,6 +406,7 @@ export function useCreateRemoteMCPServer(owner: LightWorkspaceType) {
       sharedSecret?: string;
       oauthConnection?: MCPConnectionType;
       customHeaders?: { key: string; value: string }[];
+      viewName?: string;
     }): Promise<Result<CreateMCPServerResponseBody, Error>> => {
       const body: any = { url, serverType: "remote", includeGlobal };
       if (defaultServerId !== undefined) {
@@ -420,6 +422,9 @@ export function useCreateRemoteMCPServer(owner: LightWorkspaceType) {
       }
       if (customHeaders) {
         body.customHeaders = customHeaders;
+      }
+      if (viewName !== undefined) {
+        body.viewName = viewName;
       }
       const response = await clientFetch(`/api/w/${owner.sId}/mcp`, {
         method: "POST",

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -18,6 +18,7 @@ import type {
   GetMCPServerViewsNotActivatedResponseBody,
   MCPServerType,
   MCPServerTypeWithViews,
+  MCPServerViewNameConflict,
   MCPServerViewType,
   SyncMCPServerResponseBody,
 } from "@app/lib/api/mcp";
@@ -364,25 +365,13 @@ export function useDiscoverOAuthMetadata(owner: LightWorkspaceType) {
   return { discoverOAuthMetadata };
 }
 
-export class MCPCreateServerError extends Error {
+class MCPCreateServerError extends Error {
   readonly isRemoteServerError: boolean;
-  readonly nameConflict: string | null;
-  constructor(
-    message: string,
-    isRemoteServerError: boolean,
-    nameConflict: string | null
-  ) {
+  constructor(message: string, isRemoteServerError: boolean) {
     super(message);
     this.isRemoteServerError = isRemoteServerError;
-    this.nameConflict = nameConflict;
   }
 }
-
-type MCPCreateServerErrorResponse = {
-  error?: { message?: string };
-  isRemoteServerError?: boolean;
-  nameConflict?: { name: string };
-};
 
 export function isMCPCreateServerError(
   error: Error
@@ -419,7 +408,9 @@ export function useCreateRemoteMCPServer(owner: LightWorkspaceType) {
       oauthConnection?: MCPConnectionType;
       customHeaders?: { key: string; value: string }[];
       viewName?: string;
-    }): Promise<Result<CreateMCPServerResponseBody, Error>> => {
+    }): Promise<
+      Result<CreateMCPServerResponseBody, Error | MCPServerViewNameConflict>
+    > => {
       const body: any = { url, serverType: "remote", includeGlobal };
       if (defaultServerId !== undefined) {
         body.defaultServerId = defaultServerId;
@@ -445,13 +436,15 @@ export function useCreateRemoteMCPServer(owner: LightWorkspaceType) {
       });
 
       if (!response.ok) {
-        const body: MCPCreateServerErrorResponse = await response.json();
+        const body = await response.json();
+        if (body.nameConflict?.name) {
+          return new Err({ nameConflict: body.nameConflict.name });
+        }
         return new Err(
           new MCPCreateServerError(
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             body.error?.message || "Failed to create server",
-            body.isRemoteServerError === true,
-            body.nameConflict?.name ?? null
+            body.isRemoteServerError === true
           )
         );
       }


### PR DESCRIPTION
## Description

Remote MCP server creation can fail when the server-provided name conflicts with an existing server.
We actually create the server during the flow and only allow changing the name afterwards. As a consequence users cannot choose a different name during the setup, making them unable to actually add the server.

This PR adds an optional name field to remote MCP server creation. The custom name is then used for conflict validation and persisted on the system and global views.

## Tests

- Updated the existing tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
