### PR TITLE
Require run usage on consumption items

### DIFF
--- a/front/lib/models/agent/agent_message_consumption_item.ts
+++ b/front/lib/models/agent/agent_message_consumption_item.ts
@@ -22,9 +22,6 @@ function validateConsumptionItemShape(
   if (isTool && this.agentMCPActionId === null) {
     throw new Error("Tool attribution items require an agent MCP action");
   }
-  if (!isTool && this.runUsageId === null) {
-    throw new Error("Non-tool attribution items require a run usage");
-  }
   if (!isTool && this.agentMCPActionId !== null) {
     throw new Error("Only tool attribution items may reference an action");
   }
@@ -84,7 +81,7 @@ export class AgentMessageConsumptionItemModel extends WorkspaceAwareModel<AgentM
 
   declare conversationId: ForeignKey<ConversationModel["id"]>;
   declare agentMessageId: ForeignKey<AgentMessageModel["id"]>;
-  declare runUsageId: ModelId | null;
+  declare runUsageId: ModelId;
   declare agentMCPActionId: ModelId | null;
   declare itemKey: string;
   declare itemType: AgentMessageConsumptionItemType;
@@ -126,7 +123,7 @@ AgentMessageConsumptionItemModel.init(
     },
     runUsageId: {
       type: DataTypes.BIGINT,
-      allowNull: true,
+      allowNull: false,
     },
     agentMCPActionId: {
       type: DataTypes.BIGINT,

--- a/front/lib/resources/agent_message_consumption_item_resource.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.ts
@@ -31,7 +31,7 @@ type ConsumptionItemEvidenceBase = {
 
 export type CompletedToolConsumptionItem = ConsumptionItemEvidenceBase & {
   itemType: "tool";
-  runUsageModelId: ModelId | null;
+  runUsageModelId: ModelId;
   action: AgentMCPActionResource;
   /** Estimated tokens in the result returned by this tool execution */
   inputTokensCount: number | null;
@@ -42,7 +42,7 @@ export type CompletedToolConsumptionItem = ConsumptionItemEvidenceBase & {
 
 export type PendingToolConsumptionItem = ConsumptionItemEvidenceBase & {
   action: AgentMCPActionResource;
-  runUsageModelId: ModelId | null;
+  runUsageModelId: ModelId;
   /** Estimated tokens in the model output that emitted the tool name and arguments */
   outputTokensCount: number | null;
 };

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -36,6 +36,7 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { RunFactory } from "@app/tests/utils/RunFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
@@ -825,11 +826,12 @@ describe("destroyConversation", () => {
       },
     });
 
+    const { runUsageModelId } = await RunFactory.createWithUsage(auth);
     await AgentMessageConsumptionItemModel.create({
       workspaceId: auth.getNonNullableWorkspace().id,
       conversationId: conversation.id,
       agentMessageId,
-      runUsageId: null,
+      runUsageId: runUsageModelId,
       agentMCPActionId: action.id,
       itemKey: `tool-action:${action.id}`,
       itemType: "tool",

--- a/front/migrations/post-deploy/20260807112434_require_run_usage_for_consumption_items.sql
+++ b/front/migrations/post-deploy/20260807112434_require_run_usage_for_consumption_items.sql
@@ -1,0 +1,27 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_message_consumption_items" ADD CONSTRAINT "pgschemadiff_tmpnn_E1Qf_yeWQc$aNSQs3s$I$w" CHECK("runUsageId" IS NOT NULL) NOT VALID;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_message_consumption_items" VALIDATE CONSTRAINT "pgschemadiff_tmpnn_E1Qf_yeWQc$aNSQs3s$I$w";
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_message_consumption_items" ALTER COLUMN "runUsageId" SET NOT NULL;
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_message_consumption_items" DROP CONSTRAINT "pgschemadiff_tmpnn_E1Qf_yeWQc$aNSQs3s$I$w";


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
`runUsageId` is currently nullable in the schema and TypeScript types, even though every consumption item is tied to a run usage. This forces downstream code to handle a state that does not exist.

We checked both production regions and confirmed that no existing rows have a null `runUsageId`.

This PR makes the column non-null through a post-deploy migration, tightens the related types, and updates the affected test fixture. This gives consumers a simpler and more accurate type without changing existing behavior.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

 - [ ] Deploy fron
 - [ ] Run post-deploy migration
