### PR TITLE
[front] enh: nest pod conversations and fix pod title cursor in inbox

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1407,14 +1407,9 @@ function UnreadConversationsSection({
                     )}
                   >
                     <NavigationListLabel
-                      // The pod name is a static group header, not a link:
-                      // keep the arrow cursor instead of the text I-beam so it
-                      // doesn't read as interactive or selectable. The mt-2/
-                      // pt-2 split of the label's default pt-4 keeps half of
-                      // the inter-group spacing outside the highlight block.
-                      // bg-transparent overrides the label's own background so
-                      // the section card and the mark-as-read hover block show
-                      // through.
+                      // Static group header: no text cursor, and bg-transparent
+                      // lets the hover block show through. mt-2/pt-2 splits the
+                      // label's pt-4 to keep half the spacing outside the block.
                       className="bg-transparent cursor-default select-none mt-2 pt-2"
                       label={group.podName}
                       icon={pod ? getSpaceIcon(pod) : undefined}

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1373,7 +1373,10 @@ function UnreadConversationsSection({
               return [
                 <NavigationListLabel
                   key={`pod-label-${group.spaceId}`}
-                  className="bg-background"
+                  // The pod name is a static group header, not a link: keep
+                  // the arrow cursor instead of the text I-beam so it doesn't
+                  // read as interactive or selectable.
+                  className="bg-background cursor-default select-none"
                   label={group.podName}
                   icon={pod ? getSpaceIcon(pod) : undefined}
                   isSticky
@@ -1401,7 +1404,9 @@ function UnreadConversationsSection({
                     exit={GRID_EXIT}
                     transition={{ ease: "easeOut", duration: 0.1 }}
                   >
-                    <div className="overflow-hidden">
+                    {/* Indented under the pod header so the conversation
+                     * reads as nested inside the pod group. */}
+                    <div className="overflow-hidden pl-3">
                       <ConversationListItem
                         conversation={conversation}
                         isMultiSelect={isMultiSelect}

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1272,8 +1272,7 @@ interface UnreadConversationsSectionProps {
   conversations: ConversationListItemType[];
   pods: PodListItemType[];
   isMultiSelect: boolean;
-  isMarkingAllAsRead: boolean;
-  onMarkAllAsRead: (conversationIds: string[]) => void;
+  onMarkAllAsRead: (conversationIds: string[]) => Promise<void>;
   selectedConversations: ConversationListItemType[];
   toggleConversationSelection: (c: ConversationListItemType) => void;
   activeConversationId: string | null;
@@ -1300,7 +1299,6 @@ function UnreadConversationsSection({
   conversations,
   pods,
   isMultiSelect,
-  isMarkingAllAsRead,
   titleFilter,
   onMarkAllAsRead,
   selectedConversations,
@@ -1311,6 +1309,22 @@ function UnreadConversationsSection({
   const conversationGroups = useMemo(
     () => groupUnreadConversations(conversations, pods),
     [conversations, pods]
+  );
+
+  // Which mark-as-read button is in flight ("all" or a pod's spaceId), so
+  // only the clicked button shows a spinner.
+  const [markingScope, setMarkingScope] = useState<string | null>(null);
+
+  const handleMarkAsRead = useCallback(
+    async (scope: string, conversationIds: string[]) => {
+      setMarkingScope(scope);
+      try {
+        await onMarkAllAsRead(conversationIds);
+      } finally {
+        setMarkingScope(null);
+      }
+    },
+    [onMarkAllAsRead]
   );
 
   const podById = useMemo(
@@ -1334,8 +1348,13 @@ function UnreadConversationsSection({
             size="xmini"
             variant="ghost-secondary"
             label="Mark all as read"
-            onClick={() => onMarkAllAsRead(conversations.map((c) => c.sId))}
-            isLoading={isMarkingAllAsRead}
+            onClick={() =>
+              void handleMarkAsRead(
+                "all",
+                conversations.map((c) => c.sId)
+              )
+            }
+            isLoading={markingScope === "all"}
             hasLighterFont
             className="hover:bg-hover active:bg-selected"
           />
@@ -1407,11 +1426,12 @@ function UnreadConversationsSection({
                             label="Mark as read"
                             data-mark-read="pod"
                             onClick={() =>
-                              onMarkAllAsRead(
+                              void handleMarkAsRead(
+                                group.spaceId,
                                 group.conversations.map((c) => c.sId)
                               )
                             }
-                            isLoading={isMarkingAllAsRead}
+                            isLoading={markingScope === group.spaceId}
                             hasLighterFont
                             className="hover:bg-hover active:bg-selected"
                           />
@@ -1713,7 +1733,7 @@ function NavigationListWithInbox({
     );
   }, [conversations, titleFilter]);
 
-  const { markAllAsRead, isMarkingAllAsRead } = useMarkAllConversationsAsRead({
+  const { markAllAsRead } = useMarkAllConversationsAsRead({
     owner,
   });
 
@@ -1780,7 +1800,6 @@ function NavigationListWithInbox({
                   conversations={triggeredConversations}
                   pods={pods}
                   isMultiSelect={isMultiSelect}
-                  isMarkingAllAsRead={isMarkingAllAsRead}
                   titleFilter={titleFilter}
                   onMarkAllAsRead={markAllAsRead}
                   selectedConversations={selectedConversations}
@@ -1805,7 +1824,6 @@ function NavigationListWithInbox({
                   conversations={skillSuggestionConversations}
                   pods={pods}
                   isMultiSelect={isMultiSelect}
-                  isMarkingAllAsRead={isMarkingAllAsRead}
                   titleFilter={titleFilter}
                   onMarkAllAsRead={markAllAsRead}
                   selectedConversations={selectedConversations}
@@ -1830,7 +1848,6 @@ function NavigationListWithInbox({
                   conversations={inboxConversations}
                   pods={pods}
                   isMultiSelect={isMultiSelect}
-                  isMarkingAllAsRead={isMarkingAllAsRead}
                   titleFilter={titleFilter}
                   onMarkAllAsRead={markAllAsRead}
                   selectedConversations={selectedConversations}

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1321,7 +1321,8 @@ function UnreadConversationsSection({
       try {
         await onMarkAllAsRead(conversationIds);
       } finally {
-        setMarkingScope(null);
+        // Only clear our own scope: another button may be in flight.
+        setMarkingScope((prev) => (prev === scope ? null : prev));
       }
     },
     [onMarkAllAsRead]
@@ -1403,7 +1404,8 @@ function UnreadConversationsSection({
                     className={cn(
                       "flex flex-col gap-0.5 overflow-hidden rounded-lg",
                       "transition-colors duration-150 motion-reduce:transition-none",
-                      "has-[[data-mark-read=pod]:hover]:bg-hover"
+                      "has-[[data-mark-read=pod]:hover]:bg-hover",
+                      "has-[[data-mark-read=pod]:focus-visible]:bg-hover"
                     )}
                   >
                     <NavigationListLabel

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1327,13 +1327,20 @@ function UnreadConversationsSection({
     <NavigationListCollapsibleSection
       label={label}
       count={totalCount}
-      className="bg-background rounded-xl border border-border p-1 mx-sidebar-side-spacing"
+      // Hovering "Mark all as read" highlights the whole section it would
+      // clear.
+      className={cn(
+        "bg-background rounded-xl border border-border p-1 mx-sidebar-side-spacing",
+        "transition-colors duration-150 motion-reduce:transition-none",
+        "has-[[data-mark-read=all]:hover]:bg-hover"
+      )}
       action={
         shouldShowMarkAllAsReadButton ? (
           <Button
             size="xmini"
             variant="ghost-secondary"
             label="Mark all as read"
+            data-mark-read="all"
             onClick={() => onMarkAllAsRead(conversations.map((c) => c.sId))}
             isLoading={isMarkingAllAsRead}
             hasLighterFont
@@ -1371,56 +1378,79 @@ function UnreadConversationsSection({
             case "pod": {
               const pod = podById.get(group.spaceId);
               return [
-                <NavigationListLabel
-                  key={`pod-label-${group.spaceId}`}
-                  // The pod name is a static group header, not a link: keep
-                  // the arrow cursor instead of the text I-beam so it doesn't
-                  // read as interactive or selectable.
-                  className="bg-background cursor-default select-none"
-                  label={group.podName}
-                  icon={pod ? getSpaceIcon(pod) : undefined}
-                  isSticky
-                  action={
-                    shouldShowMarkAllAsReadButton ? (
-                      <Button
-                        size="xmini"
-                        variant="ghost-secondary"
-                        label="Mark as read"
-                        onClick={() =>
-                          onMarkAllAsRead(group.conversations.map((c) => c.sId))
-                        }
-                        isLoading={isMarkingAllAsRead}
-                        hasLighterFont
-                        className="hover:bg-hover active:bg-selected"
-                      />
-                    ) : null
-                  }
-                />,
-                ...group.conversations.map((conversation) => (
-                  <motion.div
-                    key={conversation.sId}
-                    style={GRID_STYLE}
-                    animate={GRID_ANIMATE}
-                    exit={GRID_EXIT}
-                    transition={{ ease: "easeOut", duration: 0.1 }}
+                <motion.div
+                  key={`pod-group-${group.spaceId}`}
+                  style={GRID_STYLE}
+                  animate={GRID_ANIMATE}
+                  exit={GRID_EXIT}
+                  transition={{ ease: "easeOut", duration: 0.1 }}
+                >
+                  {/* Hovering the pod's "Mark as read" button highlights the
+                   * whole block (header + conversations) it would clear. */}
+                  <div
+                    className={cn(
+                      "flex flex-col gap-0.5 overflow-hidden rounded-lg",
+                      "transition-colors duration-150 motion-reduce:transition-none",
+                      "has-[[data-mark-read=pod]:hover]:bg-hover"
+                    )}
                   >
-                    {/* Indented under the pod header so the conversation
-                     * reads as nested inside the pod group. */}
-                    <div className="overflow-hidden pl-3">
-                      <ConversationListItem
-                        conversation={conversation}
-                        isMultiSelect={isMultiSelect}
-                        selectedConversations={selectedConversations}
-                        toggleConversationSelection={
-                          toggleConversationSelection
-                        }
-                        activeConversationId={activeConversationId}
-                        owner={owner}
-                        showStatusDot={false}
-                      />
-                    </div>
-                  </motion.div>
-                )),
+                    <NavigationListLabel
+                      // The pod name is a static group header, not a link:
+                      // keep the arrow cursor instead of the text I-beam so it
+                      // doesn't read as interactive or selectable. The mt-2/
+                      // pt-2 split of the label's default pt-4 keeps half of
+                      // the inter-group spacing outside the highlight block.
+                      className="cursor-default select-none mt-2 pt-2"
+                      label={group.podName}
+                      icon={pod ? getSpaceIcon(pod) : undefined}
+                      action={
+                        shouldShowMarkAllAsReadButton ? (
+                          <Button
+                            size="xmini"
+                            variant="ghost-secondary"
+                            label="Mark as read"
+                            data-mark-read="pod"
+                            onClick={() =>
+                              onMarkAllAsRead(
+                                group.conversations.map((c) => c.sId)
+                              )
+                            }
+                            isLoading={isMarkingAllAsRead}
+                            hasLighterFont
+                            className="hover:bg-hover active:bg-selected"
+                          />
+                        ) : null
+                      }
+                    />
+                    <AnimatePresence initial={false}>
+                      {group.conversations.map((conversation) => (
+                        <motion.div
+                          key={conversation.sId}
+                          style={GRID_STYLE}
+                          animate={GRID_ANIMATE}
+                          exit={GRID_EXIT}
+                          transition={{ ease: "easeOut", duration: 0.1 }}
+                        >
+                          {/* Indented under the pod header so the conversation
+                           * reads as nested inside the pod group. */}
+                          <div className="overflow-hidden pl-3">
+                            <ConversationListItem
+                              conversation={conversation}
+                              isMultiSelect={isMultiSelect}
+                              selectedConversations={selectedConversations}
+                              toggleConversationSelection={
+                                toggleConversationSelection
+                              }
+                              activeConversationId={activeConversationId}
+                              owner={owner}
+                              showStatusDot={false}
+                            />
+                          </div>
+                        </motion.div>
+                      ))}
+                    </AnimatePresence>
+                  </div>
+                </motion.div>,
               ];
             }
             default:

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1327,20 +1327,13 @@ function UnreadConversationsSection({
     <NavigationListCollapsibleSection
       label={label}
       count={totalCount}
-      // Hovering "Mark all as read" highlights the whole section it would
-      // clear.
-      className={cn(
-        "bg-background rounded-xl border border-border p-1 mx-sidebar-side-spacing",
-        "transition-colors duration-150 motion-reduce:transition-none",
-        "has-[[data-mark-read=all]:hover]:bg-hover"
-      )}
+      className="bg-background rounded-xl border border-border p-1 mx-sidebar-side-spacing"
       action={
         shouldShowMarkAllAsReadButton ? (
           <Button
             size="xmini"
             variant="ghost-secondary"
             label="Mark all as read"
-            data-mark-read="all"
             onClick={() => onMarkAllAsRead(conversations.map((c) => c.sId))}
             isLoading={isMarkingAllAsRead}
             hasLighterFont

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1400,7 +1400,10 @@ function UnreadConversationsSection({
                       // doesn't read as interactive or selectable. The mt-2/
                       // pt-2 split of the label's default pt-4 keeps half of
                       // the inter-group spacing outside the highlight block.
-                      className="cursor-default select-none mt-2 pt-2"
+                      // bg-transparent overrides the label's own background so
+                      // the section card and the mark-as-read hover block show
+                      // through.
+                      className="bg-transparent cursor-default select-none mt-2 pt-2"
                       label={group.podName}
                       icon={pod ? getSpaceIcon(pod) : undefined}
                       action={

--- a/front/hooks/useMarkAllConversationsAsRead.ts
+++ b/front/hooks/useMarkAllConversationsAsRead.ts
@@ -94,15 +94,21 @@ export function useMarkAllConversationsAsRead({
           throw new Error("Failed to mark conversations as read");
         }
 
-        void mutatePodSummary();
-        void mutatePodConversations();
-        void mutateUnreadConversationIds();
-
         sendNotification({
           type: "success",
           title: "All conversations marked as read",
           description: `${total} conversation${total > 1 ? "s" : ""} marked as read.`,
         });
+
+        // Unread pod conversations are rendered from these caches, so hold
+        // the loading state until they refresh and the rows animate out.
+        // allSettled: a failed revalidation keeps stale data but is not a
+        // mark-as-read failure.
+        await Promise.allSettled([
+          mutatePodSummary(),
+          mutatePodConversations(),
+          mutateUnreadConversationIds(),
+        ]);
       } catch {
         void mutateConversations();
 


### PR DESCRIPTION
## Description

Targeted improvements to the unread/inbox sections of the conversation sidebar (`UnreadConversationsSection`):

- **Pod group headers**: the pod title is a static group header, not a link — it now uses `cursor-default select-none` (no more text I-beam suggesting interactivity) and drops its built-in `bg-app-background` so it sits flush on the section card. Its `isSticky` was removed: sticky was already inert here (an `overflow-hidden` ancestor between the label and the scroll viewport disables it).
- **Nested conversations**: conversations grouped under a pod header are indented (`pl-3`), so the row and its hover background read as nested inside the pod group. Non-pod conversations stay flush; the indent also applies in multi-select mode.
- **Mark-as-read hover preview**: hovering (or keyboard-focusing) a pod's "Mark as read" button highlights the whole contiguous block (header + conversations) it would clear. Pure CSS via `has-[[data-mark-read=pod]:hover]` / `:focus-visible` — no hover state in React. To support this, each pod group now has a real wrapper element (group-level `motion.div` + nested `AnimatePresence` for per-conversation exits); a side effect is that clearing a whole pod collapses the header together with its conversations instead of the header popping out. The section-level "Mark all as read" intentionally has no highlight — it felt too heavy across the whole card.
- **Spinner scoping**: `isLoading` was a single shared flag wired to every mark-as-read button (pre-existing), so clicking one spun them all. Only the clicked button spins now, tracked per scope (`"all"` or the pod's `spaceId`) with a concurrency-safe clear (a finishing request only clears its own scope).
- **Loading-state timing**: `useMarkAllConversationsAsRead` now awaits the pod cache revalidations (`Promise.allSettled`) before resolving, so the spinner holds until the refreshed data lands and the rows animate out, instead of clearing a beat early. This also applies to the same button in `PodConversationsTab` (the hook's only other consumer). The success toast intentionally fires before the await so feedback isn't coupled to refetch latency.

First step of a larger inbox-hierarchy cleanup (pod header vs. conversation visual treatment, possibly a clickable pod header later).

## Tests

- `tsgo --noEmit` on front passes; biome clean.
- Manual check in the sidebar: pod headers show no I-beam and no grey band, grouped conversations are indented, pod-level mark-as-read hover/focus highlights the affected block, only the clicked button spins and holds until its rows animate out.

https://github.com/user-attachments/assets/fbacf912-6263-406b-9302-2b4f0e23e0c2


## Risk

Low — UI-only change scoped to the sidebar unread sections plus a resolve-timing change in the mark-as-read hook. Worst case, the unread sections render oddly or spinners linger. Safe to rollback.

## Deploy Plan

Standard front deploy.