### PR TITLE
Refactor how we determine isXXX flags on attachment, replace with inline usage line, centralize logic.

### DIFF
--- a/front/components/pod/conversation/PodConversationsTab.tsx
+++ b/front/components/pod/conversation/PodConversationsTab.tsx
@@ -297,7 +297,7 @@ export function PodConversationsTab({
                   <Button
                     size="sm"
                     variant="outline"
-                    icon={hideTriggeredConversations ? Zap : ZapOff}
+                    icon={hideTriggeredConversations ? ZapOff : Zap}
                     tooltip={
                       hideTriggeredConversations
                         ? "Show triggered"

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -1,5 +1,6 @@
 import type { AgentLoopRunContext } from "@app/lib/actions/types";
 import { resolveFile } from "@app/lib/api/actions/servers/files/tools/utils";
+import { getAttachmentCapabilityContext } from "@app/lib/api/assistant/conversation/attachment_capabilities";
 import {
   conversationAttachmentId,
   getAttachmentFromContentFragment,
@@ -226,12 +227,17 @@ export async function getFileFromConversationAttachment(
   const conversation = runContext.conversation;
   let attachment: ConversationAttachmentType | null = null;
 
+  const capabilities = await getAttachmentCapabilityContext(auth, conversation);
+
   for (const versions of conversation.content) {
     const m = versions[versions.length - 1];
 
     if (isContentFragmentType(m)) {
       if (m.contentFragmentVersion === "latest") {
-        const candidateAttachment = getAttachmentFromContentFragment(m);
+        const candidateAttachment = getAttachmentFromContentFragment({
+          cf: m,
+          capabilities,
+        });
         if (
           candidateAttachment &&
           conversationAttachmentId(candidateAttachment) === fileId
@@ -255,6 +261,7 @@ export async function getFileFromConversationAttachment(
             snippet: f.snippet,
             isInProjectContext: f.isInProjectContext ?? false,
             hideFromUser: f.hidden ?? false,
+            capabilities,
           });
           break;
         }

--- a/front/lib/actions/mcp_utils.ts
+++ b/front/lib/actions/mcp_utils.ts
@@ -20,6 +20,7 @@ import type { ToolContext } from "@app/lib/actions/types";
 import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import { isEnableSkillResultOutput } from "@app/lib/api/actions/servers/skill_management/rendering";
 import {
+  attachmentUsageHintsFor,
   makeFileAttachment,
   renderAttachmentXml,
 } from "@app/lib/api/assistant/conversation/attachments";
@@ -34,6 +35,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import type { FileModel } from "@app/lib/resources/storage/models/files";
 import logger from "@app/logger/logger";
+import type { AttachmentCapabilityContext } from "@app/types/api/assistant/conversation/attachments";
 import type { SupportedImageContentType } from "@app/types/files";
 import { isSupportedFileContentType } from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -101,7 +103,8 @@ export function hideFileFromActionOutput({
 }
 
 export function rewriteContentForModel(
-  content: CallToolResult["content"][number]
+  content: CallToolResult["content"][number],
+  capabilities: AttachmentCapabilityContext
 ): CallToolResult["content"][number] | null {
   // Only render tool generated files that are supported.
   if (
@@ -116,8 +119,12 @@ export function rewriteContentForModel(
       snippet: content.resource.snippet,
       isInProjectContext: content.resource.isInProjectContext ?? false,
       hideFromUser: false, // Model do not care.
+      capabilities,
     });
-    const xml = renderAttachmentXml({ attachment });
+    const xml = renderAttachmentXml({
+      attachment,
+      usage: attachmentUsageHintsFor(capabilities),
+    });
     let text = content.resource.text;
     if (text) {
       text += `\n`;

--- a/front/lib/api/actions/servers/conversation_files/metadata.ts
+++ b/front/lib/api/actions/servers/conversation_files/metadata.ts
@@ -7,7 +7,9 @@ export const CONVERSATION_FILES_SERVER_NAME = "conversation_files" as const;
 // Legacy listing action (pre file-system mode). Lists every attachment in the conversation.
 export const CONVERSATION_LIST_FILES_ACTION_NAME = "list";
 // File-system mode listing action. The conversation's regular files have moved to the `files`
-// MCP server, so this listing is narrowed to content nodes and queryable tables.
+// MCP server, so this listing is narrowed to content nodes.
+// TODO(20260504 FILE SYSTEM): the name still mentions tables. Renaming it changes a model-facing
+// tool name recorded on past actions, so it is left alone until the legacy mode is removed.
 export const CONVERSATION_LIST_CONTENT_NODES_AND_TABLES_ACTION_NAME =
   "list_content_nodes_and_tables";
 export const CONVERSATION_CAT_FILE_ACTION_NAME = "cat";
@@ -16,6 +18,11 @@ export const CONVERSATION_SEARCH_FILES_ACTION_NAME = "semantic_search";
 const CONVERSATION_LIST_FILES_TOOL_NAME = getPrefixedToolName(
   CONVERSATION_FILES_SERVER_NAME,
   CONVERSATION_LIST_FILES_ACTION_NAME
+);
+
+const CONVERSATION_LIST_CONTENT_NODES_TOOL_NAME = getPrefixedToolName(
+  CONVERSATION_FILES_SERVER_NAME,
+  CONVERSATION_LIST_CONTENT_NODES_AND_TABLES_ACTION_NAME
 );
 
 const CAT_FILE_TOOL = {
@@ -28,7 +35,8 @@ const CAT_FILE_TOOL = {
       .string()
       .describe(
         "The fileId of the conversation attachment to retrieve and read, as " +
-          `returned by \`${CONVERSATION_LIST_FILES_TOOL_NAME}\``
+          `returned by \`${CONVERSATION_LIST_FILES_TOOL_NAME}\` or ` +
+          `\`${CONVERSATION_LIST_CONTENT_NODES_TOOL_NAME}\``
       ),
     offset: z
       .number()
@@ -103,16 +111,14 @@ export const CONVERSATION_FILES_TOOLS_METADATA = [
 
 // In file-system mode, regular files are accessed via the `files` MCP server. This server is
 // narrowed to listing the attachments that don't live on the file mount: content nodes
-// (Notion pages, Slack threads, etc.) and queryable tables. The `cat` tool is kept so agents
-// can read content node attachments.
+// (Notion pages, Slack threads, etc.). The `cat` tool is kept so agents can read them.
 export const CONVERSATION_FILES_TOOLS_METADATA_WITH_FILESYSTEM = [
   {
     name: CONVERSATION_LIST_CONTENT_NODES_AND_TABLES_ACTION_NAME,
     description:
       "List content-node references (for example Notion pages and Slack " +
-      "threads) and queryable tables available " +
-      "in the current conversation. Regular files are not listed here; " +
-      `they are accessible via the \`${FILES_SERVER_NAME}\` MCP server.`,
+      "threads) available in the current conversation. Regular files are not " +
+      `listed here; they are accessible via the \`${FILES_SERVER_NAME}\` MCP server.`,
     schema: {},
     stake: "never_ask",
     displayLabels: {

--- a/front/lib/api/actions/servers/conversation_files/tools/index.test.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.test.ts
@@ -1,7 +1,29 @@
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
+import {
+  CONVERSATION_CAT_FILE_ACTION_NAME,
+  CONVERSATION_FILES_SERVER_NAME,
+  CONVERSATION_SEARCH_FILES_ACTION_NAME,
+} from "@app/lib/api/actions/servers/conversation_files/metadata";
+import { attachmentUsageHintsFor } from "@app/lib/api/assistant/conversation/attachments";
 import type { FileAttachmentType } from "@app/types/api/assistant/conversation/attachments";
 import { describe, expect, it } from "vitest";
 
 import { contentFromAttachments } from "./index";
+
+const CAT_TOOL = getPrefixedToolName(
+  CONVERSATION_FILES_SERVER_NAME,
+  CONVERSATION_CAT_FILE_ACTION_NAME
+);
+const SEARCH_TOOL = getPrefixedToolName(
+  CONVERSATION_FILES_SERVER_NAME,
+  CONVERSATION_SEARCH_FILES_ACTION_NAME
+);
+
+// The legacy mode is the one that lists file attachments, so it is what these tests exercise.
+const LEGACY_USAGE = attachmentUsageHintsFor({
+  isNewFileExplorer: false,
+  hasSandboxTools: false,
+});
 
 function makeFileAttachment(
   partial: Partial<FileAttachmentType> &
@@ -25,7 +47,7 @@ function makeFileAttachment(
 
 describe("contentFromAttachments", () => {
   it("returns an empty string when there are no attachments", () => {
-    expect(contentFromAttachments([])).toBe("");
+    expect(contentFromAttachments([], { usage: LEGACY_USAGE })).toBe("");
   });
 
   it("lists direct attachments under the direct header", () => {
@@ -38,15 +60,38 @@ describe("contentFromAttachments", () => {
       }),
     ];
 
-    const out = contentFromAttachments(attachments);
+    const out = contentFromAttachments(attachments, { usage: LEGACY_USAGE });
 
     expect(out).toContain(
       "The following files are currently attached to the conversation directly:"
     );
     expect(out).toContain('id="file-direct"');
     expect(out).toContain('title="Notes.txt"');
-    expect(out).toContain(">preview\n</attachment>");
+    expect(out).toContain(
+      `Use: read with \`${CAT_TOOL}\`; semantic search with \`${SEARCH_TOOL}\`.\npreview\n</attachment>`
+    );
     expect(out).not.toContain("via the project context");
+  });
+
+  it("advertises only the tools registered in the current mode", () => {
+    const attachments = [
+      makeFileAttachment({
+        fileId: "file-direct",
+        title: "Notes.txt",
+        isInProjectContext: false,
+        snippet: "preview",
+      }),
+    ];
+
+    const out = contentFromAttachments(attachments, {
+      usage: attachmentUsageHintsFor({
+        isNewFileExplorer: true,
+        hasSandboxTools: true,
+      }),
+    });
+
+    expect(out).toContain(`Use: read with \`${CAT_TOOL}\`.`);
+    expect(out).not.toContain(SEARCH_TOOL);
   });
 
   it("lists project-context attachments under the project header", () => {
@@ -56,16 +101,17 @@ describe("contentFromAttachments", () => {
         title: "Spec.md",
         isInProjectContext: true,
         snippet: null,
+        isIncludable: false,
+        isSearchable: false,
       }),
     ];
 
-    const out = contentFromAttachments(attachments);
+    const out = contentFromAttachments(attachments, { usage: LEGACY_USAGE });
 
     expect(out).toContain(
       "The following files are currently attached to the conversation via the pod context:"
     );
     expect(out).toContain('id="file-proj"');
-    expect(out).toContain('isInProjectContext="true"');
     expect(out).toMatch(/<attachment[\s\S]*?\/>/);
     expect(out).not.toContain("</attachment>");
     expect(out).not.toContain("attached to the conversation directly");
@@ -90,7 +136,7 @@ describe("contentFromAttachments", () => {
       }),
     ];
 
-    const out = contentFromAttachments(attachments);
+    const out = contentFromAttachments(attachments, { usage: LEGACY_USAGE });
 
     const idxDirectHeader = out.indexOf("conversation directly:");
     const idxProjectHeader = out.indexOf("via the pod context:");
@@ -119,9 +165,9 @@ describe("contentFromAttachments", () => {
       }),
     ];
 
-    const out = contentFromAttachments(attachments);
+    const out = contentFromAttachments(attachments, { usage: LEGACY_USAGE });
 
-    expect(out).toContain("/>\n<attachment");
+    expect(out).toContain("</attachment>\n<attachment");
   });
 
   it("uses snippetContent for every attachment when provided", () => {
@@ -134,12 +180,12 @@ describe("contentFromAttachments", () => {
       }),
     ];
 
-    const out = contentFromAttachments(
-      attachments,
-      "Snippet content too large."
-    );
+    const out = contentFromAttachments(attachments, {
+      usage: LEGACY_USAGE,
+      snippetContent: "Snippet content too large.",
+    });
 
-    expect(out).toContain(">Snippet content too large.\n</attachment>");
+    expect(out).toContain("Snippet content too large.\n</attachment>");
     expect(out).not.toContain("original snippet");
   });
 });

--- a/front/lib/api/actions/servers/conversation_files/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.ts
@@ -19,7 +19,10 @@ import {
 } from "@app/lib/api/actions/servers/files/tools/grep_regex";
 import { searchFunction } from "@app/lib/api/actions/servers/search/tools";
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
+import { getAttachmentCapabilityContext } from "@app/lib/api/assistant/conversation/attachment_capabilities";
+import type { AttachmentUsageHints } from "@app/lib/api/assistant/conversation/attachments";
 import {
+  attachmentUsageHintsFor,
   conversationAttachmentId,
   isContentNodeAttachmentType,
   renderAttachmentXml,
@@ -51,7 +54,10 @@ const MAX_CONTENT_SIZE_FOR_LIST_FILES = 1024 * 256; // 256KB.
 
 export const contentFromAttachments = (
   attachments: ConversationAttachmentType[],
-  snippetContent?: string
+  {
+    usage,
+    snippetContent,
+  }: { usage: AttachmentUsageHints; snippetContent?: string }
 ) => {
   let content = "";
 
@@ -65,7 +71,11 @@ export const contentFromAttachments = (
       } else {
         content += "\n";
       }
-      content += renderAttachmentXml({ attachment, content: snippetContent });
+      content += renderAttachmentXml({
+        attachment,
+        content: snippetContent,
+        usage,
+      });
     });
 
   // Project context attached files.
@@ -78,14 +88,18 @@ export const contentFromAttachments = (
       } else {
         content += "\n";
       }
-      content += renderAttachmentXml({ attachment, content: snippetContent });
+      content += renderAttachmentXml({
+        attachment,
+        content: snippetContent,
+        usage,
+      });
     });
   return content;
 };
 
 // Shared list handler used under two action names: the legacy `list` (all attachments) and the
-// file-system-mode `list_content_nodes_and_tables` (narrowed). Filtering is driven by the
-// conversation's `useFileSystem` flag so the same handler is correct under either name.
+// file-system-mode `list_content_nodes` (narrowed). Filtering is driven by the conversation's
+// `useFileSystem` flag so the same handler is correct under either name.
 const listAttachmentsHandler: ToolHandlers<
   typeof CONVERSATION_FILES_TOOLS_METADATA
 >[typeof CONVERSATION_LIST_FILES_ACTION_NAME] = async (
@@ -95,15 +109,13 @@ const listAttachmentsHandler: ToolHandlers<
   assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
 
   const conversation = runContext.conversation;
+  const capabilities = await getAttachmentCapabilityContext(auth, conversation);
   const allAttachments = await listAttachments(auth, { conversation });
 
-  // When the conversation uses the new file system, regular files are surfaced via the
-  // `files` server. Only list content nodes and queryable attachments (tables) here.
-  const useFileSystem = conversation.metadata?.useFileSystem === true;
-  const attachments = useFileSystem
-    ? allAttachments.filter(
-        (a) => isContentNodeAttachmentType(a) || a.isQueryable
-      )
+  // When the conversation uses the new file system, regular files are surfaced via the `files`
+  // server, so only content nodes remain listable here.
+  const attachments = capabilities.isNewFileExplorer
+    ? allAttachments.filter(isContentNodeAttachmentType)
     : allAttachments;
 
   if (attachments.length === 0) {
@@ -115,10 +127,14 @@ const listAttachmentsHandler: ToolHandlers<
     ]);
   }
 
-  let content = contentFromAttachments(attachments);
+  const usage = attachmentUsageHintsFor(capabilities);
+  let content = contentFromAttachments(attachments, { usage });
 
   if (content.length > MAX_CONTENT_SIZE_FOR_LIST_FILES) {
-    content = contentFromAttachments(attachments, "Snippet content too large.");
+    content = contentFromAttachments(attachments, {
+      usage,
+      snippetContent: "Snippet content too large.",
+    });
   }
 
   return new Ok([
@@ -363,9 +379,12 @@ async function getFileFromConversation(
   const attachment = attachments.find(
     (a) => conversationAttachmentId(a) === fileId
   );
+  // In file system mode only content nodes stay includable: regular files are read by path through
+  // the `files` server.
   if (!attachment || !attachment.isIncludable) {
     return new Err(`File \`${fileId}\` not found in conversation`);
   }
+
   if (attachment.contentFragmentVersion === "superseded") {
     return new Ok({
       fileId,

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
@@ -8,6 +8,7 @@ import {
   buildToolAttribution,
 } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
 import { measureToolCallFootprints } from "@app/lib/api/assistant/agent_message_consumption_attribution/tool_footprint";
+import { getAttachmentCapabilityContext } from "@app/lib/api/assistant/conversation/attachment_capabilities";
 import type { Authenticator } from "@app/lib/auth";
 import { buildAgentMessageBillingPlan } from "@app/lib/credits/agent_message_billing";
 import { roundCreditsToMicroCredits } from "@app/lib/credits/units";
@@ -23,6 +24,7 @@ import { RunResource } from "@app/lib/resources/run_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import type { AttachmentCapabilityContext } from "@app/types/api/assistant/conversation/attachments";
 import type { AgentMessageStatus } from "@app/types/assistant/conversation";
 import {
   AGENT_MESSAGE_STATUSES_TO_TRACK,
@@ -183,12 +185,14 @@ function runUsageModelIdsWithUnconsumedToolResults({
 async function buildRunUsageConsumptionEvidence(
   auth: Authenticator,
   {
+    capabilities,
     enrichedActionByModelId,
     directCreditAmountMicroByActionModelId,
     includeToolResultFootprints,
     runActions,
     usage,
   }: {
+    capabilities: AttachmentCapabilityContext;
     enrichedActionByModelId: ReadonlyMap<ModelId, AgentMCPActionWithOutputType>;
     directCreditAmountMicroByActionModelId: ReadonlyMap<ModelId, number>;
     includeToolResultFootprints: boolean;
@@ -226,6 +230,7 @@ async function buildRunUsageConsumptionEvidence(
   // output budget is partitioned consistently with the immutable evidence already stored.
   const footprintsRes = await measureToolCallFootprints(auth, {
     modelId: usage.modelId,
+    capabilities,
     // TODO(2026-07-31 FLAV) Refactor `enrichActionsWithOutputItems` so it still returns the
     // resource.
     toolCalls: modelVisibleRunActionPairs.map(({ action, enrichedAction }) => ({
@@ -526,6 +531,10 @@ async function computeAndStoreAgentMessageConsumptionAttributionComputation(
     return {};
   }
 
+  // Tool results are re-rendered below to measure them, so they need the same attachment
+  // capabilities the conversation used when the results were sent to the model.
+  const capabilities = await getAttachmentCapabilityContext(auth, conversation);
+
   // Every usage is reached through this message's own runIds, so each one belongs to this message.
   const runs = await RunResource.listByDustRunIds(auth, { dustRunIds });
   const usages = await RunResource.listRunUsagesForRuns(auth, { runs });
@@ -624,6 +633,7 @@ async function computeAndStoreAgentMessageConsumptionAttributionComputation(
     const dustRunId = dustRunIdByRunModelId.get(usage.runModelId);
     const runActions = (dustRunId && actionsByDustRunId.get(dustRunId)) || [];
     const usageEvidence = await buildRunUsageConsumptionEvidence(auth, {
+      capabilities,
       enrichedActionByModelId,
       directCreditAmountMicroByActionModelId,
       includeToolResultFootprints: !unconsumedToolResultRunUsageModelIds.has(

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.test.ts
@@ -8,6 +8,7 @@ import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
 import { tokenCountForTexts } from "@app/lib/tokenization";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import type { AttachmentCapabilityContext } from "@app/types/api/assistant/conversation/attachments";
 import {
   CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
   CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG,
@@ -75,6 +76,12 @@ function footprintInput(
 // The auth is only forwarded to getLlmCredentials, which is mocked, so a bare stub is enough.
 const auth = {} as Authenticator;
 
+// None of these outputs are attachments, so the capabilities only need to be present.
+const capabilities: AttachmentCapabilityContext = {
+  isNewFileExplorer: false,
+  hasSandboxTools: false,
+};
+
 describe("toolCallFootprintTexts", () => {
   it("serializes a call from the emitted arguments, not the augmented params", () => {
     const { callText } = toolCallFootprintTexts(
@@ -85,7 +92,8 @@ describe("toolCallFootprintTexts", () => {
           params: { query: "hello", injectedSecret: "x".repeat(500) },
         }),
         '{"query":"hello"}'
-      )
+      ),
+      capabilities
     );
 
     expect(callText).toBe('search\n{"query":"hello"}');
@@ -98,7 +106,8 @@ describe("toolCallFootprintTexts", () => {
           status: "denied",
           output: [{ type: "text", text: "leaked" }],
         })
-      )
+      ),
+      capabilities
     );
 
     expect(inputText).toBe(
@@ -108,7 +117,8 @@ describe("toolCallFootprintTexts", () => {
 
   it("renders an action awaiting validation as the validation notice", () => {
     const { inputText } = toolCallFootprintTexts(
-      footprintInput(makeAction({ status: "blocked_validation_required" }))
+      footprintInput(makeAction({ status: "blocked_validation_required" })),
+      capabilities
     );
 
     expect(inputText).toBe(
@@ -118,7 +128,8 @@ describe("toolCallFootprintTexts", () => {
 
   it("renders an empty output as the no-output notice", () => {
     const { inputText } = toolCallFootprintTexts(
-      footprintInput(makeAction({ status: "succeeded", output: [] }))
+      footprintInput(makeAction({ status: "succeeded", output: [] })),
+      capabilities
     );
 
     expect(inputText).toBe("Successfully executed action, no output.");
@@ -134,7 +145,8 @@ describe("toolCallFootprintTexts", () => {
             { type: "text", text: "second" },
           ],
         })
-      )
+      ),
+      capabilities
     );
 
     expect(inputText).toBe("first\nsecond");
@@ -152,7 +164,8 @@ describe("toolCallFootprintTexts", () => {
             },
           ],
         })
-      )
+      ),
+      capabilities
     );
 
     expect(inputText).toBe(JSON.stringify([{ uri: "u", text: "body" }]));
@@ -171,6 +184,7 @@ describe("measureToolCallFootprints", () => {
 
   it("omits deferred enabled-skill definitions for an Anthropic tool-search model", async () => {
     await measureToolCallFootprints(auth, {
+      capabilities,
       modelId: CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG.modelId,
       toolCalls: [footprintInput(makeAction())],
     });
@@ -184,6 +198,7 @@ describe("measureToolCallFootprints", () => {
 
   it("includes enabled-skill definitions when tool search is disabled", async () => {
     await measureToolCallFootprints(auth, {
+      capabilities,
       modelId: GPT_4_1_MODEL_CONFIG.modelId,
       toolCalls: [footprintInput(makeAction())],
     });
@@ -197,6 +212,7 @@ describe("measureToolCallFootprints", () => {
 
   it("returns an empty result without tokenizing when there are no actions", async () => {
     const res = await measureToolCallFootprints(auth, {
+      capabilities,
       modelId: GPT_5_MODEL_ID,
       toolCalls: [],
     });
@@ -208,6 +224,7 @@ describe("measureToolCallFootprints", () => {
 
   it("fails when the run's model is not a known configuration", async () => {
     const res = await measureToolCallFootprints(auth, {
+      capabilities,
       modelId: "not-a-real-model",
       toolCalls: [footprintInput(makeAction())],
     });
@@ -222,6 +239,7 @@ describe("measureToolCallFootprints", () => {
     STATIC_MODEL_IDS
   )("keeps a tool-footprint tokenizer configuration for static model %s", async (modelId) => {
     const res = await measureToolCallFootprints(auth, {
+      capabilities,
       modelId,
       toolCalls: [footprintInput(makeAction())],
     });
@@ -236,6 +254,7 @@ describe("measureToolCallFootprints", () => {
     GEMINI_3_FLASH_MODEL_CONFIG,
   ])("tokenizes historical $modelId runs whose model is no longer served", async (modelConfig) => {
     const res = await measureToolCallFootprints(auth, {
+      capabilities,
       modelId: modelConfig.modelId,
       toolCalls: [footprintInput(makeAction())],
     });
@@ -253,6 +272,7 @@ describe("measureToolCallFootprints", () => {
 
   it("tokenizes GPT-5 footprints without safety padding using o200k", async () => {
     const res = await measureToolCallFootprints(auth, {
+      capabilities,
       modelId: GPT_5_6_SOL_MODEL_ID,
       toolCalls: [footprintInput(makeAction())],
     });
@@ -282,6 +302,7 @@ describe("measureToolCallFootprints", () => {
     ];
 
     const res = await measureToolCallFootprints(auth, {
+      capabilities,
       modelId: GPT_5_MODEL_ID,
       toolCalls,
     });
@@ -313,6 +334,7 @@ describe("measureToolCallFootprints", () => {
     );
 
     const res = await measureToolCallFootprints(auth, {
+      capabilities,
       modelId: GPT_5_MODEL_ID,
       toolCalls: [footprintInput(makeAction())],
     });

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
@@ -6,6 +6,7 @@ import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import { isToolSearchEnabledForModel } from "@app/lib/model_constructors/types/tool_search";
 import { tokenCountForTexts } from "@app/lib/tokenization";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import type { AttachmentCapabilityContext } from "@app/types/api/assistant/conversation/attachments";
 import {
   CLAUDE_3_5_HAIKU_DEFAULT_MODEL_CONFIG,
   CLAUDE_3_5_SONNET_20240620_DEPRECATED_MODEL_CONFIG,
@@ -152,6 +153,9 @@ export interface ToolCallFootprintInput {
 
 export function toolCallFootprintTexts(
   { action, functionCallArguments }: ToolCallFootprintInput,
+  // Attachment capabilities shape the rendered result, so they must match the ones used when the
+  // result was sent to the model, otherwise the measured footprint drifts from what was billed.
+  capabilities: AttachmentCapabilityContext,
   additionalInputText?: string
 ): ToolFootprintTexts {
   return {
@@ -160,7 +164,10 @@ export function toolCallFootprintTexts(
     // Tool input means the model input created by this execution. Most tools contribute only their
     // rendered result. Enabling a skill also adds its instructions and tool definitions to later
     // requests, so those consequences belong to the same tool row.
-    inputText: [renderToolResultForModelAsText(action), additionalInputText]
+    inputText: [
+      renderToolResultForModelAsText(action, capabilities),
+      additionalInputText,
+    ]
       .filter((text): text is string => text !== undefined)
       .join("\n"),
   };
@@ -178,9 +185,11 @@ export async function measureToolCallFootprints(
   {
     modelId,
     toolCalls,
+    capabilities,
   }: {
     modelId: string;
     toolCalls: ToolCallFootprintInput[];
+    capabilities: AttachmentCapabilityContext;
   }
 ): Promise<Result<ToolFootprintMeasurement[], Error>> {
   if (toolCalls.length === 0) {
@@ -217,6 +226,7 @@ export async function measureToolCallFootprints(
   const footprints = toolCalls.map((toolCall) =>
     toolCallFootprintTexts(
       toolCall,
+      capabilities,
       enabledSkillInputTextByActionId.get(toolCall.action.sId)
     )
   );

--- a/front/lib/api/assistant/conversation/attachment_capabilities.ts
+++ b/front/lib/api/assistant/conversation/attachment_capabilities.ts
@@ -1,0 +1,26 @@
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { AttachmentCapabilityContext } from "@app/types/api/assistant/conversation/attachments";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
+
+/**
+ * Single place resolving the conversation-wide inputs to attachment capability flags. Call it once
+ * per rendering pass or tool execution and pass the result down: every consumer of `isIncludable`,
+ * `isQueryable` and `isSearchable` then reads flags that already account for the file explorer and
+ * for Computer availability.
+ */
+export async function getAttachmentCapabilityContext(
+  auth: Authenticator,
+  conversation:
+    | Pick<ConversationWithoutContentType, "metadata">
+    | Pick<ConversationResource, "metadata">
+): Promise<AttachmentCapabilityContext> {
+  const featureFlags = await getFeatureFlags(auth);
+
+  return {
+    isNewFileExplorer: conversation.metadata?.useFileSystem === true,
+    hasSandboxTools: isComputerFeatureEnabled(featureFlags),
+  };
+}

--- a/front/lib/api/assistant/conversation/attachments.test.ts
+++ b/front/lib/api/assistant/conversation/attachments.test.ts
@@ -1,14 +1,41 @@
+import { DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME } from "@app/lib/actions/constants";
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import {
+  CONVERSATION_CAT_FILE_ACTION_NAME,
+  CONVERSATION_FILES_SERVER_NAME,
+  CONVERSATION_SEARCH_FILES_ACTION_NAME,
+} from "@app/lib/api/actions/servers/conversation_files/metadata";
+import {
+  attachmentUsageHintsFor,
   getAttachmentFromContentNodeContentFragment,
   getAttachmentFromFileContentFragment,
   makeFileAttachment,
   renderAttachmentXml,
 } from "@app/lib/api/assistant/conversation/attachments";
+import type { AttachmentCapabilityContext } from "@app/types/api/assistant/conversation/attachments";
 import type {
   ContentNodeContentFragmentType,
   FileContentFragmentType,
 } from "@app/types/content_fragment";
 import { describe, expect, it } from "vitest";
+
+const CAT_TOOL = getPrefixedToolName(
+  CONVERSATION_FILES_SERVER_NAME,
+  CONVERSATION_CAT_FILE_ACTION_NAME
+);
+const SEARCH_TOOL = getPrefixedToolName(
+  CONVERSATION_FILES_SERVER_NAME,
+  CONVERSATION_SEARCH_FILES_ACTION_NAME
+);
+
+function capabilities({
+  isNewFileExplorer = false,
+  hasSandboxTools = false,
+}: Partial<AttachmentCapabilityContext> = {}): AttachmentCapabilityContext {
+  return { isNewFileExplorer, hasSandboxTools };
+}
+
+const LEGACY = capabilities();
 
 describe("makeFileAttachment", () => {
   const baseArgs = {
@@ -19,6 +46,7 @@ describe("makeFileAttachment", () => {
     snippet: "some content snippet",
     isInProjectContext: false,
     hideFromUser: true,
+    capabilities: LEGACY,
   };
 
   it("should mark pasted text files as not searchable, even with a snippet", () => {
@@ -46,6 +74,30 @@ describe("makeFileAttachment", () => {
       snippet: null,
     });
 
+    expect(attachment.isSearchable).toBe(false);
+  });
+
+  it("disables JIT flags when using the new file explorer", () => {
+    const attachment = makeFileAttachment({
+      ...baseArgs,
+      contentType: "text/csv",
+      capabilities: capabilities({ isNewFileExplorer: true }),
+    });
+
+    expect(attachment.isQueryable).toBe(false);
+    expect(attachment.isIncludable).toBe(false);
+    expect(attachment.isSearchable).toBe(false);
+  });
+
+  it("disables queryable when sandbox tools are available", () => {
+    const attachment = makeFileAttachment({
+      ...baseArgs,
+      contentType: "text/csv",
+      capabilities: capabilities({ hasSandboxTools: true }),
+    });
+
+    expect(attachment.isQueryable).toBe(false);
+    expect(attachment.isIncludable).toBe(true);
     expect(attachment.isSearchable).toBe(false);
   });
 });
@@ -136,46 +188,146 @@ function makeContentNodeContentFragment({
 }
 
 describe("renderAttachmentXml", () => {
-  it("always includes nodeId for content node attachments even when sourceUrl is null", () => {
-    const attachment = getAttachmentFromContentNodeContentFragment(
-      makeContentNodeContentFragment({ sourceUrl: null })
-    );
+  const legacyUsage = attachmentUsageHintsFor(LEGACY);
 
-    const xml = renderAttachmentXml({ attachment });
+  it("always includes nodeId for content node attachments even when sourceUrl is null", () => {
+    const attachment = getAttachmentFromContentNodeContentFragment({
+      cf: makeContentNodeContentFragment({ sourceUrl: null }),
+    });
+
+    const xml = renderAttachmentXml({ attachment, usage: legacyUsage });
 
     expect(xml).toContain('nodeId="node_abc"');
     expect(xml).not.toContain("sourceUrl");
+    expect(xml).not.toContain("isIncludable");
+    expect(xml).not.toContain("isQueryable");
+    expect(xml).not.toContain("isSearchable");
   });
 
   it("includes both nodeId and sourceUrl for content node attachments with a source URL", () => {
-    const attachment = getAttachmentFromContentNodeContentFragment(
-      makeContentNodeContentFragment({ sourceUrl: "https://example.com/doc" })
-    );
+    const attachment = getAttachmentFromContentNodeContentFragment({
+      cf: makeContentNodeContentFragment({
+        sourceUrl: "https://example.com/doc",
+      }),
+    });
 
-    const xml = renderAttachmentXml({ attachment });
+    const xml = renderAttachmentXml({ attachment, usage: legacyUsage });
 
     expect(xml).toContain('nodeId="node_abc"');
     expect(xml).toContain('sourceUrl="https://example.com/doc"');
+  });
+
+  it("emits a Use line with only applicable tools", () => {
+    const csvAttachment = getAttachmentFromFileContentFragment({
+      cf: makeFileContentFragment({ skipFileProcessing: false }),
+      capabilities: LEGACY,
+    });
+
+    const csvXml = renderAttachmentXml({
+      attachment: csvAttachment!,
+      usage: legacyUsage,
+    });
+
+    expect(csvXml).toContain(
+      `Use: read with \`${CAT_TOOL}\`; query tabular data with \`${DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME}\`.`
+    );
+    expect(csvXml).not.toContain(SEARCH_TOOL);
+    expect(csvXml).toContain("snippet");
+    expect(csvXml).not.toContain("isIncludable");
+
+    const textAttachment = getAttachmentFromFileContentFragment({
+      cf: makeFileContentFragment({
+        contentType: "text/plain",
+        skipFileProcessing: false,
+      }),
+      capabilities: LEGACY,
+    });
+
+    const textXml = renderAttachmentXml({
+      attachment: textAttachment!,
+      usage: legacyUsage,
+    });
+
+    expect(textXml).toContain(
+      `Use: read with \`${CAT_TOOL}\`; semantic search with \`${SEARCH_TOOL}\`.`
+    );
+    expect(textXml).not.toContain(
+      DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME
+    );
+  });
+
+  it("omits the Use line when no tools apply", () => {
+    const attachment = getAttachmentFromFileContentFragment({
+      cf: makeFileContentFragment({
+        contentType: "text/plain",
+        snippet: null,
+      }),
+      capabilities: capabilities({ isNewFileExplorer: true }),
+    });
+
+    const xml = renderAttachmentXml({
+      attachment: attachment!,
+      usage: legacyUsage,
+    });
+
+    expect(xml).not.toContain("Use:");
+    expect(xml).toMatch(/<attachment [^>]+\/>/);
+  });
+
+  it("omits the Use line entirely when the content is inlined", () => {
+    const attachment = getAttachmentFromFileContentFragment({
+      cf: makeFileContentFragment({ contentType: "text/plain" }),
+      capabilities: LEGACY,
+    });
+
+    const xml = renderAttachmentXml({
+      attachment: attachment!,
+      content: "the full file content",
+      usage: null,
+    });
+
+    expect(xml).not.toContain("Use:");
+    expect(xml).toContain("the full file content");
+  });
+
+  it("does not advertise semantic search when the file system tools are registered", () => {
+    // Content nodes stay searchable in file system mode, but conversation_files does not register
+    // semantic_search there, so the Use line must not point at it.
+    const attachment = getAttachmentFromContentNodeContentFragment({
+      cf: makeContentNodeContentFragment({ sourceUrl: null }),
+    });
+    expect(attachment.isSearchable).toBe(true);
+
+    const xml = renderAttachmentXml({
+      attachment,
+      usage: attachmentUsageHintsFor(capabilities({ isNewFileExplorer: true })),
+    });
+
+    expect(xml).not.toContain(SEARCH_TOOL);
+    expect(xml).toContain(`Use: read with \`${CAT_TOOL}\`.`);
   });
 });
 
 describe("getAttachmentFromFileContentFragment", () => {
   it("keeps skipped text files without snippet includable without advertising semantic search", () => {
-    const attachment = getAttachmentFromFileContentFragment(
-      makeFileContentFragment({
+    const attachment = getAttachmentFromFileContentFragment({
+      cf: makeFileContentFragment({
         contentType: "text/plain",
         snippet: null,
-      })
-    );
+      }),
+      capabilities: LEGACY,
+    });
 
-    expect(attachment?.isIncludable).toBe(true);
+    // Without a snippet, canDoJIT is false so all JIT flags stay off.
+    expect(attachment?.isIncludable).toBe(false);
     expect(attachment?.isSearchable).toBe(false);
   });
 
   it("suppresses queryable and includable hints for raw sandbox delimited files", () => {
-    const attachment = getAttachmentFromFileContentFragment(
-      makeFileContentFragment({ skipFileProcessing: true })
-    );
+    const attachment = getAttachmentFromFileContentFragment({
+      cf: makeFileContentFragment({ skipFileProcessing: true }),
+      capabilities: LEGACY,
+    });
 
     expect(attachment?.isQueryable).toBe(false);
     expect(attachment?.isIncludable).toBe(false);
@@ -184,9 +336,10 @@ describe("getAttachmentFromFileContentFragment", () => {
   });
 
   it("keeps old-style CSV files queryable when skipFileProcessing is false", () => {
-    const attachment = getAttachmentFromFileContentFragment(
-      makeFileContentFragment({ skipFileProcessing: false })
-    );
+    const attachment = getAttachmentFromFileContentFragment({
+      cf: makeFileContentFragment({ skipFileProcessing: false }),
+      capabilities: LEGACY,
+    });
 
     expect(attachment?.isQueryable).toBe(true);
     expect(attachment?.isIncludable).toBe(true);
@@ -194,14 +347,38 @@ describe("getAttachmentFromFileContentFragment", () => {
   });
 
   it("does not suppress project-context CSV hints", () => {
-    const attachment = getAttachmentFromFileContentFragment(
-      makeFileContentFragment({
+    const attachment = getAttachmentFromFileContentFragment({
+      cf: makeFileContentFragment({
         isInProjectContext: true,
         skipFileProcessing: true,
-      })
-    );
+      }),
+      capabilities: LEGACY,
+    });
 
     expect(attachment?.isQueryable).toBe(true);
     expect(attachment?.isIncludable).toBe(true);
+  });
+
+  it("disables JIT flags when using the new file explorer", () => {
+    const attachment = getAttachmentFromFileContentFragment({
+      cf: makeFileContentFragment({ skipFileProcessing: false }),
+      capabilities: capabilities({ isNewFileExplorer: true }),
+    });
+
+    expect(attachment?.isQueryable).toBe(false);
+    expect(attachment?.isIncludable).toBe(false);
+    expect(attachment?.isSearchable).toBe(false);
+  });
+
+  it("disables queryable when sandbox tools are available", () => {
+    const attachment = getAttachmentFromFileContentFragment({
+      cf: makeFileContentFragment({ skipFileProcessing: false }),
+      capabilities: capabilities({ hasSandboxTools: true }),
+    });
+
+    expect(attachment?.isQueryable).toBe(false);
+    expect(attachment?.isIncludable).toBe(true);
+    // CSV is queryable/includable but not semantically searchable.
+    expect(attachment?.isSearchable).toBe(false);
   });
 });

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -1,5 +1,12 @@
 // All mime types are okay to use from the public API.
 
+import { DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME } from "@app/lib/actions/constants";
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
+import {
+  CONVERSATION_CAT_FILE_ACTION_NAME,
+  CONVERSATION_FILES_SERVER_NAME,
+  CONVERSATION_SEARCH_FILES_ACTION_NAME,
+} from "@app/lib/api/actions/servers/conversation_files/metadata";
 import {
   isConversationIncludableFileContentType,
   isQueryableContentType,
@@ -9,6 +16,7 @@ import { isPastedFile } from "@app/lib/files";
 import logger from "@app/logger/logger";
 import type { ContentFragmentInputWithContentNode } from "@app/types/api/assistant";
 import type {
+  AttachmentCapabilityContext,
   AttachmentCreator,
   BaseConversationAttachmentType,
   ContentNodeAttachmentType,
@@ -65,26 +73,34 @@ export function conversationAttachmentId(
   return attachment.contentFragmentId;
 }
 
-export function getAttachmentFromContentFragment(
-  cf: ContentFragmentType
-): ConversationAttachmentType | null {
+export function getAttachmentFromContentFragment({
+  cf,
+  capabilities,
+}: {
+  cf: ContentFragmentType;
+  capabilities: AttachmentCapabilityContext;
+}): ConversationAttachmentType | null {
   // Expired content fragments cannot be converted to attachments
   if (isExpiredContentFragment(cf)) {
     return null;
   }
 
   if (isContentNodeContentFragment(cf)) {
-    return getAttachmentFromContentNodeContentFragment(cf);
+    // Content nodes are not files: they live outside the file mount and are reached through the
+    // conversation tools in every mode, so their capabilities do not depend on the context.
+    return getAttachmentFromContentNodeContentFragment({ cf });
   }
   if (isFileContentFragment(cf)) {
-    return getAttachmentFromFileContentFragment(cf);
+    return getAttachmentFromFileContentFragment({ cf, capabilities });
   }
   assertNever(cf);
 }
 
-export function getAttachmentFromContentNodeContentFragment(
-  cf: ContentNodeContentFragmentType & { expiredReason: null }
-): ContentNodeAttachmentType {
+export function getAttachmentFromContentNodeContentFragment({
+  cf,
+}: {
+  cf: ContentNodeContentFragmentType & { expiredReason: null };
+}): ContentNodeAttachmentType {
   const isQueryable =
     isQueryableContentType(cf.contentType) || cf.nodeType === "table";
   const isIncludable =
@@ -134,6 +150,11 @@ export function getAttachmentFromContentNodeContentFragment(
   };
 }
 
+/**
+ * `skipFileProcessing` files were uploaded raw for the Computer, so they have no table to query and
+ * no processed text to read. The project-context exemption only bites in legacy conversations: Pods
+ * always use the file explorer, which turns every flag off before we get here.
+ */
 function shouldSuppressTabularAttachmentHints({
   contentType,
   isInProjectContext,
@@ -150,9 +171,63 @@ function shouldSuppressTabularAttachmentHints({
   );
 }
 
-export function getAttachmentFromFileContentFragment(
-  cf: FileContentFragmentType
-): FileAttachmentType | null {
+/**
+ * Capability flags for file attachments. Gated early so callers (JIT, Use: lines, tools) can
+ * trust the booleans without re-checking file-explorer / Computer availability.
+ *
+ * In file explorer mode every flag is off: files are reached by path through the `files` MCP server
+ * and tabular files are analyzed by the Computer, so none of the conversation_files JIT tools apply.
+ */
+function computeFileAttachmentCapabilityFlags({
+  contentType,
+  snippet,
+  isInProjectContext,
+  skipFileProcessing,
+  capabilities: { isNewFileExplorer, hasSandboxTools },
+}: {
+  contentType: SupportedContentFragmentType;
+  snippet: string | null;
+  isInProjectContext: boolean;
+  skipFileProcessing: boolean;
+  capabilities: AttachmentCapabilityContext;
+}): {
+  isQueryable: boolean;
+  isIncludable: boolean;
+  isSearchable: boolean;
+} {
+  // snippet !== null distinguishes pre-JIT attachments (no snippet) from newer ones.
+  // Pasted files and the new file explorer do not use conversation_files JIT for regular files.
+  const canDoJIT =
+    snippet !== null && !isPastedFile(contentType) && !isNewFileExplorer;
+  if (!canDoJIT) {
+    return { isQueryable: false, isIncludable: false, isSearchable: false };
+  }
+
+  const shouldSuppressTabularHints = shouldSuppressTabularAttachmentHints({
+    contentType,
+    isInProjectContext,
+    skipFileProcessing,
+  });
+
+  return {
+    isQueryable:
+      !shouldSuppressTabularHints &&
+      isQueryableContentType(contentType) &&
+      !hasSandboxTools, // Only use query_tables_v2 if Computer is not available.
+    isIncludable:
+      !shouldSuppressTabularHints &&
+      isConversationIncludableFileContentType(contentType),
+    isSearchable: isSearchableContentType(contentType),
+  };
+}
+
+export function getAttachmentFromFileContentFragment({
+  cf,
+  capabilities,
+}: {
+  cf: FileContentFragmentType;
+  capabilities: AttachmentCapabilityContext;
+}): FileAttachmentType | null {
   const fileId = cf.fileId;
   if (!fileId) {
     logger.warn(
@@ -164,25 +239,16 @@ export function getAttachmentFromFileContentFragment(
     );
     return null;
   }
-
-  // Here, snippet not null is actually to detect file attachments that are prior to the JIT
-  // actions, and differentiate them from the newer file attachments that do have a snippet.
-  // Former ones cannot be used in JIT. For pasted files, we also do not support JIT actions.
-  const canDoJIT = cf.snippet !== null && !isPastedFile(cf.contentType);
   const isInProjectContext = cf.isInProjectContext === true;
-  const shouldSuppressTabularHints = shouldSuppressTabularAttachmentHints({
-    contentType: cf.contentType,
-    isInProjectContext,
-    skipFileProcessing: cf.skipFileProcessing === true,
-  });
-  const isQueryable =
-    !shouldSuppressTabularHints &&
-    canDoJIT &&
-    isQueryableContentType(cf.contentType);
-  const isIncludable =
-    !shouldSuppressTabularHints &&
-    isConversationIncludableFileContentType(cf.contentType);
-  const isSearchable = canDoJIT && isSearchableContentType(cf.contentType);
+
+  const { isQueryable, isIncludable, isSearchable } =
+    computeFileAttachmentCapabilityFlags({
+      contentType: cf.contentType,
+      snippet: cf.snippet,
+      isInProjectContext,
+      skipFileProcessing: cf.skipFileProcessing === true,
+      capabilities,
+    });
 
   const creator: AttachmentCreator | null = cf.context.fullName
     ? {
@@ -235,6 +301,7 @@ export function makeFileAttachment({
   hideFromUser,
   path = null,
   creator = null,
+  capabilities,
 }: {
   fileId: string;
   source: "agent" | "user" | null;
@@ -247,12 +314,17 @@ export function makeFileAttachment({
   hideFromUser: boolean;
   path?: string | null;
   creator?: AttachmentCreator | null;
+  capabilities: AttachmentCapabilityContext;
 }): FileAttachmentType {
-  // For pasted files, we also do not support JIT actions.
-  const canDoJIT = snippet !== null && !isPastedFile(contentType);
-  const isIncludable = isConversationIncludableFileContentType(contentType);
-  const isQueryable = canDoJIT && isQueryableContentType(contentType);
-  const isSearchable = canDoJIT && isSearchableContentType(contentType);
+  const { isQueryable, isIncludable, isSearchable } =
+    computeFileAttachmentCapabilityFlags({
+      contentType,
+      snippet,
+      isInProjectContext,
+      // Agent generated files are never sandbox raw uploads: they always go through processing.
+      skipFileProcessing: false,
+      capabilities,
+    });
 
   return {
     fileId,
@@ -296,22 +368,69 @@ export function renderLargePasteXml({
   return `<pastedContent ${attrs.join(" ")}>${content}</pastedContent>`;
 }
 
+/**
+ * Which conversation tools the `Use:` line may point the model at. A capability flag says what the
+ * attachment supports; this says what is callable in this conversation. They differ in file system
+ * mode, where `conversation_files` only registers `list_content_nodes_and_tables` and `cat`.
+ */
+export type AttachmentUsageHints = {
+  hasSemanticSearchTool: boolean;
+};
+
+export function attachmentUsageHintsFor({
+  isNewFileExplorer,
+}: AttachmentCapabilityContext): AttachmentUsageHints {
+  return { hasSemanticSearchTool: !isNewFileExplorer };
+}
+
+function renderAttachmentUsageLine(
+  attachment: ConversationAttachmentType,
+  { hasSemanticSearchTool }: AttachmentUsageHints
+): string | null {
+  const clauses: string[] = [];
+
+  if (attachment.isIncludable) {
+    clauses.push(
+      `read with \`${getPrefixedToolName(CONVERSATION_FILES_SERVER_NAME, CONVERSATION_CAT_FILE_ACTION_NAME)}\``
+    );
+  }
+  if (attachment.isQueryable) {
+    clauses.push(
+      `query tabular data with \`${DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME}\``
+    );
+  }
+  if (attachment.isSearchable && hasSemanticSearchTool) {
+    clauses.push(
+      `semantic search with \`${getPrefixedToolName(CONVERSATION_FILES_SERVER_NAME, CONVERSATION_SEARCH_FILES_ACTION_NAME)}\``
+    );
+  }
+
+  if (clauses.length === 0) {
+    return null;
+  }
+
+  return `Use: ${clauses.join("; ")}.`;
+}
+
+/**
+ * `usage` is null when the caller already inlines the attachment's full content: there is nothing
+ * left to retrieve, and a usage line would both contradict the content and shift the offsets
+ * callers compute over the rendered text.
+ */
 export function renderAttachmentXml({
   attachment,
   content = null,
+  usage,
 }: {
   attachment: ConversationAttachmentType;
   content?: string | null;
+  usage: AttachmentUsageHints | null;
 }): string {
   const params = [
     `id="${conversationAttachmentId(attachment)}"`,
     `type="${attachment.contentType}"`,
     `title="${attachment.title}"`,
     `version="${attachment.contentFragmentVersion}"`,
-    `isInProjectContext="${attachment.isInProjectContext}"`,
-    `isIncludable="${attachment.isIncludable}"`,
-    `isQueryable="${attachment.isQueryable}"`,
-    `isSearchable="${attachment.isSearchable}"`,
   ];
 
   if (isContentNodeAttachmentType(attachment)) {
@@ -321,15 +440,15 @@ export function renderAttachmentXml({
     }
   }
 
-  let tag = `<attachment ${params.join(" ")}`;
-
+  const usageLine = usage ? renderAttachmentUsageLine(attachment, usage) : null;
   const contentToRender = content ?? attachment.snippet;
+  const bodyParts = [usageLine, contentToRender].filter(
+    (part): part is string => part != null && part !== ""
+  );
 
-  if (contentToRender) {
-    tag += `>${contentToRender}\n</attachment>`;
-  } else {
-    tag += "/>";
+  if (bodyParts.length > 0) {
+    return `<attachment ${params.join(" ")}>${bodyParts.join("\n")}\n</attachment>`;
   }
 
-  return tag;
+  return `<attachment ${params.join(" ")}/>`;
 }

--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -130,7 +130,7 @@ export async function ensureConversationTitle(
     return null;
   }
 
-  const title = (conversation.triggerId ? "⚡" : "") + titleRes.value;
+  const title = (conversation.triggerId ? "⚡ " : "") + titleRes.value;
   const updateRes = await updateConversationTitle(auth, {
     conversationId: conversation.sId,
     title,

--- a/front/lib/api/assistant/conversation_rendering/helpers.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.test.ts
@@ -9,11 +9,18 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { mockFullAgentMessage } from "@app/tests/utils/conversation_test_factories";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import type { AttachmentCapabilityContext } from "@app/types/api/assistant/conversation/attachments";
 import type { TextContent } from "@app/types/assistant/generation";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import assert from "assert";
 import { describe, expect, it } from "vitest";
 import { getSteps, renderUserMessage } from "./helpers";
+
+// These cases render tool results that carry no attachment, so the mode does not matter.
+const LEGACY_CAPABILITIES: AttachmentCapabilityContext = {
+  isNewFileExplorer: false,
+  hasSandboxTools: false,
+};
 
 describe("renderUserMessage", () => {
   async function buildMessage(overrides: Partial<any> = {}) {
@@ -298,6 +305,7 @@ The following skills were set as favorites by the user and are also available fo
       workspaceId: "workspace_123",
       conversationId: "conv_1",
       onMissingAction: "skip",
+      capabilities: LEGACY_CAPABILITIES,
     });
 
     expect(steps).toHaveLength(1);
@@ -351,6 +359,7 @@ The following skills were set as favorites by the user and are also available fo
       workspaceId: "workspace_123",
       conversationId: "conv_1",
       onMissingAction: "skip",
+      capabilities: LEGACY_CAPABILITIES,
     });
 
     expect(steps).toHaveLength(1);
@@ -440,6 +449,7 @@ describe("vision image rendering in getSteps", () => {
       conversationId,
       enabledSkillById: new Map(),
       onMissingAction: "skip",
+      capabilities: LEGACY_CAPABILITIES,
     });
 
     expect(steps).toHaveLength(1);
@@ -468,6 +478,7 @@ describe("vision image rendering in getSteps", () => {
       conversationId,
       enabledSkillById: new Map(),
       onMissingAction: "skip",
+      capabilities: LEGACY_CAPABILITIES,
     });
 
     const result = steps[0].actions[0].result;
@@ -499,6 +510,7 @@ describe("vision image rendering in getSteps", () => {
       conversationId,
       enabledSkillById: new Map(),
       onMissingAction: "skip",
+      capabilities: LEGACY_CAPABILITIES,
     });
 
     const result = steps[0].actions[0].result;
@@ -578,6 +590,7 @@ describe("websearch resource array compaction in getSteps", () => {
       conversationId: "conv_1",
       enabledSkillById: new Map(),
       onMissingAction: "skip",
+      capabilities: LEGACY_CAPABILITIES,
     });
 
     const result = steps[0].actions[0].result;

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -24,6 +24,7 @@ import { renderLightContentFragmentForModel } from "@app/lib/resources/content_f
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import type { AttachmentCapabilityContext } from "@app/types/api/assistant/conversation/attachments";
 import type {
   AgentContentItemType,
   AgentErrorContentType,
@@ -95,7 +96,8 @@ function toolResultStatusNotice(
  * text view this returns, in which a non-text result falls back to its JSON serialization.
  */
 export function renderToolResultForModelAsText(
-  action: AgentMCPActionWithOutputType
+  action: AgentMCPActionWithOutputType,
+  capabilities: AttachmentCapabilityContext
 ): string {
   const notice = toolResultStatusNotice(action.status);
   if (notice !== null) {
@@ -103,7 +105,9 @@ export function renderToolResultForModelAsText(
   }
 
   const outputItems = removeNulls(
-    action.output?.map(rewriteContentForModel) ?? []
+    action.output?.map((content) =>
+      rewriteContentForModel(content, capabilities)
+    ) ?? []
   );
   if (outputItems.length === 0) {
     return "Successfully executed action, no output.";
@@ -201,7 +205,13 @@ async function renderActionForMultiActionsModel(
   auth: Authenticator,
   action: AgentMCPActionWithOutputType,
   model: ModelConfigurationType,
-  { conversationId }: { conversationId: string }
+  {
+    conversationId,
+    capabilities,
+  }: {
+    conversationId: string;
+    capabilities: AttachmentCapabilityContext;
+  }
 ): Promise<FunctionMessageTypeModel> {
   const notice = toolResultStatusNotice(action.status);
   if (notice !== null) {
@@ -214,7 +224,9 @@ async function renderActionForMultiActionsModel(
   }
 
   const outputItems = removeNulls(
-    action.output?.map(rewriteContentForModel) ?? []
+    action.output?.map((content) =>
+      rewriteContentForModel(content, capabilities)
+    ) ?? []
   );
 
   // When the user edited the tool inputs before approving, the result is prepended with a note so
@@ -271,7 +283,7 @@ async function renderActionForMultiActionsModel(
     };
   }
 
-  const resultText = renderToolResultForModelAsText(action);
+  const resultText = renderToolResultForModelAsText(action, capabilities);
 
   return {
     role: "function" as const,
@@ -295,6 +307,7 @@ export async function getSteps(
     conversationId,
     onMissingAction,
     enabledSkillById,
+    capabilities,
   }: {
     model: ModelConfigurationType;
     message: AgentMessageType;
@@ -302,6 +315,7 @@ export async function getSteps(
     conversationId: string;
     onMissingAction: "inject-placeholder" | "skip";
     enabledSkillById: ReadonlyMap<string, EnabledSkill>;
+    capabilities: AttachmentCapabilityContext;
   }
 ): Promise<Step[]> {
   const supportedModel = getSupportedModelConfig(model);
@@ -326,6 +340,7 @@ export async function getSteps(
       action,
       result: await renderActionForMultiActionsModel(auth, action, model, {
         conversationId,
+        capabilities,
       }),
       enabledSkillMessages: renderEnabledSkillMessagesForAction(action, {
         enabledSkillById,
@@ -593,10 +608,10 @@ export async function renderContentFragment(
   model: ModelConfigurationType,
   {
     excludeImages,
-    useFileSystem,
+    capabilities,
   }: {
     excludeImages: boolean;
-    useFileSystem: boolean;
+    capabilities: AttachmentCapabilityContext;
   }
 ): Promise<ModelMessageTypeMultiActions | null> {
   const renderedContentFragment = await renderLightContentFragmentForModel(
@@ -605,7 +620,7 @@ export async function renderContentFragment(
     model,
     {
       excludeImages: Boolean(excludeImages),
-      useFileSystem,
+      capabilities,
     }
   );
   return renderedContentFragment;

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
@@ -10,6 +10,17 @@ import type {
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// These cases exercise message ordering and visibility, not attachments, so the capability lookup
+// is stubbed out rather than backed by a workspace.
+vi.mock(
+  import("@app/lib/api/assistant/conversation/attachment_capabilities"),
+  () => ({
+    getAttachmentCapabilityContext: vi
+      .fn()
+      .mockResolvedValue({ isNewFileExplorer: false, hasSandboxTools: false }),
+  })
+);
+
 // Mock the helpers module
 vi.mock(import("./helpers"), async (importOriginal) => {
   const mod = await importOriginal();

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -2,6 +2,7 @@
  * Message rendering logic shared between legacy and enhanced implementations
  */
 
+import { getAttachmentCapabilityContext } from "@app/lib/api/assistant/conversation/attachment_capabilities";
 import type { Step } from "@app/lib/api/assistant/conversation_rendering/helpers";
 import {
   getSteps,
@@ -157,6 +158,7 @@ export async function renderAllMessages(
     enabledSkills: EnabledSkill[];
   }
 ): Promise<ModelMessageTypeMultiActions[]> {
+  const capabilities = await getAttachmentCapabilityContext(auth, conversation);
   const messages: ModelMessageTypeMultiActions[] = [];
   const enabledSkillById = new Map(
     enabledSkills.map((skill) => [skill.sId, skill])
@@ -194,6 +196,7 @@ export async function renderAllMessages(
             conversationId: conversation.sId,
             onMissingAction,
             enabledSkillById,
+            capabilities,
           });
 
           const agentMessages = renderAgentSteps(
@@ -224,7 +227,7 @@ export async function renderAllMessages(
           model,
           {
             excludeImages: !!excludeImages,
-            useFileSystem: conversation.metadata?.useFileSystem === true,
+            capabilities,
           }
         );
         if (renderedContentFragment) {

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -1,6 +1,5 @@
 import { FILE_OFFLOAD_TEXT_SIZE_BYTES } from "@app/lib/actions/action_output_limits";
 import {
-  DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
   ENABLE_SKILL_TOOL_NAME,
   TOOL_NAME_SEPARATOR,
 } from "@app/lib/actions/constants";
@@ -18,11 +17,6 @@ import {
   COMMON_UTILITIES_SERVER_NAME,
   SET_CONVERSATION_TITLE_TOOL_NAME,
 } from "@app/lib/api/actions/servers/common_utilities/metadata";
-import {
-  CONVERSATION_CAT_FILE_ACTION_NAME,
-  CONVERSATION_FILES_SERVER_NAME,
-  CONVERSATION_SEARCH_FILES_ACTION_NAME,
-} from "@app/lib/api/actions/servers/conversation_files/metadata";
 import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
 import { citationMetaPrompt } from "@app/lib/api/assistant/citations";
 import { isDustLikeAgent } from "@app/lib/api/assistant/global_agents/prompt_context";
@@ -274,14 +268,10 @@ function constructAttachmentsSection({
 
   return (
     "# ATTACHMENTS\n" +
-    'The conversation history may contain file attachments, indicated by attachment tags of the form <attachment id="{FILE_ID}" type="{MIME_TYPE}" title="{TITLE}" version="{VERSION}" isIncludable="{IS_INCLUDABLE}" isQueryable="{IS_QUERYABLE}" isSearchable="{IS_SEARCHABLE}" sourceUrl="{SOURCE_URL}"> . ' +
+    'The conversation history may contain file attachments, indicated by <attachment id="{FILE_ID}" type="{MIME_TYPE}" title="{TITLE}" version="{VERSION}"> tags. ' +
     "Attachments may originate from the user directly or from tool outputs. " +
     "These tags indicate when the file was attached but often do not contain the full contents (it may contain a small snippet or description of the file).\n" +
-    "Three flags indicate how an attachment can be used:\n\n" +
-    `- isIncludable: attachment contents can be retrieved directly, using conversation tool \`${getPrefixedToolName(CONVERSATION_FILES_SERVER_NAME, CONVERSATION_CAT_FILE_ACTION_NAME)}\`;\n` +
-    `- isQueryable: attachment contents are tabular data that can be queried alongside other queryable conversation files' tabular data using \`${DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME}\`;\n` +
-    `- isSearchable: attachment contents are available for semantic search, i.e. when semantically searching conversation files' content, using \`${getPrefixedToolName(CONVERSATION_FILES_SERVER_NAME, CONVERSATION_SEARCH_FILES_ACTION_NAME)}\`,` +
-    " contents of this attachment will be considered in the search.\n" +
+    'When a "Use:" line is present on an attachment, call those tools with the attachment id to access its content.\n' +
     sandboxFilesPrompt +
     "Other tools that accept files (referenced by their id) as arguments can be available. Rely on their description and the files' types to decide which tool to use on which file.\n"
   );
@@ -303,6 +293,7 @@ function constructAttachmentsSectionNewFileExplorer({
     `Files attached to the conversation are accessible via the \`${FILES_SERVER_NAME}\` server.\n\n` +
     "Some attachments remain visible in the conversation history as metadata tags:\n\n" +
     "- Connected data references (content nodes with a `nodeId` and `sourceUrl`) appear as `<attachment>` tags; use the available search and retrieval tools to access their full content.\n" +
+    'When a "Use:" line is present on an attachment, call those tools with the attachment id to access its content.\n' +
     sandboxFilesPrompt
   );
 }

--- a/front/lib/api/assistant/jit/query_tables_v2.ts
+++ b/front/lib/api/assistant/jit/query_tables_v2.ts
@@ -36,19 +36,9 @@ export async function getQueryTablesServer(
   auth: Authenticator,
   conversation: ConversationWithoutContentType,
   attachments: ConversationAttachmentType[],
-  autoInternalViews: Map<AutoInternalMCPServerNameType, MCPServerViewResource>,
-  { hasSandboxTools }: { hasSandboxTools: boolean }
+  autoInternalViews: Map<AutoInternalMCPServerNameType, MCPServerViewResource>
 ): Promise<ServerSideMCPServerConfigurationType | null> {
-  const filesUsableAsTableQuery = attachments.filter((f) => {
-    if (!f.isQueryable) {
-      return false;
-    }
-    // Computer handles tabular file attachments; keep content nodes on query_tables.
-    if (hasSandboxTools && isFileAttachmentType(f)) {
-      return false;
-    }
-    return true;
-  });
+  const filesUsableAsTableQuery = attachments.filter((f) => f.isQueryable);
 
   if (filesUsableAsTableQuery.length === 0) {
     return null;

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -3,6 +3,7 @@ import {
   CONVERSATION_FILES_SERVER_NAME,
   CONVERSATION_LIST_FILES_ACTION_NAME,
 } from "@app/lib/api/actions/servers/conversation_files/metadata";
+import { makeFileAttachment } from "@app/lib/api/assistant/conversation/attachments";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -936,24 +937,20 @@ describe("getJITServers", () => {
         status: "ready",
       });
 
+      // Built through the constructor so the flags cannot describe a state the product can't reach.
       const attachments: ConversationAttachmentType[] = [
-        {
+        makeFileAttachment({
           fileId: file.sId,
-          path: null,
           source: "user",
           title: "test.csv",
           contentType: "text/csv",
-          contentFragmentVersion: "latest",
           snippet: "test snippet",
-          generatedTables: [file.sId],
-          isIncludable: true,
-          isSearchable: true,
-          isQueryable: true,
           isInProjectContext: false,
-          hidden: false,
-          creator: null,
-        },
+          hideFromUser: false,
+          capabilities: { isNewFileExplorer: false, hasSandboxTools: false },
+        }),
       ];
+      expect(attachments[0].isQueryable).toBe(true);
 
       const jitServers = await getJITServers(auth, {
         agentConfiguration: agentConfig,
@@ -978,7 +975,7 @@ describe("getJITServers", () => {
       // but the server should still be created with the correct structure.
     });
 
-    it("should not include query_tables server for queryable file attachments when Computer is available", async () => {
+    it("should not include query_tables server for tabular file attachments when Computer is available", async () => {
       const user = auth.getNonNullableUser();
       const file = await FileFactory.csv(auth, user, {
         useCase: "conversation",
@@ -988,24 +985,21 @@ describe("getJITServers", () => {
         status: "ready",
       });
 
+      // With Computer available the sandbox analyzes tabular files, so the attachment comes out
+      // non-queryable and query_tables has nothing to register for.
       const attachments: ConversationAttachmentType[] = [
-        {
+        makeFileAttachment({
           fileId: file.sId,
-          path: null,
           source: "user",
           title: "test.csv",
           contentType: "text/csv",
-          contentFragmentVersion: "latest",
           snippet: "test snippet",
-          generatedTables: [file.sId],
-          isIncludable: true,
-          isSearchable: true,
-          isQueryable: true,
           isInProjectContext: false,
-          hidden: false,
-          creator: null,
-        },
+          hideFromUser: false,
+          capabilities: { isNewFileExplorer: false, hasSandboxTools: true },
+        }),
       ];
+      expect(attachments[0].isQueryable).toBe(false);
 
       const jitServers = await getJITServers(auth, {
         agentConfiguration: agentConfig,

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -1,9 +1,6 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
-import {
-  isContentNodeAttachmentType,
-  isFileAttachmentType,
-} from "@app/lib/api/assistant/conversation/attachments";
+import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { getAskUserQuestionServer } from "@app/lib/api/assistant/jit/ask_user_question";
 import { getCommonUtilitiesServer } from "@app/lib/api/assistant/jit/common_utilities";
 import {
@@ -17,12 +14,10 @@ import { getSkillManagementServer } from "@app/lib/api/assistant/jit/skills";
 import { getTriggersManagementServer } from "@app/lib/api/assistant/jit/triggers_management";
 import { isSearchableFolder } from "@app/lib/api/assistant/jit_utils";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { ConversationAttachmentType } from "@app/types/api/assistant/conversation/attachments";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
-import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import { removeNulls } from "@app/types/shared/utils/general";
 
 const ALWAYS_PREFETCHED_MCP_SERVERS: AutoInternalMCPServerNameType[] = [
@@ -35,7 +30,6 @@ const ALWAYS_PREFETCHED_MCP_SERVERS: AutoInternalMCPServerNameType[] = [
 
 type ConditionalMCPServerContext = {
   attachments: ConversationAttachmentType[];
-  hasSandboxTools: boolean;
 };
 
 const CONDITIONAL_MCP_SERVER_NAMES = [
@@ -56,12 +50,10 @@ const CONDITIONAL_MCP_SERVERS: Record<
 > = {
   // Note there is an additional filtering on the tools (see: front/lib/api/actions/servers/conversation_files/index.ts)
   conversation_files: ({ attachments }) => attachments.length > 0,
-  // Queryable content nodes always use query_tables. File attachments only do when Computer
-  // is unavailable (otherwise the sandbox handles tabular files).
-  query_tables_v2: ({ attachments, hasSandboxTools }) =>
-    attachments.some((a) => isContentNodeAttachmentType(a) && a.isQueryable) ||
-    (!hasSandboxTools &&
-      attachments.some((a) => isFileAttachmentType(a) && a.isQueryable)),
+  // `isQueryable` already accounts for Computer availability and for the file explorer, so file
+  // attachments only reach here in legacy conversations without the sandbox.
+  query_tables_v2: ({ attachments }) => attachments.some((a) => a.isQueryable),
+  // Folder search is distinct from attachment.isSearchable (conversation semantic search).
   search: ({ attachments }) =>
     attachments.some(
       (a) => isContentNodeAttachmentType(a) && isSearchableFolder(a)
@@ -131,7 +123,6 @@ async function getConditionalJITServers(
     conversation,
     attachments,
     autoInternalViews,
-    hasSandboxTools,
   }: {
     agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
     conversation: ConversationWithoutContentType;
@@ -140,7 +131,6 @@ async function getConditionalJITServers(
       AutoInternalMCPServerNameType,
       MCPServerViewResource
     >;
-    hasSandboxTools: boolean;
   }
 ): Promise<ServerSideMCPServerConfigurationType[]> {
   const servers: (ServerSideMCPServerConfigurationType | null)[] = [];
@@ -172,8 +162,7 @@ async function getConditionalJITServers(
         auth,
         conversation,
         attachments,
-        autoInternalViews,
-        { hasSandboxTools }
+        autoInternalViews
       )
     );
   }
@@ -199,16 +188,12 @@ export async function getJITServers(
     attachments: ConversationAttachmentType[];
   }
 ): Promise<ServerSideMCPServerConfigurationType[]> {
-  const featureFlags = await getFeatureFlags(auth);
-  const hasSandboxTools = isComputerFeatureEnabled(featureFlags);
-
   const mcpServersToFetch = new Set<AutoInternalMCPServerNameType>(
     ALWAYS_PREFETCHED_MCP_SERVERS
   );
 
   const conditionalContext: ConditionalMCPServerContext = {
     attachments,
-    hasSandboxTools,
   };
   for (const name of CONDITIONAL_MCP_SERVER_NAMES) {
     if (CONDITIONAL_MCP_SERVERS[name](conditionalContext)) {
@@ -233,7 +218,6 @@ export async function getJITServers(
       conversation,
       attachments,
       autoInternalViews,
-      hasSandboxTools,
     }),
   ]);
 

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -1,6 +1,7 @@
 // Okay to use public API types because here front is talking to core API.
 
 import { fetchContentFragmentsForConversation } from "@app/lib/api/assistant/content_fragments";
+import { getAttachmentCapabilityContext } from "@app/lib/api/assistant/conversation/attachment_capabilities";
 import {
   getAttachmentFromContentFragment,
   makeFileAttachment,
@@ -43,8 +44,13 @@ export async function listAttachments(
     }),
   ]);
 
+  const capabilities = await getAttachmentCapabilityContext(auth, conversation);
+
   for (const m of contentFragments) {
-    const attachment = getAttachmentFromContentFragment(m);
+    const attachment = getAttachmentFromContentFragment({
+      cf: m,
+      capabilities,
+    });
     if (attachment) {
       attachments.set(
         m.contentFragmentId,
@@ -67,6 +73,7 @@ export async function listAttachments(
         isInProjectContext: f.isInProjectContext ?? false,
         hideFromUser: f.hidden ?? false,
         creator: f.creator,
+        capabilities,
       })
     );
   }

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -1,5 +1,5 @@
 import {
-  getAttachmentFromContentFragment,
+  getAttachmentFromContentNodeContentFragment,
   isContentNodeAttachmentType,
 } from "@app/lib/api/assistant/conversation/attachments";
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
@@ -27,6 +27,10 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { ContentFragmentInputWithContentNode } from "@app/types/api/assistant";
 import type { ConversationAttachmentType } from "@app/types/api/assistant/conversation/attachments";
 import type { FileSystemDirectoryEntry } from "@app/types/api/file_system/types";
+import {
+  isContentNodeContentFragment,
+  isExpiredContentFragment,
+} from "@app/types/content_fragment";
 import type { ContentNodeType } from "@app/types/core/content_node";
 import type { ConnectorProvider } from "@app/types/data_source";
 import { DustFileSystemError, podScopedPath } from "@app/types/file_system";
@@ -99,6 +103,8 @@ export async function listProjectContextAttachments(
   const merged = new Map<string, ConversationAttachmentType>();
 
   for (const fragment of fragments) {
+    // File-backed project files are served by the GCS-backed endpoints, so only content nodes are
+    // turned into attachments here. Their capabilities do not depend on the conversation.
     if (fragment.fileId != null) {
       continue;
     }
@@ -111,10 +117,11 @@ export async function listProjectContextAttachments(
         file: null,
       }
     );
-    const attachment = getAttachmentFromContentFragment(cf);
-    if (!attachment || !isContentNodeAttachmentType(attachment)) {
+    if (isExpiredContentFragment(cf) || !isContentNodeContentFragment(cf)) {
       continue;
     }
+
+    const attachment = getAttachmentFromContentNodeContentFragment({ cf });
 
     const key = attachment.contentFragmentId;
     if (merged.has(key)) {

--- a/front/lib/resources/content_fragment_resource.test.ts
+++ b/front/lib/resources/content_fragment_resource.test.ts
@@ -8,6 +8,7 @@ import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
 import { renderLightContentFragmentForModel } from "@app/lib/resources/content_fragment_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { AttachmentCapabilityContext } from "@app/types/api/assistant/conversation/attachments";
 import type { ContentFragmentMessageTypeModel } from "@app/types/assistant/generation";
 import { isTextContent } from "@app/types/assistant/generation";
 import type {
@@ -16,6 +17,17 @@ import type {
   SupportedContentFragmentType,
 } from "@app/types/content_fragment";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const LEGACY: AttachmentCapabilityContext = {
+  isNewFileExplorer: false,
+  hasSandboxTools: false,
+};
+
+// Computer is enabled unless a workspace opts out, so file explorer conversations normally have it.
+const FILE_SYSTEM: AttachmentCapabilityContext = {
+  isNewFileExplorer: true,
+  hasSandboxTools: true,
+};
 
 const BASE_CONTEXT = {
   username: "user",
@@ -126,13 +138,13 @@ describe("renderLightContentFragmentForModel", () => {
     ).mockResolvedValue("https://signed.url/image.png");
   });
 
-  describe("useFileSystem: false", () => {
+  describe("legacy attachments (no file explorer)", () => {
     it("renders a regular file as <attachment>", async () => {
       const result = await renderLightContentFragmentForModel(
         authenticator,
         makeFileFragment("application/pdf"),
         visionModel,
-        { excludeImages: false, useFileSystem: false }
+        { excludeImages: false, capabilities: LEGACY }
       );
       expect(result?.content[0]).toMatchObject({ type: "text" });
       expect((result?.content[0] as { text: string }).text).toContain(
@@ -148,7 +160,7 @@ describe("renderLightContentFragmentForModel", () => {
           snippet: "",
         }),
         visionModel,
-        { excludeImages: false, useFileSystem: false }
+        { excludeImages: false, capabilities: LEGACY }
       );
       expect((result?.content[0] as { text: string }).text).toContain(
         "<attachment"
@@ -160,7 +172,7 @@ describe("renderLightContentFragmentForModel", () => {
         authenticator,
         makeFileFragment("text/vnd.dust.attachment.pasted"),
         visionModel,
-        { excludeImages: false, useFileSystem: false }
+        { excludeImages: false, capabilities: LEGACY }
       );
       expect((result?.content[0] as { text: string }).text).toContain(
         "<pastedContent"
@@ -175,7 +187,7 @@ describe("renderLightContentFragmentForModel", () => {
           snippet: pasteContent,
         }),
         visionModel,
-        { excludeImages: false, useFileSystem: false }
+        { excludeImages: false, capabilities: LEGACY }
       );
       const text = getTextContent(result);
       expect(text).toContain(
@@ -193,7 +205,7 @@ describe("renderLightContentFragmentForModel", () => {
           path: "conversation-conv123/pasted-text-1.txt",
         }),
         visionModel,
-        { excludeImages: false, useFileSystem: false }
+        { excludeImages: false, capabilities: LEGACY }
       );
       const text = getTextContent(result);
       expect(text).toContain('truncated="true"');
@@ -208,7 +220,7 @@ describe("renderLightContentFragmentForModel", () => {
           path: "conversation-conv123/pasted-text-1.txt",
         }),
         visionModel,
-        { excludeImages: false, useFileSystem: false }
+        { excludeImages: false, capabilities: LEGACY }
       );
       const text = getTextContent(result);
       expect(text).toContain('truncated="true"');
@@ -224,7 +236,7 @@ describe("renderLightContentFragmentForModel", () => {
           path: "conversation-conv123/pasted-text-1.txt",
         }),
         visionModel,
-        { excludeImages: false, useFileSystem: false }
+        { excludeImages: false, capabilities: LEGACY }
       );
       const text = getTextContent(result);
       expect(text).not.toContain(fullPaste);
@@ -239,7 +251,7 @@ describe("renderLightContentFragmentForModel", () => {
         authenticator,
         makeFileFragment("image/png"),
         visionModel,
-        { excludeImages: true, useFileSystem: false }
+        { excludeImages: true, capabilities: LEGACY }
       );
       const text = (result?.content[0] as { text: string }).text;
       expect(text).toContain("<attachment");
@@ -253,7 +265,7 @@ describe("renderLightContentFragmentForModel", () => {
         authenticator,
         makeFileFragment("image/png"),
         nonVisionModel,
-        { excludeImages: false, useFileSystem: false }
+        { excludeImages: false, capabilities: LEGACY }
       );
       const text = (result?.content[0] as { text: string }).text;
       expect(text).toContain("<attachment");
@@ -267,7 +279,7 @@ describe("renderLightContentFragmentForModel", () => {
         authenticator,
         makeContentNodeFragment(),
         visionModel,
-        { excludeImages: false, useFileSystem: false }
+        { excludeImages: false, capabilities: LEGACY }
       );
       expect((result?.content[0] as { text: string }).text).toContain(
         "<attachment"
@@ -275,13 +287,13 @@ describe("renderLightContentFragmentForModel", () => {
     });
   });
 
-  describe("useFileSystem: true", () => {
+  describe("file explorer", () => {
     it("renders a regular file as <file> without snippet and without path when path is null", async () => {
       const result = await renderLightContentFragmentForModel(
         authenticator,
         makeFileFragment("application/pdf"),
         visionModel,
-        { excludeImages: false, useFileSystem: true }
+        { excludeImages: false, capabilities: FILE_SYSTEM }
       );
       expect(result?.content[0]).toMatchObject({
         type: "text",
@@ -294,7 +306,7 @@ describe("renderLightContentFragmentForModel", () => {
         authenticator,
         makeFileFragment("text/plain", { snippet: "First 256 chars..." }),
         visionModel,
-        { excludeImages: false, useFileSystem: true }
+        { excludeImages: false, capabilities: FILE_SYSTEM }
       );
       expect(result?.content[0]).toMatchObject({
         type: "text",
@@ -309,7 +321,7 @@ describe("renderLightContentFragmentForModel", () => {
           path: "conversation-conv123/report_fil_abc123.pdf",
         }),
         visionModel,
-        { excludeImages: false, useFileSystem: true }
+        { excludeImages: false, capabilities: FILE_SYSTEM }
       );
       expect(result).not.toBeNull();
       expect(result?.content[0]).toMatchObject({
@@ -327,7 +339,7 @@ describe("renderLightContentFragmentForModel", () => {
             "conversation-conv123/voice-2026-07-24T11:20:00.714Z.processed.txt",
         }),
         visionModel,
-        { excludeImages: false, useFileSystem: true }
+        { excludeImages: false, capabilities: FILE_SYSTEM }
       );
       expect(result?.content[0]).toMatchObject({
         type: "text",
@@ -338,7 +350,7 @@ describe("renderLightContentFragmentForModel", () => {
       });
     });
 
-    it("renders a queryable CSV as <attachment> (bypasses new file explorer)", async () => {
+    it("renders a tabular file as <file>: the Computer reads it from the mount", async () => {
       const result = await renderLightContentFragmentForModel(
         authenticator,
         makeFileFragment("text/csv", {
@@ -346,11 +358,11 @@ describe("renderLightContentFragmentForModel", () => {
           snippet: "",
         }),
         visionModel,
-        { excludeImages: false, useFileSystem: true }
+        { excludeImages: false, capabilities: FILE_SYSTEM }
       );
-      expect((result?.content[0] as { text: string }).text).toContain(
-        "<attachment"
-      );
+      const text = (result?.content[0] as { text: string }).text;
+      expect(text).toContain("<file");
+      expect(text).not.toContain("<attachment");
     });
 
     it("renders a content node as <attachment> (bypasses new file explorer)", async () => {
@@ -358,7 +370,7 @@ describe("renderLightContentFragmentForModel", () => {
         authenticator,
         makeContentNodeFragment(),
         visionModel,
-        { excludeImages: false, useFileSystem: true }
+        { excludeImages: false, capabilities: FILE_SYSTEM }
       );
       expect((result?.content[0] as { text: string }).text).toContain(
         "<attachment"
@@ -370,7 +382,7 @@ describe("renderLightContentFragmentForModel", () => {
         authenticator,
         makeFileFragment("text/vnd.dust.attachment.pasted"),
         visionModel,
-        { excludeImages: false, useFileSystem: true }
+        { excludeImages: false, capabilities: FILE_SYSTEM }
       );
       expect((result?.content[0] as { text: string }).text).toContain(
         "<pastedContent"
@@ -384,7 +396,7 @@ describe("renderLightContentFragmentForModel", () => {
           path: "conversation-conv123/image.png",
         }),
         visionModel,
-        { excludeImages: true, useFileSystem: true }
+        { excludeImages: true, capabilities: FILE_SYSTEM }
       );
       const text = (result?.content[0] as { text: string }).text;
       expect(text).toContain(
@@ -402,7 +414,7 @@ describe("renderLightContentFragmentForModel", () => {
           path: "conversation-conv123/image.png",
         }),
         nonVisionModel,
-        { excludeImages: false, useFileSystem: true }
+        { excludeImages: false, capabilities: FILE_SYSTEM }
       );
       const text = (result?.content[0] as { text: string }).text;
       expect(text).toContain(
@@ -420,7 +432,7 @@ describe("renderLightContentFragmentForModel", () => {
           path: "conversation-conv123/image.png",
         }),
         visionModel,
-        { excludeImages: false, useFileSystem: true }
+        { excludeImages: false, capabilities: FILE_SYSTEM }
       );
       expect(result?.content).toHaveLength(2);
       expect(result?.content[0]).toMatchObject({ type: "image_url" });

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -1,7 +1,8 @@
+import type { AttachmentUsageHints } from "@app/lib/api/assistant/conversation/attachments";
 import {
+  attachmentUsageHintsFor,
   conversationAttachmentId,
   getAttachmentFromContentFragment,
-  isContentNodeAttachmentType,
   isFileAttachmentType,
   renderAttachmentXml,
   renderLargePasteXml,
@@ -37,7 +38,10 @@ import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import type { ConversationAttachmentType } from "@app/types/api/assistant/conversation/attachments";
+import type {
+  AttachmentCapabilityContext,
+  ConversationAttachmentType,
+} from "@app/types/api/assistant/conversation/attachments";
 import type { ContentFragmentMessageTypeModel } from "@app/types/assistant/generation";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type {
@@ -1003,6 +1007,10 @@ async function getSignedUrlForVersion(
   });
 }
 
+/**
+ * Retrieves an attachment's content for the `cat` tool. The rendered XML therefore never carries a
+ * usage line: the content is already here, and the caller slices offset/limit over this text.
+ */
 export async function getContentFragmentFromAttachmentFile(
   auth: Authenticator,
   {
@@ -1043,7 +1051,7 @@ export async function getContentFragmentFromAttachmentFile(
         content: [
           {
             type: "text",
-            text: renderAttachmentXml({ attachment }),
+            text: renderAttachmentXml({ attachment, usage: null }),
           },
         ],
       });
@@ -1114,6 +1122,7 @@ export async function getContentFragmentFromAttachmentFile(
           text: renderAttachmentXml({
             attachment,
             content: document.document.text ?? null,
+            usage: null,
           }),
         },
       ],
@@ -1160,6 +1169,7 @@ export async function getContentFragmentFromAttachmentFile(
           text: renderAttachmentXml({
             attachment,
             content,
+            usage: null,
           }),
         },
       ],
@@ -1176,9 +1186,11 @@ function renderFileOrAttachmentXml(
   {
     content,
     isNewFileExplorer,
+    usage,
   }: {
     content?: string | null;
     isNewFileExplorer: boolean;
+    usage: AttachmentUsageHints;
   }
 ): string {
   if (isNewFileExplorer) {
@@ -1196,7 +1208,7 @@ function renderFileOrAttachmentXml(
       : `<file name="${attachment.title}"${pathAttr}${processedPathAttr}/>`;
   }
 
-  return renderAttachmentXml({ attachment, content: content ?? null });
+  return renderAttachmentXml({ attachment, content: content ?? null, usage });
 }
 
 // Render only a tag to specify that a content fragment was injected at a given position except for
@@ -1207,10 +1219,10 @@ export async function renderLightContentFragmentForModel(
   model: ModelConfigurationType,
   {
     excludeImages,
-    useFileSystem,
+    capabilities,
   }: {
     excludeImages: boolean;
-    useFileSystem: boolean;
+    capabilities: AttachmentCapabilityContext;
   }
 ): Promise<ContentFragmentMessageTypeModel | null> {
   const { contentType } = message;
@@ -1228,7 +1240,10 @@ export async function renderLightContentFragmentForModel(
     };
   }
 
-  const rawAttachment = getAttachmentFromContentFragment(message);
+  const rawAttachment = getAttachmentFromContentFragment({
+    cf: message,
+    capabilities,
+  });
   if (!rawAttachment) {
     return null;
   }
@@ -1238,7 +1253,13 @@ export async function renderLightContentFragmentForModel(
   const fileStringId =
     message.contentFragmentType === "file" ? message.fileId : null;
 
-  const isNewFileExplorer = fileStringId ? useFileSystem : false;
+  // Whether this specific attachment lives on the file mount. Content nodes never do, even in a
+  // file system conversation, so they keep the attachment XML rendering.
+  const isNewFileExplorer = fileStringId
+    ? capabilities.isNewFileExplorer
+    : false;
+  // Tool availability is conversation-wide, so it follows the context and not the attachment.
+  const usage = attachmentUsageHintsFor(capabilities);
 
   // Pasted content is always inlined regardless of feature flags.
   if (fileStringId && isPastedFile(contentType)) {
@@ -1281,6 +1302,7 @@ export async function renderLightContentFragmentForModel(
             type: "text",
             text: renderFileOrAttachmentXml(attachment, {
               isNewFileExplorer,
+              usage,
               content:
                 "[Image content interpreted by a vision-enabled model. " +
                 "Description not available in this context.",
@@ -1309,21 +1331,20 @@ export async function renderLightContentFragmentForModel(
         },
         {
           type: "text" as const,
-          text: renderFileOrAttachmentXml(attachment, { isNewFileExplorer }),
+          text: renderFileOrAttachmentXml(attachment, {
+            isNewFileExplorer,
+            usage,
+          }),
         },
       ],
     };
   }
 
-  // When the conversation uses the new file system, regular file attachments are accessible via
-  // the `files` server (path-based). Emit a slim <file> tag so the model knows the file exists
-  // and how to reach it. Queryable tables and content nodes are excluded: they rely on legacy
-  // attachment XML for query_tables_v2 and include_file wiring.
-  if (
-    isNewFileExplorer &&
-    !attachment.isQueryable &&
-    !isContentNodeAttachmentType(attachment)
-  ) {
+  // When the conversation uses the new file system, every regular file attachment is reached by
+  // path through the `files` server, tabular ones included (the Computer analyzes those). Emit a
+  // slim <file> tag so the model knows the file exists and how to reach it. `isNewFileExplorer` is
+  // already false for content nodes, which have no path and keep the attachment XML below.
+  if (isNewFileExplorer) {
     return {
       role: "content_fragment",
       name: `attach_${contentType}`,
@@ -1332,6 +1353,7 @@ export async function renderLightContentFragmentForModel(
           type: "text",
           text: renderFileOrAttachmentXml(attachment, {
             isNewFileExplorer,
+            usage,
             content: attachment.snippet,
           }),
         },
@@ -1349,6 +1371,7 @@ export async function renderLightContentFragmentForModel(
           // Use fileId as contentFragmentId to provide a consistent identifier for the model
           // to reference content fragments across different actions like include_file.
           attachment,
+          usage,
         }),
       },
     ],

--- a/front/types/api/assistant/conversation/attachments.ts
+++ b/front/types/api/assistant/conversation/attachments.ts
@@ -10,6 +10,18 @@ export type AttachmentCreator = {
   pictureUrl: string;
 };
 
+/**
+ * Conversation-wide inputs deciding which JIT capabilities a file attachment can expose. Resolved
+ * once per conversation (see `getAttachmentCapabilityContext`) and passed down so the capability
+ * flags on an attachment can be trusted without re-checking the conversation or the workspace.
+ */
+export type AttachmentCapabilityContext = {
+  /** The conversation exposes its files through the `files` MCP server rather than by fileId. */
+  isNewFileExplorer: boolean;
+  /** The workspace can run the Computer, which handles tabular files itself. */
+  hasSandboxTools: boolean;
+};
+
 export type BaseConversationAttachmentType = {
   title: string;
   contentType: SupportedContentFragmentType;


### PR DESCRIPTION
## Description

Centralizes `isQueryable`/`isIncludable`/`isSearchable` flag computation into a single `computeFileAttachmentCapabilityFlags()` function inside `attachments.ts`, gated on a new `AttachmentCapabilityContext` (`{ isNewFileExplorer, hasSandboxTools }`). Previously, each call site re-derived these flags inline, leading to drift between JIT server eligibility checks, XML rendering, and tool footprint measurement.

- New `attachment_capabilities.ts` exposes `getAttachmentCapabilityContext(auth, conversation)` as the single resolver; callers obtain it once per rendering pass and thread it down.
- `<attachment>` XML tags drop the `isIncludable/isQueryable/isSearchable` boolean attributes in favour of an inline `Use: read with \`…\`; …` line listing only the tools registered in the current mode.
- `getJITServers` / `getConditionalJITServers` / `getQueryTablesServer` drop `hasSandboxTools` from their signatures — `attachment.isQueryable` is now already false when the sandbox handles tabular files, so the flag is redundant.
- `getAttachmentFromContentFragment`, `getAttachmentFromFileContentFragment`, and `getAttachmentFromContentNodeContentFragment` switch to named-object arguments.
- Two small bundled fixes: inverted `Zap`/`ZapOff` icon in `PodConversationsTab` when hiding triggered conversations; missing space after ⚡ in triggered conversation titles.

## Tests

Existing unit tests in `attachments.test.ts`, `conversation_files/tools/index.test.ts`, `tool_footprint.test.ts`, and `helpers.test.ts` updated to pass `capabilities`. New test cases added for `isNewFileExplorer` and `hasSandboxTools` flag combinations, the per-mode `Use:` line content, and the omission of `Use:` when content is inlined. `message_rendering.test.ts` stubs `getAttachmentCapabilityContext` via `vi.mock`.

## Risk

Low. Pure front-only refactor with no DB changes, no API contract changes, and no new feature flags. The `Use:` line replaces boolean attributes in the prompt, which is a behaviour change for the model, but the information is equivalent and more actionable. Rollback is a single front deploy revert.

## Deploy Plan

Deploy `front`.
