### PR TITLE
fix: skip Google Sheets we are not allowed to read

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -506,6 +506,14 @@ export async function syncSpreadSheet(
               isSupported: false,
               skipReason: "google_bad_request_error",
             };
+          } else if (isCallerDoesNotHavePermissionError(err)) {
+            localLogger.info(
+              "[Spreadsheet] Access forbidden to spreadsheet, marking as skipped."
+            );
+            return {
+              isSupported: true,
+              skipReason: "access_forbidden",
+            };
           }
           throw err;
         }
@@ -548,6 +556,14 @@ export async function syncSpreadSheet(
               // Allow locally retrying the API call.
               continue;
             }
+          } else if (isCallerDoesNotHavePermissionError(err)) {
+            localLogger.info(
+              "[Spreadsheet] Access forbidden to spreadsheet on batchGet, marking as skipped."
+            );
+            return {
+              isSupported: true,
+              skipReason: "access_forbidden",
+            };
           }
           throw err;
         }
@@ -724,6 +740,24 @@ function isGAxiosNotFoundError(err: unknown): err is Error {
 
 function isGAxiosBadRequestError(err: unknown): err is Error {
   return err instanceof Error && "code" in err && err.code === 400;
+}
+
+// A 403 is not enough on its own: Google also answers 403 for quota and rate-limit exhaustion,
+// and for tokens missing scopes (which the activity interceptor turns into an
+// ExternalOAuthTokenError). Only a per-file ACL denial is permanent, so we match its message.
+function isCallerDoesNotHavePermissionError(err: unknown): err is GaxiosError {
+  return !!(
+    err instanceof GaxiosError &&
+    err.response?.status === 403 &&
+    err.response?.data &&
+    typeof err.response.data === "object" &&
+    "error" in err.response.data &&
+    "message" in err.response.data.error &&
+    typeof err.response.data.error.message === "string" &&
+    err.response.data.error.message.includes(
+      "The caller does not have permission"
+    )
+  );
 }
 
 function isStringTooLongError(


### PR DESCRIPTION
## Description

A spreadsheet the connector's account can't read makes `syncFiles` fail with a 403, and nothing classified that as terminal, so Temporal retried forever. One folder sync (connector 17892) had been looping since Aug 1 with 5300+ attempts, and only moved on to the next unreadable file after the first was skipped by hand.

Marks those spreadsheets as skipped instead, so the sync drains the rest of the folder on its own.

A 403 alone isn't enough to key on, Google also answers 403 for quota and rate-limit exhaustion (a few thousand a week across hundreds of connectors). So we match the permission-denied message, the way `isUnableToParseError` just above it already does.

`skipReason` is `access_forbidden`, same string Microsoft uses for its 403 path.

## Tests

## Risk

Low.

## Deploy Plan

Normal deploy of connectors.