### PR TITLE
[front] feat: wire the usage filter panel into the consumption analytics queries

### DIFF
--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -4,10 +4,8 @@ import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/c
 import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
 import { DEFAULT_CONSUMPTION_DIMENSION } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
 import { UsageFilterPanel } from "@app/components/workspace/analytics/UsageFilterPanel";
-import {
-  toConsumptionScopeFilter,
-  type UsageFilter,
-} from "@app/components/workspace/analytics/usageFilter";
+import type { UsageFilter } from "@app/components/workspace/analytics/usageFilter";
+import { toConsumptionScopeFilter } from "@app/components/workspace/analytics/usageFilter";
 import {
   USAGE_FILTER_MOCK_GROUPS,
   USAGE_FILTER_MOCK_OPTIONS,

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -4,7 +4,10 @@ import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/c
 import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
 import { DEFAULT_CONSUMPTION_DIMENSION } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
 import { UsageFilterPanel } from "@app/components/workspace/analytics/UsageFilterPanel";
-import type { UsageFilter } from "@app/components/workspace/analytics/usageFilter";
+import {
+  toConsumptionScopeFilter,
+  type UsageFilter,
+} from "@app/components/workspace/analytics/usageFilter";
 import {
   USAGE_FILTER_MOCK_GROUPS,
   USAGE_FILTER_MOCK_OPTIONS,
@@ -15,7 +18,7 @@ import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
 import { isNavigationLocked } from "@app/lib/navigation-lock";
 import { BarChart01, cn, Page, SafeSuspense, safeLazy } from "@dust-tt/sparkle";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 const canReload = () => !isNavigationLocked();
 
@@ -44,6 +47,7 @@ export function AnalyticsConsumptionPage() {
     DEFAULT_CONSUMPTION_DIMENSION
   );
   const [filter, setFilter] = useState<UsageFilter>({});
+  const scopeFilter = useMemo(() => toConsumptionScopeFilter(filter), [filter]);
 
   if (!isEnabled) {
     return (
@@ -81,7 +85,11 @@ export function AnalyticsConsumptionPage() {
         icon={BarChart01}
       />
       <div className="flex flex-col gap-8 pb-8">
-        <ConsumptionOverview workspaceId={owner.sId} period={period} />
+        <ConsumptionOverview
+          workspaceId={owner.sId}
+          period={period}
+          filter={scopeFilter}
+        />
         <div className="flex flex-col gap-2">
           <div className="flex justify-end">
             <UsageFilterPanel
@@ -97,12 +105,14 @@ export function AnalyticsConsumptionPage() {
               workspaceId={owner.sId}
               period={period}
               dimension={dimension}
+              filter={scopeFilter}
             />
           </SafeSuspense>
         </div>
         <ConsumptionAttributionTable
           workspaceId={owner.sId}
           period={period}
+          filter={scopeFilter}
           dimension={dimension}
           onDimensionChange={setDimension}
         />

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -3,6 +3,7 @@ import type { ConsumptionTopRow } from "@app/hooks/useConsumptionTop";
 import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
 import { useDebounce } from "@app/hooks/useDebounce";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { formatCredits } from "@app/lib/client/credits";
 import {
   cn,
@@ -119,6 +120,7 @@ interface AttributionRowsProps {
   workspaceId: string;
   dimension: ConsumptionDimension;
   period: ConsumptionPeriodSelection;
+  filter?: ConsumptionScopeFilter;
   search: string;
 }
 
@@ -126,6 +128,7 @@ function AttributionRows({
   workspaceId,
   dimension,
   period,
+  filter,
   search,
 }: AttributionRowsProps) {
   const { hasAvatar, avgLabel } = CONSUMPTION_DIMENSION_CONFIG[dimension];
@@ -140,6 +143,7 @@ function AttributionRows({
     dimension,
     period,
     limit: TOP_LIMIT,
+    filter,
   });
 
   // Client-side filter over the loaded ranking. A row outside the top
@@ -186,6 +190,8 @@ function AttributionRows({
 interface ConsumptionAttributionTableProps {
   workspaceId: string;
   period: ConsumptionPeriodSelection;
+  filter?: ConsumptionScopeFilter;
+  // Owned by the page: the selected tab also drives the chart's breakdown.
   dimension: ConsumptionDimension;
   onDimensionChange: (dimension: ConsumptionDimension) => void;
 }
@@ -193,6 +199,7 @@ interface ConsumptionAttributionTableProps {
 export function ConsumptionAttributionTable({
   workspaceId,
   period,
+  filter,
   dimension,
   onDimensionChange,
 }: ConsumptionAttributionTableProps) {
@@ -235,6 +242,7 @@ export function ConsumptionAttributionTable({
           workspaceId={workspaceId}
           dimension={dimension}
           period={period}
+          filter={filter}
           search={debouncedValue}
         />
       </div>

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -6,6 +6,7 @@ import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
 import { useConsumptionTimeseries } from "@app/hooks/useConsumptionTimeseries";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { formatConsumptionDate } from "@app/lib/analytics/consumption_period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import type {
   ConsumptionTimeseriesGroup,
   ConsumptionTimeseriesPoint,
@@ -116,12 +117,14 @@ interface ConsumptionChartProps {
   workspaceId: string;
   period: ConsumptionPeriodSelection;
   dimension: ConsumptionDimension;
+  filter?: ConsumptionScopeFilter;
 }
 
 export function ConsumptionChart({
   workspaceId,
   period,
   dimension,
+  filter,
 }: ConsumptionChartProps) {
   const { timeseries, isTimeseriesLoading, isTimeseriesError } =
     useConsumptionTimeseries({
@@ -129,6 +132,7 @@ export function ConsumptionChart({
       period,
       mode: "daily",
       breakdownBy: dimension,
+      filter,
     });
 
   const groups = useMemo(() => timeseries?.groups ?? [], [timeseries]);

--- a/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
@@ -1,19 +1,22 @@
 import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { formatConsumptionDate } from "@app/lib/analytics/consumption_period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { timeAgoFrom } from "@app/lib/utils";
 
 interface ConsumptionOverviewProps {
   workspaceId: string;
   period: ConsumptionPeriodSelection;
+  filter?: ConsumptionScopeFilter;
 }
 
 export function ConsumptionOverview({
   workspaceId,
   period: periodSelection,
+  filter,
 }: ConsumptionOverviewProps) {
   const { overview, isOverviewLoading, isOverviewError } =
-    useConsumptionOverview({ workspaceId, period: periodSelection });
+    useConsumptionOverview({ workspaceId, period: periodSelection, filter });
 
   if (isOverviewLoading) {
     return (

--- a/front/components/workspace/analytics/usageFilter.ts
+++ b/front/components/workspace/analytics/usageFilter.ts
@@ -1,3 +1,4 @@
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import type { ModelMakerIdType } from "@app/types/assistant/models/types";
 import type { ConnectorProvider } from "@app/types/data_source";
 
@@ -153,4 +154,13 @@ export function removeUsageFilterGroup(
   id: string
 ): UsageFilterGroup[] {
   return groups.filter((g) => g.id !== id);
+}
+
+// Only "member" is wired to a real consumption scope dimension ("user") so
+// far; the other categories stay mock data and are not sent as query filters.
+export function toConsumptionScopeFilter(
+  filter: UsageFilter
+): ConsumptionScopeFilter {
+  const memberIds = filter.member?.map((entity) => entity.id);
+  return memberIds && memberIds.length > 0 ? { user: memberIds } : {};
 }

--- a/front/hooks/useConsumptionOverview.ts
+++ b/front/hooks/useConsumptionOverview.ts
@@ -1,23 +1,26 @@
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { consumptionQueryString } from "@app/lib/analytics/consumption_period";
 import type { GetConsumptionOverviewResponse } from "@app/lib/api/analytics/consumption/overview";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { Fetcher } from "swr";
 
 export function useConsumptionOverview({
   workspaceId,
   period,
+  filter,
   disabled,
 }: {
   workspaceId: string;
   period: ConsumptionPeriodSelection;
+  filter?: ConsumptionScopeFilter;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const overviewFetcher: Fetcher<GetConsumptionOverviewResponse> = fetcher;
 
   const { data, error, isValidating } = useSWRWithDefaults(
-    `/api/w/${workspaceId}/analytics/consumption/overview?${consumptionQueryString(period)}`,
+    `/api/w/${workspaceId}/analytics/consumption/overview?${consumptionQueryString(period, filter)}`,
     overviewFetcher,
     { disabled }
   );

--- a/front/hooks/useConsumptionTimeseries.ts
+++ b/front/hooks/useConsumptionTimeseries.ts
@@ -1,5 +1,6 @@
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { consumptionQueryString } from "@app/lib/analytics/consumption_period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import type {
   ConsumptionBreakdownDimension,
   ConsumptionTimeseriesMode,
@@ -14,6 +15,7 @@ export function useConsumptionTimeseries({
   mode,
   breakdownBy,
   breakdownCount,
+  filter,
   disabled,
 }: {
   workspaceId: string;
@@ -22,12 +24,13 @@ export function useConsumptionTimeseries({
   // Omit for a single total series.
   breakdownBy?: ConsumptionBreakdownDimension;
   breakdownCount?: number;
+  filter?: ConsumptionScopeFilter;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const timeseriesFetcher: Fetcher<GetConsumptionTimeseriesResponse> = fetcher;
 
-  const params = new URLSearchParams(consumptionQueryString(period));
+  const params = new URLSearchParams(consumptionQueryString(period, filter));
   params.set("mode", mode);
   if (breakdownBy) {
     params.set("breakdownBy", breakdownBy);

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -1,6 +1,9 @@
 import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { consumptionQueryString } from "@app/lib/analytics/consumption_period";
+// Type-only: importing a value from these modules would pull the Elasticsearch
+// client into the browser bundle (see the note in `series.ts`).
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import type { GetConsumptionTopAgentsResponse } from "@app/lib/api/analytics/consumption/top_agents";
 import type { GetConsumptionTopModelsResponse } from "@app/lib/api/analytics/consumption/top_models";
 import type { GetConsumptionTopSkillsResponse } from "@app/lib/api/analytics/consumption/top_skills";
@@ -104,18 +107,20 @@ export function useConsumptionTop({
   dimension,
   period,
   limit,
+  filter,
   disabled,
 }: {
   workspaceId: string;
   dimension: ConsumptionDimension;
   period: ConsumptionPeriodSelection;
   limit: number;
+  filter?: ConsumptionScopeFilter;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const topFetcher: Fetcher<ConsumptionTopResponse> = fetcher;
 
-  const params = new URLSearchParams(consumptionQueryString(period));
+  const params = new URLSearchParams(consumptionQueryString(period, filter));
   params.set("limit", String(limit));
 
   const { data, error, isValidating } = useSWRWithDefaults(

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -1,8 +1,6 @@
 import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { consumptionQueryString } from "@app/lib/analytics/consumption_period";
-// Type-only: importing a value from these modules would pull the Elasticsearch
-// client into the browser bundle (see the note in `series.ts`).
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import type { GetConsumptionTopAgentsResponse } from "@app/lib/api/analytics/consumption/top_agents";
 import type { GetConsumptionTopModelsResponse } from "@app/lib/api/analytics/consumption/top_models";

--- a/front/lib/analytics/consumption_period.ts
+++ b/front/lib/analytics/consumption_period.ts
@@ -1,3 +1,5 @@
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+
 export const CONSUMPTION_PERIOD_DAY_OPTIONS = [7, 30, 90] as const;
 
 export type ConsumptionPeriodDays =
@@ -57,11 +59,15 @@ export function consumptionPeriodFromKey(
  * the window would show numbers that do not add up.
  */
 export function consumptionQueryString(
-  selection: ConsumptionPeriodSelection
+  selection: ConsumptionPeriodSelection,
+  filter?: ConsumptionScopeFilter
 ): string {
   const params = new URLSearchParams({ period: selection.kind });
   if (selection.kind === "days") {
     params.set("days", String(selection.days));
+  }
+  if (filter && Object.keys(filter).length > 0) {
+    params.set("filter", JSON.stringify(filter));
   }
   return params.toString();
 }


### PR DESCRIPTION
## Description

Introduces toConsumptionScopeFilter, translating the panel's UsageFilter state into a ConsumptionScopeFilter, and threads it from AnalyticsConsumptionPage through to the overview, chart and attribution table queries.

## Tests

## Risk

## Deploy Plan

- Deploy front
