### PR TITLE
Fix: Pod's frame pinned or as tab use the same rendering path.

### DIFF
--- a/front/components/pod/PodFrameTabContent.tsx
+++ b/front/components/pod/PodFrameTabContent.tsx
@@ -1,14 +1,10 @@
-import { AuthenticatedVisualizationActionIframe } from "@app/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe";
+import { PodFrameVisualization } from "@app/components/pod/PodFrameVisualization";
+import { usePodFrameRenderableContent } from "@app/hooks/usePodFrameRenderableContent";
 import { useAuth } from "@app/lib/auth/AuthContext";
-import {
-  getFilePathContentApiPath,
-  useFileContentByUrl,
-} from "@app/lib/swr/files";
 import type { RichSpaceType } from "@app/types/api/spaces";
 import type { PodFrameTab } from "@app/types/pod_frame_tab";
 import type { WorkspaceType } from "@app/types/user";
 import { Spinner } from "@dust-tt/sparkle";
-import { useMemo, useRef } from "react";
 
 interface PodFrameTabContentProps {
   owner: WorkspaceType;
@@ -22,20 +18,13 @@ export function PodFrameTabContent({
   tab,
 }: PodFrameTabContentProps) {
   const { vizUrl } = useAuth();
-  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const { fileId, fileContent, isLoading, isNotFound } =
+    usePodFrameRenderableContent({
+      owner,
+      framePath: tab.path,
+    });
 
-  const contentUrl = useMemo(
-    () => getFilePathContentApiPath(owner, tab.path),
-    [owner, tab.path]
-  );
-
-  const { fileContent, isNotFound, isFileContentLoading } = useFileContentByUrl(
-    {
-      url: contentUrl,
-    }
-  );
-
-  if (isFileContentLoading) {
+  if (isLoading) {
     return (
       <div className="flex h-full w-full items-center justify-center">
         <Spinner />
@@ -43,7 +32,7 @@ export function PodFrameTabContent({
     );
   }
 
-  if (isNotFound || !fileContent || !vizUrl) {
+  if (isNotFound || !fileId || !fileContent || !vizUrl) {
     return (
       <div className="flex h-full w-full items-center justify-center p-8 text-center text-sm text-muted-foreground">
         This frame is no longer available in the Pod files.
@@ -54,19 +43,12 @@ export function PodFrameTabContent({
   return (
     <div className="flex h-full min-h-0 w-full flex-col overflow-hidden p-2">
       <div className="h-full overflow-hidden rounded-xl ring-1 ring-border/60">
-        <AuthenticatedVisualizationActionIframe
-          agentConfigurationId={null}
-          workspaceId={owner.sId}
-          vizUrl={vizUrl}
-          visualization={{
-            code: fileContent,
-            complete: true,
-            identifier: `viz-frame-tab-${tab.path}`,
-          }}
-          conversationId={null}
+        <PodFrameVisualization
+          owner={owner}
           spaceId={podInfo.sId}
-          isInDrawer={true}
-          ref={iframeRef}
+          fileContent={fileContent}
+          vizUrl={vizUrl}
+          identifier={`viz-frame-tab-${fileId}`}
         />
       </div>
     </div>

--- a/front/components/pod/PodFrameVisualization.tsx
+++ b/front/components/pod/PodFrameVisualization.tsx
@@ -1,0 +1,42 @@
+import { AuthenticatedVisualizationActionIframe } from "@app/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useRef } from "react";
+
+interface PodFrameVisualizationProps {
+  owner: LightWorkspaceType;
+  spaceId: string;
+  fileContent: string;
+  vizUrl: string;
+  identifier: string;
+}
+
+/**
+ * Shared viz iframe used by the Pod pinned banner and Pod frame tabs.
+ * Expects already-fetched renderable content (published bundle when available).
+ */
+export function PodFrameVisualization({
+  owner,
+  spaceId,
+  fileContent,
+  vizUrl,
+  identifier,
+}: PodFrameVisualizationProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  return (
+    <AuthenticatedVisualizationActionIframe
+      agentConfigurationId={null}
+      workspaceId={owner.sId}
+      vizUrl={vizUrl}
+      visualization={{
+        code: fileContent,
+        complete: true,
+        identifier,
+      }}
+      conversationId={null}
+      spaceId={spaceId}
+      isInDrawer={true}
+      ref={iframeRef}
+    />
+  );
+}

--- a/front/components/pod/conversation/PodPinnedBanner.tsx
+++ b/front/components/pod/conversation/PodPinnedBanner.tsx
@@ -1,9 +1,8 @@
-import { AuthenticatedVisualizationActionIframe } from "@app/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe";
+import { PodFrameVisualization } from "@app/components/pod/PodFrameVisualization";
 import { usePinPodBanner } from "@app/hooks/usePinPodBanner";
+import { usePodFrameRenderableContent } from "@app/hooks/usePodFrameRenderableContent";
 import { useScopedPodUiPreferences } from "@app/hooks/useScopedUIPreferences";
 import { useAuth } from "@app/lib/auth/AuthContext";
-import { useFileContent } from "@app/lib/swr/files";
-import { usePodFiles } from "@app/lib/swr/pods";
 import logger from "@app/logger/logger";
 import type { RichSpaceType } from "@app/types/api/spaces";
 import type { WorkspaceType } from "@app/types/user";
@@ -15,7 +14,7 @@ import {
   Minimize01,
   Pin02,
 } from "@dust-tt/sparkle";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
 const BANNER_HEIGHT_PX = 280;
@@ -27,39 +26,6 @@ const DEFAULT_POD_PINNED_BANNER_PREFERENCES = {
 interface PodPinnedBannerProps {
   owner: WorkspaceType;
   podInfo: RichSpaceType;
-}
-
-function PodPinnedBannerFrame({
-  owner,
-  podId,
-  fileId,
-  fileContent,
-  vizUrl,
-}: {
-  owner: WorkspaceType;
-  podId: string;
-  fileId: string;
-  fileContent: string;
-  vizUrl: string;
-}) {
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-
-  return (
-    <AuthenticatedVisualizationActionIframe
-      agentConfigurationId={null}
-      workspaceId={owner.sId}
-      vizUrl={vizUrl}
-      visualization={{
-        code: fileContent,
-        complete: true,
-        identifier: `viz-banner-${fileId}`,
-      }}
-      conversationId={null}
-      spaceId={podId}
-      isInDrawer={true}
-      ref={iframeRef}
-    />
-  );
 }
 
 interface PodPinnedBannerControlsProps {
@@ -177,51 +143,21 @@ export function PodPinnedBanner({ owner, podInfo }: PodPinnedBannerProps) {
     isEditor: podInfo.isEditor,
   });
 
-  const { files: podFiles, isPodFilesLoading } = usePodFiles({
-    owner,
-    podId: podInfo.sId,
-    disabled: !pinnedFramePath,
-  });
-
-  const pinnedFile = useMemo(() => {
-    if (!pinnedFramePath) {
-      return null;
-    }
-    return (
-      podFiles.find(
-        (f) => !f.isDirectory && f.path === pinnedFramePath && f.fileId
-      ) ?? null
-    );
-  }, [pinnedFramePath, podFiles]);
-
-  const fileId =
-    pinnedFile && !pinnedFile.isDirectory ? pinnedFile.fileId : null;
+  const { fileId, fileContent, isLoading, isNotFound } =
+    usePodFrameRenderableContent({
+      owner,
+      framePath: pinnedFramePath,
+      disabled: !pinnedFramePath,
+    });
 
   useEffect(() => {
-    if (
-      pinnedFramePath &&
-      !isPodFilesLoading &&
-      podFiles.length > 0 &&
-      !fileId
-    ) {
+    if (pinnedFramePath && isNotFound) {
       logger.warn(
         { spaceId: podInfo.sId, pinnedFramePath },
         "Pinned Pod banner file not found; skipping render."
       );
     }
-  }, [
-    fileId,
-    isPodFilesLoading,
-    pinnedFramePath,
-    podFiles.length,
-    podInfo.sId,
-  ]);
-
-  const { fileContent } = useFileContent({
-    fileId,
-    owner,
-    config: { disabled: !fileId },
-  });
+  }, [isNotFound, pinnedFramePath, podInfo.sId]);
 
   useEffect(() => {
     if (!isFullscreen) {
@@ -237,19 +173,17 @@ export function PodPinnedBanner({ owner, podInfo }: PodPinnedBannerProps) {
   }, [isFullscreen]);
 
   const unpinLabel =
-    pinnedFile && !pinnedFile.isDirectory
-      ? pinnedFile.fileName
-      : pinnedFramePath;
+    pinnedFramePath?.split("/").pop() ?? pinnedFramePath ?? undefined;
 
   const handleUnpin = useCallback(() => {
-    void unpinFrame({ fileName: unpinLabel ?? undefined });
+    void unpinFrame({ fileName: unpinLabel });
   }, [unpinFrame, unpinLabel]);
 
   if (!pinnedFramePath) {
     return null;
   }
 
-  if (isPodFilesLoading || (fileId && !fileContent)) {
+  if (isLoading) {
     return (
       <div
         className="mb-4 flex h-16 items-center justify-center rounded-xl bg-muted-background"
@@ -258,16 +192,16 @@ export function PodPinnedBanner({ owner, podInfo }: PodPinnedBannerProps) {
     );
   }
 
-  if (!fileId || !fileContent || !vizUrl) {
+  if (isNotFound || !fileId || !fileContent || !vizUrl) {
     return null;
   }
 
   const frameProps = {
     owner,
-    podId: podInfo.sId,
-    fileId,
+    spaceId: podInfo.sId,
     fileContent,
     vizUrl,
+    identifier: `viz-banner-${fileId}`,
   };
 
   const controlsProps = {
@@ -289,7 +223,10 @@ export function PodPinnedBanner({ owner, podInfo }: PodPinnedBannerProps) {
         />
         <div className="h-full p-4 pt-12">
           <div className="h-full overflow-hidden rounded-xl">
-            <PodPinnedBannerFrame key={`banner-fs-${fileId}`} {...frameProps} />
+            <PodFrameVisualization
+              key={`banner-fs-${fileId}`}
+              {...frameProps}
+            />
           </div>
         </div>
       </div>,
@@ -316,7 +253,7 @@ export function PodPinnedBanner({ owner, podInfo }: PodPinnedBannerProps) {
         style={{ height: BANNER_HEIGHT_PX }}
       >
         <PodPinnedBannerControls {...controlsProps} />
-        <PodPinnedBannerFrame key={`banner-${fileId}`} {...frameProps} />
+        <PodFrameVisualization key={`banner-${fileId}`} {...frameProps} />
       </div>
       {fullscreenOverlay}
     </>

--- a/front/hooks/usePodFrameRenderableContent.ts
+++ b/front/hooks/usePodFrameRenderableContent.ts
@@ -1,0 +1,48 @@
+import { useFileContent, useFileIdFromPath } from "@app/lib/swr/files";
+import type { LightWorkspaceType } from "@app/types/user";
+
+/**
+ * Load a Pod Frame's renderable content from its source mount path.
+ *
+ * Pod metadata (pinned banner / frame tabs) stores the source path. Published
+ * Frames keep their built bundle as the FileResource's processed version, so we
+ * resolve path → fileId and fetch via `?action=view` (getRenderableVersion)
+ * rather than reading the raw mount with `/files/path/...`.
+ */
+export function usePodFrameRenderableContent({
+  owner,
+  framePath,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  framePath: string | null | undefined;
+  disabled?: boolean;
+}) {
+  const isDisabled = disabled || !framePath;
+
+  const { fileId, isFileIdLoading, isFileIdNotFound, fileIdError } =
+    useFileIdFromPath({
+      owner,
+      filePath: framePath,
+      disabled: isDisabled,
+    });
+
+  const {
+    fileContent,
+    isFileContentLoading,
+    error: fileContentError,
+  } = useFileContent({
+    fileId,
+    owner,
+    config: { disabled: isDisabled || !fileId },
+  });
+
+  return {
+    fileId,
+    fileContent: fileContent ?? null,
+    isLoading:
+      !isDisabled && (isFileIdLoading || (!!fileId && isFileContentLoading)),
+    isNotFound: isFileIdNotFound,
+    error: fileIdError ?? fileContentError,
+  };
+}

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -92,6 +92,47 @@ export async function fetchFileIdFromPath({
   return response.headers.get(DUST_FILE_ID_HEADER);
 }
 
+/**
+ * Resolve the FileResource sId linked to a canonical scoped path.
+ * Returns null when the path exists but has no linked FileResource, or when
+ * the path is not found.
+ */
+export function useFileIdFromPath({
+  owner,
+  filePath,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  filePath: string | null | undefined;
+  disabled?: boolean;
+}) {
+  const path = filePath ?? null;
+  const swrKey =
+    disabled || path === null
+      ? null
+      : (`file-id-from-path:${owner.sId}:${path}` as const);
+
+  const { data, error } = useSWRWithDefaults(
+    swrKey,
+    async (): Promise<string | null> => {
+      if (path === null) {
+        return null;
+      }
+      return fetchFileIdFromPath({ owner, filePath: path });
+    },
+    { disabled: swrKey === null }
+  );
+
+  const isLoading = swrKey !== null && !error && data === undefined;
+
+  return {
+    fileId: data ?? null,
+    isFileIdLoading: isLoading,
+    isFileIdNotFound: swrKey !== null && !isLoading && data === null,
+    fileIdError: error ? normalizeError(error) : null,
+  };
+}
+
 type FileContentByUrlData =
   | { kind: "loaded"; content: string }
   | { kind: "not_found" };


### PR DESCRIPTION
## Description

`PodPinnedBanner` and `PodFrameTabContent` each had their own divergent fetch-and-render logic for Pod frames: the banner used `usePodFiles` + `useFileContent` (raw mount content), while the tab used `getFilePathContentApiPath` + `useFileContentByUrl`. Neither resolved through `?action=view`, meaning published frame bundles were never used.

- New `usePodFrameRenderableContent` hook unifies path → `fileId` → renderable content resolution for both consumers, using `useFileIdFromPath` (new SWR hook in `files.ts`) + `useFileContent` with `?action=view` so the published bundle is fetched when available.
- New `PodFrameVisualization` shared component replaces the inline `AuthenticatedVisualizationActionIframe` usage in both call sites. The iframe `identifier` now uses `fileId` (stable) instead of `tab.path`.
- `PodPinnedBanner` drops the `usePodFiles` dependency entirely; the `unpinLabel` falls back to `path.split("/").pop()`.

## Tests

Tested locally — pinned frame banner and frame tab both render the published bundle. Verified the "no longer available" fallback when the path is not found.

## Risk

Low. Front-only, no DB changes. The only behavioral shift is that published frame bundles are now served via `?action=view` instead of raw path content — this is the intended behavior. Rollback is a simple front redeploy.

## Deploy Plan

Deploy `front`.
