### PR TITLE
Centralize consumption analytics resource inputs

### DIFF
--- a/front/lib/resources/agent_message_consumption_item_resource.test.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.test.ts
@@ -15,6 +15,7 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { RunFactory } from "@app/tests/utils/RunFactory";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { LightWorkspaceType } from "@app/types/user";
+import assert from "assert";
 import { describe, expect, it, vi } from "vitest";
 
 const ATTRIBUTION_VERSION = 1;
@@ -103,6 +104,95 @@ async function listTools(
 }
 
 describe("AgentMessageConsumptionItemResource", () => {
+  it("narrows model and tool items at the resource seam", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const context = await setupMessageWithEvidence(auth, workspace);
+
+    await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+      conversation: context.conversation,
+      agentMessageModelId: context.agentMessageModelId,
+      attributionVersion: ATTRIBUTION_VERSION,
+      records: [
+        {
+          itemType: "system",
+          runUsageModelId: context.runUsageModelId,
+          inputTokensCount: 10,
+          grossAttributedCreditAmountMicro: 100_000,
+        },
+        {
+          itemType: "input",
+          runUsageModelId: context.runUsageModelId,
+          inputTokensCount: 20,
+          grossAttributedCreditAmountMicro: 200_000,
+        },
+        {
+          itemType: "output",
+          runUsageModelId: context.runUsageModelId,
+          outputTokensCount: 30,
+          grossAttributedCreditAmountMicro: 300_000,
+        },
+        {
+          itemType: "reasoning",
+          runUsageModelId: context.runUsageModelId,
+          outputTokensCount: 40,
+          grossAttributedCreditAmountMicro: 400_000,
+        },
+        completedTool(context.action, context.runUsageModelId),
+      ],
+      pendingToolItems: [],
+    });
+
+    const items =
+      await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
+        auth,
+        {
+          agentMessageModelIds: [context.agentMessageModelId],
+          maxAttributionVersion: ATTRIBUTION_VERSION,
+        }
+      );
+
+    expect(items).toHaveLength(5);
+    for (const item of items) {
+      if (item.itemType === "tool") {
+        expect(item.isModelItem()).toBe(false);
+        assert(item.isToolItem(), "Tool item was not narrowed");
+        expect(item.agentMCPActionId).toBe(context.action.id);
+      } else {
+        expect(item.isToolItem()).toBe(false);
+        assert(item.isModelItem(), "Model item was not narrowed");
+        expect(item.agentMCPActionId).toBeNull();
+        expect(item.directCreditAmountMicro).toBeNull();
+        expect(item.completedAt).toBeInstanceOf(Date);
+      }
+    }
+  });
+
+  it("rejects a malformed tool shape while narrowing", () => {
+    const item = new AgentMessageConsumptionItemResource(
+      AgentMessageConsumptionItemResource.model,
+      AgentMessageConsumptionItemModel.build({
+        id: -1,
+        workspaceId: -1,
+        conversationId: -1,
+        agentMessageId: -1,
+        runUsageId: -1,
+        agentMCPActionId: null,
+        itemKey: "tool-action:invalid",
+        itemType: "tool",
+        attributionVersion: ATTRIBUTION_VERSION,
+        inputTokensCount: 0,
+        outputTokensCount: 0,
+        grossAttributedCreditAmountMicro: 0,
+        directCreditAmountMicro: 0,
+        completedAt: new Date(),
+      }).get()
+    );
+
+    expect(() => item.isToolItem()).toThrow(
+      "Tool consumption item is missing its action"
+    );
+  });
+
   it("keeps pending state exclusive to incomplete tools", async () => {
     const { authenticator: auth, workspace } = await createResourceTest({});
     const context = await setupMessageWithEvidence(auth, workspace);

--- a/front/lib/resources/agent_message_consumption_item_resource.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.ts
@@ -7,6 +7,7 @@ import type { ConversationResource } from "@app/lib/resources/conversation_resou
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import type { AgentMessageConsumptionItemType } from "@app/types/assistant/agent_message_consumption";
 import type { AgentMessageStatus } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -79,6 +80,20 @@ type ConsumptionItemCreationAttributes =
 export interface AgentMessageConsumptionItemResource
   extends ReadonlyAttributesType<AgentMessageConsumptionItemModel> {}
 
+export interface AgentMessageModelConsumptionItemResource
+  extends AgentMessageConsumptionItemResource {
+  readonly itemType: Exclude<AgentMessageConsumptionItemType, "tool">;
+  readonly agentMCPActionId: null;
+  readonly directCreditAmountMicro: null;
+  readonly completedAt: Date;
+}
+
+export interface AgentMessageToolConsumptionItemResource
+  extends AgentMessageConsumptionItemResource {
+  readonly itemType: "tool";
+  readonly agentMCPActionId: ModelId;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessageConsumptionItemModel> {
   static model: ModelStaticWorkspaceAware<AgentMessageConsumptionItemModel> =
@@ -89,6 +104,40 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
     blob: Attributes<AgentMessageConsumptionItemModel>
   ) {
     super(model, blob);
+  }
+
+  isModelItem(): this is AgentMessageModelConsumptionItemResource {
+    switch (this.itemType) {
+      case "system":
+      case "input":
+      case "output":
+      case "reasoning":
+        assert(
+          this.agentMCPActionId === null &&
+            this.directCreditAmountMicro === null &&
+            this.completedAt !== null,
+          "Model consumption item has invalid shape"
+        );
+        return true;
+
+      case "tool":
+        return false;
+
+      default:
+        return assertNever(this.itemType);
+    }
+  }
+
+  isToolItem(): this is AgentMessageToolConsumptionItemResource {
+    if (this.itemType !== "tool") {
+      return false;
+    }
+
+    assert(
+      this.agentMCPActionId !== null,
+      "Tool consumption item is missing its action"
+    );
+    return true;
   }
 
   private static itemKey(record: CompletedAgentMessageConsumptionItem): string {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -629,6 +629,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       onlyCustom,
       withInstructions = true,
       withTools = true,
+      withToolMetadata = false,
       withFileAttachments = true,
       ...otherOptions
     } = options;
@@ -696,7 +697,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           auth,
           removeNulls(mcpServerConfigurations.map((c) => c.mcpServerViewId)),
           {
-            includeMetadata: false,
+            includeMetadata: withToolMetadata,
             includeHeavyAttributes: [
               "authorization",
               "cachedTools",
@@ -1180,6 +1181,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       transaction,
       withInstructions,
       withTools,
+      withToolMetadata,
       withFileAttachments,
     }: {
       agentLoopData?: AgentLoopExecutionData;
@@ -1188,6 +1190,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       transaction?: Transaction;
       withInstructions?: boolean;
       withTools?: boolean;
+      withToolMetadata?: boolean;
       withFileAttachments?: boolean;
     } = {}
   ): Promise<SkillResource[]> {
@@ -1204,6 +1207,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         },
         withInstructions,
         withTools,
+        withToolMetadata,
         withFileAttachments,
       },
       { agentLoopData, effectiveSpaceIds, transaction }
@@ -3856,7 +3860,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   static async listByAgentMessageId(
     auth: Authenticator,
-    agentMessageId: ModelId
+    agentMessageId: ModelId,
+    { withToolMetadata = false }: { withToolMetadata?: boolean } = {}
   ): Promise<SkillResource[]> {
     const workspace = auth.getNonNullableWorkspace();
 
@@ -3872,6 +3877,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     // Include all statuses for historical accuracy.
     return this.fetchBySkillReferences(auth, agentMessageSkills, {
       status: ["active", "archived", "suggested"],
+      withToolMetadata,
     });
   }
 

--- a/front/lib/resources/skill/types.ts
+++ b/front/lib/resources/skill/types.ts
@@ -33,6 +33,7 @@ export type SkillConfigurationFindOptions = (
   | Omit<CustomSkillConfigurationFindOptions, "attributes">
 ) & {
   withTools?: boolean;
+  withToolMetadata?: boolean;
   withInstructions?: boolean;
   withFileAttachments?: boolean;
 };


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Consumption analytics needs to distinguish model and tool consumption items and determine which skills exposed each called tool. Today, callers must understand persisted field combinations and remember to load MCP tool metadata correctly.

To associate tools with their respective skills, we should account that some servers are disabling tools, which we need to account for by loading the metadata.

This gives the document-building work clear, testable inputs. It does not write to Elasticsearch or activate any analytics workflow.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
