### PR TITLE
Admin governance: Allow to filter by role in admin people page

### DIFF
--- a/front-api/routes/w/[wId]/members/search.test.ts
+++ b/front-api/routes/w/[wId]/members/search.test.ts
@@ -19,11 +19,13 @@ vi.mock(import("@app/lib/user_search/search"), async (importOriginal) => {
         searchTerm,
         offset,
         limit,
+        userIds,
       }: {
         owner: LightWorkspaceType;
         searchTerm: string;
         offset: number;
         limit: number;
+        userIds?: string[];
       }) => {
         const { memberships } =
           await MembershipResource.getMembershipsForWorkspace({
@@ -31,9 +33,11 @@ vi.mock(import("@app/lib/user_search/search"), async (importOriginal) => {
             includeUser: true,
           });
 
+        const allowedUserIds = userIds ? new Set(userIds) : undefined;
         const users = memberships
           .map((m) => m.user)
-          .filter((u): u is NonNullable<typeof u> => u !== undefined);
+          .filter((u): u is NonNullable<typeof u> => u !== undefined)
+          .filter((u) => !allowedUserIds || allowedUserIds.has(u.sId));
 
         const filteredUsers =
           searchTerm && searchTerm.trim()
@@ -155,6 +159,87 @@ describe("GET /api/w/:wId/members/search", () => {
     expect(data.members.map((m: { email: string }) => m.email)).toContain(
       users[1].email
     );
+  });
+
+  it("filters members by role", async () => {
+    const { workspace, user: adminUser } = await setup();
+
+    const [member, otherAdmin] = await Promise.all([
+      UserFactory.basic(),
+      UserFactory.basic(),
+    ]);
+
+    await MembershipFactory.associate(workspace, member, { role: "user" });
+    await MembershipFactory.associate(workspace, otherAdmin, {
+      role: "admin",
+    });
+
+    const response = await honoApp.request(
+      searchUrl(workspace.sId, { role: "admin" })
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.total).toBe(2);
+    expect(data.members.map((m: { sId: string }) => m.sId).sort()).toEqual(
+      [adminUser.sId, otherAdmin.sId].sort()
+    );
+  });
+
+  it("includes builders when filtering on the member role", async () => {
+    const { workspace } = await setup();
+
+    const [member, builder] = await Promise.all([
+      UserFactory.basic(),
+      UserFactory.basic(),
+    ]);
+
+    await MembershipFactory.associate(workspace, member, { role: "user" });
+    await MembershipFactory.associate(workspace, builder, { role: "builder" });
+
+    const response = await honoApp.request(
+      searchUrl(workspace.sId, { role: "user" })
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.total).toBe(2);
+    expect(data.members.map((m: { sId: string }) => m.sId).sort()).toEqual(
+      [member.sId, builder.sId].sort()
+    );
+  });
+
+  it("combines the role filter with the search term", async () => {
+    const { workspace } = await setup();
+
+    const [member, otherAdmin] = await Promise.all([
+      UserFactory.basic(),
+      UserFactory.basic(),
+    ]);
+
+    await MembershipFactory.associate(workspace, member, { role: "user" });
+    await MembershipFactory.associate(workspace, otherAdmin, {
+      role: "admin",
+    });
+
+    const response = await honoApp.request(
+      searchUrl(workspace.sId, { role: "admin", searchTerm: member.email })
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.total).toBe(0);
+    expect(data.members).toHaveLength(0);
+  });
+
+  it("returns 400 on an unknown role filter", async () => {
+    const { workspace } = await setup();
+
+    const response = await honoApp.request(
+      searchUrl(workspace.sId, { role: "not-a-role" })
+    );
+
+    expect(response.status).toBe(400);
   });
 
   it("returns 400 when too many emails provided", async () => {

--- a/front-api/routes/w/[wId]/members/search.ts
+++ b/front-api/routes/w/[wId]/members/search.ts
@@ -5,7 +5,7 @@ import type {
 import { searchMembers } from "@app/lib/api/workspace";
 import { MAX_SEARCH_EMAILS } from "@app/lib/memberships";
 import { GROUP_KINDS } from "@app/types/groups";
-import { toLightUserWithWorkspace } from "@app/types/user";
+import { ActiveRoleSchema, toLightUserWithWorkspace } from "@app/types/user";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -20,6 +20,8 @@ const SearchMembersQuerySchema = z.object({
   searchTerm: z.string().optional(),
   searchEmails: z.string().optional(),
   groupKind: z.enum(GROUP_KINDS).exclude(["system"]).optional(),
+  // Restricts the results to the members holding that role.
+  role: ActiveRoleSchema.optional(),
   // Deprecated: the builder-role filter was removed; accepted but ignored to
   // avoid breaking clients that still send it. Remove once no client does.
   buildersOnly: z
@@ -60,6 +62,7 @@ app.get(
         searchTerm: query.searchTerm,
         searchEmails: emails,
         groupKind: query.groupKind,
+        role: query.role,
       },
       query
     );

--- a/front/components/members/Roles.ts
+++ b/front/components/members/Roles.ts
@@ -20,6 +20,23 @@ export function normalizeDisplayRole<T extends RoleType>(role: T): T | "user" {
   return role;
 }
 
+export type RoleFilter = Exclude<ActiveRoleType, "builder"> | "all";
+
+// `builder` is not offered: it is deprecated and displayed as a regular member,
+// so the `user` filter covers it (see `searchMembers`).
+export const ROLE_FILTER_OPTIONS: { value: RoleFilter; label: string }[] = [
+  { value: "all", label: "All roles" },
+  { value: "admin", label: displayRoleCapitalized("admin") },
+  { value: "manager", label: displayRoleCapitalized("manager") },
+  { value: "user", label: displayRoleCapitalized("user") },
+];
+
+export function getRoleFilterLabel(filter: RoleFilter): string {
+  return (
+    ROLE_FILTER_OPTIONS.find((o) => o.value === filter)?.label ?? "All roles"
+  );
+}
+
 export const ROLES_DATA: Record<
   ActiveRoleType,
   { color: "warning" | "info" | "success" | "highlight" }

--- a/front/components/members/WorkspaceMembersSection.tsx
+++ b/front/components/members/WorkspaceMembersSection.tsx
@@ -7,6 +7,11 @@ import {
   type SearchMemberWithWorkspaceType,
 } from "@app/components/members/MemberSelectionTable";
 import { MembersList } from "@app/components/members/MembersList";
+import type { RoleFilter } from "@app/components/members/Roles";
+import {
+  getRoleFilterLabel,
+  ROLE_FILTER_OPTIONS,
+} from "@app/components/members/Roles";
 import { ChangeMemberModal } from "@app/components/workspace/ChangeMemberModal";
 import { isFreePlan, isUpgraded } from "@app/lib/plans/plan_codes";
 import { useSearchMembers } from "@app/lib/swr/memberships";
@@ -21,8 +26,13 @@ import type {
 } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 import {
+  Button,
   ButtonsSwitch,
   ButtonsSwitchList,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   SearchInput,
 } from "@dust-tt/sparkle";
 import type { PaginationState } from "@tanstack/react-table";
@@ -51,6 +61,7 @@ export function WorkspaceMembersSection({
 }: WorkspaceMembersSectionProps) {
   const [view, setView] = useState("members");
   const [searchTerm, setSearchTerm] = useState("");
+  const [roleFilter, setRoleFilter] = useState<RoleFilter>("all");
   const [inviteBlockedPopupReason, setInviteBlockedPopupReason] =
     useState<WorkspaceLimit | null>(null);
 
@@ -84,6 +95,27 @@ export function WorkspaceMembersSection({
           onChange={setSearchTerm}
           className="w-full"
         />
+        {view === "members" && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                isSelect
+                className="w-32 shrink-0 justify-between"
+                label={getRoleFilterLabel(roleFilter)}
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-48">
+              {ROLE_FILTER_OPTIONS.map((option) => (
+                <DropdownMenuItem
+                  key={option.value}
+                  label={option.label}
+                  onClick={() => setRoleFilter(option.value)}
+                />
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
         {isManualInvitationsEnabled && (
           <InviteEmailButtonWithModal
             owner={owner}
@@ -115,6 +147,7 @@ export function WorkspaceMembersSection({
           currentUser={currentUser}
           owner={owner}
           searchTerm={searchTerm}
+          roleFilter={roleFilter}
           isProvisioningEnabled={isProvisioningEnabled}
         />
       )}
@@ -140,6 +173,7 @@ interface WorkspaceMembersListProps {
   currentUser: UserType | null;
   owner: WorkspaceType;
   searchTerm: string;
+  roleFilter: RoleFilter;
   isProvisioningEnabled: boolean;
 }
 
@@ -147,6 +181,7 @@ function WorkspaceMembersList({
   currentUser,
   owner,
   searchTerm,
+  roleFilter,
   isProvisioningEnabled,
 }: WorkspaceMembersListProps) {
   const [pagination, setPagination] = useState<PaginationState>({
@@ -154,6 +189,7 @@ function WorkspaceMembersList({
     pageSize: DEFAULT_PAGE_SIZE,
   });
   const [prevSearchTerm, setPrevSearchTerm] = useState(searchTerm);
+  const [prevRoleFilter, setPrevRoleFilter] = useState(roleFilter);
 
   const [selectedMember, setSelectedMember] =
     useState<UserTypeWithWorkspace | null>(null);
@@ -164,10 +200,12 @@ function WorkspaceMembersList({
     pageIndex: pagination.pageIndex,
     pageSize: DEFAULT_PAGE_SIZE,
     groupKind: isProvisioningEnabled ? "provisioned" : undefined,
+    role: roleFilter === "all" ? undefined : roleFilter,
   });
 
-  if (searchTerm !== prevSearchTerm) {
+  if (searchTerm !== prevSearchTerm || roleFilter !== prevRoleFilter) {
     setPrevSearchTerm(searchTerm);
+    setPrevRoleFilter(roleFilter);
     setPagination({ pageIndex: 0, pageSize: DEFAULT_PAGE_SIZE });
   }
 

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -36,6 +36,7 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { md5 } from "@app/types/shared/utils/encryption";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type {
+  ActiveRoleType,
   LightUserTypeWithWorkspace,
   LightWorkspaceType,
   RoleType,
@@ -297,18 +298,54 @@ export async function getGroupMembersWithWorkspaces(
   });
 }
 
+// The user search index has no role field, so a role filter is resolved from the
+// active memberships and handed to Elasticsearch as a user allowlist.
+async function resolveRoleFilterUserIds({
+  workspace,
+  role,
+}: {
+  workspace: LightWorkspaceType;
+  role: ActiveRoleType;
+}): Promise<string[]> {
+  // `builder` is deprecated and surfaced to end users as a regular member, so
+  // filtering on `user` must include both.
+  const roles: ActiveRoleType[] =
+    role === "user" ? ["user", "builder"] : [role];
+
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace,
+    roles,
+  });
+
+  // The query's filter make sure `user` is never null, so nothing
+  // is dropped here.
+  return removeNulls(memberships.map((m) => m.user?.sId));
+}
+
 export async function searchMembers(
   auth: Authenticator,
   options: {
     searchTerm?: string;
     searchEmails?: string[];
     groupKind?: Exclude<GroupKind, "system">;
+    role?: ActiveRoleType;
   },
   paginationParams: SearchMembersPaginationParams
 ): Promise<{ members: UserTypeWithWorkspace[]; total: number }> {
   const owner = auth.workspace();
   if (!owner) {
     return { members: [], total: 0 };
+  }
+
+  let restrictToUserIds: string[] | undefined;
+  if (options.role) {
+    restrictToUserIds = await resolveRoleFilterUserIds({
+      workspace: owner,
+      role: options.role,
+    });
+    if (restrictToUserIds.length === 0) {
+      return { members: [], total: 0 };
+    }
   }
 
   let users: UserResource[];
@@ -324,12 +361,17 @@ export async function searchMembers(
       owner,
       options.searchEmails
     );
+    if (restrictToUserIds) {
+      const allowedUserIds = new Set(restrictToUserIds);
+      users = users.filter((u) => allowedUserIds.has(u.sId));
+    }
     total = users.length;
   } else {
     const results = await UserResource.searchUsers(auth, {
       searchTerm: options.searchTerm ?? "",
       offset: paginationParams.offset,
       limit: paginationParams.limit,
+      restrictToUserIds,
     });
 
     if (results.isErr()) {

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -20,6 +20,7 @@ import type { MembershipSeatType, PaidSeatType } from "@app/types/memberships";
 import { MEMBERSHIP_SEAT_TYPES, PAID_SEAT_TYPES } from "@app/types/memberships";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type {
+  ActiveRoleType,
   LightUserTypeWithWorkspace,
   LightWorkspaceType,
 } from "@app/types/user";
@@ -128,6 +129,7 @@ export function useSearchMembers<
   pageIndex,
   pageSize,
   groupKind,
+  role,
   disabled,
 }: {
   workspaceId: string;
@@ -135,6 +137,7 @@ export function useSearchMembers<
   pageIndex: number;
   pageSize: number;
   groupKind?: Exclude<GroupKind, "system">;
+  role?: ActiveRoleType;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
@@ -161,6 +164,10 @@ export function useSearchMembers<
 
   if (groupKind && isGroupKind(groupKind)) {
     searchParams.set("groupKind", groupKind);
+  }
+
+  if (role) {
+    searchParams.set("role", role);
   }
 
   const { data, error, mutate, mutateRegardlessOfQueryParams } =


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/9835

Allow admin to filter by role in the admin page for people so they can gind all the admin or all the managers.

Filtering is done server side (due to server side pagination) by resolving all the ids of the users with the given role before passing it to the ES search.

<img width="2426" height="1256" alt="image" src="https://github.com/user-attachments/assets/276b690a-1c77-4c0b-9ee8-65b37c362592" />



## Tests

tested locally

https://github.com/user-attachments/assets/5d702b43-44c8-446d-b2b4-cf30910e6e58


## Risk

low

## Deploy Plan

deploy front