### PR TITLE
Fix empty static MCP server names

### DIFF
--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -10,6 +10,7 @@ import type { CreateMCPServerDialogFormValues } from "@app/components/actions/mc
 import { createMCPServerDialogFormSchema } from "@app/components/actions/mcp/forms/types";
 import {
   getCreateMCPServerDialogDefaultValues,
+  getMCPServerViewNameError,
   handleCreateMCPServerDialogSubmitError,
 } from "@app/components/actions/mcp/forms/utils";
 import type {
@@ -187,24 +188,12 @@ export function CreateMCPServerDialog({
   } | null>(null);
 
   // Client-side validation for the view name field.
-  const viewNameError = useMemo(() => {
-    const trimmed = (viewName ?? "").trim();
-    if (needsCustomName && !trimmed) {
-      return "Name is required.";
-    }
-    if (nameConflict) {
-      if (!trimmed) {
-        return `The default name "${nameConflict.name}" conflicts with an existing Tool. Enter a different name.`;
-      }
-      if (trimmed === nameConflict.name) {
-        return "This name conflicts with an existing Tool. Enter a different name.";
-      }
-    }
-    if (trimmed.length > 0 && existingViewNames.includes(trimmed)) {
-      return "This name is already in use.";
-    }
-    return null;
-  }, [needsCustomName, nameConflict, viewName, existingViewNames]);
+  const viewNameError = getMCPServerViewNameError({
+    viewName,
+    needsCustomName,
+    nameConflict: nameConflict?.name ?? null,
+    existingViewNames,
+  });
 
   const [isLoading, setIsLoading] = useState(false);
   const [serverError, setServerError] = useState<{
@@ -432,7 +421,12 @@ export function CreateMCPServerDialog({
   );
 
   const handleCreateServerAndSubmitStaticCredentials = async () => {
-    if (!internalMCPServer || !authorization || !useCase || viewNameError) {
+    if (!internalMCPServer || !authorization || !useCase) {
+      return;
+    }
+
+    const isValid = await form.trigger("viewName");
+    if (!isValid || viewNameError) {
       return;
     }
 
@@ -463,12 +457,14 @@ export function CreateMCPServerDialog({
     setExternalIsLoading(true);
 
     try {
+      const viewName = form.getValues("viewName")?.trim();
+
       // Create the internal server without an OAuth connection.
       const createRes = await createInternalMCPServer({
         name: internalMCPServer.name,
         useCase,
         includeGlobal: true,
-        viewName: form.getValues("viewName"),
+        ...(viewName ? { viewName } : {}),
       });
 
       if (createRes.isErr()) {

--- a/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.test.ts
+++ b/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.test.ts
@@ -1,5 +1,6 @@
 import { submitCreateMCPServerDialogForm } from "@app/components/actions/mcp/forms/submitCreateMCPServerDialogForm";
 import type { CreateMCPServerDialogFormValues } from "@app/components/actions/mcp/forms/types";
+import { getMCPServerViewNameError } from "@app/components/actions/mcp/forms/utils";
 import {
   DEFAULT_MCP_ACTION_VERSION,
   DEFAULT_MCP_SERVER_ICON,
@@ -12,6 +13,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock(import("@app/types/oauth/client/setup"), () => ({
   setupOAuthConnection: vi.fn(),
+}));
+
+vi.mock(import("@app/lib/actions/mcp_helper"), async (importOriginal) => ({
+  ...(await importOriginal()),
+  requiresBearerTokenConfiguration: () => false,
 }));
 
 const owner = {
@@ -54,6 +60,77 @@ const values = {
 describe("submitCreateMCPServerDialogForm", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("omits an empty view name when creating an internal server", async () => {
+    const createInternalMCPServer = vi.fn().mockResolvedValue(
+      new Ok({
+        success: true,
+        server,
+      })
+    );
+
+    const result = await submitCreateMCPServerDialogForm({
+      owner,
+      internalMCPServer: server,
+      values: { ...values, remoteServerUrl: "", viewName: "" },
+      authorization: null,
+      remoteMCPServerOAuthDiscoveryDone: false,
+      oauthConnectionId: null,
+      discoverOAuthMetadata: vi.fn(),
+      createWithURL: vi.fn(),
+      createInternalMCPServer,
+      onBeforeCreateServer: vi.fn(),
+      regionInfo: null,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(createInternalMCPServer).toHaveBeenCalledWith(
+      expect.not.objectContaining({ viewName: expect.anything() })
+    );
+  });
+
+  it("requires a custom name for a second internal server instance", () => {
+    expect(
+      getMCPServerViewNameError({
+        viewName: "",
+        needsCustomName: true,
+        nameConflict: null,
+        existingViewNames: ["Candidate"],
+      })
+    ).toBe("Name is required.");
+  });
+
+  it("uses a custom view name when creating a second internal server instance", async () => {
+    const createInternalMCPServer = vi.fn().mockResolvedValue(
+      new Ok({
+        success: true,
+        server,
+      })
+    );
+
+    const result = await submitCreateMCPServerDialogForm({
+      owner,
+      internalMCPServer: server,
+      values: {
+        ...values,
+        remoteServerUrl: "",
+        viewName: "  Candidate 2  ",
+      },
+      authorization: null,
+      remoteMCPServerOAuthDiscoveryDone: false,
+      oauthConnectionId: null,
+      discoverOAuthMetadata: vi.fn(),
+      createWithURL: vi.fn(),
+      createInternalMCPServer,
+      onBeforeCreateServer: vi.fn(),
+      regionInfo: null,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(createInternalMCPServer).toHaveBeenCalledWith(
+      expect.objectContaining({ viewName: "Candidate 2" })
+    );
   });
 
   it("reuses the OAuth connection when retrying a view name conflict", async () => {

--- a/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
+++ b/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
@@ -259,6 +259,7 @@ export async function submitCreateMCPServerDialogForm({
   let server: MCPServerType | undefined;
 
   if (internalMCPServer) {
+    const viewName = values.viewName?.trim();
     const sanitizedHeaders =
       requiresBearerTokenConfiguration(internalMCPServer) &&
       values.useCustomHeaders
@@ -286,14 +287,14 @@ export async function submitCreateMCPServerDialogForm({
           name: internalMCPServer.name,
           oauthConnection,
           includeGlobal: true,
-          viewName: values.viewName,
+          ...(viewName ? { viewName } : {}),
           ...scopeField,
           ...optionalFields,
         })
       : await createInternalMCPServer({
           name: internalMCPServer.name,
           includeGlobal: true,
-          viewName: values.viewName,
+          ...(viewName ? { viewName } : {}),
           ...scopeField,
           ...optionalFields,
         });

--- a/front/components/actions/mcp/forms/utils.ts
+++ b/front/components/actions/mcp/forms/utils.ts
@@ -31,6 +31,35 @@ interface HandleCreateMCPServerDialogSubmitErrorParams {
   loading: LoadingControls;
 }
 
+export function getMCPServerViewNameError({
+  viewName,
+  needsCustomName,
+  nameConflict,
+  existingViewNames,
+}: {
+  viewName: string | undefined;
+  needsCustomName: boolean;
+  nameConflict: string | null;
+  existingViewNames: string[];
+}): string | null {
+  const trimmed = (viewName ?? "").trim();
+  if (needsCustomName && !trimmed) {
+    return "Name is required.";
+  }
+  if (nameConflict) {
+    if (!trimmed) {
+      return `The default name "${nameConflict}" conflicts with an existing Tool. Enter a different name.`;
+    }
+    if (trimmed === nameConflict) {
+      return "This name conflicts with an existing Tool. Enter a different name.";
+    }
+  }
+  if (trimmed.length > 0 && existingViewNames.includes(trimmed)) {
+    return "This name is already in use.";
+  }
+  return null;
+}
+
 export function handleCreateMCPServerDialogSubmitError({
   error,
   context,


### PR DESCRIPTION
## Summary

Caused by: https://github.com/dust-tt/dust/pull/30107
eng runner: https://github.com/dust-tt/tasks/issues/9980

Following the addition of custom MCP server view names, first-time setup of integrations using the static-credential flow could fail with:

```text
invalid_request_error: viewName must be a non-empty string
```

The connection-name field is hidden for a first server instance and defaults to an empty string. The standard MCP creation flow trims and omits that value, but the static-credential flow forwarded `viewName: ""` directly to the API. The backend interpreted it as an explicitly supplied name and correctly rejected it.

This affected integrations using the static-credential creation path, while integrations following the standard creation flow continued to work.

## Testing
* Manual connected in localhost. did not work before now it does.

## Risk
Low - Fixing issue

## Deploy
1. Deploy front