### PR TITLE
Keep Front readiness healthy during GKE endpoint draining

### DIFF
--- a/front-api/routes/healthz.test.ts
+++ b/front-api/routes/healthz.test.ts
@@ -1,5 +1,4 @@
 import { frontSequelize } from "@app/lib/resources/storage";
-import * as shutdownSignal from "@app/lib/shutdown_signal";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -19,11 +18,7 @@ describe("GET /api/healthz", () => {
 });
 
 describe("GET /api/healthz/ready", () => {
-  beforeEach(() => {
-    vi.spyOn(shutdownSignal, "isInShutdown").mockReturnValue(false);
-  });
-
-  it("returns 200 with status ready when not shutting down", async () => {
+  it("returns 200 with status ready", async () => {
     const response = await honoApp.request("/api/healthz/ready");
 
     expect(response.status).toBe(200);
@@ -32,15 +27,6 @@ describe("GET /api/healthz/ready", () => {
       status: "ready",
       commitHash: expect.any(String),
     });
-  });
-
-  it("returns 503 with status shutting_down when in shutdown", async () => {
-    vi.spyOn(shutdownSignal, "isInShutdown").mockReturnValue(true);
-
-    const response = await honoApp.request("/api/healthz/ready");
-
-    expect(response.status).toBe(503);
-    expect(await response.json()).toEqual({ status: "shutting_down" });
   });
 });
 

--- a/front-api/routes/healthz/ready.ts
+++ b/front-api/routes/healthz/ready.ts
@@ -1,5 +1,4 @@
 import { COMMIT_HASH } from "@app/lib/commit-hash";
-import { isInShutdown } from "@app/lib/shutdown_signal";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import { createHono } from "@front-api/lib/hono";
 
@@ -10,8 +9,9 @@ import { createHono } from "@front-api/lib/hono";
  * traffic. It's kept simple and doesn't check dependencies to avoid marking all pods unready if
  * Redis/DB have transient issues.
  *
- * During pod shutdown, this probe fails immediately to signal the load balancer to stop
- * sending new connections and begin connection draining.
+ * During Pod termination this probe remains healthy. Kubernetes independently marks
+ * terminating endpoints unready, and the preStop hook keeps the process serving while
+ * GKE removes the endpoint from the NEG and drains existing connections.
  *
  * The startup probe (/api/healthz/startup) handles dependency checking at pod startup.
  */
@@ -20,14 +20,6 @@ const app = createHono();
 /** @ignoreswagger */
 app.get("/", (ctx) => {
   const startMs = performance.now();
-
-  if (isInShutdown()) {
-    const durationMs = performance.now() - startMs;
-    getStatsDClient().distribution("healthz.ready.duration_ms", durationMs);
-    getStatsDClient().increment("healthz.ready.shutdown");
-
-    return ctx.json({ status: "shutting_down" }, 503);
-  }
 
   const response = ctx.json({ status: "ready", commitHash: COMMIT_HASH }, 200);
 

--- a/front/admin/prestop.sh
+++ b/front/admin/prestop.sh
@@ -9,6 +9,8 @@ esac
 
 start_seconds=$(date +%s)
 
+# If the API call fails, sleep for the remainder so the hook still observes
+# the configured minimum drain duration.
 if ! curl \
   --fail \
   --silent \

--- a/front/admin/prestop.sh
+++ b/front/admin/prestop.sh
@@ -1,2 +1,25 @@
 #!/bin/sh
-curl -X POST "http://$(hostname -i):3000/api/$PRESTOP_SECRET/prestop"
+
+drain_duration_seconds="${PRESTOP_DRAIN_DURATION_SECONDS:-120}"
+case "$drain_duration_seconds" in
+  ''|*[!0-9]*|0)
+    drain_duration_seconds=120
+    ;;
+esac
+
+start_seconds=$(date +%s)
+
+if ! curl \
+  --fail \
+  --silent \
+  --show-error \
+  --max-time "$drain_duration_seconds" \
+  -X POST \
+  "http://$(hostname -i):3000/api/$PRESTOP_SECRET/prestop"; then
+  elapsed_seconds=$(($(date +%s) - start_seconds))
+  remaining_seconds=$((drain_duration_seconds - elapsed_seconds))
+
+  if [ "$remaining_seconds" -gt 0 ]; then
+    sleep "$remaining_seconds"
+  fi
+fi

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PRESTOP_DRAIN_DURATION_MS } from "@app/lib/constants/timeouts";
 import { isDevelopment } from "@app/types/shared/env";
 import { EnvironmentConfig } from "@app/types/shared/utils/config";
 
@@ -31,6 +32,24 @@ export function getDefaultInit(): Promise<RequestInit> | null {
 }
 
 const config = {
+  getPreStopDrainDurationMs: (): number => {
+    const value = EnvironmentConfig.getOptionalEnvVariable(
+      "PRESTOP_DRAIN_DURATION_SECONDS"
+    );
+    if (!value) {
+      return DEFAULT_PRESTOP_DRAIN_DURATION_MS;
+    }
+
+    const durationSeconds = Number(value);
+    if (!Number.isSafeInteger(durationSeconds) || durationSeconds <= 0) {
+      throw new Error(
+        "PRESTOP_DRAIN_DURATION_SECONDS must be a positive integer"
+      );
+    }
+
+    return durationSeconds * 1_000;
+  },
+
   // Dynamic API base URL: uses a custom resolver when set (SPA region switching),
   // otherwise falls back to getClientFacingUrl().
   getApiBaseUrl: (): string => {

--- a/front/lib/api/prestop.test.ts
+++ b/front/lib/api/prestop.test.ts
@@ -1,0 +1,121 @@
+import { DEFAULT_PRESTOP_DRAIN_DURATION_MS } from "@app/lib/constants/timeouts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { childLogger, statsDClient } = vi.hoisted(() => ({
+  childLogger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+  statsDClient: {
+    distribution: vi.fn(),
+    gauge: vi.fn(),
+    increment: vi.fn(),
+  },
+}));
+
+vi.mock("@app/lib/utils/statsd", () => ({
+  getStatsDClient: () => statsDClient,
+}));
+
+vi.mock("@app/logger/logger", () => ({
+  default: {
+    child: () => childLogger,
+  },
+}));
+
+describe("runPreStop", () => {
+  let runPreStop: typeof import("@app/lib/api/prestop").runPreStop;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    vi.clearAllMocks();
+    vi.resetModules();
+    global.wakeLocks = new Map();
+    delete process.env.PRESTOP_DRAIN_DURATION_SECONDS;
+    ({ runPreStop } = await import("@app/lib/api/prestop"));
+  });
+
+  afterEach(() => {
+    global.wakeLocks = undefined;
+    delete process.env.PRESTOP_DRAIN_DURATION_SECONDS;
+    vi.useRealTimers();
+  });
+
+  it("keeps the hook open for the complete drain window", async () => {
+    let completed = false;
+    const preStopPromise = runPreStop().then(() => {
+      completed = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_PRESTOP_DRAIN_DURATION_MS - 1);
+    expect(completed).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await preStopPromise;
+
+    expect(completed).toBe(true);
+    expect(statsDClient.distribution).toHaveBeenCalledWith(
+      "prestop.total_duration_ms",
+      DEFAULT_PRESTOP_DRAIN_DURATION_MS
+    );
+    expect(statsDClient.increment).toHaveBeenCalledWith(
+      "prestop.wake_locks_cleared"
+    );
+  });
+
+  it("finishes at the drain deadline when a wake lock remains active", async () => {
+    global.wakeLocks?.set("active-lock", {
+      id: "active-lock",
+      startTime: 0,
+      context: { operation: "test" },
+    });
+
+    const preStopPromise = runPreStop();
+    await vi.advanceTimersByTimeAsync(DEFAULT_PRESTOP_DRAIN_DURATION_MS);
+    await preStopPromise;
+
+    expect(statsDClient.increment).toHaveBeenCalledWith("prestop.timeouts");
+    expect(statsDClient.gauge).toHaveBeenCalledWith(
+      "prestop.timeout_wake_locks",
+      1
+    );
+    expect(childLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        totalDurationMs: DEFAULT_PRESTOP_DRAIN_DURATION_MS,
+      }),
+      "Endpoint drain deadline reached with active wake locks"
+    );
+  });
+
+  it("uses the deployment-specific drain duration", async () => {
+    process.env.PRESTOP_DRAIN_DURATION_SECONDS = "180";
+    let completed = false;
+    const preStopPromise = runPreStop().then(() => {
+      completed = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(completed).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await preStopPromise;
+    expect(completed).toBe(true);
+  });
+
+  it("shares one drain deadline across duplicate calls", async () => {
+    const firstPreStopPromise = runPreStop();
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    const duplicatePreStopPromise = runPreStop();
+    expect(duplicatePreStopPromise).toBe(firstPreStopPromise);
+
+    await vi.advanceTimersByTimeAsync(90_000);
+    await Promise.all([firstPreStopPromise, duplicatePreStopPromise]);
+    expect(
+      statsDClient.increment.mock.calls.filter(
+        ([metricName]) => metricName === "prestop.requests"
+      )
+    ).toHaveLength(1);
+  });
+});

--- a/front/lib/api/prestop.ts
+++ b/front/lib/api/prestop.ts
@@ -1,10 +1,4 @@
-import {
-  PRESTOP_GRACE_PERIOD_MS,
-  PRESTOP_LB_PROPAGATION_MS,
-  PRESTOP_MIN_DRAINING_WAIT_MS,
-  PRESTOP_WAKE_LOCK_MAX_WAIT_MS,
-} from "@app/lib/constants/timeouts";
-import { markShuttingDown } from "@app/lib/shutdown_signal";
+import config from "@app/lib/api/config";
 import { setTimeoutAsync } from "@app/lib/utils/async_utils";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import type { WakeLockEntry } from "@app/lib/wake_lock";
@@ -14,44 +8,41 @@ import logger from "@app/logger/logger";
 const PRESTOP_LOG_INTERVAL_MS = 1000; // 1 second log interval.
 const PRESTOP_LOG_MAX_LOCKS = 3; // Show top 3 longest running wake locks.
 
+let preStopPromise: Promise<void> | undefined;
+
 function getLockShortId(lock: WakeLockEntry): string {
   return lock.id.substring(0, 8);
 }
 
 /**
  * Runs the full preStop shutdown sequence:
- *   1. Mark the process as shutting down (fails readiness probe).
- *   2. Wait for load balancer to propagate readiness=false.
- *   3. Wait for wake locks (in-flight critical operations) to clear, up to a max.
- *   4. Ensure a minimum total draining period for SSE/HTTP connections.
+ *   1. Keep serving while Kubernetes marks the endpoint as terminating.
+ *   2. Give GKE time to remove the endpoint from the NEG and drain connections.
+ *   3. Observe wake locks throughout the same bounded drain window.
  *
- * Logs progress and emits statsd metrics throughout. Resolves once the
- * process can safely exit.
+ * Logs progress and emits statsd metrics throughout. Completes at the configured drain deadline.
  */
-export async function runPreStop(): Promise<void> {
+export function runPreStop(): Promise<void> {
+  preStopPromise ??= runPreStopOnce(config.getPreStopDrainDurationMs());
+  return preStopPromise;
+}
+
+async function runPreStopOnce(drainDurationMs: number): Promise<void> {
   const childLogger = logger.child({
     action: "preStop",
   });
 
   getStatsDClient().increment("prestop.requests");
 
-  // Phase 1: Signal shutdown immediately to fail readiness probe.
-  // This triggers the load balancer to stop sending new connections.
-  markShuttingDown();
-  childLogger.info("Shutdown initiated, readiness probe will now fail");
-
-  // Phase 2: Wait for load balancer to propagate readiness=false.
   childLogger.info(
-    { propagationMs: PRESTOP_LB_PROPAGATION_MS },
-    "Waiting for load balancer propagation"
+    { drainDurationMs },
+    "Pod termination initiated. Remaining ready while Kubernetes retires the endpoint"
   );
-  await setTimeoutAsync(PRESTOP_LB_PROPAGATION_MS);
 
-  // Phase 3: Wait for wake locks (critical operations), max 120s.
-  const wakeLockStartTime = Date.now();
+  const preStopStartTimeMs = Date.now();
   let initialWakeLockCount: number | null = null;
 
-  while (!wakeLockIsFree()) {
+  while (Date.now() - preStopStartTimeMs < drainDurationMs) {
     const wakeLockDetails = getWakeLockDetails();
     const currentWakeLockCount = wakeLockDetails.length;
 
@@ -59,7 +50,7 @@ export async function runPreStop(): Promise<void> {
       initialWakeLockCount = currentWakeLockCount;
       childLogger.info(
         { wakeLockCount: currentWakeLockCount },
-        "Starting to wait for wake locks to be free"
+        "Starting endpoint drain window"
       );
 
       // Record initial wake lock metrics.
@@ -89,146 +80,78 @@ export async function runPreStop(): Promise<void> {
       });
     }
 
-    const elapsedMs = Date.now() - wakeLockStartTime;
-    const remainingMs = PRESTOP_WAKE_LOCK_MAX_WAIT_MS - elapsedMs;
+    const elapsedMs = Date.now() - preStopStartTimeMs;
+    const remainingMs = drainDurationMs - elapsedMs;
 
-    // Show progress of longest-running wake locks.
-    const longestRunning = wakeLockDetails
-      .map((lock) => ({
-        ...lock,
-        durationMs: Date.now() - lock.startTime,
-      }))
-      .sort((a, b) => b.durationMs - a.durationMs)
-      .slice(0, PRESTOP_LOG_MAX_LOCKS);
+    if (currentWakeLockCount > 0) {
+      const longestRunning = wakeLockDetails
+        .map((lock) => ({
+          ...lock,
+          durationMs: Date.now() - lock.startTime,
+        }))
+        .sort((a, b) => b.durationMs - a.durationMs)
+        .slice(0, PRESTOP_LOG_MAX_LOCKS);
 
-    childLogger.info(
-      {
-        currentWakeLockCount,
-        initialWakeLockCount,
-        elapsedSeconds: Math.round(elapsedMs / 1000),
-        remainingSeconds: Math.round(remainingMs / 1000),
-        longestRunning: longestRunning.map((lock) => ({
-          durationSeconds: Math.round(lock.durationMs / 1000),
-          context: lock.context,
-        })),
-      },
-      "Waiting for wake locks to be free"
-    );
-
-    // Safety timeout to avoid exceeding grace period.
-    if (elapsedMs >= PRESTOP_WAKE_LOCK_MAX_WAIT_MS) {
-      childLogger.warn(
+      childLogger.info(
         {
-          timeoutMs: PRESTOP_WAKE_LOCK_MAX_WAIT_MS,
           currentWakeLockCount,
-          graceSecondsRemaining: Math.round(
-            (PRESTOP_GRACE_PERIOD_MS - PRESTOP_LB_PROPAGATION_MS - elapsedMs) /
-              1000
-          ),
-          activeWakeLocks: wakeLockDetails.map((lock) => ({
+          initialWakeLockCount,
+          elapsedSeconds: Math.round(elapsedMs / 1000),
+          remainingSeconds: Math.round(remainingMs / 1000),
+          longestRunning: longestRunning.map((lock) => ({
+            durationSeconds: Math.round(lock.durationMs / 1000),
             context: lock.context,
-            durationSeconds: Math.round((Date.now() - lock.startTime) / 1000),
-            lockId: getLockShortId(lock),
           })),
         },
-        "Pre-stop wake lock timeout reached, terminating with active wake locks"
+        "Endpoint draining with active wake locks"
       );
-
-      // Record timeout metrics.
-      getStatsDClient().increment("prestop.timeouts");
-      getStatsDClient().gauge(
-        "prestop.timeout_wake_locks",
-        currentWakeLockCount
-      );
-      getStatsDClient().distribution("prestop.timeout_duration_ms", elapsedMs);
-
-      break;
     }
 
-    await setTimeoutAsync(PRESTOP_LOG_INTERVAL_MS);
+    await setTimeoutAsync(Math.min(PRESTOP_LOG_INTERVAL_MS, remainingMs));
   }
 
-  const wakeLockDurationMs = Date.now() - wakeLockStartTime;
+  const totalDurationMs = Date.now() - preStopStartTimeMs;
+  const finalWakeLockDetails = getWakeLockDetails();
 
-  if (wakeLockIsFree()) {
+  if (finalWakeLockDetails.length === 0 && wakeLockIsFree()) {
     childLogger.info(
-      {
-        wakeLockDurationMs,
-        wakeLockDurationSeconds: Math.round(wakeLockDurationMs / 1000),
-      },
-      "All wake locks cleared successfully"
+      { totalDurationMs },
+      "Endpoint drain completed without active wake locks"
     );
 
-    // Record successful completion metrics.
     getStatsDClient().increment("prestop.wake_locks_cleared");
-    getStatsDClient().distribution(
-      "prestop.wake_lock_duration_ms",
-      wakeLockDurationMs
-    );
   } else {
-    // Record forced termination metrics.
+    childLogger.warn(
+      {
+        activeWakeLocks: finalWakeLockDetails.map((lock) => ({
+          context: lock.context,
+          durationSeconds: Math.round((Date.now() - lock.startTime) / 1000),
+          lockId: getLockShortId(lock),
+        })),
+        totalDurationMs,
+      },
+      "Endpoint drain deadline reached with active wake locks"
+    );
+
+    getStatsDClient().increment("prestop.timeouts");
+    getStatsDClient().gauge(
+      "prestop.timeout_wake_locks",
+      finalWakeLockDetails.length
+    );
+    getStatsDClient().distribution(
+      "prestop.timeout_duration_ms",
+      totalDurationMs
+    );
     getStatsDClient().increment("prestop.wake_locks_forced");
     getStatsDClient().distribution(
       "prestop.wake_lock_forced_duration_ms",
-      wakeLockDurationMs
+      totalDurationMs
     );
   }
-
-  // Phase 4: Ensure we wait at least 60s total for connection draining.
-  // This allows existing SSE connections and HTTP requests to complete gracefully.
-  // Wait for MAX(wakeLockDuration, 60s).
-  const remainingDrainingWaitMs = Math.max(
-    0,
-    PRESTOP_MIN_DRAINING_WAIT_MS - wakeLockDurationMs
-  );
-
-  if (remainingDrainingWaitMs > 0) {
-    childLogger.info(
-      {
-        wakeLockDurationMs,
-        additionalDrainingWaitMs: remainingDrainingWaitMs,
-        totalDrainingTimeMs: PRESTOP_MIN_DRAINING_WAIT_MS,
-      },
-      "Waiting additional time for connection draining"
-    );
-
-    getStatsDClient().increment("prestop.draining_wait_additional");
-    getStatsDClient().distribution(
-      "prestop.draining_additional_wait_ms",
-      remainingDrainingWaitMs
-    );
-
-    await setTimeoutAsync(remainingDrainingWaitMs);
-  } else {
-    childLogger.info(
-      {
-        wakeLockDurationMs,
-        drainingRequirementMet: true,
-      },
-      "Connection draining period already satisfied by wake lock wait"
-    );
-
-    getStatsDClient().increment(
-      "prestop.draining_wait_satisfied_by_wake_locks"
-    );
-  }
-
-  const totalDurationMs =
-    PRESTOP_LB_PROPAGATION_MS +
-    Math.max(wakeLockDurationMs, PRESTOP_MIN_DRAINING_WAIT_MS);
 
   childLogger.info(
-    {
-      totalDurationMs,
-      totalDurationSeconds: Math.round(totalDurationMs / 1000),
-      phaseLbPropagationMs: PRESTOP_LB_PROPAGATION_MS,
-      phaseWakeLockMs: wakeLockDurationMs,
-      phaseDrainingWaitMs: Math.max(
-        wakeLockDurationMs,
-        PRESTOP_MIN_DRAINING_WAIT_MS
-      ),
-    },
-    "PreStop complete, process can now exit"
+    { totalDurationMs },
+    "PreStop drain window complete. Process termination can proceed"
   );
 
   // Record total prestop duration.

--- a/front/lib/constants/timeouts.ts
+++ b/front/lib/constants/timeouts.ts
@@ -5,28 +5,15 @@
  * between different parts of the system (API routes, agent loops, etc.).
  */
 
-// This is defined as terminationGracePeriodSeconds in the deployment specification.
-// DO NOT CHANGE THIS VALUE unless you update the deployment specification.
-export const PRESTOP_GRACE_PERIOD_MS = 130 * 1_000; // 130 seconds grace period.
-
-// PreStop phase durations for coordinated connection draining.
-// These work together to ensure graceful shutdown:
-// 1. Load balancer propagation (10s): Time for readiness=false to reach all LB backends
-// 2. Wake locks (up to 120s): Critical operations must complete
-// 3. Connection draining (min 60s): Existing connections gracefully close
-//
-// Total time: 10s + MAX(wakeLocks, 60s) ≤ 130s (grace period)
-// Examples:
-// - Wake locks clear in 20s: 10s + 60s = 70s total (waits extra 40s for draining)
-// - Wake locks clear in 80s: 10s + 80s = 90s total (draining requirement met)
-// - Wake locks take 120s: 10s + 120s = 130s total (at grace period limit)
-export const PRESTOP_LB_PROPAGATION_MS = 10 * 1_000; // Load balancer propagation.
-export const PRESTOP_WAKE_LOCK_MAX_WAIT_MS = 120 * 1_000; // Critical operations (max).
-export const PRESTOP_MIN_DRAINING_WAIT_MS = 60 * 1_000; // Connection draining (min).
+// Keep serving during this window while Kubernetes marks the terminating endpoint
+// unready and GKE removes it from the NEG. Deployments can override this value
+// when their backend service uses a longer connection-draining timeout.
+export const DEFAULT_PRESTOP_DRAIN_DURATION_MS = 120 * 1_000;
 
 // Threshold for determining if tools should trigger async mode (2 minutes).
-// This is 10 seconds before the prestop grace period to ensure sufficient buffer time.
-export const LONG_RUNNING_TOOL_THRESHOLD_MS = PRESTOP_GRACE_PERIOD_MS - 10_000;
+// This is 10 seconds before the drain deadline to ensure sufficient buffer time.
+export const LONG_RUNNING_TOOL_THRESHOLD_MS =
+  DEFAULT_PRESTOP_DRAIN_DURATION_MS - 10_000;
 
 // Standard sync-to-async timeout for agent execution (10 seconds).
 export const SYNC_TO_ASYNC_TIMEOUT_MS = 10 * 1_000;

--- a/front/lib/shutdown_signal.ts
+++ b/front/lib/shutdown_signal.ts
@@ -1,14 +1,10 @@
 /**
- * Global shutdown signal for coordinating graceful pod termination.
+ * Global shutdown signal for coordinating worker termination.
  *
- * This module tracks whether the pod is shutting down to coordinate between:
- * - The prestop hook (which signals shutdown)
- * - The readiness probe (which should fail when shutting down)
- * - Connection draining (which needs the pod to stay alive)
- * - Worker shutdown handlers
+ * API Pod connection draining is handled independently by its preStop hook and
+ * Kubernetes endpoint termination state.
  */
 
-let isShuttingDown = false;
 const shutdownController = new AbortController();
 let shutdownAbortTimeout: NodeJS.Timeout | undefined;
 
@@ -16,32 +12,14 @@ export const DUST_WORKER_SHUTDOWN_ABORT_REASON =
   "DUST_WORKER_SHUTDOWN_ABORT" as const;
 
 /**
- * Marks the pod as shutting down.
- */
-export function markShuttingDown(): void {
-  isShuttingDown = true;
-  abortShutdownSignal();
-}
-
-/**
  * Marks the pod as shutting down, but lets active work use most of the grace period.
  */
 export function markShuttingDownWithDelayedAbort(abortDelayMs: number): void {
-  isShuttingDown = true;
-
   if (shutdownController.signal.aborted || shutdownAbortTimeout) {
     return;
   }
 
   shutdownAbortTimeout = setTimeout(abortShutdownSignal, abortDelayMs);
-}
-
-/**
- * Checks if the pod is currently in shutdown mode.
- * Used by the readiness probe to determine if it should fail.
- */
-export function isInShutdown(): boolean {
-  return isShuttingDown;
 }
 
 export function getShutdownSignal(): AbortSignal {


### PR DESCRIPTION
## What changes

- `/api/healthz/ready` continues to return HTTP 200 while a Pod is terminating.
- The `preStop` endpoint stays open for a fixed drain window instead of returning early when wake locks clear.
- `PRESTOP_DRAIN_DURATION_SECONDS` configures the window. The application default is 120 seconds.
- Duplicate `preStop` requests share the original process-wide promise and deadline.
- Wake locks are still logged and measured. Active locks no longer extend the hook past the configured deadline.
- The shell hook treats non-2xx responses and connection failures as failures, then sleeps for the remaining configured duration.
- The API shutdown path no longer changes the global shutdown signal. The delayed worker shutdown signal is unchanged.

Companion infrastructure change: https://github.com/dust-tt/dust-infra/pull/961.

## What was happening

The old `preStop` path immediately called `markShuttingDown()`. The readiness endpoint saw that process flag and returned HTTP 503 until Kubernetes killed the container.

That 503 did not identify a sick Pod. It was generated because Kubernetes was already deleting a healthy Pod. Our probe-failure monitor counted it like any other readiness failure, so normal deployments created on-call noise roughly 20 times per day.

The useful part of the monitor remains. A dead process, an event-loop stall, a connection failure, or a readiness response that exceeds the probe timeout can still fail the probe. This change removes only the deliberate termination-time 503.

## Why HTTP 200 is correct during `preStop`

Kubernetes does not require a readiness failure to drain a deleting Pod. On deletion, Kubernetes independently marks the EndpointSlice endpoint as terminating and sets `ready: false` for ordinary Service traffic. Readiness probes continue during the container lifecycle, but their result is not the deletion signal.

Kubernetes starts local shutdown and endpoint retirement at about the same time. It does not wait for every consumer of the endpoint state before starting `preStop`. Keeping the server healthy allows requests that still reach the Pod during that race to complete.

GCP HTTP, HTTPS, and HTTP/2 health checks require an exact HTTP 200 response. Other status codes, including 3xx responses, are unhealthy. Returning 200 keeps the endpoint serviceable while GKE removes it from the NEG and the load balancer drains connections.

Findings are coming from:
- [Kubernetes readiness probes](https://kubernetes.io/docs/concepts/workloads/pods/probes/#readiness-probe)
- [Kubernetes Pod termination flow](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination-flow)
- [Kubernetes EndpointSlice conditions](https://kubernetes.io/docs/reference/kubernetes-api/discovery/endpoint-slice-v1/#endpointconditions)
- [GCP HTTP health check success criteria](https://cloud.google.com/load-balancing/docs/health-check-concepts#criteria-protocol-http)

## Timing change

The old hook duration was:

```text
10s assumed load-balancer propagation + max(60s minimum drain, wake-lock wait up to 120s)
```

It therefore took between 70 and 130 seconds. A Pod with no wake locks usually reached SIGTERM after about 70 seconds.

The new hook uses a fixed duration:

```text
Front and Front Edge: 120s
Front SSE:            180s, supplied by the companion infrastructure PR
```

The fixed duration is a floor, not only a ceiling. Clearing application wake locks does not prove that GKE has removed the endpoint from the NEG. There is no acknowledgement available to the application that would justify ending the hook early.

## Failure behavior

The kubelet executes `admin/prestop.sh`, which calls the application endpoint. The shell now uses a bounded curl request and rejects non-2xx responses. If the secret is wrong, the route is missing, or the local API cannot be reached, the shell sleeps for whatever remains of the configured drain duration.

This prevents an internal hook failure from collapsing a 120 or 180 second drain window into an immediate SIGTERM.

## Operational impact

- Regular Front Pods without wake locks spend about 50 seconds longer in `preStop`, moving from about 70 seconds to 120 seconds.
- Front SSE Pods spend 180 seconds in `preStop` after the companion infrastructure configuration lands.
- Pod deletion, scale-down, node drain, rollback cleanup, and some rollout completion checks can take longer.
- RollingUpdate starts replacement Pods while old Pods drain, so deploy duration is not the drain duration multiplied by the replica count. Old and new replicas overlap for longer.

The intended outcomes are concrete. Normal Pod termination stops generating readiness-failure alerts, and Pods remain able to finish requests while GKE retires their endpoints.

## Rollout order

Deploy this application PR first, then apply the companion infrastructure PR promptly.

With the current 130 second Pod grace period, the new 120 second default leaves only about 10 seconds for hook overhead, SIGTERM delivery, and process exit. The companion infrastructure PR raises the regular grace period to 150 seconds and configures Front SSE for a 180 second hook inside a 210 second grace period.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
