### PR TITLE
Add the Pod function poller principal, work channel, and claim

### DIFF
--- a/front-api/middlewares/ctx.ts
+++ b/front-api/middlewares/ctx.ts
@@ -5,6 +5,7 @@ import type { PokeRole } from "@app/lib/poke/roles";
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { createHono } from "@front-api/lib/hono";
@@ -52,6 +53,9 @@ export type SandboxCtx = {
   Variables: {
     auth: Authenticator;
     sandboxClaims: SandboxTokenPayload;
+    // Only set for poller tokens, whose verification has to resolve the sandbox anyway to check
+    // the token still matches it. Every other sandbox route reads undefined here.
+    sandbox?: SandboxResource;
   };
 };
 

--- a/front-api/middlewares/sandbox_auth.ts
+++ b/front-api/middlewares/sandbox_auth.ts
@@ -2,6 +2,7 @@ import type { SandboxTokenPayload } from "@app/lib/api/sandbox/access_tokens";
 import {
   isSandboxExecTokenPayload,
   isSandboxFunctionInvocationTokenPayload,
+  isSandboxPollerTokenPayload,
   verifySandboxExecToken,
 } from "@app/lib/api/sandbox/access_tokens";
 import {
@@ -9,6 +10,7 @@ import {
   getAuthTokenKind,
   getFeatureFlags,
 } from "@app/lib/auth";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { getClientIp } from "@app/lib/utils/request";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import type { SandboxCtx } from "@front-api/middlewares/ctx";
@@ -17,7 +19,7 @@ import { createMiddleware } from "hono/factory";
 
 import { apiError } from "./utils";
 
-type SandboxTokenKind = "action" | "function_invocation";
+type SandboxTokenKind = "action" | "function_invocation" | "poller";
 type SandboxAuthOptions = {
   allowedTokenKinds: SandboxTokenKind[];
 };
@@ -30,6 +32,9 @@ function getSandboxTokenKind(
   }
   if (isSandboxFunctionInvocationTokenPayload(claims)) {
     return "function_invocation";
+  }
+  if (isSandboxPollerTokenPayload(claims)) {
+    return "poller";
   }
   return null;
 }
@@ -124,6 +129,25 @@ export function sandboxAuth({
           },
         });
       }
+    }
+
+    // A poller token is bound to the sandbox incarnation it was minted for. Destroying a sandbox
+    // revokes its tokens, but only on a fire-and-forget path, so this is what actually stops a
+    // token that outlived its sandbox from authenticating against the one that replaced it.
+    if (isSandboxPollerTokenPayload(claims)) {
+      const sandbox = await SandboxResource.fetchById(auth, claims.sbId);
+      if (!sandbox || sandbox.providerId !== claims.providerId) {
+        return apiError(ctx, {
+          status_code: 401,
+          api_error: {
+            type: "invalid_sandbox_token_error",
+            message: "The sandbox token no longer matches its sandbox.",
+          },
+        });
+      }
+      // Handed to the route rather than looked up again: this fetch already proved the sandbox
+      // exists and matches the token.
+      ctx.set("sandbox", sandbox);
     }
 
     const ip = getClientIp({ headers: readHeaders(ctx) });

--- a/front-api/routes/sse/index.ts
+++ b/front-api/routes/sse/index.ts
@@ -1,6 +1,7 @@
 import { unauthedApp } from "@front-api/middlewares/ctx";
 
 import v1WorkspaceSseApp from "./v1/w/[wId]";
+import v1WorkspaceSandboxSseApp from "./v1/w/[wId]/sandbox";
 import workspaceSseApp from "./w/[wId]";
 
 // Mounted at /api/sse. SSE routes mirror the non-SSE tree (`/api/w/:wId/...`
@@ -10,6 +11,9 @@ import workspaceSseApp from "./w/[wId]";
 // it stays unauthed.
 const app = unauthedApp();
 
+// Sandbox is mounted before the workspace app so it does not inherit publicApiAuth — it uses
+// `sandboxAuth`, which accepts only sandbox tokens. Mirrors `routes/v1/index.ts`.
+app.route("/v1/w/:wId/sandbox", v1WorkspaceSandboxSseApp);
 app.route("/v1/w/:wId", v1WorkspaceSseApp);
 app.route("/w/:wId", workspaceSseApp);
 

--- a/front-api/routes/sse/v1/w/[wId]/sandbox/index.ts
+++ b/front-api/routes/sse/v1/w/[wId]/sandbox/index.ts
@@ -1,0 +1,12 @@
+import { sandboxApp } from "@front-api/middlewares/ctx";
+
+import poller from "./poller";
+
+// Mounted at /api/sse/v1/w/:wId/sandbox. Mirrors /api/v1/w/:wId/sandbox: mounted before the
+// workspace SSE app so it does not inherit publicApiAuth, and left unauthenticated here so each
+// child mounts `sandboxAuth` with the token kind it accepts.
+const app = sandboxApp();
+
+app.route("/poller", poller);
+
+export default app;

--- a/front-api/routes/sse/v1/w/[wId]/sandbox/poller/index.ts
+++ b/front-api/routes/sse/v1/w/[wId]/sandbox/poller/index.ts
@@ -1,0 +1,16 @@
+import { sandboxApp } from "@front-api/middlewares/ctx";
+import { sandboxAuth } from "@front-api/middlewares/sandbox_auth";
+import { streamingTag } from "@front-api/middlewares/streaming";
+
+import work from "./work";
+
+// Mounted at /api/sse/v1/w/:wId/sandbox/poller. Only the pod's poller principal reaches this: a
+// workload's invocation token is a different token kind and is refused here.
+const app = sandboxApp();
+
+app.use("*", sandboxAuth({ allowedTokenKinds: ["poller"] }));
+app.use("*", streamingTag);
+
+app.route("/work", work);
+
+export default app;

--- a/front-api/routes/sse/v1/w/[wId]/sandbox/poller/work.test.ts
+++ b/front-api/routes/sse/v1/w/[wId]/sandbox/poller/work.test.ts
@@ -1,0 +1,141 @@
+import {
+  SANDBOX_TOKEN_PREFIX,
+  verifySandboxExecToken,
+} from "@app/lib/api/sandbox/access_tokens";
+import { isPollerChannelOpen } from "@app/lib/api/sandbox_functions/poller_channel";
+import {
+  createSandboxFunctionInvocationTokenTestContext,
+  createSandboxPollerTokenTestContext,
+} from "@app/tests/utils/SandboxTokenFactory";
+import type { SandboxFunctionPollerEvent } from "@app/types/api/sandbox_functions";
+import { honoApp } from "@front-api/app";
+import { parseSseDataPayloads } from "@front-api/tests/utils/sse";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(
+  "@app/lib/api/sandbox_functions/poller_channel",
+  async (importOriginal) => {
+    const mod =
+      await importOriginal<
+        typeof import("@app/lib/api/sandbox_functions/poller_channel")
+      >();
+    return {
+      ...mod,
+      openPollerChannel: vi.fn(),
+    };
+  }
+);
+
+import { openPollerChannel } from "@app/lib/api/sandbox_functions/poller_channel";
+
+function getPollerWork(workspace: { sId: string }, token: string) {
+  return honoApp.request(`/api/sse/v1/w/${workspace.sId}/sandbox/poller/work`, {
+    method: "GET",
+    headers: { authorization: `Bearer ${token}` },
+  });
+}
+
+describe("GET /api/sse/v1/w/[wId]/sandbox/poller/work", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The channel's own behavior is covered where it lives; here it stands in so the route's
+    // wiring, auth and rotation can be asserted without holding a stream open for a minute.
+    vi.mocked(openPollerChannel).mockImplementation(async function* ({
+      rotatedToken,
+    }) {
+      yield {
+        eventId: "",
+        data: {
+          type: "sandbox_function_poller_token",
+          created: 0,
+          token: rotatedToken,
+        },
+      };
+    });
+  });
+
+  it("streams the channel and hands the poller a rotated token", async () => {
+    const { workspace, sandbox, token } =
+      await createSandboxPollerTokenTestContext();
+
+    const res = await getPollerWork(workspace, token);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+
+    // Every streaming route emits the `{ eventId, data }` envelope, so the poller resumes from an
+    // event id the same way every other client does.
+    const payloads = parseSseDataPayloads(await res.text());
+    const events: SandboxFunctionPollerEvent[] = payloads.map(
+      (payload) => JSON.parse(payload).data
+    );
+    expect(events[0]?.type).toBe("sandbox_function_poller_token");
+
+    expect(openPollerChannel).toHaveBeenCalledWith(
+      expect.objectContaining({ sandboxId: sandbox.sId, lastEventId: null })
+    );
+    // Rotation is the point: the token handed down must not be the one used to connect.
+    const rotatedToken =
+      events[0]?.type === "sandbox_function_poller_token"
+        ? events[0].token
+        : null;
+    expect(rotatedToken).toEqual(expect.stringContaining(SANDBOX_TOKEN_PREFIX));
+    expect(rotatedToken).not.toBe(token);
+  });
+
+  it("revokes the token that was used to connect", async () => {
+    const { workspace, token } = await createSandboxPollerTokenTestContext();
+
+    expect(await verifySandboxExecToken(token)).not.toBeNull();
+
+    const res = await getPollerWork(workspace, token);
+    await res.text();
+
+    // Without this, rotation buys nothing: a leaked poller token would mint its own successor
+    // every minute and stay good for the life of the sandbox.
+    expect(await verifySandboxExecToken(token)).toBeNull();
+  });
+
+  it("resumes from the poller's last event id", async () => {
+    const { workspace, token } = await createSandboxPollerTokenTestContext();
+
+    const res = await honoApp.request(
+      `/api/sse/v1/w/${workspace.sId}/sandbox/poller/work?lastEventId=12-0`,
+      { method: "GET", headers: { authorization: `Bearer ${token}` } }
+    );
+
+    expect(res.status).toBe(200);
+    await res.text();
+    expect(openPollerChannel).toHaveBeenCalledWith(
+      expect.objectContaining({ lastEventId: "12-0" })
+    );
+  });
+
+  it("rejects a function invocation token", async () => {
+    const { workspace, token } =
+      await createSandboxFunctionInvocationTokenTestContext();
+
+    const res = await getPollerWork(workspace, token);
+
+    expect(res.status).toBe(403);
+    expect(openPollerChannel).not.toHaveBeenCalled();
+  });
+
+  it("rejects a request without a token", async () => {
+    const { workspace } = await createSandboxPollerTokenTestContext();
+
+    const res = await honoApp.request(
+      `/api/sse/v1/w/${workspace.sId}/sandbox/poller/work`,
+      { method: "GET" }
+    );
+
+    expect(res.status).toBe(401);
+    expect(openPollerChannel).not.toHaveBeenCalled();
+  });
+
+  it("leaves the pod unreachable when nothing is connected", async () => {
+    const { sandbox } = await createSandboxPollerTokenTestContext();
+
+    expect(await isPollerChannelOpen({ sandboxId: sandbox.sId })).toBe(false);
+  });
+});

--- a/front-api/routes/sse/v1/w/[wId]/sandbox/poller/work.ts
+++ b/front-api/routes/sse/v1/w/[wId]/sandbox/poller/work.ts
@@ -1,0 +1,63 @@
+import {
+  generateSandboxPollerToken,
+  isSandboxPollerTokenPayload,
+} from "@app/lib/api/sandbox/access_tokens";
+import { openPollerChannel } from "@app/lib/api/sandbox_functions/poller_channel";
+import {
+  SseQuerySchema,
+  streamEvents,
+} from "@front-api/lib/api/sse/stream_events";
+import { sandboxApp } from "@front-api/middlewares/ctx";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+
+// Mounted at /api/sse/v1/w/:wId/sandbox/poller/work. sandboxAuth is applied by the parent poller
+// sub-app, so ctx.get("sandboxClaims") is always a poller token here and ctx.get("sandbox") is the
+// sandbox it was minted for.
+const app = sandboxApp();
+
+/**
+ * @ignoreswagger
+ * internal endpoint
+ */
+app.get("/", validate("query", SseQuerySchema), async (ctx) => {
+  const auth = ctx.get("auth");
+  const sandboxClaims = ctx.get("sandboxClaims");
+  const sandbox = ctx.get("sandbox");
+  const { lastEventId } = ctx.req.valid("query");
+
+  if (!isSandboxPollerTokenPayload(sandboxClaims) || !sandbox) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "invalid_request_error",
+        message: "This endpoint requires a Pod function poller token.",
+      },
+    });
+  }
+
+
+  // Minted before the stream opens so a failure here is a plain error response rather than a
+  // stream the poller has already committed to. Connecting is what revokes the token used to
+  // connect, so a poller must persist the rotated token it receives first on the stream.
+  const rotatedToken = await generateSandboxPollerToken(auth, {
+    sandbox,
+    supersedes: sandboxClaims,
+  });
+
+  return streamEvents({
+    ctx,
+    iterator: (signal) =>
+      openPollerChannel({
+        sandboxId: sandbox.sId,
+        rotatedToken,
+        lastEventId,
+        signal,
+      }),
+    // The hybrid manager signals a truncated history replay by closing the stream, and every
+    // streaming route pairs that with the sentinel so the client reconnects to drain the rest.
+    writeDoneSentinel: true,
+  });
+});
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/sandbox/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/index.ts
@@ -1,6 +1,7 @@
 import { sandboxApp } from "@front-api/middlewares/ctx";
 
 import actions from "./actions";
+import poller from "./poller";
 import sandboxFunctions from "./sandbox-functions";
 
 // Mounted at /api/v1/w/:wId/sandbox. This sub-tree is mounted before
@@ -10,6 +11,7 @@ import sandboxFunctions from "./sandbox-functions";
 const app = sandboxApp();
 
 app.route("/actions", actions);
+app.route("/poller", poller);
 app.route("/sandbox-functions", sandboxFunctions);
 
 export default app;

--- a/front-api/routes/v1/w/[wId]/sandbox/poller/claim.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/poller/claim.test.ts
@@ -1,0 +1,120 @@
+import { publishPollerJob } from "@app/lib/api/sandbox_functions/poller_channel";
+import {
+  createSandboxFunctionInvocationTokenTestContext,
+  createSandboxPollerTokenTestContext,
+  createSandboxTokenTestContext,
+} from "@app/tests/utils/SandboxTokenFactory";
+import type { SandboxFunctionPollerJob } from "@app/types/api/sandbox_functions";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function makeJob(invocationId: string): SandboxFunctionPollerJob {
+  return {
+    invocationId,
+    functionId: "sfn_test",
+    slug: "get-state",
+    execToken: "sbt-job",
+    inputEnvelope: JSON.stringify({ method: "POST" }),
+    envVars: { DUST_API_URL: "https://dust.example" },
+    timeoutMs: 10_000,
+  };
+}
+
+function postPollerClaim(
+  workspace: { sId: string },
+  token: string,
+  body: unknown
+) {
+  return honoApp.request(`/api/v1/w/${workspace.sId}/sandbox/poller/claim`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/v1/w/[wId]/sandbox/poller/claim", () => {
+  it("hands the job to the first poller to claim it", async () => {
+    const { workspace, sandbox, token } =
+      await createSandboxPollerTokenTestContext();
+    await publishPollerJob(makeJob("sfi_claim_1"), { sandboxId: sandbox.sId });
+
+    const first = await postPollerClaim(workspace, token, {
+      invocationId: "sfi_claim_1",
+    });
+    expect(first.status).toBe(200);
+    expect(await first.json()).toEqual({
+      granted: true,
+      job: makeJob("sfi_claim_1"),
+    });
+
+    const second = await postPollerClaim(workspace, token, {
+      invocationId: "sfi_claim_1",
+    });
+    expect(second.status).toBe(200);
+    expect(await second.json()).toEqual({ granted: false });
+  });
+
+  it("refuses an invocation dispatched to another pod", async () => {
+    const { workspace, token } = await createSandboxPollerTokenTestContext();
+    await publishPollerJob(makeJob("sfi_claim_other"), {
+      sandboxId: "sbx_someone_else",
+    });
+
+    const res = await postPollerClaim(workspace, token, {
+      invocationId: "sfi_claim_other",
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ granted: false });
+  });
+
+  it("refuses an invocation that was never dispatched", async () => {
+    const { workspace, token } = await createSandboxPollerTokenTestContext();
+
+    const res = await postPollerClaim(workspace, token, {
+      invocationId: "sfi_never_dispatched",
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ granted: false });
+  });
+
+  it("rejects a function invocation token", async () => {
+    const { workspace, token } =
+      await createSandboxFunctionInvocationTokenTestContext();
+
+    const res = await postPollerClaim(workspace, token, {
+      invocationId: "sfi_claim_2",
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects an agent action token", async () => {
+    const { workspace, token } = await createSandboxTokenTestContext();
+
+    const res = await postPollerClaim(workspace, token, {
+      invocationId: "sfi_claim_3",
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects a request without a token", async () => {
+    const { workspace } = await createSandboxPollerTokenTestContext();
+
+    const res = await honoApp.request(
+      `/api/v1/w/${workspace.sId}/sandbox/poller/claim`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ invocationId: "sfi_claim_4" }),
+      }
+    );
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/front-api/routes/v1/w/[wId]/sandbox/poller/claim.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/poller/claim.ts
@@ -1,0 +1,59 @@
+import { isSandboxPollerTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import { claimPollerJob } from "@app/lib/api/sandbox_functions/poller_channel";
+import type { SandboxFunctionPollerJob } from "@app/types/api/sandbox_functions";
+import { sandboxApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const PostPollerClaimRequestBodySchema = z
+  .object({
+    invocationId: z.string().min(1),
+  })
+  .strict();
+
+// The job only comes back to the claim winner. Publishing it on the work channel instead would
+// leave the invocation's credential and the caller's input sitting in a replayable stream.
+type PostPollerClaimResponseBody =
+  | { granted: true; job: SandboxFunctionPollerJob }
+  | { granted: false };
+
+// Mounted at /api/v1/w/:wId/sandbox/poller/claim. sandboxAuth is applied by the parent poller
+// sub-app, so ctx.get("sandboxClaims") is always a poller token here.
+const app = sandboxApp();
+
+/**
+ * @ignoreswagger
+ * internal endpoint
+ */
+app.post(
+  "/",
+  validate("json", PostPollerClaimRequestBodySchema),
+  async (ctx): HandlerResult<PostPollerClaimResponseBody> => {
+    const sandboxClaims = ctx.get("sandboxClaims");
+    const { invocationId } = ctx.req.valid("json");
+
+    if (!isSandboxPollerTokenPayload(sandboxClaims)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "This endpoint requires a Pod function poller token.",
+        },
+      });
+    }
+
+    const job = await claimPollerJob({
+      invocationId,
+      sandboxId: sandboxClaims.sbId,
+    });
+    if (!job) {
+      return ctx.json({ granted: false });
+    }
+
+    return ctx.json({ granted: true, job });
+  }
+);
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/sandbox/poller/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/poller/index.ts
@@ -1,0 +1,15 @@
+import { sandboxApp } from "@front-api/middlewares/ctx";
+import { sandboxAuth } from "@front-api/middlewares/sandbox_auth";
+
+import claim from "./claim";
+
+// Mounted at /api/v1/w/:wId/sandbox/poller. Only the pod's poller principal reaches these: a
+// workload's invocation token is a different token kind and is refused here, and the poller token
+// is refused everywhere else.
+const app = sandboxApp();
+
+app.use("*", sandboxAuth({ allowedTokenKinds: ["poller"] }));
+
+app.route("/claim", claim);
+
+export default app;

--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -66,6 +66,7 @@ export type RedisUsageTagsType =
   | "lock"
   | "sandbox_exec_tokens"
   | "sandbox_function_invocation_events"
+  | "sandbox_function_poller"
   | "mcp_client_side_request"
   | "mcp_client_side_results"
   | "mentions_count"

--- a/front/lib/api/sandbox/access_tokens.test.ts
+++ b/front/lib/api/sandbox/access_tokens.test.ts
@@ -1,8 +1,10 @@
 import {
   generateSandboxExecToken,
   generateSandboxFunctionInvocationToken,
+  generateSandboxPollerToken,
   isSandboxExecTokenPayload,
   isSandboxFunctionInvocationTokenPayload,
+  isSandboxPollerTokenPayload,
   SANDBOX_TOKEN_PREFIX,
   verifySandboxExecToken,
 } from "@app/lib/api/sandbox/access_tokens";
@@ -237,6 +239,172 @@ describe("sandbox access tokens", () => {
     expect(payload.spaceId).toBe(pod.sId);
     expect(payload.sandboxFunctionId).toBe("sfn_test");
     expect(payload.invocationId).toBe("test-invocation-id");
+  });
+
+  it("round-trip: generate poller token → verify → check claims", async () => {
+    const { auth, sandbox } = await setupTest();
+
+    const token = await generateSandboxPollerToken(auth, { sandbox });
+
+    expect(token.startsWith(SANDBOX_TOKEN_PREFIX)).toBe(true);
+
+    const payload = await verifySandboxExecToken(token);
+
+    expect(payload).not.toBeNull();
+    if (!payload || !isSandboxPollerTokenPayload(payload)) {
+      throw new Error("Expected a poller token payload.");
+    }
+    expect(payload.wId).toBe(auth.getNonNullableWorkspace().sId);
+    expect(payload.sbId).toBe(sandbox.sId);
+    expect(payload.providerId).toBe(sandbox.providerId);
+  });
+
+  it("a poller token is not an action or invocation token", async () => {
+    const { auth, sandbox } = await setupTest();
+
+    const payload = await verifySandboxExecToken(
+      await generateSandboxPollerToken(auth, { sandbox })
+    );
+
+    expect(payload).not.toBeNull();
+    if (!payload) {
+      throw new Error("Expected a poller token payload.");
+    }
+    // What keeps the poller's routes out of reach of a workload token, and the workload's routes
+    // out of reach of the poller's, is that no token satisfies two of these at once.
+    expect(isSandboxPollerTokenPayload(payload)).toBe(true);
+    expect(isSandboxExecTokenPayload(payload)).toBe(false);
+    expect(isSandboxFunctionInvocationTokenPayload(payload)).toBe(false);
+  });
+
+  it("an invocation token is not a poller token", async () => {
+    const { auth, sandbox } = await setupTest();
+    const pod = await SpaceFactory.project(auth.getNonNullableWorkspace());
+
+    const payload = await verifySandboxExecToken(
+      await generateSandboxFunctionInvocationToken(auth, {
+        noTools: false,
+        sandbox,
+        sandboxFunction: { sId: "sfn_test", space: { sId: pod.sId } },
+        invocationId: "test-invocation-id",
+        execId: "test-exec-id",
+      })
+    );
+
+    expect(payload).not.toBeNull();
+    if (!payload) {
+      throw new Error("Expected an invocation token payload.");
+    }
+    expect(isSandboxPollerTokenPayload(payload)).toBe(false);
+  });
+
+  it("rejects a token that claims to be both a poller and an invocation", async () => {
+    const { auth, sandbox } = await setupTest();
+    const pod = await SpaceFactory.project(auth.getNonNullableWorkspace());
+
+    // A forged payload: signed with the real secret, but mixing the poller's claims into a
+    // workload token to reach the poller's routes.
+    const forged = jwt.sign(
+      {
+        wId: auth.getNonNullableWorkspace().sId,
+        sbId: sandbox.sId,
+        execId: "test-exec-id",
+        spaceId: pod.sId,
+        sandboxFunctionId: "sfn_test",
+        invocationId: "test-invocation-id",
+        purpose: "sandbox_function_poller",
+        providerId: sandbox.providerId,
+      },
+      TEST_SECRET,
+      { algorithm: "HS256", expiresIn: 120 }
+    );
+
+    expect(
+      await verifySandboxExecToken(`${SANDBOX_TOKEN_PREFIX}${forged}`)
+    ).toBeNull();
+  });
+
+  it("rejects a poller token naming a user", async () => {
+    const { auth, sandbox } = await setupTest();
+
+    // The authenticator resolves `uId` and adopts that user's role, so a poller token naming an
+    // admin would authenticate as one. The poller is a pod process and must not speak for a
+    // person.
+    const forged = jwt.sign(
+      {
+        wId: auth.getNonNullableWorkspace().sId,
+        sbId: sandbox.sId,
+        execId: "test-exec-id",
+        purpose: "sandbox_function_poller",
+        providerId: sandbox.providerId,
+        uId: auth.getNonNullableUser().sId,
+      },
+      TEST_SECRET,
+      { algorithm: "HS256", expiresIn: 120 }
+    );
+
+    expect(
+      await verifySandboxExecToken(`${SANDBOX_TOKEN_PREFIX}${forged}`)
+    ).toBeNull();
+  });
+
+  it("rejects a poller token that grants itself tools", async () => {
+    const { auth, sandbox } = await setupTest();
+
+    const forged = jwt.sign(
+      {
+        wId: auth.getNonNullableWorkspace().sId,
+        sbId: sandbox.sId,
+        execId: "test-exec-id",
+        purpose: "sandbox_function_poller",
+        providerId: sandbox.providerId,
+        cId: "conv_test",
+      },
+      TEST_SECRET,
+      { algorithm: "HS256", expiresIn: 120 }
+    );
+
+    expect(
+      await verifySandboxExecToken(`${SANDBOX_TOKEN_PREFIX}${forged}`)
+    ).toBeNull();
+  });
+
+  it("revokes the superseded token when rotating", async () => {
+    const { auth, sandbox } = await setupTest();
+
+    const first = await generateSandboxPollerToken(auth, { sandbox });
+    const firstPayload = await verifySandboxExecToken(first);
+    expect(firstPayload).not.toBeNull();
+    if (!firstPayload) {
+      throw new Error("Expected a poller token payload.");
+    }
+
+    const second = await generateSandboxPollerToken(auth, {
+      sandbox,
+      supersedes: firstPayload,
+    });
+
+    expect(await verifySandboxExecToken(second)).not.toBeNull();
+    expect(await verifySandboxExecToken(first)).toBeNull();
+  });
+
+  it("rejects a poller token that omits its sandbox binding", async () => {
+    const { auth, sandbox } = await setupTest();
+
+    const forged = jwt.sign(
+      {
+        wId: auth.getNonNullableWorkspace().sId,
+        sbId: sandbox.sId,
+        execId: "test-exec-id",
+        purpose: "sandbox_function_poller",
+      },
+      TEST_SECRET,
+      { algorithm: "HS256", expiresIn: 120 }
+    );
+
+    expect(
+      await verifySandboxExecToken(`${SANDBOX_TOKEN_PREFIX}${forged}`)
+    ).toBeNull();
   });
 
   it("tampered token is rejected", async () => {

--- a/front/lib/api/sandbox/access_tokens.ts
+++ b/front/lib/api/sandbox/access_tokens.ts
@@ -40,6 +40,16 @@ const SandboxTokenPayloadSchema = z
     // call can wait on the user for as long as they take, which a fast invocation has no way to
     // survive, so the token it runs under cannot make one.
     noTools: z.literal(true).optional(),
+    // Set only on the token a pod's Pod function poller authenticates with. The poller is a
+    // privileged process that receives work for the whole sandbox, so its token is a different
+    // principal from the ones workloads hold, not a workload token with extra claims: it names no
+    // invocation and grants no tool access, and the routes it may call accept nothing else.
+    purpose: z.literal("sandbox_function_poller").optional(),
+    // The sandbox incarnation the poller token was minted for. Destroying a sandbox revokes its
+    // tokens, but that revocation is fire-and-forget, so binding the token to the provider id
+    // makes a token that outlived its sandbox fail verification rather than authenticate a poller
+    // against the sandbox that replaced it.
+    providerId: z.string().optional(),
   })
   .superRefine((payload, ctx) => {
     const actionClaims = [payload.aId, payload.mId, payload.actionId];
@@ -48,9 +58,11 @@ const SandboxTokenPayloadSchema = z
       payload.sandboxFunctionId,
       payload.invocationId,
     ];
+    const pollerClaims = [payload.purpose, payload.providerId];
     const hasAction =
       payload.cId !== undefined && actionClaims.every(isDefined);
     const hasInvocation = invocationClaims.every(isDefined);
+    const hasPoller = pollerClaims.every(isDefined);
 
     if (actionClaims.some(isDefined) && !hasAction) {
       ctx.addIssue({
@@ -64,11 +76,36 @@ const SandboxTokenPayloadSchema = z
         message: "Incomplete sandbox function invocation token claims.",
       });
     }
-    if (!hasAction && !hasInvocation) {
+    if (pollerClaims.some(isDefined) && !hasPoller) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Incomplete sandbox function poller token claims.",
+      });
+    }
+    // A poller token carries nothing but its own claims. Every field below belongs to a workload
+    // token, and `uId` is the one that bites: the authenticator resolves it and adopts that user's
+    // role, so a poller token naming an admin would authenticate as an admin. The poller is a pod
+    // process, not a person, and it must stay unable to speak for one.
+    const workloadClaims = [
+      ...actionClaims,
+      ...invocationClaims,
+      payload.cId,
+      payload.uId,
+      payload.aV,
+      payload.noTools,
+    ];
+    if (hasPoller && workloadClaims.some(isDefined)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message:
-          "Sandbox token payload must include action or function invocation claims.",
+          "A sandbox function poller token cannot carry workload claims.",
+      });
+    }
+    if (!hasAction && !hasInvocation && !hasPoller) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "Sandbox token payload must include action, function invocation, or poller claims.",
       });
     }
   });
@@ -87,6 +124,11 @@ export type SandboxFunctionInvocationTokenPayload = SandboxTokenPayload & {
   spaceId: string;
   sandboxFunctionId: string;
   invocationId: string;
+};
+
+export type SandboxPollerTokenPayload = SandboxTokenPayload & {
+  purpose: "sandbox_function_poller";
+  providerId: string;
 };
 
 export function isSandboxExecTokenPayload(
@@ -172,6 +214,15 @@ export function isSandboxFunctionInvocationTokenPayload(
   );
 }
 
+export function isSandboxPollerTokenPayload(
+  payload: SandboxTokenPayload
+): payload is SandboxPollerTokenPayload {
+  return (
+    payload.purpose === "sandbox_function_poller" &&
+    payload.providerId !== undefined
+  );
+}
+
 const EXEC_TOKEN_REDIS_TTL_SECONDS = 24 * 60 * 60; // 24 hours
 
 function sandboxTokenRedisKey(sbId: string, execId: string): string {
@@ -189,11 +240,12 @@ export function generateExecId(): string {
 }
 
 async function registerExecToken(
-  token: Pick<SandboxTokenPayload, "sbId" | "execId">
+  token: Pick<SandboxTokenPayload, "sbId" | "execId">,
+  { ttlSeconds = EXEC_TOKEN_REDIS_TTL_SECONDS }: { ttlSeconds?: number } = {}
 ): Promise<void> {
   await runOnRedis({ origin: REDIS_ORIGIN }, (client) =>
     client.set(sandboxTokenRedisKey(token.sbId, token.execId), "1", {
-      EX: EXEC_TOKEN_REDIS_TTL_SECONDS,
+      EX: ttlSeconds,
     })
   );
 }
@@ -312,6 +364,56 @@ export async function generateSandboxFunctionInvocationToken(
   };
 
   await registerExecToken(payload);
+
+  const secret = config.getSandboxJwtSecret();
+
+  const token = jwt.sign(payload, secret, {
+    algorithm: "HS256",
+    expiresIn: expiryMs / 1000, // expiresIn is in seconds
+  });
+
+  return `${SANDBOX_TOKEN_PREFIX}${token}`;
+}
+
+// The poller reconnects to its work channel about once a minute and gets a fresh token on every
+// connect, so this only has to outlive a run of failed reconnects. Kept short because the token
+// authenticates the pod's whole work channel rather than one invocation.
+export const SANDBOX_POLLER_TOKEN_EXPIRY_MS = 10 * 60 * 1000;
+
+export async function generateSandboxPollerToken(
+  auth: Authenticator,
+  {
+    sandbox,
+    supersedes,
+    expiryMs = SANDBOX_POLLER_TOKEN_EXPIRY_MS,
+  }: {
+    sandbox: SandboxResource;
+    // The token this one replaces, revoked once the replacement exists. Rotation only buys
+    // anything if the token being rotated out stops working: without this, a leaked poller token
+    // mints its own successor every minute and stays good for the life of the sandbox, which is
+    // days on a warm pod.
+    supersedes?: Pick<SandboxTokenPayload, "sbId" | "execId">;
+    expiryMs?: number;
+  }
+): Promise<string> {
+  const payload: SandboxPollerTokenPayload = {
+    wId: auth.getNonNullableWorkspace().sId,
+    sbId: sandbox.sId,
+    execId: generateExecId(),
+    purpose: "sandbox_function_poller",
+    providerId: sandbox.providerId,
+  };
+
+  // Registered for its own lifetime rather than the exec default of a day. A poller rotates every
+  // minute, so the default would leave ~1440 live credentials per sandbox per day, all of them
+  // usable and all of them to be scanned when the sandbox is destroyed.
+  await registerExecToken(payload, {
+    ttlSeconds: Math.ceil(expiryMs / 1000),
+  });
+
+  if (supersedes) {
+    await revokeExecToken(supersedes);
+  }
 
   const secret = config.getSandboxJwtSecret();
 

--- a/front/lib/api/sandbox_functions/poller_channel.test.ts
+++ b/front/lib/api/sandbox_functions/poller_channel.test.ts
@@ -1,0 +1,314 @@
+import type { EventPayload } from "@app/lib/api/redis-hybrid-manager";
+import type { SandboxFunctionPollerStreamEvent } from "@app/lib/api/sandbox_functions/poller_channel";
+import {
+  claimInvocationForExec,
+  claimPollerJob,
+  clearPollerChannelPresence,
+  isPollerChannelOpen,
+  openPollerChannel,
+  POLLER_MAX_JOB_TIMEOUT_MS,
+  publishPollerJob,
+  refreshPollerChannelPresence,
+} from "@app/lib/api/sandbox_functions/poller_channel";
+import type { SandboxFunctionPollerJob } from "@app/types/api/sandbox_functions";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// A stand-in for the hybrid manager's stream half: enough to exercise what the channel depends on,
+// which is that a subscriber resuming from an event id gets everything published after it.
+const publishedEvents: EventPayload[] = [];
+const subscribeCalls: {
+  lastEventId: string | null;
+  skipHistory: boolean;
+}[] = [];
+
+vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
+  getRedisHybridManager: () => ({
+    publish: async (_channel: string, payload: string) => {
+      const eventId = `${publishedEvents.length + 1}-0`;
+      publishedEvents.push({ id: eventId, message: { payload } });
+      return eventId;
+    },
+    subscribe: async (
+      _channel: string,
+      _callback: unknown,
+      _origin: string,
+      {
+        lastEventId = null,
+        skipHistory = false,
+      }: { lastEventId?: string | null; skipHistory?: boolean }
+    ) => {
+      subscribeCalls.push({ lastEventId, skipHistory });
+      if (skipHistory) {
+        return { history: [], unsubscribe: () => {} };
+      }
+      const startIndex =
+        lastEventId === null
+          ? 0
+          : publishedEvents.findIndex((event) => event.id === lastEventId) + 1;
+      return {
+        history: publishedEvents.slice(startIndex),
+        unsubscribe: () => {},
+      };
+    },
+  }),
+}));
+
+function makeJob(invocationId: string): SandboxFunctionPollerJob {
+  return {
+    invocationId,
+    functionId: "sfn_test",
+    slug: "get-state",
+    execToken: "sbt-job",
+    inputEnvelope: JSON.stringify({ method: "POST", body: "secret-input" }),
+    envVars: { DUST_API_URL: "https://dust.example" },
+    // The ceiling rather than a comfortable value: a fixture that always sits well inside the
+    // claim's lifetime is what would hide a claim that expires mid-run.
+    timeoutMs: POLLER_MAX_JOB_TIMEOUT_MS,
+  };
+}
+
+// A connect stays open for a minute waiting for live jobs, which no test wants to sit through:
+// stop as soon as the events the test is about have arrived.
+async function collectChannel({
+  sandboxId,
+  lastEventId,
+  expectedEvents,
+}: {
+  sandboxId: string;
+  lastEventId: string | null;
+  expectedEvents: number;
+}): Promise<SandboxFunctionPollerStreamEvent[]> {
+  const controller = new AbortController();
+  const events: SandboxFunctionPollerStreamEvent[] = [];
+  for await (const event of openPollerChannel({
+    sandboxId,
+    rotatedToken: "sbt-rotated",
+    lastEventId,
+    signal: controller.signal,
+  })) {
+    events.push(event);
+    if (events.length >= expectedEvents) {
+      controller.abort();
+      break;
+    }
+  }
+  return events;
+}
+
+describe("Pod function poller channel", () => {
+  beforeEach(() => {
+    publishedEvents.length = 0;
+    subscribeCalls.length = 0;
+  });
+
+  it("reports a pod as reachable only while its presence is held", async () => {
+    expect(await isPollerChannelOpen({ sandboxId: "sbx_1" })).toBe(false);
+
+    await refreshPollerChannelPresence({
+      sandboxId: "sbx_1",
+      connectId: "connect-1",
+    });
+    expect(await isPollerChannelOpen({ sandboxId: "sbx_1" })).toBe(true);
+
+    await clearPollerChannelPresence({
+      sandboxId: "sbx_1",
+      connectId: "connect-1",
+    });
+    expect(await isPollerChannelOpen({ sandboxId: "sbx_1" })).toBe(false);
+  });
+
+  it("keeps presence scoped to one sandbox", async () => {
+    await refreshPollerChannelPresence({
+      sandboxId: "sbx_1",
+      connectId: "connect-1",
+    });
+
+    expect(await isPollerChannelOpen({ sandboxId: "sbx_1" })).toBe(true);
+    expect(await isPollerChannelOpen({ sandboxId: "sbx_2" })).toBe(false);
+  });
+
+  it("does not let a closing connect clear the presence of the one that replaced it", async () => {
+    // The poller reconnects every minute, and nothing orders the old connect's cleanup against
+    // the new one's opening. If cleanup won, the pod would look unreachable while it is in fact
+    // listening, and its invocations would take the slow path for no reason.
+    await refreshPollerChannelPresence({
+      sandboxId: "sbx_1",
+      connectId: "connect-1",
+    });
+    await refreshPollerChannelPresence({
+      sandboxId: "sbx_1",
+      connectId: "connect-2",
+    });
+
+    await clearPollerChannelPresence({
+      sandboxId: "sbx_1",
+      connectId: "connect-1",
+    });
+
+    expect(await isPollerChannelOpen({ sandboxId: "sbx_1" })).toBe(true);
+  });
+
+  it("hands the job to exactly one claimer", async () => {
+    await publishPollerJob(makeJob("sfi_1"), { sandboxId: "sbx_1" });
+
+    const job = await claimPollerJob({
+      invocationId: "sfi_1",
+      sandboxId: "sbx_1",
+    });
+    expect(job).toMatchObject({ invocationId: "sfi_1", execToken: "sbt-job" });
+
+    // The exec fallback is locked out, and a replayed doorbell does not get a second copy either.
+    expect(await claimInvocationForExec({ invocationId: "sfi_1" })).toBe(false);
+    expect(
+      await claimPollerJob({ invocationId: "sfi_1", sandboxId: "sbx_1" })
+    ).toBeNull();
+  });
+
+  it("locks the poller out once the exec fallback has claimed", async () => {
+    await publishPollerJob(makeJob("sfi_1"), { sandboxId: "sbx_1" });
+
+    expect(await claimInvocationForExec({ invocationId: "sfi_1" })).toBe(true);
+
+    expect(
+      await claimPollerJob({ invocationId: "sfi_1", sandboxId: "sbx_1" })
+    ).toBeNull();
+  });
+
+  it("claims invocations independently", async () => {
+    await publishPollerJob(makeJob("sfi_1"), { sandboxId: "sbx_1" });
+
+    expect(
+      await claimPollerJob({ invocationId: "sfi_1", sandboxId: "sbx_1" })
+    ).not.toBeNull();
+    expect(await claimInvocationForExec({ invocationId: "sfi_2" })).toBe(true);
+  });
+
+  it("refuses a claim from a pod the job was not dispatched to", async () => {
+    // Invocation ids come from a public sqids alphabet, so a compromised pod can guess ids
+    // belonging to other pods and other workspaces. If claiming them worked, it could stop them
+    // running anywhere without ever running them itself.
+    await publishPollerJob(makeJob("sfi_1"), { sandboxId: "sbx_1" });
+
+    expect(
+      await claimPollerJob({ invocationId: "sfi_1", sandboxId: "sbx_2" })
+    ).toBeNull();
+    // The rightful pod is unaffected.
+    expect(
+      await claimPollerJob({ invocationId: "sfi_1", sandboxId: "sbx_1" })
+    ).not.toBeNull();
+  });
+
+  it("refuses a claim for an invocation that was never dispatched", async () => {
+    expect(
+      await claimPollerJob({ invocationId: "sfi_unknown", sandboxId: "sbx_1" })
+    ).toBeNull();
+  });
+
+  it("refuses to publish a job that would outlive its claim", async () => {
+    await expect(
+      publishPollerJob(
+        { ...makeJob("sfi_1"), timeoutMs: POLLER_MAX_JOB_TIMEOUT_MS + 1 },
+        { sandboxId: "sbx_1" }
+      )
+    ).rejects.toThrow(/cannot run for longer/);
+  });
+
+  it("keeps the invocation's credential out of the work channel", async () => {
+    await publishPollerJob(makeJob("sfi_1"), { sandboxId: "sbx_1" });
+
+    // The channel's history is replayable by any holder of a poller token, so a credential
+    // published there would be readable long after the invocation it belonged to.
+    const published = publishedEvents.map((event) => event.message.payload);
+    expect(published.join("")).not.toContain("sbt-job");
+    expect(published.join("")).not.toContain("secret-input");
+  });
+
+  it("hands the poller its next token first", async () => {
+    const events = await collectChannel({
+      sandboxId: "sbx_1",
+      lastEventId: null,
+      expectedEvents: 1,
+    });
+
+    expect(events[0]?.data).toMatchObject({
+      type: "sandbox_function_poller_token",
+      token: "sbt-rotated",
+    });
+  });
+
+  it("gives a poller with no resume point no backlog", async () => {
+    // A poller connecting without a resume point is starting fresh, not catching up. Replaying
+    // from the start of a stream retained for minutes would re-ring invocations the exec fallback
+    // has long since run, and hand out doorbells for work that is finished.
+    await publishPollerJob(makeJob("sfi_1"), { sandboxId: "sbx_1" });
+
+    const events = await collectChannel({
+      sandboxId: "sbx_1",
+      lastEventId: null,
+      expectedEvents: 1,
+    });
+
+    expect(subscribeCalls.at(-1)?.skipHistory).toBe(true);
+    expect(
+      events.filter(
+        (event) => event.data.type === "sandbox_function_poller_job"
+      )
+    ).toEqual([]);
+  });
+
+  it("marks the pod reachable while the channel is open and drops it after", async () => {
+    let presenceDuringChannel = false;
+    const controller = new AbortController();
+    for await (const _event of openPollerChannel({
+      sandboxId: "sbx_1",
+      rotatedToken: "sbt-rotated",
+      lastEventId: null,
+      signal: controller.signal,
+    })) {
+      presenceDuringChannel = await isPollerChannelOpen({ sandboxId: "sbx_1" });
+      controller.abort();
+      break;
+    }
+
+    expect(presenceDuringChannel).toBe(true);
+    expect(await isPollerChannelOpen({ sandboxId: "sbx_1" })).toBe(false);
+  });
+
+  it("replays only the doorbells rung after the poller's last event", async () => {
+    await publishPollerJob(makeJob("sfi_1"), { sandboxId: "sbx_1" });
+    await publishPollerJob(makeJob("sfi_2"), { sandboxId: "sbx_1" });
+    // Rung while the poller was reconnecting: it must still be answered.
+    await publishPollerJob(makeJob("sfi_3"), { sandboxId: "sbx_1" });
+
+    const firstDoorbellId = publishedEvents[0]?.id ?? null;
+    const resumed = await collectChannel({
+      sandboxId: "sbx_1",
+      lastEventId: firstDoorbellId,
+      expectedEvents: 3,
+    });
+    const resumedInvocationIds = resumed.flatMap((event) =>
+      event.data.type === "sandbox_function_poller_job"
+        ? [event.data.invocationId]
+        : []
+    );
+
+    expect(subscribeCalls.at(-1)?.lastEventId).toBe(firstDoorbellId);
+    expect(resumedInvocationIds).toEqual(["sfi_2", "sfi_3"]);
+  });
+
+  it("does not rewind a poller that stores the token event's id", async () => {
+    // The token event is per-connect state, not progress through the job history. If it carried a
+    // fresh id, a poller storing every id it sees would resume from it and lose its place.
+    await publishPollerJob(makeJob("sfi_1"), { sandboxId: "sbx_1" });
+    const resumePoint = publishedEvents[0]?.id ?? null;
+
+    const events = await collectChannel({
+      sandboxId: "sbx_1",
+      lastEventId: resumePoint,
+      expectedEvents: 1,
+    });
+
+    expect(events[0]?.data.type).toBe("sandbox_function_poller_token");
+    expect(events[0]?.eventId).toBe(resumePoint);
+  });
+});

--- a/front/lib/api/sandbox_functions/poller_channel.ts
+++ b/front/lib/api/sandbox_functions/poller_channel.ts
@@ -1,0 +1,442 @@
+import { runOnRedis } from "@app/lib/api/redis";
+import type { EventPayload } from "@app/lib/api/redis-hybrid-manager";
+import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
+import { createCallbackReader } from "@app/lib/utils";
+import logger from "@app/logger/logger";
+import type {
+  SandboxFunctionPollerEvent,
+  SandboxFunctionPollerJob,
+} from "@app/types/api/sandbox_functions";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
+import crypto from "crypto";
+import { z } from "zod";
+
+const SANDBOX_FUNCTION_POLLER_ORIGIN = "sandbox_function_poller" as const;
+
+// How long a connect keeps the pod marked as reachable. Comfortably longer than the heartbeat
+// below, so an ordinary slow refresh does not read as a disconnect, and short enough that a pod
+// that died without closing stops attracting jobs quickly.
+export const POLLER_PRESENCE_TTL_SECONDS = 90;
+
+// How often an open channel refreshes its presence key.
+export const POLLER_PRESENCE_REFRESH_INTERVAL_MS = 20_000;
+
+// How long a connect stays open before the poller reconnects. Reconnecting is what rotates the
+// poller's token, and it bounds how long a job sits behind a half-open connection.
+export const POLLER_CHANNEL_DURATION_MS = 60_000;
+
+// The longest a published job may ask to run for. Enforced at publish so the claim below can
+// outlive any job it guards: a claim that lapsed mid-run would let the exec fallback start a
+// second copy of a function that is already running.
+export const POLLER_MAX_JOB_TIMEOUT_MS = 30_000;
+
+// How long a claimed invocation stays claimed. Sized off the job ceiling rather than guessed, so
+// the claim is still held when the slowest legal job finishes.
+const POLLER_CLAIM_TTL_MS = POLLER_MAX_JOB_TIMEOUT_MS * 2;
+
+// How long a published job waits to be picked up. A job nobody claims is run by the exec fallback
+// instead, so this only has to cover the handoff.
+const POLLER_JOB_TTL_MS = POLLER_MAX_JOB_TIMEOUT_MS * 2;
+
+// Who is running an invocation. Recorded rather than a bare flag so logs say which side won a
+// race, and so a claim that is never released is attributable.
+export type SandboxFunctionInvocationRunner = "poller" | "exec";
+
+// The job as stored for pickup, alongside the pod it was dispatched to. The pod is what binds a
+// claim to its addressee: invocation ids are derived from a public sqids alphabet and are
+// therefore guessable, so without this a compromised pod could claim invocations belonging to
+// other pods, and other workspaces, purely to stop them running.
+const StoredPollerJobSchema = z.object({
+  sandboxId: z.string(),
+  job: z.object({
+    invocationId: z.string(),
+    functionId: z.string(),
+    slug: z.string(),
+    execToken: z.string(),
+    inputEnvelope: z.string(),
+    envVars: z.record(z.string()),
+    timeoutMs: z.number().int().positive(),
+  }),
+});
+
+function pollerChannelId({ sandboxId }: { sandboxId: string }): string {
+  return `sandbox-function-poller-${sandboxId}`;
+}
+
+function pollerPresenceRedisKey({ sandboxId }: { sandboxId: string }): string {
+  return `sandbox:${sandboxId}:poller:presence`;
+}
+
+function pollerJobRedisKey({ invocationId }: { invocationId: string }): string {
+  return `sandbox-function-invocation:${invocationId}:poller-job`;
+}
+
+function invocationClaimRedisKey({
+  invocationId,
+}: {
+  invocationId: string;
+}): string {
+  return `sandbox-function-invocation:${invocationId}:runner`;
+}
+
+/**
+ * Mark a pod as reachable over its work channel, and keep it marked.
+ *
+ * Called on connect and again on every heartbeat. The key expiring is what makes a pod that
+ * vanished without closing stop attracting jobs, so refreshing is not optional while a channel is
+ * open.
+ *
+ * The value records which connect holds the pod, so a connect that is closing can tell its own
+ * presence from that of the connect that replaced it.
+ */
+export async function refreshPollerChannelPresence({
+  sandboxId,
+  connectId,
+}: {
+  sandboxId: string;
+  connectId: string;
+}): Promise<void> {
+  await runOnRedis({ origin: SANDBOX_FUNCTION_POLLER_ORIGIN }, (client) =>
+    client.set(pollerPresenceRedisKey({ sandboxId }), connectId, {
+      EX: POLLER_PRESENCE_TTL_SECONDS,
+    })
+  );
+}
+
+/**
+ * Drop a pod's presence as soon as its channel closes, rather than waiting out the TTL.
+ *
+ * Only clears presence this connect still holds, and does it in one atomic step. A poller
+ * reconnects every minute and nothing orders the old connect's cleanup against the new one's
+ * opening, so a delete that did not compare, or compared in a separate round trip, would blank the
+ * presence of a channel that is up and listening and send its pod's invocations down the slow path
+ * until the next heartbeat.
+ */
+export async function clearPollerChannelPresence({
+  sandboxId,
+  connectId,
+}: {
+  sandboxId: string;
+  connectId: string;
+}): Promise<void> {
+  // Same compare-and-delete as `distributedUnlock`, which exists for exactly this reason.
+  const luaScript = `
+    if redis.call("get", KEYS[1]) == ARGV[1] then
+      return redis.call("del", KEYS[1])
+    else
+      return 0
+    end
+  `;
+
+  await runOnRedis({ origin: SANDBOX_FUNCTION_POLLER_ORIGIN }, (client) =>
+    client.eval(luaScript, {
+      keys: [pollerPresenceRedisKey({ sandboxId })],
+      arguments: [connectId],
+    })
+  );
+}
+
+/**
+ * Whether a pod currently holds an open work channel.
+ *
+ * A routing hint, never a guarantee: presence can be stale in both directions, and what keeps an
+ * invocation from running twice is the claim below, not this.
+ */
+export async function isPollerChannelOpen({
+  sandboxId,
+}: {
+  sandboxId: string;
+}): Promise<boolean> {
+  return runOnRedis(
+    { origin: SANDBOX_FUNCTION_POLLER_ORIGIN },
+    async (client) => {
+      const exists = await client.exists(pollerPresenceRedisKey({ sandboxId }));
+      return exists === 1;
+    }
+  );
+}
+
+/**
+ * Claim an invocation for a pod's poller, and hand it the job if it won.
+ *
+ * The single arbiter between the poller and the exec fallback. Presence tells the caller where to
+ * ring; this decides who actually runs the invocation, which is what makes a stale presence key or
+ * a replayed doorbell safe. Returns null when the invocation was not dispatched to this pod, or
+ * when someone else already holds the claim.
+ */
+export async function claimPollerJob({
+  invocationId,
+  sandboxId,
+}: {
+  invocationId: string;
+  sandboxId: string;
+}): Promise<SandboxFunctionPollerJob | null> {
+  return runOnRedis(
+    { origin: SANDBOX_FUNCTION_POLLER_ORIGIN },
+    async (client) => {
+      const stored = await client.get(pollerJobRedisKey({ invocationId }));
+      if (!stored) {
+        return null;
+      }
+
+      const parsed = safeParseJSON(stored);
+      if (parsed.isErr()) {
+        return null;
+      }
+      const validation = StoredPollerJobSchema.safeParse(parsed.value);
+      if (!validation.success) {
+        return null;
+      }
+      if (validation.data.sandboxId !== sandboxId) {
+        logger.warn(
+          { invocationId, sandboxId },
+          "A Pod tried to claim a Pod function invocation dispatched elsewhere"
+        );
+        return null;
+      }
+
+      const claimed = await client.set(
+        invocationClaimRedisKey({ invocationId }),
+        "poller",
+        { NX: true, PX: POLLER_CLAIM_TTL_MS }
+      );
+      if (claimed !== "OK") {
+        return null;
+      }
+
+      // The job has been handed over, so it has no reason to stay: leaving it would keep the
+      // invocation's credential and its caller's input in Redis for the rest of their window.
+      await client.del(pollerJobRedisKey({ invocationId }));
+
+      return validation.data.job;
+    }
+  );
+}
+
+/**
+ * Claim an invocation for the exec fallback, so the poller cannot also run it.
+ *
+ * The other side of the same arbiter. Takes no job: the exec path already holds everything it
+ * needs, it only needs to know the poller has not started.
+ */
+export async function claimInvocationForExec({
+  invocationId,
+}: {
+  invocationId: string;
+}): Promise<boolean> {
+  return runOnRedis(
+    { origin: SANDBOX_FUNCTION_POLLER_ORIGIN },
+    async (client) => {
+      const claimed = await client.set(
+        invocationClaimRedisKey({ invocationId }),
+        "exec",
+        { NX: true, PX: POLLER_CLAIM_TTL_MS }
+      );
+      return claimed === "OK";
+    }
+  );
+}
+
+/**
+ * Dispatch a job to a pod: store it for pickup, then ring the pod's channel.
+ *
+ * The job is stored first so it is always there by the time the doorbell arrives. The doorbell
+ * goes through the hybrid manager, so it lands in the channel's stream as well as its pub/sub
+ * channel: a poller reconnecting replays from its last event id, so a job rung into the gap
+ * between two connects is still answered.
+ */
+export async function publishPollerJob(
+  job: SandboxFunctionPollerJob,
+  { sandboxId }: { sandboxId: string }
+): Promise<void> {
+  if (job.timeoutMs > POLLER_MAX_JOB_TIMEOUT_MS) {
+    // A caller asking for longer than the claim can guard would let the exec fallback start a
+    // second copy mid-run. Nothing legitimately publishes such a job, so this is a bug.
+    throw new Error(
+      `A Pod function poller job cannot run for longer than ${POLLER_MAX_JOB_TIMEOUT_MS}ms.`
+    );
+  }
+
+  await runOnRedis({ origin: SANDBOX_FUNCTION_POLLER_ORIGIN }, (client) =>
+    client.set(
+      pollerJobRedisKey({ invocationId: job.invocationId }),
+      JSON.stringify({ sandboxId, job }),
+      { PX: POLLER_JOB_TTL_MS }
+    )
+  );
+
+  const event: SandboxFunctionPollerEvent = {
+    type: "sandbox_function_poller_job",
+    created: Date.now(),
+    invocationId: job.invocationId,
+  };
+
+  await getRedisHybridManager().publish(
+    pollerChannelId({ sandboxId }),
+    JSON.stringify(event),
+    SANDBOX_FUNCTION_POLLER_ORIGIN
+  );
+}
+
+export type SandboxFunctionPollerStreamEvent = {
+  eventId: string;
+  data: SandboxFunctionPollerEvent;
+};
+
+const PollerEventSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("sandbox_function_poller_job"),
+    created: z.number(),
+    invocationId: z.string(),
+  }),
+  z.object({
+    type: z.literal("sandbox_function_poller_token"),
+    created: z.number(),
+    token: z.string(),
+  }),
+]);
+
+/**
+ * Hold a pod's work channel open, yielding what the poller should act on.
+ *
+ * Owns the whole life of one connect: it marks the pod reachable, hands the poller the token for
+ * its next connect, keeps presence fresh while it streams doorbells, and drops presence when it
+ * ends. Presence upkeep lives here rather than beside it because a channel that is open but no
+ * longer refreshing would keep attracting jobs nothing is listening for.
+ *
+ * Ends on its own after `POLLER_CHANNEL_DURATION_MS` so the poller reconnects on a known cadence,
+ * which is also what rotates its token.
+ */
+export async function* openPollerChannel({
+  sandboxId,
+  rotatedToken,
+  lastEventId,
+  signal,
+}: {
+  sandboxId: string;
+  rotatedToken: string;
+  lastEventId: string | null;
+  signal: AbortSignal;
+}): AsyncGenerator<SandboxFunctionPollerStreamEvent, void> {
+  const connectId = crypto.randomUUID();
+  const callbackReader = createCallbackReader<EventPayload | "close">();
+  const { history, unsubscribe } = await getRedisHybridManager().subscribe(
+    pollerChannelId({ sandboxId }),
+    callbackReader.callback,
+    SANDBOX_FUNCTION_POLLER_ORIGIN,
+    // A poller with no resume point is starting fresh, not catching up: replaying from the start
+    // of a stream that is retained for minutes would re-ring every invocation the exec fallback
+    // has long since run.
+    lastEventId === null ? { skipHistory: true } : { lastEventId }
+  );
+
+  let unsubscribed = false;
+  const unsubscribeOnce = () => {
+    if (unsubscribed) {
+      return;
+    }
+    unsubscribed = true;
+    unsubscribe();
+  };
+
+  signal.addEventListener("abort", unsubscribeOnce, { once: true });
+
+  try {
+    await refreshPollerChannelPresence({ sandboxId, connectId });
+
+    // Sent before any doorbell so a poller that drops mid-connect still has a usable credential to
+    // reconnect with. Carries the resume point it arrived with, so a poller that stores every
+    // event id it sees does not rewind itself by treating this one as progress.
+    yield {
+      eventId: lastEventId ?? "",
+      data: {
+        type: "sandbox_function_poller_token",
+        created: Date.now(),
+        token: rotatedToken,
+      },
+    };
+
+    for (const rawEvent of history) {
+      const event = parsePollerEvent(rawEvent);
+      if (event) {
+        yield event;
+      }
+    }
+
+    const deadlineMs = Date.now() + POLLER_CHANNEL_DURATION_MS;
+    // Held across iterations on purpose. `createCallbackReader` only buffers when no waiter is
+    // registered, so abandoning this promise on every heartbeat would drop any doorbell that
+    // arrived while the heartbeat was in flight.
+    let pendingEvent = callbackReader.next();
+    while (!signal.aborted) {
+      const remainingMs = deadlineMs - Date.now();
+      if (remainingMs <= 0) {
+        break;
+      }
+
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      const waitMs = Math.min(remainingMs, POLLER_PRESENCE_REFRESH_INTERVAL_MS);
+      const timeoutPromise = new Promise<"timeout">((resolve) => {
+        timeoutId = setTimeout(() => resolve("timeout"), waitMs);
+      });
+      const rawEvent = await Promise.race([pendingEvent, timeoutPromise]);
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+      if (rawEvent === "close") {
+        break;
+      }
+      // A quiet channel is the common case: the wait elapsing means it is time to refresh
+      // presence, not that the channel is done.
+      if (rawEvent === "timeout") {
+        await refreshPollerChannelPresence({ sandboxId, connectId });
+        continue;
+      }
+
+      pendingEvent = callbackReader.next();
+      const event = parsePollerEvent(rawEvent);
+      if (event) {
+        yield event;
+      }
+    }
+  } catch (error) {
+    logger.error(
+      { error: normalizeError(error).message, sandboxId },
+      "Error streaming Pod function poller doorbells"
+    );
+  } finally {
+    signal.removeEventListener("abort", unsubscribeOnce);
+    unsubscribeOnce();
+    await clearPollerChannelPresence({ sandboxId, connectId }).catch((error) =>
+      logger.error(
+        { error: normalizeError(error).message, sandboxId },
+        "Failed to clear Pod function poller presence"
+      )
+    );
+  }
+}
+
+function parsePollerEvent(
+  rawEvent: EventPayload
+): SandboxFunctionPollerStreamEvent | null {
+  const parsed = safeParseJSON(rawEvent.message.payload);
+  if (parsed.isErr()) {
+    logger.error(
+      { eventId: rawEvent.id },
+      "Skipping an unparseable Pod function poller event"
+    );
+    return null;
+  }
+
+  const validation = PollerEventSchema.safeParse(parsed.value);
+  if (!validation.success) {
+    logger.error(
+      { eventId: rawEvent.id },
+      "Skipping a Pod function poller event that does not match the contract"
+    );
+    return null;
+  }
+
+  return { eventId: rawEvent.id, data: validation.data };
+}

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -8,6 +8,7 @@ import type {
 import {
   isSandboxExecTokenPayload,
   isSandboxFunctionInvocationTokenPayload,
+  isSandboxPollerTokenPayload,
   SANDBOX_TOKEN_PREFIX,
 } from "@app/lib/api/sandbox/access_tokens";
 import type { WorkOSJwtPayload } from "@app/lib/api/workos";
@@ -553,7 +554,17 @@ export class Authenticator {
     let baseGroupModelIds: ModelId[];
     let subscription: SubscriptionResource | null;
 
-    if (user) {
+    if (isSandboxPollerTokenPayload(claims)) {
+      // The poller is a pod process, not a member of the workspace: it receives work for one
+      // sandbox and claims it, and needs no standing to do either. Giving it the "user" floor the
+      // userless workload branch uses would leave anything role-gated but not group-gated open to
+      // it, so it gets no role and no groups at all.
+      role = "none";
+      baseGroupModelIds = [];
+      subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+        workspace.id
+      );
+    } else if (user) {
       const authData = await this.fetchRoleGroupsAndSubscription({
         user,
         workspace,
@@ -623,6 +634,12 @@ export class Authenticator {
         return new Err(groupModelIdsRes.error);
       }
       groupModelIdSets.push(groupModelIdsRes.value);
+    }
+    // The poller is not a workload: it runs no function code, names no space, and reads nothing
+    // space-scoped, so it gets the workspace and no groups at all. Handled explicitly rather than
+    // left to fall through, since the branch below exists to reject token shapes nobody scoped.
+    if (isSandboxPollerTokenPayload(claims)) {
+      groupModelIdSets.push([]);
     }
     if (groupModelIdSets.length === 0) {
       return new Err({

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -28,7 +28,11 @@ import {
 } from "@app/lib/resources/storage/models/sandbox";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
-import { makeSId } from "@app/lib/resources/string_ids";
+import {
+  getResourceIdFromSId,
+  isResourceSId,
+  makeSId,
+} from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
@@ -167,6 +171,22 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     workspaceId: ModelId;
   }): string {
     return makeSId("sandbox", { id, workspaceId });
+  }
+
+  static async fetchById(
+    auth: Authenticator,
+    sandboxId: string
+  ): Promise<SandboxResource | null> {
+    if (!isResourceSId("sandbox", sandboxId)) {
+      return null;
+    }
+
+    const sandboxModelId = getResourceIdFromSId(sandboxId);
+    if (sandboxModelId === null) {
+      return null;
+    }
+
+    return this.fetchByModelIdForWorkspace(auth, sandboxModelId);
   }
 
   static async fetchByModelIdForWorkspace(

--- a/front/tests/utils/SandboxTokenFactory.ts
+++ b/front/tests/utils/SandboxTokenFactory.ts
@@ -2,6 +2,7 @@ import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import {
   generateSandboxExecToken,
   generateSandboxFunctionInvocationToken,
+  generateSandboxPollerToken,
 } from "@app/lib/api/sandbox/access_tokens";
 import { Authenticator } from "@app/lib/auth";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
@@ -166,6 +167,19 @@ export async function createSandboxFunctionInvocationTokenTestContext({
     },
     invocationId: `test-invocation-${context.sandbox.sId}`,
     execId: `test-function-exec-${context.sandbox.sId}`,
+  });
+
+  return {
+    ...context,
+    token,
+  };
+}
+
+// The pod's poller principal: authenticates the sandbox's work channel, and names no invocation.
+export async function createSandboxPollerTokenTestContext() {
+  const context = await createSandboxTokenTestContext();
+  const token = await generateSandboxPollerToken(context.auth, {
+    sandbox: context.sandbox,
   });
 
   return {

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -178,3 +178,43 @@ export type PostSandboxFunctionInvocationResponseBody = {
   // everything published so far.
   outcome?: SandboxFunctionInvocationOutcome;
 };
+
+// A unit of work handed to whichever poller wins the claim for it, which runs it by spawning the
+// same runner the exec path spawns.
+//
+// Deliberately not what travels on the work channel. The channel's history is replayable by any
+// holder of a poller token, so anything sensitive published there would be readable long after the
+// invocation it belonged to: the credential, the caller's input and their identity are handed out
+// once, to the one poller that claimed the invocation, and never enter the stream.
+export type SandboxFunctionPollerJob = {
+  invocationId: string;
+  functionId: string;
+  slug: string;
+  // The invocation's own exec token. Doubles as the runner's credential for its result callback
+  // and as the bound on what the poller can settle: one job, one invocation.
+  execToken: string;
+  // Handed to the runner's stdin verbatim.
+  inputEnvelope: string;
+  envVars: Record<string, string>;
+  timeoutMs: number;
+};
+
+// The doorbell: tells a pod an invocation is waiting for it, and nothing more. The poller answers
+// by claiming the invocation, which is what hands it the job.
+export type SandboxFunctionPollerJobEvent = {
+  type: "sandbox_function_poller_job";
+  created: number;
+  invocationId: string;
+};
+
+// Sent first on every connect. The poller persists it and authenticates its next connect with it,
+// so a channel that keeps reconnecting never runs its credential to expiry.
+export type SandboxFunctionPollerTokenEvent = {
+  type: "sandbox_function_poller_token";
+  created: number;
+  token: string;
+};
+
+export type SandboxFunctionPollerEvent =
+  | SandboxFunctionPollerJobEvent
+  | SandboxFunctionPollerTokenEvent;

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -74,10 +74,34 @@ function createStatefulMockRedisClient() {
       }
       return entry.value;
     }),
-    set: vi.fn(async (key: string, value: string, opts?: { EX?: number }) => {
-      const expiresAtMs = opts?.EX ? Date.now() + opts.EX * 1000 : 0;
-      redisStore.set(key, { value, expiresAtMs });
-    }),
+    set: vi.fn(
+      async (
+        key: string,
+        value: string,
+        opts?: { EX?: number; PX?: number; NX?: boolean }
+      ) => {
+        const existing = redisStore.get(key);
+        const isLive =
+          existing !== undefined &&
+          (existing.expiresAtMs === 0 || Date.now() <= existing.expiresAtMs);
+        // NX is what makes SET usable as a lock, so it has to be modelled rather than ignored:
+        // silently overwriting would make every contender believe it won.
+        if (opts?.NX && isLive) {
+          return null;
+        }
+        // Compared against undefined rather than truthiness: real Redis rejects a zero expiry
+        // outright, so treating it as "no expiry" would turn a computed-zero TTL into a key that
+        // lives forever under test and an error in production.
+        const expiresAtMs =
+          opts?.EX !== undefined
+            ? Date.now() + opts.EX * 1000
+            : opts?.PX !== undefined
+              ? Date.now() + opts.PX
+              : 0;
+        redisStore.set(key, { value, expiresAtMs });
+        return "OK";
+      }
+    ),
     del: vi.fn(async (key: string) => {
       redisStore.delete(key);
       redisHashStore.delete(key);
@@ -104,7 +128,35 @@ function createStatefulMockRedisClient() {
     subscribe: vi.fn().mockResolvedValue(undefined),
     unsubscribe: vi.fn().mockResolvedValue(undefined),
     ping: vi.fn().mockResolvedValue("PONG"),
-    eval: vi.fn().mockResolvedValue(1),
+    // Only the compare-and-delete script is modelled, which is the one the codebase actually runs
+    // (`distributedUnlock`, and the poller channel's presence release). A blanket stub would make
+    // every lock acquirable but never releasable now that `set` honours NX, which surfaces as a
+    // test that stalls until its timeout rather than one that fails.
+    eval: vi.fn(
+      async (
+        script: string,
+        options?: { keys?: string[]; arguments?: string[] }
+      ) => {
+        const key = options?.keys?.[0];
+        const expected = options?.arguments?.[0];
+        if (
+          !script.includes('redis.call("get", KEYS[1]) == ARGV[1]') ||
+          key === undefined ||
+          expected === undefined
+        ) {
+          return 1;
+        }
+        const entry = redisStore.get(key);
+        const isLive =
+          entry !== undefined &&
+          (entry.expiresAtMs === 0 || Date.now() <= entry.expiresAtMs);
+        if (!isLive || entry?.value !== expected) {
+          return 0;
+        }
+        redisStore.delete(key);
+        return 1;
+      }
+    ),
     exists: vi.fn(async (key: string) => {
       const entry = redisStore.get(key);
       if (!entry) {


### PR DESCRIPTION
## Description

First of five slices adding a warm path for fast Pod function invocations. Today a fast invocation still costs ~800ms server side, and the measurements say almost all of it is the E2B exec API round trip, not Temporal and not bun startup. The plan is a resident poller process in the pod that holds an outbound SSE channel to front-api and receives work directly, so the exec API leaves the hot path.

This slice adds only what front owns: the poller token, the work channel it connects to, and the claim that arbitrates who runs an invocation. Nothing publishes jobs yet, so `publishPollerJob`, `isPollerChannelOpen` and `claimInvocationForExec` have no production callers until the routing slice. Merging this changes no behaviour.

The poller is a separate principal, not a workload token with extra claims. Its token names no invocation, carries no user, and is refused on every workload route; workload tokens are refused on its two. It resolves to workspace identity with no role and no groups, which is all it needs to receive work for one sandbox and claim it. It is bound to the sandbox's provider id, so a token that outlives its sandbox stops verifying rather than authenticating against the sandbox that replaced it, and it is revoked when it is rotated, so a leaked token cannot mint its own successor indefinitely.

Jobs do not travel on the channel. The channel carries a doorbell naming an invocation, and the job itself (the invocation's exec token, the caller's input, the user identity) is returned only to the poller that wins the claim. Channel history is replayable by any holder of a poller token, so anything published there would be readable long after the invocation it belonged to. The claim also checks the invocation was dispatched to the pod asking for it: invocation ids come from a public sqids alphabet and are guessable, so without that check a compromised pod could claim other pods' and other workspaces' invocations purely to stop them running.

## Tests

Covered the security invariants directly rather than trusting the shape: forged tokens mixing poller and workload claims, a poller token naming a user (which would otherwise inherit that user's role), rotation actually revoking the old token, and a pod claiming an invocation dispatched elsewhere. Also a regression test for the presence race, where a closing connect must not clear the presence of the connect that already replaced it, and one asserting the credential never appears in the channel payloads.

`front/vite.setup.ts` needed two fixes to test any of this honestly. Its in-memory Redis `set` ignored `NX`, so every contender for a lock believed it won; and `eval` was stubbed to return 1, so compare-and-delete never deleted. Both are now modelled. Ran the full front and front-api suites to confirm nothing depended on the old behaviour.

## Risk

Low. No production caller, and the one shared file touched outside the new code is the test harness. The pieces that will carry risk are the routing and the pod-side process, in later slices.

## Deploy Plan

Standard deploy.