### PR TITLE
Admin governance: add group seeding to dust-hive seed

### DIFF
--- a/front/scripts/seed/factories/index.ts
+++ b/front/scripts/seed/factories/index.ts
@@ -5,6 +5,7 @@ export * from "./seedContext";
 export * from "./seedConversations";
 export * from "./seedDataSources";
 export * from "./seedFeedbacks";
+export * from "./seedGroup";
 export * from "./seedMCPTools";
 export * from "./seedSkill";
 export * from "./seedSkillSuggestions";

--- a/front/scripts/seed/factories/seedGroup.ts
+++ b/front/scripts/seed/factories/seedGroup.ts
@@ -1,0 +1,51 @@
+import { GroupResource } from "@app/lib/resources/group_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+
+import type { SeedContext } from "./types";
+
+interface SeedGroupOptions {
+  name: string;
+  kind: "provisioned" | "regular_manual";
+  members: UserResource[];
+}
+
+export async function seedGroup(
+  ctx: SeedContext,
+  { name, kind, members }: SeedGroupOptions
+): Promise<GroupResource | undefined> {
+  const { auth, workspace, execute, logger } = ctx;
+
+  const existingGroup = await GroupResource.fetchByName(auth, name);
+  if (existingGroup) {
+    logger.info(
+      { sId: existingGroup.sId, name },
+      "Group already exists, skipping"
+    );
+    return existingGroup;
+  }
+
+  if (!execute) {
+    return undefined;
+  }
+
+  const group = await GroupResource.makeNew({
+    name,
+    kind,
+    workspaceId: workspace.id,
+    // Provisioned groups mirror an identity provider group, which the seed fakes.
+    workOSGroupId: kind === "provisioned" ? `workos-group-${name}` : null,
+  });
+
+  const addMembersResult = await group.dangerouslyAddMembers(auth, {
+    users: members.map((u) => u.toJSON()),
+    allowProvisionedGroups: kind === "provisioned",
+  });
+  if (addMembersResult.isErr()) {
+    throw new Error(
+      `Failed to add users to group ${name}: ${addMembersResult.error.message}`
+    );
+  }
+
+  logger.info({ sId: group.sId, name, kind }, "Group created");
+  return group;
+}

--- a/front/scripts/seed/governance/groups.ts
+++ b/front/scripts/seed/governance/groups.ts
@@ -1,0 +1,66 @@
+import type { GroupResource } from "@app/lib/resources/group_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import type { SeedContext } from "@app/scripts/seed/factories";
+import { seedGroup } from "@app/scripts/seed/factories";
+import { removeNulls } from "@app/types/shared/utils/general";
+
+export const DEV_TEAM_GROUP_NAME = "Dev team";
+export const GO_TO_MARKET_GROUP_NAME = "Go To Market Team";
+export const FRANCE_GROUP_NAME = "France";
+export const LONG_NAME_GROUP_NAME =
+  "test-group-with-very-long-name-to-see-how-it-displays-in-ui";
+
+/**
+ * Seeds the provisioned and manual groups the member panel and the groups tab display, so both
+ * kinds of membership (and a name long enough to stress the UI) are covered. Returns the groups by
+ * name.
+ */
+export async function seedGovernanceGroups(
+  ctx: SeedContext,
+  {
+    alfred,
+    bob,
+    charly,
+  }: {
+    alfred: UserResource | undefined;
+    bob: UserResource | undefined;
+    charly: UserResource | undefined;
+  }
+): Promise<Map<string, GroupResource>> {
+  const groupSpecs: {
+    name: string;
+    kind: "provisioned" | "regular_manual";
+    members: UserResource[];
+  }[] = [
+    {
+      name: DEV_TEAM_GROUP_NAME,
+      kind: "provisioned",
+      members: removeNulls([ctx.user, alfred]),
+    },
+    {
+      name: GO_TO_MARKET_GROUP_NAME,
+      kind: "provisioned",
+      members: removeNulls([alfred, bob]),
+    },
+    {
+      name: FRANCE_GROUP_NAME,
+      kind: "regular_manual",
+      members: removeNulls([ctx.user, charly]),
+    },
+    {
+      name: LONG_NAME_GROUP_NAME,
+      kind: "regular_manual",
+      members: [ctx.user],
+    },
+  ];
+
+  const groups = new Map<string, GroupResource>();
+  for (const spec of groupSpecs) {
+    const group = await seedGroup(ctx, spec);
+    if (group) {
+      groups.set(spec.name, group);
+    }
+  }
+
+  return groups;
+}

--- a/front/scripts/seed/governance/seed.test.ts
+++ b/front/scripts/seed/governance/seed.test.ts
@@ -8,6 +8,13 @@ import {
   seedSpace,
   seedUsers,
 } from "@app/scripts/seed/factories";
+import {
+  DEV_TEAM_GROUP_NAME,
+  FRANCE_GROUP_NAME,
+  GO_TO_MARKET_GROUP_NAME,
+  LONG_NAME_GROUP_NAME,
+  seedGovernanceGroups,
+} from "@app/scripts/seed/governance/groups";
 import type { Assets } from "@app/scripts/seed/governance/seed";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import * as fs from "fs";
@@ -16,6 +23,7 @@ import { describe, expect, it } from "vitest";
 
 const ALFRED_USER_ID = "SeedUserAlfred";
 const BOB_USER_ID = "SeedUserBob";
+const CHARLY_USER_ID = "SeedUserCharly";
 const RESTRICTED_SPACE_NAME = "Governance Restricted Space";
 
 // Load assets from JSON files (same as seed.ts)
@@ -58,6 +66,11 @@ describe("governance seed script integration test", () => {
     const bob = createdUsers.get(BOB_USER_ID);
     expect(bob).toBeDefined();
 
+    const charly = createdUsers.get(CHARLY_USER_ID);
+    expect(charly).toBeDefined();
+
+    const groups = await seedGovernanceGroups(ctx, { alfred, bob, charly });
+
     const restrictedSpace = await seedSpace(ctx, {
       name: RESTRICTED_SPACE_NAME,
       members: [bob!],
@@ -77,6 +90,22 @@ describe("governance seed script integration test", () => {
     const createdAgents = await seedAgents(ctx, assets.agents, {
       skills: alfredSkill ? [alfredSkill] : [],
     });
+
+    // The groups hold the expected members, with the expected kinds.
+    for (const [name, kind, expectedMembers] of [
+      [DEV_TEAM_GROUP_NAME, "provisioned", [user.sId, alfred!.sId]],
+      [GO_TO_MARKET_GROUP_NAME, "provisioned", [alfred!.sId, bob!.sId]],
+      [FRANCE_GROUP_NAME, "regular_manual", [user.sId, charly!.sId]],
+      [LONG_NAME_GROUP_NAME, "regular_manual", [user.sId]],
+    ] as const) {
+      const group = groups.get(name);
+      expect(group).toBeDefined();
+      expect(group!.kind).toBe(kind);
+      const groupMembers = await group!.getActiveMembers(authenticator);
+      expect(new Set(groupMembers.map((m) => m.sId))).toEqual(
+        new Set(expectedMembers)
+      );
+    }
 
     // The restricted space holds the current user and Bob.
     expect(restrictedSpace).toBeDefined();

--- a/front/scripts/seed/governance/seed.ts
+++ b/front/scripts/seed/governance/seed.ts
@@ -12,6 +12,7 @@ import {
   seedSpace,
   seedUsers,
 } from "@app/scripts/seed/factories";
+import { seedGovernanceGroups } from "@app/scripts/seed/governance/groups";
 import { removeNulls } from "@app/types/shared/utils/general";
 import * as fs from "fs";
 import * as path from "path";
@@ -42,6 +43,7 @@ function loadAssets(): Assets {
 
 const ALFRED_USER_ID = "SeedUserAlfred";
 const BOB_USER_ID = "SeedUserBob";
+const CHARLY_USER_ID = "SeedUserCharly";
 const RESTRICTED_SPACE_NAME = "Governance Restricted Space";
 
 makeScript({}, async ({ execute }, logger) => {
@@ -62,14 +64,23 @@ makeScript({}, async ({ execute }, logger) => {
     throw new Error(`User ${BOB_USER_ID} was not created`);
   }
 
-  // 2. Create a restricted space holding the current user and Bob.
+  const charly = createdUsers.get(CHARLY_USER_ID);
+  if (execute && !charly) {
+    throw new Error(`User ${CHARLY_USER_ID} was not created`);
+  }
+
+  // 2. Create the provisioned and manual groups.
+  logger.info("Seeding groups...");
+  await seedGovernanceGroups(ctx, { alfred, bob, charly });
+
+  // 3. Create a restricted space holding the current user and Bob.
   logger.info("Seeding the restricted space...");
   const restrictedSpace = await seedSpace(ctx, {
     name: RESTRICTED_SPACE_NAME,
     members: bob ? [bob] : [],
   });
 
-  // 3. Open skill creation to everyone
+  // 4. Open skill creation to everyone
   logger.info("Opening skill creation to everyone...");
   if (execute) {
     const res = await setWorkspaceGovernancePermission(ctx.auth, {
@@ -82,7 +93,7 @@ makeScript({}, async ({ execute }, logger) => {
     }
   }
 
-  // 4. Create skills. The current user's skill requires the restricted space and has both Bob and
+  // 5. Create skills. The current user's skill requires the restricted space and has both Bob and
   // Alfred as editors. Bob is a member of the space, Alfred is not, so the skill builder shows the
   // warning for Alfred only.
   logger.info("Seeding Alfred's unpublished skill...");
@@ -95,7 +106,7 @@ makeScript({}, async ({ execute }, logger) => {
     spaces: restrictedSpace ? [restrictedSpace] : [],
   });
 
-  // 5. Create an agent edited by the current user that uses Alfred's unpublished skill.
+  // 6. Create an agent edited by the current user that uses Alfred's unpublished skill.
   logger.info("Seeding agents...");
   await seedAgents(ctx, agents, {
     skills: alfredSkill ? [alfredSkill] : [],


### PR DESCRIPTION
## Description

Seed to add 4 groups: 2 provisioned and 2 regular manual.
One has intentionally a very long name to see if it may break things

## Tests

tested locally + unit tested

## Risk

low, only a script

## Deploy Plan

None
