### PR TITLE
[front] Fix sandbox function staging reads against symlink swap (TOCTOU)

### DIFF
--- a/front/lib/api/sandbox_functions/build_on_sandbox.test.ts
+++ b/front/lib/api/sandbox_functions/build_on_sandbox.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
@@ -14,6 +16,48 @@ vi.mock("@app/lib/api/sandbox/lifecycle", () => ({
 const SRC = "/files/pod-spc123/greet.ts";
 
 const okEnvelope = JSON.stringify({ ok: true });
+
+function sha256Hex(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+/**
+ * Mocks the producing exec: extracts the bundle/schema staging paths from the command and
+ * returns the build envelope followed by the integrity marker and per-file sha256 lines for
+ * `contents`, mirroring what the real `sha256sum` capture prints.
+ */
+function mockExecWithHashes(
+  sandbox: SandboxResource,
+  contents: Record<"bundle.js" | "schema.json", string>
+) {
+  return vi
+    .spyOn(sandbox, "exec")
+    .mockImplementation(async (_auth, command) => {
+      // Paths are shell-quoted in the command; strip the surrounding single quotes.
+      const paths = [
+        ...new Set(
+          [
+            ...command.matchAll(
+              /'?(\/[\w./-]+\/(?:bundle\.js|schema\.json))'?/g
+            ),
+          ].map((m) => m[1])
+        ),
+      ];
+      const hashLines = paths
+        .map((p) => {
+          const name = p.endsWith("bundle.js") ? "bundle.js" : "schema.json";
+          return `${sha256Hex(contents[name])}  ${p}`;
+        })
+        .join("\n");
+      return new Ok({
+        exitCode: 0,
+        stdout: `${okEnvelope}\n__DUST_STAGING_SHA256__\n${hashLines}\n`,
+        stderr: "",
+      });
+    });
+}
+
+const BUNDLE_CONTENT = "export default {/*bundle*/};";
 
 const validSchemaFile = JSON.stringify({
   name: "greet",
@@ -57,16 +101,13 @@ beforeEach(() => {
 describe("buildSandboxFunctionOnSandbox", () => {
   it("builds the bundle and returns the extracted contract", async () => {
     const { authenticator, sandbox, space } = await setup();
-    const execSpy = vi
-      .spyOn(sandbox, "exec")
-      .mockResolvedValue(
-        new Ok({ exitCode: 0, stdout: okEnvelope, stderr: "" })
-      );
+    const execSpy = mockExecWithHashes(sandbox, {
+      "bundle.js": BUNDLE_CONTENT,
+      "schema.json": validSchemaFile,
+    });
     const readSpy = vi
       .spyOn(sandbox, "readFile")
-      .mockResolvedValueOnce(
-        new Ok(Buffer.from("export default {/*bundle*/};"))
-      )
+      .mockResolvedValueOnce(new Ok(Buffer.from(BUNDLE_CONTENT)))
       .mockResolvedValueOnce(new Ok(Buffer.from(validSchemaFile)));
 
     const result = await buildSandboxFunctionOnSandbox(authenticator, {
@@ -78,7 +119,7 @@ describe("buildSandboxFunctionOnSandbox", () => {
     if (result.isErr()) {
       return;
     }
-    expect(result.value.bundleCode).toBe("export default {/*bundle*/};");
+    expect(result.value.bundleCode).toBe(BUNDLE_CONTENT);
     expect(result.value.userIdentity).toBe(
       "interactive_workspace_user_required"
     );
@@ -175,9 +216,16 @@ describe("buildSandboxFunctionOnSandbox", () => {
 
   it("rejects a function missing an input or output schema", async () => {
     const { authenticator, sandbox, space } = await setup();
-    vi.spyOn(sandbox, "exec").mockResolvedValue(
-      new Ok({ exitCode: 0, stdout: okEnvelope, stderr: "" })
-    );
+    mockExecWithHashes(sandbox, {
+      "bundle.js": "bundle",
+      "schema.json": JSON.stringify({
+        name: "greet",
+        description: null,
+        userIdentity: "optional",
+        input_schema: null,
+        output_schema: { type: "object" },
+      }),
+    });
     vi.spyOn(sandbox, "readFile")
       .mockResolvedValueOnce(new Ok(Buffer.from("bundle")))
       .mockResolvedValueOnce(
@@ -208,9 +256,15 @@ describe("buildSandboxFunctionOnSandbox", () => {
 
   it("rejects an older sandbox image that omits user identity", async () => {
     const { authenticator, sandbox, space } = await setup();
-    vi.spyOn(sandbox, "exec").mockResolvedValue(
-      new Ok({ exitCode: 0, stdout: okEnvelope, stderr: "" })
-    );
+    mockExecWithHashes(sandbox, {
+      "bundle.js": "bundle",
+      "schema.json": JSON.stringify({
+        name: "greet",
+        description: null,
+        input_schema: { type: "object" },
+        output_schema: { type: "object" },
+      }),
+    });
     vi.spyOn(sandbox, "readFile")
       .mockResolvedValueOnce(new Ok(Buffer.from("bundle")))
       .mockResolvedValueOnce(
@@ -273,6 +327,81 @@ describe("buildSandboxFunctionOnSandbox", () => {
       return;
     }
     expect(result.error.code).toBe("internal");
+  });
+
+  it("refuses a bundle artifact swapped after the build", async () => {
+    const { authenticator, sandbox, space } = await setup();
+    mockExecWithHashes(sandbox, {
+      "bundle.js": BUNDLE_CONTENT,
+      "schema.json": validSchemaFile,
+    });
+    const swapped = Buffer.from('{"name":"CTF","value":"root-only-content"}');
+    vi.spyOn(sandbox, "readFile")
+      .mockResolvedValueOnce(new Ok(swapped))
+      .mockResolvedValueOnce(new Ok(Buffer.from(validSchemaFile)));
+
+    const result = await buildSandboxFunctionOnSandbox(authenticator, {
+      space,
+      srcSandboxPath: SRC,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("internal");
+    expect(result.error.message).toContain(
+      "changed between production and read-back"
+    );
+    // The swapped content must not leak through the error path.
+    expect(result.error.message).not.toContain("root-only-content");
+  });
+
+  it("refuses a schema artifact swapped after the build", async () => {
+    const { authenticator, sandbox, space } = await setup();
+    mockExecWithHashes(sandbox, {
+      "bundle.js": BUNDLE_CONTENT,
+      "schema.json": validSchemaFile,
+    });
+    vi.spyOn(sandbox, "readFile")
+      .mockResolvedValueOnce(new Ok(Buffer.from(BUNDLE_CONTENT)))
+      .mockResolvedValueOnce(new Ok(Buffer.from("swapped-schema")));
+
+    const result = await buildSandboxFunctionOnSandbox(authenticator, {
+      space,
+      srcSandboxPath: SRC,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("internal");
+    expect(result.error.message).toContain(
+      "changed between production and read-back"
+    );
+  });
+
+  it("fails closed when the exec output carries no integrity hashes", async () => {
+    const { authenticator, sandbox, space } = await setup();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({ exitCode: 0, stdout: okEnvelope, stderr: "" })
+    );
+    vi.spyOn(sandbox, "readFile")
+      .mockResolvedValueOnce(new Ok(Buffer.from(BUNDLE_CONTENT)))
+      .mockResolvedValueOnce(new Ok(Buffer.from(validSchemaFile)));
+
+    const result = await buildSandboxFunctionOnSandbox(authenticator, {
+      space,
+      srcSandboxPath: SRC,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("internal");
+    expect(result.error.message).toContain("Missing integrity hash");
   });
 
   it("maps a sandbox failure to sandbox_unavailable", async () => {

--- a/front/lib/api/sandbox_functions/build_on_sandbox.ts
+++ b/front/lib/api/sandbox_functions/build_on_sandbox.ts
@@ -4,6 +4,11 @@ import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import type { SandboxFunctionErrorCode } from "@app/lib/api/sandbox_functions/errors";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import {
+  splitStagingStdout,
+  stagingHashCaptureLines,
+  verifyStagingContent,
+} from "@app/lib/api/sandbox_functions/staging_integrity";
 import type { Authenticator } from "@app/lib/auth";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { SandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
@@ -101,6 +106,10 @@ export async function buildSandboxFunctionOnSandbox(
     `mkdir -p -- ${shellEscape(buildDir)}`,
     // `--` stops the model-supplied source path from being read as a dsbx flag.
     `${DSBX_BIN_PATH} function build -- ${shellEscape(srcSandboxPath)} ${shellEscape(bundlePath)} ${shellEscape(schemaPath)}`,
+    // Pin the artifact hashes in the same exec; verified after the provider read-back
+    // below (the read-back runs as root and follows symlinks, so a swapped staging
+    // file would otherwise read an arbitrary root file).
+    ...stagingHashCaptureLines([bundlePath, schemaPath]),
   ].join("\n");
 
   const execResult = await sandbox.exec(auth, command, {
@@ -113,7 +122,8 @@ export async function buildSandboxFunctionOnSandbox(
     );
   }
 
-  const envelope = parseBuildEnvelope(execResult.value.stdout);
+  const { dsbxStdout, hashes } = splitStagingStdout(execResult.value.stdout);
+  const envelope = parseBuildEnvelope(dsbxStdout);
   if (envelope.isErr()) {
     return envelope;
   }
@@ -129,11 +139,27 @@ export async function buildSandboxFunctionOnSandbox(
       new SandboxFunctionError("internal", bundleResult.error.message)
     );
   }
+  const bundleIntegrity = verifyStagingContent(
+    bundlePath,
+    bundleResult.value,
+    hashes
+  );
+  if (bundleIntegrity.isErr()) {
+    return bundleIntegrity;
+  }
   const schemaResult = await sandbox.readFile(auth, schemaPath);
   if (schemaResult.isErr()) {
     return new Err(
       new SandboxFunctionError("internal", schemaResult.error.message)
     );
+  }
+  const schemaIntegrity = verifyStagingContent(
+    schemaPath,
+    schemaResult.value,
+    hashes
+  );
+  if (schemaIntegrity.isErr()) {
+    return schemaIntegrity;
   }
 
   return parseSchemaFile(

--- a/front/lib/api/sandbox_functions/build_on_sandbox.ts
+++ b/front/lib/api/sandbox_functions/build_on_sandbox.ts
@@ -142,7 +142,8 @@ export async function buildSandboxFunctionOnSandbox(
   const bundleIntegrity = verifyStagingContent(
     bundlePath,
     bundleResult.value,
-    hashes
+    hashes,
+    { execStderr: execResult.value.stderr }
   );
   if (bundleIntegrity.isErr()) {
     return bundleIntegrity;
@@ -156,7 +157,8 @@ export async function buildSandboxFunctionOnSandbox(
   const schemaIntegrity = verifyStagingContent(
     schemaPath,
     schemaResult.value,
-    hashes
+    hashes,
+    { execStderr: execResult.value.stderr }
   );
   if (schemaIntegrity.isErr()) {
     return schemaIntegrity;

--- a/front/lib/api/sandbox_functions/dsbx_db.test.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.test.ts
@@ -1,0 +1,131 @@
+import { createHash } from "node:crypto";
+
+import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import { getDatabaseSchemaOnSandbox } from "@app/lib/api/sandbox_functions/dsbx_db";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/sandbox/lifecycle", () => ({
+  ensurePodSandboxReady: vi.fn(),
+}));
+
+const sha256Hex = (content: string): string =>
+  createHash("sha256").update(content).digest("hex");
+
+const SCHEMA_CONTENT = 'export const secAudit = sqliteTable("sec_audit", {});';
+
+async function setup(): Promise<{
+  authenticator: Awaited<
+    ReturnType<typeof createResourceTest>
+  >["authenticator"];
+  sandbox: SandboxResource;
+  space: SpaceResource;
+}> {
+  const { authenticator, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  const space = await SpaceFactory.project(workspace);
+  const sandbox = await SandboxResource.makeNew(authenticator, {
+    providerId: "test-provider-id",
+    status: "running",
+    baseImage: "dust-base",
+    version: "0.0.0-test",
+  });
+  vi.mocked(ensurePodSandboxReady).mockResolvedValue(
+    new Ok({ sandbox, freshlyCreated: false })
+  );
+
+  return { authenticator, sandbox, space };
+}
+
+function mockExecWithSchemaHash(
+  sandbox: SandboxResource,
+  schemaContent: string
+) {
+  return vi
+    .spyOn(sandbox, "exec")
+    .mockImplementation(async (_auth, command) => {
+      // The staging path is shell-quoted in the command; strip the quotes.
+      const match = /'?(\/[\w./-]+\.db\.ts)'?/.exec(command);
+      const outPath = match ? match[1] : "";
+      return new Ok({
+        exitCode: 0,
+        stdout: `${JSON.stringify({ ok: true })}\n__DUST_STAGING_SHA256__\n${sha256Hex(schemaContent)}  ${outPath}\n`,
+        stderr: "",
+      });
+    });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getDatabaseSchemaOnSandbox", () => {
+  it("returns the schema file content when the hash matches", async () => {
+    const { authenticator, sandbox, space } = await setup();
+    mockExecWithSchemaHash(sandbox, SCHEMA_CONTENT);
+    vi.spyOn(sandbox, "readFile").mockResolvedValue(
+      new Ok(Buffer.from(SCHEMA_CONTENT))
+    );
+
+    const result = await getDatabaseSchemaOnSandbox(authenticator, {
+      space,
+      database: "sec_audit",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value).toBe(SCHEMA_CONTENT);
+  });
+
+  it("refuses a staging file swapped between the exec and the read-back", async () => {
+    const { authenticator, sandbox, space } = await setup();
+    mockExecWithSchemaHash(sandbox, SCHEMA_CONTENT);
+    vi.spyOn(sandbox, "readFile").mockResolvedValue(
+      new Ok(Buffer.from('{"name":"CTF","value":"root-only-content"}'))
+    );
+
+    const result = await getDatabaseSchemaOnSandbox(authenticator, {
+      space,
+      database: "sec_audit",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("internal");
+    expect(result.error.message).toContain(
+      "changed between production and read-back"
+    );
+    expect(result.error.message).not.toContain("root-only-content");
+  });
+
+  it("fails closed when the exec output carries no integrity hash", async () => {
+    const { authenticator, sandbox, space } = await setup();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({ exitCode: 0, stdout: JSON.stringify({ ok: true }), stderr: "" })
+    );
+    vi.spyOn(sandbox, "readFile").mockResolvedValue(
+      new Ok(Buffer.from(SCHEMA_CONTENT))
+    );
+
+    const result = await getDatabaseSchemaOnSandbox(authenticator, {
+      space,
+      database: "sec_audit",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("internal");
+    expect(result.error.message).toContain("Missing integrity hash");
+  });
+});

--- a/front/lib/api/sandbox_functions/dsbx_db.test.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.test.ts
@@ -1,7 +1,10 @@
 import { createHash } from "node:crypto";
 
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
-import { getDatabaseSchemaOnSandbox } from "@app/lib/api/sandbox_functions/dsbx_db";
+import {
+  getDatabaseSchemaOnSandbox,
+  listDatabasesOnSandbox,
+} from "@app/lib/api/sandbox_functions/dsbx_db";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -127,5 +130,34 @@ describe("getDatabaseSchemaOnSandbox", () => {
     }
     expect(result.error.code).toBe("internal");
     expect(result.error.message).toContain("Missing integrity hash");
+  });
+});
+
+describe("non-staging db commands", () => {
+  it("does not split stdout on a forged marker, so the real envelope stays last", async () => {
+    const { authenticator, sandbox, space } = await setup();
+    // Realistic vector: during reconcile the model-written schema file is imported and its
+    // top-level code can print a forged envelope followed by a marker line. Only staging
+    // execs opt into the marker split, so the real (last) envelope must win here.
+    const forged = JSON.stringify({
+      ok: true,
+      databases: [{ name: "forged", size_bytes: 1 }],
+    });
+    const real = JSON.stringify({ ok: true, databases: [] });
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout: `${forged}\n__DUST_STAGING_SHA256__\n${real}\n`,
+        stderr: "",
+      })
+    );
+
+    const result = await listDatabasesOnSandbox(authenticator, { space });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value).toEqual([]);
   });
 });

--- a/front/lib/api/sandbox_functions/dsbx_db.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.ts
@@ -109,6 +109,7 @@ async function execDbCommand<S extends z.ZodTypeAny>(
       sandbox: SandboxResource;
       envelope: z.infer<S>;
       stagingHashes: StagingHashes;
+      execStderr: string;
     },
     SandboxFunctionError
   >
@@ -143,7 +144,12 @@ async function execDbCommand<S extends z.ZodTypeAny>(
   if (envelope.isErr()) {
     return envelope;
   }
-  return new Ok({ sandbox, envelope: envelope.value, stagingHashes: hashes });
+  return new Ok({
+    sandbox,
+    envelope: envelope.value,
+    stagingHashes: hashes,
+    execStderr: execResult.value.stderr,
+  });
 }
 
 // Success mirrors the reconcile result in cli/dust-sandbox/functions-runner/db/reconcile.ts.
@@ -358,7 +364,12 @@ export async function getDatabaseSchemaOnSandbox(
   if (result.isErr()) {
     return result;
   }
-  const { sandbox, envelope, stagingHashes } = result.value;
+  const {
+    sandbox,
+    envelope,
+    stagingHashes,
+    execStderr: execStderrForIntegrity,
+  } = result.value;
   if (!("ok" in envelope) || !envelope.ok) {
     return new Err(
       dbErrorToSandboxFunctionError(database, envelope, "internal")
@@ -374,7 +385,8 @@ export async function getDatabaseSchemaOnSandbox(
   const integrity = verifyStagingContent(
     outPath,
     fileResult.value,
-    stagingHashes
+    stagingHashes,
+    { execStderr: execStderrForIntegrity }
   );
   if (integrity.isErr()) {
     return integrity;

--- a/front/lib/api/sandbox_functions/dsbx_db.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.ts
@@ -96,12 +96,15 @@ async function execDbCommand<S extends z.ZodTypeAny>(
     what,
     envVars,
     stdin,
+    stagingCapture = false,
   }: {
     command: string;
     schema: S;
     what: string;
     envVars?: Record<string, string>;
     stdin?: string;
+    // Set only when `command` appends stagingHashCaptureLines.
+    stagingCapture?: boolean;
   }
 ): Promise<
   Result<
@@ -137,9 +140,12 @@ async function execDbCommand<S extends z.ZodTypeAny>(
     );
   }
 
-  // Staging execs append a marker and per-file sha256 lines after the dsbx output;
-  // other `dsbx db` commands leave the stdout untouched.
-  const { dsbxStdout, hashes } = splitStagingStdout(execResult.value.stdout);
+  // Split only when this exec appended capture lines. Splitting unconditionally would let code
+  // the command imports (e.g. the model-written schema file during reconcile) print a forged
+  // marker line and shadow the real envelope, which is otherwise always the last stdout line.
+  const { dsbxStdout, hashes } = stagingCapture
+    ? splitStagingStdout(execResult.value.stdout)
+    : { dsbxStdout: execResult.value.stdout, hashes: {} };
   const envelope = parseDbEnvelope(dsbxStdout, schema, what);
   if (envelope.isErr()) {
     return envelope;
@@ -360,6 +366,7 @@ export async function getDatabaseSchemaOnSandbox(
     ].join("\n"),
     schema: schemaEnvelopeSchema,
     what: `dsbx db schema ${database}`,
+    stagingCapture: true,
   });
   if (result.isErr()) {
     return result;

--- a/front/lib/api/sandbox_functions/dsbx_db.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.ts
@@ -11,8 +11,8 @@ import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import type { SandboxFunctionErrorCode } from "@app/lib/api/sandbox_functions/errors";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { StagingHashes } from "@app/lib/api/sandbox_functions/staging_integrity";
 import {
-  type StagingHashes,
   splitStagingStdout,
   stagingHashCaptureLines,
   verifyStagingContent,

--- a/front/lib/api/sandbox_functions/dsbx_db.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.ts
@@ -11,6 +11,12 @@ import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import type { SandboxFunctionErrorCode } from "@app/lib/api/sandbox_functions/errors";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import {
+  type StagingHashes,
+  splitStagingStdout,
+  stagingHashCaptureLines,
+  verifyStagingContent,
+} from "@app/lib/api/sandbox_functions/staging_integrity";
 import type { Authenticator } from "@app/lib/auth";
 import { distributedLock, distributedUnlock } from "@app/lib/lock";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
@@ -99,7 +105,11 @@ async function execDbCommand<S extends z.ZodTypeAny>(
   }
 ): Promise<
   Result<
-    { sandbox: SandboxResource; envelope: z.infer<S> },
+    {
+      sandbox: SandboxResource;
+      envelope: z.infer<S>;
+      stagingHashes: StagingHashes;
+    },
     SandboxFunctionError
   >
 > {
@@ -126,11 +136,14 @@ async function execDbCommand<S extends z.ZodTypeAny>(
     );
   }
 
-  const envelope = parseDbEnvelope(execResult.value.stdout, schema, what);
+  // Staging execs append a marker and per-file sha256 lines after the dsbx output;
+  // other `dsbx db` commands leave the stdout untouched.
+  const { dsbxStdout, hashes } = splitStagingStdout(execResult.value.stdout);
+  const envelope = parseDbEnvelope(dsbxStdout, schema, what);
   if (envelope.isErr()) {
     return envelope;
   }
-  return new Ok({ sandbox, envelope: envelope.value });
+  return new Ok({ sandbox, envelope: envelope.value, stagingHashes: hashes });
 }
 
 // Success mirrors the reconcile result in cli/dust-sandbox/functions-runner/db/reconcile.ts.
@@ -334,6 +347,10 @@ export async function getDatabaseSchemaOnSandbox(
       `mkdir -p -- ${shellEscape(outDir)}`,
       // `--` stops the model-influenced database name from being read as a flag.
       `${DSBX_BIN_PATH} db schema -- ${shellEscape(database)} ${shellEscape(outPath)}`,
+      // Pin the artifact hash in the same exec; verified after the provider
+      // read-back below (the read-back runs as root and follows symlinks, so a
+      // swapped staging file would otherwise read an arbitrary root file).
+      ...stagingHashCaptureLines([outPath]),
     ].join("\n"),
     schema: schemaEnvelopeSchema,
     what: `dsbx db schema ${database}`,
@@ -341,7 +358,7 @@ export async function getDatabaseSchemaOnSandbox(
   if (result.isErr()) {
     return result;
   }
-  const { sandbox, envelope } = result.value;
+  const { sandbox, envelope, stagingHashes } = result.value;
   if (!("ok" in envelope) || !envelope.ok) {
     return new Err(
       dbErrorToSandboxFunctionError(database, envelope, "internal")
@@ -353,6 +370,14 @@ export async function getDatabaseSchemaOnSandbox(
     return new Err(
       new SandboxFunctionError("internal", fileResult.error.message)
     );
+  }
+  const integrity = verifyStagingContent(
+    outPath,
+    fileResult.value,
+    stagingHashes
+  );
+  if (integrity.isErr()) {
+    return integrity;
   }
   return new Ok(fileResult.value.toString("utf8"));
 }

--- a/front/lib/api/sandbox_functions/staging_integrity.test.ts
+++ b/front/lib/api/sandbox_functions/staging_integrity.test.ts
@@ -1,0 +1,102 @@
+import { createHash } from "node:crypto";
+import {
+  splitStagingStdout,
+  stagingHashCaptureLines,
+  verifyStagingContent,
+} from "@app/lib/api/sandbox_functions/staging_integrity";
+import { describe, expect, it } from "vitest";
+
+const sha256Hex = (content: string): string =>
+  createHash("sha256").update(content).digest("hex");
+
+describe("stagingHashCaptureLines", () => {
+  it("emits the marker then a single sha256sum invocation", () => {
+    const lines = stagingHashCaptureLines([
+      "/tmp/x/bundle.js",
+      "/tmp/x/schema.json",
+    ]);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe("echo __DUST_STAGING_SHA256__");
+    expect(lines[1]).toBe(
+      "/usr/bin/sha256sum '/tmp/x/bundle.js' '/tmp/x/schema.json'"
+    );
+  });
+
+  it("shell-escapes unsafe paths", () => {
+    const lines = stagingHashCaptureLines(["/tmp/x/a b.js"]);
+    expect(lines[1]).toBe("/usr/bin/sha256sum '/tmp/x/a b.js'");
+  });
+});
+
+describe("splitStagingStdout", () => {
+  it("returns untouched stdout and no hashes without the marker", () => {
+    const { dsbxStdout, hashes } = splitStagingStdout('{"ok":true}');
+    expect(dsbxStdout).toBe('{"ok":true}');
+    expect(hashes).toEqual({});
+  });
+
+  it("splits dsbx output from hash lines at the marker", () => {
+    const bundle = "/tmp/dust-sandbox-function-builds/uuid/bundle.js";
+    const schema = "/tmp/dust-sandbox-function-builds/uuid/schema.json";
+    const stdout = [
+      "some noise",
+      '{"ok":true}',
+      "__DUST_STAGING_SHA256__",
+      `${sha256Hex("bundle")}  ${bundle}`,
+      `${sha256Hex("schema")}  ${schema}`,
+      "",
+    ].join("\n");
+    const { dsbxStdout, hashes } = splitStagingStdout(stdout);
+    expect(dsbxStdout).toBe('some noise\n{"ok":true}\n');
+    expect(hashes).toEqual({
+      [bundle]: sha256Hex("bundle"),
+      [schema]: sha256Hex("schema"),
+    });
+  });
+
+  it("ignores malformed hash lines", () => {
+    const stdout = '{"ok":true}\n__DUST_STAGING_SHA256__\nnot-a-hash-line\n';
+    const { hashes } = splitStagingStdout(stdout);
+    expect(hashes).toEqual({});
+  });
+});
+
+describe("verifyStagingContent", () => {
+  it("accepts content matching the captured hash", () => {
+    const result = verifyStagingContent(
+      "/tmp/x/bundle.js",
+      Buffer.from("bundle"),
+      {
+        "/tmp/x/bundle.js": sha256Hex("bundle"),
+      }
+    );
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("rejects mismatched content without leaking it in the error", () => {
+    const result = verifyStagingContent(
+      "/tmp/x/bundle.js",
+      Buffer.from("secret-bytes"),
+      { "/tmp/x/bundle.js": sha256Hex("bundle") }
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("internal");
+    expect(result.error.message).not.toContain("secret-bytes");
+  });
+
+  it("rejects when the hash is missing", () => {
+    const result = verifyStagingContent(
+      "/tmp/x/bundle.js",
+      Buffer.from("bundle"),
+      {}
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.message).toContain("Missing integrity hash");
+  });
+});

--- a/front/lib/api/sandbox_functions/staging_integrity.test.ts
+++ b/front/lib/api/sandbox_functions/staging_integrity.test.ts
@@ -47,11 +47,34 @@ describe("splitStagingStdout", () => {
       "",
     ].join("\n");
     const { dsbxStdout, hashes } = splitStagingStdout(stdout);
-    expect(dsbxStdout).toBe('some noise\n{"ok":true}\n');
+    expect(dsbxStdout).toBe('some noise\n{"ok":true}');
     expect(hashes).toEqual({
       [bundle]: sha256Hex("bundle"),
       [schema]: sha256Hex("schema"),
     });
+  });
+
+  it("anchors on the last full-line marker, so a forged marker cannot shadow the capture", () => {
+    const schema = "/tmp/dust-sandbox-function-builds/uuid/schema.json";
+    const stdout = [
+      "model printed __DUST_STAGING_SHA256__ mid-stream",
+      "__DUST_STAGING_SHA256__", // forged full-line marker before the real one
+      `${"0".repeat(64)}  ${schema}`, // forged hash line, shadowed below
+      '{"ok":true}',
+      "__DUST_STAGING_SHA256__", // real capture marker
+      `${sha256Hex("schema")}  ${schema}`,
+      "",
+    ].join("\n");
+    const { dsbxStdout, hashes } = splitStagingStdout(stdout);
+    expect(hashes).toEqual({ [schema]: sha256Hex("schema") });
+    expect(dsbxStdout).toContain('{"ok":true}');
+  });
+
+  it("does not split on a marker substring inside another line", () => {
+    const stdout = 'noise __DUST_STAGING_SHA256__ noise\n{"ok":true}\n';
+    const { dsbxStdout, hashes } = splitStagingStdout(stdout);
+    expect(dsbxStdout).toBe(stdout);
+    expect(hashes).toEqual({});
   });
 
   it("ignores malformed hash lines", () => {
@@ -85,6 +108,22 @@ describe("verifyStagingContent", () => {
     }
     expect(result.error.code).toBe("internal");
     expect(result.error.message).not.toContain("secret-bytes");
+  });
+
+  it("includes the exec stderr hint when the hash is missing", () => {
+    const result = verifyStagingContent(
+      "/tmp/x/bundle.js",
+      Buffer.from("bundle"),
+      {},
+      {
+        execStderr: "sha256sum: /tmp/x/bundle.js: Permission denied",
+      }
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.message).toContain("Permission denied");
   });
 
   it("rejects when the hash is missing", () => {

--- a/front/lib/api/sandbox_functions/staging_integrity.ts
+++ b/front/lib/api/sandbox_functions/staging_integrity.ts
@@ -27,27 +27,29 @@ export function stagingHashCaptureLines(paths: string[]): string[] {
 }
 
 /**
- * Split exec stdout at the marker: everything before it is dsbx output, everything after is
+ * Split exec stdout at the marker line: everything before it is dsbx output, everything after is
  * `<sha256>  <path>` lines. Without a marker the input is returned untouched with no hashes.
+ * The split anchors on the LAST full-line marker so a model that prints the marker string from
+ * its own code cannot shadow the real capture (the sha256 lines are always the last stdout
+ * lines) and cannot truncate its own output by emitting a marker mid-stream.
  */
 export function splitStagingStdout(stdout: string): {
   dsbxStdout: string;
   hashes: StagingHashes;
 } {
-  const markerIndex = stdout.indexOf(HASH_MARKER);
+  const lines = stdout.split("\n");
+  const markerIndex = lines.findLastIndex((line) => line === HASH_MARKER);
   if (markerIndex === -1) {
     return { dsbxStdout: stdout, hashes: {} };
   }
   const hashes: StagingHashes = {};
-  for (const line of stdout
-    .slice(markerIndex + HASH_MARKER.length)
-    .split("\n")) {
+  for (const line of lines.slice(markerIndex + 1)) {
     const match = /^([0-9a-f]{64}) {2}(\S.*)$/.exec(line.trim());
     if (match) {
       hashes[match[2]] = match[1];
     }
   }
-  return { dsbxStdout: stdout.slice(0, markerIndex), hashes };
+  return { dsbxStdout: lines.slice(0, markerIndex).join("\n"), hashes };
 }
 
 function sha256Hex(content: Buffer): string {
@@ -61,14 +63,20 @@ function sha256Hex(content: Buffer): string {
 export function verifyStagingContent(
   path: string,
   content: Buffer,
-  hashes: StagingHashes
+  hashes: StagingHashes,
+  opts?: { execStderr?: string }
 ): Result<void, SandboxFunctionError> {
   const expected = hashes[path];
   if (expected === undefined) {
+    // A missing hash is how a failed capture surfaces (e.g. sha256sum could not open a
+    // swapped target); include the exec stderr so the failure is debuggable.
+    const stderrHint = opts?.execStderr?.trim()
+      ? ` Exec stderr: ${opts.execStderr.trim().slice(0, 300)}`
+      : "";
     return new Err(
       new SandboxFunctionError(
         "internal",
-        `Missing integrity hash for staging file ${path}.`
+        `Missing integrity hash for staging file ${path}.${stderrHint}`
       )
     );
   }

--- a/front/lib/api/sandbox_functions/staging_integrity.ts
+++ b/front/lib/api/sandbox_functions/staging_integrity.ts
@@ -1,0 +1,84 @@
+import { createHash } from "node:crypto";
+
+import { shellEscape } from "@app/lib/api/sandbox/shell";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+// Front reads build/schema artifacts back through the provider's file API, which envd serves as
+// root and follows symlinks. The producing exec runs as agent-proxied and stages artifacts in an
+// agent-writable /tmp dir, so anything the agent runs concurrently can replace an artifact with a
+// symlink to a root-only file between the exec and the read (TOCTOU), and the root read then
+// returns that file's content. Pin every artifact to the sha256 captured at the end of the
+// producing exec: a swap before the capture fails the capture itself (`set -e`, sha256sum cannot
+// open the swapped target as agent-proxied), a swap after the capture no longer hashes equal.
+
+const HASH_MARKER = "__DUST_STAGING_SHA256__";
+const SHA256SUM_BIN = "/usr/bin/sha256sum";
+
+export type StagingHashes = Record<string, string>;
+
+/** Shell lines appended to a staging exec: a marker line, then one sha256 line per artifact. */
+export function stagingHashCaptureLines(paths: string[]): string[] {
+  return [
+    `echo ${HASH_MARKER}`,
+    `${SHA256SUM_BIN} ${paths.map((p) => shellEscape(p)).join(" ")}`,
+  ];
+}
+
+/**
+ * Split exec stdout at the marker: everything before it is dsbx output, everything after is
+ * `<sha256>  <path>` lines. Without a marker the input is returned untouched with no hashes.
+ */
+export function splitStagingStdout(stdout: string): {
+  dsbxStdout: string;
+  hashes: StagingHashes;
+} {
+  const markerIndex = stdout.indexOf(HASH_MARKER);
+  if (markerIndex === -1) {
+    return { dsbxStdout: stdout, hashes: {} };
+  }
+  const hashes: StagingHashes = {};
+  for (const line of stdout
+    .slice(markerIndex + HASH_MARKER.length)
+    .split("\n")) {
+    const match = /^([0-9a-f]{64}) {2}(\S.*)$/.exec(line.trim());
+    if (match) {
+      hashes[match[2]] = match[1];
+    }
+  }
+  return { dsbxStdout: stdout.slice(0, markerIndex), hashes };
+}
+
+function sha256Hex(content: Buffer): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+/**
+ * Verify a read-back artifact against its captured hash. Error messages never carry content, so
+ * a swapped-in secret cannot leak through the error path.
+ */
+export function verifyStagingContent(
+  path: string,
+  content: Buffer,
+  hashes: StagingHashes
+): Result<void, SandboxFunctionError> {
+  const expected = hashes[path];
+  if (expected === undefined) {
+    return new Err(
+      new SandboxFunctionError(
+        "internal",
+        `Missing integrity hash for staging file ${path}.`
+      )
+    );
+  }
+  if (sha256Hex(content) !== expected) {
+    return new Err(
+      new SandboxFunctionError(
+        "internal",
+        `Staging file ${path} changed between production and read-back; refusing to use it.`
+      )
+    );
+  }
+  return new Ok(undefined);
+}


### PR DESCRIPTION
## Description

`buildSandboxFunctionOnSandbox` and `getDatabaseSchemaOnSandbox` stage artifacts in agent-writable `/tmp` dirs as `agent-proxied`, then read them back through the provider file API, which envd serves as root while following symlinks. Code running as the agent on the same sandbox VM could swap a staging file for a symlink to a root-only file (e.g. `/run/dust/egress-secrets.json`) between the exec and the read, and the root read would return that file's content to the caller or persist it as a published function bundle.

Each producing exec now appends a marker and per-file sha256 lines after the dsbx output, and the read-back content is verified against those hashes before use, failing closed on any mismatch:
- swap before the capture: the capture itself fails (`set -e`; `sha256sum` cannot open the swapped target as `agent-proxied`)
- swap after the capture: content no longer hashes equal
- error messages never carry content, so a swapped-in file cannot leak through the error path either

Follow-ups not in this PR: same hardening for any future `provider.readFile`/`writeFile` caller under agent-writable paths, and the dsbx port-80 Host pinning issue tracked separately.

## Tests

- New `staging_integrity.test.ts` for the split/verify helpers.
- New swap-detection tests in `build_on_sandbox.test.ts` and a new `dsbx_db.test.ts` covering the schema flow (match, swapped file, missing hash).
- Full `lib/api/sandbox_functions` and `lib/api/sandbox` suites pass locally in a dust-hive env (70 + 363 tests).

## Risk

Low. Only the two staging flows change; both fail closed on any anomaly (missing marker, missing hash, mismatch), so worst case is a failed publish/schema read that the model can retry. Rollback is a revert.

## Deploy Plan

Standard deploy.