### PR TITLE
feat: allow managers to see groups tab in usage page

### DIFF
--- a/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.test.ts
@@ -100,7 +100,7 @@ beforeEach(() => {
 
 describe("/api/w/[wId]/groups/[groupId]/spend_limit", () => {
   describe("auth", () => {
-    it("returns 403 when caller is not an admin", async () => {
+    it("returns 403 when caller is neither an admin nor a manager", async () => {
       const workspace = await makeMetronomeWorkspaceWithCustomer();
       const group = await makeProvisionedGroup(workspace);
       await createPrivateApiMockRequest({
@@ -118,10 +118,10 @@ describe("/api/w/[wId]/groups/[groupId]/spend_limit", () => {
       expect((await response.json()).error.type).toBe("workspace_auth_error");
     });
 
-    it("returns 403 for a manager (admin-only write)", async () => {
+    it("lets a manager set the cap on a provisioned group", async () => {
       const workspace = await makeMetronomeWorkspaceWithCustomer();
       const group = await makeProvisionedGroup(workspace);
-      await createPrivateApiMockRequest({
+      const { auth } = await createPrivateApiMockRequest({
         method: "PUT",
         role: "manager",
         workspace,
@@ -132,8 +132,13 @@ describe("/api/w/[wId]/groups/[groupId]/spend_limit", () => {
         awuCredits: 1500,
       });
 
-      expect(response.status).toBe(403);
-      expect((await response.json()).error.type).toBe("workspace_auth_error");
+      expect(response.status).toBe(200);
+
+      const reloaded = await GroupResource.fetchById(auth, group.sId);
+      if (reloaded.isErr()) {
+        throw reloaded.error;
+      }
+      expect(reloaded.value.poolCapAwuCredits).toBe(1500);
     });
   });
 

--- a/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/spend_limit.ts
@@ -9,7 +9,7 @@ import type { PutGroupSpendLimitResponseBody } from "@app/types/api/groups/spend
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
@@ -80,7 +80,7 @@ const app = workspaceApp();
 app.put(
   "/",
   validate("param", ParamsSchema),
-  ensureIsAdmin(),
+  ensureIsManager(),
   validate("json", UpdateGroupSpendLimitBodySchema),
   async (ctx): HandlerResult<PutGroupSpendLimitResponseBody> => {
     const auth = ctx.get("auth");

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -1082,7 +1082,7 @@ export function UsagePage() {
         <Tabs defaultValue="members">
           <TabsList className="mb-4">
             <TabsTrigger value="members" label="Members" />
-            {isWorkspaceAdmin && <TabsTrigger value="groups" label="Groups" />}
+            <TabsTrigger value="groups" label="Groups" />
             {isWorkspaceAdmin && isCreditPriced && (
               <TabsTrigger value="top-ups" label="Top-ups history" />
             )}
@@ -1150,16 +1150,13 @@ export function UsagePage() {
               </div>
             </Page.Vertical>
           </TabsContent>
-
-          {isWorkspaceAdmin && (
-            <TabsContent value="groups">
-              <GroupsUsageTable
-                owner={owner}
-                readOnly={isReadOnly}
-                showModelTiersColumn={modelsPickerEnabled}
-              />
-            </TabsContent>
-          )}
+          <TabsContent value="groups">
+            <GroupsUsageTable
+              owner={owner}
+              readOnly={isReadOnly}
+              showModelTiersColumn={modelsPickerEnabled}
+            />
+          </TabsContent>
 
           {isWorkspaceAdmin && isCreditPriced && (
             <TabsContent value="top-ups">

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2444,8 +2444,10 @@ export class GroupResource extends BaseResource<GroupModel> {
     auth: Authenticator,
     poolCapAwuCredits: number | null
   ): Promise<Result<undefined, Error>> {
-    if (!auth.canAdministrate(this.requestedPermissions())) {
-      return new Err(new Error("Only admins can update group spend limits."));
+    if (!auth.isManager()) {
+      return new Err(
+        new Error("Only admins and managers can update group spend limits.")
+      );
     }
 
     await this.update({ poolCapAwuCredits });


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9838

This PR extends access to the Groups tab in the usage page and the group spend limit API to managers.

## Tests

Added tests: the existing test asserting that managers receive a 403 on the spend limit endpoint has been updated to instead assert a 200 and verify the cap is correctly persisted.

## Risks

Low. The change broadens permissions from admins-only to admins and managers. Managers gaining the ability to set group spend limits is intentional.

## Deploy Plan

Standard deployment.