### PR TITLE
[front] perf: run sandbox commands in a single round trip

### DIFF
--- a/front/lib/api/sandbox/provider.ts
+++ b/front/lib/api/sandbox/provider.ts
@@ -70,6 +70,16 @@ export interface ExecOptions {
   envVars?: Record<string, string>;
   /** Data to send to the command over stdin. Never encoded into argv. */
   stdin?: string | Uint8Array;
+  /**
+   * Allows a small `stdin` to be handed to the command through its environment instead of over
+   * separate calls to the sandbox, saving two round trips.
+   *
+   * Off by default, and it must stay off for anything secret. Delivering stdin out of band is how
+   * callers keep tokens and credentials out of process metadata, and a provider reports the
+   * environment of a running command in its process listing. Set this only where the payload is
+   * the command's own input and the latency is worth it.
+   */
+  allowStdinInEnvironment?: boolean;
   /** Optional non-root user to run the command as. Use execRoot for root. */
   user?: SandboxExecUser;
 }

--- a/front/lib/api/sandbox/providers/e2b.test.ts
+++ b/front/lib/api/sandbox/providers/e2b.test.ts
@@ -183,11 +183,6 @@ describe("E2BSandboxProvider", () => {
   });
 
   it("runs root commands with a safe PATH that excludes agent-writable directories", async () => {
-    mockRun.mockResolvedValueOnce({
-      exitCode: 0,
-      stdout: "ok",
-      stderr: "",
-    });
     const provider = new E2BSandboxProvider({
       apiKey: "api-key",
       domain: undefined,
@@ -275,11 +270,6 @@ describe("E2BSandboxProvider", () => {
   });
 
   it("runs default agent service commands without sourcing user dotfiles", async () => {
-    mockRun.mockResolvedValueOnce({
-      exitCode: 0,
-      stdout: "ok",
-      stderr: "",
-    });
     const provider = new E2BSandboxProvider({
       apiKey: "api-key",
       domain: undefined,
@@ -316,11 +306,6 @@ describe("E2BSandboxProvider", () => {
   });
 
   it("runs agent-proxied workload commands in a clean shell with its own home", async () => {
-    mockRun.mockResolvedValueOnce({
-      exitCode: 0,
-      stdout: "ok",
-      stderr: "",
-    });
     const provider = new E2BSandboxProvider({
       apiKey: "api-key",
       domain: undefined,
@@ -434,7 +419,7 @@ describe("E2BSandboxProvider", () => {
     });
   });
 
-  it("sends stdin through the command handle without putting it in argv", async () => {
+  it("pipes small stdin from the environment instead of extra round trips", async () => {
     const provider = new E2BSandboxProvider({
       apiKey: "api-key",
       domain: undefined,
@@ -460,16 +445,48 @@ describe("E2BSandboxProvider", () => {
     expect(wrappedCommand).toContain(`PATH='${SANDBOX_ROOT_SAFE_PATH}'`);
     expect(wrappedCommand).toContain("/bin/bash --noprofile --norc -c");
     expect(wrappedCommand).toContain(command);
+    // The payload travels in the environment, which is where this file already puts secrets such
+    // as DUST_SANDBOX_TOKEN, and is unset before the command runs. What it must never reach is
+    // argv, which is world-readable through /proc.
+    expect(wrappedCommand).toContain(`printf '%s' "$DUST_EXEC_STDIN"`);
+    expect(wrappedCommand).toContain("unset DUST_EXEC_STDIN");
+    expect(wrappedCommand).not.toContain(stdin);
     expect(mockRun).toHaveBeenCalledWith(
       wrappedCommand,
       expect.objectContaining({
         background: true,
-        stdin: true,
+        envs: expect.objectContaining({ DUST_EXEC_STDIN: stdin }),
         timeoutMs: 5_000,
         user: "root",
       })
     );
-    expect(wrappedCommand).not.toContain(stdin);
+    // Asking envd to hold stdin open is what costs the two extra calls, so the inline path must
+    // not request it at all.
+    expect(mockRun.mock.calls[0][1]).not.toHaveProperty("stdin");
+    expect(mockSendStdin).not.toHaveBeenCalled();
+    expect(mockCloseStdin).not.toHaveBeenCalled();
+    expect(mockCommandHandleWait).toHaveBeenCalledTimes(1);
+  });
+
+  it("streams stdin that is too large to pass through the environment", async () => {
+    const provider = new E2BSandboxProvider({
+      apiKey: "api-key",
+      domain: undefined,
+    });
+    const stdin = "x".repeat(64 * 1_024);
+
+    const result = await provider.exec(
+      "provider-id",
+      "/opt/bin/dsbx function run big",
+      { stdin, user: "agent-proxied" },
+      { workspaceId: "workspace-id" }
+    );
+
+    expect(result).toEqual(new Ok({ exitCode: 0, stdout: "ok", stderr: "" }));
+    expect(mockRun).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ background: true, stdin: true })
+    );
     expect(JSON.stringify(mockRun.mock.calls[0][1])).not.toContain(stdin);
     expect(mockSendStdin).toHaveBeenCalledWith(123, stdin, {
       requestTimeoutMs: 30_000,
@@ -477,7 +494,30 @@ describe("E2BSandboxProvider", () => {
     expect(mockCloseStdin).toHaveBeenCalledWith(123, {
       requestTimeoutMs: 30_000,
     });
-    expect(mockCommandHandleWait).toHaveBeenCalledTimes(1);
+  });
+
+  it("streams binary stdin, which an environment value cannot carry", async () => {
+    const provider = new E2BSandboxProvider({
+      apiKey: "api-key",
+      domain: undefined,
+    });
+    const stdin = new Uint8Array([0, 1, 2, 3]);
+
+    const result = await provider.exec(
+      "provider-id",
+      "/opt/bin/dsbx function run binary",
+      { stdin, user: "agent-proxied" },
+      { workspaceId: "workspace-id" }
+    );
+
+    expect(result).toEqual(new Ok({ exitCode: 0, stdout: "ok", stderr: "" }));
+    expect(mockRun).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ background: true, stdin: true })
+    );
+    expect(mockSendStdin).toHaveBeenCalledWith(123, stdin, {
+      requestTimeoutMs: 30_000,
+    });
   });
 
   it("kills the background handle when sendStdin fails to avoid orphaned commands", async () => {
@@ -500,7 +540,7 @@ describe("E2BSandboxProvider", () => {
         "install -m 600 /dev/stdin /run/dust/egress-secrets.json",
         "test legacy stdin root command"
       ),
-      { stdin: "secret-json", timeoutMs: 5_000 },
+      { stdin: "secret-json".repeat(8_192), timeoutMs: 5_000 },
       { workspaceId: "workspace-id" }
     );
 
@@ -539,7 +579,7 @@ describe("E2BSandboxProvider", () => {
     const result = await provider.exec(
       "provider-id",
       "/opt/bin/dsbx function run new-function",
-      { stdin: "request-json", user: "agent-proxied" },
+      { stdin: "request-json".repeat(8_192), user: "agent-proxied" },
       { workspaceId: "workspace-id" }
     );
 
@@ -553,5 +593,234 @@ describe("E2BSandboxProvider", () => {
     expect(mockCommandHandleWait).toHaveBeenCalledTimes(1);
     expect(mockHandleKill).not.toHaveBeenCalled();
     expect(mockCloseStdin).not.toHaveBeenCalled();
+  });
+
+  describe("connection reuse", () => {
+    it("connects once for repeated operations on the same sandbox", async () => {
+      const provider = new E2BSandboxProvider({
+        apiKey: "api-key",
+        domain: undefined,
+      });
+
+      await provider.exec("provider-id", "echo one", undefined, {
+        workspaceId: "workspace-id",
+      });
+      await provider.exec("provider-id", "echo two", undefined, {
+        workspaceId: "workspace-id",
+      });
+
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+      expect(mockRun).toHaveBeenCalledTimes(2);
+    });
+
+    it("keeps a connection per sandbox", async () => {
+      const provider = new E2BSandboxProvider({
+        apiKey: "api-key",
+        domain: undefined,
+      });
+
+      await provider.exec("provider-a", "echo a", undefined, {
+        workspaceId: "workspace-id",
+      });
+      await provider.exec("provider-b", "echo b", undefined, {
+        workspaceId: "workspace-id",
+      });
+
+      expect(mockConnect).toHaveBeenCalledTimes(2);
+    });
+
+    it("shares one connect between operations racing on a cold cache", async () => {
+      const provider = new E2BSandboxProvider({
+        apiKey: "api-key",
+        domain: undefined,
+      });
+
+      await Promise.all([
+        provider.exec("provider-id", "echo one", undefined, {
+          workspaceId: "workspace-id",
+        }),
+        provider.exec("provider-id", "echo two", undefined, {
+          workspaceId: "workspace-id",
+        }),
+      ]);
+
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+    });
+
+    it("never re-runs a command whose start reported failure", async () => {
+      const provider = new E2BSandboxProvider({
+        apiKey: "api-key",
+        domain: undefined,
+      });
+
+      await provider.exec("provider-id", "echo warm", undefined, {
+        workspaceId: "workspace-id",
+      });
+      mockRun.mockRejectedValueOnce(new Error("connection refused"));
+
+      const result = await provider.exec("provider-id", "echo two", undefined, {
+        workspaceId: "workspace-id",
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("connection refused");
+      }
+      // The SDK aborts a start on its own request timeout, which can fire after envd has already
+      // forked the process. A failed start is not proof that nothing ran, and pod functions are
+      // not idempotent, so the error is surfaced rather than retried.
+      expect(mockRun).toHaveBeenCalledTimes(2);
+    });
+
+    it("drops a connection that failed so the next command reconnects", async () => {
+      const provider = new E2BSandboxProvider({
+        apiKey: "api-key",
+        domain: undefined,
+      });
+
+      await provider.exec("provider-id", "echo warm", undefined, {
+        workspaceId: "workspace-id",
+      });
+      mockRun.mockRejectedValueOnce(new Error("connection refused"));
+      await provider.exec("provider-id", "echo two", undefined, {
+        workspaceId: "workspace-id",
+      });
+
+      const result = await provider.exec(
+        "provider-id",
+        "echo three",
+        undefined,
+        { workspaceId: "workspace-id" }
+      );
+
+      expect(result).toEqual(new Ok({ exitCode: 0, stdout: "ok", stderr: "" }));
+      // One for the first command, one for the command after the failure.
+      expect(mockConnect).toHaveBeenCalledTimes(2);
+    });
+
+    it("retries a file read on a fresh connection", async () => {
+      const mockFilesRead = vi.fn().mockResolvedValue(new Uint8Array([1, 2]));
+      mockConnect.mockResolvedValue({
+        commands: {
+          run: mockRun,
+          sendStdin: mockSendStdin,
+          closeStdin: mockCloseStdin,
+        },
+        files: { read: mockFilesRead },
+      });
+      const provider = new E2BSandboxProvider({
+        apiKey: "api-key",
+        domain: undefined,
+      });
+
+      await provider.readFile("provider-id", "/tmp/a", {
+        workspaceId: "workspace-id",
+      });
+      mockFilesRead.mockRejectedValueOnce(new Error("connection refused"));
+
+      // Reading the same path twice returns the same bytes, so unlike a command this is safe to
+      // repeat once the stale connection has been replaced.
+      const result = await provider.readFile("provider-id", "/tmp/a", {
+        workspaceId: "workspace-id",
+      });
+
+      expect(result).toEqual(Buffer.from([1, 2]));
+      expect(mockConnect).toHaveBeenCalledTimes(2);
+      expect(mockFilesRead).toHaveBeenCalledTimes(3);
+    });
+
+    it("drops the cached connection when the sandbox is paused", async () => {
+      const mockBetaPause = vi.fn().mockResolvedValue(undefined);
+      mockConnect.mockResolvedValue({
+        betaPause: mockBetaPause,
+        commands: {
+          run: mockRun,
+          sendStdin: mockSendStdin,
+          closeStdin: mockCloseStdin,
+        },
+      });
+      const provider = new E2BSandboxProvider({
+        apiKey: "api-key",
+        domain: undefined,
+      });
+
+      await provider.exec("provider-id", "echo warm", undefined, {
+        workspaceId: "workspace-id",
+      });
+      await provider.sleep("provider-id", { workspaceId: "workspace-id" });
+      await provider.exec("provider-id", "echo after", undefined, {
+        workspaceId: "workspace-id",
+      });
+
+      expect(mockBetaPause).toHaveBeenCalledTimes(1);
+      // One for the first exec, one for the pause, and one for the exec after it: a handle from
+      // before the pause points at a suspended VM.
+      expect(mockConnect).toHaveBeenCalledTimes(3);
+    });
+
+    it("drops the cached connection when the sandbox is destroyed", async () => {
+      const provider = new E2BSandboxProvider({
+        apiKey: "api-key",
+        domain: undefined,
+      });
+
+      await provider.exec("provider-id", "echo warm", undefined, {
+        workspaceId: "workspace-id",
+      });
+      await provider.destroy("provider-id", { workspaceId: "workspace-id" });
+      await provider.exec("provider-id", "echo after", undefined, {
+        workspaceId: "workspace-id",
+      });
+
+      expect(mockConnect).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not reconnect when the sandbox reports a missing file", async () => {
+      const mockFilesRead = vi.fn().mockResolvedValue(new Uint8Array([1, 2]));
+      mockConnect.mockResolvedValue({
+        commands: {
+          run: mockRun,
+          sendStdin: mockSendStdin,
+          closeStdin: mockCloseStdin,
+        },
+        files: { read: mockFilesRead },
+      });
+      const provider = new E2BSandboxProvider({
+        apiKey: "api-key",
+        domain: undefined,
+      });
+
+      await provider.readFile("provider-id", "/tmp/a", {
+        workspaceId: "workspace-id",
+      });
+      mockFilesRead.mockRejectedValueOnce(new NotFoundError("no such file"));
+
+      await expect(
+        provider.readFile("provider-id", "/tmp/missing", {
+          workspaceId: "workspace-id",
+        })
+      ).rejects.toThrow("no such file");
+      // The sandbox answered, so the connection is fine: reconnecting and reading again would
+      // only add round trips to a read that is going to fail either way.
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+      expect(mockFilesRead).toHaveBeenCalledTimes(2);
+    });
+
+    it("reports a sandbox that no longer exists rather than a missing file", async () => {
+      mockConnect.mockRejectedValueOnce(new NotFoundError("gone"));
+      const provider = new E2BSandboxProvider({
+        apiKey: "api-key",
+        domain: undefined,
+      });
+
+      const result = await provider.exec("provider-id", "echo one", undefined, {
+        workspaceId: "workspace-id",
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.name).toBe("SandboxNotFoundError");
+      }
+    });
   });
 });

--- a/front/lib/api/sandbox/providers/e2b.test.ts
+++ b/front/lib/api/sandbox/providers/e2b.test.ts
@@ -419,20 +419,22 @@ describe("E2BSandboxProvider", () => {
     });
   });
 
-  it("pipes small stdin from the environment instead of extra round trips", async () => {
+  it("hands small stdin to the command through the environment when allowed", async () => {
     const provider = new E2BSandboxProvider({
       apiKey: "api-key",
       domain: undefined,
     });
-    const stdin = "super-secret-json";
-    const command = "install -m 600 /dev/stdin /run/dust/egress-secrets.json";
+    const stdin = '{"message":"hi"}';
+    const command = "/opt/bin/dsbx function run greet";
 
-    const result = await provider.execRoot(
+    const result = await provider.exec(
       "provider-id",
-      rootCommand.unsafeShell(command, "test legacy stdin root command"),
+      command,
       {
         stdin,
+        allowStdinInEnvironment: true,
         timeoutMs: 5_000,
+        user: "agent-proxied",
       },
       { workspaceId: "workspace-id" }
     );
@@ -442,22 +444,24 @@ describe("E2BSandboxProvider", () => {
     if (typeof wrappedCommand !== "string") {
       throw new Error("expected wrappedCommand to be a string");
     }
-    expect(wrappedCommand).toContain(`PATH='${SANDBOX_ROOT_SAFE_PATH}'`);
     expect(wrappedCommand).toContain("/bin/bash --noprofile --norc -c");
     expect(wrappedCommand).toContain(command);
-    // The payload travels in the environment, which is where this file already puts secrets such
-    // as DUST_SANDBOX_TOKEN, and is unset before the command runs. What it must never reach is
-    // argv, which is world-readable through /proc.
-    expect(wrappedCommand).toContain(`printf '%s' "$DUST_EXEC_STDIN"`);
+    // The payload travels in the environment and is unexported before the command starts. What it
+    // must never reach is argv, which is world-readable through /proc.
+    expect(wrappedCommand).toContain(`printf '%s' "$__dust_stdin"`);
     expect(wrappedCommand).toContain("unset DUST_EXEC_STDIN");
     expect(wrappedCommand).not.toContain(stdin);
+    // `exec` keeps the pid envd started as the pid running the workload. Without it envd holds a
+    // wrapper shell, and killing that on timeout leaves the workload running as a grandchild.
+    expect(wrappedCommand).toContain("exec /bin/bash");
+    expect(wrappedCommand).not.toContain("| {");
     expect(mockRun).toHaveBeenCalledWith(
       wrappedCommand,
       expect.objectContaining({
         background: true,
         envs: expect.objectContaining({ DUST_EXEC_STDIN: stdin }),
         timeoutMs: 5_000,
-        user: "root",
+        user: "agent-proxied",
       })
     );
     // Asking envd to hold stdin open is what costs the two extra calls, so the inline path must
@@ -478,7 +482,7 @@ describe("E2BSandboxProvider", () => {
     const result = await provider.exec(
       "provider-id",
       "/opt/bin/dsbx function run big",
-      { stdin, user: "agent-proxied" },
+      { stdin, allowStdinInEnvironment: true, user: "agent-proxied" },
       { workspaceId: "workspace-id" }
     );
 
@@ -506,7 +510,7 @@ describe("E2BSandboxProvider", () => {
     const result = await provider.exec(
       "provider-id",
       "/opt/bin/dsbx function run binary",
-      { stdin, user: "agent-proxied" },
+      { stdin, allowStdinInEnvironment: true, user: "agent-proxied" },
       { workspaceId: "workspace-id" }
     );
 

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -74,8 +74,8 @@ const CONNECTION_TTL_MS = 5 * 60 * 1_000;
 const MAX_CACHED_CONNECTIONS = 1_000;
 
 /**
- * Environment variable carrying inline stdin. Unset by the wrapper below before the command runs,
- * so the payload reaches the workload through the pipe and not through its environment.
+ * Environment variable carrying inline stdin. The wrapper below unexports it before handing over
+ * to the command, so the payload reaches the workload on its stdin and not in its environment.
  */
 const INLINE_STDIN_ENV = "DUST_EXEC_STDIN";
 
@@ -185,6 +185,7 @@ interface E2BCommandOpts {
   cwd?: string;
   envs?: Record<string, string>;
   stdin?: string | Uint8Array;
+  allowStdinInEnvironment?: boolean;
   timeoutMs?: number;
   user?: string;
 }
@@ -199,17 +200,20 @@ type StdinDelivery =
  *
  * envd has no way to carry stdin in the start request: it takes a boolean saying stdin will be
  * open, after which `sendStdin` and `closeStdin` are two more sequential calls to the sandbox.
- * Passing the payload through the environment and piping it in collapses all three into the
- * single start call. Binary and oversized payloads keep the streamed path, because an environment
- * value can hold neither NUL nor an unbounded string.
+ * Handing the payload over through the environment collapses all three into the single start
+ * call, but only a caller that has opted in gets it: `Commands.list` reports the environment of
+ * every running command, so a secret has to keep the streamed path. Binary and oversized payloads
+ * do too, because an environment value can hold neither NUL nor an unbounded string.
  */
 function getStdinDelivery(
-  stdin: string | Uint8Array | undefined
+  stdin: string | Uint8Array | undefined,
+  allowStdinInEnvironment: boolean
 ): StdinDelivery {
   if (stdin === undefined) {
     return { mode: "none" };
   }
   if (
+    !allowStdinInEnvironment ||
     typeof stdin !== "string" ||
     stdin.includes("\0") ||
     Buffer.byteLength(stdin, "utf8") > MAX_INLINE_STDIN_BYTES
@@ -223,18 +227,26 @@ function getStdinDelivery(
 /**
  * Feeds inline stdin to `command` from the environment.
  *
- * `printf` is a bash builtin, so this resolves nothing through PATH (SEC3), and passing the
- * payload as an argument to `%s` keeps it out of the format string. The variable is unset before
- * the command starts so the workload only ever sees the payload on its stdin. `printf`'s own
- * stderr is dropped: the only thing it can report here is a write error against a command that
- * exited without reading, which is not a failure of the command itself.
+ * `exec` and the process substitution are both load bearing, and a pipeline is NOT a valid
+ * substitute. envd tracks the single pid it started and signals only that pid when a command
+ * exceeds its timeout. Piping into the command would leave envd holding the wrapper shell while
+ * the workload ran on as a grandchild, so a timed out command would keep running in the sandbox
+ * after we gave up on it (verified against a live sandbox). Replacing the wrapper with the
+ * command keeps the pid envd owns the pid that matters.
+ *
+ * `exec`, `unset` and `printf` are bash builtins, so nothing here resolves through PATH (SEC3),
+ * and passing the payload as an argument to `%s` keeps it out of the format string. The payload
+ * is copied to a shell variable and unexported before the `exec`, so it is absent from the
+ * environment of the command and of everything it spawns.
  */
 function withInlineStdin(command: string): string {
   return [
-    `printf '%s' "$${INLINE_STDIN_ENV}" 2>/dev/null | { unset ${INLINE_STDIN_ENV}`,
-    command,
-    "}",
-  ].join("\n");
+    `__dust_stdin="$${INLINE_STDIN_ENV}"`,
+    `unset ${INLINE_STDIN_ENV}`,
+    // printf's own stderr is dropped: the only thing it can report is a write error against a
+    // command that exited without reading its stdin, which is not a failure of that command.
+    `exec /bin/bash --noprofile --norc -c ${shellEscape(command)} < <(printf '%s' "$__dust_stdin" 2>/dev/null)`,
+  ].join("; ");
 }
 
 /**
@@ -508,7 +520,10 @@ export class E2BSandboxProvider implements SandboxProvider {
     commandOpts: E2BCommandOpts,
     tracingOpts: { workspaceId: string }
   ): Promise<Result<ExecResult, Error>> {
-    const stdin = getStdinDelivery(commandOpts.stdin);
+    const stdin = getStdinDelivery(
+      commandOpts.stdin,
+      commandOpts.allowStdinInEnvironment ?? false
+    );
     const start = buildStartRequest(command, commandOpts, stdin);
 
     return traceSandboxOperation(
@@ -812,6 +827,7 @@ export class E2BSandboxProvider implements SandboxProvider {
         envs: getNonRootOuterEnvironment(execOpts?.envVars),
         timeoutMs: execOpts?.timeoutMs,
         stdin: execOpts?.stdin,
+        allowStdinInEnvironment: execOpts?.allowStdinInEnvironment,
         user: execUser,
       },
       tracingOpts
@@ -832,6 +848,8 @@ export class E2BSandboxProvider implements SandboxProvider {
         envs: execOpts?.envVars,
         timeoutMs: execOpts?.timeoutMs,
         stdin: execOpts?.stdin,
+        // Deliberately not forwarded: every root command that carries stdin today is handing
+        // over a token or a secrets file, and those must not appear in a process listing.
         user: "root",
       },
       tracingOpts

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -37,7 +37,12 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { CommandExitError, NotFoundError, Sandbox } from "e2b";
+import {
+  CommandExitError,
+  type CommandHandle,
+  NotFoundError,
+  Sandbox,
+} from "e2b";
 
 const ONE_HOUR_MS = 60 * 60 * 1_000;
 
@@ -52,6 +57,34 @@ const SANDBOX_LIFETIME_MS = 24 * ONE_HOUR_MS;
 /** Timeout for individual API calls to E2B (create, connect, etc.). */
 const REQUEST_TIMEOUT_MS = 30_000;
 const LOCAL_ACCOUNT_HARDENING_TIMEOUT_MS = 120_000;
+
+/**
+ * How long a connected sandbox handle is reused before reconnecting.
+ *
+ * This is also the refresh interval for the sandbox's provider-side expiry: every connect passes
+ * `timeoutMs: SANDBOX_LIFETIME_MS`, so reconnecting on a fixed interval keeps any sandbox we are
+ * still working with from reaching its deadline, the way a connect on every operation used to.
+ */
+const CONNECTION_TTL_MS = 5 * 60 * 1_000;
+
+/**
+ * Cap on cached handles. A handle is small (connection config plus a fetch transport, no socket
+ * of its own), so this only needs to stay ahead of the sandboxes one process talks to.
+ */
+const MAX_CACHED_CONNECTIONS = 1_000;
+
+/**
+ * Environment variable carrying inline stdin. Unset by the wrapper below before the command runs,
+ * so the payload reaches the workload through the pipe and not through its environment.
+ */
+const INLINE_STDIN_ENV = "DUST_EXEC_STDIN";
+
+/**
+ * Cap on inline stdin, kept under a pipe's 64KiB buffer so `printf` writes the whole payload and
+ * exits rather than blocking on a command that never reads it. Also well under the kernel's
+ * per-environment-string limit (MAX_ARG_STRLEN, 128KiB). Larger payloads take the streamed path.
+ */
+const MAX_INLINE_STDIN_BYTES = 32 * 1_024;
 
 const ALL_TRAFFIC = "0.0.0.0/0";
 
@@ -156,22 +189,101 @@ interface E2BCommandOpts {
   user?: string;
 }
 
-// Send command stdin via the E2B Commands API rather than baking it into argv.
-// The command is started in the background with stdin open; if anything goes
-// wrong on the SDK round-trip, we kill the handle so we don't leak a running
-// command on the VM until the lifetime cap kicks in.
-async function runWithStdin(
-  sandbox: Sandbox,
+type StdinDelivery =
+  | { mode: "none" }
+  | { mode: "inline"; payload: string }
+  | { mode: "streamed"; payload: string | Uint8Array };
+
+/**
+ * How stdin reaches the command.
+ *
+ * envd has no way to carry stdin in the start request: it takes a boolean saying stdin will be
+ * open, after which `sendStdin` and `closeStdin` are two more sequential calls to the sandbox.
+ * Passing the payload through the environment and piping it in collapses all three into the
+ * single start call. Binary and oversized payloads keep the streamed path, because an environment
+ * value can hold neither NUL nor an unbounded string.
+ */
+function getStdinDelivery(
+  stdin: string | Uint8Array | undefined
+): StdinDelivery {
+  if (stdin === undefined) {
+    return { mode: "none" };
+  }
+  if (
+    typeof stdin !== "string" ||
+    stdin.includes("\0") ||
+    Buffer.byteLength(stdin, "utf8") > MAX_INLINE_STDIN_BYTES
+  ) {
+    return { mode: "streamed", payload: stdin };
+  }
+
+  return { mode: "inline", payload: stdin };
+}
+
+/**
+ * Feeds inline stdin to `command` from the environment.
+ *
+ * `printf` is a bash builtin, so this resolves nothing through PATH (SEC3), and passing the
+ * payload as an argument to `%s` keeps it out of the format string. The variable is unset before
+ * the command starts so the workload only ever sees the payload on its stdin. `printf`'s own
+ * stderr is dropped: the only thing it can report here is a write error against a command that
+ * exited without reading, which is not a failure of the command itself.
+ */
+function withInlineStdin(command: string): string {
+  return [
+    `printf '%s' "$${INLINE_STDIN_ENV}" 2>/dev/null | { unset ${INLINE_STDIN_ENV}`,
+    command,
+    "}",
+  ].join("\n");
+}
+
+/**
+ * The single start call that carries the command, its environment, and, when it fits, its stdin.
+ *
+ * Always started in the background: waiting is the caller's job, because only the start is safe
+ * to retry on a new connection.
+ */
+function buildStartRequest(
   command: string,
   commandOpts: E2BCommandOpts,
+  stdin: StdinDelivery
+) {
+  const opts = {
+    cwd: commandOpts.cwd,
+    envs: commandOpts.envs,
+    timeoutMs: commandOpts.timeoutMs,
+    user: commandOpts.user,
+    background: true as const,
+  };
+
+  switch (stdin.mode) {
+    case "none":
+      return { command, opts };
+    case "inline":
+      return {
+        command: withInlineStdin(command),
+        opts: {
+          ...opts,
+          envs: { ...commandOpts.envs, [INLINE_STDIN_ENV]: stdin.payload },
+        },
+      };
+    case "streamed":
+      // Passing `stdin: false` explicitly is rejected by envd versions that predate the option,
+      // so it is only ever set on the path that needs envd to hold stdin open.
+      return { command, opts: { ...opts, stdin: true as const } };
+    default:
+      return assertNever(stdin);
+  }
+}
+
+// Sends command stdin over the E2B Commands API for payloads that cannot be inlined. The command
+// is started with stdin open; if anything goes wrong on the SDK round-trip, we kill the handle so
+// we don't leak a running command on the VM until the lifetime cap kicks in.
+async function sendStdinAndWait(
+  sandbox: Sandbox,
+  handle: CommandHandle,
   stdin: string | Uint8Array
 ) {
-  const handle = await sandbox.commands.run(command, {
-    ...commandOpts,
-    background: true,
-    stdin: true,
-  });
-
   try {
     // Per-RPC timeout, not the command's total runtime — clamping to the
     // overall timeoutMs would block sendStdin/closeStdin for the entire
@@ -201,6 +313,12 @@ async function runWithStdin(
   }
 }
 
+interface CachedConnection {
+  // Held as a promise so concurrent operations on one sandbox share a single connect.
+  sandbox: Promise<Sandbox>;
+  expiresAtMs: number;
+}
+
 /**
  * E2B implementation of SandboxProvider.
  *
@@ -210,6 +328,17 @@ async function runWithStdin(
 export class E2BSandboxProvider implements SandboxProvider {
   private readonly apiKey: string;
   private readonly domain: string | undefined;
+
+  /**
+   * Connected sandbox handles, keyed by provider id.
+   *
+   * `Sandbox.connect` is a control-plane POST to E2B that every operation used to pay before it
+   * could address the sandbox at all — around 100ms from our region, on top of the call that does
+   * the actual work. The handle it returns stays valid for the sandbox's lifetime, so we keep it.
+   * The provider is a per-process singleton, which makes this cache per-process too: no handle,
+   * and therefore no sandbox access token, is shared or persisted anywhere.
+   */
+  private readonly connections = new Map<string, CachedConnection>();
 
   constructor(config: E2BConfig) {
     this.apiKey = config.apiKey;
@@ -221,6 +350,138 @@ export class E2BSandboxProvider implements SandboxProvider {
       apiKey: this.apiKey,
       ...(this.domain ? { domain: this.domain } : {}),
     };
+  }
+
+  private hasFreshConnection(providerId: string): boolean {
+    const existing = this.connections.get(providerId);
+
+    return existing !== undefined && existing.expiresAtMs > Date.now();
+  }
+
+  /**
+   * Returns a handle for `providerId`, reusing a cached one while it is fresh.
+   *
+   * `cached` reports whether the handle predates this call, which is what makes a retry worth
+   * attempting: a handle we just opened and that already failed will fail the same way again.
+   */
+  private async getConnection(
+    providerId: string
+  ): Promise<{ sandbox: Sandbox; cached: boolean }> {
+    const existing = this.connections.get(providerId);
+    if (existing && existing.expiresAtMs > Date.now()) {
+      try {
+        return { sandbox: await existing.sandbox, cached: true };
+      } catch (err) {
+        this.dropConnection(providerId, existing);
+        throw err;
+      }
+    }
+
+    return { sandbox: await this.openConnection(providerId), cached: false };
+  }
+
+  private async openConnection(providerId: string): Promise<Sandbox> {
+    const entry: CachedConnection = {
+      // Translated here rather than at each call site so that callers can tell a sandbox that is
+      // gone from a NotFoundError raised by the operation itself, such as reading a missing file.
+      sandbox: Sandbox.connect(providerId, {
+        ...this.connectionOpts(),
+        timeoutMs: SANDBOX_LIFETIME_MS,
+      }).catch((err: unknown) => {
+        throw err instanceof NotFoundError
+          ? new SandboxNotFoundError(providerId)
+          : normalizeError(err);
+      }),
+      expiresAtMs: Date.now() + CONNECTION_TTL_MS,
+    };
+    // Delete before setting so the entry moves to the end of the map's insertion order, which is
+    // what makes the eviction below drop the least recently opened connection.
+    this.connections.delete(providerId);
+    this.connections.set(providerId, entry);
+    this.evictConnections();
+
+    try {
+      return await entry.sandbox;
+    } catch (err) {
+      this.dropConnection(providerId, entry);
+      throw err;
+    }
+  }
+
+  // Only drops `entry` when it is still the cached one: a concurrent caller may already have
+  // replaced a failed handle with a working one.
+  private dropConnection(providerId: string, entry?: CachedConnection): void {
+    if (!entry || this.connections.get(providerId) === entry) {
+      this.connections.delete(providerId);
+    }
+  }
+
+  private evictConnections(): void {
+    if (this.connections.size <= MAX_CACHED_CONNECTIONS) {
+      return;
+    }
+
+    const nowMs = Date.now();
+    for (const [providerId, entry] of this.connections) {
+      if (entry.expiresAtMs <= nowMs) {
+        this.connections.delete(providerId);
+      }
+    }
+
+    // Map iterates in insertion order, so this drops the connections opened longest ago first.
+    for (const providerId of this.connections.keys()) {
+      if (this.connections.size <= MAX_CACHED_CONNECTIONS) {
+        break;
+      }
+      this.connections.delete(providerId);
+    }
+  }
+
+  /**
+   * Runs `op` against the sandbox, optionally retrying it once on a freshly connected handle.
+   *
+   * A handle does not survive the sandbox being paused or recreated. `sleep` and `destroy` drop
+   * it, so what is left is the sandbox disappearing underneath us; rather than probe for that on
+   * every call, the operation is allowed to fail and reconnect, and `Sandbox.connect` resumes a
+   * paused sandbox the way the connect-every-time path did.
+   *
+   * `retryOnStaleConnection` must only be set for an operation that is safe to run twice, which
+   * running a command is NOT: the SDK aborts `Commands.start` on its own request timeout, and
+   * that timeout can fire after envd has already forked the process, so a throw there does not
+   * prove the command never ran. Commands therefore drop the connection and surface the error,
+   * exactly as they did when every call connected first, and the next call reconnects.
+   */
+  private async withConnection<T>(
+    providerId: string,
+    op: (sandbox: Sandbox) => Promise<T>,
+    { retryOnStaleConnection }: { retryOnStaleConnection: boolean }
+  ): Promise<T> {
+    const { sandbox, cached } = await this.getConnection(providerId);
+
+    try {
+      return await op(sandbox);
+    } catch (err) {
+      // envd answering "not found" means the connection is healthy and the thing the operation
+      // named is what is missing, so there is nothing to reconnect for. A connect that hit a
+      // missing sandbox cannot land here: openConnection turns that into SandboxNotFoundError.
+      if (err instanceof NotFoundError) {
+        throw err;
+      }
+
+      // Otherwise stop handing this connection to the next caller. Reconnecting costs one round
+      // trip; continuing to use a handle that just failed can cost every call after it.
+      this.dropConnection(providerId);
+      if (!cached || !retryOnStaleConnection) {
+        throw err;
+      }
+
+      logger.info(
+        { providerId, err: normalizeError(err) },
+        "Cached E2B sandbox connection failed, reconnecting"
+      );
+
+      return op(await this.openConnection(providerId));
+    }
   }
 
   private async killSandboxAfterLocalAccountHardeningFailure(
@@ -247,34 +508,36 @@ export class E2BSandboxProvider implements SandboxProvider {
     commandOpts: E2BCommandOpts,
     tracingOpts: { workspaceId: string }
   ): Promise<Result<ExecResult, Error>> {
+    const stdin = getStdinDelivery(commandOpts.stdin);
+    const start = buildStartRequest(command, commandOpts, stdin);
+
     return traceSandboxOperation(
       "exec",
       async () => {
         let sandbox: Sandbox;
+        let handle: CommandHandle;
         try {
-          sandbox = await Sandbox.connect(providerId, {
-            ...this.connectionOpts(),
-            timeoutMs: SANDBOX_LIFETIME_MS,
-          });
+          ({ sandbox, handle } = await this.withConnection(
+            providerId,
+            async (connected) => ({
+              sandbox: connected,
+              handle: await connected.commands.run(start.command, start.opts),
+            }),
+            // A command may have started even when starting it reported failure.
+            { retryOnStaleConnection: false }
+          ));
         } catch (err) {
-          if (err instanceof NotFoundError) {
-            return new Err(new SandboxNotFoundError(providerId));
+          if (err instanceof SandboxNotFoundError) {
+            return new Err(err);
           }
           return new Err(normalizeError(err));
         }
 
         try {
-          const stdin = commandOpts.stdin;
-          const e2bCommandOpts = {
-            cwd: commandOpts.cwd,
-            envs: commandOpts.envs,
-            timeoutMs: commandOpts.timeoutMs,
-            user: commandOpts.user,
-          };
           const result =
-            stdin === undefined
-              ? await sandbox.commands.run(command, e2bCommandOpts)
-              : await runWithStdin(sandbox, command, e2bCommandOpts, stdin);
+            stdin.mode === "streamed"
+              ? await sendStdinAndWait(sandbox, handle, stdin.payload)
+              : await handle.wait();
 
           return new Ok({
             exitCode: result.exitCode,
@@ -297,6 +560,10 @@ export class E2BSandboxProvider implements SandboxProvider {
       {
         provider_id: providerId,
         workspace_id: tracingOpts.workspaceId,
+        // Both known before the operation runs, and both are what a rollout needs to read: how
+        // often a command reuses a connection, and how often stdin still costs extra round trips.
+        connection: this.hasFreshConnection(providerId) ? "cached" : "fresh",
+        stdin_mode: stdin.mode,
       }
     );
   }
@@ -418,15 +685,14 @@ export class E2BSandboxProvider implements SandboxProvider {
       async () => {
         logger.info({ providerId }, "Waking E2B sandbox");
 
-        // Sandbox.connect auto-resumes paused sandboxes.
+        // Sandbox.connect auto-resumes paused sandboxes. Always a real connect, never a cached
+        // handle — a handle from before the pause is exactly what cannot be trusted here — and
+        // it leaves the fresh one cached for the commands that follow the wake.
         try {
-          await Sandbox.connect(providerId, {
-            ...this.connectionOpts(),
-            timeoutMs: SANDBOX_LIFETIME_MS,
-          });
+          await this.openConnection(providerId);
         } catch (err) {
-          if (err instanceof NotFoundError) {
-            return new Err(new SandboxNotFoundError(providerId));
+          if (err instanceof SandboxNotFoundError) {
+            return new Err(err);
           }
           return new Err(normalizeError(err));
         }
@@ -468,6 +734,10 @@ export class E2BSandboxProvider implements SandboxProvider {
             return new Err(new SandboxNotFoundError(providerId));
           }
           return new Err(normalizeError(err));
+        } finally {
+          // Whether or not the pause reported success, any cached handle for this sandbox may now
+          // point at a suspended VM.
+          this.dropConnection(providerId);
         }
 
         logger.info({ providerId }, "E2B sandbox paused");
@@ -497,6 +767,8 @@ export class E2BSandboxProvider implements SandboxProvider {
             return new Err(new SandboxNotFoundError(providerId));
           }
           return new Err(normalizeError(err));
+        } finally {
+          this.dropConnection(providerId);
         }
 
         logger.info({ providerId }, "E2B sandbox killed");
@@ -575,23 +847,19 @@ export class E2BSandboxProvider implements SandboxProvider {
     return traceSandboxOperation(
       "writeFile",
       async () => {
-        let sandbox: Sandbox;
         try {
-          sandbox = await Sandbox.connect(providerId, {
-            ...this.connectionOpts(),
-            timeoutMs: SANDBOX_LIFETIME_MS,
-          });
+          // Note: this creates the necessary directories if missing. Safe to retry on a fresh
+          // connection: a repeat writes the same bytes to the same path.
+          await this.withConnection(
+            providerId,
+            (sandbox) => sandbox.files.write(path, data),
+            // A repeat writes the same bytes to the same path.
+            { retryOnStaleConnection: true }
+          );
         } catch (err) {
-          if (err instanceof NotFoundError) {
-            return new Err(new SandboxNotFoundError(providerId));
+          if (err instanceof SandboxNotFoundError) {
+            return new Err(err);
           }
-          return new Err(normalizeError(err));
-        }
-
-        try {
-          // Note: this creates the necessary directories if missing.
-          await sandbox.files.write(path, data);
-        } catch (err) {
           return new Err(normalizeError(err));
         }
 
@@ -612,20 +880,12 @@ export class E2BSandboxProvider implements SandboxProvider {
     return traceSandboxOperation(
       "readFile",
       async () => {
-        let sandbox: Sandbox;
-        try {
-          sandbox = await Sandbox.connect(providerId, {
-            ...this.connectionOpts(),
-            timeoutMs: SANDBOX_LIFETIME_MS,
-          });
-        } catch (err) {
-          if (err instanceof NotFoundError) {
-            throw new SandboxNotFoundError(providerId);
-          }
-          throw normalizeError(err);
-        }
+        const bytes = await this.withConnection(
+          providerId,
+          (sandbox) => sandbox.files.read(path, { format: "bytes" }),
+          { retryOnStaleConnection: true }
+        );
 
-        const bytes = await sandbox.files.read(path, { format: "bytes" });
         return Buffer.from(bytes);
       },
       {
@@ -644,22 +904,14 @@ export class E2BSandboxProvider implements SandboxProvider {
     return traceSandboxOperation(
       "listFiles",
       async () => {
-        let sandbox: Sandbox;
-        try {
-          sandbox = await Sandbox.connect(providerId, {
-            ...this.connectionOpts(),
-            timeoutMs: SANDBOX_LIFETIME_MS,
-          });
-        } catch (err) {
-          if (err instanceof NotFoundError) {
-            throw new SandboxNotFoundError(providerId);
-          }
-          throw normalizeError(err);
-        }
-
-        const entries = await sandbox.files.list(path, {
-          depth: opts?.recursive ? 10 : 1,
-        });
+        const entries = await this.withConnection(
+          providerId,
+          (sandbox) =>
+            sandbox.files.list(path, {
+              depth: opts?.recursive ? 10 : 1,
+            }),
+          { retryOnStaleConnection: true }
+        );
 
         return entries.map((e) => ({
           path: e.path,

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -373,23 +373,24 @@ export class E2BSandboxProvider implements SandboxProvider {
   /**
    * Returns a handle for `providerId`, reusing a cached one while it is fresh.
    *
-   * `cached` reports whether the handle predates this call, which is what makes a retry worth
-   * attempting: a handle we just opened and that already failed will fail the same way again.
+   * `entry` is the cache entry the handle came from, or null when this call opened it. That both
+   * says whether a retry is worth attempting (a handle we just opened and that already failed
+   * will fail the same way again) and identifies exactly which entry to evict if it does.
    */
   private async getConnection(
     providerId: string
-  ): Promise<{ sandbox: Sandbox; cached: boolean }> {
+  ): Promise<{ sandbox: Sandbox; entry: CachedConnection | null }> {
     const existing = this.connections.get(providerId);
     if (existing && existing.expiresAtMs > Date.now()) {
       try {
-        return { sandbox: await existing.sandbox, cached: true };
+        return { sandbox: await existing.sandbox, entry: existing };
       } catch (err) {
         this.dropConnection(providerId, existing);
         throw err;
       }
     }
 
-    return { sandbox: await this.openConnection(providerId), cached: false };
+    return { sandbox: await this.openConnection(providerId), entry: null };
   }
 
   private async openConnection(providerId: string): Promise<Sandbox> {
@@ -468,7 +469,7 @@ export class E2BSandboxProvider implements SandboxProvider {
     op: (sandbox: Sandbox) => Promise<T>,
     { retryOnStaleConnection }: { retryOnStaleConnection: boolean }
   ): Promise<T> {
-    const { sandbox, cached } = await this.getConnection(providerId);
+    const { sandbox, entry } = await this.getConnection(providerId);
 
     try {
       return await op(sandbox);
@@ -481,9 +482,11 @@ export class E2BSandboxProvider implements SandboxProvider {
       }
 
       // Otherwise stop handing this connection to the next caller. Reconnecting costs one round
-      // trip; continuing to use a handle that just failed can cost every call after it.
-      this.dropConnection(providerId);
-      if (!cached || !retryOnStaleConnection) {
+      // trip; continuing to use a handle that just failed can cost every call after it. Scoped to
+      // the entry we actually used, so that when a batch of calls fails together, the first one
+      // to reconnect is not evicted again by each of its peers.
+      this.dropConnection(providerId, entry ?? undefined);
+      if (entry === null || !retryOnStaleConnection) {
         throw err;
       }
 

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -599,6 +599,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
             : "",
         },
         stdin: JSON.stringify(inputEnvelope),
+        // The envelope is this function's own input, and the same exec already hands it a token
+        // through the environment, so there is nothing here that the environment newly exposes.
+        // Worth two fewer round trips to the sandbox on the latency-sensitive path.
+        allowStdinInEnvironment: true,
         timeoutMs: inline
           ? SANDBOX_FUNCTION_INLINE_EXEC_TIMEOUT_MS
           : SANDBOX_FUNCTION_EXEC_TIMEOUT_MS,


### PR DESCRIPTION
## Description

A fast Pod function made four sequential round trips to E2B before its output could stream back: `Sandbox.connect`, then `commands.run`, then `sendStdin` and `closeStdin`. This makes it one.

Connected handles are now cached per provider id for 5 minutes, so operations skip the `Sandbox.connect` control plane POST. The TTL doubles as the sandbox keepalive, since every connect refreshes the provider side expiry. `sleep` and `destroy` drop the handle, `wake` opens a fresh one. The cache is per process (the provider is a singleton), so no sandbox access token is persisted or shared between replicas.

Small text stdin can also travel in an environment variable that the command wrapper feeds to stdin, replacing the two extra calls. Opt in per call and off by default: `Commands.list` reports the environment of every running command, and the four root call sites that pass stdin are handing over secrets that are deliberately kept out of process metadata. Only the Pod function invocation opts in, where the payload is the function's own input and the same exec already carries `DUST_SANDBOX_TOKEN` in its environment. Binary and >32KiB payloads always stream.

Measured against a real `dust-base_0-8-66` sandbox, latency is linear in round trips (about 175ms each from a laptop, about 70ms in prod):

| round trips | path | ms mean |
| --- | --- | --- |
| 4 | connect + streamed stdin (before) | 742 |
| 2 | connect, no stdin | 473 |
| 1 | cached + inline stdin (after) | 175 |

## Tests

23 unit tests in `e2b.test.ts`: both stdin paths, that the wrapper execs rather than pipes, connection reuse and invalidation, one connect shared by concurrent callers, the no retry rule for commands, the retry for file reads. Full front suite green (7375 passed). CI on a front-only change runs no test job here, so the suite and typecheck were run locally.

Verified end to end against a live sandbox: stdin round trips byte for byte through quotes, backslashes, `%`, `$`, tabs, newlines and multibyte characters; the variable never reaches the workload environment; exit codes, `workingDirectory` and caller env vars survive the wrapper; oversized and binary payloads fall back to streaming; root stdin keeps the streamed path.

## Risk

The wrapper uses `exec` and a process substitution rather than a pipeline, and that is load bearing. envd signals only the pid it started, so a pipeline leaves the workload running as a grandchild when a command is killed on timeout. Confirmed live: with a pipeline a command with inline stdin was still running 4s past its deadline, with `exec` it stops like the no stdin path.

Commands are never retried on a stale connection. The SDK aborts `Commands.start` on its own request timeout, which can fire after envd has forked the process, so a failed start does not prove nothing ran, and Pod functions are not idempotent. Commands surface the error as they did before and the next call reconnects. File reads, writes and lists are safe to repeat, so they do retry.

Rollback is a plain revert with no state to unwind. A stale cached handle costs one failed operation before the next call reconnects.

## Deploy Plan

Normal front deploy. No migration, no image change, no feature flag.

Watch `sandbox.provider.exec`, tagged `connection` (cached or fresh) and `stdin_mode` (none, inline, streamed). Front runs several replicas and the cache is per process, so within a 5 minute window the misses equal the number of distinct replicas that touched a sandbox, not the number of calls. The two halves degrade independently: a cache miss still saves the two stdin round trips, so the worst case is 4 round trips down to 2 rather than down to 1.
