### PR TITLE
[front] fix: handle Poke fallback routes

### DIFF
--- a/front-spa/src/poke/routes.tsx
+++ b/front-spa/src/poke/routes.tsx
@@ -42,8 +42,8 @@ import { PokeWorkspacePage } from "@spa/poke/layouts/PokeWorkspacePage";
 import type { RouteObject } from "react-router-dom";
 import { Navigate, useLocation, useParams } from "react-router-dom";
 
-// Redirect component that strips a compatibility prefix.
-function PrefixRedirect() {
+// Redirect component that strips /poke prefix
+function PokeRedirect() {
   const params = useParams();
   const location = useLocation();
   const rest = params["*"] || "";
@@ -162,9 +162,9 @@ export const routes: RouteObject[] = [
           },
         ],
       },
-      // Redirect compatibility prefixes to canonical Poke routes.
-      { path: "poke/*", element: <PrefixRedirect /> },
-      { path: "w/*", element: <PrefixRedirect /> },
+      // Redirect /poke/* to /* (strip /poke prefix)
+      { path: "poke/*", element: <PokeRedirect /> },
+      { path: "w/*", element: <PokeRedirect /> },
       {
         element: <UnauthenticatedPage />,
         children: [{ path: "*", element: <Custom404 /> }],

--- a/front-spa/src/poke/routes.tsx
+++ b/front-spa/src/poke/routes.tsx
@@ -36,13 +36,14 @@ import { WebhookSourceDetailsPage } from "@dust-tt/front/components/poke/pages/W
 import { WorkspacePage } from "@dust-tt/front/components/poke/pages/WorkspacePage";
 import { GlobalErrorFallback } from "@spa/app/components/GlobalErrorFallback";
 import { RootRouterLayout } from "@spa/app/layouts/RootRouterLayout";
+import { UnauthenticatedPage } from "@spa/app/layouts/UnauthenticatedPage";
 import { PokePage } from "@spa/poke/layouts/PokePage";
 import { PokeWorkspacePage } from "@spa/poke/layouts/PokeWorkspacePage";
 import type { RouteObject } from "react-router-dom";
 import { Navigate, useLocation, useParams } from "react-router-dom";
 
-// Redirect component that strips /poke prefix
-function PokeRedirect() {
+// Redirect component that strips a compatibility prefix.
+function PrefixRedirect() {
   const params = useParams();
   const location = useLocation();
   const rest = params["*"] || "";
@@ -161,9 +162,13 @@ export const routes: RouteObject[] = [
           },
         ],
       },
-      // Redirect /poke/* to /* (strip /poke prefix)
-      { path: "poke/*", element: <PokeRedirect /> },
-      { path: "*", element: <Custom404 /> },
+      // Redirect compatibility prefixes to canonical Poke routes.
+      { path: "poke/*", element: <PrefixRedirect /> },
+      { path: "w/*", element: <PrefixRedirect /> },
+      {
+        element: <UnauthenticatedPage />,
+        children: [{ path: "*", element: <Custom404 /> }],
+      },
     ],
   },
 ];


### PR DESCRIPTION
## Description

This PR solves 2 issues:
- When we try a route that does not exist, we see a loading screen forever. Since poke is globally slow to load it's hard to tell if it's extremely slow or if the URL is incorrect. This even happens to the best of us :)
- If we copy paste an URL from the app we always have to remove the `/w/` in it. Combined to the first issue this can lead to seeing the spinner forever if we forget about it. This PR adds a redirect.

the poke routes are only mounted in `PokeApp`, which is only loaded in `front-spa/poke.html`, not the main app's index. so the redirect only happens when you're already on `poke.dust.tt`

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
