### PR TITLE
[front] fix: show agent mention invite cards in real time

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -815,7 +815,16 @@ export const ConversationViewer = ({
                   exists.sId === agentMessage.sId &&
                   !isAtInitialStreamState(exists);
 
-                if (!shouldSkipReplace) {
+                if (shouldSkipReplace && agentMessage.richMentions.length > 0) {
+                  // User mentions are resolved after the agent finishes and
+                  // arrive through a second agent_message_new event. Keep the
+                  // streamed message state, but apply the resolved mentions.
+                  virtuosoMessageListRef.current.data.map((m) =>
+                    isAgentMessageWithStreaming(m) && m.sId === agentMessage.sId
+                      ? { ...m, richMentions: agentMessage.richMentions }
+                      : m
+                  );
+                } else if (!shouldSkipReplace) {
                   virtuosoMessageListRef.current.data.map((m) =>
                     predicate(m) ? agentMessage : m
                   );


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#9964

When an agent mentions a user who is not already in the conversation, the invite card only appears after a full page refresh (because it fetches again).

This PR keeps the same-message replay protection while merging non-empty `richMentions` into the existing streamed message. The invite card and later mention status updates now render in real time without replacing message content or streaming state.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
