### PR TITLE
[front] fix: remove unused SidebarMenu import breaking format-check

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -71,7 +71,6 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { PodListItemType, PodType, SpaceType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
 import {
-  ActionSparklesIcon,
   ArrowRight,
   Avatar,
   Brackets,


### PR DESCRIPTION
## Description

`front/components/assistant/conversation/SidebarMenu.tsx` carries an unused `ActionSparklesIcon` import that fails `biome ci --error-on-warnings` repo-wide. It landed during the GitHub Actions outage, when format-check never ran on merges, and now every open PR fails the format-check job. One-line removal, biome and typecheck clean.

## Tests

`npx biome ci --error-on-warnings` on the file passes; front typechecks clean.

## Risk

None; unused import removal.

## Deploy Plan

Merge ahead of other PRs so their format-check runs go green after a rebase or merge-from-main.
