### PR TITLE
[front] perf: lock-free fast path for requireRunning sandbox reads

### DIFF
--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -48,7 +48,7 @@ export async function distributedUnlock(
   });
 }
 
-const WAIT_BETWEEN_RETRIES = 100;
+const DEFAULT_RETRY_INTERVAL_MS = 100;
 
 export const executeWithLock = async <T>(
   lockName: string,
@@ -60,8 +60,17 @@ export const executeWithLock = async <T>(
   // existing callers are unchanged and we don't span every lock app-wide.
   {
     lockTtlMs = 5_000,
+    retryIntervalMs = DEFAULT_RETRY_INTERVAL_MS,
     traceAcquireResource,
-  }: { lockTtlMs?: number; traceAcquireResource?: string } = {}
+  }: {
+    lockTtlMs?: number;
+    // How long a waiter sleeps between acquisition attempts. The wait is blind
+    // (no notification on release), so on a contended lock every waiter loses
+    // in quanta of this interval — locks with short hold times on
+    // latency-sensitive paths should pass something well under the default.
+    retryIntervalMs?: number;
+    traceAcquireResource?: string;
+  } = {}
 ): Promise<T> => {
   const client = await getRedisStreamClient({ origin: "lock" });
 
@@ -74,8 +83,11 @@ export const executeWithLock = async <T>(
       if (acquired) {
         break;
       }
-      // Wait a bit before retrying
-      await new Promise((resolve) => setTimeout(resolve, WAIT_BETWEEN_RETRIES));
+      // Wait before retrying, jittered to half..full interval so concurrent
+      // waiters spread out instead of stampeding the same retry tick.
+      const jitteredWaitMs =
+        retryIntervalMs / 2 + Math.random() * (retryIntervalMs / 2);
+      await new Promise((resolve) => setTimeout(resolve, jitteredWaitMs));
     }
     return acquired;
   };

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -609,8 +609,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         return ensureResult;
       }
 
-      // No updateLastActivityAt here: ensurePodSandboxReady's ensureActive just wrote it under
-      // the lifecycle lock.
+      // No updateLastActivityAt here: ensurePodSandboxReady's ensureActive just wrote it.
       const sandbox = ensureResult.value.sandbox;
       const stdoutResultDelivery = await hasFeatureFlag(
         auth,

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -1026,9 +1026,11 @@ describe("SandboxResource.ensureActive", () => {
   });
 
   // requireRunning is what lets a caller running inside a request use a sandbox without ever
-  // waiting on one being made ready. It is enforced under the lifecycle lock rather than by the
-  // caller, because a kill-requested sandbox reports itself as running right up until it is
-  // destroyed and recreated.
+  // waiting on one being made ready. It runs entirely off a lock-free read: it performs no
+  // lifecycle transition, and queueing concurrent invocations of a busy pod behind the lifecycle
+  // lock was measured as their dominant latency under load. A kill-requested sandbox reports
+  // itself as running right up until it is destroyed and recreated, so the kill marker is part
+  // of the check.
   describe("with requireRunning", () => {
     it("refuses a running sandbox that has a kill requested", async () => {
       const pod = await SpaceFactory.project(
@@ -1083,14 +1085,17 @@ describe("SandboxResource.ensureActive", () => {
       expect(mockProviderCreate).not.toHaveBeenCalled();
     });
 
-    it("uses a running sandbox", async () => {
+    it("uses a running sandbox without taking the lifecycle lock", async () => {
       const pod = await SpaceFactory.project(
         authenticator.getNonNullableWorkspace()
       );
       const running = await SandboxFactory.createForPod(authenticator, pod, {
         status: "running",
+        // Old enough that the fast path's throttled activity touch writes.
+        lastActivityAt: new Date(Date.now() - 60_000),
       });
 
+      mockExecuteWithLock.mockClear();
       const result = await PodSandboxAdapter.ensureSandboxActive(
         authenticator,
         pod,
@@ -1102,6 +1107,36 @@ describe("SandboxResource.ensureActive", () => {
         return;
       }
       expect(result.value.sandbox.sId).toBe(running.sId);
+      expect(mockExecuteWithLock).not.toHaveBeenCalled();
+
+      // The reaper's inactivity clock must keep running for sandboxes served
+      // entirely through the fast path.
+      const persisted = await PodSandboxAdapter.fetchSandbox(
+        authenticator,
+        pod
+      );
+      expect(persisted?.lastActivityAt?.getTime()).toBeGreaterThan(
+        Date.now() - 5_000
+      );
+    });
+
+    it("refuses without taking the lifecycle lock", async () => {
+      const pod = await SpaceFactory.project(
+        authenticator.getNonNullableWorkspace()
+      );
+      await SandboxFactory.createForPod(authenticator, pod, {
+        status: "sleeping",
+      });
+
+      mockExecuteWithLock.mockClear();
+      const result = await PodSandboxAdapter.ensureSandboxActive(
+        authenticator,
+        pod,
+        { requireRunning: true }
+      );
+
+      expect(result.isErr()).toBe(true);
+      expect(mockExecuteWithLock).not.toHaveBeenCalled();
     });
   });
 

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -536,13 +536,19 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     // invocation of a busy pod queue behind a blind-polling Redis lock for work that reads two
     // rows.
     //
-    // The read is a snapshot, so a transition can land right after it — which is exactly as racy
-    // as the same transition landing right after the locked version released. Every such race
-    // converges: a concurrent kill or sleep makes the exec fail, the caller escalates to the
-    // durable path, and the locked ensure there runs the transition machinery (kill-requested
-    // recreation included). A sandbox that is NOT running never takes the fast path: the error
-    // return below preserves requireRunning's contract without touching the lock, since waiting
-    // behind an in-flight multi-second wake would defeat the caller's latency bound anyway.
+    // The read is a snapshot, so a concurrent kill or sleep can invalidate the sandbox between
+    // this check and the caller's exec. That race is accepted, not converged: the exec fails
+    // with a provider error and the invocation fails (escalation to the durable path only
+    // happens on SandboxNotRunningError, and escalating on an arbitrary exec failure would risk
+    // re-running a function that partially executed). The lock never protected running execs —
+    // it only serialized admission — so an exec racing a sleep's pre-pause flush was already
+    // possible for any exec admitted before the reaper took the lock; this path widens
+    // admission into that window but does not create it. Both windows need the reaper to pick
+    // an actively-used pod, which the activity touch below makes minutes-rare.
+    //
+    // A sandbox that is NOT running never takes the fast path: the error return below preserves
+    // requireRunning's contract without touching the lock, since waiting behind an in-flight
+    // multi-second wake would defeat the caller's latency bound anyway.
     if (opts.requireRunning) {
       const existing = await owner.fetchSandbox();
       if (

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -435,7 +435,14 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       `sandbox:lifecycle:${lockKey}`,
       () => fn(provider),
       undefined,
-      { traceAcquireResource: "sandbox:lifecycle" }
+      {
+        traceAcquireResource: "sandbox:lifecycle",
+        // Contended by concurrent invocations of the same pod: transitions
+        // hold this lock from milliseconds (status checks) to seconds
+        // (wake/create), and waiters on the fast side of that range should
+        // not lose in 100ms quanta.
+        retryIntervalMs: 25,
+      }
     );
   }
 
@@ -523,22 +530,41 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       "Cannot ensure sandbox without a workspace"
     );
 
-    return this.withLifecycleLock(owner.lockKey, async (provider) => {
-      const tracingOpts = { workspaceId: auth.getNonNullableWorkspace().sId };
+    // Lock-free fast path: `requireRunning` never creates, wakes, or recreates, so a running,
+    // not-kill-requested sandbox can be used off a plain read. The lock exists to serialize
+    // lifecycle transitions, and this path performs none; taking it here made every concurrent
+    // invocation of a busy pod queue behind a blind-polling Redis lock for work that reads two
+    // rows.
+    //
+    // The read is a snapshot, so a transition can land right after it — which is exactly as racy
+    // as the same transition landing right after the locked version released. Every such race
+    // converges: a concurrent kill or sleep makes the exec fail, the caller escalates to the
+    // durable path, and the locked ensure there runs the transition machinery (kill-requested
+    // recreation included). A sandbox that is NOT running never takes the fast path: the error
+    // return below preserves requireRunning's contract without touching the lock, since waiting
+    // behind an in-flight multi-second wake would defeat the caller's latency bound anyway.
+    if (opts.requireRunning) {
       const existing = await owner.fetchSandbox();
-
-      // Decided here rather than by the caller: only under the lifecycle lock are the status and
-      // the kill marker stable, and a kill-requested sandbox is recreated below however it is
-      // reported, so a caller checking `status === "running"` beforehand would still get a cold
-      // start during an image rollout.
       if (
-        opts.requireRunning &&
-        (!existing ||
-          existing.killRequestedAt !== null ||
-          existing.status !== "running")
+        !existing ||
+        existing.killRequestedAt !== null ||
+        existing.status !== "running"
       ) {
         return new Err(new SandboxNotRunningError());
       }
+      // Same touch the locked path performs, so the reaper's inactivity clock keeps running for
+      // sandboxes served entirely through the fast path. Throttled internally to one write/30s.
+      await existing.updateLastActivityAt();
+      return new Ok({
+        sandbox: existing,
+        freshlyCreated: false,
+        wokeFromSleep: false,
+      });
+    }
+
+    return this.withLifecycleLock(owner.lockKey, async (provider) => {
+      const tracingOpts = { workspaceId: auth.getNonNullableWorkspace().sId };
+      const existing = await owner.fetchSandbox();
 
       if (!existing) {
         const imageResult = getSandboxImage(auth);

--- a/front/tests/utils/SandboxFactory.ts
+++ b/front/tests/utils/SandboxFactory.ts
@@ -70,7 +70,11 @@ export class SandboxFactory {
   static async createForPod(
     auth: Authenticator,
     pod: SpaceResource,
-    opts?: { status?: SandboxStatus; killRequestedAt?: Date }
+    opts?: {
+      status?: SandboxStatus;
+      killRequestedAt?: Date;
+      lastActivityAt?: Date;
+    }
   ): Promise<SandboxResource> {
     const sandbox = await SandboxResource.makeNew(auth, {
       providerId: `test-provider-${Date.now()}`,
@@ -81,6 +85,12 @@ export class SandboxFactory {
     if (opts?.killRequestedAt) {
       await SandboxModel.update(
         { killRequestedAt: opts.killRequestedAt } as Partial<SandboxModel>,
+        { where: { id: sandbox.id } }
+      );
+    }
+    if (opts?.lastActivityAt !== undefined) {
+      await SandboxModel.update(
+        { lastActivityAt: opts.lastActivityAt } as Partial<SandboxModel>,
         { where: { id: sandbox.id } }
       );
     }


### PR DESCRIPTION
## Description

Concurrent invocations of the same pod's functions degrade linearly with overlap: chatpro-sync p50 went from 101ms isolated to 1128ms at 8 concurrent callers, while the in-sandbox exec stayed flat at ~79ms. The `lock.acquire` APM span shows why: every invocation, even on a running sandbox, entered `SandboxResource.ensureActive` under the per-pod `sandbox:lifecycle` Redis lock, and the median lock wait went from 1-2ms quiet to 139-599ms during a real multi-user session. The lock waits in blind 100ms sleeps, so contenders lose in 100ms quanta even though the lock holds only two row reads on the happy path.

Two changes:

`requireRunning` no longer takes the lifecycle lock. It performs no lifecycle transition, so it runs off a plain read: running and not kill-requested means use it (plus the same throttled `lastActivityAt` touch the locked path did), anything else is `SandboxNotRunningError` without waiting behind an in-flight multi-second wake. The read is a snapshot, but every race converges the same way it did when the transition landed right after the locked version released: the exec fails, the caller escalates to the durable path, and the locked ensure there runs the transition machinery, kill-requested recreation included.

`executeWithLock` gains a `retryIntervalMs` option (default unchanged at 100ms), jittered to half..full interval so waiters stop stampeding the same retry tick. The lifecycle lock passes 25ms, which bounds the queueing penalty for the paths that still need the lock (create, wake, sleep, kill).

## Tests

sandbox_resource suite: the requireRunning block now asserts the fast path never calls `executeWithLock`, both when serving a running sandbox and when refusing, and that `lastActivityAt` is written through the fast path so the reaper's inactivity clock keeps running. Existing refusal tests (kill-requested, sleeping, absent) pass unchanged. front typechecks clean.

## Risk

The fast path can hand out a sandbox that a concurrent kill or sleep is about to invalidate. That race ends in a failed invocation, not escalation: the escalation gate is SandboxNotRunningError, and escalating on an arbitrary exec failure would risk re-running a partially executed function. Relatedly, an exec admitted during the reaper's pre-sleep flush can commit pod-state writes the flush never saw. Both windows are pre-existing in kind — the lock only ever serialized admission, never running execs, so an exec admitted before the reaper locked was always able to race the flush — but this widens admission into them. Both need the reaper to sleep a pod that is actively invoking, which the fast path's activity touch keeps minutes-rare. The proper closure (exec/sleep mutual exclusion or a post-flush activity re-check in the reaper) is left to a follow-up.

The retry-interval change only affects wait cadence, never lock semantics; the added jitter shifts the default wait from a fixed 100ms to 50-100ms for all executeWithLock callers, none of which depend on cadence.

## Deploy Plan

Normal deploy. Watch the `lock.acquire` span for `sandbox:lifecycle` (its volume should collapse) and invocation latency under concurrent load on a single pod, which should sit near its isolated latency.
