### PR TITLE
[front] enh: treat Frames in a Pod as apps

### DIFF
--- a/front/lib/api/actions/servers/interactive_content/instructions.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions.ts
@@ -7,6 +7,7 @@ import {
   FILES_CAT_ACTION_NAME,
   FILES_EDIT_ACTION_NAME,
   FILES_LIST_ACTION_NAME,
+  FILES_MOVE_ACTION_NAME,
   FILES_RESOLVE_ACTION_NAME,
   FILES_SERVER_NAME,
 } from "@app/lib/api/actions/servers/files/metadata";
@@ -41,6 +42,10 @@ const FILES_LIST_TOOL = getPrefixedToolName(
 const FILES_RESOLVE_TOOL = getPrefixedToolName(
   FILES_SERVER_NAME,
   FILES_RESOLVE_ACTION_NAME
+);
+const FILES_MOVE_TOOL = getPrefixedToolName(
+  FILES_SERVER_NAME,
+  FILES_MOVE_ACTION_NAME
 );
 
 const UPDATING_SECTION_LEGACY = `\
@@ -89,9 +94,9 @@ Create a Frame only when the content does not exist yet. When the user asks for 
 const UPDATING_SECTION_COMPUTER_FIRST = `\
 ### Updating Existing Files (edit the source, then publish):
 
-After a Frame is created, its source file is already mounted in the Computer at \`/files/conversation-<conversationId>/<FrameName>.tsx\`. To update the Frame:
-1. Edit that file in place with your file tools, changing only the parts that need to change. Do not rewrite the whole file for partial changes. When the Computer is not available, edit it with \`${FILES_EDIT_TOOL}\` using the scoped path \`conversation-<conversationId>/<FrameName>.tsx\`.
-2. Publish with \`${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` using \`path: conversation-<conversationId>\` (the directory holding the file, not a subdirectory).
+After a Frame is created, its source file is already mounted in the Computer at \`/files/conversation-<conversationId>/<FrameName>.tsx\`. A Frame whose source was moved elsewhere, for example into a Pod app folder, is mounted at its current path instead; resolve it with \`${FILES_RESOLVE_TOOL}\` when unsure. To update the Frame:
+1. Edit that file in place with your file tools, changing only the parts that need to change. Do not rewrite the whole file for partial changes. When the Computer is not available, edit it with \`${FILES_EDIT_TOOL}\` using its scoped path, e.g. \`conversation-<conversationId>/<FrameName>.tsx\`.
+2. Publish with \`${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\`, passing \`path\` set to the source file's own scoped path (the entry file itself, not the directory holding it), e.g. \`conversation-<conversationId>/<FrameName>.tsx\`.
 
 If an edit fails because the text to replace is not found, the file differs from what you remember: re-read it and retry the targeted edit. Never respond to a failed match by resending the whole file.
 
@@ -103,10 +108,10 @@ ${PUBLISH_PARAGRAPH}
 const UPDATING_SECTION_FILES_FIRST = `\
 ### Updating Existing Files (edit the source, then publish):
 
-After a Frame is created, its source file is available to your file tools at \`conversation-<conversationId>/<FrameName>.tsx\`. To update the Frame:
+After a Frame is created, its source file is available to your file tools at \`conversation-<conversationId>/<FrameName>.tsx\`. A Frame whose source was moved elsewhere, for example into a Pod app folder, is available at its current path instead. To update the Frame:
 1. Read the source with \`${FILES_CAT_TOOL}\` if you need the current content. If you are unsure of the exact path, list the directory with \`${FILES_LIST_TOOL}\` or resolve the Frame's file id with \`${FILES_RESOLVE_TOOL}\`.
 2. Make targeted edits with \`${FILES_EDIT_TOOL}\`, replacing only the text that changes. Do not rewrite the whole file for partial changes.
-3. Publish with \`${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` using \`path: conversation-<conversationId>\` (the directory holding the file, not a subdirectory).
+3. Publish with \`${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\`, passing \`path\` set to the source file's own scoped path (the entry file itself, not the directory holding it).
 
 If an edit fails because the text to replace is not found, the file differs from what you remember: re-read it with \`${FILES_CAT_TOOL}\` and retry the targeted edit. Never respond to a failed match by resending the whole file.
 
@@ -119,19 +124,69 @@ ${FILES_EDIT_TOOL}({
 })
 ${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}({
   file_id: "fil_abc123",
-  path: "conversation-<conversationId>",
+  path: "conversation-<conversationId>/Dashboard.tsx",
 })
 \`\`\`
 
 ${PUBLISH_PARAGRAPH}
 `;
 
+// Pod conversations only. A Pod's Frames belong to the Pod rather than to the conversation that
+// happened to create them, and each one gets its own folder so the pod functions and database
+// schema it may grow later land next to it instead of forcing a second move.
+const POD_APP_SECTION = `\
+### Frames In A Pod
+
+This conversation belongs to a Pod, so its Frames belong to the Pod, not to this conversation: every conversation in the Pod sees the same Frame, and it outlives this one.
+
+Give each Frame its own folder on the Pod file system, named after the Frame, and keep the Frame's source inside it:
+
+\`\`\`
+/files/pod-<podId>/
+  MyApp/
+    MyApp.tsx
+\`\`\`
+
+Do this even for a Frame that is a single file today. The folder is where everything the Frame grows later belongs, from extra components to the functions and database schema behind it, so nothing has to move a second time.
+
+\`${CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` creates the Frame's source in the current conversation, so move it into its folder before publishing. Use \`${FILES_MOVE_TOOL}\` (copying does not work on Frame files), then publish it from its Pod path:
+
+\`\`\`
+${FILES_MOVE_TOOL}({
+  source: "conversation-<conversationId>/MyApp.tsx",
+  dest: "pod-<podId>/MyApp/MyApp.tsx",
+})
+${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}({
+  file_id: "fil_abc123",
+  path: "pod-<podId>/MyApp/MyApp.tsx",
+})
+\`\`\`
+
+From then on, edit the source at its Pod path and publish it again. Anything the Frame imports relatively must live under its folder, which is the bundling root.
+`;
+
+// Pod conversations where pod functions are available. Without this, a Frame asked to hold data
+// silently ends up with a `useState` array that dies on reload, and the user only finds out after
+// entering real data.
+const podStorageSection = (podFunctionsSkillName: string) => `\
+### Where The Frame's Data Lives
+
+Decide this before writing the Frame. A Frame is a browser component: a \`useState\` array is gone on reload and private to the one person who typed into it. That is right for a Frame that displays data already living somewhere else, and wrong for a Frame the user will come back to.
+
+If the Frame lets people add, edit, check off, reorder, delete, save, assign, comment, vote, or upload, its data has to survive the page: store it in a Pod database behind pod functions, and enable the \`${podFunctionsSkillName}\` skill to do it. That is the default for a task list, tracker, backlog, roster, inventory, log, queue, notes app, or any form that keeps its answers. The user does not have to say "persisted", "saved", or "shared" to mean it: those are simply what such a Frame is. Build it that way in the same turn as the Frame, rather than shipping an in-memory version and rebuilding it once the user notices their data disappeared.
+
+Keep in component state only what is genuinely throwaway: the selected tab, a filter, a sort order, an expanded row, a draft the user has not submitted.
+`;
+
 interface InstructionsVariant {
   updatingSection: string;
   validationFixExample: string;
+  // Pod-specific sections, empty outside a Pod conversation.
+  podSections: string;
 }
 
 const interactiveContentProseBeforeAuthoring = ({
+  podSections,
   updatingSection,
   validationFixExample,
 }: InstructionsVariant) => `\
@@ -141,7 +196,7 @@ You have access to an Interactive Content system that allows you to create and u
 This toolset is called Frame in the product, users may refer to it as such.
 
 ${CREATE_VS_UPDATE_SECTION}
-### Creating Files
+${podSections}### Creating Files
 
 Use the \`${CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` tool to create JavaScript/TypeScript files:
 - Use MIME type \`${VIZ_MIME_TYPE}\` for visualizations/dashboards or \`${VIZ_SLIDESHOW_MIME_TYPE}\` for slideshows
@@ -343,22 +398,51 @@ const buildInstructions = (variant: InstructionsVariant) =>
   `${interactiveContentProseBeforeAuthoring(variant)}\n${INTERACTIVE_CONTENT_AUTHORING_PROSE_V2}\n${INTERACTIVE_CONTENT_TOOLS_PROSE_AFTER_AUTHORING}`;
 
 // Legacy conversations (no conversation file system): the Frame's source is not reachable by
-// path, so the model updates Frames through the retrieve and file-id edit tools.
+// path, so the model updates Frames through the retrieve and file-id edit tools. Legacy Pod
+// conversations get no Pod sections either, since promoting a Frame into the Pod needs the
+// path-based files tools.
 export const INTERACTIVE_CONTENT_INSTRUCTIONS = buildInstructions({
   updatingSection: UPDATING_SECTION_LEGACY,
   validationFixExample: VALIDATION_FIX_EXAMPLE_LEGACY,
+  podSections: "",
 });
 
-// Conversation file system available, no Computer: the model edits the source through the
-// files server and republishes.
-export const INTERACTIVE_CONTENT_INSTRUCTIONS_FILES_FIRST = buildInstructions({
-  updatingSection: UPDATING_SECTION_FILES_FIRST,
-  validationFixExample: VALIDATION_FIX_EXAMPLE_SOURCE_EDIT,
-});
+// Sections are newline-terminated, so joining and terminating again leaves exactly one blank line
+// between them and before the section that follows.
+const joinPodSections = (sections: string[]): string =>
+  sections.length > 0 ? `${sections.join("\n")}\n` : "";
 
-// Computer available: the model edits the mounted source in the Computer and republishes.
-export const INTERACTIVE_CONTENT_INSTRUCTIONS_COMPUTER_FIRST =
+/**
+ * Instructions for a conversation that has the file system.
+ *
+ * `hasComputer` picks how the Frame's source is edited (in the Computer mount, or through the
+ * files server). `isPod` adds the Pod app layout, and `hasPodFunctions` the storage decision that
+ * depends on the Pod Functions skill actually being available in the workspace.
+ */
+export const buildInteractiveContentInstructions = ({
+  hasComputer,
+  isPod,
+  hasPodFunctions,
+  podFunctionsSkillName,
+}: {
+  hasComputer: boolean;
+  isPod: boolean;
+  hasPodFunctions: boolean;
+  podFunctionsSkillName: string;
+}): string =>
   buildInstructions({
-    updatingSection: UPDATING_SECTION_COMPUTER_FIRST,
+    updatingSection: hasComputer
+      ? UPDATING_SECTION_COMPUTER_FIRST
+      : UPDATING_SECTION_FILES_FIRST,
     validationFixExample: VALIDATION_FIX_EXAMPLE_SOURCE_EDIT,
+    podSections: joinPodSections(
+      isPod
+        ? [
+            POD_APP_SECTION,
+            ...(hasPodFunctions
+              ? [podStorageSection(podFunctionsSkillName)]
+              : []),
+          ]
+        : []
+    ),
   });

--- a/front/lib/api/actions/servers/interactive_content/instructions.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions.ts
@@ -147,8 +147,6 @@ Give each Frame its own folder on the Pod file system, named after the Frame, an
     MyApp.tsx
 \`\`\`
 
-Do this even for a Frame that is a single file today. The folder is where everything the Frame grows later belongs, from extra components to the functions and database schema behind it, so nothing has to move a second time.
-
 \`${CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` creates the Frame's source in the current conversation, so move it into its folder before publishing. Use \`${FILES_MOVE_TOOL}\` (copying does not work on Frame files), then publish it from its Pod path:
 
 \`\`\`
@@ -171,11 +169,9 @@ From then on, edit the source at its Pod path and publish it again. Anything the
 const podStorageSection = (podFunctionsSkillName: string) => `\
 ### Where The Frame's Data Lives
 
-Decide this before writing the Frame. A Frame is a browser component: a \`useState\` array is gone on reload and private to the one person who typed into it. That is right for a Frame that displays data already living somewhere else, and wrong for a Frame the user will come back to.
+If the Frame lets people add, edit, check off, reorder, delete, save, assign, comment, vote, or upload, its data has to survive the page: store it in a Pod database behind pod functions, and enable the \`${podFunctionsSkillName}\` skill to do it. That is the default for a task list, tracker, backlog, roster, inventory, log, queue, notes app, or any form that keeps its answers.
 
-If the Frame lets people add, edit, check off, reorder, delete, save, assign, comment, vote, or upload, its data has to survive the page: store it in a Pod database behind pod functions, and enable the \`${podFunctionsSkillName}\` skill to do it. That is the default for a task list, tracker, backlog, roster, inventory, log, queue, notes app, or any form that keeps its answers. The user does not have to say "persisted", "saved", or "shared" to mean it: those are simply what such a Frame is. Build it that way in the same turn as the Frame, rather than shipping an in-memory version and rebuilding it once the user notices their data disappeared.
-
-Keep in component state only what is genuinely throwaway: the selected tab, a filter, a sort order, an expanded row, a draft the user has not submitted.
+Keep in component state only what is genuinely throwaway. e.g. the selected tab, a filter, or a sort order.
 `;
 
 interface InstructionsVariant {

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -284,11 +284,12 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = [
     name: PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
     description:
       "Publish a Frame from its source files, applying source edits to the live rendered Frame. " +
-      "A Frame's source lives on the conversation file system at " +
+      "A Frame's source lives on the file system it currently belongs to: by default " +
       "`conversation-<conversationId>/<filename>` (mounted in the Computer at " +
-      "`/files/conversation-<conversationId>/<filename>` when the Computer is available), so " +
-      "edit it in place rather than copying it elsewhere, then call this to build it into the " +
-      "live Frame. It resolves the Frame's dependency tree from the entry file's directory " +
+      "`/files/conversation-<conversationId>/<filename>` when the Computer is available), or a " +
+      "Pod path such as `pod-<podId>/<AppName>/<AppName>.tsx` for a Frame that is part of a Pod " +
+      "app. Edit that file in place rather than duplicating it, then call this to build it into " +
+      "the live Frame. It resolves the Frame's dependency tree from the entry file's directory " +
       "(inlining relative imports), validates TypeScript and JSX, then updates the canonical " +
       "Frame so viewers and shares see the new version. A syntax error blocks publishing and is " +
       "reported back so you can fix it. Tailwind warnings are returned but do not block. Pass " +
@@ -305,10 +306,10 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = [
         .string()
         .describe(
           "Scoped path of the Frame's entry source file, not just its directory, e.g. " +
-            "`conversation-<conversationId>/<filename>`, or `pod-<id>/<filename>` for a Frame " +
-            "stored in a project's shared space. If the file was renamed, use its current " +
-            "name, listing the directory first if unsure. This path's directory becomes the " +
-            "bundling root."
+            "`conversation-<conversationId>/<filename>`, or " +
+            "`pod-<podId>/<AppName>/<AppName>.tsx` for a Frame stored in a Pod's shared space. " +
+            "If the file was renamed or moved, use its current path, listing the directory " +
+            "first if unsure. This path's directory becomes the bundling root."
         ),
     },
     enableAlerting: true,

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -70,8 +70,8 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
         .min(1)
         .describe(
           "Scoped path to the function's TypeScript source in the pod, as shown by the files " +
-            "tools. It lives directly in its app's folder (e.g. " +
-            "`pod-<id>/MyApp/greet.ts`)."
+            "tools. It lives in its app's `functions` folder (e.g. " +
+            "`pod-<id>/MyApp/functions/greet.ts`)."
         ),
       executionMode: z
         .enum(SANDBOX_FUNCTION_EXECUTION_MODES)

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -70,7 +70,8 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
         .min(1)
         .describe(
           "Scoped path to the function's TypeScript source in the pod, as shown by the files " +
-            "tools (e.g. `pod-<id>/greet.ts`)."
+            "tools. It lives directly in its app's folder (e.g. " +
+            "`pod-<id>/MyApp/greet.ts`)."
         ),
       executionMode: z
         .enum(SANDBOX_FUNCTION_EXECUTION_MODES)
@@ -236,7 +237,7 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
         .min(1)
         .describe(
           "Scoped path to the database's drizzle schema file in the pod, as shown by the " +
-            "files tools (e.g. `pod-<id>/databases/chat.db.ts`)."
+            "files tools (e.g. `pod-<id>/MyApp/databases/chat.db.ts`)."
         ),
     },
     stake: "never_ask",

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -9,6 +9,7 @@ import {
   RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
 } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { framesSkill } from "@app/lib/resources/skill/code_defined/global/frames";
+import { POD_FUNCTIONS_SKILL_NAME } from "@app/lib/resources/skill/code_defined/global/pod_functions";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
@@ -20,6 +21,10 @@ const COMPUTER_FIRST_MARKER =
 const FILES_FIRST_MARKER =
   "available to your file tools at `conversation-<conversationId>";
 
+// Markers unique to each Pod-only section.
+const POD_APP_MARKER = "### Frames In A Pod";
+const POD_STORAGE_MARKER = "### Where The Frame's Data Lives";
+
 const FILES_EDIT_TOOL = getPrefixedToolName(
   FILES_SERVER_NAME,
   FILES_EDIT_ACTION_NAME
@@ -30,6 +35,12 @@ function agentLoopDataWithUseFileSystem(
 ): AgentLoopExecutionData {
   return {
     conversation: { metadata: { useFileSystem } },
+  } as unknown as AgentLoopExecutionData;
+}
+
+function agentLoopDataInPod(spaceId: string | null): AgentLoopExecutionData {
+  return {
+    conversation: { metadata: { useFileSystem: true }, spaceId },
   } as unknown as AgentLoopExecutionData;
 }
 
@@ -91,5 +102,60 @@ describe("framesSkill.fetchInstructions", () => {
 
     expect(instructions).toContain(COMPUTER_FIRST_MARKER);
     expect(instructions).not.toContain(EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
+  });
+
+  it("keeps Frames in the conversation outside a Pod", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    await FeatureFlagFactory.basic(auth, "sandbox_functions");
+
+    const instructions = await framesSkill.fetchInstructions(auth, {
+      spaceIds: [],
+      agentLoopData: agentLoopDataInPod(null),
+    });
+
+    expect(instructions).not.toContain(POD_APP_MARKER);
+    expect(instructions).not.toContain(POD_STORAGE_MARKER);
+  });
+
+  it("teaches the Pod app layout and storage decision in a Pod", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    await FeatureFlagFactory.basic(auth, "sandbox_functions");
+
+    const instructions = await framesSkill.fetchInstructions(auth, {
+      spaceIds: [],
+      agentLoopData: agentLoopDataInPod("vlt_abc123"),
+    });
+
+    expect(instructions).toContain(POD_APP_MARKER);
+    expect(instructions).toContain("pod-<podId>/MyApp/MyApp.tsx");
+    expect(instructions).toContain(POD_STORAGE_MARKER);
+    expect(instructions).toContain(`\`${POD_FUNCTIONS_SKILL_NAME}\` skill`);
+  });
+
+  it("omits the storage decision when pod functions are unavailable", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+
+    const instructions = await framesSkill.fetchInstructions(auth, {
+      spaceIds: [],
+      agentLoopData: agentLoopDataInPod("vlt_abc123"),
+    });
+
+    expect(instructions).toContain(POD_APP_MARKER);
+    expect(instructions).not.toContain(POD_STORAGE_MARKER);
+  });
+
+  it("keeps the legacy flow for a Pod conversation without the file system", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    await FeatureFlagFactory.basic(auth, "sandbox_functions");
+
+    const instructions = await framesSkill.fetchInstructions(auth, {
+      spaceIds: [],
+      agentLoopData: {
+        conversation: { metadata: { useFileSystem: false }, spaceId: "vlt_a" },
+      } as unknown as AgentLoopExecutionData,
+    });
+
+    expect(instructions).not.toContain(POD_APP_MARKER);
+    expect(instructions).toContain(RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
   });
 });

--- a/front/lib/resources/skill/code_defined/global/frames.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.ts
@@ -1,12 +1,13 @@
 import {
+  buildInteractiveContentInstructions,
   INTERACTIVE_CONTENT_INSTRUCTIONS,
-  INTERACTIVE_CONTENT_INSTRUCTIONS_COMPUTER_FIRST,
-  INTERACTIVE_CONTENT_INSTRUCTIONS_FILES_FIRST,
 } from "@app/lib/api/actions/servers/interactive_content/instructions";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
+import { POD_FUNCTIONS_SKILL_NAME } from "@app/lib/resources/skill/code_defined/global/pod_functions";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
+import { isPodConversation } from "@app/types/assistant/conversation";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 
 export const framesSkill = {
@@ -28,6 +29,10 @@ export const framesSkill = {
   // the Frame's source by path. Legacy conversations (created before the file system defaulted
   // on) keep the retrieve and file-id edit flow. Without a conversation at hand, assume the
   // file system is on since every new conversation has it.
+  //
+  // In a Pod, Frames are Pod apps: they live in the Pod's shared file system, and the ones holding
+  // data the user expects to keep are backed by pod functions. Both only make sense with a
+  // conversation to check, so a Pod-less agent loop keeps the conversation-scoped guidance.
   fetchInstructions: async (
     auth: Authenticator,
     params: { spaceIds: string[]; agentLoopData?: AgentLoopExecutionData }
@@ -38,9 +43,12 @@ export const framesSkill = {
     }
 
     const flags = await getFeatureFlags(auth);
-    return isComputerFeatureEnabled(flags)
-      ? INTERACTIVE_CONTENT_INSTRUCTIONS_COMPUTER_FIRST
-      : INTERACTIVE_CONTENT_INSTRUCTIONS_FILES_FIRST;
+    return buildInteractiveContentInstructions({
+      hasComputer: isComputerFeatureEnabled(flags),
+      isPod: conversation ? isPodConversation(conversation) : false,
+      hasPodFunctions: flags.includes("sandbox_functions"),
+      podFunctionsSkillName: POD_FUNCTIONS_SKILL_NAME,
+    });
   },
   mcpServers: [{ name: "interactive_content" }],
   version: 3,

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -1,5 +1,14 @@
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import {
+  FILES_MOVE_ACTION_NAME,
+  FILES_SERVER_NAME,
+} from "@app/lib/api/actions/servers/files/metadata";
+import {
+  CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+  INTERACTIVE_CONTENT_SERVER_NAME,
+  PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+} from "@app/lib/api/actions/servers/interactive_content/metadata";
+import {
   SANDBOX_FUNCTIONS_SERVER_NAME,
   type SANDBOX_FUNCTIONS_TOOLS_METADATA,
 } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
@@ -14,16 +23,36 @@ function toolName(
   return getPrefixedToolName(SANDBOX_FUNCTIONS_SERVER_NAME, name);
 }
 
+const FILES_MOVE_TOOL = getPrefixedToolName(
+  FILES_SERVER_NAME,
+  FILES_MOVE_ACTION_NAME
+);
+const CREATE_FRAME_TOOL = getPrefixedToolName(
+  INTERACTIVE_CONTENT_SERVER_NAME,
+  CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME
+);
+const PUBLISH_FRAME_TOOL = getPrefixedToolName(
+  INTERACTIVE_CONTENT_SERVER_NAME,
+  PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME
+);
+
+export const POD_FUNCTIONS_SKILL_NAME = "Pod Functions";
+
 export const podFunctionsSkill = {
   sId: "pod_functions",
   kind: "global",
-  name: "Pod Functions",
+  name: POD_FUNCTIONS_SKILL_NAME,
   userFacingDescription:
     "Run hosted functions on the Pod's Computer that can persist data and call other tools.",
   agentFacingDescription:
     "A pod function is a hosted function that runs on the Pod's own Computer, shared across " +
     "every conversation in the Pod, with the ability to persist data and call other tools. It's " +
-    "callable by slug from this conversation or from a Frame's own runtime.",
+    "callable by slug from this conversation or from a Frame's own runtime. This is how a Frame " +
+    "stores data: use it whenever a Frame's content must survive a reload and be the same for " +
+    "everyone who opens it (a task list, tracker, backlog, inventory, log, notes app, or any " +
+    "Frame whose entries users add and expect to find again), or whenever a Frame needs a " +
+    "server-side capability it cannot hold itself, such as calling another tool or using a " +
+    "workspace secret.",
   instructions: `Pod functions are versioned, typed functions published on the Pod's own
 Computer: a persistent environment shared across every conversation in the Pod, not the one
 scoped to this conversation. Each one is a TypeScript module with zod-typed input and output,
@@ -39,11 +68,35 @@ Reach for a pod function instead of inline code or an ad hoc tool call when any 
   there on the next call and visible to a Frame that always reflects the latest state (see
   "Persisting state across calls" below).
 
+#### Laying out a Pod app
+
+A Frame and the pod functions behind it are one app. Keep the whole app in a single folder on the
+Pod file system rather than splitting it between the conversation and the Pod root:
+
+\`\`\`
+/files/pod-<podId>/
+  MyApp/
+    MyApp.tsx        the Frame's source; its directory is the Frame's bundling root
+    list-notes.ts    one file per function, named after the function's slug
+    post-note.ts
+    databases/
+      notes.db.ts    one shared drizzle schema file per database
+\`\`\`
+
+Nothing the app owns stays in the conversation file system: a conversation file belongs to one
+conversation, while the app is shared by every conversation in the Pod, exactly like the functions
+it publishes. If the app's Frame does not exist yet, or still sits in the conversation, the Frames
+skill covers creating it and moving it into the app folder with \`${FILES_MOVE_TOOL}\` before
+\`${PUBLISH_FRAME_TOOL}\`; \`${CREATE_FRAME_TOOL}\` always creates it in the conversation first.
+
+Functions that no Frame calls still get an app folder, named after what they do together.
+
 #### Authoring a function
 
-Write the source as a TypeScript file on the Pod file system (the Computer's mount at
-\`/files/pod-<podId>\`, or through the \`files\` MCP server under a \`pod-<podId>/<rel>\` path). The module
-must:
+Write the source as a TypeScript file directly in the app's folder, at
+\`pod-<podId>/<AppName>/<slug>.ts\` (the Computer mounts it at
+\`/files/pod-<podId>/<AppName>/<slug>.ts\`; the \`files\` MCP server reaches it under the same scoped
+path). The module must:
 
 - export a \`schema\` object with a \`description\` and zod \`input\` and \`output\` schemas,
 - default-export an object with a \`fetch(request: Request): Promise<Response>\` method (the Bun and
@@ -70,10 +123,10 @@ export default {
 };
 \`\`\`
 
-You can split the implementation across several files on the Pod and import them with relative paths
-(e.g. \`import { parse } from "./lib/parse.ts"\`). Publishing bundles the entrypoint and all of its
-relative imports into one module. The bundle is a snapshot taken at publish time, so editing an
-imported helper has no effect until you re-publish.
+You can split the implementation across several files in the app folder and import them with
+relative paths (e.g. \`import { parse } from "./lib/parse.ts"\`). Publishing bundles the entrypoint
+and all of its relative imports into one module. The bundle is a snapshot taken at publish time, so
+editing an imported helper has no effect until you re-publish.
 
 The external packages you can import are \`zod\`, \`drizzle-orm\` and \`@dust/pod\`. Other npm packages
 are not available at build time.
@@ -86,10 +139,12 @@ written there persists across calls and conversations, not just for the duration
 invocation.
 
 Functions of the same Pod can share durable SQLite databases (via \`drizzle-orm\`):
-- **One schema file per database** at \`databases/{db}.db.ts\`, relative to the sources: the single
-  source of truth declaring that database's full schema with drizzle's \`sqliteTable\` DSL. Every
-  function imports its table objects from it (never hand-write tables in a function file), so
-  functions sharing a database must live in the same source directory.
+- **One schema file per database** at \`<AppName>/databases/{db}.db.ts\`: the single source of truth
+  declaring that database's full schema with drizzle's \`sqliteTable\` DSL. Every function imports
+  its table objects from it as \`./databases/{db}.db.ts\` (never hand-write tables in a function
+  file), so functions sharing a database belong to the same app. The database name itself is
+  Pod-wide rather than app-scoped, so pick one that will not collide with another app's
+  (\`${toolName("db_list")}\` shows what the Pod already has).
 - **Name functions that use this db.ts by writting a comment a the top** 
 - **Apply the schema file with \`${toolName("db_reconcile")}\`**; it creates the database and
   applies additive DDL after edits, and enforces the rules below. Publishing does not touch
@@ -98,7 +153,7 @@ Functions of the same Pod can share durable SQLite databases (via \`drizzle-orm\
   table objects.
 
 \`\`\`ts
-// databases/chat.db.ts; the full intended schema, shared by every chat function
+// MyApp/databases/chat.db.ts; the full intended schema, shared by every chat function
 import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 export const messages = sqliteTable("messages", {
@@ -108,7 +163,7 @@ export const messages = sqliteTable("messages", {
   createdAt: integer("created_at", { mode: "timestamp" }),
 }, (t) => [index("messages_created_idx").on(t.createdAt)]);
 
-// post-message.ts; declares schema.databases: ["chat"], then inside fetch:
+// MyApp/post-message.ts; declares schema.databases: ["chat"], then inside fetch:
 import { db } from "@dust/pod";
 import { messages } from "./databases/chat.db.ts";
 const row = db("chat").insert(messages)
@@ -205,7 +260,9 @@ return inline is written to a pod file whose path it reports), and \`${toolName(
 A Frame calls published functions through the injected \`@dust/react-hooks\` module, not the
 \`call\` tool. Always pass the fully qualified \`<podId>/<slug>\` reference reported by
 \`${toolName("get")}\`. Never pass a bare slug or infer the function from the Frame's current Pod.
-This keeps the reference stable if the Frame is moved.
+This keeps the reference stable if the Frame is moved. The app folder is only where the sources
+live: it does not namespace the slug, so the reference stays \`<podId>/<slug>\` and never includes
+the app name.
 
 ##### Designing functions for a Frame
 
@@ -332,7 +389,7 @@ Frames. That single column is what turns a shared Pod database into per-user sta
 you create the table rather than retrofitting it later (schema evolution is additive-only).
 
 \`\`\`ts
-// databases/notes.db.ts
+// MyApp/databases/notes.db.ts
 export const notes = sqliteTable("notes", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   userId: text("user_id"),        // currentUser().sId
@@ -340,7 +397,7 @@ export const notes = sqliteTable("notes", {
   createdAt: integer("created_at", { mode: "timestamp" }),
 }, (t) => [index("notes_user_idx").on(t.userId)]);
 
-// list-notes.ts, declared "workspace_user_required"
+// MyApp/list-notes.ts, declared "workspace_user_required"
 const user = currentUser();
 const rows = db("notes").select().from(notes).where(eq(notes.userId, user.sId)).all();
 \`\`\`

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -76,11 +76,12 @@ Pod file system rather than splitting it between the conversation and the Pod ro
 \`\`\`
 /files/pod-<podId>/
   MyApp/
-    MyApp.tsx        the Frame's source; its directory is the Frame's bundling root
-    list-notes.ts    one file per function, named after the function's slug
-    post-note.ts
+    MyApp.tsx          the Frame's source; its directory is the Frame's bundling root
+    functions/
+      list-notes.ts    one file per function, named after the function's slug
+      post-note.ts
     databases/
-      notes.db.ts    one shared drizzle schema file per database
+      notes.db.ts      one shared drizzle schema file per database
 \`\`\`
 
 Nothing the app owns stays in the conversation file system: a conversation file belongs to one
@@ -93,10 +94,10 @@ Functions that no Frame calls still get an app folder, named after what they do 
 
 #### Authoring a function
 
-Write the source as a TypeScript file directly in the app's folder, at
-\`pod-<podId>/<AppName>/<slug>.ts\` (the Computer mounts it at
-\`/files/pod-<podId>/<AppName>/<slug>.ts\`; the \`files\` MCP server reaches it under the same scoped
-path). The module must:
+Write the source as a TypeScript file in the app's \`functions\` folder, at
+\`pod-<podId>/<AppName>/functions/<slug>.ts\` (the Computer mounts it at
+\`/files/pod-<podId>/<AppName>/functions/<slug>.ts\`; the \`files\` MCP server reaches it under the
+same scoped path). The module must:
 
 - export a \`schema\` object with a \`description\` and zod \`input\` and \`output\` schemas,
 - default-export an object with a \`fetch(request: Request): Promise<Response>\` method (the Bun and
@@ -124,7 +125,8 @@ export default {
 \`\`\`
 
 You can split the implementation across several files in the app folder and import them with
-relative paths (e.g. \`import { parse } from "./lib/parse.ts"\`). Publishing bundles the entrypoint
+relative paths (e.g. \`import { parse } from "./lib/parse.ts"\` for a helper under
+\`functions/lib/\`). Publishing bundles the entrypoint
 and all of its relative imports into one module. The bundle is a snapshot taken at publish time, so
 editing an imported helper has no effect until you re-publish.
 
@@ -141,7 +143,7 @@ invocation.
 Functions of the same Pod can share durable SQLite databases (via \`drizzle-orm\`):
 - **One schema file per database** at \`<AppName>/databases/{db}.db.ts\`: the single source of truth
   declaring that database's full schema with drizzle's \`sqliteTable\` DSL. Every function imports
-  its table objects from it as \`./databases/{db}.db.ts\` (never hand-write tables in a function
+  its table objects from it as \`../databases/{db}.db.ts\` (never hand-write tables in a function
   file), so functions sharing a database belong to the same app. The database name itself is
   Pod-wide rather than app-scoped, so pick one that will not collide with another app's
   (\`${toolName("db_list")}\` shows what the Pod already has).
@@ -163,9 +165,9 @@ export const messages = sqliteTable("messages", {
   createdAt: integer("created_at", { mode: "timestamp" }),
 }, (t) => [index("messages_created_idx").on(t.createdAt)]);
 
-// MyApp/post-message.ts; declares schema.databases: ["chat"], then inside fetch:
+// MyApp/functions/post-message.ts; declares schema.databases: ["chat"], then inside fetch:
 import { db } from "@dust/pod";
-import { messages } from "./databases/chat.db.ts";
+import { messages } from "../databases/chat.db.ts";
 const row = db("chat").insert(messages)
   .values({ author, body, createdAt: new Date() })
   .returning({ id: messages.id }).get();
@@ -397,7 +399,7 @@ export const notes = sqliteTable("notes", {
   createdAt: integer("created_at", { mode: "timestamp" }),
 }, (t) => [index("notes_user_idx").on(t.userId)]);
 
-// MyApp/list-notes.ts, declared "workspace_user_required"
+// MyApp/functions/list-notes.ts, declared "workspace_user_required"
 const user = currentUser();
 const rows = db("notes").select().from(notes).where(eq(notes.userId, user.sId)).all();
 \`\`\`

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -80,6 +80,8 @@ Pod file system rather than splitting it between the conversation and the Pod ro
     functions/
       list-notes.ts    one file per function, named after the function's slug
       post-note.ts
+      lib/
+        notes.ts       helpers shared by several functions
     databases/
       notes.db.ts      one shared drizzle schema file per database
 \`\`\`
@@ -124,11 +126,18 @@ export default {
 };
 \`\`\`
 
-You can split the implementation across several files in the app folder and import them with
-relative paths (e.g. \`import { parse } from "./lib/parse.ts"\` for a helper under
-\`functions/lib/\`). Publishing bundles the entrypoint
-and all of its relative imports into one module. The bundle is a snapshot taken at publish time, so
-editing an imported helper has no effect until you re-publish.
+Keep a function file to its own endpoint and put anything two functions both need in
+\`functions/lib/\`: validation, formatting, an external API client, a query several endpoints run.
+Import helpers with relative paths (\`import { parse } from "./lib/parse.ts"\`). Before writing a
+helper, read what \`functions/lib/\` already has and extend it rather than adding a near-duplicate;
+when a second function needs logic that currently sits inline in the first, move it to
+\`functions/lib/\` instead of copying it.
+
+Publishing bundles the entrypoint and all of its relative imports into one module, so each
+published function carries its own copy of the helpers it uses. The bundle is a snapshot taken at
+publish time: editing a helper changes nothing until you re-publish, and re-publishing one consumer
+leaves the others on the old copy. After changing a shared helper, re-publish every function that
+imports it.
 
 The external packages you can import are \`zod\`, \`drizzle-orm\` and \`@dust/pod\`. Other npm packages
 are not available at build time.


### PR DESCRIPTION
## Problem

Creating a Frame with functions in a Pod produced a structure that did not reflect what was being built. The Frame's source landed in the conversation file system, while the pod functions behind it went flat into the Pod root — two file systems, no folder tying them together, and the Frame scoped to a single conversation even though the functions it called were shared across the whole Pod.

Separately, "Create a frame that implements a simple task list" produced a `useState` array. The data vanished on reload, and the user only found out after entering real tasks — they had to re-prompt with "a *persisted* task list" to get the right thing.

## What changes

**Frames in a Pod are Pod apps.** They live in the Pod's shared file system, each in its own folder holding the Frame's source, the functions behind it, and their shared database schemas:

```
/files/pod-<podId>/
  MyApp/
    MyApp.tsx
    functions/
      list-notes.ts
      post-note.ts
      lib/
        notes.ts
    databases/
      notes.db.ts
```

The folder is created even for a Frame that is a single file today, so nothing has to move a second time when functions are added later. Since `create_interactive_content_file` always creates the source in the conversation, the instructions spell out the create → `files__move` → publish-from-Pod-path flow (`copy` is rejected for Frame files; `move` updates the `FileResource` mount so publishing from the new path works).

**Persistence is the default.** A new "Where The Frame's Data Lives" section names the trigger behaviourally — if the Frame lets people add, edit, check off, reorder, delete, assign, comment, vote or upload, the data goes in a Pod database behind pod functions — and states outright that the user does not have to say "persisted" for that to be what they meant. It also bounds the rule, so tab/filter/sort/expanded-row state stays in the component.

This had to go in the Frames instructions rather than the Pod Functions skill: equipped skills are fetched with `withInstructions: false`, so the model only sees that skill's name and description until it calls `enable_skill` — the decision has to be reachable before the model knows functions are involved. Two supporting changes make it actionable: the section names the `Pod Functions` skill as an exact backtick literal, and that skill's `agentFacingDescription` (the only text visible while equipped) now leads with "this is how a Frame stores data".

## Implementation notes

`fetchInstructions` composes the prose via `buildInteractiveContentInstructions({ hasComputer, isPod, hasPodFunctions, podFunctionsSkillName })` instead of selecting from fixed constants — three independent booleans made eight exported constants untenable. Legacy conversations still short-circuit to `INTERACTIVE_CONTENT_INSTRUCTIONS`: without the path-based files tools there is no way to promote a Frame into the Pod.

The storage section is gated on the `sandbox_functions` flag; the app-folder layout is not, since it is only file placement. A Pod conversation in a workspace without the flag gets the layout and no dangling pointer to a skill it cannot enable.

The Pod-app layout also appears in the Pod Functions skill, trimmed to the function side and deferring to the Frames skill for the Frame move/publish mechanics, so the two do not teach the same flow and drift apart.

## Drive-by fix

The publish instructions told the model to pass `path: conversation-<conversationId>` — the directory. `splitFrameEntryScopedPath` takes `dirname`, so that yields root `"."` and errors out; the tool's own schema correctly asks for the entry file. Already broken, and it would have blocked the new Pod flow too, so both variants and the worked example now pass the entry file path.

## Test plan

- `npx tsgo --noEmit` clean, biome clean.
- 169 tests pass across `lib/resources/skill`, `interactive_content`, `sandbox_functions`, `publish_frame` and `skills_rendering`.
- Four new cases in `frames.test.ts`: Pod gets both sections; non-Pod gets neither; Pod without the `sandbox_functions` flag gets the layout but not the storage section; a legacy Pod conversation keeps the retrieve/file-id flow.


