### PR TITLE
Index group IDs in consumption analytics

### DIFF
--- a/front/lib/analytics/agent_message_consumption/llm_documents.test.ts
+++ b/front/lib/analytics/agent_message_consumption/llm_documents.test.ts
@@ -155,6 +155,10 @@ describe("buildLlmConsumptionDocuments", () => {
           reasoning: 5,
         },
         tool: null,
+        user: {
+          id: auth.getNonNullableUser().sId,
+          group_ids: [],
+        },
       }),
     ]);
   });

--- a/front/lib/analytics/agent_message_consumption/load.test.ts
+++ b/front/lib/analytics/agent_message_consumption/load.test.ts
@@ -11,6 +11,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { RunFactory } from "@app/tests/utils/RunFactory";
 import { GPT_5_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
@@ -123,6 +124,7 @@ async function appendHandoverMessage({
 
 async function setupSettledMessage({
   authorless = false,
+  completedAt = new Date("2026-08-05T12:00:00.000Z"),
   depth = 0,
   agenticOriginMessageId,
   agentName,
@@ -130,6 +132,7 @@ async function setupSettledMessage({
   usageType = USAGE_TYPE_USER,
 }: {
   authorless?: boolean;
+  completedAt?: Date;
   depth?: number;
   agenticOriginMessageId?: string;
   agentName?: string;
@@ -155,7 +158,6 @@ async function setupSettledMessage({
     outputTokens: 20,
     modelId: GPT_5_MINI_MODEL_CONFIG.modelId,
   });
-  const completedAt = new Date("2026-08-05T12:00:00.000Z");
   await AgentMessageModel.update(
     {
       completedAt,
@@ -216,8 +218,36 @@ describe("loadAgentMessageConsumptionAnalyticsInput", () => {
           usageType: USAGE_TYPE_USER,
         },
       ],
-      user: { id: context.auth.getNonNullableUser().sId },
+      user: {
+        id: context.auth.getNonNullableUser().sId,
+        group_ids: [],
+      },
       workspaceId: context.workspace.sId,
+    });
+  });
+
+  it("loads the user's consumption groups at message completion", async () => {
+    const testContext = await createResourceTest({ role: "admin" });
+    const group = await GroupFactory.regularManual(
+      testContext.workspace,
+      "Analytics group"
+    );
+    await GroupFactory.withMembers(testContext.authenticator, group, [
+      testContext.authenticator.getNonNullableUser(),
+    ]);
+    const context = await setupSettledMessage({
+      completedAt: new Date(),
+      testContext,
+    });
+
+    const input = await loadAgentMessageConsumptionAnalyticsInput(
+      context.auth,
+      { agentMessageId: context.agentMessage.sId }
+    );
+
+    expect(input?.user).toEqual({
+      id: testContext.authenticator.getNonNullableUser().sId,
+      group_ids: [group.sId],
     });
   });
 

--- a/front/lib/analytics/agent_message_consumption/load.ts
+++ b/front/lib/analytics/agent_message_consumption/load.ts
@@ -12,6 +12,7 @@ import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_reso
 import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import {
   RunResource,
@@ -20,6 +21,7 @@ import {
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TagResource } from "@app/lib/resources/tags_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import type {
   AgentMessageAnalyticsModel,
   AgentMessageConsumptionAnalyticsAgent,
@@ -35,8 +37,11 @@ import {
   AGENT_MESSAGE_STATUSES_TO_TRACK,
   isTerminalAgentMessageStatus,
 } from "@app/types/assistant/conversation";
+import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { LightWorkspaceType } from "@app/types/user";
+import assert from "assert";
 
 export type BilledRunUsage = RunUsageWithRunKeyType & {
   usageType: AgentMessageConsumptionAnalyticsUsageType;
@@ -128,6 +133,38 @@ async function loadAgentTagIds(
   return tags.map((tag) => tag.sId);
 }
 
+async function loadAnalyticsUser({
+  completedAt,
+  userId,
+  workspace,
+}: {
+  completedAt: Date;
+  userId: string | null;
+  workspace: LightWorkspaceType;
+}): Promise<AgentMessageConsumptionAnalyticsUser | null> {
+  if (userId === null) {
+    return null;
+  }
+
+  const [user] = await UserResource.fetchByIds([userId]);
+  assert(
+    user,
+    "Triggering user is missing while loading consumption analytics"
+  );
+
+  const groups = await GroupResource.listUserGroupsInWorkspace({
+    user,
+    workspace,
+    groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
+    at: completedAt,
+  });
+
+  return {
+    id: user.sId,
+    group_ids: groups.map((group) => group.sId).sort(),
+  };
+}
+
 export async function loadAgentMessageConsumptionAnalyticsInput(
   auth: Authenticator,
   { agentMessageId }: { agentMessageId: string }
@@ -211,6 +248,11 @@ export async function loadAgentMessageConsumptionAnalyticsInput(
     .map((ancestor) => ancestor.agentConfigurationId)
     .reverse();
   const agentTagIds = await loadAgentTagIds(auth, agentMessage);
+  const user = await loadAnalyticsUser({
+    completedAt: agentMessage.completedAt,
+    userId: triggeringUserMessage.userId,
+    workspace,
+  });
 
   const resolvedModel = resolvedModelFromAgentMessageRow({
     resolvedModelId: agentMessage.resolvedModelId,
@@ -264,10 +306,7 @@ export async function loadAgentMessageConsumptionAnalyticsInput(
     ),
     usages: billedUsages,
     // userId is a nullable FK with ON DELETE SET NULL. Never substitute the worker identity.
-    user:
-      triggeringUserMessage.userId === null
-        ? null
-        : { id: triggeringUserMessage.userId },
+    user,
     workspaceId: workspace.sId,
   };
 }

--- a/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
+++ b/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
@@ -78,6 +78,9 @@
       "properties": {
         "id": {
           "type": "keyword"
+        },
+        "group_ids": {
+          "type": "keyword"
         }
       }
     },

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -129,6 +129,8 @@ export interface AgentMessageConsumptionAnalyticsAgent {
 
 export interface AgentMessageConsumptionAnalyticsUser {
   id: string;
+  // Group sIds the user belonged to when the message completed.
+  group_ids: string[];
 }
 
 export interface AgentMessageConsumptionAnalyticsTool {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
To offer the "groups" dimension in the consumption analytics, this adds `group_ids` to consumption analytics documents. Each document stores the manual and provisioned groups the triggering user belonged to when the message completed. Authorless messages use an empty array.

Only stable group IDs are stored. Group names and other metadata remain in Postgres, where group rows and membership history can be retained for historical resolution and backfills.

> [!WARNING]
> We do hard delete groups, so we can't guarantee that groups will still be available to be fetched of if we need to backfill. I considered storing more in the mapping but that would require to add a `nested` object, and do `reverse_nested` query sometimes. Definitely something that we can avoid ideally. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [x] Apply mapping update
- [ ] Deploy front
