### PR TITLE
[dsbx] perf: runner serve mode keeping one bundle warm behind a unix socket

### DIFF
--- a/cli/dust-sandbox/functions-runner/fixtures/env-probe.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/env-probe.ts
@@ -1,0 +1,10 @@
+// Echoes marker env vars so warm-server tests can observe which environment
+// an invocation ran under.
+export default {
+  async fetch(): Promise<Response> {
+    return Response.json({
+      marker: process.env.WARM_TEST_MARKER ?? "unset",
+      token: process.env.DUST_SANDBOX_TOKEN ?? "unset",
+    });
+  },
+};

--- a/cli/dust-sandbox/functions-runner/fixtures/slow.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/slow.ts
@@ -1,0 +1,7 @@
+// Sleeps briefly so warm-server tests can observe the busy reply.
+export default {
+  async fetch(): Promise<Response> {
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    return Response.json({ done: true });
+  },
+};

--- a/cli/dust-sandbox/functions-runner/runner.ts
+++ b/cli/dust-sandbox/functions-runner/runner.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env bun
 // Embedded runner for `dsbx function` and `dsbx db`. Subcommands:
 //   runner run <path>                            stdin request envelope -> stdout Output JSON
+//   runner serve <path> <socketPath>             warm server: keep <path> imported, serve
+//                                                invocations over a unix socket until idle
 //   runner get <path>                            -> stdout FunctionSchema JSON (or {error})
 //   runner build <src> <outBundle> <outSchema>   bundle + extract schema to files
 //   runner db-reconcile <dbPath> <schemaFile>    additive-only DDL reconcile -> stdout envelope
@@ -17,6 +19,7 @@ import { generateSchemaFileText } from "./db/schema.ts";
 import { invoke } from "./invoke.ts";
 import { BadInputError, parseInput, type RequestInput } from "./protocol.ts";
 import { getFunctionSchema } from "./schema.ts";
+import { serve } from "./serve.ts";
 
 async function runHandler(handlerPath: string): Promise<number> {
   const raw = await Bun.stdin.text();
@@ -152,7 +155,7 @@ async function main(): Promise<number> {
 
   const [handlerPath] = rest;
   if (!handlerPath) {
-    process.stderr.write("usage: runner <run|get> <handler-path>\n");
+    process.stderr.write("usage: runner <run|get|serve> <handler-path>\n");
     return 2;
   }
   switch (command) {
@@ -160,6 +163,17 @@ async function main(): Promise<number> {
       return runHandler(handlerPath);
     case "get":
       return getHandler(handlerPath);
+    case "serve": {
+      const [, socketPath] = rest;
+      if (!socketPath) {
+        process.stderr.write(
+          "usage: runner serve <handler-path> <socket-path>\n"
+        );
+        return 2;
+      }
+      // Never returns: the server exits itself (idle, lifetime, staleness).
+      return serve(handlerPath, socketPath);
+    }
     default:
       process.stderr.write(`runner: unknown command "${command}"\n`);
       return 2;

--- a/cli/dust-sandbox/functions-runner/serve.test.ts
+++ b/cli/dust-sandbox/functions-runner/serve.test.ts
@@ -1,0 +1,349 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  applyRequestEnv,
+  clearAppliedEnv,
+  parseWarmRequest,
+  WARM_PROTOCOL_VERSION,
+} from "./serve.ts";
+
+const runner = join(import.meta.dir, "runner.ts");
+const fx = (n: string) => join(import.meta.dir, "fixtures", n);
+
+// Each test gets its own scratch dir holding the socket.
+let scratchDirs: string[] = [];
+
+function scratch(): string {
+  const dir = mkdtempSync(join(tmpdir(), "dsbx-serve-test-"));
+  scratchDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of scratchDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  scratchDirs = [];
+});
+
+interface ServerHandle {
+  proc: ReturnType<typeof Bun.spawn>;
+  socketPath: string;
+}
+
+async function startServer(handlerPath: string): Promise<ServerHandle> {
+  const socketPath = join(scratch(), "fn.sock");
+  const proc = Bun.spawn(["bun", runner, "serve", handlerPath, socketPath], {
+    stdin: "ignore",
+    stdout: "ignore",
+    stderr: "inherit",
+  });
+  // Wait for the socket to accept connections.
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    try {
+      const probe = await Bun.connect({
+        unix: socketPath,
+        socket: { data() {} },
+      });
+      probe.end();
+      return { proc, socketPath };
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+  throw new Error("warm server did not come up");
+}
+
+interface WarmReply {
+  v: number;
+  ack?: boolean;
+  outcome?: { ok: boolean; output?: unknown; error?: { code: string } };
+  busy?: boolean;
+  error?: string;
+}
+
+// Collects every newline-delimited frame until the server closes the
+// connection: a served invocation is [ack, outcome], every refusal is a
+// single frame.
+async function requestFrames(
+  socketPath: string,
+  payload: unknown
+): Promise<WarmReply[]> {
+  let buffered = "";
+  const frames: WarmReply[] = [];
+  let resolveDone: () => void;
+  const done = new Promise<void>((resolve) => {
+    resolveDone = resolve;
+  });
+  const socket = await Bun.connect({
+    unix: socketPath,
+    socket: {
+      data(_socket, chunk) {
+        buffered += chunk.toString();
+        let newline = buffered.indexOf("\n");
+        while (newline !== -1) {
+          frames.push(JSON.parse(buffered.slice(0, newline)) as WarmReply);
+          buffered = buffered.slice(newline + 1);
+          newline = buffered.indexOf("\n");
+        }
+      },
+      close() {
+        resolveDone();
+      },
+      error() {
+        resolveDone();
+      },
+    },
+  });
+  socket.write(`${JSON.stringify(payload)}\n`);
+  await done;
+  return frames;
+}
+
+// The last frame carries the request's terminal answer (outcome or refusal).
+async function request(
+  socketPath: string,
+  payload: unknown
+): Promise<WarmReply> {
+  const frames = await requestFrames(socketPath, payload);
+  if (frames.length === 0) {
+    throw new Error("server closed without any frame");
+  }
+  return frames[frames.length - 1]!;
+}
+
+function warmRequest(env: Record<string, string>, input: unknown) {
+  return {
+    v: WARM_PROTOCOL_VERSION,
+    env,
+    input: JSON.stringify(input),
+  };
+}
+
+describe("runner serve", () => {
+  test("serves an invocation over the socket", async () => {
+    const { proc, socketPath } = await startServer(fx("hello.ts"));
+    try {
+      const reply = await request(
+        socketPath,
+        warmRequest({}, { url: "http://localhost/?name=warm" })
+      );
+      expect(reply.v).toBe(WARM_PROTOCOL_VERSION);
+      expect(reply.outcome?.ok).toBe(true);
+      expect(reply.outcome?.output).toEqual({ hello: "warm" });
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("serves repeat invocations from the same process", async () => {
+    const { proc, socketPath } = await startServer(fx("hello.ts"));
+    try {
+      for (const name of ["one", "two", "three"]) {
+        const reply = await request(
+          socketPath,
+          warmRequest({}, { url: `http://localhost/?name=${name}` })
+        );
+        expect(reply.outcome?.output).toEqual({ hello: name });
+      }
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("applies per-request env and clears it between requests", async () => {
+    // env-probe.ts echoes process.env.WARM_TEST_MARKER, so the reply proves
+    // which env the invocation ran under.
+    const { proc, socketPath } = await startServer(fx("env-probe.ts"));
+    try {
+      const first = await request(
+        socketPath,
+        warmRequest(
+          { WARM_TEST_MARKER: "alpha", DUST_SANDBOX_TOKEN: "tok-alpha" },
+          { url: "http://localhost/" }
+        )
+      );
+      expect(first.outcome?.output).toEqual({
+        marker: "alpha",
+        token: "tok-alpha",
+      });
+
+      // The second request carries neither: nothing may leak over from the
+      // first invocation — in particular not its sandbox token.
+      const second = await request(
+        socketPath,
+        warmRequest({}, { url: "http://localhost/" })
+      );
+      expect(second.outcome?.output).toEqual({
+        marker: "unset",
+        token: "unset",
+      });
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("rejects a protocol version it does not speak and exits", async () => {
+    const { proc, socketPath } = await startServer(fx("hello.ts"));
+    try {
+      const reply = await request(socketPath, {
+        v: 999,
+        env: {},
+        input: "{}",
+      });
+      expect(reply.error).toBe("bad warm request");
+      expect(await proc.exited).toBe(0);
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("acks before the outcome so the client can pin execution start", async () => {
+    const { proc, socketPath } = await startServer(fx("hello.ts"));
+    try {
+      const frames = await requestFrames(
+        socketPath,
+        warmRequest({}, { url: "http://localhost/?name=frames" })
+      );
+      expect(frames.length).toBe(2);
+      expect(frames[0]?.ack).toBe(true);
+      expect(frames[1]?.outcome?.output).toEqual({ hello: "frames" });
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("replies busy instead of queueing behind a running invocation", async () => {
+    const { proc, socketPath } = await startServer(fx("slow.ts"));
+    try {
+      const slow = request(
+        socketPath,
+        warmRequest({}, { url: "http://localhost/" })
+      );
+      // Give the slow request time to reach the server and start executing.
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      const overlapped = await request(
+        socketPath,
+        warmRequest({}, { url: "http://localhost/" })
+      );
+      // Queueing would run this request for a client whose front-side
+      // timeout may already have fired; busy sends it cold immediately.
+      expect(overlapped.busy).toBe(true);
+      expect(overlapped.outcome).toBeUndefined();
+
+      const first = await slow;
+      expect(first.outcome?.output).toEqual({ done: true });
+
+      // The server survives and serves again once free.
+      const after = await request(
+        socketPath,
+        warmRequest({}, { url: "http://localhost/" })
+      );
+      expect(after.outcome?.output).toEqual({ done: true });
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("reports runner errors as structured outcomes", async () => {
+    const { proc, socketPath } = await startServer(fx("throws.ts"));
+    try {
+      const reply = await request(
+        socketPath,
+        warmRequest({}, { url: "http://localhost/" })
+      );
+      expect(reply.outcome?.ok).toBe(false);
+      expect(reply.outcome?.error?.code).toBe("threw");
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("reports malformed envelopes as bad_input without dying", async () => {
+    const { proc, socketPath } = await startServer(fx("hello.ts"));
+    try {
+      const bad = await request(socketPath, {
+        v: WARM_PROTOCOL_VERSION,
+        env: {},
+        input: "not json",
+      });
+      expect(bad.outcome?.ok).toBe(false);
+      expect(bad.outcome?.error?.code).toBe("bad_input");
+
+      // The server survives a bad envelope: the next request still works.
+      const good = await request(
+        socketPath,
+        warmRequest({}, { url: "http://localhost/?name=alive" })
+      );
+      expect(good.outcome?.output).toEqual({ hello: "alive" });
+    } finally {
+      proc.kill();
+    }
+  });
+});
+
+describe("parseWarmRequest", () => {
+  test("parses a request and keeps only string env values", () => {
+    const parsed = parseWarmRequest(
+      JSON.stringify({
+        v: WARM_PROTOCOL_VERSION,
+        env: { KEEP: "yes", DROP_NUMBER: 3, DROP_NULL: null },
+        input: "{}",
+      })
+    );
+    expect(parsed).toEqual({
+      v: WARM_PROTOCOL_VERSION,
+      env: { KEEP: "yes" },
+      input: "{}",
+    });
+  });
+
+  test("returns null for every malformed request", () => {
+    expect(parseWarmRequest("not json")).toBeNull();
+    expect(parseWarmRequest('"a string"')).toBeNull();
+    expect(
+      parseWarmRequest(JSON.stringify({ v: 999, env: {}, input: "{}" }))
+    ).toBeNull();
+    expect(
+      parseWarmRequest(
+        JSON.stringify({ v: WARM_PROTOCOL_VERSION, input: "{}" })
+      )
+    ).toBeNull();
+    expect(
+      parseWarmRequest(
+        JSON.stringify({ v: WARM_PROTOCOL_VERSION, env: null, input: "{}" })
+      )
+    ).toBeNull();
+    expect(
+      parseWarmRequest(
+        JSON.stringify({ v: WARM_PROTOCOL_VERSION, env: {}, input: 7 })
+      )
+    ).toBeNull();
+  });
+});
+
+describe("applyRequestEnv", () => {
+  test("applies for the invocation and clears afterwards", () => {
+    const original = process.env.SERVE_TEST_KEY;
+    try {
+      const applied = applyRequestEnv({ SERVE_TEST_KEY: "one" });
+      expect(process.env.SERVE_TEST_KEY).toBe("one");
+
+      // Cleared after the invocation: per-request secrets (the sandbox
+      // token travels in env) must not sit in the idle server's environment.
+      clearAppliedEnv(applied);
+      expect(process.env.SERVE_TEST_KEY).toBeUndefined();
+    } finally {
+      if (original === undefined) {
+        delete process.env.SERVE_TEST_KEY;
+      } else {
+        process.env.SERVE_TEST_KEY = original;
+      }
+    }
+  });
+});

--- a/cli/dust-sandbox/functions-runner/serve.ts
+++ b/cli/dust-sandbox/functions-runner/serve.ts
@@ -1,0 +1,278 @@
+// Warm function server: keeps one imported function bundle resident in a bun
+// process and serves invocations over a unix socket, so repeat invocations skip
+// process spawn, bundle resolution, and the import of the bundle and its
+// dependencies (the dominant sandbox-side costs of a cold run).
+//
+// One server serves exactly one handler path, one invocation at a time. The
+// per-invocation environment (sandbox token, user identity) travels in the
+// request and is applied to process.env for the duration of the invocation,
+// then cleared — concurrency would race those swaps, so a request arriving
+// while one is running gets an immediate `busy` reply and the client runs
+// cold instead of queueing behind work of unknown duration.
+//
+// Duplicate executions are the failure mode this protocol is shaped around:
+// pod functions are arbitrary side-effectful code, and front assumes a failed
+// start means nothing ran. The server acks before executing; the client only
+// falls back to the cold path on failures that precede the ack. After the
+// ack, a lost outcome is reported as a failed invocation, never re-run.
+//
+// The server is disposable: it exits on idle and on any malformed request.
+// The staleness, secret-scrubbing, backpressure, lifetime, and deadline
+// hardening lands separately on top of this core.
+
+import { unlinkSync } from "node:fs";
+import { unlink } from "node:fs/promises";
+
+import { z } from "zod";
+
+import { invoke } from "./invoke.ts";
+import type { RequestInput } from "./protocol.ts";
+import { BadInputError, parseInput } from "./protocol.ts";
+
+export const WARM_PROTOCOL_VERSION = 1;
+
+// How long the server waits for another invocation before exiting.
+const IDLE_TIMEOUT_MS = 120_000;
+
+const WarmRequestSchema = z.object({
+  v: z.literal(WARM_PROTOCOL_VERSION),
+  // Non-string values are dropped rather than refused: only strings can be
+  // applied to process.env, and the request must not die for an ignorable
+  // field.
+  env: z.record(z.string(), z.unknown()).transform((env) => {
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(env)) {
+      if (typeof value === "string") {
+        out[key] = value;
+      }
+    }
+    return out;
+  }),
+  input: z.string(),
+});
+
+type WarmRequest = z.infer<typeof WarmRequestSchema>;
+
+export function parseWarmRequest(line: string): WarmRequest | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  const result = WarmRequestSchema.safeParse(parsed);
+  return result.success ? result.data : null;
+}
+
+/**
+ * Applies a request's environment on top of process.env and returns the keys
+ * it set, so the caller can clear them once the invocation completes. The
+ * request carries the client's full environment, so the invocation sees
+ * exactly what a cold run's child would have inherited; clearing afterwards
+ * keeps per-invocation secrets out of the idle server's environment.
+ */
+export function applyRequestEnv(env: Record<string, string>): Set<string> {
+  const applied = new Set<string>();
+  for (const [key, value] of Object.entries(env)) {
+    process.env[key] = value;
+    applied.add(key);
+  }
+  return applied;
+}
+
+export function clearAppliedEnv(applied: Set<string>): void {
+  for (const key of applied) {
+    delete process.env[key];
+  }
+}
+
+// Minimal surface of Bun's unix socket needed here.
+interface WarmSocket {
+  write(data: string | Uint8Array): number;
+  end(): void;
+}
+
+export async function serve(
+  handlerPath: string,
+  socketPath: string
+): Promise<never> {
+  // Import eagerly: the server is spawned right after a cold run, so warming
+  // now (rather than on first request) makes the very next invocation fast.
+  // The module cache keyed by path is the whole point of this process. A
+  // static import is impossible here: the bundle to serve is a runtime
+  // argument, a different published function per server.
+  try {
+    await import(handlerPath);
+  } catch {
+    // A bundle that fails to import still gets served: invoke() reports the
+    // import error as a structured outcome, exactly like a cold run would.
+  }
+
+  let boundSocket = false;
+  const exit = (code: number): never => {
+    // Remove the socket first so no client connects to a dying server — but
+    // only if this server owns it: a duplicate that lost the bind race must
+    // not delete the winner's socket on its way out.
+    if (boundSocket) {
+      try {
+        unlinkSync(socketPath);
+      } catch {
+        // Best effort.
+      }
+    }
+    process.exit(code);
+  };
+
+  let busy = false;
+  let idleTimer = setTimeout(() => exit(0), IDLE_TIMEOUT_MS);
+  const armIdle = () => {
+    clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => exit(0), IDLE_TIMEOUT_MS);
+  };
+
+  const socketBuffers = new Map<object, string>();
+
+  function reply(
+    socket: WarmSocket,
+    response: Record<string, unknown>,
+    { exitAfter = false }: { exitAfter?: boolean } = {}
+  ): void {
+    socket.write(`${JSON.stringify(response)}\n`);
+    socket.end();
+    if (exitAfter) {
+      // Exit on the next tick so the write callbacks run.
+      setTimeout(() => exit(0), 0);
+    }
+  }
+
+  async function runInvocation(
+    socket: WarmSocket,
+    request: WarmRequest
+  ): Promise<void> {
+    let input: RequestInput;
+    try {
+      input = parseInput(request.input);
+    } catch (e) {
+      // Pre-ack: a malformed envelope never executed anything, and the cold
+      // runner would classify it the same way.
+      const message = e instanceof BadInputError ? e.message : String(e);
+      reply(socket, {
+        v: WARM_PROTOCOL_VERSION,
+        outcome: { ok: false, error: { code: "bad_input", message } },
+      });
+      return;
+    }
+
+    // The ack is the point of no return: from here the client must never
+    // fall back to the cold path, because the function may have side effects
+    // in flight. A lost outcome after this frame is a failed invocation, not
+    // a retried one.
+    busy = true;
+    const ackWritten = socket.write(
+      `${JSON.stringify({ v: WARM_PROTOCOL_VERSION, ack: true })}\n`
+    );
+    if (ackWritten <= 0) {
+      // The client is already gone; do not execute for a dead client.
+      busy = false;
+      socket.end();
+      return;
+    }
+
+    const applied = applyRequestEnv(request.env);
+    try {
+      const outcome = await invoke(handlerPath, input);
+      reply(socket, { v: WARM_PROTOCOL_VERSION, outcome });
+    } finally {
+      clearAppliedEnv(applied);
+      busy = false;
+      armIdle();
+    }
+  }
+
+  function handleLine(socket: WarmSocket, line: string): void {
+    if (busy) {
+      // Never queue: the caller's timeout is shorter than any queue wait
+      // guarantee this server could make, and a queued request would execute
+      // for a client that already gave up. An immediate busy reply sends the
+      // client down the cold path before anything ran.
+      reply(socket, { v: WARM_PROTOCOL_VERSION, busy: true });
+      return;
+    }
+    const request = parseWarmRequest(line);
+    if (request === null) {
+      // A client this server does not understand; dying lets the cold path
+      // respawn a matching one.
+      reply(
+        socket,
+        { v: WARM_PROTOCOL_VERSION, error: "bad warm request" },
+        { exitAfter: true }
+      );
+      return;
+    }
+    void runInvocation(socket, request);
+  }
+
+  const bind = () =>
+    Bun.listen({
+      unix: socketPath,
+      socket: {
+        open() {
+          // Probe connections (the client checks for a listener before
+          // spawning a duplicate server) send no data; the idle timer keeps
+          // running so they cannot pin the server alive.
+        },
+        data(socket, chunk) {
+          const buffered = (socketBuffers.get(socket) ?? "") + chunk.toString();
+          const newline = buffered.indexOf("\n");
+          if (newline === -1) {
+            socketBuffers.set(socket, buffered);
+            return;
+          }
+          socketBuffers.delete(socket);
+          handleLine(socket, buffered.slice(0, newline));
+        },
+        close(socket) {
+          socketBuffers.delete(socket);
+        },
+        error(socket) {
+          socketBuffers.delete(socket);
+        },
+      },
+    });
+
+  try {
+    bind();
+    boundSocket = true;
+  } catch {
+    // The socket path exists. Either a live server owns it — this process is
+    // a lost spawn race and must exit without touching the winner's socket —
+    // or it is a stale leftover from a dead server, which is safe to replace.
+    const listening = await new Promise<boolean>((resolve) => {
+      Bun.connect({
+        unix: socketPath,
+        socket: {
+          open(probe) {
+            resolve(true);
+            probe.end();
+          },
+          data() {},
+          error() {
+            resolve(false);
+          },
+          connectError() {
+            resolve(false);
+          },
+        },
+      }).catch(() => resolve(false));
+    });
+    if (listening) {
+      process.exit(0);
+    }
+    await unlink(socketPath).catch(() => {});
+    bind();
+    boundSocket = true;
+  }
+
+  // The process stays alive on the event loop; exits go through exit() above.
+  return new Promise<never>(() => {});
+}


### PR DESCRIPTION
## Description

First slice of the warm function runner stack (this, #30160 hardening, #30144 dsbx client and version bumps, #30146 metric, #30165 bundle-hash stamping).

A cold `dsbx function run` pays bundle resolution against the gcsfuse mount, a runner temp-file write, a bun process spawn, and the import of the bundle and its dependencies, on every invocation. Measured locally, the import alone is ~150ms cold versus ~10ms once cached.

The runner gains a `serve` subcommand: a bun process that keeps one imported bundle resident behind a unix socket so a repeat invocation costs one local socket round trip. This PR is the core mechanism and protocol; nothing invokes `serve` until the dsbx client lands in #30144.

Protocol decisions reviewed here: the server acks before executing, so a client can distinguish pre-ack failures (safe to fall back cold) from a lost outcome after the ack (never retried — pod functions are side-effectful and must not run twice). Requests are never queued: one invocation at a time, and a request arriving while one runs gets an immediate busy reply so the client runs cold instead of waiting behind work of unknown duration. Per-request environment (the sandbox token and user identity travel in env) is applied for the invocation and cleared afterwards. The server exits on idle (120s), on any malformed request, and it resolves the spawn race on an existing socket by probing for a live listener.

The hardening — bundle staleness (stat plus the envelope's bundle hash), spawn-time secret scrubbing, backpressure-safe replies, the lifetime cap, and the invocation deadline — lands in #30160 on top of this.

## Tests

bun test: served invocation, repeat invocations from one process, env applied and cleared between requests (including the sandbox token), busy instead of queueing with recovery, ack-before-outcome framing, protocol version refusal, structured runner errors, malformed envelopes survived. Biome clean.

## Risk

None at runtime: the subcommand is unreachable until #30144 ships the client, and `runner.js` is only rebuilt by the dsbx release workflow.

## Deploy Plan

Nothing on its own; ships with #30144's version bumps.
