### PR TITLE
[front] fix: align button size for batch actions between skills and agents

### DIFF
--- a/front/components/skills/ArchiveSkillsDialog.tsx
+++ b/front/components/skills/ArchiveSkillsDialog.tsx
@@ -45,7 +45,7 @@ export function ArchiveSkillsDialog({
     <Dialog>
       <DialogTrigger asChild>
         <Button
-          size="sm"
+          size="xs"
           variant="warning"
           icon={Trash01}
           label="Archive selection"

--- a/front/components/skills/SkillsBatchEdit.tsx
+++ b/front/components/skills/SkillsBatchEdit.tsx
@@ -96,7 +96,7 @@ export function SkillsBatchEditBar({
           <DropdownMenuTrigger asChild>
             <Button
               variant="outline"
-              size="sm"
+              size="xs"
               label="Set availability"
               isSelect
               isLoading={isUpdating}

--- a/front/components/skills/SkillsBatchEdit.tsx
+++ b/front/components/skills/SkillsBatchEdit.tsx
@@ -86,7 +86,7 @@ export function SkillsBatchEditBar({
     <div className="flex flex-row items-center justify-between gap-2 rounded-xl bg-muted-background px-2 py-2 dark:bg-muted-background-night">
       <Button
         variant="outline"
-        size="sm"
+        size="xs"
         icon={XClose}
         label="Close edition"
         onClick={onClose}


### PR DESCRIPTION
## Description

Follow up on [this thread](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1786026410641279).

This PR aligns the size of the buttons for batch actions between Manage Skills (sm) and Manage Agents (xs).
Aligned on xs.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
