### PR TITLE
[front] enh: support custom Google Calendar conference data

### DIFF
--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1446,6 +1446,7 @@ const QUERIES: LabeledQuery[] = [
   {
     query: "schedule a meeting on my google calendar",
     expected: "google_calendar.create_event",
+    maxRank: 2, // conference variants expand the indexed input schema
   },
   {
     query: "reschedule a calendar event to a new time",

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -170,7 +170,9 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = [
   {
     name: "create_event",
     description:
-      "Create and schedule a meeting, event, or appointment on Google Calendar. By default, add the calling user as organizer and attendee, call check_availability first, and call get_user_timezones before scheduling.",
+      "Create and schedule a meeting, event, or appointment on Google Calendar. " +
+      "By default, add the calling user as organizer and attendee, call " +
+      "check_availability first, and call get_user_timezones before scheduling.",
     schema: {
       calendarId: z
         .string()
@@ -198,7 +200,9 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = [
       conference: createEventConferenceSchema
         .default({ type: "google_meet" })
         .describe(
-          "Conference setup. Defaults to a new Google Meet conference. Use 'custom' for phone, SIP, video, or third-party conferencing, or 'none' to create the event without a conference."
+          "Conference setup. Defaults to a new Google Meet conference. Use " +
+            "'custom' for phone, SIP, video, or third-party conferencing, or " +
+            "'none' to create the event without a conference."
         ),
       eventType: z
         .enum(["default", "focusTime", "outOfOffice"])
@@ -219,7 +223,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = [
   {
     name: "update_event",
     description:
-      "Update or reschedule a Google Calendar event or meeting to a new time, location, set of attendees, or conference.",
+      "Update or reschedule a Google Calendar event or meeting to a new time, " +
+      "location, set of attendees, or conference.",
     schema: {
       calendarId: z
         .string()
@@ -250,7 +255,9 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = [
       conference: updateEventConferenceSchema
         .optional()
         .describe(
-          "Conference setup. Use 'google_meet' to create a new Google Meet conference or 'custom' for phone, SIP, video, or third-party conferencing. Omit to preserve the existing conference."
+          "Conference setup. Use 'google_meet' to create a new Google Meet " +
+            "conference or 'custom' for phone, SIP, video, or third-party " +
+            "conferencing. Omit to preserve the existing conference."
         ),
       ...sharedEventFields,
     },

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -1,6 +1,42 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
+const conferenceDataSchema = z.object({
+  conferenceSolution: z.object({
+    key: z.object({
+      type: z
+        .enum(["eventHangout", "eventNamedHangout", "hangoutsMeet", "addOn"])
+        .describe(
+          "The conference solution type. Use 'addOn' for a third-party conference provider."
+        ),
+    }),
+    name: z.string().describe("The user-visible conference solution name."),
+  }),
+  entryPoints: z
+    .array(
+      z.object({
+        entryPointType: z
+          .enum(["video", "phone", "sip", "more"])
+          .describe("How attendees join the conference."),
+        uri: z
+          .string()
+          .max(1300)
+          .describe(
+            "The entry point URI. Use http(s): for video/more, tel: for phone, or sip: for SIP."
+          ),
+        label: z
+          .string()
+          .max(512)
+          .optional()
+          .describe("The user-visible label for the entry point."),
+      })
+    )
+    .min(1)
+    .describe(
+      "Ways to join the conference. All must belong to the same conference."
+    ),
+});
+
 const sharedEventFields = {
   transparency: z
     .enum(["opaque", "transparent"])
@@ -115,7 +151,7 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = [
   {
     name: "create_event",
     description:
-      "Create a new event on a Google Calendar to schedule a meeting or appointment. By default: (1) add the calling user as both organizer and attendee, (2) call check_availability to verify attendee availability beforehand, (3) call get_user_timezones first to determine attendee timezones for accurate scheduling.",
+      "Create and schedule a meeting, event, or appointment on Google Calendar. By default, add the calling user as organizer and attendee, call check_availability first, and call get_user_timezones before scheduling.",
     schema: {
       calendarId: z
         .string()
@@ -144,7 +180,12 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = [
         .boolean()
         .default(true)
         .describe(
-          "Whether to create a conference (Google Meet) for the event. Defaults to true."
+          "Whether to create a Google Meet conference. Defaults to true. Ignored when conferenceData is provided."
+        ),
+      conferenceData: conferenceDataSchema
+        .optional()
+        .describe(
+          "Google Calendar conference solution and meeting entry points. Use for phone, SIP, video, or third-party conferencing. Takes precedence over createConference."
         ),
       eventType: z
         .enum(["default", "focusTime", "outOfOffice"])
@@ -165,7 +206,7 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = [
   {
     name: "update_event",
     description:
-      "Update or reschedule an existing event on a Google Calendar to a new time, location, or set of attendees.",
+      "Update or reschedule a Google Calendar event or meeting to a new time, location, set of attendees, or conference.",
     schema: {
       calendarId: z
         .string()
@@ -197,7 +238,12 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = [
         .boolean()
         .optional()
         .describe(
-          "Whether to create a conference (Google Meet) for the event. If not provided, existing conference settings are preserved."
+          "Whether to create a Google Meet conference. If not provided, existing conference settings are preserved. Ignored when conferenceData is provided."
+        ),
+      conferenceData: conferenceDataSchema
+        .optional()
+        .describe(
+          "Google Calendar conference solution and meeting entry points. Use for phone, SIP, video, or third-party conferencing. Takes precedence over createConference."
         ),
       ...sharedEventFields,
     },

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -1,41 +1,60 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { z } from "zod";
 
-const conferenceDataSchema = z.object({
-  conferenceSolution: z.object({
-    key: z.object({
-      type: z
-        .enum(["eventHangout", "eventNamedHangout", "hangoutsMeet", "addOn"])
+const conferenceEntryPointsSchema = z
+  .array(
+    z.object({
+      entryPointType: z
+        .enum(["video", "phone", "sip", "more"])
+        .describe("How attendees join the conference."),
+      uri: z
+        .string()
+        .max(1300)
         .describe(
-          "The conference solution type. Use 'addOn' for a third-party conference provider."
+          "The entry point URI. Use http(s): for video/more, tel: for phone, or sip: for SIP."
         ),
-    }),
-    name: z.string().describe("The user-visible conference solution name."),
-  }),
-  entryPoints: z
-    .array(
-      z.object({
-        entryPointType: z
-          .enum(["video", "phone", "sip", "more"])
-          .describe("How attendees join the conference."),
-        uri: z
-          .string()
-          .max(1300)
-          .describe(
-            "The entry point URI. Use http(s): for video/more, tel: for phone, or sip: for SIP."
-          ),
-        label: z
-          .string()
-          .max(512)
-          .optional()
-          .describe("The user-visible label for the entry point."),
-      })
-    )
-    .min(1)
-    .describe(
-      "Ways to join the conference. All must belong to the same conference."
-    ),
+      label: z
+        .string()
+        .max(512)
+        .optional()
+        .describe("The user-visible label for the entry point."),
+    })
+  )
+  .min(1)
+  .describe(
+    "Ways to join the conference. All must belong to the same conference."
+  );
+
+const googleMeetConferenceSchema = z.object({
+  type: z
+    .literal("google_meet")
+    .describe("Create a new Google Meet conference."),
 });
+
+const customConferenceSchema = z.object({
+  type: z.literal("custom").describe("Use a custom or third-party conference."),
+  name: z.string().describe("The user-visible conference solution name."),
+  entryPoints: conferenceEntryPointsSchema,
+});
+
+const noConferenceSchema = z.object({
+  type: z.literal("none").describe("Create the event without a conference."),
+});
+
+const createEventConferenceSchema = z.discriminatedUnion("type", [
+  googleMeetConferenceSchema,
+  customConferenceSchema,
+  noConferenceSchema,
+]);
+
+const updateEventConferenceSchema = z.discriminatedUnion("type", [
+  googleMeetConferenceSchema,
+  customConferenceSchema,
+]);
+
+export type GoogleCalendarConference = z.infer<
+  typeof createEventConferenceSchema
+>;
 
 const sharedEventFields = {
   transparency: z
@@ -176,16 +195,10 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = [
         .describe("List of attendee email addresses."),
       location: z.string().optional().describe("Location of the event."),
       colorId: z.string().optional().describe("Color ID for the event."),
-      createConference: z
-        .boolean()
-        .default(true)
+      conference: createEventConferenceSchema
+        .default({ type: "google_meet" })
         .describe(
-          "Whether to create a Google Meet conference. Defaults to true. Ignored when conferenceData is provided."
-        ),
-      conferenceData: conferenceDataSchema
-        .optional()
-        .describe(
-          "Google Calendar conference solution and meeting entry points. Use for phone, SIP, video, or third-party conferencing. Takes precedence over createConference."
+          "Conference setup. Defaults to a new Google Meet conference. Use 'custom' for phone, SIP, video, or third-party conferencing, or 'none' to create the event without a conference."
         ),
       eventType: z
         .enum(["default", "focusTime", "outOfOffice"])
@@ -234,16 +247,10 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = [
         .describe("List of attendee email addresses."),
       location: z.string().optional().describe("Location of the event."),
       colorId: z.string().optional().describe("Color ID for the event."),
-      createConference: z
-        .boolean()
+      conference: updateEventConferenceSchema
         .optional()
         .describe(
-          "Whether to create a Google Meet conference. If not provided, existing conference settings are preserved. Ignored when conferenceData is provided."
-        ),
-      conferenceData: conferenceDataSchema
-        .optional()
-        .describe(
-          "Google Calendar conference solution and meeting entry points. Use for phone, SIP, video, or third-party conferencing. Takes precedence over createConference."
+          "Conference setup. Use 'google_meet' to create a new Google Meet conference or 'custom' for phone, SIP, video, or third-party conferencing. Omit to preserve the existing conference."
         ),
       ...sharedEventFields,
     },

--- a/front/lib/api/actions/servers/google_calendar/tools/index.ts
+++ b/front/lib/api/actions/servers/google_calendar/tools/index.ts
@@ -13,8 +13,10 @@ import {
   isGoogleCalendarEvent,
   mergeIntervals,
 } from "@app/lib/api/actions/servers/google_calendar/helpers";
-import type { GoogleCalendarConference } from "@app/lib/api/actions/servers/google_calendar/metadata";
-import { GOOGLE_CALENDAR_TOOLS_METADATA } from "@app/lib/api/actions/servers/google_calendar/metadata";
+import {
+  GOOGLE_CALENDAR_TOOLS_METADATA,
+  type GoogleCalendarConference,
+} from "@app/lib/api/actions/servers/google_calendar/metadata";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";

--- a/front/lib/api/actions/servers/google_calendar/tools/index.ts
+++ b/front/lib/api/actions/servers/google_calendar/tools/index.ts
@@ -13,13 +13,41 @@ import {
   isGoogleCalendarEvent,
   mergeIntervals,
 } from "@app/lib/api/actions/servers/google_calendar/helpers";
+import type { GoogleCalendarConference } from "@app/lib/api/actions/servers/google_calendar/metadata";
 import { GOOGLE_CALENDAR_TOOLS_METADATA } from "@app/lib/api/actions/servers/google_calendar/metadata";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import assert from "assert";
 import { randomUUID } from "crypto";
-import { google } from "googleapis";
+import { type calendar_v3, google } from "googleapis";
 import { DateTime, Interval } from "luxon";
+
+function buildConferenceData(
+  conference: GoogleCalendarConference
+): calendar_v3.Schema$ConferenceData | undefined {
+  switch (conference.type) {
+    case "google_meet":
+      return {
+        createRequest: {
+          requestId: `conference-${randomUUID()}`,
+          conferenceSolutionKey: { type: "hangoutsMeet" },
+        },
+      };
+    case "custom":
+      return {
+        conferenceSolution: {
+          key: { type: "addOn" },
+          name: conference.name,
+        },
+        entryPoints: conference.entryPoints,
+      };
+    case "none":
+      return undefined;
+    default:
+      return assertNever(conference);
+  }
+}
 
 const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
   list_calendars: async ({ pageToken, maxResults }, { authInfo }) => {
@@ -135,8 +163,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
       attendees,
       location,
       colorId,
-      createConference = true,
-      conferenceData,
+      conference,
       transparency,
       visibility,
       reminders,
@@ -153,17 +180,10 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
 
     try {
       const conferenceDataRequest =
-        conferenceData ??
-        (createConference &&
-        eventType !== "focusTime" &&
-        eventType !== "outOfOffice"
-          ? {
-              createRequest: {
-                requestId: `conference-${randomUUID()}`,
-                conferenceSolutionKey: { type: "hangoutsMeet" },
-              },
-            }
-          : undefined);
+        conference.type === "google_meet" &&
+        (eventType === "focusTime" || eventType === "outOfOffice")
+          ? undefined
+          : buildConferenceData(conference);
 
       const res = await calendar.events.insert({
         calendarId,
@@ -234,8 +254,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
       attendees,
       location,
       colorId,
-      createConference,
-      conferenceData,
+      conference,
       transparency,
       visibility,
       reminders,
@@ -250,16 +269,9 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
     );
 
     try {
-      const conferenceDataRequest =
-        conferenceData ??
-        (createConference
-          ? {
-              createRequest: {
-                requestId: `conference-${randomUUID()}`,
-                conferenceSolutionKey: { type: "hangoutsMeet" },
-              },
-            }
-          : undefined);
+      const conferenceDataRequest = conference
+        ? buildConferenceData(conference)
+        : undefined;
 
       const res = await calendar.events.patch({
         calendarId,

--- a/front/lib/api/actions/servers/google_calendar/tools/index.ts
+++ b/front/lib/api/actions/servers/google_calendar/tools/index.ts
@@ -136,6 +136,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
       location,
       colorId,
       createConference = true,
+      conferenceData,
       transparency,
       visibility,
       reminders,
@@ -151,6 +152,19 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
     );
 
     try {
+      const conferenceDataRequest =
+        conferenceData ??
+        (createConference &&
+        eventType !== "focusTime" &&
+        eventType !== "outOfOffice"
+          ? {
+              createRequest: {
+                requestId: `conference-${randomUUID()}`,
+                conferenceSolutionKey: { type: "hangoutsMeet" },
+              },
+            }
+          : undefined);
+
       const res = await calendar.events.insert({
         calendarId,
         conferenceDataVersion: 1,
@@ -179,16 +193,9 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
               autoDeclineMode: "declineAllConflictingInvitations",
             },
           }),
-          ...(createConference &&
-            eventType !== "focusTime" &&
-            eventType !== "outOfOffice" && {
-              conferenceData: {
-                createRequest: {
-                  requestId: `conference-${randomUUID()}`,
-                  conferenceSolutionKey: { type: "hangoutsMeet" },
-                },
-              },
-            }),
+          ...(conferenceDataRequest && {
+            conferenceData: conferenceDataRequest,
+          }),
         },
       });
 
@@ -228,6 +235,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
       location,
       colorId,
       createConference,
+      conferenceData,
       transparency,
       visibility,
       reminders,
@@ -242,6 +250,17 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
     );
 
     try {
+      const conferenceDataRequest =
+        conferenceData ??
+        (createConference
+          ? {
+              createRequest: {
+                requestId: `conference-${randomUUID()}`,
+                conferenceSolutionKey: { type: "hangoutsMeet" },
+              },
+            }
+          : undefined);
+
       const res = await calendar.events.patch({
         calendarId,
         eventId,
@@ -260,13 +279,8 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
           ...(visibility && { visibility }),
           ...(reminders && { reminders }),
           ...(extendedProperties && { extendedProperties }),
-          ...(createConference && {
-            conferenceData: {
-              createRequest: {
-                requestId: `conference-${randomUUID()}`,
-                conferenceSolutionKey: { type: "hangoutsMeet" },
-              },
-            },
+          ...(conferenceDataRequest && {
+            conferenceData: conferenceDataRequest,
           }),
         },
       });


### PR DESCRIPTION
## Description

Closes dust-tt/tasks#9962

The Google Calendar tools support adding a Google Meet link to the events it creates

This PR adds support to also attach phone, SIP, video, or third-party conference details.
The default remains to add a google meet.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
