### PR TITLE
[front] feat: add activation_work_areas model and migration

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -1,6 +1,7 @@
 import { ActivationNudgeModel } from "@app/lib/models/activation/activation_nudge";
 import { ActivationPodModel } from "@app/lib/models/activation/activation_pod";
 import { ActivationRecommendationModel } from "@app/lib/models/activation/activation_recommendation";
+import { ActivationWorkAreaModel } from "@app/lib/models/activation/activation_work_area";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
 import { ConversationMCPServerViewModel } from "@app/lib/models/agent/actions/conversation_mcp_server_view";
 import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";

--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -288,6 +288,7 @@ export function loadAllModels() {
     ActivationPodModel,
     ActivationRecommendationModel,
     ActivationNudgeModel,
+    ActivationWorkAreaModel,
   ];
 }
 

--- a/front/lib/models/activation/activation_work_area.ts
+++ b/front/lib/models/activation/activation_work_area.ts
@@ -18,7 +18,7 @@ export class ActivationWorkAreaModel extends WorkspaceAwareModel<ActivationWorkA
   declare podId: ForeignKey<ActivationPodModel["id"]> | null;
 
   declare title: string;
-  declare intent: string;
+  declare description: string;
   declare status: ActivationWorkAreaStatus;
 }
 
@@ -38,7 +38,7 @@ ActivationWorkAreaModel.init(
       type: DataTypes.STRING(255),
       allowNull: false,
     },
-    intent: {
+    description: {
       type: DataTypes.STRING(512),
       allowNull: false,
     },

--- a/front/lib/models/activation/activation_work_area.ts
+++ b/front/lib/models/activation/activation_work_area.ts
@@ -1,0 +1,75 @@
+import { ActivationPodModel } from "@app/lib/models/activation/activation_pod";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional, ForeignKey } from "sequelize";
+
+export type ActivationWorkAreaStatus =
+  | "candidate"
+  | "confirmed"
+  | "dismissed";
+
+export class ActivationWorkAreaModel extends WorkspaceAwareModel<ActivationWorkAreaModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare userId: ForeignKey<UserModel["id"]>;
+  declare podId: ForeignKey<ActivationPodModel["id"]> | null;
+
+  declare title: string;
+  declare intent: string;
+  declare status: ActivationWorkAreaStatus;
+}
+
+ActivationWorkAreaModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    title: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    intent: {
+      type: DataTypes.STRING(512),
+      allowNull: false,
+    },
+    status: {
+      type: DataTypes.STRING(50),
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "activation_work_area",
+    sequelize: frontSequelize,
+    indexes: [
+      { fields: ["userId"], concurrently: true },
+      { fields: ["podId"], concurrently: true },
+      { fields: ["workspaceId", "userId", "status"], concurrently: true },
+    ],
+  }
+);
+
+ActivationWorkAreaModel.belongsTo(UserModel, {
+  foreignKey: { name: "userId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+UserModel.hasMany(ActivationWorkAreaModel, {
+  foreignKey: { name: "userId", allowNull: false },
+});
+
+ActivationWorkAreaModel.belongsTo(ActivationPodModel, {
+  foreignKey: { name: "podId", allowNull: true },
+  onDelete: "RESTRICT",
+});
+ActivationPodModel.hasMany(ActivationWorkAreaModel, {
+  foreignKey: { name: "podId", allowNull: true },
+});

--- a/front/lib/models/activation/activation_work_area.ts
+++ b/front/lib/models/activation/activation_work_area.ts
@@ -5,10 +5,7 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey } from "sequelize";
 
-export type ActivationWorkAreaStatus =
-  | "candidate"
-  | "confirmed"
-  | "dismissed";
+export type ActivationWorkAreaStatus = "candidate" | "confirmed" | "dismissed";
 
 export class ActivationWorkAreaModel extends WorkspaceAwareModel<ActivationWorkAreaModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/migrations/pre-deploy/20260806120000_add_activation_work_areas.sql
+++ b/front/migrations/pre-deploy/20260806120000_add_activation_work_areas.sql
@@ -1,0 +1,115 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE SEQUENCE "public"."activation_work_areas_id_seq"
+	AS bigint
+	INCREMENT BY 1
+	MINVALUE 1 MAXVALUE 9223372036854775807
+	START WITH 1 CACHE 1 NO CYCLE
+;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE TABLE "public"."activation_work_areas" (
+	"createdAt" timestamp with time zone NOT NULL DEFAULT NOW(),
+	"updatedAt" timestamp with time zone NOT NULL DEFAULT NOW(),
+	"workspaceId" bigint NOT NULL,
+	"userId" bigint NOT NULL,
+	"podId" bigint,
+	"title" character varying(255) NOT NULL,
+	"intent" character varying(512) NOT NULL,
+	"status" character varying(50) NOT NULL,
+	"id" bigint DEFAULT nextval('activation_work_areas_id_seq'::regclass) NOT NULL
+);
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY activation_work_areas_pkey ON public.activation_work_areas USING btree (id);
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_work_areas" ADD CONSTRAINT "activation_work_areas_pkey" PRIMARY KEY USING INDEX "activation_work_areas_pkey";
+
+/*
+Statement 4
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY activation_work_areas_user_id ON public.activation_work_areas USING btree ("userId");
+
+/*
+Statement 5
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY activation_work_areas_pod_id ON public.activation_work_areas USING btree ("podId");
+
+/*
+Statement 6
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY activation_work_areas_workspace_user_status ON public.activation_work_areas USING btree ("workspaceId", "userId", "status");
+
+/*
+Statement 7
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER SEQUENCE "public"."activation_work_areas_id_seq" OWNED BY "public"."activation_work_areas"."id";
+
+/*
+Statement 8
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_work_areas" ADD CONSTRAINT "activation_work_areas_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES workspaces(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 9
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_work_areas" VALIDATE CONSTRAINT "activation_work_areas_workspaceId_fkey";
+
+/*
+Statement 10
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_work_areas" ADD CONSTRAINT "activation_work_areas_userId_fkey" FOREIGN KEY ("userId") REFERENCES users(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 11
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_work_areas" VALIDATE CONSTRAINT "activation_work_areas_userId_fkey";
+
+/*
+Statement 12
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_work_areas" ADD CONSTRAINT "activation_work_areas_podId_fkey" FOREIGN KEY ("podId") REFERENCES activation_pods(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 13
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_work_areas" VALIDATE CONSTRAINT "activation_work_areas_podId_fkey";

--- a/front/migrations/pre-deploy/20260806120000_add_activation_work_areas.sql
+++ b/front/migrations/pre-deploy/20260806120000_add_activation_work_areas.sql
@@ -22,7 +22,7 @@ CREATE TABLE "public"."activation_work_areas" (
 	"userId" bigint NOT NULL,
 	"podId" bigint,
 	"title" character varying(255) NOT NULL,
-	"intent" character varying(512) NOT NULL,
+	"description" character varying(512) NOT NULL,
 	"status" character varying(50) NOT NULL,
 	"id" bigint DEFAULT nextval('activation_work_areas_id_seq'::regclass) NOT NULL
 );


### PR DESCRIPTION
## Summary

- Adding new table to story "activation work area". This is _experimental_ and will be used to annotate what we know about the user's work responsibilities.
- The work areas will be generated during skill invocation runtime.
- The work areas will be injected into the recommendation logic to help curate recommendations
- We will surface this via the get started page:
<img width="730" height="791" alt="Screenshot 2026-08-06 at 9 48 53 PM" src="https://github.com/user-attachments/assets/ea9cacc9-e935-4d2e-a474-6d7d1055d95b" />

## Testing

- Local env testing (see screenshot above)

## Risk

Low — Additive, not customer facing yet. New standalone table (`activation_work_areas`) behind the activation feature; no existing tables, columns, or queries are modified.

## Deploy Plan

1. Merge and deploy `front` as usual.
2. Run the migration `20260806120000_add_activation_work_areas.sql` from prodbox (creates the `activation_work_areas` table and its indexes; the `migration-ack` label is set). The migration is purely additive (`CREATE TABLE` + `CREATE INDEX`), so it is safe to run before or after the code deploy and requires no backfill.
3. No feature flag flip or rollback steps required — the table is unused by customer-facing paths until the follow-up work-area generation/recommendation PRs land.
