### PR TITLE
Add pace-aware credit usage display

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -1,3 +1,7 @@
+import {
+  CreditUsage,
+  type CreditUsageState,
+} from "@app/components/app/CreditUsage";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { useConversationDrafts } from "@app/components/assistant/conversation/input_bar/useConversationDrafts";
 import { UserSettingsPopover } from "@app/components/UserSettingsPopover";
@@ -64,9 +68,15 @@ interface UserMenuProps {
   user: UserTypeWithWorkspaces;
   owner: WorkspaceType;
   subscription: SubscriptionType | null;
+  creditUsageState?: CreditUsageState | null;
 }
 
-export function UserMenu({ user, owner, subscription }: UserMenuProps) {
+export function UserMenu({
+  user,
+  owner,
+  subscription,
+  creditUsageState,
+}: UserMenuProps) {
   const router = useAppRouter();
   const { featureFlags } = useFeatureFlags();
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -272,6 +282,13 @@ export function UserMenu({ user, owner, subscription }: UserMenuProps) {
           sideOffset={8}
           className="w-64"
         >
+          {creditUsageState && (
+            <>
+              <CreditUsage state={creditUsageState} variant="profile_menu" />
+              <Separator className="my-1" />
+            </>
+          )}
+
           {hasMultipleWorkspaces && (
             <>
               <DropdownMenuLabel label="Workspace" />

--- a/front/components/app/CreditUsage.test.tsx
+++ b/front/components/app/CreditUsage.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CreditUsage, type CreditUsageState } from "./CreditUsage";
+
+const ON_PACE_STATE = {
+  usedPercentage: 80,
+  resetInDays: 5,
+  pace: "on_pace",
+} satisfies CreditUsageState;
+
+describe("CreditUsage", () => {
+  it("renders the compact profile menu presentation", () => {
+    render(<CreditUsage state={ON_PACE_STATE} variant="profile_menu" />);
+
+    expect(screen.getByText("Credits")).toBeInTheDocument();
+    expect(screen.getByText("80%")).toBeInTheDocument();
+    expect(screen.getByText("80%")).toHaveClass("text-highlight-500");
+    expect(screen.getByText("Reset in 5 days")).toBeInTheDocument();
+    expect(
+      screen.getByRole("progressbar", { name: "Credits used" })
+    ).toHaveAttribute("aria-valuenow", "80");
+  });
+
+  it("renders the companion presentation and clamps displayed usage", () => {
+    const rendered = render(
+      <CreditUsage
+        state={{
+          ...ON_PACE_STATE,
+          usedPercentage: 120,
+          resetInDays: 1,
+          pace: "critical",
+        }}
+        variant="companion"
+      />
+    );
+
+    expect(screen.getByText("100%")).toBeInTheDocument();
+    expect(
+      screen.getByText("Usage is well above pace · Credit reset in 1 day")
+    ).toBeInTheDocument();
+    const progressbar = rendered.getByRole("progressbar", {
+      name: "Credits used",
+    });
+    expect(progressbar.firstElementChild).toHaveStyle({ width: "100%" });
+    expect(progressbar.firstElementChild).toHaveClass("bg-red-500");
+  });
+
+  it("uses the warning treatment for elevated usage", () => {
+    render(
+      <CreditUsage
+        state={{ ...ON_PACE_STATE, pace: "elevated" }}
+        variant="companion"
+      />
+    );
+
+    expect(screen.getByText("80%")).toHaveClass("text-warning-500");
+    expect(
+      screen.getByRole("progressbar", { name: "Credits used" })
+        .firstElementChild
+    ).toHaveClass("bg-warning-500");
+  });
+});

--- a/front/components/app/CreditUsage.tsx
+++ b/front/components/app/CreditUsage.tsx
@@ -1,0 +1,49 @@
+import {
+  CreditUsageCard,
+  type CreditUsageCardVariant,
+} from "@app/components/app/CreditUsageCard";
+import type { CreditUsagePace } from "@app/types/api/credits/usage_status";
+
+export interface CreditUsageState {
+  usedPercentage: number;
+  resetInDays: number;
+  pace: CreditUsagePace;
+}
+
+const RESET_LABEL_PREFIX: Record<CreditUsageCardVariant, string> = {
+  profile_menu: "Reset",
+  companion: "Credit reset",
+};
+
+const COMPANION_STATUS_LABELS: Record<
+  Exclude<CreditUsagePace, "on_pace">,
+  string
+> = {
+  elevated: "Usage is above pace",
+  critical: "Usage is well above pace",
+};
+
+interface CreditUsageProps {
+  state: CreditUsageState;
+  variant: CreditUsageCardVariant;
+}
+
+export function CreditUsage({ state, variant }: CreditUsageProps) {
+  const resetUnit = state.resetInDays === 1 ? "day" : "days";
+  const companionStatusLabel =
+    variant === "companion" && state.pace !== "on_pace"
+      ? COMPANION_STATUS_LABELS[state.pace]
+      : null;
+
+  return (
+    <CreditUsageCard
+      label="Credits"
+      usedPercentage={state.usedPercentage}
+      tone={state.pace}
+      variant={variant}
+    >
+      {companionStatusLabel ? `${companionStatusLabel} · ` : null}
+      {RESET_LABEL_PREFIX[variant]} in {state.resetInDays} {resetUnit}
+    </CreditUsageCard>
+  );
+}

--- a/front/components/app/CreditUsageCard.tsx
+++ b/front/components/app/CreditUsageCard.tsx
@@ -1,0 +1,71 @@
+import { CoinsStacked01, cn } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
+
+export type CreditUsageTone = "on_pace" | "elevated" | "critical";
+export type CreditUsageCardVariant = "profile_menu" | "companion";
+
+const CONTAINER_CLASSES: Record<CreditUsageCardVariant, string> = {
+  profile_menu: "p-2",
+  companion:
+    "w-full rounded-xl border border-border bg-background p-3 shadow-sm",
+};
+
+const TONE_BAR_CLASSES: Record<CreditUsageTone, string> = {
+  on_pace: "bg-highlight-500",
+  elevated: "bg-warning-500",
+  critical: "bg-red-500",
+};
+
+const TONE_TEXT_CLASSES: Record<CreditUsageTone, string> = {
+  on_pace: "text-highlight-500",
+  elevated: "text-warning-500",
+  critical: "text-red-500",
+};
+
+interface CreditUsageCardProps {
+  label: string;
+  usedPercentage: number;
+  tone: CreditUsageTone;
+  variant: CreditUsageCardVariant;
+  children: ReactNode;
+}
+
+export function CreditUsageCard({
+  label,
+  usedPercentage: rawUsedPercentage,
+  tone,
+  variant,
+  children,
+}: CreditUsageCardProps) {
+  const usedPercentage = Math.min(Math.max(rawUsedPercentage, 0), 100);
+
+  return (
+    <div className={cn("flex flex-col gap-2", CONTAINER_CLASSES[variant])}>
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center justify-between text-sm font-medium text-foreground">
+          <div className="flex items-center gap-1">
+            <CoinsStacked01 className="h-4 w-4 text-muted-foreground" />
+            <span>{label}</span>
+          </div>
+          <span className={TONE_TEXT_CLASSES[tone]}>{usedPercentage}%</span>
+        </div>
+        <div
+          aria-label={`${label} used`}
+          aria-valuemax={100}
+          aria-valuemin={0}
+          aria-valuenow={usedPercentage}
+          className="h-1 w-full overflow-hidden rounded-full bg-border"
+          role="progressbar"
+        >
+          <div
+            className={cn("h-full rounded-full", TONE_BAR_CLASSES[tone])}
+            style={{ width: `${usedPercentage}%` }}
+          />
+        </div>
+      </div>
+      <div className="text-xs font-medium text-muted-foreground">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/front/components/app/FairUseCreditsUsage.tsx
+++ b/front/components/app/FairUseCreditsUsage.tsx
@@ -1,8 +1,9 @@
+import { CreditUsageCard } from "@app/components/app/CreditUsageCard";
 import { FairUsageModal } from "@app/components/FairUsageModal";
 import { formatCredits, formatFairUseTimeframe } from "@app/lib/client/credits";
 import { AGENT_MESSAGE_COMPLETED_EVENT } from "@app/lib/notifications/events";
 import { useFairUseCredits } from "@app/lib/swr/fair_use_credits";
-import { cn, Hoverable } from "@dust-tt/sparkle";
+import { Hoverable } from "@dust-tt/sparkle";
 import { useEffect, useRef, useState } from "react";
 
 const CREDITS_USAGE_DISPLAY_THRESHOLD = 0.75;
@@ -71,48 +72,22 @@ export function FairUseCreditsUsage({ workspaceId }: FairUseCreditsUsageProps) {
         onClose={() => setIsFairUsageModalOpened(false)}
         seatLimit={{ kind: "credits", limit, timeframe }}
       />
-      <div
-        className={cn(
-          // Spacing lives here rather than on a wrapper so that it only applies when the gauge is
-          // actually visible.
-          "mx-3 mb-3",
-          "rounded-lg border p-3",
-          "border-border",
-          "bg-background"
-        )}
-      >
-        <div className="mb-2 flex items-center justify-between text-sm">
-          <span className="font-semibold text-foreground">Fair usage</span>
-          <span className="font-medium text-foreground">
-            <span className={cn(isCritical && "text-warning-600")}>
-              {formatCredits(count)}
-            </span>{" "}
-            / {formatCredits(limit)} credits
-            {timeframeLabel ? ` ${timeframeLabel}` : ""}
-          </span>
-        </div>
-        <div
-          className={cn(
-            "h-2 w-full overflow-hidden rounded-full",
-            "bg-primary-100"
-          )}
+      <div className="mx-3 mb-3">
+        <CreditUsageCard
+          label="Fair usage"
+          usedPercentage={percentage * 100}
+          tone={isCritical ? "critical" : "elevated"}
+          variant="companion"
         >
-          <div
-            className={cn(
-              "h-full rounded-full transition-all",
-              isCritical ? "bg-warning-700" : "bg-foreground"
-            )}
-            style={{ width: `${Math.min(percentage * 100, 100)}%` }}
-          />
-        </div>
-        <div className="mt-2 text-xs">
+          {formatCredits(count)} / {formatCredits(limit)} credits
+          {timeframeLabel ? ` ${timeframeLabel}` : ""} ·{" "}
           <Hoverable
             variant="highlight"
             onClick={() => setIsFairUsageModalOpened(true)}
           >
             Fair Use policy
           </Hoverable>
-        </div>
+        </CreditUsageCard>
       </div>
     </>
   );

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -1,3 +1,4 @@
+import { CreditUsage } from "@app/components/app/CreditUsage";
 import { FairUseCreditsUsage } from "@app/components/app/FairUseCreditsUsage";
 import { TrialMessageUsage } from "@app/components/app/TrialMessageUsage";
 import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
@@ -10,12 +11,13 @@ import { UserMenu } from "@app/components/UserMenu";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { FREE_TRIAL_PHONE_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
+import { useMyUsage } from "@app/lib/swr/credits";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import type {
   ConcreteResourceType,
   GrantVerb,
 } from "@app/types/group_permissions";
-import type { SubscriptionType } from "@app/types/plan";
+import { isCreditPricedPlan, type SubscriptionType } from "@app/types/plan";
 import type { UserTypeWithWorkspaces, WorkspaceType } from "@app/types/user";
 import { isAdmin, isManager } from "@app/types/user";
 import {
@@ -32,6 +34,8 @@ import {
   XClose,
 } from "@dust-tt/sparkle";
 import React, { useCallback, useContext, useMemo } from "react";
+
+const DAY_DURATION_MS = 24 * 60 * 60 * 1000;
 
 function getAdminSectionHref(
   owner: WorkspaceType,
@@ -113,6 +117,26 @@ export const NavigationSidebar = React.forwardRef<
   const { setSidebarOpen } = useContext(SidebarContext);
   const { setIsNavigationBarOpen } = useDesktopNavigation();
 
+  const isCreditBased = isCreditPricedPlan(subscription.plan);
+  const { creditUsageStatus } = useMyUsage({
+    workspaceId: owner.sId,
+    disabled: !isCreditBased,
+  });
+  const creditUsageState = creditUsageStatus
+    ? {
+        usedPercentage: creditUsageStatus.usedPercentage,
+        resetInDays: Math.max(
+          0,
+          Math.ceil(
+            (new Date(creditUsageStatus.resetAt).getTime() - Date.now()) /
+              DAY_DURATION_MS
+          )
+        ),
+        pace: creditUsageStatus.pace,
+      }
+    : null;
+  const showCreditUsageInProfileMenu = creditUsageState?.pace === "on_pace";
+
   return (
     <div ref={ref} className="flex min-w-0 grow flex-col">
       <div className={cn("flex flex-col gap-3")}>
@@ -188,19 +212,30 @@ export const NavigationSidebar = React.forwardRef<
         )}
       </div>
       <div className="flex grow flex-col">{children}</div>
-      {subscription.plan.code === FREE_TRIAL_PHONE_PLAN_CODE ? (
+      {subscription.plan.code === FREE_TRIAL_PHONE_PLAN_CODE && (
         <div className="mx-3 mb-3">
           <TrialMessageUsage isAdmin={isAdmin(owner)} workspaceId={owner.sId} />
         </div>
-      ) : (
-        // Only mount when the plan has a fair-use credits limit so that the
-        // fair-use-credits endpoint is never called for unlimited plans.
+      )}
+      {subscription.plan.code !== FREE_TRIAL_PHONE_PLAN_CODE &&
+        !isCreditBased &&
         subscription.plan.limits.assistant.maxAwuCredits !== -1 && (
           <FairUseCreditsUsage workspaceId={owner.sId} />
-        )
+        )}
+      {creditUsageState && !showCreditUsageInProfileMenu && (
+        <div className="mx-3 mb-3">
+          <CreditUsage state={creditUsageState} variant="companion" />
+        </div>
       )}
       {user && (
-        <UserMenu user={user} owner={owner} subscription={subscription} />
+        <UserMenu
+          user={user}
+          owner={owner}
+          subscription={subscription}
+          creditUsageState={
+            showCreditUsageInProfileMenu ? creditUsageState : null
+          }
+        />
       )}
     </div>
   );

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -1,23 +1,20 @@
-import { CreditUsage } from "@app/components/app/CreditUsage";
-import { FairUseCreditsUsage } from "@app/components/app/FairUseCreditsUsage";
 import { TrialMessageUsage } from "@app/components/app/TrialMessageUsage";
 import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
 import { SidebarBanners } from "@app/components/navigation/AppStatusBanner";
 import type { SidebarNavigation } from "@app/components/navigation/config";
 import { getTopNavigationTabs } from "@app/components/navigation/config";
 import { useDesktopNavigation } from "@app/components/navigation/DesktopNavigationContext";
+import { SidebarUserMenu } from "@app/components/navigation/SidebarUserMenu";
 import { SidebarContext } from "@app/components/sparkle/SidebarContext";
-import { UserMenu } from "@app/components/UserMenu";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { FREE_TRIAL_PHONE_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
-import { useMyUsage } from "@app/lib/swr/credits";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import type {
   ConcreteResourceType,
   GrantVerb,
 } from "@app/types/group_permissions";
-import { isCreditPricedPlan, type SubscriptionType } from "@app/types/plan";
+import type { SubscriptionType } from "@app/types/plan";
 import type { UserTypeWithWorkspaces, WorkspaceType } from "@app/types/user";
 import { isAdmin, isManager } from "@app/types/user";
 import {
@@ -34,8 +31,6 @@ import {
   XClose,
 } from "@dust-tt/sparkle";
 import React, { useCallback, useContext, useMemo } from "react";
-
-const DAY_DURATION_MS = 24 * 60 * 60 * 1000;
 
 function getAdminSectionHref(
   owner: WorkspaceType,
@@ -117,26 +112,6 @@ export const NavigationSidebar = React.forwardRef<
   const { setSidebarOpen } = useContext(SidebarContext);
   const { setIsNavigationBarOpen } = useDesktopNavigation();
 
-  const isCreditBased = isCreditPricedPlan(subscription.plan);
-  const { creditUsageStatus } = useMyUsage({
-    workspaceId: owner.sId,
-    disabled: !isCreditBased,
-  });
-  const creditUsageState = creditUsageStatus
-    ? {
-        usedPercentage: creditUsageStatus.usedPercentage,
-        resetInDays: Math.max(
-          0,
-          Math.ceil(
-            (new Date(creditUsageStatus.resetAt).getTime() - Date.now()) /
-              DAY_DURATION_MS
-          )
-        ),
-        pace: creditUsageStatus.pace,
-      }
-    : null;
-  const showCreditUsageInProfileMenu = creditUsageState?.pace === "on_pace";
-
   return (
     <div ref={ref} className="flex min-w-0 grow flex-col">
       <div className={cn("flex flex-col gap-3")}>
@@ -217,24 +192,11 @@ export const NavigationSidebar = React.forwardRef<
           <TrialMessageUsage isAdmin={isAdmin(owner)} workspaceId={owner.sId} />
         </div>
       )}
-      {subscription.plan.code !== FREE_TRIAL_PHONE_PLAN_CODE &&
-        !isCreditBased &&
-        subscription.plan.limits.assistant.maxAwuCredits !== -1 && (
-          <FairUseCreditsUsage workspaceId={owner.sId} />
-        )}
-      {creditUsageState && !showCreditUsageInProfileMenu && (
-        <div className="mx-3 mb-3">
-          <CreditUsage state={creditUsageState} variant="companion" />
-        </div>
-      )}
       {user && (
-        <UserMenu
+        <SidebarUserMenu
           user={user}
           owner={owner}
           subscription={subscription}
-          creditUsageState={
-            showCreditUsageInProfileMenu ? creditUsageState : null
-          }
         />
       )}
     </div>

--- a/front/components/navigation/SidebarUserMenu.tsx
+++ b/front/components/navigation/SidebarUserMenu.tsx
@@ -1,0 +1,64 @@
+import { CreditUsage } from "@app/components/app/CreditUsage";
+import { FairUseCreditsUsage } from "@app/components/app/FairUseCreditsUsage";
+import { UserMenu } from "@app/components/UserMenu";
+import { FREE_TRIAL_PHONE_PLAN_CODE } from "@app/lib/plans/plan_codes";
+import { useMyUsage } from "@app/lib/swr/credits";
+import { isCreditPricedPlan, type SubscriptionType } from "@app/types/plan";
+import type { UserTypeWithWorkspaces, WorkspaceType } from "@app/types/user";
+
+const DAY_DURATION_MS = 24 * 60 * 60 * 1000;
+
+interface SidebarUserMenuProps {
+  user: UserTypeWithWorkspaces;
+  owner: WorkspaceType;
+  subscription: SubscriptionType;
+}
+
+export function SidebarUserMenu({
+  user,
+  owner,
+  subscription,
+}: SidebarUserMenuProps) {
+  const isCreditBased = isCreditPricedPlan(subscription.plan);
+  const { creditUsageStatus } = useMyUsage({
+    workspaceId: owner.sId,
+    disabled: !isCreditBased,
+  });
+  const creditUsageState = creditUsageStatus
+    ? {
+        usedPercentage: creditUsageStatus.usedPercentage,
+        resetInDays: Math.max(
+          0,
+          Math.ceil(
+            (new Date(creditUsageStatus.resetAt).getTime() - Date.now()) /
+              DAY_DURATION_MS
+          )
+        ),
+        pace: creditUsageStatus.pace,
+      }
+    : null;
+  const showCreditUsageInProfileMenu = creditUsageState?.pace === "on_pace";
+
+  return (
+    <>
+      {subscription.plan.code !== FREE_TRIAL_PHONE_PLAN_CODE &&
+        !isCreditBased &&
+        subscription.plan.limits.assistant.maxAwuCredits !== -1 && (
+          <FairUseCreditsUsage workspaceId={owner.sId} />
+        )}
+      {creditUsageState && !showCreditUsageInProfileMenu && (
+        <div className="mx-3 mb-3">
+          <CreditUsage state={creditUsageState} variant="companion" />
+        </div>
+      )}
+      <UserMenu
+        user={user}
+        owner={owner}
+        subscription={subscription}
+        creditUsageState={
+          showCreditUsageInProfileMenu ? creditUsageState : null
+        }
+      />
+    </>
+  );
+}

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -2,6 +2,7 @@ import {
   makeSpendLimitAwuCreditsRateLimitKeyForUser,
   makeSpendLimitCycleWindowBounds,
 } from "@app/lib/api/assistant/rate_limits";
+import { computeCreditUsageStatus } from "@app/lib/api/credits/usage_status";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import type { BillingCycle } from "@app/lib/client/subscription";
@@ -58,6 +59,7 @@ import {
   setFixedWindowCount,
 } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
+import type { CreditUsageStatus } from "@app/types/api/credits/usage_status";
 import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
 import type {
   MembershipSeatType,
@@ -72,6 +74,7 @@ import {
   toBaseSeatType,
   USER_CREDIT_STATES,
 } from "@app/types/memberships";
+import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -1061,6 +1064,9 @@ export async function resyncSpendLimitCountersFromEsUsage(
 
 export type GetMemberUsageResponseBody = {
   member: MemberUsageType | null;
+  // Optional for backward compatibility with clients deployed before pace
+  // information was added to this endpoint.
+  creditUsageStatus?: CreditUsageStatus | null;
 };
 
 export async function getMemberUsage({
@@ -1079,6 +1085,14 @@ export async function getMemberUsage({
   const { metronomeCustomerId } = workspace;
   const metronomeContractId = subscription?.metronomeContractId ?? null;
   const userId = userResource.sId;
+  const plan = auth.plan();
+  const cycleOverride = spendLimitCycleOverrideForAuth(auth);
+  const billingCyclePromise =
+    plan && isCreditPricedPlan(plan)
+      ? cycleOverride
+        ? Promise.resolve(cycleOverride)
+        : resolveMetronomeCycle(workspace)
+      : Promise.resolve(null);
 
   // The workspace-wide default pool cap lives on the credit-usage
   // configuration row (created lazily; absent → no default configured).
@@ -1090,6 +1104,7 @@ export async function getMemberUsage({
     perUserTotalConsumedCredits,
     seatDataByUserId,
     perUserSpendLimits,
+    billingCycle,
   ] = await Promise.all([
     MembershipResource.getActiveMemberships({
       workspace,
@@ -1114,6 +1129,7 @@ export async function getMemberUsage({
         creditUsageConfig?.defaultPoolCapAwuCredits ?? 0,
       includeAlertLinks: false,
     }),
+    billingCyclePromise,
   ]);
 
   const { defaultCapAwuCreditsBySeatType, seatAllowanceBySeatType } =
@@ -1216,41 +1232,54 @@ export async function getMemberUsage({
     defaultAwuCredits: effectiveDefaultAwuCredits,
   });
 
+  const spendLimitAwuCredits = resolveEffectiveSpendLimitAwuCredits({
+    overrideAwuCredits,
+    groupCapAwuCredits,
+    defaultAwuCredits: effectiveDefaultAwuCredits,
+  });
+
+  const member: MemberUsageType = {
+    sId: userId,
+    name: userResource.fullName() || userResource.name,
+    email: userResource.email ?? null,
+    image: userResource.imageUrl ?? null,
+    groups: groupNamesByUserModelId.get(userResource.id) ?? [],
+    seatType: membership.seatType ?? null,
+    memberUsageLimit:
+      effectiveAllocationAwu > 0 ? effectiveAllocationAwu : null,
+    seatBalanceAwu: freeSeatBalanceAwu,
+    consumedAwuCredits: totalConsumedCredits,
+    consumedFromAllowanceAwuCredits,
+    consumedFromPoolAwuCredits,
+    billingFrequency:
+      seatData?.billingFrequency ??
+      deriveWorkspaceSeatBillingFrequency(membership.seatType ?? null),
+    nextCreditResetAt: seatData?.nextCreditResetAt ?? null,
+    scheduledSeatType: null,
+    scheduledSeatChangeAt: null,
+    spendLimitAwuCredits,
+    rateLimiterSpendAwuCredits: null,
+    metronomeConsumedAwuCredits: null,
+    spendLimitSource,
+    spendLimitAlertId: null,
+    spendLimitWarningAlertId: null,
+    freeCreditLowAlert: null,
+    freeCreditEmptyAlert: null,
+    creditState: membership.creditState,
+    nearLimit: false,
+  };
+
   return {
-    member: {
-      sId: userId,
-      name: userResource.fullName() || userResource.name,
-      email: userResource.email ?? null,
-      image: userResource.imageUrl ?? null,
-      groups: groupNamesByUserModelId.get(userResource.id) ?? [],
-      seatType: membership.seatType ?? null,
-      memberUsageLimit:
-        effectiveAllocationAwu > 0 ? effectiveAllocationAwu : null,
-      seatBalanceAwu: freeSeatBalanceAwu,
-      consumedAwuCredits: totalConsumedCredits,
-      consumedFromAllowanceAwuCredits,
-      consumedFromPoolAwuCredits,
-      billingFrequency:
-        seatData?.billingFrequency ??
-        deriveWorkspaceSeatBillingFrequency(membership.seatType ?? null),
-      nextCreditResetAt: seatData?.nextCreditResetAt ?? null,
-      scheduledSeatType: null,
-      scheduledSeatChangeAt: null,
-      spendLimitAwuCredits: resolveEffectiveSpendLimitAwuCredits({
-        overrideAwuCredits,
-        groupCapAwuCredits,
-        defaultAwuCredits: effectiveDefaultAwuCredits,
-      }),
-      rateLimiterSpendAwuCredits: null,
-      metronomeConsumedAwuCredits: null,
-      spendLimitSource,
-      spendLimitAlertId: null,
-      spendLimitWarningAlertId: null,
-      freeCreditLowAlert: null,
-      freeCreditEmptyAlert: null,
-      creditState: membership.creditState,
-      nearLimit: false,
-    },
+    member,
+    creditUsageStatus:
+      billingCycle && spendLimitAwuCredits !== null
+        ? computeCreditUsageStatus({
+            consumedAwuCredits: totalConsumedCredits,
+            limitAwuCredits: spendLimitAwuCredits,
+            billingCycle,
+            nowMs: Date.now(),
+          })
+        : null,
   };
 }
 

--- a/front/lib/api/credits/usage_status.test.ts
+++ b/front/lib/api/credits/usage_status.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { computeCreditUsageStatus } from "./usage_status";
+
+const billingCycle = {
+  cycleStart: new Date("2026-08-01T00:00:00.000Z"),
+  cycleEnd: new Date("2026-09-01T00:00:00.000Z"),
+};
+
+describe("computeCreditUsageStatus", () => {
+  it("marks usage with enough remaining-cycle coverage as on pace", () => {
+    expect(
+      computeCreditUsageStatus({
+        consumedAwuCredits: 80,
+        limitAwuCredits: 100,
+        billingCycle,
+        nowMs: new Date("2026-08-31T00:00:00.000Z").getTime(),
+      })
+    ).toEqual({
+      usedPercentage: 80,
+      resetAt: "2026-09-01T00:00:00.000Z",
+      pace: "on_pace",
+    });
+  });
+
+  it("marks moderately ahead usage as elevated", () => {
+    expect(
+      computeCreditUsageStatus({
+        consumedAwuCredits: 65,
+        limitAwuCredits: 100,
+        billingCycle,
+        nowMs: new Date("2026-08-16T12:00:00.000Z").getTime(),
+      })
+    ).toMatchObject({
+      usedPercentage: 65,
+      pace: "elevated",
+    });
+  });
+
+  it("marks high early-cycle usage as critical", () => {
+    expect(
+      computeCreditUsageStatus({
+        consumedAwuCredits: 80,
+        limitAwuCredits: 100,
+        billingCycle,
+        nowMs: new Date("2026-08-07T00:00:00.000Z").getTime(),
+      })
+    ).toMatchObject({
+      usedPercentage: 80,
+      pace: "critical",
+    });
+  });
+
+  it("always marks exhausted credits as critical", () => {
+    expect(
+      computeCreditUsageStatus({
+        consumedAwuCredits: 100,
+        limitAwuCredits: 100,
+        billingCycle,
+        nowMs: billingCycle.cycleEnd.getTime(),
+      })
+    ).toMatchObject({
+      usedPercentage: 100,
+      pace: "critical",
+    });
+  });
+
+  it("does not return a status when no positive limit applies", () => {
+    expect(
+      computeCreditUsageStatus({
+        consumedAwuCredits: 0,
+        limitAwuCredits: 0,
+        billingCycle,
+        nowMs: billingCycle.cycleStart.getTime(),
+      })
+    ).toBeNull();
+  });
+});

--- a/front/lib/api/credits/usage_status.ts
+++ b/front/lib/api/credits/usage_status.ts
@@ -1,0 +1,90 @@
+import type { BillingCycle } from "@app/lib/client/subscription";
+import type {
+  CreditUsagePace,
+  CreditUsageStatus,
+} from "@app/types/api/credits/usage_status";
+
+const ON_PACE_REMAINING_COVERAGE = 0.85;
+const ELEVATED_REMAINING_COVERAGE = 0.5;
+
+/**
+ * Classifies whether the user's remaining credits can cover the remaining
+ * billing cycle:
+ *
+ *   remaining coverage = remaining credit ratio / remaining cycle ratio
+ *
+ * - on_pace (blue): coverage >= 0.85. The 15% relative tolerance absorbs
+ *   normal usage variation and avoids noisy warnings near the boundary. For
+ *   example, with 80% of the cycle left, 68% of credits remaining is blue.
+ * - elevated (orange): 0.5 <= coverage < 0.85. Usage is meaningfully ahead of
+ *   pace and deserves attention.
+ * - critical (red): coverage < 0.5. The remaining credits cover less than half
+ *   of the remaining cycle, so the user is likely to run out well before reset.
+ *
+ * Exhausted credits are always critical. Once the cycle has ended, any
+ * positive remaining balance is on pace.
+ */
+function classifyCreditUsagePace({
+  remainingCreditRatio,
+  remainingCycleRatio,
+}: {
+  remainingCreditRatio: number;
+  remainingCycleRatio: number;
+}): CreditUsagePace {
+  if (remainingCreditRatio <= 0) {
+    return "critical";
+  }
+
+  if (remainingCycleRatio <= 0) {
+    return "on_pace";
+  }
+
+  const remainingCoverage = remainingCreditRatio / remainingCycleRatio;
+  if (remainingCoverage >= ON_PACE_REMAINING_COVERAGE) {
+    return "on_pace";
+  }
+  if (remainingCoverage >= ELEVATED_REMAINING_COVERAGE) {
+    return "elevated";
+  }
+  return "critical";
+}
+
+export function computeCreditUsageStatus({
+  consumedAwuCredits,
+  limitAwuCredits,
+  billingCycle,
+  nowMs,
+}: {
+  consumedAwuCredits: number;
+  limitAwuCredits: number;
+  billingCycle: BillingCycle;
+  nowMs: number;
+}): CreditUsageStatus | null {
+  const cycleStartMs = billingCycle.cycleStart.getTime();
+  const cycleEndMs = billingCycle.cycleEnd.getTime();
+  const cycleDurationMs = cycleEndMs - cycleStartMs;
+
+  if (limitAwuCredits <= 0 || cycleDurationMs <= 0) {
+    return null;
+  }
+
+  const usedRatio = Math.min(
+    Math.max(consumedAwuCredits / limitAwuCredits, 0),
+    1
+  );
+  const elapsedRatio = Math.min(
+    Math.max((nowMs - cycleStartMs) / cycleDurationMs, 0),
+    1
+  );
+  const remainingCreditRatio = 1 - usedRatio;
+  const remainingCycleRatio = 1 - elapsedRatio;
+
+  return {
+    usedPercentage: Math.round(usedRatio * 100),
+    resetAt: billingCycle.cycleEnd.toISOString(),
+    pace: classifyCreditUsagePace({
+      remainingCreditRatio,
+      remainingCycleRatio,
+    }),
+  };
+}

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -417,6 +417,7 @@ export function useMyUsage({
 
   return {
     myUsage: data?.member ?? null,
+    creditUsageStatus: data?.creditUsageStatus ?? null,
     nextCreditResetAt: data?.member?.nextCreditResetAt ?? null,
     isMyUsageLoading: !error && !data && !disabled,
     isMyUsageError: error,

--- a/front/types/api/credits/usage_status.ts
+++ b/front/types/api/credits/usage_status.ts
@@ -1,0 +1,7 @@
+export type CreditUsagePace = "on_pace" | "elevated" | "critical";
+
+export interface CreditUsageStatus {
+  usedPercentage: number;
+  resetAt: string;
+  pace: CreditUsagePace;
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR introduces a pace-aware credit usage companion designed to raise awareness without creating unnecessary anxiety. See design [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=12710-33268&p=f&m=dev).

The credit indicator adapts its placement based on the user’s consumption pace:
1. When usage is on pace, it stays discreetly available in the profile menu. Users can check their consumption without being continuously confronted with it.
2. When usage moves ahead of the billing cycle, it appears in the sidebar Companion so it enters the user’s field of attention.

## Pace calculation

Pace compares the proportion of credits remaining with the proportion of the billing cycle remaining:

remaining credits ratio / remaining cycle ratio

- Blue: on pace, with a 15% tolerance to avoid noisy warnings.
- Orange: usage is above pace.
- Red: usage is well above pace.
- Exhausted credits are always red.

<img width="313" height="208" alt="image" src="https://github.com/user-attachments/assets/d36f81b6-f43c-4010-8920-41230e4bd276" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
