### PR TITLE
[front/front-api/viz] Enable callFunction for email-shared frame viewers

### DIFF
--- a/front-api/lib/api/frames/access.ts
+++ b/front-api/lib/api/frames/access.ts
@@ -1,0 +1,105 @@
+import {
+  FRAME_SESSION_COOKIE_NAME,
+  getFrameSessionEmail,
+} from "@app/lib/api/share/frame_session";
+import { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { Context } from "hono";
+import { getCookie } from "hono/cookie";
+
+export type FrameViewerAccess = {
+  workspace: LightWorkspaceType;
+  file: FileResource;
+  shareableFileId: ModelId;
+  podSpaceId: string;
+  email: string;
+  auth: Authenticator;
+};
+
+/**
+ * Resolves the pod (project space) sId that a frame's functions run in. A frame is attached either
+ * directly to a space (project frame → useCaseMetadata.spaceId) or to a conversation (conversation
+ * frame → useCaseMetadata.conversationId), whose own space is the pod. Returns null when neither
+ * yields a space (e.g. a global conversation with no pod → no functions to call).
+ */
+async function resolvePodSpaceId(
+  workspace: LightWorkspaceType,
+  file: FileResource
+): Promise<string | null> {
+  const directSpaceId = file.useCaseMetadata?.spaceId;
+  if (directSpaceId) {
+    return directSpaceId;
+  }
+
+  const conversationId = file.useCaseMetadata?.conversationId;
+  if (!conversationId) {
+    return null;
+  }
+
+  // Conversation frames carry no spaceId; the pod is the conversation's own space. Authorization is
+  // proven by the frame grant checked below, so read the conversation directly (skipping
+  // space-membership filtering) and encode its spaceId — no permissioned space fetch needed.
+  const adminAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+  const conversation = await ConversationResource.fetchById(
+    adminAuth,
+    conversationId,
+    { dangerouslySkipPermissionFiltering: true }
+  );
+  if (!conversation?.spaceId) {
+    return null;
+  }
+
+  return SpaceResource.modelIdToSId({
+    id: conversation.spaceId,
+    workspaceId: workspace.id,
+  });
+}
+
+/**
+ * Resolves and authorizes an external frame viewer for a share token, then builds the userless
+ * execution Authenticator confined to the frame's pod. Returns null on any failure so callers
+ * respond with a uniform 404 that reveals nothing about why access was denied.
+ */
+export async function resolveFrameViewerAccess(
+  ctx: Context,
+  token: string
+): Promise<FrameViewerAccess | null> {
+  const shareResult = await FileResource.fetchByShareToken(token);
+  if (shareResult.isErr()) {
+    return null;
+  }
+  const { file, shareableFileId, workspace } = shareResult.value;
+
+  // Functions are only reachable when the frame is backed by a pod (project space).
+  const podSpaceId = await resolvePodSpaceId(workspace, file);
+  if (!podSpaceId) {
+    return null;
+  }
+
+  // Verified email (frame-session cookie) + active grant on this frame. The cookie proves the
+  // email; the grant proves it was invited here.
+  const sessionToken = getCookie(ctx, FRAME_SESSION_COOKIE_NAME);
+  const email = sessionToken
+    ? await getFrameSessionEmail(workspace, { token: sessionToken })
+    : null;
+  if (email === null) {
+    return null;
+  }
+
+  const grant = await FileResource.getActiveGrantForEmail(workspace, {
+    email,
+    shareableFileId,
+  });
+  if (!grant) {
+    return null;
+  }
+
+  const auth = await Authenticator.frameViewerForPod(workspace.sId, podSpaceId);
+  return { workspace, file, shareableFileId, podSpaceId, email, auth };
+}

--- a/front-api/lib/api/sse/sandbox_function_invocation_events.ts
+++ b/front-api/lib/api/sse/sandbox_function_invocation_events.ts
@@ -18,10 +18,12 @@ export async function streamSandboxFunctionInvocationEventsForRoute(
     functionId,
     invocationId,
     lastEventId,
+    access = "viewer",
   }: {
     functionId: string;
     invocationId: string;
     lastEventId: string | null;
+    access?: "viewer" | "email_viewer";
   }
 ) {
   const sandboxFunction = await SandboxFunctionResource.fetchById(
@@ -35,6 +37,7 @@ export async function streamSandboxFunctionInvocationEventsForRoute(
   const invocation = await SandboxFunctionInvocationResource.fetchById(auth, {
     sandboxFunction,
     invocationId,
+    access,
   });
   if (!invocation) {
     return ctx.notFound();

--- a/front-api/routes/sse/index.ts
+++ b/front-api/routes/sse/index.ts
@@ -1,5 +1,6 @@
 import { unauthedApp } from "@front-api/middlewares/ctx";
 
+import publicFrameSandboxFunctionEvents from "./v1/public/frames/[token]/sandbox-functions/[functionId]/invocations/[invocationId]/events";
 import v1WorkspaceSseApp from "./v1/w/[wId]";
 import workspaceSseApp from "./w/[wId]";
 
@@ -12,5 +13,9 @@ const app = unauthedApp();
 
 app.route("/v1/w/:wId", v1WorkspaceSseApp);
 app.route("/w/:wId", workspaceSseApp);
+app.route(
+  "/v1/public/frames/:token/sandbox-functions/:functionId/invocations/:invocationId/events",
+  publicFrameSandboxFunctionEvents
+);
 
 export default app;

--- a/front-api/routes/sse/v1/public/frames/[token]/sandbox-functions/[functionId]/invocations/[invocationId]/events.ts
+++ b/front-api/routes/sse/v1/public/frames/[token]/sandbox-functions/[functionId]/invocations/[invocationId]/events.ts
@@ -1,0 +1,61 @@
+/** @ignoreswagger */
+
+import { hasFeatureFlag } from "@app/lib/auth";
+import { resolveFrameViewerAccess } from "@front-api/lib/api/frames/access";
+import { streamSandboxFunctionInvocationEventsForRoute } from "@front-api/lib/api/sse/sandbox_function_invocation_events";
+import { SseQuerySchema } from "@front-api/lib/api/sse/stream_events";
+import { unauthedApp } from "@front-api/middlewares/ctx";
+import { streamingTag } from "@front-api/middlewares/streaming";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  token: z.string().min(1),
+  functionId: z.string().min(1),
+  invocationId: z.string().min(1),
+});
+
+// Mounted at /api/sse/v1/public/frames/:token/sandbox-functions/:functionId/invocations/:invocationId/events.
+// Public SSE twin of the member events stream, for external email-only frame viewers.
+const app = unauthedApp();
+
+app.use("*", streamingTag);
+
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  validate("query", SseQuerySchema),
+  async (ctx) => {
+    const { token, functionId, invocationId } = ctx.req.valid("param");
+    const { lastEventId } = ctx.req.valid("query");
+
+    const access = await resolveFrameViewerAccess(ctx, token);
+    if (!access) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: { type: "file_not_found", message: "Share not found." },
+      });
+    }
+
+    if (!(await hasFeatureFlag(access.auth, "sandbox_functions"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "feature_flag_not_found",
+          message: "Sandbox Functions are not enabled for this workspace.",
+        },
+      });
+    }
+
+    // The pod-confined auth makes fetchById reject any invocation outside this frame's pod.
+    return streamSandboxFunctionInvocationEventsForRoute(ctx, access.auth, {
+      functionId,
+      invocationId,
+      lastEventId,
+      access: "email_viewer",
+    });
+  }
+);
+
+export default app;

--- a/front-api/routes/v1/public/frames/[token]/index.ts
+++ b/front-api/routes/v1/public/frames/[token]/index.ts
@@ -20,6 +20,7 @@ import { resolveOptionalAuth } from "@front-api/routes/v1/public/frames/shared_a
 import { getCookie } from "hono/cookie";
 import { z } from "zod";
 
+import sandboxFunctions from "./sandbox-functions";
 import verifyCode from "./verify-code";
 import verifyEmail from "./verify-email";
 
@@ -127,6 +128,9 @@ app.get(
       });
     }
 
+    // Set when access is granted to a non-member through an active email grant (external viewer).
+    let isEmailViewer = false;
+
     // Handle email-based share scopes (treat legacy "workspace" as "workspace_and_emails").
     if (
       shareScope === "emails_only" ||
@@ -179,6 +183,8 @@ app.get(
           email: verifiedEmail!,
           shareableFileId,
         });
+
+        isEmailViewer = authUserModelId === null;
       }
     }
 
@@ -207,6 +213,7 @@ app.get(
       contentType: file.contentType,
       fileToken: token,
       userId: user?.sId,
+      isEmailViewer,
       shareScope,
       workspaceId: workspace.sId,
     });
@@ -229,10 +236,13 @@ app.get(
       // Lets the frame enable member-only tools (e.g. callFunction) client-side;
       // real authorization still happens server-side on invocation.
       isAuthenticatedMember: !!user,
+      // Grant-authorized external viewer: enables callFunction via the public invocation endpoint.
+      isEmailViewer,
     });
   }
 );
 
+app.route("/sandbox-functions", sandboxFunctions);
 app.route("/verify-code", verifyCode);
 app.route("/verify-email", verifyEmail);
 

--- a/front-api/routes/v1/public/frames/[token]/sandbox-functions.ts
+++ b/front-api/routes/v1/public/frames/[token]/sandbox-functions.ts
@@ -1,0 +1,100 @@
+/** @ignoreswagger */
+
+import { hasFeatureFlag } from "@app/lib/auth";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type {
+  PostSandboxFunctionInvocationRequestBody,
+  PostSandboxFunctionInvocationResponseBody,
+} from "@app/types/api/sandbox_functions";
+import { resolveFrameViewerAccess } from "@front-api/lib/api/frames/access";
+import { unauthedApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  token: z.string().min(1),
+  functionIdOrSlug: z.string().min(1),
+});
+
+const PostSandboxFunctionInvocationBodySchema = z
+  .object({
+    input: z.unknown().optional(),
+    context: z
+      .object({
+        timezone: z.string().optional(),
+      })
+      .optional(),
+  })
+  .strict();
+
+// Mounted at /api/v1/public/frames/:token/sandbox-functions.
+const app = unauthedApp();
+
+// Invoke a sandbox function from a shared frame, as an external email-only viewer. Access is
+// gated by the verified frame-session cookie + an active grant; execution runs under a userless
+// Authenticator confined to the frame's pod (see Authenticator.frameViewerForPod).
+app.post(
+  "/:functionIdOrSlug/invocations",
+  validate("param", ParamsSchema),
+  validate("json", PostSandboxFunctionInvocationBodySchema),
+  async (ctx): HandlerResult<PostSandboxFunctionInvocationResponseBody> => {
+    const { token, functionIdOrSlug } = ctx.req.valid("param");
+    const body: PostSandboxFunctionInvocationRequestBody =
+      ctx.req.valid("json");
+
+    const access = await resolveFrameViewerAccess(ctx, token);
+    if (!access) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: { type: "file_not_found", message: "Share not found." },
+      });
+    }
+    const { auth, podSpaceId } = access;
+
+    if (!(await hasFeatureFlag(auth, "sandbox_functions"))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "feature_flag_not_found",
+          message: "Sandbox Functions are not enabled for this workspace.",
+        },
+      });
+    }
+
+    // The pod-confined auth makes only this frame's pod reachable; the explicit space check is a
+    // belt-and-suspenders guard against a function resolving from anywhere else.
+    const sandboxFunction = await SandboxFunctionResource.fetchByIdOrSlug(
+      auth,
+      functionIdOrSlug
+    );
+    if (!sandboxFunction || sandboxFunction.space.sId !== podSpaceId) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "sandbox_function_not_found",
+          message: "Sandbox function not found.",
+        },
+      });
+    }
+
+    const invocationResult = await sandboxFunction.invoke(auth, body);
+    if (invocationResult.isErr()) {
+      return apiError(
+        ctx,
+        {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Sandbox function invocation failed.",
+          },
+        },
+        invocationResult.error
+      );
+    }
+
+    return ctx.json({ invocation: invocationResult.value.toJSON() }, 201);
+  }
+);
+
+export default app;

--- a/front-api/routes/v1/viz/content.test.ts
+++ b/front-api/routes/v1/viz/content.test.ts
@@ -87,6 +87,7 @@ describe("/api/v1/viz/content endpoint tests", () => {
         conversationId: "conversation-A",
       },
       isAuthenticatedMember: false,
+      isEmailViewer: false,
     });
   });
 
@@ -272,6 +273,7 @@ describe("/api/v1/viz/content endpoint tests", () => {
         conversationId: "conversation-A",
       },
       isAuthenticatedMember: false,
+      isEmailViewer: false,
     });
   });
 
@@ -313,6 +315,7 @@ describe("/api/v1/viz/content endpoint tests", () => {
         conversationId: "conversation-A",
       },
       isAuthenticatedMember: true,
+      isEmailViewer: false,
     });
   });
 });

--- a/front-api/routes/v1/viz/content.ts
+++ b/front-api/routes/v1/viz/content.ts
@@ -30,7 +30,7 @@ app.get("/", async (ctx): HandlerResult<PublicVizContentResponseBodyType> => {
     });
   }
   const tokenPayload = tokenRes.value;
-  const { fileToken, userId } = tokenPayload;
+  const { fileToken, userId, isEmailViewer } = tokenPayload;
 
   const result = await FileResource.fetchByShareTokenWithContent(fileToken);
   if (!result) {
@@ -127,6 +127,7 @@ app.get("/", async (ctx): HandlerResult<PublicVizContentResponseBodyType> => {
       spaceId: result.file.useCaseMetadata?.spaceId,
     },
     isAuthenticatedMember: !!userId,
+    isEmailViewer: !!isEmailViewer,
   });
 });
 

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
@@ -26,6 +26,7 @@ describe("getFrameRuntimeAccess", () => {
         isWorkspaceMember: true,
         user,
       },
+      invocationRoute: { kind: "workspace" },
     });
   });
 
@@ -37,6 +38,7 @@ describe("getFrameRuntimeAccess", () => {
         isWorkspaceMember: false,
         user: null,
       },
+      invocationRoute: { kind: "workspace" },
     });
   });
 
@@ -50,6 +52,21 @@ describe("getFrameRuntimeAccess", () => {
         isWorkspaceMember: true,
         user,
       },
+      invocationRoute: { kind: "workspace" },
+    });
+  });
+
+  it("enables access and routes to the public endpoint for an email viewer", () => {
+    expect(
+      getFrameRuntimeAccess("w_current", false, undefined, true, "share-token")
+    ).toEqual({
+      canInvokeFunctions: true,
+      userIdentity: {
+        isAuthenticated: false,
+        isWorkspaceMember: false,
+        user: null,
+      },
+      invocationRoute: { kind: "public", shareToken: "share-token" },
     });
   });
 });

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -77,13 +77,20 @@ type ProtectedVisualization = BaseVisualization & {
 
 export type Visualization = PublicVisualization | ProtectedVisualization;
 
+export type FrameInvocationRoute =
+  | { kind: "workspace" }
+  | { kind: "public"; shareToken: string };
+
 export function getFrameRuntimeAccess(
   workspaceId: string,
   canInvokeFunctions: boolean,
-  scopedUserIdentity?: ScopedWorkspaceUserIdentity
+  scopedUserIdentity?: ScopedWorkspaceUserIdentity,
+  isEmailViewer?: boolean,
+  shareToken?: string
 ): {
   canInvokeFunctions: boolean;
   userIdentity: UserIdentityState;
+  invocationRoute: FrameInvocationRoute;
 } {
   const userIdentity: UserIdentityState =
     scopedUserIdentity?.workspaceId === workspaceId
@@ -99,8 +106,15 @@ export function getFrameRuntimeAccess(
         };
 
   return {
-    canInvokeFunctions: canInvokeFunctions && userIdentity.isWorkspaceMember,
+    // Members invoke via their workspace session; grant-authorized email viewers invoke via the
+    // public frame endpoint. Server auth re-checks either way, so this only gates the attempt.
+    canInvokeFunctions:
+      (canInvokeFunctions && userIdentity.isWorkspaceMember) || !!isEmailViewer,
     userIdentity,
+    invocationRoute:
+      isEmailViewer && shareToken
+        ? { kind: "public", shareToken }
+        : { kind: "workspace" },
   };
 }
 
@@ -174,6 +188,7 @@ interface SandboxFunctionInvocationProps {
   workspaceId: string;
   functionId: string;
   invocationId: string;
+  invocationRoute: FrameInvocationRoute;
   onBlocked: (eventId: string, event: SandboxFunctionBlockingEvent) => void;
   onSettle: (
     invocationId: string,
@@ -200,12 +215,16 @@ function SandboxFunctionInvocation({
   workspaceId,
   functionId,
   invocationId,
+  invocationRoute,
   onBlocked,
   onSettle,
 }: SandboxFunctionInvocationProps) {
   const buildEventSourceURL = useCallback(
     (lastEvent: string | null) => {
-      const esURL = `/api/sse/w/${workspaceId}/sandbox-functions/${functionId}/invocations/${invocationId}/events`;
+      const esURL =
+        invocationRoute.kind === "public"
+          ? `/api/sse/v1/public/frames/${encodeURIComponent(invocationRoute.shareToken)}/sandbox-functions/${functionId}/invocations/${invocationId}/events`
+          : `/api/sse/w/${workspaceId}/sandbox-functions/${functionId}/invocations/${invocationId}/events`;
       let lastEventId = "";
       if (lastEvent) {
         const eventPayload: { eventId: string } = JSON.parse(lastEvent);
@@ -213,7 +232,7 @@ function SandboxFunctionInvocation({
       }
       return esURL + "?lastEventId=" + lastEventId;
     },
-    [workspaceId, functionId, invocationId]
+    [invocationRoute, workspaceId, functionId, invocationId]
   );
 
   const onEventCallback = useCallback(
@@ -602,6 +621,8 @@ export interface VisualizationActionIframeProps {
   visualization: Visualization;
   vizUrl: string;
   workspaceId: string;
+  shareToken?: string;
+  isEmailViewer?: boolean;
 }
 
 export const VisualizationActionIframe = forwardRef<
@@ -718,9 +739,11 @@ export const VisualizationActionIframe = forwardRef<
     canInvokeFunctions,
     conversationId,
     isEditable = false,
+    isEmailViewer = false,
     isInDrawer = false,
     onEditText,
     scopedUserIdentity,
+    shareToken,
     spaceId,
     viewer,
     visualization,
@@ -736,9 +759,17 @@ export const VisualizationActionIframe = forwardRef<
     return getFrameRuntimeAccess(
       workspaceId,
       canInvokeFunctions,
-      scopedUserIdentity
+      scopedUserIdentity,
+      isEmailViewer,
+      shareToken
     );
-  }, [canInvokeFunctions, scopedUserIdentity, workspaceId]);
+  }, [
+    canInvokeFunctions,
+    isEmailViewer,
+    scopedUserIdentity,
+    shareToken,
+    workspaceId,
+  ]);
 
   const isPublic = visualization.accessToken !== undefined;
 
@@ -807,16 +838,17 @@ export const VisualizationActionIframe = forwardRef<
         };
 
         const encodedFunctionIdOrSlug = encodeURIComponent(functionIdOrSlug);
-        const response = await clientFetch(
-          `/api/w/${workspaceId}/sandbox-functions/${encodedFunctionIdOrSlug}/invocations`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify(body),
-          }
-        );
+        const url =
+          runtimeAccess.invocationRoute.kind === "public"
+            ? `/api/v1/public/frames/${encodeURIComponent(runtimeAccess.invocationRoute.shareToken)}/sandbox-functions/${encodedFunctionIdOrSlug}/invocations`
+            : `/api/w/${workspaceId}/sandbox-functions/${encodedFunctionIdOrSlug}/invocations`;
+        const response = await clientFetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(body),
+        });
 
         if (!response.ok) {
           const error = await getErrorFromResponse(response);
@@ -841,7 +873,11 @@ export const VisualizationActionIframe = forwardRef<
         });
       }
     },
-    [runtimeAccess.canInvokeFunctions, workspaceId]
+    [
+      runtimeAccess.canInvokeFunctions,
+      runtimeAccess.invocationRoute,
+      workspaceId,
+    ]
   );
 
   useVisualizationDataHandler({
@@ -922,6 +958,7 @@ export const VisualizationActionIframe = forwardRef<
           workspaceId={workspaceId}
           functionId={invocation.functionId}
           invocationId={invocation.invocationId}
+          invocationRoute={runtimeAccess.invocationRoute}
           onBlocked={enqueueBlockedAction}
           onSettle={settleSandboxFunctionInvocation}
         />

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
@@ -71,6 +71,7 @@ export function PublicFrameRenderer({
     error,
     accessToken,
     isAuthenticatedMember,
+    isEmailViewer,
   } = usePublicFrame({
     shareToken,
   });
@@ -147,6 +148,8 @@ export function PublicFrameRenderer({
             }}
             key={`viz-${fileId}`}
             canInvokeFunctions={publicUserIdentity !== undefined}
+            isEmailViewer={isEmailViewer}
+            shareToken={shareToken}
             scopedUserIdentity={publicUserIdentity}
             viewer={viewer}
             isInDrawer

--- a/front/lib/api/share/frame_session.ts
+++ b/front/lib/api/share/frame_session.ts
@@ -41,7 +41,7 @@ export async function createFrameSession(
  * Returns the session's verified email, or null if invalid/expired.
  */
 export async function getFrameSessionEmail(
-  workspace: WorkspaceResource,
+  workspace: LightWorkspaceType | WorkspaceResource,
   {
     token,
   }: {

--- a/front/lib/api/viz/access_tokens.ts
+++ b/front/lib/api/viz/access_tokens.ts
@@ -21,6 +21,7 @@ const VizAccessTokenPayloadSchema = z.object({
   fileToken: z.string(),
   shareScope: fileShareScopeSchema,
   userId: z.string().optional(),
+  isEmailViewer: z.boolean().optional(),
   workspaceId: z.string(),
 });
 
@@ -30,12 +31,14 @@ export function generateVizAccessToken({
   contentType,
   fileToken,
   userId,
+  isEmailViewer,
   shareScope,
   workspaceId,
 }: {
   contentType: InteractiveContentFileContentType;
   fileToken: string;
   userId?: string;
+  isEmailViewer?: boolean;
   shareScope: FileShareScope;
   workspaceId: string;
 }): string {
@@ -44,6 +47,7 @@ export function generateVizAccessToken({
     fileToken,
     shareScope,
     userId,
+    isEmailViewer,
     workspaceId,
   };
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -95,7 +95,8 @@ export type AuthMethodType =
   | "oauth"
   | "session"
   | "sandbox_token"
-  | "internal";
+  | "internal"
+  | "frame_viewer";
 
 // Bearer tokens are identified by their prefix: API keys start with `sk-`,
 // sandbox exec tokens with `sbt-`. Anything else is treated as an OAuth
@@ -596,6 +597,26 @@ export class Authenticator {
       role = "user";
       baseGroupModelIds = [globalGroup.id];
       subscription = activeSubscription;
+
+      // The userless base is [global] only, so for a restricted pod the intersection below would
+      // drop the pod's group and the sandbox callback couldn't reach the function. Re-grant the
+      // pod's groups from claims.spaceId (safe: the token is minted only after invoke-time auth).
+      if (
+        isSandboxFunctionInvocationTokenPayload(claims) &&
+        isResourceSId("space", claims.spaceId)
+      ) {
+        const podSpaceModelId = getResourceIdFromSId(claims.spaceId);
+        if (podSpaceModelId !== null) {
+          const podGroups = await GroupSpaceModel.findAll({
+            where: { vaultId: [podSpaceModelId], workspaceId: workspace.id },
+            attributes: ["groupId"],
+          });
+          baseGroupModelIds = [
+            ...baseGroupModelIds,
+            ...podGroups.map((sg) => sg.groupId),
+          ];
+        }
+      }
     }
 
     // Restrict groups to the sandbox owner's spaces so sandbox auth can only
@@ -1012,6 +1033,53 @@ export class Authenticator {
       workspace,
       role: "admin",
       groupModelIds: groups.map((g) => g.id),
+      subscription,
+      providersHealth,
+    });
+  }
+
+  /**
+   * Userless Authenticator for an external frame viewer, confined to a single pod. Used to run a
+   * sandbox function invoked from a shared frame. Role is "user" (not "none") so the pod groups
+   * grant access; the caller must have verified the viewer's email + active grant beforehand.
+   */
+  static async frameViewerForPod(
+    workspaceId: string,
+    podSpaceId: string
+  ): Promise<Authenticator> {
+    const workspace = await WorkspaceResource.fetchById(workspaceId);
+    if (!workspace) {
+      throw new Error(`Could not find workspace with sId ${workspaceId}`);
+    }
+
+    if (!isResourceSId("space", podSpaceId)) {
+      throw new Error(`Invalid pod space sId ${podSpaceId}`);
+    }
+    const podSpaceModelId = getResourceIdFromSId(podSpaceId);
+    if (podSpaceModelId === null) {
+      throw new Error(`Invalid pod space sId ${podSpaceId}`);
+    }
+
+    const [spaceGroups, subscription] = await Promise.all([
+      GroupSpaceModel.findAll({
+        where: { vaultId: [podSpaceModelId], workspaceId: workspace.id },
+        attributes: ["groupId"],
+      }),
+      SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id),
+    ]);
+
+    const groupModelIds = spaceGroups.map((sg) => sg.groupId);
+
+    const providersHealth = await this.fetchByokProvidersHealth(
+      workspace,
+      subscription
+    );
+
+    return new Authenticator({
+      authMethod: "frame_viewer",
+      workspace,
+      role: "user",
+      groupModelIds,
       subscription,
       providersHealth,
     });

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -145,6 +145,7 @@ const shouldByPassPrivateByDefaultUrlRestriction = (auth: Authenticator) => {
     case "oauth":
     case "session":
     case "sandbox_token":
+    case "frame_viewer":
       return false;
     default:
       assertNever(authMethod);

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -78,7 +78,11 @@ const POD_USER_IDENTITY_ENV = "DUST_POD_USER_IDENTITY";
 // operators are dust superusers, not members of the workspace they inspect, so "viewer" would
 // find no user and return nothing. Kept distinct from "system", which is reserved for paths that
 // already validated a server-owned invocation token.
-type SandboxFunctionInvocationReadAccess = "viewer" | "system" | "admin";
+type SandboxFunctionInvocationReadAccess =
+  | "viewer"
+  | "email_viewer"
+  | "system"
+  | "admin";
 
 // A listing row: the DB columns only, without the invocation's GCS blob. `baseFetch` always
 // hydrates the blob, and an unhydrated resource reports `input: undefined` rather than "not
@@ -842,21 +846,29 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     // User-facing reads expose the caller's invocations, or every invocation to a Pod
     // administrator. Execution and callback paths use the explicit system access after validating
     // their server-owned invocation token or workflow input.
-    let viewerModelId: ModelId | undefined;
+    // undefined → no userId filter; { userId } → scoped to that value (a member's id, or null for
+    // external email viewers).
+    let userIdWhere: { userId: ModelId | null } | undefined;
     switch (access) {
       case "viewer": {
         const viewer = await getAuthenticatedWorkspaceUser(auth);
         if (!viewer) {
           return [];
         }
-        viewerModelId = sandboxFunction.space.canAdministrate(auth)
+        userIdWhere = sandboxFunction.space.canAdministrate(auth)
           ? undefined
-          : viewer.id;
+          : { userId: viewer.id };
         break;
       }
+      case "email_viewer":
+        // External email viewers are userless; scope to userless invocations so one viewer cannot
+        // read a member's invocation. Same-frame viewers share userId=null — the unguessable
+        // invocationId is the per-request capability.
+        userIdWhere = { userId: null };
+        break;
       case "system":
       case "admin":
-        viewerModelId = undefined;
+        userIdWhere = undefined;
         break;
       default:
         return assertNever(access);
@@ -867,7 +879,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         ...where,
         sandboxFunctionId: sandboxFunction.id,
         workspaceId: auth.getNonNullableWorkspace().id,
-        ...(viewerModelId !== undefined ? { userId: viewerModelId } : {}),
+        ...(userIdWhere ?? {}),
       },
       ...rest,
     });

--- a/front/lib/swr/frames.ts
+++ b/front/lib/swr/frames.ts
@@ -36,6 +36,7 @@ export function usePublicFrame({ shareToken }: { shareToken: string | null }) {
     accessToken: data?.accessToken ?? null,
     isFrameLoading: !error && !data,
     isAuthenticatedMember: data?.isAuthenticatedMember ?? false,
+    isEmailViewer: data?.isEmailViewer ?? false,
     error,
     mutateFrame: mutate,
   };

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -3192,6 +3192,7 @@ export const PublicFrameResponseBodySchema = z.object({
   projectUrl: z.string().nullable(),
   file: FileTypeSchema,
   isAuthenticatedMember: z.boolean().optional(),
+  isEmailViewer: z.boolean().optional(),
 });
 
 export type PublicFrameResponseBodyType = z.infer<
@@ -3203,6 +3204,7 @@ export const PublicVizContentResponseBodySchema = z.object({
   contentType: z.string(),
   metadata: z.record(z.unknown()).optional(),
   isAuthenticatedMember: z.boolean().optional(),
+  isEmailViewer: z.boolean().optional(),
 });
 
 export type PublicVizContentResponseBodyType = z.infer<

--- a/viz/app/content/ServerVisualizationWrapper.tsx
+++ b/viz/app/content/ServerVisualizationWrapper.tsx
@@ -120,6 +120,7 @@ export async function ServerSideVisualizationWrapper({
   let prefetchedCode: string | undefined;
   let preFetchedFiles: PreFetchedFile[] = [];
   let isAuthenticatedMember = false;
+  let isEmailViewer = false;
 
   try {
     const headers: Record<string, string> = {};
@@ -137,6 +138,7 @@ export async function ServerSideVisualizationWrapper({
       const responseData = await codeResponse.json();
       prefetchedCode = responseData.content;
       isAuthenticatedMember = responseData.isAuthenticatedMember ?? false;
+      isEmailViewer = responseData.isEmailViewer ?? false;
 
       if (!prefetchedCode) {
         logger.warn({ identifier }, "No code content found for visualization");
@@ -171,6 +173,7 @@ export async function ServerSideVisualizationWrapper({
       prefetchedCode={prefetchedCode}
       prefetchedFiles={preFetchedFiles}
       isAuthenticatedMember={isAuthenticatedMember}
+      isEmailViewer={isEmailViewer}
     />
   );
 }

--- a/viz/app/content/ServerVisualizationWrapperClient.tsx
+++ b/viz/app/content/ServerVisualizationWrapperClient.tsx
@@ -22,6 +22,7 @@ interface ServerVisualizationWrapperClientProps {
   allowedOrigins: string[];
   identifier: string;
   isAuthenticatedMember?: boolean;
+  isEmailViewer?: boolean;
   isFullHeight?: boolean;
   isPdfMode?: boolean;
   prefetchedCode?: string;
@@ -44,6 +45,7 @@ export function ServerVisualizationWrapperClient({
   identifier,
   allowedOrigins,
   isAuthenticatedMember = false,
+  isEmailViewer = false,
   isFullHeight = false,
   isPdfMode = false,
   prefetchedCode,
@@ -51,12 +53,12 @@ export function ServerVisualizationWrapperClient({
 }: ServerVisualizationWrapperClientProps) {
   const dataAPI = useMemo(() => {
     const cache = new CacheDataAPI(prefetchedFiles, prefetchedCode);
-    if (!isAuthenticatedMember) {
+    if (!isAuthenticatedMember && !isEmailViewer) {
       return cache;
     }
 
-    // Authenticated member on a public frame: keep SSR reads from the cache,
-    // route callFunction over RPC.
+    // Authenticated member or grant-authorized email viewer on a public frame: keep SSR reads from
+    // the cache, route callFunction over RPC.
     const sendMessage = makeSendCrossDocumentMessage({
       allowedOrigins,
       identifier,
@@ -66,6 +68,7 @@ export function ServerVisualizationWrapperClient({
     prefetchedCode,
     prefetchedFiles,
     isAuthenticatedMember,
+    isEmailViewer,
     allowedOrigins,
     identifier,
   ]);


### PR DESCRIPTION
## Description

Extend `callFunction` to external **email-only frame viewers** (grant + OTP frame session, non-members, possibly no Dust account). Previously only workspace members could invoke functions on a shared frame.

- Public endpoints (`unauthedApp`): POST `/api/v1/public/frames/:token/sandbox-functions/:fn/invocations` + SSE twin. Gated by `resolveFrameViewerAccess` (frame-session cookie → verified email → active grant).
- `Authenticator.frameViewerForPod`: userless auth confined to the frame's pod (`authMethod: "frame_viewer"`). Pod resolved from `useCaseMetadata.spaceId` or, for conversation frames, the conversation's own space.
- `fromSandboxToken`: userless function-invocation tokens re-derive the pod's groups from `claims.spaceId` so the sandbox result callback reaches the function.
- New `"email_viewer"` invocation-read access (`userId IS NULL`) so the public SSE streams the viewer's own invocations without exposing members'.
- Client (viz/front): propagate `isEmailViewer` + `shareToken`; `getFrameRuntimeAccess` allows email viewers and routes invocation/SSE to the public endpoints.

## Tests

e2e: external email viewer (no Dust account, grant + OTP) runs a pod function on a **shared conversation frame in a restricted pod** → invocation created, result streamed back and rendered. Member and anonymous paths unchanged.
tests for the two new public endpoints: TODO (follow-up).

## Risk

Low. Additive: new public endpoints + a new read-access mode; member/anonymous paths untouched. Authorization is server-side (cookie + grant + function-in-pod), the client flags only gate the attempt. No migration. Rollback-safe

## Deploy Plan
Standard deploy.
