### PR TITLE
[front] feat: batch archive skills UI

### DIFF
--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -242,6 +242,10 @@ export function ManageSkillsPage() {
         .map(([sId]) => sId),
     [rowSelection]
   );
+  const selectedSkills = useMemo(
+    () => activeSkills.filter((skill) => rowSelection[skill.sId]),
+    [activeSkills, rowSelection]
+  );
 
   const closeBatchEdition = () => {
     setIsBatchEditing(false);
@@ -473,9 +477,10 @@ export function ManageSkillsPage() {
           </div>
           {isBatchEditionAvailable && isBatchEditing && (
             <SkillsBatchEditBar
-              selectedCount={selectedSkillIds.length}
+              selectedSkills={selectedSkills}
               isUpdating={isBatchUpdating}
               canMakeSkillAutoDiscoverable={canMakeSkillAutoDiscoverable}
+              owner={owner}
               onClose={closeBatchEdition}
               onSelectAction={setPendingBatchAction}
             />

--- a/front/components/skills/ArchiveSkillsDialog.tsx
+++ b/front/components/skills/ArchiveSkillsDialog.tsx
@@ -1,0 +1,105 @@
+import { useBatchArchiveSkills } from "@app/lib/swr/skill_configurations";
+import type { GetSkillsWithRelationsResponseBody } from "@app/types/api/skills";
+import { pluralize } from "@app/types/shared/utils/string_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  Trash01,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+interface ArchiveSkillsDialogProps {
+  skills: GetSkillsWithRelationsResponseBody["skills"];
+  disabled: boolean;
+  owner: LightWorkspaceType;
+  onSave: () => void;
+}
+
+export function ArchiveSkillsDialog({
+  skills,
+  disabled,
+  owner,
+  onSave,
+}: ArchiveSkillsDialogProps) {
+  const [isArchiving, setIsArchiving] = useState(false);
+  const doArchive = useBatchArchiveSkills({
+    owner,
+    skillIds: skills.map((skill) => skill.sId),
+  });
+  const totalUsage = skills.reduce(
+    (total, skill) => total + (skill.messageCount ?? 0),
+    0
+  );
+  const isSingleSkill = skills.length === 1;
+  const skillLabel = `skill${pluralize(skills.length)}`;
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button
+          size="sm"
+          variant="warning"
+          icon={Trash01}
+          label="Archive selection"
+          disabled={disabled}
+        />
+      </DialogTrigger>
+      <DialogContent size="md" isAlertDialog>
+        <DialogHeader hideButton>
+          <DialogTitle>
+            Archiving {skills.length} {skillLabel}
+          </DialogTitle>
+          <DialogDescription>
+            <div>
+              {totalUsage > 0 && (
+                <>
+                  <span className="font-bold">
+                    {isSingleSkill ? "This skill has" : "These skills have"}
+                    {" been used "}
+                    {totalUsage} time
+                    {pluralize(totalUsage)}.
+                  </span>{" "}
+                </>
+              )}
+              This will archive {isSingleSkill ? "this skill" : "these skills"}
+              {" for everyone."}
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+        <DialogContainer>
+          <div className="font-bold">Are you sure you want to proceed?</div>
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            disabled: isArchiving,
+            variant: "outline",
+          }}
+          rightButtonProps={{
+            label: `Archive the ${skillLabel}`,
+            variant: "warning",
+            disabled: isArchiving,
+            isLoading: isArchiving,
+            onClick: async (e: React.MouseEvent) => {
+              e.preventDefault();
+              setIsArchiving(true);
+              const success = await doArchive();
+              setIsArchiving(false);
+              if (success) {
+                onSave();
+              }
+            },
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/skills/SkillsBatchEdit.tsx
+++ b/front/components/skills/SkillsBatchEdit.tsx
@@ -1,5 +1,8 @@
+import { ArchiveSkillsDialog } from "@app/components/skills/ArchiveSkillsDialog";
+import type { GetSkillsWithRelationsResponseBody } from "@app/types/api/skills";
 import type { SkillAvailability } from "@app/types/assistant/skill_configuration";
 import { pluralize } from "@app/types/shared/utils/string_utils";
+import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
   Dialog,
@@ -58,20 +61,27 @@ const BATCH_AVAILABILITY_ACTIONS: BatchAvailabilityAction[] = [
 ];
 
 interface SkillsBatchEditBarProps {
-  selectedCount: number;
+  selectedSkills: GetSkillsWithRelationsResponseBody["skills"];
   isUpdating: boolean;
   canMakeSkillAutoDiscoverable: boolean;
+  owner: LightWorkspaceType;
   onClose: () => void;
   onSelectAction: (action: BatchAvailabilityAction) => void;
 }
 
 export function SkillsBatchEditBar({
-  selectedCount,
+  selectedSkills,
   isUpdating,
   canMakeSkillAutoDiscoverable,
+  owner,
   onClose,
   onSelectAction,
 }: SkillsBatchEditBarProps) {
+  const selectedCount = selectedSkills.length;
+  const canArchiveSelection = selectedSkills.every(
+    (skill) => skill.canAdministrate
+  );
+
   return (
     <div className="flex flex-row items-center justify-between gap-2 rounded-xl bg-muted-background px-2 py-2 dark:bg-muted-background-night">
       <Button
@@ -81,38 +91,46 @@ export function SkillsBatchEditBar({
         label="Close edition"
         onClick={onClose}
       />
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="outline"
-            size="sm"
-            label="Set availability"
-            isSelect
-            isLoading={isUpdating}
-            disabled={selectedCount === 0 || isUpdating}
-          />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          {BATCH_AVAILABILITY_ACTIONS.map((action) => {
-            const isActionDisabled =
-              action.availability === "users_and_agents" &&
-              !canMakeSkillAutoDiscoverable;
-            return (
-              <DropdownMenuItem
-                key={action.availability}
-                label={action.label}
-                description={
-                  isActionDisabled
-                    ? "You don’t have permission to make skills auto-discoverable"
-                    : action.description
-                }
-                disabled={isActionDisabled}
-                onClick={() => onSelectAction(action)}
-              />
-            );
-          })}
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <div className="flex flex-row items-center gap-2">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              label="Set availability"
+              isSelect
+              isLoading={isUpdating}
+              disabled={selectedCount === 0 || isUpdating}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {BATCH_AVAILABILITY_ACTIONS.map((action) => {
+              const isActionDisabled =
+                action.availability === "users_and_agents" &&
+                !canMakeSkillAutoDiscoverable;
+              return (
+                <DropdownMenuItem
+                  key={action.availability}
+                  label={action.label}
+                  description={
+                    isActionDisabled
+                      ? "You don’t have permission to make skills auto-discoverable"
+                      : action.description
+                  }
+                  disabled={isActionDisabled}
+                  onClick={() => onSelectAction(action)}
+                />
+              );
+            })}
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <ArchiveSkillsDialog
+          skills={selectedSkills}
+          disabled={selectedCount === 0 || isUpdating || !canArchiveSelection}
+          owner={owner}
+          onSave={onClose}
+        />
+      </div>
     </div>
   );
 }

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -349,6 +349,56 @@ export function useArchiveSkill({
   return doArchive;
 }
 
+export function useBatchArchiveSkills({
+  owner,
+  skillIds,
+}: {
+  owner: LightWorkspaceType;
+  skillIds: string[];
+}) {
+  const { fetcher } = useFetcher();
+  const sendNotification = useSendNotification();
+  const {
+    mutateSkillsWithRelationsRegardlessOfQueryParams: mutateSkillsWithRelations,
+  } = useSkillsWithRelations({
+    owner,
+    status: "active",
+    disabled: true,
+  });
+
+  const doArchive = async () => {
+    if (skillIds.length === 0) {
+      return false;
+    }
+
+    try {
+      await fetcher(`/api/w/${owner.sId}/skills/archive`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ skillIds }),
+      });
+
+      void mutateSkillsWithRelations();
+
+      sendNotification({
+        type: "success",
+        title: "Successfully archived skills",
+        description: `${skillIds.length} skill${pluralize(skillIds.length)} ${skillIds.length === 1 ? "was" : "were"} successfully archived.`,
+      });
+      return true;
+    } catch (err) {
+      sendNotification({
+        type: "error",
+        title: "Error archiving skills",
+        description: `Error: ${isAPIErrorResponse(err) ? err.error.message : "An unexpected error occurred."}`,
+      });
+      return false;
+    }
+  };
+
+  return doArchive;
+}
+
 export function useUpdateSkillFavorite({
   owner,
 }: {


### PR DESCRIPTION
## Description

We can't archive skills in batch currently. We can update availability in batch from Manage Skills that said.

This PR adds an `Archive selection` action matching the one in Manage Agents. Relies on the backend part introduced in https://github.com/dust-tt/dust/pull/30117.

<img width="2184" height="248" alt="image" src="https://github.com/user-attachments/assets/4c0f4203-9df6-43d4-8d48-99c61ae3dedd" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
