### PR TITLE
[Activation] feat: add work area MCP tools to activation_recommendations server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -7,6 +7,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
+    "create_work_areas": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
     "get_tool_execution_modes": {
       "freeUsage": true,
       "toolCostCategory": "basic",
@@ -15,7 +19,15 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
+    "list_work_areas": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
     "update_recommendation": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
+    "update_work_area": {
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
@@ -2636,9 +2648,12 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
 {
   "activation_recommendations": {
     "create_recommendation": "never_ask",
+    "create_work_areas": "never_ask",
     "get_tool_execution_modes": "never_ask",
     "list_recommendations": "never_ask",
+    "list_work_areas": "never_ask",
     "update_recommendation": "never_ask",
+    "update_work_area": "never_ask",
   },
   "agent_memory": {
     "compact_memory": "never_ask",

--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -14,12 +14,14 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { ActivationRecommendationResource } from "@app/lib/resources/activation_recommendation_resource";
+import { ActivationWorkAreaResource } from "@app/lib/resources/activation_work_area_resource";
 import type { MCPServerConnectionConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -250,6 +252,106 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
           text: `Previous recommendations (${recs.length}):\n${lines.join("\n")}`,
         },
       ]);
+    },
+
+    list_work_areas: async ({ status }, { auth }) => {
+      const rows = await ActivationWorkAreaResource.listByUserAndStatus(auth, {
+        status,
+      });
+
+      if (rows.length === 0) {
+        return new Ok([
+          {
+            type: "text" as const,
+            text:
+              status === "confirmed"
+                ? "No confirmed work areas yet. Phase A bootstrap is needed."
+                : "No work areas found.",
+          },
+        ]);
+      }
+
+      const lines = rows.map(
+        (r, i) =>
+          `${i + 1}. [${r.status}] ${r.sId} — "${r.title}": ${r.description}`
+      );
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Work areas (${rows.length}):\n${lines.join("\n")}`,
+        },
+      ]);
+    },
+
+    create_work_areas: async ({ workAreas }, { auth }) => {
+      const pod = await ActivationPodResource.fetchByUser(auth);
+
+      const created = await concurrentExecutor(
+        workAreas,
+        (item) =>
+          ActivationWorkAreaResource.makeNew(auth, {
+            title: item.title,
+            description: item.description,
+            podId: pod?.id ?? null,
+          }),
+        { concurrency: 8 }
+      );
+
+      const lines = created.map(
+        (r) => `${r.sId} — "${r.title}" (status: candidate)`
+      );
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Created ${created.length} candidate work areas:\n${lines.join("\n")}\n\nPresent these to the user for triage using update_work_area with status='confirmed' or 'dismissed'.`,
+        },
+      ]);
+    },
+
+    update_work_area: async (
+      { workAreaId, status, title, description },
+      { auth }
+    ) => {
+      const row = await ActivationWorkAreaResource.fetchById(auth, workAreaId);
+
+      if (!row) {
+        return new Err(new MCPError(`Work area not found: ${workAreaId}.`));
+      }
+
+      if (row.userId !== auth.getNonNullableUser().id) {
+        return new Err(
+          new MCPError(
+            `Cannot update work area ${workAreaId}: not owned by the calling user.`
+          )
+        );
+      }
+
+      const updateRes = await row.updateFields({
+        status,
+        title,
+        description,
+      });
+
+      if (updateRes.isErr()) {
+        return new Err(
+          new MCPError(`Failed to update work area: ${updateRes.error.message}`)
+        );
+      }
+
+      const parts: string[] = [`Work area ${workAreaId} updated.`];
+      if (status) {
+        parts.push(`Status: ${status}.`);
+      }
+      if (title) {
+        parts.push(`Title updated.`);
+      }
+      if (description) {
+        parts.push(`Intent updated.`);
+      }
+
+      return new Ok([{ type: "text" as const, text: parts.join(" ") }]);
     },
 
     get_tool_execution_modes: async (

--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -263,10 +263,7 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
         return new Ok([
           {
             type: "text" as const,
-            text:
-              status === "confirmed"
-                ? "No confirmed work areas yet. Phase A bootstrap is needed."
-                : "No work areas found.",
+            text: "No work areas found.",
           },
         ]);
       }
@@ -305,7 +302,7 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
       return new Ok([
         {
           type: "text" as const,
-          text: `Created ${created.length} candidate work areas:\n${lines.join("\n")}\n\nPresent these to the user for triage using update_work_area with status='confirmed' or 'dismissed'.`,
+          text: `Created ${created.length} work areas:\n${lines.join("\n")}`,
         },
       ]);
     },
@@ -348,7 +345,7 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
         parts.push(`Title updated.`);
       }
       if (description) {
-        parts.push(`Intent updated.`);
+        parts.push(`Description updated.`);
       }
 
       return new Ok([{ type: "text" as const, text: parts.join(" ") }]);

--- a/front/lib/api/actions/servers/activation_recommendations/metadata.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/metadata.ts
@@ -102,14 +102,6 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
           "Optional short label shown alongside the source icon (e.g. 'Slack', 'GitHub'). " +
             "Can be set independently of sourceIcon."
         ),
-      workAreaId: z
-        .string()
-        .optional()
-        .describe(
-          "Optional sId of the confirmed work area this recommendation serves. " +
-            "Set this when the recommendation was chosen because it advances a specific confirmed work area. " +
-            "Returned by list_work_areas or create_work_areas."
-        ),
     },
     stake: "never_ask",
     toolCostCategory: "basic",
@@ -171,19 +163,13 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
   {
     name: "list_work_areas",
     description:
-      "List work areas for this user. " +
-      "Call at the start of every session to check whether work areas have been confirmed (Phase B) " +
-      "or whether Phase A bootstrap is needed (no confirmed rows). " +
-      "Also call before generating session goals to rank against confirmed work areas.",
+      "List the current user's work areas. Returns each work area's id, " +
+      "title, description, and status.",
     schema: {
       status: z
         .enum(["candidate", "confirmed", "dismissed"])
         .optional()
-        .describe(
-          "Filter by status. Omit to return all. " +
-            "Use 'confirmed' to check if Phase B is active. " +
-            "Use 'candidate' to show triage-pending rows."
-        ),
+        .describe("Only return work areas with this status. Omit for all."),
     },
     stake: "never_ask",
     toolCostCategory: "basic",
@@ -196,9 +182,8 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
   {
     name: "create_work_areas",
     description:
-      "Persist a batch of inferred candidate work areas (Phase A bootstrap). " +
-      "Call after researching the user to create 3-7 candidate rows, then present them for triage. " +
-      "All rows start with status=candidate. Use update_work_area for triage dispositions.",
+      "Create one or more work areas for the current user. Each is created " +
+      "with status 'candidate'. Returns the created work areas with their ids.",
     schema: {
       workAreas: z
         .array(
@@ -212,14 +197,12 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
             description: z
               .string()
               .max(512)
-              .describe(
-                "One sentence describing what good looks like for this work area."
-              ),
+              .describe("One sentence describing what the work area covers."),
           })
         )
         .min(1)
         .max(10)
-        .describe("Batch of candidate work areas to persist."),
+        .describe("The work areas to create."),
     },
     stake: "never_ask",
     toolCostCategory: "basic",
@@ -231,27 +214,15 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
   },
   {
     name: "update_work_area",
-    description:
-      "Update a single work area's status or content (triage disposition or user edit). " +
-      "Use status='confirmed' when the user accepts it, 'dismissed' when they reject it.",
+    description: "Update a single work area's status, title, or description.",
     schema: {
-      workAreaId: z
-        .string()
-        .describe("The sId returned by list_work_areas or create_work_areas."),
+      workAreaId: z.string().describe("The id of the work area to update."),
       status: z
         .enum(["confirmed", "dismissed"])
         .optional()
         .describe("New status for the work area."),
-      title: z
-        .string()
-        .max(255)
-        .optional()
-        .describe("Updated title (user-edited)."),
-      description: z
-        .string()
-        .max(512)
-        .optional()
-        .describe("Updated description (user-edited)."),
+      title: z.string().max(255).optional().describe("New title."),
+      description: z.string().max(512).optional().describe("New description."),
     },
     stake: "never_ask",
     toolCostCategory: "basic",

--- a/front/lib/api/actions/servers/activation_recommendations/metadata.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/metadata.ts
@@ -102,6 +102,14 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
           "Optional short label shown alongside the source icon (e.g. 'Slack', 'GitHub'). " +
             "Can be set independently of sourceIcon."
         ),
+      workAreaId: z
+        .string()
+        .optional()
+        .describe(
+          "Optional sId of the confirmed work area this recommendation serves. " +
+            "Set this when the recommendation was chosen because it advances a specific confirmed work area. " +
+            "Returned by list_work_areas or create_work_areas."
+        ),
     },
     stake: "never_ask",
     toolCostCategory: "basic",
@@ -158,6 +166,99 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
     displayLabels: {
       running: "Fetching recommendation history",
       done: "Recommendation history fetched",
+    },
+  },
+  {
+    name: "list_work_areas",
+    description:
+      "List work areas for this user. " +
+      "Call at the start of every session to check whether work areas have been confirmed (Phase B) " +
+      "or whether Phase A bootstrap is needed (no confirmed rows). " +
+      "Also call before generating session goals to rank against confirmed work areas.",
+    schema: {
+      status: z
+        .enum(["candidate", "confirmed", "dismissed"])
+        .optional()
+        .describe(
+          "Filter by status. Omit to return all. " +
+            "Use 'confirmed' to check if Phase B is active. " +
+            "Use 'candidate' to show triage-pending rows."
+        ),
+    },
+    stake: "never_ask",
+    toolCostCategory: "basic",
+    freeUsage: true,
+    displayLabels: {
+      running: "Fetching work areas",
+      done: "Work areas fetched",
+    },
+  },
+  {
+    name: "create_work_areas",
+    description:
+      "Persist a batch of inferred candidate work areas (Phase A bootstrap). " +
+      "Call after researching the user to create 3-7 candidate rows, then present them for triage. " +
+      "All rows start with status=candidate. Use update_work_area for triage dispositions.",
+    schema: {
+      workAreas: z
+        .array(
+          z.object({
+            title: z
+              .string()
+              .max(255)
+              .describe(
+                "Short name of the work area (e.g. 'Weekly pipeline reporting')."
+              ),
+            description: z
+              .string()
+              .max(512)
+              .describe(
+                "One sentence describing what good looks like for this work area."
+              ),
+          })
+        )
+        .min(1)
+        .max(10)
+        .describe("Batch of candidate work areas to persist."),
+    },
+    stake: "never_ask",
+    toolCostCategory: "basic",
+    freeUsage: true,
+    displayLabels: {
+      running: "Saving work areas",
+      done: "Work areas saved",
+    },
+  },
+  {
+    name: "update_work_area",
+    description:
+      "Update a single work area's status or content (triage disposition or user edit). " +
+      "Use status='confirmed' when the user accepts it, 'dismissed' when they reject it.",
+    schema: {
+      workAreaId: z
+        .string()
+        .describe("The sId returned by list_work_areas or create_work_areas."),
+      status: z
+        .enum(["confirmed", "dismissed"])
+        .optional()
+        .describe("New status for the work area."),
+      title: z
+        .string()
+        .max(255)
+        .optional()
+        .describe("Updated title (user-edited)."),
+      description: z
+        .string()
+        .max(512)
+        .optional()
+        .describe("Updated description (user-edited)."),
+    },
+    stake: "never_ask",
+    toolCostCategory: "basic",
+    freeUsage: true,
+    displayLabels: {
+      running: "Updating work area",
+      done: "Work area updated",
     },
   },
   {


### PR DESCRIPTION
## Summary

- Same as https://github.com/dust-tt/dust/pull/30208/changes#diff-bc5dcd5b03d14d4c41724b690dd502d5c325c4f7dff56f39623a0ed372f259fa, but adds the tools to generate the work areas

## Testing
See https://github.com/dust-tt/dust/pull/30208/changes#diff-bc5dcd5b03d14d4c41724b690dd502d5c325c4f7dff56f39623a0ed372f259fa

## Risk
Low

## deploy
1. Deploy front