### PR TITLE
fix: let archive_agents_from_csv reach agents in restricted spaces

### DIFF
--- a/front/scripts/archive_agents_from_csv.ts
+++ b/front/scripts/archive_agents_from_csv.ts
@@ -21,12 +21,28 @@ const argumentSpecs: ArgumentSpecs = {
     description: "Workspace ID to archive agents from",
     demandOption: true,
   },
+  includeRestrictedSpaces: {
+    type: "boolean",
+    description:
+      "Also archive agents that request a restricted space (grants the script read access to every space in the workspace)",
+    default: false,
+  },
 };
 
 makeScript(
   argumentSpecs,
-  async ({ csvPath, workspaceId, execute }, scriptLogger) => {
-    const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  async (
+    { csvPath, workspaceId, includeRestrictedSpaces, execute },
+    scriptLogger
+  ) => {
+    // Agents requesting a restricted space are filtered out of getAgentConfiguration unless the
+    // auth holds that space's group, and the default admin auth only holds the global group.
+    const auth = await Authenticator.internalAdminForWorkspace(
+      workspaceId,
+      includeRestrictedSpaces
+        ? { dangerouslyRequestAllGroups: true }
+        : undefined
+    );
 
     // Read and parse CSV file
     const fileContent = readFileSync(csvPath, "utf-8");
@@ -36,7 +52,7 @@ makeScript(
     }) as AgentRecord[];
 
     scriptLogger.info(
-      { workspaceId, recordCount: records.length },
+      { workspaceId, recordCount: records.length, includeRestrictedSpaces },
       "Starting agent archival process"
     );
 


### PR DESCRIPTION
## Description

Ran this script on a bulk archival request and 79 of 1514 agents failed with `Could not find agent <sId>`. They were all still active and in the right workspace, just on restricted space.

`archiveAgentConfiguration` calls `getAgentConfiguration` without `dangerouslySkipPermissionFiltering`, so agents go through `filterAgentsByRequestedSpaces`, which drops anything the auth can't read.

Adds `--include-restricted-spaces` to opt into `dangerouslyRequestAllGroups`. Off by default, since it hands the script read access to every space in the workspace.

## Tests

Manual, on the run that surfaced this. First pass without the flag: 1435 archived, 79 failed. Re-ran the 79 with `--include-restricted-spaces`: 79 archived, 0 errors.

## Risk

Low. 

`dangerouslyRequestAllGroups` is broad by design, which is why it's behind a flag rather than always on.

## Deploy Plan

None.