### PR TITLE
Gate agent_memory record/edit writes behind the user_memory flag 

### DIFF
--- a/front/lib/api/actions/servers/agent_memory/tools/index.test.ts
+++ b/front/lib/api/actions/servers/agent_memory/tools/index.test.ts
@@ -1,0 +1,83 @@
+import {
+  AGENT_MEMORY_EDIT_TOOL_NAME,
+  AGENT_MEMORY_RECORD_TOOL_NAME,
+} from "@app/lib/api/actions/servers/agent_memory/metadata";
+import {
+  AGENT_MEMORY_WRITE_DISABLED_MESSAGE,
+  TOOLS,
+} from "@app/lib/api/actions/servers/agent_memory/tools/index";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("agent_memory write tools gated by the user_memory feature flag", () => {
+  let auth: Authenticator;
+  let agentConfiguration: LightAgentConfigurationType;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    auth = setup.authenticator;
+    agentConfiguration = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+    });
+  });
+
+  function makeExtra() {
+    return {
+      auth,
+      runContext: {
+        contextType: "agent_loop",
+        agentConfiguration,
+      },
+      signal: new AbortController().signal,
+    } as never;
+  }
+
+  function getTool(name: string) {
+    const tool = TOOLS.find((t) => t.name === name);
+    if (!tool) {
+      throw new Error(`tool ${name} not found`);
+    }
+    return tool;
+  }
+
+  it("redirects record to personal memory when the flag is on", async () => {
+    await FeatureFlagFactory.basic(auth, "user_memory");
+
+    const result = await getTool(AGENT_MEMORY_RECORD_TOOL_NAME).handler(
+      { entries: ["I prefer concise answers"] },
+      makeExtra()
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe(AGENT_MEMORY_WRITE_DISABLED_MESSAGE);
+    }
+  });
+
+  it("redirects edit to personal memory when the flag is on", async () => {
+    await FeatureFlagFactory.basic(auth, "user_memory");
+
+    const result = await getTool(AGENT_MEMORY_EDIT_TOOL_NAME).handler(
+      { edits: [{ index: 0, content: "I prefer concise answers" }] },
+      makeExtra()
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe(AGENT_MEMORY_WRITE_DISABLED_MESSAGE);
+    }
+  });
+
+  it("records normally when the flag is off", async () => {
+    const result = await getTool(AGENT_MEMORY_RECORD_TOOL_NAME).handler(
+      { entries: ["I prefer concise answers"] },
+      makeExtra()
+    );
+
+    expect(result.isOk()).toBe(true);
+  });
+});

--- a/front/lib/api/actions/servers/agent_memory/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_memory/tools/index.ts
@@ -1,6 +1,7 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import {
   AGENT_MEMORY_COMPACT_TOOL_NAME,
@@ -10,11 +11,37 @@ import {
   AGENT_MEMORY_RETRIEVE_TOOL_NAME,
   AGENT_MEMORY_TOOLS_METADATA,
 } from "@app/lib/api/actions/servers/agent_memory/metadata";
+import {
+  USER_MEMORY_EDIT_TOOL_NAME,
+  USER_MEMORY_SERVER_NAME,
+} from "@app/lib/api/actions/servers/user_memory/metadata";
+import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
 import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
+
+const USER_MEMORY_EDIT_TOOL = getPrefixedToolName(
+  USER_MEMORY_SERVER_NAME,
+  USER_MEMORY_EDIT_TOOL_NAME
+);
+
+export const AGENT_MEMORY_WRITE_DISABLED_MESSAGE =
+  `This tool is disabled. Use the \`${USER_MEMORY_EDIT_TOOL}\` tool to add or ` +
+  `update the user's personal memory instead.`;
+
+async function agentMemoryWriteDisabledError(
+  auth: Authenticator
+): Promise<MCPError | null> {
+  if (await hasFeatureFlag(auth, "user_memory")) {
+    return new MCPError(AGENT_MEMORY_WRITE_DISABLED_MESSAGE, {
+      tracked: false,
+    });
+  }
+  return null;
+}
 
 const renderMemory = (
   memory: { lastUpdated: Date; content: string }[]
@@ -61,6 +88,11 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     { entries },
     { auth, runContext }
   ) => {
+    const writeDisabled = await agentMemoryWriteDisabledError(auth);
+    if (writeDisabled) {
+      return new Err(writeDisabled);
+    }
+
     const user = auth.user();
     if (!user) {
       return new Err(
@@ -108,6 +140,11 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
   },
 
   [AGENT_MEMORY_EDIT_TOOL_NAME]: async ({ edits }, { auth, runContext }) => {
+    const writeDisabled = await agentMemoryWriteDisabledError(auth);
+    if (writeDisabled) {
+      return new Err(writeDisabled);
+    }
+
     const user = auth.user();
     if (!user) {
       return new Err(


### PR DESCRIPTION
## Description

Gated agent_memory record and edit tools behind the user_memory feature flag to stop further expansion of agent_memory and to help users transition from agent_memory to user_memory

## Tests

Tested locally 

## Risk

Low, preventing additional usage of agent_memory but not affecting existing usage 

## Deploy Plan

Deploy front 
