### PR TITLE
[front] fix: store unmatched trigger payloads in GCS for iterating on filter

### DIFF
--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -424,45 +424,29 @@ function matchesPayloadFilter({
   return false;
 }
 
-async function filterTriggers({
-  auth,
-  webhookSource,
-  receivedEventValue,
-  webhookRequest,
-  body,
-}: {
-  auth: Authenticator;
-  webhookSource: { id: number; provider: WebhookProvider | null };
-  receivedEventValue: string | null;
-  webhookRequest: WebhookRequestResource;
-  body: Record<string, unknown>;
-}): Promise<Result<WebhookTriggerType[], Error>> {
+async function filterTriggers(
+  auth: Authenticator,
+  {
+    enabledWebhookTriggers,
+    webhookSource,
+    receivedEventValue,
+    webhookRequest,
+    body,
+  }: {
+    enabledWebhookTriggers: TriggerResource[];
+    webhookSource: WebhookSourceResource;
+    receivedEventValue: string | null;
+    webhookRequest: WebhookRequestResource;
+    body: Record<string, unknown>;
+  }
+): Promise<Result<WebhookTriggerType[], Error>> {
   const workspaceId = auth.getNonNullableWorkspace().sId;
-  const webhookRequestId = webhookRequest.id;
   const { provider } = webhookSource;
-  // Fetch all webhook source views for this webhook source.
-  // We use the internal method that skips space permission filtering because:
-  // 1. The webhook request was already authorized via the URL secret.
-  // 2. Webhook source views in private spaces should still trigger their associated agents.
-  const views =
-    await WebhookSourcesViewResource.listByWebhookSourceForInternalProcessing(
-      auth,
-      webhookSource.id
-    );
 
-  // Fetch all triggers based on the webhook source id and flatten the result.
-  const allTriggers = await TriggerResource.listByWebhookSourceViewIds(
-    auth,
-    views.map((view) => view.id)
-  );
-
-  const triggers = allTriggers
-    .flat()
+  const triggers = enabledWebhookTriggers
     .map((t) => t.toJSON())
     // Filter here to avoid a lot of type checking later.
-    .filter(isWebhookTrigger)
-    // Filter out disabled triggers
-    .filter((t) => t.status === "enabled");
+    .filter(isWebhookTrigger);
 
   const filteredTriggers: WebhookTriggerType[] = [];
 
@@ -498,7 +482,7 @@ async function filterTriggers({
       auth,
       trigger,
       workspaceId,
-      webhookRequestId,
+      webhookRequestId: webhookRequest.id,
       provider,
     });
     if (workspaceRateLimitResult.rateLimited) {
@@ -516,7 +500,7 @@ async function filterTriggers({
       auth,
       trigger,
       workspaceId,
-      webhookRequestId,
+      webhookRequestId: webhookRequest.id,
       provider,
     });
     if (triggerRateLimitResult.rateLimited) {
@@ -714,8 +698,27 @@ export async function processWebhookRequest(
     return new Ok({ triggerIds: [] });
   }
 
-  const filteredTriggersResult = await filterTriggers({
+  // Fetch all webhook source views for this webhook source.
+  // We use the internal method that skips space permission filtering because:
+  // 1. The webhook request was already authorized via the URL secret.
+  // 2. Webhook source views in private spaces should still trigger their associated agents.
+  const views =
+    await WebhookSourcesViewResource.listByWebhookSourceForInternalProcessing(
+      auth,
+      webhookSource.id
+    );
+
+  // Fetch all triggers based on the webhook source id and flatten the result.
+  const webhookTriggers = await TriggerResource.listByWebhookSourceViewIds(
     auth,
+    views.map((view) => view.id)
+  );
+  const enabledWebhookTriggers = webhookTriggers.filter(
+    ({ status }) => status === "enabled"
+  );
+
+  const filteredTriggersResult = await filterTriggers(auth, {
+    enabledWebhookTriggers,
     webhookSource,
     receivedEventValue,
     webhookRequest,

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -18,7 +18,6 @@ import {
   checkTriggerForExecutionPerDayLimit,
   checkWebhookRequestForRateLimit,
 } from "@app/lib/triggers/rate_limits";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import { verifySignature } from "@app/lib/webhook_source_server";
 import logger from "@app/logger/logger";
@@ -452,15 +451,12 @@ async function filterTriggers({
     );
 
   // Fetch all triggers based on the webhook source id and flatten the result.
-  const triggers = (
-    await concurrentExecutor(
-      views,
-      async (view) => {
-        return TriggerResource.listByWebhookSourceViewId(auth, view.id);
-      },
-      { concurrency: 10 }
-    )
-  )
+  const allTriggers = await TriggerResource.listByWebhookSourceViewIds(
+    auth,
+    views.map((view) => view.id)
+  );
+
+  const triggers = allTriggers
     .flat()
     .map((t) => t.toJSON())
     // Filter here to avoid a lot of type checking later.

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -717,6 +717,21 @@ export async function processWebhookRequest(
     ({ status }) => status === "enabled"
   );
 
+  if (
+    enabledWebhookTriggers.some(
+      (t) =>
+        "includePayload" in t.configuration && t.configuration.includePayload
+    )
+  ) {
+    await storePayloadInGCS(auth, {
+      webhookSource,
+      webhookRequest,
+      headers,
+      body,
+      provider: webhookSource.provider ?? "custom",
+    });
+  }
+
   const filteredTriggersResult = await filterTriggers(auth, {
     enabledWebhookTriggers,
     webhookSource,
@@ -736,16 +751,6 @@ export async function processWebhookRequest(
     localLogger.info("No triggers matched the webhook request.");
     await webhookRequest.markAsProcessed();
     return new Ok({ triggerIds: [] });
-  }
-
-  if (filteredTriggers.some((t) => t.configuration.includePayload)) {
-    await storePayloadInGCS(auth, {
-      webhookSource,
-      webhookRequest,
-      headers,
-      body,
-      provider: webhookSource.provider ?? "custom",
-    });
   }
 
   const launchResult = await launchTriggersWorkflows(auth, {


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9978

https://github.com/dust-tt/dust/pull/26181 changed the logic for storing trigger payloads to avoid storing excessive amounts of data. It filters out payloads that did not match the filter expression.

This PR changes this behavior to store the payload in GCS as long as one webhook trigger is enabled with `"includePayload"` to true.
The rationale is that even if no trigger matched, we need the payload for the user to iterate on the filter expression. For their first trigger on the webhook source this is currently practically impossible to iterate on the filter.

Also removes an N+1 query.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
