### PR TITLE
[front-api] Hide the files server from dsbx tools

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/actions/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/index.test.ts
@@ -1,3 +1,4 @@
+import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentMCPServerConfigurationFactory } from "@app/tests/utils/AgentMCPServerConfigurationFactory";
@@ -144,5 +145,29 @@ describe("GET /api/v1/w/[wId]/sandbox/actions", () => {
         .map((sv: { server: { name: string } }) => sv.server.name)
         .sort()
     ).toEqual(["common_utilities", "remote_server", "search"]);
+  });
+
+  it("hides the files server", async () => {
+    const { auth, token, workspace, globalSpace } =
+      await createSandboxFunctionInvocationTokenTestContext();
+
+    const files = await InternalMCPServerInMemoryResource.makeNew(auth, {
+      name: FILES_SERVER_NAME,
+      useCase: null,
+    });
+    await MCPServerViewFactory.create(workspace, files.id, globalSpace);
+    const search = await InternalMCPServerInMemoryResource.makeNew(auth, {
+      name: "search",
+      useCase: null,
+    });
+    await MCPServerViewFactory.create(workspace, search.id, globalSpace);
+
+    const response = await getSandboxActions(workspace, token);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(
+      body.serverViews.map((sv: { server: { name: string } }) => sv.server.name)
+    ).toEqual(["search"]);
   });
 });

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/index.ts
@@ -1,4 +1,5 @@
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
+import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
 import { SANDBOX_TOOL_NAME } from "@app/lib/api/actions/servers/sandbox/metadata";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
@@ -31,13 +32,23 @@ app.use(
   sandboxAuth({ allowedTokenKinds: ["action", "function_invocation"] })
 );
 
+// Servers the sandbox must never see: `sandbox` is the server that runs the sandbox itself, and
+// the file system the `files` server exposes is mounted in the sandbox under `/files`, so direct
+// file operations always beat a round-trip through the tool.
+const SANDBOX_HIDDEN_SERVER_NAMES: string[] = [
+  SANDBOX_TOOL_NAME,
+  FILES_SERVER_NAME,
+];
+
 // Response shaping shared by both token kinds: `?server=` name filtering and `?light=true`
 // inputSchema stripping.
 function filterServerViews(
   views: MCPServerViewType[],
   { server, light }: { server?: string; light?: string }
 ): MCPServerViewType[] {
-  let serverViews = views.filter((sv) => sv.server.name !== SANDBOX_TOOL_NAME);
+  let serverViews = views.filter(
+    (sv) => !SANDBOX_HIDDEN_SERVER_NAMES.includes(sv.server.name)
+  );
 
   if (server !== undefined) {
     serverViews = serverViews.filter((sv) => sv.server.name === server);


### PR DESCRIPTION
### Description

The sandbox mounts the file system that the `files` MCP server exposes under `/files`, so a process running in the sandbox is always better off reading and editing files directly than round-tripping through `dsbx tools exec files ...`. This hides the `files` server from the sandbox actions listing that backs `dsbx tools`.

The listing endpoint already stripped one server for a similar reason — `sandbox`, the server that runs the sandbox itself — so that single-name check becomes a named list:

```ts
// Servers the sandbox must never see: `sandbox` is the server that runs the sandbox itself, and
// the file system the `files` server exposes is mounted in the sandbox under `/files`, so direct
// file operations always beat a round-trip through the tool.
const SANDBOX_HIDDEN_SERVER_NAMES: string[] = [SANDBOX_TOOL_NAME, FILES_SERVER_NAME];
```

This applies to both token kinds (conversation exec tokens and pod function invocation tokens), and to `?server=files` as well, since the exclusion runs before the name filter — `dsbx tools list files` now reports `server 'files' not found`.

Two notes on scope:

- Only the listing is filtered. `POST /sandbox/actions/call` still resolves a `files` tool given its `serverViewId` directly; that matches the existing treatment of the `sandbox` server, which is hidden from the list but not blocked at `/call`. Happy to refuse it there too if we'd rather.
- The `pod_functions` and `projects` global skills mention falling back to the `files` MCP tools when the mount layout isn't known. Those instructions go to the main agent loop, which still sees the server, so they are unaffected.

### Risk

Low. Listing-only change on an internal endpoint, scoped to one server name.

### Deploy Plan

Deploy front-api.
