### PR TITLE
[front] Namespace published pod functions by app folder

### DIFF
--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -75,8 +75,8 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
         .describe(
           "Scoped path to the function's TypeScript source in the pod, as shown by the files " +
             "tools. It lives in its app's `functions` folder (e.g. " +
-            "`pod-<id>/MyApp/functions/greet.ts`). The app folder is required, and its name " +
-            "becomes the published slug's prefix; a source at the pod root is rejected."
+            "`pod-<id>/MyApp/functions/greet.ts`). The app folder's name becomes the published " +
+            "slug's prefix; a source at the pod root keeps its bare name."
         ),
       executionMode: z
         .enum(SANDBOX_FUNCTION_EXECUTION_MODES)

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -3,6 +3,7 @@ import {
   POD_DATABASE_NAME_REGEX,
   SANDBOX_FUNCTION_EXECUTION_MODES,
   SANDBOX_FUNCTION_SLUG_REGEX,
+  SANDBOX_FUNCTION_SLUG_SEGMENT_REGEX,
 } from "@app/types/api/sandbox_functions";
 import { z } from "zod";
 
@@ -50,14 +51,17 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
       "`schema` with zod `input` and `output`. Set `schema.userIdentity` to `optional`, " +
       "`workspace_user_required`, or `interactive_workspace_user_required`. It is bundled on the " +
       "pod sandbox (only `zod` is available to import), and its contract is extracted from the " +
-      "`schema` export. Re-publishing the same slug replaces the previous version.",
+      "`schema` export. The published slug is prefixed with the app the source lives in, so " +
+      "re-publishing the same name from the same app replaces the previous version while another " +
+      "app's function of the same name is left alone.",
     schema: {
       slug: z
         .string()
-        .regex(SANDBOX_FUNCTION_SLUG_REGEX)
+        .regex(SANDBOX_FUNCTION_SLUG_SEGMENT_REGEX)
         .describe(
-          "Unique function identifier within the pod: lowercase alphanumeric with single hyphen " +
-            "separators (e.g. `send-slack-message`)."
+          "The function's name within its app: lowercase alphanumeric with single hyphen " +
+            "separators (e.g. `send-slack-message`). Do not include the app prefix; publish " +
+            "derives it from `path` and reports the full slug back."
         ),
       description: z
         .string()
@@ -71,7 +75,8 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
         .describe(
           "Scoped path to the function's TypeScript source in the pod, as shown by the files " +
             "tools. It lives in its app's `functions` folder (e.g. " +
-            "`pod-<id>/MyApp/functions/greet.ts`)."
+            "`pod-<id>/MyApp/functions/greet.ts`). The app folder is required, and its name " +
+            "becomes the published slug's prefix; a source at the pod root is rejected."
         ),
       executionMode: z
         .enum(SANDBOX_FUNCTION_EXECUTION_MODES)

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.test.ts
@@ -78,7 +78,7 @@ describe("publishHandler", () => {
     expect(result.value).toEqual([
       {
         type: "text",
-        text: `Published pod function "tasklist__add-task". Call it by reference "${projectId}/tasklist__add-task".`,
+        text: `Published pod function "tasklist__add-task". Frames call it by reference "${projectId}/tasklist__add-task".`,
       },
     ]);
   });

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.test.ts
@@ -1,0 +1,99 @@
+import { SANDBOX_FUNCTIONS_TOOLS_METADATA } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
+import { publishHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/publish";
+import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
+import {
+  makeExtra,
+  setupProjectConversation,
+} from "@app/tests/utils/conversation_test_factories";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { Ok } from "@app/types/shared/result";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(
+  "@app/lib/api/sandbox_functions/build_on_sandbox",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@app/lib/api/sandbox_functions/build_on_sandbox")
+      >();
+
+    return { ...actual, buildSandboxFunctionOnSandbox: vi.fn() };
+  }
+);
+
+vi.mock("@app/lib/lock", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@app/lib/lock")>();
+  return {
+    ...actual,
+    executeWithLock: async (
+      _lockName: string,
+      callback: () => Promise<unknown>
+    ) => callback(),
+  };
+});
+
+const inputSchema: JSONSchema = {
+  type: "object",
+  properties: { name: { type: "string" } },
+  required: ["name"],
+};
+
+const outputSchema: JSONSchema = {
+  type: "object",
+  properties: { greeting: { type: "string" } },
+  required: ["greeting"],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fileStorageMock.reset();
+  vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+    new Ok({
+      bundleCode: "export default {};",
+      userIdentity: "optional",
+      inputSchema,
+      outputSchema,
+    })
+  );
+});
+
+describe("publishHandler", () => {
+  it("reports the app-prefixed slug and the reference a Frame needs", async () => {
+    const { auth, conversation, projectId } = await setupProjectConversation();
+
+    const result = await publishHandler(
+      {
+        slug: "add-task",
+        description: "Add a task.",
+        path: `pod-${projectId}/TaskList/functions/add-task.ts`,
+        executionMode: "fast",
+      },
+      makeExtra(auth, conversation)
+    );
+
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value).toEqual([
+      {
+        type: "text",
+        text: `Published pod function "tasklist__add-task". Call it by reference "${projectId}/tasklist__add-task".`,
+      },
+    ]);
+  });
+
+  it("accepts a bare function name but not one that already carries a prefix", () => {
+    const metadata = SANDBOX_FUNCTIONS_TOOLS_METADATA.find(
+      (tool) => tool.name === "publish"
+    );
+
+    expect(metadata).toBeDefined();
+    expect(metadata?.schema.slug.safeParse("add-task").success).toBe(true);
+    // Publish derives the prefix from `path`, so the caller must not supply one.
+    expect(metadata?.schema.slug.safeParse("tasklist__add-task").success).toBe(
+      false
+    );
+    expect(metadata?.schema.slug.safeParse("Add Task").success).toBe(false);
+  });
+});

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
@@ -42,10 +42,14 @@ export async function publishHandler(
     return new Err(toMCPError(result.error));
   }
 
+  // The slug carries the app prefix publish derived from `path`, so state it and the reference a
+  // Frame needs rather than letting the model assume the name it passed.
+  const { slug: publishedSlug } = result.value;
+
   return new Ok([
     {
       type: "text",
-      text: `Published pod function "${result.value.slug}".`,
+      text: `Published pod function "${publishedSlug}". Call it by reference "${podResult.value.pod.sId}/${publishedSlug}".`,
     },
   ]);
 }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
@@ -42,14 +42,15 @@ export async function publishHandler(
     return new Err(toMCPError(result.error));
   }
 
-  // The slug carries the app prefix publish derived from `path`, so state it and the reference a
-  // Frame needs rather than letting the model assume the name it passed.
+  // The slug carries the app prefix publish derived from `path`, so state it rather than letting the
+  // model assume the name it passed. The other tools resolve the pod from the run context and take
+  // the slug alone; only a Frame needs the qualified reference, so name that consumer.
   const { slug: publishedSlug } = result.value;
 
   return new Ok([
     {
       type: "text",
-      text: `Published pod function "${publishedSlug}". Call it by reference "${podResult.value.pod.sId}/${publishedSlug}".`,
+      text: `Published pod function "${publishedSlug}". Frames call it by reference "${podResult.value.pod.sId}/${publishedSlug}".`,
     },
   ]);
 }

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
@@ -327,8 +327,16 @@ describe("publishSandboxFunction", () => {
     ]);
   });
 
-  it("rejects a source that sits directly at the pod root", async () => {
-    const { space, auth } = await setupPod();
+  it("publishes a source at the pod root under its bare name", async () => {
+    const { workspace, space, auth } = await setupPod();
+    vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+      new Ok({
+        bundleCode: "export default {};",
+        userIdentity: "optional",
+        inputSchema,
+        outputSchema,
+      })
+    );
 
     const result = await publishSandboxFunction(auth, {
       space,
@@ -337,12 +345,18 @@ describe("publishSandboxFunction", () => {
       path: `pod-${space.sId}/greet.ts`,
     });
 
-    expect(result.isErr()).toBe(true);
-    if (result.isOk()) {
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
       return;
     }
-    expect(result.error.code).toBe("invalid_path");
-    expect(buildSandboxFunctionOnSandbox).not.toHaveBeenCalled();
+    expect(result.value.slug).toBe("greet");
+
+    const files = await FileModel.findAll({
+      where: { workspaceId: workspace.id },
+    });
+    expect(files[0].mountFilePath).toBe(
+      `w/${workspace.sId}/pods/${space.sId}/sandbox-functions/greet.ts`
+    );
   });
 
   it("rejects a path that escapes the pod mount", async () => {

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
@@ -85,7 +85,7 @@ describe("publishSandboxFunction", () => {
       space,
       slug: "greet",
       description: "Greet someone.",
-      path: `pod-${space.sId}/greet.ts`,
+      path: `pod-${space.sId}/Greeter/functions/greet.ts`,
     });
 
     expect(result.isOk()).toBe(true);
@@ -93,7 +93,7 @@ describe("publishSandboxFunction", () => {
       return;
     }
     const fn = result.value;
-    expect(fn.slug).toBe("greet");
+    expect(fn.slug).toBe("greeter__greet");
     expect(fn.description).toBe("Greet someone.");
     expect(fn.userIdentity).toBe("interactive_workspace_user_required");
     expect(fn.inputSchema).toEqual(inputSchema);
@@ -101,7 +101,7 @@ describe("publishSandboxFunction", () => {
 
     expect(buildSandboxFunctionOnSandbox).toHaveBeenCalledWith(auth, {
       space,
-      srcSandboxPath: `/files/pod-${space.sId}/greet.ts`,
+      srcSandboxPath: `/files/pod-${space.sId}/Greeter/functions/greet.ts`,
     });
 
     // The source stays on the mount, so the bundle is the only FileResource.
@@ -113,10 +113,10 @@ describe("publishSandboxFunction", () => {
     expect(bundle.id).toBe(fn.fileId);
     expect(bundle.contentType).toBe(sandboxFunctionContentType);
     expect(bundle.useCase).toBe("project_context");
-    expect(bundle.fileName).toBe("greet.ts");
+    expect(bundle.fileName).toBe("greeter__greet.ts");
     expect(bundle.useCaseMetadata?.spaceId).toBe(space.sId);
     expect(bundle.mountFilePath).toBe(
-      `w/${workspace.sId}/pods/${space.sId}/sandbox-functions/greet.ts`
+      `w/${workspace.sId}/pods/${space.sId}/sandbox-functions/greeter__greet.ts`
     );
 
     const listed = await SandboxFunctionResource.listBySpace(auth, space);
@@ -138,7 +138,7 @@ describe("publishSandboxFunction", () => {
       space,
       slug: "greet",
       description: "Greet someone.",
-      path: `pod-${space.sId}/greet.ts`,
+      path: `pod-${space.sId}/Greeter/functions/greet.ts`,
     });
     expect(durable.isOk()).toBe(true);
     if (durable.isErr()) {
@@ -150,7 +150,7 @@ describe("publishSandboxFunction", () => {
       space,
       slug: "read-state",
       description: "Read pod state.",
-      path: `pod-${space.sId}/read-state.ts`,
+      path: `pod-${space.sId}/Greeter/functions/read-state.ts`,
       executionMode: "fast",
     });
     expect(fast.isOk()).toBe(true);
@@ -175,7 +175,7 @@ describe("publishSandboxFunction", () => {
       space,
       slug: "greet",
       description: "Greet someone.",
-      path: `pod-${space.sId}/greet.ts`,
+      path: `pod-${space.sId}/Greeter/functions/greet.ts`,
       executionMode: "fast",
     });
     expect(created.isOk()).toBe(true);
@@ -185,7 +185,7 @@ describe("publishSandboxFunction", () => {
       space,
       slug: "greet",
       description: "Greet someone, again.",
-      path: `pod-${space.sId}/greet.ts`,
+      path: `pod-${space.sId}/Greeter/functions/greet.ts`,
     });
     expect(republished.isOk()).toBe(true);
     if (republished.isErr()) {
@@ -197,7 +197,7 @@ describe("publishSandboxFunction", () => {
       space,
       slug: "greet",
       description: "Greet someone, again.",
-      path: `pod-${space.sId}/greet.ts`,
+      path: `pod-${space.sId}/Greeter/functions/greet.ts`,
       executionMode: "fast",
     });
     expect(restated.isOk()).toBe(true);
@@ -222,7 +222,7 @@ describe("publishSandboxFunction", () => {
       space,
       slug: "greet",
       description: "v1",
-      path: `pod-${space.sId}/greet.ts`,
+      path: `pod-${space.sId}/Greeter/functions/greet.ts`,
     });
     expect(first.isOk()).toBe(true);
     if (first.isErr()) {
@@ -251,7 +251,7 @@ describe("publishSandboxFunction", () => {
       space,
       slug: "greet",
       description: "v2",
-      path: `pod-${space.sId}/greet.ts`,
+      path: `pod-${space.sId}/Greeter/functions/greet.ts`,
     });
     expect(second.isOk()).toBe(true);
     if (second.isErr()) {
@@ -273,9 +273,76 @@ describe("publishSandboxFunction", () => {
     });
     expect(files.map((file) => file.id)).toEqual([firstFileId]);
     expect(files[0].mountFilePath).toBe(
-      `w/${workspace.sId}/pods/${space.sId}/sandbox-functions/greet.ts`
+      `w/${workspace.sId}/pods/${space.sId}/sandbox-functions/greeter__greet.ts`
     );
     expect(files[0].version).toBeGreaterThan(firstVersion ?? 0);
+  });
+
+  it("keeps two apps that publish the same name as separate functions", async () => {
+    const { workspace, space, auth } = await setupPod();
+    vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+      new Ok({
+        bundleCode: "export default {};",
+        userIdentity: "optional",
+        inputSchema,
+        outputSchema,
+      })
+    );
+
+    const taskList = await publishSandboxFunction(auth, {
+      space,
+      slug: "refresh",
+      description: "Refresh the task list.",
+      path: `pod-${space.sId}/TaskList/functions/refresh.ts`,
+    });
+    const inbox = await publishSandboxFunction(auth, {
+      space,
+      slug: "refresh",
+      description: "Refresh the inbox.",
+      path: `pod-${space.sId}/Inbox/functions/refresh.ts`,
+    });
+
+    expect(taskList.isOk()).toBe(true);
+    expect(inbox.isOk()).toBe(true);
+    if (taskList.isErr() || inbox.isErr()) {
+      return;
+    }
+
+    // The second publish must not have replaced the first: two rows, two slugs, two bundles.
+    expect(taskList.value.slug).toBe("tasklist__refresh");
+    expect(inbox.value.slug).toBe("inbox__refresh");
+    expect(inbox.value.id).not.toBe(taskList.value.id);
+    expect(taskList.value.description).toBe("Refresh the task list.");
+    expect(inbox.value.description).toBe("Refresh the inbox.");
+
+    const listed = await SandboxFunctionResource.listBySpace(auth, space);
+    expect(listed).toHaveLength(2);
+
+    const files = await FileModel.findAll({
+      where: { workspaceId: workspace.id },
+    });
+    expect(files.map((file) => file.mountFilePath).sort()).toEqual([
+      `w/${workspace.sId}/pods/${space.sId}/sandbox-functions/inbox__refresh.ts`,
+      `w/${workspace.sId}/pods/${space.sId}/sandbox-functions/tasklist__refresh.ts`,
+    ]);
+  });
+
+  it("rejects a source that sits directly at the pod root", async () => {
+    const { space, auth } = await setupPod();
+
+    const result = await publishSandboxFunction(auth, {
+      space,
+      slug: "greet",
+      description: "Greet someone.",
+      path: `pod-${space.sId}/greet.ts`,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("invalid_path");
+    expect(buildSandboxFunctionOnSandbox).not.toHaveBeenCalled();
   });
 
   it("rejects a path that escapes the pod mount", async () => {
@@ -306,7 +373,7 @@ describe("publishSandboxFunction", () => {
       space,
       slug: "greet",
       description: "Greet someone.",
-      path: `pod-${space.sId}/greet.ts`,
+      path: `pod-${space.sId}/Greeter/functions/greet.ts`,
     });
 
     expect(result.isErr()).toBe(true);
@@ -332,7 +399,7 @@ describe("publishSandboxFunction", () => {
       space,
       slug: "greet",
       description: "Greet someone.",
-      path: `pod-${space.sId}/greet.ts`,
+      path: `pod-${space.sId}/Greeter/functions/greet.ts`,
     });
 
     expect(result.isErr()).toBe(true);

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.ts
@@ -1,6 +1,7 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { deriveSandboxFunctionSlug } from "@app/lib/api/sandbox_functions/slug";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
@@ -18,7 +19,9 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
  * The bundle is stored as a single `project_context` FileResource with the sandbox-function content
  * type, which FileResource routes into the dedicated, front-only sandbox-functions prefix. The
  * SandboxFunctionResource is upserted on (space, slug): re-publish swaps the bundle, otherwise a new
- * row is created. Returns a domain Result, no HTTP shapes (BACK18).
+ * row is created. `slug` here is the caller's bare function name; the stored slug prefixes it with
+ * the app folder the source lives in (see deriveSandboxFunctionSlug), so the upsert is scoped to one
+ * app rather than the whole pod. Returns a domain Result, no HTTP shapes (BACK18).
  */
 export async function publishSandboxFunction(
   auth: Authenticator,
@@ -51,6 +54,21 @@ export async function publishSandboxFunction(
     );
   }
 
+  // The published slug namespaces the caller's name under the app folder the source lives in, so
+  // two apps in one pod can each own a function called `refresh`. Derived before the build so a
+  // misplaced source fails without paying for a bundle.
+  const slugResult = deriveSandboxFunctionSlug({
+    sourcePath,
+    podId: space.sId,
+    name: slug,
+  });
+  if (slugResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError("invalid_path", slugResult.error.message)
+    );
+  }
+  const qualifiedSlug = slugResult.value;
+
   const buildResult = await buildSandboxFunctionOnSandbox(auth, {
     space,
     srcSandboxPath: srcResult.value,
@@ -66,7 +84,7 @@ export async function publishSandboxFunction(
   const existing = await SandboxFunctionResource.fetchBySpaceAndSlug(
     auth,
     space,
-    slug
+    qualifiedSlug
   );
   if (existing) {
     const updateResult = await existing.updateContent(auth, {
@@ -86,7 +104,11 @@ export async function publishSandboxFunction(
     return new Ok(existing);
   }
 
-  const fileResult = await createBundleFile(auth, { space, slug, bundleCode });
+  const fileResult = await createBundleFile(auth, {
+    space,
+    slug: qualifiedSlug,
+    bundleCode,
+  });
   if (fileResult.isErr()) {
     return fileResult;
   }
@@ -94,7 +116,7 @@ export async function publishSandboxFunction(
   const created = await SandboxFunctionResource.makeNew(auth, {
     space,
     file: fileResult.value,
-    slug,
+    slug: qualifiedSlug,
     description,
     userIdentity,
     executionMode,

--- a/front/lib/api/sandbox_functions/slug.test.ts
+++ b/front/lib/api/sandbox_functions/slug.test.ts
@@ -61,8 +61,37 @@ describe("deriveSandboxFunctionSlug", () => {
     expect(result.value).toBe("tasklist__add-task");
   });
 
-  it("rejects a source that sits directly at the pod root", () => {
+  it("leaves a source at the pod root unprefixed", () => {
     const result = derive(`pod-${POD_ID}/greet.ts`, "greet");
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value).toBe("greet");
+  });
+
+  // An unprefixed slug can never collide with an app's: the name is one segment so it carries no
+  // `__`, and a prefix never contains one either, so every prefixed slug has exactly one.
+  it("keeps root and app namespaces disjoint", () => {
+    const root = derive(`pod-${POD_ID}/refresh.ts`, "refresh");
+    const app = derive(
+      `pod-${POD_ID}/TaskList/functions/refresh.ts`,
+      "refresh"
+    );
+
+    expect(root.isOk()).toBe(true);
+    expect(app.isOk()).toBe(true);
+    if (root.isErr() || app.isErr()) {
+      return;
+    }
+    expect(root.value).not.toBe(app.value);
+    expect(root.value).not.toContain("__");
+    expect(app.value.match(/__/g)).toHaveLength(1);
+  });
+
+  it("rejects a path with no file component", () => {
+    const result = derive(`pod-${POD_ID}`, "greet");
 
     expect(result.isErr()).toBe(true);
   });

--- a/front/lib/api/sandbox_functions/slug.test.ts
+++ b/front/lib/api/sandbox_functions/slug.test.ts
@@ -1,0 +1,87 @@
+import { deriveSandboxFunctionSlug } from "@app/lib/api/sandbox_functions/slug";
+import { describe, expect, it } from "vitest";
+
+const POD_ID = "vlt_abc123";
+
+function derive(sourcePath: string, name: string) {
+  return deriveSandboxFunctionSlug({ sourcePath, podId: POD_ID, name });
+}
+
+describe("deriveSandboxFunctionSlug", () => {
+  it("prefixes the name with the app folder", () => {
+    const result = derive(
+      `pod-${POD_ID}/TaskList/functions/add-task.ts`,
+      "add-task"
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value).toBe("tasklist__add-task");
+  });
+
+  it("ignores folders between the app folder and the source", () => {
+    const nested = derive(
+      `pod-${POD_ID}/TaskList/functions/admin/purge.ts`,
+      "purge"
+    );
+    const flat = derive(`pod-${POD_ID}/TaskList/purge.ts`, "purge");
+
+    expect(nested.isOk()).toBe(true);
+    expect(flat.isOk()).toBe(true);
+    if (nested.isErr() || flat.isErr()) {
+      return;
+    }
+    // Moving a source inside its app must not rename the published function.
+    expect(nested.value).toBe("tasklist__purge");
+    expect(flat.value).toBe("tasklist__purge");
+  });
+
+  it("normalizes an app folder that is not already slug-shaped", () => {
+    const spaced = derive(`pod-${POD_ID}/Task List/functions/x.ts`, "x");
+    const underscored = derive(`pod-${POD_ID}/my_app/functions/x.ts`, "x");
+
+    expect(spaced.isOk()).toBe(true);
+    expect(underscored.isOk()).toBe(true);
+    if (spaced.isErr() || underscored.isErr()) {
+      return;
+    }
+    expect(spaced.value).toBe("task-list__x");
+    expect(underscored.value).toBe("my-app__x");
+  });
+
+  it("resolves a legacy pod-scoped path", () => {
+    const result = derive("pod/TaskList/functions/add-task.ts", "add-task");
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value).toBe("tasklist__add-task");
+  });
+
+  it("rejects a source that sits directly at the pod root", () => {
+    const result = derive(`pod-${POD_ID}/greet.ts`, "greet");
+
+    expect(result.isErr()).toBe(true);
+  });
+
+  it("rejects an app folder that normalizes to nothing", () => {
+    const result = derive(`pod-${POD_ID}/---/functions/x.ts`, "x");
+
+    expect(result.isErr()).toBe(true);
+  });
+
+  it("rejects a path outside the pod scope", () => {
+    const result = derive("conversation-abc/TaskList/functions/x.ts", "x");
+
+    expect(result.isErr()).toBe(true);
+  });
+
+  it("rejects a name that is not slug-shaped", () => {
+    const result = derive(`pod-${POD_ID}/TaskList/functions/x.ts`, "Add_Task");
+
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/front/lib/api/sandbox_functions/slug.ts
+++ b/front/lib/api/sandbox_functions/slug.ts
@@ -28,6 +28,12 @@ function normalizeAppPrefix(folderName: string): string {
  * and anything nested below it) are the app's own business, so moving a source inside its app never
  * renames the published function and never orphans a Frame's `<podId>/<slug>` reference.
  *
+ * A source sitting directly at the pod root has no app folder and keeps the bare name. That cannot
+ * collide with an app's function: `name` is a single segment so it carries no `__`, and a prefix
+ * never contains one either, so a prefixed slug always has exactly one and the two namespaces stay
+ * disjoint. Moving such a source into an app folder does rename its function, which is the one
+ * rename this scheme does not absorb.
+ *
  * This checks shape, not access: callers resolve `sourcePath` through `DustFileSystem`, which is
  * what rejects traversal, foreign pods and scopes that are not sandbox-mounted.
  */
@@ -62,12 +68,13 @@ export function deriveSandboxFunctionSlug({
   }
 
   const segments = parsed.relPath.split("/").filter((s) => s.length > 0);
-  if (segments.length < 2) {
+  if (segments.length === 0) {
     return new Err(
-      new Error(
-        `A function's source must live in its app folder, e.g. 'pod-${podId}/MyApp/functions/${name}.ts': got '${sourcePath}'.`
-      )
+      new Error(`Path has no file component: got '${sourcePath}'.`)
     );
+  }
+  if (segments.length === 1) {
+    return new Ok(name);
   }
 
   const prefix = normalizeAppPrefix(segments[0]);

--- a/front/lib/api/sandbox_functions/slug.ts
+++ b/front/lib/api/sandbox_functions/slug.ts
@@ -1,0 +1,83 @@
+import {
+  parseCanonicalScopedPath,
+  resolveCanonicalScopedPath,
+} from "@app/lib/api/files/mount_path";
+import { SANDBOX_FUNCTION_SLUG_SEGMENT_REGEX } from "@app/types/api/sandbox_functions";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+
+export const SANDBOX_FUNCTION_SLUG_SEPARATOR = "__";
+
+/**
+ * Normalize an app folder name into one slug segment: lowercase, every run of characters outside
+ * `[a-z0-9]` collapsed to a hyphen, no leading or trailing hyphen. Deliberately no camel-case
+ * splitting, so `TaskList` becomes `tasklist` rather than `task-list`: a predictable rule beats a
+ * prettier heuristic that has to decide what to do with `MyAPIApp`.
+ */
+function normalizeAppPrefix(folderName: string): string {
+  return folderName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Compose a published function's slug as `<appPrefix>__<name>`, where the prefix comes from the app
+ * folder the source lives in: the first path segment under the pod root.
+ *
+ * Only that folder contributes. Folders between it and the source (the conventional `functions/`,
+ * and anything nested below it) are the app's own business, so moving a source inside its app never
+ * renames the published function and never orphans a Frame's `<podId>/<slug>` reference.
+ *
+ * This checks shape, not access: callers resolve `sourcePath` through `DustFileSystem`, which is
+ * what rejects traversal, foreign pods and scopes that are not sandbox-mounted.
+ */
+export function deriveSandboxFunctionSlug({
+  sourcePath,
+  podId,
+  name,
+}: {
+  sourcePath: string;
+  podId: string;
+  name: string;
+}): Result<string, Error> {
+  if (!SANDBOX_FUNCTION_SLUG_SEGMENT_REGEX.test(name)) {
+    return new Err(
+      new Error(
+        `Function name must be lowercase alphanumeric with single hyphen separators: got '${name}'.`
+      )
+    );
+  }
+
+  const canonicalPath = resolveCanonicalScopedPath(sourcePath, {
+    conversationId: null,
+    spaceId: podId,
+  });
+  const parsed = canonicalPath ? parseCanonicalScopedPath(canonicalPath) : null;
+  if (!parsed || parsed.scope.kind !== "canonical-pod") {
+    return new Err(
+      new Error(
+        `Path must point into the pod's file system: got '${sourcePath}'.`
+      )
+    );
+  }
+
+  const segments = parsed.relPath.split("/").filter((s) => s.length > 0);
+  if (segments.length < 2) {
+    return new Err(
+      new Error(
+        `A function's source must live in its app folder, e.g. 'pod-${podId}/MyApp/functions/${name}.ts': got '${sourcePath}'.`
+      )
+    );
+  }
+
+  const prefix = normalizeAppPrefix(segments[0]);
+  if (!prefix) {
+    return new Err(
+      new Error(
+        `App folder '${segments[0]}' has no alphanumeric characters to derive a function prefix from.`
+      )
+    );
+  }
+
+  return new Ok(`${prefix}${SANDBOX_FUNCTION_SLUG_SEPARATOR}${name}`);
+}

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -100,8 +100,8 @@ Functions that no Frame calls still get an app folder, named after what they do 
 Write the source as a TypeScript file in the app's \`functions\` folder, at
 \`pod-<podId>/<AppName>/functions/<name>.ts\` (the Computer mounts it at
 \`/files/pod-<podId>/<AppName>/functions/<name>.ts\`; the \`files\` MCP server reaches it under the
-same scoped path). The app folder is required: a source at the Pod root is rejected at publish
-time, because the app folder is what namespaces the function. The module must:
+same scoped path). Keep it in an app folder: that folder is what namespaces the function, and a
+source left at the Pod root publishes under its bare name instead. The module must:
 
 - export a \`schema\` object with a \`description\` and zod \`input\` and \`output\` schemas,
 - default-export an object with a \`fetch(request: Request): Promise<Response>\` method (the Bun and
@@ -256,7 +256,9 @@ from the app folder in \`path\` (\`TaskList\` becomes \`tasklist\`, \`Task List\
 reports the full slug back. Use that reported slug everywhere afterwards: \`${toolName("get")}\`,
 \`${toolName("call")}\`, \`${toolName("unpublish")}\`, and a Frame's reference. Only the app folder
 contributes, so \`functions/\` and any folder nested under it never appear in the slug, and moving a
-source inside its app does not rename the function.
+source inside its app does not rename the function. A source at the Pod root has no app folder and
+keeps its bare name; moving it into one later *does* rename its function, leaving the old slug
+published and stale, so put it in its app folder from the start.
 
 Publishing again under the same app and name replaces that version. Two different apps can each
 publish a \`refresh\` and they stay separate functions, so you never have to invent

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -78,7 +78,8 @@ Pod file system rather than splitting it between the conversation and the Pod ro
   MyApp/
     MyApp.tsx          the Frame's source; its directory is the Frame's bundling root
     functions/
-      list-notes.ts    one file per function, named after the function's slug
+      list-notes.ts    one file per function, named after the function; the app folder
+                       above becomes the published slug's prefix (myapp__list-notes)
       post-note.ts
       lib/
         notes.ts       helpers shared by several functions
@@ -97,9 +98,10 @@ Functions that no Frame calls still get an app folder, named after what they do 
 #### Authoring a function
 
 Write the source as a TypeScript file in the app's \`functions\` folder, at
-\`pod-<podId>/<AppName>/functions/<slug>.ts\` (the Computer mounts it at
-\`/files/pod-<podId>/<AppName>/functions/<slug>.ts\`; the \`files\` MCP server reaches it under the
-same scoped path). The module must:
+\`pod-<podId>/<AppName>/functions/<name>.ts\` (the Computer mounts it at
+\`/files/pod-<podId>/<AppName>/functions/<name>.ts\`; the \`files\` MCP server reaches it under the
+same scoped path). The app folder is required: a source at the Pod root is rejected at publish
+time, because the app folder is what namespaces the function. The module must:
 
 - export a \`schema\` object with a \`description\` and zod \`input\` and \`output\` schemas,
 - default-export an object with a \`fetch(request: Request): Promise<Response>\` method (the Bun and
@@ -245,10 +247,20 @@ loading state.
 
 Once the source is on the Pod, use \`${toolName("publish")}\` to build it. It requires you to state
 \`executionMode\` on every publish. Publishing bundles and type-checks the source on the Computer
-and extracts the input and output JSON schemas from the \`schema\` export. Publishing again under
-the same name replaces the previous version. The stored bundle is owned by the platform and runs
-from a read-only mount, so a published function can be executed but never overwritten from within
-the Computer.
+and extracts the input and output JSON schemas from the \`schema\` export. The stored bundle is owned
+by the platform and runs from a read-only mount, so a published function can be executed but never
+overwritten from within the Computer.
+
+**The published slug is \`<app>__<name>\`.** You pass the bare \`<name>\`; publish derives the prefix
+from the app folder in \`path\` (\`TaskList\` becomes \`tasklist\`, \`Task List\` becomes \`task-list\`) and
+reports the full slug back. Use that reported slug everywhere afterwards: \`${toolName("get")}\`,
+\`${toolName("call")}\`, \`${toolName("unpublish")}\`, and a Frame's reference. Only the app folder
+contributes, so \`functions/\` and any folder nested under it never appear in the slug, and moving a
+source inside its app does not rename the function.
+
+Publishing again under the same app and name replaces that version. Two different apps can each
+publish a \`refresh\` and they stay separate functions, so you never have to invent
+\`refresh-tasklist\` to dodge a clash.
 
 Use \`${toolName("list")}\` and \`${toolName("get")}\` to see what the Pod has already
 published and to inspect a function's contract before relying on it or publishing a near-duplicate.
@@ -271,9 +283,9 @@ return inline is written to a pod file whose path it reports), and \`${toolName(
 A Frame calls published functions through the injected \`@dust/react-hooks\` module, not the
 \`call\` tool. Always pass the fully qualified \`<podId>/<slug>\` reference reported by
 \`${toolName("get")}\`. Never pass a bare slug or infer the function from the Frame's current Pod.
-This keeps the reference stable if the Frame is moved. The app folder is only where the sources
-live: it does not namespace the slug, so the reference stays \`<podId>/<slug>\` and never includes
-the app name.
+This keeps the reference stable if the Frame is moved. The slug in that reference is the full
+published slug, app prefix included (\`<podId>/tasklist__add-task\`), never the bare name you passed
+to \`${toolName("publish")}\`.
 
 ##### Designing functions for a Frame
 

--- a/front/types/api/sandbox_functions.test.ts
+++ b/front/types/api/sandbox_functions.test.ts
@@ -1,9 +1,58 @@
 import { describe, expect, it } from "vitest";
 import { RUNNER_ERROR_CODES } from "../../../cli/dust-sandbox/functions-runner/protocol";
-import { SANDBOX_FUNCTION_RUNNER_ERROR_CODES } from "./sandbox_functions";
+import {
+  isValidSandboxFunctionSlug,
+  SANDBOX_FUNCTION_RUNNER_ERROR_CODES,
+} from "./sandbox_functions";
 
 describe("SANDBOX_FUNCTION_RUNNER_ERROR_CODES", () => {
   it("stays aligned with the runner protocol", () => {
     expect(SANDBOX_FUNCTION_RUNNER_ERROR_CODES).toEqual(RUNNER_ERROR_CODES);
+  });
+});
+
+describe("isValidSandboxFunctionSlug", () => {
+  it("accepts an app-prefixed slug", () => {
+    expect(isValidSandboxFunctionSlug("tasklist__add-task")).toBe(true);
+    expect(isValidSandboxFunctionSlug("task-list__add-task")).toBe(true);
+  });
+
+  it("accepts a bare slug, as published before app namespacing existed", () => {
+    expect(isValidSandboxFunctionSlug("greet")).toBe(true);
+    expect(isValidSandboxFunctionSlug("send-slack-message")).toBe(true);
+  });
+
+  it("rejects more than one app prefix", () => {
+    expect(isValidSandboxFunctionSlug("tasklist__admin__purge")).toBe(false);
+  });
+
+  it("rejects a separator with a missing segment", () => {
+    expect(isValidSandboxFunctionSlug("__greet")).toBe(false);
+    expect(isValidSandboxFunctionSlug("tasklist__")).toBe(false);
+    expect(isValidSandboxFunctionSlug("__")).toBe(false);
+  });
+
+  it("rejects a single underscore as a separator", () => {
+    expect(isValidSandboxFunctionSlug("tasklist_add-task")).toBe(false);
+  });
+
+  it("still rejects uppercase, spaces and path separators", () => {
+    expect(isValidSandboxFunctionSlug("TaskList__addTask")).toBe(false);
+    expect(isValidSandboxFunctionSlug("tasklist add-task")).toBe(false);
+    expect(isValidSandboxFunctionSlug("tasklist/add-task")).toBe(false);
+  });
+
+  // `dsbx function run <name>` validates against is_valid_name in
+  // cli/dust-sandbox/src/commands/function/mod.rs, which allows [A-Za-z0-9_-] only, and then
+  // resolves the name to `<name>.<ext>` in a flat read_dir of $DUST_FUNCTIONS_DIR. Encoding the app
+  // prefix in the slug rather than nesting directories is what keeps that contract intact, so a
+  // slug must never grow a character dsbx would refuse.
+  it("produces names dsbx can resolve", () => {
+    const dsbxValidName = /^[A-Za-z0-9_-]+$/;
+
+    for (const slug of ["greet", "tasklist__add-task", "task-list__x"]) {
+      expect(isValidSandboxFunctionSlug(slug)).toBe(true);
+      expect(dsbxValidName.test(slug)).toBe(true);
+    }
   });
 });

--- a/front/types/api/sandbox_functions.test.ts
+++ b/front/types/api/sandbox_functions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { RUNNER_ERROR_CODES } from "../../../cli/dust-sandbox/functions-runner/protocol";
+import { POD_FUNCTION_REFERENCE_REGEX } from "../../../viz/app/lib/pod-function-slug";
 import {
   isValidSandboxFunctionSlug,
   SANDBOX_FUNCTION_RUNNER_ERROR_CODES,
@@ -40,6 +41,35 @@ describe("isValidSandboxFunctionSlug", () => {
     expect(isValidSandboxFunctionSlug("TaskList__addTask")).toBe(false);
     expect(isValidSandboxFunctionSlug("tasklist add-task")).toBe(false);
     expect(isValidSandboxFunctionSlug("tasklist/add-task")).toBe(false);
+  });
+
+  // A Frame validates the `<podId>/<slug>` reference in the viz workspace, which cannot import from
+  // front and so carries its own copy of this grammar. Drift there is silent and expensive: a
+  // reference viz rejects resolves to a null SWR key, so the Frame issues no request at all rather
+  // than failing loudly.
+  it("stays aligned with the reference grammar Frames validate against", () => {
+    const slugs = [
+      "greet",
+      "send-slack-message",
+      "tasklist__add-task",
+      "task-list__x",
+      "tasklist__admin__purge",
+      "__greet",
+      "tasklist__",
+      "tasklist_add-task",
+      "TaskList__addTask",
+      "tasklist add-task",
+    ];
+
+    for (const slug of slugs) {
+      expect({
+        slug,
+        accepted: POD_FUNCTION_REFERENCE_REGEX.test(`vlt_1/${slug}`),
+      }).toEqual({
+        slug,
+        accepted: isValidSandboxFunctionSlug(slug),
+      });
+    }
   });
 
   // `dsbx function run <name>` validates against is_valid_name in

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -52,8 +52,25 @@ export const SANDBOX_FUNCTION_INVOCATION_ORIGINS = [
 export type SandboxFunctionInvocationOrigin =
   (typeof SANDBOX_FUNCTION_INVOCATION_ORIGINS)[number];
 
-// Lowercase alphanumeric with single hyphen separators (e.g. `greet`, `send-slack-message`).
-export const SANDBOX_FUNCTION_SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+// One slug segment: lowercase alphanumeric with single hyphen separators (e.g. `greet`,
+// `send-slack-message`). A function's own name is a single segment; the app prefix publish derives
+// from the source path is another.
+const SANDBOX_FUNCTION_SLUG_SEGMENT = "[a-z0-9]+(?:-[a-z0-9]+)*";
+
+export const SANDBOX_FUNCTION_SLUG_SEGMENT_REGEX = new RegExp(
+  `^${SANDBOX_FUNCTION_SLUG_SEGMENT}$`
+);
+
+// A published function's slug: `<appPrefix>__<name>` (e.g. `tasklist__add-task`), where publish
+// derives the prefix from the app folder the source lives in. The prefix is optional so slugs
+// published before app namespacing existed stay valid.
+//
+// Stays deliberately stricter than dsbx's own `[A-Za-z0-9_-]+` (is_valid_name in
+// cli/dust-sandbox/src/commands/function/mod.rs), which is what lets `<slug>.ts` resolve in the flat
+// $DUST_FUNCTIONS_DIR mount without any CLI change.
+export const SANDBOX_FUNCTION_SLUG_REGEX = new RegExp(
+  `^${SANDBOX_FUNCTION_SLUG_SEGMENT}(?:__${SANDBOX_FUNCTION_SLUG_SEGMENT})?$`
+);
 
 // Mirrors DB_NAME_REGEX in cli/dust-sandbox/functions-runner/types/db.ts. Regex values cannot
 // be type-checked and front cannot runtime-import cli code; equality is asserted in

--- a/viz/app/lib/pod-function-hooks.test.tsx
+++ b/viz/app/lib/pod-function-hooks.test.tsx
@@ -123,6 +123,23 @@ describe("usePodFunction", () => {
     expect(callFunction).toHaveBeenCalledTimes(1);
   });
 
+  it("calls a slug carrying its app prefix", async () => {
+    const callFunction = vi.fn().mockResolvedValue([{ id: 1, title: "Task" }]);
+    const dataAPI = makeDataAPI(callFunction);
+    const { result } = renderHook(
+      () => usePodFunction("vlt_123/tasklist__list-tasks", { done: false }),
+      { wrapper: makeWrapper(dataAPI) }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ id: 1, title: "Task" }]);
+    });
+    expect(result.current.error).toBeUndefined();
+    expect(callFunction).toHaveBeenCalledWith("vlt_123/tasklist__list-tasks", {
+      done: false,
+    });
+  });
+
   it("does not call the function when disabled", async () => {
     const callFunction = vi.fn();
     const { result } = renderHook(

--- a/viz/app/lib/pod-function-hooks.tsx
+++ b/viz/app/lib/pod-function-hooks.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { normalizeSandboxFunctionCallError } from "@viz/app/lib/data-apis/sandbox-function-call-error";
+import { POD_FUNCTION_REFERENCE_REGEX } from "@viz/app/lib/pod-function-slug";
 import type { VisualizationDataAPI } from "@viz/app/lib/visualization-api";
 import type { UserIdentityState } from "@viz/app/types";
 import {
@@ -63,7 +64,7 @@ function resolvePodFunction(slug: string | null): {
   if (slug === null) {
     return { functionId: null };
   }
-  if (!/^[^/]+\/[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)) {
+  if (!POD_FUNCTION_REFERENCE_REGEX.test(slug)) {
     return {
       functionId: null,
       error: new Error(

--- a/viz/app/lib/pod-function-slug.ts
+++ b/viz/app/lib/pod-function-slug.ts
@@ -1,0 +1,18 @@
+/**
+ * Grammar of a fully qualified pod function reference, `<podId>/<slug>`, as a Frame passes it to
+ * `usePodFunction`.
+ *
+ * The slug half mirrors SANDBOX_FUNCTION_SLUG_REGEX in front
+ * (`front/types/api/sandbox_functions.ts`): one optional `<app>__` prefix that publish derives from
+ * the source's app folder, then the function's own name. `viz` cannot import from front, so
+ * equality is asserted from front's side in `front/types/api/sandbox_functions.test.ts` — the same
+ * arrangement as the runner protocol in `cli/dust-sandbox/functions-runner/protocol.ts`.
+ *
+ * Keeping this in step matters more than it looks: a reference this rejects resolves to a null SWR
+ * key, so the Frame silently issues no request at all.
+ */
+const SLUG_SEGMENT = "[a-z0-9]+(?:-[a-z0-9]+)*";
+
+export const POD_FUNCTION_REFERENCE_REGEX = new RegExp(
+  `^[^/]+/${SLUG_SEGMENT}(?:__${SLUG_SEGMENT})?$`
+);


### PR DESCRIPTION
## Description

A published pod function is identified by a slug unique per pod. Two apps in the same pod therefore cannot both own a function called `refresh` — and the failure is silent: `publishSandboxFunction` upserts on `(space, slug)`, so the second app's publish **replaces** the first app's function, bundle and contract included. The flat `w/<ws>/pods/<pod>/sandbox-functions/<slug>.ts` layout is the visible symptom of that flat namespace.

The published slug becomes `<app>__<name>`, where publish derives the prefix from the app folder the source lives in:

```
publish({ slug: "add-task", path: "pod-vlt_x/TaskList/functions/add-task.ts" })
  → tasklist__add-task
  → bundle at w/<ws>/pods/<pod>/sandbox-functions/tasklist__add-task.ts
  → dsbx function run tasklist__add-task
```

**Only the app folder contributes.** `functions/` and anything nested below it never appear in the slug, so moving a source inside its app does not rename the published function and does not orphan a Frame's `<podId>/<slug>` reference. That also keeps the source-layout question independent of identity — whether `functions/` stays a good idea can be revisited without touching any of this.

Encoding the prefix in the slug rather than nesting directories is what keeps the rest of the chain untouched. `__` already passes dsbx's `is_valid_name` (`cli/dust-sandbox/src/commands/function/mod.rs:359`, which allows `[A-Za-z0-9_-]`) and already resolves in the flat `read_dir` of `$DUST_FUNCTIONS_DIR`; and `podId/slug` stays a two-segment reference, so no route, resolution or `%2F`-encoding change either. A real nested tree would have meant Rust changes plus a dsbx build shipped into the sandbox image, in exchange for grouping in a bucket listing.

A source sitting directly at the pod root has no app folder and publishes under its bare name. That cannot collide with an app's function: a name is a single slug segment so it carries no `__`, and a normalized prefix carries none either, so every prefixed slug has exactly one and every bare slug has none — the namespaces are disjoint by construction. The skill still directs sources into an app folder, and now says why: moving one in later renames its function, leaving the old slug published and stale.

The `pod_functions` skill is updated accordingly — including the paragraph that previously promised the opposite ("it does not namespace the slug ... never includes the app name").

## Tests

Written test-first; each test was watched fail before the implementing change (the four pre-existing publish tests failed on `expected 'greet' to be 'greeter__greet'`).

- `front/lib/api/sandbox_functions/slug.test.ts` (new): prefix derivation, the ignore-intermediate-folders property, folder-name normalization, legacy `pod/...` paths, and the pod-root / empty-prefix / wrong-scope / bad-name rejections.
- `front/types/api/sandbox_functions.test.ts`: slug grammar, plus a guard that the grammar only produces names dsbx's `is_valid_name` accepts — the assumption the whole approach rests on.
- `front/lib/api/sandbox_functions/publish_sandbox_function.test.ts`: existing tests moved to app-folder paths; added the regression test that two apps publishing `refresh` yield two functions and two bundles with neither overwriting the other, and that a root source keeps its bare name.
- `front/lib/api/actions/servers/sandbox_functions/tools/publish.test.ts` (new): the handler reports the prefixed slug and the `<podId>/<slug>` reference, and the tool schema takes a bare name.

141/141 across all 18 sandbox-function suites; 240/240 across `file_resource`, `mount_path` and the skill suites. `npx tsgo --noEmit` and biome clean.

## Risk

Low. `sandbox_functions` is a `dust_only` flag, so the blast radius is our own workspaces.

No migration and no schema change: the unique index `(workspaceId, spaceId, slug)` now simply means *(pod, app, function)*. Bare slugs stay valid under the widened grammar, so existing rows and the already-published Frames that reference them keep working untouched.

The one behavioral edge: re-publishing an existing function renames it (it picks up its prefix), which breaks that Frame's reference until the Frame is re-published too. That is the same edit cycle as any function change, but worth knowing before touching a live pod app.

Rollback is a plain revert — nothing is persisted that the old code cannot read, since a reverted deploy just goes back to treating the stored `<app>__<name>` as an opaque slug.

## Deploy Plan

Standard deploy, no ordering constraints. front, the CLI and the sandbox image are independent here: no dsbx release is required, and no coordinated client rollout.

## Follow-up: the Frame reference grammar (viz)

Caught while testing a real Frame end to end. The `viz` workspace cannot import from front, so it carries its own copy of the slug grammar (`viz/app/lib/pod-function-hooks.tsx`). Widening front's copy without viz's meant `usePodFunction("<podId>/tasklist__add-task")` failed validation, resolved to a **null SWR key**, and the Frame issued no request at all — a broken function with an empty network tab, which is a nastier failure mode than a 404.

The grammar now lives in its own module (`viz/app/lib/pod-function-slug.ts`) and front asserts the two accept exactly the same slugs, so the copies cannot drift silently again. That mirrors how `cli/dust-sandbox/functions-runner/protocol.ts` is already kept in step. The guard was verified by reverting the viz side and watching it fail on `tasklist__add-task`.

viz: 51/51. front: 81/81 across the sandbox-function and slug suites.

