### PR TITLE
Add optional group filtering to the members search endpoint

### DIFF
--- a/front-api/routes/w/[wId]/members/search.ts
+++ b/front-api/routes/w/[wId]/members/search.ts
@@ -20,6 +20,7 @@ const SearchMembersQuerySchema = z.object({
   searchTerm: z.string().optional(),
   searchEmails: z.string().optional(),
   groupKind: z.enum(GROUP_KINDS).exclude(["system"]).optional(),
+  groupIds: z.string().optional(),
   // Deprecated: the builder-role filter was removed; accepted but ignored to
   // avoid breaking clients that still send it. Remove once no client does.
   buildersOnly: z
@@ -60,6 +61,7 @@ app.get(
         searchTerm: query.searchTerm,
         searchEmails: emails,
         groupKind: query.groupKind,
+        groupIds: query.groupIds?.split(","),
       },
       query
     );

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -303,12 +303,36 @@ export async function searchMembers(
     searchTerm?: string;
     searchEmails?: string[];
     groupKind?: Exclude<GroupKind, "system">;
+    // Narrows results to members belonging to at least one of these groups.
+    // Membership is resolved from Postgres first, then handed to the (ES-backed)
+    // user search as a restrictToUserIds allowlist — the two stores are never
+    // queried with a mixed filter.
+    groupIds?: string[];
   },
   paginationParams: SearchMembersPaginationParams
 ): Promise<{ members: UserTypeWithWorkspace[]; total: number }> {
   const owner = auth.workspace();
   if (!owner) {
     return { members: [], total: 0 };
+  }
+
+  let restrictToUserIds: string[] | undefined;
+  if (options.groupIds && options.groupIds.length > 0) {
+    const groupsRes = await GroupResource.fetchByIds(auth, options.groupIds);
+    if (groupsRes.isErr()) {
+      logger.error({ err: groupsRes.error }, "Error fetching groups");
+      return { members: [], total: 0 };
+    }
+
+    const groupMembers = await GroupResource.getActiveMembersForGroups(
+      auth,
+      groupsRes.value
+    );
+    restrictToUserIds = groupMembers.map((u) => u.sId);
+
+    if (restrictToUserIds.length === 0) {
+      return { members: [], total: 0 };
+    }
   }
 
   let users: UserResource[];
@@ -324,12 +348,17 @@ export async function searchMembers(
       owner,
       options.searchEmails
     );
+    if (restrictToUserIds) {
+      const allowedUserIds = new Set(restrictToUserIds);
+      users = users.filter((u) => allowedUserIds.has(u.sId));
+    }
     total = users.length;
   } else {
     const results = await UserResource.searchUsers(auth, {
       searchTerm: options.searchTerm ?? "",
       offset: paginationParams.offset,
       limit: paginationParams.limit,
+      restrictToUserIds,
     });
 
     if (results.isErr()) {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1544,6 +1544,47 @@ export class GroupResource extends BaseResource<GroupModel> {
     );
   }
 
+  // Active members across a set of groups, unioned. A single batched query
+  // covers every non-global group; the global group short-circuits to all
+  // workspace members since it has no per-member DB rows.
+  static async getActiveMembersForGroups(
+    auth: Authenticator,
+    groups: GroupResource[]
+  ): Promise<UserResource[]> {
+    const owner = auth.getNonNullableWorkspace();
+
+    if (groups.some((group) => group.isGlobal())) {
+      const { memberships } = await MembershipResource.getActiveMemberships({
+        workspace: owner,
+      });
+      return UserResource.fetchByModelIds(memberships.map((m) => m.userId));
+    }
+
+    const memberships = await GroupMembershipModel.findAll({
+      where: {
+        workspaceId: owner.id,
+        groupId: { [Op.in]: groups.map((group) => group.id) },
+        status: "active",
+        startAt: { [Op.lte]: new Date() },
+        [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
+      },
+    });
+
+    const userModelIds = [...new Set(memberships.map((m) => m.userId))];
+    const users = await UserResource.fetchByModelIds(userModelIds);
+
+    const { memberships: workspaceMemberships } =
+      await MembershipResource.getActiveMemberships({
+        users,
+        workspace: owner,
+      });
+
+    // Only return users that have an active membership in the workspace.
+    return users.filter((user) =>
+      workspaceMemberships.some((m) => m.userId === user.id)
+    );
+  }
+
   async getAllMembers(auth: Authenticator): Promise<UserResource[]> {
     const owner = auth.getNonNullableWorkspace();
 

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -128,6 +128,7 @@ export function useSearchMembers<
   pageIndex,
   pageSize,
   groupKind,
+  groupIds,
   disabled,
 }: {
   workspaceId: string;
@@ -135,6 +136,8 @@ export function useSearchMembers<
   pageIndex: number;
   pageSize: number;
   groupKind?: Exclude<GroupKind, "system">;
+  // Narrows results to members belonging to at least one of these groups.
+  groupIds?: string[];
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
@@ -161,6 +164,10 @@ export function useSearchMembers<
 
   if (groupKind && isGroupKind(groupKind)) {
     searchParams.set("groupKind", groupKind);
+  }
+
+  if (groupIds && groupIds.length > 0) {
+    searchParams.set("groupIds", groupIds.join(","));
   }
 
   const { data, error, mutate, mutateRegardlessOfQueryParams } =


### PR DESCRIPTION
Resolve group membership in Postgres, then use it as a restrictToUserIds allowlist into the existing Elasticsearch-backed user search.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
