### PR TITLE
[front] enh: show agent questions in the input bar

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -545,7 +545,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
             />
           )}
       </div>
-      {blockedActions.length > 0 && !userAnswerRequiredItem (
+      {blockedActions.length > 0 && !userAnswerRequiredItem && (
         <ContentMessageInline
           icon={InfoCircle}
           variant="primary"

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -545,7 +545,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
             />
           )}
       </div>
-      {blockedActions.length > 0 && (
+      {blockedActions.length > 0 && !userAnswerRequiredItem (
         <ContentMessageInline
           icon={InfoCircle}
           variant="primary"

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -46,12 +46,8 @@ import {
   useVirtuosoLocation,
   useVirtuosoMethods,
 } from "@virtuoso.dev/message-list";
-import {
-  AnimatePresence,
-  motion,
-  type Transition,
-  useReducedMotion,
-} from "framer-motion";
+import type { Transition } from "framer-motion";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 const MAX_DISTANCE_FOR_SMOOTH_SCROLL = 2048;

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -41,6 +41,8 @@ import {
   ContentMessageInline,
   EmptyCTA,
   InfoCircle,
+  MOTION_DURATIONS,
+  MOTION_EASINGS,
 } from "@dust-tt/sparkle";
 import {
   useVirtuosoLocation,
@@ -53,16 +55,6 @@ import { useEffect, useMemo, useRef, useState } from "react";
 const MAX_DISTANCE_FOR_SMOOTH_SCROLL = 2048;
 const DOUBLE_ESC_WINDOW_MS = 300;
 
-// Framer Motion requires numeric durations and Bezier tuples. Keep these
-// aligned with Sparkle's semantic motion tokens.
-const SPARKLE_MOTION = {
-  duration: { enter: 0.2, exit: 0.16 },
-  ease: {
-    enter: [0.215, 0.61, 0.355, 1],
-    move: [0.455, 0.03, 0.515, 0.955],
-  },
-} as const;
-
 const INPUT_BAR_SWAP_TRANSFORMS = {
   initial: "translateY(calc(var(--spacing) * 2))",
   idle: "translateY(calc(var(--spacing) * 0))",
@@ -70,17 +62,17 @@ const INPUT_BAR_SWAP_TRANSFORMS = {
 } as const;
 
 const INPUT_BAR_SWAP_TRANSITION = {
-  duration: SPARKLE_MOTION.duration.enter,
-  ease: SPARKLE_MOTION.ease.enter,
+  duration: MOTION_DURATIONS.enter,
+  ease: MOTION_EASINGS.enter,
   layout: {
-    duration: SPARKLE_MOTION.duration.enter,
-    ease: SPARKLE_MOTION.ease.move,
+    duration: MOTION_DURATIONS.enter,
+    ease: MOTION_EASINGS.move,
   },
 } satisfies Transition;
 
 const INPUT_BAR_SWAP_EXIT_TRANSITION = {
-  duration: SPARKLE_MOTION.duration.exit,
-  ease: SPARKLE_MOTION.ease.enter,
+  duration: MOTION_DURATIONS.exit,
+  ease: MOTION_EASINGS.enter,
 } satisfies Transition;
 
 interface AgentInputBarProps {

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -46,10 +46,30 @@ import {
   useVirtuosoLocation,
   useVirtuosoMethods,
 } from "@virtuoso.dev/message-list";
+import {
+  AnimatePresence,
+  motion,
+  type Transition,
+  useReducedMotion,
+} from "framer-motion";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 const MAX_DISTANCE_FOR_SMOOTH_SCROLL = 2048;
 const DOUBLE_ESC_WINDOW_MS = 300;
+const INPUT_BAR_SWAP_TRANSITION = {
+  layout: {
+    duration: 0.2,
+    ease: [0.455, 0.03, 0.515, 0.955],
+  },
+  opacity: {
+    duration: 0.2,
+    ease: [0.215, 0.61, 0.355, 1],
+  },
+  transform: {
+    duration: 0.2,
+    ease: [0.215, 0.61, 0.355, 1],
+  },
+} satisfies Transition;
 
 interface AgentInputBarProps {
   context: VirtuosoMessageListContext;
@@ -80,6 +100,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
   const agentBuilderContext = context.agentBuilderContext;
 
   const isMobile = useIsMobile();
+  const shouldReduceMotion = useReducedMotion();
   const accessibleAgentIds = useAccessibleAgentIds({
     workspaceId: context.owner.sId,
   });
@@ -306,6 +327,8 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
   const userAnswerRequiredItem = blockedActionItems.find(
     (item) => item.blockedAction.status === "blocked_user_answer_required"
   );
+  const inputBarContentKey =
+    userAnswerRequiredItem?.blockedAction.actionId ?? "input-bar";
 
   // Keep blockedActionIndex in sync when blockedActions array changes.
   useEffect(() => {
@@ -619,46 +642,75 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
             "flex items-center gap-2"
         )}
       >
-        {userAnswerRequiredItem?.blockedAction.status ===
-        "blocked_user_answer_required" ? (
-          <UserAnswerRequired
-            key={userAnswerRequiredItem.blockedAction.actionId}
-            blockedAction={userAnswerRequiredItem.blockedAction}
-            triggeringUser={
-              userAnswerRequiredItem.blockedAction.userId === context.user.sId
-                ? context.user
-                : null
+        <AnimatePresence initial={false} mode="popLayout" anchorY="bottom">
+          <motion.div
+            key={inputBarContentKey}
+            layoutId={
+              shouldReduceMotion
+                ? undefined
+                : `${context.draftKey}-input-bar-content`
             }
-            owner={context.owner}
-            retryHandler={retryUserAnswerRequired}
-          />
-        ) : (
-          <InputBar
-            owner={context.owner}
-            user={context.user}
-            onSubmit={context.handleSubmit}
-            stickyMentions={autoMentions}
-            lastRequestedModel={lastRequestedModel}
-            conversation={context.conversation}
-            draftKey={context.draftKey}
-            disableAutoFocus={isMobile}
-            disableUserMentions={!!agentBuilderContext}
-            disableAgentMentions={
-              agentBuilderContext?.disableAgentMentions === true
+            initial={
+              shouldReduceMotion
+                ? false
+                : { opacity: 0, transform: "translateY(8px)" }
             }
-            actions={agentBuilderContext?.actionsToShow}
-            isSubmitting={agentBuilderContext?.isSubmitting === true}
-            isAgentBuilder={!!agentBuilderContext}
-            submitBlockMessage={
-              forkBlockMessage ?? wakeUpBlockMessage ?? compactionBlockMessage
+            animate={{ opacity: 1, transform: "translateY(0px)" }}
+            exit={
+              shouldReduceMotion
+                ? undefined
+                : { opacity: 0, transform: "translateY(-4px)" }
             }
-            effectiveIsCompact={effectiveIsCompact}
-            onExpandInputBar={expandInputBar}
-            onEditorFocusChange={onEditorFocusChange}
-            onOverlayOpenChange={onOverlayOpenChange}
-            onVoiceActiveChange={onVoiceActiveChange}
-          />
-        )}
+            transition={INPUT_BAR_SWAP_TRANSITION}
+            className={classNames(
+              "w-full",
+              effectiveIsCompact && !userAnswerRequiredItem && "min-w-0 flex-1"
+            )}
+          >
+            {userAnswerRequiredItem?.blockedAction.status ===
+            "blocked_user_answer_required" ? (
+              <UserAnswerRequired
+                blockedAction={userAnswerRequiredItem.blockedAction}
+                triggeringUser={
+                  userAnswerRequiredItem.blockedAction.userId ===
+                  context.user.sId
+                    ? context.user
+                    : null
+                }
+                owner={context.owner}
+                retryHandler={retryUserAnswerRequired}
+              />
+            ) : (
+              <InputBar
+                owner={context.owner}
+                user={context.user}
+                onSubmit={context.handleSubmit}
+                stickyMentions={autoMentions}
+                lastRequestedModel={lastRequestedModel}
+                conversation={context.conversation}
+                draftKey={context.draftKey}
+                disableAutoFocus={isMobile}
+                disableUserMentions={!!agentBuilderContext}
+                disableAgentMentions={
+                  agentBuilderContext?.disableAgentMentions === true
+                }
+                actions={agentBuilderContext?.actionsToShow}
+                isSubmitting={agentBuilderContext?.isSubmitting === true}
+                isAgentBuilder={!!agentBuilderContext}
+                submitBlockMessage={
+                  forkBlockMessage ??
+                  wakeUpBlockMessage ??
+                  compactionBlockMessage
+                }
+                effectiveIsCompact={effectiveIsCompact}
+                onExpandInputBar={expandInputBar}
+                onEditorFocusChange={onEditorFocusChange}
+                onOverlayOpenChange={onOverlayOpenChange}
+                onVoiceActiveChange={onVoiceActiveChange}
+              />
+            )}
+          </motion.div>
+        </AnimatePresence>
         {effectiveIsCompact &&
           !userAnswerRequiredItem &&
           showNavigationContainer && (

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -16,6 +16,7 @@ import {
   isHiddenMessage,
   isUserMessage,
 } from "@app/components/assistant/conversation/types";
+import { UserAnswerRequired } from "@app/components/assistant/conversation/UserAnswerRequired";
 import { WakeUpBanner } from "@app/components/assistant/conversation/WakeUpBanner";
 import { PodJoinCTA } from "@app/components/pod/conversation/PodJoinCTA";
 import {
@@ -24,6 +25,7 @@ import {
   useConversationContextUsage,
 } from "@app/hooks/conversations";
 import { CONTEXT_USAGE_PERCENT_THRESHOLDS } from "@app/hooks/conversations/useConversationContextUsage";
+import { useRetryMessage } from "@app/hooks/useRetryMessage";
 import { useAccessibleAgentIds } from "@app/lib/swr/assistants";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { useConversationWakeUps } from "@app/lib/swr/wakeups";
@@ -61,7 +63,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
   const pendingActionRef = useRef(pendingAction);
   pendingActionRef.current = pendingAction;
   const generationContext = useGenerationContext();
-  const { getBlockedActions, hasPendingValidations, startPulsingAction } =
+  const { getBlockedActionItems, hasPendingValidations, startPulsingAction } =
     useBlockedActionsContext();
 
   const { mutateConversation } = useConversation({
@@ -73,6 +75,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     owner: context.owner,
     conversationId: context.conversation?.sId,
   });
+  const retryMessage = useRetryMessage({ owner: context.owner });
 
   const agentBuilderContext = context.agentBuilderContext;
 
@@ -298,9 +301,10 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     };
   }, [methods, listOffset, visibleListHeight, bottomOffset]);
 
-  const blockedActions = getBlockedActions(context.user.sId);
-  const hasUserAnswerRequired = blockedActions.some(
-    (action) => action.status === "blocked_user_answer_required"
+  const blockedActionItems = getBlockedActionItems(context.user.sId);
+  const blockedActions = blockedActionItems.map((item) => item.blockedAction);
+  const userAnswerRequiredItem = blockedActionItems.find(
+    (item) => item.blockedAction.status === "blocked_user_answer_required"
   );
 
   // Keep blockedActionIndex in sync when blockedActions array changes.
@@ -448,6 +452,57 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     }
   };
 
+  const retryUserAnswerRequired = async () => {
+    if (!context.conversation || !userAnswerRequiredItem) {
+      return;
+    }
+
+    const { blockedAction, messageId: outerMessageId } = userAnswerRequiredItem;
+
+    methods.data.map((message) =>
+      isAgentMessageWithStreaming(message) && message.sId === outerMessageId
+        ? {
+            ...message,
+            status: "created",
+            error: null,
+            streaming: {
+              ...message.streaming,
+              agentState: "acting",
+            },
+          }
+        : message
+    );
+
+    const retryBlockedMessage = async ({
+      conversationId,
+      messageId,
+    }: {
+      conversationId: string;
+      messageId: string;
+    }) => {
+      const result = await retryMessage({
+        conversationId,
+        messageId,
+        blockedOnly: true,
+      });
+      if (result.isErr()) {
+        context.setLimitReachedCode?.(result.error);
+      }
+    };
+
+    if (blockedAction.conversationId !== context.conversation.sId) {
+      await retryBlockedMessage({
+        conversationId: blockedAction.conversationId,
+        messageId: blockedAction.messageId,
+      });
+    }
+
+    await retryBlockedMessage({
+      conversationId: context.conversation.sId,
+      messageId: outerMessageId,
+    });
+  };
+
   const messageNavigationProps = {
     showStopButton,
     showMessageNavigation,
@@ -482,12 +537,13 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
       )}
     >
       <div className="flex w-full justify-center gap-2">
-        {showNavigationContainer && !effectiveIsCompact && (
-          <InputBarMessageNavigation
-            variant="floating"
-            {...messageNavigationProps}
-          />
-        )}
+        {showNavigationContainer &&
+          (!effectiveIsCompact || !!userAnswerRequiredItem) && (
+            <InputBarMessageNavigation
+              variant="floating"
+              {...messageNavigationProps}
+            />
+          )}
       </div>
       {blockedActions.length > 0 && (
         <ContentMessageInline
@@ -507,15 +563,14 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
               variant="outline"
               size="xs"
               onClick={() => {
-                const blockedAction = blockedActions[blockedActionIndex];
-                const blockedActionTargetMessageId = blockedAction.messageId;
+                const { blockedAction, messageId: outerMessageId } =
+                  blockedActionItems[blockedActionIndex];
 
                 startPulsingAction(blockedAction.actionId);
 
                 const blockedActionMessageIndex = methods.data.findIndex(
                   (m) =>
-                    isAgentMessageWithStreaming(m) &&
-                    blockedActionTargetMessageId === m.sId
+                    isAgentMessageWithStreaming(m) && outerMessageId === m.sId
                 );
 
                 methods.scrollToItem({
@@ -559,44 +614,63 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
       <div
         className={classNames(
           "relative w-full",
-          effectiveIsCompact && "flex items-center gap-2"
+          effectiveIsCompact &&
+            !userAnswerRequiredItem &&
+            "flex items-center gap-2"
         )}
       >
-        <InputBar
-          owner={context.owner}
-          user={context.user}
-          onSubmit={context.handleSubmit}
-          stickyMentions={autoMentions}
-          lastRequestedModel={lastRequestedModel}
-          conversation={context.conversation}
-          draftKey={context.draftKey}
-          disableAutoFocus={isMobile || hasUserAnswerRequired}
-          disableUserMentions={!!agentBuilderContext}
-          disableAgentMentions={
-            agentBuilderContext?.disableAgentMentions === true
-          }
-          actions={agentBuilderContext?.actionsToShow}
-          isSubmitting={agentBuilderContext?.isSubmitting === true}
-          isAgentBuilder={!!agentBuilderContext}
-          submitBlockMessage={
-            forkBlockMessage ?? wakeUpBlockMessage ?? compactionBlockMessage
-          }
-          effectiveIsCompact={effectiveIsCompact}
-          onExpandInputBar={expandInputBar}
-          onEditorFocusChange={onEditorFocusChange}
-          onOverlayOpenChange={onOverlayOpenChange}
-          onVoiceActiveChange={onVoiceActiveChange}
-        />
-        {effectiveIsCompact && showNavigationContainer && (
-          <div className="shrink-0">
-            <div className={INPUT_BAR_COMPACT_NAV_ENTER_ANIMATION_CLASSES}>
-              <InputBarMessageNavigation
-                variant="compact"
-                {...messageNavigationProps}
-              />
-            </div>
-          </div>
+        {userAnswerRequiredItem?.blockedAction.status ===
+        "blocked_user_answer_required" ? (
+          <UserAnswerRequired
+            key={userAnswerRequiredItem.blockedAction.actionId}
+            blockedAction={userAnswerRequiredItem.blockedAction}
+            triggeringUser={
+              userAnswerRequiredItem.blockedAction.userId === context.user.sId
+                ? context.user
+                : null
+            }
+            owner={context.owner}
+            retryHandler={retryUserAnswerRequired}
+          />
+        ) : (
+          <InputBar
+            owner={context.owner}
+            user={context.user}
+            onSubmit={context.handleSubmit}
+            stickyMentions={autoMentions}
+            lastRequestedModel={lastRequestedModel}
+            conversation={context.conversation}
+            draftKey={context.draftKey}
+            disableAutoFocus={isMobile}
+            disableUserMentions={!!agentBuilderContext}
+            disableAgentMentions={
+              agentBuilderContext?.disableAgentMentions === true
+            }
+            actions={agentBuilderContext?.actionsToShow}
+            isSubmitting={agentBuilderContext?.isSubmitting === true}
+            isAgentBuilder={!!agentBuilderContext}
+            submitBlockMessage={
+              forkBlockMessage ?? wakeUpBlockMessage ?? compactionBlockMessage
+            }
+            effectiveIsCompact={effectiveIsCompact}
+            onExpandInputBar={expandInputBar}
+            onEditorFocusChange={onEditorFocusChange}
+            onOverlayOpenChange={onOverlayOpenChange}
+            onVoiceActiveChange={onVoiceActiveChange}
+          />
         )}
+        {effectiveIsCompact &&
+          !userAnswerRequiredItem &&
+          showNavigationContainer && (
+            <div className="shrink-0">
+              <div className={INPUT_BAR_COMPACT_NAV_ENTER_ANIMATION_CLASSES}>
+                <InputBarMessageNavigation
+                  variant="compact"
+                  {...messageNavigationProps}
+                />
+              </div>
+            </div>
+          )}
       </div>
     </div>
   );

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -679,6 +679,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
                 }
                 owner={context.owner}
                 retryHandler={retryUserAnswerRequired}
+                isMobile={isMobile}
               />
             ) : (
               <InputBar

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -52,19 +52,35 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 const MAX_DISTANCE_FOR_SMOOTH_SCROLL = 2048;
 const DOUBLE_ESC_WINDOW_MS = 300;
+
+// Framer Motion requires numeric durations and Bezier tuples. Keep these
+// aligned with Sparkle's semantic motion tokens.
+const SPARKLE_MOTION = {
+  duration: { enter: 0.2, exit: 0.16 },
+  ease: {
+    enter: [0.215, 0.61, 0.355, 1],
+    move: [0.455, 0.03, 0.515, 0.955],
+  },
+} as const;
+
+const INPUT_BAR_SWAP_TRANSFORMS = {
+  initial: "translateY(calc(var(--spacing) * 2))",
+  idle: "translateY(calc(var(--spacing) * 0))",
+  exit: "translateY(calc(var(--spacing) * -1))",
+} as const;
+
 const INPUT_BAR_SWAP_TRANSITION = {
+  duration: SPARKLE_MOTION.duration.enter,
+  ease: SPARKLE_MOTION.ease.enter,
   layout: {
-    duration: 0.2,
-    ease: [0.455, 0.03, 0.515, 0.955],
+    duration: SPARKLE_MOTION.duration.enter,
+    ease: SPARKLE_MOTION.ease.move,
   },
-  opacity: {
-    duration: 0.2,
-    ease: [0.215, 0.61, 0.355, 1],
-  },
-  transform: {
-    duration: 0.2,
-    ease: [0.215, 0.61, 0.355, 1],
-  },
+} satisfies Transition;
+
+const INPUT_BAR_SWAP_EXIT_TRANSITION = {
+  duration: SPARKLE_MOTION.duration.exit,
+  ease: SPARKLE_MOTION.ease.enter,
 } satisfies Transition;
 
 interface AgentInputBarProps {
@@ -649,13 +665,20 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
             initial={
               shouldReduceMotion
                 ? false
-                : { opacity: 0, transform: "translateY(8px)" }
+                : { opacity: 0, transform: INPUT_BAR_SWAP_TRANSFORMS.initial }
             }
-            animate={{ opacity: 1, transform: "translateY(0px)" }}
+            animate={{
+              opacity: 1,
+              transform: INPUT_BAR_SWAP_TRANSFORMS.idle,
+            }}
             exit={
               shouldReduceMotion
                 ? undefined
-                : { opacity: 0, transform: "translateY(-4px)" }
+                : {
+                    opacity: 0,
+                    transform: INPUT_BAR_SWAP_TRANSFORMS.exit,
+                    transition: INPUT_BAR_SWAP_EXIT_TRANSITION,
+                  }
             }
             transition={INPUT_BAR_SWAP_TRANSITION}
             className={classNames(

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -679,7 +679,6 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
                 }
                 owner={context.owner}
                 retryHandler={retryUserAnswerRequired}
-                isMobile={isMobile}
               />
             ) : (
               <InputBar

--- a/front/components/assistant/conversation/BlockedAction.tsx
+++ b/front/components/assistant/conversation/BlockedAction.tsx
@@ -3,6 +3,8 @@ import { MCPServerPersonalAuthenticationRequired } from "@app/components/assista
 import { MCPToolValidationRequired } from "@app/components/assistant/conversation/MCPToolValidationRequired";
 import { UserAnswerRequired } from "@app/components/assistant/conversation/UserAnswerRequired";
 import type { AgentLoopBlockedToolExecution } from "@app/lib/actions/mcp";
+import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 
@@ -24,6 +26,8 @@ export function BlockedAction({
   conversationId,
   retryHandler,
 }: BlockedActionProps) {
+  const { user } = useAuth();
+
   switch (blockedAction.status) {
     case "blocked_validation_required":
       return (
@@ -65,6 +69,15 @@ export function BlockedAction({
       );
 
     case "blocked_user_answer_required":
+      if (
+        canCurrentUserRespondToParentUserMessage({
+          parentUserId: blockedAction.userId,
+          currentUserId: user?.sId,
+        })
+      ) {
+        return null;
+      }
+
       return (
         <UserAnswerRequired
           blockedAction={blockedAction}

--- a/front/components/assistant/conversation/BlockedActionsProvider.test.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.test.tsx
@@ -87,16 +87,24 @@ function makeAuthBlockedAction(
 
 function Consumer() {
   const {
+    getBlockedActionItems,
     getFirstBlockedActionForMessage,
     refreshBlockedActions,
     removeCompletedAction,
   } = useBlockedActionsContext();
 
   const firstAction = getFirstBlockedActionForMessage("msg_1");
+  const firstActionItem = getBlockedActionItems("user_1")[0];
 
   return (
     <div>
       <span data-testid="first-action">{firstAction?.actionId ?? "none"}</span>
+      <span data-testid="outer-message-id">
+        {firstActionItem?.messageId ?? "none"}
+      </span>
+      <span data-testid="blocked-message-id">
+        {firstActionItem?.blockedAction.messageId ?? "none"}
+      </span>
       <button
         type="button"
         onClick={() => {
@@ -168,5 +176,31 @@ describe("BlockedActionsProvider", () => {
     await user.click(screen.getByRole("button", { name: "refresh" }));
 
     expect(mutateBlockedActionsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the outer message id for a nested blocked action", () => {
+    const childAction = {
+      ...makeAuthBlockedAction("action_child"),
+      conversationId: "conv_child",
+      messageId: "msg_child",
+    };
+    const parentAction: AgentLoopBlockedToolExecution = {
+      ...makeAuthBlockedAction("action_parent"),
+      messageId: "msg_parent",
+      status: "blocked_child_action_input_required",
+      authorizationInfo: null,
+      resumeState: null,
+      childBlockedActionsList: [childAction],
+    };
+    blockedActionsMock = [parentAction];
+
+    renderProvider();
+
+    expect(screen.getByTestId("outer-message-id")).toHaveTextContent(
+      "msg_parent"
+    );
+    expect(screen.getByTestId("blocked-message-id")).toHaveTextContent(
+      "msg_child"
+    );
   });
 });

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -36,6 +36,7 @@ type BlockedActionsContextType = {
   }) => void;
   hasPendingValidations: (userId: string) => boolean;
   getBlockedActions: (userId: string) => AgentLoopBlockedToolExecution[];
+  getBlockedActionItems: (userId: string) => BlockedActionQueueItem[];
   getFirstBlockedActionForMessage: (
     messageId: string
   ) => AgentLoopBlockedToolExecution | undefined;
@@ -223,18 +224,22 @@ export function BlockedActionsProvider({
     [blockedActionsQueue]
   );
 
-  const getBlockedActions = useCallback(
+  const getBlockedActionItems = useCallback(
     (userId: string) => {
-      return blockedActionsQueue
-        .filter((action) =>
-          canCurrentUserRespondToParentUserMessage({
-            parentUserId: action.blockedAction.userId,
-            currentUserId: userId,
-          })
-        )
-        .map((action) => action.blockedAction);
+      return blockedActionsQueue.filter((action) =>
+        canCurrentUserRespondToParentUserMessage({
+          parentUserId: action.blockedAction.userId,
+          currentUserId: userId,
+        })
+      );
     },
     [blockedActionsQueue]
+  );
+
+  const getBlockedActions = useCallback(
+    (userId: string) =>
+      getBlockedActionItems(userId).map((action) => action.blockedAction),
+    [getBlockedActionItems]
   );
 
   const { mutateConversations } = useConversations({
@@ -295,6 +300,7 @@ export function BlockedActionsProvider({
       removeAllBlockedActionsForMessage,
       hasPendingValidations,
       getBlockedActions,
+      getBlockedActionItems,
       getFirstBlockedActionForMessage,
       startPulsingAction,
       stopPulsingAction,
@@ -307,6 +313,7 @@ export function BlockedActionsProvider({
       removeAllBlockedActionsForMessage,
       hasPendingValidations,
       getBlockedActions,
+      getBlockedActionItems,
       getFirstBlockedActionForMessage,
       startPulsingAction,
       stopPulsingAction,

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -18,6 +18,7 @@ interface UserAnswerRequiredProps {
   triggeringUser: UserType | null;
   owner: LightWorkspaceType;
   retryHandler: () => Promise<void>;
+  isMobile?: boolean;
 }
 
 type SubmissionState = {
@@ -44,6 +45,7 @@ export function UserAnswerRequired({
   triggeringUser,
   owner,
   retryHandler,
+  isMobile = false,
 }: UserAnswerRequiredProps) {
   const { user } = useAuth();
   const { removeCompletedAction } = useBlockedActionsContext();
@@ -288,7 +290,7 @@ export function UserAnswerRequired({
         }
       }}
       className={cn(
-        "flex flex-col gap-4 rounded-2xl border border-dark bg-background p-5 outline-hidden",
+        "flex flex-col gap-3 rounded-2xl border border-border-dark bg-muted-background p-3 outline-hidden md:border-border-dark/50 md:p-4 md:focus-within:border-highlight-300",
         "ease-enter motion-reduce:animate-none",
         submission?.phase === "exiting" &&
           "animate-out fill-mode-forwards fade-out-0 duration-exit",
@@ -313,7 +315,6 @@ export function UserAnswerRequired({
               key={index}
               label={option.label}
               description={option.description}
-              counterValue={index + 1}
               selected={answerDraft.selectedOptions.includes(index)}
               disableHover={isKeyboardNavigating}
               selectionIndicator={question.multiSelect ? "checkbox" : "radio"}
@@ -332,7 +333,6 @@ export function UserAnswerRequired({
           ))}
           <OptionCard
             type="input"
-            counterValue={question.options.length + 1}
             selected={isCustomResponseActive}
             disableHover={isKeyboardNavigating}
             className={cn(isKeyboardNavigating && "cursor-none")}
@@ -377,8 +377,8 @@ export function UserAnswerRequired({
       <div className="flex items-center justify-between gap-3">
         <Button
           label="Skip"
-          variant="outline"
-          size="sm"
+          variant="ghost-secondary"
+          size={isMobile ? "sm" : "xs"}
           onClick={handleSkip}
           isLoading={submission?.kind === "skip"}
           disabled={isSubmitting}
@@ -386,11 +386,12 @@ export function UserAnswerRequired({
         <Button
           icon={ArrowUp}
           variant="highlight"
-          size="sm"
+          size={isMobile ? "sm" : "xs"}
           isLoading={submission?.kind === "answer"}
           disabled={isSubmitting || answerDraft.answerToSubmit === null}
           onClick={handleSubmit}
           aria-label="Send answer"
+          className="rounded-full"
         />
       </div>
     </div>

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -18,7 +18,6 @@ interface UserAnswerRequiredProps {
   triggeringUser: UserType | null;
   owner: LightWorkspaceType;
   retryHandler: () => Promise<void>;
-  isMobile?: boolean;
 }
 
 type SubmissionState = {
@@ -45,7 +44,6 @@ export function UserAnswerRequired({
   triggeringUser,
   owner,
   retryHandler,
-  isMobile = false,
 }: UserAnswerRequiredProps) {
   const { user } = useAuth();
   const { removeCompletedAction } = useBlockedActionsContext();
@@ -290,7 +288,7 @@ export function UserAnswerRequired({
         }
       }}
       className={cn(
-        "flex flex-col gap-3 rounded-2xl border border-border-dark bg-muted-background p-3 outline-hidden md:border-border-dark/50 md:p-4 md:focus-within:border-highlight-300",
+        "flex flex-col gap-4 rounded-2xl border border-dark bg-background p-5 outline-hidden",
         "ease-enter motion-reduce:animate-none",
         submission?.phase === "exiting" &&
           "animate-out fill-mode-forwards fade-out-0 duration-exit",
@@ -377,8 +375,8 @@ export function UserAnswerRequired({
       <div className="flex items-center justify-between gap-3">
         <Button
           label="Skip"
-          variant="ghost-secondary"
-          size={isMobile ? "sm" : "xs"}
+          variant="outline"
+          size="sm"
           onClick={handleSkip}
           isLoading={submission?.kind === "skip"}
           disabled={isSubmitting}
@@ -386,7 +384,7 @@ export function UserAnswerRequired({
         <Button
           icon={ArrowUp}
           variant="highlight"
-          size={isMobile ? "sm" : "xs"}
+          size="sm"
           isLoading={submission?.kind === "answer"}
           disabled={isSubmitting || answerDraft.answerToSubmit === null}
           onClick={handleSubmit}

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -313,6 +313,7 @@ export function UserAnswerRequired({
               key={index}
               label={option.label}
               description={option.description}
+              counterValue={index + 1}
               selected={answerDraft.selectedOptions.includes(index)}
               disableHover={isKeyboardNavigating}
               selectionIndicator={question.multiSelect ? "checkbox" : "radio"}

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -290,9 +290,8 @@ export function UserAnswerRequired({
       className={cn(
         "flex flex-col gap-4 rounded-2xl border border-dark bg-background p-5 outline-hidden",
         "ease-enter motion-reduce:animate-none",
-        submission?.phase === "exiting"
-          ? "animate-out fill-mode-forwards fade-out-0 duration-exit"
-          : "animate-in fade-in-0 duration-enter",
+        submission?.phase === "exiting" &&
+          "animate-out fill-mode-forwards fade-out-0 duration-exit",
         isKeyboardNavigating && "cursor-none"
       )}
     >

--- a/sparkle/src/lib/index.ts
+++ b/sparkle/src/lib/index.ts
@@ -1,4 +1,5 @@
 export * as avatarUtils from "./avatar/utils";
+export * from "./motion";
 export * from "./reportToDatadog";
 export * from "./SafeSuspense";
 export * from "./safeLazy";

--- a/sparkle/src/lib/motion.ts
+++ b/sparkle/src/lib/motion.ts
@@ -1,0 +1,18 @@
+/**
+ * Semantic motion tokens for JavaScript animation libraries such as Framer
+ * Motion. Durations are expressed in seconds.
+ *
+ * Keep these values aligned with the CSS tokens in `../styles/theme.css`.
+ */
+export const MOTION_DURATIONS = {
+  enter: 0.2,
+  exit: 0.16,
+  modalEnter: 0.3,
+  modalExit: 0.24,
+} as const;
+
+export const MOTION_EASINGS = {
+  enter: [0.215, 0.61, 0.355, 1],
+  emphasized: [0.23, 1, 0.32, 1],
+  move: [0.455, 0.03, 0.515, 0.955],
+} as const;

--- a/sparkle/src/stories/Motion.stories.tsx
+++ b/sparkle/src/stories/Motion.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
     layout: "padded",
     docs: {
       description: {
-        component: `Motion tokens as Tailwind utilities. Two decisions: **easing** (entering/exiting → ease-out, moving on screen → ease-in-out) and **duration** (bigger element → longer). Prefer the semantic aliases (\`ease-enter\`, \`duration-enter\`, …). Each token is shown as a reference row: a continuously looping specimen (a ball tracing the curve, a square spinning at the duration), a click-to-copy class chip, its resolved value, and a description of intended use.`,
+        component: `Motion tokens as Tailwind utilities. Two decisions: **easing** (entering/exiting → ease-out, moving on screen → ease-in-out) and **duration** (bigger element → longer). Prefer the semantic aliases (\`ease-enter\`, \`duration-enter\`, …). For JavaScript animation libraries, import \`MOTION_EASINGS\` and \`MOTION_DURATIONS\` from \`@dust-tt/sparkle\`. Each token is shown as a reference row: a continuously looping specimen (a ball tracing the curve, a square spinning at the duration), a click-to-copy class chip, its resolved value, and a description of intended use.`,
       },
     },
   },

--- a/sparkle/src/styles/theme.css
+++ b/sparkle/src/styles/theme.css
@@ -102,6 +102,7 @@
   --ease-in-out-quad: cubic-bezier(0.455, 0.03, 0.515, 0.955);
   --ease-in-out-cubic: cubic-bezier(0.645, 0.045, 0.355, 1);
   --ease-in-out-quint: cubic-bezier(0.86, 0, 0.07, 1);
+  /* Semantic aliases are also exported for JS from ../lib/motion.ts. */
   --ease-enter: cubic-bezier(0.215, 0.61, 0.355, 1);
   --ease-emphasized: cubic-bezier(0.23, 1, 0.32, 1);
   --ease-move: cubic-bezier(0.455, 0.03, 0.515, 0.955);
@@ -112,7 +113,8 @@
   --ease-in-expo: cubic-bezier(0.95, 0.05, 0.795, 0.035);
   --ease-in-circ: cubic-bezier(0.6, 0.04, 0.98, 0.335);
 
-  /* Transition durations (was theme.extend.transitionDuration). */
+  /* Transition durations (was theme.extend.transitionDuration).
+     Semantic values are also exported for JS from ../lib/motion.ts. */
   --transition-duration-enter: 200ms;
   --transition-duration-exit: 160ms;
   --transition-duration-modal-enter: 300ms;


### PR DESCRIPTION
## Description

Context in [thread](https://dust4ai.slack.com/archives/C0B1VFWD0TW/p1786117382597449?thread_ts=1786115305.835439&cid=C0B1VFWD0TW).

This PR moves the ask user question tool's option selection to the bottom of the screen, replacing the input bar.
This prevents having an idle input bar that creates confusion next to the free text input. Makes the blocking action actually blocking.

## Tests

- Added tests.
- Tested locally.

## Risk

- Low. UI-only change, safe to rollback.

## Deploy Plan

- Deploy front.
