### PR TITLE
[User Memory] Fix dark mode in the MarkdownEditor 

### DIFF
--- a/front/components/editor/MarkdownEditor.tsx
+++ b/front/components/editor/MarkdownEditor.tsx
@@ -20,7 +20,7 @@ const editorVariants = cva(
   [
     "overflow-auto p-2 resize-y min-h-60",
     "rounded-xl border transition-all duration-200",
-    "bg-muted-background",
+    "bg-muted-background text-foreground",
     "focus-within:ring-highlight-300",
     "focus-within:outline-highlight-200",
     "focus-within:border-highlight-300",


### PR DESCRIPTION
## Description

Fix the Memory.md rendering in darkmode

## Tests

Tested locally 

## Risk

Low

## Deploy Plan

Deploy front 
