### PR TITLE
[Activation] Activation notification links to Get Started page

### DIFF
--- a/front/lib/notifications/workflows/activation-new-conversation.ts
+++ b/front/lib/notifications/workflows/activation-new-conversation.ts
@@ -13,7 +13,7 @@ import {
   getConversationDetails,
 } from "@app/lib/notifications/helpers";
 import type { UserResource } from "@app/lib/resources/user_resource";
-import { getConversationRoute } from "@app/lib/utils/router";
+import { getGetStartedRoute } from "@app/lib/utils/router";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import {
   ACTIVATION_NEW_CONVERSATION_TRIGGER_ID,
@@ -164,9 +164,7 @@ export const activationNewConversationWorkflow = workflow(
           goal: details.goal,
           action: {
             label: details.subject,
-            url:
-              config.getAppUrl() +
-              getConversationRoute(payload.workspaceId, payload.conversationId),
+            url: config.getAppUrl() + getGetStartedRoute(payload.workspaceId),
           },
         });
 


### PR DESCRIPTION
## Description
Instead of linking to the conversation, activation email notifications now link to the Get Started homepage. The rest of the notification remains untouched.

## Tests
Local test.

## Risk
Low

## Deploy Plan
Deploy front.
