### PR TITLE
[front] fix: update unmatched webhook payload test

### DIFF
--- a/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
@@ -329,6 +329,26 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
     expect(launchTriggersWorkflowsMock).not.toHaveBeenCalled();
   });
 
+  it("does not store payload when no enabled triggers include payload", async () => {
+    const { workspace } = await createPublicApiMockRequest();
+
+    const webhookSource = await createWebhookSourceAndTrigger(workspace, {
+      includePayload: false,
+      filter: '(eq "type" "wanted")',
+    });
+
+    const response = await postWebhook(
+      workspace,
+      webhookSource.sId,
+      webhookSource.urlSecret,
+      { type: "ignored" }
+    );
+
+    expect(response.status).toBe(200);
+    expect(uploadWebhookPayloadMock).not.toHaveBeenCalled();
+    expect(launchTriggersWorkflowsMock).not.toHaveBeenCalled();
+  });
+
   it("returns 200 when GitHub webhook source does not subscribe to pull_request event", async () => {
     const { workspace } = await createPublicApiMockRequest();
 

--- a/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
@@ -309,7 +309,7 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
     expect(launchTriggersWorkflowsMock).toHaveBeenCalledTimes(1);
   });
 
-  it("does not store payload when no triggers match", async () => {
+  it("stores payload when no triggers match if a trigger includes payload", async () => {
     const { workspace } = await createPublicApiMockRequest();
 
     const webhookSource = await createWebhookSourceAndTrigger(workspace, {
@@ -325,7 +325,7 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
     );
 
     expect(response.status).toBe(200);
-    expect(uploadWebhookPayloadMock).not.toHaveBeenCalled();
+    expect(uploadWebhookPayloadMock).toHaveBeenCalledTimes(1);
     expect(launchTriggersWorkflowsMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Description

Fixes the failing tests broken in https://github.com/dust-tt/dust/pull/30210
This PR tweaks the test that checked that we did not store the payload in GCS, adding more refined cases.

## Tests

Yes.

## Risk

- N/A, only affects the tests.

## Deploy Plan

- No deploy.
