### PR TITLE
[front] fix: unblock pod hard delete on sandbox FKs

### DIFF
--- a/front/lib/resources/sandbox_env_var_resource.test.ts
+++ b/front/lib/resources/sandbox_env_var_resource.test.ts
@@ -631,6 +631,34 @@ describe("SandboxEnvVarResource pod scope", () => {
     expect(fetched?.allowedDomains).toEqual(["api.example.com"]);
   });
 
+  it("deletes only the pod-scoped rows on pod scrub", async () => {
+    const { authenticator, pod } = await setupPod();
+
+    const podResult = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      podScope(pod),
+      { name: "CONFIG_TOKEN", value: "pod-config-value" }
+    );
+    expect(podResult.isOk()).toBe(true);
+    const workspaceResult = await SandboxEnvVarResource.makeNew(
+      authenticator,
+      wsScope(authenticator),
+      { name: "CONFIG_TOKEN", value: "workspace-config-value" }
+    );
+    expect(workspaceResult.isOk()).toBe(true);
+
+    await SandboxEnvVarResource.deleteAllForPod(authenticator, pod);
+
+    await expect(
+      SandboxEnvVarResource.listForScope(authenticator, podScope(pod))
+    ).resolves.toEqual([]);
+    const workspaceVars = await SandboxEnvVarResource.listForScope(
+      authenticator,
+      wsScope(authenticator)
+    );
+    expect(workspaceVars.map(({ name }) => name)).toEqual(["CONFIG_TOKEN"]);
+  });
+
   it("rejects non-pod spaces", async () => {
     const { authenticator, globalSpace } = await createResourceTest({
       role: "admin",

--- a/front/lib/resources/sandbox_env_var_resource.ts
+++ b/front/lib/resources/sandbox_env_var_resource.ts
@@ -788,6 +788,8 @@ export class SandboxEnvVarResource extends BaseResource<SandboxEnvVarModel> {
     auth: Authenticator,
     pod: SpaceResource
   ): Promise<undefined> {
+    assert(pod.isProject(), "Sandbox env vars can only be scoped to pods.");
+
     await this.model.destroy({
       where: {
         spaceId: pod.id,

--- a/front/lib/resources/sandbox_env_var_resource.ts
+++ b/front/lib/resources/sandbox_env_var_resource.ts
@@ -782,6 +782,20 @@ export class SandboxEnvVarResource extends BaseResource<SandboxEnvVarModel> {
     return new Ok(undefined);
   }
 
+  // Pod scrub: the FK to spaces is `onDelete: "RESTRICT"`, so the pod-scoped
+  // rows must go before the pod itself can be hard-deleted.
+  static async deleteAllForPod(
+    auth: Authenticator,
+    pod: SpaceResource
+  ): Promise<undefined> {
+    await this.model.destroy({
+      where: {
+        spaceId: pod.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+  }
+
   // Workspace scrub: spaces (and their pod-scoped rows) are already gone by
   // the time this runs; destroying by workspaceId sweeps the remaining
   // workspace-scoped rows plus any stragglers.

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -1,6 +1,7 @@
 import { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import {
   SandboxFunctionInvocationModel,
   SandboxFunctionModel,
@@ -12,6 +13,7 @@ import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { sandboxFunctionContentType } from "@app/types/files";
+import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -551,6 +553,54 @@ describe("SandboxFunctionResource", () => {
         },
       })
     ).resolves.toBeNull();
+  });
+
+  it("deletes all sandbox functions for a soft-deleted space", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const space = await SpaceFactory.project(workspace);
+    const file = await FileFactory.create(authenticator, null, {
+      contentType: sandboxFunctionContentType,
+      fileName: "comments.ts",
+      fileSize: 100,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: space.sId },
+    });
+    await SandboxFunctionResource.makeNew(authenticator, {
+      space,
+      file,
+      slug: "add-comment",
+      description: "Add a comment.",
+      inputSchema,
+      outputSchema,
+    });
+
+    // The pod is soft-deleted before the scrub runs, exactly as the poke deletion workflow does.
+    const softDeleteResult = await space.delete(authenticator, {
+      hardDelete: false,
+    });
+    expect(softDeleteResult.isOk()).toBe(true);
+    const deletedSpace = await SpaceResource.fetchById(
+      authenticator,
+      space.sId,
+      { includeDeleted: true }
+    );
+    assert(deletedSpace);
+
+    const deleteResult = await SandboxFunctionResource.deleteAllForSpace(
+      authenticator,
+      deletedSpace
+    );
+
+    expect(deleteResult.isOk()).toBe(true);
+    expect(deleteResult.isOk() ? deleteResult.value : undefined).toBe(1);
+    await expect(
+      SandboxFunctionModel.count({
+        where: { spaceId: space.id, workspaceId: workspace.id },
+      })
+    ).resolves.toBe(0);
   });
 
   it("refuses to delete when the user cannot access the space", async () => {

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -374,17 +374,13 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
   static async listBySpace(
     auth: Authenticator,
-    space: SpaceResource,
-    { includeDeletedSpace }: { includeDeletedSpace?: boolean } = {}
+    space: SpaceResource
   ): Promise<SandboxFunctionResource[]> {
     if (!space.isProject()) {
       return [];
     }
 
-    return this.baseFetch(auth, {
-      where: { spaceId: space.id },
-      includeDeletedSpace,
-    });
+    return this.baseFetch(auth, { where: { spaceId: space.id } });
   }
 
   static async fetchBySpaceAndSlug(
@@ -435,7 +431,8 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     assert(space.isProject(), "Sandbox functions can only belong to pods.");
 
     // The pod is already soft-deleted when the scrub runs, hence `includeDeletedSpace`.
-    const sandboxFunctions = await this.listBySpace(auth, space, {
+    const sandboxFunctions = await this.baseFetch(auth, {
+      where: { spaceId: space.id },
       includeDeletedSpace: true,
     });
     for (const sandboxFunction of sandboxFunctions) {
@@ -447,19 +444,21 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       }
     }
 
-    // `listBySpace` drops rows it cannot fully hydrate, so a partial list would leave rows behind
-    // and surface much later as a foreign key violation on the pod hard delete. Fail here instead,
-    // naming what was left.
-    const remaining = await this.model.count({
+    // `baseFetch` drops rows it cannot fully hydrate, so a partial list would leave rows behind and
+    // surface much later as a foreign key violation on the pod hard delete. Fail here instead, with
+    // the ids an operator needs to unblock the scrub.
+    const remaining = await this.model.findAll({
+      attributes: ["id"],
       where: {
         spaceId: space.id,
         workspaceId: auth.getNonNullableWorkspace().id,
       },
     });
-    if (remaining > 0) {
+    if (remaining.length > 0) {
       return new Err(
         new Error(
-          `${remaining} sandbox function(s) of pod ${space.sId} could not be deleted.`
+          `Sandbox function(s) of pod ${space.sId} could not be deleted: ` +
+            `${remaining.map(({ id }) => id).join(", ")}.`
         )
       );
     }

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -250,11 +250,19 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     }
   }
 
+  // `includeDeletedSpace` refers to the pod, not to the functions themselves: pods are
+  // soft-deleted before being scrubbed, and without it every function of a pod being deleted
+  // resolves to no space and is silently dropped here.
   private static async baseFetch(
     auth: Authenticator,
-    options?: ResourceFindOptions<SandboxFunctionModel>
+    {
+      includeDeletedSpace,
+      ...options
+    }: ResourceFindOptions<SandboxFunctionModel> & {
+      includeDeletedSpace?: boolean;
+    } = {}
   ): Promise<SandboxFunctionResource[]> {
-    const { where, ...rest } = options ?? {};
+    const { where, ...rest } = options;
     const sandboxFunctions = await this.model.findAll({
       where: {
         ...where,
@@ -271,7 +279,8 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
             (sandboxFunction) => sandboxFunction.get().spaceId
           )
         )
-      )
+      ),
+      { includeDeleted: includeDeletedSpace }
     );
     const accessibleSpacesById = new Map(
       spaces
@@ -365,13 +374,17 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
   static async listBySpace(
     auth: Authenticator,
-    space: SpaceResource
+    space: SpaceResource,
+    { includeDeletedSpace }: { includeDeletedSpace?: boolean } = {}
   ): Promise<SandboxFunctionResource[]> {
     if (!space.isProject()) {
       return [];
     }
 
-    return this.baseFetch(auth, { where: { spaceId: space.id } });
+    return this.baseFetch(auth, {
+      where: { spaceId: space.id },
+      includeDeletedSpace,
+    });
   }
 
   static async fetchBySpaceAndSlug(
@@ -421,7 +434,10 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
   ): Promise<Result<number, Error>> {
     assert(space.isProject(), "Sandbox functions can only belong to pods.");
 
-    const sandboxFunctions = await this.listBySpace(auth, space);
+    // The pod is already soft-deleted when the scrub runs, hence `includeDeletedSpace`.
+    const sandboxFunctions = await this.listBySpace(auth, space, {
+      includeDeletedSpace: true,
+    });
     for (const sandboxFunction of sandboxFunctions) {
       // TODO(spolu): potentially optimize as this may be quite slow (each delete calls file delete
       // which deletes a whole bunch of records).
@@ -429,6 +445,23 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       if (result.isErr()) {
         return new Err(result.error);
       }
+    }
+
+    // `listBySpace` drops rows it cannot fully hydrate, so a partial list would leave rows behind
+    // and surface much later as a foreign key violation on the pod hard delete. Fail here instead,
+    // naming what was left.
+    const remaining = await this.model.count({
+      where: {
+        spaceId: space.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+    if (remaining > 0) {
+      return new Err(
+        new Error(
+          `${remaining} sandbox function(s) of pod ${space.sId} could not be deleted.`
+        )
+      );
     }
 
     return new Ok(sandboxFunctions.length);

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -175,6 +175,26 @@ export async function scrubSpaceActivity({
       throw deleteSandboxFunctionsResult.error;
     }
 
+    // Destroy the pod sandbox at the provider and drop its ownership row. The
+    // FK from sandbox_owners to spaces is `onDelete: "RESTRICT"`, so the row
+    // must be gone before the space can be hard-deleted. Runs before the pod
+    // state prefix is wiped: a live sandbox keeps replicating into it.
+    // Skipped when the pod never booted one, so pods stay scrubbable in
+    // deployments with no sandbox provider configured.
+    const sandbox = await PodSandboxAdapter.fetchSandbox(auth, space);
+    if (sandbox) {
+      const deleteSandboxResult = await PodSandboxAdapter.deleteSandbox(
+        auth,
+        space
+      );
+      if (deleteSandboxResult.isErr()) {
+        throw deleteSandboxResult.error;
+      }
+    }
+
+    // Same for the pod-scoped env vars.
+    await SandboxEnvVarResource.deleteAllForPod(auth, space);
+
     // Pod state (litestream replica) objects are never FileResources, so the
     // per-function deletes above cannot reach them — scrub the whole GCS
     // prefix or the replica chain leaks forever.
@@ -182,20 +202,6 @@ export async function scrubSpaceActivity({
     if (deletePodStateResult.isErr()) {
       throw deletePodStateResult.error;
     }
-
-    // Destroy the pod sandbox at the provider and drop its ownership row. The
-    // FK from sandbox_owners to spaces is `onDelete: "RESTRICT"`, so the row
-    // must be gone before the space can be hard-deleted.
-    const deleteSandboxResult = await PodSandboxAdapter.deleteSandbox(
-      auth,
-      space
-    );
-    if (deleteSandboxResult.isErr()) {
-      throw deleteSandboxResult.error;
-    }
-
-    // Same for the pod-scoped env vars.
-    await SandboxEnvVarResource.deleteAllForPod(auth, space);
   }
 
   // Delete all the data sources of the spaces.

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -48,6 +48,7 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { OnboardingTaskResource } from "@app/lib/resources/onboarding_task_resource";
 import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
+import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
@@ -55,6 +56,7 @@ import { ProjectTaskStateResource } from "@app/lib/resources/project_task_state_
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
+import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SelfImprovingSkillsUsageResource } from "@app/lib/resources/self_improving_skills_usage_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -180,6 +182,20 @@ export async function scrubSpaceActivity({
     if (deletePodStateResult.isErr()) {
       throw deletePodStateResult.error;
     }
+
+    // Destroy the pod sandbox at the provider and drop its ownership row. The
+    // FK from sandbox_owners to spaces is `onDelete: "RESTRICT"`, so the row
+    // must be gone before the space can be hard-deleted.
+    const deleteSandboxResult = await PodSandboxAdapter.deleteSandbox(
+      auth,
+      space
+    );
+    if (deleteSandboxResult.isErr()) {
+      throw deleteSandboxResult.error;
+    }
+
+    // Same for the pod-scoped env vars.
+    await SandboxEnvVarResource.deleteAllForPod(auth, space);
   }
 
   // Delete all the data sources of the spaces.


### PR DESCRIPTION
## Description

Pod scrub for workspace `0ec9852c2f` / pod `vlt_nWqafL1MP70ik` has been retrying for hours on
`ForeignKeyConstraintError: update or delete on table "vaults" violates foreign key constraint "sandbox_functions_spaceId_fkey"`.

The pod is soft-deleted before `scrubSpaceActivity` runs. `SandboxFunctionResource.baseFetch`
re-resolves each function's space via `SpaceResource.fetchByModelIds` without `includeDeleted`, so
the space came back empty and every function was silently dropped from the list
`deleteAllForSpace` iterates over. It returned `Ok(0)` and the hard delete then hit the RESTRICT FK.

- Thread `includeDeletedSpace` through `listBySpace` / `baseFetch`, set it in `deleteAllForSpace`.
- Count leftover rows after the loop so a partial list fails there with a clear message instead of
  surfacing as an opaque FK violation later.
- `sandbox_owners.spaceId` and `sandbox_env_vars.spaceId` are RESTRICT too and were never cleaned by
  the pod scrub, so they would be the next walls: destroy the pod sandbox and delete its env vars in
  `scrubSpaceActivity`.

## Tests

Added a regression test that soft-deletes the pod before calling `deleteAllForSpace` (fails on main,
passes here), and one covering that pod env var cleanup leaves workspace-scoped rows alone.

## Risk

Low. `includeDeletedSpace` defaults to false, so read paths are unchanged. New behavior only runs in
the scrub path.

## Deploy Plan

Standard deploy. The stuck workflow should recover on its next retry once the worker ships.