### PR TITLE
[front] enh: always enable Agents/Skills in sidebar menu

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1099,6 +1099,7 @@ export function AgentSidebarMenu({
                     "manage_agents",
                     () => setSidebarOpen(false)
                   )}
+                  keepHoverOnMoreMenu
                   moreMenu={
                     canCreateAgent ? (
                       <div
@@ -1189,6 +1190,7 @@ export function AgentSidebarMenu({
                     "manage_skills",
                     () => setSidebarOpen(false)
                   )}
+                  keepHoverOnMoreMenu
                   moreMenu={
                     canCreateSkill ? (
                       <div

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -48,9 +48,7 @@ import {
   useActivationPod,
   useActivationRecommendations,
 } from "@app/lib/swr/activation";
-import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
-import { useSkills } from "@app/lib/swr/skill_configurations";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { getConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
 import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
@@ -103,7 +101,6 @@ import {
   Robot,
   ScrollArea,
   Spinner,
-  Tooltip,
   Trash01,
   XClose,
   Zap,
@@ -111,7 +108,6 @@ import {
 } from "@dust-tt/sparkle";
 import { AnimatePresence, motion } from "framer-motion";
 import {
-  type ComponentProps,
   memo,
   useCallback,
   useContext,
@@ -129,41 +125,6 @@ interface AgentSidebarMenuProps {
   owner: WorkspaceType;
   hideActions?: boolean;
   hideInAppBanner?: boolean;
-}
-
-type PermissionedNavigationListItemProps = Omit<
-  ComponentProps<typeof NavigationListItem>,
-  "disabled"
-> & {
-  canAccess: boolean;
-  permissionTooltip: string;
-};
-
-function PermissionedNavigationListItem({
-  canAccess,
-  permissionTooltip,
-  moreMenu,
-  onClick,
-  ...props
-}: PermissionedNavigationListItemProps) {
-  const item = (
-    <NavigationListItem
-      {...props}
-      aria-disabled={!canAccess || undefined}
-      disabled={!canAccess}
-      moreMenu={canAccess ? moreMenu : undefined}
-      onClick={canAccess ? onClick : undefined}
-      tabIndex={canAccess ? props.tabIndex : 0}
-    />
-  );
-
-  if (canAccess) {
-    return item;
-  }
-
-  return (
-    <Tooltip label={permissionTooltip} trigger={item} tooltipTriggerAsChild />
-  );
 }
 
 type GroupLabel =
@@ -485,13 +446,6 @@ export function AgentSidebarMenu({
       workspaceId: owner.sId,
       disabled: !showGetStarted,
     });
-  const { agentConfigurations } = useUnifiedAgentConfigurations({
-    workspaceId: owner.sId,
-  });
-  const { skills } = useSkills({
-    owner,
-    status: "active",
-  });
 
   const [podSearchText, setPodSearchText] = useState("");
   const { setSidebarOpen } = useContext(SidebarContext);
@@ -547,15 +501,6 @@ export function AgentSidebarMenu({
 
   const canCreateAgent = hasPermission("create", "agent");
   const canCreateSkill = hasPermission("create", "skill");
-  const canManageAgents =
-    canCreateAgent ||
-    hasPermission("publish", "agent") ||
-    agentConfigurations.some((agent) => agent.canEdit);
-  const canManageSkills =
-    canCreateSkill ||
-    hasPermission("publish", "skill") ||
-    hasPermission("make_discoverable", "skill") ||
-    skills.some((skill) => skill.canAdministrate);
 
   const [showDeleteDialog, setShowDeleteDialog] = useState<
     "all" | "selection" | null
@@ -1140,9 +1085,7 @@ export function AgentSidebarMenu({
             )}
             {!isMultiSelect && !hideActions && (
               <NavigationList className="mx-sidebar-side-spacing mb-4 flex-shrink-0 pt-1">
-                <PermissionedNavigationListItem
-                  canAccess={canManageAgents}
-                  permissionTooltip="Ask an admin for permission to manage agents."
+                <NavigationListItem
                   href={getAgentBuilderRoute(owner.sId, "manage")}
                   icon={Robot}
                   label="Agents"
@@ -1234,9 +1177,7 @@ export function AgentSidebarMenu({
                     ) : undefined
                   }
                 />
-                <PermissionedNavigationListItem
-                  canAccess={canManageSkills}
-                  permissionTooltip="Ask an admin for permission to manage skills."
+                <NavigationListItem
                   href={getSkillBuilderRoute(owner.sId, "manage")}
                   icon={SKILL_ICON}
                   label="Skills"

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -61,6 +61,7 @@ interface NavigationListItemProps
   icon?: React.ComponentType;
   avatar?: React.ReactNode;
   moreMenu?: React.ReactNode;
+  keepHoverOnMoreMenu?: boolean;
   status?: NavigationListItemStatus;
   count?: number;
   hasActivity?: boolean;
@@ -87,6 +88,7 @@ const NavigationListItem = React.forwardRef<
       replace,
       shallow,
       moreMenu,
+      keepHoverOnMoreMenu,
       status = "idle",
       count,
       hasActivity,
@@ -136,7 +138,9 @@ const NavigationListItem = React.forwardRef<
               "items-center outline-hidden rounded-lg text-sm p-2 transition-colors duration-150 motion-reduce:transition-none",
               "data-[disabled]:pointer-events-none",
               !disabled &&
-                "group-hover/menu-item:bg-hover group-hover/menu-item:text-primary",
+                (keepHoverOnMoreMenu
+                  ? "group-hover/menu-item:bg-hover group-hover/menu-item:text-primary"
+                  : "hover:bg-hover hover:text-primary"),
               selected && "bg-selected text-primary",
               disabled && "pointer-events-none cursor-default opacity-50"
             )}

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -135,7 +135,8 @@ const NavigationListItem = React.forwardRef<
               "box-border flex items-center w-full gap-1.5 cursor-pointer select-none",
               "items-center outline-hidden rounded-lg text-sm p-2 transition-colors duration-150 motion-reduce:transition-none",
               "data-[disabled]:pointer-events-none",
-              "hover:bg-hover hover:text-primary",
+              !disabled &&
+                "group-hover/menu-item:bg-hover group-hover/menu-item:text-primary",
               selected && "bg-selected text-primary",
               disabled && "pointer-events-none cursor-default opacity-50"
             )}


### PR DESCRIPTION
## Description

Context in this [thread](https://dust4ai.slack.com/archives/C0A04EWRV0E/p1786109765559929?thread_ts=1785954047.171149&cid=C0A04EWRV0E).

https://github.com/dust-tt/dust/pull/30070 moved the buttons to create and manage agents and skills to the sidebar.
It disabled the row to users who could not create nor publish agents/skills.
This PR removes this behavior.

The access to Agent/Skill Builder remains gated, it's only the shortcut to the Manage pages that is not.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
