### PR TITLE
feat: allow fetching user groups at a given date

### DIFF
--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -76,6 +76,7 @@ import {
   GroupResource,
   MANUAL_BUILDERS_GROUP_NAME,
 } from "@app/lib/resources/group_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
@@ -210,6 +211,146 @@ describe("GroupResource", () => {
       );
 
       expect(result.size).toBe(0);
+    });
+  });
+
+  describe("listUserGroupsInWorkspace with `at`", () => {
+    const JANUARY = new Date("2026-01-15T00:00:00Z");
+    const FEBRUARY = new Date("2026-02-15T00:00:00Z");
+    const MARCH = new Date("2026-03-15T00:00:00Z");
+
+    // Group memberships are historized by startAt/endAt, but no resource method
+    // lets a caller choose those values, so the window is backdated directly.
+    async function setGroupMembershipWindow(
+      group: GroupResource,
+      member: UserResource,
+      { startAt, endAt }: { startAt: Date; endAt: Date | null }
+    ) {
+      await GroupMembershipModel.update(
+        { startAt, endAt },
+        {
+          where: {
+            workspaceId: workspace.id,
+            groupId: group.id,
+            userId: member.id,
+          },
+        }
+      );
+    }
+
+    it("returns the groups the user was in at `at`, not today's groups", async () => {
+      const member = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, member, {
+        role: "user",
+        startAt: JANUARY,
+      });
+
+      const sales = await GroupResource.makeNew({
+        name: "Sales",
+        workspaceId: workspace.id,
+        kind: "regular_manual",
+      });
+      await sales.dangerouslyAddMembers(authenticator, {
+        users: [member.toJSON()],
+      });
+      // In Sales from January until March.
+      await setGroupMembershipWindow(sales, member, {
+        startAt: JANUARY,
+        endAt: MARCH,
+      });
+
+      const inFebruary = await GroupResource.listUserGroupsInWorkspace({
+        user: member,
+        workspace,
+        groupKinds: ["regular_manual"],
+        at: FEBRUARY,
+      });
+      expect(inFebruary.map((g) => g.name)).toEqual(["Sales"]);
+
+      // Omitting `at` defaults to now, after the membership ended.
+      const today = await GroupResource.listUserGroupsInWorkspace({
+        user: member,
+        workspace,
+        groupKinds: ["regular_manual"],
+      });
+      expect(today).toEqual([]);
+    });
+
+    it("still resolves groups for a user who has since left the workspace", async () => {
+      const member = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, member, {
+        role: "user",
+        startAt: JANUARY,
+      });
+
+      const sales = await GroupResource.makeNew({
+        name: "Sales",
+        workspaceId: workspace.id,
+        kind: "regular_manual",
+      });
+      await sales.dangerouslyAddMembers(authenticator, {
+        users: [member.toJSON()],
+      });
+      await setGroupMembershipWindow(sales, member, {
+        startAt: JANUARY,
+        endAt: null,
+      });
+
+      const revoked = await MembershipResource.revokeMembership({
+        user: member,
+        workspace,
+        endAt: MARCH,
+      });
+      expect(revoked.isOk()).toBe(true);
+
+      // The workspace membership gate is evaluated at `at` too, so a member who
+      // left in March is still resolvable in February. This is what analytics
+      // reindexing of their past messages depends on.
+      const inFebruary = await GroupResource.listUserGroupsInWorkspace({
+        user: member,
+        workspace,
+        groupKinds: ["regular_manual"],
+        at: FEBRUARY,
+      });
+      expect(inFebruary.map((g) => g.name)).toEqual(["Sales"]);
+
+      // Today they are no longer a workspace member.
+      const today = await GroupResource.listUserGroupsInWorkspace({
+        user: member,
+        workspace,
+        groupKinds: ["regular_manual"],
+      });
+      expect(today).toEqual([]);
+    });
+
+    it("excludes memberships that had not started yet at `at`", async () => {
+      const member = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, member, {
+        role: "user",
+        startAt: JANUARY,
+      });
+
+      const sales = await GroupResource.makeNew({
+        name: "Sales",
+        workspaceId: workspace.id,
+        kind: "regular_manual",
+      });
+      await sales.dangerouslyAddMembers(authenticator, {
+        users: [member.toJSON()],
+      });
+      await setGroupMembershipWindow(sales, member, {
+        startAt: FEBRUARY,
+        endAt: null,
+      });
+
+      const inJanuary = await GroupResource.listUserGroupsInWorkspace({
+        user: member,
+        workspace,
+        groupKinds: ["regular_manual"],
+        at: JANUARY,
+      });
+
+      expect(inJanuary).toEqual([]);
     });
   });
 

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1156,18 +1156,28 @@ export class GroupResource extends BaseResource<GroupModel> {
     return groups.filter((group) => group.canRead(auth));
   }
 
+  /**
+   * Group model ids the user was a member of at `at`, defaulting to now.
+   *
+   * Two caveats:
+   * - `global` groups are included regardless of `at` if requested (they are not historized).
+   * - `status` is mutated in place by suspend/restore, so a membership
+   *   suspended today is filtered out even for a past `at`.
+   */
   private static async listUserGroupModelIdsInWorkspace({
     user,
     workspace,
     groupKinds = GROUP_KINDS.filter((k) => k !== "system"),
     transaction,
     dangerouslySkipMembershipCheck = false,
+    at = new Date(),
   }: {
     user: UserResource;
     workspace: LightWorkspaceType;
     groupKinds?: Exclude<GroupKind, "system">[];
     transaction?: Transaction;
     dangerouslySkipMembershipCheck?: boolean;
+    at?: Date;
   }): Promise<ModelId[]> {
     if (!dangerouslySkipMembershipCheck) {
       const workspaceMembership =
@@ -1175,6 +1185,7 @@ export class GroupResource extends BaseResource<GroupModel> {
           user,
           workspace,
           transaction,
+          at,
         });
       if (!workspaceMembership) {
         return [];
@@ -1209,7 +1220,7 @@ export class GroupResource extends BaseResource<GroupModel> {
           workspaceId: workspace.id,
           groupKinds,
           userId: user.id,
-          now: new Date(),
+          now: at,
         },
         type: QueryTypes.SELECT,
         raw: true,
@@ -1231,17 +1242,20 @@ export class GroupResource extends BaseResource<GroupModel> {
     workspace,
     groupKinds = GROUP_KINDS.filter((k) => k !== "system"),
     transaction,
+    at,
   }: {
     user: UserResource;
     workspace: LightWorkspaceType;
     groupKinds?: Exclude<GroupKind, "system">[];
     transaction?: Transaction;
+    at?: Date;
   }): Promise<GroupResource[]> {
     const groupIds = await this.listUserGroupModelIdsInWorkspace({
       user,
       workspace,
       groupKinds,
       transaction,
+      at,
     });
 
     const groups = await GroupModel.findAll({

--- a/front/lib/resources/membership_resource.test.ts
+++ b/front/lib/resources/membership_resource.test.ts
@@ -257,6 +257,38 @@ describe("MembershipResource", () => {
 
         expect(seatType).toBeNull();
       });
+
+      it("returns the seat type held at `at`, not today's", async () => {
+        const user = await UserFactory.basic();
+        await MembershipFactory.associate(workspace, user, {
+          role: "user",
+          seatType: "free",
+          startAt: new Date("2026-01-15T00:00:00Z"),
+        });
+        const revoked = await MembershipResource.revokeMembership({
+          user,
+          workspace,
+          endAt: new Date("2026-03-15T00:00:00Z"),
+        });
+        expect(revoked.isOk()).toBe(true);
+
+        // Mid-window: the seat the user actually held then.
+        expect(
+          await MembershipResource.getActiveSeatTypeForUserModelId({
+            workspace,
+            userModelId: user.id,
+            at: new Date("2026-02-15T00:00:00Z"),
+          })
+        ).toBe("free");
+
+        // Defaulting to now, after revocation: no membership.
+        expect(
+          await MembershipResource.getActiveSeatTypeForUserModelId({
+            workspace,
+            userModelId: user.id,
+          })
+        ).toBeNull();
+      });
     });
   });
 

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -50,6 +50,7 @@ type GetMembershipsOptions = RequireAtLeastOne<{
   roles?: MembershipRoleType[];
   seatTypes?: MembershipSeatType[];
   transaction?: Transaction;
+  at?: Date;
 };
 
 export type MembershipsPaginationParams = {
@@ -145,6 +146,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     seatTypes,
     transaction,
     paginationParams,
+    at = new Date(),
   }: GetMembershipsOptions & {
     paginationParams?: MembershipsPaginationParams;
   }): Promise<MembershipsWithTotal> {
@@ -154,10 +156,10 @@ export class MembershipResource extends BaseResource<MembershipModel> {
 
     const whereClause: WhereOptions<InferAttributes<MembershipModel>> = {
       startAt: {
-        [Op.lte]: new Date(),
+        [Op.lte]: at,
       },
       endAt: {
-        [Op.or]: [{ [Op.eq]: null }, { [Op.gte]: new Date() }],
+        [Op.or]: [{ [Op.eq]: null }, { [Op.gte]: at }],
       },
     };
 
@@ -645,15 +647,18 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     user,
     workspace,
     transaction,
+    at,
   }: {
     user: UserResource;
     workspace: LightWorkspaceType;
     transaction?: Transaction;
+    at?: Date;
   }): Promise<MembershipResource | null> {
     const { memberships, total } = await this.getActiveMemberships({
       users: [user],
       workspace,
       transaction,
+      at,
     });
     if (total === 0) {
       return null;
@@ -682,18 +687,20 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     workspace,
     userModelId,
     transaction,
+    at = new Date(),
   }: {
     workspace: LightWorkspaceType;
     userModelId: ModelId;
     transaction?: Transaction;
+    at?: Date;
   }): Promise<MembershipSeatType | null> {
     const row = await this.model.findOne({
       attributes: ["seatType"],
       where: {
         workspaceId: workspace.id,
         userId: userModelId,
-        startAt: { [Op.lte]: new Date() },
-        endAt: { [Op.or]: [{ [Op.eq]: null }, { [Op.gte]: new Date() }] },
+        startAt: { [Op.lte]: at },
+        endAt: { [Op.or]: [{ [Op.eq]: null }, { [Op.gte]: at }] },
       },
       transaction,
     });

--- a/front/temporal/analytics_queue/activities/agent_analytics.ts
+++ b/front/temporal/analytics_queue/activities/agent_analytics.ts
@@ -209,7 +209,9 @@ export async function storeAgentAnalytics(
     });
   }
 
-  // Seat type at index time, to stamp `is_free_seat`. Mirrors Metronome's
+  const messageCreatedAt = new Date(agentMessageRow.createdAt);
+
+  // Seat type as of the message time, to stamp `is_free_seat`. Mirrors Metronome's
   // free-seat user-id split: free-seat usage is dropped from a user's consumed
   // credits once they upgrade to a paid seat. Defaults to non-free when the
   // message has no associated user (system/doNotAssociateUser messages).
@@ -217,6 +219,7 @@ export async function storeAgentAnalytics(
     ? await MembershipResource.getActiveSeatTypeForUserModelId({
         workspace: auth.getNonNullableWorkspace(),
         userModelId: userModel.id,
+        at: messageCreatedAt,
       })
     : null;
   const isFreeSeat = seatType === "free";
@@ -317,7 +320,7 @@ export async function storeAgentAnalytics(
     skills_used: skillsUsed,
     status: agentAgentMessageRow.status,
     is_free_seat: isFreeSeat,
-    timestamp: new Date(agentMessageRow.createdAt).toISOString(),
+    timestamp: messageCreatedAt.toISOString(),
     tokens,
     tools_used: toolsUsed,
     // Fall back to the authenticated user when the UserMessage row has no

--- a/front/tests/utils/MembershipFactory.ts
+++ b/front/tests/utils/MembershipFactory.ts
@@ -16,10 +16,12 @@ export class MembershipFactory {
       role,
       origin = "invited",
       seatType,
+      startAt,
     }: {
       role: MembershipRoleType;
       origin?: MembershipOriginType;
       seatType?: MembershipSeatType;
+      startAt?: Date;
     },
     t?: Transaction
   ) {
@@ -29,6 +31,7 @@ export class MembershipFactory {
       role,
       origin,
       seatType,
+      startAt,
       transaction: t,
     });
   }


### PR DESCRIPTION
## Description

Make it possible to fetch user group ids at a given point in time.
This is useful when we want to persist user memberships without being dependent on current time, e.g when re-indexing documents in ES, the index shouldn't change based on when the indexing runs.

The group memberships function already have a notion of `start` and `end` date so we only need to modify existing functions to filter by something else than `now`.

Done by adding an optional `at?: date` parameter to:
- `getActiveMemberships`
- `getActiveMembershipOfUserInWorkspace`
- `listUserGroupModelIdsInWorkspace`

## Tests

added uts.

## Risk

Safe to rollback.

## Deploy Plan

Front only