### PR TITLE
Start the Pod function poller in the pod

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.41"
+version = "0.1.42"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.41"
+version = "0.1.42"
 edition = "2021"
 
 [[bin]]

--- a/front/lib/api/sandbox/hardening.test.ts
+++ b/front/lib/api/sandbox/hardening.test.ts
@@ -1,0 +1,91 @@
+import {
+  getSandboxServicePathHardeningCommand,
+  SANDBOX_AGENT_PROXIED_SAFE_PATH,
+  SANDBOX_ROOT_INVOKED_HELPERS,
+  SANDBOX_STATIC_ROOT_CONSUMED_DIRS,
+} from "@app/lib/api/sandbox/hardening";
+import {
+  SANDBOX_AGENT_PROXIED_UID,
+  SANDBOX_AGENT_UID,
+} from "@app/lib/api/sandbox/image/types";
+import fs from "fs";
+import path from "path";
+import { describe, expect, it } from "vitest";
+
+const POLLER_JOB_SOURCE = path.resolve(
+  __dirname,
+  "../../../../cli/dust-sandbox/src/commands/poller/job.rs"
+);
+
+function readPollerJobSource(): string {
+  return fs.readFileSync(POLLER_JOB_SOURCE, "utf-8");
+}
+
+describe("sandbox root-consumed path hardening", () => {
+  it("covers the directory root reads the poller's identity out of", () => {
+    // The poller's credential and settings live under /etc/dust, and root installs them there. A
+    // workload able to write it would be running as root without needing to hijack a command.
+    expect(SANDBOX_STATIC_ROOT_CONSUMED_DIRS).toContain("/etc/dust");
+  });
+
+  it("keeps the runner root-owned, since a root process spawns it", () => {
+    expect(SANDBOX_ROOT_INVOKED_HELPERS).toContain("/opt/bin/dsbx");
+  });
+
+  it("pins the poller's unit to root ownership", () => {
+    const command = getSandboxServicePathHardeningCommand();
+
+    expect(command).toContain(
+      "/usr/bin/chown root:root /etc/systemd/system/dust-poller.service"
+    );
+    expect(command).toContain(
+      "/bin/chmod 644 /etc/systemd/system/dust-poller.service"
+    );
+  });
+
+  it("fails the build when the poller's unit is writable by anyone but root", () => {
+    const command = getSandboxServicePathHardeningCommand();
+
+    // An assertion rather than a fix-up: if the copy step ever lands it differently, the image
+    // build has to stop rather than quietly produce a sandbox a workload can take over.
+    expect(command).toContain(
+      "/etc/systemd/system/dust-poller.service \\( ! -user root -o ! -group root -o -perm /022 \\)"
+    );
+    expect(command).toContain(
+      "poller service files must be root-owned and not group/other writable"
+    );
+  });
+});
+
+describe("Pod function poller credential drop", () => {
+  // The poller runs as root and drops each function to the workload account itself. Neither side
+  // can import the other's constants, and getting any of these wrong means function code running
+  // with the wrong privileges, so they are asserted equal here.
+  it("drops to the same account the exec path runs functions as", () => {
+    const source = readPollerJobSource();
+
+    expect(source).toContain(
+      `const WORKLOAD_UID: u32 = ${SANDBOX_AGENT_PROXIED_UID};`
+    );
+    expect(source).toContain(
+      `const WORKLOAD_GID: u32 = ${SANDBOX_AGENT_PROXIED_UID};`
+    );
+  });
+
+  it("keeps the agent group membership that pod state depends on", () => {
+    const source = readPollerJobSource();
+
+    // agent-proxied is a supplementary member of `agent`, which is what grants read/write on the
+    // shared pod databases. A function that loses it loses its own state.
+    expect(source).toContain(`const AGENT_GID: u32 = ${SANDBOX_AGENT_UID};`);
+  });
+
+  it("gives the function the workload account's PATH", () => {
+    const source = readPollerJobSource();
+
+    // The exec path inherits this from the sandbox exec environment. The poller clears the
+    // environment, so it has to state it, and a drifted copy means functions resolving binaries
+    // differently depending on which transport ran them.
+    expect(source).toContain(`"${SANDBOX_AGENT_PROXIED_SAFE_PATH}"`);
+  });
+});

--- a/front/lib/api/sandbox/hardening.ts
+++ b/front/lib/api/sandbox/hardening.ts
@@ -15,6 +15,9 @@ export const SANDBOX_AGENT_PROXIED_SAFE_PATH = [
 ].join(":");
 export const SANDBOX_STATIC_ROOT_CONSUMED_DIRS = [
   "/opt/bin",
+  // Root and the poller read the poller's settings and credential out of /etc/dust. A workload
+  // able to write it owns the sandbox without ever needing a PATH trick.
+  "/etc/dust",
   "/usr/local",
   "/usr/local/sbin",
   "/usr/local/bin",
@@ -85,6 +88,13 @@ export function getSandboxServicePathHardeningCommand(): string {
     "/bin/chmod 644 /opt/dust/profile/*.sh",
     "/bin/chmod 755 /opt/dust/profile/dust-tools /opt/dust/profile/soffice/*.py",
   ].join(" && ");
+  // The poller's unit is read as root by systemd, and the poller it starts runs as root. A
+  // workload able to write it is a straight path to running as root, so ownership and mode are
+  // pinned here rather than left to whatever the copy step happened to produce.
+  const hardenPollerFiles = [
+    "/usr/bin/chown root:root /etc/systemd/system/dust-poller.service",
+    "/bin/chmod 644 /etc/systemd/system/dust-poller.service",
+  ].join(" && ");
   const assertPermissions = [
     `if [ "$(/usr/bin/getent passwd agent | /usr/bin/cut -d: -f6)" != ${SANDBOX_AGENT_SERVICE_HOME} ]; then`,
     "echo 'agent service account must use the root-owned empty home' >&2;",
@@ -93,6 +103,10 @@ export function getSandboxServicePathHardeningCommand(): string {
     "if /usr/bin/find /home/agent /opt/venv /opt/dust/profile \\( -type f -o -type d \\) -perm /022 -print -quit | /usr/bin/grep -q .; then",
     "echo 'sandbox service paths must not be group/other writable' >&2;",
     "exit 1;",
+    "fi;",
+    "if /usr/bin/find /etc/systemd/system/dust-poller.service \\( ! -user root -o ! -group root -o -perm /022 \\) -print -quit | /usr/bin/grep -q .; then",
+    "echo 'poller service files must be root-owned and not group/other writable' >&2;",
+    "exit 1;",
     "fi",
   ].join(" ");
 
@@ -100,6 +114,7 @@ export function getSandboxServicePathHardeningCommand(): string {
     hardenAgentHome,
     hardenPythonVenv,
     hardenDustProfiles,
+    hardenPollerFiles,
     assertPermissions,
   ].join(" && ");
 }

--- a/front/lib/api/sandbox/image/poller/dust-poller.service
+++ b/front/lib/api/sandbox/image/poller/dust-poller.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Dust Pod function poller
+After=network.target
+
+[Service]
+Type=simple
+# Runs as root because it drops each Pod function to the workload account itself: sandbox images
+# purge sudo and strip setuid from the local auth helpers, so there is no unprivileged way to
+# change credentials. Function code never runs in this process.
+User=root
+ExecStart=/opt/bin/dsbx poller
+Restart=always
+RestartSec=2
+# Stop only the poller itself. The default control-group kill would take every Pod function
+# runner in its cgroup with it, so a restart would kill invocations that are mid-flight.
+KillMode=process
+# A credential front no longer accepts is not something restarting fixes, so stop hammering it and
+# wait for the next wake to install a fresh one.
+StartLimitIntervalSec=60
+StartLimitBurst=5
+StateDirectory=dust-poller
+StateDirectoryMode=0700
+
+[Install]
+WantedBy=multi-user.target

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.66",
+      tag: "0.8.67",
     });
   });
 
@@ -188,7 +188,7 @@ describe("sandbox image registry", () => {
       expect(command).toContain("/usr/bin/passwd");
       expect(command).toContain("chmod u-s");
       expect(command).toContain(
-        "install -d -o root -g root -m 755 /opt/bin /usr/local /usr/local/sbin /usr/local/bin /usr/local/lib"
+        `install -d -o root -g root -m 755 ${SANDBOX_STATIC_ROOT_CONSUMED_DIRS.join(" ")}`
       );
       expect(command).toContain("/usr/bin/systemd-analyze unit-paths");
       expect(command).toContain("systemd unit path must be absolute");
@@ -459,7 +459,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.41/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.42/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,8 +26,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.66";
-const DSBX_CLI_VERSION = "0.1.41";
+const DUST_BASE_IMAGE_VERSION = "0.8.67";
+const DSBX_CLI_VERSION = "0.1.42";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
 // the stable identity used when creating the workload account.
@@ -58,6 +58,7 @@ const LIBREOFFICE_PPA = "ppa:libreoffice/ppa";
 const LITESTREAM_VERSION = "0.5.13";
 const EGRESS_LOCAL_DIR = path.resolve(__dirname, "egress");
 const LITESTREAM_LOCAL_DIR = path.resolve(__dirname, "litestream");
+const POLLER_LOCAL_DIR = path.resolve(__dirname, "poller");
 const PROFILE_LOCAL_DIR = path.resolve(__dirname, "profile");
 const TELEMETRY_LOCAL_DIR = path.resolve(__dirname, "telemetry");
 const TOKEN_LOCAL_DIR = path.resolve(__dirname, "token");
@@ -635,6 +636,15 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
   .copy(
     getLocalContent(TELEMETRY_LOCAL_DIR, "fluent-bit.service"),
     "/etc/systemd/system/fluent-bit.service",
+    { user: "root" }
+  )
+  // Pod function poller unit. Deliberately NOT enabled: front starts it at runtime once it has
+  // installed the settings and the credential the poller needs, neither of which exists at build
+  // time. Ownership and mode are pinned by the service path hardening, since systemd reads this
+  // as root and a workload able to write it would own the sandbox.
+  .copy(
+    getLocalContent(POLLER_LOCAL_DIR, "dust-poller.service"),
+    "/etc/systemd/system/dust-poller.service",
     { user: "root" }
   )
   // Seed /etc/dust/ca-bundle.pem with the system roots so replace-style trust

--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -30,6 +30,7 @@ type SandboxStartupPhase =
   | "gcs_refresh"
   | "egress_on_exec"
   | "telemetry_start"
+  | "poller_start"
   // provider.create split.
   | "provider.create_vm"
   | "provider.hardening"

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -12,6 +12,7 @@ import {
 import type { SandboxRuntimeOwner } from "@app/lib/api/sandbox/owner";
 import { podSandboxOnlyMounts } from "@app/lib/api/sandbox/pod_mounts";
 import { startTelemetry } from "@app/lib/api/sandbox/telemetry";
+import { startSandboxFunctionPoller } from "@app/lib/api/sandbox_functions/poller_runtime";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
@@ -191,6 +192,20 @@ async function ensureOwnerSandboxReady(
       if (ensureEgressResult.isErr()) {
         status = "error";
         return ensureEgressResult;
+      }
+
+      // After egress, since the poller's first act is to call front. Pods only: a conversation
+      // sandbox runs no Pod functions, so it has nothing to receive.
+      //
+      // Only on a new or woken sandbox, like telemetry above. Starting it installs a fresh
+      // credential and restarts the unit, and the routine five-minute refresh runs on the critical
+      // path of whatever invocation happened to trigger it: doing this then would restart the
+      // poller under its own in-flight runs, every five minutes, forever.
+      if (runtimeOwner.kind === "pod" && (freshlyCreated || wokeFromSleep)) {
+        await traceSandboxStartupPhase("poller_start", async () => {
+          await startSandboxFunctionPoller(auth, sandbox);
+          return new Ok(undefined);
+        });
       }
 
       await sandbox.updateLastRuntimeRefreshAt(new Date());

--- a/front/lib/api/sandbox/providers/e2b.test.ts
+++ b/front/lib/api/sandbox/providers/e2b.test.ts
@@ -76,12 +76,12 @@ vi.mock("e2b", () => {
 });
 
 import { CommandExitError, NotFoundError } from "e2b";
-
 import {
   SANDBOX_AGENT_PROXIED_SAFE_PATH,
   SANDBOX_AGENT_SAFE_PATH,
   SANDBOX_AGENT_SERVICE_HOME,
   SANDBOX_ROOT_SAFE_PATH,
+  SANDBOX_STATIC_ROOT_CONSUMED_DIRS,
 } from "../hardening";
 import { rootCommand } from "../root_command";
 import { E2BSandboxProvider } from "./e2b";
@@ -166,7 +166,7 @@ describe("E2BSandboxProvider", () => {
       "sudo must not be installed in sandbox images"
     );
     expect(hardeningCommand).toContain(
-      "install -d -o root -g root -m 755 /opt/bin /usr/local /usr/local/sbin /usr/local/bin /usr/local/lib"
+      `install -d -o root -g root -m 755 ${SANDBOX_STATIC_ROOT_CONSUMED_DIRS.join(" ")}`
     );
     expect(hardeningCommand).toContain("/usr/bin/systemd-analyze unit-paths");
     expect(hardeningCommand).toContain("systemd unit path must be absolute");

--- a/front/lib/api/sandbox_functions/poller_runtime.ts
+++ b/front/lib/api/sandbox_functions/poller_runtime.ts
@@ -1,0 +1,158 @@
+import config from "@app/lib/api/config";
+import { generateSandboxPollerToken } from "@app/lib/api/sandbox/access_tokens";
+import { rootCommand } from "@app/lib/api/sandbox/root_command";
+import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import logger from "@app/logger/logger";
+import { isDevelopment } from "@app/types/shared/env";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { randomBytes } from "crypto";
+
+const POLLER_CONFIG_DIR = "/etc/dust";
+const POLLER_CONFIG_PATH = `${POLLER_CONFIG_DIR}/poller.json`;
+const POLLER_TOKEN_PATH = `${POLLER_CONFIG_DIR}/poller-token`;
+const POLLER_STATE_PATH = "/var/lib/dust-poller/token";
+const POLLER_UNIT = "dust-poller.service";
+
+function pollerApiBaseUrl(): string {
+  return isDevelopment() && config.getSandboxDevFrontHostName()
+    ? `https://${config.getSandboxDevFrontHostName()}`
+    : config.getApiBaseUrl();
+}
+
+/**
+ * Install the poller's settings and credential, and start it.
+ *
+ * Run on every wake so the pod is reachable from its first invocation rather than from the second.
+ * Restarting is what makes the freshly installed credential take effect: a poller already running
+ * holds one front revoked when it last connected, and only a restart makes it read the new file.
+ *
+ * Never fails a wake. A pod without a poller is a pod whose invocations take the sandbox exec
+ * path, which is exactly what they do today.
+ */
+export async function startSandboxFunctionPoller(
+  auth: Authenticator,
+  sandbox: SandboxResource
+): Promise<void> {
+  if (!(await hasFeatureFlag(auth, "sandbox_function_warm_channel"))) {
+    return;
+  }
+
+  const result = await installAndStartPoller(auth, sandbox);
+  if (result.isErr()) {
+    logger.error(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        sandboxId: sandbox.sId,
+        error: result.error.message,
+      },
+      "Failed to start the Pod function poller"
+    );
+  }
+}
+
+async function installAndStartPoller(
+  auth: Authenticator,
+  sandbox: SandboxResource
+): Promise<Result<undefined, Error>> {
+  const token = await generateSandboxPollerToken(auth, { sandbox });
+  const pollerConfig = JSON.stringify({
+    apiUrl: pollerApiBaseUrl(),
+    workspaceId: auth.getNonNullableWorkspace().sId,
+  });
+
+  // Both files land through a temp file and a move so the poller, which may be mid-restart, never
+  // reads a partial one. The token goes in over stdin so it never reaches argv or the journal.
+  const tokenTmpPath = `${POLLER_CONFIG_DIR}/.poller-token.${randomBytes(8).toString("hex")}.tmp`;
+  const writeToken = rootCommand.and([
+    rootCommand.exec("/usr/bin/install", [
+      "-d",
+      "-o",
+      "root",
+      "-g",
+      "root",
+      "-m",
+      "755",
+      POLLER_CONFIG_DIR,
+    ]),
+    rootCommand.exec("/usr/bin/install", [
+      "-o",
+      "root",
+      "-g",
+      "root",
+      "-m",
+      "600",
+      "/dev/stdin",
+      tokenTmpPath,
+    ]),
+    rootCommand.exec("/usr/bin/mv", [tokenTmpPath, POLLER_TOKEN_PATH]),
+  ]);
+
+  const tokenResult = await sandbox.execRoot(auth, writeToken, {
+    stdin: token,
+  });
+  if (tokenResult.isErr()) {
+    return tokenResult;
+  }
+  if (tokenResult.value.exitCode !== 0) {
+    return new Err(
+      new Error(
+        `Failed to install the Pod function poller token: ${
+          tokenResult.value.stderr ||
+          tokenResult.value.stdout ||
+          "unknown error"
+        }`
+      )
+    );
+  }
+
+  const configTmpPath = `${POLLER_CONFIG_DIR}/.poller.${randomBytes(8).toString("hex")}.tmp`;
+  const startPoller = rootCommand.and([
+    rootCommand.exec("/usr/bin/install", [
+      "-o",
+      "root",
+      "-g",
+      "root",
+      "-m",
+      "600",
+      "/dev/stdin",
+      configTmpPath,
+    ]),
+    rootCommand.exec("/usr/bin/mv", [configTmpPath, POLLER_CONFIG_PATH]),
+    // The credential the poller last rotated to is gone the moment we install a new one, and it
+    // would otherwise take precedence over what we just wrote.
+    rootCommand.exec("/bin/rm", ["-f", POLLER_STATE_PATH]),
+    rootCommand.exec("/usr/bin/systemctl", ["daemon-reload"]),
+    rootCommand.exec("/usr/bin/systemctl", ["restart", POLLER_UNIT]),
+  ]);
+
+  const startResult = await sandbox.execRoot(auth, startPoller, {
+    stdin: pollerConfig,
+  });
+  if (startResult.isErr()) {
+    return startResult;
+  }
+  if (startResult.value.exitCode !== 0) {
+    return new Err(
+      new Error(
+        `Failed to start the Pod function poller: ${
+          startResult.value.stderr ||
+          startResult.value.stdout ||
+          "unknown error"
+        }`
+      )
+    );
+  }
+
+  logger.info(
+    {
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      sandboxId: sandbox.sId,
+    },
+    "Started the Pod function poller"
+  );
+
+  return new Ok(undefined);
+}


### PR DESCRIPTION
## Description

Stacked on #30136. Fourth of five slices adding a warm path for fast Pod function invocations, and the one that turns it on.

The image gains the poller's systemd unit, and every pod wake installs its settings and credential and restarts it. Restarting is what makes a freshly installed credential take effect: a poller already running holds one front revoked when it last connected. Doing this on every wake rather than only on creation is what makes a pod reachable from its first invocation instead of its second.

The poller runs as root. That is not incidental: it drops each function to the workload account itself, and sandbox images purge sudo and strip setuid from every local auth helper on purpose, so there is no unprivileged way to change credentials. Function code still runs as `agent-proxied` with the same groups the exec path gives it.

Because the poller runs as root, its unit and the directory its credential lives in are things a workload must never be able to write. Both are pinned root-owned and non group or other writable, and the image build now fails rather than producing a sandbox where either could be tampered with. `/etc/dust` was missing from the root-consumed directory list, which this adds.

Starting the poller never fails a wake. A pod without one is a pod whose invocations take the sandbox exec path, which is exactly what they do today.

## Tests

The hardening assertions are covered directly, including that the build refuses a unit that is not root-owned. Also added the cross-language guard the uid drop needs: the poller's uid, gid and PATH constants live in Rust and cannot import the TypeScript ones, so a test asserts them equal against `SANDBOX_AGENT_PROXIED_UID`, `SANDBOX_AGENT_UID` and `SANDBOX_AGENT_PROXIED_SAFE_PATH`. Getting any of those wrong means function code running with the wrong privileges or resolving binaries differently depending on which transport ran it.

While updating the image tests I made two of them derive the expected directory list from the constant instead of restating it, since adding one directory broke both.

Not yet exercised end to end against a real sandbox: that needs the image rollout this triggers.

## Risk

This is the slice that carries real risk, and it should not be merged without a manual check on a dev sandbox first.

Merging bumps the base image and the dsbx release, so every sandbox is marked for recreation. The poller only starts for workspaces with `sandbox_function_warm_channel`, which is nobody, so a pod that fails to start one behaves exactly as it does today.

The thing to watch after enabling the flag is the routing log's reason field. A pod that is listening but cannot claim shows up as `pickup_timeout` on every invocation, which is the shape a broken credential path takes.

## Deploy Plan

Standard deploy. Merging triggers the base image rollout, which marks running sandboxes for recreation on next access. Leave the flag off until a dev pod is confirmed warm-routing, then enable it on one workspace and compare the routing reasons against the exec baseline.