### PR TITLE
[front] feat: wire Skills tab of the usage filter panel to real, period-scoped data

### DIFF
--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -91,7 +91,6 @@ export function AnalyticsConsumptionPage() {
           <div className="flex justify-end">
             <UsageFilterPanel
               owner={owner}
-              period={period}
               categoryOptions={USAGE_FILTER_MOCK_OPTIONS}
               filter={filter}
               onFilterChange={setFilter}

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -91,6 +91,7 @@ export function AnalyticsConsumptionPage() {
           <div className="flex justify-end">
             <UsageFilterPanel
               owner={owner}
+              period={period}
               categoryOptions={USAGE_FILTER_MOCK_OPTIONS}
               filter={filter}
               onFilterChange={setFilter}

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -281,9 +281,6 @@ export function UsageFilterPanel({
     [mcpServers]
   );
 
-  // Every skill in the workspace, regardless of the selected period. Keyed
-  // by sId, matching the skill sIds usage data stores for the skill
-  // dimension (see resolveDimensionLabels).
   const skillOptions = useMemo<UsageFilterSkillOption[]>(
     () =>
       skillCatalog.map((skill) => ({

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -39,6 +39,7 @@ import { useGroups } from "@app/lib/swr/groups";
 import { useMCPServers } from "@app/lib/swr/mcp_servers";
 import { useSearchMembers } from "@app/lib/swr/memberships";
 import { useModels } from "@app/lib/swr/models";
+import { useSkills } from "@app/lib/swr/skill_configurations";
 import type { AgentConfigurationScope } from "@app/types/assistant/agent";
 import { AGENT_CONFIGURATION_SCOPES } from "@app/types/assistant/agent";
 import { isModelStreamId } from "@app/types/assistant/models/auto";
@@ -68,15 +69,14 @@ interface UsageFilterPaginationState {
 
 interface UsageFilterPanelProps {
   owner: LightWorkspaceType;
-  period: ConsumptionPeriodSelection;
   // Sources are still mock data (see usageFilterMockData.ts — fake
   // connectors standing in for a real db call); agents come from
   // useAgentConfigurations, members from useSearchMembers, teams from
   // useGroups, models from the workspace's full model catalog (useModels),
-  // and tools from the workspace's full MCP server catalog (useMCPServers)
-  // — the same endpoints that back the model and tool pickers elsewhere in
-  // the app. Skills are fetched live too, scoped to `period`
-  // (useConsumptionTop).
+  // tools from the workspace's full MCP server catalog (useMCPServers), and
+  // skills from the workspace's full skill catalog (useSkills) — the same
+  // endpoints that back the model, tool, and skill pickers elsewhere in the
+  // app.
   categoryOptions: {
     source: UsageFilterSourceOption[];
   };
@@ -86,7 +86,6 @@ interface UsageFilterPanelProps {
 
 export function UsageFilterPanel({
   owner,
-  period,
   categoryOptions,
   filter,
   onFilterChange,
@@ -206,14 +205,13 @@ export function UsageFilterPanel({
     disabled: !isToolCategoryActive,
   });
 
-  const { rows: topSkillRows } = useConsumptionTop({
-    workspaceId: owner.sId,
-    dimension: "skill",
-    period,
-    // Same rationale as members/agents/tools: broader than the Attribution
-    // table's own top-N so the picker covers most of the period's active
-    // skills.
-    limit: 100,
+  // The workspace's full, period-independent skill catalog — the same
+  // endpoint backing the skill picker elsewhere in the app — rather than a
+  // period-scoped top-N, so every skill is listable and searchable
+  // regardless of the selected period.
+  const { skills: skillCatalog } = useSkills({
+    owner,
+    status: "active",
     disabled: !isSkillCategoryActive,
   });
 
@@ -289,17 +287,17 @@ export function UsageFilterPanel({
     [mcpServers]
   );
 
-  // Same client-side search caveat as members/agents/models/tools: a skill
-  // outside the top 100 by credits over the period will not be searchable
-  // here.
+  // Every skill in the workspace, regardless of the selected period. Keyed
+  // by sId, matching the skill sIds usage data stores for the skill
+  // dimension (see resolveDimensionLabels).
   const skillOptions = useMemo<UsageFilterSkillOption[]>(
     () =>
-      topSkillRows.map((row) => ({
-        id: row.id,
-        name: row.name,
+      skillCatalog.map((skill) => ({
+        id: skill.sId,
+        name: skill.name,
         kind: "skill" as const,
       })),
-    [topSkillRows]
+    [skillCatalog]
   );
 
   const resolvedCategoryOptions = useMemo<{

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -27,11 +27,13 @@ import { UsageFilterModelComplexityControls } from "@app/components/workspace/an
 import { UsageFilterOptionCheckboxList } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterOptionCheckboxList";
 import { UsageFilterSelectionSummary } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterSelectionSummary";
 import { useUsageFilter } from "@app/components/workspace/analytics/useUsageFilter";
+import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
 import { useToggleSelectionList } from "@app/hooks/useToggleSelectionList";
 import {
   getMcpServerDisplayName,
   isRemoteMCPServerType,
 } from "@app/lib/actions/mcp_helper";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useGroups } from "@app/lib/swr/groups";
 import { useMCPServers } from "@app/lib/swr/mcp_servers";
@@ -66,15 +68,16 @@ interface UsageFilterPaginationState {
 
 interface UsageFilterPanelProps {
   owner: LightWorkspaceType;
-  // Skills/sources are still mock data (see usageFilterMockData.ts — sources
-  // are fake connectors standing in for a real db call); agents come from
+  period: ConsumptionPeriodSelection;
+  // Sources are still mock data (see usageFilterMockData.ts — fake
+  // connectors standing in for a real db call); agents come from
   // useAgentConfigurations, members from useSearchMembers, teams from
   // useGroups, models from the workspace's full model catalog (useModels),
   // and tools from the workspace's full MCP server catalog (useMCPServers)
   // — the same endpoints that back the model and tool pickers elsewhere in
-  // the app.
+  // the app. Skills are fetched live too, scoped to `period`
+  // (useConsumptionTop).
   categoryOptions: {
-    skill: UsageFilterSkillOption[];
     source: UsageFilterSourceOption[];
   };
   filter: UsageFilter;
@@ -83,6 +86,7 @@ interface UsageFilterPanelProps {
 
 export function UsageFilterPanel({
   owner,
+  period,
   categoryOptions,
   filter,
   onFilterChange,
@@ -117,6 +121,7 @@ export function UsageFilterPanel({
   const isAgentCategoryActive = isOpen && activeCategory === "agent";
   const isModelCategoryActive = isOpen && activeCategory === "model";
   const isToolCategoryActive = isOpen && activeCategory === "tool";
+  const isSkillCategoryActive = isOpen && activeCategory === "skill";
 
   // Every category picker supports scroll-to-load-more:
   const [memberPageIndex, setMemberPageIndex] = useState(0);
@@ -201,6 +206,17 @@ export function UsageFilterPanel({
     disabled: !isToolCategoryActive,
   });
 
+  const { rows: topSkillRows } = useConsumptionTop({
+    workspaceId: owner.sId,
+    dimension: "skill",
+    period,
+    // Same rationale as members/agents/tools: broader than the Attribution
+    // table's own top-N so the picker covers most of the period's active
+    // skills.
+    limit: 100,
+    disabled: !isSkillCategoryActive,
+  });
+
   // The workspace's full, period-independent model catalog — the same
   // endpoint backing the model picker elsewhere in the app — rather than a
   // period-scoped top-N, so every enabled model is listable and searchable
@@ -273,6 +289,19 @@ export function UsageFilterPanel({
     [mcpServers]
   );
 
+  // Same client-side search caveat as members/agents/models/tools: a skill
+  // outside the top 100 by credits over the period will not be searchable
+  // here.
+  const skillOptions = useMemo<UsageFilterSkillOption[]>(
+    () =>
+      topSkillRows.map((row) => ({
+        id: row.id,
+        name: row.name,
+        kind: "skill" as const,
+      })),
+    [topSkillRows]
+  );
+
   const resolvedCategoryOptions = useMemo<{
     [C in UsageFilterCategory]: UsageFilterOptionForCategory<C>[];
   }>(
@@ -283,6 +312,7 @@ export function UsageFilterPanel({
       agent: agentOptions,
       model: modelCatalogOptions,
       tool: toolOptions,
+      skill: skillOptions,
     }),
     [
       categoryOptions,
@@ -291,6 +321,7 @@ export function UsageFilterPanel({
       agentOptions,
       modelCatalogOptions,
       toolOptions,
+      skillOptions,
     ]
   );
 

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -27,13 +27,11 @@ import { UsageFilterModelComplexityControls } from "@app/components/workspace/an
 import { UsageFilterOptionCheckboxList } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterOptionCheckboxList";
 import { UsageFilterSelectionSummary } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterSelectionSummary";
 import { useUsageFilter } from "@app/components/workspace/analytics/useUsageFilter";
-import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
 import { useToggleSelectionList } from "@app/hooks/useToggleSelectionList";
 import {
   getMcpServerDisplayName,
   isRemoteMCPServerType,
 } from "@app/lib/actions/mcp_helper";
-import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useGroups } from "@app/lib/swr/groups";
 import { useMCPServers } from "@app/lib/swr/mcp_servers";
@@ -205,10 +203,6 @@ export function UsageFilterPanel({
     disabled: !isToolCategoryActive,
   });
 
-  // The workspace's full, period-independent skill catalog — the same
-  // endpoint backing the skill picker elsewhere in the app — rather than a
-  // period-scoped top-N, so every skill is listable and searchable
-  // regardless of the selected period.
   const { skills: skillCatalog } = useSkills({
     owner,
     status: "active",

--- a/front/components/workspace/analytics/usageFilter.ts
+++ b/front/components/workspace/analytics/usageFilter.ts
@@ -184,6 +184,11 @@ export function toConsumptionScopeFilter(
     scopeFilter.tools = toolIds;
   }
 
+  const skillIds = filter.skill?.map((entity) => entity.id);
+  if (skillIds && skillIds.length > 0) {
+    scopeFilter.skills = skillIds;
+  }
+
   return scopeFilter;
 }
 

--- a/front/components/workspace/analytics/usageFilterMockData.ts
+++ b/front/components/workspace/analytics/usageFilterMockData.ts
@@ -1,28 +1,10 @@
-import type {
-  UsageFilterSkillOption,
-  UsageFilterSourceOption,
-} from "@app/components/workspace/analytics/usageFilter";
+import type { UsageFilterSourceOption } from "@app/components/workspace/analytics/usageFilter";
 import type { ConnectorProvider } from "@app/types/data_source";
 
-// Placeholder data for categories not yet wired to a real backend endpoint.
-// Agents are fetched live in UsageFilterPanel (useAgentConfigurations);
-// members via useSearchMembers; groups via useGroups; models via useModels;
-// tools via useMCPServers. Lists are long enough to exercise scrolling
-// in the preview.
-const MOCK_ENTITY_NAMES = {
-  skill: [
-    "Summarize",
-    "Translate",
-    "Extract data",
-    "Draft email",
-    "Brainstorm ideas",
-    "Review code",
-    "Analyze spreadsheet",
-    "Write SQL",
-    "Proofread",
-    "Generate outline",
-  ],
-};
+// Placeholder data for "source", the only category not yet wired to a real
+// backend endpoint. Agents are fetched live in UsageFilterPanel
+// (useAgentConfigurations); members via useSearchMembers; groups via
+// useGroups; models via useModels; tools and skills via useConsumptionTop.
 
 // Fake connectors, standing in for the real per-workspace data source list
 // until "source" is wired to a real db call. Covers a broad mix of
@@ -51,16 +33,7 @@ const MOCK_SOURCE_CONNECTORS: Array<{
   { name: "Uploaded files — Legal templates", connectorProvider: undefined },
 ];
 
-function buildSkillOptions(names: string[]): UsageFilterSkillOption[] {
-  return names.map((name, index) => ({
-    id: `skill_${index + 1}`,
-    name,
-    kind: "skill",
-  }));
-}
-
 export const USAGE_FILTER_MOCK_OPTIONS = {
-  skill: buildSkillOptions(MOCK_ENTITY_NAMES.skill),
   source: MOCK_SOURCE_CONNECTORS.map<UsageFilterSourceOption>(
     (connector, index) => ({
       id: `source_${index + 1}`,

--- a/front/components/workspace/analytics/usageFilterMockData.ts
+++ b/front/components/workspace/analytics/usageFilterMockData.ts
@@ -4,7 +4,8 @@ import type { ConnectorProvider } from "@app/types/data_source";
 // Placeholder data for "source", the only category not yet wired to a real
 // backend endpoint. Agents are fetched live in UsageFilterPanel
 // (useAgentConfigurations); members via useSearchMembers; groups via
-// useGroups; models via useModels; tools and skills via useConsumptionTop.
+// useGroups; models via useModels; tools via useMCPServers; skills via
+// useSkills.
 
 // Fake connectors, standing in for the real per-workspace data source list
 // until "source" is wired to a real db call. Covers a broad mix of


### PR DESCRIPTION
## Description

Wire the **Skills** tab in the usage filter panel to real workspace skill data and consumption filtering.

- Replace the mock skill options with active skills fetched through `useSkills`.
- Use the canonical skill `sId` values, matching the identifiers stored in usage data.
- Include selected skills in the `ConsumptionScopeFilter` sent to analytics queries.
- Keep the full active skill catalog available independently of the selected reporting period, while usage results remain scoped to the selected date range.
- Remove the obsolete mock skill data.
- Leave Sources as the only usage filter category still backed by mock data.

## Tests

Ran locally

## Risk

Low. This changes the frontend usage filter wiring and adds the skill dimension to analytics query filters. No database schema or migration changes are involved. The impact is limited to displaying active workspace skills and filtering analytics data by selected skills.

## Deploy Plan

- Deploy front