### PR TITLE
Make the warm path's rollout observable

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.test.ts
@@ -1,3 +1,4 @@
+import { refreshPollerChannelPresence } from "@app/lib/api/sandbox_functions/poller_channel";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -25,7 +26,31 @@ describe("GET /api/poke/workspaces/:wId/spaces/:spaceId/details", () => {
     expect(data.sandbox).toEqual({
       providerId: sandbox.providerId,
       status: "running",
+      // Nothing is listening in tests, which is also the production default until a pod's poller
+      // connects.
+      pollerChannelOpen: false,
     });
+  });
+
+  it("reports the pod as reachable while its poller holds the channel", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const pod = await SpaceFactory.project(workspace);
+    const sandbox = await SandboxFactory.createForPod(auth, pod);
+    await refreshPollerChannelPresence({
+      sandboxId: sandbox.sId,
+      connectId: "connect-1",
+    });
+
+    const response = await honoApp.request(detailsUrl(workspace.sId, pod.sId));
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    // The first thing to check when a pod's functions are unexpectedly slow.
+    expect(data.sandbox.pollerChannelOpen).toBe(true);
   });
 
   it("returns a null sandbox when the pod owns none", async () => {

--- a/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
@@ -1,4 +1,5 @@
 import type { PokeGetSpaceDetails } from "@app/lib/api/poke/spaces";
+import { isPollerChannelOpen } from "@app/lib/api/sandbox_functions/poller_channel";
 import { getMembers } from "@app/lib/api/workspace";
 import { spaceToPokeJSON } from "@app/lib/poke/utils";
 import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
@@ -63,11 +64,16 @@ app.get(
     const sandbox = space.isProject()
       ? await PodSandboxAdapter.fetchSandbox(auth, space)
       : null;
+    // Read here rather than in `toPokeJSON`, which is synchronous: whether a pod is listening
+    // lives in Redis, and it is the first thing to check when its functions are unexpectedly slow.
+    const pollerChannelOpen = sandbox
+      ? await isPollerChannelOpen({ sandboxId: sandbox.sId })
+      : false;
 
     return ctx.json({
       members,
       metadata: metadata ? metadata.toJSON() : null,
-      sandbox: sandbox ? sandbox.toPokeJSON() : null,
+      sandbox: sandbox ? { ...sandbox.toPokeJSON(), pollerChannelOpen } : null,
       space: await spaceToPokeJSON(auth, space),
     });
   }

--- a/front/components/poke/spaces/view.tsx
+++ b/front/components/poke/spaces/view.tsx
@@ -77,6 +77,15 @@ export function ViewSpaceViewTable({ sandbox, space }: ViewSpaceTableProps) {
                     <PokeTableCell>{sandbox.status}</PokeTableCell>
                   </PokeTableRow>
                   <PokeTableRow>
+                    <PokeTableHead>Pod Function Channel</PokeTableHead>
+                    {/* The first thing to check when a pod's functions are
+                        unexpectedly slow: closed means every fast invocation
+                        is falling back to the sandbox exec API. */}
+                    <PokeTableCell>
+                      {sandbox.pollerChannelOpen ? "open" : "closed"}
+                    </PokeTableCell>
+                  </PokeTableRow>
+                  <PokeTableRow>
                     <PokeTableHead>Sandbox Connect</PokeTableHead>
                     {/* The `e2b sandbox connect` command is too wide for the
                         Overview; the copy button is what matters here. */}

--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -100,6 +100,31 @@ export function recordLifecycleOperation(
   ]);
 }
 
+/**
+ * Which transport ran a fast Pod function invocation, and why.
+ *
+ * The one number this rollout turns on: the share of invocations that reached a listening pod.
+ * Emitted for every routing decision including the ones that never touch the channel, so the
+ * warm share is a ratio rather than a count with no denominator.
+ */
+export function recordSandboxFunctionRouting({
+  route,
+  reason,
+  durationMs,
+}: {
+  route: "channel" | "exec";
+  reason: string;
+  durationMs: number;
+}): void {
+  const tags = [regionTag(), `route:${route}`, `reason:${reason}`];
+  getStatsDClient().increment("sandbox.functions.routing", 1, tags);
+  getStatsDClient().distribution(
+    "sandbox.functions.routing.duration",
+    durationMs,
+    tags
+  );
+}
+
 export function recordStateDuration(
   previousStatus: SandboxStatus,
   durationMs: number

--- a/front/types/poke/index.ts
+++ b/front/types/poke/index.ts
@@ -41,6 +41,10 @@ export type PokeSpaceType = SpaceType & {
 export type PokeSandboxType = {
   providerId: string;
   status: SandboxStatus;
+  // Whether the pod holds an open Pod function work channel, and so whether its fast invocations
+  // reach it directly or fall back to the sandbox exec API. Absent for sandboxes that run no Pod
+  // functions.
+  pollerChannelOpen?: boolean;
 };
 
 export type PokeDataSourceType = DataSourceType &


### PR DESCRIPTION
## Description

Stacked on #30137. Last of five slices adding a warm path for fast Pod function invocations.

One metric for every routing decision, including the ones that never touch the channel, so the share of invocations reaching a listening pod is a ratio rather than a count with no denominator. Tagged by route and reason, which is what tells apart a pod that is not listening from one that is listening but not answering.

Poke now shows whether a pod holds an open work channel. That is the first thing to check when a pod's functions are unexpectedly slow: closed means every fast invocation is falling back to the sandbox exec API, and the reason tag says why.

## Tests

Covered the poke endpoint in both states, since the interesting one is a pod that is up but not reachable.

## Risk

Read-only. The metric is a counter and a distribution, tagged by region, route and reason, so cardinality stays flat.

## Deploy Plan

Standard deploy. Once the stack is out, enable `sandbox_function_warm_channel` on one workspace and watch the routing reasons: a healthy pod should show `settled` on the channel, and anything dominated by `pickup_timeout` means pods are listening but not claiming.