### PR TITLE
[front] feat: stamp invocations with the published bundle hash

### DIFF
--- a/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
@@ -12,6 +12,7 @@ import { sandboxFunctionContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 import assert from "assert";
+import { createHash } from "crypto";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -96,6 +97,9 @@ describe("publishSandboxFunction", () => {
     expect(fn.slug).toBe("greeter__greet");
     expect(fn.description).toBe("Greet someone.");
     expect(fn.userIdentity).toBe("interactive_workspace_user_required");
+    expect(fn.bundleSha256).toBe(
+      createHash("sha256").update("export default {};", "utf8").digest("hex")
+    );
     expect(fn.inputSchema).toEqual(inputSchema);
     expect(fn.outputSchema).toEqual(outputSchema);
 
@@ -261,6 +265,11 @@ describe("publishSandboxFunction", () => {
     expect(second.value.id).toBe(first.value.id);
     expect(second.value.description).toBe("v2");
     expect(second.value.userIdentity).toBe("optional");
+    // The hash follows the bundle: a republish must restamp it, or warm servers holding the old
+    // import would keep matching and serve stale code.
+    expect(second.value.bundleSha256).toBe(
+      createHash("sha256").update("v2", "utf8").digest("hex")
+    );
     expect(second.value.outputSchema).toEqual(newOutputSchema);
     // The bundle file is reused in place, not replaced: same row, canonical mount path retained, and
     // its version bumped by the re-upload.

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.ts
@@ -4,7 +4,10 @@ import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { deriveSandboxFunctionSlug } from "@app/lib/api/sandbox_functions/slug";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
-import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import {
+  computeSandboxFunctionBundleSha256,
+  SandboxFunctionResource,
+} from "@app/lib/resources/sandbox_function_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { SandboxFunctionExecutionMode } from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
@@ -120,6 +123,7 @@ export async function publishSandboxFunction(
     description,
     userIdentity,
     executionMode,
+    bundleSha256: computeSandboxFunctionBundleSha256(bundleCode),
     inputSchema,
     outputSchema,
   });

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -91,6 +91,9 @@ const outputSchema: JSONSchema = {
   required: ["commentId"],
 };
 
+// Stamped on the function at creation and expected back on every exec envelope.
+const TEST_BUNDLE_SHA256 = "a".repeat(64);
+
 beforeEach(() => {
   vi.clearAllMocks();
   fileStorageMock.reset();
@@ -121,6 +124,7 @@ async function setupExecutionTest(
     description: "Add a comment.",
     userIdentity,
     executionMode,
+    bundleSha256: TEST_BUNDLE_SHA256,
     inputSchema,
     outputSchema,
   });
@@ -750,6 +754,7 @@ describe("SandboxFunctionInvocationResource", () => {
       },
       body: JSON.stringify({ message: "hello" }),
       encoding: "utf8",
+      bundleSha256: TEST_BUNDLE_SHA256,
     });
   });
 

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -646,6 +646,13 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
           ? {}
           : { body: JSON.stringify(this.input) }),
         encoding: "utf8",
+        // From the persisted row, like the mode above: the warm server refuses to serve a
+        // bundle that does not hash to this, so a republished function is never run from a
+        // stale warm import. Null only for functions last published before hashes existed —
+        // those keep the server's stat/lifetime backstops.
+        ...(persistedFunction.bundleSha256 === null
+          ? {}
+          : { bundleSha256: persistedFunction.bundleSha256 }),
       };
       const userIdentity = getSandboxFunctionUserIdentity(
         auth,

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -40,6 +40,7 @@ import { Err, Ok, type Result } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import assert from "assert";
+import { createHash } from "crypto";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import type { Attributes, Transaction } from "sequelize";
 
@@ -48,6 +49,14 @@ export interface SandboxFunctionResource
   extends ReadonlyAttributesType<SandboxFunctionModel> {}
 
 export const SANDBOX_FUNCTION_PUBLISH_LOCK_TTL_MS = 5 * 60_000;
+
+/**
+ * Sha256 hex of a published bundle's utf8 bytes — the same bytes uploadContent writes and the
+ * in-sandbox warm server hashes off disk, so the two sides can compare (see the runner's serve.ts).
+ */
+export function computeSandboxFunctionBundleSha256(bundleCode: string): string {
+  return createHash("sha256").update(bundleCode, "utf8").digest("hex");
+}
 
 export function getSandboxFunctionPublishLockName(
   sandboxFunctionSId: string
@@ -115,6 +124,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       description,
       userIdentity = "optional",
       executionMode = DEFAULT_SANDBOX_FUNCTION_EXECUTION_MODE,
+      bundleSha256 = null,
       inputSchema,
       outputSchema,
     }: {
@@ -124,6 +134,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       description: string;
       userIdentity?: SandboxFunctionUserIdentityPolicy;
       executionMode?: SandboxFunctionExecutionMode;
+      bundleSha256?: string | null;
       inputSchema: JSONSchema;
       outputSchema: JSONSchema;
     },
@@ -164,6 +175,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         description,
         userIdentity,
         executionMode,
+        bundleSha256,
         inputSchema,
         outputSchema,
       },
@@ -236,6 +248,11 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
             description,
             userIdentity,
             executionMode,
+            // Derived from the exact code the upload above wrote. Landing with the row update
+            // (not before the upload) means a warm server can never be told to expect a bundle
+            // that is not on disk yet; invocations racing this publish carry the old hash and
+            // settle against whichever bundle they were issued for.
+            bundleSha256: computeSandboxFunctionBundleSha256(bundleCode),
             inputSchema,
             outputSchema,
           });

--- a/front/lib/resources/storage/models/sandbox_function.ts
+++ b/front/lib/resources/storage/models/sandbox_function.ts
@@ -54,6 +54,10 @@ export class SandboxFunctionModel extends WorkspaceAwareModel<SandboxFunctionMod
   declare description: string;
   declare userIdentity: SandboxFunctionUserIdentityPolicy | null;
   declare executionMode: CreationOptional<SandboxFunctionExecutionMode>;
+  // Sha256 hex of the published bundle. Stamped onto every invocation envelope so the in-sandbox
+  // warm server can refuse to serve a bundle the publisher has since replaced. Null only for
+  // functions last published before the column existed.
+  declare bundleSha256: string | null;
   declare inputSchema: JSONSchema;
   declare outputSchema: JSONSchema;
 
@@ -121,6 +125,10 @@ SandboxFunctionModel.init(
       validate: {
         isIn: [SANDBOX_FUNCTION_EXECUTION_MODES],
       },
+    },
+    bundleSha256: {
+      type: DataTypes.STRING(64),
+      allowNull: true,
     },
     inputSchema: {
       type: DataTypes.JSONB,

--- a/front/migrations/pre-deploy/20260807150000_add_bundle_sha256_to_sandbox_functions.sql
+++ b/front/migrations/pre-deploy/20260807150000_add_bundle_sha256_to_sandbox_functions.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_functions" ADD COLUMN "bundleSha256" character varying(64) COLLATE "pg_catalog"."default";


### PR DESCRIPTION
## Description

Last slice of the warm runner stack (#30160, #30144, #30146, this). Makes republish-then-invoke deterministic: an agent that republishes a function can never be served the previous bundle from a warm server.

Publish stores the sha256 of the bundle it uploaded (new `bundleSha256` column, restamped by every republish alongside the upload), and every invocation envelope carries it, read from the persisted row like the execution mode. The warm server (#30160) hashes the bundle it imported and refuses any request whose expected hash differs, pre-ack, so the client re-runs cold against the fresh bundle and respawns a matching server. This does not depend on gcsfuse metadata behavior; the server's stat check and 600s lifetime remain as backstops for envelopes without a hash.

The hash lands with the row update after the upload, so a warm server is never told to expect a bundle that is not on disk yet. Functions last published before the column existed have a null hash and keep today's backstop-only behavior until their next republish. Deployed dsbx 0.1.41 runners ignore the extra envelope field (verified against its parser), so this is safe to merge independently of the image rollout.

## Tests

Publish suite asserts the hash is stored on first publish and restamped on republish; invocation suite asserts the exec envelope carries the function's hash. The server-side refusal is tested in #30160 (matching hash served, mismatched hash refused as stale with server exit, unstamped envelope served). front typechecks clean.

## Risk

Envelope field is additive and ignored by every deployed runner. Worst case of a bad hash would be warm refusals falling back to cold runs, never a wrong result. Pre-deploy migration adds a nullable column.

## Deploy Plan

Pre-deploy migration, then normal deploy. No ordering constraint with the dsbx release: stamped envelopes are inert until sandboxes run the 0.1.42 image from #30144.
