### PR TITLE
[front] feat: wire Tools tab of the usage filter panel to real, period-scoped data

### DIFF
--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -91,7 +91,6 @@ export function AnalyticsConsumptionPage() {
           <div className="flex justify-end">
             <UsageFilterPanel
               owner={owner}
-              period={period}
               categoryOptions={USAGE_FILTER_MOCK_OPTIONS}
               filter={filter}
               onFilterChange={setFilter}

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -91,6 +91,7 @@ export function AnalyticsConsumptionPage() {
           <div className="flex justify-end">
             <UsageFilterPanel
               owner={owner}
+              period={period}
               categoryOptions={USAGE_FILTER_MOCK_OPTIONS}
               filter={filter}
               onFilterChange={setFilter}

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -27,11 +27,14 @@ import { UsageFilterModelComplexityControls } from "@app/components/workspace/an
 import { UsageFilterOptionCheckboxList } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterOptionCheckboxList";
 import { UsageFilterSelectionSummary } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterSelectionSummary";
 import { useUsageFilter } from "@app/components/workspace/analytics/useUsageFilter";
-import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
 import { useToggleSelectionList } from "@app/hooks/useToggleSelectionList";
-import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import {
+  getMcpServerDisplayName,
+  isRemoteMCPServerType,
+} from "@app/lib/actions/mcp_helper";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useGroups } from "@app/lib/swr/groups";
+import { useMCPServers } from "@app/lib/swr/mcp_servers";
 import { useSearchMembers } from "@app/lib/swr/memberships";
 import { useModels } from "@app/lib/swr/models";
 import type { AgentConfigurationScope } from "@app/types/assistant/agent";
@@ -63,14 +66,13 @@ interface UsageFilterPaginationState {
 
 interface UsageFilterPanelProps {
   owner: LightWorkspaceType;
-  period: ConsumptionPeriodSelection;
   // Skills/sources are still mock data (see usageFilterMockData.ts — sources
   // are fake connectors standing in for a real db call); agents come from
   // useAgentConfigurations, members from useSearchMembers, teams from
-  // useGroups, and models from the workspace's full model catalog
-  // (useModels) — the same endpoint that backs the model picker elsewhere in
-  // the app. Tools are fetched live too, scoped to `period`
-  // (useConsumptionTop).
+  // useGroups, models from the workspace's full model catalog (useModels),
+  // and tools from the workspace's full MCP server catalog (useMCPServers)
+  // — the same endpoints that back the model and tool pickers elsewhere in
+  // the app.
   categoryOptions: {
     skill: UsageFilterSkillOption[];
     source: UsageFilterSourceOption[];
@@ -81,7 +83,6 @@ interface UsageFilterPanelProps {
 
 export function UsageFilterPanel({
   owner,
-  period,
   categoryOptions,
   filter,
   onFilterChange,
@@ -195,14 +196,12 @@ export function UsageFilterPanel({
     disabled: !isAgentCategoryActive,
   });
 
-  const { rows: topToolRows } = useConsumptionTop({
-    workspaceId: owner.sId,
-    dimension: "tool",
-    period,
-    // Same rationale as members/agents: broader than the Attribution
-    // table's own top-N so the picker covers most of the period's active
-    // tools.
-    limit: 100,
+  // The workspace's full, period-independent MCP server catalog — the same
+  // endpoint backing the tool picker elsewhere in the app — rather than a
+  // period-scoped top-N, so every tool is listable and searchable regardless
+  // of the selected period.
+  const { mcpServers } = useMCPServers({
+    owner,
     disabled: !isToolCategoryActive,
   });
 
@@ -268,16 +267,18 @@ export function UsageFilterPanel({
     [modelCatalog]
   );
 
-  // Same client-side search caveat as members/agents/models: a tool outside
-  // the top 100 by credits over the period will not be searchable here.
+  // Every MCP server in the workspace, regardless of the selected period.
+  // Remote servers are identified by sId and internal ones by their static
+  // name, matching the key `tool.server_name` stores in usage data (see
+  // resolveServerDisplayNames).
   const toolOptions = useMemo<UsageFilterToolOption[]>(
     () =>
-      topToolRows.map((row) => ({
-        id: row.id,
-        name: row.name,
+      mcpServers.map((server) => ({
+        id: isRemoteMCPServerType(server) ? server.sId : server.name,
+        name: getMcpServerDisplayName(server),
         kind: "tool" as const,
       })),
-    [topToolRows]
+    [mcpServers]
   );
 
   const resolvedCategoryOptions = useMemo<{

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -196,10 +196,6 @@ export function UsageFilterPanel({
     disabled: !isAgentCategoryActive,
   });
 
-  // The workspace's full, period-independent MCP server catalog — the same
-  // endpoint backing the tool picker elsewhere in the app — rather than a
-  // period-scoped top-N, so every tool is listable and searchable regardless
-  // of the selected period.
   const { mcpServers } = useMCPServers({
     owner,
     disabled: !isToolCategoryActive,
@@ -267,10 +263,6 @@ export function UsageFilterPanel({
     [modelCatalog]
   );
 
-  // Every MCP server in the workspace, regardless of the selected period.
-  // Remote servers are identified by sId and internal ones by their static
-  // name, matching the key `tool.server_name` stores in usage data (see
-  // resolveServerDisplayNames).
   const toolOptions = useMemo<UsageFilterToolOption[]>(
     () =>
       mcpServers.map((server) => ({

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -27,7 +27,9 @@ import { UsageFilterModelComplexityControls } from "@app/components/workspace/an
 import { UsageFilterOptionCheckboxList } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterOptionCheckboxList";
 import { UsageFilterSelectionSummary } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterSelectionSummary";
 import { useUsageFilter } from "@app/components/workspace/analytics/useUsageFilter";
+import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
 import { useToggleSelectionList } from "@app/hooks/useToggleSelectionList";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useGroups } from "@app/lib/swr/groups";
 import { useSearchMembers } from "@app/lib/swr/memberships";
@@ -61,14 +63,15 @@ interface UsageFilterPaginationState {
 
 interface UsageFilterPanelProps {
   owner: LightWorkspaceType;
-  // Tools/skills/sources are still mock data (see usageFilterMockData.ts —
-  // sources are fake connectors standing in for a real db call); agents come
-  // from useAgentConfigurations, members from useSearchMembers, teams from
+  period: ConsumptionPeriodSelection;
+  // Skills/sources are still mock data (see usageFilterMockData.ts — sources
+  // are fake connectors standing in for a real db call); agents come from
+  // useAgentConfigurations, members from useSearchMembers, teams from
   // useGroups, and models from the workspace's full model catalog
   // (useModels) — the same endpoint that backs the model picker elsewhere in
-  // the app.
+  // the app. Tools are fetched live too, scoped to `period`
+  // (useConsumptionTop).
   categoryOptions: {
-    tool: UsageFilterToolOption[];
     skill: UsageFilterSkillOption[];
     source: UsageFilterSourceOption[];
   };
@@ -78,6 +81,7 @@ interface UsageFilterPanelProps {
 
 export function UsageFilterPanel({
   owner,
+  period,
   categoryOptions,
   filter,
   onFilterChange,
@@ -111,6 +115,7 @@ export function UsageFilterPanel({
   const isTeamCategoryActive = isOpen && activeCategory === "team";
   const isAgentCategoryActive = isOpen && activeCategory === "agent";
   const isModelCategoryActive = isOpen && activeCategory === "model";
+  const isToolCategoryActive = isOpen && activeCategory === "tool";
 
   // Every category picker supports scroll-to-load-more:
   const [memberPageIndex, setMemberPageIndex] = useState(0);
@@ -190,6 +195,17 @@ export function UsageFilterPanel({
     disabled: !isAgentCategoryActive,
   });
 
+  const { rows: topToolRows } = useConsumptionTop({
+    workspaceId: owner.sId,
+    dimension: "tool",
+    period,
+    // Same rationale as members/agents: broader than the Attribution
+    // table's own top-N so the picker covers most of the period's active
+    // tools.
+    limit: 100,
+    disabled: !isToolCategoryActive,
+  });
+
   // The workspace's full, period-independent model catalog — the same
   // endpoint backing the model picker elsewhere in the app — rather than a
   // period-scoped top-N, so every enabled model is listable and searchable
@@ -252,6 +268,18 @@ export function UsageFilterPanel({
     [modelCatalog]
   );
 
+  // Same client-side search caveat as members/agents/models: a tool outside
+  // the top 100 by credits over the period will not be searchable here.
+  const toolOptions = useMemo<UsageFilterToolOption[]>(
+    () =>
+      topToolRows.map((row) => ({
+        id: row.id,
+        name: row.name,
+        kind: "tool" as const,
+      })),
+    [topToolRows]
+  );
+
   const resolvedCategoryOptions = useMemo<{
     [C in UsageFilterCategory]: UsageFilterOptionForCategory<C>[];
   }>(
@@ -261,6 +289,7 @@ export function UsageFilterPanel({
       team: teamOptions,
       agent: agentOptions,
       model: modelCatalogOptions,
+      tool: toolOptions,
     }),
     [
       categoryOptions,
@@ -268,6 +297,7 @@ export function UsageFilterPanel({
       teamOptions,
       agentOptions,
       modelCatalogOptions,
+      toolOptions,
     ]
   );
 

--- a/front/components/workspace/analytics/usageFilter.ts
+++ b/front/components/workspace/analytics/usageFilter.ts
@@ -151,9 +151,9 @@ export function selectAllUsageFilterOptions<C extends UsageFilterCategory>(
   return { ...filter, [category]: [...current, ...additions] };
 }
 
-// Members, teams, agents, and models are wired to real consumption scope
-// dimensions. The other categories stay mock data and are not sent as query
-// filters yet.
+// Members, teams, agents, models, and tools are wired to real consumption
+// scope dimensions. The other categories stay mock data and are not sent as
+// query filters yet.
 export function toConsumptionScopeFilter(
   filter: UsageFilter
 ): ConsumptionScopeFilter {
@@ -177,6 +177,11 @@ export function toConsumptionScopeFilter(
   const modelIds = filter.model?.map((entity) => entity.id);
   if (modelIds && modelIds.length > 0) {
     scopeFilter.models = modelIds;
+  }
+
+  const toolIds = filter.tool?.map((entity) => entity.id);
+  if (toolIds && toolIds.length > 0) {
+    scopeFilter.tools = toolIds;
   }
 
   return scopeFilter;

--- a/front/components/workspace/analytics/usageFilterMockData.ts
+++ b/front/components/workspace/analytics/usageFilterMockData.ts
@@ -7,7 +7,7 @@ import type { ConnectorProvider } from "@app/types/data_source";
 // Placeholder data for categories not yet wired to a real backend endpoint.
 // Agents are fetched live in UsageFilterPanel (useAgentConfigurations);
 // members via useSearchMembers; groups via useGroups; models via useModels;
-// tools via useConsumptionTop. Lists are long enough to exercise scrolling
+// tools via useMCPServers. Lists are long enough to exercise scrolling
 // in the preview.
 const MOCK_ENTITY_NAMES = {
   skill: [

--- a/front/components/workspace/analytics/usageFilterMockData.ts
+++ b/front/components/workspace/analytics/usageFilterMockData.ts
@@ -1,32 +1,15 @@
 import type {
   UsageFilterSkillOption,
   UsageFilterSourceOption,
-  UsageFilterToolOption,
 } from "@app/components/workspace/analytics/usageFilter";
 import type { ConnectorProvider } from "@app/types/data_source";
 
 // Placeholder data for categories not yet wired to a real backend endpoint.
 // Agents are fetched live in UsageFilterPanel (useAgentConfigurations);
-// members via useSearchMembers; groups via useGroups; models via useModels.
-// Lists are long enough to exercise scrolling in the preview.
+// members via useSearchMembers; groups via useGroups; models via useModels;
+// tools via useConsumptionTop. Lists are long enough to exercise scrolling
+// in the preview.
 const MOCK_ENTITY_NAMES = {
-  tool: [
-    "web_search",
-    "file_search",
-    "run_code",
-    "browse_page",
-    "generate_image",
-    "send_email",
-    "create_calendar_event",
-    "query_database",
-    "read_spreadsheet",
-    "post_to_slack",
-    "create_jira_ticket",
-    "translate_text",
-    "summarize_document",
-    "extract_table",
-    "fetch_url",
-  ],
   skill: [
     "Summarize",
     "Translate",
@@ -68,14 +51,6 @@ const MOCK_SOURCE_CONNECTORS: Array<{
   { name: "Uploaded files — Legal templates", connectorProvider: undefined },
 ];
 
-function buildToolOptions(names: string[]): UsageFilterToolOption[] {
-  return names.map((name, index) => ({
-    id: `tool_${index + 1}`,
-    name,
-    kind: "tool",
-  }));
-}
-
 function buildSkillOptions(names: string[]): UsageFilterSkillOption[] {
   return names.map((name, index) => ({
     id: `skill_${index + 1}`,
@@ -85,7 +60,6 @@ function buildSkillOptions(names: string[]): UsageFilterSkillOption[] {
 }
 
 export const USAGE_FILTER_MOCK_OPTIONS = {
-  tool: buildToolOptions(MOCK_ENTITY_NAMES.tool),
   skill: buildSkillOptions(MOCK_ENTITY_NAMES.skill),
   source: MOCK_SOURCE_CONNECTORS.map<UsageFilterSourceOption>(
     (connector, index) => ({


### PR DESCRIPTION
## Description

Wire the **Tools** tab in the usage filter panel to the workspace’s real MCP server catalog and consumption data.

- Replace the mock tool options with MCP servers fetched through `useMCPServers`.
- Use the canonical MCP server display names in the picker.
- Map remote MCP servers to their `sId` and internal servers to their static name, matching the `tool.server_name` values stored in usage data.
- Include selected tools in the `ConsumptionScopeFilter` sent to analytics queries.
- Keep the full workspace tool catalog available independently of the selected reporting period, while the usage results remain scoped to the selected date range.
- Remove the obsolete mock tool data.

## Tests

Ran localy

## Risk

Low. This only changes the frontend usage filter wiring and query filter construction. No database schema or migration changes are involved. The impact is limited to filtering analytics data by selected tools.

## Deploy Plan

- Deploy front