### PR TITLE
[front] feat: measure warm vs cold function runs

### DIFF
--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -99,6 +99,27 @@ export function recordLifecycleOperation(
   ]);
 }
 
+/**
+ * One fast Pod function run, tagged by which runner served it (resident warm
+ * server vs cold spawn). The warm share is the number the warm-runner rollout
+ * turns on; duration is the exec's wall time as front saw it.
+ */
+export function recordSandboxFunctionRun({
+  runnerKind,
+  durationMs,
+}: {
+  runnerKind: "warm" | "cold" | "unknown";
+  durationMs: number;
+}): void {
+  const tags = [regionTag(), `runner_kind:${runnerKind}`];
+  getStatsDClient().increment("sandbox.functions.run", 1, tags);
+  getStatsDClient().distribution(
+    "sandbox.functions.run.duration",
+    durationMs,
+    tags
+  );
+}
+
 export function recordStateDuration(
   previousStatus: SandboxStatus,
   durationMs: number

--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -106,12 +106,14 @@ export function recordLifecycleOperation(
  */
 export function recordSandboxFunctionRun({
   runnerKind,
+  status,
   durationMs,
 }: {
   runnerKind: "warm" | "cold" | "unknown";
+  status: "success" | "error";
   durationMs: number;
 }): void {
-  const tags = [regionTag(), `runner_kind:${runnerKind}`];
+  const tags = [regionTag(), `runner_kind:${runnerKind}`, `status:${status}`];
   getStatsDClient().increment("sandbox.functions.run", 1, tags);
   getStatsDClient().distribution(
     "sandbox.functions.run.duration",

--- a/front/lib/api/sandbox_functions/result_delivery.test.ts
+++ b/front/lib/api/sandbox_functions/result_delivery.test.ts
@@ -14,8 +14,24 @@ describe("parseStdoutResultEnvelope", () => {
           "\n"
       )
     ).toEqual({
-      ok: true,
-      output: { hello: "world" },
+      outcome: { ok: true, output: { hello: "world" } },
+      timings: null,
+    });
+  });
+
+  it("extracts the runner kind from the envelope timings in the same parse", () => {
+    expect(
+      parseStdoutResultEnvelope(
+        JSON.stringify({
+          protocolVersion: 3,
+          delivery: "stdout",
+          outcome: { ok: true, output: 1 },
+          timingsMs: { total: 12, runner: 8, runnerKind: "warm" },
+        })
+      )
+    ).toEqual({
+      outcome: { ok: true, output: 1 },
+      timings: { runnerKind: "warm" },
     });
   });
 
@@ -32,19 +48,19 @@ describe("parseStdoutResultEnvelope", () => {
         })
       )
     ).toEqual({
-      ok: false,
-      error: { code: "threw", message: "boom" },
+      outcome: { ok: false, error: { code: "threw", message: "boom" } },
+      timings: null,
     });
   });
 
   it("returns invocation_failed for empty or non-JSON stdout", () => {
     expect(parseStdoutResultEnvelope("")).toMatchObject({
-      ok: false,
-      error: { code: "invocation_failed" },
+      outcome: { ok: false, error: { code: "invocation_failed" } },
+      timings: null,
     });
     expect(parseStdoutResultEnvelope("not-json")).toMatchObject({
-      ok: false,
-      error: { code: "invocation_failed" },
+      outcome: { ok: false, error: { code: "invocation_failed" } },
+      timings: null,
     });
   });
 });

--- a/front/lib/api/sandbox_functions/result_delivery.ts
+++ b/front/lib/api/sandbox_functions/result_delivery.ts
@@ -1,16 +1,24 @@
+import type { SandboxFunctionResultTimings } from "@app/lib/api/sandbox_functions/result_envelope";
 import {
+  extractResultEnvelopeTimings,
   type NormalizedSandboxFunctionOutcome,
   normalizeSandboxFunctionResult,
 } from "@app/lib/api/sandbox_functions/result_envelope";
 
+export interface ParsedStdoutResult {
+  outcome: NormalizedSandboxFunctionOutcome;
+  // Observational diagnostics from the envelope (runner kind), null when the
+  // envelope carried none or could not be parsed. Never affects the outcome.
+  timings: SandboxFunctionResultTimings | null;
+}
+
 /**
  * Parse a protocol v3 (or legacy) result envelope from dsbx stdout.
- * Uses the last non-empty line, matching other dsbx stdout parsers.
+ * Uses the last non-empty line, matching other dsbx stdout parsers, and parses
+ * it exactly once for both the outcome and the timing diagnostics.
  * Never throws: malformed output becomes an invocation_failed outcome.
  */
-export function parseStdoutResultEnvelope(
-  stdout: string
-): NormalizedSandboxFunctionOutcome {
+export function parseStdoutResultEnvelope(stdout: string): ParsedStdoutResult {
   const lastLine =
     stdout
       .split("\n")
@@ -20,11 +28,14 @@ export function parseStdoutResultEnvelope(
 
   if (lastLine.length === 0) {
     return {
-      ok: false,
-      error: {
-        code: "invocation_failed",
-        message: "Pod function produced no stdout result envelope.",
+      outcome: {
+        ok: false,
+        error: {
+          code: "invocation_failed",
+          message: "Pod function produced no stdout result envelope.",
+        },
       },
+      timings: null,
     };
   }
 
@@ -33,13 +44,19 @@ export function parseStdoutResultEnvelope(
     json = JSON.parse(lastLine);
   } catch {
     return {
-      ok: false,
-      error: {
-        code: "invocation_failed",
-        message: "Pod function stdout was not valid JSON.",
+      outcome: {
+        ok: false,
+        error: {
+          code: "invocation_failed",
+          message: "Pod function stdout was not valid JSON.",
+        },
       },
+      timings: null,
     };
   }
 
-  return normalizeSandboxFunctionResult(json);
+  return {
+    outcome: normalizeSandboxFunctionResult(json),
+    timings: extractResultEnvelopeTimings(json),
+  };
 }

--- a/front/lib/api/sandbox_functions/result_envelope.ts
+++ b/front/lib/api/sandbox_functions/result_envelope.ts
@@ -1,7 +1,6 @@
 import logger from "@app/logger/logger";
 import type { SandboxFunctionCallError } from "@app/types/api/sandbox_functions";
 import { SANDBOX_FUNCTION_RUNNER_ERROR_CODES } from "@app/types/api/sandbox_functions";
-import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import { truncate } from "@app/types/shared/utils/string_utils";
 import { z } from "zod";
 
@@ -88,36 +87,22 @@ const ProtocolVersionProbeSchema = z.object({
 });
 
 // Lenient by design: timings are diagnostics from whatever dsbx version runs in the sandbox, and
-// absence or new shapes must never affect result handling.
+// absence or new shapes must never affect result handling. Only the consumed field is modeled.
 const ResultTimingsSchema = z.object({
-  total: z.number().optional(),
-  runner: z.number().optional(),
   runnerKind: z.enum(["warm", "cold"]).optional(),
 });
 
 export type SandboxFunctionResultTimings = z.infer<typeof ResultTimingsSchema>;
 
 /**
- * Extract the timings block from a stdout result envelope, if any. Purely observational: used to
- * tag latency metrics with the runner kind (warm server vs cold spawn); never affects the outcome.
+ * Extract the timings block from an already-parsed stdout envelope value. Purely observational:
+ * used to tag latency metrics with the runner kind (warm server vs cold spawn); never affects the
+ * outcome, and never throws.
  */
-export function parseResultEnvelopeTimings(
-  stdout: string
+export function extractResultEnvelopeTimings(
+  parsedEnvelope: unknown
 ): SandboxFunctionResultTimings | null {
-  const lastLine =
-    stdout
-      .split("\n")
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0)
-      .at(-1) ?? "";
-  if (lastLine.length === 0) {
-    return null;
-  }
-  const json = safeParseJSON(lastLine);
-  if (json.isErr()) {
-    return null;
-  }
-  const envelope = ResultEnvelopeV3Schema.safeParse(json.value);
+  const envelope = ResultEnvelopeV3Schema.safeParse(parsedEnvelope);
   if (!envelope.success) {
     return null;
   }
@@ -245,7 +230,7 @@ export function normalizeSandboxFunctionResult(
       });
     }
 
-    // timingsMs is accepted on the wire for forward compatibility but not consumed yet.
+    // timingsMs is not consumed here: extractResultEnvelopeTimings reads it for metrics.
     return normalizeRunnerOutcome(v3.data.outcome);
   }
 

--- a/front/lib/api/sandbox_functions/result_envelope.ts
+++ b/front/lib/api/sandbox_functions/result_envelope.ts
@@ -1,6 +1,7 @@
 import logger from "@app/logger/logger";
 import type { SandboxFunctionCallError } from "@app/types/api/sandbox_functions";
 import { SANDBOX_FUNCTION_RUNNER_ERROR_CODES } from "@app/types/api/sandbox_functions";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import { truncate } from "@app/types/shared/utils/string_utils";
 import { z } from "zod";
 
@@ -85,6 +86,44 @@ const ResultEnvelopeV3Schema = z.object({
 const ProtocolVersionProbeSchema = z.object({
   protocolVersion: z.number(),
 });
+
+// Lenient by design: timings are diagnostics from whatever dsbx version runs in the sandbox, and
+// absence or new shapes must never affect result handling.
+const ResultTimingsSchema = z.object({
+  total: z.number().optional(),
+  runner: z.number().optional(),
+  runnerKind: z.enum(["warm", "cold"]).optional(),
+});
+
+export type SandboxFunctionResultTimings = z.infer<typeof ResultTimingsSchema>;
+
+/**
+ * Extract the timings block from a stdout result envelope, if any. Purely observational: used to
+ * tag latency metrics with the runner kind (warm server vs cold spawn); never affects the outcome.
+ */
+export function parseResultEnvelopeTimings(
+  stdout: string
+): SandboxFunctionResultTimings | null {
+  const lastLine =
+    stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .at(-1) ?? "";
+  if (lastLine.length === 0) {
+    return null;
+  }
+  const json = safeParseJSON(lastLine);
+  if (json.isErr()) {
+    return null;
+  }
+  const envelope = ResultEnvelopeV3Schema.safeParse(json.value);
+  if (!envelope.success) {
+    return null;
+  }
+  const timings = ResultTimingsSchema.safeParse(envelope.data.timingsMs);
+  return timings.success ? timings.data : null;
+}
 
 function invalidResultEnvelope(
   reason: string,

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -19,7 +19,6 @@ import { shellEscape } from "@app/lib/api/sandbox/shell";
 import { SandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
 import { parseStdoutResultEnvelope } from "@app/lib/api/sandbox_functions/result_delivery";
-import { parseResultEnvelopeTimings } from "@app/lib/api/sandbox_functions/result_envelope";
 import {
   authorizeSandboxFunctionInvocation,
   getAuthenticatedWorkspaceUser,
@@ -680,6 +679,13 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         user: "agent-proxied",
       });
       if (execResult.isErr()) {
+        // Exec-level failures (timeouts included) must land in the same metric as served runs,
+        // or the duration distribution silently drops the slowest attempts.
+        recordSandboxFunctionRun({
+          runnerKind: "unknown",
+          status: "error",
+          durationMs: Date.now() - execStartedAtMs,
+        });
         if (inline) {
           // An inline exec that fails is usually one that ran past its ceiling, but nothing in the
           // provider result says so: the timeout is handed to the sandbox provider and comes back
@@ -716,10 +722,11 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         );
         // Persist from the envelope even on non-zero exit: dsbx may still have
         // written a well-formed invocation_failed envelope the worker should keep.
-        const normalized = parseStdoutResultEnvelope(stdout);
-        const timings = parseResultEnvelopeTimings(stdout);
+        const { outcome: normalized, timings } =
+          parseStdoutResultEnvelope(stdout);
         recordSandboxFunctionRun({
           runnerKind: timings?.runnerKind ?? "unknown",
+          status: normalized.ok ? "success" : "error",
           durationMs: Date.now() - execStartedAtMs,
         });
         if (!normalized.ok || exitCode !== 0) {

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -13,11 +13,13 @@ import {
   generateSandboxFunctionInvocationToken,
 } from "@app/lib/api/sandbox/access_tokens";
 import { isSandboxNotRunningError } from "@app/lib/api/sandbox/errors";
+import { recordSandboxFunctionRun } from "@app/lib/api/sandbox/instrumentation";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import { SandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
 import { parseStdoutResultEnvelope } from "@app/lib/api/sandbox_functions/result_delivery";
+import { parseResultEnvelopeTimings } from "@app/lib/api/sandbox_functions/result_envelope";
 import {
   authorizeSandboxFunctionInvocation,
   getAuthenticatedWorkspaceUser,
@@ -652,6 +654,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         this
       );
 
+      const execStartedAtMs = Date.now();
       const execResult = await sandbox.exec(auth, command, {
         workingDirectory: SANDBOX_FUNCTION_WORKING_DIRECTORY,
         envVars: {
@@ -714,6 +717,11 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         // Persist from the envelope even on non-zero exit: dsbx may still have
         // written a well-formed invocation_failed envelope the worker should keep.
         const normalized = parseStdoutResultEnvelope(stdout);
+        const timings = parseResultEnvelopeTimings(stdout);
+        recordSandboxFunctionRun({
+          runnerKind: timings?.runnerKind ?? "unknown",
+          durationMs: Date.now() - execStartedAtMs,
+        });
         if (!normalized.ok || exitCode !== 0) {
           // Mirror the callback path's failure logging: without the raw
           // stdout/stderr there is no way to diagnose a rejected envelope.


### PR DESCRIPTION
## Description

Stacked on #30144, which ships the warm runner and its version pins. This PR is the measurement.

Front reads the additive `runnerKind` field from the stdout result envelope's timings and emits `sandbox.functions.run` (count plus duration distribution) tagged `runner_kind`: warm, cold, or unknown for envelopes from older dsbx. Parsing is deliberately lenient and never affects result handling; the timings block is diagnostics from whatever dsbx version answered. The stdout envelope is now parsed once and its outcome and timings read from that single parse, replacing four copies of the same extraction.

## Tests

Result delivery and envelope suites cover the warm, cold, and missing-timings cases and the single-parse path. front typechecks clean. The warm/cold behavior itself is tested in #30144.

## Risk

Observational only. An envelope without timings tags the run unknown, and no parsing failure can change how a result is handled.

## Deploy Plan

Nothing on its own. Merge after #30144 and its image rollout, then watch `sandbox.functions.run` by `runner_kind`: the warm share should climb as pods see repeat invocations, and warm durations should sit well under cold ones.
