### PR TITLE
feat: add searchbar in move to pod dropdown

### DIFF
--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -38,6 +38,7 @@ import {
   getConversationUrlAccessMode,
   isPodConversation,
 } from "@app/types/assistant/conversation";
+import type { SpaceType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
 import {
   ArrowRight,
@@ -47,6 +48,7 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuPortal,
+  DropdownMenuSearchbar,
   DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
@@ -243,9 +245,13 @@ export function ConversationMenu({
     options: { disabled: shouldWaitBeforeFetching },
   });
 
+  const [podSearchText, setPodSearchText] = useState<string>("");
   const filteredPods = summary
     .map(({ space }) => space)
-    .filter((space) => space.sId !== conversation?.spaceId);
+    .filter((space) => space.sId !== conversation?.spaceId)
+    .filter((space) =>
+      space.name.toLowerCase().includes(podSearchText.toLowerCase().trim())
+    );
 
   const conversationSpaceId =
     conversation && isPodConversation(conversation)
@@ -264,6 +270,16 @@ export function ConversationMenu({
   const moveConversationOutOfPod = useMoveConversationOutOfPod(
     owner,
     activeConversationId
+  );
+
+  const moveToPod = useCallback(
+    async (pod: SpaceType) => {
+      if (!conversation) {
+        return;
+      }
+      await moveConversationToPod(conversation, pod);
+    },
+    [conversation, moveConversationToPod]
   );
 
   const joinConversation = useJoinConversation({
@@ -429,7 +445,13 @@ export function ConversationMenu({
             disabled={isBranching}
           />
           <DropdownMenuSeparator />
-          <DropdownMenuSub>
+          <DropdownMenuSub
+            onOpenChange={(open) => {
+              if (!open) {
+                setPodSearchText("");
+              }
+            }}
+          >
             <DropdownMenuSubTrigger
               icon={ArrowRight}
               label={canMoveOutOfPod ? "Move to..." : "Move to Pod"}
@@ -438,6 +460,15 @@ export function ConversationMenu({
               <DropdownMenuSubContent
                 collisionPadding={16}
                 className="max-w-60"
+                dropdownHeaders={
+                  <DropdownMenuSearchbar
+                    name="pod-search"
+                    placeholder="Search Pods"
+                    value={podSearchText}
+                    onChange={setPodSearchText}
+                    autoFocus
+                  />
+                }
               >
                 <DropdownMenuItem
                   icon={Plus}
@@ -456,24 +487,22 @@ export function ConversationMenu({
                     />
                   </>
                 )}
-                {filteredPods.length > 0 && (
-                  <>
-                    <DropdownMenuSeparator />
-                    {canMoveOutOfPod && <DropdownMenuLabel label="Pods" />}
-                    {filteredPods.map((pod) => (
-                      <DropdownMenuItem
-                        key={pod.sId}
-                        icon={getSpaceIcon(pod)}
-                        label={pod.name}
-                        truncateText
-                        onClick={async () =>
-                          conversation
-                            ? moveConversationToPod(conversation, pod)
-                            : Promise.resolve(false)
-                        }
-                      />
-                    ))}
-                  </>
+                <DropdownMenuSeparator />
+                {canMoveOutOfPod && <DropdownMenuLabel label="Pods" />}
+                {filteredPods.length > 0 ? (
+                  filteredPods.map((pod) => (
+                    <DropdownMenuItem
+                      key={pod.sId}
+                      icon={getSpaceIcon(pod)}
+                      label={pod.name}
+                      truncateText
+                      onClick={async () => moveToPod(pod)}
+                    />
+                  ))
+                ) : (
+                  <div className="px-3 py-4 text-center text-xs italic text-muted-foreground">
+                    {!!podSearchText ? "No matches" : "No Pods"}
+                  </div>
                 )}
               </DropdownMenuSubContent>
             </DropdownMenuPortal>

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -458,6 +458,7 @@ export function AgentSidebarMenu({
   const agentsSearchInputRef = useRef<HTMLInputElement>(null);
   const [agentSearchText, setAgentSearchText] = useState("");
   const [skillSearchText, setSkillSearchText] = useState("");
+  const [podSearchText, setPodSearchText] = useState("");
   const [hasOpenedActionsMenu, setHasOpenedActionsMenu] = useState(false);
   const { agentConfigurations } = useUnifiedAgentConfigurations({
     workspaceId: owner.sId,
@@ -672,8 +673,13 @@ export function AgentSidebarMenu({
   }, [doDelete, selectedConversations, sendNotification, toggleMultiSelect]);
 
   const availablePods = useMemo(
-    () => summary.map(({ space }) => space),
-    [summary]
+    () =>
+      summary
+        .map(({ space }) => space)
+        .filter((space) =>
+          space.name.toLowerCase().includes(podSearchText.toLowerCase().trim())
+        ),
+    [summary, podSearchText]
   );
 
   const moveSelectionToPod = useCallback(
@@ -990,7 +996,14 @@ export function AgentSidebarMenu({
             {isMultiSelect ? (
               <div className="z-50 flex justify-between gap-2 border-b border-border-dark/60 p-2 mb-4">
                 <div className="flex gap-2">
-                  <DropdownMenu modal={false}>
+                  <DropdownMenu
+                    modal={false}
+                    onOpenChange={(open) => {
+                      if (!open) {
+                        setPodSearchText("");
+                      }
+                    }}
+                  >
                     <DropdownMenuTrigger asChild>
                       <Button
                         variant="outline"
@@ -1003,6 +1016,15 @@ export function AgentSidebarMenu({
                     <DropdownMenuContent
                       className="max-w-60"
                       onFocusOutside={(e) => e.preventDefault()}
+                      dropdownHeaders={
+                        <DropdownMenuSearchbar
+                          name="pod-search"
+                          placeholder="Search Pods"
+                          value={podSearchText}
+                          onChange={setPodSearchText}
+                          autoFocus
+                        />
+                      }
                     >
                       <DropdownMenuItem
                         icon={Plus}
@@ -1012,20 +1034,22 @@ export function AgentSidebarMenu({
                           setIsCreatePodModalOpen(true);
                         }}
                       />
-                      {availablePods.length > 0 && (
-                        <>
-                          <DropdownMenuSeparator />
-                          <DropdownMenuLabel label="Pods" />
-                          {availablePods.map((pod) => (
-                            <DropdownMenuItem
-                              key={pod.sId}
-                              icon={getSpaceIcon(pod)}
-                              label={pod.name}
-                              truncateText
-                              onClick={() => moveSelectionToPod(pod)}
-                            />
-                          ))}
-                        </>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuLabel label="Pods" />
+                      {availablePods.length > 0 ? (
+                        availablePods.map((pod) => (
+                          <DropdownMenuItem
+                            key={pod.sId}
+                            icon={getSpaceIcon(pod)}
+                            label={pod.name}
+                            truncateText
+                            onClick={() => moveSelectionToPod(pod)}
+                          />
+                        ))
+                      ) : (
+                        <div className="px-3 py-4 text-center text-xs italic text-muted-foreground">
+                          {!!podSearchText ? "No matches" : "No Pods"}
+                        </div>
                       )}
                     </DropdownMenuContent>
                   </DropdownMenu>


### PR DESCRIPTION
## Description

This PR adds a search bar to the "Move to Pod" dropdown in the conversation menu, allowing users to filter Pods by name when selecting a destination.

<img width="402" height="182" alt="Capture d’écran 2026-08-07 à 11 01 02" src="https://github.com/user-attachments/assets/609ba2a1-ab08-4ae6-b5d3-fab01315386b" />


## Tests

Manually.

## Risks

Low.

## Deploy Plan

Standard deployment.