### PR TITLE
[front] fix: prevent sidebar dropdown items from blinking

### DIFF
--- a/extension/ui/pages/MainPage.tsx
+++ b/extension/ui/pages/MainPage.tsx
@@ -35,8 +35,7 @@ export const MainPage = () => {
     isMenuOpen,
     isMenuOpenOrClosing,
     menuTriggerPosition,
-    handleMenuOpenChange,
-    handleMenuCloseComplete,
+    handleMenuPhaseChange,
   } = useConversationMenu();
 
   const headerTitle = useMemo(() => {
@@ -85,8 +84,7 @@ export const MainPage = () => {
               isConversationDisplayed={true}
               isOpen={isMenuOpen}
               isOpenOrClosing={isMenuOpenOrClosing}
-              onOpenChange={handleMenuOpenChange}
-              onCloseComplete={handleMenuCloseComplete}
+              onPhaseChange={handleMenuPhaseChange}
               triggerPosition={menuTriggerPosition}
               displayOpenInBrowser
               openDetailsInNewTab

--- a/extension/ui/pages/MainPage.tsx
+++ b/extension/ui/pages/MainPage.tsx
@@ -31,8 +31,13 @@ export const MainPage = () => {
       workspaceId: workspace.sId,
     });
 
-  const { isMenuOpen, menuTriggerPosition, handleMenuOpenChange } =
-    useConversationMenu();
+  const {
+    isMenuOpen,
+    isMenuOpenOrClosing,
+    menuTriggerPosition,
+    handleMenuOpenChange,
+    handleMenuCloseComplete,
+  } = useConversationMenu();
 
   const headerTitle = useMemo(() => {
     if (!conversationId) {
@@ -79,7 +84,9 @@ export const MainPage = () => {
               }
               isConversationDisplayed={true}
               isOpen={isMenuOpen}
+              isOpenOrClosing={isMenuOpenOrClosing}
               onOpenChange={handleMenuOpenChange}
+              onCloseComplete={handleMenuCloseComplete}
               triggerPosition={menuTriggerPosition}
               displayOpenInBrowser
               openDetailsInNewTab

--- a/front/components/assistant/conversation/ConversationMenu.test.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.test.tsx
@@ -1,0 +1,52 @@
+import { useConversationMenu } from "@app/components/assistant/conversation/ConversationMenu";
+import { createEvent, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+function ConversationMenuHarness() {
+  const {
+    isMenuOpen,
+    handleRightClick,
+    handleRightPointerDown,
+    handleMenuPhaseChange,
+  } = useConversationMenu();
+
+  return (
+    <div
+      data-testid="conversation-row"
+      data-menu-open={isMenuOpen}
+      onPointerDownCapture={handleRightPointerDown}
+      onContextMenu={handleRightClick}
+    >
+      <button
+        type="button"
+        onClick={() => {
+          handleMenuPhaseChange("closing");
+          handleMenuPhaseChange("closed");
+        }}
+      >
+        Close menu
+      </button>
+    </div>
+  );
+}
+
+describe("useConversationMenu", () => {
+  it("does not reopen from the right-click gesture that closed the menu", () => {
+    render(<ConversationMenuHarness />);
+    const conversationRow = screen.getByTestId("conversation-row");
+
+    fireEvent.contextMenu(conversationRow);
+    expect(conversationRow).toHaveAttribute("data-menu-open", "true");
+
+    const pointerDown = createEvent.pointerDown(conversationRow);
+    Object.defineProperty(pointerDown, "button", { value: 2 });
+    fireEvent(conversationRow, pointerDown);
+    fireEvent.click(screen.getByRole("button", { name: "Close menu" }));
+    fireEvent.contextMenu(conversationRow);
+
+    expect(conversationRow).toHaveAttribute("data-menu-open", "false");
+
+    fireEvent.contextMenu(conversationRow);
+    expect(conversationRow).toHaveAttribute("data-menu-open", "true");
+  });
+});

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -80,18 +80,19 @@ import { useCallback, useContext, useState } from "react";
  * while the menu is open still trigger our handlers. Due to React's async state updates,
  * when the menu closes, our right-click handler sees isMenuOpen as false and reopens the menu.
  */
+type MenuPhase = "closed" | "open" | "closing";
+
 export function useConversationMenu() {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [menuPhase, setMenuPhase] = useState<MenuPhase>("closed");
   const [menuTriggerPosition, setMenuTriggerPosition] = useState<
     { x: number; y: number } | undefined
   >();
 
-  // Tracks the closing animation so the menu stays stable and cannot reopen mid-exit.
-  const [wasMenuJustClosed, setWasMenuJustClosed] = useState(false);
-
-  const handleMenuOpenChange = useCallback((open: boolean) => {
-    setIsMenuOpen(open);
-    setWasMenuJustClosed(!open);
+  const handleMenuPhaseChange = useCallback((phase: MenuPhase) => {
+    setMenuPhase(phase);
+    if (phase === "closed") {
+      setMenuTriggerPosition(undefined);
+    }
   }, []);
 
   const handleRightClick = useCallback(
@@ -99,31 +100,24 @@ export function useConversationMenu() {
       e.preventDefault();
       e.stopPropagation();
 
-      // Ignore right-clicks if menu is currently open OR was just closed
-      // This prevents the close -> immediate reopen behavior
-      if (isMenuOpen || wasMenuJustClosed) {
+      // Prevent the menu from reopening while its closing animation is running.
+      if (menuPhase !== "closed") {
         return;
       }
 
       // Open menu at cursor position
       setMenuTriggerPosition({ x: e.clientX, y: e.clientY });
-      setIsMenuOpen(true);
+      setMenuPhase("open");
     },
-    [isMenuOpen, wasMenuJustClosed]
+    [menuPhase]
   );
 
-  const handleMenuCloseComplete = useCallback(() => {
-    setWasMenuJustClosed(false);
-    setMenuTriggerPosition(undefined);
-  }, []);
-
   return {
-    isMenuOpen,
-    isMenuOpenOrClosing: isMenuOpen || wasMenuJustClosed,
+    isMenuOpen: menuPhase === "open",
+    isMenuOpenOrClosing: menuPhase !== "closed",
     menuTriggerPosition,
     handleRightClick,
-    handleMenuOpenChange,
-    handleMenuCloseComplete,
+    handleMenuPhaseChange,
   };
 }
 
@@ -137,8 +131,7 @@ interface ConversationMenuProps {
   isConversationDisplayed: boolean;
   isOpen: boolean;
   isOpenOrClosing: boolean;
-  onOpenChange: (open: boolean) => void;
-  onCloseComplete: () => void;
+  onPhaseChange: (phase: MenuPhase) => void;
   triggerPosition?: { x: number; y: number };
   displayOpenInBrowser?: boolean;
   openDetailsInNewTab?: boolean;
@@ -152,8 +145,7 @@ export function ConversationMenu({
   isConversationDisplayed,
   isOpen,
   isOpenOrClosing,
-  onOpenChange,
-  onCloseComplete,
+  onPhaseChange,
   triggerPosition,
   displayOpenInBrowser,
   openDetailsInNewTab,
@@ -389,7 +381,11 @@ export function ConversationMenu({
         }}
         owner={owner}
       />
-      <DropdownMenu modal={false} open={isOpen} onOpenChange={onOpenChange}>
+      <DropdownMenu
+        modal={false}
+        open={isOpen}
+        onOpenChange={(open) => onPhaseChange(open ? "open" : "closing")}
+      >
         {triggerPosition ? (
           <>
             {menuTrigger}
@@ -410,7 +406,7 @@ export function ConversationMenu({
           <DropdownMenuTrigger asChild>{menuTrigger}</DropdownMenuTrigger>
         )}
         <DropdownMenuContent
-          onCloseAutoFocus={onCloseComplete}
+          onCloseAutoFocus={() => onPhaseChange("closed")}
           onFocusOutside={(e) => e.preventDefault()}
         >
           <DropdownMenuItem

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -68,7 +68,7 @@ import {
 } from "@dust-tt/sparkle";
 import type React from "react";
 import type { ReactElement } from "react";
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useState } from "react";
 
 /**
  * Hook for handling right-click context menu with timing protection
@@ -112,19 +112,10 @@ export function useConversationMenu() {
     [isMenuOpen, wasMenuJustClosed]
   );
 
-  // Keep the menu data and trigger position until the closing animation completes.
-  useEffect(() => {
-    if (!wasMenuJustClosed) {
-      return;
-    }
-
-    const closeAnimationTimeoutId = setTimeout(() => {
-      setWasMenuJustClosed(false);
-      setMenuTriggerPosition(undefined);
-    }, 150);
-
-    return () => clearTimeout(closeAnimationTimeoutId);
-  }, [wasMenuJustClosed]);
+  const handleMenuCloseComplete = useCallback(() => {
+    setWasMenuJustClosed(false);
+    setMenuTriggerPosition(undefined);
+  }, []);
 
   return {
     isMenuOpen,
@@ -132,6 +123,7 @@ export function useConversationMenu() {
     menuTriggerPosition,
     handleRightClick,
     handleMenuOpenChange,
+    handleMenuCloseComplete,
   };
 }
 
@@ -146,6 +138,7 @@ interface ConversationMenuProps {
   isOpen: boolean;
   isOpenOrClosing: boolean;
   onOpenChange: (open: boolean) => void;
+  onCloseComplete: () => void;
   triggerPosition?: { x: number; y: number };
   displayOpenInBrowser?: boolean;
   openDetailsInNewTab?: boolean;
@@ -160,6 +153,7 @@ export function ConversationMenu({
   isOpen,
   isOpenOrClosing,
   onOpenChange,
+  onCloseComplete,
   triggerPosition,
   displayOpenInBrowser,
   openDetailsInNewTab,
@@ -415,7 +409,10 @@ export function ConversationMenu({
         ) : (
           <DropdownMenuTrigger asChild>{menuTrigger}</DropdownMenuTrigger>
         )}
-        <DropdownMenuContent onFocusOutside={(e) => e.preventDefault()}>
+        <DropdownMenuContent
+          onCloseAutoFocus={onCloseComplete}
+          onFocusOutside={(e) => e.preventDefault()}
+        >
           <DropdownMenuItem
             label="Rename conversation"
             onClick={() => setShowRenameDialog(true)}

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -86,20 +86,12 @@ export function useConversationMenu() {
     { x: number; y: number } | undefined
   >();
 
-  // Tracks if the menu was just closed to prevent immediate reopening
-  // This flag creates a brief "cooldown" period after menu closure
+  // Tracks the closing animation so the menu stays stable and cannot reopen mid-exit.
   const [wasMenuJustClosed, setWasMenuJustClosed] = useState(false);
 
   const handleMenuOpenChange = useCallback((open: boolean) => {
     setIsMenuOpen(open);
-    if (!open) {
-      // When menu closes, set the "just closed" flag for 100ms
-      // This prevents right-click handlers from immediately reopening the menu
-      setWasMenuJustClosed(true);
-      setTimeout(() => {
-        setWasMenuJustClosed(false);
-      }, 100);
-    }
+    setWasMenuJustClosed(!open);
   }, []);
 
   const handleRightClick = useCallback(
@@ -120,18 +112,23 @@ export function useConversationMenu() {
     [isMenuOpen, wasMenuJustClosed]
   );
 
-  // Clear the trigger position when menu closes to allow animations to complete
-  // The 150ms delay ensures smooth closing animation before position reset
+  // Keep the menu data and trigger position until the closing animation completes.
   useEffect(() => {
-    if (!isMenuOpen) {
-      setTimeout(() => {
-        setMenuTriggerPosition(undefined);
-      }, 150);
+    if (!wasMenuJustClosed) {
+      return;
     }
-  }, [isMenuOpen]);
+
+    const closeAnimationTimeoutId = setTimeout(() => {
+      setWasMenuJustClosed(false);
+      setMenuTriggerPosition(undefined);
+    }, 150);
+
+    return () => clearTimeout(closeAnimationTimeoutId);
+  }, [wasMenuJustClosed]);
 
   return {
     isMenuOpen,
+    isMenuOpenOrClosing: isMenuOpen || wasMenuJustClosed,
     menuTriggerPosition,
     handleRightClick,
     handleMenuOpenChange,
@@ -147,6 +144,7 @@ interface ConversationMenuProps {
     | (({ isPendingAction }: { isPendingAction: boolean }) => ReactElement);
   isConversationDisplayed: boolean;
   isOpen: boolean;
+  isOpenOrClosing: boolean;
   onOpenChange: (open: boolean) => void;
   triggerPosition?: { x: number; y: number };
   displayOpenInBrowser?: boolean;
@@ -160,6 +158,7 @@ export function ConversationMenu({
   trigger,
   isConversationDisplayed,
   isOpen,
+  isOpenOrClosing,
   onOpenChange,
   triggerPosition,
   displayOpenInBrowser,
@@ -218,7 +217,9 @@ export function ConversationMenu({
   };
 
   const shouldWaitBeforeFetching =
-    activeConversationId === null || user?.sId === undefined || !isOpen;
+    activeConversationId === null ||
+    user?.sId === undefined ||
+    !isOpenOrClosing;
   const { mutateConversation } = useConversation({
     conversationId: isConversationDisplayed ? activeConversationId : null,
     workspaceId: owner.sId,

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -68,7 +68,7 @@ import {
 } from "@dust-tt/sparkle";
 import type React from "react";
 import type { ReactElement } from "react";
-import { useCallback, useContext, useState } from "react";
+import { useCallback, useContext, useRef, useState } from "react";
 
 /**
  * Hook for handling right-click context menu with timing protection
@@ -87,6 +87,7 @@ export function useConversationMenu() {
   const [menuTriggerPosition, setMenuTriggerPosition] = useState<
     { x: number; y: number } | undefined
   >();
+  const ignoreNextContextMenuRef = useRef(false);
 
   const handleMenuPhaseChange = useCallback((phase: MenuPhase) => {
     setMenuPhase(phase);
@@ -100,8 +101,11 @@ export function useConversationMenu() {
       e.preventDefault();
       e.stopPropagation();
 
+      const shouldIgnore = ignoreNextContextMenuRef.current;
+      ignoreNextContextMenuRef.current = false;
+
       // Prevent the menu from reopening while its closing animation is running.
-      if (menuPhase !== "closed") {
+      if (shouldIgnore || menuPhase !== "closed") {
         return;
       }
 
@@ -112,11 +116,27 @@ export function useConversationMenu() {
     [menuPhase]
   );
 
+  const handleRightPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
+      const isContextMenuGesture =
+        e.button === 2 || (e.button === 0 && e.ctrlKey);
+      const target = e.target;
+
+      ignoreNextContextMenuRef.current =
+        isContextMenuGesture &&
+        target instanceof Node &&
+        e.currentTarget.contains(target) &&
+        menuPhase !== "closed";
+    },
+    [menuPhase]
+  );
+
   return {
     isMenuOpen: menuPhase === "open",
     isMenuOpenOrClosing: menuPhase !== "closed",
     menuTriggerPosition,
     handleRightClick,
+    handleRightPointerDown,
     handleMenuPhaseChange,
   };
 }

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -55,6 +55,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
     menuTriggerPosition,
     handleRightClick,
     handleMenuOpenChange,
+    handleMenuCloseComplete,
   } = useConversationMenu();
 
   const currentTitle = conversation
@@ -205,6 +206,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
             isOpen={isMenuOpen}
             isOpenOrClosing={isMenuOpenOrClosing}
             onOpenChange={handleMenuOpenChange}
+            onCloseComplete={handleMenuCloseComplete}
             triggerPosition={menuTriggerPosition}
           />
         </div>

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -54,8 +54,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
     isMenuOpenOrClosing,
     menuTriggerPosition,
     handleRightClick,
-    handleMenuOpenChange,
-    handleMenuCloseComplete,
+    handleMenuPhaseChange,
   } = useConversationMenu();
 
   const currentTitle = conversation
@@ -205,8 +204,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
             isConversationDisplayed={true}
             isOpen={isMenuOpen}
             isOpenOrClosing={isMenuOpenOrClosing}
-            onOpenChange={handleMenuOpenChange}
-            onCloseComplete={handleMenuCloseComplete}
+            onPhaseChange={handleMenuPhaseChange}
             triggerPosition={menuTriggerPosition}
           />
         </div>

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -54,6 +54,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
     isMenuOpenOrClosing,
     menuTriggerPosition,
     handleRightClick,
+    handleRightPointerDown,
     handleMenuPhaseChange,
   } = useConversationMenu();
 
@@ -129,6 +130,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
     <AppLayoutTitle>
       <div
         className="grid h-full min-w-0 max-w-full grid-cols-[1fr_auto] items-center gap-3"
+        onPointerDownCapture={handleRightPointerDown}
         onContextMenu={handleRightClick}
       >
         <div

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -51,6 +51,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
 
   const {
     isMenuOpen,
+    isMenuOpenOrClosing,
     menuTriggerPosition,
     handleRightClick,
     handleMenuOpenChange,
@@ -202,6 +203,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
             )}
             isConversationDisplayed={true}
             isOpen={isMenuOpen}
+            isOpenOrClosing={isMenuOpenOrClosing}
             onOpenChange={handleMenuOpenChange}
             triggerPosition={menuTriggerPosition}
           />

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1550,6 +1550,7 @@ const ConversationListItem = memo(
     const { sidebarOpen, setSidebarOpen } = useContext(SidebarContext);
     const {
       isMenuOpen,
+      isMenuOpenOrClosing,
       menuTriggerPosition,
       handleRightClick,
       handleMenuOpenChange,
@@ -1645,6 +1646,7 @@ const ConversationListItem = memo(
             trigger={() => <NavigationListItemAction />}
             isConversationDisplayed={activeConversationId === conversation.sId}
             isOpen={isMenuOpen}
+            isOpenOrClosing={isMenuOpenOrClosing}
             onOpenChange={handleMenuOpenChange}
             triggerPosition={menuTriggerPosition}
           />

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1553,6 +1553,7 @@ const ConversationListItem = memo(
       isMenuOpenOrClosing,
       menuTriggerPosition,
       handleRightClick,
+      handleRightPointerDown,
       handleMenuPhaseChange,
     } = useConversationMenu();
 
@@ -1651,6 +1652,7 @@ const ConversationListItem = memo(
             triggerPosition={menuTriggerPosition}
           />
         }
+        onPointerDownCapture={handleRightPointerDown}
         onContextMenu={handleRightClick}
         onClick={async () => {
           // Side bar is the floating sidebar that appears when the screen is small.

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1554,6 +1554,7 @@ const ConversationListItem = memo(
       menuTriggerPosition,
       handleRightClick,
       handleMenuOpenChange,
+      handleMenuCloseComplete,
     } = useConversationMenu();
 
     const [showTypingAnimation, setShowTypingAnimation] = useState(false);
@@ -1648,6 +1649,7 @@ const ConversationListItem = memo(
             isOpen={isMenuOpen}
             isOpenOrClosing={isMenuOpenOrClosing}
             onOpenChange={handleMenuOpenChange}
+            onCloseComplete={handleMenuCloseComplete}
             triggerPosition={menuTriggerPosition}
           />
         }

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1553,8 +1553,7 @@ const ConversationListItem = memo(
       isMenuOpenOrClosing,
       menuTriggerPosition,
       handleRightClick,
-      handleMenuOpenChange,
-      handleMenuCloseComplete,
+      handleMenuPhaseChange,
     } = useConversationMenu();
 
     const [showTypingAnimation, setShowTypingAnimation] = useState(false);
@@ -1648,8 +1647,7 @@ const ConversationListItem = memo(
             isConversationDisplayed={activeConversationId === conversation.sId}
             isOpen={isMenuOpen}
             isOpenOrClosing={isMenuOpenOrClosing}
-            onOpenChange={handleMenuOpenChange}
-            onCloseComplete={handleMenuCloseComplete}
+            onPhaseChange={handleMenuPhaseChange}
             triggerPosition={menuTriggerPosition}
           />
         }

--- a/front/components/assistant/conversation/sidebar/PodList.tsx
+++ b/front/components/assistant/conversation/sidebar/PodList.tsx
@@ -45,8 +45,7 @@ const PodListItem = memo(
       isMenuOpen,
       isMenuOpenOrClosing,
       menuTriggerPosition,
-      handleMenuOpenChange,
-      handleMenuCloseComplete,
+      handleMenuPhaseChange,
     } = usePodMenu();
 
     const activeConversationId = useActiveConversationId();
@@ -174,8 +173,7 @@ const PodListItem = memo(
             isPodDisplayed={activeConversationId === pod.sId}
             isOpen={isMenuOpen}
             isOpenOrClosing={isMenuOpenOrClosing}
-            onOpenChange={handleMenuOpenChange}
-            onCloseComplete={handleMenuCloseComplete}
+            onPhaseChange={handleMenuPhaseChange}
             triggerPosition={menuTriggerPosition}
           />
         }

--- a/front/components/assistant/conversation/sidebar/PodList.tsx
+++ b/front/components/assistant/conversation/sidebar/PodList.tsx
@@ -41,8 +41,12 @@ const PodListItem = memo(
 
     const podPath = getPodRoute(owner.sId, pod.sId);
 
-    const { isMenuOpen, menuTriggerPosition, handleMenuOpenChange } =
-      usePodMenu();
+    const {
+      isMenuOpen,
+      isMenuOpenOrClosing,
+      menuTriggerPosition,
+      handleMenuOpenChange,
+    } = usePodMenu();
 
     const activeConversationId = useActiveConversationId();
     const { conversation } = useConversation({
@@ -168,6 +172,7 @@ const PodListItem = memo(
             trigger={<NavigationListItemAction />}
             isPodDisplayed={activeConversationId === pod.sId}
             isOpen={isMenuOpen}
+            isOpenOrClosing={isMenuOpenOrClosing}
             onOpenChange={handleMenuOpenChange}
             triggerPosition={menuTriggerPosition}
           />

--- a/front/components/assistant/conversation/sidebar/PodList.tsx
+++ b/front/components/assistant/conversation/sidebar/PodList.tsx
@@ -46,6 +46,7 @@ const PodListItem = memo(
       isMenuOpenOrClosing,
       menuTriggerPosition,
       handleMenuOpenChange,
+      handleMenuCloseComplete,
     } = usePodMenu();
 
     const activeConversationId = useActiveConversationId();
@@ -174,6 +175,7 @@ const PodListItem = memo(
             isOpen={isMenuOpen}
             isOpenOrClosing={isMenuOpenOrClosing}
             onOpenChange={handleMenuOpenChange}
+            onCloseComplete={handleMenuCloseComplete}
             triggerPosition={menuTriggerPosition}
           />
         }

--- a/front/components/pod/PodMenu.tsx
+++ b/front/components/pod/PodMenu.tsx
@@ -37,7 +37,7 @@ import {
 } from "@dust-tt/sparkle";
 import type React from "react";
 import type { ReactElement } from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { PodNotificationMenu } from "./settings/PodNotificationMenu";
 
 /**
@@ -82,19 +82,10 @@ export function usePodMenu() {
     [isMenuOpen, wasMenuJustClosed]
   );
 
-  // Keep the menu data and trigger position until the closing animation completes.
-  useEffect(() => {
-    if (!wasMenuJustClosed) {
-      return;
-    }
-
-    const closeAnimationTimeoutId = setTimeout(() => {
-      setWasMenuJustClosed(false);
-      setMenuTriggerPosition(undefined);
-    }, 150);
-
-    return () => clearTimeout(closeAnimationTimeoutId);
-  }, [wasMenuJustClosed]);
+  const handleMenuCloseComplete = useCallback(() => {
+    setWasMenuJustClosed(false);
+    setMenuTriggerPosition(undefined);
+  }, []);
 
   return {
     isMenuOpen,
@@ -102,6 +93,7 @@ export function usePodMenu() {
     menuTriggerPosition,
     handleRightClick,
     handleMenuOpenChange,
+    handleMenuCloseComplete,
   };
 }
 
@@ -115,6 +107,7 @@ interface PodMenuProps {
   isOpen: boolean;
   isOpenOrClosing: boolean;
   onOpenChange: (open: boolean) => void;
+  onCloseComplete: () => void;
   triggerPosition?: { x: number; y: number };
 }
 
@@ -128,6 +121,7 @@ export function PodMenu({
   isOpen,
   isOpenOrClosing,
   onOpenChange,
+  onCloseComplete,
   triggerPosition,
 }: PodMenuProps) {
   const { user } = useAuth();
@@ -251,7 +245,10 @@ export function PodMenu({
         ) : (
           <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
         )}
-        <DropdownMenuContent onFocusOutside={(e) => e.preventDefault()}>
+        <DropdownMenuContent
+          onCloseAutoFocus={onCloseComplete}
+          onFocusOutside={(e) => e.preventDefault()}
+        >
           <DropdownMenuLabel label="My settings" />
           <DropdownMenuItem
             label={isStarred ? "Remove from starred" : "Add to starred"}

--- a/front/components/pod/PodMenu.tsx
+++ b/front/components/pod/PodMenu.tsx
@@ -50,18 +50,19 @@ import { PodNotificationMenu } from "./settings/PodNotificationMenu";
  * while the menu is open still trigger our handlers. Due to React's async state updates,
  * when the menu closes, our right-click handler sees isMenuOpen as false and reopens the menu.
  */
+type MenuPhase = "closed" | "open" | "closing";
+
 export function usePodMenu() {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [menuPhase, setMenuPhase] = useState<MenuPhase>("closed");
   const [menuTriggerPosition, setMenuTriggerPosition] = useState<
     { x: number; y: number } | undefined
   >();
 
-  // Tracks the closing animation so the menu stays stable and cannot reopen mid-exit.
-  const [wasMenuJustClosed, setWasMenuJustClosed] = useState(false);
-
-  const handleMenuOpenChange = useCallback((open: boolean) => {
-    setIsMenuOpen(open);
-    setWasMenuJustClosed(!open);
+  const handleMenuPhaseChange = useCallback((phase: MenuPhase) => {
+    setMenuPhase(phase);
+    if (phase === "closed") {
+      setMenuTriggerPosition(undefined);
+    }
   }, []);
 
   const handleRightClick = useCallback(
@@ -69,31 +70,24 @@ export function usePodMenu() {
       e.preventDefault();
       e.stopPropagation();
 
-      // Ignore right-clicks if menu is currently open OR was just closed
-      // This prevents the close -> immediate reopen behavior
-      if (isMenuOpen || wasMenuJustClosed) {
+      // Prevent the menu from reopening while its closing animation is running.
+      if (menuPhase !== "closed") {
         return;
       }
 
       // Open menu at cursor position
       setMenuTriggerPosition({ x: e.clientX, y: e.clientY });
-      setIsMenuOpen(true);
+      setMenuPhase("open");
     },
-    [isMenuOpen, wasMenuJustClosed]
+    [menuPhase]
   );
 
-  const handleMenuCloseComplete = useCallback(() => {
-    setWasMenuJustClosed(false);
-    setMenuTriggerPosition(undefined);
-  }, []);
-
   return {
-    isMenuOpen,
-    isMenuOpenOrClosing: isMenuOpen || wasMenuJustClosed,
+    isMenuOpen: menuPhase === "open",
+    isMenuOpenOrClosing: menuPhase !== "closed",
     menuTriggerPosition,
     handleRightClick,
-    handleMenuOpenChange,
-    handleMenuCloseComplete,
+    handleMenuPhaseChange,
   };
 }
 
@@ -106,8 +100,7 @@ interface PodMenuProps {
   isPodDisplayed: boolean;
   isOpen: boolean;
   isOpenOrClosing: boolean;
-  onOpenChange: (open: boolean) => void;
-  onCloseComplete: () => void;
+  onPhaseChange: (phase: MenuPhase) => void;
   triggerPosition?: { x: number; y: number };
 }
 
@@ -120,8 +113,7 @@ export function PodMenu({
   isPodDisplayed,
   isOpen,
   isOpenOrClosing,
-  onOpenChange,
-  onCloseComplete,
+  onPhaseChange,
   triggerPosition,
 }: PodMenuProps) {
   const { user } = useAuth();
@@ -225,7 +217,11 @@ export function PodMenu({
           currentTitle={pod.name}
         />
       )}
-      <DropdownMenu modal={false} open={isOpen} onOpenChange={onOpenChange}>
+      <DropdownMenu
+        modal={false}
+        open={isOpen}
+        onOpenChange={(open) => onPhaseChange(open ? "open" : "closing")}
+      >
         {triggerPosition ? (
           <>
             {trigger}
@@ -246,7 +242,7 @@ export function PodMenu({
           <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
         )}
         <DropdownMenuContent
-          onCloseAutoFocus={onCloseComplete}
+          onCloseAutoFocus={() => onPhaseChange("closed")}
           onFocusOutside={(e) => e.preventDefault()}
         >
           <DropdownMenuLabel label="My settings" />

--- a/front/components/pod/PodMenu.tsx
+++ b/front/components/pod/PodMenu.tsx
@@ -56,20 +56,12 @@ export function usePodMenu() {
     { x: number; y: number } | undefined
   >();
 
-  // Tracks if the menu was just closed to prevent immediate reopening
-  // This flag creates a brief "cooldown" period after menu closure
+  // Tracks the closing animation so the menu stays stable and cannot reopen mid-exit.
   const [wasMenuJustClosed, setWasMenuJustClosed] = useState(false);
 
   const handleMenuOpenChange = useCallback((open: boolean) => {
     setIsMenuOpen(open);
-    if (!open) {
-      // When menu closes, set the "just closed" flag for 100ms
-      // This prevents right-click handlers from immediately reopening the menu
-      setWasMenuJustClosed(true);
-      setTimeout(() => {
-        setWasMenuJustClosed(false);
-      }, 100);
-    }
+    setWasMenuJustClosed(!open);
   }, []);
 
   const handleRightClick = useCallback(
@@ -90,18 +82,23 @@ export function usePodMenu() {
     [isMenuOpen, wasMenuJustClosed]
   );
 
-  // Clear the trigger position when menu closes to allow animations to complete
-  // The 150ms delay ensures smooth closing animation before position reset
+  // Keep the menu data and trigger position until the closing animation completes.
   useEffect(() => {
-    if (!isMenuOpen) {
-      setTimeout(() => {
-        setMenuTriggerPosition(undefined);
-      }, 150);
+    if (!wasMenuJustClosed) {
+      return;
     }
-  }, [isMenuOpen]);
+
+    const closeAnimationTimeoutId = setTimeout(() => {
+      setWasMenuJustClosed(false);
+      setMenuTriggerPosition(undefined);
+    }, 150);
+
+    return () => clearTimeout(closeAnimationTimeoutId);
+  }, [wasMenuJustClosed]);
 
   return {
     isMenuOpen,
+    isMenuOpenOrClosing: isMenuOpen || wasMenuJustClosed,
     menuTriggerPosition,
     handleRightClick,
     handleMenuOpenChange,
@@ -116,6 +113,7 @@ interface PodMenuProps {
   trigger: ReactElement;
   isPodDisplayed: boolean;
   isOpen: boolean;
+  isOpenOrClosing: boolean;
   onOpenChange: (open: boolean) => void;
   triggerPosition?: { x: number; y: number };
 }
@@ -128,6 +126,7 @@ export function PodMenu({
   trigger,
   isPodDisplayed,
   isOpen,
+  isOpenOrClosing,
   onOpenChange,
   triggerPosition,
 }: PodMenuProps) {
@@ -143,7 +142,7 @@ export function PodMenu({
   };
 
   const shouldWaitBeforeFetching =
-    activePodId === null || user?.sId === undefined || !isOpen;
+    activePodId === null || user?.sId === undefined || !isOpenOrClosing;
 
   const { spaceInfo: podInfo } = useSpaceInfo({
     workspaceId: owner.sId,


### PR DESCRIPTION
## Description

Sidebar Pod and conversation dropdowns could change their list of items as soon as closing started. This made permission and data-dependent items blink during the exit animation.

This PR fixes that by keeping menu data enabled while the dropdown is open or closing. Reopening cancels pending teardown, so the item list and context-menu position remain stable throughout the transition.

blink (not really enough fps to see it well)
<img width="418" height="434" alt="Aug-06-2026 5-28-22 PM" src="https://github.com/user-attachments/assets/c4cdd98d-eb90-4fe1-8671-f4efbd9af9cb" />

blink fixed
<img width="418" height="434" alt="Aug-06-2026 5-28-30 PM" src="https://github.com/user-attachments/assets/536c18d2-db44-4a9b-b91d-f2e0272e6ff5" />

## Tests

- Not tested manually.

## Risk

- Low. Affects Pod and conversation dropdown teardown timing.

## Deploy Plan

- Deploy front.
