### PR TITLE
[dsbx] perf: harden the warm server: staleness, secrets, backpressure, lifetime

### DIFF
--- a/cli/dust-sandbox/functions-runner/protocol.ts
+++ b/cli/dust-sandbox/functions-runner/protocol.ts
@@ -9,6 +9,10 @@ export interface RequestInput {
   headers: Record<string, string>;
   body?: string;
   encoding: Encoding;
+  // Sha256 hex of the bundle the publisher expects to run. The warm server
+  // refuses to serve an import that does not match (see serve.ts); the cold
+  // runner ignores it, since a cold run reads the bundle straight from disk.
+  bundleSha256?: string;
 }
 
 export const RUNNER_ERROR_CODES = [
@@ -76,7 +80,12 @@ export function parseInput(raw: string): RequestInput {
   if (encoding !== "utf8" && encoding !== "base64") {
     throw new BadInputError('input.encoding must be "utf8" or "base64"');
   }
-  return { method, url, headers, body, encoding };
+  if (obj.bundleSha256 !== undefined && typeof obj.bundleSha256 !== "string") {
+    throw new BadInputError("input.bundleSha256 must be a string");
+  }
+  const bundleSha256 =
+    typeof obj.bundleSha256 === "string" ? obj.bundleSha256 : undefined;
+  return { method, url, headers, body, encoding, bundleSha256 };
 }
 
 export function decodeRequestBody(input: RequestInput): Uint8Array | undefined {

--- a/cli/dust-sandbox/functions-runner/serve.test.ts
+++ b/cli/dust-sandbox/functions-runner/serve.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { copyFileSync, mkdtempSync, rmSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -13,7 +13,8 @@ import {
 const runner = join(import.meta.dir, "runner.ts");
 const fx = (n: string) => join(import.meta.dir, "fixtures", n);
 
-// Each test gets its own scratch dir holding the socket.
+// Each test gets its own scratch dir holding the socket and a private copy of
+// the fixture (staleness tests rewrite it).
 let scratchDirs: string[] = [];
 
 function scratch(): string {
@@ -62,6 +63,7 @@ interface WarmReply {
   v: number;
   ack?: boolean;
   outcome?: { ok: boolean; output?: unknown; error?: { code: string } };
+  stale?: boolean;
   busy?: boolean;
   error?: string;
 }
@@ -187,6 +189,80 @@ describe("runner serve", () => {
     }
   });
 
+  test("reports a rewritten bundle as stale and exits", async () => {
+    const dir = scratch();
+    const bundle = join(dir, "hello.ts");
+    copyFileSync(fx("hello.ts"), bundle);
+    const { proc, socketPath } = await startServer(bundle);
+    try {
+      // Same content, different mtime — a republish rewrites the object, and
+      // mtime/size is the staleness signal.
+      const later = new Date(Date.now() + 5_000);
+      utimesSync(bundle, later, later);
+
+      const reply = await request(
+        socketPath,
+        warmRequest({}, { url: "http://localhost/" })
+      );
+      expect(reply.stale).toBe(true);
+      expect(await proc.exited).toBe(0);
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("serves a request stamped with the matching bundle hash", async () => {
+    const { proc, socketPath } = await startServer(fx("hello.ts"));
+    try {
+      const bytes = await Bun.file(fx("hello.ts")).arrayBuffer();
+      const bundleSha256 = new Bun.CryptoHasher("sha256")
+        .update(new Uint8Array(bytes))
+        .digest("hex");
+      const reply = await request(
+        socketPath,
+        warmRequest({}, { url: "http://localhost/?name=stamped", bundleSha256 })
+      );
+      expect(reply.outcome?.ok).toBe(true);
+      expect(reply.outcome?.output).toEqual({ hello: "stamped" });
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("refuses a mismatched bundle hash as stale and exits", async () => {
+    // The stat cannot see the rewrite here (the file is untouched), which is
+    // exactly the gcsfuse-cached-metadata case: the request's hash is the
+    // only signal, and it must win.
+    const { proc, socketPath } = await startServer(fx("hello.ts"));
+    try {
+      const reply = await request(
+        socketPath,
+        warmRequest(
+          {},
+          { url: "http://localhost/", bundleSha256: "0".repeat(64) }
+        )
+      );
+      expect(reply.stale).toBe(true);
+      expect(reply.outcome).toBeUndefined();
+      expect(await proc.exited).toBe(0);
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("serves an unstamped request from an older front", async () => {
+    const { proc, socketPath } = await startServer(fx("hello.ts"));
+    try {
+      const reply = await request(
+        socketPath,
+        warmRequest({}, { url: "http://localhost/?name=unstamped" })
+      );
+      expect(reply.outcome?.output).toEqual({ hello: "unstamped" });
+    } finally {
+      proc.kill();
+    }
+  });
+
   test("rejects a protocol version it does not speak and exits", async () => {
     const { proc, socketPath } = await startServer(fx("hello.ts"));
     try {
@@ -245,6 +321,49 @@ describe("runner serve", () => {
         warmRequest({}, { url: "http://localhost/" })
       );
       expect(after.outcome?.output).toEqual({ done: true });
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("scrubs the spawn-time invocation secrets from its own environment", async () => {
+    const dir = scratch();
+    const socketPath = join(dir, "fn.sock");
+    // Spawned the way dsbx spawns it: with the cold invocation's token in
+    // env. The server must not serve requests under that inherited value.
+    const proc = Bun.spawn(
+      ["bun", runner, "serve", fx("env-probe.ts"), socketPath],
+      {
+        stdin: "ignore",
+        stdout: "ignore",
+        stderr: "inherit",
+        env: {
+          ...process.env,
+          WARM_TEST_MARKER: "from-spawn",
+          DUST_SANDBOX_TOKEN: "spawn-invocation-token",
+        },
+      }
+    );
+    try {
+      const deadline = Date.now() + 10_000;
+      let reply: WarmReply | null = null;
+      while (Date.now() < deadline && reply === null) {
+        try {
+          reply = await request(
+            socketPath,
+            warmRequest({}, { url: "http://localhost/" })
+          );
+        } catch {
+          await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+      }
+      // WARM_TEST_MARKER is not in the scrub list, so it survives spawn env
+      // inheritance like any other var; the spawn-time DUST_SANDBOX_TOKEN
+      // must have been scrubbed at startup.
+      expect(reply?.outcome?.output).toEqual({
+        marker: "from-spawn",
+        token: "unset",
+      });
     } finally {
       proc.kill();
     }

--- a/cli/dust-sandbox/functions-runner/serve.ts
+++ b/cli/dust-sandbox/functions-runner/serve.ts
@@ -16,12 +16,14 @@
 // falls back to the cold path on failures that precede the ack. After the
 // ack, a lost outcome is reported as a failed invocation, never re-run.
 //
-// The server is disposable: it exits on idle and on any malformed request.
-// The staleness, secret-scrubbing, backpressure, lifetime, and deadline
-// hardening lands separately on top of this core.
+// The server is disposable. It exits on idle, at a hard lifetime cap (drained,
+// never mid-invocation), when the bundle on disk changes, on any malformed
+// request, or when an invocation outlives its deadline (without replying: the
+// client's front-side timeout killed it long before).
 
+import { createHash } from "node:crypto";
 import { unlinkSync } from "node:fs";
-import { unlink } from "node:fs/promises";
+import { stat, unlink } from "node:fs/promises";
 
 import { z } from "zod";
 
@@ -31,8 +33,20 @@ import { BadInputError, parseInput } from "./protocol.ts";
 
 export const WARM_PROTOCOL_VERSION = 1;
 
-// How long the server waits for another invocation before exiting.
+// Idle: how long the server waits for another invocation before exiting.
+// Lifetime: hard cap bounding how long a republished bundle can keep being
+// served when the envelope carries no bundle hash and gcsfuse metadata
+// caching hides the change from the per-request stat. Deadline: an
+// invocation that runs this long lost its client to front's much shorter
+// exec timeout ages ago; exit and free the socket.
 const IDLE_TIMEOUT_MS = 120_000;
+const MAX_LIFETIME_MS = 600_000;
+const INVOCATION_DEADLINE_MS = 120_000;
+
+// Per-invocation env vars inherited from the cold run that spawned this
+// server. Scrubbed at startup: they belong to that invocation, and every
+// request carries its own.
+const SPAWN_ENV_SCRUB_KEYS = ["DUST_SANDBOX_TOKEN", "DUST_POD_USER_IDENTITY"];
 
 const WarmRequestSchema = z.object({
   v: z.literal(WARM_PROTOCOL_VERSION),
@@ -52,6 +66,35 @@ const WarmRequestSchema = z.object({
 });
 
 type WarmRequest = z.infer<typeof WarmRequestSchema>;
+
+interface BundleStamp {
+  mtimeMs: number;
+  size: number;
+}
+
+async function statBundle(handlerPath: string): Promise<BundleStamp | null> {
+  try {
+    const s = await stat(handlerPath);
+    return { mtimeMs: s.mtimeMs, size: s.size };
+  } catch {
+    return null;
+  }
+}
+
+function sameStamp(a: BundleStamp | null, b: BundleStamp | null): boolean {
+  return (
+    a !== null && b !== null && a.mtimeMs === b.mtimeMs && a.size === b.size
+  );
+}
+
+async function sha256OfFile(path: string): Promise<string | null> {
+  try {
+    const bytes = await Bun.file(path).arrayBuffer();
+    return createHash("sha256").update(new Uint8Array(bytes)).digest("hex");
+  } catch {
+    return null;
+  }
+}
 
 export function parseWarmRequest(line: string): WarmRequest | null {
   let parsed: unknown;
@@ -86,21 +129,68 @@ export function clearAppliedEnv(applied: Set<string>): void {
   }
 }
 
-// Minimal surface of Bun's unix socket needed here.
+// Minimal surface of Bun's unix socket needed here, typed so the write path
+// can honor partial writes.
 interface WarmSocket {
   write(data: string | Uint8Array): number;
   end(): void;
+}
+
+/**
+ * Backpressure-aware write: Bun's socket.write returns how many bytes it
+ * accepted, and a large outcome can exceed the kernel buffer. The remainder
+ * is retried from the drain callback via the pending map; end() only happens
+ * once everything is flushed, so the client never sees a truncated JSON line.
+ */
+const pendingWrites = new Map<object, Uint8Array>();
+
+function writeThenEnd(socket: WarmSocket, payload: string): void {
+  const bytes = new TextEncoder().encode(payload);
+  const written = socket.write(bytes);
+  if (written >= bytes.length) {
+    socket.end();
+    return;
+  }
+  pendingWrites.set(socket, bytes.subarray(Math.max(written, 0)));
+}
+
+function drainPending(socket: WarmSocket): void {
+  const remaining = pendingWrites.get(socket);
+  if (!remaining) {
+    return;
+  }
+  const written = socket.write(remaining);
+  if (written >= remaining.length) {
+    pendingWrites.delete(socket);
+    socket.end();
+    return;
+  }
+  pendingWrites.set(socket, remaining.subarray(Math.max(written, 0)));
 }
 
 export async function serve(
   handlerPath: string,
   socketPath: string
 ): Promise<never> {
+  for (const key of SPAWN_ENV_SCRUB_KEYS) {
+    delete process.env[key];
+  }
+
   // Import eagerly: the server is spawned right after a cold run, so warming
   // now (rather than on first request) makes the very next invocation fast.
   // The module cache keyed by path is the whole point of this process. A
   // static import is impossible here: the bundle to serve is a runtime
   // argument, a different published function per server.
+  const importedStamp = await statBundle(handlerPath);
+  if (importedStamp === null) {
+    process.exit(1);
+  }
+  // Hash before importing so the hash describes the bytes the import reads;
+  // a write landing between the two is caught by the per-request stat.
+  const importedSha256 = await sha256OfFile(handlerPath);
+  if (importedSha256 === null) {
+    process.exit(1);
+  }
   try {
     await import(handlerPath);
   } catch {
@@ -124,11 +214,21 @@ export async function serve(
   };
 
   let busy = false;
+  let draining = false;
   let idleTimer = setTimeout(() => exit(0), IDLE_TIMEOUT_MS);
   const armIdle = () => {
     clearTimeout(idleTimer);
     idleTimer = setTimeout(() => exit(0), IDLE_TIMEOUT_MS);
   };
+  setTimeout(() => {
+    // Never exit mid-invocation: the in-flight request finishes and replies,
+    // then the drained server exits. New requests get `busy` meanwhile.
+    if (busy) {
+      draining = true;
+    } else {
+      exit(0);
+    }
+  }, MAX_LIFETIME_MS);
 
   const socketBuffers = new Map<object, string>();
 
@@ -137,10 +237,10 @@ export async function serve(
     response: Record<string, unknown>,
     { exitAfter = false }: { exitAfter?: boolean } = {}
   ): void {
-    socket.write(`${JSON.stringify(response)}\n`);
-    socket.end();
+    writeThenEnd(socket, `${JSON.stringify(response)}\n`);
     if (exitAfter) {
-      // Exit on the next tick so the write callbacks run.
+      // The flush of a tiny control frame cannot realistically backpressure;
+      // exit on the next tick so the write callbacks run.
       setTimeout(() => exit(0), 0);
     }
   }
@@ -149,6 +249,19 @@ export async function serve(
     socket: WarmSocket,
     request: WarmRequest
   ): Promise<void> {
+    // A republished bundle must never be served from the old import. One
+    // metadata call per request; any difference (or a vanished file) sends
+    // the client down the cold path, which respawns a fresh server.
+    const current = await statBundle(handlerPath);
+    if (!sameStamp(importedStamp, current)) {
+      reply(
+        socket,
+        { v: WARM_PROTOCOL_VERSION, stale: true },
+        { exitAfter: true }
+      );
+      return;
+    }
+
     let input: RequestInput;
     try {
       input = parseInput(request.input);
@@ -160,6 +273,25 @@ export async function serve(
         v: WARM_PROTOCOL_VERSION,
         outcome: { ok: false, error: { code: "bad_input", message } },
       });
+      return;
+    }
+
+    // Deterministic republish detection: front stamps each invocation with
+    // the sha256 of the bundle it published, so a server that imported older
+    // bytes is refused even while gcsfuse metadata caching still hides the
+    // rewrite from the stat above. Pre-ack, like every refusal: the client
+    // re-runs cold, which reads the bundle fresh and respawns a matching
+    // server. Unstamped envelopes (older front) keep the stat and lifetime
+    // backstops only.
+    if (
+      input.bundleSha256 !== undefined &&
+      input.bundleSha256 !== importedSha256
+    ) {
+      reply(
+        socket,
+        { v: WARM_PROTOCOL_VERSION, stale: true },
+        { exitAfter: true }
+      );
       return;
     }
 
@@ -178,11 +310,21 @@ export async function serve(
       return;
     }
 
+    // An invocation that outlives this deadline lost its client to front's
+    // exec timeout long ago. Exit without replying and free the socket; the
+    // hung function was never going to produce an outcome anyway.
+    const deadline = setTimeout(() => exit(1), INVOCATION_DEADLINE_MS);
+
     const applied = applyRequestEnv(request.env);
     try {
       const outcome = await invoke(handlerPath, input);
-      reply(socket, { v: WARM_PROTOCOL_VERSION, outcome });
+      reply(
+        socket,
+        { v: WARM_PROTOCOL_VERSION, outcome },
+        { exitAfter: draining }
+      );
     } finally {
+      clearTimeout(deadline);
       clearAppliedEnv(applied);
       busy = false;
       armIdle();
@@ -190,7 +332,7 @@ export async function serve(
   }
 
   function handleLine(socket: WarmSocket, line: string): void {
-    if (busy) {
+    if (busy || draining) {
       // Never queue: the caller's timeout is shorter than any queue wait
       // guarantee this server could make, and a queued request would execute
       // for a client that already gave up. An immediate busy reply sends the
@@ -231,11 +373,16 @@ export async function serve(
           socketBuffers.delete(socket);
           handleLine(socket, buffered.slice(0, newline));
         },
+        drain(socket) {
+          drainPending(socket);
+        },
         close(socket) {
           socketBuffers.delete(socket);
+          pendingWrites.delete(socket);
         },
         error(socket) {
           socketBuffers.delete(socket);
+          pendingWrites.delete(socket);
         },
       },
     });


### PR DESCRIPTION
## Description

Stacked on #30167 (the warm server core). This PR is the hardening pass; the mechanism and protocol are reviewed there.

Staleness: a republished bundle must never be served from the old import. The server stats the bundle (mtime/size) before every request, and additionally refuses any request whose `bundleSha256` (an additive envelope field, stamped by front in #30165) does not match the hash of the bytes it imported — deterministic even when gcsfuse metadata caching hides the rewrite from the stat. Both refusals are pre-ack: the client re-runs cold against the fresh bundle and respawns a matching server. A hard 600s lifetime bounds staleness for unstamped envelopes; the lifetime cap drains the in-flight invocation instead of exiting under it.

Secrets: the spawn-time invocation's token and user identity are scrubbed at server startup, so they never sit in an idle server's environment; every request carries its own.

Delivery: replies are flushed through the drain callback, so a large outcome that exceeds the kernel buffer cannot reach the client as a truncated JSON line. An invocation that outlives a 120s deadline exits the server without replying — its client lost to front's much shorter exec timeout long ago.

## Tests

bun test: rewritten bundle refused as stale with server exit, matching bundle hash served, mismatched hash refused as stale even with an unchanged stat, unstamped envelope served (older front), spawn-time secrets scrubbed while unrelated spawn env survives. Biome clean.

## Risk

None at runtime until #30144 ships the client. The refusal direction is safe by construction: a false stale costs one cold run, never a wrong result.

## Deploy Plan

Nothing on its own; ships with #30144's version bumps.
