### PR TITLE
fix(activation): address evaluator review feedback

### DIFF
--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -10,9 +10,11 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { z } from "zod";
 
+export const RUN_AGENT_SERVER_NAME = "run_agent" as const;
+
 // This is a placeholder tool name used in the metadata for UI detection.
 // The actual tool name is dynamic: `run_<agent_name>`.
-export const RUN_AGENT_PLACEHOLDER_TOOL_NAME = "run_agent" as const;
+export const RUN_AGENT_PLACEHOLDER_TOOL_NAME = RUN_AGENT_SERVER_NAME;
 
 type RunAgentToolDescriptionArgs =
   | {
@@ -137,7 +139,7 @@ export const RUN_AGENT_TOOL_SCHEMA = {
 
 export const RUN_AGENT_SERVER = {
   serverInfo: {
-    name: "run_agent",
+    name: RUN_AGENT_SERVER_NAME,
     version: "1.0.0",
     description: "Run a child agent (agent as tool).",
     authorization: null,

--- a/front/lib/api/activation/orchestrator.ts
+++ b/front/lib/api/activation/orchestrator.ts
@@ -1,7 +1,7 @@
 import { evaluateActivation } from "@app/lib/api/activation/evaluator";
 import { isEligibleForNudge } from "@app/lib/api/activation/nudge";
 import { emitActivationEvent } from "@app/lib/api/activation/trigger";
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { ActivationNudgeResource } from "@app/lib/resources/activation_nudge_resource";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -53,7 +53,7 @@ export async function determineEligibleActivationUsers(
   // Build the candidate (pod, member) list and the deduped set of user sIds to
   // evaluate in a single batch.
   const candidates: { podId: string; spaceId: string; userId: string }[] = [];
-  const userSIds = new Set<string>();
+  const userIds = new Set<string>();
   for (const pod of pods) {
     const space = spaceByModelId.get(pod.spaceId);
     if (!space) {
@@ -69,7 +69,7 @@ export async function determineEligibleActivationUsers(
         spaceId: space.sId,
         userId: member.sId,
       });
-      userSIds.add(member.sId);
+      userIds.add(member.sId);
     }
   }
 
@@ -78,7 +78,7 @@ export async function determineEligibleActivationUsers(
   }
 
   const activationResult = await evaluateActivation(auth, {
-    userIds: [...userSIds],
+    userIds: Array.from(userIds),
     asOf,
   });
   if (activationResult.isErr()) {
@@ -122,22 +122,19 @@ export async function determineEligibleActivationUsers(
   return new Ok({ eligible, skipped });
 }
 
-export async function runActivationForWorkspace({
-  workspaceId,
-  userId = null,
-  dryRun,
-  asOf,
-}: {
-  workspaceId: string;
-  userId?: string | null;
-  dryRun: boolean;
-  asOf?: Date;
-}): Promise<Result<OrchestratorResult, Error>> {
-  // Activation conversations live in Pods, which are restricted spaces: request
-  // all groups so admin auth can read/write them.
-  const auth = await Authenticator.internalAdminForWorkspace(workspaceId, {
-    dangerouslyRequestAllGroups: true,
-  });
+export async function runActivationForWorkspace(
+  auth: Authenticator,
+  {
+    userId = null,
+    dryRun,
+    asOf,
+  }: {
+    userId?: string | null;
+    dryRun: boolean;
+    asOf?: Date;
+  }
+): Promise<Result<OrchestratorResult, Error>> {
+  const workspaceId = auth.getNonNullableWorkspace().sId;
 
   const planResult = await determineEligibleActivationUsers(auth, {
     userId,
@@ -159,7 +156,7 @@ export async function runActivationForWorkspace({
   }
   const uniqueSpaceIds = [...new Set(plan.eligible.map((p) => p.spaceId))];
   const pods = await SpaceResource.fetchByIds(auth, uniqueSpaceIds);
-  const podBySId = new Map(pods.map((pod) => [pod.sId, pod]));
+  const podById = new Map(pods.map((pod) => [pod.sId, pod]));
 
   const users = await UserResource.fetchByIds([
     ...new Set(plan.eligible.map((p) => p.targetUserId)),
@@ -173,7 +170,7 @@ export async function runActivationForWorkspace({
   await concurrentExecutor(
     plan.eligible,
     async ({ spaceId, targetUserId }) => {
-      const pod = podBySId.get(spaceId);
+      const pod = podById.get(spaceId);
       if (!pod) {
         logger.error(
           { workspaceId, spaceId },

--- a/front/lib/api/activation/queries/user_day_cells.ts
+++ b/front/lib/api/activation/queries/user_day_cells.ts
@@ -1,5 +1,5 @@
 import { INTERACTIVE_CONTENT_SERVER_NAME } from "@app/lib/api/actions/servers/interactive_content/metadata";
-import { RUN_AGENT_PLACEHOLDER_TOOL_NAME } from "@app/lib/api/actions/servers/run_agent/metadata";
+import { RUN_AGENT_SERVER_NAME } from "@app/lib/api/actions/servers/run_agent/metadata";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
 import { USER_USAGE_ORIGINS } from "@app/lib/api/programmatic_usage/common";
@@ -163,7 +163,7 @@ export async function fetchUserDayCells({
             },
             {
               term: {
-                "tools_used.server_name": RUN_AGENT_PLACEHOLDER_TOOL_NAME,
+                "tools_used.server_name": RUN_AGENT_SERVER_NAME,
               },
             },
           ],

--- a/front/lib/api/activation/queries/user_day_cells.ts
+++ b/front/lib/api/activation/queries/user_day_cells.ts
@@ -1,7 +1,9 @@
+import { INTERACTIVE_CONTENT_SERVER_NAME } from "@app/lib/api/actions/servers/interactive_content/metadata";
+import { RUN_AGENT_PLACEHOLDER_TOOL_NAME } from "@app/lib/api/actions/servers/run_agent/metadata";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
-import { USAGE_ORIGINS_CLASSIFICATION } from "@app/lib/api/programmatic_usage/common";
+import { USER_USAGE_ORIGINS } from "@app/lib/api/programmatic_usage/common";
 import { TOOL_COST_CATEGORY_AWU_WEIGHTS } from "@app/lib/metronome/events";
-import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -16,27 +18,10 @@ import type { estypes } from "@elastic/elasticsearch";
 // high-value use case signal (≥1 succeeded tool call that is either
 // advanced-cost, a frame touch (interactive_content), or run_agent).
 
-const FRAME_SERVER_NAME = "interactive_content";
-const RUN_AGENT_SERVER_NAME = "run_agent";
-const TRIGGERED_ORIGIN: UserMessageOrigin = "triggered";
-
-// Programmatic origins are dropped from the query entirely
-const PROGRAMMATIC_ORIGINS: UserMessageOrigin[] = (
-  Object.keys(
-    USAGE_ORIGINS_CLASSIFICATION
-  ) as (keyof typeof USAGE_ORIGINS_CLASSIFICATION)[]
-).filter((origin) => USAGE_ORIGINS_CLASSIFICATION[origin] === "programmatic");
-
 // Origins that make a day count as a daily active user day: human-initiated
 // organic ("user") origins, with `triggered` deliberately EXCLUDED.
-const DAU_ORIGINS: UserMessageOrigin[] = (
-  Object.keys(
-    USAGE_ORIGINS_CLASSIFICATION
-  ) as (keyof typeof USAGE_ORIGINS_CLASSIFICATION)[]
-).filter(
-  (origin) =>
-    USAGE_ORIGINS_CLASSIFICATION[origin] === "user" &&
-    origin !== TRIGGERED_ORIGIN
+const DAILY_ACTIVE_USER_ORIGINS = USER_USAGE_ORIGINS.filter(
+  (origin) => origin !== "triggered"
 );
 
 // Hard cap on users per call. The composite page size is sized so that the
@@ -133,8 +118,15 @@ export async function fetchUserDayCells({
   const query: estypes.QueryDslQueryContainer = {
     bool: {
       filter: [
-        { term: { workspace_id: workspaceId } },
-        { terms: { user_id: uniqueUserIds } },
+        // Reuse the workspace-scoped analytics query so this aggregation can
+        // never search documents from another workspace.
+        buildAgentAnalyticsBaseQuery({
+          workspaceId,
+          userIds: uniqueUserIds,
+          // Include only known human/user origins rather than excluding
+          // programmatic ones with a costly must_not clause.
+          contextOrigin: USER_USAGE_ORIGINS,
+        }),
         {
           range: {
             timestamp: {
@@ -144,10 +136,6 @@ export async function fetchUserDayCells({
           },
         },
         { terms: { status: AGENT_MESSAGE_STATUSES_TO_TRACK } },
-      ],
-      must_not: [
-        // Organic constraint: drop programmatic-origin activity entirely.
-        { terms: { context_origin: PROGRAMMATIC_ORIGINS } },
       ],
     },
   };
@@ -168,8 +156,16 @@ export async function fetchUserDayCells({
                 },
               },
             },
-            { term: { "tools_used.server_name": FRAME_SERVER_NAME } },
-            { term: { "tools_used.server_name": RUN_AGENT_SERVER_NAME } },
+            {
+              term: {
+                "tools_used.server_name": INTERACTIVE_CONTENT_SERVER_NAME,
+              },
+            },
+            {
+              term: {
+                "tools_used.server_name": RUN_AGENT_PLACEHOLDER_TOOL_NAME,
+              },
+            },
           ],
           minimum_should_match: 1,
         },
@@ -202,7 +198,11 @@ export async function fetchUserDayCells({
         by_user_day: {
           composite,
           aggregations: {
-            dau: { filter: { terms: { context_origin: DAU_ORIGINS } } },
+            dau: {
+              filter: {
+                terms: { context_origin: DAILY_ACTIVE_USER_ORIGINS },
+              },
+            },
             hvuc_signal: { filter: hvucNestedQuery },
           },
         },

--- a/front/lib/api/activation/trigger.ts
+++ b/front/lib/api/activation/trigger.ts
@@ -41,8 +41,8 @@ export type ActivationNudgeContext = {
 
 // Filtering on both podId and userId ensures a given event only fires the target user.
 // Note, these filter values are visible to the user in the trigger's configuration.
-function activationTriggerFilter(podSId: string, userId: string): string {
-  return `(and (eq "${ACTIVATION_POD_ID_FIELD}" "${podSId}") (eq "${ACTIVATION_USER_ID_FIELD}" "${userId}"))`;
+function activationTriggerFilter(podId: string, userId: string): string {
+  return `(and (eq "${ACTIVATION_POD_ID_FIELD}" "${podId}") (eq "${ACTIVATION_USER_ID_FIELD}" "${userId}"))`;
 }
 
 // The webhook event body. podId/userId drive the trigger filter; the nudge
@@ -50,12 +50,12 @@ function activationTriggerFilter(podSId: string, userId: string): string {
 // payload content fragment (the trigger sets `includePayload: true`), so we
 // never mutate the shared trigger's prompt per-nudge.
 function activationEventBody(
-  podSId: string,
+  podId: string,
   userId: string,
   context?: ActivationNudgeContext
 ): Record<string, unknown> {
   return {
-    [ACTIVATION_POD_ID_FIELD]: podSId,
+    [ACTIVATION_POD_ID_FIELD]: podId,
     [ACTIVATION_USER_ID_FIELD]: userId,
     sessionGoal: context?.sessionGoal ?? null,
     pushedResourceType: context?.pushedResourceType ?? null,

--- a/front/temporal/activation/admin/cli.ts
+++ b/front/temporal/activation/admin/cli.ts
@@ -1,4 +1,5 @@
 import { runActivationForWorkspace } from "@app/lib/api/activation/orchestrator";
+import { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import parseArgs from "minimist";
 
@@ -41,11 +42,10 @@ const main = async () => {
 
   cliLogger.info({ workspaceId, userId, dryRun }, "starting run");
 
-  const planResult = await runActivationForWorkspace({
-    workspaceId,
-    userId,
-    dryRun,
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId, {
+    dangerouslyRequestAllGroups: true,
   });
+  const planResult = await runActivationForWorkspace(auth, { userId, dryRun });
   if (planResult.isErr()) {
     cliLogger.error(
       { workspaceId, userId, error: planResult.error.message },


### PR DESCRIPTION
## Summary
- Long overdue, dressing feedback on https://github.com/dust-tt/dust/pull/29123
- scope activation analytics to known user origins through the shared workspace query
- reuse server metadata and simplify activation orchestration identifiers
- require callers to provide the all-groups admin authenticator
- Fix IDS

## Testing
- Local orchestrator run

## Risk
- Low, not customer facing yet

## Deploy
1. Deploy front