### PR TITLE
Pricing: fix the isFreePlan method

### DIFF
--- a/front/lib/plans/plan_codes.test.ts
+++ b/front/lib/plans/plan_codes.test.ts
@@ -1,11 +1,10 @@
-import { describe, expect, it } from "vitest";
-
 import {
   CREDIT_PRICED_BUSINESS_PLAN_CODE,
   CREDIT_PRICED_FREE_PLAN_CODE,
   FREE_NO_PLAN_CODE,
   isFreePlan,
 } from "@app/lib/plans/plan_codes";
+import { describe, expect, it } from "vitest";
 
 describe("isFreePlan", () => {
   it("is false for custom credit-priced business plans", () => {

--- a/front/lib/plans/plan_codes.test.ts
+++ b/front/lib/plans/plan_codes.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CREDIT_PRICED_BUSINESS_PLAN_CODE,
+  CREDIT_PRICED_FREE_PLAN_CODE,
+  FREE_NO_PLAN_CODE,
+  isFreePlan,
+} from "@app/lib/plans/plan_codes";
+
+describe("isFreePlan", () => {
+  it("is false for custom credit-priced business plans", () => {
+    expect(isFreePlan("CP_BUSINESS_SWEEP")).toBe(false);
+  });
+
+  it("is false for the standard credit-priced business plan", () => {
+    expect(isFreePlan(CREDIT_PRICED_BUSINESS_PLAN_CODE)).toBe(false);
+  });
+
+  it("is true for free plans", () => {
+    expect(isFreePlan(CREDIT_PRICED_FREE_PLAN_CODE)).toBe(true);
+    expect(isFreePlan(FREE_NO_PLAN_CODE)).toBe(true);
+  });
+});

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -65,10 +65,6 @@ export const isProPlanPrefix = (planCode: string) =>
 export const isFriendsAndFamilyPlan = (planCode: string) =>
   planCode === "FREE_FRIENDSAMILY";
 
-export const isCreditPricedBusinessPlan = (planCode: string) =>
-  planCode === CREDIT_PRICED_BUSINESS_PLAN_CODE ||
-  planCode === CREDIT_PRICED_BUSINESS_LEGACY_LARGE_PLAN_CODE;
-
 export const isCreditPricedFreePlan = (planCode: string) =>
   planCode === CREDIT_PRICED_FREE_PLAN_CODE;
 
@@ -80,7 +76,7 @@ export const isFreePlan = (planCode: string) =>
   !isEnterprisePlanPrefix(planCode) &&
   !isDustCompanyPlan(planCode) &&
   !isProPlanPrefix(planCode) &&
-  !isCreditPricedBusinessPlan(planCode);
+  !isBusinessPlanPrefix(planCode);
 
 export const isFreeTrialPhonePlan = (planCode: string) =>
   planCode === FREE_TRIAL_PHONE_PLAN_CODE;

--- a/marketing/lib/plans/plan_codes.ts
+++ b/marketing/lib/plans/plan_codes.ts
@@ -55,9 +55,6 @@ export const isProPlanPrefix = (planCode: string) =>
 export const isFriendsAndFamilyPlan = (planCode: string) =>
   planCode === "FREE_FRIENDSAMILY";
 
-export const isCreditPricedBusinessPlan = (planCode: string) =>
-  planCode === CREDIT_PRICED_BUSINESS_PLAN_CODE;
-
 export const isBusinessPlanPrefix = (planCode: string) =>
   planCode.startsWith("CP_BUSINESS_");
 
@@ -65,7 +62,7 @@ export const isBusinessPlanPrefix = (planCode: string) =>
 export const isFreePlan = (planCode: string) =>
   !isEnterprisePlanPrefix(planCode) &&
   !isProPlanPrefix(planCode) &&
-  !isCreditPricedBusinessPlan(planCode);
+  !isBusinessPlanPrefix(planCode);
 
 export const isFreeTrialPhonePlan = (planCode: string) =>
   planCode === FREE_TRIAL_PHONE_PLAN_CODE;


### PR DESCRIPTION
## Description

Use the `isBusinessPlanPrefix` which check the prefix and allows not hardcoded plans.
Drop the useless isCreditPricedBusinessPlan

## Tests

unit test added 

## Risk

low

## Deploy Plan

deploy front
deploy marketing
