### PR TITLE
feat: improve analytics scaffolding

### DIFF
--- a/front/lib/api/analytics/consumption/period.test.ts
+++ b/front/lib/api/analytics/consumption/period.test.ts
@@ -1,13 +1,31 @@
 import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import { Authenticator } from "@app/lib/auth";
+import type * as contracts from "@app/lib/metronome/contracts";
+import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Err, Ok } from "@app/types/shared/result";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/contracts", async () => {
+  const actual = await vi.importActual<typeof contracts>(
+    "@app/lib/metronome/contracts"
+  );
+  return { ...actual, getCachedMetronomeCurrentBillingPeriod: vi.fn() };
+});
 
 // Jul 13 2026 09:30 UTC.
 const NOW_MS = Date.UTC(2026, 6, 13, 9, 30);
 
 async function setup() {
   const workspace = await WorkspaceFactory.basic();
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  return { auth };
+}
+
+// A workspace on a credit-priced (`CP_`) plan: the only case where the billing
+// cycle is resolved from Metronome rather than the calendar month.
+async function setupCreditPriced() {
+  const workspace = await WorkspaceFactory.creditPriced();
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
   return { auth };
 }
@@ -39,6 +57,57 @@ describe("resolveConsumptionPeriod", () => {
 
   it("resolves the cycle to the current UTC calendar month for a workspace with no billing cycle", async () => {
     const { auth } = await setup();
+
+    const period = await resolveConsumptionPeriod(auth, { kind: "cycle" });
+
+    expect(period).toEqual({
+      startDate: "2026-07-01T00:00:00.000Z",
+      endDate: "2026-08-01T00:00:00.000Z",
+    });
+  });
+
+  it("resolves the cycle to the Metronome billing cycle for a credit-priced workspace", async () => {
+    const { auth } = await setupCreditPriced();
+
+    vi.mocked(getCachedMetronomeCurrentBillingPeriod).mockResolvedValue(
+      new Ok({
+        cycleStart: new Date(Date.UTC(2026, 5, 18)),
+        cycleEnd: new Date(Date.UTC(2026, 6, 18)),
+      })
+    );
+
+    const period = await resolveConsumptionPeriod(auth, { kind: "cycle" });
+
+    expect(getCachedMetronomeCurrentBillingPeriod).toHaveBeenCalledWith(
+      auth.getNonNullableWorkspace().sId
+    );
+    expect(period).toEqual({
+      startDate: "2026-06-18T00:00:00.000Z",
+      endDate: "2026-07-18T00:00:00.000Z",
+    });
+  });
+
+  it("falls back to the calendar month when the billing cycle cannot be resolved", async () => {
+    const { auth } = await setupCreditPriced();
+
+    vi.mocked(getCachedMetronomeCurrentBillingPeriod).mockResolvedValue(
+      new Err(new Error("metronome unavailable"))
+    );
+
+    const period = await resolveConsumptionPeriod(auth, { kind: "cycle" });
+
+    expect(period).toEqual({
+      startDate: "2026-07-01T00:00:00.000Z",
+      endDate: "2026-08-01T00:00:00.000Z",
+    });
+  });
+
+  it("falls back to the calendar month when the workspace has no billing period", async () => {
+    const { auth } = await setupCreditPriced();
+
+    vi.mocked(getCachedMetronomeCurrentBillingPeriod).mockResolvedValue(
+      new Ok(null)
+    );
 
     const period = await resolveConsumptionPeriod(auth, { kind: "cycle" });
 

--- a/front/lib/api/analytics/consumption/period.ts
+++ b/front/lib/api/analytics/consumption/period.ts
@@ -2,6 +2,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
 import logger from "@app/logger/logger";
 import { isCreditPricedPlan } from "@app/types/plan";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import moment from "moment-timezone";
 
 /**
@@ -73,21 +74,24 @@ export async function resolveConsumptionPeriod(
 ): Promise<ConsumptionPeriod> {
   const now = new Date();
 
-  if (input.kind === "days") {
-    const startMs = moment
-      .utc(now)
-      .subtract(input.days - 1, "days")
-      .startOf("day")
-      .valueOf();
-    return {
-      startDate: new Date(startMs).toISOString(),
-      endDate: now.toISOString(),
-    };
+  switch (input.kind) {
+    case "cycle":
+      const { cycleStart, cycleEnd } = await resolveCycleBounds(auth, now);
+      return {
+        startDate: cycleStart.toISOString(),
+        endDate: cycleEnd.toISOString(),
+      };
+    case "days":
+      const startMs = moment
+        .utc(now)
+        .subtract(input.days - 1, "days")
+        .startOf("day")
+        .valueOf();
+      return {
+        startDate: new Date(startMs).toISOString(),
+        endDate: now.toISOString(),
+      };
+    default:
+      assertNever(input);
   }
-
-  const { cycleStart, cycleEnd } = await resolveCycleBounds(auth, now);
-  return {
-    startDate: cycleStart.toISOString(),
-    endDate: cycleEnd.toISOString(),
-  };
 }

--- a/front/lib/api/analytics/consumption/scope.test.ts
+++ b/front/lib/api/analytics/consumption/scope.test.ts
@@ -1,4 +1,5 @@
 import { buildConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/scope";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { describe, expect, it } from "vitest";
 
 const WINDOW = {
@@ -7,13 +8,18 @@ const WINDOW = {
 };
 
 describe("buildConsumptionScopeQuery", () => {
-  it("scopes to the workspace over a half-open window", () => {
+  it("scopes to the workspace over a half-open window", async () => {
+    const { authenticator } = await createResourceTest({
+      role: "admin",
+    });
     expect(
-      buildConsumptionScopeQuery({ workspaceId: "w1", ...WINDOW })
+      buildConsumptionScopeQuery({ auth: authenticator, ...WINDOW })
     ).toEqual({
       bool: {
         filter: [
-          { term: { workspace_id: "w1" } },
+          {
+            term: { workspace_id: authenticator.getNonNullableWorkspace().sId },
+          },
           {
             range: {
               completed_at: { gte: WINDOW.startDate, lt: WINDOW.endDate },
@@ -24,9 +30,12 @@ describe("buildConsumptionScopeQuery", () => {
     });
   });
 
-  it("maps each dimension to its index field, single value as a term", () => {
+  it("maps each dimension to its index field, single value as a term", async () => {
+    const { authenticator } = await createResourceTest({
+      role: "admin",
+    });
     const query = buildConsumptionScopeQuery({
-      workspaceId: "w1",
+      auth: authenticator,
       ...WINDOW,
       filter: {
         agent: ["a1"],
@@ -39,7 +48,7 @@ describe("buildConsumptionScopeQuery", () => {
     });
 
     expect(query.bool?.filter).toEqual([
-      { term: { workspace_id: "w1" } },
+      { term: { workspace_id: authenticator.getNonNullableWorkspace().sId } },
       expect.objectContaining({ range: expect.anything() }),
       { term: { "agent.id": "a1" } },
       { terms: { "user.id": ["u1", "u2"] } },
@@ -50,9 +59,12 @@ describe("buildConsumptionScopeQuery", () => {
     ]);
   });
 
-  it("ignores empty selections", () => {
+  it("ignores empty selections", async () => {
+    const { authenticator } = await createResourceTest({
+      role: "admin",
+    });
     const query = buildConsumptionScopeQuery({
-      workspaceId: "w1",
+      auth: authenticator,
       ...WINDOW,
       filter: { agent: [], member: [""] },
     });

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -1,3 +1,4 @@
+import type { Authenticator } from "@app/lib/auth";
 import type { estypes } from "@elastic/elasticsearch";
 
 export const COMPLETED_AT_FIELD = "completed_at";
@@ -54,18 +55,19 @@ function termFilter(
  * Workspace-scoped query over a half-open [startDate, endDate) window.
  */
 export function buildConsumptionScopeQuery({
-  workspaceId,
+  auth,
   startDate,
   endDate,
   filter = {},
   extraFilters = [],
 }: {
-  workspaceId: string;
+  auth: Authenticator;
   startDate: string;
   endDate: string;
   filter?: ConsumptionScopeFilter;
   extraFilters?: estypes.QueryDslQueryContainer[];
 }): estypes.QueryDslQueryContainer {
+  const workspaceId = auth.getNonNullableWorkspace().sId;
   const filters: estypes.QueryDslQueryContainer[] = [
     { term: { workspace_id: workspaceId } },
     { range: { [COMPLETED_AT_FIELD]: { gte: startDate, lt: endDate } } },


### PR DESCRIPTION
## Description

Follow up to comments that should have been committed with #30079:
- use `auth` rather than `workspaceId`
- add test for cycle resolution when a workspace has a billing cycle
- switch + assert instead of ifs

## Tests

uts

## Risk

Low. Safe to rollback.

## Deploy Plan

Front only.
