### PR TITLE
[dsbx] perf: serve repeat function invocations from the warm runner

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.41"
+version = "0.1.42"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.41"
+version = "0.1.42"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/src/commands/function/envelope.rs
+++ b/cli/dust-sandbox/src/commands/function/envelope.rs
@@ -21,11 +21,24 @@ pub struct ResultEnvelope {
     pub timings_ms: Option<TimingsMs>,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum RunnerKind {
+    /// Served by a resident warm server over its unix socket.
+    Warm,
+    /// Fresh runner process spawn, today's default behavior.
+    Cold,
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TimingsMs {
     pub total: u64,
     pub runner: u64,
+    /// Additive: absent on envelopes from older dsbx versions, and front
+    /// treats timingsMs as opaque, so this cannot break the wire contract.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runner_kind: Option<RunnerKind>,
 }
 
 impl ResultEnvelope {
@@ -70,6 +83,7 @@ mod tests {
             Some(TimingsMs {
                 total: 12,
                 runner: 8,
+                runner_kind: Some(RunnerKind::Warm),
             }),
         );
 
@@ -80,7 +94,7 @@ mod tests {
                 "protocolVersion": 3,
                 "delivery": "stdout",
                 "outcome": { "ok": true, "output": { "hello": "world" } },
-                "timingsMs": { "total": 12, "runner": 8 },
+                "timingsMs": { "total": 12, "runner": 8, "runnerKind": "warm" },
             })
         );
     }

--- a/cli/dust-sandbox/src/commands/function/get.rs
+++ b/cli/dust-sandbox/src/commands/function/get.rs
@@ -6,6 +6,6 @@ use super::spawn_function;
 /// through from the runner. The bundle import (which executes the module's
 /// top-level code) runs unprivileged (agent uid) when dsbx is invoked as root.
 pub async fn cmd_function_get(name: &str) -> Result<()> {
-    let (code, _) = spawn_function("get", name, false, false).await?;
+    let (code, _) = spawn_function("get", name, None, false).await?;
     std::process::exit(code);
 }

--- a/cli/dust-sandbox/src/commands/function/mod.rs
+++ b/cli/dust-sandbox/src/commands/function/mod.rs
@@ -13,6 +13,7 @@ mod build;
 mod envelope;
 mod get;
 mod run;
+mod warm;
 
 pub use build::cmd_function_build;
 pub use envelope::ResultDelivery;
@@ -102,10 +103,22 @@ fn running_as_root() -> bool {
 pub(crate) async fn spawn_function(
     subcommand: &str,
     name: &str,
-    inherit_stdin: bool,
+    input: Option<&str>,
     capture_stdout: bool,
 ) -> Result<(i32, Option<String>)> {
     let handler = resolve_existing(name)?;
+    spawn_function_at(&handler, subcommand, input, capture_stdout).await
+}
+
+/// Like [`spawn_function`], for an already-resolved handler path. `input` is
+/// written to the child's stdin over a pipe when present (the caller has
+/// already consumed its own stdin); `None` gives the child no stdin at all.
+pub(crate) async fn spawn_function_at(
+    handler: &Path,
+    subcommand: &str,
+    input: Option<&str>,
+    capture_stdout: bool,
+) -> Result<(i32, Option<String>)> {
     let runner = ensure_runner()?;
     let as_agent = running_as_root();
     let function_working_dir = function_working_dir();
@@ -130,19 +143,19 @@ pub(crate) async fn spawn_function(
             .arg("bun")
             .arg(&*runner)
             .arg(subcommand)
-            .arg(&handler);
+            .arg(handler);
         c
     } else {
         let mut c = Command::new("bun");
-        c.arg(&*runner).arg(subcommand).arg(&handler);
+        c.arg(&*runner).arg(subcommand).arg(handler);
         c
     };
     // No env_clear: the child inherits dsbx's env verbatim, so per-exec vars
     // front sets (e.g. DUST_POD_DATABASES_DIR, read by `@dust/pod`) flow
     // through without dsbx naming each one — pinned by the inheritance tests.
     cmd.env("NODE_PATH", harness_node_path())
-        .stdin(if inherit_stdin {
-            Stdio::inherit()
+        .stdin(if input.is_some() {
+            Stdio::piped()
         } else {
             Stdio::null()
         })
@@ -158,8 +171,22 @@ pub(crate) async fn spawn_function(
         .spawn()
         .map_err(|e| emit_error(anyhow!("failed to run function: {e}")))?;
 
+    // Feed stdin from a task so a child that never reads it cannot deadlock
+    // against us while we wait on its stdout: the write and the read below
+    // progress independently, and a broken pipe (child exited early) is fine.
+    if let Some(input) = input {
+        if let Some(mut stdin) = child.stdin.take() {
+            let payload = input.as_bytes().to_vec();
+            tokio::spawn(async move {
+                use tokio::io::AsyncWriteExt as _;
+                let _ = stdin.write_all(&payload).await;
+                let _ = stdin.shutdown().await;
+            });
+        }
+    }
+
     // Capturing reads stdout to EOF (child closes it on exit) before waiting.
-    // Only stdout is piped; stderr/stdin are inherited, so there is no deadlock.
+    // Only stdout is piped for reading; stderr is inherited, so no deadlock.
     let captured = if capture_stdout {
         let mut buf = Vec::new();
         if let Some(mut out) = child.stdout.take() {
@@ -363,15 +390,18 @@ pub(crate) fn is_valid_name(name: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
 }
 
+// The environment is process-global and `cargo test` runs tests on parallel
+// threads within one process: any test (in this module or `warm`) that reads
+// or mutates env vars must hold this lock for the whole window where it
+// relies on them.
+#[cfg(test)]
+pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use std::sync::Mutex;
-    // The environment is process-global and `cargo test` runs tests on
-    // parallel threads within one process: any test that reads or mutates env
-    // vars must hold this lock for the whole window where it relies on them.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    use super::ENV_LOCK;
 
     #[test]
     fn accepts_simple_names() {
@@ -525,7 +555,7 @@ export default {
 
         // A var set on dsbx's own process reaches the child by inheritance.
         std::env::set_var(POD_DATABASES_DIR_ENV, "/custom/pod-databases");
-        let (code, stdout) = spawn_function("get", "envprobe", false, true)
+        let (code, stdout) = spawn_function("get", "envprobe", None, true)
             .await
             .expect("spawn get");
         let stdout = stdout.unwrap_or_default();
@@ -538,7 +568,7 @@ export default {
         // Absent env var: no dsbx-side default, the child sees it unset.
         // (Empty-string normalization is `@dust/pod`'s job, tested there.)
         std::env::remove_var(POD_DATABASES_DIR_ENV);
-        let (code, stdout) = spawn_function("get", "envprobe", false, true)
+        let (code, stdout) = spawn_function("get", "envprobe", None, true)
             .await
             .expect("spawn get");
         let stdout = stdout.unwrap_or_default();

--- a/cli/dust-sandbox/src/commands/function/run.rs
+++ b/cli/dust-sandbox/src/commands/function/run.rs
@@ -1,9 +1,11 @@
 use std::time::Instant;
 
 use anyhow::{anyhow, Result};
+use tokio::io::AsyncReadExt as _;
 
-use super::envelope::{ResultDelivery, ResultEnvelope, TimingsMs};
-use super::{emit_error, spawn_function};
+use super::envelope::{ResultDelivery, ResultEnvelope, RunnerKind, TimingsMs};
+use super::warm::{self, WarmRun};
+use super::{emit_error, resolve_existing, spawn_function_at};
 use crate::api::DustApiClient;
 
 const SANDBOX_TOKEN_ENV: &str = "DUST_SANDBOX_TOKEN";
@@ -13,6 +15,11 @@ const NON_JSON_SNIPPET_MAX_CHARS: usize = 512;
 ///
 /// The request envelope is read from stdin and the function runs unprivileged
 /// (agent uid) when dsbx is invoked as root.
+///
+/// The invocation is served warm when a resident server for this function is
+/// listening (see `warm.rs`): one unix-socket round trip instead of a runner
+/// spawn. A cold run additionally leaves a warm server behind for the next
+/// invocation. Both paths produce the same runner `Output` JSON.
 ///
 /// Delivery modes:
 /// - `callback` (default): POST the runner response to the Dust result API when
@@ -25,8 +32,58 @@ const NON_JSON_SNIPPET_MAX_CHARS: usize = 512;
 ///   callback.
 pub async fn cmd_function_run(name: &str, result_delivery: ResultDelivery) -> Result<()> {
     let started = Instant::now();
-    let spawned = spawn_function("run", name, true, true).await;
+
+    // The envelope is consumed here rather than inherited by the runner child:
+    // the warm path forwards it over the socket, and the cold path pipes it.
+    let mut input = String::new();
+    if let Err(e) = tokio::io::stdin().read_to_string(&mut input).await {
+        let err = emit_error(anyhow!("failed to read request envelope: {e}"));
+        return match result_delivery {
+            ResultDelivery::Callback => Err(err),
+            ResultDelivery::Stdout => deliver_stdout_envelope(
+                ResultEnvelope::stdout_invocation_failed(err.to_string()),
+                0,
+            ),
+        };
+    }
+
+    if let WarmRun::Outcome(outcome) = warm::try_warm_run(name, &input).await {
+        let runner_ms = started.elapsed().as_millis() as u64;
+        return match result_delivery {
+            ResultDelivery::Callback => deliver_callback_outcome(name, outcome).await,
+            ResultDelivery::Stdout => deliver_stdout_envelope(
+                ResultEnvelope::stdout_outcome(
+                    outcome,
+                    Some(TimingsMs {
+                        total: started.elapsed().as_millis() as u64,
+                        runner: runner_ms,
+                        runner_kind: Some(RunnerKind::Warm),
+                    }),
+                ),
+                0,
+            ),
+        };
+    }
+
+    // Cold path. Resolve once: the run below and the warm server spawn both
+    // need the handler path, and resolution lists the (gcsfuse-backed)
+    // functions directory.
+    let (spawned, handler) = match resolve_existing(name) {
+        Ok(handler) => {
+            let spawned = spawn_function_at(&handler, "run", Some(&input), true).await;
+            (spawned, Some(handler))
+        }
+        // resolve_existing already emitted the `{error}` line; the message
+        // (bad name, unset dir, missing or ambiguous bundle) propagates.
+        Err(e) => (Err(e), None),
+    };
     let runner_ms = started.elapsed().as_millis() as u64;
+
+    // Leave a warm server behind so the next invocation of this function
+    // skips the spawn. Fire-and-forget; never affects this run's outcome.
+    if let Some(handler) = &handler {
+        warm::spawn_server(name, handler);
+    }
 
     match result_delivery {
         // Spawn failures keep propagating: the bare `{error}` line emit_error
@@ -40,9 +97,47 @@ pub async fn cmd_function_run(name: &str, result_delivery: ResultDelivery) -> Re
             TimingsMs {
                 total: started.elapsed().as_millis() as u64,
                 runner: runner_ms,
+                runner_kind: Some(RunnerKind::Cold),
             },
         ),
     }
+}
+
+/// Callback delivery for a warm outcome: the runner `Output` is already
+/// parsed, so it goes straight to the result API (or to stdout in the
+/// local/no-token case, mirroring the cold path's convenience behavior).
+async fn deliver_callback_outcome(name: &str, outcome: serde_json::Value) -> Result<()> {
+    let have_token = std::env::var(SANDBOX_TOKEN_ENV)
+        .map(|t| !t.is_empty())
+        .unwrap_or(false);
+
+    if !have_token {
+        // Exit-code parity with the cold runner: 0 for ok, 2 for bad_input,
+        // 1 for every other failure.
+        let ok = outcome
+            .get("ok")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        let bad_input = outcome
+            .pointer("/error/code")
+            .and_then(serde_json::Value::as_str)
+            == Some("bad_input");
+        println!("{outcome}");
+        std::process::exit(if ok {
+            0
+        } else if bad_input {
+            2
+        } else {
+            1
+        });
+    }
+
+    let client = DustApiClient::from_env()?;
+    client
+        .post_function_result(name, &outcome)
+        .await
+        .map_err(emit_error)?;
+    std::process::exit(0);
 }
 
 async fn deliver_callback(name: &str, code: i32, response: &str) -> Result<()> {
@@ -78,6 +173,10 @@ async fn deliver_callback(name: &str, code: i32, response: &str) -> Result<()> {
 
 fn deliver_stdout(spawned: Result<(i32, Option<String>)>, timings_ms: TimingsMs) -> ! {
     let (envelope, code) = stdout_result(spawned, timings_ms);
+    deliver_stdout_envelope(envelope, code)
+}
+
+fn deliver_stdout_envelope(envelope: ResultEnvelope, code: i32) -> ! {
     envelope.write_to_stdout();
     std::process::exit(code);
 }
@@ -149,14 +248,19 @@ fn truncate_chars(value: &str, max_chars: usize) -> String {
 mod tests {
     use super::*;
 
+    fn timings(total: u64, runner: u64) -> TimingsMs {
+        TimingsMs {
+            total,
+            runner,
+            runner_kind: Some(RunnerKind::Cold),
+        }
+    }
+
     #[test]
     fn stdout_result_wraps_valid_json_and_exits_0() {
         let (envelope, code) = stdout_result(
             Ok((0, Some("noise\n{\"ok\":true,\"output\":1}\n".to_string()))),
-            TimingsMs {
-                total: 12,
-                runner: 8,
-            },
+            timings(12, 8),
         );
         assert_eq!(code, 0);
         assert_eq!(envelope.delivery, ResultDelivery::Stdout);
@@ -168,26 +272,14 @@ mod tests {
 
     #[test]
     fn stdout_result_exits_0_for_empty_and_non_json() {
-        let (empty, empty_code) = stdout_result(
-            Ok((7, Some(String::new()))),
-            TimingsMs {
-                total: 1,
-                runner: 1,
-            },
-        );
+        let (empty, empty_code) = stdout_result(Ok((7, Some(String::new()))), timings(1, 1));
         assert_eq!(empty_code, 0);
         assert_eq!(
             empty.outcome["error"]["message"],
             "function produced no output (runner exit 7)"
         );
 
-        let (bad, bad_code) = stdout_result(
-            Ok((1, Some("not-json\n".to_string()))),
-            TimingsMs {
-                total: 1,
-                runner: 1,
-            },
-        );
+        let (bad, bad_code) = stdout_result(Ok((1, Some("not-json\n".to_string()))), timings(1, 1));
         assert_eq!(bad_code, 0);
         let message = bad.outcome["error"]["message"]
             .as_str()
@@ -198,13 +290,8 @@ mod tests {
 
     #[test]
     fn stdout_result_envelopes_spawn_failures_and_exits_0() {
-        let (envelope, code) = stdout_result(
-            Err(anyhow!("function not found: greet")),
-            TimingsMs {
-                total: 1,
-                runner: 1,
-            },
-        );
+        let (envelope, code) =
+            stdout_result(Err(anyhow!("function not found: greet")), timings(1, 1));
         assert_eq!(code, 0);
         assert_eq!(envelope.delivery, ResultDelivery::Stdout);
         assert_eq!(

--- a/cli/dust-sandbox/src/commands/function/warm.rs
+++ b/cli/dust-sandbox/src/commands/function/warm.rs
@@ -1,0 +1,503 @@
+//! Warm-path client for `dsbx function run`.
+//!
+//! A cold function run pays process spawn, bundle resolution against the
+//! gcsfuse-backed functions dir, and the import of the bundle and its
+//! dependencies on every invocation. The warm path keeps a per-bundle bun
+//! server (the embedded runner's `serve` subcommand) resident behind a unix
+//! socket and forwards invocations to it, so a repeat invocation costs one
+//! local socket round trip.
+//!
+//! Everything here is best-effort: any irregularity — missing socket, wrong
+//! directory ownership, protocol mismatch, stale bundle — falls back to the
+//! cold path, which is exactly today's behavior. The warm path can only ever
+//! be a fast alternative, never a new failure mode.
+//!
+//! Security: the warm directory lives under $HOME, which in the sandbox is
+//! `/home/agent-proxied`, owned by the agent-proxied uid (created by
+//! `useradd --create-home`). The other untrusted sandbox user (`agent`,
+//! uid 1002) must be unable to plant a socket that receives the request
+//! environment, which carries the per-invocation sandbox token — hence the
+//! strict ownership and mode verification on the directory before any use,
+//! and the refusal to follow a directory we did not create with 0700.
+
+use std::io::ErrorKind;
+use std::os::unix::fs::{DirBuilderExt as _, MetadataExt as _, PermissionsExt as _};
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::Result;
+use serde::Deserialize;
+use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
+use tokio::net::UnixStream;
+use tokio::process::Command;
+
+use super::RUNNER_JS;
+
+pub const WARM_PROTOCOL_VERSION: u32 = 1;
+
+/// Ceiling on how long the warm path waits for the server to answer before
+/// giving up. Generous on purpose: the function itself runs inside this
+/// window, and the caller (front) enforces the real invocation timeout by
+/// killing dsbx. This only bounds a wedged server.
+const WARM_RESPONSE_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Connect timeout: the server is either listening or it is not.
+const WARM_CONNECT_TIMEOUT: Duration = Duration::from_millis(250);
+
+#[derive(Debug, Deserialize)]
+struct WarmFrame {
+    v: u32,
+    #[serde(default)]
+    ack: bool,
+    #[serde(default)]
+    outcome: Option<serde_json::Value>,
+    #[serde(default)]
+    stale: bool,
+    #[serde(default)]
+    busy: bool,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+/// The outcome of asking the warm server to run an invocation.
+pub enum WarmRun {
+    /// The server ran the function; this is the runner `Output` JSON. Also
+    /// carries the synthesized failure outcome when the server acked (the
+    /// function started executing) but the outcome was lost: past the ack the
+    /// cold path is off the table, because re-running a function that may
+    /// already have fired its side effects is worse than failing the
+    /// invocation.
+    Outcome(serde_json::Value),
+    /// No usable warm server (not running, busy, stale bundle, protocol
+    /// mismatch, ownership refusal...). Nothing executed; run cold.
+    Miss,
+}
+
+/// FNV-1a, inline rather than a hashing crate: these hashes only ever
+/// disambiguate names between runs of the same binary (slug collisions,
+/// runner versions) — nothing security-relevant depends on them, since the
+/// warm directory itself is ownership-verified.
+fn fnv1a(bytes: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+/// Hash of the embedded runner source: a dsbx upgrade changes the runner and
+/// must never talk to a server built from the old one.
+fn runner_hash8() -> String {
+    format!("{:08x}", fnv1a(RUNNER_JS.as_bytes()) as u32)
+}
+
+/// Warm state directory: `$HOME/.dust-fn`. In the sandbox $HOME is the
+/// invoking user's home (`/home/agent-proxied` for function runs), which the
+/// other untrusted uid cannot write into. No fallback: without a HOME there
+/// is no directory we can trust, and cold is always correct.
+fn warm_dir() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME").filter(|h| !h.is_empty())?;
+    Some(PathBuf::from(home).join(".dust-fn"))
+}
+
+/// Creates the warm dir if needed and verifies it is exactly ours: a real
+/// directory (not a symlink), owned by our euid, mode 0700. Returns None —
+/// meaning "stay cold" — on any deviation.
+fn ensure_trusted_warm_dir() -> Option<PathBuf> {
+    let dir = warm_dir()?;
+    let mut builder = std::fs::DirBuilder::new();
+    builder.mode(0o700);
+    match builder.create(&dir) {
+        Ok(()) => {}
+        Err(e) if e.kind() == ErrorKind::AlreadyExists => {}
+        Err(_) => return None,
+    }
+    let meta = std::fs::symlink_metadata(&dir).ok()?;
+    if !meta.is_dir() {
+        return None;
+    }
+    if meta.uid() != rustix::process::geteuid().as_raw() {
+        return None;
+    }
+    if meta.permissions().mode() & 0o777 != 0o700 {
+        return None;
+    }
+    Some(dir)
+}
+
+/// Socket path for a function slug. The slug is already validated to
+/// `[A-Za-z0-9_-]+`; it is truncated and suffixed with its own hash so two
+/// long slugs sharing a prefix cannot collide, and with the runner hash so a
+/// dsbx upgrade gets fresh servers. Unix socket paths must stay short
+/// (~104 bytes); with a 20-char slug prefix this stays well under.
+fn socket_path(dir: &Path, name: &str) -> PathBuf {
+    // The functions dir is part of the key: the same slug under a different
+    // DUST_FUNCTIONS_DIR is a different bundle, and the mtime/size staleness
+    // stamp would not catch the swap.
+    let functions_dir = std::env::var("DUST_FUNCTIONS_DIR").unwrap_or_default();
+    let key = format!("{functions_dir}\0{name}");
+    let prefix: String = name.chars().take(20).collect();
+    dir.join(format!(
+        "{prefix}-{:08x}-{}-v{WARM_PROTOCOL_VERSION}.sock",
+        fnv1a(key.as_bytes()) as u32,
+        runner_hash8(),
+    ))
+}
+
+/// Stages the embedded runner at a stable content-addressed path inside the
+/// warm dir, so the detached server outlives the dsbx process that spawned
+/// it (the tempfile used by cold runs is deleted when dsbx exits).
+fn stage_runner(dir: &Path) -> Result<PathBuf> {
+    let path = dir.join(format!("runner-{}.js", runner_hash8()));
+    if std::fs::metadata(&path).is_ok() {
+        return Ok(path);
+    }
+    // Write-then-rename so a concurrent dsbx never observes a half-written
+    // runner file.
+    let tmp = dir.join(format!(
+        "runner-{}.js.tmp-{}",
+        runner_hash8(),
+        std::process::id()
+    ));
+    std::fs::write(&tmp, RUNNER_JS.as_bytes())?;
+    std::fs::rename(&tmp, &path)?;
+    Ok(path)
+}
+
+/// Tries to run `input` (the raw stdin envelope) against a warm server for
+/// `name`/`handler_hint`. Never errors: every failure is a `Miss`.
+pub async fn try_warm_run(name: &str, input: &str) -> WarmRun {
+    // The name feeds the socket path before resolve_existing validates it on
+    // the cold path, so it is validated here too.
+    if !super::is_valid_name(name) {
+        return WarmRun::Miss;
+    }
+    // Warm serving is for unprivileged runs only: the production fast path
+    // execs dsbx as agent-proxied. A root dsbx stays cold — a root client
+    // must not hand invocation env to a workload-owned server it would then
+    // have to trust for lifecycle management.
+    if rustix::process::geteuid().is_root() {
+        return WarmRun::Miss;
+    }
+    let Some(dir) = ensure_trusted_warm_dir() else {
+        return WarmRun::Miss;
+    };
+    let socket = socket_path(&dir, name);
+
+    let connect = tokio::time::timeout(WARM_CONNECT_TIMEOUT, UnixStream::connect(&socket)).await;
+    let stream = match connect {
+        Ok(Ok(stream)) => stream,
+        _ => return WarmRun::Miss,
+    };
+
+    match tokio::time::timeout(WARM_RESPONSE_TIMEOUT, roundtrip(stream, input)).await {
+        Ok(Ok(run)) => run,
+        // Pre-ack IO error or timeout: nothing executed, run cold. roundtrip
+        // itself converts post-ack losses into a failure Outcome.
+        _ => WarmRun::Miss,
+    }
+}
+
+/// The outcome delivered when the server acked (execution started) but the
+/// outcome frame never arrived. Failing the invocation is the only safe call:
+/// the function may already have fired its side effects, so neither the warm
+/// nor the cold path may run it again.
+fn lost_outcome_after_ack() -> serde_json::Value {
+    serde_json::json!({
+        "ok": false,
+        "error": {
+            "code": "invocation_failed",
+            "message": "The warm function server stopped responding after execution started.",
+        }
+    })
+}
+
+async fn roundtrip(mut stream: UnixStream, input: &str) -> Result<WarmRun> {
+    // The request carries the client's full environment: per-invocation
+    // values (sandbox token, user identity, pod databases dir) travel in env
+    // vars, and the resident server's own env is stale by definition. This
+    // mirrors the env inheritance of the cold path's bun child.
+    // vars_os + lossy filtering: std::env::vars() panics on non-unicode
+    // values, and a hostile env var must never crash the client.
+    let env: std::collections::HashMap<String, String> = std::env::vars_os()
+        .filter_map(|(k, v)| Some((k.into_string().ok()?, v.into_string().ok()?)))
+        .collect();
+    let request = serde_json::json!({
+        "v": WARM_PROTOCOL_VERSION,
+        "env": env,
+        "input": input,
+    });
+    let mut line = serde_json::to_string(&request)?;
+    line.push('\n');
+    stream.write_all(line.as_bytes()).await?;
+
+    let mut reader = BufReader::new(stream);
+
+    // First frame: ack (execution starting), or a pre-execution refusal
+    // (busy, stale, protocol error) that safely sends the client cold.
+    let mut first = String::new();
+    if reader.read_line(&mut first).await? == 0 {
+        return Ok(WarmRun::Miss);
+    }
+    let frame: WarmFrame = serde_json::from_str(first.trim())?;
+    if frame.v != WARM_PROTOCOL_VERSION || frame.busy || frame.stale || frame.error.is_some() {
+        return Ok(WarmRun::Miss);
+    }
+    if let Some(outcome) = frame.outcome {
+        // Single-frame outcome: a pre-execution classification such as
+        // bad_input, delivered without an ack. Safe either way.
+        return Ok(WarmRun::Outcome(outcome));
+    }
+    if !frame.ack {
+        return Ok(WarmRun::Miss);
+    }
+
+    // Past the ack: never Miss again. A lost or unparsable outcome frame is
+    // a failed invocation, not a cold retry.
+    let mut second = String::new();
+    match reader.read_line(&mut second).await {
+        Ok(0) | Err(_) => return Ok(WarmRun::Outcome(lost_outcome_after_ack())),
+        Ok(_) => {}
+    }
+    match serde_json::from_str::<WarmFrame>(second.trim()) {
+        Ok(WarmFrame {
+            v: WARM_PROTOCOL_VERSION,
+            outcome: Some(outcome),
+            ..
+        }) => Ok(WarmRun::Outcome(outcome)),
+        _ => Ok(WarmRun::Outcome(lost_outcome_after_ack())),
+    }
+}
+
+/// Spawns a detached warm server for `handler` so the *next* invocation of
+/// this function is warm. Fire-and-forget: failures are ignored (the next
+/// run is simply cold again), and the server is its own process group so it
+/// survives dsbx exiting and is not collateral of anything that signals
+/// dsbx's group.
+pub fn spawn_server(name: &str, handler: &Path) {
+    if !super::is_valid_name(name) {
+        return;
+    }
+    if rustix::process::geteuid().is_root() {
+        return;
+    }
+    let Some(dir) = ensure_trusted_warm_dir() else {
+        return;
+    };
+    let Ok(runner) = stage_runner(&dir) else {
+        return;
+    };
+    let socket = socket_path(&dir, name);
+    // If a server is already listening, leave it alone: it will serve the
+    // next request or exit stale on its own. Binding a second one would
+    // steal the socket mid-request.
+    if UnixStreamStdCheck::is_listening(&socket) {
+        return;
+    }
+
+    // The server's stderr goes to a log file in the warm dir rather than
+    // /dev/null: a warm-served function's console.error output would
+    // otherwise vanish, where a cold run's reaches the exec output that
+    // front logs on failure.
+    let log = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(dir.join("server.log"))
+        .ok();
+
+    let mut cmd = Command::new("bun");
+    cmd.arg(&runner)
+        .arg("serve")
+        .arg(handler)
+        .arg(&socket)
+        .env("NODE_PATH", super::harness_node_path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(log.map(Stdio::from).unwrap_or_else(Stdio::null))
+        .process_group(0);
+    // Spawn and forget: tokio children are not killed on drop by default,
+    // and the server terminates itself on idle/lifetime/staleness.
+    drop(cmd.spawn());
+}
+
+/// Cheap "is anything listening" probe used to avoid double-spawning.
+struct UnixStreamStdCheck;
+
+impl UnixStreamStdCheck {
+    fn is_listening(socket: &Path) -> bool {
+        std::os::unix::net::UnixStream::connect(socket).is_ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use super::super::ENV_LOCK;
+
+    /// The e2e tests spawn the real runner under `bun`; skip gracefully where
+    /// bun is unavailable (CI installs it before cargo test).
+    fn bun_available() -> bool {
+        std::process::Command::new("bun")
+            .arg("--version")
+            .output()
+            .is_ok()
+    }
+
+    const HELLO_FIXTURE: &str = r#"export default {
+  async fetch(req) {
+    const url = new URL(req.url);
+    return Response.json({ hello: url.searchParams.get("name") ?? "world" });
+  },
+};
+"#;
+
+    fn restore_env(key: &str, original: Option<std::ffi::OsString>) {
+        match original {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
+    }
+
+    /// Cold-spawn then warm-hit then staleness, against the real runner:
+    /// spawn_server leaves a resident bun process behind, try_warm_run gets an
+    /// outcome from it without any runner spawn, and a rewritten bundle turns
+    /// the next attempt into a miss.
+    #[tokio::test]
+    // The env lock intentionally spans the awaits: the spawned server and the
+    // client both read process-global env (HOME). Each #[tokio::test] runs
+    // its own runtime, so contending tests just block on the mutex.
+    #[allow(clippy::await_holding_lock)]
+    async fn warm_cycle_end_to_end() {
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
+        if !bun_available() {
+            eprintln!("skipping: bun not on PATH");
+            return;
+        }
+        let original_home = std::env::var_os("HOME");
+
+        let home = tempfile::tempdir().expect("home tempdir");
+        std::env::set_var("HOME", home.path());
+        let bundle_dir = tempfile::tempdir().expect("bundle tempdir");
+        let handler = bundle_dir.path().join("greet.ts");
+        std::fs::write(&handler, HELLO_FIXTURE).expect("fixture");
+
+        let input = serde_json::json!({ "url": "http://localhost/?name=warm" }).to_string();
+
+        // Nothing is listening yet: a warm attempt must miss, not error.
+        assert!(matches!(try_warm_run("greet", &input).await, WarmRun::Miss));
+
+        spawn_server("greet", &handler);
+
+        // The server needs a moment to import the bundle and bind the socket.
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        let outcome = loop {
+            match try_warm_run("greet", &input).await {
+                WarmRun::Outcome(outcome) => break outcome,
+                WarmRun::Miss if std::time::Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                }
+                WarmRun::Miss => panic!("warm server never came up"),
+            }
+        };
+        assert_eq!(
+            outcome,
+            serde_json::json!({ "ok": true, "output": { "hello": "warm" } })
+        );
+
+        // A republished bundle (same path, new mtime/size) must not be served
+        // from the stale import: the server refuses and the client misses.
+        std::fs::write(
+            &handler,
+            format!(
+                "{HELLO_FIXTURE}
+// republished
+"
+            ),
+        )
+        .expect("rewrite fixture");
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            match try_warm_run("greet", &input).await {
+                WarmRun::Miss => break,
+                WarmRun::Outcome(_) if std::time::Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                }
+                WarmRun::Outcome(_) => panic!("stale bundle kept being served"),
+            }
+        }
+
+        restore_env("HOME", original_home);
+    }
+
+    /// A squatted warm dir (wrong owner is hard to fake unprivileged, but a
+    /// wrong mode is the same refusal path) must disable the warm path
+    /// entirely rather than be used.
+    #[test]
+    fn refuses_a_squatted_warm_dir() {
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
+        let original_home = std::env::var_os("HOME");
+
+        let home = tempfile::tempdir().expect("home tempdir");
+        std::env::set_var("HOME", home.path());
+        let dir = home.path().join(".dust-fn");
+        std::fs::create_dir(&dir).expect("mkdir");
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o777)).expect("chmod");
+
+        assert!(ensure_trusted_warm_dir().is_none());
+
+        restore_env("HOME", original_home);
+    }
+
+    #[test]
+    fn creates_and_accepts_its_own_warm_dir() {
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
+        let original_home = std::env::var_os("HOME");
+
+        let home = tempfile::tempdir().expect("home tempdir");
+        std::env::set_var("HOME", home.path());
+
+        let dir = ensure_trusted_warm_dir().expect("fresh warm dir accepted");
+        assert!(dir.ends_with(".dust-fn"));
+        // Idempotent: the second call accepts the dir it just created.
+        assert!(ensure_trusted_warm_dir().is_some());
+
+        restore_env("HOME", original_home);
+    }
+
+    #[test]
+    fn socket_path_is_short_and_stable() {
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
+        let dir = PathBuf::from("/home/agent-proxied/.dust-fn");
+        let a = socket_path(&dir, "my-function");
+        let b = socket_path(&dir, "my-function");
+        assert_eq!(a, b);
+        assert!(a.as_os_str().len() < 100, "socket path too long: {a:?}");
+    }
+
+    #[test]
+    fn socket_path_distinguishes_long_slugs_sharing_a_prefix() {
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
+        let dir = PathBuf::from("/tmp");
+        let a = socket_path(&dir, "a-very-long-function-name-one");
+        let b = socket_path(&dir, "a-very-long-function-name-two");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn socket_path_distinguishes_functions_dirs() {
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
+        let original = std::env::var_os("DUST_FUNCTIONS_DIR");
+        let dir = PathBuf::from("/tmp");
+
+        std::env::set_var("DUST_FUNCTIONS_DIR", "/mnt/functions/space-a");
+        let a = socket_path(&dir, "greet");
+        std::env::set_var("DUST_FUNCTIONS_DIR", "/mnt/functions/space-b");
+        let b = socket_path(&dir, "greet");
+        assert_ne!(a, b);
+
+        restore_env("DUST_FUNCTIONS_DIR", original);
+    }
+}

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.66",
+      tag: "0.8.67",
     });
   });
 
@@ -459,7 +459,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.41/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.42/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,8 +26,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.66";
-const DSBX_CLI_VERSION = "0.1.41";
+const DUST_BASE_IMAGE_VERSION = "0.8.67";
+const DSBX_CLI_VERSION = "0.1.42";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
 // the stable identity used when creating the workload account.


### PR DESCRIPTION
## Description

Stacked on #30160 (the runner's warm serve mode). This PR is the dsbx client and the version bumps that ship it; #30146 adds the metric on top.

`dsbx function run` forwards the invocation to the warm server when one is listening for this bundle, so a repeat invocation costs one local socket round trip instead of a runner spawn. A cold run leaves a detached server behind for the next invocation, so the first call pays nothing extra. No front or wire change: the stdout envelope's timings gain an additive `runnerKind` (warm|cold) field, and front treats `timingsMs` as opaque.

The client mirrors the never-re-run contract from #30160: it falls back to the cold path only on failures that precede the server's ack (no server, busy, stale bundle, protocol mismatch), and a lost outcome after the ack is reported as a failed invocation, never retried.

Security: the warm directory is `$HOME/.dust-fn` (under `/home/agent-proxied` in the sandbox, owned by the invoking uid) and is refused unless it is a real euid-owned 0700 directory, because the other untrusted sandbox uid must not be able to plant a socket that would receive the request environment. The function name is validated before it feeds the socket path, and the functions dir is part of the socket key so a slug from another dir cannot be served from the wrong bundle. Root dsbx never uses the warm path.

The final commit pins dsbx 0.1.42 and base image 0.8.67, which puts the warm-server dsbx into sandboxes as they are created or recreated after the image rollout.

## Tests

Cargo: 275 passing, including an end-to-end warm cycle against real bun (miss, spawn, warm hit with the exact outcome, republish, stale, miss), refusal of a squatted warm dir, and socket keying by slug and functions dir. Image registry tests updated to the pinned 0.8.67 / dsbx 0.1.42. Clippy clean, front typechecks clean. The server half is tested in #30160.

## Risk

The image bump is the consequential part: it triggers the base image rollout, and existing sandboxes pick the new image up on their next recreation. The dsbx v0.1.42 release must exist before the image builds, which the deploy plan below handles by dispatching the release workflow against this branch before merge.

The one intentional new failure mode: if the server dies between ack and outcome delivery, the invocation fails rather than re-running cold. For non-idempotent functions that is the correct trade, and it replaces the silent duplicate execution a naive fallback would produce. Concurrent invocations of the same function serialize onto one warm server only in the sense that the loser goes cold immediately; nothing waits.

Worth a manual check on a dev pod before merge: invoke a fast function twice and confirm the second run reports `runnerKind` warm with a lower duration.

## Deploy Plan

Both workflows are `workflow_dispatch` and read the version from the ref they run against, so the release and the image can be built from this branch before merge, leaving no window where main points at artifacts that do not exist:

1. `gh workflow run release-dsbx-cli.yml --ref fn-warm-runner` to publish the dsbx-v0.1.42 GitHub release the image build downloads.
2. `gh workflow run sandbox-img-registry.yml --ref fn-warm-runner` to build base image 0.8.67 in both regions.
3. Merge, then deploy front.
4. Open /poke/kill and request a kill of base image versions older than 0.8.67, so live conversations get sandboxes running the warm-capable dsbx instead of waiting for natural recreation. This is what the `sandbox-image-ack` label acknowledges.

If the merge lands first instead, run the two dispatches promptly: until the release exists, a front deploy fails its ensure-sandbox-images step looking for it.

The kill switch for warm serving is reverting the dsbx behavior in a patch release; no front flag is involved.

