### PR TITLE
Pricing: clean typing around poolLimitAwuCredits

### DIFF
--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -65,13 +65,11 @@ function resolvePoolLimitForUser({
   }
   // Remaining seat types (pro/max/workspace) have pool access following the
   // shared ladder: per-user override > max group cap > workspace default.
-  return (
-    resolveEffectiveSpendLimitAwuCredits({
-      overrideAwuCredits: membership.poolCapOverrideAwuCredits,
-      groupCapAwuCredits,
-      defaultAwuCredits: defaultPoolCapAwuCredits,
-    }) ?? defaultPoolCapAwuCredits
-  );
+  return resolveEffectiveSpendLimitAwuCredits({
+    overrideAwuCredits: membership.poolCapOverrideAwuCredits,
+    groupCapAwuCredits,
+    defaultAwuCredits: defaultPoolCapAwuCredits,
+  });
 }
 
 // Max group cap (pool-only, excluding seat allowance) across a single user's

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -402,12 +402,11 @@ async function handlePerUserSpendThresholdEvent({
     ).get(membership.userId) ?? null;
   const defaultPoolCapAwuCredits =
     creditUsageConfig?.defaultPoolCapAwuCredits ?? 0;
-  const poolCap =
-    resolveEffectiveSpendLimitAwuCredits({
-      overrideAwuCredits: membership.poolCapOverrideAwuCredits,
-      groupCapAwuCredits,
-      defaultAwuCredits: defaultPoolCapAwuCredits,
-    }) ?? defaultPoolCapAwuCredits;
+  const poolCap = resolveEffectiveSpendLimitAwuCredits({
+    overrideAwuCredits: membership.poolCapOverrideAwuCredits,
+    groupCapAwuCredits,
+    defaultAwuCredits: defaultPoolCapAwuCredits,
+  });
   const capSource = resolveEffectiveSpendLimitSource({
     overrideAwuCredits: membership.poolCapOverrideAwuCredits,
     groupCapAwuCredits,

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -631,12 +631,11 @@ export async function reconcileWorkspaceUserCreditStates({
     // ladder).
     const groupCapAwuCredits =
       groupCapByUserModelId.get(membership.userId) ?? null;
-    const poolCapAwuCredits =
-      resolveEffectiveSpendLimitAwuCredits({
-        overrideAwuCredits: membership.poolCapOverrideAwuCredits,
-        groupCapAwuCredits,
-        defaultAwuCredits: defaultPoolCapAwuCredits,
-      }) ?? defaultPoolCapAwuCredits;
+    const poolCapAwuCredits = resolveEffectiveSpendLimitAwuCredits({
+      overrideAwuCredits: membership.poolCapOverrideAwuCredits,
+      groupCapAwuCredits,
+      defaultAwuCredits: defaultPoolCapAwuCredits,
+    });
     const effectiveCapAwuCredits = normalizedSeatType
       ? poolCapAwuCredits + (seatAllowances[normalizedSeatType] ?? 0)
       : null;

--- a/front/lib/metronome/live_user_credit_inputs.ts
+++ b/front/lib/metronome/live_user_credit_inputs.ts
@@ -151,14 +151,12 @@ export async function fetchLiveUserCreditInputs({
 
   if (normalizedSeatType) {
     // Priority: per-user override > max group cap > workspace default (shared
-    // ladder). The `?? defaultPoolCapAwuCredits` is unreachable — the default is
-    // always a number here — but keeps the type non-null for the arithmetic.
-    const poolCapAwuCredits =
-      resolveEffectiveSpendLimitAwuCredits({
-        overrideAwuCredits: poolCapOverrideAwuCredits,
-        groupCapAwuCredits,
-        defaultAwuCredits: defaultPoolCapAwuCredits,
-      }) ?? defaultPoolCapAwuCredits;
+    // ladder).
+    const poolCapAwuCredits = resolveEffectiveSpendLimitAwuCredits({
+      overrideAwuCredits: poolCapOverrideAwuCredits,
+      groupCapAwuCredits,
+      defaultAwuCredits: defaultPoolCapAwuCredits,
+    });
     capSource = resolveEffectiveSpendLimitSource({
       overrideAwuCredits: poolCapOverrideAwuCredits,
       groupCapAwuCredits,

--- a/front/lib/metronome/user_credit_state_machine.test.ts
+++ b/front/lib/metronome/user_credit_state_machine.test.ts
@@ -353,12 +353,12 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
     );
   });
 
-  it("user_seat + pro seat + pool limit null (unlimited) → on_pool", async () => {
+  it("user_seat + pro seat + no resolved pool limit → on_pool", async () => {
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
       { type: "seat_balance_exhausted" },
-      { ...baseCtx, seatType: "pro", poolLimitAwuCredits: null }
+      { ...baseCtx, seatType: "pro" }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -397,12 +397,12 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
     );
   });
 
-  it("legacy user_seat_low_balance (alias → user_seat) + max seat + pool limit null → on_pool", async () => {
+  it("legacy user_seat_low_balance (alias → user_seat) + max seat + pool limit > 0 → on_pool", async () => {
     const membership = makeMembership("user_seat_low_balance", "max");
     const result = await transitionUserCreditState(
       membership,
       { type: "seat_balance_exhausted" },
-      { ...baseCtx, seatType: "max", poolLimitAwuCredits: null }
+      { ...baseCtx, seatType: "max", poolLimitAwuCredits: 5000 }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -482,7 +482,7 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
         ...baseCtx,
         seatType: "pro",
         remainingCapCreditsPercentage: 0.1,
-        poolLimitAwuCredits: null,
+        poolLimitAwuCredits: 5000,
       }
     );
     expect(result.isOk()).toBe(true);
@@ -504,7 +504,7 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
         ...baseCtx,
         seatType: "pro",
         remainingCapCreditsPercentage: 0.19,
-        poolLimitAwuCredits: null,
+        poolLimitAwuCredits: 5000,
       }
     );
     expect(result.isOk()).toBe(true);
@@ -526,7 +526,7 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
         ...baseCtx,
         seatType: "pro",
         remainingCapCreditsPercentage: 0.2,
-        poolLimitAwuCredits: null,
+        poolLimitAwuCredits: 5000,
       }
     );
     expect(result.isOk()).toBe(true);
@@ -548,29 +548,7 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
         ...baseCtx,
         seatType: "pro",
         remainingCapCreditsPercentage: 0.5,
-        poolLimitAwuCredits: null,
-      }
-    );
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      expect(result.value).toBe("on_pool");
-    }
-    expect(membership.updateCreditState).toHaveBeenCalledWith(
-      "on_pool",
-      undefined
-    );
-  });
-
-  it("user_seat + pro + null cap percentage → on_pool (no cap configured)", async () => {
-    const membership = makeMembership("user_seat", "pro");
-    const result = await transitionUserCreditState(
-      membership,
-      { type: "seat_balance_exhausted" },
-      {
-        ...baseCtx,
-        seatType: "pro",
-        remainingCapCreditsPercentage: null,
-        poolLimitAwuCredits: null,
+        poolLimitAwuCredits: 5000,
       }
     );
     expect(result.isOk()).toBe(true);

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -44,12 +44,13 @@ export type UserCreditContext = {
   remainingCapCreditsPercentage?: number | null;
   /**
    * The user's effective pool budget in AWU credits: `0` = no pool access
-   * (e.g. free seats), `> 0` = capped pool, `null` = unlimited. A property of
-   * the user's situation (like `remainingCapCreditsPercentage`), so it lives in
-   * the context — it's what the `seat_balance_exhausted` guards use to route
-   * `capped` vs `on_pool`, with no seat-type special-casing.
+   * (e.g. free seats), `> 0` = capped pool. Unlimited is not supported. A
+   * property of the user's situation (like `remainingCapCreditsPercentage`), so
+   * it lives in the context — it's what the `seat_balance_exhausted` guards use
+   * to route `capped` vs `on_pool`, with no seat-type special-casing. Absent
+   * for events that don't carry a resolved pool limit.
    */
-  poolLimitAwuCredits?: number | null;
+  poolLimitAwuCredits?: number;
 };
 
 type UserCreditEvent =
@@ -70,7 +71,7 @@ type UserCreditEvent =
    * This user's personal seat balance is exhausted. The next state is decided
    * by `ctx.poolLimitAwuCredits`:
    *   - `0` (no pool access, e.g. free seats) → `capped`
-   *   - `> 0` or `null` (unlimited) → `on_pool` (band depends on cap usage)
+   *   - `> 0` (or absent) → `on_pool` (band depends on cap usage)
    */
   | { type: "seat_balance_exhausted" }
   /**

--- a/front/lib/spend_limits/effective.ts
+++ b/front/lib/spend_limits/effective.ts
@@ -12,6 +12,16 @@ type SpendLimitAlertState = CustomerAlert["customer_status"];
 // seat-type `default`. `groupCapAwuCredits` is the max cap across the groups the
 // user belongs to (null when none of them carry a cap). All three values must be
 // expressed in the same unit (all pool-only, or all pool + seat allowance).
+export function resolveEffectiveSpendLimitAwuCredits(args: {
+  overrideAwuCredits: number | null;
+  groupCapAwuCredits: number | null;
+  defaultAwuCredits: number;
+}): number;
+export function resolveEffectiveSpendLimitAwuCredits(args: {
+  overrideAwuCredits: number | null;
+  groupCapAwuCredits: number | null;
+  defaultAwuCredits: number | null;
+}): number | null;
 export function resolveEffectiveSpendLimitAwuCredits({
   overrideAwuCredits,
   groupCapAwuCredits,


### PR DESCRIPTION
## Description

The workspace default value can never be null (non nullable column defaulting to 0) so the poolLimitAwuCredits can never be null.
Change the type in UserCreditContext to reflect that
Also fixes the typing in resolveEffectiveSpendLimitAwuCredits when we know defaultAwuCredits is not null.

## Tests

updated unit tests

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
