### PR TITLE
[Activation] add work areas to For you page

### DIFF
--- a/front-api/routes/w/[wId]/activation-work-areas/index.ts
+++ b/front-api/routes/w/[wId]/activation-work-areas/index.ts
@@ -13,6 +13,7 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 const ListWorkAreasQuerySchema = z.object({
+  podId: z.string().optional(),
   status: z.enum(["candidate", "confirmed", "dismissed"]).optional(),
 });
 
@@ -31,9 +32,12 @@ app.get(
   validate("query", ListWorkAreasQuerySchema),
   async (ctx): HandlerResult<GetActivationWorkAreasResponseBody> => {
     const auth = ctx.get("auth");
-    const { status } = ctx.req.valid("query");
+    const { podId, status } = ctx.req.valid("query");
 
-    const workAreas = await listActivationWorkAreasForUser(auth, { status });
+    const workAreas = await listActivationWorkAreasForUser(auth, {
+      podId,
+      status,
+    });
 
     return ctx.json({ workAreas });
   }

--- a/front-spa/src/app/routes/getStartedRoutes.tsx
+++ b/front-spa/src/app/routes/getStartedRoutes.tsx
@@ -8,7 +8,7 @@ const GetStartedPage = withSuspense(
 
 export const getStartedRoutes: RouteObject[] = [
   {
-    path: "get-started",
+    path: "for-you",
     element: <GetStartedPage />,
   },
 ];

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -86,7 +86,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
     const isActivationPod = spaceId === activationPodId;
     breadcrumbItems.push({
       icon: isMobile ? undefined : ArrowLeft,
-      label: isActivationPod ? "Get started" : spaceInfo.name,
+      label: isActivationPod ? "For you" : spaceInfo.name,
       href: isActivationPod
         ? getGetStartedRoute(owner.sId)
         : getPodRoute(owner.sId, spaceId),

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1027,29 +1027,29 @@ export function AgentSidebarMenu({
                 </div>
               </div>
             )}
-            {showGetStarted && (
-              <NavigationList className="px-sidebar-side-spacing py-1">
-                <NavigationListItem
-                  label="For you"
-                  icon={Lightbulb04}
-                  href={getGetStartedRoute(owner.sId)}
-                  selected={router.asPath?.startsWith(
-                    getGetStartedRoute(owner.sId)
-                  )}
-                  suffix={
-                    activationRecsForBadge.length > 0 ? (
-                      <Counter
-                        value={activationRecsForBadge.length}
-                        size="xs"
-                        variant="highlight"
-                      />
-                    ) : undefined
-                  }
-                />
-              </NavigationList>
-            )}
-            {!isMultiSelect && !hideActions && (
+            {(showGetStarted || (!isMultiSelect && !hideActions)) && (
               <NavigationList className="mx-sidebar-side-spacing mb-4 flex-shrink-0 pt-1">
+                {showGetStarted && (
+                  <NavigationListItem
+                    label="For you"
+                    icon={Lightbulb04}
+                    href={getGetStartedRoute(owner.sId)}
+                    selected={router.asPath?.startsWith(
+                      getGetStartedRoute(owner.sId)
+                    )}
+                    suffix={
+                      activationRecsForBadge.length > 0 ? (
+                        <Counter
+                          value={activationRecsForBadge.length}
+                          size="xs"
+                          variant="highlight"
+                        />
+                      ) : undefined
+                    }
+                  />
+                )}
+                {!isMultiSelect && !hideActions && (
+                  <>
                 <NavigationListItem
                   href={getAgentBuilderRoute(owner.sId, "manage")}
                   icon={Robot}
@@ -1204,44 +1204,48 @@ export function AgentSidebarMenu({
                     ) : undefined
                   }
                 />
+                  </>
+                )}
               </NavigationList>
             )}
-            {isConversationsError && (
-              <Label className="px-3 py-4 text-xs font-medium text-muted-foreground">
-                Error loading conversations
-              </Label>
-            )}
-            {isSearchActive ? (
-              <SearchResults
-                owner={owner}
-                allPods={pods}
-                isSearchingPods={isSearchingPods}
-                hasMorePods={hasMorePods}
-                loadMorePods={loadMorePods}
-                isLoadingMorePods={isLoadingMorePods}
-                podConversationResults={podConversationSearchResults}
-                privateConversations={privateConversationSearchResults}
-                isSearchingPrivateConversations={
-                  isSearchingPrivateConversations
-                }
-                hasMorePrivateConversations={hasMorePrivateConversations}
-                loadMorePrivateConversations={loadMorePrivateConversations}
-                isLoadingMorePrivateConversations={
-                  isLoadingMorePrivateConversations
-                }
-                isSearchingPodConversations={isSearchingPodConversations}
-                onCreatePod={() => setIsCreatePodModalOpen(true)}
-                activeConversationId={activeConversationId}
-                activeSpaceId={activePodId}
-                hideTriggeredConversations={hideTriggeredConversations}
-                setHideTriggeredConversations={setHideTriggeredConversations}
-                isMultiSelect={isMultiSelect}
-                selectedConversations={selectedConversations}
-                toggleConversationSelection={toggleConversationSelection}
-              />
-            ) : (
-              conversationsList
-            )}
+            <div className="min-h-0 flex-1 overflow-hidden">
+              {isConversationsError && (
+                <Label className="px-3 py-4 text-xs font-medium text-muted-foreground">
+                  Error loading conversations
+                </Label>
+              )}
+              {isSearchActive ? (
+                <SearchResults
+                  owner={owner}
+                  allPods={pods}
+                  isSearchingPods={isSearchingPods}
+                  hasMorePods={hasMorePods}
+                  loadMorePods={loadMorePods}
+                  isLoadingMorePods={isLoadingMorePods}
+                  podConversationResults={podConversationSearchResults}
+                  privateConversations={privateConversationSearchResults}
+                  isSearchingPrivateConversations={
+                    isSearchingPrivateConversations
+                  }
+                  hasMorePrivateConversations={hasMorePrivateConversations}
+                  loadMorePrivateConversations={loadMorePrivateConversations}
+                  isLoadingMorePrivateConversations={
+                    isLoadingMorePrivateConversations
+                  }
+                  isSearchingPodConversations={isSearchingPodConversations}
+                  onCreatePod={() => setIsCreatePodModalOpen(true)}
+                  activeConversationId={activeConversationId}
+                  activeSpaceId={activePodId}
+                  hideTriggeredConversations={hideTriggeredConversations}
+                  setHideTriggeredConversations={setHideTriggeredConversations}
+                  isMultiSelect={isMultiSelect}
+                  selectedConversations={selectedConversations}
+                  toggleConversationSelection={toggleConversationSelection}
+                />
+              ) : (
+                conversationsList
+              )}
+            </div>
 
             {!hideInAppBanner && (
               <StackedInAppBanners

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -47,7 +47,6 @@ import { getSpaceIcon } from "@app/lib/spaces";
 import {
   useActivationPod,
   useActivationRecommendations,
-  useActivationWorkAreas,
 } from "@app/lib/swr/activation";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
@@ -449,11 +448,6 @@ export function AgentSidebarMenu({
       podId: activationPodId ?? undefined,
       disabled: !showGetStarted,
     });
-  const { workAreas: candidateWorkAreas } = useActivationWorkAreas({
-    workspaceId: owner.sId,
-    status: "candidate",
-    disabled: !showGetStarted,
-  });
 
   const [podSearchText, setPodSearchText] = useState("");
   const { setSidebarOpen } = useContext(SidebarContext);
@@ -1042,11 +1036,8 @@ export function AgentSidebarMenu({
                     getGetStartedRoute(owner.sId)
                   )}
                   count={
-                    activationRecsForBadge.length +
-                      candidateWorkAreas.length >
-                    0
-                      ? activationRecsForBadge.length +
-                        candidateWorkAreas.length
+                    activationRecsForBadge.length > 0
+                      ? activationRecsForBadge.length
                       : undefined
                   }
                 />

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -47,6 +47,7 @@ import { getSpaceIcon } from "@app/lib/spaces";
 import {
   useActivationPod,
   useActivationRecommendations,
+  useActivationWorkAreas,
 } from "@app/lib/swr/activation";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
@@ -89,6 +90,7 @@ import {
   FolderOpen,
   Icon,
   Label,
+  Lightbulb04,
   MagicWand02,
   MessagePlusCircle,
   NavigationList,
@@ -444,8 +446,14 @@ export function AgentSidebarMenu({
   const { recommendations: activationRecsForBadge } =
     useActivationRecommendations({
       workspaceId: owner.sId,
+      podId: activationPodId ?? undefined,
       disabled: !showGetStarted,
     });
+  const { workAreas: candidateWorkAreas } = useActivationWorkAreas({
+    workspaceId: owner.sId,
+    status: "candidate",
+    disabled: !showGetStarted,
+  });
 
   const [podSearchText, setPodSearchText] = useState("");
   const { setSidebarOpen } = useContext(SidebarContext);
@@ -1027,15 +1035,18 @@ export function AgentSidebarMenu({
             {showGetStarted && (
               <NavigationList className="px-sidebar-side-spacing py-1">
                 <NavigationListItem
-                  label="Get started"
-                  icon={MagicWand02}
+                  label="For you"
+                  icon={Lightbulb04}
                   href={getGetStartedRoute(owner.sId)}
                   selected={router.asPath?.startsWith(
                     getGetStartedRoute(owner.sId)
                   )}
                   count={
-                    activationRecsForBadge.length > 0
-                      ? activationRecsForBadge.length
+                    activationRecsForBadge.length +
+                      candidateWorkAreas.length >
+                    0
+                      ? activationRecsForBadge.length +
+                        candidateWorkAreas.length
                       : undefined
                   }
                 />

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -77,6 +77,7 @@ import {
   Chip,
   Clock,
   cn,
+  Counter,
   DotsHorizontal,
   DropdownMenu,
   DropdownMenuContent,
@@ -1035,10 +1036,14 @@ export function AgentSidebarMenu({
                   selected={router.asPath?.startsWith(
                     getGetStartedRoute(owner.sId)
                   )}
-                  count={
-                    activationRecsForBadge.length > 0
-                      ? activationRecsForBadge.length
-                      : undefined
+                  suffix={
+                    activationRecsForBadge.length > 0 ? (
+                      <Counter
+                        value={activationRecsForBadge.length}
+                        size="xs"
+                        variant="highlight"
+                      />
+                    ) : undefined
                   }
                 />
               </NavigationList>

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -76,8 +76,8 @@ import {
   CheckDone01,
   Chip,
   Clock,
-  cn,
   Counter,
+  cn,
   DotsHorizontal,
   DropdownMenu,
   DropdownMenuContent,
@@ -1050,160 +1050,167 @@ export function AgentSidebarMenu({
                 )}
                 {!isMultiSelect && !hideActions && (
                   <>
-                <NavigationListItem
-                  href={getAgentBuilderRoute(owner.sId, "manage")}
-                  icon={Robot}
-                  label="Agents"
-                  selected={router.asPath.startsWith(
-                    `/w/${owner.sId}/builder/agents`
-                  )}
-                  data-gtm-label="assistantManagementButton"
-                  data-gtm-location="sidebarMenu"
-                  onClick={withTracking(
-                    TRACKING_AREAS.BUILDER,
-                    "manage_agents",
-                    () => setSidebarOpen(false)
-                  )}
-                  keepHoverOnMoreMenu
-                  moreMenu={
-                    canCreateAgent ? (
-                      <div
-                        className={cn(
-                          "absolute right-2 top-1.5",
-                          "transition-opacity",
-                          "[@media(hover:hover)_and_(pointer:fine)]:opacity-0",
-                          "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100",
-                          "has-[[data-state=open]]:opacity-100"
-                        )}
-                      >
-                        <DropdownMenu modal={false}>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              size="xs"
-                              icon={Plus}
-                              label="New"
-                              variant="ghost-secondary"
-                              className="data-[state=open]:bg-hover"
-                              disabled={noHealthyProviders}
-                              onClick={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                              }}
-                            />
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent
-                            side="bottom"
-                            align="center"
-                            onClick={(e) => e.stopPropagation()}
+                    <NavigationListItem
+                      href={getAgentBuilderRoute(owner.sId, "manage")}
+                      icon={Robot}
+                      label="Agents"
+                      selected={router.asPath.startsWith(
+                        `/w/${owner.sId}/builder/agents`
+                      )}
+                      data-gtm-label="assistantManagementButton"
+                      data-gtm-location="sidebarMenu"
+                      onClick={withTracking(
+                        TRACKING_AREAS.BUILDER,
+                        "manage_agents",
+                        () => setSidebarOpen(false)
+                      )}
+                      keepHoverOnMoreMenu
+                      moreMenu={
+                        canCreateAgent ? (
+                          <div
+                            className={cn(
+                              "absolute right-2 top-1.5",
+                              "transition-opacity",
+                              "[@media(hover:hover)_and_(pointer:fine)]:opacity-0",
+                              "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100",
+                              "has-[[data-state=open]]:opacity-100"
+                            )}
                           >
-                            <DropdownMenuLabel label="New agent" />
-                            <DropdownMenuItem
-                              href={getAgentBuilderRoute(owner.sId, "new")}
-                              icon={File02}
-                              label="From scratch"
-                              data-gtm-label="assistantCreationButton"
-                              data-gtm-location="sidebarMenu"
-                              onClick={withTracking(
-                                TRACKING_AREAS.BUILDER,
-                                "create_from_scratch",
-                                () => setSidebarOpen(false)
-                              )}
-                            />
-                            <DropdownMenuItem
-                              href={getAgentBuilderRoute(owner.sId, "create")}
-                              icon={MagicWand02}
-                              label="From template"
-                              data-gtm-label="assistantCreationButton"
-                              data-gtm-location="sidebarMenu"
-                              onClick={withTracking(
-                                TRACKING_AREAS.BUILDER,
-                                "create_from_template",
-                                () => setSidebarOpen(false)
-                              )}
-                            />
-                            <DropdownMenuItem
-                              icon={
-                                isUploadingYAML ? (
-                                  <Spinner size="xs" />
-                                ) : (
-                                  Brackets
-                                )
-                              }
-                              label={
-                                isUploadingYAML ? "Uploading..." : "From YAML"
-                              }
-                              disabled={isUploadingYAML}
-                              onClick={triggerYAMLUpload}
-                              data-gtm-label="yamlUploadButton"
-                              data-gtm-location="sidebarMenu"
-                            />
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      </div>
-                    ) : undefined
-                  }
-                />
-                <NavigationListItem
-                  href={getSkillBuilderRoute(owner.sId, "manage")}
-                  icon={SKILL_ICON}
-                  label="Skills"
-                  selected={router.asPath.startsWith(
-                    `/w/${owner.sId}/builder/skills`
-                  )}
-                  onClick={withTracking(
-                    TRACKING_AREAS.BUILDER,
-                    "manage_skills",
-                    () => setSidebarOpen(false)
-                  )}
-                  keepHoverOnMoreMenu
-                  moreMenu={
-                    canCreateSkill ? (
-                      <div
-                        className={cn(
-                          "absolute right-2 top-1.5",
-                          "transition-opacity",
-                          "[@media(hover:hover)_and_(pointer:fine)]:opacity-0",
-                          "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100",
-                          "has-[[data-state=open]]:opacity-100"
-                        )}
-                      >
-                        <DropdownMenu modal={false}>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              size="xs"
-                              icon={Plus}
-                              label="New"
-                              variant="ghost-secondary"
-                              className="data-[state=open]:bg-hover"
-                              onClick={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                              }}
-                            />
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent
-                            side="bottom"
-                            align="center"
-                            onClick={(e) => e.stopPropagation()}
+                            <DropdownMenu modal={false}>
+                              <DropdownMenuTrigger asChild>
+                                <Button
+                                  size="xs"
+                                  icon={Plus}
+                                  label="New"
+                                  variant="ghost-secondary"
+                                  className="data-[state=open]:bg-hover"
+                                  disabled={noHealthyProviders}
+                                  onClick={(e) => {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                  }}
+                                />
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent
+                                side="bottom"
+                                align="center"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                <DropdownMenuLabel label="New agent" />
+                                <DropdownMenuItem
+                                  href={getAgentBuilderRoute(owner.sId, "new")}
+                                  icon={File02}
+                                  label="From scratch"
+                                  data-gtm-label="assistantCreationButton"
+                                  data-gtm-location="sidebarMenu"
+                                  onClick={withTracking(
+                                    TRACKING_AREAS.BUILDER,
+                                    "create_from_scratch",
+                                    () => setSidebarOpen(false)
+                                  )}
+                                />
+                                <DropdownMenuItem
+                                  href={getAgentBuilderRoute(
+                                    owner.sId,
+                                    "create"
+                                  )}
+                                  icon={MagicWand02}
+                                  label="From template"
+                                  data-gtm-label="assistantCreationButton"
+                                  data-gtm-location="sidebarMenu"
+                                  onClick={withTracking(
+                                    TRACKING_AREAS.BUILDER,
+                                    "create_from_template",
+                                    () => setSidebarOpen(false)
+                                  )}
+                                />
+                                <DropdownMenuItem
+                                  icon={
+                                    isUploadingYAML ? (
+                                      <Spinner size="xs" />
+                                    ) : (
+                                      Brackets
+                                    )
+                                  }
+                                  label={
+                                    isUploadingYAML
+                                      ? "Uploading..."
+                                      : "From YAML"
+                                  }
+                                  disabled={isUploadingYAML}
+                                  onClick={triggerYAMLUpload}
+                                  data-gtm-label="yamlUploadButton"
+                                  data-gtm-location="sidebarMenu"
+                                />
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          </div>
+                        ) : undefined
+                      }
+                    />
+                    <NavigationListItem
+                      href={getSkillBuilderRoute(owner.sId, "manage")}
+                      icon={SKILL_ICON}
+                      label="Skills"
+                      selected={router.asPath.startsWith(
+                        `/w/${owner.sId}/builder/skills`
+                      )}
+                      onClick={withTracking(
+                        TRACKING_AREAS.BUILDER,
+                        "manage_skills",
+                        () => setSidebarOpen(false)
+                      )}
+                      keepHoverOnMoreMenu
+                      moreMenu={
+                        canCreateSkill ? (
+                          <div
+                            className={cn(
+                              "absolute right-2 top-1.5",
+                              "transition-opacity",
+                              "[@media(hover:hover)_and_(pointer:fine)]:opacity-0",
+                              "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100",
+                              "has-[[data-state=open]]:opacity-100"
+                            )}
                           >
-                            <DropdownMenuLabel label="New skill" />
-                            <DropdownMenuItem
-                              href={getSkillBuilderRoute(owner.sId, "new")}
-                              icon={SKILL_ICON}
-                              label="From scratch"
-                              onClick={() => setSidebarOpen(false)}
-                            />
-                            <DropdownMenuItem
-                              icon={FolderOpen}
-                              label="From existing"
-                              onClick={() => setIsImportSkillDialogOpen(true)}
-                            />
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      </div>
-                    ) : undefined
-                  }
-                />
+                            <DropdownMenu modal={false}>
+                              <DropdownMenuTrigger asChild>
+                                <Button
+                                  size="xs"
+                                  icon={Plus}
+                                  label="New"
+                                  variant="ghost-secondary"
+                                  className="data-[state=open]:bg-hover"
+                                  onClick={(e) => {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                  }}
+                                />
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent
+                                side="bottom"
+                                align="center"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                <DropdownMenuLabel label="New skill" />
+                                <DropdownMenuItem
+                                  href={getSkillBuilderRoute(owner.sId, "new")}
+                                  icon={SKILL_ICON}
+                                  label="From scratch"
+                                  onClick={() => setSidebarOpen(false)}
+                                />
+                                <DropdownMenuItem
+                                  icon={FolderOpen}
+                                  label="From existing"
+                                  onClick={() =>
+                                    setIsImportSkillDialogOpen(true)
+                                  }
+                                />
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          </div>
+                        ) : undefined
+                      }
+                    />
                   </>
                 )}
               </NavigationList>

--- a/front/components/pages/workspace/GetStartedPage/JustAskComposer.tsx
+++ b/front/components/pages/workspace/GetStartedPage/JustAskComposer.tsx
@@ -2,10 +2,7 @@ import { FilePreviewProvider } from "@app/components/assistant/conversation/File
 import { FileDropProvider } from "@app/components/assistant/conversation/FileUploaderContext";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
-import {
-  InputBarContext,
-  InputBarProvider,
-} from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import { InputBarProvider } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { DustError } from "@app/lib/error";
@@ -18,16 +15,7 @@ import type { ContentFragmentsType } from "@app/types/content_fragment";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
-import { Button } from "@dust-tt/sparkle";
-import { useCallback, useContext } from "react";
-
-// One-tap starters under "Or just ask" — activation-oriented, phrased as things
-// the user can ask their learning space to do.
-const ASK_SUGGESTIONS = [
-  "Scan my connected sources for repetitive work I can automate",
-  "Ask me questions to learn how I work",
-  "How does my learning space work?",
-];
+import { useCallback } from "react";
 
 interface JustAskComposerProps {
   owner: WorkspaceType;
@@ -99,41 +87,18 @@ export function JustAskComposer({
       <FilePreviewProvider owner={owner}>
         <FileDropProvider>
           <GenerationContextProvider>
-            {/* Chips live inside the InputBarProvider so they can prefill the
-                composer below via shared context. */}
-            <AskChips />
-            <div className="mt-4">
-              <InputBar
-                owner={owner}
-                user={user}
-                onSubmit={startConversation}
-                draftKey="get-started-new-conversation"
-                disableAutoFocus
-                defaultAgentId={defaultAgentId}
-                placeholder="Ask your agents anything, or describe a task…"
-              />
-            </div>
+            <InputBar
+              owner={owner}
+              user={user}
+              onSubmit={startConversation}
+              draftKey="get-started-new-conversation"
+              disableAutoFocus
+              defaultAgentId={defaultAgentId}
+              placeholder="Ask your agents anything, or describe a task…"
+            />
           </GenerationContextProvider>
         </FileDropProvider>
       </FilePreviewProvider>
     </InputBarProvider>
-  );
-}
-
-function AskChips() {
-  const { setPendingInputText } = useContext(InputBarContext);
-  return (
-    <div className="flex flex-wrap gap-2">
-      {ASK_SUGGESTIONS.map((suggestion) => (
-        <Button
-          key={suggestion}
-          variant="outline"
-          size="sm"
-          isRounded
-          label={suggestion}
-          onClick={() => setPendingInputText(suggestion, { replace: true })}
-        />
-      ))}
-    </div>
   );
 }

--- a/front/components/pages/workspace/GetStartedPage/PreviouslyDoneRow.tsx
+++ b/front/components/pages/workspace/GetStartedPage/PreviouslyDoneRow.tsx
@@ -29,17 +29,17 @@ export function PreviouslyDoneRow({ owner, podId }: PreviouslyDoneRowProps) {
   }
 
   return (
-    <div className="py-6">
+    <div className="py-4">
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
         className="flex w-full items-center justify-between gap-3 text-left"
       >
         <div className="flex items-center gap-2">
-          <span className="text-base font-semibold text-foreground">
+          <span className="text-base font-semibold leading-6 tracking-tight text-foreground">
             Previously done
           </span>
-          <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-highlight-50 px-1.5 text-xs font-medium text-highlight">
+          <span className="flex h-5 min-w-5 items-center justify-center rounded-lg bg-highlight-50 px-1.5 text-xs font-medium text-highlight">
             {recommendations.length}
           </span>
         </div>

--- a/front/components/pages/workspace/GetStartedPage/RecentConversations.tsx
+++ b/front/components/pages/workspace/GetStartedPage/RecentConversations.tsx
@@ -5,7 +5,7 @@ import { getConversationRoute } from "@app/lib/utils/router";
 import type { PodConversationListItemType } from "@app/types/api/assistant/conversation/spaces";
 import { stripMarkdown } from "@app/types/shared/utils/markdown";
 import type { WorkspaceType } from "@app/types/user";
-import { Avatar, cn, ListItemSection } from "@dust-tt/sparkle";
+import { Avatar, cn } from "@dust-tt/sparkle";
 import { format } from "date-fns";
 import { useMemo } from "react";
 
@@ -33,11 +33,11 @@ function RecentConversationRow({
           }
         );
       }}
-      className="flex w-full items-center gap-3 rounded-lg py-2.5 pr-2 text-left hover:bg-muted-background"
+      className="relative flex w-full items-center gap-2 p-3 text-left hover:bg-muted-background"
     >
       <span
         className={cn(
-          "h-8 w-0.5 shrink-0 rounded-full",
+          "h-4 w-0.5 shrink-0 rounded-r-full",
           unread ? "bg-highlight" : "bg-transparent"
         )}
       />
@@ -52,7 +52,7 @@ function RecentConversationRow({
           {conversation.creator.name}
         </span>
       )}
-      <span className="shrink-0 text-sm font-semibold text-foreground">
+      <span className="shrink-0 text-sm font-medium text-foreground">
         {conversation.title}
       </span>
       <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
@@ -89,16 +89,18 @@ export function RecentConversations({
   }
 
   return (
-    <div className="mt-10">
-      <h2 className="text-xl font-bold text-foreground">
+    <div className="mt-14">
+      <h2 className="text-base font-semibold leading-6 tracking-tight text-foreground">
         Recent conversations
       </h2>
-      <div className="mt-3">
+      <div className="mt-2 flex flex-col gap-2">
         {Object.entries(grouped).map(([label, items]) =>
           items.length === 0 ? null : (
             <div key={label}>
-              <ListItemSection>{label}</ListItemSection>
-              <div className="flex flex-col">
+              <p className="mb-2 text-sm font-semibold leading-5 text-muted-foreground">
+                {label}
+              </p>
+              <div className="overflow-hidden rounded-xl border border-border">
                 {items
                   .toSorted((a, b) => b.updated - a.updated)
                   .map((c) => (

--- a/front/components/pages/workspace/GetStartedPage/RecommendationItem.tsx
+++ b/front/components/pages/workspace/GetStartedPage/RecommendationItem.tsx
@@ -53,49 +53,54 @@ export function RecommendationItem({
   };
 
   return (
-    <div className="py-6">
+    <div className="py-4">
       <button
         type="button"
         onClick={onToggle}
-        className="flex w-full items-center justify-between gap-3 text-left"
+        className="relative flex w-full items-start justify-between gap-3 text-left"
       >
-        <div className="flex items-center gap-2 text-sm">
-          {rec.sourceIcon && <SourceIcon sourceIcon={rec.sourceIcon} />}
-          <span className="text-muted-foreground">
-            {rec.sourceLabel ?? "Suggested for you"}
-          </span>
-          <span className="text-faint">
-            {SOURCE_META_SEPARATOR} {recencyLabel(rec.createdAt)}
-          </span>
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-1 text-sm leading-5">
+            {rec.sourceIcon && <SourceIcon sourceIcon={rec.sourceIcon} />}
+            <span className="text-muted-foreground">
+              {rec.sourceLabel ?? "Suggested for you"}
+            </span>
+            <span className="text-faint">
+              {SOURCE_META_SEPARATOR} {recencyLabel(rec.createdAt)}
+            </span>
+          </div>
+          <h3 className="text-base font-semibold leading-6 tracking-tight text-foreground">
+            {rec.title}
+          </h3>
+          <p className="text-sm leading-5 tracking-tight text-muted-foreground">
+            {rec.content}
+          </p>
         </div>
         <Icon
           visual={expanded ? ChevronUp : ChevronDown}
           size="sm"
-          className="shrink-0 text-faint"
+          className="mt-0.5 shrink-0 text-faint"
         />
       </button>
-
-      <h3 className="mt-2 text-base font-semibold text-foreground">
-        {rec.title}
-      </h3>
-      <p className="mt-1 text-sm text-muted-foreground">{rec.content}</p>
 
       {expanded && (
         <>
           {rec.body && (
-            <p className="mt-4 text-sm leading-relaxed text-foreground">
+            <p className="mt-4 text-sm leading-5 tracking-tight text-foreground">
               {rec.body}
             </p>
           )}
 
           {rec.steps && rec.steps.length > 0 && (
-            <ol className="mt-4 flex flex-col gap-3">
+            <ol className="mt-4 flex flex-col gap-2">
               {rec.steps.map((step, i) => (
-                <li key={step} className="flex items-center gap-3 text-sm">
-                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-border-dark text-xs text-muted-foreground">
+                <li key={step} className="flex items-start gap-2 text-sm">
+                  <span className="flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full border border-stone-100 bg-gradient-to-t from-stone-50 to-white px-1 text-xs font-semibold leading-4 text-muted-foreground shadow-sm">
                     {i + 1}
                   </span>
-                  <span className="text-muted-foreground">{step}</span>
+                  <span className="leading-5 text-muted-foreground">
+                    {step}
+                  </span>
                 </li>
               ))}
             </ol>
@@ -107,7 +112,7 @@ export function RecommendationItem({
               size="sm"
               isRounded
               label={rec.ctaLabel ?? "Create this agent"}
-              iconRight={ArrowRight}
+              icon={ArrowRight}
               disabled={isUpdating}
               onClick={handleCreate}
             />

--- a/front/components/pages/workspace/GetStartedPage/RecommendationItem.tsx
+++ b/front/components/pages/workspace/GetStartedPage/RecommendationItem.tsx
@@ -4,7 +4,6 @@ import {
 } from "@app/components/pages/workspace/GetStartedPage/recency";
 import { SourceIcon } from "@app/components/pages/workspace/GetStartedPage/SourceIcon";
 import type { ActivationRecommendationForUserType } from "@app/lib/api/activation/recommendations";
-import { useAppRouter } from "@app/lib/platform";
 import { useUpdateActivationRecommendation } from "@app/lib/swr/activation";
 import { getConversationRoute } from "@app/lib/utils/router";
 import {
@@ -32,19 +31,10 @@ export function RecommendationItem({
   onToggle,
   onResolved,
 }: RecommendationItemProps) {
-  const router = useAppRouter();
   const [isUpdating, setIsUpdating] = useState(false);
   const { updateRecommendation } = useUpdateActivationRecommendation({
     workspaceId: owner.sId,
   });
-
-  // "Create this agent" deep-links into the activation conversation where this
-  // recommendation was surfaced; the agent marks it executed once the work
-  // actually runs there (via the update_recommendation tool). We don't mark it
-  // executed on click — clicking is navigation, not completion.
-  const handleCreate = () => {
-    void router.push(getConversationRoute(owner.sId, rec.conversationId));
-  };
 
   const handleDismiss = async () => {
     setIsUpdating(true);
@@ -114,7 +104,7 @@ export function RecommendationItem({
               label={rec.ctaLabel ?? "Create this agent"}
               icon={ArrowRight}
               disabled={isUpdating}
-              onClick={handleCreate}
+              href={getConversationRoute(owner.sId, rec.conversationId)}
             />
             <Button
               variant="outline"

--- a/front/components/pages/workspace/GetStartedPage/WorkAreaSection.tsx
+++ b/front/components/pages/workspace/GetStartedPage/WorkAreaSection.tsx
@@ -68,7 +68,7 @@ export function WorkAreaSection({
       void mutateWorkAreas();
       setUpdatingId(null);
     },
-    [updateWorkArea, mutateWorkAreas],
+    [updateWorkArea, mutateWorkAreas]
   );
 
   const startConversation = useCallback(
@@ -103,7 +103,7 @@ export function WorkAreaSection({
       owner.sId,
       router,
       sendNotification,
-    ],
+    ]
   );
 
   return (

--- a/front/components/pages/workspace/GetStartedPage/WorkAreaSection.tsx
+++ b/front/components/pages/workspace/GetStartedPage/WorkAreaSection.tsx
@@ -47,7 +47,11 @@ export function WorkAreaSection({
   const [updatingId, setUpdatingId] = useState<string | null>(null);
 
   const { workAreas, isWorkAreasLoading, mutateWorkAreas } =
-    useActivationWorkAreas({ workspaceId: owner.sId, disabled });
+    useActivationWorkAreas({
+      workspaceId: owner.sId,
+      podId: podId ?? undefined,
+      disabled,
+    });
 
   const { updateWorkArea } = useUpdateActivationWorkArea({
     workspaceId: owner.sId,

--- a/front/components/pages/workspace/GetStartedPage/WorkAreaSection.tsx
+++ b/front/components/pages/workspace/GetStartedPage/WorkAreaSection.tsx
@@ -1,0 +1,243 @@
+import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
+import { useSendNotification } from "@app/hooks/useNotification";
+import type { ActivationWorkAreaForUserType } from "@app/lib/api/activation/work_areas";
+import { useAppRouter } from "@app/lib/platform";
+import {
+  useActivationWorkAreas,
+  useUpdateActivationWorkArea,
+} from "@app/lib/swr/activation";
+import { getConversationRoute } from "@app/lib/utils/router";
+import type { UserType, WorkspaceType } from "@app/types/user";
+import { Button, Chip, Spinner, Tooltip } from "@dust-tt/sparkle";
+import { useCallback, useState } from "react";
+
+const WORK_AREA_ACTIONS = [
+  {
+    label: "Scan my sources",
+    message: "Scan my connected sources for repetitive work I can automate",
+  },
+  {
+    label: "Ask me questions",
+    message: "Ask me questions to learn how I work",
+  },
+];
+
+interface WorkAreaSectionProps {
+  owner: WorkspaceType;
+  user: UserType | null;
+  podId: string | null;
+  defaultAgentId: string | null;
+  disabled?: boolean;
+}
+
+export function WorkAreaSection({
+  owner,
+  user,
+  podId,
+  defaultAgentId,
+  disabled,
+}: WorkAreaSectionProps) {
+  const router = useAppRouter();
+  const sendNotification = useSendNotification();
+  const createConversationWithMessage = useCreateConversationWithMessage({
+    owner,
+    user,
+  });
+  const [isCreating, setIsCreating] = useState(false);
+  const [updatingId, setUpdatingId] = useState<string | null>(null);
+
+  const { workAreas, isWorkAreasLoading, mutateWorkAreas } =
+    useActivationWorkAreas({ workspaceId: owner.sId, disabled });
+
+  const { updateWorkArea } = useUpdateActivationWorkArea({
+    workspaceId: owner.sId,
+  });
+
+  const confirmed = workAreas.filter((r) => r.status === "confirmed");
+  const candidates = workAreas.filter((r) => r.status === "candidate");
+  const hasContent = confirmed.length > 0 || candidates.length > 0;
+
+  const handleUpdate = useCallback(
+    async (sId: string, status: "confirmed" | "dismissed") => {
+      setUpdatingId(sId);
+      await updateWorkArea(sId, { status });
+      void mutateWorkAreas();
+      setUpdatingId(null);
+    },
+    [updateWorkArea, mutateWorkAreas],
+  );
+
+  const startConversation = useCallback(
+    async (message: string) => {
+      setIsCreating(true);
+      const mentions = defaultAgentId
+        ? [{ configurationId: defaultAgentId }]
+        : [];
+      const res = await createConversationWithMessage({
+        messageData: {
+          input: message,
+          mentions,
+          contentFragments: { uploaded: [], contentNodes: [] },
+        },
+        spaceId: podId,
+      });
+      if (res.isErr()) {
+        sendNotification({
+          type: "error",
+          title: "Couldn't start conversation",
+          description: res.error.message,
+        });
+      } else {
+        await router.push(getConversationRoute(owner.sId, res.value.sId));
+      }
+      setIsCreating(false);
+    },
+    [
+      createConversationWithMessage,
+      defaultAgentId,
+      podId,
+      owner.sId,
+      router,
+      sendNotification,
+    ],
+  );
+
+  return (
+    <div className="mt-12 rounded-2xl bg-white px-6 pb-8 pt-6 shadow-[0px_3px_3px_-1.5px_rgba(0,0,0,0.06),0px_1px_1px_-0.5px_rgba(0,0,0,0.06),0px_0px_0px_1px_rgba(0,0,0,0.06)]">
+      <h2 className="text-xl font-semibold leading-7 tracking-tight text-foreground">
+        Your work
+      </h2>
+      <p className="mt-1 text-sm leading-5 tracking-tight text-muted-foreground">
+        What Dust thinks you're responsible for.
+      </p>
+
+      <div className="mt-6 border-t border-border">
+        {isWorkAreasLoading ? (
+          <div className="flex items-center justify-center py-10">
+            <Spinner size="md" />
+          </div>
+        ) : !hasContent ? (
+          <div className="py-4">
+            <p className="text-sm leading-5 tracking-tight text-muted-foreground">
+              No work areas yet. Help Dust learn what you own so it can suggest
+              relevant ideas.
+            </p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              {WORK_AREA_ACTIONS.map((action) => (
+                <Button
+                  key={action.label}
+                  variant="outline"
+                  size="sm"
+                  isRounded
+                  label={action.label}
+                  disabled={isCreating}
+                  onClick={() => void startConversation(action.message)}
+                />
+              ))}
+            </div>
+          </div>
+        ) : (
+          <>
+            {confirmed.length > 0 && (
+              <div className="flex flex-wrap gap-2 py-4">
+                {confirmed.map((r) => (
+                  <ConfirmedWorkAreaChip
+                    key={r.sId}
+                    workArea={r}
+                    isUpdating={updatingId === r.sId}
+                    onDismiss={() => void handleUpdate(r.sId, "dismissed")}
+                  />
+                ))}
+              </div>
+            )}
+
+            {candidates.length > 0 && (
+              <div className="divide-y divide-border border-t border-border">
+                {candidates.map((r) => (
+                  <CandidateWorkAreaRow
+                    key={r.sId}
+                    workArea={r}
+                    isUpdating={updatingId === r.sId}
+                    onConfirm={() => void handleUpdate(r.sId, "confirmed")}
+                    onDismiss={() => void handleUpdate(r.sId, "dismissed")}
+                  />
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface ConfirmedWorkAreaChipProps {
+  workArea: ActivationWorkAreaForUserType;
+  isUpdating: boolean;
+  onDismiss: () => void;
+}
+
+function ConfirmedWorkAreaChip({
+  workArea,
+  isUpdating,
+  onDismiss,
+}: ConfirmedWorkAreaChipProps) {
+  return (
+    <Tooltip
+      label={workArea.description}
+      trigger={
+        <Chip
+          label={workArea.title}
+          color="highlight"
+          size="sm"
+          isBusy={isUpdating}
+          onRemove={isUpdating ? undefined : onDismiss}
+        />
+      }
+    />
+  );
+}
+
+interface CandidateWorkAreaRowProps {
+  workArea: ActivationWorkAreaForUserType;
+  isUpdating: boolean;
+  onConfirm: () => void;
+  onDismiss: () => void;
+}
+
+function CandidateWorkAreaRow({
+  workArea,
+  isUpdating,
+  onConfirm,
+  onDismiss,
+}: CandidateWorkAreaRowProps) {
+  return (
+    <div className="py-4">
+      <h3 className="text-base font-semibold leading-6 tracking-tight text-foreground">
+        {workArea.title}
+      </h3>
+      <p className="mt-1 text-sm leading-5 tracking-tight text-muted-foreground">
+        {workArea.description}
+      </p>
+      <div className="mt-4 flex items-center gap-2">
+        <Button
+          variant="highlight"
+          size="sm"
+          isRounded
+          label="Confirm"
+          disabled={isUpdating}
+          onClick={onConfirm}
+        />
+        <Button
+          variant="outline"
+          size="sm"
+          isRounded
+          label="Not Relevant"
+          disabled={isUpdating}
+          onClick={onDismiss}
+        />
+        {isUpdating && <Spinner size="xs" />}
+      </div>
+    </div>
+  );
+}

--- a/front/components/pages/workspace/GetStartedPage/index.tsx
+++ b/front/components/pages/workspace/GetStartedPage/index.tsx
@@ -4,13 +4,13 @@ import { PreviouslyDoneRow } from "@app/components/pages/workspace/GetStartedPag
 import { RecentConversations } from "@app/components/pages/workspace/GetStartedPage/RecentConversations";
 import { RecommendationItem } from "@app/components/pages/workspace/GetStartedPage/RecommendationItem";
 import { WorkAreaSection } from "@app/components/pages/workspace/GetStartedPage/WorkAreaSection";
+import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
+import { useSendNotification } from "@app/hooks/useNotification";
 import {
   useAuth,
   useFeatureFlags,
   useWorkspace,
 } from "@app/lib/auth/AuthContext";
-import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
-import { useSendNotification } from "@app/hooks/useNotification";
 import { useAppRouter } from "@app/lib/platform";
 import {
   useActivationPod,
@@ -118,11 +118,11 @@ export function GetStartedPage() {
         <div
           aria-hidden
           className="pointer-events-none absolute inset-0"
-        style={{
+          style={{
             backgroundImage:
               "linear-gradient(to right, rgba(0, 0, 0, 0.02) 1px, transparent 1px)",
             backgroundSize: "calc(100% / 7) 100%",
-        }}
+          }}
         />
         <img
           alt=""

--- a/front/components/pages/workspace/GetStartedPage/index.tsx
+++ b/front/components/pages/workspace/GetStartedPage/index.tsx
@@ -3,6 +3,7 @@ import { JustAskComposer } from "@app/components/pages/workspace/GetStartedPage/
 import { PreviouslyDoneRow } from "@app/components/pages/workspace/GetStartedPage/PreviouslyDoneRow";
 import { RecentConversations } from "@app/components/pages/workspace/GetStartedPage/RecentConversations";
 import { RecommendationItem } from "@app/components/pages/workspace/GetStartedPage/RecommendationItem";
+import { WorkAreaSection } from "@app/components/pages/workspace/GetStartedPage/WorkAreaSection";
 import {
   useAuth,
   useFeatureFlags,
@@ -82,6 +83,14 @@ export function GetStartedPage() {
             Nothing here is a demo. It is already wired to how your team works,
             and it is waiting for you.
           </p>
+
+          <WorkAreaSection
+            owner={owner}
+            user={user}
+            podId={activationPodId}
+            defaultAgentId={defaultAgentId}
+            disabled={isActivationPodLoading}
+          />
 
           <div className="mt-10 rounded-2xl border border-border bg-background p-7 shadow-sm">
             <h2 className="text-xl font-bold text-foreground">

--- a/front/components/pages/workspace/GetStartedPage/index.tsx
+++ b/front/components/pages/workspace/GetStartedPage/index.tsx
@@ -119,13 +119,22 @@ export function GetStartedPage() {
           aria-hidden
           className="pointer-events-none absolute inset-0"
         style={{
-            backgroundImage: [
+            backgroundImage:
               "linear-gradient(to right, rgba(0, 0, 0, 0.02) 1px, transparent 1px)",
-              "radial-gradient(68% 52% at 60% -8%, rgba(255, 203, 99, 0.55) 0%, rgba(255, 138, 128, 0.32) 35%, rgba(122, 159, 255, 0.24) 58%, transparent 76%)",
-              "radial-gradient(52% 44% at 14% 2%, rgba(132, 202, 255, 0.32) 0%, transparent 72%)",
-            ].join(", "),
-            backgroundSize: "calc(100% / 7) 100%, 100% 100%, 100% 100%",
+            backgroundSize: "calc(100% / 7) 100%",
         }}
+        />
+        <img
+          alt=""
+          aria-hidden
+          className="pointer-events-none absolute -top-[307.6px] left-[227.4px] w-[1067.2px] max-w-none"
+          src="/static/activation/for-you-orb-large.svg"
+        />
+        <img
+          alt=""
+          aria-hidden
+          className="pointer-events-none absolute -top-[307.6px] -left-[72.6px] w-[859.2px] max-w-none"
+          src="/static/activation/for-you-orb-small.svg"
         />
         <div className="relative ml-6 w-[calc(100%-48px)] pb-16 pt-[130px] md:ml-24 md:w-[566px]">
           <div className="flex flex-col gap-1">

--- a/front/components/pages/workspace/GetStartedPage/index.tsx
+++ b/front/components/pages/workspace/GetStartedPage/index.tsx
@@ -9,18 +9,34 @@ import {
   useFeatureFlags,
   useWorkspace,
 } from "@app/lib/auth/AuthContext";
+import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
+import { useSendNotification } from "@app/hooks/useNotification";
+import { useAppRouter } from "@app/lib/platform";
 import {
   useActivationPod,
   useActivationRecommendations,
 } from "@app/lib/swr/activation";
 import { usePodMetadata } from "@app/lib/swr/pods";
+import { getConversationRoute } from "@app/lib/utils/router";
 import { resolveDefaultAgentId } from "@app/types/user";
-import { Spinner } from "@dust-tt/sparkle";
-import { useState } from "react";
+import { Button, Spinner } from "@dust-tt/sparkle";
+import { useCallback, useState } from "react";
+
+const QUICK_PROMPTS = [
+  "Scan my connected sources for repetitive work I can automate.",
+  "Ask me questions to learn how I work.",
+  "How does my learning space work?",
+];
 
 export function GetStartedPage() {
   const owner = useWorkspace();
   const { user } = useAuth();
+  const router = useAppRouter();
+  const sendNotification = useSendNotification();
+  const createConversationWithMessage = useCreateConversationWithMessage({
+    owner,
+    user,
+  });
 
   // The whole surface is scoped to the user's activation Pod: recommendations
   // and recent conversations both come from it.
@@ -55,28 +71,75 @@ export function GetStartedPage() {
   const effectiveExpandedId =
     expandedId === undefined ? (recommendations[0]?.sId ?? null) : expandedId;
 
+  const [isGeneratingIdea, setIsGeneratingIdea] = useState(false);
+  const startConversation = useCallback(
+    async (input: string) => {
+      const res = await createConversationWithMessage({
+        messageData: {
+          input,
+          mentions: defaultAgentId ? [{ configurationId: defaultAgentId }] : [],
+          contentFragments: { uploaded: [], contentNodes: [] },
+        },
+        spaceId: activationPodId,
+      });
+
+      if (res.isErr()) {
+        sendNotification({
+          type: "error",
+          title: "Couldn't start conversation",
+          description: res.error.message,
+        });
+        return;
+      }
+
+      await router.push(getConversationRoute(owner.sId, res.value.sId));
+    },
+    [
+      activationPodId,
+      createConversationWithMessage,
+      defaultAgentId,
+      owner.sId,
+      router,
+      sendNotification,
+    ]
+  );
+
+  const generateIdea = useCallback(async () => {
+    setIsGeneratingIdea(true);
+    await startConversation("Generate a new idea for me");
+    setIsGeneratingIdea(false);
+  }, [startConversation]);
+
   const firstName = user?.firstName ?? user?.fullName?.split(" ")[0] ?? "there";
 
   return (
     <AssistantLayout owner={owner} user={user}>
-      <div
-        className="min-h-full w-full"
+      <div className="relative min-h-full w-full overflow-x-hidden bg-white">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0"
         style={{
-          background:
-            "radial-gradient(120% 90% at 100% 0%, rgba(28,145,255,0.10) 0%, rgba(28,145,255,0) 45%)",
+            backgroundImage: [
+              "linear-gradient(to right, rgba(0, 0, 0, 0.02) 1px, transparent 1px)",
+              "radial-gradient(68% 52% at 60% -8%, rgba(255, 203, 99, 0.55) 0%, rgba(255, 138, 128, 0.32) 35%, rgba(122, 159, 255, 0.24) 58%, transparent 76%)",
+              "radial-gradient(52% 44% at 14% 2%, rgba(132, 202, 255, 0.32) 0%, transparent 72%)",
+            ].join(", "),
+            backgroundSize: "calc(100% / 7) 100%, 100% 100%, 100% 100%",
         }}
-      >
-        <div className="mx-auto max-w-3xl px-8 py-14 md:px-16">
-          <h1 className="text-5xl font-bold tracking-tight text-foreground">
-            Welcome back, {firstName}.
-          </h1>
-          <h1 className="text-5xl font-bold tracking-tight text-highlight">
-            Let's get started
-          </h1>
+        />
+        <div className="relative ml-6 w-[calc(100%-48px)] pb-16 pt-[130px] md:ml-24 md:w-[566px]">
+          <div className="flex flex-col gap-1">
+            <h1 className="text-5xl font-medium leading-[52px] tracking-[-0.06em] text-foreground">
+              Welcome back, {firstName}.
+            </h1>
+            <h1 className="text-5xl font-medium leading-[52px] tracking-[-0.06em] text-highlight">
+              This is your learning space
+            </h1>
+          </div>
 
-          <div className="my-6 h-0.5 w-16 rounded-full bg-highlight-200" />
+          <div className="mt-6 h-px w-[82px] bg-highlight-200" />
 
-          <p className="text-sm leading-relaxed text-muted-foreground">
+          <p className="mt-6 text-sm leading-5 tracking-tight text-muted-foreground">
             Your own corner of Dust, where your agents and connected tools come
             together.
             <br />
@@ -92,11 +155,11 @@ export function GetStartedPage() {
             disabled={isActivationPodLoading}
           />
 
-          <div className="mt-10 rounded-2xl border border-border bg-background p-7 shadow-sm">
-            <h2 className="text-xl font-bold text-foreground">
+          <div className="mt-12 rounded-2xl bg-white px-6 pb-8 pt-6 shadow-[0px_3px_3px_-1.5px_rgba(0,0,0,0.06),0px_1px_1px_-0.5px_rgba(0,0,0,0.06),0px_0px_0px_1px_rgba(0,0,0,0.06)]">
+            <h2 className="text-xl font-semibold leading-7 tracking-tight text-foreground">
               Ideas for right now
             </h2>
-            <p className="mt-1 text-sm text-muted-foreground">
+            <p className="mt-1 text-sm leading-5 tracking-tight text-muted-foreground">
               These change as you work. New ones surface as your context shifts.
             </p>
 
@@ -108,37 +171,67 @@ export function GetStartedPage() {
               ) : (
                 <div className="divide-y divide-border">
                   {recommendations.length === 0 ? (
-                    <p className="py-10 text-center text-sm text-muted-foreground">
-                      No ideas yet. Start a conversation and Dust will suggest
-                      things to try.
-                    </p>
+                    <div className="py-4">
+                      <p className="text-sm text-muted-foreground">
+                        No ideas yet. Let Dust suggest things to try.
+                      </p>
+                      <div className="mt-4">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          isRounded
+                          label="Generate a new idea for me"
+                          disabled={isGeneratingIdea}
+                          onClick={() => void generateIdea()}
+                        />
+                      </div>
+                    </div>
                   ) : (
-                    recommendations.map((rec) => (
-                      <RecommendationItem
-                        key={rec.sId}
-                        rec={rec}
+                    <>
+                      {recommendations.map((rec) => (
+                        <RecommendationItem
+                          key={rec.sId}
+                          rec={rec}
+                          owner={owner}
+                          expanded={rec.sId === effectiveExpandedId}
+                          onToggle={() =>
+                            setExpandedId(
+                              rec.sId === effectiveExpandedId ? null : rec.sId
+                            )
+                          }
+                          onResolved={() => void mutateRecommendations()}
+                        />
+                      ))}
+                      <PreviouslyDoneRow
                         owner={owner}
-                        expanded={rec.sId === effectiveExpandedId}
-                        onToggle={() =>
-                          setExpandedId(
-                            rec.sId === effectiveExpandedId ? null : rec.sId
-                          )
-                        }
-                        onResolved={() => void mutateRecommendations()}
+                        podId={activationPodId}
                       />
-                    ))
+                    </>
                   )}
-                  <PreviouslyDoneRow owner={owner} podId={activationPodId} />
                 </div>
               )}
             </div>
           </div>
 
           <div className="mt-12">
-            <h2 className="text-xl font-bold text-foreground">Or just ask</h2>
-            <p className="mt-1 text-sm text-muted-foreground">
-              New here? Try one of these, or just start typing.
+            <h2 className="text-base font-semibold leading-6 tracking-tight text-foreground">
+              Or just ask
+            </h2>
+            <p className="mt-1 text-sm leading-5 tracking-tight text-muted-foreground">
+              New here? Start with one of these to see what your agents can do.
             </p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {QUICK_PROMPTS.map((prompt) => (
+                <Button
+                  key={prompt}
+                  variant="outline"
+                  size="sm"
+                  isRounded
+                  label={prompt}
+                  onClick={() => void startConversation(prompt)}
+                />
+              ))}
+            </div>
             <div className="mt-4">
               <JustAskComposer
                 owner={owner}

--- a/front/lib/api/activation/work_areas.ts
+++ b/front/lib/api/activation/work_areas.ts
@@ -1,7 +1,9 @@
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import type { ActivationWorkAreaStatus } from "@app/lib/models/activation/activation_work_area";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { ActivationWorkAreaResource } from "@app/lib/resources/activation_work_area_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -23,10 +25,31 @@ export interface UpdateActivationWorkAreaResponseBody {
 
 export async function listActivationWorkAreasForUser(
   auth: Authenticator,
-  { status }: { status?: ActivationWorkAreaStatus } = {}
+  {
+    status,
+    podId,
+  }: {
+    status?: ActivationWorkAreaStatus;
+    podId?: string;
+  } = {}
 ): Promise<ActivationWorkAreaForUserType[]> {
+  let activationPodModelId;
+  if (podId !== undefined) {
+    const space = await SpaceResource.fetchById(auth, podId);
+    if (!space) {
+      return [];
+    }
+
+    const activationPod = await ActivationPodResource.fetchByUser(auth);
+    if (!activationPod || activationPod.spaceId !== space.id) {
+      return [];
+    }
+    activationPodModelId = activationPod.id;
+  }
+
   const rows = await ActivationWorkAreaResource.listByUserAndStatus(auth, {
     status,
+    activationPodModelId,
   });
 
   return rows.map((r) => r.toJSON());

--- a/front/lib/resources/activation_work_area_resource.ts
+++ b/front/lib/resources/activation_work_area_resource.ts
@@ -97,7 +97,13 @@ export class ActivationWorkAreaResource extends BaseResource<ActivationWorkAreaM
 
   static async listByUserAndStatus(
     auth: Authenticator,
-    { status }: { status?: ActivationWorkAreaStatus }
+    {
+      status,
+      activationPodModelId,
+    }: {
+      status?: ActivationWorkAreaStatus;
+      activationPodModelId?: ModelId;
+    }
   ): Promise<ActivationWorkAreaResource[]> {
     const user = auth.getNonNullableUser();
 
@@ -108,6 +114,9 @@ export class ActivationWorkAreaResource extends BaseResource<ActivationWorkAreaM
 
     if (status !== undefined) {
       where.status = status;
+    }
+    if (activationPodModelId !== undefined) {
+      where.podId = activationPodModelId;
     }
 
     const rows = await this.model.findAll({

--- a/front/lib/swr/activation.ts
+++ b/front/lib/swr/activation.ts
@@ -3,7 +3,9 @@ import type {
   GetActivationPodResponseBody,
   GetActivationRecommendationsResponseBody,
 } from "@app/lib/api/activation/recommendations";
+import type { GetActivationWorkAreasResponseBody } from "@app/lib/api/activation/work_areas";
 import { clientFetch } from "@app/lib/egress/client";
+import type { ActivationWorkAreaStatus } from "@app/lib/models/activation/activation_work_area";
 import {
   emptyArray,
   getErrorFromResponse,
@@ -122,4 +124,90 @@ export function useUpdateActivationRecommendation({
   );
 
   return { updateRecommendation };
+}
+
+export function useActivationWorkAreas({
+  workspaceId,
+  status,
+  disabled,
+}: {
+  workspaceId: string;
+  status?: ActivationWorkAreaStatus;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const workAreasFetcher: Fetcher<GetActivationWorkAreasResponseBody> = fetcher;
+
+  const params = new URLSearchParams();
+  if (status) {
+    params.set("status", status);
+  }
+  const queryString = params.toString();
+  const url = queryString
+    ? `/api/w/${workspaceId}/activation-work-areas?${queryString}`
+    : `/api/w/${workspaceId}/activation-work-areas`;
+
+  const { data, error, mutate, isLoading } = useSWRWithDefaults(
+    url,
+    workAreasFetcher,
+    { disabled, revalidateOnFocus: false }
+  );
+
+  return {
+    workAreas: data?.workAreas ?? emptyArray(),
+    isWorkAreasLoading: disabled ? false : isLoading,
+    isWorkAreasError: !!error,
+    mutateWorkAreas: mutate,
+  };
+}
+
+export function useUpdateActivationWorkArea({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  const updateWorkArea = useCallback(
+    async (
+      workAreaId: string,
+      body: {
+        status?: "confirmed" | "dismissed";
+        title?: string;
+        description?: string;
+      }
+    ): Promise<boolean> => {
+      try {
+        const res = await clientFetch(
+          `/api/w/${workspaceId}/activation-work-areas/${workAreaId}`,
+          {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          }
+        );
+
+        if (!res.ok) {
+          const errorData = await getErrorFromResponse(res);
+          sendNotification({
+            type: "error",
+            title: "Failed to update work area",
+            description: errorData.message,
+          });
+          return false;
+        }
+
+        return true;
+      } catch {
+        sendNotification({
+          type: "error",
+          title: "Failed to update work area",
+        });
+        return false;
+      }
+    },
+    [workspaceId, sendNotification]
+  );
+
+  return { updateWorkArea };
 }

--- a/front/lib/swr/activation.ts
+++ b/front/lib/swr/activation.ts
@@ -128,10 +128,12 @@ export function useUpdateActivationRecommendation({
 
 export function useActivationWorkAreas({
   workspaceId,
+  podId,
   status,
   disabled,
 }: {
   workspaceId: string;
+  podId?: string;
   status?: ActivationWorkAreaStatus;
   disabled?: boolean;
 }) {
@@ -139,6 +141,9 @@ export function useActivationWorkAreas({
   const workAreasFetcher: Fetcher<GetActivationWorkAreasResponseBody> = fetcher;
 
   const params = new URLSearchParams();
+  if (podId) {
+    params.set("podId", podId);
+  }
   if (status) {
     params.set("status", status);
   }

--- a/front/lib/utils/router.ts
+++ b/front/lib/utils/router.ts
@@ -93,5 +93,5 @@ export const getPodRoute = (workspaceId: string, spaceId: string) => {
 };
 
 export const getGetStartedRoute = (workspaceId: string) => {
-  return `/w/${workspaceId}/get-started`;
+  return `/w/${workspaceId}/for-you`;
 };

--- a/front/public/static/activation/for-you-orb-large.svg
+++ b/front/public/static/activation/for-you-orb-large.svg
@@ -1,0 +1,24 @@
+<svg preserveAspectRatio="none" overflow="visible" style="display: block;" width="1067.2" height="845.2" viewBox="0 0 1067.2 845.2" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Ellipse 1" opacity="0.5" filter="url(#filter0_fn_0_1117)">
+<path d="M755.6 311.6C755.6 434.207 656.207 533.6 533.6 533.6C410.993 533.6 311.6 434.207 311.6 311.6C311.6 311.6 399.993 311.6 522.6 311.6C645.207 311.6 755.6 311.6 755.6 311.6Z" fill="#1C91FF"/>
+</g>
+<defs>
+<filter id="filter0_fn_0_1117" x="0" y="0" width="1067.2" height="845.2" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="155.8" result="effect1_foregroundBlur_0_1117"/>
+<feTurbulence type="fractalNoise" baseFrequency="2 2" stitchTiles="stitch" numOctaves="3" result="noise" seed="9092" />
+<feColorMatrix in="noise" type="luminanceToAlpha" result="alphaNoise" />
+<feComponentTransfer in="alphaNoise" result="coloredNoise1">
+<feFuncA type="discrete" tableValues="1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 "/>
+</feComponentTransfer>
+<feComposite operator="in" in2="effect1_foregroundBlur_0_1117" in="coloredNoise1" result="noise1Clipped" />
+<feFlood flood-color="rgba(0, 0, 0, 0.25)" result="color1Flood" />
+<feComposite operator="in" in2="noise1Clipped" in="color1Flood" result="color1" />
+<feMerge result="effect2_noise_0_1117">
+<feMergeNode in="effect1_foregroundBlur_0_1117" />
+<feMergeNode in="color1" />
+</feMerge>
+</filter>
+</defs>
+</svg>

--- a/front/public/static/activation/for-you-orb-small.svg
+++ b/front/public/static/activation/for-you-orb-small.svg
@@ -1,0 +1,24 @@
+<svg preserveAspectRatio="none" overflow="visible" style="display: block;" width="859.2" height="741.2" viewBox="0 0 859.2 741.2" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Ellipse 2" opacity="0.5" filter="url(#filter0_fn_0_1116)">
+<path d="M547.6 311.6C547.6 376.77 494.77 429.6 429.6 429.6C364.43 429.6 311.6 376.77 311.6 311.6C311.6 311.6 358.584 311.6 423.753 311.6C488.923 311.6 547.6 311.6 547.6 311.6Z" fill="#1C91FF"/>
+</g>
+<defs>
+<filter id="filter0_fn_0_1116" x="0" y="0" width="859.2" height="741.2" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="155.8" result="effect1_foregroundBlur_0_1116"/>
+<feTurbulence type="fractalNoise" baseFrequency="2 2" stitchTiles="stitch" numOctaves="3" result="noise" seed="9092" />
+<feColorMatrix in="noise" type="luminanceToAlpha" result="alphaNoise" />
+<feComponentTransfer in="alphaNoise" result="coloredNoise1">
+<feFuncA type="discrete" tableValues="1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 "/>
+</feComponentTransfer>
+<feComposite operator="in" in2="effect1_foregroundBlur_0_1116" in="coloredNoise1" result="noise1Clipped" />
+<feFlood flood-color="rgba(0, 0, 0, 0.25)" result="color1Flood" />
+<feComposite operator="in" in2="noise1Clipped" in="color1Flood" result="color1" />
+<feMerge result="effect2_noise_0_1116">
+<feMergeNode in="effect1_foregroundBlur_0_1116" />
+<feMergeNode in="color1" />
+</feMerge>
+</filter>
+</defs>
+</svg>


### PR DESCRIPTION
## Summary
- General changes to match latest Figma: https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=13222-6012&t=0O8Oyq67jWncq0yP-0, including**For you** activation page, including background treatment, recommendations, quick prompts, and recent conversations.
- Route the activation entry through `/for-you` and align its navigation labels.
- Let users review and confirm their work areas. This is an experimental concept we are surfacing directly to users

## Testing
<img width="2912" height="1784" alt="Screenshot 2026-08-07 at 1 56 15 PM" src="https://github.com/user-attachments/assets/368b0d6e-0ab2-45a9-97d1-fd97ef9146f2" />


## Risk
Low

## Deploy
1. Deploy front