### PR TITLE
Admin governance: API to list user's groups and add/remove user from group

### DIFF
--- a/front-api/routes/w/[wId]/groups/index.ts
+++ b/front-api/routes/w/[wId]/groups/index.ts
@@ -46,17 +46,9 @@ app.get(
       ? await GroupResource.listForSpaceById(auth, spaceId, { groupKinds })
       : await GroupResource.listAllWorkspaceGroups(auth, { groupKinds });
 
-    const memberCounts = await GroupResource.getMemberCountsForGroups(
-      auth,
-      groups
-    );
-
-    const groupsWithMemberCount = groups.map((group) => ({
-      ...group.toJSON(),
-      memberCount: memberCounts.get(group.id) ?? 0,
-    }));
-
-    return ctx.json({ groups: groupsWithMemberCount });
+    return ctx.json({
+      groups: await GroupResource.toJSONWithMemberCounts(auth, groups),
+    });
   }
 );
 

--- a/front-api/routes/w/[wId]/members/[uId]/groups.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/groups.test.ts
@@ -1,0 +1,263 @@
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function getMemberGroups(workspace: { sId: string }, userId: string) {
+  return honoApp.request(`/api/w/${workspace.sId}/members/${userId}/groups`);
+}
+
+function postMemberGroup(
+  workspace: { sId: string },
+  userId: string,
+  body: Record<string, unknown>
+) {
+  return honoApp.request(`/api/w/${workspace.sId}/members/${userId}/groups`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function deleteMemberGroup(
+  workspace: { sId: string },
+  userId: string,
+  groupId: string
+) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/members/${userId}/groups/${groupId}`,
+    { method: "DELETE" }
+  );
+}
+
+describe("GET /api/w/:wId/members/:uId/groups", () => {
+  it("returns the manageable groups of the member with their member counts", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    const manualGroup = await GroupFactory.regularManual(workspace, "Billing");
+    const addManualRes = await manualGroup.dangerouslyAddMembers(auth, {
+      users: [user.toJSON()],
+    });
+    if (addManualRes.isErr()) {
+      throw addManualRes.error;
+    }
+
+    const provisionedGroup = await GroupFactory.provisioned(workspace, "Dev");
+    const addProvisionedRes = await provisionedGroup.dangerouslyAddMembers(
+      auth,
+      { users: [user.toJSON()], allowProvisionedGroups: true }
+    );
+    if (addProvisionedRes.isErr()) {
+      throw addProvisionedRes.error;
+    }
+
+    // Groups the member is not part of, and kinds that are not manageable, must not show up.
+    await GroupFactory.regularManual(workspace, "Other");
+    const autoGroup = await GroupFactory.regularAuto(workspace, "Automatic");
+    const addAutoRes = await autoGroup.dangerouslyAddMembers(auth, {
+      users: [user.toJSON()],
+    });
+    if (addAutoRes.isErr()) {
+      throw addAutoRes.error;
+    }
+
+    const response = await getMemberGroups(workspace, user.sId);
+
+    expect(response.status).toBe(200);
+    const { groups } = await response.json();
+    expect(
+      groups
+        .map((g: { name: string }) => g.name)
+        .sort((a: string, b: string) => a.localeCompare(b))
+    ).toEqual(["Billing", "Dev"]);
+    expect(
+      groups.find((g: { name: string }) => g.name === "Billing").memberCount
+    ).toBe(1);
+    expect(groups.find((g: { name: string }) => g.name === "Dev").kind).toBe(
+      "provisioned"
+    );
+  });
+
+  it("returns 403 for a regular user", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await getMemberGroups(workspace, user.sId);
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("workspace_auth_error");
+  });
+
+  it("returns 404 when the user is not a member of the workspace", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+    const outsider = await UserFactory.basic();
+
+    const response = await getMemberGroups(workspace, outsider.sId);
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).error.type).toBe("workspace_user_not_found");
+  });
+});
+
+describe("POST /api/w/:wId/members/:uId/groups", () => {
+  it("lets a manager add a member to a manual group", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "manager",
+    });
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+    const group = await GroupFactory.regularManual(workspace, "Billing");
+
+    const response = await postMemberGroup(workspace, otherUser.sId, {
+      groupId: group.sId,
+    });
+
+    expect(response.status).toBe(200);
+    const { group: updatedGroup } = await response.json();
+    expect(updatedGroup.memberCount).toBe(1);
+
+    const members = await group.getActiveMembers(auth);
+    expect(members.map((m) => m.sId)).toEqual([otherUser.sId]);
+  });
+
+  it("returns 400 when the member is already in the group", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    const group = await GroupFactory.regularManual(workspace, "Billing");
+    const addRes = await group.dangerouslyAddMembers(auth, {
+      users: [user.toJSON()],
+    });
+    if (addRes.isErr()) {
+      throw addRes.error;
+    }
+
+    const response = await postMemberGroup(workspace, user.sId, {
+      groupId: group.sId,
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 404 for a provisioned group", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    const group = await GroupFactory.provisioned(workspace, "Dev");
+
+    const response = await postMemberGroup(workspace, user.sId, {
+      groupId: group.sId,
+    });
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).error.type).toBe("group_not_found");
+  });
+
+  it("returns 403 for a regular user", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "user",
+    });
+    const group = await GroupFactory.regularManual(workspace, "Billing");
+
+    const response = await postMemberGroup(workspace, user.sId, {
+      groupId: group.sId,
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 400 when groupId is missing", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    const response = await postMemberGroup(workspace, user.sId, {});
+
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("DELETE /api/w/:wId/members/:uId/groups/:groupId", () => {
+  it("lets an admin remove a member from a manual group", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "admin",
+    });
+    const group = await GroupFactory.regularManual(workspace, "Billing");
+    const addRes = await group.dangerouslyAddMembers(auth, {
+      users: [user.toJSON()],
+    });
+    if (addRes.isErr()) {
+      throw addRes.error;
+    }
+
+    const response = await deleteMemberGroup(workspace, user.sId, group.sId);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+
+    const members = await group.getActiveMembers(auth);
+    expect(members).toEqual([]);
+  });
+
+  it("returns 400 when the member is not in the group", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "admin",
+    });
+    const group = await GroupFactory.regularManual(workspace, "Billing");
+
+    const response = await deleteMemberGroup(workspace, user.sId, group.sId);
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 404 for a provisioned group", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "admin",
+    });
+    const group = await GroupFactory.provisioned(workspace, "Dev");
+    const addRes = await group.dangerouslyAddMembers(auth, {
+      users: [user.toJSON()],
+      allowProvisionedGroups: true,
+    });
+    if (addRes.isErr()) {
+      throw addRes.error;
+    }
+
+    const response = await deleteMemberGroup(workspace, user.sId, group.sId);
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).error.type).toBe("group_not_found");
+  });
+
+  it("returns 403 for a user", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "user",
+    });
+    const group = await GroupFactory.regularManual(workspace, "Billing");
+
+    const response = await deleteMemberGroup(workspace, user.sId, group.sId);
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/front-api/routes/w/[wId]/members/[uId]/groups.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/groups.ts
@@ -1,0 +1,132 @@
+import type { GroupMembershipError } from "@app/lib/api/groups/members";
+import {
+  getMemberGroups,
+  updateMemberGroupMembership,
+} from "@app/lib/api/groups/members";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import type {
+  DeleteMemberGroupResponseBody,
+  GetMemberGroupsResponseBody,
+  PostMemberGroupResponseBody,
+} from "@app/types/api/groups/manage";
+import { PostMemberGroupBodySchema } from "@app/types/api/groups/manage";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsManager } from "@front-api/middlewares/ensure_role";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  uId: z.string(),
+});
+
+const GroupParamsSchema = z.object({
+  uId: z.string(),
+  groupId: z.string(),
+});
+
+function toApiError(
+  err: GroupMembershipError
+): APIErrorWithContentfulStatusCode {
+  switch (err.type) {
+    case "unauthorized":
+      return {
+        status_code: 403,
+        api_error: { type: "workspace_auth_error", message: err.message },
+      };
+    case "user_not_found":
+      return {
+        status_code: 404,
+        api_error: { type: "workspace_user_not_found", message: err.message },
+      };
+    case "group_not_found":
+      return {
+        status_code: 404,
+        api_error: { type: "group_not_found", message: err.message },
+      };
+    case "group_requirements_not_met":
+    case "invalid_group_id":
+    case "system_or_global_group":
+    case "user_already_member":
+    case "user_not_member":
+      return {
+        status_code: 400,
+        api_error: { type: "invalid_request_error", message: err.message },
+      };
+    default:
+      assertNever(err.type);
+  }
+}
+
+// Mounted at /api/w/:wId/members/:uId/groups.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsManager(),
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetMemberGroupsResponseBody> => {
+    const auth = ctx.get("auth");
+    const { uId } = ctx.req.valid("param");
+
+    const res = await getMemberGroups(auth, { userId: uId });
+    if (res.isErr()) {
+      return apiError(ctx, toApiError(res.error));
+    }
+
+    return ctx.json({
+      groups: await GroupResource.toJSONWithMemberCounts(auth, res.value),
+    });
+  }
+);
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  ensureIsManager(),
+  validate("param", ParamsSchema),
+  validate("json", PostMemberGroupBodySchema),
+  async (ctx): HandlerResult<PostMemberGroupResponseBody> => {
+    const auth = ctx.get("auth");
+    const { uId } = ctx.req.valid("param");
+    const { groupId } = ctx.req.valid("json");
+
+    const res = await updateMemberGroupMembership(auth, {
+      groupId,
+      userId: uId,
+      direction: "add",
+    });
+    if (res.isErr()) {
+      return apiError(ctx, toApiError(res.error));
+    }
+
+    return ctx.json({ group: await res.value.toJSONWithMemberCount(auth) });
+  }
+);
+
+/** @ignoreswagger */
+app.delete(
+  "/:groupId",
+  ensureIsManager(),
+  validate("param", GroupParamsSchema),
+  async (ctx): HandlerResult<DeleteMemberGroupResponseBody> => {
+    const auth = ctx.get("auth");
+    const { uId, groupId } = ctx.req.valid("param");
+
+    const res = await updateMemberGroupMembership(auth, {
+      groupId,
+      userId: uId,
+      direction: "remove",
+    });
+    if (res.isErr()) {
+      return apiError(ctx, toApiError(res.error));
+    }
+
+    return ctx.json({ success: true });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/members/[uId]/index.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/index.ts
@@ -23,6 +23,7 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
+import groups from "./groups";
 import seatType from "./seat-type";
 import spendLimit from "./spend_limit";
 
@@ -38,6 +39,7 @@ const ParamsSchema = z.object({
 // Mounted at /api/w/:wId/members/:uId.
 const app = workspaceApp();
 
+app.route("/groups", groups);
 app.route("/seat-type", seatType);
 app.route("/spend_limit", spendLimit);
 

--- a/front/lib/api/groups/members.ts
+++ b/front/lib/api/groups/members.ts
@@ -1,0 +1,112 @@
+import { emitGroupMemberAuditLogs } from "@app/lib/api/groups/audit";
+import { getUserForWorkspace } from "@app/lib/api/user";
+import type { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+type GroupMembershipErrorType =
+  | "group_not_found"
+  | "group_requirements_not_met"
+  | "invalid_group_id"
+  | "system_or_global_group"
+  | "unauthorized"
+  | "user_already_member"
+  | "user_not_found"
+  | "user_not_member";
+
+export class GroupMembershipError extends Error {
+  constructor(
+    readonly type: GroupMembershipErrorType,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Groups (provisioned and manually-managed) a workspace member belongs to.
+ */
+export async function getMemberGroups(
+  auth: Authenticator,
+  { userId }: { userId: string }
+): Promise<Result<GroupResource[], GroupMembershipError>> {
+  const user = await getUserForWorkspace(auth, { userId });
+  if (!user) {
+    return new Err(
+      new GroupMembershipError(
+        "user_not_found",
+        "The user requested was not found."
+      )
+    );
+  }
+
+  const groups = await GroupResource.listUserGroupsInWorkspace({
+    user,
+    workspace: auth.getNonNullableWorkspace(),
+    groupKinds: [...MANAGEABLE_GROUP_KINDS],
+  });
+
+  return new Ok(groups);
+}
+
+/**
+ * Adds or removes a single workspace member from a manually-managed group, and audit-logs the
+ * change. Returns the updated group.
+ */
+export async function updateMemberGroupMembership(
+  auth: Authenticator,
+  {
+    groupId,
+    userId,
+    direction,
+  }: { groupId: string; userId: string; direction: "add" | "remove" }
+): Promise<Result<GroupResource, GroupMembershipError>> {
+  const user = await getUserForWorkspace(auth, { userId });
+  if (!user) {
+    return new Err(
+      new GroupMembershipError(
+        "user_not_found",
+        "The user requested was not found."
+      )
+    );
+  }
+
+  const groupRes = await GroupResource.fetchById(auth, groupId);
+  if (groupRes.isErr()) {
+    switch (groupRes.error.code) {
+      case "invalid_id":
+        return new Err(
+          new GroupMembershipError("invalid_group_id", groupRes.error.message)
+        );
+      case "unauthorized":
+        return new Err(
+          new GroupMembershipError("unauthorized", groupRes.error.message)
+        );
+      case "group_not_found":
+        return new Err(
+          new GroupMembershipError("group_not_found", groupRes.error.message)
+        );
+      default:
+        assertNever(groupRes.error.code);
+    }
+  }
+
+  const group = groupRes.value;
+
+  const updateRes = await group.updateRegularManualGroupMembers(auth, {
+    addUserIds: direction === "add" ? [user.sId] : [],
+    removeUserIds: direction === "remove" ? [user.sId] : [],
+  });
+  if (updateRes.isErr()) {
+    return new Err(
+      new GroupMembershipError(updateRes.error.code, updateRes.error.message)
+    );
+  }
+
+  emitGroupMemberAuditLogs(auth, group, updateRes.value);
+
+  return new Ok(group);
+}

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2315,6 +2315,86 @@ export class GroupResource extends BaseResource<GroupModel> {
     return new Ok({ addedUsers: [], removedUsers: [] });
   }
 
+  /**
+   * Adds and/or removes members of a manually-managed group, leaving the other members untouched.
+   */
+  async updateRegularManualGroupMembers(
+    auth: Authenticator,
+    {
+      addUserIds,
+      removeUserIds,
+    }: { addUserIds: string[]; removeUserIds: string[] }
+  ): Promise<
+    Result<
+      { addedUsers: UserType[]; removedUsers: UserType[] },
+      DustError<
+        | "unauthorized"
+        | "group_not_found"
+        | "user_not_found"
+        | "user_not_member"
+        | "user_already_member"
+        | "group_requirements_not_met"
+        | "system_or_global_group"
+      >
+    >
+  > {
+    if (!auth.isManager()) {
+      return new Err(
+        new DustError(
+          "unauthorized",
+          `Only workspace admins and ${MANAGER_ROLE_NAME}s can update groups.`
+        )
+      );
+    }
+
+    if (!this.isRegularManual()) {
+      return new Err(new DustError("group_not_found", "Group not found."));
+    }
+
+    // Both sides are fetched at once, then split back by id.
+    const uniqueAddUserIds = [...new Set(addUserIds)];
+    const uniqueRemoveUserIds = [...new Set(removeUserIds)];
+    const users = await UserResource.fetchByIds([
+      ...new Set([...uniqueAddUserIds, ...uniqueRemoveUserIds]),
+    ]);
+    const usersById = new Map(users.map((u) => [u.sId, u.toJSON()]));
+
+    const addedUsers = removeNulls(
+      uniqueAddUserIds.map((userId) => usersById.get(userId))
+    );
+    const removedUsers = removeNulls(
+      uniqueRemoveUserIds.map((userId) => usersById.get(userId))
+    );
+    if (
+      addedUsers.length !== uniqueAddUserIds.length ||
+      removedUsers.length !== uniqueRemoveUserIds.length
+    ) {
+      return new Err(
+        new DustError("user_not_found", "Some users were not found.")
+      );
+    }
+
+    if (addedUsers.length > 0) {
+      const addRes = await this.dangerouslyAddMembers(auth, {
+        users: addedUsers,
+      });
+      if (addRes.isErr()) {
+        return addRes;
+      }
+    }
+
+    if (removedUsers.length > 0) {
+      const removeRes = await this.dangerouslyRemoveMembers(auth, {
+        users: removedUsers,
+      });
+      if (removeRes.isErr()) {
+        return removeRes;
+      }
+    }
+
+    return new Ok({ addedUsers, removedUsers });
+  }
+
   async deleteRegularManualGroup(
     auth: Authenticator
   ): Promise<
@@ -2843,5 +2923,24 @@ export class GroupResource extends BaseResource<GroupModel> {
       memberCount,
       poolCapAwuCredits: this.poolCapAwuCredits,
     };
+  }
+
+  /**
+   * Batched counterpart of `toJSONWithMemberCount`: resolves the member counts of all the groups in
+   * a single query instead of one per group.
+   */
+  static async toJSONWithMemberCounts(
+    auth: Authenticator,
+    groups: GroupResource[]
+  ): Promise<GroupType[]> {
+    const memberCounts = await GroupResource.getMemberCountsForGroups(
+      auth,
+      groups
+    );
+
+    return groups.map((group) => ({
+      ...group.toJSON(),
+      memberCount: memberCounts.get(group.id) ?? 0,
+    }));
   }
 }

--- a/front/types/api/groups/manage.ts
+++ b/front/types/api/groups/manage.ts
@@ -29,3 +29,19 @@ export type PatchGroupResponseBody = {
 export type DeleteGroupResponseBody = {
   success: true;
 };
+
+export type GetMemberGroupsResponseBody = {
+  groups: GroupType[];
+};
+
+export const PostMemberGroupBodySchema = z.object({
+  groupId: z.string(),
+});
+
+export type PostMemberGroupResponseBody = {
+  group: GroupType;
+};
+
+export type DeleteMemberGroupResponseBody = {
+  success: true;
+};


### PR DESCRIPTION
## Description

Backend part of https://github.com/dust-tt/tasks/issues/9848

Add A new endpoint with GET/DELETE/POST at `/api/w/:wId/members/:uId/groups/:groupId`

Add a new method in the group resource to add/remove member from a manual group.


## Tests

unit tests added 

## Risk

low

## Deploy Plan

deploy front
