### PR TITLE
[front] feat: add batch skill archive endpoint

### DIFF
--- a/front-api/routes/w/[wId]/skills/archive.test.ts
+++ b/front-api/routes/w/[wId]/skills/archive.test.ts
@@ -1,0 +1,109 @@
+import { Authenticator } from "@app/lib/auth";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+async function setupTest(role: MembershipRoleType = "admin") {
+  const { workspace, user: requestUser } = await createPrivateApiMockRequest({
+    role,
+  });
+  const skillOwner = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, skillOwner, {
+    role: "builder",
+  });
+
+  const requestUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    requestUser.sId,
+    workspace.sId
+  );
+  const skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    skillOwner.sId,
+    workspace.sId
+  );
+
+  return { workspace, requestUserAuth, skillOwnerAuth };
+}
+
+function archiveSkills(workspace: { sId: string }, skillIds: string[]) {
+  return honoApp.request(`/api/w/${workspace.sId}/skills/archive`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ skillIds }),
+  });
+}
+
+describe("POST /api/w/:wId/skills/archive", () => {
+  it("archives several skills at once", async () => {
+    const { workspace, requestUserAuth, skillOwnerAuth } = await setupTest();
+    const firstSkill = await SkillFactory.create(skillOwnerAuth, {
+      name: "First Skill",
+    });
+    const secondSkill = await SkillFactory.create(skillOwnerAuth, {
+      name: "Second Skill",
+    });
+
+    const response = await archiveSkills(workspace, [
+      firstSkill.sId,
+      secondSkill.sId,
+    ]);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ archived: 2 });
+    const archivedSkills = await SkillResource.fetchByIds(requestUserAuth, [
+      firstSkill.sId,
+      secondSkill.sId,
+    ]);
+    expect(archivedSkills.map((skill) => skill.status)).toEqual([
+      "archived",
+      "archived",
+    ]);
+  });
+
+  it("denies a caller who cannot administrate every skill", async () => {
+    const { workspace, requestUserAuth, skillOwnerAuth } =
+      await setupTest("builder");
+    const administratedSkill = await SkillFactory.create(requestUserAuth, {
+      name: "Administrated Skill",
+    });
+    const otherSkill = await SkillFactory.create(skillOwnerAuth, {
+      name: "Other Skill",
+    });
+
+    const response = await archiveSkills(workspace, [
+      administratedSkill.sId,
+      otherSkill.sId,
+    ]);
+
+    expect(response.status).toBe(403);
+    const unchangedSkills = await SkillResource.fetchByIds(requestUserAuth, [
+      administratedSkill.sId,
+      otherSkill.sId,
+    ]);
+    expect(unchangedSkills.map((skill) => skill.status)).toEqual([
+      "active",
+      "active",
+    ]);
+  });
+
+  it("does not archive any skill when one is missing", async () => {
+    const { workspace, requestUserAuth, skillOwnerAuth } = await setupTest();
+    const skill = await SkillFactory.create(skillOwnerAuth);
+
+    const response = await archiveSkills(workspace, [
+      skill.sId,
+      "skl_0000000000",
+    ]);
+
+    expect(response.status).toBe(404);
+    const unchangedSkill = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(unchangedSkill?.status).toBe("active");
+  });
+});

--- a/front-api/routes/w/[wId]/skills/archive.ts
+++ b/front-api/routes/w/[wId]/skills/archive.ts
@@ -1,0 +1,82 @@
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { isResourceSId } from "@app/lib/resources/string_ids";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import uniq from "lodash/uniq";
+import { z } from "zod";
+
+const MAX_SKILLS_PER_BATCH = 1000;
+
+const PostSkillsArchiveBodySchema = z.object({
+  skillIds: z.array(z.string()).min(1).max(MAX_SKILLS_PER_BATCH),
+});
+
+export type PostSkillsArchiveResponseBody = {
+  archived: number;
+};
+
+// Mounted at /api/w/:wId/skills/archive.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  validate("json", PostSkillsArchiveBodySchema),
+  async (ctx): HandlerResult<PostSkillsArchiveResponseBody> => {
+    const auth = ctx.get("auth");
+    const { skillIds: requestedSkillIds } = ctx.req.valid("json");
+    const skillIds = uniq(requestedSkillIds);
+
+    const invalidSkillIds = skillIds.filter(
+      (skillId) => !isResourceSId("skill", skillId)
+    );
+    if (invalidSkillIds.length > 0) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Only custom skills can be archived: ${invalidSkillIds.join(", ")}.`,
+        },
+      });
+    }
+
+    const skills = await SkillResource.fetchByIds(auth, skillIds, {
+      onlyActive: true,
+    });
+    const foundSkillIds = new Set(skills.map((skill) => skill.sId));
+    const missingSkillIds = skillIds.filter(
+      (skillId) => !foundSkillIds.has(skillId)
+    );
+    if (missingSkillIds.length > 0) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "skill_not_found",
+          message: `Skills not found: ${missingSkillIds.join(", ")}.`,
+        },
+      });
+    }
+
+    if (skills.some((skill) => !skill.canAdministrate(auth))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message: "Only admins and editors can archive skills.",
+        },
+      });
+    }
+
+    // Archiving a skill updates its dependent agents, parent skills, and editor
+    // memberships in one transaction, so preserve that resource-level operation.
+    for (const skill of skills) {
+      await skill.archive(auth);
+    }
+
+    return ctx.json({ archived: skills.length });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -30,6 +30,7 @@ import { validate } from "@front-api/middlewares/validator";
 import uniq from "lodash/uniq";
 import { z } from "zod";
 import skill from "./[sId]";
+import archive from "./archive";
 import availability from "./availability";
 import detect from "./detect";
 import importRoute from "./import";
@@ -108,6 +109,7 @@ function resolveRequestedAvailability({
 const app = workspaceApp();
 
 // Static sub-paths must be registered before the param sub-app.
+app.route("/archive", archive);
 app.route("/availability", availability);
 app.route("/detect", detect);
 app.route("/import", importRoute);


### PR DESCRIPTION
## Description

The goal here is to allow archiving skills in batch.
This PR handles the backend part.

The endpoint validates all requested custom skill IDs and archive permissions before calling the existing resource-level archive behavior for each skill.

## Tests

- Added tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
