### PR TITLE
Load billed agent message consumption inputs

### DIFF
--- a/front/lib/analytics/agent_message_consumption/load.test.ts
+++ b/front/lib/analytics/agent_message_consumption/load.test.ts
@@ -1,4 +1,5 @@
 import { loadAgentMessageConsumptionAnalyticsInput } from "@app/lib/analytics/agent_message_consumption/load";
+import type { Authenticator } from "@app/lib/auth";
 import {
   USAGE_TYPE_FREE,
   USAGE_TYPE_PROGRAMMATIC,
@@ -13,22 +14,31 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { RunFactory } from "@app/tests/utils/RunFactory";
 import { GPT_5_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
+import type { WorkspaceType } from "@app/types/user";
 import { describe, expect, it } from "vitest";
 
-async function setupSettledMessage({
+async function createAgenticMessage({
+  auth,
+  workspace,
+  depth,
+  agenticOriginMessageId,
   authorless = false,
-  usageType = USAGE_TYPE_USER,
+  agentName,
 }: {
+  auth: Authenticator;
+  workspace: WorkspaceType;
+  depth: number;
+  agenticOriginMessageId?: string;
   authorless?: boolean;
-  usageType?: UsageType | null;
-} = {}) {
-  const { authenticator: auth, workspace } = await createResourceTest({
-    role: "admin",
+  agentName?: string;
+}) {
+  const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+    name: agentName,
   });
-  const agent = await AgentConfigurationFactory.createTestAgent(auth);
   const conversationType = await ConversationFactory.create(auth, {
     agentConfigurationId: agent.sId,
     messagesCreatedAt: [],
+    depth,
   });
   const conversation = await ConversationResource.fetchById(
     auth,
@@ -45,13 +55,10 @@ async function setupSettledMessage({
       conversation,
       rank: 0,
       content: "Hello",
+      agenticMessageType: agenticOriginMessageId ? "run_agent" : undefined,
+      agenticOriginMessageId,
       authorless,
     });
-  const { run } = await RunFactory.createWithUsage(auth, {
-    inputTokens: 100,
-    outputTokens: 20,
-    modelId: GPT_5_MINI_MODEL_CONFIG.modelId,
-  });
   const agentMessage = await ConversationFactory.createAgentMessageWithRank({
     workspace,
     conversationId: conversation.id,
@@ -66,10 +73,88 @@ async function setupSettledMessage({
     },
     modelResolutionMethod: "agent",
   });
-  if (!agentMessage.agentMessageId) {
+  const agentMessageModelId = agentMessage.agentMessageId;
+  if (!agentMessageModelId) {
     throw new Error("Agent message was not created");
   }
 
+  return { agent, agentMessage, agentMessageModelId, conversation };
+}
+
+async function appendHandoverMessage({
+  auth,
+  workspace,
+  conversation,
+  rank,
+  agenticOriginMessageId,
+  agentName,
+}: {
+  auth: Authenticator;
+  workspace: WorkspaceType;
+  conversation: ConversationResource;
+  rank: number;
+  agenticOriginMessageId: string;
+  agentName: string;
+}) {
+  const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+    name: agentName,
+  });
+  const { messageRow: userMessage } =
+    await ConversationFactory.createUserMessage({
+      auth,
+      workspace,
+      conversation,
+      rank,
+      content: "Continue with another agent",
+      agenticMessageType: "agent_handover",
+      agenticOriginMessageId,
+    });
+  const agentMessage = await ConversationFactory.createAgentMessageWithRank({
+    workspace,
+    conversationId: conversation.id,
+    rank: rank + 1,
+    parentId: userMessage.id,
+    agentConfigurationId: agent.sId,
+    agentConfigurationVersion: agent.version,
+  });
+
+  return { agent, agentMessage };
+}
+
+async function setupSettledMessage({
+  authorless = false,
+  depth = 0,
+  agenticOriginMessageId,
+  agentName,
+  testContext,
+  usageType = USAGE_TYPE_USER,
+}: {
+  authorless?: boolean;
+  depth?: number;
+  agenticOriginMessageId?: string;
+  agentName?: string;
+  testContext?: { authenticator: Authenticator; workspace: WorkspaceType };
+  usageType?: UsageType | null;
+} = {}) {
+  const { authenticator: auth, workspace } =
+    testContext ??
+    (await createResourceTest({
+      role: "admin",
+    }));
+  const { agent, agentMessage, agentMessageModelId, conversation } =
+    await createAgenticMessage({
+      auth,
+      workspace,
+      depth,
+      agenticOriginMessageId,
+      authorless,
+      agentName,
+    });
+  const { run } = await RunFactory.createWithUsage(auth, {
+    inputTokens: 100,
+    outputTokens: 20,
+    modelId: GPT_5_MINI_MODEL_CONFIG.modelId,
+  });
   const completedAt = new Date("2026-08-05T12:00:00.000Z");
   await AgentMessageModel.update(
     {
@@ -80,7 +165,7 @@ async function setupSettledMessage({
     },
     {
       where: {
-        id: agentMessage.agentMessageId,
+        id: agentMessageModelId,
         workspaceId: workspace.id,
       },
     }
@@ -133,6 +218,71 @@ describe("loadAgentMessageConsumptionAnalyticsInput", () => {
       ],
       user: { id: context.auth.getNonNullableUser().sId },
       workspaceId: context.workspace.sId,
+    });
+  });
+
+  it("lists the full agent chain from the root to the direct parent", async () => {
+    const testContext = await createResourceTest({ role: "admin" });
+    const root = await createAgenticMessage({
+      auth: testContext.authenticator,
+      workspace: testContext.workspace,
+      depth: 0,
+      agentName: "Root agent",
+    });
+    const firstHandover = await appendHandoverMessage({
+      auth: testContext.authenticator,
+      workspace: testContext.workspace,
+      conversation: root.conversation,
+      rank: 2,
+      agenticOriginMessageId: root.agentMessage.sId,
+      agentName: "First handover agent",
+    });
+    const secondHandover = await appendHandoverMessage({
+      auth: testContext.authenticator,
+      workspace: testContext.workspace,
+      conversation: root.conversation,
+      rank: 4,
+      agenticOriginMessageId: firstHandover.agentMessage.sId,
+      agentName: "Second handover agent",
+    });
+    const thirdHandover = await appendHandoverMessage({
+      auth: testContext.authenticator,
+      workspace: testContext.workspace,
+      conversation: root.conversation,
+      rank: 6,
+      agenticOriginMessageId: secondHandover.agentMessage.sId,
+      agentName: "Third handover agent",
+    });
+    const directParent = await appendHandoverMessage({
+      auth: testContext.authenticator,
+      workspace: testContext.workspace,
+      conversation: root.conversation,
+      rank: 8,
+      agenticOriginMessageId: thirdHandover.agentMessage.sId,
+      agentName: "Direct parent agent",
+    });
+    const child = await setupSettledMessage({
+      testContext,
+      depth: 1,
+      agenticOriginMessageId: directParent.agentMessage.sId,
+      agentName: "Child agent",
+    });
+
+    const input = await loadAgentMessageConsumptionAnalyticsInput(child.auth, {
+      agentMessageId: child.agentMessage.sId,
+    });
+
+    expect(input?.agent).toMatchObject({
+      parent_ids: [
+        root.agent.sId,
+        firstHandover.agent.sId,
+        secondHandover.agent.sId,
+        thirdHandover.agent.sId,
+        directParent.agent.sId,
+      ],
+      direct_parent_id: directParent.agent.sId,
+      root_id: root.agent.sId,
+      depth: 1,
     });
   });
 

--- a/front/lib/analytics/agent_message_consumption/load.test.ts
+++ b/front/lib/analytics/agent_message_consumption/load.test.ts
@@ -1,0 +1,204 @@
+import { loadAgentMessageConsumptionAnalyticsInput } from "@app/lib/analytics/agent_message_consumption/load";
+import {
+  USAGE_TYPE_FREE,
+  USAGE_TYPE_PROGRAMMATIC,
+  USAGE_TYPE_USER,
+} from "@app/lib/metronome/constants";
+import type { UsageType } from "@app/lib/metronome/types";
+import { AgentMessageModel } from "@app/lib/models/agent/conversation";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { RunResource } from "@app/lib/resources/run_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { RunFactory } from "@app/tests/utils/RunFactory";
+import { GPT_5_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
+import { describe, expect, it } from "vitest";
+
+async function setupSettledMessage({
+  usageType = USAGE_TYPE_USER,
+}: {
+  usageType?: UsageType | null;
+} = {}) {
+  const { authenticator: auth, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  const agent = await AgentConfigurationFactory.createTestAgent(auth);
+  const conversationType = await ConversationFactory.create(auth, {
+    agentConfigurationId: agent.sId,
+    messagesCreatedAt: [],
+  });
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationType.sId
+  );
+  if (!conversation) {
+    throw new Error("Conversation was not created");
+  }
+
+  const userMessage = await ConversationFactory.createUserMessageWithRank({
+    auth,
+    workspace,
+    conversationId: conversation.id,
+    rank: 0,
+    content: "Hello",
+  });
+  const { run } = await RunFactory.createWithUsage(auth, {
+    inputTokens: 100,
+    outputTokens: 20,
+    modelId: GPT_5_MINI_MODEL_CONFIG.modelId,
+  });
+  const agentMessage = await ConversationFactory.createAgentMessageWithRank({
+    workspace,
+    conversationId: conversation.id,
+    rank: 1,
+    parentId: userMessage.id,
+    agentConfigurationId: agent.sId,
+    agentConfigurationVersion: agent.version,
+    resolvedModel: {
+      providerId: GPT_5_MINI_MODEL_CONFIG.providerId,
+      modelId: GPT_5_MINI_MODEL_CONFIG.modelId,
+      reasoningEffort: "none",
+    },
+    modelResolutionMethod: "agent",
+  });
+  if (!agentMessage.agentMessageId) {
+    throw new Error("Agent message was not created");
+  }
+
+  const completedAt = new Date("2026-08-05T12:00:00.000Z");
+  await AgentMessageModel.update(
+    {
+      completedAt,
+      costCredits: 5,
+      runIds: [run.dustRunId],
+      status: "succeeded",
+    },
+    {
+      where: {
+        id: agentMessage.agentMessageId,
+        workspaceId: workspace.id,
+      },
+    }
+  );
+  if (usageType !== null) {
+    await RunResource.setUsageTypeForRuns(auth, {
+      runs: [run],
+      usageType,
+    });
+  }
+
+  return {
+    agent,
+    agentMessage,
+    auth,
+    completedAt,
+    conversation,
+    run,
+    workspace,
+  };
+}
+
+describe("loadAgentMessageConsumptionAnalyticsInput", () => {
+  it("loads the authoritative inputs for billed user usage", async () => {
+    const context = await setupSettledMessage();
+
+    const input = await loadAgentMessageConsumptionAnalyticsInput(
+      context.auth,
+      { agentMessageId: context.agentMessage.sId }
+    );
+
+    expect(input).toMatchObject({
+      agent: {
+        id: context.agent.sId,
+        version: context.agent.version.toString(),
+        parent_ids: [],
+        direct_parent_id: null,
+        root_id: context.agent.sId,
+        depth: 0,
+      },
+      agentMessageId: context.agentMessage.sId,
+      billedCredits: 5,
+      completedAt: context.completedAt,
+      conversationId: context.conversation.sId,
+      usages: [
+        {
+          runModelId: context.run.id,
+          usageType: USAGE_TYPE_USER,
+        },
+      ],
+      user: { id: context.auth.getNonNullableUser().sId },
+      workspaceId: context.workspace.sId,
+    });
+  });
+
+  it("includes usage explicitly classified as programmatic", async () => {
+    const context = await setupSettledMessage({
+      usageType: USAGE_TYPE_PROGRAMMATIC,
+    });
+
+    const input = await loadAgentMessageConsumptionAnalyticsInput(
+      context.auth,
+      { agentMessageId: context.agentMessage.sId }
+    );
+
+    expect(input?.usages).toEqual([
+      expect.objectContaining({ usageType: USAGE_TYPE_PROGRAMMATIC }),
+    ]);
+  });
+
+  it("returns null when every usage is explicitly free", async () => {
+    const context = await setupSettledMessage({ usageType: USAGE_TYPE_FREE });
+
+    const input = await loadAgentMessageConsumptionAnalyticsInput(
+      context.auth,
+      { agentMessageId: context.agentMessage.sId }
+    );
+
+    expect(input).toBeNull();
+  });
+
+  it("fails when usage has not been classified for billing", async () => {
+    const context = await setupSettledMessage({ usageType: null });
+
+    await expect(
+      loadAgentMessageConsumptionAnalyticsInput(context.auth, {
+        agentMessageId: context.agentMessage.sId,
+      })
+    ).rejects.toThrow("Run usage billing classification is incomplete");
+  });
+
+  it("fails when billed usage has no authoritative message cost", async () => {
+    const context = await setupSettledMessage();
+    await ConversationResource.updateAgentMessageCostCredits(context.auth, {
+      agentMessageModelId: context.agentMessage.agentMessageId!,
+      costCredits: null,
+    });
+
+    await expect(
+      loadAgentMessageConsumptionAnalyticsInput(context.auth, {
+        agentMessageId: context.agentMessage.sId,
+      })
+    ).rejects.toThrow("Billed agent message is missing costCredits");
+  });
+
+  it("returns null while the message can still resume", async () => {
+    const context = await setupSettledMessage();
+    await AgentMessageModel.update(
+      { status: "created" },
+      {
+        where: {
+          id: context.agentMessage.agentMessageId!,
+          workspaceId: context.workspace.id,
+        },
+      }
+    );
+
+    const input = await loadAgentMessageConsumptionAnalyticsInput(
+      context.auth,
+      { agentMessageId: context.agentMessage.sId }
+    );
+
+    expect(input).toBeNull();
+  });
+});

--- a/front/lib/analytics/agent_message_consumption/load.test.ts
+++ b/front/lib/analytics/agent_message_consumption/load.test.ts
@@ -16,8 +16,10 @@ import { GPT_5_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import { describe, expect, it } from "vitest";
 
 async function setupSettledMessage({
+  authorless = false,
   usageType = USAGE_TYPE_USER,
 }: {
+  authorless?: boolean;
   usageType?: UsageType | null;
 } = {}) {
   const { authenticator: auth, workspace } = await createResourceTest({
@@ -36,13 +38,15 @@ async function setupSettledMessage({
     throw new Error("Conversation was not created");
   }
 
-  const userMessage = await ConversationFactory.createUserMessageWithRank({
-    auth,
-    workspace,
-    conversationId: conversation.id,
-    rank: 0,
-    content: "Hello",
-  });
+  const { messageRow: userMessage } =
+    await ConversationFactory.createUserMessage({
+      auth,
+      workspace,
+      conversation,
+      rank: 0,
+      content: "Hello",
+      authorless,
+    });
   const { run } = await RunFactory.createWithUsage(auth, {
     inputTokens: 100,
     outputTokens: 20,
@@ -145,6 +149,17 @@ describe("loadAgentMessageConsumptionAnalyticsInput", () => {
     expect(input?.usages).toEqual([
       expect.objectContaining({ usageType: USAGE_TYPE_PROGRAMMATIC }),
     ]);
+  });
+
+  it("keeps the user null when the triggering message is authorless", async () => {
+    const context = await setupSettledMessage({ authorless: true });
+
+    const input = await loadAgentMessageConsumptionAnalyticsInput(
+      context.auth,
+      { agentMessageId: context.agentMessage.sId }
+    );
+
+    expect(input?.user).toBeNull();
   });
 
   it("returns null when every usage is explicitly free", async () => {

--- a/front/lib/analytics/agent_message_consumption/load.ts
+++ b/front/lib/analytics/agent_message_consumption/load.ts
@@ -1,4 +1,5 @@
 import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
+import { listAgenticAncestors } from "@app/lib/api/assistant/conversation/agentic_ancestors";
 import { resolvedModelFromAgentMessageRow } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import {
@@ -182,10 +183,18 @@ export async function loadAgentMessageConsumptionAnalyticsInput(
     auth,
     agentMessage.agentMessageModelId
   );
-  const ancestorAgentIds =
-    await ConversationResource.listAgenticAncestorAgentConfigurationIds(auth, {
-      agentMessageId,
-    });
+  const messageConversation = await ConversationResource.fetchById(
+    auth,
+    conversation.conversationId
+  );
+  if (!messageConversation) {
+    throw new Error("Agent message conversation not found");
+  }
+  const ancestorAgentIds = (
+    await listAgenticAncestors(auth, messageConversation, { agentMessageId })
+  )
+    .map((ancestor) => ancestor.agentConfigurationId)
+    .reverse();
   const agentTagIds = await loadAgentTagIds(auth, agentMessage);
 
   const resolvedModel = resolvedModelFromAgentMessageRow({

--- a/front/lib/analytics/agent_message_consumption/load.ts
+++ b/front/lib/analytics/agent_message_consumption/load.ts
@@ -1,0 +1,258 @@
+import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
+import { resolvedModelFromAgentMessageRow } from "@app/lib/api/assistant/models";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  USAGE_TYPE_FREE,
+  USAGE_TYPE_PROGRAMMATIC,
+  USAGE_TYPE_USER,
+} from "@app/lib/metronome/constants";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
+import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { KeyResource } from "@app/lib/resources/key_resource";
+import {
+  RunResource,
+  type RunUsageWithRunKeyType,
+} from "@app/lib/resources/run_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { TagResource } from "@app/lib/resources/tags_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import type {
+  AgentMessageAnalyticsModel,
+  AgentMessageConsumptionAnalyticsAgent,
+  AgentMessageConsumptionAnalyticsUsageType,
+  AgentMessageConsumptionAnalyticsUser,
+} from "@app/types/assistant/analytics";
+import { isGlobalAgentId } from "@app/types/assistant/assistant";
+import type {
+  AgentMessageStatus,
+  UserMessageOrigin,
+} from "@app/types/assistant/conversation";
+import {
+  AGENT_MESSAGE_STATUSES_TO_TRACK,
+  isTerminalAgentMessageStatus,
+} from "@app/types/assistant/conversation";
+import type { ModelId } from "@app/types/shared/model_id";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export type BilledRunUsage = RunUsageWithRunKeyType & {
+  usageType: AgentMessageConsumptionAnalyticsUsageType;
+};
+
+function isBilledRunUsage(
+  usage: RunUsageWithRunKeyType
+): usage is BilledRunUsage {
+  switch (usage.usageType) {
+    case USAGE_TYPE_USER:
+    case USAGE_TYPE_PROGRAMMATIC:
+      return true;
+    case USAGE_TYPE_FREE:
+      return false;
+    case null:
+      throw new Error("Run usage billing classification is incomplete");
+    default:
+      return assertNever(usage.usageType);
+  }
+}
+
+export type ConsumptionAnalyticsMessageMetadata = {
+  agent: AgentMessageConsumptionAnalyticsAgent;
+  agentMessageId: string;
+  apiKeyName: string | null;
+  completedAt: Date;
+  contextOrigin: UserMessageOrigin | null;
+  conversationId: string;
+  messageStatus: AgentMessageStatus;
+  messageVersion: number;
+  model: AgentMessageAnalyticsModel | null;
+  spaceId: string | null;
+  triggerId: string | null;
+  user: AgentMessageConsumptionAnalyticsUser | null;
+  workspaceId: string;
+};
+
+export type AgentMessageConsumptionAnalyticsInput =
+  ConsumptionAnalyticsMessageMetadata & {
+    actions: AgentMCPActionResource[];
+    billedCredits: number;
+    dustRunIds: string[];
+    items: AgentMessageConsumptionItemResource[];
+    runs: RunResource[];
+    skills: SkillResource[];
+    stepContents: AgentStepContentResource[];
+    usages: BilledRunUsage[];
+  };
+
+async function loadAnalyticsUser(
+  auth: Authenticator,
+  userModelId: ModelId | null
+): Promise<AgentMessageConsumptionAnalyticsUser | null> {
+  if (userModelId !== null) {
+    const [user] = await UserResource.fetchByModelIds([userModelId]);
+    if (user) {
+      return { id: user.sId };
+    }
+  }
+
+  const authenticatedUser = auth.user();
+  return authenticatedUser ? { id: authenticatedUser.sId } : null;
+}
+
+async function loadApiKeyName(
+  auth: Authenticator,
+  apiKeyModelId: ModelId | null
+): Promise<string | null> {
+  if (apiKeyModelId === null) {
+    return null;
+  }
+
+  const apiKey = await KeyResource.fetchByWorkspaceAndId({
+    workspace: auth.getNonNullableWorkspace(),
+    id: apiKeyModelId,
+  });
+  return apiKey && !apiKey.isSystem ? apiKey.name : null;
+}
+
+async function loadAgentTagIds(
+  auth: Authenticator,
+  {
+    agentConfigurationId,
+    agentConfigurationVersion,
+  }: {
+    agentConfigurationId: string;
+    agentConfigurationVersion: number;
+  }
+): Promise<string[]> {
+  if (isGlobalAgentId(agentConfigurationId)) {
+    return [];
+  }
+
+  const tags = await TagResource.listForAgentVersion(
+    auth,
+    agentConfigurationId,
+    agentConfigurationVersion
+  );
+  return tags.map((tag) => tag.sId);
+}
+
+export async function loadAgentMessageConsumptionAnalyticsInput(
+  auth: Authenticator,
+  { agentMessageId }: { agentMessageId: string }
+): Promise<AgentMessageConsumptionAnalyticsInput | null> {
+  const workspace = auth.getNonNullableWorkspace();
+  const context =
+    await ConversationResource.fetchAgentMessageConsumptionAnalyticsContext(
+      auth,
+      { agentMessageId }
+    );
+  if (!context) {
+    throw new Error(
+      "Agent message, conversation, or triggering user message not found"
+    );
+  }
+
+  const { agentMessage, conversation, triggeringUserMessage } = context;
+  if (
+    !AGENT_MESSAGE_STATUSES_TO_TRACK.includes(agentMessage.status) ||
+    !isTerminalAgentMessageStatus(agentMessage.status)
+  ) {
+    return null;
+  }
+  if (!agentMessage.completedAt) {
+    throw new Error("Settled agent message is missing completedAt");
+  }
+
+  const dustRunIds = [...new Set(agentMessage.runIds ?? [])];
+  const runs = await RunResource.listByDustRunIds(auth, { dustRunIds });
+  const usages = await RunResource.listRunUsagesForRuns(auth, { runs });
+  const billedUsages = usages.filter(isBilledRunUsage);
+  if (billedUsages.length === 0) {
+    return null;
+  }
+  if (agentMessage.costCredits === null) {
+    throw new Error("Billed agent message is missing costCredits");
+  }
+
+  const user = await loadAnalyticsUser(auth, triggeringUserMessage.userModelId);
+  const apiKeyName = await loadApiKeyName(
+    auth,
+    triggeringUserMessage.apiKeyModelId
+  );
+  const items =
+    await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(auth, {
+      agentMessageModelIds: [agentMessage.agentMessageModelId],
+      maxAttributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+    });
+  const actions = await AgentMCPActionResource.listByAgentMessageIds(auth, [
+    agentMessage.agentMessageModelId,
+  ]);
+  const stepContents = await AgentStepContentResource.fetchByAgentMessages(
+    auth,
+    { agentMessageIds: [agentMessage.agentMessageModelId] }
+  );
+  const skills = await SkillResource.listByAgentMessageId(
+    auth,
+    agentMessage.agentMessageModelId
+  );
+  const ancestorAgentIds =
+    await ConversationResource.listAgenticAncestorAgentConfigurationIds(auth, {
+      agentMessageId,
+    });
+  const agentTagIds = await loadAgentTagIds(auth, agentMessage);
+
+  const resolvedModel = resolvedModelFromAgentMessageRow({
+    resolvedModelId: agentMessage.resolvedModelId,
+    resolvedProviderId: agentMessage.resolvedProviderId,
+    resolvedReasoningEffort: agentMessage.resolvedReasoningEffort,
+  });
+
+  return {
+    actions,
+    agent: {
+      id: agentMessage.agentConfigurationId,
+      version: agentMessage.agentConfigurationVersion.toString(),
+      tag_ids: agentTagIds,
+      parent_ids: ancestorAgentIds,
+      direct_parent_id: ancestorAgentIds.at(-1) ?? null,
+      root_id: ancestorAgentIds[0] ?? agentMessage.agentConfigurationId,
+      depth: conversation.depth,
+    },
+    agentMessageId,
+    apiKeyName,
+    billedCredits: agentMessage.costCredits,
+    completedAt: agentMessage.completedAt,
+    contextOrigin: triggeringUserMessage.origin,
+    conversationId: conversation.conversationId,
+    dustRunIds,
+    items,
+    messageStatus: agentMessage.status,
+    messageVersion: agentMessage.version,
+    model: resolvedModel
+      ? {
+          provider_id: resolvedModel.providerId,
+          model_id: resolvedModel.modelId,
+          reasoning_effort: resolvedModel.reasoningEffort,
+          resolution_method: agentMessage.modelResolutionMethod,
+        }
+      : null,
+    runs,
+    skills,
+    spaceId:
+      conversation.spaceModelId === null
+        ? null
+        : SpaceResource.modelIdToSId({
+            id: conversation.spaceModelId,
+            workspaceId: workspace.id,
+          }),
+    stepContents,
+    triggerId: ConversationResource.triggerIdToSId(
+      conversation.triggerModelId,
+      workspace.id
+    ),
+    usages: billedUsages,
+    user,
+    workspaceId: workspace.sId,
+  };
+}

--- a/front/lib/analytics/agent_message_consumption/load.ts
+++ b/front/lib/analytics/agent_message_consumption/load.ts
@@ -41,25 +41,6 @@ export type BilledRunUsage = RunUsageWithRunKeyType & {
   usageType: AgentMessageConsumptionAnalyticsUsageType;
 };
 
-function isBilledRunUsage(
-  usage: RunUsageWithRunKeyType
-): usage is BilledRunUsage {
-  switch (usage.usageType) {
-    case USAGE_TYPE_USER:
-    case USAGE_TYPE_PROGRAMMATIC:
-      return true;
-
-    case USAGE_TYPE_FREE:
-      return false;
-
-    case null:
-      throw new Error("Run usage billing classification is incomplete");
-
-    default:
-      return assertNever(usage.usageType);
-  }
-}
-
 export type ConsumptionAnalyticsMessageMetadata = {
   agent: AgentMessageConsumptionAnalyticsAgent;
   agentMessageId: string;
@@ -87,6 +68,26 @@ export type AgentMessageConsumptionAnalyticsInput =
     stepContents: AgentStepContentResource[];
     usages: BilledRunUsage[];
   };
+
+// We only account for billed usage types in the analytics pipeline.
+function isBilledRunUsage(
+  usage: RunUsageWithRunKeyType
+): usage is BilledRunUsage {
+  switch (usage.usageType) {
+    case USAGE_TYPE_USER:
+    case USAGE_TYPE_PROGRAMMATIC:
+      return true;
+
+    case USAGE_TYPE_FREE:
+      return false;
+
+    case null:
+      throw new Error("Run usage billing classification is incomplete");
+
+    default:
+      return assertNever(usage.usageType);
+  }
+}
 
 async function loadApiKeyName(
   auth: Authenticator,

--- a/front/lib/analytics/agent_message_consumption/load.ts
+++ b/front/lib/analytics/agent_message_consumption/load.ts
@@ -238,7 +238,7 @@ export async function loadAgentMessageConsumptionAnalyticsInput(
       workspace.id
     ),
     usages: billedUsages,
-    // The triggering message is the source of truth. Background auth may represent another user.
+    // userId is a nullable FK with ON DELETE SET NULL. Never substitute the worker identity.
     user:
       triggeringUserMessage.userId === null
         ? null

--- a/front/lib/analytics/agent_message_consumption/load.ts
+++ b/front/lib/analytics/agent_message_consumption/load.ts
@@ -18,7 +18,6 @@ import {
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TagResource } from "@app/lib/resources/tags_resource";
-import { UserResource } from "@app/lib/resources/user_resource";
 import type {
   AgentMessageAnalyticsModel,
   AgentMessageConsumptionAnalyticsAgent,
@@ -48,10 +47,13 @@ function isBilledRunUsage(
     case USAGE_TYPE_USER:
     case USAGE_TYPE_PROGRAMMATIC:
       return true;
+
     case USAGE_TYPE_FREE:
       return false;
+
     case null:
       throw new Error("Run usage billing classification is incomplete");
+
     default:
       return assertNever(usage.usageType);
   }
@@ -84,21 +86,6 @@ export type AgentMessageConsumptionAnalyticsInput =
     stepContents: AgentStepContentResource[];
     usages: BilledRunUsage[];
   };
-
-async function loadAnalyticsUser(
-  auth: Authenticator,
-  userModelId: ModelId | null
-): Promise<AgentMessageConsumptionAnalyticsUser | null> {
-  if (userModelId !== null) {
-    const [user] = await UserResource.fetchByModelIds([userModelId]);
-    if (user) {
-      return { id: user.sId };
-    }
-  }
-
-  const authenticatedUser = auth.user();
-  return authenticatedUser ? { id: authenticatedUser.sId } : null;
-}
 
 async function loadApiKeyName(
   auth: Authenticator,
@@ -175,7 +162,6 @@ export async function loadAgentMessageConsumptionAnalyticsInput(
     throw new Error("Billed agent message is missing costCredits");
   }
 
-  const user = await loadAnalyticsUser(auth, triggeringUserMessage.userModelId);
   const apiKeyName = await loadApiKeyName(
     auth,
     triggeringUserMessage.apiKeyModelId
@@ -252,7 +238,11 @@ export async function loadAgentMessageConsumptionAnalyticsInput(
       workspace.id
     ),
     usages: billedUsages,
-    user,
+    // The triggering message is the source of truth. Background auth may represent another user.
+    user:
+      triggeringUserMessage.userId === null
+        ? null
+        : { id: triggeringUserMessage.userId },
     workspaceId: workspace.sId,
   };
 }

--- a/front/lib/api/assistant/conversation/agentic_ancestors.ts
+++ b/front/lib/api/assistant/conversation/agentic_ancestors.ts
@@ -1,0 +1,59 @@
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+
+export type AgenticAncestor = {
+  agentConfigurationId: string;
+  agentMessageId: string;
+  conversation: ConversationResource;
+};
+
+/**
+ * Lists the agent messages that led to the current conversation, starting with the direct parent.
+ */
+export async function listAgenticAncestors(
+  auth: Authenticator,
+  conversation: ConversationResource,
+  {
+    agentMessageId,
+    maxAncestors,
+  }: { agentMessageId: string; maxAncestors?: number }
+): Promise<AgenticAncestor[]> {
+  const ancestors: AgenticAncestor[] = [];
+  const visitedAgentMessageIds = new Set([agentMessageId]);
+  let cursor = { conversation, agentMessageId };
+
+  while (maxAncestors === undefined || ancestors.length < maxAncestors) {
+    const parentAgentMessage = await cursor.conversation.findAgenticParent(
+      auth,
+      { agentMessageId: cursor.agentMessageId }
+    );
+    if (
+      !parentAgentMessage ||
+      visitedAgentMessageIds.has(parentAgentMessage.agentMessageId)
+    ) {
+      break;
+    }
+
+    const [parentConversation] = await ConversationResource.fetchByModelIds(
+      auth,
+      [parentAgentMessage.conversationModelId],
+      { loadSpaces: true }
+    );
+    if (!parentConversation) {
+      break;
+    }
+
+    visitedAgentMessageIds.add(parentAgentMessage.agentMessageId);
+    ancestors.push({
+      agentConfigurationId: parentAgentMessage.agentConfigurationId,
+      agentMessageId: parentAgentMessage.agentMessageId,
+      conversation: parentConversation,
+    });
+    cursor = {
+      conversation: parentConversation,
+      agentMessageId: parentAgentMessage.agentMessageId,
+    };
+  }
+
+  return ancestors;
+}

--- a/front/lib/api/assistant/conversation/resume_ancestor_conversations.ts
+++ b/front/lib/api/assistant/conversation/resume_ancestor_conversations.ts
@@ -1,9 +1,10 @@
+import { listAgenticAncestors } from "@app/lib/api/assistant/conversation/agentic_ancestors";
 import { MAX_CONVERSATION_DEPTH } from "@app/lib/api/assistant/conversation/constants";
 import { retryBlockedActions } from "@app/lib/api/assistant/conversation/retry_blocked_actions";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustErrorCode } from "@app/lib/error";
 import { DustError } from "@app/lib/error";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 
 // Outcomes that mean "this ancestor has nothing to resume", not "resuming failed": a handover
@@ -31,36 +32,22 @@ export async function resumeAncestorConversations(
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
 
-  let cursor: {
-    conversation: ConversationResource;
-    agentMessageId: string;
-  } = { conversation, agentMessageId };
+  const ancestors = await listAgenticAncestors(auth, conversation, {
+    agentMessageId,
+    maxAncestors: MAX_CONVERSATION_DEPTH,
+  });
 
-  for (let depth = 0; depth < MAX_CONVERSATION_DEPTH; depth++) {
-    const parentAgentMessage = await cursor.conversation.findAgenticParent(
-      auth,
-      {
-        agentMessageId: cursor.agentMessageId,
-      }
-    );
-    if (!parentAgentMessage) {
-      break;
-    }
-
-    const [parentConversation] = await ConversationResource.fetchByModelIds(
-      auth,
-      [parentAgentMessage.conversationId],
-      { loadSpaces: true }
-    );
-    if (!parentConversation) {
-      break;
-    }
+  for (const ancestor of ancestors) {
+    const {
+      agentMessageId: parentAgentMessageId,
+      conversation: parentConversation,
+    } = ancestor;
 
     const retryRes = await retryBlockedActions(
       auth,
       parentConversation.toJSON(),
       {
-        messageId: parentAgentMessage.sId,
+        messageId: parentAgentMessageId,
         waitForCompletion: true,
       }
     );
@@ -69,7 +56,7 @@ export async function resumeAncestorConversations(
       const logBlob = {
         workspaceId: owner.sId,
         parentConversationId: parentConversation.sId,
-        parentAgentMessageId: parentAgentMessage.sId,
+        parentAgentMessageId,
         err: retryRes.error,
       };
 
@@ -85,10 +72,5 @@ export async function resumeAncestorConversations(
         );
       }
     }
-
-    cursor = {
-      conversation: parentConversation,
-      agentMessageId: parentAgentMessage.sId,
-    };
   }
 }

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1000,89 +1000,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return row.total_credits;
   }
 
-  /**
-   * Returns an agent message's ancestor agent configuration IDs from the root agent to the direct
-   * parent. The recursive query follows persisted run-agent and handover origins across
-   * conversations in one database round trip.
-   */
-  static async listAgenticAncestorAgentConfigurationIds(
-    auth: Authenticator,
-    {
-      agentMessageId,
-      maxDepth = 64,
-    }: { agentMessageId: string; maxDepth?: number }
-  ): Promise<string[]> {
-    const workspaceId = auth.getNonNullableWorkspace().id;
-    const query = `
-      WITH RECURSIVE agent_ancestors AS (
-        SELECT
-          origin."sId"                    AS agent_message_sid,
-          origin_am."agentConfigurationId" AS agent_configuration_id,
-          1                               AS depth
-        FROM messages current_message
-        JOIN messages parent_user_message
-          ON parent_user_message.id = current_message."parentId"
-         AND parent_user_message."workspaceId" = current_message."workspaceId"
-        JOIN user_messages parent_user
-          ON parent_user.id = parent_user_message."userMessageId"
-         AND parent_user."workspaceId" = current_message."workspaceId"
-        JOIN messages origin
-          ON origin."sId" = parent_user."agenticOriginMessageId"
-         AND origin."workspaceId" = current_message."workspaceId"
-        JOIN agent_messages origin_am
-          ON origin_am.id = origin."agentMessageId"
-         AND origin_am."workspaceId" = current_message."workspaceId"
-        WHERE current_message."workspaceId" = :workspaceId
-          AND current_message."sId" = :agentMessageId
-
-        UNION ALL
-
-        SELECT
-          origin."sId",
-          origin_am."agentConfigurationId",
-          ancestors.depth + 1
-        FROM agent_ancestors ancestors
-        JOIN messages current_message
-          ON current_message."sId" = ancestors.agent_message_sid
-         AND current_message."workspaceId" = :workspaceId
-        JOIN messages parent_user_message
-          ON parent_user_message.id = current_message."parentId"
-         AND parent_user_message."workspaceId" = :workspaceId
-        JOIN user_messages parent_user
-          ON parent_user.id = parent_user_message."userMessageId"
-         AND parent_user."workspaceId" = :workspaceId
-        JOIN messages origin
-          ON origin."sId" = parent_user."agenticOriginMessageId"
-         AND origin."workspaceId" = :workspaceId
-        JOIN agent_messages origin_am
-          ON origin_am.id = origin."agentMessageId"
-         AND origin_am."workspaceId" = :workspaceId
-        WHERE ancestors.depth < :maxDepth
-      )
-      SELECT agent_configuration_id, depth
-      FROM agent_ancestors
-      ORDER BY depth DESC
-    `;
-
-    // biome-ignore lint/plugin/noRawSql: recursive ancestry has no Sequelize equivalent.
-    const rows = await frontSequelize.query<{
-      agent_configuration_id: string;
-      depth: number;
-    }>(query, {
-      type: QueryTypes.SELECT,
-      replacements: { workspaceId, agentMessageId, maxDepth },
-    });
-
-    if (rows.some((row) => row.depth >= maxDepth)) {
-      logger.warn(
-        { workspaceId: auth.getNonNullableWorkspace().sId, agentMessageId },
-        "[ConsumptionAnalytics] Agent ancestry hit the depth cap."
-      );
-    }
-
-    return rows.map((row) => row.agent_configuration_id);
-  }
-
   private static getOptions(
     options?: FetchConversationOptions
   ): ResourceFindOptions<ConversationModel> {
@@ -3245,7 +3162,11 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   async findAgenticParent(
     auth: Authenticator,
     { agentMessageId }: { agentMessageId: string }
-  ): Promise<MessageModel | null> {
+  ): Promise<{
+    agentConfigurationId: string;
+    agentMessageId: string;
+    conversationModelId: ModelId;
+  } | null> {
     const owner = auth.getNonNullableWorkspace();
 
     const agentMessage = await MessageModel.findOne({
@@ -3289,9 +3210,27 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         workspaceId: owner.id,
         sId: agenticOriginMessageId,
       },
+      attributes: ["sId", "conversationId"],
+      include: [
+        {
+          model: AgentMessageModel,
+          as: "agentMessage",
+          required: true,
+          attributes: ["agentConfigurationId"],
+        },
+      ],
     });
 
-    return agenticOriginMessage;
+    if (!agenticOriginMessage?.agentMessage) {
+      return null;
+    }
+
+    return {
+      agentConfigurationId:
+        agenticOriginMessage.agentMessage.agentConfigurationId,
+      agentMessageId: agenticOriginMessage.sId,
+      conversationModelId: agenticOriginMessage.conversationId,
+    };
   }
 
   /**

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -55,6 +55,7 @@ import {
   getConversationDisplayTitle,
   getConversationUrlAccessMode,
 } from "@app/types/assistant/conversation";
+import type { ModelResolutionMethodType } from "@app/types/assistant/models/types";
 import {
   ACTIVE_WAKE_UP_STATUSES,
   type WakeUpScheduleConfig,
@@ -109,6 +110,34 @@ export type RunningAgentMessageContext = {
   agentMessageId: number;
   agentConfigurationId: string;
   rank: number;
+};
+
+export type AgentMessageConsumptionAnalyticsContext = {
+  agentMessage: {
+    agentConfigurationId: string;
+    agentConfigurationVersion: number;
+    completedAt: Date | null;
+    costCredits: number | null;
+    agentMessageModelId: ModelId;
+    modelResolutionMethod: ModelResolutionMethodType | null;
+    resolvedModelId: string | null;
+    resolvedProviderId: string | null;
+    resolvedReasoningEffort: string | null;
+    runIds: string[] | null;
+    status: AgentMessageStatus;
+    version: number;
+  };
+  conversation: {
+    depth: number;
+    conversationId: string;
+    spaceModelId: ModelId | null;
+    triggerModelId: ModelId | null;
+  };
+  triggeringUserMessage: {
+    apiKeyModelId: ModelId | null;
+    origin: UserMessageOrigin;
+    userModelId: ModelId | null;
+  };
 };
 
 type RunningCompactionMessageContext = {
@@ -774,6 +803,77 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     };
   }
 
+  /**
+   * Loads the message graph needed to build consumption analytics without exposing Sequelize rows
+   * outside the Resource layer.
+   *
+   * // TODO(2026-08-06 FLAV): I wish we had a MessageResource layer.
+   */
+  static async fetchAgentMessageConsumptionAnalyticsContext(
+    auth: Authenticator,
+    { agentMessageId }: { agentMessageId: string }
+  ): Promise<AgentMessageConsumptionAnalyticsContext | null> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const messageRow = await MessageModel.findOne({
+      where: { sId: agentMessageId, workspaceId },
+      include: [
+        { model: AgentMessageModel, as: "agentMessage", required: true },
+        { model: ConversationModel, as: "conversation", required: true },
+      ],
+    });
+    const agentMessage = messageRow?.agentMessage;
+    const conversation = messageRow?.conversation;
+    if (!messageRow || !agentMessage || !conversation) {
+      return null;
+    }
+
+    const triggeringMessageRow =
+      messageRow.parentId === null
+        ? null
+        : await MessageModel.findOne({
+            where: {
+              id: messageRow.parentId,
+              conversationId: conversation.id,
+              workspaceId,
+            },
+            include: [
+              { model: UserMessageModel, as: "userMessage", required: true },
+            ],
+          });
+    const triggeringUserMessage = triggeringMessageRow?.userMessage;
+    if (!triggeringUserMessage) {
+      return null;
+    }
+
+    return {
+      agentMessage: {
+        agentConfigurationId: agentMessage.agentConfigurationId,
+        agentConfigurationVersion: agentMessage.agentConfigurationVersion,
+        completedAt: agentMessage.completedAt,
+        costCredits: agentMessage.costCredits,
+        agentMessageModelId: agentMessage.id,
+        modelResolutionMethod: agentMessage.modelResolutionMethod,
+        resolvedModelId: agentMessage.resolvedModelId,
+        resolvedProviderId: agentMessage.resolvedProviderId,
+        resolvedReasoningEffort: agentMessage.resolvedReasoningEffort,
+        runIds: agentMessage.runIds,
+        status: agentMessage.status,
+        version: messageRow.version,
+      },
+      conversation: {
+        depth: conversation.depth,
+        conversationId: conversation.sId,
+        spaceModelId: conversation.spaceId,
+        triggerModelId: conversation.triggerId,
+      },
+      triggeringUserMessage: {
+        apiKeyModelId: triggeringUserMessage.userContextApiKeyId,
+        origin: triggeringUserMessage.userContextOrigin,
+        userModelId: triggeringUserMessage.userId,
+      },
+    };
+  }
+
   static async updateAgentMessageCostCredits(
     auth: Authenticator,
     {
@@ -887,6 +987,89 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     }
 
     return row.total_credits;
+  }
+
+  /**
+   * Returns an agent message's ancestor agent configuration IDs from the root agent to the direct
+   * parent. The recursive query follows persisted run-agent and handover origins across
+   * conversations in one database round trip.
+   */
+  static async listAgenticAncestorAgentConfigurationIds(
+    auth: Authenticator,
+    {
+      agentMessageId,
+      maxDepth = 64,
+    }: { agentMessageId: string; maxDepth?: number }
+  ): Promise<string[]> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const query = `
+      WITH RECURSIVE agent_ancestors AS (
+        SELECT
+          origin."sId"                    AS agent_message_sid,
+          origin_am."agentConfigurationId" AS agent_configuration_id,
+          1                               AS depth
+        FROM messages current_message
+        JOIN messages parent_user_message
+          ON parent_user_message.id = current_message."parentId"
+         AND parent_user_message."workspaceId" = current_message."workspaceId"
+        JOIN user_messages parent_user
+          ON parent_user.id = parent_user_message."userMessageId"
+         AND parent_user."workspaceId" = current_message."workspaceId"
+        JOIN messages origin
+          ON origin."sId" = parent_user."agenticOriginMessageId"
+         AND origin."workspaceId" = current_message."workspaceId"
+        JOIN agent_messages origin_am
+          ON origin_am.id = origin."agentMessageId"
+         AND origin_am."workspaceId" = current_message."workspaceId"
+        WHERE current_message."workspaceId" = :workspaceId
+          AND current_message."sId" = :agentMessageId
+
+        UNION ALL
+
+        SELECT
+          origin."sId",
+          origin_am."agentConfigurationId",
+          ancestors.depth + 1
+        FROM agent_ancestors ancestors
+        JOIN messages current_message
+          ON current_message."sId" = ancestors.agent_message_sid
+         AND current_message."workspaceId" = :workspaceId
+        JOIN messages parent_user_message
+          ON parent_user_message.id = current_message."parentId"
+         AND parent_user_message."workspaceId" = :workspaceId
+        JOIN user_messages parent_user
+          ON parent_user.id = parent_user_message."userMessageId"
+         AND parent_user."workspaceId" = :workspaceId
+        JOIN messages origin
+          ON origin."sId" = parent_user."agenticOriginMessageId"
+         AND origin."workspaceId" = :workspaceId
+        JOIN agent_messages origin_am
+          ON origin_am.id = origin."agentMessageId"
+         AND origin_am."workspaceId" = :workspaceId
+        WHERE ancestors.depth < :maxDepth
+      )
+      SELECT agent_configuration_id, depth
+      FROM agent_ancestors
+      ORDER BY depth DESC
+    `;
+
+    // biome-ignore lint/plugin/noRawSql: recursive ancestry has no Sequelize equivalent.
+    const rows = await frontSequelize.query<{
+      agent_configuration_id: string;
+      depth: number;
+    }>(query, {
+      type: QueryTypes.SELECT,
+      replacements: { workspaceId, agentMessageId, maxDepth },
+    });
+
+    if (rows.some((row) => row.depth >= maxDepth)) {
+      logger.warn(
+        { workspaceId: auth.getNonNullableWorkspace().sId, agentMessageId },
+        "[ConsumptionAnalytics] Agent ancestry hit the depth cap."
+      );
+    }
+
+    return rows.map((row) => row.agent_configuration_id);
   }
 
   private static getOptions(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -136,7 +136,7 @@ export type AgentMessageConsumptionAnalyticsContext = {
   triggeringUserMessage: {
     apiKeyModelId: ModelId | null;
     origin: UserMessageOrigin;
-    userModelId: ModelId | null;
+    userId: string | null;
   };
 };
 
@@ -837,7 +837,18 @@ export class ConversationResource extends BaseResource<ConversationModel> {
               workspaceId,
             },
             include: [
-              { model: UserMessageModel, as: "userMessage", required: true },
+              {
+                model: UserMessageModel,
+                as: "userMessage",
+                required: true,
+                include: [
+                  {
+                    model: UserModel,
+                    required: false,
+                    attributes: ["sId"],
+                  },
+                ],
+              },
             ],
           });
     const triggeringUserMessage = triggeringMessageRow?.userMessage;
@@ -869,7 +880,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       triggeringUserMessage: {
         apiKeyModelId: triggeringUserMessage.userContextApiKeyId,
         origin: triggeringUserMessage.userContextOrigin,
-        userModelId: triggeringUserMessage.userId,
+        userId: triggeringUserMessage.user?.sId ?? null,
       },
     };
   }


### PR DESCRIPTION
As we start ingesting data into the new consumption analytics index, we need one clear entry point that loads everything required for a single agent message and answers the first important question: was this usage actually billed?

This PR adds that loading layer. It reads the authoritative message cost and the related runs, usage classification, attribution items, actions, step contents, skills, model, user, space, trigger, API key, tags, and agent ancestry. User and programmatic usage are included. Fully free usage, such as sidekick and activations, is ignored, as are messages that can still resume. If usage has not been classified yet, or billed usage has no message cost, we fail explicitly instead of producing incomplete analytics.

Agent ancestry follows the persisted `run_agent` and handover links in application code. Nested conversations are limited to a depth of four, **but** handovers stay in the same conversation and can create a longer chain, so analytics keeps the full chain from the root agent to the direct parent.

This PR does not create Elasticsearch documents, write to Elasticsearch, or trigger the analytics workflow yet. It gives the next activity a stable input with the billing decision already made and keeps Sequelize rows and relationship details behind the Resource and application layers.
