### PR TITLE
[front] perf: speed up Poke conversation loading

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/index.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/index.test.ts
@@ -1,0 +1,123 @@
+import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { honoApp } from "@front-api/app";
+import { assert, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/assistant/credit_cost", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@app/lib/api/assistant/credit_cost")>();
+
+  return {
+    ...original,
+    fetchAgentMessageCostAnalyticsByMessageIds: vi
+      .fn()
+      .mockResolvedValue(new Map()),
+  };
+});
+
+function conversationUrl(workspaceId: string, conversationId: string) {
+  return `/api/poke/workspaces/${workspaceId}/conversations/${conversationId}`;
+}
+
+describe("GET /api/poke/workspaces/:wId/conversations/:cId", () => {
+  it("paginates messages while preserving the unpaginated response", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "unused",
+      messagesCreatedAt: [],
+    });
+
+    for (let rank = 0; rank < 3; rank++) {
+      await ConversationFactory.createUserMessageWithRank({
+        auth,
+        workspace,
+        conversationId: conversation.id,
+        rank,
+        content: `Message ${rank}`,
+      });
+    }
+
+    const url = conversationUrl(workspace.sId, conversation.sId);
+    const firstResponse = await honoApp.request(`${url}?limit=2`);
+
+    expect(firstResponse.status).toBe(200);
+    const firstPage = await firstResponse.json();
+    expect(
+      firstPage.conversation.content
+        .flat()
+        .map((message: { content: string }) => message.content)
+    ).toEqual(["Message 1", "Message 2"]);
+    expect(firstPage.hasMore).toBe(true);
+    expect(firstPage.lastValue).toBe(1);
+
+    const secondResponse = await honoApp.request(
+      `${url}?limit=2&lastValue=${firstPage.lastValue}`
+    );
+
+    expect(secondResponse.status).toBe(200);
+    const secondPage = await secondResponse.json();
+    expect(
+      secondPage.conversation.content
+        .flat()
+        .map((message: { content: string }) => message.content)
+    ).toEqual(["Message 0"]);
+    expect(secondPage.hasMore).toBe(false);
+    expect(secondPage.lastValue).toBe(0);
+
+    const fullResponse = await honoApp.request(url);
+
+    expect(fullResponse.status).toBe(200);
+    const fullConversation = await fullResponse.json();
+    expect(
+      fullConversation.conversation.content
+        .flat()
+        .map((message: { content: string }) => message.content)
+    ).toEqual(["Message 0", "Message 1", "Message 2"]);
+    expect(fullConversation).not.toHaveProperty("hasMore");
+    expect(fullConversation).not.toHaveProperty("lastValue");
+  });
+
+  it("does not load tool output content with the conversation", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "dust",
+      messagesCreatedAt: [new Date()],
+    });
+    const agentMessage = conversation.content
+      .flat()
+      .find((message) => message.type === "agent_message");
+    assert(agentMessage);
+
+    const { action } = await AgentMCPActionFactory.create(auth, {
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId: agentMessage.agentMessageId,
+      status: "succeeded",
+      output: [{ type: "text", text: "large tool output" }],
+    });
+
+    const response = await honoApp.request(
+      `${conversationUrl(workspace.sId, conversation.sId)}?limit=50`
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    const responseAgentMessage = data.conversation.content
+      .flat()
+      .find((message: { sId: string }) => message.sId === agentMessage.sId);
+    assert(responseAgentMessage);
+    const responseAction = responseAgentMessage.actions.find(
+      (candidate: { sId: string }) => candidate.sId === action.sId
+    );
+    assert(responseAction);
+    expect(responseAction.output).toEqual([]);
+    expect(responseAction).not.toHaveProperty("mcpIO");
+  });
+});

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/index.ts
@@ -1,21 +1,23 @@
 import { getConversationApiError } from "@app/lib/api/assistant/conversation/helper";
+import type { PokeGetConversationResponseBody } from "@app/lib/api/poke/conversations";
 import { getPokeConversation } from "@app/lib/poke/conversation";
-import type { PokeConversationType } from "@app/types/poke";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 import config from "./config";
+import messages from "./messages";
 import reinforcementTestCase from "./reinforcement_test_case";
 import render from "./render";
 
-export type PokeGetConversationResponseBody = {
-  conversation: PokeConversationType;
-};
-
 const ParamsSchema = z.object({
   cId: z.string(),
+});
+
+const QuerySchema = z.object({
+  lastValue: z.coerce.number().int().nonnegative().optional(),
+  limit: z.coerce.number().int().positive().max(100).optional(),
 });
 
 // Mounted at /api/poke/workspaces/:wId/conversations/:cId.
@@ -25,20 +27,45 @@ const app = pokeApp();
 app.get(
   "/",
   validate("param", ParamsSchema),
+  validate("query", QuerySchema),
   async (ctx): HandlerResult<PokeGetConversationResponseBody> => {
     const auth = ctx.get("auth");
     const { cId } = ctx.req.valid("param");
+    const { lastValue, limit } = ctx.req.valid("query");
 
-    const conversationRes = await getPokeConversation(auth, cId, true);
+    const conversationRes = await getPokeConversation(
+      auth,
+      cId,
+      true,
+      limit
+        ? {
+            limit,
+            lastRank: lastValue ?? null,
+          }
+        : undefined,
+      false
+    );
     if (conversationRes.isErr()) {
       return apiError(ctx, getConversationApiError(conversationRes.error));
     }
 
-    return ctx.json({ conversation: conversationRes.value });
+    const {
+      hasMore,
+      lastValue: paginationLastValue,
+      ...conversation
+    } = conversationRes.value;
+
+    return ctx.json({
+      conversation,
+      ...(hasMore !== undefined
+        ? { hasMore, lastValue: paginationLastValue ?? null }
+        : {}),
+    });
   }
 );
 
 app.route("/config", config);
+app.route("/messages", messages);
 app.route("/reinforcement_test_case", reinforcementTestCase);
 app.route("/render", render);
 

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/messages/[mId]/actions/[aId]/index.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/messages/[mId]/actions/[aId]/index.test.ts
@@ -1,0 +1,42 @@
+import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { honoApp } from "@front-api/app";
+import { assert, describe, expect, it } from "vitest";
+
+describe("GET /api/poke/workspaces/:wId/conversations/:cId/messages/:mId/actions/:aId", () => {
+  it("returns the action inputs and output", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "dust",
+      messagesCreatedAt: [new Date()],
+    });
+    const agentMessage = conversation.content
+      .flat()
+      .find((message) => message.type === "agent_message");
+    assert(agentMessage);
+
+    const { action } = await AgentMCPActionFactory.create(auth, {
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId: agentMessage.agentMessageId,
+      status: "succeeded",
+      inputs: { query: "test query" },
+      output: [{ type: "text", text: "test output" }],
+    });
+
+    const response = await honoApp.request(
+      `/api/poke/workspaces/${workspace.sId}/conversations/${conversation.sId}/messages/${agentMessage.sId}/actions/${action.sId}`
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.action.sId).toBe(action.sId);
+    expect(data.action.params).toEqual({ query: "test query" });
+    expect(data.action.output).toEqual([{ type: "text", text: "test output" }]);
+    expect(data.messageStatus).toBe(agentMessage.status);
+  });
+});

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/messages/[mId]/actions/[aId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/messages/[mId]/actions/[aId]/index.ts
@@ -1,0 +1,85 @@
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { FetchConversationMessageActionResponse } from "@app/types/api/assistant/messages";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  aId: z.string(),
+  cId: z.string(),
+  mId: z.string(),
+});
+
+// Mounted at /api/poke/workspaces/:wId/conversations/:cId/messages/:mId/actions/:aId.
+const app = pokeApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<FetchConversationMessageActionResponse> => {
+    const auth = ctx.get("auth");
+    const { aId, cId, mId } = ctx.req.valid("param");
+
+    const conversation = await ConversationResource.fetchById(auth, cId, {
+      includeDeleted: true,
+    });
+    if (!conversation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: "Conversation not found.",
+        },
+      });
+    }
+
+    const messageRes = await conversation.getMessageById(auth, mId);
+    if (messageRes.isErr()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "message_not_found",
+          message: "Message not found.",
+        },
+      });
+    }
+
+    const message = messageRes.value;
+    if (!message.agentMessage) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Message is not an agent message.",
+        },
+      });
+    }
+
+    const action = await AgentMCPActionResource.fetchById(auth, aId);
+    if (!action || action.agentMessageId !== message.agentMessage.id) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "action_not_found",
+          message: "Action not found.",
+        },
+      });
+    }
+
+    const [enrichedAction] =
+      await AgentMCPActionResource.enrichActionsWithOutputItems(auth, {
+        actions: [action],
+        ignoreContent: false,
+      });
+
+    return ctx.json({
+      action: enrichedAction,
+      messageStatus: message.agentMessage.status,
+    });
+  }
+);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/messages/[mId]/actions/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/messages/[mId]/actions/index.ts
@@ -1,0 +1,10 @@
+import { pokeApp } from "@front-api/middlewares/ctx";
+
+import actionId from "./[aId]";
+
+// Mounted at /api/poke/workspaces/:wId/conversations/:cId/messages/:mId/actions.
+const app = pokeApp();
+
+app.route("/:aId", actionId);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/messages/[mId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/messages/[mId]/index.ts
@@ -1,0 +1,10 @@
+import { pokeApp } from "@front-api/middlewares/ctx";
+
+import actions from "./actions";
+
+// Mounted at /api/poke/workspaces/:wId/conversations/:cId/messages/:mId.
+const app = pokeApp();
+
+app.route("/actions", actions);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/messages/index.ts
@@ -1,0 +1,10 @@
+import { pokeApp } from "@front-api/middlewares/ctx";
+
+import messageId from "./[mId]";
+
+// Mounted at /api/poke/workspaces/:wId/conversations/:cId/messages.
+const app = pokeApp();
+
+app.route("/:mId", messageId);
+
+export default app;

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -7,6 +7,7 @@ import { useRequiredPathParam } from "@app/lib/platform";
 import { makeSandboxConnectCommand } from "@app/lib/poke/sandbox";
 import { usePokeConversation } from "@app/poke/swr";
 import { usePokeAgentConfigurations } from "@app/poke/swr/agent_configurations";
+import { usePokeConversationAction } from "@app/poke/swr/conversation_action";
 import { usePokeConversationConfig } from "@app/poke/swr/conversation_config";
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
 import { useCopyReinforcementTestCase } from "@app/poke/swr/reinforcement_test_case";
@@ -24,7 +25,6 @@ import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
-  Check,
   ChevronDown,
   Chip,
   Clipboard,
@@ -319,8 +319,19 @@ function getActionStatus(
 
 interface ToolActionViewProps {
   action: PokeAgentMessageType["actions"][number];
+  conversationId: string;
   cost?: AgentMessageCreditsToolBreakdown;
   isExpanded: boolean;
+  messageId: string;
+  onToggle: () => void;
+  owner: LightWorkspaceType;
+}
+
+interface ToolActionContentProps {
+  action: ToolActionViewProps["action"];
+  cost: ToolActionViewProps["cost"];
+  isExpanded: boolean;
+  isLoading: boolean;
   onToggle: () => void;
 }
 
@@ -328,10 +339,10 @@ function ToolActionContent({
   action,
   cost,
   isExpanded,
+  isLoading,
   onToggle,
-}: ToolActionViewProps) {
+}: ToolActionContentProps) {
   const actionStatus = getActionStatus(action.status);
-  const ActionIcon = action.status === "errored" ? XClose : Check;
   const actionLabel = getActionLabel(action);
   const duration =
     "executionDurationMs" in action &&
@@ -342,29 +353,29 @@ function ToolActionContent({
   return (
     <>
       <span className="shrink-0">
-        {action.mcpIO ? (
-          <Button
-            variant="outline"
-            size="icon"
-            icon={
-              <ChevronDown
-                className={cn(
-                  "h-4 w-4 transition-transform",
-                  !isExpanded ? "-rotate-90" : null
-                )}
-              />
-            }
-            onClick={onToggle}
-            aria-expanded={isExpanded}
-            aria-label={
-              isExpanded ? "Collapse tool details" : "Expand tool details"
-            }
-          />
-        ) : (
-          <span className="flex h-7 w-7 items-center justify-center rounded-md border border-separator bg-background">
-            <ActionIcon className="h-4 w-4 text-muted-foreground" />
-          </span>
-        )}
+        <Button
+          variant="outline"
+          size="icon"
+          icon={
+            <ChevronDown
+              className={cn(
+                "h-4 w-4 transition-transform",
+                !isExpanded ? "-rotate-90" : null
+              )}
+            />
+          }
+          isLoading={isLoading}
+          disabled={isLoading}
+          onClick={onToggle}
+          aria-expanded={isExpanded}
+          aria-label={
+            isLoading
+              ? "Loading tool details"
+              : isExpanded
+                ? "Collapse tool details"
+                : "Expand tool details"
+          }
+        />
       </span>
       <span className="flex min-w-0 flex-1 items-center gap-3">
         <span className="w-24 shrink-0 font-mono text-sm tabular-nums text-muted-foreground">
@@ -422,10 +433,33 @@ function ToolActionContent({
 
 function ToolActionView({
   action,
+  conversationId,
   cost,
   isExpanded,
+  messageId,
   onToggle,
+  owner,
 }: ToolActionViewProps) {
+  const {
+    action: detailedAction,
+    isError,
+    isLoading,
+    retry,
+  } = usePokeConversationAction({
+    actionId: action.sId,
+    conversationId,
+    disabled: !isExpanded || Boolean(action.mcpIO),
+    messageId,
+    owner,
+  });
+  const mcpIO = detailedAction
+    ? {
+        params: detailedAction.params,
+        output: detailedAction.output,
+        generatedFiles: detailedAction.generatedFiles,
+      }
+    : action.mcpIO;
+
   return (
     <div>
       <div
@@ -440,17 +474,31 @@ function ToolActionView({
           action={action}
           cost={cost}
           isExpanded={isExpanded}
+          isLoading={isLoading}
           onToggle={onToggle}
         />
       </div>
-      {action.mcpIO && isExpanded && (
+      {isExpanded && isError && (
+        <div className="ml-9 mt-2 flex items-center gap-2 rounded-md border border-border-warning bg-background px-3 py-2 text-sm font-medium text-warning">
+          <span>Failed to load tool details.</span>
+          <Button
+            label="Retry"
+            variant="outline"
+            size="xs"
+            isLoading={isLoading}
+            disabled={isLoading}
+            onClick={() => void retry()}
+          />
+        </div>
+      )}
+      {mcpIO && isExpanded && (
         <div className="ml-9 mt-2 overflow-hidden rounded-md border border-separator bg-background">
           <CodeBlock wrapLongLines className="language-json">
             {JSON.stringify(
               {
-                params: action.mcpIO.params,
-                output: action.mcpIO.output,
-                generatedFiles: action.mcpIO.generatedFiles,
+                params: mcpIO.params,
+                output: mcpIO.output,
+                generatedFiles: mcpIO.generatedFiles,
               },
               undefined,
               2
@@ -630,6 +678,7 @@ const UserMessageView = ({ message, useMarkdown }: UserMessageViewProps) => {
 };
 
 interface AgentMessageViewProps {
+  conversationId: string;
   message: PokeAgentMessageType;
   useMarkdown: boolean;
   owner: LightWorkspaceType;
@@ -637,6 +686,7 @@ interface AgentMessageViewProps {
 }
 
 const AgentMessageView = ({
+  conversationId,
   message,
   useMarkdown,
   owner,
@@ -768,9 +818,12 @@ const AgentMessageView = ({
             <ToolActionView
               key={a.sId}
               action={a}
+              conversationId={conversationId}
               cost={costByActionId.get(a.sId)}
               isExpanded={isExpanded}
+              messageId={message.sId}
               onToggle={() => toggleAction(a.sId)}
+              owner={owner}
             />
           );
         })}
@@ -850,17 +903,20 @@ export function ConversationPage() {
   const owner = useWorkspace();
 
   const conversationId = useRequiredPathParam("cId");
-  const {
-    data: conversationConfig,
-    isLoading: isConfigLoading,
-    isError: isConfigError,
-  } = usePokeConversationConfig({
+  const { data: conversationConfig } = usePokeConversationConfig({
     owner,
     conversationId,
     disabled: false,
   });
 
-  const { conversation } = usePokeConversation({
+  const {
+    conversation,
+    hasOlderMessages,
+    isConversationError,
+    isConversationLoading,
+    isLoadingOlderMessages,
+    loadOlderMessages,
+  } = usePokeConversation({
     workspaceId: owner.sId,
     conversationId,
   });
@@ -880,9 +936,11 @@ export function ConversationPage() {
     spaceDetails?.space.kind === "project" ? spaceDetails.space : null;
 
   const [useMarkdown, setUseMarkdown] = useState(false);
+  const [showRenderControls, setShowRenderControls] = useState(false);
   const { data: agents } = usePokeAgentConfigurations({
     owner,
     agentsGetView: "admin_internal",
+    disabled: !showRenderControls,
   });
 
   const defaultAgentId = (() => {
@@ -914,7 +972,6 @@ export function ConversationPage() {
     systemPrompt: string;
     toolsTokenCountApprox: number;
   }>(null);
-  const [showRenderControls, setShowRenderControls] = useState(false);
   const [isCopiedJSON, copyJSON] = useCopyToClipboard();
   const [isCopiedSandboxCommand, copySandboxCommand] = useCopyToClipboard();
 
@@ -963,7 +1020,7 @@ export function ConversationPage() {
     }
   }
 
-  if (isConfigLoading) {
+  if (isConversationLoading) {
     return (
       <div className="flex h-64 items-center justify-center">
         <Spinner />
@@ -971,20 +1028,20 @@ export function ConversationPage() {
     );
   }
 
-  if (isConfigError || !conversationConfig) {
+  if (isConversationError || !conversation) {
     return (
       <div className="flex h-64 items-center justify-center">
-        <p>Error loading conversation config.</p>
+        <p>Error loading conversation.</p>
       </div>
     );
   }
 
   const {
-    conversationDataSourceId,
-    langfuseUiBaseUrl,
-    sandbox,
-    temporalWorkspace,
-  } = conversationConfig;
+    conversationDataSourceId = null,
+    langfuseUiBaseUrl = null,
+    sandbox = null,
+    temporalWorkspace = "",
+  } = conversationConfig ?? {};
 
   const sandboxConnect = sandbox
     ? { command: makeSandboxConnectCommand(sandbox), status: sandbox.status }
@@ -1046,11 +1103,16 @@ export function ConversationPage() {
                 target="_blank"
               />
               <Button
-                href={`https://cloud.temporal.io/namespaces/${temporalWorkspace}/workflows?query=%60conversationId%60%3D"${conversationId}"`}
+                href={
+                  temporalWorkspace
+                    ? `https://cloud.temporal.io/namespaces/${temporalWorkspace}/workflows?query=%60conversationId%60%3D"${conversationId}"`
+                    : undefined
+                }
                 label="Temporal Workflows"
                 variant="primary"
                 size="xs"
                 target="_blank"
+                disabled={!temporalWorkspace}
               />
               <Button
                 href={getDatadogSandboxLogsUrl(conversationId)}
@@ -1282,15 +1344,30 @@ export function ConversationPage() {
             </div>
           )}
           <div className="flex w-full flex-1 flex-col justify-start gap-8 py-4">
+            {hasOlderMessages && (
+              <div className="flex justify-center">
+                <Button
+                  label="Load older messages"
+                  variant="outline"
+                  isLoading={isLoadingOlderMessages}
+                  disabled={isLoadingOlderMessages}
+                  onClick={loadOlderMessages}
+                />
+              </div>
+            )}
             {conversation.content.map((messages, i) => {
               return (
-                <div key={`messages-${i}`} className="flex flex-col gap-4">
-                  {messages.map((m, j) => {
+                <div
+                  key={`messages-${messages.at(0)?.rank ?? i}`}
+                  className="flex flex-col gap-4"
+                >
+                  {messages.map((m) => {
                     switch (m.type) {
                       case "agent_message": {
                         return (
                           <AgentMessageView
-                            key={`message-${i}-${j}`}
+                            key={`${m.sId}-${m.version}`}
+                            conversationId={conversationId}
                             message={m}
                             useMarkdown={useMarkdown}
                             owner={owner}
@@ -1302,7 +1379,7 @@ export function ConversationPage() {
                         return (
                           <UserMessageView
                             message={m}
-                            key={`message-${i}-${j}`}
+                            key={`${m.sId}-${m.version}`}
                             useMarkdown={useMarkdown}
                           />
                         );
@@ -1311,7 +1388,7 @@ export function ConversationPage() {
                         return (
                           <ContentFragmentView
                             message={m}
-                            key={`message-${i}-${j}`}
+                            key={`${m.sId}-${m.version}`}
                           />
                         );
                       }
@@ -1319,7 +1396,7 @@ export function ConversationPage() {
                         return (
                           <CompactionMessageView
                             message={m}
-                            key={`message-${i}-${j}`}
+                            key={`${m.sId}-${m.version}`}
                           />
                         );
                       }

--- a/front/lib/api/poke/conversations.ts
+++ b/front/lib/api/poke/conversations.ts
@@ -3,7 +3,7 @@ import type {
   ConversationVisibility,
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
-import type { PokeSandboxType } from "@app/types/poke";
+import type { PokeConversationType, PokeSandboxType } from "@app/types/poke";
 
 export type PokeListConversationItem = ConversationWithoutContentType & {
   visibility?: ConversationVisibility;
@@ -11,6 +11,12 @@ export type PokeListConversationItem = ConversationWithoutContentType & {
 
 export type PokeListConversations = {
   conversations: PokeListConversationItem[];
+};
+
+export type PokeGetConversationResponseBody = {
+  conversation: PokeConversationType;
+  hasMore?: boolean;
+  lastValue?: number | null;
 };
 
 export type PokeGetConversationConfig = {

--- a/front/lib/poke/conversation.ts
+++ b/front/lib/poke/conversation.ts
@@ -14,47 +14,54 @@ import type {
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 
+type PokeConversationWithPagination = PokeConversationType & {
+  hasMore?: boolean;
+  lastValue?: number | null;
+};
+
 export async function getPokeConversation(
   auth: Authenticator,
   conversationId: string,
-  includeDeleted?: boolean
-): Promise<Result<PokeConversationType, ConversationError>> {
+  includeDeleted?: boolean,
+  messagePagination?: { limit: number; lastRank: number | null },
+  includeActionOutputContent: boolean = true
+): Promise<Result<PokeConversationWithPagination, ConversationError>> {
   const owner = auth.getNonNullableWorkspace();
-  // biome-ignore lint/plugin/noExpensiveConversationFetch: intentional full conversation load
+  // biome-ignore lint/plugin/noExpensiveConversationFetch: Poke UI requests are paginated; tool callers intentionally load the full conversation.
   const conversation = await getConversation(
     auth,
     conversationId,
-    includeDeleted
+    includeDeleted,
+    includeActionOutputContent ? null : 0,
+    messagePagination
   );
 
   // Enrich the returned conversation with the apps runs linked to the agent messages
   // Decided to do it as a separate step because I didn't want to modify the getConversation to make it more complex based on the use case
   // and I still wanted to use the existing getConversation code for rendering.
   if (conversation.isOk()) {
-    const pokeConversation = conversation.value as PokeConversationType;
+    const pokeConversation =
+      conversation.value as PokeConversationWithPagination;
 
     const agentMessages = pokeConversation.content
       .flat()
       .filter((m): m is PokeAgentMessageType => m.type === "agent_message");
 
-    const agentMessagesWithRunIds = await AgentMessageModel.findAll({
-      where: {
-        id: [...new Set(agentMessages.map((m) => m.agentMessageId))],
-        workspaceId: owner.id,
-      },
-      attributes: ["id", "runIds"],
-    });
+    const [agentMessagesWithRunIds, analyticsByMessageId] = await Promise.all([
+      AgentMessageModel.findAll({
+        where: {
+          id: [...new Set(agentMessages.map((m) => m.agentMessageId))],
+          workspaceId: owner.id,
+        },
+        attributes: ["id", "runIds"],
+      }),
+      fetchAgentMessageCostAnalyticsByMessageIds(auth, {
+        messageIds: agentMessages.map((m) => m.sId),
+      }),
+    ]);
     const runIdsByAgentMessageId = new Map(
       agentMessagesWithRunIds.map((m) => [m.id, m.runIds])
     );
-
-    // Batch-fetch the stored cost analytics document for every agent message in the
-    // conversation in one shot (rather than per message), so each message's cost
-    // breakdown can be attached with zero additional queries per message.
-    const analyticsByMessageId =
-      await fetchAgentMessageCostAnalyticsByMessageIds(auth, {
-        messageIds: agentMessages.map((m) => m.sId),
-      });
 
     // Cycle through the messages and actions and enrich them with runId(s) and timestamps.
     for (const messages of pokeConversation.content) {
@@ -75,12 +82,14 @@ export async function getPokeConversation(
 
           if (m.actions.length > 0) {
             for (const a of m.actions) {
-              a.mcpIO = {
-                params: a.params,
-                output: a.output,
-                generatedFiles: a.generatedFiles,
-                isError: a.status === "errored",
-              };
+              if (includeActionOutputContent) {
+                a.mcpIO = {
+                  params: a.params,
+                  output: a.output,
+                  generatedFiles: a.generatedFiles,
+                  isError: a.status === "errored",
+                };
+              }
               a.created = a.createdAt;
             }
           }

--- a/front/poke/swr/conversation_action.ts
+++ b/front/poke/swr/conversation_action.ts
@@ -1,0 +1,36 @@
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { FetchConversationMessageActionResponse } from "@app/types/api/assistant/messages";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { Fetcher } from "swr";
+
+interface UsePokeConversationActionProps {
+  actionId: string;
+  conversationId: string;
+  disabled: boolean;
+  messageId: string;
+  owner: LightWorkspaceType;
+}
+
+export function usePokeConversationAction({
+  actionId,
+  conversationId,
+  disabled,
+  messageId,
+  owner,
+}: UsePokeConversationActionProps) {
+  const { fetcher } = useFetcher();
+  const actionFetcher: Fetcher<FetchConversationMessageActionResponse> =
+    fetcher;
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/conversations/${conversationId}/messages/${messageId}/actions/${actionId}`,
+    actionFetcher,
+    { disabled }
+  );
+
+  return {
+    action: data?.action ?? null,
+    isError: error,
+    isLoading: isValidating && !data && !disabled,
+    retry: mutate,
+  };
+}

--- a/front/poke/swr/index.ts
+++ b/front/poke/swr/index.ts
@@ -1,8 +1,13 @@
 import type { LLMTrace } from "@app/lib/api/llm/traces/types";
+import type { PokeGetConversationResponseBody } from "@app/lib/api/poke/conversations";
 import type { PokeFetchAssistantTemplateResponse } from "@app/lib/api/poke/templates";
 import { clientFetch } from "@app/lib/egress/client";
 import type { FetchAssistantTemplatesResponse } from "@app/lib/resources/template_resource";
-import { emptyArray, useFetcher } from "@app/lib/swr/swr";
+import {
+  emptyArray,
+  useFetcher,
+  useSWRInfiniteWithDefaults,
+} from "@app/lib/swr/swr";
 import type {
   GetDocumentsResponseBody,
   GetTablesResponseBody,
@@ -17,9 +22,10 @@ interface PokeAssistantTemplatesResponse
   dustRegionSyncEnabled: boolean;
 }
 
-import type { ConversationType } from "@app/types/assistant/conversation";
 import type { DataSourceType } from "@app/types/data_source";
 import type { LightWorkspaceType } from "@app/types/user";
+
+const POKE_CONVERSATION_PAGE_SIZE = 50;
 
 export function usePokePullTemplates() {
   const { mutateAssistantTemplates } = usePokeAssistantTemplates();
@@ -101,20 +107,63 @@ export function usePokeConversation({
   conversationId: string | null;
 }) {
   const { fetcher } = useFetcher();
-  const conversationFetcher: Fetcher<{ conversation: ConversationType }> =
-    fetcher;
+  const conversationFetcher: Fetcher<PokeGetConversationResponseBody> = fetcher;
 
-  const { data, error, mutate } = useSWR(
-    conversationId
-      ? `/api/poke/workspaces/${workspaceId}/conversations/${conversationId}`
-      : null,
-    conversationFetcher
-  );
+  const { data, error, isValidating, mutate, setSize, size } =
+    useSWRInfiniteWithDefaults(
+      (
+        _pageIndex: number,
+        previousPageData: PokeGetConversationResponseBody | null
+      ) => {
+        if (
+          !conversationId ||
+          (previousPageData && !previousPageData.hasMore)
+        ) {
+          return null;
+        }
+
+        const baseUrl = `/api/poke/workspaces/${workspaceId}/conversations/${conversationId}?limit=${POKE_CONVERSATION_PAGE_SIZE}`;
+        if (previousPageData === null) {
+          return baseUrl;
+        }
+
+        return previousPageData.lastValue !== null &&
+          previousPageData.lastValue !== undefined
+          ? `${baseUrl}&lastValue=${previousPageData.lastValue}`
+          : null;
+      },
+      conversationFetcher,
+      { revalidateAll: false }
+    );
+
+  const conversation = useMemo(() => {
+    const firstPage = data?.[0];
+    if (!firstPage) {
+      return null;
+    }
+
+    return {
+      ...firstPage.conversation,
+      content: [...data].reverse().flatMap((page) => page.conversation.content),
+    };
+  }, [data]);
+
+  const hasOlderMessages = data
+    ? (data[data.length - 1]?.hasMore ?? false)
+    : false;
+  const loadOlderMessages = useCallback(() => {
+    if (hasOlderMessages && !isValidating) {
+      void setSize(size + 1);
+    }
+  }, [hasOlderMessages, isValidating, setSize, size]);
 
   return {
-    conversation: data ? data.conversation : null,
+    conversation,
+    hasOlderMessages,
     isConversationLoading: !error && !data,
     isConversationError: error,
+    isLoadingOlderMessages: isValidating && size > 1,
+    loadOlderMessages,
     mutateConversation: mutate,
   };
 }

--- a/front/types/poke/index.ts
+++ b/front/types/poke/index.ts
@@ -7,6 +7,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 import type {
   AgentMessageType,
+  CompactionMessageType,
   ConversationType,
   UserMessageType,
 } from "../assistant/conversation";
@@ -96,5 +97,6 @@ export type PokeConversationType = Omit<ConversationType, "content"> & {
     | UserMessageType[]
     | PokeAgentMessageType[]
     | ContentFragmentType[]
+    | CompactionMessageType[]
   )[];
 };


### PR DESCRIPTION
## Description

Large conversations in Poke currently fetch the full history and hydrate every tool output before the page can render.

This paginates messages 50 at a time, lets the conversation render without waiting for its secondary configuration, defers the agent list until render controls are opened, and fetches run metadata and cost analytics concurrently. Tool outputs are omitted from conversation pages and fetched for one action when it is expanded, with loading and retry states. Other `getPokeConversation` callers keep the existing full-output behavior.

## Tests

- Added coverage for conversation pagination, initial tool output omission, and lazy action output fetching.

## Risk

- Low. Limited to the internal Poke conversation page.

## Deploy Plan

- Deploy front and front-api.
