### PR TITLE
[front] chore: type MCP connection responses

### DIFF
--- a/front-api/routes/w/[wId]/mcp/connections/[connectionType]/[cId]/index.ts
+++ b/front-api/routes/w/[wId]/mcp/connections/[connectionType]/[cId]/index.ts
@@ -7,10 +7,21 @@ import {
   MCPServerConnectionResource,
 } from "@app/lib/resources/mcp_server_connection_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { apiError } from "@front-api/middlewares/utils";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { Context } from "hono";
 import { z } from "zod";
+
+export type GetConnectionResponseBody = {
+  connection: Omit<MCPServerConnectionType, "createdAt" | "updatedAt"> & {
+    createdAt: string;
+    updatedAt: string;
+  };
+};
+
+export type DeleteConnectionResponseBody = {
+  success: boolean;
+};
 
 const ParamsSchema = z.object({
   cId: z.string(),
@@ -30,71 +41,79 @@ async function loadConnection(
 }
 
 /** @ignoreswagger */
-app.get("/", validate("param", ParamsSchema), async (ctx) => {
-  const { cId, connectionType } = ctx.req.valid("param");
-  if (!isMCPServerConnectionConnectionType(connectionType)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid connection type",
-      },
-    });
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetConnectionResponseBody> => {
+    const { cId, connectionType } = ctx.req.valid("param");
+    if (!isMCPServerConnectionConnectionType(connectionType)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid connection type",
+        },
+      });
+    }
+
+    const connectionRes = await loadConnection(ctx, cId, connectionType);
+    if (connectionRes.isErr()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "mcp_server_connection_not_found",
+          message: "Connection not found",
+        },
+      });
+    }
+
+    const value: { connection: MCPServerConnectionType } = {
+      connection: connectionRes.value.toJSON(),
+    };
+    return ctx.json(value);
   }
+);
 
-  const connectionRes = await loadConnection(ctx, cId, connectionType);
-  if (connectionRes.isErr()) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "mcp_server_connection_not_found",
-        message: "Connection not found",
-      },
-    });
+app.delete(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<DeleteConnectionResponseBody> => {
+    const auth = ctx.get("auth");
+    const { cId, connectionType } = ctx.req.valid("param");
+    if (!isMCPServerConnectionConnectionType(connectionType)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid connection type",
+        },
+      });
+    }
+
+    const connectionRes = await loadConnection(ctx, cId, connectionType);
+    if (connectionRes.isErr()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "mcp_server_connection_not_found",
+          message: "Connection not found",
+        },
+      });
+    }
+
+    const result = await connectionRes.value.delete(auth);
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to delete connection",
+        },
+      });
+    }
+
+    return ctx.json({ success: true });
   }
-
-  const value: { connection: MCPServerConnectionType } = {
-    connection: connectionRes.value.toJSON(),
-  };
-  return ctx.json(value);
-});
-
-app.delete("/", validate("param", ParamsSchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const { cId, connectionType } = ctx.req.valid("param");
-  if (!isMCPServerConnectionConnectionType(connectionType)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid connection type",
-      },
-    });
-  }
-
-  const connectionRes = await loadConnection(ctx, cId, connectionType);
-  if (connectionRes.isErr()) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "mcp_server_connection_not_found",
-        message: "Connection not found",
-      },
-    });
-  }
-
-  const result = await connectionRes.value.delete(auth);
-  if (result.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to delete connection",
-      },
-    });
-  }
-
-  return ctx.json({ success: true });
-});
+);
 
 export default app;


### PR DESCRIPTION
## Description

The MCP connection detail handlers rely on inferred Hono response types.

Add named GET and DELETE response bodies with explicit `HandlerResult` annotations. The GET type reflects JSON serialization by typing connection timestamps as strings. This is type-only and does not change runtime behavior.

Stacked on #30182.

## Tests

- Covered by existing MCP connection route tests.

## Risk

- Low.

## Deploy Plan

- No deploy.