### PR TITLE
fix(front): also display skills used in UsedBy button

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -12400,6 +12400,50 @@
                 "nullable": true
               }
             }
+          },
+          "usage": {
+            "type": "object",
+            "description": "Present when the view was fetched with usage details (withDetails query param). Counts agents and skills that use this data source view.",
+            "properties": {
+              "count": {
+                "type": "integer"
+              },
+              "agents": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "sId": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "pictureUrl": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "skills": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "sId": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "icon": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       },

--- a/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/index.ts
@@ -1,3 +1,4 @@
+import { getDataSourceViewUsage } from "@app/lib/api/agent_data_sources";
 import { softDeleteDataSourceAndLaunchScrubWorkflow } from "@app/lib/api/data_sources";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -51,7 +52,9 @@ app.delete(
       [dataSource]
     );
     const viewsUsageByAgentsRes = await Promise.all(
-      dataSourceViews.map((view) => view.getUsagesByAgents(auth))
+      dataSourceViews.map((view) =>
+        getDataSourceViewUsage({ auth, dataSourceView: view })
+      )
     );
 
     const viewsUsedByAgentsName = viewsUsageByAgentsRes.reduce(

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -1215,6 +1215,35 @@
  *             userId:
  *               type: string
  *               nullable: true
+ *         usage:
+ *           type: object
+ *           description: Present when the view was fetched with usage details (withDetails query param). Counts agents and skills that use this data source view.
+ *           properties:
+ *             count:
+ *               type: integer
+ *             agents:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   sId:
+ *                     type: string
+ *                   name:
+ *                     type: string
+ *                   pictureUrl:
+ *                     type: string
+ *             skills:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   sId:
+ *                     type: string
+ *                   name:
+ *                     type: string
+ *                   icon:
+ *                     type: string
+ *                     nullable: true
  *     PrivateDataSource:
  *       type: object
  *       description: A data source in the workspace.

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.test.ts
@@ -1,0 +1,69 @@
+import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function deleteDataSourceView(
+  workspace: { sId: string },
+  spaceId: string,
+  dsvId: string,
+  query: Record<string, string> = {}
+) {
+  const qs = new URLSearchParams(query).toString();
+  const suffix = qs ? `?${qs}` : "";
+  return honoApp.request(
+    `/api/w/${workspace.sId}/spaces/${spaceId}/data_source_views/${dsvId}${suffix}`,
+    { method: "DELETE" }
+  );
+}
+
+describe("DELETE /api/w/:wId/spaces/:spaceId/data_source_views/:dsvId", () => {
+  it("blocks deletion and names the skill when only a skill uses it, not an agent", async () => {
+    const { workspace, globalSpace, auth } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "admin",
+    });
+
+    const dataSourceView = await DataSourceViewFactory.folder(
+      workspace,
+      globalSpace
+    );
+    const skill = await SkillFactory.create(auth, {
+      name: "Space Knowledge Skill",
+      availability: "workspace_users",
+      attachedKnowledge: [{ dataSourceView, nodeId: "node-1" }],
+    });
+
+    const response = await deleteDataSourceView(
+      workspace,
+      globalSpace.sId,
+      dataSourceView.sId
+    );
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.error.message).toContain(skill.name);
+  });
+
+  it("deletes successfully when forced, bypassing the usage guard", async () => {
+    const { workspace, globalSpace } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "admin",
+    });
+
+    const dataSourceView = await DataSourceViewFactory.folder(
+      workspace,
+      globalSpace
+    );
+
+    const response = await deleteDataSourceView(
+      workspace,
+      globalSpace.sId,
+      dataSourceView.sId,
+      { force: "true" }
+    );
+
+    expect(response.status).toBe(204);
+  });
+});

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -1,5 +1,8 @@
 import config from "@app/lib/api/config";
-import { handlePatchDataSourceView } from "@app/lib/api/data_source_view";
+import {
+  handleDeleteDataSourceView,
+  handlePatchDataSourceView,
+} from "@app/lib/api/data_source_view";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import logger from "@app/logger/logger";
 import type {
@@ -263,34 +266,34 @@ app.delete(
   async (ctx) => {
     const auth = ctx.get("auth");
     const dataSourceView = ctx.get("dataSourceView");
-
-    if (!dataSourceView.canAdministrate(auth)) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message: "Only users that are `admins` can administrate spaces.",
-        },
-      });
-    }
-
     const force = ctx.req.query("force") === "true";
-    if (!force) {
-      const usageRes = await dataSourceView.getUsagesByAgents(auth);
-      if (usageRes.isErr() || usageRes.value.count > 0) {
-        return apiError(ctx, {
-          status_code: 401,
-          api_error: {
-            type: "data_source_error",
-            message: usageRes.isOk()
-              ? `The data source view is in use by ${usageRes.value.agents.map((a) => a.name).join(", ")} and cannot be deleted.`
-              : "The data source view is in use and cannot be deleted.",
-          },
-        });
+
+    const result = await handleDeleteDataSourceView(auth, dataSourceView, {
+      force,
+    });
+    if (result.isErr()) {
+      switch (result.error.code) {
+        case "unauthorized":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message: result.error.message,
+            },
+          });
+        case "in_use":
+          return apiError(ctx, {
+            status_code: 401,
+            api_error: {
+              type: "data_source_error",
+              message: result.error.message,
+            },
+          });
+        default:
+          assertNever(result.error.code);
       }
     }
 
-    await dataSourceView.delete(auth, { hardDelete: true });
     return ctx.body(null, 204);
   }
 );

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -1,4 +1,4 @@
-import type { DataSourcesUsageByAgent } from "@app/lib/api/agent_data_sources";
+import type { DataSourcesUsage } from "@app/lib/api/agent_data_sources";
 import {
   getDataSourcesUsageByCategory,
   getDataSourceViewsUsageByModelIds,
@@ -167,7 +167,7 @@ app.get(
       });
     }
 
-    let usages: DataSourcesUsageByAgent = {};
+    let usages: DataSourcesUsage = {};
     if (space.isSystem()) {
       // In system spaces, reflect usage by data sources themselves (across all
       // spaces), then remap onto this space's views.
@@ -200,7 +200,11 @@ app.get(
                 fetchConnectorError: false,
                 fetchConnectorErrorMessage: null,
               },
-              usage: usages[dataSourceView.id] ?? { count: 0, agents: [] },
+              usage: usages[dataSourceView.id] ?? {
+                count: 0,
+                agents: [],
+                skills: [],
+              },
             };
           }
 
@@ -209,7 +213,11 @@ app.get(
           return {
             ...dataSourceView,
             dataSource: augmentedDataSource,
-            usage: usages[dataSourceView.id] ?? { count: 0, agents: [] },
+            usage: usages[dataSourceView.id] ?? {
+              count: 0,
+              agents: [],
+              skills: [],
+            },
           };
         })
       );

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/index.test.ts
@@ -1,0 +1,101 @@
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { AgentMCPServerConfigurationFactory } from "@app/tests/utils/AgentMCPServerConfigurationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import { WebhookSourceViewFactory } from "@app/tests/utils/WebhookSourceViewFactory";
+import { honoApp } from "@front-api/app";
+import assert from "assert";
+import { beforeAll, describe, expect, it } from "vitest";
+
+function getSpace(workspace: { sId: string }, spaceId: string) {
+  return honoApp.request(`/api/w/${workspace.sId}/spaces/${spaceId}`);
+}
+
+describe("GET /api/w/:wId/spaces/:spaceId", () => {
+  beforeAll(() => {
+    process.env.FRONT_DATABASE_READ_REPLICA_URI =
+      process.env.FRONT_DATABASE_URI;
+  });
+
+  it("reflects real Tools and Triggers usage on the category rows, and shows a Triggers row at all", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const regularSpace = await SpaceFactory.regular(workspace);
+
+    const server = await RemoteMCPServerFactory.create(workspace);
+    const mcpServerView = await MCPServerViewFactory.create(
+      workspace,
+      server.sId,
+      regularSpace
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Tool User",
+      scope: "visible",
+    });
+    await AgentMCPServerConfigurationFactory.create(auth, regularSpace, {
+      agent,
+      mcpServerView,
+    });
+
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const webhookView = await webhookSourceViewFactory.create(regularSpace);
+    await TriggerFactory.webhook(auth, {
+      name: "Trigger User",
+      agentConfigurationId: agent.sId,
+      status: "enabled",
+      configuration: { includePayload: true },
+      webhookSourceViewId: Number(webhookView.id),
+    });
+
+    const response = await getSpace(workspace, regularSpace.sId);
+    expect(response.status).toBe(200);
+    const { space } = await response.json();
+
+    expect(space.categories.triggers.count).toBe(1);
+    expect(space.categories.triggers.usage.count).toBe(1);
+    expect(
+      space.categories.triggers.usage.agents.map((a: { sId: string }) => a.sId)
+    ).toEqual([agent.sId]);
+
+    expect(space.categories.actions.usage.count).toBe(1);
+    expect(
+      space.categories.actions.usage.agents.map((a: { sId: string }) => a.sId)
+    ).toEqual([agent.sId]);
+  });
+
+  it("excludes auto-provisioned tools from the Tools usage row, even in the global space", async () => {
+    const { workspace, auth, globalSpace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+
+    // Auto tools (e.g. Pods, Computer) get a view auto-provisioned into the global space for
+    // every workspace — they aren't meaningfully "this space's tools." A skill using one must
+    // not inflate the global space's Tools usage row.
+    const autoView =
+      await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+        auth,
+        "common_utilities"
+      );
+    assert(autoView, "auto tool view should exist for the global space");
+
+    await SkillFactory.create(auth, {
+      name: "Auto Tool Skill",
+      availability: "workspace_users",
+      mcpServerViews: [autoView],
+    });
+
+    const response = await getSpace(workspace, globalSpace.sId);
+    expect(response.status).toBe(200);
+    const { space } = await response.json();
+
+    expect(space.categories.actions.count).toBe(0);
+    expect(space.categories.actions.usage.count).toBe(0);
+    expect(space.categories.actions.usage.skills).toEqual([]);
+  });
+});

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
@@ -1,21 +1,19 @@
-import { getDataSourceViewsUsageByModelIds } from "@app/lib/api/agent_data_sources";
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
-import { softDeleteSpaceAndLaunchScrubWorkflow } from "@app/lib/api/spaces";
-import { AppResource } from "@app/lib/resources/app_resource";
+import {
+  getSpaceCategoriesWithUsage,
+  softDeleteSpaceAndLaunchScrubWorkflow,
+} from "@app/lib/api/spaces";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import { DATA_SOURCE_VIEW_CATEGORIES } from "@app/types/api/public/spaces";
 import type {
   GetSpaceResponseBody,
   PatchSpaceResponseBody,
-  SpaceCategoryInfo,
 } from "@app/types/api/spaces";
 import { PatchSpaceRequestBodySchema } from "@app/types/api/spaces";
 import { normalizeTabsOrder, sortPodFrameTabs } from "@app/types/pod_frame_tab";
@@ -264,42 +262,7 @@ app.get(
     const auth = ctx.get("auth");
     const space = ctx.get("space");
 
-    const dataSourceViewsList = await DataSourceViewResource.listBySpace(
-      auth,
-      space
-    );
-    const appsList = await AppResource.listBySpace(auth, space);
-    const actions = await MCPServerViewResource.listBySpace(auth, space);
-    const actionsCount = actions.filter(
-      (a) => a.getServerDisplayMetadata().availability === "manual"
-    ).length;
-
-    const usages = await getDataSourceViewsUsageByModelIds({
-      auth,
-      dataSourceViewModelIds: dataSourceViewsList.map((dsv) => dsv.id),
-    });
-
-    const categories: { [key: string]: SpaceCategoryInfo } = {};
-    for (const category of DATA_SOURCE_VIEW_CATEGORIES) {
-      const dataSourceViewsInCategory = dataSourceViewsList.filter(
-        (view) => view.toJSON().category === category
-      );
-
-      const agents = uniqBy(
-        dataSourceViewsInCategory.flatMap(
-          (view) => usages[view.id]?.agents ?? []
-        ),
-        "sId"
-      );
-
-      categories[category] = {
-        count: dataSourceViewsInCategory.length,
-        usage: { count: agents.length, agents },
-      };
-    }
-
-    categories["apps"].count = appsList.length;
-    categories["actions"].count = actionsCount;
+    const categories = await getSpaceCategoriesWithUsage(auth, space);
 
     const shouldIncludeAllMembers =
       ctx.req.query("includeAllMembers") === "true";

--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -3,10 +3,9 @@ import {
   AddToolsDialog,
 } from "@app/components/actions/mcp/AddToolsDialog";
 import { CreateMCPServerDialog } from "@app/components/actions/mcp/create/CreateMCPServerDialog";
-import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
-import { SkillDetailsSheetById } from "@app/components/command_palette/SkillDetailsSheetById";
 import { ACTION_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHeaders";
 import { UsedByButton } from "@app/components/spaces/UsedByButton";
+import { useUsedByDetailsSheets } from "@app/components/spaces/useUsedByDetailsSheets";
 import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
 import {
   getMcpServerDisplayName,
@@ -27,7 +26,10 @@ import {
 } from "@app/lib/swr/mcp_servers";
 import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import type { SkillUsageType } from "@app/types/assistant/skill_configuration";
+import type {
+  AgentsAndSkillsUsageType,
+  AgentsUsageType,
+} from "@app/types/data_source";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
@@ -38,7 +40,7 @@ import { useMemo, useState } from "react";
 type RowData = {
   mcpServer: MCPServerType;
   mcpServerView?: MCPServerViewType;
-  usage: SkillUsageType | null;
+  usage: AgentsUsageType | AgentsAndSkillsUsageType | null;
   isConnected: boolean;
   account: string;
   spaces: SpaceType[];
@@ -112,8 +114,10 @@ export const AdminActionsList = ({
     owner,
   });
 
-  const [agentId, setAgentId] = useState<string | null>(null);
-  const [skillId, setSkillId] = useState<string | null>(null);
+  const { onAgentClick, onSkillClick, sheets } = useUsedByDetailsSheets(
+    owner,
+    user
+  );
 
   const { usage } = useMCPServersUsage({
     owner,
@@ -278,8 +282,8 @@ export const AdminActionsList = ({
           <div className="flex h-12 w-full items-center justify-center">
             <UsedByButton
               usage={info.row.original.usage}
-              onItemClick={setAgentId}
-              onSkillClick={setSkillId}
+              onItemClick={onAgentClick}
+              onSkillClick={onSkillClick}
             />
           </div>
         ),
@@ -378,22 +382,11 @@ export const AdminActionsList = ({
     );
 
     return columns;
-  }, []);
+  }, [onAgentClick, onSkillClick]);
 
   return (
     <>
-      <AgentDetailsSheet
-        owner={owner}
-        user={user}
-        agentId={agentId}
-        onClose={() => setAgentId(null)}
-      />
-      <SkillDetailsSheetById
-        owner={owner}
-        user={user}
-        skillId={skillId}
-        onClose={() => setSkillId(null)}
-      />
+      {sheets}
       <CreateMCPServerDialog
         isOpen={isCreateOpen}
         internalMCPServer={internalMCPServerToCreate}

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -7,10 +7,8 @@ import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import type { GetSkillsWithRelationsResponseBody } from "@app/types/api/skills";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
-import type {
-  SkillAvailability,
-  SkillUsageType,
-} from "@app/types/assistant/skill_configuration";
+import type { SkillAvailability } from "@app/types/assistant/skill_configuration";
+import type { AgentsAndSkillsUsageType } from "@app/types/data_source";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import type { MenuItem } from "@dust-tt/sparkle";
 import {
@@ -38,7 +36,7 @@ type RowData = {
   description: string;
   availability: SkillAvailability;
   editors: UserType[] | null;
-  usage: SkillUsageType;
+  usage: AgentsAndSkillsUsageType;
   messageCount: number | null;
   updatedAt: number | null;
   createdAt: number | null;

--- a/front/components/spaces/ConfirmDeleteSpaceDialog.tsx
+++ b/front/components/spaces/ConfirmDeleteSpaceDialog.tsx
@@ -38,9 +38,20 @@ export function ConfirmDeleteSpaceDialog({
         ),
       ]
     : [];
+  const uniqueSkillNames = spaceInfoByCategory
+    ? [
+        ...new Set(
+          Object.values(spaceInfoByCategory)
+            .flatMap((category) => category.usage.skills)
+            .map((skill) => skill.name)
+            .filter((name) => name && name.length > 0)
+        ),
+      ]
+    : [];
 
   const spaceName = `${getSpaceName(space)}`;
   const hasAgents = uniqueAgentNames.length > 0;
+  const hasSkills = uniqueSkillNames.length > 0;
 
   return (
     <Dialog>
@@ -69,8 +80,16 @@ export function ConfirmDeleteSpaceDialog({
                 <ContentMessage
                   variant="warning"
                   // TODO: change to show names of public agents and then number of unpublished agents
-                  title={`${uniqueAgentNames.length} agent${uniqueAgentNames.length === 1 ? "" : "s"} 
-                    use${uniqueAgentNames.length === 1 ? "s" : ""} tools that depend on this space 
+                  title={`${uniqueAgentNames.length} agent${uniqueAgentNames.length === 1 ? "" : "s"}
+                    use${uniqueAgentNames.length === 1 ? "s" : ""} tools that depend on this space
+                    and will be impacted by its deletion`}
+                />
+              )}
+              {hasSkills && (
+                <ContentMessage
+                  variant="warning"
+                  title={`${uniqueSkillNames.length} skill${uniqueSkillNames.length === 1 ? "" : "s"}
+                    depend${uniqueSkillNames.length === 1 ? "s" : ""} on this space
                     and will be impacted by its deletion`}
                 />
               )}

--- a/front/components/spaces/SpaceCategoriesList.tsx
+++ b/front/components/spaces/SpaceCategoriesList.tsx
@@ -1,7 +1,7 @@
-import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
 import { ACTION_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHeaders";
 import { SpaceSearchContext } from "@app/components/spaces/search/SpaceSearchContext";
 import { UsedByButton } from "@app/components/spaces/UsedByButton";
+import { useUsedByDetailsSheets } from "@app/components/spaces/useUsedByDetailsSheets";
 import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
 import { MCP_SPECIFICATION } from "@app/lib/actions/utils_ui";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
@@ -9,7 +9,7 @@ import { CATEGORY_DETAILS } from "@app/lib/spaces";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { DATA_SOURCE_VIEW_CATEGORIES } from "@app/types/api/public/spaces";
-import type { AgentsUsageType } from "@app/types/data_source";
+import type { AgentsAndSkillsUsageType } from "@app/types/data_source";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { SpaceType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
@@ -37,14 +37,17 @@ type RowData = {
   category: string;
   name: string;
   icon: ComponentType;
-  usage: AgentsUsageType;
+  usage: AgentsAndSkillsUsageType;
   count: number;
   onClick?: () => void;
 };
 
 type Info = CellContext<RowData, unknown>;
 
-const getTableColumns = (onAgentClick: (agentId: string) => void) => {
+const getTableColumns = (
+  onAgentClick: (agentId: string | null) => void,
+  onSkillClick: (skillId: string | null) => void
+) => {
   return [
     {
       header: "Name",
@@ -69,6 +72,7 @@ const getTableColumns = (onAgentClick: (agentId: string) => void) => {
           <UsedByButton
             usage={info.row.original.usage}
             onItemClick={onAgentClick}
+            onSkillClick={onSkillClick}
           />
         </DataTable.CellContent>
       ),
@@ -104,7 +108,10 @@ export const SpaceCategoriesList = ({
   const canAdministrateApps = hasPermission("admin", "dust_app");
   const { setIsSearchDisabled } = React.useContext(SpaceSearchContext);
 
-  const [assistantId, setAssistantId] = React.useState<string | null>(null);
+  const { onAgentClick, onSkillClick, sheets } = useUsedByDetailsSheets(
+    owner,
+    user
+  );
 
   const rows: RowData[] = spaceInfo
     ? removeNulls(
@@ -200,12 +207,7 @@ export const SpaceCategoriesList = ({
 
   return (
     <>
-      <AgentDetailsSheet
-        owner={owner}
-        user={user}
-        agentId={assistantId}
-        onClose={() => setAssistantId(null)}
-      />
+      {sheets}
       {isEmpty && (
         <div
           className={cn(
@@ -220,7 +222,7 @@ export const SpaceCategoriesList = ({
       {rows.length > 0 && (
         <DataTable
           data={rows}
-          columns={getTableColumns(setAssistantId)}
+          columns={getTableColumns(onAgentClick, onSkillClick)}
           className="pb-4"
           columnsBreakpoints={{
             usage: "md",

--- a/front/components/spaces/SpaceResourcesList.tsx
+++ b/front/components/spaces/SpaceResourcesList.tsx
@@ -1,4 +1,3 @@
-import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
 import { ConnectorPermissionsModal } from "@app/components/data_source/ConnectorPermissionsModal";
 import ConnectorSyncingChip from "@app/components/data_source/DataSourceSyncChip";
 import { DeleteStaticDataSourceDialog } from "@app/components/data_source/DeleteStaticDataSourceDialog";
@@ -9,6 +8,7 @@ import { EditSpaceStaticDatasourcesViews } from "@app/components/spaces/EditSpac
 import { ACTION_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHeaders";
 import { SpaceSearchContext } from "@app/components/spaces/search/SpaceSearchContext";
 import { UsedByButton } from "@app/components/spaces/UsedByButton";
+import { useUsedByDetailsSheets } from "@app/components/spaces/useUsedByDetailsSheets";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { ViewFolderAPIModal } from "@app/components/ViewFolderAPIModal";
 import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
@@ -91,7 +91,8 @@ const hasConfigureSlackConnectionQuery = (
   query.configureConnection === "slack";
 
 function getTableColumns(
-  setAssistantSId: (a: string | null) => void,
+  onAgentClick: (id: string | null) => void,
+  onSkillClick: (id: string | null) => void,
   isManaged: boolean,
   isWebsite: boolean,
   space: SpaceType,
@@ -144,7 +145,8 @@ function getTableColumns(
       <DataTable.CellContent>
         <UsedByButton
           usage={info.row.original.dataSourceView.usage}
-          onItemClick={setAssistantSId}
+          onItemClick={onAgentClick}
+          onSkillClick={onSkillClick}
         />
       </DataTable.CellContent>
     ),
@@ -279,7 +281,10 @@ export const SpaceResourcesList = ({
   activeSeats,
 }: SpaceResourcesListProps) => {
   const { isDark } = useTheme();
-  const [assistantSId, setAssistantSId] = useState<string | null>(null);
+  const { onAgentClick, onSkillClick, sheets } = useUsedByDetailsSheets(
+    owner,
+    user
+  );
   const [showConnectorPermissionsModal, setShowConnectorPermissionsModal] =
     useState(false);
   const [selectedDataSourceView, setSelectedDataSourceView] =
@@ -607,12 +612,7 @@ export const SpaceResourcesList = ({
 
   return (
     <>
-      <AgentDetailsSheet
-        owner={owner}
-        user={user}
-        agentId={assistantSId}
-        onClose={() => setAssistantSId(null)}
-      />
+      {sheets}
 
       {isEmpty && (
         <div
@@ -633,7 +633,8 @@ export const SpaceResourcesList = ({
           className="dd-privacy-mask"
           data={rows}
           columns={getTableColumns(
-            setAssistantSId,
+            onAgentClick,
+            onSkillClick,
             isManagedCategory,
             isWebsite,
             space,

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -1,9 +1,9 @@
 import { getSkillAvatarIcon } from "@app/lib/skill";
+import type { UsedBySkillType } from "@app/types/assistant/skill_configuration";
 import type {
-  SkillUsageType,
-  UsedBySkillType,
-} from "@app/types/assistant/skill_configuration";
-import type { AgentsUsageType } from "@app/types/data_source";
+  AgentsAndSkillsUsageType,
+  AgentsUsageType,
+} from "@app/types/data_source";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { pluralize } from "@app/types/shared/utils/string_utils";
@@ -25,7 +25,7 @@ import { useState } from "react";
 type UsedByDropdownItem =
   | {
       kind: "agent";
-      agent: SkillUsageType["agents"][number];
+      agent: AgentsAndSkillsUsageType["agents"][number];
     }
   | {
       kind: "skill";
@@ -108,7 +108,7 @@ const USED_BY_BUTTON_CLASSES =
   "w-auto border-0 px-2 hover:bg-muted-background hover:text-foreground";
 
 interface UsedByButtonProps {
-  usage: AgentsUsageType | SkillUsageType | null;
+  usage: AgentsUsageType | AgentsAndSkillsUsageType | null;
   onItemClick: (assistantSid: string) => void;
   onSkillClick?: (skillId: string) => void;
 }

--- a/front/components/spaces/useUsedByDetailsSheets.tsx
+++ b/front/components/spaces/useUsedByDetailsSheets.tsx
@@ -1,0 +1,36 @@
+import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
+import { SkillDetailsSheetById } from "@app/components/command_palette/SkillDetailsSheetById";
+import type { UserType, WorkspaceType } from "@app/types/user";
+import { useState } from "react";
+
+/**
+ * Shared "Used By" click-through state: clicking an agent or a skill in a `UsedByButton`
+ * dropdown opens the corresponding details sheet. Factored out of `AdminActionsList` so
+ * every other `UsedByButton` caller (Connections, space category rows, ...) doesn't have to
+ * duplicate the agentId/skillId state and the two sheets.
+ */
+export function useUsedByDetailsSheets(owner: WorkspaceType, user: UserType) {
+  const [agentId, setAgentId] = useState<string | null>(null);
+  const [skillId, setSkillId] = useState<string | null>(null);
+
+  return {
+    onAgentClick: setAgentId,
+    onSkillClick: setSkillId,
+    sheets: (
+      <>
+        <AgentDetailsSheet
+          owner={owner}
+          user={user}
+          agentId={agentId}
+          onClose={() => setAgentId(null)}
+        />
+        <SkillDetailsSheetById
+          owner={owner}
+          user={user}
+          skillId={skillId}
+          onClose={() => setSkillId(null)}
+        />
+      </>
+    ),
+  };
+}

--- a/front/lib/api/agent_actions.ts
+++ b/front/lib/api/agent_actions.ts
@@ -3,10 +3,8 @@ import type { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
-import type {
-  SkillUsageType,
-  UsedBySkillType,
-} from "@app/types/assistant/skill_configuration";
+import type { UsedBySkillType } from "@app/types/assistant/skill_configuration";
+import type { AgentsAndSkillsUsageType } from "@app/types/data_source";
 import type { ModelId } from "@app/types/shared/model_id";
 import { QueryTypes } from "sequelize";
 
@@ -14,7 +12,7 @@ import { QueryTypes } from "sequelize";
 // If it is a problem, let's add caching
 const DISABLE_QUERIES = false;
 
-export type MCPServersUsage = Record<string, SkillUsageType>;
+export type MCPServersUsage = Record<string, AgentsAndSkillsUsageType>;
 
 interface MCPServerUsageRow {
   internalMCPServerId: string | null;
@@ -69,7 +67,7 @@ async function buildVisibilityFilter(auth: Authenticator): Promise<{
 function rowToUsageEntry(
   row: MCPServerUsageRow,
   workspaceId: ModelId
-): { key: string; usage: SkillUsageType } {
+): { key: string; usage: AgentsAndSkillsUsageType } {
   const key =
     row.internalMCPServerId ||
     remoteMCPServerNameToSId({

--- a/front/lib/api/agent_data_sources.test.ts
+++ b/front/lib/api/agent_data_sources.test.ts
@@ -1,0 +1,119 @@
+import {
+  getDataSourcesUsageByCategory,
+  getDataSourceUsage,
+  getDataSourceViewsUsageByModelIds,
+  getDataSourceViewUsage,
+} from "@app/lib/api/agent_data_sources";
+import { Authenticator } from "@app/lib/auth";
+import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { describe, expect, it } from "vitest";
+
+describe("data source view/source usage with skills", () => {
+  it("includes skills that attached the view as knowledge, respecting visibility", async () => {
+    const testContext = await createResourceTest({ role: "admin" });
+    const regularSpace = await SpaceFactory.regular(testContext.workspace);
+    const view = await DataSourceViewFactory.folder(
+      testContext.workspace,
+      regularSpace
+    );
+    const unrelatedView = await DataSourceViewFactory.folder(
+      testContext.workspace,
+      regularSpace
+    );
+
+    const visibleSkill = await SkillFactory.create(testContext.authenticator, {
+      name: "Visible skill",
+      availability: "workspace_users",
+      attachedKnowledge: [{ dataSourceView: view, nodeId: "node-1" }],
+    });
+    const restrictedSkill = await SkillFactory.create(
+      testContext.authenticator,
+      {
+        name: "Restricted skill",
+        availability: "editors",
+        attachedKnowledge: [{ dataSourceView: view, nodeId: "node-1" }],
+      }
+    );
+
+    // Admin sees both skills.
+    const adminUsage = await getDataSourceViewsUsageByModelIds({
+      auth: testContext.authenticator,
+      dataSourceViewModelIds: [view.id, unrelatedView.id],
+    });
+
+    expect(adminUsage[view.id]?.count).toBe(2);
+    expect(adminUsage[view.id]?.agents).toEqual([]);
+    // Skills are sorted by name ("Restricted skill" < "Visible skill").
+    expect(adminUsage[view.id]?.skills.map((skill) => skill.sId)).toEqual([
+      restrictedSkill.sId,
+      visibleSkill.sId,
+    ]);
+    expect(adminUsage[unrelatedView.id]).toBeUndefined();
+
+    // A non-admin, non-editor member only sees the workspace_users-visible skill.
+    const member = await UserFactory.basic();
+    await MembershipFactory.associate(testContext.workspace, member, {
+      role: "user",
+    });
+    const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      member.sId,
+      testContext.workspace.sId
+    );
+
+    const memberUsage = await getDataSourceViewsUsageByModelIds({
+      auth: memberAuth,
+      dataSourceViewModelIds: [view.id],
+    });
+
+    expect(memberUsage[view.id]?.count).toBe(1);
+    expect(memberUsage[view.id]?.skills.map((skill) => skill.sId)).toEqual([
+      visibleSkill.sId,
+    ]);
+
+    // The category-scoped variant (used for the system space) is keyed by
+    // dataSource.id instead, but exercises the same skills merge.
+    const categoryUsage = await getDataSourcesUsageByCategory({
+      auth: testContext.authenticator,
+      category: "folder",
+    });
+
+    expect(categoryUsage[view.dataSource.id]?.count).toBe(2);
+    expect(
+      categoryUsage[view.dataSource.id]?.skills.map((skill) => skill.sId)
+    ).toEqual([restrictedSkill.sId, visibleSkill.sId]);
+
+    // Single-item variants used by Poke and the delete-confirmation dialogs.
+    const singleViewUsage = await getDataSourceViewUsage({
+      auth: testContext.authenticator,
+      dataSourceView: view,
+    });
+    expect(singleViewUsage.isOk() && singleViewUsage.value.count).toBe(2);
+    expect(
+      singleViewUsage.isOk() &&
+        singleViewUsage.value.skills.map((skill) => skill.sId)
+    ).toEqual([restrictedSkill.sId, visibleSkill.sId]);
+
+    const singleSourceUsage = await getDataSourceUsage({
+      auth: testContext.authenticator,
+      dataSource: view.dataSource,
+    });
+    expect(singleSourceUsage.isOk() && singleSourceUsage.value.count).toBe(2);
+
+    // A view with no skill (and no agent) attached has zero usage.
+    const unrelatedSingleUsage = await getDataSourceViewUsage({
+      auth: testContext.authenticator,
+      dataSourceView: unrelatedView,
+    });
+    expect(
+      unrelatedSingleUsage.isOk() && unrelatedSingleUsage.value.count
+    ).toBe(0);
+    expect(
+      unrelatedSingleUsage.isOk() && unrelatedSingleUsage.value.skills
+    ).toEqual([]);
+  });
+});

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -56,77 +56,98 @@ const agentAggregates: ProjectionAlias[] = (
   alias,
 ]);
 
+// Usage only needs each skill's identity, so skip the rest of the hydration.
+const SKILL_USAGE_HYDRATION = {
+  withInstructions: false,
+  withTools: false,
+  withFileAttachments: false,
+} as const;
+
 /**
- * Skills can attach a data source view directly as "knowledge" (independently of any
- * MCP server/tool configuration). Mirrors `fetchSkillsByMCPServer` in `agent_actions.ts`,
- * but reads `skill.dataSourceConfigurations` instead of `skill.mcpServerViews`.
+ * Buckets skills by the knowledge id they attached, dropping skills the current user may not
+ * see. Skills are fetched scoped to `requestedIds`, but each one carries all of its
+ * configurations, so ids we did not ask about are skipped here.
  */
-async function fetchSkillsByDataSource(auth: Authenticator): Promise<{
-  byDataSourceViewId: Map<ModelId, UsedBySkillType[]>;
-  byDataSourceId: Map<ModelId, UsedBySkillType[]>;
-}> {
-  const workspaceSkills = await SkillResource.listByWorkspace(auth, {
-    status: "active",
-    withInstructions: false,
-    withTools: false,
-    withFileAttachments: false,
-  });
-  const skills = auth.isAdmin()
-    ? workspaceSkills
-    : workspaceSkills.filter(
+function groupSkillsByKnowledgeId(
+  auth: Authenticator,
+  skills: SkillResource[],
+  requestedIds: ModelId[],
+  knowledgeIdsOf: (skill: SkillResource) => ModelId[]
+): Map<ModelId, UsedBySkillType[]> {
+  const visibleSkills = auth.isAdmin()
+    ? skills
+    : skills.filter(
         (skill) => skill.availability !== "editors" || skill.canWrite(auth)
       );
 
-  const byDataSourceViewId = new Map<ModelId, UsedBySkillType[]>();
-  const byDataSourceId = new Map<ModelId, UsedBySkillType[]>();
+  const requested = new Set(requestedIds);
+  const skillsById = new Map<ModelId, UsedBySkillType[]>();
 
-  const pushSkill = (
-    map: Map<ModelId, UsedBySkillType[]>,
-    id: ModelId,
-    usedBySkill: UsedBySkillType
-  ) => {
-    const usedBySkills = map.get(id) ?? [];
-    usedBySkills.push(usedBySkill);
-    map.set(id, usedBySkills);
-  };
-
-  for (const skill of skills) {
+  for (const skill of visibleSkills) {
     const usedBySkill: UsedBySkillType = {
       sId: skill.sId,
       name: skill.name,
       icon: skill.icon,
     };
-    for (const dataSourceViewId of new Set(
-      skill.dataSourceConfigurations.map((c) => c.dataSourceViewId)
-    )) {
-      pushSkill(byDataSourceViewId, dataSourceViewId, usedBySkill);
-    }
-    for (const dataSourceId of new Set(
-      skill.dataSourceConfigurations.map((c) => c.dataSourceId)
-    )) {
-      pushSkill(byDataSourceId, dataSourceId, usedBySkill);
+    for (const id of new Set(knowledgeIdsOf(skill))) {
+      if (!requested.has(id)) {
+        continue;
+      }
+      const usedBySkills = skillsById.get(id) ?? [];
+      usedBySkills.push(usedBySkill);
+      skillsById.set(id, usedBySkills);
     }
   }
 
-  for (const usedBySkills of [
-    ...byDataSourceViewId.values(),
-    ...byDataSourceId.values(),
-  ]) {
+  for (const usedBySkills of skillsById.values()) {
     usedBySkills.sort((a, b) => a.name.localeCompare(b.name));
   }
 
-  return { byDataSourceViewId, byDataSourceId };
+  return skillsById;
+}
+
+/**
+ * Skills can attach a data source view directly as "knowledge" (independently of any
+ * MCP server/tool configuration). Mirrors `fetchSkillsByMCPServer` in `agent_actions.ts`,
+ * but reads `skill.dataSourceConfigurations` instead of `skill.mcpServerViews`.
+ */
+async function fetchSkillsByDataSourceViewIds(
+  auth: Authenticator,
+  dataSourceViewIds: ModelId[]
+): Promise<Map<ModelId, UsedBySkillType[]>> {
+  const skills = await SkillResource.listByDataSourceViewIds(
+    auth,
+    dataSourceViewIds,
+    SKILL_USAGE_HYDRATION
+  );
+
+  return groupSkillsByKnowledgeId(auth, skills, dataSourceViewIds, (skill) =>
+    skill.dataSourceConfigurations.map((c) => c.dataSourceViewId)
+  );
+}
+
+async function fetchSkillsByDataSourceIds(
+  auth: Authenticator,
+  dataSourceIds: ModelId[]
+): Promise<Map<ModelId, UsedBySkillType[]>> {
+  const skills = await SkillResource.listByDataSourceIds(
+    auth,
+    dataSourceIds,
+    SKILL_USAGE_HYDRATION
+  );
+
+  return groupSkillsByKnowledgeId(auth, skills, dataSourceIds, (skill) =>
+    skill.dataSourceConfigurations.map((c) => c.dataSourceId)
+  );
 }
 
 /**
  * Folds a skills-by-id map into an agent-only usage map, bumping `.count` for any id that
- * gains skills. `allowedIds`, when passed, drops skill entries for ids outside the batch that
- * was actually requested (skills are fetched workspace-wide, so this re-scopes the result).
+ * gains skills.
  */
 function mergeSkillsIntoUsage(
   agentOnly: Record<ModelId, AgentOnlyUsage>,
-  skillsById: Map<ModelId, UsedBySkillType[]>,
-  allowedIds?: ModelId[]
+  skillsById: Map<ModelId, UsedBySkillType[]>
 ): DataSourcesUsage {
   const result: DataSourcesUsage = {};
   for (const key of Object.keys(agentOnly)) {
@@ -134,9 +155,6 @@ function mergeSkillsIntoUsage(
     result[id] = { ...agentOnly[id], skills: [] };
   }
   for (const [id, skills] of skillsById) {
-    if (allowedIds && !allowedIds.includes(id)) {
-      continue;
-    }
     const usage = result[id];
     if (usage) {
       usage.skills = skills;
@@ -175,29 +193,26 @@ export async function getDataSourceViewsUsageByModelIds({
 
   // Step 1 & 2: fetch the config links from both sources, plus skill usage — nothing here
   // depends on anything else, so fetch them all together instead of sequentially.
-  const [
-    dataSourceConfigLinks,
-    tableConfigLinks,
-    { byDataSourceViewId: skillsByDataSourceViewId },
-  ] = await Promise.all([
-    AgentDataSourceConfigurationModel.findAll({
-      raw: true,
-      attributes: ["dataSourceViewId", "mcpServerConfigurationId"],
-      where: {
-        workspaceId: owner.id,
-        dataSourceViewId: { [Op.in]: uniqueDataSourceViewModelIds },
-      },
-    }),
-    AgentTablesQueryConfigurationTableModel.findAll({
-      raw: true,
-      attributes: ["dataSourceViewId", "mcpServerConfigurationId"],
-      where: {
-        workspaceId: owner.id,
-        dataSourceViewId: { [Op.in]: uniqueDataSourceViewModelIds },
-      },
-    }),
-    fetchSkillsByDataSource(auth),
-  ]);
+  const [dataSourceConfigLinks, tableConfigLinks, skillsByDataSourceViewId] =
+    await Promise.all([
+      AgentDataSourceConfigurationModel.findAll({
+        raw: true,
+        attributes: ["dataSourceViewId", "mcpServerConfigurationId"],
+        where: {
+          workspaceId: owner.id,
+          dataSourceViewId: { [Op.in]: uniqueDataSourceViewModelIds },
+        },
+      }),
+      AgentTablesQueryConfigurationTableModel.findAll({
+        raw: true,
+        attributes: ["dataSourceViewId", "mcpServerConfigurationId"],
+        where: {
+          workspaceId: owner.id,
+          dataSourceViewId: { [Op.in]: uniqueDataSourceViewModelIds },
+        },
+      }),
+      fetchSkillsByDataSourceViewIds(auth, uniqueDataSourceViewModelIds),
+    ]);
 
   // Step 3: fetch the MCP server configuration -> agent configuration mappings
   // once for both sources.
@@ -376,11 +391,7 @@ export async function getDataSourceViewsUsageByModelIds({
     }
   });
 
-  return mergeSkillsIntoUsage(
-    result,
-    skillsByDataSourceViewId,
-    uniqueDataSourceViewModelIds
-  );
+  return mergeSkillsIntoUsage(result, skillsByDataSourceViewId);
 }
 
 export async function getDataSourcesUsageByCategory({
@@ -415,93 +426,103 @@ export async function getDataSourcesUsageByCategory({
     };
   }
 
-  const [
-    dataSourceConfigRows,
-    tableConfigRows,
-    { byDataSourceId: skillsByDataSourceId },
-  ] = await Promise.all([
-    AgentDataSourceConfigurationModel.findAll({
+  // The skills lookup is keyed by data source id, so resolve this category's ids first. Same
+  // `workspaceId` + `connectorProvider` predicate as the joins below.
+  const categoryDataSourceModelIds = (
+    await DataSourceModel.findAll({
       raw: true,
-      group: ["dataSource.id"],
+      attributes: ["id"],
       where: {
         workspaceId: owner.id,
+        connectorProvider,
       },
-      attributes: [
-        [Sequelize.col("dataSource.id"), "dataSourceId"],
-        ...agentAggregates,
-      ],
-      include: [
-        {
-          model: DataSourceModel,
-          as: "dataSource",
-          attributes: [],
-          required: true,
-          where: {
-            connectorProvider: connectorProvider,
-          },
+    })
+  ).map((ds) => ds.id);
+
+  const [dataSourceConfigRows, tableConfigRows, skillsByDataSourceId] =
+    await Promise.all([
+      AgentDataSourceConfigurationModel.findAll({
+        raw: true,
+        group: ["dataSource.id"],
+        where: {
+          workspaceId: owner.id,
         },
-        {
-          model: AgentMCPServerConfigurationModel,
-          as: "agent_mcp_server_configuration",
-          attributes: [],
-          required: true,
-          include: [
-            {
-              model: AgentConfigurationModel,
-              as: "agent_configuration",
-              attributes: [],
-              required: true,
-              where: {
-                status: "active",
-                workspaceId: owner.id,
-              },
+        attributes: [
+          [Sequelize.col("dataSource.id"), "dataSourceId"],
+          ...agentAggregates,
+        ],
+        include: [
+          {
+            model: DataSourceModel,
+            as: "dataSource",
+            attributes: [],
+            required: true,
+            where: {
+              connectorProvider: connectorProvider,
             },
-          ],
-        },
-      ],
-    }),
-    AgentTablesQueryConfigurationTableModel.findAll({
-      raw: true,
-      group: ["dataSource.id"],
-      where: {
-        workspaceId: owner.id,
-      },
-      attributes: [
-        [Sequelize.col("dataSource.id"), "dataSourceId"],
-        ...agentAggregates,
-      ],
-      include: [
-        {
-          model: DataSourceModel,
-          as: "dataSource",
-          attributes: [],
-          required: true,
-          where: {
-            connectorProvider: connectorProvider,
           },
-        },
-        {
-          model: AgentMCPServerConfigurationModel,
-          as: "agent_mcp_server_configuration",
-          attributes: [],
-          required: true,
-          include: [
-            {
-              model: AgentConfigurationModel,
-              as: "agent_configuration",
-              attributes: [],
-              required: true,
-              where: {
-                status: "active",
-                workspaceId: owner.id,
+          {
+            model: AgentMCPServerConfigurationModel,
+            as: "agent_mcp_server_configuration",
+            attributes: [],
+            required: true,
+            include: [
+              {
+                model: AgentConfigurationModel,
+                as: "agent_configuration",
+                attributes: [],
+                required: true,
+                where: {
+                  status: "active",
+                  workspaceId: owner.id,
+                },
               },
-            },
-          ],
+            ],
+          },
+        ],
+      }),
+      AgentTablesQueryConfigurationTableModel.findAll({
+        raw: true,
+        group: ["dataSource.id"],
+        where: {
+          workspaceId: owner.id,
         },
-      ],
-    }),
-    fetchSkillsByDataSource(auth),
-  ] as const);
+        attributes: [
+          [Sequelize.col("dataSource.id"), "dataSourceId"],
+          ...agentAggregates,
+        ],
+        include: [
+          {
+            model: DataSourceModel,
+            as: "dataSource",
+            attributes: [],
+            required: true,
+            where: {
+              connectorProvider: connectorProvider,
+            },
+          },
+          {
+            model: AgentMCPServerConfigurationModel,
+            as: "agent_mcp_server_configuration",
+            attributes: [],
+            required: true,
+            include: [
+              {
+                model: AgentConfigurationModel,
+                as: "agent_configuration",
+                attributes: [],
+                required: true,
+                where: {
+                  status: "active",
+                  workspaceId: owner.id,
+                },
+              },
+            ],
+          },
+        ],
+      }),
+      fetchSkillsByDataSourceIds(auth, categoryDataSourceModelIds),
+    ] as const);
 
   const result = (
     [dataSourceConfigRows, tableConfigRows] as unknown as {
@@ -571,69 +592,66 @@ export async function getDataSourceUsage({
     return new Ok({ count: 0, agents: [], skills: [] });
   }
 
-  const [
-    dataSourceConfigRow,
-    tableConfigRow,
-    { byDataSourceId: skillsByDataSourceId },
-  ] = await Promise.all([
-    AgentDataSourceConfigurationModel.findOne({
-      raw: true,
-      attributes: [...agentAggregates],
-      where: {
-        workspaceId: owner.id,
-        dataSourceId: dataSource.id,
-      },
-      include: [
-        {
-          model: AgentMCPServerConfigurationModel,
-          as: "agent_mcp_server_configuration",
-          attributes: [],
-          required: true,
-          include: [
-            {
-              model: AgentConfigurationModel,
-              as: "agent_configuration",
-              attributes: [],
-              required: true,
-              where: {
-                status: "active",
-                workspaceId: owner.id,
-              },
-            },
-          ],
+  const [dataSourceConfigRow, tableConfigRow, skillsByDataSourceId] =
+    await Promise.all([
+      AgentDataSourceConfigurationModel.findOne({
+        raw: true,
+        attributes: [...agentAggregates],
+        where: {
+          workspaceId: owner.id,
+          dataSourceId: dataSource.id,
         },
-      ],
-    }),
-    AgentTablesQueryConfigurationTableModel.findOne({
-      raw: true,
-      attributes: [...agentAggregates],
-      where: {
-        workspaceId: owner.id,
-        dataSourceId: dataSource.id,
-      },
-      include: [
-        {
-          model: AgentMCPServerConfigurationModel,
-          as: "agent_mcp_server_configuration",
-          attributes: [],
-          required: true,
-          include: [
-            {
-              model: AgentConfigurationModel,
-              as: "agent_configuration",
-              attributes: [],
-              required: true,
-              where: {
-                status: "active",
-                workspaceId: owner.id,
+        include: [
+          {
+            model: AgentMCPServerConfigurationModel,
+            as: "agent_mcp_server_configuration",
+            attributes: [],
+            required: true,
+            include: [
+              {
+                model: AgentConfigurationModel,
+                as: "agent_configuration",
+                attributes: [],
+                required: true,
+                where: {
+                  status: "active",
+                  workspaceId: owner.id,
+                },
               },
-            },
-          ],
+            ],
+          },
+        ],
+      }),
+      AgentTablesQueryConfigurationTableModel.findOne({
+        raw: true,
+        attributes: [...agentAggregates],
+        where: {
+          workspaceId: owner.id,
+          dataSourceId: dataSource.id,
         },
-      ],
-    }),
-    fetchSkillsByDataSource(auth),
-  ]);
+        include: [
+          {
+            model: AgentMCPServerConfigurationModel,
+            as: "agent_mcp_server_configuration",
+            attributes: [],
+            required: true,
+            include: [
+              {
+                model: AgentConfigurationModel,
+                as: "agent_configuration",
+                attributes: [],
+                required: true,
+                where: {
+                  status: "active",
+                  workspaceId: owner.id,
+                },
+              },
+            ],
+          },
+        ],
+      }),
+      fetchSkillsByDataSourceIds(auth, [dataSource.id]),
+    ]);
 
   const skills = skillsByDataSourceId.get(dataSource.id) ?? [];
   const res = [dataSourceConfigRow, tableConfigRow] as unknown as
@@ -690,69 +708,66 @@ export async function getDataSourceViewUsage({
     return new Ok({ count: 0, agents: [], skills: [] });
   }
 
-  const [
-    dataSourceConfigRow,
-    tableConfigRow,
-    { byDataSourceViewId: skillsByDataSourceViewId },
-  ] = await Promise.all([
-    AgentDataSourceConfigurationModel.findOne({
-      raw: true,
-      attributes: [...agentAggregates],
-      where: {
-        workspaceId: owner.id,
-        dataSourceViewId: dataSourceView.id,
-      },
-      include: [
-        {
-          model: AgentMCPServerConfigurationModel,
-          as: "agent_mcp_server_configuration",
-          attributes: [],
-          required: true,
-          include: [
-            {
-              model: AgentConfigurationModel,
-              as: "agent_configuration",
-              attributes: [],
-              required: true,
-              where: {
-                status: "active",
-                workspaceId: owner.id,
-              },
-            },
-          ],
+  const [dataSourceConfigRow, tableConfigRow, skillsByDataSourceViewId] =
+    await Promise.all([
+      AgentDataSourceConfigurationModel.findOne({
+        raw: true,
+        attributes: [...agentAggregates],
+        where: {
+          workspaceId: owner.id,
+          dataSourceViewId: dataSourceView.id,
         },
-      ],
-    }),
-    AgentTablesQueryConfigurationTableModel.findOne({
-      raw: true,
-      attributes: [...agentAggregates],
-      where: {
-        workspaceId: owner.id,
-        dataSourceViewId: dataSourceView.id,
-      },
-      include: [
-        {
-          model: AgentMCPServerConfigurationModel,
-          as: "agent_mcp_server_configuration",
-          attributes: [],
-          required: true,
-          include: [
-            {
-              model: AgentConfigurationModel,
-              as: "agent_configuration",
-              attributes: [],
-              required: true,
-              where: {
-                status: "active",
-                workspaceId: owner.id,
+        include: [
+          {
+            model: AgentMCPServerConfigurationModel,
+            as: "agent_mcp_server_configuration",
+            attributes: [],
+            required: true,
+            include: [
+              {
+                model: AgentConfigurationModel,
+                as: "agent_configuration",
+                attributes: [],
+                required: true,
+                where: {
+                  status: "active",
+                  workspaceId: owner.id,
+                },
               },
-            },
-          ],
+            ],
+          },
+        ],
+      }),
+      AgentTablesQueryConfigurationTableModel.findOne({
+        raw: true,
+        attributes: [...agentAggregates],
+        where: {
+          workspaceId: owner.id,
+          dataSourceViewId: dataSourceView.id,
         },
-      ],
-    }),
-    fetchSkillsByDataSource(auth),
-  ]);
+        include: [
+          {
+            model: AgentMCPServerConfigurationModel,
+            as: "agent_mcp_server_configuration",
+            attributes: [],
+            required: true,
+            include: [
+              {
+                model: AgentConfigurationModel,
+                as: "agent_configuration",
+                attributes: [],
+                required: true,
+                where: {
+                  status: "active",
+                  workspaceId: owner.id,
+                },
+              },
+            ],
+          },
+        ],
+      }),
+      fetchSkillsByDataSourceViewIds(auth, [dataSourceView.id]),
+    ]);
 
   const skills = skillsByDataSourceViewId.get(dataSourceView.id) ?? [];
   const res = [dataSourceConfigRow, tableConfigRow] as unknown as

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -7,10 +7,12 @@ import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import type { DataSourceViewCategory } from "@app/types/api/public/spaces";
+import type { UsedBySkillType } from "@app/types/assistant/skill_configuration";
 import type {
-  AgentsUsageType,
+  AgentsAndSkillsUsageType,
   ConnectorProvider,
 } from "@app/types/data_source";
 import { CONNECTOR_PROVIDERS } from "@app/types/data_source";
@@ -28,7 +30,12 @@ import { Op, Sequelize } from "sequelize";
 // If it is a problem, let's add caching
 const DISABLE_QUERIES = false;
 
-export type DataSourcesUsageByAgent = Record<ModelId, AgentsUsageType | null>;
+export type DataSourcesUsage = Record<ModelId, AgentsAndSkillsUsageType | null>;
+
+type AgentOnlyUsage = {
+  count: number;
+  agents: { sId: string; name: string; pictureUrl: string }[];
+};
 
 const AGENT_CONFIG_PATH =
   '"agent_mcp_server_configuration->agent_configuration"';
@@ -49,13 +56,105 @@ const agentAggregates: ProjectionAlias[] = (
   alias,
 ]);
 
+/**
+ * Skills can attach a data source view directly as "knowledge" (independently of any
+ * MCP server/tool configuration). Mirrors `fetchSkillsByMCPServer` in `agent_actions.ts`,
+ * but reads `skill.dataSourceConfigurations` instead of `skill.mcpServerViews`.
+ */
+async function fetchSkillsByDataSource(auth: Authenticator): Promise<{
+  byDataSourceViewId: Map<ModelId, UsedBySkillType[]>;
+  byDataSourceId: Map<ModelId, UsedBySkillType[]>;
+}> {
+  const workspaceSkills = await SkillResource.listByWorkspace(auth, {
+    status: "active",
+    withInstructions: false,
+    withTools: false,
+    withFileAttachments: false,
+  });
+  const skills = auth.isAdmin()
+    ? workspaceSkills
+    : workspaceSkills.filter(
+        (skill) => skill.availability !== "editors" || skill.canWrite(auth)
+      );
+
+  const byDataSourceViewId = new Map<ModelId, UsedBySkillType[]>();
+  const byDataSourceId = new Map<ModelId, UsedBySkillType[]>();
+
+  const pushSkill = (
+    map: Map<ModelId, UsedBySkillType[]>,
+    id: ModelId,
+    usedBySkill: UsedBySkillType
+  ) => {
+    const usedBySkills = map.get(id) ?? [];
+    usedBySkills.push(usedBySkill);
+    map.set(id, usedBySkills);
+  };
+
+  for (const skill of skills) {
+    const usedBySkill: UsedBySkillType = {
+      sId: skill.sId,
+      name: skill.name,
+      icon: skill.icon,
+    };
+    for (const dataSourceViewId of new Set(
+      skill.dataSourceConfigurations.map((c) => c.dataSourceViewId)
+    )) {
+      pushSkill(byDataSourceViewId, dataSourceViewId, usedBySkill);
+    }
+    for (const dataSourceId of new Set(
+      skill.dataSourceConfigurations.map((c) => c.dataSourceId)
+    )) {
+      pushSkill(byDataSourceId, dataSourceId, usedBySkill);
+    }
+  }
+
+  for (const usedBySkills of [
+    ...byDataSourceViewId.values(),
+    ...byDataSourceId.values(),
+  ]) {
+    usedBySkills.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  return { byDataSourceViewId, byDataSourceId };
+}
+
+/**
+ * Folds a skills-by-id map into an agent-only usage map, bumping `.count` for any id that
+ * gains skills. `allowedIds`, when passed, drops skill entries for ids outside the batch that
+ * was actually requested (skills are fetched workspace-wide, so this re-scopes the result).
+ */
+function mergeSkillsIntoUsage(
+  agentOnly: Record<ModelId, AgentOnlyUsage>,
+  skillsById: Map<ModelId, UsedBySkillType[]>,
+  allowedIds?: ModelId[]
+): DataSourcesUsage {
+  const result: DataSourcesUsage = {};
+  for (const key of Object.keys(agentOnly)) {
+    const id = Number(key);
+    result[id] = { ...agentOnly[id], skills: [] };
+  }
+  for (const [id, skills] of skillsById) {
+    if (allowedIds && !allowedIds.includes(id)) {
+      continue;
+    }
+    const usage = result[id];
+    if (usage) {
+      usage.skills = skills;
+      usage.count += skills.length;
+    } else {
+      result[id] = { count: skills.length, agents: [], skills };
+    }
+  }
+  return result;
+}
+
 export async function getDataSourceViewsUsageByModelIds({
   auth,
   dataSourceViewModelIds,
 }: {
   auth: Authenticator;
   dataSourceViewModelIds: ModelId[];
-}): Promise<DataSourcesUsageByAgent> {
+}): Promise<DataSourcesUsage> {
   const owner = auth.workspace();
 
   // This condition is critical it checks that we can identify the workspace and that the current
@@ -74,8 +173,13 @@ export async function getDataSourceViewsUsageByModelIds({
     return {};
   }
 
-  // Step 1 & 2: fetch the config links from both sources.
-  const [dataSourceConfigLinks, tableConfigLinks] = await Promise.all([
+  // Step 1 & 2: fetch the config links from both sources, plus skill usage — nothing here
+  // depends on anything else, so fetch them all together instead of sequentially.
+  const [
+    dataSourceConfigLinks,
+    tableConfigLinks,
+    { byDataSourceViewId: skillsByDataSourceViewId },
+  ] = await Promise.all([
     AgentDataSourceConfigurationModel.findAll({
       raw: true,
       attributes: ["dataSourceViewId", "mcpServerConfigurationId"],
@@ -92,6 +196,7 @@ export async function getDataSourceViewsUsageByModelIds({
         dataSourceViewId: { [Op.in]: uniqueDataSourceViewModelIds },
       },
     }),
+    fetchSkillsByDataSource(auth),
   ]);
 
   // Step 3: fetch the MCP server configuration -> agent configuration mappings
@@ -205,7 +310,7 @@ export async function getDataSourceViewsUsageByModelIds({
     tableAgents.map((agent) => [agent.id, agent])
   );
 
-  const result: DataSourcesUsageByAgent = {};
+  const result: Record<ModelId, AgentOnlyUsage> = {};
 
   const pushAgentForDataSourceView = ({
     dataSourceViewId,
@@ -271,7 +376,11 @@ export async function getDataSourceViewsUsageByModelIds({
     }
   });
 
-  return result;
+  return mergeSkillsIntoUsage(
+    result,
+    skillsByDataSourceViewId,
+    uniqueDataSourceViewModelIds
+  );
 }
 
 export async function getDataSourcesUsageByCategory({
@@ -280,7 +389,7 @@ export async function getDataSourcesUsageByCategory({
 }: {
   auth: Authenticator;
   category: DataSourceViewCategory;
-}): Promise<DataSourcesUsageByAgent> {
+}): Promise<DataSourcesUsage> {
   const owner = auth.workspace();
 
   // This condition is critical it checks that we can identify the workspace and that the current
@@ -306,7 +415,11 @@ export async function getDataSourcesUsageByCategory({
     };
   }
 
-  const res = (await Promise.all([
+  const [
+    dataSourceConfigRows,
+    tableConfigRows,
+    { byDataSourceId: skillsByDataSourceId },
+  ] = await Promise.all([
     AgentDataSourceConfigurationModel.findAll({
       raw: true,
       group: ["dataSource.id"],
@@ -387,41 +500,46 @@ export async function getDataSourcesUsageByCategory({
         },
       ],
     }),
-  ])) as unknown as {
-    dataSourceId: ModelId;
-    names: string[];
-    sIds: string[];
-    pictureUrls: string[];
-  }[][];
+    fetchSkillsByDataSource(auth),
+  ] as const);
 
-  const result = res.flat().reduce<DataSourcesUsageByAgent>((acc, dsConfig) => {
-    let usage = acc[dsConfig.dataSourceId];
+  const result = (
+    [dataSourceConfigRows, tableConfigRows] as unknown as {
+      dataSourceId: ModelId;
+      names: string[];
+      sIds: string[];
+      pictureUrls: string[];
+    }[][]
+  )
+    .flat()
+    .reduce<Record<ModelId, AgentOnlyUsage>>((acc, dsConfig) => {
+      let usage = acc[dsConfig.dataSourceId];
 
-    if (!usage) {
-      usage = {
-        count: 0,
-        agents: [],
-      };
-      acc[dsConfig.dataSourceId] = usage;
-    }
+      if (!usage) {
+        usage = {
+          count: 0,
+          agents: [],
+        };
+        acc[dsConfig.dataSourceId] = usage;
+      }
 
-    const newAgents = dsConfig.sIds
-      .map((sId, index) => ({
-        sId,
-        name: dsConfig.names[index],
-        pictureUrl: dsConfig.pictureUrls[index],
-      }))
-      .filter(
-        (agent) =>
-          agent.sId &&
-          agent.sId.length > 0 &&
-          agent.name &&
-          agent.name.length > 0
-      );
+      const newAgents = dsConfig.sIds
+        .map((sId, index) => ({
+          sId,
+          name: dsConfig.names[index],
+          pictureUrl: dsConfig.pictureUrls[index],
+        }))
+        .filter(
+          (agent) =>
+            agent.sId &&
+            agent.sId.length > 0 &&
+            agent.name &&
+            agent.name.length > 0
+        );
 
-    usage.agents.push(...newAgents);
-    return acc;
-  }, {});
+      usage.agents.push(...newAgents);
+      return acc;
+    }, {});
 
   Object.values(result).forEach((usage) => {
     if (usage) {
@@ -430,7 +548,7 @@ export async function getDataSourcesUsageByCategory({
     }
   });
 
-  return result;
+  return mergeSkillsIntoUsage(result, skillsByDataSourceId);
 }
 
 export async function getDataSourceUsage({
@@ -439,7 +557,7 @@ export async function getDataSourceUsage({
 }: {
   auth: Authenticator;
   dataSource: DataSourceResource;
-}): Promise<Result<AgentsUsageType, Error>> {
+}): Promise<Result<AgentsAndSkillsUsageType, Error>> {
   const owner = auth.workspace();
 
   // This condition is critical it checks that we can identify the workspace and that the current
@@ -450,10 +568,14 @@ export async function getDataSourceUsage({
   }
 
   if (DISABLE_QUERIES) {
-    return new Ok({ count: 0, agents: [] });
+    return new Ok({ count: 0, agents: [], skills: [] });
   }
 
-  const res = (await Promise.all([
+  const [
+    dataSourceConfigRow,
+    tableConfigRow,
+    { byDataSourceId: skillsByDataSourceId },
+  ] = await Promise.all([
     AgentDataSourceConfigurationModel.findOne({
       raw: true,
       attributes: [...agentAggregates],
@@ -510,12 +632,16 @@ export async function getDataSourceUsage({
         },
       ],
     }),
-  ])) as unknown as
+    fetchSkillsByDataSource(auth),
+  ]);
+
+  const skills = skillsByDataSourceId.get(dataSource.id) ?? [];
+  const res = [dataSourceConfigRow, tableConfigRow] as unknown as
     | { names: string[]; sIds: string[]; pictureUrls: string[] }[]
     | null;
 
   if (!res) {
-    return new Ok({ count: 0, agents: [] });
+    return new Ok({ count: skills.length, agents: [], skills });
   } else {
     const agents = res
       .filter((r) => r && Array.isArray(r.sIds) && Array.isArray(r.names))
@@ -537,8 +663,9 @@ export async function getDataSourceUsage({
     const sortedAgents = sortBy(uniqBy(agents, "sId"), "name");
 
     return new Ok({
-      count: sortedAgents.length,
+      count: sortedAgents.length + skills.length,
       agents: sortedAgents,
+      skills,
     });
   }
 }
@@ -549,7 +676,7 @@ export async function getDataSourceViewUsage({
 }: {
   auth: Authenticator;
   dataSourceView: DataSourceViewResource;
-}): Promise<Result<AgentsUsageType, Error>> {
+}): Promise<Result<AgentsAndSkillsUsageType, Error>> {
   const owner = auth.workspace();
 
   // This condition is critical it checks that we can identify the workspace and that the current
@@ -560,10 +687,14 @@ export async function getDataSourceViewUsage({
   }
 
   if (DISABLE_QUERIES) {
-    return new Ok({ count: 0, agents: [] });
+    return new Ok({ count: 0, agents: [], skills: [] });
   }
 
-  const res = (await Promise.all([
+  const [
+    dataSourceConfigRow,
+    tableConfigRow,
+    { byDataSourceViewId: skillsByDataSourceViewId },
+  ] = await Promise.all([
     AgentDataSourceConfigurationModel.findOne({
       raw: true,
       attributes: [...agentAggregates],
@@ -620,12 +751,16 @@ export async function getDataSourceViewUsage({
         },
       ],
     }),
-  ])) as unknown as
+    fetchSkillsByDataSource(auth),
+  ]);
+
+  const skills = skillsByDataSourceViewId.get(dataSourceView.id) ?? [];
+  const res = [dataSourceConfigRow, tableConfigRow] as unknown as
     | { names: string[]; sIds: string[]; pictureUrls: string[] }[]
     | null;
 
   if (!res) {
-    return new Ok({ count: 0, agents: [] });
+    return new Ok({ count: skills.length, agents: [], skills });
   } else {
     const agents = res
       .filter((r) => r && Array.isArray(r.sIds) && Array.isArray(r.names))
@@ -647,8 +782,9 @@ export async function getDataSourceViewUsage({
     const sortedAgents = sortBy(uniqBy(agents, "sId"), "name");
 
     return new Ok({
-      count: sortedAgents.length,
+      count: sortedAgents.length + skills.length,
       agents: sortedAgents,
+      skills,
     });
   }
 }

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -20,7 +20,7 @@ import { ContentNodesViewTypeCodec } from "@app/types/connectors/content_nodes";
 import type { CoreAPIContentNode } from "@app/types/core/content_node";
 import type { CoreAPIDatasourceViewFilter } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { AgentsUsageType } from "@app/types/data_source";
+import type { AgentsAndSkillsUsageType } from "@app/types/data_source";
 import type {
   DataSourceViewContentNode,
   DataSourceViewType,
@@ -335,14 +335,57 @@ export async function handlePatchDataSourceView(
   return new Ok(dataSourceView);
 }
 
+export async function handleDeleteDataSourceView(
+  auth: Authenticator,
+  dataSourceView: DataSourceViewResource,
+  { force }: { force: boolean }
+): Promise<
+  Result<
+    void,
+    Omit<DustError, "code"> & {
+      code: "unauthorized" | "in_use";
+    }
+  >
+> {
+  if (!dataSourceView.canAdministrate(auth)) {
+    return new Err({
+      name: "dust_error",
+      code: "unauthorized",
+      message: "Only users that are `admins` can administrate spaces.",
+    });
+  }
+
+  if (!force) {
+    const usageRes = await getDataSourceViewUsage({ auth, dataSourceView });
+    if (usageRes.isErr() || usageRes.value.count > 0) {
+      const names = usageRes.isOk()
+        ? [...usageRes.value.agents, ...usageRes.value.skills].map(
+            (u) => u.name
+          )
+        : [];
+      return new Err({
+        name: "dust_error",
+        code: "in_use",
+        message: usageRes.isOk()
+          ? `The data source view is in use by ${names.join(", ")} and cannot be deleted.`
+          : "The data source view is in use and cannot be deleted.",
+      });
+    }
+  }
+
+  await dataSourceView.delete(auth, { hardDelete: true });
+
+  return new Ok(undefined);
+}
+
 export type DataSourceViewWithUsage = DataSourceViewType & {
-  usage: AgentsUsageType | null;
+  usage: AgentsAndSkillsUsageType | null;
 };
 
 /**
- * Every data source view in the workspace, each enriched with its agent
- * usage. Usage fetches run concurrently with bounded parallelism. Used by
- * the poke admin UI.
+ * Every data source view in the workspace, each enriched with its agent and
+ * skill usage. Usage fetches run concurrently with bounded parallelism. Used
+ * by the poke admin UI.
  */
 export async function listDataSourceViewsWithUsage(
   auth: Authenticator

--- a/front/lib/api/poke/plugins/data_sources/delete_data_source.ts
+++ b/front/lib/api/poke/plugins/data_sources/delete_data_source.ts
@@ -1,3 +1,4 @@
+import { getDataSourceViewUsage } from "@app/lib/api/agent_data_sources";
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,
@@ -38,7 +39,7 @@ export const deleteDataSourcePlugin = createPlugin({
 
     const viewsUsageByAgentsRes = await concurrentExecutor(
       dataSourceViews,
-      (view) => view.getUsagesByAgents(auth),
+      (view) => getDataSourceViewUsage({ auth, dataSourceView: view }),
       { concurrency: 5 }
     );
 

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -16,6 +16,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
@@ -1188,6 +1189,43 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
           false
         );
         expect(deleteResult.isOk()).toBe(true);
+      }
+    });
+  });
+
+  describe("usage guard", () => {
+    it("blocks deletion and names the skill when only a skill uses the space's data, not an agent", async () => {
+      const spaceResult = await createSpaceAndGroup(
+        adminAuth,
+        {
+          name: "Test Space With Skill Knowledge",
+          isRestricted: false,
+          spaceKind: "regular",
+          managementMode: "manual",
+          memberIds: [],
+        },
+        { ignoreWorkspaceLimit: true }
+      );
+      expect(spaceResult.isOk()).toBe(true);
+      const space = spaceResult.isOk() ? spaceResult.value : null;
+      expect(space).not.toBeNull();
+
+      const view = await DataSourceViewFactory.folder(workspace, space!);
+      const skill = await SkillFactory.create(adminAuth, {
+        name: "Space Knowledge Skill",
+        availability: "workspace_users",
+        attachedKnowledge: [{ dataSourceView: view, nodeId: "node-1" }],
+      });
+
+      const deleteResult = await softDeleteSpaceAndLaunchScrubWorkflow(
+        adminAuth,
+        space!,
+        false // do not force — the guard should block
+      );
+
+      expect(deleteResult.isErr()).toBe(true);
+      if (deleteResult.isErr()) {
+        expect(deleteResult.error.message).toContain(skill.name);
       }
     });
   });

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -1,3 +1,11 @@
+import { remoteMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import { getToolsUsage } from "@app/lib/api/agent_actions";
+import {
+  getDataSourceUsage,
+  getDataSourceViewsUsageByModelIds,
+  getDataSourceViewUsage,
+} from "@app/lib/api/agent_data_sources";
+import { getWebhookSourcesUsage } from "@app/lib/api/agent_triggers";
 import { hardDeleteApp } from "@app/lib/api/apps";
 import { updateAgentRequirements } from "@app/lib/api/assistant/configuration/agent_requirements";
 import { createDataSourceAndConnectorForProject } from "@app/lib/api/projects/connector";
@@ -29,7 +37,8 @@ import {
   launchOrSignalProjectTodoWorkflow,
   stopProjectTodoWorkflow,
 } from "@app/temporal/project_task/client";
-import type { AgentsUsageType } from "@app/types/data_source";
+import { DATA_SOURCE_VIEW_CATEGORIES } from "@app/types/api/public/spaces";
+import type { SpaceCategoryInfo } from "@app/types/api/spaces";
 import {
   PROJECT_EDITOR_GROUP_PREFIX,
   PROJECT_GROUP_PREFIX,
@@ -40,7 +49,124 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import assert from "assert";
 import uniq from "lodash/uniq";
+import uniqBy from "lodash/uniqBy";
 import { Op, UniqueConstraintError } from "sequelize";
+
+/**
+ * Summarizes a Space's contents by category (Connected Data, Folders, Websites, Tools,
+ * Triggers, Apps) with a count and agent+skill usage per category. Space landing page read model.
+ *
+ * Apps are legacy (`legacy_dust_apps`) and left zeroed out — not worth computing.
+ *
+ * Perf: Tools/Triggers usage comes from `getToolsUsage`/`getWebhookSourcesUsage`, which are
+ * workspace-wide, not space-scoped; this function narrows after the fact. Fine at
+ * small-to-medium scale, but repeats the full-workspace query on every space visited. If it
+ * becomes hot, add view-id-scoped variants mirroring `getDataSourceViewsUsageByModelIds`.
+ *
+ * Known gap: `getToolsUsage` groups by MCP server, not by view, so a manually-added tool with
+ * views in two regular spaces will leak combined usage into both. Same fix as above resolves it.
+ */
+export async function getSpaceCategoriesWithUsage(
+  auth: Authenticator,
+  space: SpaceResource
+): Promise<Record<string, SpaceCategoryInfo>> {
+  // These three listings are mutually independent — fetch together rather than one at a time.
+  const [dataSourceViewsList, actions, webhookViews] = await Promise.all([
+    DataSourceViewResource.listBySpace(auth, space),
+    MCPServerViewResource.listBySpace(auth, space),
+    WebhookSourcesViewResource.listBySpace(auth, space),
+  ]);
+  // "auto" tools (e.g. Pods, Computer) get a view auto-provisioned into every space —
+  // they aren't meaningfully "this space's tools," so both the count and the usage below
+  // are scoped to manually-added tools only, matching `getSpaceIdToActionsMap`'s convention.
+  const manualActions = actions.filter(
+    (a) => a.getServerDisplayMetadata().availability === "manual"
+  );
+  const actionsCount = manualActions.length;
+
+  // Same here: each usage computation only needs one of the lists above, not each other's
+  // output, so they can all run together too.
+  const [usages, webhookUsages, toolsUsage] = await Promise.all([
+    getDataSourceViewsUsageByModelIds({
+      auth,
+      dataSourceViewModelIds: dataSourceViewsList.map((dsv) => dsv.id),
+    }),
+    getWebhookSourcesUsage({ auth }),
+    getToolsUsage(auth),
+  ]);
+
+  const categories: Record<string, SpaceCategoryInfo> = {};
+  for (const category of DATA_SOURCE_VIEW_CATEGORIES) {
+    const dataSourceViewsInCategory = dataSourceViewsList.filter(
+      (view) => view.toJSON().category === category
+    );
+
+    const agents = uniqBy(
+      dataSourceViewsInCategory.flatMap(
+        (view) => usages[view.id]?.agents ?? []
+      ),
+      "sId"
+    );
+    const skills = uniqBy(
+      dataSourceViewsInCategory.flatMap(
+        (view) => usages[view.id]?.skills ?? []
+      ),
+      "sId"
+    );
+
+    categories[category] = {
+      count: dataSourceViewsInCategory.length,
+      usage: { count: agents.length + skills.length, agents, skills },
+    };
+  }
+
+  categories["actions"].count = actionsCount;
+  // Triggers aren't `DataSourceView`s, so the loop above leaves this at 0; patch it here.
+  categories["triggers"].count = webhookViews.length;
+
+  // Tools and Triggers aren't `DataSourceView`s, so the loop above never computes real usage
+  // for them. Reuse the same batched usage functions their own admin pages already rely on,
+  // narrowed down to this space's own tools/webhook sources.
+  //
+  // Skills never have triggers, so this stays agents-only.
+  const triggerAgents = uniqBy(
+    webhookViews.flatMap(
+      (view) => webhookUsages[view.webhookSourceId]?.agents ?? []
+    ),
+    "sId"
+  );
+  categories["triggers"].usage = {
+    count: triggerAgents.length,
+    agents: triggerAgents,
+    skills: [],
+  };
+
+  const getToolUsageKey = (view: MCPServerViewResource) =>
+    view.internalMCPServerId ??
+    remoteMCPServerNameToSId({
+      remoteMCPServerId: view.remoteMCPServerId!,
+      workspaceId: auth.getNonNullableWorkspace().id,
+    });
+  const toolAgents = uniqBy(
+    manualActions.flatMap(
+      (view) => toolsUsage[getToolUsageKey(view)]?.agents ?? []
+    ),
+    "sId"
+  );
+  const toolSkills = uniqBy(
+    manualActions.flatMap(
+      (view) => toolsUsage[getToolUsageKey(view)]?.skills ?? []
+    ),
+    "sId"
+  );
+  categories["actions"].usage = {
+    count: toolAgents.length + toolSkills.length,
+    agents: toolAgents,
+    skills: toolSkills,
+  };
+
+  return categories;
+}
 
 export async function softDeleteSpaceAndLaunchScrubWorkflow(
   auth: Authenticator,
@@ -56,47 +182,61 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
     "Only project editors or workspace admins can delete project spaces."
   );
 
-  const usages: AgentsUsageType[] = [];
-
+  // Fetched unconditionally: the delete transaction below reuses these lists either way.
   const dataSourceViews = await DataSourceViewResource.listBySpace(auth, space);
-  for (const view of dataSourceViews) {
-    const usage = await view.getUsagesByAgents(auth);
-    if (usage.isErr()) {
-      throw usage.error;
-    } else if (usage.value.count > 0) {
-      usages.push(usage.value);
-    }
-  }
-
   const dataSources = await DataSourceResource.listBySpace(auth, space);
-  for (const ds of dataSources) {
-    const usage = await ds.getUsagesByAgents(auth);
-    if (usage.isErr()) {
-      throw usage.error;
-    } else if (usage.value.count > 0) {
-      usages.push(usage.value);
-    }
-  }
-
   const apps = await AppResource.listBySpace(auth, space);
-  for (const app of apps) {
-    const usage = await app.getUsagesByAgents(auth);
-    if (usage.isErr()) {
-      throw usage.error;
-    } else if (usage.value.count > 0) {
-      usages.push(usage.value);
-    }
-  }
 
-  if (!force && usages.length > 0) {
-    const agentNames = uniq(
-      usages.flatMap((u) => u.agents).map((agent) => agent.name)
-    );
-    return new Err(
-      new Error(
-        `Cannot delete space with data source or app in use by agent(s): ${agentNames.join(", ")}. If you'd like to continue set the force query parameter to true.`
-      )
-    );
+  if (!force) {
+    let blockedByUsage = false;
+    const agentNames: string[] = [];
+    const skillNames: string[] = [];
+
+    for (const view of dataSourceViews) {
+      const usage = await getDataSourceViewUsage({
+        auth,
+        dataSourceView: view,
+      });
+      if (usage.isErr()) {
+        throw usage.error;
+      } else if (usage.value.count > 0) {
+        blockedByUsage = true;
+        agentNames.push(...usage.value.agents.map((agent) => agent.name));
+        skillNames.push(...usage.value.skills.map((skill) => skill.name));
+      }
+    }
+
+    for (const ds of dataSources) {
+      const usage = await getDataSourceUsage({ auth, dataSource: ds });
+      if (usage.isErr()) {
+        throw usage.error;
+      } else if (usage.value.count > 0) {
+        blockedByUsage = true;
+        agentNames.push(...usage.value.agents.map((agent) => agent.name));
+        skillNames.push(...usage.value.skills.map((skill) => skill.name));
+      }
+    }
+
+    for (const app of apps) {
+      const usage = await app.getUsagesByAgents(auth);
+      if (usage.isErr()) {
+        throw usage.error;
+      } else if (usage.value.count > 0) {
+        blockedByUsage = true;
+        agentNames.push(...usage.value.agents.map((agent) => agent.name));
+      }
+    }
+
+    if (blockedByUsage) {
+      // Apps are always agents-only (skills never reference them); data sources/views can be
+      // blocked by either, so the message names whichever actually uses the resource.
+      const names = uniq([...agentNames, ...skillNames]);
+      return new Err(
+        new Error(
+          `Cannot delete space with data source or app in use by: ${names.join(", ")}. If you'd like to continue set the force query parameter to true.`
+        )
+      );
+    }
   }
 
   const workspaceId = auth.getNonNullableWorkspace().sId;

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -1,4 +1,3 @@
-import { getDataSourceUsage } from "@app/lib/api/agent_data_sources";
 import { default as config } from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
@@ -619,10 +618,6 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
     return this.update({
       connectorId,
     });
-  }
-
-  getUsagesByAgents(auth: Authenticator) {
-    return getDataSourceUsage({ auth, dataSource: this });
   }
 
   // sId logic.

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -1,7 +1,6 @@
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 
-import { getDataSourceViewUsage } from "@app/lib/api/agent_data_sources";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { isFolder, isWebsite } from "@app/lib/data_sources";
@@ -873,10 +872,6 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
   static isDataSourceViewSId(sId: string): boolean {
     return isResourceSId("data_source_view", sId);
   }
-
-  getUsagesByAgents = async (auth: Authenticator) => {
-    return getDataSourceViewUsage({ auth, dataSourceView: this });
-  };
 
   // Serialization.
 

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@app/lib/models/skill";
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
 import { SkillUserFavoriteModel } from "@app/lib/models/skill/skill_user_favorite";
-import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -1903,6 +1903,109 @@ describe("SkillResource", () => {
         []
       );
       expect(emptyArrayResult).toHaveLength(0);
+    });
+  });
+
+  describe("listByDataSourceIds", () => {
+    it("should return skills that use any of the given data source IDs", async () => {
+      const space = await SpaceFactory.regular(testContext.workspace);
+      await GroupSpaceFactory.associate(space, testContext.globalGroup);
+
+      const dsv1 = await DataSourceViewFactory.folder(
+        testContext.workspace,
+        space,
+        testContext.user
+      );
+      const dsv2 = await DataSourceViewFactory.folder(
+        testContext.workspace,
+        space,
+        testContext.user
+      );
+      const skill1 = await SkillFactory.create(testContext.authenticator, {
+        name: "Skill With DS1",
+        requestedSpaceIds: [space.id],
+      });
+
+      await createDataSourceConfiguration({
+        dataSourceView: dsv1,
+        parentsIn: ["node1"],
+        skillId: skill1.id,
+      });
+
+      // Create another skill without data source configuration
+      await SkillFactory.create(testContext.authenticator, {
+        name: "Skill Without DS",
+        requestedSpaceIds: [],
+      });
+
+      // Test that skills with ds1 are returned
+      const skillsWithDs1 = await SkillResource.listByDataSourceIds(
+        testContext.authenticator,
+        [dsv1.dataSource.id]
+      );
+      expect(skillsWithDs1).toHaveLength(1);
+      expect(skillsWithDs1[0].id).toBe(skill1.id);
+
+      // Test with an unused data source returns empty
+      const emptyResult = await SkillResource.listByDataSourceIds(
+        testContext.authenticator,
+        [dsv2.dataSource.id]
+      );
+      expect(emptyResult).toHaveLength(0);
+
+      // Test with empty array returns empty
+      const emptyArrayResult = await SkillResource.listByDataSourceIds(
+        testContext.authenticator,
+        []
+      );
+      expect(emptyArrayResult).toHaveLength(0);
+    });
+
+    it("should return skills configured through any view of the given data source", async () => {
+      const ownerSpace = await SpaceFactory.regular(testContext.workspace);
+      await GroupSpaceFactory.associate(ownerSpace, testContext.globalGroup);
+      const otherSpace = await SpaceFactory.regular(testContext.workspace);
+      await GroupSpaceFactory.associate(otherSpace, testContext.globalGroup);
+
+      const defaultView = await DataSourceViewFactory.folder(
+        testContext.workspace,
+        ownerSpace,
+        testContext.user
+      );
+      const sharedViewResult =
+        await DataSourceViewResource.createViewInSpaceFromDataSource(
+          testContext.authenticator,
+          otherSpace,
+          defaultView.dataSource,
+          ["node1"]
+        );
+      assert(sharedViewResult.isOk(), "shared view should be created");
+
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name: "Skill With Shared View",
+        requestedSpaceIds: [otherSpace.id],
+      });
+
+      await createDataSourceConfiguration({
+        dataSourceView: sharedViewResult.value,
+        parentsIn: ["node1"],
+        skillId: skill.id,
+      });
+
+      // The skill is not attached to the default view of the data source...
+      const skillsForDefaultView = await SkillResource.listByDataSourceViewIds(
+        testContext.authenticator,
+        [defaultView.id]
+      );
+      expect(skillsForDefaultView).toHaveLength(0);
+
+      // ...but it is still found when listing by the underlying data source.
+      const skillsForDataSource = await SkillResource.listByDataSourceIds(
+        testContext.authenticator,
+        [defaultView.dataSource.id]
+      );
+      expect(skillsForDataSource).toHaveLength(1);
+      expect(skillsForDataSource[0].id).toBe(skill.id);
     });
   });
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -49,7 +49,10 @@ import type {
   SkillDefinition,
 } from "@app/lib/resources/skill/code_defined/shared";
 import { SystemSkillsRegistry } from "@app/lib/resources/skill/code_defined/system_registry";
-import type { SkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
+import type {
+  SkillConfigurationFindOptions,
+  SkillHydrationOptions,
+} from "@app/lib/resources/skill/types";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import {
@@ -1627,7 +1630,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
    */
   static async listByDataSourceViewIds(
     auth: Authenticator,
-    dataSourceViewIds: ModelId[]
+    dataSourceViewIds: ModelId[],
+    opts: SkillHydrationOptions = {}
   ): Promise<SkillResource[]> {
     if (dataSourceViewIds.length === 0) {
       return [];
@@ -1660,6 +1664,50 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         status: "active",
       },
       onlyCustom: true,
+      ...opts,
+    });
+  }
+
+  /**
+   * List skills that use any of the given data source IDs.
+   */
+  static async listByDataSourceIds(
+    auth: Authenticator,
+    dataSourceIds: ModelId[],
+    opts: SkillHydrationOptions = {}
+  ): Promise<SkillResource[]> {
+    if (dataSourceIds.length === 0) {
+      return [];
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+
+    // Query skill IDs that have any of the given data sources.
+    const skillConfigs = await SkillDataSourceConfigurationModel.findAll({
+      attributes: ["skillConfigurationId"],
+      where: {
+        workspaceId: workspace.id,
+        dataSourceId: {
+          [Op.in]: dataSourceIds,
+        },
+      },
+    });
+
+    if (skillConfigs.length === 0) {
+      return [];
+    }
+
+    const skillIds = uniq(skillConfigs.map((c) => c.skillConfigurationId));
+
+    return this.baseFetch(auth, {
+      where: {
+        id: {
+          [Op.in]: skillIds,
+        },
+        status: "active",
+      },
+      onlyCustom: true,
+      ...opts,
     });
   }
 

--- a/front/lib/resources/skill/types.ts
+++ b/front/lib/resources/skill/types.ts
@@ -37,3 +37,9 @@ export type SkillConfigurationFindOptions = (
   withInstructions?: boolean;
   withFileAttachments?: boolean;
 };
+
+// The hydration subset a caller can opt out of when it only needs a skill's identity.
+export type SkillHydrationOptions = Pick<
+  SkillConfigurationFindOptions,
+  "withInstructions" | "withTools" | "withFileAttachments"
+>;

--- a/front/mailing/20250704_slackstorm_rate_limited_users.ts
+++ b/front/mailing/20250704_slackstorm_rate_limited_users.ts
@@ -1,6 +1,7 @@
 import sgMail from "@sendgrid/mail";
 import assert from "assert";
 
+import { getDataSourceViewUsage } from "@app/lib/api/agent_data_sources";
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -111,7 +112,9 @@ async function contactWorkspace(workspaceId: string) {
     slackDataSources
   );
   const viewsUsageByAgentsRes = await Promise.all(
-    dataSourceViews.map((view) => view.getUsagesByAgents(auth))
+    dataSourceViews.map((view) =>
+      getDataSourceViewUsage({ auth, dataSourceView: view })
+    )
   );
 
   const viewsUsedByAgents = viewsUsageByAgentsRes.reduce((acc, usageRes) => {

--- a/front/types/api/agent_data_sources.ts
+++ b/front/types/api/agent_data_sources.ts
@@ -1,5 +1,5 @@
-import type { AgentsUsageType } from "@app/types/data_source";
+import type { AgentsAndSkillsUsageType } from "@app/types/data_source";
 
 export type GetDataSourceUsageResponseBody = {
-  usage: AgentsUsageType;
+  usage: AgentsAndSkillsUsageType;
 };

--- a/front/types/api/spaces.ts
+++ b/front/types/api/spaces.ts
@@ -1,4 +1,4 @@
-import type { AgentsUsageType } from "@app/types/data_source";
+import type { AgentsAndSkillsUsageType } from "@app/types/data_source";
 import type { PodFrameTab } from "@app/types/pod_frame_tab";
 import {
   PodFrameTabsSchema,
@@ -87,7 +87,7 @@ export type PostSpacesResponseBody = {
 };
 
 export type SpaceCategoryInfo = {
-  usage: AgentsUsageType;
+  usage: AgentsAndSkillsUsageType;
   count: number;
 };
 

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -1,5 +1,5 @@
 import { MCPServerViewSchema } from "@app/lib/api/mcp_schemas";
-import type { AgentsUsageType } from "@app/types/data_source";
+import type { AgentsAndSkillsUsageType } from "@app/types/data_source";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { UserType } from "@app/types/user";
 import { z } from "zod";
@@ -108,12 +108,8 @@ export type UsedBySkillType = {
   icon: string | null;
 };
 
-export type SkillUsageType = AgentsUsageType & {
-  skills: UsedBySkillType[];
-};
-
 export type SkillRelations = {
-  usage: SkillUsageType;
+  usage: AgentsAndSkillsUsageType;
   editors: UserType[] | null;
   editedByUser: UserType | null;
   childSkills: SkillWithoutInstructionsAndToolsType[];

--- a/front/types/data_source.ts
+++ b/front/types/data_source.ts
@@ -1,3 +1,4 @@
+import type { UsedBySkillType } from "@app/types/assistant/skill_configuration";
 import type { InternalConnectorType } from "@app/types/connectors/connectors_api";
 import type { ModelId } from "./shared/model_id";
 import type { Result } from "./shared/result";
@@ -69,6 +70,10 @@ export type DataSourceWithConnectorDetailsType = DataSourceType &
 export type AgentsUsageType = {
   count: number;
   agents: Array<{ sId: string; name: string; pictureUrl: string }>;
+};
+
+export type AgentsAndSkillsUsageType = AgentsUsageType & {
+  skills: UsedBySkillType[];
 };
 
 export function isDataSourceNameValid(name: string): Result<void, string> {

--- a/front/types/data_source_view.ts
+++ b/front/types/data_source_view.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import type { DataSourceViewCategory } from "./api/public/spaces";
 import type { ContentNodeWithParent } from "./connectors/connectors_api";
 import type {
-  AgentsUsageType,
+  AgentsAndSkillsUsageType,
   ConnectorStatusDetails,
   DataSourceType,
 } from "./data_source";
@@ -28,7 +28,7 @@ export interface DataSourceViewType {
 
 export type DataSourceViewsWithDetails = DataSourceViewType & {
   dataSource: DataSourceType & ConnectorStatusDetails;
-  usage: AgentsUsageType;
+  usage: AgentsAndSkillsUsageType;
 };
 
 export type DataSourceViewContentNode = ContentNodeWithParent & {


### PR DESCRIPTION
## Description

Adds skills (not just agents) to the "Used By" usage shown on Connected Data/Folders/Websites and the space landing page, matching what the Tools page has shown since #29819.

Also fixes real bugs found while building/reviewing this:
- Tools/Triggers rows on the space landing page showed 0 usage / never rendered.
- Auto-provisioned tools (Pods, Computer, Author Skills, ... — auto-added to every global/system space) were leaking unrelated agents/skills into the Tools usage row on the global space.
- Deletion guards (space delete, data source view delete) and the pre-delete warning dialog now correctly name skills, not just agents, when they block/warn deletion.

Refactors for consistency: moved usage orchestration out of route handlers into `lib/api/*` (`getSpaceCategoriesWithUsage`, `handleDeleteDataSourceView`), removed Apps-usage computation entirely (legacy feature, gated behind `legacy_dust_apps`, not worth computing), renamed `SkillUsageType` → `AgentsAndSkillsUsageType`.

## Tests

New/updated: `agent_data_sources.test.ts`, `spaces.test.ts` (skill-only deletion-guard case), `data_source_views/[dsvId]/index.test.ts` (new file — skill-only block + force bypass), `spaces/[spaceId]/index.test.ts` (Tools/Triggers usage, Triggers row appearing, and the auto-tools-exclusion regression).

Full regression sweep passing. `tsgo`/`biome` clean.

## Risk

- **Deletion guard behavior change**: skill usage now blocks deletion too (space + data source view), not just agents. Intentional correctness fix — both guard error messages and the pre-delete warning dialog now name the skill(s).
- **Auto-tools usage fix changes what the Tools row shows on global/system spaces**: previously inflated (counted every workspace-wide user of an auto tool like Pods/Computer), now accurate. Documented residual, non-blocking gap: two *regular* spaces sharing the same *manually*-added tool can still leak usage into each other (pre-existing — `getToolsUsage` groups by MCP server, not by view).
- **Import-cycle fix removes two Resource methods** (`DataSourceViewResource`/`DataSourceResource`.`getUsagesByAgents`); all known call sites updated in this PR.
- No schema/data changes, no migrations.
- **Rollback**: straightforward revert, no migrations, no feature flags.

## Deploy Plan

Standard deploy, no migrations, no feature flags. Safe to roll back by reverting the commit.
