### PR TITLE
feat(sandbox): pod env vars list and create routes

### DIFF
--- a/front-api/middlewares/with_space.ts
+++ b/front-api/middlewares/with_space.ts
@@ -14,6 +14,8 @@ interface WithSpaceOptions {
   requireCanReadOrAdministrate?: boolean;
   requireCanRead?: boolean;
   requireCanWrite?: boolean;
+  // Pods are project spaces — pod-scoped surfaces 404 on any other kind.
+  requireProject?: boolean;
   routeParam?: "spaceId" | "podId";
 }
 
@@ -73,13 +75,16 @@ export function withSpace(options: WithSpaceOptions) {
     if (
       !space ||
       space.isConversations() ||
+      (options.requireProject && !space.isProject()) ||
       !hasPermission(auth, space, options)
     ) {
       return apiError(ctx, {
         status_code: 404,
         api_error: {
           type: "space_not_found",
-          message: "The space you requested was not found.",
+          message: options.requireProject
+            ? "The pod you requested was not found."
+            : "The space you requested was not found.",
         },
       });
     }

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/index.test.ts
@@ -1,0 +1,212 @@
+import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEmitAuditLogEvent } = vi.hoisted(() => ({
+  mockEmitAuditLogEvent: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/audit/workos_audit")>();
+
+  return {
+    ...actual,
+    emitAuditLogEvent: mockEmitAuditLogEvent,
+  };
+});
+
+async function setupTest({
+  role = "admin",
+  withoutSandboxFunctionsFeature = false,
+}: {
+  role?: MembershipRoleType;
+  withoutSandboxFunctionsFeature?: boolean;
+} = {}) {
+  const { workspace, auth, user, ...rest } = await createPrivateApiMockRequest({
+    role,
+  });
+
+  if (!withoutSandboxFunctionsFeature) {
+    await FeatureFlagFactory.basic(auth, "sandbox_functions");
+  }
+
+  const pod = await SpaceFactory.project(workspace, user.id);
+
+  return { workspace, auth, user, pod, ...rest };
+}
+
+function listEnvVars(wId: string, spaceId: string) {
+  return honoApp.request(`/api/w/${wId}/spaces/${spaceId}/sandbox/env-vars`);
+}
+
+function postEnvVar(wId: string, spaceId: string, body: unknown) {
+  return honoApp.request(`/api/w/${wId}/spaces/${spaceId}/sandbox/env-vars`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("GET/POST /api/w/:wId/spaces/:spaceId/sandbox/env-vars", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    const { workspace, pod } = await setupTest({ role: "user" });
+
+    const response = await listEnvVars(workspace.sId, pod.sId);
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: { type: "workspace_auth_error" },
+    });
+  });
+
+  it("returns 403 without the sandbox_functions feature", async () => {
+    const { workspace, pod } = await setupTest({
+      withoutSandboxFunctionsFeature: true,
+    });
+
+    const response = await listEnvVars(workspace.sId, pod.sId);
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: { type: "feature_flag_not_found" },
+    });
+  });
+
+  it("returns 404 for an unknown space", async () => {
+    const { workspace } = await setupTest();
+
+    const response = await listEnvVars(workspace.sId, "spc_unknown");
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({
+      error: { type: "space_not_found" },
+    });
+  });
+
+  it("returns 404 for a non-project space", async () => {
+    const { workspace } = await setupTest();
+    const regularSpace = await SpaceFactory.regular(workspace);
+
+    const response = await listEnvVars(workspace.sId, regularSpace.sId);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({
+      error: { type: "space_not_found" },
+    });
+  });
+
+  it("returns an empty list when no env vars exist", async () => {
+    const { workspace, pod } = await setupTest();
+
+    const response = await listEnvVars(workspace.sId, pod.sId);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ envVars: [] });
+  });
+
+  it("lists only this pod's env vars, not workspace or other pod ones", async () => {
+    const { workspace, auth, user, pod } = await setupTest();
+    const otherPod = await SpaceFactory.project(workspace, user.id);
+
+    const workspaceUpsert = await SandboxEnvVarResource.upsert(
+      auth,
+      { kind: "workspace", workspace: auth.getNonNullableWorkspace() },
+      { name: "WORKSPACE_TOKEN", value: "workspace-value" }
+    );
+    if (workspaceUpsert.isErr()) {
+      throw workspaceUpsert.error;
+    }
+    const otherPodUpsert = await SandboxEnvVarResource.upsert(
+      auth,
+      { kind: "pod", pod: otherPod },
+      { name: "OTHER_POD_TOKEN", value: "other-pod-value" }
+    );
+    if (otherPodUpsert.isErr()) {
+      throw otherPodUpsert.error;
+    }
+    const podUpsert = await SandboxEnvVarResource.upsert(
+      auth,
+      { kind: "pod", pod },
+      { name: "POD_TOKEN", value: "pod-value" }
+    );
+    if (podUpsert.isErr()) {
+      throw podUpsert.error;
+    }
+
+    const response = await listEnvVars(workspace.sId, pod.sId);
+
+    expect(response.status).toBe(200);
+    // toMatchObject on an array also pins its length.
+    expect(await response.json()).toMatchObject({
+      envVars: [{ name: "DST_POD_TOKEN", spaceId: pod.sId }],
+    });
+  });
+
+  it("creates a config env var with the DST_ prefix and returns 201", async () => {
+    const { workspace, auth, pod } = await setupTest();
+
+    const response = await postEnvVar(workspace.sId, pod.sId, {
+      name: "DST_API_TOKEN",
+      value: "super-secret-token",
+    });
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toMatchObject({
+      created: true,
+      envVar: { name: "DST_API_TOKEN", kind: "config", spaceId: pod.sId },
+    });
+
+    // The pod-scoped row must not leak into the workspace scope.
+    const workspaceVars = await SandboxEnvVarResource.listForScope(auth, {
+      kind: "workspace",
+      workspace: auth.getNonNullableWorkspace(),
+    });
+    expect(workspaceVars).toHaveLength(0);
+  });
+
+  it("returns 200 when overwriting an existing env var", async () => {
+    const { workspace, auth, pod } = await setupTest();
+
+    const upsert = await SandboxEnvVarResource.upsert(
+      auth,
+      { kind: "pod", pod },
+      {
+        name: "API_TOKEN",
+        value: "initial-value",
+      }
+    );
+    if (upsert.isErr()) {
+      throw upsert.error;
+    }
+
+    const response = await postEnvVar(workspace.sId, pod.sId, {
+      name: "DST_API_TOKEN",
+      value: "rotated-value",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ created: false });
+  });
+
+  it("rejects invalid POST body via zod", async () => {
+    const { workspace, pod } = await setupTest();
+
+    const response = await postEnvVar(workspace.sId, pod.sId, {
+      name: "MY_VAR",
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { type: "invalid_request_error" },
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/index.ts
@@ -1,0 +1,113 @@
+import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
+import {
+  parseSandboxEnvVarNameForKind,
+  validateEnvVarValueForKind,
+} from "@app/lib/api/sandbox/env_vars";
+import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
+import type {
+  GetSandboxEnvVarsResponseBody,
+  PostSandboxEnvVarsResponseBody,
+} from "@app/types/api/sandbox/env_vars";
+import { SANDBOX_ENV_VAR_KINDS } from "@app/types/sandbox/env_var";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { withSpace } from "@front-api/middlewares/with_space";
+import { z } from "zod";
+
+const PostPodSandboxEnvVarBodySchema = z.object({
+  name: z.string(),
+  value: z.string(),
+  kind: z.enum(SANDBOX_ENV_VAR_KINDS).optional(),
+  allowedDomains: z.array(z.string()).nullable().optional(),
+});
+
+// Mounted at /api/w/:wId/spaces/:spaceId/sandbox/env-vars. Pods are project
+// spaces: non-project spaces have no pod-scoped env vars and 404.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  withSpace({ requireProject: true, requireCanReadOrAdministrate: true }),
+  async (ctx): HandlerResult<GetSandboxEnvVarsResponseBody> => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
+
+    const envVars = await SandboxEnvVarResource.listForScope(auth, {
+      kind: "pod",
+      pod: space,
+    });
+
+    return ctx.json({
+      envVars: envVars.map((envVar) => envVar.toJSON()),
+    });
+  }
+);
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  withSpace({ requireProject: true, requireCanReadOrAdministrate: true }),
+  validate("json", PostPodSandboxEnvVarBodySchema),
+  async (ctx): HandlerResult<PostSandboxEnvVarsResponseBody> => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
+    const body = ctx.req.valid("json");
+
+    const kind = body.kind ?? "config";
+    const parsedName = parseSandboxEnvVarNameForKind({
+      kind,
+      name: body.name,
+    });
+    const parsedValue = validateEnvVarValueForKind({
+      kind,
+      value: body.value,
+    });
+    if (parsedName.isErr() || parsedValue.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: [
+            parsedName.isErr() ? `name: ${parsedName.error}` : null,
+            parsedValue.isErr() ? `value: ${parsedValue.error}` : null,
+          ]
+            .filter((message) => message !== null)
+            .join("; "),
+        },
+      });
+    }
+
+    const result = await SandboxEnvVarResource.upsert(
+      auth,
+      { kind: "pod", pod: space },
+      {
+        name: parsedName.value,
+        value: body.value,
+        kind,
+        allowedDomains: body.allowedDomains,
+        context: getAuditLogContext(auth),
+      }
+    );
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: result.error.message,
+        },
+      });
+    }
+
+    return ctx.json(
+      {
+        envVar: result.value.resource.toJSON(),
+        created: result.value.created,
+      },
+      result.value.created ? 201 : 200
+    );
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/index.ts
@@ -3,6 +3,7 @@ import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { withSandboxFunctionsFeature } from "@front-api/middlewares/with_sandbox_functions_feature";
 
 import egressPolicy from "./egress-policy";
+import envVars from "./env-vars";
 
 // Mounted at /api/w/:wId/spaces/:spaceId/sandbox. The workspace-admin and
 // `sandbox_functions` feature gates are applied here so every leaf below
@@ -20,5 +21,6 @@ app.use("*", ensureIsAdmin());
 app.use("*", withSandboxFunctionsFeature());
 
 app.route("/egress-policy", egressPolicy);
+app.route("/env-vars", envVars);
 
 export default app;


### PR DESCRIPTION
## Description

Follow up of #28862 (pod env vars injected at sandbox boot). First of two route PRs — splitting the pod env vars API by route to keep each reviewable: this PR adds **list and create** (`GET`/`POST /api/w/:wId/spaces/:spaceId/sandbox/env-vars`); update/delete follow in #29348.

Workspace-admin + `sandbox_functions` gates apply at the sandbox router. Pods are project spaces — the kind check lives in `withSpace` as a `requireProject` option (one predicate beside the existing `isConversations` kind-check; additive and default-off, existing consumers unchanged), so the handlers don't each repeat the guard. Create goes through the scope-aware resource `upsert` — re-posting an existing name rotates its value: 201 on create, 200 on overwrite; per-pod encryption key, per-scope name uniqueness.

## Risk

New endpoints, admin + FF gated, no consumers until the UI PR. The `withSpace` option is additive and default-off. Safe to rollback.

## Tests

List/create functional tests: gating (non-admin 403, missing FF 403), non-project space 404, create + overwrite (201/200), invalid body 400, list scoping (this pod only — not workspace or other pods' vars). Pod audit attribution (space_id metadata + schemas) lands with #29346 upstack.
