### PR TITLE
[front] enh: remove dot menu in sidebar

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1076,48 +1076,6 @@ export function AgentSidebarMenu({
                     tooltip="Create a new conversation"
                     onClick={handleNewClick}
                   />
-                  {!hideActions && (
-                    <DropdownMenu modal={false}>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          size="sm"
-                          icon={DotsHorizontal}
-                          variant="outline"
-                          aria-label="Conversation options"
-                        />
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent>
-                        <DropdownMenuLabel>Conversations</DropdownMenuLabel>
-                        <DropdownMenuItem
-                          label={
-                            hideTriggeredConversations
-                              ? "Show triggered"
-                              : "Hide triggered"
-                          }
-                          icon={hideTriggeredConversations ? Zap : ZapOff}
-                          disabled={!hasTriggeredConversations}
-                          onClick={() =>
-                            setHideTriggeredConversations(
-                              !hideTriggeredConversations
-                            )
-                          }
-                        />
-                        <DropdownMenuItem
-                          label="Edit history"
-                          onClick={toggleMultiSelect}
-                          icon={CheckDone01}
-                          disabled={filteredConversations.length === 0}
-                        />
-                        <DropdownMenuItem
-                          label="Clear history"
-                          variant="warning"
-                          onClick={() => setShowDeleteDialog("all")}
-                          icon={Trash01}
-                          disabled={filteredConversations.length === 0}
-                        />
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  )}
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Description

Context in [this thread](https://dust4ai.slack.com/archives/C0A04EWRV0E/p1785954047171149).
This PR removes the `...` menu in the sidebar next to the `New` button.
The same actions (Hide triggered, edit and clear history) are available on the `Conversations` row, which is a better place for them as the actions are relative to the conversations only.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
