### PR TITLE
fix: pause connectors when the workspace plan blocks API access

### DIFF
--- a/connectors/src/lib/temporal_monitoring.test.ts
+++ b/connectors/src/lib/temporal_monitoring.test.ts
@@ -157,4 +157,38 @@ describe("ActivityInboundLogInterceptor", () => {
       reason: "Stopped on RemoteDatabaseConnectionNotReadonlyError",
     });
   });
+
+  it("pauses the connector when the workspace plan does not allow API access", async () => {
+    const interceptor = new ActivityInboundLogInterceptor(
+      makeActivityContext(),
+      logger,
+      "snowflake"
+    );
+    const error = new Error(
+      `Error uploading to dust: ${JSON.stringify({
+        error: {
+          type: "workspace_can_use_product_required_error",
+          message:
+            "Your current plan does not allow API access. Please upgrade your plan.",
+        },
+      })}`
+    );
+    const input = {
+      args: [],
+      headers: {},
+    } satisfies ActivityExecuteInput;
+    const next = vi.fn(async () => {
+      throw error;
+    }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+
+    await expect(interceptor.execute(input, next)).rejects.toBe(error);
+
+    expect(mocks.syncFailed).toHaveBeenCalledWith(
+      42,
+      "workspace_plan_no_api_access"
+    );
+    expect(mocks.pauseAndStop).toHaveBeenCalledWith({
+      reason: "Stopped on workspace_can_use_product_required_error",
+    });
+  });
 });

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -3,6 +3,7 @@ import type logger from "@connectors/logger/logger";
 import type { Logger } from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
+import type { ConnectorErrorType } from "@connectors/types";
 import { WithRetriesError } from "@connectors/types";
 import type { ConnectorProvider } from "@dust-tt/client";
 import type { Context } from "@temporalio/activity";
@@ -26,6 +27,60 @@ import { getConnectorId } from "./temporal";
 
 const TRACK_SUCCESSFUL_ACTIVITIES_FOR_CONNECTOR_IDS = [145];
 const TRANSIENT_ERROR_PRE_BACKOFF_RETRY_ATTEMPTS = 19;
+
+// Dust API errors reach the interceptor as opaque errors whose message embeds
+// the serialized API response, so we match on the error type in the message.
+function isWorkspacePlanNoApiAccessError(err: unknown): err is Error {
+  return (
+    err instanceof Error &&
+    err.message.includes("workspace_can_use_product_required_error")
+  );
+}
+
+// Errors the connector cannot make progress on without a human action: it gets
+// marked as failed and paused instead of being retried.
+function categorizeFinalConnectorError(err: unknown): {
+  connectorErrorType: ConnectorErrorType;
+  logMessage: string;
+  pauseReason: string;
+} | null {
+  if (err instanceof ExternalOAuthTokenError) {
+    return {
+      connectorErrorType: "oauth_token_revoked",
+      logMessage: "Stopping connector manager because of expired token.",
+      pauseReason: `Stopped on ${err.name}`,
+    };
+  }
+
+  if (err instanceof RemoteDatabaseConnectionNotReadonlyError) {
+    return {
+      connectorErrorType: "remote_database_connection_not_readonly",
+      logMessage:
+        "Stopping connector manager because the remote database connection is not read-only.",
+      pauseReason: `Stopped on ${err.name}`,
+    };
+  }
+
+  if (err instanceof WorkspaceQuotaExceededError) {
+    return {
+      connectorErrorType: "workspace_quota_exceeded",
+      logMessage:
+        "Stopping connector manager because of quota exceeded for the workspace.",
+      pauseReason: `Stopped on ${err.name}`,
+    };
+  }
+
+  if (isWorkspacePlanNoApiAccessError(err)) {
+    return {
+      connectorErrorType: "workspace_plan_no_api_access",
+      logMessage:
+        "Stopping connector manager because the workspace plan does not allow API access.",
+      pauseReason: "Stopped on workspace_can_use_product_required_error",
+    };
+  }
+
+  return null;
+}
 
 function redactErrorForLogs(err: unknown) {
   if (err instanceof WithRetriesError) {
@@ -208,11 +263,8 @@ export class ActivityInboundLogInterceptor
         );
       }
 
-      if (
-        err instanceof ExternalOAuthTokenError ||
-        err instanceof RemoteDatabaseConnectionNotReadonlyError ||
-        err instanceof WorkspaceQuotaExceededError
-      ) {
+      const finalConnectorError = categorizeFinalConnectorError(err);
+      if (finalConnectorError) {
         // The connector cannot make progress without a human action, so pause it
         // and stop its workflow.
         if (connectorId) {
@@ -222,43 +274,16 @@ export class ActivityInboundLogInterceptor
             );
           }
 
-          if (err instanceof ExternalOAuthTokenError) {
-            await syncFailed(connectorId, "oauth_token_revoked");
-            this.logger.info(
-              {
-                connectorId,
-                dataSourceId,
-                error: err,
-                workspaceId,
-              },
-              `Stopping connector manager because of expired token.`
-            );
-          } else if (err instanceof RemoteDatabaseConnectionNotReadonlyError) {
-            await syncFailed(
+          await syncFailed(connectorId, finalConnectorError.connectorErrorType);
+          this.logger.info(
+            {
               connectorId,
-              "remote_database_connection_not_readonly"
-            );
-            this.logger.info(
-              {
-                connectorId,
-                dataSourceId,
-                error: err,
-                workspaceId,
-              },
-              `Stopping connector manager because the remote database connection is not read-only.`
-            );
-          } else {
-            await syncFailed(connectorId, "workspace_quota_exceeded");
-            this.logger.info(
-              {
-                connectorId,
-                dataSourceId,
-                error: err,
-                workspaceId,
-              },
-              `Stopping connector manager because of quota exceeded for the workspace.`
-            );
-          }
+              dataSourceId,
+              error: err,
+              workspaceId,
+            },
+            finalConnectorError.logMessage
+          );
 
           const connectorManager = getConnectorManager({
             connectorId: connector.id,
@@ -267,7 +292,7 @@ export class ActivityInboundLogInterceptor
 
           if (connectorManager) {
             await connectorManager.pauseAndStop({
-              reason: `Stopped on ${err.name}`,
+              reason: finalConnectorError.pauseReason,
             });
           } else {
             this.logger.error(

--- a/connectors/src/types/api.ts
+++ b/connectors/src/types/api.ts
@@ -69,6 +69,7 @@ const CONNECTORS_ERROR_TYPES = [
   "webcrawling_synchronization_limit_reached",
   "remote_database_connection_not_readonly",
   "remote_database_network_error",
+  "workspace_plan_no_api_access",
 ] as const;
 
 export type ConnectorErrorType = (typeof CONNECTORS_ERROR_TYPES)[number];

--- a/front/components/data_source/DataSourceSyncChip.tsx
+++ b/front/components/data_source/DataSourceSyncChip.tsx
@@ -111,6 +111,13 @@ export default function ConnectorSyncingChip({
             trigger={<Chip color="warning">Quota exceeded</Chip>}
           />
         );
+      case "workspace_plan_no_api_access":
+        return (
+          <Tooltip
+            label="Your current plan does not allow API access, which is required to synchronize data. Contact support@dust.tt to upgrade your plan."
+            trigger={<Chip color="warning">Synchronization failed</Chip>}
+          />
+        );
       default:
         assertNeverAndIgnore(connector.errorType);
     }

--- a/front/types/connectors/connectors_api.ts
+++ b/front/types/connectors/connectors_api.ts
@@ -62,6 +62,7 @@ export const CONNECTORS_ERROR_TYPES = [
   "webcrawling_synchronization_limit_reached",
   "remote_database_connection_not_readonly",
   "remote_database_network_error",
+  "workspace_plan_no_api_access",
 ] as const;
 
 export type ConnectorErrorType = (typeof CONNECTORS_ERROR_TYPES)[number];


### PR DESCRIPTION
## Description

Saw connector activities retrying forever on `workspace_can_use_product_required_error` (the workspace plan doesn't allow API access). Nothing about that gets better with a retry, so it now goes down the same path as the other errors requiring a human action in `ActivityInboundLogInterceptor`: `syncFailed` + `pauseAndStop`.

The three-way `instanceof` chain plus its nested `if/else if/else` became a `categorizeFinalConnectorError()` helper returning the error type, log message and pause reason.

## Tests

Added a case in `temporal_monitoring.test.ts` with the actual payload, asserting `syncFailed` and `pauseAndStop`.

## Risk

Low. Only widens an existing branch, no change for the other errors.

## Deploy Plan

Deploy `connectors` after `front`.