### PR TITLE
Admin governance: Add group picker to user side panel for managers

### DIFF
--- a/front/components/groups/GroupKinds.ts
+++ b/front/components/groups/GroupKinds.ts
@@ -1,4 +1,5 @@
 import type { GroupKind } from "@app/types/groups";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { Chip } from "@dust-tt/sparkle";
 import type React from "react";
 
@@ -17,8 +18,19 @@ export function getGroupKindChip(kind: GroupKind): {
   switch (kind) {
     case "provisioned":
       return { label: "Provisioned", color: "success" };
-    default:
+    case "regular_manual":
       return { label: "Manual", color: "info" };
+    // Only provisioned and manual groups are surfaced to users, so this should never be displayed.
+    case "agent_editors":
+    case "global":
+    case "regular_auto":
+    case "skill_editors":
+    case "space_editors":
+    case "system":
+      return { label: "Other", color: "primary" };
+    default:
+      assertNeverAndIgnore(kind);
+      return { label: "Other", color: "primary" };
   }
 }
 

--- a/front/components/groups/GroupKinds.ts
+++ b/front/components/groups/GroupKinds.ts
@@ -1,0 +1,26 @@
+import type { GroupKind } from "@app/types/groups";
+import type { Chip } from "@dust-tt/sparkle";
+import type React from "react";
+
+export type GroupChipColor = NonNullable<
+  React.ComponentProps<typeof Chip>["color"]
+>;
+
+/**
+ * Chip label and color for a group kind. Single source of truth so provisioned groups read the same
+ * (green) and manually-managed ones the same (golden) everywhere they are surfaced.
+ */
+export function getGroupKindChip(kind: GroupKind): {
+  label: string;
+  color: GroupChipColor;
+} {
+  switch (kind) {
+    case "provisioned":
+      return { label: "Provisioned", color: "success" };
+    default:
+      return { label: "Manual", color: "info" };
+  }
+}
+
+export const PROVISIONED_GROUP_TOOLTIP =
+  "Synced from your identity provider. Manage membership in your IdP.";

--- a/front/components/groups/WorkspaceGroupsList.tsx
+++ b/front/components/groups/WorkspaceGroupsList.tsx
@@ -1,5 +1,6 @@
 import { ConfirmContext } from "@app/components/Confirm";
 import { GroupDialog } from "@app/components/groups/GroupDialog";
+import { getGroupKindChip } from "@app/components/groups/GroupKinds";
 import { LinkedSectionNotice } from "@app/components/workspace/LinkedSectionNotice";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { isSCIMEnabled } from "@app/lib/plans/scim";
@@ -34,20 +35,6 @@ import type { ColumnDef, PaginationState } from "@tanstack/react-table";
 import { useCallback, useContext, useMemo, useState } from "react";
 
 const DEFAULT_PAGE_SIZE = 25;
-
-type ChipColor = NonNullable<React.ComponentProps<typeof Chip>["color"]>;
-
-function getGroupKindChip(kind: GroupKind): {
-  label: string;
-  color: ChipColor;
-} {
-  switch (kind) {
-    case "provisioned":
-      return { label: "Provisioned", color: "success" };
-    default:
-      return { label: "Manual", color: "info" };
-  }
-}
 
 type GroupRowData = {
   groupId: string;

--- a/front/components/pages/workspace/governance/GroupSelector.tsx
+++ b/front/components/pages/workspace/governance/GroupSelector.tsx
@@ -1,4 +1,5 @@
 import { GroupDialog } from "@app/components/groups/GroupDialog";
+import { getGroupKindChip } from "@app/components/groups/GroupKinds";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import type { GroupType } from "@app/types/groups";
 import {
@@ -68,13 +69,7 @@ export const GroupSelector = ({
               label={group.name}
               disabled={disabled}
               endComponent={
-                <Chip
-                  label={
-                    group.kind === "provisioned" ? "Provisioned" : "Manual"
-                  }
-                  color={group.kind === "provisioned" ? "success" : "info"}
-                  size="xs"
-                />
+                <Chip {...getGroupKindChip(group.kind)} size="xs" />
               }
               onClick={() =>
                 onSelectionChange([...selectedGroupIds, group.sId])

--- a/front/components/workspace/ChangeMemberModal.tsx
+++ b/front/components/workspace/ChangeMemberModal.tsx
@@ -3,6 +3,7 @@ import {
   ROLE_PROVISIONING_GROUPS_LABEL,
 } from "@app/components/members/Roles";
 import { RoleDropDown } from "@app/components/members/RolesDropDown";
+import { MemberGroupsSection } from "@app/components/workspace/MemberGroupsSection";
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { SearchMembersAdminResponseBody } from "@app/lib/api/workspace";
 import { handleMembersRoleChange } from "@app/lib/client/members";
@@ -153,6 +154,8 @@ export function ChangeMemberModal({
                   </div>
                   <Page.P>{roleMessage}</Page.P>
                 </div>
+
+                <MemberGroupsSection owner={workspace} userId={member.sId} />
 
                 {canRevokeMember && (
                   <div className="flex flex-none flex-col gap-2">

--- a/front/components/workspace/MemberGroupsSection.tsx
+++ b/front/components/workspace/MemberGroupsSection.tsx
@@ -1,0 +1,195 @@
+import {
+  getGroupKindChip,
+  PROVISIONED_GROUP_TOOLTIP,
+} from "@app/components/groups/GroupKinds";
+import {
+  useAddMemberToGroup,
+  useGroups,
+  useMemberGroups,
+  useRemoveMemberFromGroup,
+} from "@app/lib/swr/groups";
+import type { GroupType } from "@app/types/groups";
+import { pluralize } from "@app/types/shared/utils/string_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  Chip,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSearchbar,
+  DropdownMenuTrigger,
+  Plus,
+  Spinner,
+  Tooltip,
+} from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
+
+// Only manually-managed groups can be assigned from Dust: provisioned group membership is owned
+// by the identity provider.
+const ADDABLE_GROUP_KINDS = ["regular_manual"] as const;
+
+interface MemberGroupsSectionProps {
+  owner: LightWorkspaceType;
+  userId: string;
+  disabled?: boolean;
+}
+
+export function MemberGroupsSection({
+  owner,
+  userId,
+  disabled,
+}: MemberGroupsSectionProps) {
+  const [groupSearch, setGroupSearch] = useState("");
+  const [pendingGroupId, setPendingGroupId] = useState<string | null>(null);
+
+  const { memberGroups, isMemberGroupsLoading } = useMemberGroups({
+    owner,
+    userId,
+    disabled,
+  });
+  const { groups: addableGroups } = useGroups({
+    owner,
+    kinds: ADDABLE_GROUP_KINDS,
+    disabled,
+  });
+
+  const { doAddMemberToGroup } = useAddMemberToGroup({ owner, userId });
+  const { doRemoveMemberFromGroup } = useRemoveMemberFromGroup({
+    owner,
+    userId,
+  });
+
+  const selectableGroups = useMemo(() => {
+    const memberGroupIds = new Set(memberGroups.map((g) => g.sId));
+    return addableGroups.filter(
+      (group) =>
+        !memberGroupIds.has(group.sId) &&
+        group.name.toLowerCase().includes(groupSearch.toLowerCase())
+    );
+  }, [addableGroups, memberGroups, groupSearch]);
+
+  // While an addition is in flight the group is not in `memberGroups` yet: show it as a busy chip
+  // so the change is visible immediately.
+  const displayedGroups = useMemo(() => {
+    const pendingAddedGroup =
+      pendingGroupId && !memberGroups.some((g) => g.sId === pendingGroupId)
+        ? addableGroups.find((g) => g.sId === pendingGroupId)
+        : undefined;
+
+    return pendingAddedGroup
+      ? [...memberGroups, pendingAddedGroup].sort((a, b) =>
+          a.name.localeCompare(b.name)
+        )
+      : memberGroups;
+  }, [memberGroups, addableGroups, pendingGroupId]);
+
+  const onAdd = async (group: GroupType) => {
+    setPendingGroupId(group.sId);
+    await doAddMemberToGroup({ groupId: group.sId, groupName: group.name });
+    setPendingGroupId(null);
+  };
+
+  const onRemove = async (group: GroupType) => {
+    setPendingGroupId(group.sId);
+    await doRemoveMemberFromGroup({
+      groupId: group.sId,
+      groupName: group.name,
+    });
+    setPendingGroupId(null);
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="heading-base text-foreground">Groups</div>
+        <DropdownMenu
+          onOpenChange={(open) => {
+            if (open) {
+              setGroupSearch("");
+            }
+          }}
+        >
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              size="xs"
+              icon={Plus}
+              label="Add to group"
+              isSelect
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="min-w-[320px]" collisionPadding={8}>
+            <DropdownMenuSearchbar
+              name="group-search"
+              placeholder="Search groups"
+              value={groupSearch}
+              onChange={setGroupSearch}
+              autoFocus
+            />
+            {selectableGroups.map((group) => (
+              <DropdownMenuItem
+                key={group.sId}
+                label={group.name}
+                endComponent={
+                  <span className="text-sm text-muted-foreground">
+                    {group.memberCount} member{pluralize(group.memberCount)}
+                  </span>
+                }
+                onClick={() => void onAdd(group)}
+              />
+            ))}
+            {selectableGroups.length === 0 && (
+              <DropdownMenuItem
+                label={groupSearch ? "No groups found" : "All groups added"}
+                disabled
+              />
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      {isMemberGroupsLoading ? (
+        <div className="flex py-1">
+          <Spinner size="xs" />
+        </div>
+      ) : (
+        <div className="flex flex-wrap items-center gap-2">
+          {displayedGroups.map((group) =>
+            group.kind === "provisioned" ? (
+              <Tooltip
+                key={group.sId}
+                tooltipTriggerAsChild
+                trigger={
+                  // Chip does not forward DOM props, so the trigger handlers go on a wrapper.
+                  <span className="inline-flex">
+                    <Chip
+                      size="xs"
+                      color={getGroupKindChip(group.kind).color}
+                      label={group.name}
+                    />
+                  </span>
+                }
+                label={PROVISIONED_GROUP_TOOLTIP}
+              />
+            ) : (
+              <Chip
+                key={group.sId}
+                size="xs"
+                color={getGroupKindChip(group.kind).color}
+                label={group.name}
+                isBusy={pendingGroupId === group.sId}
+                onRemove={() => void onRemove(group)}
+              />
+            )
+          )}
+          {displayedGroups.length === 0 && (
+            <div className="text-sm text-muted-foreground">
+              This member is not part of any group.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/lib/swr/groups.ts
+++ b/front/lib/swr/groups.ts
@@ -8,6 +8,7 @@ import type {
   GetMemberGroupsResponseBody,
   PatchGroupResponseBody,
   PostGroupResponseBody,
+  PostMemberGroupResponseBody,
 } from "@app/types/api/groups/manage";
 import type { PutGroupSpendLimitResponseBody } from "@app/types/api/groups/spend_limit";
 import { type GroupKind, MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
@@ -176,13 +177,21 @@ export function useAddMemberToGroup({
           return false;
         }
 
+        const body: PostMemberGroupResponseBody = await res.json();
+
         sendNotification({
           type: "success",
           title: "Member added to group",
           description: `The member has been added to ${groupName}.`,
         });
 
-        await mutateMemberGroups();
+        await mutateMemberGroups(
+          (previous) =>
+            previous
+              ? { ...previous, groups: [...previous.groups, body.group] }
+              : previous,
+          { revalidate: false }
+        );
         // Member counts changed in the workspace groups list.
         await invalidateWorkspaceGroups(owner.sId);
 
@@ -247,7 +256,16 @@ export function useRemoveMemberFromGroup({
           description: `The member has been removed from ${groupName}.`,
         });
 
-        await mutateMemberGroups();
+        await mutateMemberGroups(
+          (previous) =>
+            previous
+              ? {
+                  ...previous,
+                  groups: previous.groups.filter((g) => g.sId !== groupId),
+                }
+              : previous,
+          { revalidate: false }
+        );
         // Member counts changed in the workspace groups list.
         await invalidateWorkspaceGroups(owner.sId);
 

--- a/front/lib/swr/groups.ts
+++ b/front/lib/swr/groups.ts
@@ -5,6 +5,7 @@ import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetGroupsResponseBody } from "@app/types/api/groups";
 import type {
   GetGroupResponseBody,
+  GetMemberGroupsResponseBody,
   PatchGroupResponseBody,
   PostGroupResponseBody,
 } from "@app/types/api/groups/manage";
@@ -87,6 +88,178 @@ export function useGroup({
     isGroupError: !!error,
     mutateGroup: mutate,
   };
+}
+
+function memberGroupsUrl(workspaceId: string, userId: string): string {
+  return `/api/w/${workspaceId}/members/${userId}/groups`;
+}
+
+/**
+ * Groups (provisioned and manually-managed) a given workspace member belongs to.
+ */
+export function useMemberGroups({
+  owner,
+  userId,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  userId: string | null;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const memberGroupsFetcher: Fetcher<GetMemberGroupsResponseBody> = fetcher;
+
+  const isDisabled = disabled || !userId;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    memberGroupsUrl(owner.sId, userId ?? "unknown"),
+    memberGroupsFetcher,
+    { disabled: isDisabled }
+  );
+
+  const groups = useMemo(
+    () =>
+      data ? [...data.groups].sort((a, b) => a.name.localeCompare(b.name)) : [],
+    [data]
+  );
+
+  return {
+    memberGroups: groups,
+    isMemberGroupsLoading: !error && !data && !isDisabled,
+    isMemberGroupsError: !!error,
+    mutateMemberGroups: mutate,
+  };
+}
+
+export function useAddMemberToGroup({
+  owner,
+  userId,
+}: {
+  owner: LightWorkspaceType;
+  userId: string | null;
+}) {
+  const sendNotification = useSendNotification();
+  const [isAdding, setIsAdding] = useState(false);
+  const { mutateMemberGroups } = useMemberGroups({
+    owner,
+    userId,
+    disabled: true,
+  });
+
+  const doAddMemberToGroup = useCallback(
+    async ({
+      groupId,
+      groupName,
+    }: {
+      groupId: string;
+      groupName: string;
+    }): Promise<boolean> => {
+      if (!userId) {
+        return false;
+      }
+      setIsAdding(true);
+      try {
+        const res = await clientFetch(memberGroupsUrl(owner.sId, userId), {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ groupId }),
+        });
+
+        if (!res.ok) {
+          const error = await res.json();
+          sendNotification({
+            type: "error",
+            title: "Failed to add member to group",
+            description:
+              error?.error?.message ?? "An unexpected error occurred.",
+          });
+          return false;
+        }
+
+        sendNotification({
+          type: "success",
+          title: "Member added to group",
+          description: `The member has been added to ${groupName}.`,
+        });
+
+        await mutateMemberGroups();
+        // Member counts changed in the workspace groups list.
+        await invalidateWorkspaceGroups(owner.sId);
+
+        return true;
+      } finally {
+        setIsAdding(false);
+      }
+    },
+    [owner.sId, userId, mutateMemberGroups, sendNotification]
+  );
+
+  return { doAddMemberToGroup, isAdding };
+}
+
+export function useRemoveMemberFromGroup({
+  owner,
+  userId,
+}: {
+  owner: LightWorkspaceType;
+  userId: string | null;
+}) {
+  const sendNotification = useSendNotification();
+  const [isRemoving, setIsRemoving] = useState(false);
+  const { mutateMemberGroups } = useMemberGroups({
+    owner,
+    userId,
+    disabled: true,
+  });
+
+  const doRemoveMemberFromGroup = useCallback(
+    async ({
+      groupId,
+      groupName,
+    }: {
+      groupId: string;
+      groupName: string;
+    }): Promise<boolean> => {
+      if (!userId) {
+        return false;
+      }
+      setIsRemoving(true);
+      try {
+        const res = await clientFetch(
+          `${memberGroupsUrl(owner.sId, userId)}/${groupId}`,
+          { method: "DELETE" }
+        );
+
+        if (!res.ok) {
+          const error = await res.json();
+          sendNotification({
+            type: "error",
+            title: "Failed to remove member from group",
+            description:
+              error?.error?.message ?? "An unexpected error occurred.",
+          });
+          return false;
+        }
+
+        sendNotification({
+          type: "success",
+          title: "Member removed from group",
+          description: `The member has been removed from ${groupName}.`,
+        });
+
+        await mutateMemberGroups();
+        // Member counts changed in the workspace groups list.
+        await invalidateWorkspaceGroups(owner.sId);
+
+        return true;
+      } finally {
+        setIsRemoving(false);
+      }
+    },
+    [owner.sId, userId, mutateMemberGroups, sendNotification]
+  );
+
+  return { doRemoveMemberFromGroup, isRemoving };
 }
 
 function groupSpendLimitUrl(workspaceId: string, groupId: string): string {

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -95,6 +95,23 @@ interface SheetContentProps
   preventAutoFocusOnOpen?: boolean;
 }
 
+type PointerDownOutsideEvent = Parameters<
+  NonNullable<SheetContentProps["onPointerDownOutside"]>
+>[0];
+
+type InteractOutsideEvent = Parameters<
+  NonNullable<SheetContentProps["onInteractOutside"]>
+>[0];
+
+// Notifications are rendered by sonner in their own portal, outside of the sheet: interacting with
+// a toast (typically dismissing it) must not be treated as an interaction outside the sheet.
+function isEventInsideNotification(event: {
+  detail: { originalEvent: Event };
+}): boolean {
+  const target = event.detail.originalEvent.target;
+  return target instanceof Element && !!target.closest("[data-sonner-toaster]");
+}
+
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
@@ -110,6 +127,8 @@ const SheetContent = React.forwardRef<
       preventAutoFocusOnOpen = true,
       onCloseAutoFocus,
       onOpenAutoFocus,
+      onPointerDownOutside,
+      onInteractOutside,
       ...props
     },
     ref
@@ -132,6 +151,28 @@ const SheetContent = React.forwardRef<
         onOpenAutoFocus?.(event);
       },
       [preventAutoFocusOnOpen, onOpenAutoFocus]
+    );
+
+    const handlePointerDownOutside = React.useCallback(
+      (event: PointerDownOutsideEvent) => {
+        if (isEventInsideNotification(event)) {
+          event.preventDefault();
+          return;
+        }
+        onPointerDownOutside?.(event);
+      },
+      [onPointerDownOutside]
+    );
+
+    const handleInteractOutside = React.useCallback(
+      (event: InteractOutsideEvent) => {
+        if (isEventInsideNotification(event)) {
+          event.preventDefault();
+          return;
+        }
+        onInteractOutside?.(event);
+      },
+      [onInteractOutside]
     );
 
     const onKeyDownCapture = React.useCallback(
@@ -163,6 +204,8 @@ const SheetContent = React.forwardRef<
             )}
             onCloseAutoFocus={handleCloseAutoFocus}
             onOpenAutoFocus={handleOpenAutoFocus}
+            onPointerDownOutside={handlePointerDownOutside}
+            onInteractOutside={handleInteractOutside}
             onKeyDownCapture={onKeyDownCapture}
             {...props}
           >


### PR DESCRIPTION
## Description

follow up of https://github.com/dust-tt/dust/pull/30131
closes https://github.com/dust-tt/tasks/issues/9848
This is the UI part of the dev

Add a new "group" section which displayes the group and let you pick/remove some regular manual groups.

This PR also include:
 - a small fix to sparkle Sheet so closing a toast does not close the whole sheet
 - a refacto to extract the chip color depending on group type into a constant

<img width="2812" height="1742" alt="image" src="https://github.com/user-attachments/assets/5971a106-dc5e-47aa-a33d-e79c22eea8c4" />


## Tests

tested manually

https://github.com/user-attachments/assets/77fb1f77-9b5b-4db6-9def-c2bd1376550d

## Risk

low, only UI

## Deploy Plan

deploy front
