### PR TITLE
[front] fix: validate MCP connection type in endpoint handler

### DIFF
--- a/front-api/routes/w/[wId]/mcp/connections/[connectionType]/[cId]/index.test.ts
+++ b/front-api/routes/w/[wId]/mcp/connections/[connectionType]/[cId]/index.test.ts
@@ -67,6 +67,45 @@ describe("MCP connections handler", () => {
     expect((await response.json()).connection.sId).toBe(connection.sId);
   });
 
+  it("GET should return 404 when the connection type does not match", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
+
+    const remoteServer = await RemoteMCPServerFactory.create(workspace);
+    const connection = await MCPServerConnectionFactory.remote(
+      auth,
+      remoteServer,
+      "personal"
+    );
+
+    const response = await get(workspace, "workspace", connection.sId);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "mcp_server_connection_not_found",
+        message: "Connection not found",
+      },
+    });
+  });
+
+  it("GET should return 400 for an invalid connection type", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
+
+    const response = await get(workspace, "invalid", "connection_id");
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "Invalid connection type",
+      },
+    });
+  });
+
   it("GET cannot return a connection from another workspace", async () => {
     const { workspace: workspace1, auth: auth1 } =
       await createPrivateApiMockRequest({ method: "GET" });
@@ -165,6 +204,27 @@ describe("MCP connections handler", () => {
         connectionType: "personal",
       });
     expect(remainingForSecondUser).toHaveLength(1);
+  });
+
+  it("DELETE should not delete a connection when the connection type does not match", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "DELETE",
+    });
+    const remoteServer = await RemoteMCPServerFactory.create(workspace);
+    const connection = await MCPServerConnectionFactory.remote(
+      auth,
+      remoteServer,
+      "personal"
+    );
+
+    const response = await del(workspace, "workspace", connection.sId);
+
+    expect(response.status).toBe(404);
+    const connectionRes = await MCPServerConnectionResource.fetchById(
+      auth,
+      connection.sId
+    );
+    expect(connectionRes.isOk()).toBe(true);
   });
 
   it("DELETE workspace connection deletes all connections for the same server", async () => {

--- a/front-api/routes/w/[wId]/mcp/connections/[connectionType]/[cId]/index.test.ts
+++ b/front-api/routes/w/[wId]/mcp/connections/[connectionType]/[cId]/index.test.ts
@@ -222,7 +222,8 @@ describe("MCP connections handler", () => {
     expect(response.status).toBe(404);
     const connectionRes = await MCPServerConnectionResource.fetchById(
       auth,
-      connection.sId
+      connection.sId,
+      { connectionType: "personal" }
     );
     expect(connectionRes.isOk()).toBe(true);
   });

--- a/front-api/routes/w/[wId]/mcp/connections/[connectionType]/[cId]/index.ts
+++ b/front-api/routes/w/[wId]/mcp/connections/[connectionType]/[cId]/index.ts
@@ -1,4 +1,7 @@
-import type { MCPServerConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
+import type {
+  MCPServerConnectionConnectionType,
+  MCPServerConnectionType,
+} from "@app/lib/resources/mcp_server_connection_resource";
 import {
   isMCPServerConnectionConnectionType,
   MCPServerConnectionResource,
@@ -17,9 +20,13 @@ const ParamsSchema = z.object({
 // Mounted at /api/w/:wId/mcp/connections/:connectionType/:cId.
 const app = workspaceApp();
 
-async function loadConnection(ctx: Context, cId: string) {
+async function loadConnection(
+  ctx: Context,
+  cId: string,
+  connectionType: MCPServerConnectionConnectionType
+) {
   const auth = ctx.get("auth");
-  return MCPServerConnectionResource.fetchById(auth, cId);
+  return MCPServerConnectionResource.fetchById(auth, cId, { connectionType });
 }
 
 /** @ignoreswagger */
@@ -35,11 +42,8 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
     });
   }
 
-  const connectionRes = await loadConnection(ctx, cId);
-  if (
-    connectionRes.isErr() ||
-    connectionRes.value.connectionType !== connectionType
-  ) {
+  const connectionRes = await loadConnection(ctx, cId, connectionType);
+  if (connectionRes.isErr()) {
     return apiError(ctx, {
       status_code: 404,
       api_error: {
@@ -68,11 +72,8 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
     });
   }
 
-  const connectionRes = await loadConnection(ctx, cId);
-  if (
-    connectionRes.isErr() ||
-    connectionRes.value.connectionType !== connectionType
-  ) {
+  const connectionRes = await loadConnection(ctx, cId, connectionType);
+  if (connectionRes.isErr()) {
     return apiError(ctx, {
       status_code: 404,
       api_error: {

--- a/front-api/routes/w/[wId]/mcp/connections/[connectionType]/[cId]/index.ts
+++ b/front-api/routes/w/[wId]/mcp/connections/[connectionType]/[cId]/index.ts
@@ -1,5 +1,8 @@
 import type { MCPServerConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
-import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import {
+  isMCPServerConnectionConnectionType,
+  MCPServerConnectionResource,
+} from "@app/lib/resources/mcp_server_connection_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -8,6 +11,7 @@ import { z } from "zod";
 
 const ParamsSchema = z.object({
   cId: z.string(),
+  connectionType: z.string(),
 });
 
 // Mounted at /api/w/:wId/mcp/connections/:connectionType/:cId.
@@ -20,9 +24,22 @@ async function loadConnection(ctx: Context, cId: string) {
 
 /** @ignoreswagger */
 app.get("/", validate("param", ParamsSchema), async (ctx) => {
-  const { cId } = ctx.req.valid("param");
+  const { cId, connectionType } = ctx.req.valid("param");
+  if (!isMCPServerConnectionConnectionType(connectionType)) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid connection type",
+      },
+    });
+  }
+
   const connectionRes = await loadConnection(ctx, cId);
-  if (connectionRes.isErr()) {
+  if (
+    connectionRes.isErr() ||
+    connectionRes.value.connectionType !== connectionType
+  ) {
     return apiError(ctx, {
       status_code: 404,
       api_error: {
@@ -40,9 +57,22 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
 
 app.delete("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const { cId } = ctx.req.valid("param");
+  const { cId, connectionType } = ctx.req.valid("param");
+  if (!isMCPServerConnectionConnectionType(connectionType)) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid connection type",
+      },
+    });
+  }
+
   const connectionRes = await loadConnection(ctx, cId);
-  if (connectionRes.isErr()) {
+  if (
+    connectionRes.isErr() ||
+    connectionRes.value.connectionType !== connectionType
+  ) {
     return apiError(ctx, {
       status_code: 404,
       api_error: {

--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -151,9 +151,10 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
 
   static async fetchById(
     auth: Authenticator,
-    id: string
+    id: string,
+    { connectionType }: { connectionType: MCPServerConnectionConnectionType }
   ): Promise<Result<MCPServerConnectionResource, DustError>> {
-    const connRes = await this.fetchByIds(auth, [id]);
+    const connRes = await this.fetchByIds(auth, [id], { connectionType });
 
     if (connRes.isErr()) {
       return connRes;
@@ -164,7 +165,8 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
 
   static async fetchByIds(
     auth: Authenticator,
-    ids: string[]
+    ids: string[],
+    { connectionType }: { connectionType: MCPServerConnectionConnectionType }
   ): Promise<Result<MCPServerConnectionResource[], DustError>> {
     const connModelIds = removeNulls(ids.map((id) => getResourceIdFromSId(id)));
     if (connModelIds.length !== ids.length) {
@@ -176,6 +178,7 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
         id: {
           [Op.in]: connModelIds,
         },
+        connectionType,
       },
     });
 


### PR DESCRIPTION
## Description

MCP connection detail routes contain a `connectionType` in their path but never check its value.

This PR validate the connection type and include it in the filter.

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
