### PR TITLE
Add the dsbx poller that runs Pod function work in the pod

### DIFF
--- a/cli/dust-sandbox/src/commands/poller/config.rs
+++ b/cli/dust-sandbox/src/commands/poller/config.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 use anyhow::{bail, Context};
 use serde::Deserialize;
 
-/// Where root installs the poller's initial credential. Readable by the poller's group and nobody
-/// else, so a sandbox workload cannot pick it up.
+/// Where root installs the poller's initial credential. Root-owned and root-readable only, since
+/// the poller runs as root and no sandbox workload may pick it up.
 pub const DEFAULT_INSTALLED_TOKEN_PATH: &str = "/etc/dust/poller-token";
 
 /// Where root installs the poller's static settings.
@@ -94,51 +94,92 @@ impl TokenStore {
         })?;
         let token = token.trim().to_string();
         if token.is_empty() {
-            bail!(
-                "poller token at {} is empty",
-                self.installed_path.display()
-            );
+            bail!("poller token at {} is empty", self.installed_path.display());
         }
 
         Ok(token)
     }
 
+    /// Forget the stored credential, so the next load falls back to the installed one.
+    ///
+    /// Used when front refuses what we have: a state file holding a revoked token would otherwise
+    /// be retried forever, since nothing else rewrites it until the sandbox next wakes.
+    pub fn forget(&self) -> anyhow::Result<()> {
+        match std::fs::remove_file(&self.state_path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error).with_context(|| {
+                format!(
+                    "failed to clear the poller token at {}",
+                    self.state_path.display()
+                )
+            }),
+        }
+    }
+
     pub fn store(&self, token: &str) -> anyhow::Result<()> {
         if let Some(parent) = self.state_path.parent() {
-            std::fs::create_dir_all(parent).with_context(|| {
-                format!("failed to create poller state dir at {}", parent.display())
-            })?;
+            create_private_dir(parent)?;
         }
 
         // Written through a temporary file in the same directory so a crash mid-write cannot leave
-        // a truncated credential behind, which would lock the poller out until the next wake.
+        // a truncated credential behind, which would lock the poller out until the next wake. The
+        // file is created already restricted rather than chmod'd afterwards: the window between
+        // the two is a live credential readable by anyone, once a minute, forever.
         let temp_path = self.state_path.with_extension("tmp");
-        std::fs::write(&temp_path, token).with_context(|| {
-            format!("failed to write poller token to {}", temp_path.display())
-        })?;
-        restrict_to_owner(&temp_path)?;
-        std::fs::rename(&temp_path, &self.state_path).with_context(|| {
-            format!(
-                "failed to move poller token into {}",
-                self.state_path.display()
-            )
-        })?;
+        let write = write_private_file(&temp_path, token).and_then(|()| {
+            std::fs::rename(&temp_path, &self.state_path).with_context(|| {
+                format!(
+                    "failed to move poller token into {}",
+                    self.state_path.display()
+                )
+            })
+        });
 
-        Ok(())
+        if write.is_err() {
+            // Leaving it behind would strand a usable credential in a file nothing rewrites.
+            let _ = std::fs::remove_file(&temp_path);
+        }
+
+        write
     }
 }
 
 #[cfg(unix)]
-fn restrict_to_owner(path: &Path) -> anyhow::Result<()> {
-    use std::os::unix::fs::PermissionsExt;
+fn write_private_file(path: &Path, contents: &str) -> anyhow::Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
 
-    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
-        .with_context(|| format!("failed to restrict {}", path.display()))
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+        .with_context(|| format!("failed to create {}", path.display()))?;
+    file.write_all(contents.as_bytes())
+        .with_context(|| format!("failed to write {}", path.display()))
 }
 
 #[cfg(not(unix))]
-fn restrict_to_owner(_path: &Path) -> anyhow::Result<()> {
-    Ok(())
+fn write_private_file(path: &Path, contents: &str) -> anyhow::Result<()> {
+    std::fs::write(path, contents).with_context(|| format!("failed to write {}", path.display()))
+}
+
+#[cfg(unix)]
+fn create_private_dir(path: &Path) -> anyhow::Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(path)
+        .with_context(|| format!("failed to create poller state dir at {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn create_private_dir(path: &Path) -> anyhow::Result<()> {
+    std::fs::create_dir_all(path)
+        .with_context(|| format!("failed to create poller state dir at {}", path.display()))
 }
 
 #[cfg(test)]
@@ -193,12 +234,56 @@ mod tests {
         assert_eq!(store.load().expect("load"), "sbt-installed");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn stores_the_rotated_token_readable_only_by_the_poller() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = dir.path().join("nested").join("token");
+        let store = TokenStore::new(state.clone(), dir.path().join("installed"));
+
+        store.store("sbt-rotated").expect("store");
+
+        // Creating the file already restricted matters more than restricting it after: the window
+        // between the two would be a live credential any account could read, once a minute.
+        let mode = std::fs::metadata(&state)
+            .expect("metadata")
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600);
+        let dir_mode = std::fs::metadata(state.parent().expect("parent"))
+            .expect("dir metadata")
+            .permissions()
+            .mode();
+        assert_eq!(dir_mode & 0o777, 0o700);
+    }
+
+    #[test]
+    fn forgetting_a_refused_token_falls_back_to_the_installed_one() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let installed = dir.path().join("installed");
+        let state = dir.path().join("state");
+        std::fs::write(&installed, "sbt-installed").expect("write installed");
+        let store = TokenStore::new(state, installed);
+        store.store("sbt-revoked").expect("store");
+
+        store.forget().expect("forget");
+
+        assert_eq!(store.load().expect("load"), "sbt-installed");
+        // Forgetting what is already gone is not an error: it runs on every refused connect.
+        store.forget().expect("forget again");
+    }
+
     #[test]
     fn rejects_an_incomplete_config() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("poller.json");
-        std::fs::write(&path, r#"{"apiUrl":"https://dust.example","workspaceId":""}"#)
-            .expect("write config");
+        std::fs::write(
+            &path,
+            r#"{"apiUrl":"https://dust.example","workspaceId":""}"#,
+        )
+        .expect("write config");
 
         assert!(PollerConfig::load(&path).is_err());
     }

--- a/cli/dust-sandbox/src/commands/poller/job.rs
+++ b/cli/dust-sandbox/src/commands/poller/job.rs
@@ -10,16 +10,36 @@ use tracing::warn;
 
 use crate::commands::function::envelope::ResultEnvelope;
 
-/// The runner, invoked by absolute path. The poller runs as its own user and must not resolve
-/// anything through PATH.
+/// The runner, invoked by absolute path. The poller is privileged and must not resolve anything
+/// through PATH.
 const DSBX_BIN_PATH: &str = "/opt/bin/dsbx";
-const SUDO_BIN_PATH: &str = "/usr/bin/sudo";
 
-/// The user a Pod function runs as. The poller is more privileged than this and only ever drops
-/// down to it: function code never runs in the poller's own process.
-const WORKLOAD_USER: &str = "agent-proxied";
+/// The account a Pod function runs as: `agent-proxied`, whose uid is fixed by the image and
+/// mirrored in `SANDBOX_AGENT_PROXIED_UID` (front/lib/api/sandbox/image/types.ts).
+///
+/// Dropped to by uid rather than through a helper: sandbox images purge `sudo` and strip the setuid
+/// bit from every local auth helper, on purpose, so there is nothing to shell out to. Setting the
+/// child's credentials directly is also the narrower move, since it never puts the environment or
+/// the function's slug through another program's parser.
+const WORKLOAD_UID: u32 = 1003;
+/// agent-proxied's own group, and the `agent` group it is a supplementary member of. The image
+/// grants the shared pod databases to `agent`, so a function that loses that membership loses its
+/// own state. Mirrors `SANDBOX_AGENT_PROXIED_UID` and `SANDBOX_AGENT_UID`.
+const WORKLOAD_GID: u32 = 1003;
+const AGENT_GID: u32 = 1002;
 
 const WORKING_DIRECTORY: &str = "/home/agent";
+
+/// The workload account's baseline environment. Mirrors `SANDBOX_AGENT_PROXIED_SAFE_PATH` in
+/// front/lib/api/sandbox/hardening.ts, and the home `useradd --create-home` gives agent-proxied in
+/// front/lib/api/sandbox/image/registry.ts. Equality is asserted in
+/// front/lib/api/sandbox/hardening.test.ts, since neither side can import the other.
+const WORKLOAD_PATH: &str =
+    "/opt/venv/bin:/opt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+const WORKLOAD_HOME: &str = "/home/agent-proxied";
+
+/// How much of a failed run's stderr reaches the log.
+const LOG_TAIL_MAX_CHARS: usize = 2_048;
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -43,19 +63,12 @@ pub struct ClaimResponse {
 
 /// Build the command that runs one job.
 ///
-/// Drops to the workload user through sudo rather than running the function as the poller. The
-/// environment is passed through sudo's preserve list rather than on the command line: it carries
-/// the invocation's credential, and argv is world-readable through /proc.
+/// The function runs as the workload account, never as the poller. The environment carries the
+/// invocation's credential and is set on the child directly, so it never reaches argv, which is
+/// world-readable through /proc.
 pub fn build_run_command(job: &PollerJob) -> Command {
-    let preserved: Vec<&str> = job.env_vars.keys().map(String::as_str).collect();
-
-    let mut command = Command::new(SUDO_BIN_PATH);
+    let mut command = Command::new(DSBX_BIN_PATH);
     command
-        .arg(format!("--preserve-env={}", preserved.join(",")))
-        .arg("-u")
-        .arg(WORKLOAD_USER)
-        .arg("--")
-        .arg(DSBX_BIN_PATH)
         .arg("function")
         .arg("run")
         .arg("--result-delivery")
@@ -65,14 +78,67 @@ pub fn build_run_command(job: &PollerJob) -> Command {
         .arg("--")
         .arg(&job.slug)
         .current_dir(WORKING_DIRECTORY)
+        // Cleared so nothing of the poller's own environment reaches function code, then given the
+        // workload account's baseline explicitly. The exec path inherits these from the sandbox
+        // exec environment; here there is nothing to inherit, so they are stated. Mirrors
+        // SANDBOX_AGENT_PROXIED_SAFE_PATH in front/lib/api/sandbox/hardening.ts.
         .env_clear()
+        .env("PATH", WORKLOAD_PATH)
+        .env("HOME", WORKLOAD_HOME)
         .envs(&job.env_vars)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+        .stderr(Stdio::piped())
+        // A runner that outran its ceiling has to go with it. Without this the poller reports the
+        // timeout while the function keeps running, past the deadline front sized the claim
+        // against, still holding pod state and the invocation's credential.
+        .kill_on_drop(true);
+
+    drop_to_workload_account(&mut command);
 
     command
 }
+
+/// Drop the child to the workload account: supplementary groups, then group, then user.
+///
+/// Done in one `pre_exec` rather than through `Command::uid`/`gid` because the order is the whole
+/// point and those run the callback after the uid is already dropped, which would leave `setgroups`
+/// without the privilege it needs. `Command::groups` would express this directly but is still
+/// nightly-only.
+///
+/// The supplementary list has to be stated. Inheriting it would both hand function code the
+/// poller's groups and drop the `agent` membership that grants Pod functions read/write on the
+/// shared pod databases.
+#[cfg(unix)]
+fn drop_to_workload_account(command: &mut Command) {
+    use std::io::Error;
+
+    // Safety: only async-signal-safe libc calls between fork and exec.
+    unsafe {
+        command.pre_exec(|| {
+            // Its own process group, so the timeout can stop the whole run. The runner spawns bun
+            // as a separate process, and killing only the direct child would leave function code
+            // running past the deadline with the invocation's credential still in its environment.
+            if libc::setpgid(0, 0) != 0 {
+                return Err(Error::last_os_error());
+            }
+            let groups = [WORKLOAD_GID as libc::gid_t, AGENT_GID as libc::gid_t];
+            if libc::setgroups(groups.len() as _, groups.as_ptr()) != 0 {
+                return Err(Error::last_os_error());
+            }
+            if libc::setgid(WORKLOAD_GID as libc::gid_t) != 0 {
+                return Err(Error::last_os_error());
+            }
+            if libc::setuid(WORKLOAD_UID as libc::uid_t) != 0 {
+                return Err(Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+}
+
+#[cfg(not(unix))]
+fn drop_to_workload_account(_command: &mut Command) {}
 
 /// Run one job and return the result envelope to hand back to front.
 ///
@@ -97,32 +163,73 @@ async fn run_to_envelope(job: &PollerJob) -> anyhow::Result<serde_json::Value> {
     let mut child = build_run_command(job)
         .spawn()
         .context("failed to start the Pod function runner")?;
+    let child_pid = child.id();
 
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin
-            .write_all(job.input_envelope.as_bytes())
+    // The whole run is under one deadline, the write included. A runner that is alive but not
+    // reading its stdin would otherwise block here forever on an input larger than the pipe
+    // buffer, leaving a task and a child behind for the life of the pod.
+    let run = async {
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin
+                .write_all(job.input_envelope.as_bytes())
+                .await
+                .context("failed to write the Pod function input")?;
+            stdin.shutdown().await.ok();
+        }
+
+        child
+            .wait_with_output()
             .await
-            .context("failed to write the Pod function input")?;
-        stdin.shutdown().await.ok();
-    }
+            .context("failed to run the Pod function")
+    };
 
-    let output = match tokio::time::timeout(
-        Duration::from_millis(job.timeout_ms),
-        child.wait_with_output(),
-    )
-    .await
-    {
-        Ok(result) => result.context("failed to run the Pod function")?,
+    let output = match tokio::time::timeout(Duration::from_millis(job.timeout_ms), run).await {
+        Ok(result) => result?,
         Err(_) => {
-            anyhow::bail!(
-                "Pod function did not finish within {}ms.",
-                job.timeout_ms
-            );
+            // The whole group, not just the child `kill_on_drop` would reach: the runner's own bun
+            // process is what is actually executing the function.
+            kill_run_group(child_pid);
+            anyhow::bail!("Pod function did not finish within {}ms.", job.timeout_ms);
         }
     };
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    parse_result_envelope(&stdout)
+    let envelope = parse_result_envelope(&stdout);
+    if envelope.is_err() {
+        // The exec path logs both streams when an envelope is rejected. Without stderr the only
+        // thing left to go on is "produced no stdout result envelope", which says nothing about
+        // why.
+        warn!(
+            invocation_id = %job.invocation_id,
+            exit_code = output.status.code(),
+            stderr = %truncate_for_log(&String::from_utf8_lossy(&output.stderr)),
+            "Pod function did not produce a usable result envelope"
+        );
+    }
+
+    envelope
+}
+
+/// Stop a timed-out run and everything it spawned.
+///
+/// The runner is its own process group leader, so one signal reaches the bun process actually
+/// running the function. Best effort: a run that already exited is not an error.
+#[cfg(unix)]
+fn kill_run_group(child_pid: Option<u32>) {
+    let Some(pid) = child_pid else {
+        return;
+    };
+    // Safety: `killpg` on a pid we spawned into its own group.
+    unsafe {
+        libc::killpg(pid as libc::pid_t, libc::SIGKILL);
+    }
+}
+
+#[cfg(not(unix))]
+fn kill_run_group(_child_pid: Option<u32>) {}
+
+fn truncate_for_log(value: &str) -> String {
+    value.chars().take(LOG_TAIL_MAX_CHARS).collect()
 }
 
 /// Take the envelope the runner wrote, which is its last non-empty stdout line.
@@ -134,8 +241,7 @@ fn parse_result_envelope(stdout: &str) -> anyhow::Result<serde_json::Value> {
     let last_line = stdout
         .lines()
         .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .next_back()
+        .rfind(|line| !line.is_empty())
         .unwrap_or_default();
 
     if last_line.is_empty() {
@@ -157,7 +263,10 @@ mod tests {
             exec_token: "sbt-job".to_string(),
             input_envelope: r#"{"method":"POST"}"#.to_string(),
             env_vars: BTreeMap::from([
-                ("DUST_API_URL".to_string(), "https://dust.example".to_string()),
+                (
+                    "DUST_API_URL".to_string(),
+                    "https://dust.example".to_string(),
+                ),
                 ("DUST_SANDBOX_TOKEN".to_string(), "sbt-job".to_string()),
             ]),
             timeout_ms: 10_000,
@@ -173,23 +282,21 @@ mod tests {
     }
 
     #[test]
-    fn drops_to_the_workload_user_through_absolute_paths() {
+    fn runs_the_runner_by_absolute_path() {
         let argv = command_argv(&build_run_command(&job()));
 
-        assert_eq!(argv[0], SUDO_BIN_PATH);
-        assert!(argv.contains(&"-u".to_string()));
-        assert!(argv.contains(&WORKLOAD_USER.to_string()));
-        assert!(argv.contains(&DSBX_BIN_PATH.to_string()));
+        // The poller is privileged and must not resolve the runner through PATH.
+        assert_eq!(argv[0], DSBX_BIN_PATH);
     }
 
     #[test]
     fn keeps_the_invocation_credential_out_of_argv() {
         let argv = command_argv(&build_run_command(&job())).join(" ");
 
-        // argv is world-readable through /proc, so the token travels in the environment and only
-        // its name may appear here.
+        // argv is world-readable through /proc, so the token travels in the environment and never
+        // appears here, under any name.
         assert!(!argv.contains("sbt-job"));
-        assert!(argv.contains("DUST_SANDBOX_TOKEN"));
+        assert!(!argv.contains("DUST_SANDBOX_TOKEN"));
     }
 
     #[test]

--- a/cli/dust-sandbox/src/commands/poller/mod.rs
+++ b/cli/dust-sandbox/src/commands/poller/mod.rs
@@ -24,7 +24,15 @@ const RECONNECT_BACKOFF_CAP: Duration = Duration::from_secs(30);
 /// something reconnecting fixes: only a fresh install does.
 const MAX_CONSECUTIVE_AUTH_FAILURES: u32 = 3;
 
+/// Deadline for the short request/response calls: claiming a job and reporting its result.
 const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The work channel is deliberately long-lived, so it gets a client with no total deadline. A
+/// total deadline follows the response body in reqwest, which would cut every connect short of the
+/// minute front holds it open, leaving the poller disconnected for a growing share of the time.
+/// Liveness comes from the read timeout instead: front sends at least the rotated token
+/// immediately and closes cleanly at the end.
+const CHANNEL_READ_TIMEOUT: Duration = Duration::from_secs(90);
 
 #[derive(clap::Args)]
 pub struct PollerArgs {
@@ -52,6 +60,10 @@ pub async fn cmd_poller(args: PollerArgs) -> anyhow::Result<()> {
         .timeout(HTTP_REQUEST_TIMEOUT)
         .build()
         .context("failed to build the poller HTTP client")?;
+    let channel_client = reqwest::Client::builder()
+        .read_timeout(CHANNEL_READ_TIMEOUT)
+        .build()
+        .context("failed to build the poller work channel client")?;
 
     let mut last_event_id: Option<String> = None;
     let mut consecutive_auth_failures = 0;
@@ -59,7 +71,16 @@ pub async fn cmd_poller(args: PollerArgs) -> anyhow::Result<()> {
 
     loop {
         let token = tokens.load()?;
-        match stream::run_connect(&client, &config, &tokens, &token, last_event_id.clone()).await {
+        match stream::run_connect(
+            &channel_client,
+            &client,
+            &config,
+            &tokens,
+            &token,
+            last_event_id.clone(),
+        )
+        .await
+        {
             Ok(resume_point) => {
                 consecutive_auth_failures = 0;
                 backoff = RECONNECT_BACKOFF;
@@ -73,6 +94,13 @@ pub async fn cmd_poller(args: PollerArgs) -> anyhow::Result<()> {
                     consecutive_auth_failures,
                     "Pod function work channel refused the poller's credential"
                 );
+                // A rotated token that no longer authenticates is not something retrying fixes, so
+                // fall back to the one root installed before giving up on it entirely. Without
+                // this, a token lost between front revoking the old one and this process storing
+                // the new one leaves the poller retrying a dead credential until the next wake.
+                if let Err(error) = tokens.forget() {
+                    warn!(error = %error, "Failed to clear the poller's stored credential");
+                }
                 if consecutive_auth_failures >= MAX_CONSECUTIVE_AUTH_FAILURES {
                     anyhow::bail!(
                         "the poller's credential was refused {MAX_CONSECUTIVE_AUTH_FAILURES} times"

--- a/cli/dust-sandbox/src/commands/poller/stream.rs
+++ b/cli/dust-sandbox/src/commands/poller/stream.rs
@@ -33,6 +33,14 @@ pub enum ConnectError {
     Transport(anyhow::Error),
 }
 
+/// How many jobs this pod runs at once. The sandbox is a small VM and every run forks a runner
+/// plus a bun process, so this is what keeps a burst of doorbells from taking the pod down.
+const MAX_CONCURRENT_RUNS: usize = 4;
+
+/// A frame this large means the stream is not carrying frames. Bounded so a channel that never
+/// sends a newline cannot grow the buffer for the life of the pod.
+const MAX_BUFFERED_FRAME_BYTES: usize = 1024 * 1024;
+
 /// Read one `data:` frame from the channel.
 ///
 /// Returns `None` for the frames the channel uses for flow control rather than content: the open
@@ -49,13 +57,16 @@ pub fn parse_sse_payload(line: &str) -> Option<anyhow::Result<PollerStreamEvent>
 
 /// Hold one connect open, acting on what arrives, and return where to resume.
 pub async fn run_connect(
-    client: &reqwest::Client,
+    // Two clients: the channel one has no total deadline so a connect can last its full minute,
+    // the job one keeps the short deadline that a claim or a result callback should have.
+    channel_client: &reqwest::Client,
+    job_client: &reqwest::Client,
     config: &Arc<PollerConfig>,
     tokens: &TokenStore,
     token: &str,
     last_event_id: Option<String>,
 ) -> Result<Option<String>, ConnectError> {
-    let mut request = client
+    let mut request = channel_client
         .get(config.work_channel_url())
         .header("authorization", format!("Bearer {token}"))
         .header("accept", "text/event-stream");
@@ -80,16 +91,34 @@ pub async fn run_connect(
         )));
     }
 
+    let run_permits = Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_RUNS));
     let mut resume_point = last_event_id;
-    let mut buffer = String::new();
+    // The credential the claim endpoint will accept. Connecting is what revokes the one this
+    // connect was opened with, so every claim has to use what front hands down on the stream, not
+    // what got us here.
+    let mut current_token = token.to_string();
+    // Bytes, not a string: chunks arrive on arbitrary boundaries, and decoding each one on its own
+    // would turn a multi-byte character split across two chunks into replacement characters, which
+    // is a corrupted frame that only shows up as an unreadable event.
+    let mut buffer: Vec<u8> = Vec::new();
     let mut stream = response.bytes_stream();
 
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.map_err(|error| ConnectError::Transport(error.into()))?;
-        buffer.push_str(&String::from_utf8_lossy(&chunk));
+        buffer.extend_from_slice(&chunk);
+        if buffer.len() > MAX_BUFFERED_FRAME_BYTES {
+            return Err(ConnectError::Transport(anyhow::anyhow!(
+                "work channel sent {} bytes without a frame boundary",
+                buffer.len()
+            )));
+        }
 
-        while let Some(newline) = buffer.find('\n') {
-            let line: String = buffer.drain(..=newline).collect();
+        while let Some(newline) = buffer.iter().position(|byte| *byte == b'\n') {
+            let line_bytes: Vec<u8> = buffer.drain(..=newline).collect();
+            let Ok(line) = String::from_utf8(line_bytes) else {
+                warn!("Skipping a Pod function channel frame that was not valid UTF-8");
+                continue;
+            };
             let Some(parsed) = parse_sse_payload(&line) else {
                 continue;
             };
@@ -111,17 +140,28 @@ pub async fn run_connect(
                     if let Err(error) = tokens.store(&rotated) {
                         return Err(ConnectError::Transport(error));
                     }
+                    current_token = rotated;
                 }
                 PollerEvent::Job { invocation_id } => {
+                    // Only a doorbell moves the resume point. The token event carries the id this
+                    // connect started from, and treating it as progress would rewind the poller.
                     if !event.event_id.is_empty() {
                         resume_point = Some(event.event_id.clone());
                     }
                     // Not awaited: a slow job must not stop the channel from delivering the next
                     // doorbell, and each one settles itself.
-                    let client = client.clone();
+                    let client = job_client.clone();
                     let config = Arc::clone(config);
-                    let token = token.to_string();
+                    let token = current_token.clone();
+                    let permits = Arc::clone(&run_permits);
                     tokio::spawn(async move {
+                        // Bounded because the pod is a small VM and each run forks a runner and a
+                        // bun process. The exec path was implicitly capped by the exec API; without
+                        // this the channel replaces that with nothing. A doorbell that waits here
+                        // long enough loses its claim to front, which is the fallback working.
+                        let Ok(_permit) = permits.acquire().await else {
+                            return;
+                        };
                         handle_doorbell(&client, &config, &token, &invocation_id).await;
                     });
                 }
@@ -181,5 +221,35 @@ mod tests {
         assert!(parse_sse_payload("data: {not json}\n")
             .expect("frame")
             .is_err());
+    }
+
+    #[test]
+    fn reads_a_frame_split_across_chunk_boundaries() {
+        // Chunks arrive on byte boundaries, so a frame is only readable once its newline has
+        // arrived. Decoding a partial chunk on its own would corrupt any multi-byte character it
+        // was cut through, and the frame would be dropped as unreadable.
+        let frame = r#"data: {"eventId":"5-0","data":{"type":"sandbox_function_poller_job","created":1,"invocationId":"caf\u00e9"}}"#;
+        let bytes = format!("{frame}\n").into_bytes();
+        let mut buffer: Vec<u8> = Vec::new();
+
+        let mut events = Vec::new();
+        for chunk in bytes.chunks(7) {
+            buffer.extend_from_slice(chunk);
+            while let Some(newline) = buffer.iter().position(|byte| *byte == b'\n') {
+                let line_bytes: Vec<u8> = buffer.drain(..=newline).collect();
+                let line = String::from_utf8(line_bytes).expect("utf8");
+                if let Some(parsed) = parse_sse_payload(&line) {
+                    events.push(parsed.expect("event"));
+                }
+            }
+        }
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].data,
+            PollerEvent::Job {
+                invocation_id: "caf\u{e9}".to_string()
+            }
+        );
     }
 }


### PR DESCRIPTION
## Description

Stacked on #30134. Third of five slices adding a warm path for fast Pod function invocations, and the side that answers.

The poller holds an outbound stream to front, claims the invocations it is rung about, and runs them in the pod. That is what takes the sandbox exec API round trip, which is where today's ~800ms goes, off the hot path.

It is privileged relative to the workload and never runs function code itself. Every job is spawned having dropped supplementary groups, then group, then user, in one step: setting only uid and gid would leave the child holding the poller's groups while losing the `agent` membership that grants Pod functions access to their own pod state. The drop is direct rather than through a helper because sandbox images purge sudo and strip setuid from the local auth helpers on purpose, so there is nothing to shell out to, and because it keeps the environment and the function's slug out of another program's parser. The invocation's credential travels in that environment and never in argv, which is world-readable through /proc.

Two things about the connect are load-bearing and easy to get wrong. Claims use the credential front sends down the stream, not the one used to open the connect, because connecting is what revokes that one. And the channel gets its own HTTP client with no total deadline, since a total deadline follows the response body and would cut every connect short of the minute front holds it open.

A claimed job always settles, and always within its ceiling. A runner that cannot start, outruns its ceiling or writes nothing usable still produces a result envelope, because the alternative is an invocation nobody finishes. The whole run including the stdin write sits under one deadline, and the runner is killed with it rather than left running past the point front considers the invocation over.

Nothing starts this yet. The image and lifecycle work that installs the unit and the credential is the next slice.

## Tests

Unit tests cover the parts that are pure: token store precedence and fallback, credential file permissions, SSE frame parsing including a frame split across chunk boundaries, argv shape, and envelope handling for a runner that cannot start.

What they do not cover is the connect loop itself, which is where the two bugs above lived. Worth adding a mock-server test that serves a token frame followed by a job frame and asserts the claim carries the rotated token, before the flag goes on.

Verified locally that the credential never appears in argv and that a failed run reports its stderr, since the previous behaviour gave nothing but "produced no stdout result envelope".

## Risk

Nothing invokes this. The binary gains a subcommand that no image starts until the next slice, so merging changes no behaviour.

The risk it carries into the next slice is the privilege drop. If the child were ever spawned without it, function code would run with the poller's credentials.

## Deploy Plan

Ships as a dsbx release. Nothing pins the new version until the image slice bumps it.