### PR TITLE
[front] perf: write-behind terminal persistence for inline Pod function invocations

### DIFF
--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -1157,8 +1157,10 @@ describe("SandboxFunctionInvocationResource.createAndStartExecution", () => {
       status: "succeeded",
       result: { commentId: "inline" },
     });
-    // The initial blob write is deferred on the inline path; the terminal write must still leave
-    // a complete blob (input and result) behind for later fetches.
+    // Both blob writes are behind the response on the inline path (deferred initial write,
+    // write-behind terminal write); settling drains them, after which the blob must be complete
+    // (input and result) for later fetches.
+    await result.value.settleInitialPersistence();
     const refetched = await SandboxFunctionInvocationResource.fetchById(
       authenticator,
       { sandboxFunction, invocationId: result.value.sId }
@@ -1176,6 +1178,39 @@ describe("SandboxFunctionInvocationResource.createAndStartExecution", () => {
       expect.anything(),
       expect.objectContaining({ noTools: true })
     );
+  });
+
+  it("delivers the inline outcome even when write-behind persistence fails", async () => {
+    const { authenticator, sandboxFunction, execSpy } = await setupInlineTest();
+    enableFlags([
+      "sandbox_function_fast_execution",
+      "sandbox_function_stdout_result",
+    ]);
+    // Every blob write for this invocation fails: the deferred initial write and the
+    // write-behind terminal write. Neither may take down the caller's response — the outcome
+    // already reached the caller and the event stream, and the loss is logged, not thrown.
+    fileStorageMock.setFileSaveFails((filePath) =>
+      filePath.includes("sandbox_functions")
+    );
+
+    const result =
+      await SandboxFunctionInvocationResource.createAndStartExecution(
+        authenticator,
+        { sandboxFunction, body: { input: { message: "hello" } } }
+      );
+
+    expect(result.isOk()).toBe(true);
+    expect(execSpy).toHaveBeenCalledOnce();
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value.status).toBe("succeeded");
+    expect(result.value.settledOutcome()).toEqual({
+      status: "succeeded",
+      result: { commentId: "inline" },
+    });
+    // Draining the chain must also not throw: the failure is contained to the log.
+    await result.value.settleInitialPersistence();
   });
 
   it("runs a durable function under a token that can call tools", async () => {

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -295,9 +295,14 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   private pendingInitialPersistence: Promise<void> | undefined;
 
   async settleInitialPersistence(): Promise<void> {
-    if (this.pendingInitialPersistence) {
-      await this.pendingInitialPersistence;
-      this.pendingInitialPersistence = undefined;
+    // Re-read after each await: a terminal transition can chain a write-behind onto the field
+    // while a settle is in flight, and clearing blindly would drop that chain undrained.
+    while (this.pendingInitialPersistence) {
+      const pending = this.pendingInitialPersistence;
+      await pending;
+      if (this.pendingInitialPersistence === pending) {
+        this.pendingInitialPersistence = undefined;
+      }
     }
   }
 
@@ -411,22 +416,22 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     if (this.pendingInitialPersistence !== undefined) {
       const pending = this.pendingInitialPersistence;
       this.pendingInitialPersistence = (async () => {
-        // The catch guards the floating promise: nothing awaits this chain on the request
-        // path, and a rejection would otherwise surface as an unhandled rejection.
-        try {
-          await pending;
-          const writeResult = await this.writeDataToGcs();
-          if (writeResult.isErr()) {
-            throw writeResult.error;
-          }
-        } catch (error) {
+        // Invariant: `pending` never rejects — its producers settle internally (makeNew logs
+        // its write failure, createAndStartExecution wraps in Promise.allSettled) — and
+        // writeDataToGcs returns a Result, so this floating chain cannot produce an unhandled
+        // rejection. The claim is deliberately kept on failure, unlike the awaited branch:
+        // releasing here would strand a row whose caller already got the outcome, with nothing
+        // left to retry it.
+        await pending;
+        const writeResult = await this.writeDataToGcs();
+        if (writeResult.isErr()) {
           logger.error(
             {
               workspaceModelId: this.workspaceId,
               sandboxFunctionId: this.sandboxFunction.sId,
               invocationId: this.sId,
               claimedStatus: claimed,
-              err: normalizeError(error),
+              err: writeResult.error,
             },
             "Write-behind terminal Pod function invocation persistence failed"
           );

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -285,10 +285,12 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
   private data: SandboxFunctionInvocationData;
 
   /**
-   * In-flight initial persistence (blob write + created event) for an inline execution. Terminal
-   * transitions await it so the terminal blob write cannot be overwritten by the initial one and
-   * the result event cannot outrun the created event. Only ever set on the instance that runs the
-   * invocation inline; instances rehydrated from the DB never have one, and never need one.
+   * In-flight blob persistence for an inline execution: the deferred initial write (blob +
+   * created event), and after a terminal transition also the write-behind terminal blob write
+   * chained onto it. The chaining keeps the object-level ordering (the terminal write can never
+   * be overwritten by a late initial one) without holding the caller's response on GCS. Only
+   * ever set on the instance that runs the invocation inline; instances rehydrated from the DB
+   * never have one, and never need one.
    */
   private pendingInitialPersistence: Promise<void> | undefined;
 
@@ -388,6 +390,59 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
     return true;
   }
 
+  /**
+   * Persist the terminal blob (input, context, outcome), set on `this.data` by the caller.
+   *
+   * Inline path (a deferred initial persistence is pending): the write chains behind it,
+   * write-behind. The caller's response and the result event carry the outcome, and every
+   * cross-process blob reader is either explicitly settled first (the workflow handoff awaits
+   * settleInitialPersistence) or reads well after the write's ~100-500ms window (inspection,
+   * listings), so nothing is left holding a request on GCS tail latency. The cost is a
+   * narrower durability guarantee: a write that fails, or a process that dies right after
+   * responding, leaves a terminal row whose blob is missing the outcome. Logged loudly; the
+   * outcome itself was still delivered to the caller and the event stream.
+   *
+   * Every other path keeps the awaited write, and gives the terminal claim back on failure so
+   * a retry can record the outcome.
+   */
+  private async persistTerminalData(
+    claimed: Exclude<SandboxFunctionInvocationStatus, "created">
+  ): Promise<void> {
+    if (this.pendingInitialPersistence !== undefined) {
+      const pending = this.pendingInitialPersistence;
+      this.pendingInitialPersistence = (async () => {
+        // The catch guards the floating promise: nothing awaits this chain on the request
+        // path, and a rejection would otherwise surface as an unhandled rejection.
+        try {
+          await pending;
+          const writeResult = await this.writeDataToGcs();
+          if (writeResult.isErr()) {
+            throw writeResult.error;
+          }
+        } catch (error) {
+          logger.error(
+            {
+              workspaceModelId: this.workspaceId,
+              sandboxFunctionId: this.sandboxFunction.sId,
+              invocationId: this.sId,
+              claimedStatus: claimed,
+              err: normalizeError(error),
+            },
+            "Write-behind terminal Pod function invocation persistence failed"
+          );
+        }
+      })();
+      return;
+    }
+
+    await this.settleInitialPersistence();
+    const writeResult = await this.writeDataToGcs();
+    if (writeResult.isErr()) {
+      await this.releaseTerminalClaim(claimed);
+      throw writeResult.error;
+    }
+  }
+
   // Give the claim back if terminal blob persistence fails, so a later fail()/
   // markCreatedAsErrored() path can still record the outcome.
   private async releaseTerminalClaim(
@@ -433,10 +488,6 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       return false;
     }
 
-    // A deferred initial persistence (inline path) must land before the terminal blob write
-    // overwrites the same object, and before the result event can outrun the created event.
-    await this.settleInitialPersistence();
-
     this.data = {
       version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
       input: this.input,
@@ -446,11 +497,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       // record of a failure the stream classified precisely.
       error: callError,
     };
-    const writeResult = await this.writeDataToGcs();
-    if (writeResult.isErr()) {
-      await this.releaseTerminalClaim("errored");
-      throw writeResult.error;
-    }
+    await this.persistTerminalData("errored");
     await publishSandboxFunctionInvocationEvent(
       {
         type: "sandbox_function_invocation_error",
@@ -487,21 +534,13 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       return false;
     }
 
-    // A deferred initial persistence (inline path) must land before the terminal blob write
-    // overwrites the same object, and before the result event can outrun the created event.
-    await this.settleInitialPersistence();
-
     this.data = {
       version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
       input: this.input,
       context: this.context,
       result,
     };
-    const writeResult = await this.writeDataToGcs();
-    if (writeResult.isErr()) {
-      await this.releaseTerminalClaim("succeeded");
-      throw writeResult.error;
-    }
+    await this.persistTerminalData("succeeded");
     await publishSandboxFunctionInvocationEvent(
       {
         type: "sandbox_function_invocation_result",
@@ -983,8 +1022,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
 
     if (inline) {
       // The created event rides with the deferred blob write: nothing before the terminal
-      // transition consumes either, and succeed()/fail() await the combined promise before
-      // publishing the result, which keeps the created event ahead of the result event.
+      // transition consumes either. The result event may outrun the created event (the terminal
+      // transition chains its blob write behind this promise instead of awaiting it), which
+      // stream consumers already tolerate: they settle on the first terminal event and treat
+      // the created event as optional.
       const pendingBlobWrite = invocation.pendingInitialPersistence;
       invocation.pendingInitialPersistence = Promise.allSettled([
         pendingBlobWrite,


### PR DESCRIPTION
## Description

Traces of inline Pod function invocations show the request finishing its real work (auth, sandbox ensure, warm exec, status update) by ~160ms and then spending 200ms to 1.1s awaiting the terminal GCS blob writes before responding: route p50 sits at ~1s while the invocation row closes at ~140ms, and the tail is two sequential GCS POSTs with fat tails plus their retries.

`succeed()`/`fail()` now persist the terminal blob write-behind on the inline path: the write chains onto the existing `pendingInitialPersistence` promise (which keeps the object-level ordering — a late initial write can never overwrite the terminal one) instead of holding the response. The result event publishes immediately, so the caller's response and every stream consumer see the outcome at the same point as before, just ~200ms-1s earlier. All other paths (workflow activity, callback delivery) keep the awaited write with the release-claim-on-failure behavior unchanged.

The result event may now outrun the created event on the stream; consumers already treat the created event as optional and settle on the first terminal event, so ordering between the two was never load-bearing.

## Tests

Invocation suite: the inline test drains `settleInitialPersistence()` (which now includes the chained terminal write) before asserting the blob holds input and result; a new test fails every blob write for the invocation and asserts the caller still gets the outcome, the row still lands terminal, and draining the chain does not throw. front typechecks clean.

## Risk

Durability narrows on the inline path: a terminal write that fails, or a process death in the ~100-500ms after responding, leaves a terminal row whose blob is missing the outcome (input stays durable from the initial write). The outcome was still delivered to the caller and the event stream; the loss affects later inspection reads only, and is logged as an error. A blob read racing the write (inspection within ~500ms of completion) sees the input-only blob, same as the deferred initial write's existing window.

## Deploy Plan

Normal deploy. Route p50 for POST invocations should drop from ~1s toward ~200-300ms; watch for "Write-behind terminal Pod function invocation persistence failed" in logs, which should be rare to absent.
