### PR TITLE
Pricing: fix export analytics to include all the statuses

### DIFF
--- a/front/lib/api/analytics/messages_export.test.ts
+++ b/front/lib/api/analytics/messages_export.test.ts
@@ -26,6 +26,7 @@ vi.mock("@app/lib/resources/storage", async (importActual) => {
 });
 
 function mockMessageHits(docs: ElasticsearchBaseDocument[]) {
+  vi.mocked(searchAnalytics).mockClear();
   vi.mocked(searchAnalytics).mockResolvedValue(
     new Ok({
       took: 1,
@@ -81,6 +82,38 @@ describe("fetchMessageExportRows", () => {
     }
     expect(result.value).toHaveLength(1);
     expect(result.value[0].credits).toBe(7);
+  });
+
+  it("does not filter on status, so failed messages keep their billable credits", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    // A multi-execution message whose terminal execution errored: still billed
+    // for the work of its successful executions.
+    mockMessageHits([
+      messageDoc({
+        message_id: "msg_failed",
+        status: "failed",
+        cost: { full_awu: 10, llm_awu: 4, tool_awu: 3, billable_awu: 5 },
+      }),
+    ]);
+
+    const result = await fetchMessageExportRows({
+      auth: authenticator,
+      owner: workspace,
+      startDate: "2026-07-01",
+      endDate: "2026-07-02",
+      timezone: "UTC",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0].messageId).toBe("msg_failed");
+    expect(result.value[0].credits).toBe(5);
   });
 
   it("resolves agent_tag_ids to sorted, distinct tag names in the assistantTags column", async () => {

--- a/front/lib/api/analytics/messages_export.ts
+++ b/front/lib/api/analytics/messages_export.ts
@@ -5,6 +5,7 @@ import {
   fetchUserEmails,
 } from "@app/lib/api/analytics/enrichment";
 import { resolveServerDisplayNames } from "@app/lib/api/assistant/observability/tool_usage";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
@@ -135,15 +136,11 @@ export async function fetchMessageExportRows({
   endDate: string;
   timezone: string;
 }): Promise<Result<MessageExportRow[], Error>> {
-  const query: estypes.QueryDslQueryContainer = {
-    bool: {
-      filter: [
-        { term: { workspace_id: owner.sId } },
-        { term: { status: "succeeded" } },
-        { range: { timestamp: { gte: startDate, lte: endDate } } },
-      ],
-    },
-  };
+  const query = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    startDate,
+    endDate,
+  });
 
   const docsResult = await fetchAllMessageDocuments(query);
   if (docsResult.isErr()) {


### PR DESCRIPTION
## Description

The messages export was the only analytics table filtering on `status: "succeeded"`, while the users, agents and usage-metrics tables all scope through `buildAgentAnalyticsBaseQuery`, which has no status filter, so the messages CSV under-reported both its row count and its summed credits against the other exports and against Metronome.
This is wrong on credits specifically because `cost.billable_awu` already encodes the billed amount per execution (0 for the non-billable errored part), so a message that ends failed/interrupted after billable earlier executions still carries real billed credits that the filter silently dropped. Replaced the hand-rolled query with `buildAgentAnalyticsBaseQuery` so the scope matches every other table, and added a test asserting the query carries no status clause and that a failed doc is exported with its billable_awu.


## Tests

added unit test

## Risk

will change all the export of "messages" table in anlytics

## Deploy Plan

deploy front
