### PR TITLE
[front] fix: pass auth to buildConsumptionScopeQuery call sites

### DIFF
--- a/front/lib/api/analytics/consumption/overview.ts
+++ b/front/lib/api/analytics/consumption/overview.ts
@@ -52,7 +52,7 @@ export async function fetchConsumptionOverview(
   const period = await resolveConsumptionPeriod(auth, periodInput);
 
   const query = buildConsumptionScopeQuery({
-    auth: auth,
+    auth,
     startDate: period.startDate,
     endDate: period.endDate,
     filter,

--- a/front/lib/api/analytics/consumption/timeseries.ts
+++ b/front/lib/api/analytics/consumption/timeseries.ts
@@ -112,7 +112,7 @@ export async function fetchConsumptionTimeseries(
   }
 ): Promise<Result<ConsumptionTimeseries, ElasticsearchError>> {
   const query = buildConsumptionScopeQuery({
-    auth: auth,
+    auth,
     startDate: period.startDate,
     endDate: period.endDate,
     filter,


### PR DESCRIPTION
## Description

overview.ts, and timeseries.ts were still calling buildConsumptionScopeQuery with workspaceId, but the function already requires auth. Fixes the type mismatch.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- Deploy front
