### PR TITLE
fix(dsbx): resolve drizzle-kit at its image install path

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.43"
+version = "0.1.44"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.43"
+version = "0.1.44"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/functions-runner/db/schema.test.ts
+++ b/cli/dust-sandbox/functions-runner/db/schema.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveDrizzleKitBin } from "./schema.ts";
+
+async function withDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "dsbx-schema-test-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function makeBin(path: string): Promise<string> {
+  await mkdir(join(path, ".."), { recursive: true });
+  await writeFile(path, "");
+  return path;
+}
+
+describe("resolveDrizzleKitBin", () => {
+  test("prefers the image install when both exist", async () => {
+    await withDir(async (dir) => {
+      const imageBin = await makeBin(join(dir, "image", "drizzle-kit"));
+      const localBin = await makeBin(join(dir, "local", "drizzle-kit"));
+
+      const result = resolveDrizzleKitBin({ imageBin, localBin });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe(imageBin);
+      }
+    });
+  });
+
+  test("falls back to the local .bin when the image install is absent", async () => {
+    await withDir(async (dir) => {
+      const localBin = await makeBin(join(dir, "local", "drizzle-kit"));
+
+      const result = resolveDrizzleKitBin({
+        imageBin: join(dir, "image", "drizzle-kit"),
+        localBin,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe(localBin);
+      }
+    });
+  });
+
+  test("errors naming both candidates when neither exists", async () => {
+    await withDir(async (dir) => {
+      const imageBin = join(dir, "image", "drizzle-kit");
+      const localBin = join(dir, "local", "drizzle-kit");
+
+      const result = resolveDrizzleKitBin({ imageBin, localBin });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.kind).toBe("internal");
+        expect(result.error.message).toContain(imageBin);
+        expect(result.error.message).toContain(localBin);
+      }
+    });
+  });
+});

--- a/cli/dust-sandbox/functions-runner/db/schema.ts
+++ b/cli/dust-sandbox/functions-runner/db/schema.ts
@@ -69,21 +69,57 @@ export function generateSchemaFileText(
   }
 }
 
-// drizzle-kit is a CLI on PATH in the sandbox image (global install). In tests it is only a
-// devDependency, so prepend this package's node_modules/.bin so the same spawn resolves it there.
+// Where the sandbox image installs drizzle-kit (root-owned `npm install -g` at image
+// build). Hardened sandbox exec runs with a pinned PATH that deliberately excludes
+// /opt/npm-global/bin, so runtime resolution must not go through PATH — login shells
+// source the profile and see a wider PATH, which makes PATH-based failures here
+// especially confusing to debug.
+const SANDBOX_DRIZZLE_KIT_BIN = "/opt/npm-global/bin/drizzle-kit";
+
+// Dev/test install: drizzle-kit is a devDependency of this package.
+const LOCAL_DRIZZLE_KIT_BIN = join(
+  import.meta.dir,
+  "..",
+  "node_modules",
+  ".bin",
+  "drizzle-kit"
+);
+
+// Spawn env for the drizzle-kit child; prepending the local .bin keeps any
+// sub-resolutions it does working in dev, where nothing is globally installed.
 function drizzleKitEnv(): Record<string, string | undefined> {
   const localBin = join(import.meta.dir, "..", "node_modules", ".bin");
   return { ...process.env, PATH: `${localBin}:${process.env.PATH ?? ""}` };
 }
 
-// Resolve the drizzle-kit bin against the same PATH the spawn uses (global install on the
-// sandbox, local .bin in tests), so it can be handed to bun as a script path.
-function drizzleKitBinPath(): Result<string, DbCommandError> {
-  const bin = Bun.which("drizzle-kit", { PATH: drizzleKitEnv().PATH });
-  if (!bin) {
-    return new Err(
-      new DbCommandError("internal", "drizzle-kit not found on PATH")
-    );
+// Resolve drizzle-kit by explicit path only — never through the caller's PATH.
+// Image install first: on the sandbox it's a root-owned constant, and preferring
+// it keeps production resolution independent of whatever sits next to the
+// deployed bundle. The local .bin only exists on dev machines and CI.
+export function resolveDrizzleKitBin({
+  imageBin,
+  localBin,
+}: {
+  imageBin: string;
+  localBin: string;
+}): Result<string, DbCommandError> {
+  if (existsSync(imageBin)) {
+    return new Ok(imageBin);
   }
-  return new Ok(bin);
+  if (existsSync(localBin)) {
+    return new Ok(localBin);
+  }
+  return new Err(
+    new DbCommandError(
+      "internal",
+      `drizzle-kit not found; checked ${imageBin} and ${localBin}`
+    )
+  );
+}
+
+function drizzleKitBinPath(): Result<string, DbCommandError> {
+  return resolveDrizzleKitBin({
+    imageBin: SANDBOX_DRIZZLE_KIT_BIN,
+    localBin: LOCAL_DRIZZLE_KIT_BIN,
+  });
 }

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.68",
+      tag: "0.8.69",
     });
   });
 
@@ -457,7 +457,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.43/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.44/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,8 +26,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.68";
-const DSBX_CLI_VERSION = "0.1.43";
+const DUST_BASE_IMAGE_VERSION = "0.8.69";
+const DSBX_CLI_VERSION = "0.1.44";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
 // the stable identity used when creating the workload account.


### PR DESCRIPTION
## Description

`dsbx db schema` (the get-DB-schema MCP path) fails with `drizzle-kit not found on PATH`, while the binary is visibly present in an interactive sandbox shell.

**Root cause:** non-root `sandbox.exec` commands run in a `--noprofile --norc` shell with PATH pinned to `/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin` (sandbox service-account hardening). `/opt/bin/dsbx` resolves, but the runner then looked up `drizzle-kit` via `Bun.which` against that inherited PATH — and the image's global npm install lives at `/opt/npm-global/bin`, which the pinned PATH deliberately excludes. Interactive shells source the profile and see the full PATH, which is why shell-based debugging shows the binary "on PATH".

**Fix:** resolve drizzle-kit by explicit path only, never through the caller's PATH — the image install (`/opt/npm-global/bin/drizzle-kit`, root-owned `npm install -g` at image build) first, the package-local `node_modules/.bin` (devDependency) as the dev/test fallback. The failure message names both candidates. The bun-shebang-bypass invocation is unchanged.

Deliberately **not** done: widening the hardened PATHs. Note the exec runs as the `agent` service user (`execOpts?.user ?? "agent"`), whose safe PATH is the same constant as root's — a PATH-based fix would widen root's exec PATH or require splitting that alias plus standing ownership guarantees on `/opt/npm-global`, for what an audit shows is a single-caller problem (every other binary dsbx spawns — `bun`, `runuser`, `nft` — lives in `/opt/bin` or `/usr/sbin`, already on the pinned PATHs).

## Risk

Worst case, drizzle-kit resolution fails with an error naming both checked paths — same failure mode as today, better message. No hardening/PATH changes. Safe to rollback.

## Tests

Resolver unit tests (image install wins / local fallback / neither → error naming both paths); existing db suite green (48 tests).

## Deploy Plan

Mirrors the image-rollout process from `Harden sandbox uid 1002 service boundary` (#29411) — this fix rides inside the dsbx binary embedded in the sandbox image, so a front deploy alone does not reach sandboxes, and sleeping sandboxes retain their original image.

1. [x] Dispatch the `Release dsbx CLI` workflow on the merged commit — it reads `0.1.44` from `Cargo.toml` and publishes the `dsbx-v0.1.44` release this PR's registry pin points at (image builds 404 on the dsbx download until this runs).
2. [x] Build `dust-base:0.8.69` (embeds dsbx 0.1.44); confirm the validated templates are available in both E2B regions (the deploy workflow gates front on image availability).
3. [x] Deploy front pinned to `dust-base:0.8.69` — new sandboxes pick up the patched dsbx.
4. [x] Kill sandboxes on older `dust-base` versions via `/poke/kill` — sleeping sandboxes retain their original image, so without this, existing Computers (including the pod this was reported on) wake up with the old dsbx and keep the bug. At minimum, kill the affected pods' sandboxes; a full sweep matches the #29411 process.
5. [ ] Verify no non-deleted sandbox remains on an older version, then re-run the get-DB-schema MCP on the reporting pod — covering both a fresh Computer and a woken one.

> [!NOTE]
> Validated ahead of rollout: the patched dsbx was hot-swapped into a live sandbox via `upsert_dsbx_to_sandbox.sh` and the get-DB-schema flow succeeds under the hardened exec PATH.
