### PR TITLE
Add ps to front production images

### DIFF
--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -90,7 +90,7 @@ RUN if [ -n "$DATADOG_API_KEY" ] && [ -n "$NEXT_PUBLIC_DATADOG_SERVICE" ]; then 
 FROM node:24.16.0-slim AS workers
 
 RUN apt-get update && \
-  apt-get install -y redis-tools postgresql-client libjemalloc2 curl && \
+  apt-get install -y redis-tools postgresql-client libjemalloc2 curl procps && \
   rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -233,7 +233,7 @@ RUN npm run build && \
 FROM node:24.16.0-slim AS front-api
 
 RUN apt-get update && \
-  apt-get install -y redis-tools postgresql-client libjemalloc2 curl && \
+  apt-get install -y redis-tools postgresql-client libjemalloc2 curl procps && \
   rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Description

We used to have `ps` available on our production pods, but it was removed when we moved to the `slim` version. This PR adds it back as it's pretty convenient (yes, even in production).