### PR TITLE
[front] perf: trim the fast Pod function invocation setup path

### DIFF
--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -155,10 +155,13 @@ app.post(
     }
 
     const invocation = invocationResult.value;
+    // An inline execution settles the instance it ran on, so the outcome is usually already in
+    // memory; the stream read-back is only for invocations that escalated to the workflow.
     const outcome = fastExecution
-      ? await awaitSandboxFunctionInvocationOutcome({
+      ? (invocation.settledOutcome() ??
+        (await awaitSandboxFunctionInvocationOutcome({
           invocationId: invocation.sId,
-        })
+        })))
       : null;
 
     return ctx.json(

--- a/front/lib/api/sandbox_functions/call_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.ts
@@ -8,6 +8,7 @@ import type {
 } from "@app/types/api/sandbox_functions";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 // Safety ceiling on waiting for the result event delivered over the invocation stream.
@@ -45,9 +46,14 @@ export async function callSandboxFunction(
   // subscribing to the stream to read back an outcome this process just produced.
   const settled = invocation.settledOutcome();
   if (settled) {
-    return settled.status === "succeeded"
-      ? new Ok(settled.result)
-      : new Err(settled.error);
+    switch (settled.status) {
+      case "succeeded":
+        return new Ok(settled.result);
+      case "errored":
+        return new Err(settled.error);
+      default:
+        assertNever(settled);
+    }
   }
 
   try {

--- a/front/lib/api/sandbox_functions/call_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.ts
@@ -41,6 +41,15 @@ export async function callSandboxFunction(
   const invocation = invocationResult.value;
   const { sId: invocationId } = invocation;
 
+  // An inline execution settles the instance it ran on: return from memory rather than
+  // subscribing to the stream to read back an outcome this process just produced.
+  const settled = invocation.settledOutcome();
+  if (settled) {
+    return settled.status === "succeeded"
+      ? new Ok(settled.result)
+      : new Err(settled.error);
+  }
+
   try {
     for await (const { data } of getSandboxFunctionInvocationEvents({
       invocationId,

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -691,7 +691,10 @@ describe("SandboxFunctionInvocationResource", () => {
         invocationId: invocation.sId,
       });
     expect(refetchedInvocation?.status).toBe("created");
-    expect(updateLastActivityAtSpy).toHaveBeenCalledOnce();
+    // execute() itself never touches lastActivityAt: ensurePodSandboxReady's
+    // ensureActive already writes it under the lifecycle lock, and a second
+    // write per invocation was pure hot-row churn on the sandbox row.
+    expect(updateLastActivityAtSpy).not.toHaveBeenCalled();
     expect(ensurePodSandboxReady).toHaveBeenCalledWith(authenticator, space, {
       requireRunning: false,
     });
@@ -1143,6 +1146,22 @@ describe("SandboxFunctionInvocationResource.createAndStartExecution", () => {
     }
     expect(result.value.status).toBe("succeeded");
     expect(result.value.result).toEqual({ commentId: "inline" });
+    // The settled outcome is available in memory, so callers can answer without reading the
+    // event stream back out of Redis.
+    expect(result.value.settledOutcome()).toEqual({
+      status: "succeeded",
+      result: { commentId: "inline" },
+    });
+    // The initial blob write is deferred on the inline path; the terminal write must still leave
+    // a complete blob (input and result) behind for later fetches.
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: result.value.sId }
+    );
+    expect(refetched?.input).toEqual({ message: "hello" });
+    expect(refetched?.result).toEqual({ commentId: "inline" });
+    // A rehydrated instance never short-circuits: it did not run the invocation.
+    expect(refetched?.settledOutcome()).toBeNull();
     // An inline invocation holds a request while it runs, so it gets a far shorter ceiling than
     // the workflow's.
     const [, , execOptions] = execSpy.mock.calls[0]!;

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -50,6 +50,7 @@ import type {
   SandboxFunctionCallError,
   SandboxFunctionInvocationContext,
   SandboxFunctionInvocationOrigin,
+  SandboxFunctionInvocationOutcome,
   SandboxFunctionInvocationStatus,
   SandboxFunctionInvocationType,
 } from "@app/types/api/sandbox_functions";
@@ -282,6 +283,33 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   readonly sandboxFunction: SandboxFunctionResource;
   private data: SandboxFunctionInvocationData;
 
+  /**
+   * In-flight initial persistence (blob write + created event) for an inline execution. Terminal
+   * transitions await it so the terminal blob write cannot be overwritten by the initial one and
+   * the result event cannot outrun the created event. Only ever set on the instance that runs the
+   * invocation inline; instances rehydrated from the DB never have one, and never need one.
+   */
+  private pendingInitialPersistence: Promise<void> | undefined;
+
+  private async settleInitialPersistence(): Promise<void> {
+    if (this.pendingInitialPersistence) {
+      await this.pendingInitialPersistence;
+      this.pendingInitialPersistence = undefined;
+    }
+  }
+
+  /**
+   * The outcome recorded by a terminal transition that ran on this instance, kept with its
+   * original types (the stored blob deliberately widens error codes to plain strings). Callers
+   * use it to skip the event-stream read-back after an inline execution: subscribing to Redis
+   * would only re-fetch what this process just produced.
+   */
+  private lastSettledOutcome: SandboxFunctionInvocationOutcome | undefined;
+
+  settledOutcome(): SandboxFunctionInvocationOutcome | null {
+    return this.lastSettledOutcome ?? null;
+  }
+
   constructor(
     model: ModelStaticWorkspaceAware<SandboxFunctionInvocationModel>,
     blob: Attributes<SandboxFunctionInvocationModel>,
@@ -404,6 +432,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       return false;
     }
 
+    // A deferred initial persistence (inline path) must land before the terminal blob write
+    // overwrites the same object, and before the result event can outrun the created event.
+    await this.settleInitialPersistence();
+
     this.data = {
       version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
       input: this.input,
@@ -428,6 +460,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       },
       { invocationId: this.sId }
     );
+    this.lastSettledOutcome = { status: "errored", error: callError };
     return true;
   }
 
@@ -453,6 +486,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       return false;
     }
 
+    // A deferred initial persistence (inline path) must land before the terminal blob write
+    // overwrites the same object, and before the result event can outrun the created event.
+    await this.settleInitialPersistence();
+
     this.data = {
       version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
       input: this.input,
@@ -474,6 +511,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       },
       { invocationId: this.sId }
     );
+    this.lastSettledOutcome = { status: "succeeded", result };
     return true;
   }
   /**
@@ -512,36 +550,46 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
           )
         );
       }
-      const persistedFunction = await SandboxFunctionModel.findOne({
-        where: {
-          id: this.sandboxFunctionId,
-          workspaceId: this.workspaceId,
-        },
-      });
-      if (!persistedFunction) {
+      // The function re-fetch (it guards a re-publish race on `noTools` below) and its dependent
+      // authorization are independent of the sandbox readiness check: overlapping the two chains
+      // takes the slower one off the critical path. The authorization chains on the re-fetch
+      // because it reads the persisted userIdentity.
+      const [functionCheck, ensureResult] = await Promise.all([
+        (async () => {
+          const persistedFunction = await SandboxFunctionModel.findOne({
+            where: {
+              id: this.sandboxFunctionId,
+              workspaceId: this.workspaceId,
+            },
+          });
+          if (!persistedFunction) {
+            return null;
+          }
+          const authorization = await authorizeSandboxFunctionInvocation(auth, {
+            userIdentity: persistedFunction.userIdentity,
+            origin: this.origin ?? "delegated",
+          });
+          return { persistedFunction, authorization };
+        })(),
+        ensurePodSandboxReady(auth, sandboxFunction.space, {
+          requireRunning: inline,
+        }),
+      ]);
+      if (!functionCheck) {
         return new Err(new Error("The Pod Function no longer exists."));
       }
-      const authorization = await authorizeSandboxFunctionInvocation(auth, {
-        userIdentity: persistedFunction.userIdentity,
-        origin: this.origin ?? "delegated",
-      });
+      const { persistedFunction, authorization } = functionCheck;
       if (!authorization.authorized) {
         return new Err(
           new SandboxFunctionInvocationError(authorization.errorMessage)
         );
       }
-
-      const ensureResult = await ensurePodSandboxReady(
-        auth,
-        sandboxFunction.space,
-        { requireRunning: inline }
-      );
       if (ensureResult.isErr()) {
         return ensureResult;
       }
 
-      await ensureResult.value.sandbox.updateLastActivityAt();
-
+      // No updateLastActivityAt here: ensurePodSandboxReady's ensureActive just wrote it under
+      // the lifecycle lock.
       const sandbox = ensureResult.value.sandbox;
       const stdoutResultDelivery = await hasFeatureFlag(
         auth,
@@ -788,7 +836,11 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       context?: SandboxFunctionInvocationContext;
       origin?: SandboxFunctionInvocationOrigin;
     },
-    transaction?: Transaction
+    transaction?: Transaction,
+    // Inline executions defer the initial blob write (see createAndStartExecution): the terminal
+    // transition rewrites the full blob anyway, so the upload only needs to finish before that
+    // write, not before execution starts.
+    { deferInitialWrite = false }: { deferInitialWrite?: boolean } = {}
   ): Promise<SandboxFunctionInvocationResource> {
     const resource = await withTransaction(async (t) => {
       const invocation = await this.model.create(
@@ -822,9 +874,29 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       return resource;
     }, transaction);
 
-    const writeResult = await resource.writeDataToGcs();
-    if (writeResult.isErr()) {
-      throw writeResult.error;
+    if (deferInitialWrite) {
+      resource.pendingInitialPersistence = resource
+        .writeDataToGcs()
+        .then((result) => {
+          if (result.isErr()) {
+            // Surfaced here rather than thrown: the terminal transition rewrites the full blob,
+            // so a failed initial upload only matters if the invocation never settles.
+            logger.error(
+              {
+                workspaceModelId: resource.workspaceId,
+                sandboxFunctionId: sandboxFunction.sId,
+                invocationId: resource.sId,
+                err: result.error,
+              },
+              "Deferred Pod function invocation blob write failed"
+            );
+          }
+        });
+    } else {
+      const writeResult = await resource.writeDataToGcs();
+      if (writeResult.isErr()) {
+        throw writeResult.error;
+      }
     }
     return resource;
   }
@@ -841,22 +913,42 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       origin?: SandboxFunctionInvocationOrigin;
     }
   ): Promise<Result<SandboxFunctionInvocationResource, Error>> {
-    const invocation = await this.makeNew(auth, {
-      sandboxFunction,
-      input: body.input,
-      context: body.context,
-      origin,
-    });
-    await publishSandboxFunctionInvocationEvent(
+    const inline = await shouldExecuteInline(auth, sandboxFunction);
+    const invocation = await this.makeNew(
+      auth,
       {
-        type: "sandbox_function_invocation_created",
-        created: invocation.createdAt.getTime(),
-        invocation: invocation.toJSON(),
+        sandboxFunction,
+        input: body.input,
+        context: body.context,
+        origin,
       },
-      { invocationId: invocation.sId }
+      undefined,
+      { deferInitialWrite: inline }
     );
+    const publishCreated = () =>
+      publishSandboxFunctionInvocationEvent(
+        {
+          type: "sandbox_function_invocation_created",
+          created: invocation.createdAt.getTime(),
+          invocation: invocation.toJSON(),
+        },
+        { invocationId: invocation.sId }
+      );
 
-    if (await shouldExecuteInline(auth, sandboxFunction)) {
+    if (inline) {
+      // The created event rides with the deferred blob write: nothing before the terminal
+      // transition consumes either, and succeed()/fail() await the combined promise before
+      // publishing the result, which keeps the created event ahead of the result event.
+      const pendingBlobWrite = invocation.pendingInitialPersistence;
+      invocation.pendingInitialPersistence = Promise.allSettled([
+        pendingBlobWrite,
+        publishCreated(),
+      ]).then(() => undefined);
+    } else {
+      await publishCreated();
+    }
+
+    if (inline) {
       const executionResult = await invocation.execute(auth, { inline: true });
       if (executionResult.isOk()) {
         return new Ok(invocation);

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -291,7 +291,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
    */
   private pendingInitialPersistence: Promise<void> | undefined;
 
-  private async settleInitialPersistence(): Promise<void> {
+  async settleInitialPersistence(): Promise<void> {
     if (this.pendingInitialPersistence) {
       await this.pendingInitialPersistence;
       this.pendingInitialPersistence = undefined;
@@ -551,30 +551,46 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         );
       }
       // The function re-fetch (it guards a re-publish race on `noTools` below) and its dependent
-      // authorization are independent of the sandbox readiness check: overlapping the two chains
-      // takes the slower one off the critical path. The authorization chains on the re-fetch
-      // because it reads the persisted userIdentity.
-      const [functionCheck, ensureResult] = await Promise.all([
-        (async () => {
-          const persistedFunction = await SandboxFunctionModel.findOne({
-            where: {
-              id: this.sandboxFunctionId,
-              workspaceId: this.workspaceId,
-            },
-          });
-          if (!persistedFunction) {
-            return null;
-          }
-          const authorization = await authorizeSandboxFunctionInvocation(auth, {
-            userIdentity: persistedFunction.userIdentity,
-            origin: this.origin ?? "delegated",
-          });
-          return { persistedFunction, authorization };
-        })(),
+      // authorization are independent of the sandbox readiness check. On the inline path
+      // (requireRunning) readiness is a read with no side effect, so the two chains overlap to
+      // take the slower one off the critical path. On the durable path readiness may create or
+      // wake a sandbox, a paid side effect that stays gated behind the checks.
+      const runFunctionCheck = async () => {
+        const persistedFunction = await SandboxFunctionModel.findOne({
+          where: {
+            id: this.sandboxFunctionId,
+            workspaceId: this.workspaceId,
+          },
+        });
+        if (!persistedFunction) {
+          return null;
+        }
+        const authorization = await authorizeSandboxFunctionInvocation(auth, {
+          userIdentity: persistedFunction.userIdentity,
+          origin: this.origin ?? "delegated",
+        });
+        return { persistedFunction, authorization };
+      };
+      const runEnsure = () =>
         ensurePodSandboxReady(auth, sandboxFunction.space, {
           requireRunning: inline,
-        }),
-      ]);
+        });
+
+      let functionCheck;
+      let ensureResult;
+      if (inline) {
+        [functionCheck, ensureResult] = await Promise.all([
+          runFunctionCheck(),
+          runEnsure(),
+        ]);
+      } else {
+        functionCheck = await runFunctionCheck();
+        if (functionCheck === null || !functionCheck.authorization.authorized) {
+          ensureResult = null;
+        } else {
+          ensureResult = await runEnsure();
+        }
+      }
       if (!functionCheck) {
         return new Err(new Error("The Pod Function no longer exists."));
       }
@@ -583,6 +599,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         return new Err(
           new SandboxFunctionInvocationError(authorization.errorMessage)
         );
+      }
+      if (!ensureResult) {
+        // Unreachable: ensureResult is only null when a check above already returned.
+        return new Err(new Error("The Pod sandbox could not be prepared."));
       }
       if (ensureResult.isErr()) {
         return ensureResult;
@@ -914,6 +934,11 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     }
   ): Promise<Result<SandboxFunctionInvocationResource, Error>> {
     const inline = await shouldExecuteInline(auth, sandboxFunction);
+    // Deferring is only safe when no other process reads the blob during execution: with stdout
+    // delivery the result comes back on the exec's own stdout, but callback delivery has dsbx
+    // POST to a route that fetches the invocation (and its blob) mid-execution.
+    const deferInitialWrite =
+      inline && (await hasFeatureFlag(auth, "sandbox_function_stdout_result"));
     const invocation = await this.makeNew(
       auth,
       {
@@ -923,7 +948,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         origin,
       },
       undefined,
-      { deferInitialWrite: inline }
+      { deferInitialWrite }
     );
     const publishCreated = () =>
       publishSandboxFunctionInvocationEvent(
@@ -942,7 +967,19 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       const pendingBlobWrite = invocation.pendingInitialPersistence;
       invocation.pendingInitialPersistence = Promise.allSettled([
         pendingBlobWrite,
-        publishCreated(),
+        Promise.resolve(publishCreated()).catch((error) => {
+          // Stream consumers tolerate a missing created event (they stop at the first terminal
+          // event), but losing one must be visible.
+          logger.error(
+            {
+              workspaceModelId: invocation.workspaceId,
+              sandboxFunctionId: sandboxFunction.sId,
+              invocationId: invocation.sId,
+              err: normalizeError(error),
+            },
+            "Deferred Pod function invocation created-event publish failed"
+          );
+        }),
       ]).then(() => undefined);
     } else {
       await publishCreated();
@@ -970,6 +1007,15 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         },
         "Escalating a fast Pod function invocation to the invocation workflow"
       );
+    }
+
+    // The workflow activity re-reads the invocation, blob included, from another process: a
+    // deferred initial write must be durable before the workflow can be allowed to start. The
+    // rewrite is idempotent (same object, same content) and this is already the slow path.
+    await invocation.settleInitialPersistence();
+    const persistResult = await invocation.writeDataToGcs();
+    if (persistResult.isErr()) {
+      throw persistResult.error;
     }
 
     const launchResult = await launchSandboxFunctionInvocationWorkflow(auth, {

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -1135,3 +1135,26 @@ describe("SandboxResource.ensureActive", () => {
     expect(persisted?.status).toBe("running");
   });
 });
+
+describe("SandboxResource.updateLastActivityAt", () => {
+  it("skips the write while the recorded activity is fresh", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const sandbox = await SandboxResource.makeNew(authenticator, {
+      providerId: "throttle-test-provider",
+      status: "running",
+      baseImage: "dust-base",
+      version: "0.0.0-test",
+    });
+
+    // makeNew stamps lastActivityAt with now, so an immediate touch is within
+    // the throttle window and must not issue a write.
+    const [affectedFresh] = await sandbox.updateLastActivityAt();
+    expect(affectedFresh).toBe(0);
+
+    // Backdate the in-memory timestamp past the 30s window: the next touch
+    // writes through.
+    Object.assign(sandbox, { lastActivityAt: new Date(Date.now() - 60_000) });
+    const [affectedStale] = await sandbox.updateLastActivityAt();
+    expect(affectedStale).toBe(1);
+  });
+});

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -90,6 +90,11 @@ export type SandboxDeleteOwner = SandboxLifecycleOwner & {
   ) => Promise<void>;
 };
 
+// Activity writes are throttled to this granularity; the reaper's inactivity
+// thresholds are minutes-scale, so a lastActivityAt up to 30s stale is
+// indistinguishable to it.
+const LAST_ACTIVITY_WRITE_INTERVAL_MS = 30_000;
+
 // Owner identity env vars are reserved for owner adapters. SandboxResource
 // only enforces the env contract and does not interpret owner types.
 const SANDBOX_OWNER_ENV_VAR_CONTRACT_NAMES = new Set([
@@ -313,6 +318,13 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   }: {
     transaction?: Transaction;
   } = {}): Promise<[affectedCount: number]> {
+    // Throttled: every operation on a busy sandbox calls this, which makes the sandbox row a
+    // hot write under concurrent invocations. The reaper compares lastActivityAt against
+    // inactivity thresholds measured in minutes, so a value up to 30s stale changes nothing.
+    const lastActivityAtMs = this.lastActivityAt?.getTime() ?? 0;
+    if (Date.now() - lastActivityAtMs < LAST_ACTIVITY_WRITE_INTERVAL_MS) {
+      return [0];
+    }
     return this.update({ lastActivityAt: new Date() }, transaction);
   }
 

--- a/front/temporal/sandbox_reaper/config.ts
+++ b/front/temporal/sandbox_reaper/config.ts
@@ -11,7 +11,13 @@ const ONE_MINUTE_MS = 60 * 1_000;
 const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
 const ONE_DAY_MS = 24 * ONE_HOUR_MS;
 
-/** Sleep sandboxes that have been inactive for this long. Default: 5 min. */
+/**
+ * Sleep sandboxes that have been inactive for this long. Default: 5 min.
+ *
+ * Floor: lastActivityAt writes are throttled to 30s granularity
+ * (LAST_ACTIVITY_WRITE_INTERVAL_MS in sandbox_resource.ts), so an override
+ * anywhere near that value would sleep sandboxes that are actively in use.
+ */
 const sleepThresholdEnv = EnvironmentConfig.getOptionalEnvVariable(
   "SANDBOX_SLEEP_THRESHOLD_MS"
 );


### PR DESCRIPTION
## Description

A fast Pod function invocation spends about 180ms of its ~545ms in front, spread over nine Postgres round trips, six Redis round trips, two GCS uploads and a Redis stream read-back, nearly all sequential. This trims the four costs that are pure waste:

The initial GCS blob write and the created-event publish sat between row creation and execution, though nothing before the terminal transition reads either. On the inline path both now run concurrently with execution; succeed()/fail() await them before the terminal blob write and the result publish, which keeps the blob write ordered (the terminal write rewrites the same object) and the created event ahead of the result event. The durable path is unchanged: the workflow reads the blob, so it still waits.

execute() re-fetched the function, authorized, and readied the sandbox serially; the function-check chain and the sandbox-readiness chain are independent and now overlap.

execute() wrote the sandbox's lastActivityAt immediately after ensureActive had written it under the lifecycle lock. The duplicate is gone and the write is throttled to 30s granularity: the reaper compares it against minutes-scale inactivity thresholds, and every invocation was hammering the shared sandbox row.

Both invocation callers subscribed to the Redis event stream to read back an outcome the inline execution had just produced in this process. The terminal transitions now record the outcome on the instance and callers short-circuit on it, falling back to the stream only for invocations that escalated to the workflow.

Expected effect on a fast invocation: one GCS round trip (~40-80ms) plus the subscribe round trips off the critical path, plus the smaller DB trims. Independent of the warm-runner work in #30144; the two compose.

## Tests

`lib/resources/sandbox`, `lib/api/sandbox_functions`, `lib/api/sandbox`: 483 passing. The inline execution test now also asserts the settled outcome is served from memory, that the deferred initial write still leaves a complete blob (input and result) for later fetches, and that a rehydrated instance never short-circuits. The execute test pins that lastActivityAt is written by the lifecycle, not a second time by execute. front and front-api typecheck clean.

## Risk

The ordering invariants the deferral must preserve are: terminal blob write after initial blob write (same GCS object), and result event after created event (same stream). Both are enforced at one place, the settleInitialPersistence gate inside the terminal transitions, and tested. If the deferred initial write fails and the invocation never settles, the row exists without a blob, which is the same state markCreatedAsErrored already produces today. Rollback is a plain revert; no schema or wire change.

## Deploy Plan

Normal front deploy, no flag. Invocation p50 (updatedAt minus createdAt on sandbox_function_invocations) is the number to watch.
