### PR TITLE
Fix and simplify logic for getConditionalJITServers

### DIFF
--- a/front/lib/api/assistant/jit/conversation.ts
+++ b/front/lib/api/assistant/jit/conversation.ts
@@ -5,7 +5,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
-import type { ConversationAttachmentType } from "@app/types/api/assistant/conversation/attachments";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import assert from "assert";
 
@@ -63,17 +62,12 @@ export async function getConversationMCPServers(
 
 /**
  * Get the conversation_files MCP server for accessing conversation files.
- * Only created if conversation has attachments.
+ * Caller must only invoke this when the conversation_files view was prefetched.
  */
 export async function getConversationFilesServer(
   auth: Authenticator,
-  attachments: ConversationAttachmentType[],
   autoInternalViews: Map<AutoInternalMCPServerNameType, MCPServerViewResource>
-): Promise<ServerSideMCPServerConfigurationType | null> {
-  if (attachments.length === 0) {
-    return null;
-  }
-
+): Promise<ServerSideMCPServerConfigurationType> {
   const conversationFilesView =
     autoInternalViews.get("conversation_files") ?? null;
 

--- a/front/lib/api/assistant/jit/query_tables_v2.ts
+++ b/front/lib/api/assistant/jit/query_tables_v2.ts
@@ -26,16 +26,29 @@ import type { ConversationWithoutContentType } from "@app/types/assistant/conver
 import assert from "assert";
 
 /**
- * Get the query_tables_v2 MCP server for querying CSV/Excel files.
- * Only created if conversation has queryable attachments (tables).
+ * Get the query_tables_v2 MCP server for querying CSV/Excel tables.
+ * Only created if conversation has queryable attachments.
+ *
+ * With Computer available, queryable file attachments are handled by the sandbox and are
+ * excluded here; queryable content nodes always remain eligible.
  */
 export async function getQueryTablesServer(
   auth: Authenticator,
   conversation: ConversationWithoutContentType,
   attachments: ConversationAttachmentType[],
-  autoInternalViews: Map<AutoInternalMCPServerNameType, MCPServerViewResource>
+  autoInternalViews: Map<AutoInternalMCPServerNameType, MCPServerViewResource>,
+  { hasSandboxTools }: { hasSandboxTools: boolean }
 ): Promise<ServerSideMCPServerConfigurationType | null> {
-  const filesUsableAsTableQuery = attachments.filter((f) => f.isQueryable);
+  const filesUsableAsTableQuery = attachments.filter((f) => {
+    if (!f.isQueryable) {
+      return false;
+    }
+    // Computer handles tabular file attachments; keep content nodes on query_tables.
+    if (hasSandboxTools && isFileAttachmentType(f)) {
+      return false;
+    }
+    return true;
+  });
 
   if (filesUsableAsTableQuery.length === 0) {
     return null;

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -926,7 +926,7 @@ describe("getJITServers", () => {
   });
 
   describe("attachment-based servers", () => {
-    it("should include query_tables server when queryable attachments exist and Computer is disabled", async () => {
+    it("should include query_tables server when queryable file attachments exist and Computer is disabled", async () => {
       await FeatureFlagFactory.basic(auth, "disable_computer_feature");
 
       const user = auth.getNonNullableUser();
@@ -980,7 +980,7 @@ describe("getJITServers", () => {
       // but the server should still be created with the correct structure.
     });
 
-    it("should not include query_tables server when Computer is available", async () => {
+    it("should not include query_tables server for queryable file attachments when Computer is available", async () => {
       const user = auth.getNonNullableUser();
       const file = await FileFactory.csv(auth, user, {
         useCase: "conversation",
@@ -1026,6 +1026,49 @@ describe("getJITServers", () => {
           (server) => server.name === CONVERSATION_FILES_SERVER_NAME
         )
       ).toBe(true);
+    });
+
+    it("should include query_tables server for queryable content nodes even when Computer is available", async () => {
+      const attachments: ConversationAttachmentType[] = [
+        {
+          contentFragmentId: "cf_queryable_node",
+          nodeId: "table_node_1",
+          nodeDataSourceViewId: "dsv_test",
+          nodeType: "table",
+          sourceUrl: null,
+          title: "Sales sheet",
+          contentType: "text/csv",
+          contentFragmentVersion: "latest",
+          snippet: null,
+          generatedTables: ["table_node_1"],
+          isIncludable: true,
+          isSearchable: false,
+          isQueryable: true,
+          isInProjectContext: false,
+          hidden: false,
+          creator: null,
+        },
+      ];
+
+      const jitServers = await getJITServers(auth, {
+        agentConfiguration: agentConfig,
+        conversation,
+        attachments,
+      });
+
+      const queryTablesServer = jitServers.find(
+        (server) =>
+          server.name === DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME
+      );
+
+      expect(queryTablesServer).toBeDefined();
+      expect(queryTablesServer?.tables).toEqual([
+        {
+          workspaceId: workspace.sId,
+          dataSourceViewId: "dsv_test",
+          tableId: "table_node_1",
+        },
+      ]);
     });
 
     it("should include search server when searchable attachments exist", async () => {

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -1,6 +1,9 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
-import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import {
+  isContentNodeAttachmentType,
+  isFileAttachmentType,
+} from "@app/lib/api/assistant/conversation/attachments";
 import { getAskUserQuestionServer } from "@app/lib/api/assistant/jit/ask_user_question";
 import { getCommonUtilitiesServer } from "@app/lib/api/assistant/jit/common_utilities";
 import {
@@ -28,6 +31,41 @@ const ALWAYS_PREFETCHED_MCP_SERVERS: AutoInternalMCPServerNameType[] = [
   "schedules_management",
   "skill_management",
 ];
+
+type ConditionalMCPServerContext = {
+  attachments: ConversationAttachmentType[];
+  hasSandboxTools: boolean;
+};
+
+const CONDITIONAL_MCP_SERVER_NAMES = [
+  "conversation_files",
+  "query_tables_v2",
+  "search",
+] as const;
+
+type ConditionalMCPServerName = (typeof CONDITIONAL_MCP_SERVER_NAMES)[number];
+
+/**
+ * Eligibility for attachment-dependent JIT servers. Decided once in getJITServers;
+ * getConditionalJITServers only materializes servers whose views were prefetched.
+ */
+const CONDITIONAL_MCP_SERVERS: Record<
+  ConditionalMCPServerName,
+  (ctx: ConditionalMCPServerContext) => boolean
+> = {
+  // Note there is an additional filtering on the tools (see: front/lib/api/actions/servers/conversation_files/index.ts)
+  conversation_files: ({ attachments }) => attachments.length > 0,
+  // Queryable content nodes always use query_tables. File attachments only do when Computer
+  // is unavailable (otherwise the sandbox handles tabular files).
+  query_tables_v2: ({ attachments, hasSandboxTools }) =>
+    attachments.some((a) => isContentNodeAttachmentType(a) && a.isQueryable) ||
+    (!hasSandboxTools &&
+      attachments.some((a) => isFileAttachmentType(a) && a.isQueryable)),
+  search: ({ attachments }) =>
+    attachments.some(
+      (a) => isContentNodeAttachmentType(a) && isSearchableFolder(a)
+    ),
+};
 
 /**
  * Servers whose tool specifications are mostly always added or never added.
@@ -83,6 +121,7 @@ async function getUnconditionalJITServers(
 
 /**
  * Servers whose presence depends heavily on the conversation state and may change mid-conversation.
+ * Prefetch via CONDITIONAL_MCP_SERVERS is the source of truth for which of these to build.
  */
 async function getConditionalJITServers(
   auth: Authenticator,
@@ -122,37 +161,27 @@ async function getConditionalJITServers(
   );
   servers.push(schedulesManagementServer);
 
-  // Add tools to manipulate conversation files, if any.
-
-  if (attachments.length === 0) {
-    return removeNulls(servers);
+  if (autoInternalViews.has("conversation_files")) {
+    servers.push(await getConversationFilesServer(auth, autoInternalViews));
   }
 
-  const conversationFilesServer = await getConversationFilesServer(
-    auth,
-    attachments,
-    autoInternalViews
-  );
-  servers.push(conversationFilesServer);
-
-  // With Computer available, tabular files are handled via the sandbox instead of
-  // the legacy conversation query_tables JIT server.
-  if (!hasSandboxTools) {
-    const queryTablesServer = await getQueryTablesServer(
-      auth,
-      conversation,
-      attachments,
-      autoInternalViews
+  if (autoInternalViews.has("query_tables_v2")) {
+    servers.push(
+      await getQueryTablesServer(
+        auth,
+        conversation,
+        attachments,
+        autoInternalViews,
+        { hasSandboxTools }
+      )
     );
-    servers.push(queryTablesServer);
   }
 
-  const folderSearchServers = await getFolderSearchServers(
-    auth,
-    attachments,
-    autoInternalViews
-  );
-  servers.push(...folderSearchServers);
+  if (autoInternalViews.has("search")) {
+    servers.push(
+      ...(await getFolderSearchServers(auth, attachments, autoInternalViews))
+    );
+  }
 
   return removeNulls(servers);
 }
@@ -176,20 +205,13 @@ export async function getJITServers(
     ALWAYS_PREFETCHED_MCP_SERVERS
   );
 
-  if (attachments.length > 0) {
-    mcpServersToFetch.add("conversation_files");
-
-    // If the computer feature is enabled, we rely on the computer to do the querying.
-    if (!hasSandboxTools && attachments.some((a) => a.isQueryable)) {
-      mcpServersToFetch.add("query_tables_v2");
-    }
-
-    if (
-      attachments.some(
-        (a) => isContentNodeAttachmentType(a) && isSearchableFolder(a)
-      )
-    ) {
-      mcpServersToFetch.add("search");
+  const conditionalContext: ConditionalMCPServerContext = {
+    attachments,
+    hasSandboxTools,
+  };
+  for (const name of CONDITIONAL_MCP_SERVER_NAMES) {
+    if (CONDITIONAL_MCP_SERVERS[name](conditionalContext)) {
+      mcpServersToFetch.add(name);
     }
   }
 


### PR DESCRIPTION
## Description

Extracts conditional JIT MCP server eligibility into a `CONDITIONAL_MCP_SERVERS` record in `jit_actions.ts` — one source of truth replacing scattered `if` checks duplicated between `getJITServers` and `getConditionalJITServers`. `getConditionalJITServers` now simply checks `autoInternalViews.has(...)`.

Fixes a logic bug along the way: when Computer (sandbox) is available, the old code excluded *all* queryable attachments from `query_tables_v2`, but queryable content nodes (vs file attachments) must still route to `query_tables_v2` regardless. Fixed with `isFileAttachmentType` discrimination in both the eligibility predicate and inside `getQueryTablesServer`. `getConversationFilesServer` is also simplified — the `attachments` guard is dropped since the caller now ensures the view was prefetched before calling.

## Tests

Updated existing test descriptions to be more precise. Added a new unit test verifying that a queryable content-node attachment produces a `query_tables_v2` server even when Computer is available.

## Risk

Low. Pure logic refactor with a targeted bug fix. No DB changes, no new APIs. The content-node fix restores the intended behavior; the refactor is covered by existing + new tests. Safe to rollback.

## Deploy Plan

Deploy front.
