### PR TITLE
Admin governance: show similar 'members and agents' skills

### DIFF
--- a/front-api/routes/w/[wId]/skills/similar.test.ts
+++ b/front-api/routes/w/[wId]/skills/similar.test.ts
@@ -155,11 +155,77 @@ describe("POST /api/w/:wId/skills/similar", () => {
     const response = await post(workspace, {});
 
     expect(response.status).toBe(400);
-    expect(await response.json()).toEqual({
-      error: {
-        type: "invalid_request_error",
-        message: "naturalDescription is required and must be a string.",
-      },
+    const body = await response.json();
+    expect(body.error.type).toBe("invalid_request_error");
+    expect(body.error.message).toContain("naturalDescription");
+  });
+
+  it("returns 400 when availabilities contains an unknown value", async () => {
+    const { workspace } = await setup();
+
+    const response = await post(workspace, {
+      naturalDescription: "Create GitHub issues for support",
+      availabilities: ["not_an_availability"],
     });
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error.type).toBe("invalid_request_error");
+    expect(body.error.message).toContain("availabilities");
+  });
+
+  it("only compares against skills matching the requested availabilities", async () => {
+    const { workspace, auth } = await setup();
+
+    const discoverableSkill = await SkillFactory.create(auth, {
+      name: "Discoverable Skill",
+      agentFacingDescription: "Open support cards on github.com",
+      availability: "users_and_agents",
+    });
+    await SkillFactory.create(auth, {
+      name: "Members Only Skill",
+      agentFacingDescription: "Create issues on GitHub repositories",
+      availability: "workspace_users",
+    });
+
+    vi.mocked(runMultiActionsAgent).mockResolvedValue(
+      mockSimilarSkillsResponse([discoverableSkill.sId])
+    );
+
+    const response = await post(workspace, {
+      naturalDescription: "Create GitHub issues for support",
+      availabilities: ["users_and_agents"],
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      similar_skills: [discoverableSkill.sId],
+    });
+    expect(runMultiActionsAgent).toHaveBeenCalledTimes(1);
+
+    // Only the users_and_agents skill was submitted to the LLM.
+    const [, , { conversation }] =
+      vi.mocked(runMultiActionsAgent).mock.calls[0];
+    const inputText = JSON.stringify(conversation.messages);
+    expect(inputText).toContain(discoverableSkill.sId);
+    expect(inputText).not.toContain("Create issues on GitHub repositories");
+  });
+
+  it("returns empty similar skills without calling the LLM when no skill matches the requested availabilities", async () => {
+    const { workspace, auth } = await setup();
+
+    await SkillFactory.create(auth, {
+      name: "Members Only Skill",
+      availability: "workspace_users",
+    });
+
+    const response = await post(workspace, {
+      naturalDescription: "Create GitHub issues for support",
+      availabilities: ["users_and_agents"],
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ similar_skills: [] });
+    expect(runMultiActionsAgent).not.toHaveBeenCalled();
   });
 });

--- a/front-api/routes/w/[wId]/skills/similar.ts
+++ b/front-api/routes/w/[wId]/skills/similar.ts
@@ -1,11 +1,19 @@
 import { getSimilarSkills } from "@app/lib/api/skills/existing_skill_checker";
 import logger from "@app/logger/logger";
-import { isString } from "@app/types/shared/utils/general";
+import { SKILL_AVAILABILITIES } from "@app/types/assistant/skill_configuration";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 // Mounted at /api/w/:wId/skills/similar.
 const app = workspaceApp();
+
+const PostSimilarSkillsBodySchema = z.object({
+  naturalDescription: z.string(),
+  excludeSkillId: z.string().optional(),
+  availabilities: z.array(z.enum(SKILL_AVAILABILITIES)).nonempty().optional(),
+});
 
 /** @ignoreswagger */
 app.post("/", async (ctx) => {
@@ -13,32 +21,25 @@ app.post("/", async (ctx) => {
   const owner = auth.getNonNullableWorkspace();
 
   const body = await ctx.req.json().catch(() => null);
-  const naturalDescription = body?.naturalDescription;
-  const excludeSkillId = body?.excludeSkillId;
+  const bodyValidation = PostSimilarSkillsBodySchema.safeParse(body);
 
-  if (!isString(naturalDescription)) {
+  if (!bodyValidation.success) {
     return apiError(ctx, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "naturalDescription is required and must be a string.",
+        message: fromError(bodyValidation.error).toString(),
       },
     });
   }
 
-  if (excludeSkillId !== undefined && !isString(excludeSkillId)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "excludeSkillId must be a string if provided.",
-      },
-    });
-  }
+  const { naturalDescription, excludeSkillId, availabilities } =
+    bodyValidation.data;
 
   const result = await getSimilarSkills(auth, {
     naturalDescription,
     excludeSkillId: excludeSkillId ?? null,
+    availabilities,
   });
 
   if (result.isErr()) {

--- a/front/components/skill_builder/SimilarSkillsDisplay.tsx
+++ b/front/components/skill_builder/SimilarSkillsDisplay.tsx
@@ -8,12 +8,16 @@ interface SimilarSkillsDisplayProps {
   owner: LightWorkspaceType;
   similarSkills: SkillWithoutInstructionsAndToolsType[];
   isLoading: boolean;
+  loadingLabel?: string;
+  title?: string;
 }
 
 export function SimilarSkillsDisplay({
   owner,
   similarSkills,
   isLoading,
+  loadingLabel = "Checking for similar skills...",
+  title = "Similar skills found",
 }: SimilarSkillsDisplayProps) {
   if (similarSkills.length === 0 && !isLoading) {
     return null;
@@ -23,7 +27,7 @@ export function SimilarSkillsDisplay({
     return (
       <div className="flex items-center gap-2 text-sm text-muted-foreground">
         <Spinner size="xs" />
-        <span>Checking for similar skills...</span>
+        <span>{loadingLabel}</span>
       </div>
     );
   }
@@ -31,7 +35,7 @@ export function SimilarSkillsDisplay({
   return (
     <div className="space-y-3">
       <div className="flex items-center gap-2">
-        <span className="heading-sm text-foreground">Similar skills found</span>
+        <span className="heading-sm text-foreground">{title}</span>
         {isLoading && <Spinner size="xs" />}
       </div>
       <div className="space-y-3">

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -3,6 +3,7 @@ import { SkillBuilderEnableSuggestionsSection } from "@app/components/skill_buil
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { SkillBuilderIconSection } from "@app/components/skill_builder/SkillBuilderIconSection";
 import { SkillBuilderNameSection } from "@app/components/skill_builder/SkillBuilderNameSection";
+import { SkillBuilderSimilarDiscoverableSkills } from "@app/components/skill_builder/SkillBuilderSimilarDiscoverableSkills";
 import { SkillBuilderUserFacingDescriptionSection } from "@app/components/skill_builder/SkillBuilderUserFacingDescriptionSection";
 import { SkillEditorsAccessWarning } from "@app/components/skill_builder/SkillEditorsAccessWarning";
 import { SkillEditorsSheetWithButton } from "@app/components/skill_builder/SkillEditorsSheetWithButton";
@@ -225,6 +226,7 @@ export function SkillBuilderSettingsSection({
             restrictedSpaces={nonGlobalSpacesWithRestrictions}
           />
         )}
+        <SkillBuilderSimilarDiscoverableSkills />
       </div>
 
       {hasSelfImprovingSkills && (

--- a/front/components/skill_builder/SkillBuilderSimilarDiscoverableSkills.tsx
+++ b/front/components/skill_builder/SkillBuilderSimilarDiscoverableSkills.tsx
@@ -1,0 +1,94 @@
+import { SimilarSkillsDisplay } from "@app/components/skill_builder/SimilarSkillsDisplay";
+import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
+import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import { useDebounceWithAbort } from "@app/hooks/useDebounce";
+import { useSimilarSkills, useSkills } from "@app/lib/swr/skill_configurations";
+import type {
+  SkillAvailability,
+  SkillWithoutInstructionsAndToolsType,
+} from "@app/types/assistant/skill_configuration";
+import { useCallback, useEffect, useState } from "react";
+import { useWatch } from "react-hook-form";
+
+const DEBOUNCE_DELAY_MS = 250;
+const MIN_DESCRIPTION_LENGTH = 10;
+
+const DISCOVERABLE_AVAILABILITIES: SkillAvailability[] = ["users_and_agents"];
+
+// Skills available to members and agents are auto-discovered by agents, so a duplicate there is
+// more harmful than elsewhere: we surface the overlap with that subset specifically.
+export function SkillBuilderSimilarDiscoverableSkills() {
+  const { owner, skillId } = useSkillBuilderContext();
+
+  const { getSimilarSkills } = useSimilarSkills({ owner });
+  const { skills } = useSkills({ owner });
+
+  const availability = useWatch<SkillBuilderFormData, "availability">({
+    name: "availability",
+  });
+  const agentFacingDescription = useWatch<
+    SkillBuilderFormData,
+    "agentFacingDescription"
+  >({ name: "agentFacingDescription" });
+
+  const [similarSkills, setSimilarSkills] = useState<
+    SkillWithoutInstructionsAndToolsType[]
+  >([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const fetchSimilarSkills = useCallback(
+    async (description: string, signal: AbortSignal) => {
+      setIsLoading(true);
+
+      const result = await getSimilarSkills(description, {
+        excludeSkillId: skillId,
+        availabilities: DISCOVERABLE_AVAILABILITIES,
+        signal,
+      });
+
+      if (!signal.aborted) {
+        setIsLoading(false);
+        if (result.isOk()) {
+          const similarSkillIds = new Set(result.value);
+          setSimilarSkills(
+            skills.filter((skill) => similarSkillIds.has(skill.sId))
+          );
+        }
+      }
+    },
+    [getSimilarSkills, skillId, skills]
+  );
+
+  const triggerSimilarSkillsFetch = useDebounceWithAbort(fetchSimilarSkills, {
+    delayMs: DEBOUNCE_DELAY_MS,
+  });
+
+  const isDiscoverable = availability === "users_and_agents";
+  const description = agentFacingDescription?.trim() ?? "";
+
+  // Runs on mount, whenever the description changes, and whenever the availability switches to
+  // (or away from) "Members and agents".
+  useEffect(() => {
+    if (!isDiscoverable || description.length < MIN_DESCRIPTION_LENGTH) {
+      setSimilarSkills([]);
+      setIsLoading(false);
+      return;
+    }
+
+    triggerSimilarSkillsFetch(description);
+  }, [description, isDiscoverable, triggerSimilarSkillsFetch]);
+
+  if (!isDiscoverable) {
+    return null;
+  }
+
+  return (
+    <SimilarSkillsDisplay
+      owner={owner}
+      similarSkills={similarSkills}
+      isLoading={isLoading}
+      loadingLabel="Checking for similar skills available to members and agents..."
+      title="Similar skills already available to members and agents"
+    />
+  );
+}

--- a/front/lib/api/skills/existing_skill_checker.ts
+++ b/front/lib/api/skills/existing_skill_checker.ts
@@ -5,6 +5,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import type { SkillAvailability } from "@app/types/assistant/skill_configuration";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import chunk from "lodash/chunk";
@@ -181,11 +182,19 @@ ${existingSkills}
   return new Ok(similar_skills);
 }
 
+// By default we compare against all existing published custom skills: unpublished
+// (editors-only) skills should not prevent someone else from creating a similar skill.
+export const DEFAULT_SIMILAR_SKILLS_AVAILABILITIES: SkillAvailability[] = [
+  "workspace_users",
+  "users_and_agents",
+];
+
 export async function getSimilarSkills(
   auth: Authenticator,
   inputs: {
     naturalDescription: string;
     excludeSkillId: string | null;
+    availabilities?: SkillAvailability[];
   }
 ): Promise<Result<{ similar_skills: string[] }, Error>> {
   const model = await getSmallWhitelistedModel(auth);
@@ -195,11 +204,10 @@ export async function getSimilarSkills(
     );
   }
 
-  // Retrieve all existing published custom skills: unpublished (editors-only) skills
-  // should not prevent someone else from creating a similar skill.
   const allSkills: SkillResource[] = await SkillResource.listByWorkspace(auth, {
     onlyCustom: true,
-    availability: ["workspace_users", "users_and_agents"],
+    availability:
+      inputs.availabilities ?? DEFAULT_SIMILAR_SKILLS_AVAILABILITIES,
   });
 
   const skills = inputs.excludeSkillId

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -263,6 +263,8 @@ export function useSimilarSkills({ owner }: { owner: LightWorkspaceType }) {
       naturalDescription: string,
       options: {
         excludeSkillId: string | null;
+        // Restricts the skills to compare against. Defaults server-side to all published skills.
+        availabilities?: SkillAvailability[];
         signal?: AbortSignal;
       }
     ) => {
@@ -276,6 +278,7 @@ export function useSimilarSkills({ owner }: { owner: LightWorkspaceType }) {
           body: JSON.stringify({
             naturalDescription,
             excludeSkillId: options?.excludeSkillId ?? undefined,
+            availabilities: options?.availabilities,
           }),
           signal: options?.signal,
         }


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/9892

 - refactor the /similar skills endpoint to take a availability param
 - add a new "similar" check below the "Availability" sections only enabled when skill is in "Members and agents" to check if there are similar "Members and agents" skills.

## Tests

tested locally


<img width="1060" height="224" alt="Screenshot 2026-08-06 at 15 10 28" src="https://github.com/user-attachments/assets/2ee2ade3-3840-4f73-8153-7909aeeee4dd" />

<hr>

<img width="1393" height="634" alt="Screenshot 2026-08-06 at 15 10 45" src="https://github.com/user-attachments/assets/24bdacdf-2f95-488b-afb9-132a6c5efdb1" />

## Risk

low, easy to revert UI change if needed

## Deploy Plan

deploy front 
