### PR TITLE
[front] fix: keep the reaper from sleeping a sandbox with an exec in flight

### DIFF
--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -64,6 +64,7 @@ export type RedisUsageTagsType =
   | "force_reload_commits"
   | "key_usage_tracking"
   | "lock"
+  | "sandbox_exec_activity"
   | "sandbox_exec_tokens"
   | "sandbox_function_invocation_events"
   | "mcp_client_side_request"

--- a/front/lib/api/sandbox/exec_activity.ts
+++ b/front/lib/api/sandbox/exec_activity.ts
@@ -17,10 +17,13 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
  *   moves it;
  * - `started - finished` is the in-flight count.
  *
- * Both keys expire a few minutes after the last exec: a replica that dies mid-exec leaves the
- * pair unbalanced, and expiry is what un-wedges the sleep rather than a count that never
- * settles. The TTL comfortably exceeds the exec ceiling (2 minutes), so a live exec can never
- * have its start expire from under it.
+ * Both keys expire together a few minutes after the last record on either: every record
+ * refreshes both TTLs in one MULTI, so the pair cannot drift apart and a replica that dies
+ * mid-exec leaves an imbalance that expiry clears rather than a count that never settles. The
+ * TTL comfortably exceeds every exec ceiling (SANDBOX_MAX_COMMAND_TIMEOUT_MS,
+ * SANDBOX_FUNCTION_EXEC_TIMEOUT_MS and BUILD_EXEC_TIMEOUT_MS are all <= 2 minutes), so a live
+ * exec can never have its start expire from under it; a caller introducing a longer timeout
+ * must bump this in step.
  */
 
 const EXEC_ACTIVITY_TTL_SECONDS = 10 * 60;
@@ -41,16 +44,22 @@ export interface SandboxExecActivity {
 }
 
 /**
- * Best-effort: an exec must never fail because the activity counter could not be written. A
- * missed increment weakens one reaper cycle's guard, which the pre-existing rarity of the race
- * already bounds.
+ * Best-effort: an exec must never fail because the activity counter could not be written. The
+ * MULTI keeps each record atomic (no increment can land without its TTL refresh), but a lost
+ * start with a surviving end still leaves a deficit the read-side clamp absorbs — the guard
+ * then under-reports until a quiet TTL window expires both keys together. The pre-existing
+ * rarity of the race this module closes bounds that exposure.
  */
 export async function recordSandboxExecStart(sandboxId: string): Promise<void> {
   try {
-    await runOnRedis({ origin: REDIS_ORIGIN }, async (client) => {
-      await client.incr(startedKey(sandboxId));
-      await client.expire(startedKey(sandboxId), EXEC_ACTIVITY_TTL_SECONDS);
-    });
+    await runOnRedis({ origin: REDIS_ORIGIN }, (client) =>
+      client
+        .multi()
+        .incr(startedKey(sandboxId))
+        .expire(startedKey(sandboxId), EXEC_ACTIVITY_TTL_SECONDS)
+        .expire(finishedKey(sandboxId), EXEC_ACTIVITY_TTL_SECONDS)
+        .exec()
+    );
   } catch (err) {
     logger.warn(
       { sandboxId, err: normalizeError(err) },
@@ -61,10 +70,14 @@ export async function recordSandboxExecStart(sandboxId: string): Promise<void> {
 
 export async function recordSandboxExecEnd(sandboxId: string): Promise<void> {
   try {
-    await runOnRedis({ origin: REDIS_ORIGIN }, async (client) => {
-      await client.incr(finishedKey(sandboxId));
-      await client.expire(finishedKey(sandboxId), EXEC_ACTIVITY_TTL_SECONDS);
-    });
+    await runOnRedis({ origin: REDIS_ORIGIN }, (client) =>
+      client
+        .multi()
+        .incr(finishedKey(sandboxId))
+        .expire(finishedKey(sandboxId), EXEC_ACTIVITY_TTL_SECONDS)
+        .expire(startedKey(sandboxId), EXEC_ACTIVITY_TTL_SECONDS)
+        .exec()
+    );
   } catch (err) {
     logger.warn(
       { sandboxId, err: normalizeError(err) },

--- a/front/lib/api/sandbox/exec_activity.ts
+++ b/front/lib/api/sandbox/exec_activity.ts
@@ -1,0 +1,99 @@
+import { runOnRedis } from "@app/lib/api/redis";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+/**
+ * Exec-activity counters for the reaper's sleep flow.
+ *
+ * The lifecycle lock serializes transitions but has never covered a running exec, so the reaper
+ * could pause a sandbox while an exec was still committing pod-state writes after the pre-sleep
+ * flush — writes a later destroy would drop, since sleepers are not re-flushed. These counters
+ * give the sleep flow a precise signal where `lastActivityAt` cannot (its writes are throttled
+ * to one per 30s):
+ *
+ * - `started` is monotonic, so an exec that both started and finished during the flush still
+ *   moves it;
+ * - `started - finished` is the in-flight count.
+ *
+ * Both keys expire a few minutes after the last exec: a replica that dies mid-exec leaves the
+ * pair unbalanced, and expiry is what un-wedges the sleep rather than a count that never
+ * settles. The TTL comfortably exceeds the exec ceiling (2 minutes), so a live exec can never
+ * have its start expire from under it.
+ */
+
+const EXEC_ACTIVITY_TTL_SECONDS = 10 * 60;
+
+const REDIS_ORIGIN = "sandbox_exec_activity" as const;
+
+function startedKey(sandboxId: string): string {
+  return `sandbox:exec-activity:started:${sandboxId}`;
+}
+
+function finishedKey(sandboxId: string): string {
+  return `sandbox:exec-activity:finished:${sandboxId}`;
+}
+
+export interface SandboxExecActivity {
+  started: number;
+  inFlight: number;
+}
+
+/**
+ * Best-effort: an exec must never fail because the activity counter could not be written. A
+ * missed increment weakens one reaper cycle's guard, which the pre-existing rarity of the race
+ * already bounds.
+ */
+export async function recordSandboxExecStart(sandboxId: string): Promise<void> {
+  try {
+    await runOnRedis({ origin: REDIS_ORIGIN }, async (client) => {
+      await client.incr(startedKey(sandboxId));
+      await client.expire(startedKey(sandboxId), EXEC_ACTIVITY_TTL_SECONDS);
+    });
+  } catch (err) {
+    logger.warn(
+      { sandboxId, err: normalizeError(err) },
+      "Failed to record sandbox exec start"
+    );
+  }
+}
+
+export async function recordSandboxExecEnd(sandboxId: string): Promise<void> {
+  try {
+    await runOnRedis({ origin: REDIS_ORIGIN }, async (client) => {
+      await client.incr(finishedKey(sandboxId));
+      await client.expire(finishedKey(sandboxId), EXEC_ACTIVITY_TTL_SECONDS);
+    });
+  } catch (err) {
+    logger.warn(
+      { sandboxId, err: normalizeError(err) },
+      "Failed to record sandbox exec end"
+    );
+  }
+}
+
+/**
+ * Errors propagate: the sleep flow must fail closed (skip the sleep and retry next cycle) when
+ * the signal is unreadable, not pause a sandbox it cannot clear.
+ */
+export async function readSandboxExecActivity(
+  sandboxId: string
+): Promise<Result<SandboxExecActivity, Error>> {
+  try {
+    const [startedRaw, finishedRaw] = await runOnRedis(
+      { origin: REDIS_ORIGIN },
+      (client) => client.mGet([startedKey(sandboxId), finishedKey(sandboxId)])
+    );
+    const started = startedRaw === null ? 0 : parseInt(startedRaw, 10);
+    const finished = finishedRaw === null ? 0 : parseInt(finishedRaw, 10);
+    return new Ok({
+      started,
+      // Expiry (or a crashed replica) can leave the pair unbalanced in either direction; a
+      // negative in-flight count means "finished outlived started" and carries no signal.
+      inFlight: Math.max(0, started - finished),
+    });
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}

--- a/front/lib/api/sandbox/exec_activity.ts
+++ b/front/lib/api/sandbox/exec_activity.ts
@@ -68,6 +68,11 @@ export async function recordSandboxExecStart(sandboxId: string): Promise<void> {
   }
 }
 
+/**
+ * Same best-effort contract as the start, and callers need not await it: this only ever lowers
+ * the in-flight count, so arriving late (or not at all) can only make the guard conservative.
+ * Records commute, so an end landing after an unrelated exec's start is harmless.
+ */
 export async function recordSandboxExecEnd(sandboxId: string): Promise<void> {
   try {
     await runOnRedis({ origin: REDIS_ORIGIN }, (client) =>

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -10,6 +10,9 @@ const {
   mockProviderDestroy,
   mockProviderExec,
   mockProviderWake,
+  mockReadSandboxExecActivity,
+  mockRecordSandboxExecEnd,
+  mockRecordSandboxExecStart,
   mockRevokeAllExecTokensForSandbox,
 } = vi.hoisted(() => ({
   mockDeleteLegacySandboxPolicy: vi.fn(),
@@ -21,6 +24,9 @@ const {
   mockProviderDestroy: vi.fn(),
   mockProviderExec: vi.fn(),
   mockProviderWake: vi.fn(),
+  mockReadSandboxExecActivity: vi.fn(),
+  mockRecordSandboxExecEnd: vi.fn(),
+  mockRecordSandboxExecStart: vi.fn(),
   mockRevokeAllExecTokensForSandbox: vi.fn(),
 }));
 
@@ -41,6 +47,12 @@ vi.mock("@app/lib/api/sandbox/access_tokens", () => ({
 
 vi.mock("@app/lib/api/sandbox/egress_policy", () => ({
   deleteLegacySandboxPolicy: mockDeleteLegacySandboxPolicy,
+}));
+
+vi.mock("@app/lib/api/sandbox/exec_activity", () => ({
+  readSandboxExecActivity: mockReadSandboxExecActivity,
+  recordSandboxExecEnd: mockRecordSandboxExecEnd,
+  recordSandboxExecStart: mockRecordSandboxExecStart,
 }));
 
 vi.mock("@app/lib/api/sandbox/image", () => ({
@@ -68,7 +80,7 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { encrypt } from "@app/types/shared/utils/encryption";
 import type { WhereOptions } from "sequelize";
 
@@ -1325,5 +1337,178 @@ describe("SandboxResource.updateLastActivityAt", () => {
     Object.assign(sandbox, { lastActivityAt: new Date(Date.now() - 60_000) });
     const [affectedStale] = await sandbox.updateLastActivityAt();
     expect(affectedStale).toBe(1);
+  });
+});
+
+describe("SandboxResource.dangerouslySleepIfRunning", () => {
+  let authenticator: Authenticator;
+  const mockProviderSleep = vi.fn();
+  const mockBeforeSleep = vi.fn();
+
+  // The adapter's real beforeSleep flushes pod state through the provider; a
+  // stub keeps these tests on the flow under test (activity read -> flush ->
+  // activity re-read -> pause) without mocking the whole pod-state stack.
+  async function sleepPod(pod: Awaited<ReturnType<typeof SpaceFactory.project>>) {
+    return SandboxResource.dangerouslySleepIfRunning(
+      authenticator,
+      {
+        lockKey: pod.sId,
+        fetchSandbox: () => PodSandboxAdapter.fetchSandbox(authenticator, pod),
+      },
+      { beforeSleep: mockBeforeSleep }
+    );
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockExecuteWithLock.mockImplementation(
+      async (_key: string, fn: () => Promise<unknown>) => fn()
+    );
+    mockGetSandboxProvider.mockReturnValue({
+      sleep: mockProviderSleep,
+    });
+    mockProviderSleep.mockResolvedValue(new Ok(undefined));
+    mockBeforeSleep.mockResolvedValue(new Ok(undefined));
+    // Default: no exec activity, stable across the pre/post-flush reads.
+    mockReadSandboxExecActivity.mockResolvedValue(
+      new Ok({ started: 4, inFlight: 0 })
+    );
+
+    const testSetup = await createResourceTest({ role: "admin" });
+    authenticator = testSetup.authenticator;
+  });
+
+  it("sleeps a quiet running sandbox", async () => {
+    const pod = await SpaceFactory.project(
+      authenticator.getNonNullableWorkspace()
+    );
+    await SandboxFactory.createForPod(authenticator, pod, {
+      status: "running",
+    });
+
+    const result = await sleepPod(pod);
+
+    expect(result.isOk()).toBe(true);
+    expect(mockBeforeSleep).toHaveBeenCalledTimes(1);
+    expect(mockProviderSleep).toHaveBeenCalledTimes(1);
+    const reloaded = await PodSandboxAdapter.fetchSandbox(authenticator, pod);
+    expect(reloaded?.status).toBe("sleeping");
+    // Once before the flush, once after: an exec landing during the flush
+    // writes pod state the flush never saw.
+    expect(mockReadSandboxExecActivity).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips the sleep when an exec is in flight", async () => {
+    const pod = await SpaceFactory.project(
+      authenticator.getNonNullableWorkspace()
+    );
+    await SandboxFactory.createForPod(authenticator, pod, {
+      status: "running",
+    });
+    mockReadSandboxExecActivity.mockResolvedValue(
+      new Ok({ started: 5, inFlight: 1 })
+    );
+
+    const result = await sleepPod(pod);
+
+    // Not an error: the reaper retries on its next cycle, like a pod that
+    // was never idle. The flush is skipped too, not just the pause.
+    expect(result.isOk()).toBe(true);
+    expect(mockBeforeSleep).not.toHaveBeenCalled();
+    expect(mockProviderSleep).not.toHaveBeenCalled();
+    const reloaded = await PodSandboxAdapter.fetchSandbox(authenticator, pod);
+    expect(reloaded?.status).toBe("running");
+  });
+
+  it("skips the sleep when an exec started during the pre-sleep flush", async () => {
+    const pod = await SpaceFactory.project(
+      authenticator.getNonNullableWorkspace()
+    );
+    await SandboxFactory.createForPod(authenticator, pod, {
+      status: "running",
+    });
+    // Clean before the flush; a whole exec (started AND finished) lands
+    // during it. The monotonic `started` counter is what catches this —
+    // in-flight is already back to 0.
+    mockReadSandboxExecActivity
+      .mockResolvedValueOnce(new Ok({ started: 4, inFlight: 0 }))
+      .mockResolvedValueOnce(new Ok({ started: 5, inFlight: 0 }));
+
+    const result = await sleepPod(pod);
+
+    expect(result.isOk()).toBe(true);
+    expect(mockBeforeSleep).toHaveBeenCalledTimes(1);
+    expect(mockProviderSleep).not.toHaveBeenCalled();
+    const reloaded = await PodSandboxAdapter.fetchSandbox(authenticator, pod);
+    expect(reloaded?.status).toBe("running");
+  });
+
+  it("fails closed when the activity signal is unreadable", async () => {
+    const pod = await SpaceFactory.project(
+      authenticator.getNonNullableWorkspace()
+    );
+    await SandboxFactory.createForPod(authenticator, pod, {
+      status: "running",
+    });
+    mockReadSandboxExecActivity.mockResolvedValue(
+      new Err(new Error("redis unreachable"))
+    );
+
+    const result = await sleepPod(pod);
+
+    expect(result.isErr()).toBe(true);
+    expect(mockProviderSleep).not.toHaveBeenCalled();
+    const reloaded = await PodSandboxAdapter.fetchSandbox(authenticator, pod);
+    expect(reloaded?.status).toBe("running");
+  });
+});
+
+describe("SandboxResource.exec activity accounting", () => {
+  let authenticator: Authenticator;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockGetSandboxProvider.mockReturnValue({
+      exec: mockProviderExec,
+    });
+
+    const testSetup = await createResourceTest({ role: "admin" });
+    authenticator = testSetup.authenticator;
+  });
+
+  it("brackets a successful exec with start and end records", async () => {
+    const pod = await SpaceFactory.project(
+      authenticator.getNonNullableWorkspace()
+    );
+    const sandbox = await SandboxFactory.createForPod(authenticator, pod, {
+      status: "running",
+    });
+    mockProviderExec.mockResolvedValue(
+      new Ok({ exitCode: 0, stdout: "", stderr: "" })
+    );
+
+    const result = await sandbox.exec(authenticator, "true");
+
+    expect(result.isOk()).toBe(true);
+    expect(mockRecordSandboxExecStart).toHaveBeenCalledWith(sandbox.sId);
+    expect(mockRecordSandboxExecEnd).toHaveBeenCalledWith(sandbox.sId);
+  });
+
+  it("records the end even when the provider exec throws", async () => {
+    const pod = await SpaceFactory.project(
+      authenticator.getNonNullableWorkspace()
+    );
+    const sandbox = await SandboxFactory.createForPod(authenticator, pod, {
+      status: "running",
+    });
+    mockProviderExec.mockRejectedValue(new Error("provider blew up"));
+
+    await expect(sandbox.exec(authenticator, "true")).rejects.toThrow(
+      "provider blew up"
+    );
+    expect(mockRecordSandboxExecStart).toHaveBeenCalledWith(sandbox.sId);
+    // A start without a matching end would report a phantom in-flight exec
+    // and block the reaper's sleep until the Redis TTL clears it.
+    expect(mockRecordSandboxExecEnd).toHaveBeenCalledWith(sandbox.sId);
   });
 });

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -201,6 +201,9 @@ describe("ConversationSandboxAdapter.dangerouslyDestroySandboxIfSleeping", () =>
     mockProviderDestroy.mockResolvedValue(new Ok(undefined));
     mockDeleteLegacySandboxPolicy.mockResolvedValue(new Ok(undefined));
     mockRevokeAllExecTokensForSandbox.mockResolvedValue(undefined);
+    mockReadSandboxExecActivity.mockResolvedValue(
+      new Ok({ started: 2, inFlight: 0 })
+    );
 
     const testSetup = await createResourceTest({ role: "admin" });
     authenticator = testSetup.authenticator;
@@ -328,6 +331,9 @@ describe("ConversationSandboxAdapter.dangerouslyDestroySandboxIfKillRequested", 
     mockProviderDestroy.mockResolvedValue(new Ok(undefined));
     mockDeleteLegacySandboxPolicy.mockResolvedValue(new Ok(undefined));
     mockRevokeAllExecTokensForSandbox.mockResolvedValue(undefined);
+    mockReadSandboxExecActivity.mockResolvedValue(
+      new Ok({ started: 2, inFlight: 0 })
+    );
 
     const testSetup = await createResourceTest({ role: "admin" });
     authenticator = testSetup.authenticator;
@@ -415,6 +421,37 @@ describe("ConversationSandboxAdapter.dangerouslyDestroySandboxIfKillRequested", 
 
     expect(result.isOk()).toBe(true);
     expect(mockProviderDestroy).not.toHaveBeenCalled();
+  });
+
+  it("defers the destroy when an exec is in flight", async () => {
+    const sandbox = await SandboxFactory.create(
+      authenticator,
+      conversationResource.toJSON(),
+      {
+        status: "running",
+        killRequestedAt: new Date(),
+      }
+    );
+    mockReadSandboxExecActivity.mockResolvedValue(
+      new Ok({ started: 3, inFlight: 1 })
+    );
+
+    const result =
+      await ConversationSandboxAdapter.dangerouslyDestroySandboxIfKillRequested(
+        authenticator,
+        conversationResource
+      );
+
+    // Destroy is the worse race to lose: no later wake or re-flush ever
+    // recovers writes committed after the flush.
+    expect(result.isOk()).toBe(true);
+    expect(mockProviderDestroy).not.toHaveBeenCalled();
+    const reloaded = await ConversationSandboxAdapter.fetchSandbox(
+      authenticator,
+      conversationResource.toJSON()
+    );
+    expect(reloaded?.status).toBe("running");
+    expect(reloaded?.sId).toBe(sandbox.sId);
   });
 });
 
@@ -1348,7 +1385,9 @@ describe("SandboxResource.dangerouslySleepIfRunning", () => {
   // The adapter's real beforeSleep flushes pod state through the provider; a
   // stub keeps these tests on the flow under test (activity read -> flush ->
   // activity re-read -> pause) without mocking the whole pod-state stack.
-  async function sleepPod(pod: Awaited<ReturnType<typeof SpaceFactory.project>>) {
+  async function sleepPod(
+    pod: Awaited<ReturnType<typeof SpaceFactory.project>>
+  ) {
     return SandboxResource.dangerouslySleepIfRunning(
       authenticator,
       {

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -1281,6 +1281,9 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     // Workload execs only, not execRoot: root commands are lifecycle plumbing — the pre-sleep
     // flush itself runs root commands, which would otherwise trip the very guard that consults
     // these counters.
+    //
+    // The start is awaited — that ordering IS the guarantee: a start still in flight when the
+    // sleep flow reads would let the pause proceed against a live exec.
     await recordSandboxExecStart(this.sId);
     try {
       const result = await provider.exec(
@@ -1300,7 +1303,11 @@ export class SandboxResource extends BaseResource<SandboxModel> {
 
       return result;
     } finally {
-      await recordSandboxExecEnd(this.sId);
+      // The end is not awaited: it only ever lowers the in-flight count, so a late (or lost)
+      // record makes the guard over-report, which costs one reaper cycle and never a lost write.
+      // Keeping it off the return path spares every workload exec a Redis round trip.
+      // recordSandboxExecEnd swallows its own errors, so this can never reject.
+      void recordSandboxExecEnd(this.sId);
     }
   }
 

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -2,6 +2,11 @@ import { getSandboxProvider } from "@app/lib/api/sandbox";
 import { revokeAllExecTokensForSandbox } from "@app/lib/api/sandbox/access_tokens";
 import { deleteLegacySandboxPolicy } from "@app/lib/api/sandbox/egress_policy";
 import { SandboxNotRunningError } from "@app/lib/api/sandbox/errors";
+import {
+  readSandboxExecActivity,
+  recordSandboxExecEnd,
+  recordSandboxExecStart,
+} from "@app/lib/api/sandbox/exec_activity";
 import { getSandboxImage } from "@app/lib/api/sandbox/image";
 import {
   recordLifecycleOperation,
@@ -826,6 +831,25 @@ export class SandboxResource extends BaseResource<SandboxModel> {
 
       const tracingOpts = { workspaceId: auth.getNonNullableWorkspace().sId };
 
+      // The lifecycle lock never covered a running exec, so an exec can be committing pod-state
+      // writes while this flow flushes and pauses — writes the flush never saw, silently dropped
+      // when the sleeper is later destroyed without a re-flush. The exec-activity counters close
+      // that: skip the sleep when an exec is in flight before the flush, and re-check after it —
+      // `started` is monotonic, so even an exec that began and finished during the flush moves
+      // it. Skipping is not an error: status stays `running` and the reaper retries next cycle,
+      // exactly like a pod that was never idle. An unreadable signal fails closed the same way.
+      const activityBefore = await readSandboxExecActivity(sandbox.sId);
+      if (activityBefore.isErr()) {
+        return activityBefore;
+      }
+      if (activityBefore.value.inFlight > 0) {
+        logger.info(
+          { sandbox: sandbox.toLogJSON() },
+          "Sandbox has an exec in flight — not sleeping."
+        );
+        return new Ok(undefined);
+      }
+
       const checkResult = await this.runPreSleepCheck(
         opts.beforeSleep,
         sandbox
@@ -838,6 +862,21 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           "Sandbox pre-sleep health check failed — not sleeping."
         );
         return checkResult;
+      }
+
+      const activityAfter = await readSandboxExecActivity(sandbox.sId);
+      if (activityAfter.isErr()) {
+        return activityAfter;
+      }
+      if (
+        activityAfter.value.inFlight > 0 ||
+        activityAfter.value.started !== activityBefore.value.started
+      ) {
+        logger.info(
+          { sandbox: sandbox.toLogJSON() },
+          "Sandbox exec activity during pre-sleep flush — not sleeping."
+        );
+        return new Ok(undefined);
       }
 
       const result = await provider.sleep(sandbox.providerId, tracingOpts);
@@ -1207,22 +1246,30 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     }
 
     const tracingOpts = { workspaceId: auth.getNonNullableWorkspace().sId };
-    const result = await provider.exec(
-      this.providerId,
-      command,
-      opts,
-      tracingOpts
-    );
-
-    if (result.isErr() && result.error instanceof SandboxNotFoundError) {
-      logger.error(
-        { sandbox: this.toLogJSON() },
-        "Sandbox not found at provider during exec — marking as deleted"
+    // Workload execs only, not execRoot: root commands are lifecycle plumbing — the pre-sleep
+    // flush itself runs root commands, which would otherwise trip the very guard that consults
+    // these counters.
+    await recordSandboxExecStart(this.sId);
+    try {
+      const result = await provider.exec(
+        this.providerId,
+        command,
+        opts,
+        tracingOpts
       );
-      await this.updateStatus("deleted");
-    }
 
-    return result;
+      if (result.isErr() && result.error instanceof SandboxNotFoundError) {
+        logger.error(
+          { sandbox: this.toLogJSON() },
+          "Sandbox not found at provider during exec — marking as deleted"
+        );
+        await this.updateStatus("deleted");
+      }
+
+      return result;
+    } finally {
+      await recordSandboxExecEnd(this.sId);
+    }
   }
 
   /**

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -1179,6 +1179,23 @@ export class SandboxResource extends BaseResource<SandboxModel> {
 
       const tracingOpts = { workspaceId: auth.getNonNullableWorkspace().sId };
 
+      // Same guard as the sleep flow, and destroy is the worse race to lose: there is no later
+      // wake or re-flush, so an exec whose writes land after the flush loses them permanently.
+      // Deferring is safe — a busy pod's next invocation escalates through ensureActive's
+      // kill-requested branch, which recreates on access regardless, and a quiet pod is caught
+      // by the next sweep.
+      const activityBefore = await readSandboxExecActivity(sandbox.sId);
+      if (activityBefore.isErr()) {
+        return activityBefore;
+      }
+      if (activityBefore.value.inFlight > 0) {
+        logger.info(
+          { sandbox: sandbox.toLogJSON() },
+          "Kill-requested sandbox has an exec in flight — deferring destroy."
+        );
+        return new Ok(undefined);
+      }
+
       // Pre-destroy flush: kill-requested destroys (image rollouts) would
       // otherwise lose state that never reached its replica.
       const checkResult = await this.runPreSleepCheck(
@@ -1196,6 +1213,21 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           "Kill-requested destroy: pre-destroy health check failed — skipping destroy this sweep."
         );
         return checkResult;
+      }
+
+      const activityAfter = await readSandboxExecActivity(sandbox.sId);
+      if (activityAfter.isErr()) {
+        return activityAfter;
+      }
+      if (
+        activityAfter.value.inFlight > 0 ||
+        activityAfter.value.started !== activityBefore.value.started
+      ) {
+        logger.info(
+          { sandbox: sandbox.toLogJSON() },
+          "Exec activity during kill-requested pre-destroy flush — deferring destroy."
+        );
+        return new Ok(undefined);
       }
 
       const result = await provider.destroy(sandbox.providerId, tracingOpts);

--- a/front/temporal/sandbox_reaper/activities.test.ts
+++ b/front/temporal/sandbox_reaper/activities.test.ts
@@ -19,6 +19,7 @@ const {
   mockHeartbeat,
   mockProviderDestroy,
   mockProviderSleep,
+  mockReadSandboxExecActivity,
 } = vi.hoisted(() => ({
   mockEnsurePodStateHealthOnSleep: vi.fn(),
   mockExecuteWithLock: vi.fn(),
@@ -27,6 +28,7 @@ const {
   mockHeartbeat: vi.fn(),
   mockProviderDestroy: vi.fn(),
   mockProviderSleep: vi.fn(),
+  mockReadSandboxExecActivity: vi.fn(),
 }));
 
 vi.mock("@temporalio/activity", () => ({
@@ -36,6 +38,19 @@ vi.mock("@temporalio/activity", () => ({
 vi.mock("@app/lib/api/sandbox", () => ({
   getSandboxProvider: mockGetSandboxProvider,
 }));
+
+// The sleep and kill flows read the exec-activity counters from Redis, which
+// these tests do not run. The reaper contract under test is the phase
+// orchestration; the guard's own behavior is covered in sandbox_resource
+// tests.
+vi.mock("@app/lib/api/sandbox/exec_activity", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/sandbox/exec_activity")>();
+  return {
+    ...actual,
+    readSandboxExecActivity: mockReadSandboxExecActivity,
+  };
+});
 
 vi.mock("@app/lib/api/sandbox/image", () => ({
   getSandboxImage: mockGetSandboxImage,
@@ -64,6 +79,9 @@ describe("reapSandboxPhaseActivity", () => {
     vi.clearAllMocks();
     mockExecuteWithLock.mockImplementation(
       async (_key: string, fn: () => Promise<unknown>) => fn()
+    );
+    mockReadSandboxExecActivity.mockResolvedValue(
+      new Ok({ started: 0, inFlight: 0 })
     );
     mockEnsurePodStateHealthOnSleep.mockImplementation(
       async (...args: Parameters<typeof ensurePodStateHealthOnSleep>) => {


### PR DESCRIPTION
## Description

The lifecycle lock serializes sandbox transitions but has never covered a running exec, so the reaper can pause a sandbox while an exec is still committing pod-state writes. The sleep flow flushes SQLite state to the GCS replica, pauses at the provider, then flips status — and an exec whose writes land after the flush loses them silently, because sleepers are later destroyed without a re-flush. Flagged during review of #30194, which widened admission into this window; the window itself predates it.

Fix: exec-activity counters in Redis, consulted by the flows that flush and then transition. `SandboxResource.exec` brackets every workload exec with a monotonic `started` increment and a matching `finished` one, each record an atomic MULTI that refreshes both keys' TTLs so the pair cannot drift apart (execRoot is excluded: root commands are lifecycle plumbing, including the pre-sleep flush itself). `dangerouslySleepIfRunning` and the kill sweep's `dangerouslyDestroyIfKillRequested` — where losing the race is permanent, since a destroyed sandbox is never re-flushed — skip their transition when an exec is in flight before the flush, and re-check after it — `started` being monotonic catches even an exec that began and finished entirely during the flush, which an in-flight gauge alone would miss (and which `lastActivityAt` cannot signal, being throttled to one write per 30s). Skipping is not an error: status stays running and the reaper retries next cycle, exactly like a pod that was never idle. An unreadable signal fails closed the same way.

The counters are best-effort on the write side (an exec never fails because Redis hiccuped) and both expire 10 minutes after the last record, so a replica that dies mid-exec un-wedges the sleep via TTL rather than a count that never settles. Deferring a kill is safe: a busy pod's next invocation escalates through ensureActive's kill-requested branch, which recreates on access regardless. A residual window remains between the post-flush read and the provider pause — milliseconds against the previous seconds-long flush — and `pauseForApproval` keeps today's behavior, since aborting an approval pause has UX cost and the approval flow's own exec is blocked waiting.

## Tests

sandbox_resource suite: quiet sandbox sleeps with the activity read on both sides of the flush, in-flight exec skips the sleep before flushing anything, an exec that started and finished during the flush skips the pause, unreadable signal fails closed, an in-flight exec defers the kill-sweep destroy, and exec brackets start/end records including when the provider throws. front typechecks clean.

## Risk

False positives only delay a sleep by one reaper cycle. A lost `finished` record blocks sleep for at most the 10-minute TTL. The exec-side Redis cost is two INCR+EXPIRE round trips per exec, off the latency-critical path's measured contention point.

## Deploy Plan

Normal deploy. No migration, no flag. Worth watching the reaper's "not sleeping" log lines for a stuck sandbox that never sleeps, which would indicate a leaked in-flight count before its TTL.
