### PR TITLE
[front] fix: filter high stake tools on activation origin

### DIFF
--- a/front/lib/actions/approval_tools_listing.test.ts
+++ b/front/lib/actions/approval_tools_listing.test.ts
@@ -5,14 +5,18 @@ import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFa
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import type { UserMessageOrigin } from "@app/types/assistant/conversation";
+import { ACTIVATION_NUDGE_ORIGIN } from "@app/types/assistant/conversation";
 import { describe, expect, it } from "vitest";
 
 // Lists the tools an agent sees when answering `content`, from a server that mixes tools running
 // without approval with tools that ask for one.
 async function listedToolNames({
   authorless,
+  origin,
 }: {
   authorless: boolean;
+  origin: UserMessageOrigin;
 }): Promise<string[]> {
   const { authenticator, globalSpace, workspace } = await createResourceTest({
     role: "admin",
@@ -51,6 +55,7 @@ async function listedToolNames({
     // The agent message factory sits at rank 0.
     rank: 1,
     authorless,
+    origin,
   });
 
   const serverToolsAndInstructions = await tryListMCPTools(
@@ -78,14 +83,32 @@ async function listedToolNames({
 
 describe("tryListMCPTools approval-requiring tools", () => {
   it("lists them when a person wrote the message", async () => {
-    const toolNames = await listedToolNames({ authorless: false });
+    const toolNames = await listedToolNames({
+      authorless: false,
+      origin: "web",
+    });
 
     expect(toolNames).toContain("list_schedules");
     expect(toolNames).toContain("create_schedule");
   });
 
-  it("leaves them out for a message nobody wrote", async () => {
-    const toolNames = await listedToolNames({ authorless: true });
+  // An agent posting for someone leaves no author on the message, and the person it posts for still
+  // opens the conversation and answers the approval there.
+  it("lists them for a message nobody wrote outside of a nudge", async () => {
+    const toolNames = await listedToolNames({
+      authorless: true,
+      origin: "web",
+    });
+
+    expect(toolNames).toContain("list_schedules");
+    expect(toolNames).toContain("create_schedule");
+  });
+
+  it("leaves them out of a nudge", async () => {
+    const toolNames = await listedToolNames({
+      authorless: true,
+      origin: ACTIVATION_NUDGE_ORIGIN,
+    });
 
     expect(toolNames).toContain("list_schedules");
     expect(toolNames).not.toContain("create_schedule");

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -97,7 +97,10 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { fromEvent } from "@app/lib/utils/events";
 import logger from "@app/logger/logger";
-import { isUserMessageWithoutConcreteUser } from "@app/types/assistant/conversation";
+import {
+  ACTIVATION_NUDGE_ORIGIN,
+  isUserMessageWithoutConcreteUser,
+} from "@app/types/assistant/conversation";
 import type { OAuthProvider } from "@app/types/oauth/lib";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -1082,6 +1085,9 @@ export async function tryListMCPTools(
   const isWithoutConcreteUser = isUserMessageWithoutConcreteUser(
     agentLoopListToolsContext.userMessage
   );
+  const isActivationNudge =
+    agentLoopListToolsContext.userMessage.context.origin ===
+    ACTIVATION_NUDGE_ORIGIN;
 
   // An admin scoping a server to `personal_actions` decided it runs on each
   // person's own credentials. A message nobody wrote (posted by Dust on the
@@ -1166,10 +1172,11 @@ export async function tryListMCPTools(
       const processedTools: MCPToolConfigurationType[] = [];
 
       for (const toolConfig of rawToolsFromServer) {
-        // Nobody wrote this message, so nobody is waiting on its answer: an approval prompt would
-        // be addressed to a person who never asked anything, and the run would sit blocked until
-        // they happen to open the conversation. Only `never_ask` tools run without one.
-        if (isWithoutConcreteUser && toolConfig.permission !== "never_ask") {
+        // A nudge is not something the user asked for, so nobody is waiting on its answer: an
+        // approval prompt would be addressed to a person who never asked anything, and the run
+        // would sit blocked until they happen to open the conversation. Only `never_ask` tools
+        // run there.
+        if (isActivationNudge && toolConfig.permission !== "never_ask") {
           continue;
         }
 


### PR DESCRIPTION
## Description

I introduced a filter on highstake tools based on the presence of userMessage.user == null, which had unwanted ripple effects like a conversation created by pod_manager's create_conversation (which passes doNotAssociateuser which sets userMsg.user to null).

This PR instead filters based on the new activation nudge origin. Less elegant, but much easier to understand.



## Tests

Unit tests 


## Risk

Low


## Deploy Plan

- Deploy front