### PR TITLE
Add: ability to hide triggered convos in pods, refactor a bit the menu in sidebar.

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
@@ -57,6 +57,7 @@ app.get(
 
     const pagination = paginationRes.value;
     const conversationFilter = parseFilter(ctx.req.query("filter"));
+    const excludeTriggered = ctx.req.query("excludeTriggered") === "true";
 
     // Fetch and verify space access.
     const space = await SpaceResource.fetchById(auth, spaceId);
@@ -84,6 +85,7 @@ app.get(
         orderDirection: pagination.orderDirection,
       },
       filter: conversationFilter,
+      excludeTriggered,
     });
 
     let isEmpty = spaceConversations.length === 0;

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1247,13 +1247,28 @@ export function AgentSidebarMenu({
                         )}
                         <DropdownMenuLabel>Conversations</DropdownMenuLabel>
                         <DropdownMenuItem
-                          label="Edit conversations"
+                          label={
+                            hideTriggeredConversations
+                              ? "Show triggered"
+                              : "Hide triggered"
+                          }
+                          icon={hideTriggeredConversations ? Zap : ZapOff}
+                          disabled={!hasTriggeredConversations}
+                          onClick={() =>
+                            setHideTriggeredConversations(
+                              !hideTriggeredConversations
+                            )
+                          }
+                        />
+                        <DropdownMenuItem
+                          label="Edit history"
                           onClick={toggleMultiSelect}
                           icon={CheckDone01}
                           disabled={filteredConversations.length === 0}
                         />
                         <DropdownMenuItem
-                          label="Clear conversation history"
+                          label="Clear history"
+                          variant="warning"
                           onClick={() => setShowDeleteDialog("all")}
                           icon={Trash01}
                           disabled={filteredConversations.length === 0}

--- a/front/components/assistant/conversation/sidebar/PodsBrowsePopover.tsx
+++ b/front/components/assistant/conversation/sidebar/PodsBrowsePopover.tsx
@@ -45,6 +45,7 @@ function PodBrowseItemSkeleton({ count = 5 }: { count?: number }) {
 }
 
 function PodBrowseItem({ pod, onClick }: PodBrowseItemProps) {
+  const description = pod.description ? pod.description : "No description";
   return (
     <div
       className="flex cursor-pointer items-start gap-2 rounded-lg p-2 hover:bg-muted-background"
@@ -53,22 +54,20 @@ function PodBrowseItem({ pod, onClick }: PodBrowseItemProps) {
       <Icon visual={getSpaceIcon(pod)} size="sm" className="mt-0.5 shrink-0" />
       <div className="min-w-0 flex-1">
         <div className="flex flex-row items-center justify-between gap-1.5">
-          <div className="truncate font-medium">{pod.name}</div>
+          <div className="truncate text-sm">{pod.name}</div>
           {pod.archivedAt && (
             <Chip size="mini" color="primary" label="Archived" />
           )}
         </div>
-        {pod.description && (
-          <Tooltip
-            label={pod.description}
-            tooltipTriggerAsChild
-            trigger={
-              <div className="truncate text-xs text-muted-foreground">
-                {pod.description}
-              </div>
-            }
-          />
-        )}
+        <Tooltip
+          label={description}
+          tooltipTriggerAsChild
+          trigger={
+            <div className="truncate text-xs text-muted-foreground">
+              {description}
+            </div>
+          }
+        />
       </div>
     </div>
   );

--- a/front/components/pod/PodPageContent.tsx
+++ b/front/components/pod/PodPageContent.tsx
@@ -65,6 +65,8 @@ export function PodPageContent({
   const conversationFilter: PodConversationListFilter = isSingleMemberPod
     ? "all"
     : podUiPreferences.conversationsFilter;
+  const hideTriggeredConversations =
+    podUiPreferences.hideTriggeredConversations;
 
   const {
     conversations,
@@ -78,6 +80,7 @@ export function PodPageContent({
     workspaceId: owner.sId,
     podId: podInfo.sId,
     filter: conversationFilter,
+    excludeTriggered: hideTriggeredConversations,
   });
 
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -90,6 +93,13 @@ export function PodPageContent({
     setPodUiPreferences({
       ...podUiPreferences,
       conversationsFilter: filter,
+    });
+  };
+
+  const handleHideTriggeredConversationsChange = (hideTriggered: boolean) => {
+    setPodUiPreferences({
+      ...podUiPreferences,
+      hideTriggeredConversations: hideTriggered,
     });
   };
 
@@ -192,6 +202,10 @@ export function PodPageContent({
           isPodEmpty={isPodEmpty}
           conversationFilter={conversationFilter}
           onConversationFilterChange={handleConversationFilterChange}
+          hideTriggeredConversations={hideTriggeredConversations}
+          onHideTriggeredConversationsChange={
+            handleHideTriggeredConversationsChange
+          }
           onSubmit={handleConversationCreation}
           onNavigateToTasks={() => onTabChange("tasks")}
         />

--- a/front/components/pod/conversation/PodConversationsTab.tsx
+++ b/front/components/pod/conversation/PodConversationsTab.tsx
@@ -46,6 +46,8 @@ import {
   LoadingBlock,
   SearchInputWithPopover,
   Spinner,
+  Zap,
+  ZapOff,
 } from "@dust-tt/sparkle";
 import moment from "moment";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
@@ -71,6 +73,8 @@ interface PodConversationsTabProps {
   isPodEmpty: boolean;
   conversationFilter: PodConversationListFilter;
   onConversationFilterChange: (filter: PodConversationListFilter) => void;
+  hideTriggeredConversations: boolean;
+  onHideTriggeredConversationsChange: (hide: boolean) => void;
   onSubmit: (
     input: string,
     mentions: RichMention[],
@@ -94,6 +98,8 @@ export function PodConversationsTab({
   isPodEmpty,
   conversationFilter,
   onConversationFilterChange,
+  hideTriggeredConversations,
+  onHideTriggeredConversationsChange,
   onSubmit,
   onNavigateToTasks,
 }: PodConversationsTabProps) {
@@ -295,6 +301,22 @@ export function PodConversationsTab({
                       />
                     </ButtonsSwitchList>
                   )}
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    icon={hideTriggeredConversations ? Zap : ZapOff}
+                    tooltip={
+                      hideTriggeredConversations
+                        ? "Show triggered"
+                        : "Hide triggered"
+                    }
+                    className="shrink-0"
+                    onClick={() =>
+                      onHideTriggeredConversationsChange(
+                        !hideTriggeredConversations
+                      )
+                    }
+                  />
                   <SearchInputWithPopover
                     name="conversation-search"
                     value={searchText}

--- a/front/hooks/conversations/usePodConversations.ts
+++ b/front/hooks/conversations/usePodConversations.ts
@@ -46,12 +46,14 @@ export function usePodConversations({
   podId,
   limit = DEFAULT_CONVERSATIONS_PAGE_SIZE,
   filter = "all",
+  excludeTriggered = false,
   options,
 }: {
   workspaceId: string;
   podId: string | null;
   limit?: number;
   filter?: PodConversationListFilter;
+  excludeTriggered?: boolean;
   options?: { disabled?: boolean };
 }) {
   const { fetcher } = useFetcher();
@@ -71,6 +73,9 @@ export function usePodConversations({
         const searchParams = new URLSearchParams({
           filter,
         });
+        if (excludeTriggered) {
+          searchParams.set("excludeTriggered", "true");
+        }
 
         if (previousPageData === null) {
           return `/api/w/${workspaceId}/assistant/conversations/spaces/${podId}?${searchParams.toString()}`;

--- a/front/hooks/useScopedUIPreferences.ts
+++ b/front/hooks/useScopedUIPreferences.ts
@@ -16,6 +16,8 @@ const scopedUIPreferencesSchemaByScope = {
   podUi: z.object({
     tab: z.union([z.enum(SYSTEM_POD_TABS), z.string().regex(/^frame:.+/)]),
     conversationsFilter: z.enum(["all", "group", "with_me"]),
+    // Default false so older persisted blobs without this field still parse.
+    hideTriggeredConversations: z.boolean().default(false),
     tasksOwnerFilter: z
       .unknown()
       .transform(normalizeTasksOwnerFilterFromPersistedBlob),

--- a/front/hooks/useSpaceProjectTabs.ts
+++ b/front/hooks/useSpaceProjectTabs.ts
@@ -19,6 +19,7 @@ export type PodTab = PodUiScopedPreferences["tab"];
 export const DEFAULT_POD_UI_PREFERENCES: PodUiScopedPreferences = {
   tab: "conversations",
   conversationsFilter: "all",
+  hideTriggeredConversations: false,
   tasksOwnerFilter: DEFAULT_TASK_OWNER_FILTER,
 };
 

--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -130,7 +130,7 @@ export async function ensureConversationTitle(
     return null;
   }
 
-  const title = (conversation.triggerId ? "Triggered - " : "") + titleRes.value;
+  const title = (conversation.triggerId ? "⚡" : "") + titleRes.value;
   const updateRes = await updateConversationTitle(auth, {
     conversationId: conversation.sId,
     title,

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -37,6 +37,7 @@ import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
@@ -7125,6 +7126,40 @@ describe("ConversationResource.listConversationsInSpacePaginated", () => {
       );
 
     expect(counts.get(convo.id)).toBe(2);
+  });
+
+  it("excludeTriggered omits conversations with a triggerId", async () => {
+    const humanConvo = await createConvoWithUpdatedAt(1);
+    const triggeredConvo = await createConvoWithUpdatedAt(0);
+
+    const trigger = await TriggerFactory.webhook(adminAuth, {
+      agentConfigurationId: agents[0].sId,
+      spaceId: space.id,
+    });
+    await ConversationFactory.setTriggerIdForTest(
+      triggeredConvo.id,
+      workspace.id,
+      trigger.id
+    );
+
+    const included =
+      await ConversationResource.listConversationsInSpacePaginated(adminAuth, {
+        spaceId: space.sId,
+        pagination: { limit: 10 },
+      });
+    expect(included.conversations.map((c) => c.sId)).toEqual(
+      expect.arrayContaining([humanConvo.sId, triggeredConvo.sId])
+    );
+
+    const excluded =
+      await ConversationResource.listConversationsInSpacePaginated(adminAuth, {
+        spaceId: space.sId,
+        excludeTriggered: true,
+        pagination: { limit: 10 },
+      });
+    const excludedIds = excluded.conversations.map((c) => c.sId);
+    expect(excludedIds).toContain(humanConvo.sId);
+    expect(excludedIds).not.toContain(triggeredConvo.sId);
   });
 });
 

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2253,6 +2253,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       pagination,
       restrictToConversationModelIds,
       filter = "all",
+      excludeTriggered = false,
     }: {
       spaceId: string;
       options?: FetchConversationOptions;
@@ -2263,6 +2264,12 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       };
       restrictToConversationModelIds?: ModelId[];
       filter?: SpaceConversationsFilter;
+      /**
+       * When true, conversations created by a trigger (`triggerId IS NOT NULL`)
+       * are excluded in SQL so pagination stays dense under heavy automation.
+       * Orthogonal to `filter` (participation scope).
+       */
+      excludeTriggered?: boolean;
     }
   ): Promise<{
     conversations: ConversationResource[];
@@ -2290,6 +2297,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       ...(restrictToConversationModelIds && {
         id: { [Op.in]: restrictToConversationModelIds },
       }),
+      ...(excludeTriggered && { triggerId: null }),
     };
 
     if (pagination.lastValue) {


### PR DESCRIPTION
## Description

Adds a "Hide triggered" toggle to Pod conversation lists so users can declutter their view when automation creates many conversations. The preference persists in `podUi` scoped UI preferences (`hideTriggeredConversations`, Zod-defaulted to `false` for backward compat with existing blobs).

- `listConversationsInSpacePaginated` gets an `excludeTriggered` flag → appends `triggerId: null` to the WHERE clause; propagated through `usePodConversations` and `GET /assistant/conversations/spaces/:spaceId?excludeTriggered=true`.
- `PodConversationsTab` exposes a Zap/ZapOff icon button; `AgentSidebarMenu` gets a matching dropdown item (disabled when no triggered conversations exist).
- Triggered conversation title prefix changed from `"Triggered - "` to `"⚡"`.
- Sidebar menu copy: "Edit conversations" → "Edit history", "Clear conversation history" → "Clear history" (+ `warning` variant on the clear item).
- `PodBrowseItem` always renders the description tooltip, falling back to "No description".

<img width="1000" height="301" alt="file-d94d17d7276688b9918008e7a8374982" src="https://github.com/user-attachments/assets/bebf378e-8e1e-46f3-a6ea-a991f04a4e04" />

<img width="209" height="491" alt="file-c07289944cb41886f33cdb70d6e2ca7d" src="https://github.com/user-attachments/assets/bd36f36d-5759-4c30-8562-a1f08ec350a2" />


## Tests

- Added unit test `excludeTriggered omits conversations with a triggerId` in `conversation_resource.test.ts` using `TriggerFactory` and `ConversationFactory.setTriggerIdForTest`.
- Tested manually in Pod conversation view.

## Risk

Low. No DB migrations. The new preference field is Zod-defaulted so older persisted blobs parse cleanly. The `excludeTriggered` SQL clause is purely additive. Safe to rollback.

## Deploy Plan

Deploy front
