### PR TITLE
[front] fix: polish conversation invite memory warning

### DIFF
--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -157,8 +157,8 @@ export function MentionValidationRequired({
       status === "pending_project_membership");
 
   const memoryWarning = showMemoryWarning ? (
-    <span className="mt-2 flex items-start gap-1.5 text-muted-foreground">
-      <InfoCircle className="mt-0.5 h-4 w-4 shrink-0" />
+    <span className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
+      <InfoCircle className="h-4 w-4 shrink-0" />
       <span>
         The content of your personal memory may be disclosed to invited users.
       </span>

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -156,15 +156,6 @@ export function MentionValidationRequired({
     (status === "pending_conversation_access" ||
       status === "pending_project_membership");
 
-  const memoryWarning = showMemoryWarning ? (
-    <span className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
-      <InfoCircle className="h-4 w-4 shrink-0" />
-      <span>
-        The content of your personal memory may be disclosed to invited users.
-      </span>
-    </span>
-  ) : null;
-
   let approveLabel: string;
   switch (status) {
     case "agent_restricted_by_space_usage":
@@ -195,7 +186,15 @@ export function MentionValidationRequired({
         description={
           <>
             {description}
-            {memoryWarning}
+            {showMemoryWarning && (
+              <span className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
+                <InfoCircle className="h-4 w-4 shrink-0" />
+                <span>
+                  The content of your personal memory may be disclosed to
+                  invited users.
+                </span>
+              </span>
+            )}
           </>
         }
         actions={

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -157,9 +157,11 @@ export function MentionValidationRequired({
       status === "pending_project_membership");
 
   const memoryWarning = showMemoryWarning ? (
-    <span className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
+    <span className="mt-2 flex items-center gap-1.5 text-xs text-muted-foreground">
       <InfoCircle className="h-4 w-4 shrink-0" />
-      <span>Your personal memory may be disclosed to invited users.</span>
+      <span>
+        Content from your personal memory may be disclosed to invited users.
+      </span>
     </span>
   ) : null;
 

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -157,10 +157,10 @@ export function MentionValidationRequired({
       status === "pending_project_membership");
 
   const memoryWarning = showMemoryWarning ? (
-    <span className="mt-2 flex items-center gap-1.5 text-xs text-muted-foreground">
+    <span className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
       <InfoCircle className="h-4 w-4 shrink-0" />
       <span>
-        Content from your personal memory may be disclosed to invited users.
+        The content of your personal memory may be disclosed to invited users.
       </span>
     </span>
   ) : null;

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -159,9 +159,7 @@ export function MentionValidationRequired({
   const memoryWarning = showMemoryWarning ? (
     <span className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
       <InfoCircle className="h-4 w-4 shrink-0" />
-      <span>
-        The content of your personal memory may be disclosed to invited users.
-      </span>
+      <span>Your personal memory may be disclosed to invited users.</span>
     </span>
   ) : null;
 


### PR DESCRIPTION
## Description

The personal memory warning in conversation invite cards takes 2 lines and its information icon is visually misaligned.

This PR fixes that.

Before

<img width="530" height="228" alt="image" src="https://github.com/user-attachments/assets/6afe4625-b581-4fd8-a9b5-c8918bfe349b" />

After

<img width="525" height="235" alt="image" src="https://github.com/user-attachments/assets/7d83ae5d-bb01-439f-bcd3-507ac48c5941" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
