### PR TITLE
[sparkle] Redesign ContentMessage per Figma

### DIFF
--- a/sparkle/src/components/ContentMessage.tsx
+++ b/sparkle/src/components/ContentMessage.tsx
@@ -23,12 +23,6 @@ const CONTENT_MESSAGE_SIZES = ["sm", "md", "lg"] as const;
 
 type ContentMessageSizeType = (typeof CONTENT_MESSAGE_SIZES)[number];
 
-// Background/border pair for each variant — matches the Figma spec's
-// light-50 background + light-100/200 border recipe for every color.
-// warning/rose use border-rose-100 (not border-red-100): red's own 100 step
-// is much darker than every other color's 100/150 step, so it visually pops
-// against the rest — rose-100 matches their lightness while staying the same
-// hue family as bg-red-50/text-red-800 (rose and red converge at dark shades).
 const sharedVariantStyles = {
   primary: "bg-stone-50 border-stone-150",
   success: "bg-success-50 border-success-200",
@@ -42,10 +36,6 @@ const sharedVariantStyles = {
   outline: "bg-transparent border-stone-150",
 };
 
-// The Figma spec defines two size recipes (compact/cozy) that scale padding,
-// radius, icon size, and typography together — `sm` maps to the compact
-// recipe, `md`/`lg` to the cozy one (`md`/`lg` differ only by max-width, as
-// before).
 const contentMessageVariants = cva("flex flex-col gap-3 border", {
   variants: {
     variant: sharedVariantStyles,
@@ -61,9 +51,6 @@ const contentMessageVariants = cva("flex flex-col gap-3 border", {
   },
 });
 
-// Reuses the compact (Figma "xs") recipe: same border, padding, radius,
-// icon size, and typography as `<ContentMessage size="sm">`, laid out as a
-// single row instead of stacked.
 const contentMessageInlineVariants = cva(
   "flex items-center gap-2 rounded-xl border p-3",
   {
@@ -127,10 +114,6 @@ const textVariants = cva("", {
   },
 });
 
-// Icon/typography scale driven by `size`: `sm` renders the compact Figma
-// recipe (16px icon, heading-xs/text-xs), `md`/`lg` the cozy one (20px icon,
-// heading-sm/text-sm). Title is one step down from the Figma spec's
-// heading-sm/heading-base.
 const contentMessageSizeConfig: Record<
   ContentMessageSizeType,
   {

--- a/sparkle/src/components/ContentMessage.tsx
+++ b/sparkle/src/components/ContentMessage.tsx
@@ -23,39 +23,49 @@ const CONTENT_MESSAGE_SIZES = ["sm", "md", "lg"] as const;
 
 type ContentMessageSizeType = (typeof CONTENT_MESSAGE_SIZES)[number];
 
+// Background/border pair for each variant — matches the Figma spec's
+// light-50 background + light-100/200 border recipe for every color.
+// warning/rose use border-rose-100 (not border-red-100): red's own 100 step
+// is much darker than every other color's 100/150 step, so it visually pops
+// against the rest — rose-100 matches their lightness while staying the same
+// hue family as bg-red-50/text-red-800 (rose and red converge at dark shades).
 const sharedVariantStyles = {
-  primary: "bg-muted-background",
-  success: "bg-success-100",
-  warning: "bg-warning-100",
-  highlight: "bg-highlight-100",
-  info: "bg-info-100",
-  green: "bg-success-100",
-  blue: "bg-highlight-100",
-  rose: "bg-warning-100",
-  golden: "bg-info-100",
-  outline: "bg-transparent border border-border",
+  primary: "bg-stone-50 border-stone-150",
+  success: "bg-success-50 border-success-200",
+  warning: "bg-red-50 border-rose-100",
+  highlight: "bg-highlight-50 border-highlight-100",
+  info: "bg-orange-50 border-orange-100",
+  green: "bg-success-50 border-success-200",
+  blue: "bg-highlight-50 border-highlight-100",
+  rose: "bg-red-50 border-rose-100",
+  golden: "bg-orange-50 border-orange-100",
+  outline: "bg-transparent border-stone-150",
 };
 
-const contentMessageVariants = cva(
-  "flex flex-col gap-1 rounded-2xl p-4 pl-5 min-h-[52px]",
-  {
-    variants: {
-      variant: sharedVariantStyles,
-      size: {
-        lg: "",
-        md: "max-w-xl",
-        sm: "max-w-sm",
-      },
+// The Figma spec defines two size recipes (compact/cozy) that scale padding,
+// radius, icon size, and typography together — `sm` maps to the compact
+// recipe, `md`/`lg` to the cozy one (`md`/`lg` differ only by max-width, as
+// before).
+const contentMessageVariants = cva("flex flex-col gap-3 border", {
+  variants: {
+    variant: sharedVariantStyles,
+    size: {
+      lg: "rounded-2xl p-4",
+      md: "rounded-2xl p-4 max-w-xl",
+      sm: "rounded-xl p-3 max-w-sm",
     },
-    defaultVariants: {
-      variant: "info",
-      size: "md",
-    },
-  }
-);
+  },
+  defaultVariants: {
+    variant: "info",
+    size: "md",
+  },
+});
 
+// Reuses the compact (Figma "xs") recipe: same border, padding, radius,
+// icon size, and typography as `<ContentMessage size="sm">`, laid out as a
+// single row instead of stacked.
 const contentMessageInlineVariants = cva(
-  "flex items-center gap-3 rounded-xl p-3 pl-4 min-h-[52px]",
+  "flex items-center gap-2 rounded-xl border p-3",
   {
     variants: {
       variant: sharedVariantStyles,
@@ -69,53 +79,94 @@ const contentMessageInlineVariants = cva(
 const iconVariants = cva("shrink-0", {
   variants: {
     variant: {
-      primary: "text-muted-foreground",
-      warning: "text-warning-900",
-      success: "text-success-900",
-      highlight: "text-highlight-900",
-      info: "text-info-900",
-      green: "text-success-900",
-      blue: "text-highlight-900",
-      rose: "text-warning-900",
-      golden: "text-info-900",
+      primary: "text-stone-800",
+      warning: "text-red-800",
+      success: "text-success-800",
+      highlight: "text-highlight-800",
+      info: "text-orange-800",
+      green: "text-success-800",
+      blue: "text-highlight-800",
+      rose: "text-red-800",
+      golden: "text-orange-800",
       outline: "text-muted-foreground",
     },
   },
 });
 
-const titleVariants = cva("heading-sm", {
+const titleVariants = cva("", {
   variants: {
     variant: {
-      primary: "text-foreground",
-      warning: "text-warning-900",
-      success: "text-success-900",
-      highlight: "text-highlight-900",
-      info: "text-info-900",
-      green: "text-success-900",
-      blue: "text-highlight-900",
-      rose: "text-warning-900",
-      golden: "text-info-900",
+      primary: "text-stone-800",
+      warning: "text-red-800",
+      success: "text-success-800",
+      highlight: "text-highlight-800",
+      info: "text-orange-800",
+      green: "text-success-800",
+      blue: "text-highlight-800",
+      rose: "text-red-800",
+      golden: "text-orange-800",
       outline: "text-foreground",
     },
   },
 });
 
-const textVariants = cva("text-sm", {
+const textVariants = cva("", {
   variants: {
     variant: {
-      primary: "text-muted-foreground",
-      warning: "text-warning-900",
-      success: "text-success-900",
-      highlight: "text-highlight-900",
-      info: "text-info-900",
-      green: "text-success-900",
-      blue: "text-highlight-900",
-      rose: "text-warning-900",
-      golden: "text-info-900",
+      primary: "text-stone-800",
+      warning: "text-red-800",
+      success: "text-success-800",
+      highlight: "text-highlight-800",
+      info: "text-orange-800",
+      green: "text-success-800",
+      blue: "text-highlight-800",
+      rose: "text-red-800",
+      golden: "text-orange-800",
       outline: "text-muted-foreground",
     },
   },
 });
+
+// Icon/typography scale driven by `size`: `sm` renders the compact Figma
+// recipe (16px icon, heading-xs/text-xs), `md`/`lg` the cozy one (20px icon,
+// heading-sm/text-sm). Title is one step down from the Figma spec's
+// heading-sm/heading-base.
+const contentMessageSizeConfig: Record<
+  ContentMessageSizeType,
+  {
+    iconSize: "xs" | "sm";
+    headerGap: string;
+    headerHeight: string;
+    stackGap: string;
+    titleClassName: string;
+    textClassName: string;
+  }
+> = {
+  sm: {
+    iconSize: "xs",
+    headerGap: "gap-1",
+    headerHeight: "h-5",
+    stackGap: "gap-1.5",
+    titleClassName: "heading-xs",
+    textClassName: "text-xs",
+  },
+  md: {
+    iconSize: "sm",
+    headerGap: "gap-1.5",
+    headerHeight: "h-6",
+    stackGap: "gap-2",
+    titleClassName: "heading-sm",
+    textClassName: "text-sm",
+  },
+  lg: {
+    iconSize: "sm",
+    headerGap: "gap-1.5",
+    headerHeight: "h-6",
+    stackGap: "gap-2",
+    titleClassName: "heading-sm",
+    textClassName: "text-sm",
+  },
+};
 
 export interface ContentMessageProps {
   title?: string;
@@ -136,6 +187,15 @@ function ContentMessage({
   icon,
   action,
 }: ContentMessageProps) {
+  const {
+    iconSize,
+    headerGap,
+    headerHeight,
+    stackGap,
+    titleClassName,
+    textClassName,
+  } = contentMessageSizeConfig[size];
+
   return (
     <div className={cn(contentMessageVariants({ variant, size }), className)}>
       <div
@@ -144,23 +204,27 @@ function ContentMessage({
           action ? "items-center justify-between" : "flex-col"
         )}
       >
-        <div className="flex flex-col gap-1">
+        <div className={cn("flex flex-col", stackGap)}>
           {(icon || title) && (
-            <div className="flex items-center gap-1.5">
+            <div className={cn("flex items-center", headerGap, headerHeight)}>
               {icon && (
                 <Icon
-                  size="sm"
+                  size={iconSize}
                   visual={icon}
                   className={iconVariants({ variant })}
                 />
               )}
               {title && (
-                <div className={titleVariants({ variant })}>{title}</div>
+                <div className={cn(titleClassName, titleVariants({ variant }))}>
+                  {title}
+                </div>
               )}
             </div>
           )}
           {children && (
-            <div className={textVariants({ variant })}>{children}</div>
+            <div className={cn(textClassName, textVariants({ variant }))}>
+              {children}
+            </div>
           )}
         </div>
         {action && <div className="shrink-0">{action}</div>}
@@ -210,13 +274,19 @@ function ContentMessageInline({
 
   return (
     <div className={cn(contentMessageInlineVariants({ variant }), className)}>
-      {icon && (
-        <Icon size="sm" visual={icon} className={iconVariants({ variant })} />
-      )}
-      <div className={cn("flex-1 min-w-0", textVariants({ variant }))}>
-        {title && <span className={titleVariants({ variant })}>{title}</span>}
-        {title && contentChildren.length > 0 && ": "}
-        {contentChildren}
+      <div className="flex min-w-0 flex-1 items-center gap-1">
+        {icon && (
+          <Icon size="xs" visual={icon} className={iconVariants({ variant })} />
+        )}
+        <div className={cn("min-w-0 text-xs", textVariants({ variant }))}>
+          {title && (
+            <span className={cn("heading-xs", titleVariants({ variant }))}>
+              {title}
+            </span>
+          )}
+          {title && contentChildren.length > 0 && ": "}
+          {contentChildren}
+        </div>
       </div>
       {actionChilds}
     </div>

--- a/sparkle/src/stories/ContentMessage.stories.tsx
+++ b/sparkle/src/stories/ContentMessage.stories.tsx
@@ -34,7 +34,13 @@ const meta: Meta<ContentMessageStoryProps> = {
 - To explain a state ("This agent is read-only") or surface a non-urgent warning.
 
 **Guidelines**
-- Match the **variant** to the intent — \`warning\`, \`success\`, \`info\`.
+- Color should signal the *consequence for the user*, not the message's topic:
+  - \`primary\` — neutral context, no action needed.
+  - \`blue\` — useful info, guidance, or discoverability.
+  - \`warning\` / \`rose\` — a blocking error or failed action that needs the user to intervene.
+  - \`info\` / \`golden\` — a risk or degraded capability; the user can usually continue.
+- Despite the name, \`info\` renders the **orange** tokens, not blue — use \`blue\` for informational messages and \`primary\` for a neutral gray one.
+- Pair color with a clear title and icon; never rely on color alone.
 - For transient feedback after an action, use a **Notification** (toast) instead.
 - For a decision that must block the flow, use a **Dialog**.`,
       },


### PR DESCRIPTION
## Summary
- `ContentMessage` redesigned to match the updated Figma spec — bordered card, two size recipes (compact/cozy), precise icon/typography scale — without changing the public API (`variant`/`size`/`icon`/`action` props untouched, so no product call site needs updates).
- Color roles: `primary`=gray, `success`/`green`=green, `highlight`/`blue`=blue (unchanged); `warning`/`rose`=red (blocking error — matches how `warning` is actually used across the product, e.g. `ErrorMessage.tsx`); `info`/`golden`=orange (risk/degraded capability).
- `ContentMessageInline` reuses the same compact recipe as `ContentMessage size="sm"`.
- Title downsized one type step (`heading-sm`/`heading-base` → `heading-xs`/`heading-sm`).

<img width="981" height="468" alt="image" src="https://github.com/user-attachments/assets/242ab8a5-c987-425b-b3fd-baaaa7c88bfe" />


Supersedes #30123 (closed — that PR's branch was renamed/rescoped to drop the spinner + product-wide variant migration work, which will come back as separate, focused PRs).

## Test plan
- [x] Verified Color Variants, With Icon, Basic (with/without action), and Docs stories in Storybook, light + dark theme
- [x] `biome check` clean
- [x] `tsgo --noEmit` clean for the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)