### PR TITLE
[dsbx] perf: pod-scoped warm worker pool with hash-affinity routing

### DIFF
--- a/cli/dust-sandbox/functions-runner/fixtures/slow-import.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/slow-import.ts
@@ -1,0 +1,9 @@
+// Top-level await delays the IMPORT itself, so tests can pin behaviors that
+// depend on the worker being inside its pre-ack resolve/import phase.
+await new Promise((resolve) => setTimeout(resolve, 400));
+
+export default {
+  async fetch(): Promise<Response> {
+    return Response.json({ imported: true });
+  },
+};

--- a/cli/dust-sandbox/functions-runner/runner.ts
+++ b/cli/dust-sandbox/functions-runner/runner.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env bun
 // Embedded runner for `dsbx function` and `dsbx db`. Subcommands:
 //   runner run <path>                            stdin request envelope -> stdout Output JSON
-//   runner serve <path> <socketPath>             warm server: keep <path> imported, serve
-//                                                invocations over a unix socket until idle
+//   runner serve <socketPath> <idleMs>           warm worker: serve any function from
+//                                                $DUST_FUNCTIONS_DIR over a unix socket,
+//                                                importing bundles on first use, until idle
 //   runner get <path>                            -> stdout FunctionSchema JSON (or {error})
 //   runner build <src> <outBundle> <outSchema>   bundle + extract schema to files
 //   runner db-reconcile <dbPath> <schemaFile>    additive-only DDL reconcile -> stdout envelope
@@ -153,6 +154,20 @@ async function main(): Promise<number> {
     return dbQueryHandler(rest);
   }
 
+  if (command === "serve") {
+    // Generic warm worker: the functions dir comes from DUST_FUNCTIONS_DIR
+    // and each request names the function to serve. The idle timeout is the
+    // spawner's choice (burst workers get seconds, base workers minutes).
+    const [socketPath, idleMsRaw] = rest;
+    const idleTimeoutMs = Number(idleMsRaw);
+    if (!socketPath || !Number.isFinite(idleTimeoutMs) || idleTimeoutMs <= 0) {
+      process.stderr.write("usage: runner serve <socket-path> <idle-ms>\n");
+      return 2;
+    }
+    // Never returns: the worker exits itself (idle, lifetime, staleness).
+    return serve(socketPath, idleTimeoutMs);
+  }
+
   const [handlerPath] = rest;
   if (!handlerPath) {
     process.stderr.write("usage: runner <run|get|serve> <handler-path>\n");
@@ -163,17 +178,6 @@ async function main(): Promise<number> {
       return runHandler(handlerPath);
     case "get":
       return getHandler(handlerPath);
-    case "serve": {
-      const [, socketPath] = rest;
-      if (!socketPath) {
-        process.stderr.write(
-          "usage: runner serve <handler-path> <socket-path>\n"
-        );
-        return 2;
-      }
-      // Never returns: the server exits itself (idle, lifetime, staleness).
-      return serve(handlerPath, socketPath);
-    }
     default:
       process.stderr.write(`runner: unknown command "${command}"\n`);
       return 2;

--- a/cli/dust-sandbox/functions-runner/serve.test.ts
+++ b/cli/dust-sandbox/functions-runner/serve.test.ts
@@ -355,6 +355,54 @@ describe("runner serve", () => {
     }
   });
 
+  test("an idle timeout shorter than the invocation never kills it", async () => {
+    // Burst workers run a 15s idle, far under the invocation deadline: the
+    // idle exit firing mid-invocation must be dropped, not sever a running
+    // function post-ack.
+    const { proc, socketPath } = await startWorker(fixturesDir, {
+      idleTimeoutMs: 150,
+    });
+    try {
+      const reply = await request(
+        socketPath,
+        warmRequest({}, "slow", { url: "http://localhost/" })
+      );
+      expect(reply.outcome?.output).toEqual({ done: true });
+      // After completing, the re-armed idle drains the worker normally.
+      expect(await proc.exited).toBe(0);
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("claims the worker before the import, not at the ack", async () => {
+    // slow-import.ts delays its own import with a top-level await, holding
+    // the worker inside its pre-ack resolve/import phase. A second request
+    // arriving there must see busy: two invocations in flight would race the
+    // process-global env swap and hand one caller's identity to another's
+    // function.
+    const { proc, socketPath } = await startWorker(fixturesDir);
+    try {
+      const first = request(
+        socketPath,
+        warmRequest({}, "slow-import", { url: "http://localhost/" })
+      );
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const overlapped = await request(
+        socketPath,
+        warmRequest({}, "hello", { url: "http://localhost/" })
+      );
+      expect(overlapped.busy).toBe(true);
+      expect(overlapped.outcome).toBeUndefined();
+
+      const served = await first;
+      expect(served.outcome?.output).toEqual({ imported: true });
+    } finally {
+      proc.kill();
+    }
+  });
+
   test("exits on idle", async () => {
     const { proc, socketPath } = await startWorker(fixturesDir, {
       idleTimeoutMs: 300,

--- a/cli/dust-sandbox/functions-runner/serve.test.ts
+++ b/cli/dust-sandbox/functions-runner/serve.test.ts
@@ -7,14 +7,18 @@ import {
   applyRequestEnv,
   clearAppliedEnv,
   parseWarmRequest,
+  resolveBundle,
   WARM_PROTOCOL_VERSION,
 } from "./serve.ts";
 
 const runner = join(import.meta.dir, "runner.ts");
 const fx = (n: string) => join(import.meta.dir, "fixtures", n);
+const fixturesDir = join(import.meta.dir, "fixtures");
 
-// Each test gets its own scratch dir holding the socket and a private copy of
-// the fixture (staleness tests rewrite it).
+const DEFAULT_IDLE_MS = 60_000;
+
+// Each test gets its own scratch dir holding the socket and, for staleness
+// tests, a private functions dir whose bundles it rewrites.
 let scratchDirs: string[] = [];
 
 function scratch(): string {
@@ -35,13 +39,23 @@ interface ServerHandle {
   socketPath: string;
 }
 
-async function startServer(handlerPath: string): Promise<ServerHandle> {
-  const socketPath = join(scratch(), "fn.sock");
-  const proc = Bun.spawn(["bun", runner, "serve", handlerPath, socketPath], {
-    stdin: "ignore",
-    stdout: "ignore",
-    stderr: "inherit",
-  });
+async function startWorker(
+  functionsDir: string,
+  {
+    idleTimeoutMs = DEFAULT_IDLE_MS,
+    env = {},
+  }: { idleTimeoutMs?: number; env?: Record<string, string> } = {}
+): Promise<ServerHandle> {
+  const socketPath = join(scratch(), "w.sock");
+  const proc = Bun.spawn(
+    ["bun", runner, "serve", socketPath, String(idleTimeoutMs)],
+    {
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "inherit",
+      env: { ...process.env, DUST_FUNCTIONS_DIR: functionsDir, ...env },
+    }
+  );
   // Wait for the socket to accept connections.
   const deadline = Date.now() + 10_000;
   while (Date.now() < deadline) {
@@ -56,19 +70,20 @@ async function startServer(handlerPath: string): Promise<ServerHandle> {
       await new Promise((resolve) => setTimeout(resolve, 25));
     }
   }
-  throw new Error("warm server did not come up");
+  throw new Error("warm worker did not come up");
 }
 
 interface WarmReply {
   v: number;
   ack?: boolean;
   outcome?: { ok: boolean; output?: unknown; error?: { code: string } };
+  importKind?: "cached" | "fresh";
   stale?: boolean;
   busy?: boolean;
   error?: string;
 }
 
-// Collects every newline-delimited frame until the server closes the
+// Collects every newline-delimited frame until the worker closes the
 // connection: a served invocation is [ack, outcome], every refusal is a
 // single frame.
 async function requestFrames(
@@ -113,45 +128,85 @@ async function request(
 ): Promise<WarmReply> {
   const frames = await requestFrames(socketPath, payload);
   if (frames.length === 0) {
-    throw new Error("server closed without any frame");
+    throw new Error("worker closed without any frame");
   }
   return frames[frames.length - 1]!;
 }
 
-function warmRequest(env: Record<string, string>, input: unknown) {
+function warmRequest(
+  env: Record<string, string>,
+  name: string,
+  input: unknown
+) {
   return {
     v: WARM_PROTOCOL_VERSION,
     env,
     input: JSON.stringify(input),
+    name,
   };
 }
 
 describe("runner serve", () => {
-  test("serves an invocation over the socket", async () => {
-    const { proc, socketPath } = await startServer(fx("hello.ts"));
+  test("serves an invocation, importing the bundle on first use", async () => {
+    const { proc, socketPath } = await startWorker(fixturesDir);
     try {
       const reply = await request(
         socketPath,
-        warmRequest({}, { url: "http://localhost/?name=warm" })
+        warmRequest({}, "hello", { url: "http://localhost/?name=warm" })
       );
       expect(reply.v).toBe(WARM_PROTOCOL_VERSION);
       expect(reply.outcome?.ok).toBe(true);
       expect(reply.outcome?.output).toEqual({ hello: "warm" });
+      expect(reply.importKind).toBe("fresh");
     } finally {
       proc.kill();
     }
   });
 
-  test("serves repeat invocations from the same process", async () => {
-    const { proc, socketPath } = await startServer(fx("hello.ts"));
+  test("serves repeat invocations from the module cache", async () => {
+    const { proc, socketPath } = await startWorker(fixturesDir);
     try {
-      for (const name of ["one", "two", "three"]) {
+      const first = await request(
+        socketPath,
+        warmRequest({}, "hello", { url: "http://localhost/?name=one" })
+      );
+      expect(first.importKind).toBe("fresh");
+      for (const name of ["two", "three"]) {
         const reply = await request(
           socketPath,
-          warmRequest({}, { url: `http://localhost/?name=${name}` })
+          warmRequest({}, "hello", { url: `http://localhost/?name=${name}` })
         );
         expect(reply.outcome?.output).toEqual({ hello: name });
+        expect(reply.importKind).toBe("cached");
       }
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("serves several functions from one worker", async () => {
+    const { proc, socketPath } = await startWorker(fixturesDir);
+    try {
+      const hello = await request(
+        socketPath,
+        warmRequest({}, "hello", { url: "http://localhost/?name=multi" })
+      );
+      expect(hello.outcome?.output).toEqual({ hello: "multi" });
+
+      const threw = await request(
+        socketPath,
+        warmRequest({}, "throws", { url: "http://localhost/" })
+      );
+      expect(threw.outcome?.ok).toBe(false);
+      expect(threw.outcome?.error?.code).toBe("threw");
+
+      // The first function's import survives serving the second.
+      const again = await request(
+        socketPath,
+        warmRequest({}, "hello", { url: "http://localhost/?name=back" })
+      );
+      expect(again.outcome?.output).toEqual({ hello: "back" });
+      expect(again.importKind).toBe("cached");
     } finally {
       proc.kill();
     }
@@ -160,12 +215,13 @@ describe("runner serve", () => {
   test("applies per-request env and clears it between requests", async () => {
     // env-probe.ts echoes process.env.WARM_TEST_MARKER, so the reply proves
     // which env the invocation ran under.
-    const { proc, socketPath } = await startServer(fx("env-probe.ts"));
+    const { proc, socketPath } = await startWorker(fixturesDir);
     try {
       const first = await request(
         socketPath,
         warmRequest(
           { WARM_TEST_MARKER: "alpha", DUST_SANDBOX_TOKEN: "tok-alpha" },
+          "env-probe",
           { url: "http://localhost/" }
         )
       );
@@ -178,7 +234,7 @@ describe("runner serve", () => {
       // first invocation — in particular not its sandbox token.
       const second = await request(
         socketPath,
-        warmRequest({}, { url: "http://localhost/" })
+        warmRequest({}, "env-probe", { url: "http://localhost/" })
       );
       expect(second.outcome?.output).toEqual({
         marker: "unset",
@@ -189,20 +245,26 @@ describe("runner serve", () => {
     }
   });
 
-  test("reports a rewritten bundle as stale and exits", async () => {
+  test("reports a rewritten bundle as stale and recycles", async () => {
     const dir = scratch();
-    const bundle = join(dir, "hello.ts");
-    copyFileSync(fx("hello.ts"), bundle);
-    const { proc, socketPath } = await startServer(bundle);
+    copyFileSync(fx("hello.ts"), join(dir, "hello.ts"));
+    const { proc, socketPath } = await startWorker(dir);
     try {
+      const first = await request(
+        socketPath,
+        warmRequest({}, "hello", { url: "http://localhost/" })
+      );
+      expect(first.outcome?.ok).toBe(true);
+
       // Same content, different mtime — a republish rewrites the object, and
-      // mtime/size is the staleness signal.
+      // mtime/size is the staleness signal. The stale import can never be
+      // evicted, so the worker drains and exits.
       const later = new Date(Date.now() + 5_000);
-      utimesSync(bundle, later, later);
+      utimesSync(join(dir, "hello.ts"), later, later);
 
       const reply = await request(
         socketPath,
-        warmRequest({}, { url: "http://localhost/" })
+        warmRequest({}, "hello", { url: "http://localhost/" })
       );
       expect(reply.stale).toBe(true);
       expect(await proc.exited).toBe(0);
@@ -211,65 +273,114 @@ describe("runner serve", () => {
     }
   });
 
-  test("serves a request stamped with the matching bundle hash", async () => {
-    const { proc, socketPath } = await startServer(fx("hello.ts"));
+  test("refuses a mismatched bundle hash as stale without importing", async () => {
+    // The stat cannot see a rewrite here (the file is untouched), which is
+    // exactly the gcsfuse-cached-metadata case: the request's hash is the
+    // only signal, and it must win.
+    const { proc, socketPath } = await startWorker(fixturesDir);
     try {
+      const reply = await request(
+        socketPath,
+        warmRequest({}, "hello", {
+          url: "http://localhost/",
+          bundleSha256: "0".repeat(64),
+        })
+      );
+      expect(reply.stale).toBe(true);
+      expect(reply.outcome).toBeUndefined();
+
+      // The refusal happened before the import, so the worker is not
+      // poisoned: a correctly-stamped request still gets served.
       const bytes = await Bun.file(fx("hello.ts")).arrayBuffer();
       const bundleSha256 = new Bun.CryptoHasher("sha256")
         .update(new Uint8Array(bytes))
         .digest("hex");
-      const reply = await request(
+      const served = await request(
         socketPath,
-        warmRequest({}, { url: "http://localhost/?name=stamped", bundleSha256 })
+        warmRequest({}, "hello", {
+          url: "http://localhost/?name=stamped",
+          bundleSha256,
+        })
       );
-      expect(reply.outcome?.ok).toBe(true);
-      expect(reply.outcome?.output).toEqual({ hello: "stamped" });
+      expect(served.outcome?.output).toEqual({ hello: "stamped" });
+      expect(served.importKind).toBe("fresh");
     } finally {
       proc.kill();
     }
   });
 
-  test("refuses a mismatched bundle hash as stale and exits", async () => {
-    // The stat cannot see the rewrite here (the file is untouched), which is
-    // exactly the gcsfuse-cached-metadata case: the request's hash is the
-    // only signal, and it must win.
-    const { proc, socketPath } = await startServer(fx("hello.ts"));
+  test("refuses a cached bundle when the stamped hash stops matching", async () => {
+    const dir = scratch();
+    copyFileSync(fx("hello.ts"), join(dir, "hello.ts"));
+    const { proc, socketPath } = await startWorker(dir);
     try {
+      const first = await request(
+        socketPath,
+        warmRequest({}, "hello", { url: "http://localhost/" })
+      );
+      expect(first.outcome?.ok).toBe(true);
+
       const reply = await request(
         socketPath,
-        warmRequest(
-          {},
-          { url: "http://localhost/", bundleSha256: "0".repeat(64) }
-        )
+        warmRequest({}, "hello", {
+          url: "http://localhost/",
+          bundleSha256: "0".repeat(64),
+        })
       );
       expect(reply.stale).toBe(true);
-      expect(reply.outcome).toBeUndefined();
+      // The cached import can never serve the stamped version: recycle.
       expect(await proc.exited).toBe(0);
     } finally {
       proc.kill();
     }
   });
 
-  test("serves an unstamped request from an older front", async () => {
-    const { proc, socketPath } = await startServer(fx("hello.ts"));
+  test("reports an unknown function as stale, keeping the cold path's error", async () => {
+    const { proc, socketPath } = await startWorker(fixturesDir);
     try {
       const reply = await request(
         socketPath,
-        warmRequest({}, { url: "http://localhost/?name=unstamped" })
+        warmRequest({}, "no-such-function", { url: "http://localhost/" })
       );
-      expect(reply.outcome?.output).toEqual({ hello: "unstamped" });
+      expect(reply.stale).toBe(true);
+
+      // The worker survives: an unknown name poisons nothing.
+      const served = await request(
+        socketPath,
+        warmRequest({}, "hello", { url: "http://localhost/?name=alive" })
+      );
+      expect(served.outcome?.output).toEqual({ hello: "alive" });
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("exits on idle", async () => {
+    const { proc, socketPath } = await startWorker(fixturesDir, {
+      idleTimeoutMs: 300,
+    });
+    try {
+      const reply = await request(
+        socketPath,
+        warmRequest({}, "hello", { url: "http://localhost/" })
+      );
+      expect(reply.outcome?.ok).toBe(true);
+      // Burst workers are configured with short idles exactly so they drain
+      // once load drops; nothing else references this process again.
+      expect(await proc.exited).toBe(0);
     } finally {
       proc.kill();
     }
   });
 
   test("rejects a protocol version it does not speak and exits", async () => {
-    const { proc, socketPath } = await startServer(fx("hello.ts"));
+    const { proc, socketPath } = await startWorker(fixturesDir);
     try {
       const reply = await request(socketPath, {
         v: 999,
         env: {},
         input: "{}",
+        name: "hello",
       });
       expect(reply.error).toBe("bad warm request");
       expect(await proc.exited).toBe(0);
@@ -279,11 +390,11 @@ describe("runner serve", () => {
   });
 
   test("acks before the outcome so the client can pin execution start", async () => {
-    const { proc, socketPath } = await startServer(fx("hello.ts"));
+    const { proc, socketPath } = await startWorker(fixturesDir);
     try {
       const frames = await requestFrames(
         socketPath,
-        warmRequest({}, { url: "http://localhost/?name=frames" })
+        warmRequest({}, "hello", { url: "http://localhost/?name=frames" })
       );
       expect(frames.length).toBe(2);
       expect(frames[0]?.ack).toBe(true);
@@ -294,31 +405,32 @@ describe("runner serve", () => {
   });
 
   test("replies busy instead of queueing behind a running invocation", async () => {
-    const { proc, socketPath } = await startServer(fx("slow.ts"));
+    const { proc, socketPath } = await startWorker(fixturesDir);
     try {
       const slow = request(
         socketPath,
-        warmRequest({}, { url: "http://localhost/" })
+        warmRequest({}, "slow", { url: "http://localhost/" })
       );
-      // Give the slow request time to reach the server and start executing.
+      // Give the slow request time to reach the worker and start executing.
       await new Promise((resolve) => setTimeout(resolve, 150));
 
       const overlapped = await request(
         socketPath,
-        warmRequest({}, { url: "http://localhost/" })
+        warmRequest({}, "hello", { url: "http://localhost/" })
       );
       // Queueing would run this request for a client whose front-side
-      // timeout may already have fired; busy sends it cold immediately.
+      // timeout may already have fired; busy sends it to the next slot (or
+      // cold) immediately.
       expect(overlapped.busy).toBe(true);
       expect(overlapped.outcome).toBeUndefined();
 
       const first = await slow;
       expect(first.outcome?.output).toEqual({ done: true });
 
-      // The server survives and serves again once free.
+      // The worker survives and serves again once free.
       const after = await request(
         socketPath,
-        warmRequest({}, { url: "http://localhost/" })
+        warmRequest({}, "slow", { url: "http://localhost/" })
       );
       expect(after.outcome?.output).toEqual({ done: true });
     } finally {
@@ -327,40 +439,23 @@ describe("runner serve", () => {
   });
 
   test("scrubs the spawn-time invocation secrets from its own environment", async () => {
-    const dir = scratch();
-    const socketPath = join(dir, "fn.sock");
     // Spawned the way dsbx spawns it: with the cold invocation's token in
-    // env. The server must not serve requests under that inherited value.
-    const proc = Bun.spawn(
-      ["bun", runner, "serve", fx("env-probe.ts"), socketPath],
-      {
-        stdin: "ignore",
-        stdout: "ignore",
-        stderr: "inherit",
-        env: {
-          ...process.env,
-          WARM_TEST_MARKER: "from-spawn",
-          DUST_SANDBOX_TOKEN: "spawn-invocation-token",
-        },
-      }
-    );
+    // env. The worker must not serve requests under that inherited value.
+    const { proc, socketPath } = await startWorker(fixturesDir, {
+      env: {
+        WARM_TEST_MARKER: "from-spawn",
+        DUST_SANDBOX_TOKEN: "spawn-invocation-token",
+      },
+    });
     try {
-      const deadline = Date.now() + 10_000;
-      let reply: WarmReply | null = null;
-      while (Date.now() < deadline && reply === null) {
-        try {
-          reply = await request(
-            socketPath,
-            warmRequest({}, { url: "http://localhost/" })
-          );
-        } catch {
-          await new Promise((resolve) => setTimeout(resolve, 25));
-        }
-      }
+      const reply = await request(
+        socketPath,
+        warmRequest({}, "env-probe", { url: "http://localhost/" })
+      );
       // WARM_TEST_MARKER is not in the scrub list, so it survives spawn env
       // inheritance like any other var; the spawn-time DUST_SANDBOX_TOKEN
       // must have been scrubbed at startup.
-      expect(reply?.outcome?.output).toEqual({
+      expect(reply.outcome?.output).toEqual({
         marker: "from-spawn",
         token: "unset",
       });
@@ -369,35 +464,22 @@ describe("runner serve", () => {
     }
   });
 
-  test("reports runner errors as structured outcomes", async () => {
-    const { proc, socketPath } = await startServer(fx("throws.ts"));
-    try {
-      const reply = await request(
-        socketPath,
-        warmRequest({}, { url: "http://localhost/" })
-      );
-      expect(reply.outcome?.ok).toBe(false);
-      expect(reply.outcome?.error?.code).toBe("threw");
-    } finally {
-      proc.kill();
-    }
-  });
-
   test("reports malformed envelopes as bad_input without dying", async () => {
-    const { proc, socketPath } = await startServer(fx("hello.ts"));
+    const { proc, socketPath } = await startWorker(fixturesDir);
     try {
       const bad = await request(socketPath, {
         v: WARM_PROTOCOL_VERSION,
         env: {},
         input: "not json",
+        name: "hello",
       });
       expect(bad.outcome?.ok).toBe(false);
       expect(bad.outcome?.error?.code).toBe("bad_input");
 
-      // The server survives a bad envelope: the next request still works.
+      // The worker survives a bad envelope: the next request still works.
       const good = await request(
         socketPath,
-        warmRequest({}, { url: "http://localhost/?name=alive" })
+        warmRequest({}, "hello", { url: "http://localhost/?name=alive" })
       );
       expect(good.outcome?.output).toEqual({ hello: "alive" });
     } finally {
@@ -413,36 +495,50 @@ describe("parseWarmRequest", () => {
         v: WARM_PROTOCOL_VERSION,
         env: { KEEP: "yes", DROP_NUMBER: 3, DROP_NULL: null },
         input: "{}",
+        name: "greet",
       })
     );
     expect(parsed).toEqual({
       v: WARM_PROTOCOL_VERSION,
       env: { KEEP: "yes" },
       input: "{}",
+      name: "greet",
     });
   });
 
   test("returns null for every malformed request", () => {
     expect(parseWarmRequest("not json")).toBeNull();
     expect(parseWarmRequest('"a string"')).toBeNull();
+    const base = { v: WARM_PROTOCOL_VERSION, env: {}, input: "{}" };
     expect(
-      parseWarmRequest(JSON.stringify({ v: 999, env: {}, input: "{}" }))
+      parseWarmRequest(JSON.stringify({ ...base, v: 999, name: "greet" }))
+    ).toBeNull();
+    expect(parseWarmRequest(JSON.stringify(base))).toBeNull();
+    expect(
+      parseWarmRequest(JSON.stringify({ ...base, name: "bad name!" }))
     ).toBeNull();
     expect(
-      parseWarmRequest(
-        JSON.stringify({ v: WARM_PROTOCOL_VERSION, input: "{}" })
-      )
+      parseWarmRequest(JSON.stringify({ ...base, env: null, name: "greet" }))
     ).toBeNull();
     expect(
-      parseWarmRequest(
-        JSON.stringify({ v: WARM_PROTOCOL_VERSION, env: null, input: "{}" })
-      )
+      parseWarmRequest(JSON.stringify({ ...base, input: 7, name: "greet" }))
     ).toBeNull();
-    expect(
-      parseWarmRequest(
-        JSON.stringify({ v: WARM_PROTOCOL_VERSION, env: {}, input: 7 })
-      )
-    ).toBeNull();
+  });
+});
+
+describe("resolveBundle", () => {
+  test("resolves a name to its single bundle, extension-agnostically", () => {
+    const resolved = resolveBundle(fixturesDir, "hello");
+    expect(resolved).toBe(join(fixturesDir, "hello.ts"));
+  });
+
+  test("returns null for missing or ambiguous names", () => {
+    expect(resolveBundle(fixturesDir, "no-such-function")).toBeNull();
+    const dir = scratch();
+    copyFileSync(fx("hello.ts"), join(dir, "greet.ts"));
+    copyFileSync(fx("hello.ts"), join(dir, "greet.js"));
+    expect(resolveBundle(dir, "greet")).toBeNull();
+    expect(resolveBundle(join(dir, "does-not-exist"), "greet")).toBeNull();
   });
 });
 
@@ -454,7 +550,7 @@ describe("applyRequestEnv", () => {
       expect(process.env.SERVE_TEST_KEY).toBe("one");
 
       // Cleared after the invocation: per-request secrets (the sandbox
-      // token travels in env) must not sit in the idle server's environment.
+      // token travels in env) must not sit in the idle worker's environment.
       clearAppliedEnv(applied);
       expect(process.env.SERVE_TEST_KEY).toBeUndefined();
     } finally {

--- a/cli/dust-sandbox/functions-runner/serve.ts
+++ b/cli/dust-sandbox/functions-runner/serve.ts
@@ -45,11 +45,12 @@ export const WARM_PROTOCOL_VERSION = 2;
 // staleness that gcsfuse metadata caching could hide from unstamped
 // envelopes. Deadline: an invocation that runs this long lost its client to
 // front's much shorter exec timeout ages ago; exit and free the socket.
-// RSS cap: recycles a worker whose imported working set outgrew its share of
-// the sandbox's memory.
+// RSS cap: recycles a worker whose imported working set outgrew its share
+// of the sandbox's memory. Sized so a full pool of 8 stays bounded at
+// ~1.6GB inside the 2GB sandbox, alongside its mounts and daemons.
 const MAX_LIFETIME_MS = 600_000;
 const INVOCATION_DEADLINE_MS = 120_000;
-const MAX_RSS_BYTES = 300 * 1024 * 1024;
+const MAX_RSS_BYTES = 200 * 1024 * 1024;
 
 // Per-invocation env vars inherited from the cold run that spawned this
 // worker. Scrubbed at startup: they belong to that invocation, and every
@@ -137,20 +138,23 @@ export function resolveBundle(
   functionsDir: string,
   name: string
 ): string | null {
-  let entries: string[];
+  let entries: import("node:fs").Dirent[];
   try {
-    entries = readdirSync(functionsDir);
+    entries = readdirSync(functionsDir, { withFileTypes: true });
   } catch {
     return null;
   }
   const matches = entries.filter((entry) => {
-    const dot = entry.lastIndexOf(".");
-    return (dot === -1 ? entry : entry.slice(0, dot)) === name;
+    if (!entry.isFile()) {
+      return false;
+    }
+    const dot = entry.name.lastIndexOf(".");
+    return (dot <= 0 ? entry.name : entry.name.slice(0, dot)) === name;
   });
   if (matches.length !== 1) {
     return null;
   }
-  return join(functionsDir, matches[0]!);
+  return join(functionsDir, matches[0]!.name);
 }
 
 /**
@@ -254,10 +258,19 @@ export async function serve(
   // finishes and replies, then the worker exits. Imports are permanent, so
   // rebirth is the only way to shed a stale or bloated working set.
   let draining = false;
-  let idleTimer = setTimeout(() => exit(0), idleTimeoutMs);
+  // The busy guard matters: burst workers run a 15s idle, far under the
+  // invocation deadline, and an idle exit mid-invocation would sever a
+  // legitimately running function post-ack. A timer that fires while busy is
+  // simply dropped; the invocation's release re-arms it.
+  const idleExit = () => {
+    if (!busy) {
+      exit(0);
+    }
+  };
+  let idleTimer = setTimeout(idleExit, idleTimeoutMs);
   const armIdle = () => {
     clearTimeout(idleTimer);
-    idleTimer = setTimeout(() => exit(0), idleTimeoutMs);
+    idleTimer = setTimeout(idleExit, idleTimeoutMs);
   };
   setTimeout(() => {
     if (busy) {
@@ -268,6 +281,10 @@ export async function serve(
   }, MAX_LIFETIME_MS);
 
   const socketBuffers = new Map<object, string>();
+  // Sockets whose exit must wait for their reply to flush: a draining
+  // worker's final outcome can exceed the kernel buffer, and exiting on the
+  // next tick would truncate it — reporting a completed invocation as lost.
+  const exitWhenDrained = new Set<object>();
 
   function reply(
     socket: WarmSocket,
@@ -276,9 +293,12 @@ export async function serve(
   ): void {
     writeThenEnd(socket, `${JSON.stringify(response)}\n`);
     if (exitAfter) {
-      // The flush of a tiny control frame cannot realistically backpressure;
-      // exit on the next tick so the write callbacks run.
-      setTimeout(() => exit(0), 0);
+      if (pendingWrites.has(socket)) {
+        exitWhenDrained.add(socket);
+      } else {
+        // Fully flushed; exit on the next tick so the write callbacks run.
+        setTimeout(() => exit(0), 0);
+      }
     }
   }
 
@@ -297,9 +317,13 @@ export async function serve(
     importKind: "cached" | "fresh";
   } | null> {
     const staleReply = ({ recycle = false }: { recycle?: boolean } = {}) => {
-      // A recycle exits right after the reply flushes: nothing is in flight
-      // (busy requests never reach here), and the worker holds an import it
-      // can never serve again.
+      // A recycle exits right after the reply flushes: this request holds
+      // the busy claim (no invocation is in flight), and the worker holds an
+      // import it can never serve again. Draining gates the tick before the
+      // exit lands.
+      if (recycle) {
+        draining = true;
+      }
       reply(
         socket,
         { v: WARM_PROTOCOL_VERSION, stale: true },
@@ -363,63 +387,68 @@ export async function serve(
     return { bundle, importKind: "fresh" };
   }
 
+  // Runs under the busy claim taken synchronously in handleLine; releases it
+  // (and re-arms the idle exit) on every path that does not exit the worker.
   async function runInvocation(
     socket: WarmSocket,
     request: WarmRequest
   ): Promise<void> {
-    let input: RequestInput;
     try {
-      input = parseInput(request.input);
-    } catch (e) {
-      // Pre-ack: a malformed envelope never executed anything, and the cold
-      // runner would classify it the same way.
-      const message = e instanceof BadInputError ? e.message : String(e);
-      reply(socket, {
-        v: WARM_PROTOCOL_VERSION,
-        outcome: { ok: false, error: { code: "bad_input", message } },
-      });
-      return;
-    }
-
-    const ensured = await ensureBundle(socket, request, input.bundleSha256);
-    if (ensured === null) {
-      return;
-    }
-    const { bundle, importKind } = ensured;
-
-    // The ack is the point of no return: from here the client must never
-    // fall back to the cold path, because the function may have side effects
-    // in flight. A lost outcome after this frame is a failed invocation, not
-    // a retried one.
-    busy = true;
-    const ackWritten = socket.write(
-      `${JSON.stringify({ v: WARM_PROTOCOL_VERSION, ack: true })}\n`
-    );
-    if (ackWritten <= 0) {
-      // The client is already gone; do not execute for a dead client.
-      busy = false;
-      return;
-    }
-
-    // An invocation that outlives this deadline lost its client to front's
-    // exec timeout long ago. Exit without replying and free the socket; the
-    // hung function was never going to produce an outcome anyway.
-    const deadline = setTimeout(() => exit(1), INVOCATION_DEADLINE_MS);
-
-    const applied = applyRequestEnv(request.env);
-    try {
-      const outcome = await invoke(bundle.handlerPath, input);
-      if (process.memoryUsage.rss() > MAX_RSS_BYTES) {
-        draining = true;
+      let input: RequestInput;
+      try {
+        input = parseInput(request.input);
+      } catch (e) {
+        // Pre-ack: a malformed envelope never executed anything, and the
+        // cold runner would classify it the same way.
+        const message = e instanceof BadInputError ? e.message : String(e);
+        reply(socket, {
+          v: WARM_PROTOCOL_VERSION,
+          outcome: { ok: false, error: { code: "bad_input", message } },
+        });
+        return;
       }
-      reply(
-        socket,
-        { v: WARM_PROTOCOL_VERSION, outcome, importKind },
-        { exitAfter: draining }
+
+      const ensured = await ensureBundle(socket, request, input.bundleSha256);
+      if (ensured === null) {
+        return;
+      }
+      const { bundle, importKind } = ensured;
+
+      // The ack is the point of no return: from here the client must never
+      // fall back to the cold path, because the function may have side
+      // effects in flight. A lost outcome after this frame is a failed
+      // invocation, not a retried one.
+      const ackWritten = socket.write(
+        `${JSON.stringify({ v: WARM_PROTOCOL_VERSION, ack: true })}\n`
       );
+      if (ackWritten <= 0) {
+        // The client is already gone; do not execute for a dead client.
+        socket.end();
+        return;
+      }
+
+      // An invocation that outlives this deadline lost its client to
+      // front's exec timeout long ago. Exit without replying and free the
+      // socket; the hung function was never going to produce an outcome
+      // anyway.
+      const deadline = setTimeout(() => exit(1), INVOCATION_DEADLINE_MS);
+
+      const applied = applyRequestEnv(request.env);
+      try {
+        const outcome = await invoke(bundle.handlerPath, input);
+        if (process.memoryUsage.rss() > MAX_RSS_BYTES) {
+          draining = true;
+        }
+        reply(
+          socket,
+          { v: WARM_PROTOCOL_VERSION, outcome, importKind },
+          { exitAfter: draining }
+        );
+      } finally {
+        clearTimeout(deadline);
+        clearAppliedEnv(applied);
+      }
     } finally {
-      clearTimeout(deadline);
-      clearAppliedEnv(applied);
       busy = false;
       armIdle();
     }
@@ -445,6 +474,12 @@ export async function serve(
       );
       return;
     }
+    // Claim the worker synchronously, before runInvocation's first await:
+    // ensureBundle suspends on stat/read/import, and a second request
+    // arriving during that suspension must see busy — two invocations in
+    // flight would race the process-global env swap and hand one caller's
+    // identity to another's function.
+    busy = true;
     void runInvocation(socket, request);
   }
 
@@ -469,14 +504,25 @@ export async function serve(
         },
         drain(socket) {
           drainPending(socket);
+          if (!pendingWrites.has(socket) && exitWhenDrained.has(socket)) {
+            setTimeout(() => exit(0), 0);
+          }
         },
         close(socket) {
           socketBuffers.delete(socket);
           pendingWrites.delete(socket);
+          if (exitWhenDrained.has(socket)) {
+            // The client died before the flush completed; nothing left to
+            // deliver, and the exit must not be lost with it.
+            setTimeout(() => exit(0), 0);
+          }
         },
         error(socket) {
           socketBuffers.delete(socket);
           pendingWrites.delete(socket);
+          if (exitWhenDrained.has(socket)) {
+            setTimeout(() => exit(0), 0);
+          }
         },
       },
     });

--- a/cli/dust-sandbox/functions-runner/serve.ts
+++ b/cli/dust-sandbox/functions-runner/serve.ts
@@ -1,29 +1,36 @@
-// Warm function server: keeps one imported function bundle resident in a bun
-// process and serves invocations over a unix socket, so repeat invocations skip
-// process spawn, bundle resolution, and the import of the bundle and its
-// dependencies (the dominant sandbox-side costs of a cold run).
+// Warm function worker: a generic bun process that keeps imported function
+// bundles resident and serves invocations over a unix socket, so repeat
+// invocations skip process spawn, bundle resolution, and the import of the
+// bundle and its dependencies (the dominant sandbox-side costs of a cold run).
 //
-// One server serves exactly one handler path, one invocation at a time. The
-// per-invocation environment (sandbox token, user identity) travels in the
-// request and is applied to process.env for the duration of the invocation,
-// then cleared — concurrency would race those swaps, so a request arriving
-// while one is running gets an immediate `busy` reply and the client runs
-// cold instead of queueing behind work of unknown duration.
+// Workers are pod-scoped, not function-scoped: the request names the function
+// and the worker resolves and imports its bundle on first use (the module
+// cache keeps it). One invocation at a time per worker — the per-invocation
+// environment (sandbox token, user identity) travels in the request and is
+// applied to process.env for the duration of the invocation, then cleared.
+// Concurrency would race those swaps and break the serial-execution semantics
+// every published bundle was written under, so a request arriving while one
+// is running gets an immediate `busy` reply and the client tries another
+// worker or runs cold instead of queueing behind work of unknown duration.
 //
 // Duplicate executions are the failure mode this protocol is shaped around:
 // pod functions are arbitrary side-effectful code, and front assumes a failed
-// start means nothing ran. The server acks before executing; the client only
+// start means nothing ran. The worker acks before executing; the client only
 // falls back to the cold path on failures that precede the ack. After the
 // ack, a lost outcome is reported as a failed invocation, never re-run.
 //
-// The server is disposable. It exits on idle, at a hard lifetime cap (drained,
-// never mid-invocation), when the bundle on disk changes, on any malformed
-// request, or when an invocation outlives its deadline (without replying: the
-// client's front-side timeout killed it long before).
+// The worker is disposable. It exits on idle (the timeout is the spawner's
+// choice: burst workers get seconds, base workers minutes), at a hard
+// lifetime cap (drained, never mid-invocation), on any malformed request,
+// when an invocation outlives its deadline (without replying: the client's
+// front-side timeout killed it long before), and it self-recycles — drain,
+// then exit — when a bundle it imported goes stale (ES modules cannot be
+// evicted, so rebirth is the only pruning) or when its RSS crosses the cap.
 
 import { createHash } from "node:crypto";
-import { unlinkSync } from "node:fs";
+import { readdirSync, unlinkSync } from "node:fs";
 import { stat, unlink } from "node:fs/promises";
+import { join } from "node:path";
 
 import { z } from "zod";
 
@@ -31,22 +38,26 @@ import { invoke } from "./invoke.ts";
 import type { RequestInput } from "./protocol.ts";
 import { BadInputError, parseInput } from "./protocol.ts";
 
-export const WARM_PROTOCOL_VERSION = 1;
+export const WARM_PROTOCOL_VERSION = 2;
 
-// Idle: how long the server waits for another invocation before exiting.
-// Lifetime: hard cap bounding how long a republished bundle can keep being
-// served when the envelope carries no bundle hash and gcsfuse metadata
-// caching hides the change from the per-request stat. Deadline: an
-// invocation that runs this long lost its client to front's much shorter
-// exec timeout ages ago; exit and free the socket.
-const IDLE_TIMEOUT_MS = 120_000;
+// Lifetime: hard cap that recycles the worker, bounding both bundle
+// accumulation (imports are permanent for the life of the process) and
+// staleness that gcsfuse metadata caching could hide from unstamped
+// envelopes. Deadline: an invocation that runs this long lost its client to
+// front's much shorter exec timeout ages ago; exit and free the socket.
+// RSS cap: recycles a worker whose imported working set outgrew its share of
+// the sandbox's memory.
 const MAX_LIFETIME_MS = 600_000;
 const INVOCATION_DEADLINE_MS = 120_000;
+const MAX_RSS_BYTES = 300 * 1024 * 1024;
 
 // Per-invocation env vars inherited from the cold run that spawned this
-// server. Scrubbed at startup: they belong to that invocation, and every
+// worker. Scrubbed at startup: they belong to that invocation, and every
 // request carries its own.
 const SPAWN_ENV_SCRUB_KEYS = ["DUST_SANDBOX_TOKEN", "DUST_POD_USER_IDENTITY"];
+
+// Mirrors dsbx's function-name validation: the name feeds a directory scan.
+const VALID_NAME = /^[A-Za-z0-9_-]+$/;
 
 const WarmRequestSchema = z.object({
   v: z.literal(WARM_PROTOCOL_VERSION),
@@ -63,13 +74,34 @@ const WarmRequestSchema = z.object({
     return out;
   }),
   input: z.string(),
+  // The function to serve. Workers are generic: the bundle is resolved from
+  // the functions directory and imported on first use.
+  name: z.string().regex(VALID_NAME),
 });
 
 type WarmRequest = z.infer<typeof WarmRequestSchema>;
 
+export function parseWarmRequest(line: string): WarmRequest | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  const result = WarmRequestSchema.safeParse(parsed);
+  return result.success ? result.data : null;
+}
+
 interface BundleStamp {
   mtimeMs: number;
   size: number;
+}
+
+/** A bundle this worker has imported; the module cache pins it until exit. */
+interface ImportedBundle {
+  handlerPath: string;
+  stamp: BundleStamp;
+  sha256: string;
 }
 
 async function statBundle(handlerPath: string): Promise<BundleStamp | null> {
@@ -96,15 +128,29 @@ async function sha256OfFile(path: string): Promise<string | null> {
   }
 }
 
-export function parseWarmRequest(line: string): WarmRequest | null {
-  let parsed: unknown;
+/**
+ * Resolve a function name to its bundle file, extension-agnostically —
+ * the same contract as dsbx's resolve_existing: exactly one file in the
+ * functions directory whose stem is the name.
+ */
+export function resolveBundle(
+  functionsDir: string,
+  name: string
+): string | null {
+  let entries: string[];
   try {
-    parsed = JSON.parse(line);
+    entries = readdirSync(functionsDir);
   } catch {
     return null;
   }
-  const result = WarmRequestSchema.safeParse(parsed);
-  return result.success ? result.data : null;
+  const matches = entries.filter((entry) => {
+    const dot = entry.lastIndexOf(".");
+    return (dot === -1 ? entry : entry.slice(0, dot)) === name;
+  });
+  if (matches.length !== 1) {
+    return null;
+  }
+  return join(functionsDir, matches[0]!);
 }
 
 /**
@@ -112,7 +158,7 @@ export function parseWarmRequest(line: string): WarmRequest | null {
  * it set, so the caller can clear them once the invocation completes. The
  * request carries the client's full environment, so the invocation sees
  * exactly what a cold run's child would have inherited; clearing afterwards
- * keeps per-invocation secrets out of the idle server's environment.
+ * keeps per-invocation secrets out of the idle worker's environment.
  */
 export function applyRequestEnv(env: Record<string, string>): Set<string> {
   const applied = new Set<string>();
@@ -169,39 +215,28 @@ function drainPending(socket: WarmSocket): void {
 }
 
 export async function serve(
-  handlerPath: string,
-  socketPath: string
+  socketPath: string,
+  idleTimeoutMs: number
 ): Promise<never> {
   for (const key of SPAWN_ENV_SCRUB_KEYS) {
     delete process.env[key];
   }
 
-  // Import eagerly: the server is spawned right after a cold run, so warming
-  // now (rather than on first request) makes the very next invocation fast.
-  // The module cache keyed by path is the whole point of this process. A
-  // static import is impossible here: the bundle to serve is a runtime
-  // argument, a different published function per server.
-  const importedStamp = await statBundle(handlerPath);
-  if (importedStamp === null) {
+  const functionsDir = process.env.DUST_FUNCTIONS_DIR;
+  if (!functionsDir) {
     process.exit(1);
   }
-  // Hash before importing so the hash describes the bytes the import reads;
-  // a write landing between the two is caught by the per-request stat.
-  const importedSha256 = await sha256OfFile(handlerPath);
-  if (importedSha256 === null) {
-    process.exit(1);
-  }
-  try {
-    await import(handlerPath);
-  } catch {
-    // A bundle that fails to import still gets served: invoke() reports the
-    // import error as a structured outcome, exactly like a cold run would.
-  }
+
+  // name -> imported bundle. Both the resolution and the module are cached
+  // for the life of the worker: a cached resolution that goes bad (bundle
+  // deleted, extension changed) fails its per-request stat and takes the
+  // stale path below, which recycles the worker.
+  const imported = new Map<string, ImportedBundle>();
 
   let boundSocket = false;
   const exit = (code: number): never => {
-    // Remove the socket first so no client connects to a dying server — but
-    // only if this server owns it: a duplicate that lost the bind race must
+    // Remove the socket first so no client connects to a dying worker — but
+    // only if this worker owns it: a duplicate that lost the bind race must
     // not delete the winner's socket on its way out.
     if (boundSocket) {
       try {
@@ -214,15 +249,17 @@ export async function serve(
   };
 
   let busy = false;
+  // Set when the worker must not serve further requests (lifetime cap
+  // reached, a bundle went stale, RSS over cap): the in-flight invocation
+  // finishes and replies, then the worker exits. Imports are permanent, so
+  // rebirth is the only way to shed a stale or bloated working set.
   let draining = false;
-  let idleTimer = setTimeout(() => exit(0), IDLE_TIMEOUT_MS);
+  let idleTimer = setTimeout(() => exit(0), idleTimeoutMs);
   const armIdle = () => {
     clearTimeout(idleTimer);
-    idleTimer = setTimeout(() => exit(0), IDLE_TIMEOUT_MS);
+    idleTimer = setTimeout(() => exit(0), idleTimeoutMs);
   };
   setTimeout(() => {
-    // Never exit mid-invocation: the in-flight request finishes and replies,
-    // then the drained server exits. New requests get `busy` meanwhile.
     if (busy) {
       draining = true;
     } else {
@@ -245,23 +282,91 @@ export async function serve(
     }
   }
 
+  /**
+   * Ensure the request's bundle is imported and current. Returns the bundle
+   * and whether this request paid the import, or null after a pre-ack `stale`
+   * reply was sent (the client re-runs cold, which reads the bundle fresh and
+   * respawns workers as needed).
+   */
+  async function ensureBundle(
+    socket: WarmSocket,
+    request: WarmRequest,
+    expectedSha256: string | undefined
+  ): Promise<{
+    bundle: ImportedBundle;
+    importKind: "cached" | "fresh";
+  } | null> {
+    const staleReply = ({ recycle = false }: { recycle?: boolean } = {}) => {
+      // A recycle exits right after the reply flushes: nothing is in flight
+      // (busy requests never reach here), and the worker holds an import it
+      // can never serve again.
+      reply(
+        socket,
+        { v: WARM_PROTOCOL_VERSION, stale: true },
+        {
+          exitAfter: recycle,
+        }
+      );
+      return null;
+    };
+
+    const existing = imported.get(request.name);
+    if (existing) {
+      // A republished bundle must never be served from the old import. One
+      // metadata call per request; any difference (or a vanished file), or a
+      // request stamped with a hash this import does not match, sends the
+      // client down the cold path — and recycles this worker, since the old
+      // module can never be evicted.
+      const current = await statBundle(existing.handlerPath);
+      if (
+        !sameStamp(existing.stamp, current) ||
+        (expectedSha256 !== undefined && expectedSha256 !== existing.sha256)
+      ) {
+        return staleReply({ recycle: true });
+      }
+      return { bundle: existing, importKind: "cached" };
+    }
+
+    const handlerPath = resolveBundle(functionsDir!, request.name);
+    if (handlerPath === null) {
+      // Missing or ambiguous bundle: the cold path owes the caller the
+      // structured error, not this worker.
+      return staleReply();
+    }
+    const stamp = await statBundle(handlerPath);
+    if (stamp === null) {
+      return staleReply();
+    }
+    // Hash before importing so the hash describes the bytes the import
+    // reads; a write landing between the two is caught by the next
+    // request's stat.
+    const sha256 = await sha256OfFile(handlerPath);
+    if (sha256 === null) {
+      return staleReply();
+    }
+    if (expectedSha256 !== undefined && expectedSha256 !== sha256) {
+      // The on-disk bundle does not match what the publisher stamped
+      // (gcsfuse lag): refuse WITHOUT importing, so this worker is not
+      // poisoned with a module it would have to recycle over.
+      return staleReply();
+    }
+    try {
+      // A static import is impossible here: the bundle to serve is resolved
+      // at request time, a different published function per request.
+      await import(handlerPath);
+    } catch {
+      // A bundle that fails to import still gets served: invoke() reports
+      // the import error as a structured outcome, exactly like a cold run.
+    }
+    const bundle: ImportedBundle = { handlerPath, stamp, sha256 };
+    imported.set(request.name, bundle);
+    return { bundle, importKind: "fresh" };
+  }
+
   async function runInvocation(
     socket: WarmSocket,
     request: WarmRequest
   ): Promise<void> {
-    // A republished bundle must never be served from the old import. One
-    // metadata call per request; any difference (or a vanished file) sends
-    // the client down the cold path, which respawns a fresh server.
-    const current = await statBundle(handlerPath);
-    if (!sameStamp(importedStamp, current)) {
-      reply(
-        socket,
-        { v: WARM_PROTOCOL_VERSION, stale: true },
-        { exitAfter: true }
-      );
-      return;
-    }
-
     let input: RequestInput;
     try {
       input = parseInput(request.input);
@@ -276,24 +381,11 @@ export async function serve(
       return;
     }
 
-    // Deterministic republish detection: front stamps each invocation with
-    // the sha256 of the bundle it published, so a server that imported older
-    // bytes is refused even while gcsfuse metadata caching still hides the
-    // rewrite from the stat above. Pre-ack, like every refusal: the client
-    // re-runs cold, which reads the bundle fresh and respawns a matching
-    // server. Unstamped envelopes (older front) keep the stat and lifetime
-    // backstops only.
-    if (
-      input.bundleSha256 !== undefined &&
-      input.bundleSha256 !== importedSha256
-    ) {
-      reply(
-        socket,
-        { v: WARM_PROTOCOL_VERSION, stale: true },
-        { exitAfter: true }
-      );
+    const ensured = await ensureBundle(socket, request, input.bundleSha256);
+    if (ensured === null) {
       return;
     }
+    const { bundle, importKind } = ensured;
 
     // The ack is the point of no return: from here the client must never
     // fall back to the cold path, because the function may have side effects
@@ -306,7 +398,6 @@ export async function serve(
     if (ackWritten <= 0) {
       // The client is already gone; do not execute for a dead client.
       busy = false;
-      socket.end();
       return;
     }
 
@@ -317,10 +408,13 @@ export async function serve(
 
     const applied = applyRequestEnv(request.env);
     try {
-      const outcome = await invoke(handlerPath, input);
+      const outcome = await invoke(bundle.handlerPath, input);
+      if (process.memoryUsage.rss() > MAX_RSS_BYTES) {
+        draining = true;
+      }
       reply(
         socket,
-        { v: WARM_PROTOCOL_VERSION, outcome },
+        { v: WARM_PROTOCOL_VERSION, outcome, importKind },
         { exitAfter: draining }
       );
     } finally {
@@ -334,15 +428,15 @@ export async function serve(
   function handleLine(socket: WarmSocket, line: string): void {
     if (busy || draining) {
       // Never queue: the caller's timeout is shorter than any queue wait
-      // guarantee this server could make, and a queued request would execute
+      // guarantee this worker could make, and a queued request would execute
       // for a client that already gave up. An immediate busy reply sends the
-      // client down the cold path before anything ran.
+      // client to the next worker (or the cold path) before anything ran.
       reply(socket, { v: WARM_PROTOCOL_VERSION, busy: true });
       return;
     }
     const request = parseWarmRequest(line);
     if (request === null) {
-      // A client this server does not understand; dying lets the cold path
+      // A client this worker does not understand; dying lets the cold path
       // respawn a matching one.
       reply(
         socket,
@@ -360,8 +454,8 @@ export async function serve(
       socket: {
         open() {
           // Probe connections (the client checks for a listener before
-          // spawning a duplicate server) send no data; the idle timer keeps
-          // running so they cannot pin the server alive.
+          // spawning a duplicate worker) send no data; the idle timer keeps
+          // running so they cannot pin the worker alive.
         },
         data(socket, chunk) {
           const buffered = (socketBuffers.get(socket) ?? "") + chunk.toString();
@@ -391,9 +485,9 @@ export async function serve(
     bind();
     boundSocket = true;
   } catch {
-    // The socket path exists. Either a live server owns it — this process is
+    // The socket path exists. Either a live worker owns it — this process is
     // a lost spawn race and must exit without touching the winner's socket —
-    // or it is a stale leftover from a dead server, which is safe to replace.
+    // or it is a stale leftover from a dead worker, which is safe to replace.
     const listening = await new Promise<boolean>((resolve) => {
       Bun.connect({
         unix: socketPath,

--- a/cli/dust-sandbox/src/commands/function/envelope.rs
+++ b/cli/dust-sandbox/src/commands/function/envelope.rs
@@ -24,10 +24,20 @@ pub struct ResultEnvelope {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum RunnerKind {
-    /// Served by a resident warm server over its unix socket.
+    /// Served by a resident warm worker over its unix socket.
     Warm,
     /// Fresh runner process spawn, today's default behavior.
     Cold,
+}
+
+/// Whether a warm worker served the request from its module cache or paid the
+/// bundle import on this request. The gauge for whether warmth-aware routing
+/// beyond hash affinity would earn its complexity.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum ImportKind {
+    Cached,
+    Fresh,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -39,6 +49,9 @@ pub struct TimingsMs {
     /// treats timingsMs as opaque, so this cannot break the wire contract.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runner_kind: Option<RunnerKind>,
+    /// Additive, warm runs only: see [`ImportKind`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub import_kind: Option<ImportKind>,
 }
 
 impl ResultEnvelope {
@@ -84,6 +97,7 @@ mod tests {
                 total: 12,
                 runner: 8,
                 runner_kind: Some(RunnerKind::Warm),
+                import_kind: Some(ImportKind::Cached),
             }),
         );
 
@@ -94,7 +108,7 @@ mod tests {
                 "protocolVersion": 3,
                 "delivery": "stdout",
                 "outcome": { "ok": true, "output": { "hello": "world" } },
-                "timingsMs": { "total": 12, "runner": 8, "runnerKind": "warm" },
+                "timingsMs": { "total": 12, "runner": 8, "runnerKind": "warm", "importKind": "cached" },
             })
         );
     }

--- a/cli/dust-sandbox/src/commands/function/run.rs
+++ b/cli/dust-sandbox/src/commands/function/run.rs
@@ -16,10 +16,11 @@ const NON_JSON_SNIPPET_MAX_CHARS: usize = 512;
 /// The request envelope is read from stdin and the function runs unprivileged
 /// (agent uid) when dsbx is invoked as root.
 ///
-/// The invocation is served warm when a resident server for this function is
-/// listening (see `warm.rs`): one unix-socket round trip instead of a runner
-/// spawn. A cold run additionally leaves a warm server behind for the next
-/// invocation. Both paths produce the same runner `Output` JSON.
+/// The invocation is served warm when a pool worker accepts it (see
+/// `warm.rs`): one unix-socket round trip instead of a runner spawn. A cold
+/// run additionally leaves a warm worker behind for the next invocation, if
+/// the pool has a free slot. Both paths produce the same runner `Output`
+/// JSON.
 ///
 /// Delivery modes:
 /// - `callback` (default): POST the runner response to the Dust result API when
@@ -47,7 +48,7 @@ pub async fn cmd_function_run(name: &str, result_delivery: ResultDelivery) -> Re
         };
     }
 
-    if let WarmRun::Outcome(outcome) = warm::try_warm_run(name, &input).await {
+    if let WarmRun::Outcome(outcome, import_kind) = warm::try_warm_run(name, &input).await {
         let runner_ms = started.elapsed().as_millis() as u64;
         return match result_delivery {
             ResultDelivery::Callback => deliver_callback_outcome(name, outcome).await,
@@ -58,6 +59,7 @@ pub async fn cmd_function_run(name: &str, result_delivery: ResultDelivery) -> Re
                         total: started.elapsed().as_millis() as u64,
                         runner: runner_ms,
                         runner_kind: Some(RunnerKind::Warm),
+                        import_kind,
                     }),
                 ),
                 0,
@@ -65,25 +67,22 @@ pub async fn cmd_function_run(name: &str, result_delivery: ResultDelivery) -> Re
         };
     }
 
-    // Cold path. Resolve once: the run below and the warm server spawn both
-    // need the handler path, and resolution lists the (gcsfuse-backed)
-    // functions directory.
-    let (spawned, handler) = match resolve_existing(name) {
+    // Cold path.
+    let spawned = match resolve_existing(name) {
         Ok(handler) => {
             let spawned = spawn_function_at(&handler, "run", Some(&input), true).await;
-            (spawned, Some(handler))
+            // Leave a warm worker behind (if a pool slot is free) so the
+            // next invocation skips the spawn. Only after a successful
+            // resolution: a bad name or missing bundle should not grow the
+            // pool. Fire-and-forget; never affects this run's outcome.
+            warm::spawn_worker();
+            spawned
         }
         // resolve_existing already emitted the `{error}` line; the message
         // (bad name, unset dir, missing or ambiguous bundle) propagates.
-        Err(e) => (Err(e), None),
+        Err(e) => Err(e),
     };
     let runner_ms = started.elapsed().as_millis() as u64;
-
-    // Leave a warm server behind so the next invocation of this function
-    // skips the spawn. Fire-and-forget; never affects this run's outcome.
-    if let Some(handler) = &handler {
-        warm::spawn_server(name, handler);
-    }
 
     match result_delivery {
         // Spawn failures keep propagating: the bare `{error}` line emit_error
@@ -98,6 +97,7 @@ pub async fn cmd_function_run(name: &str, result_delivery: ResultDelivery) -> Re
                 total: started.elapsed().as_millis() as u64,
                 runner: runner_ms,
                 runner_kind: Some(RunnerKind::Cold),
+                import_kind: None,
             },
         ),
     }
@@ -253,6 +253,7 @@ mod tests {
             total,
             runner,
             runner_kind: Some(RunnerKind::Cold),
+            import_kind: None,
         }
     }
 

--- a/cli/dust-sandbox/src/commands/function/warm.rs
+++ b/cli/dust-sandbox/src/commands/function/warm.rs
@@ -2,10 +2,21 @@
 //!
 //! A cold function run pays process spawn, bundle resolution against the
 //! gcsfuse-backed functions dir, and the import of the bundle and its
-//! dependencies on every invocation. The warm path keeps a per-bundle bun
-//! server (the embedded runner's `serve` subcommand) resident behind a unix
-//! socket and forwards invocations to it, so a repeat invocation costs one
-//! local socket round trip.
+//! dependencies on every invocation. The warm path keeps a pod-scoped pool of
+//! generic bun workers (the embedded runner's `serve` subcommand) resident
+//! behind unix sockets and forwards invocations to them, so a repeat
+//! invocation costs one local socket round trip.
+//!
+//! Workers are generic — the request names the function, the worker resolves
+//! and imports its bundle on first use — so memory scales with the pool size
+//! (POOL_SLOTS x one bun process), not with the number of functions on the
+//! pod. Each worker serves one invocation at a time; the client scans slots
+//! starting at a hash of the function name, so a function keeps hitting the
+//! worker that already imported it, and spills to the next slot under
+//! contention — which warms that worker for the burst, the pool's only
+//! scale-up mechanism. Scale-down is each worker's own idle exit: base slots
+//! idle out in minutes, burst slots in seconds, so an unused pod holds no
+//! workers at all.
 //!
 //! Everything here is best-effort: any irregularity — missing socket, wrong
 //! directory ownership, protocol mismatch, stale bundle — falls back to the
@@ -32,17 +43,28 @@ use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
 use tokio::net::UnixStream;
 use tokio::process::Command;
 
+use super::envelope::ImportKind;
 use super::RUNNER_JS;
 
-pub const WARM_PROTOCOL_VERSION: u32 = 1;
+pub const WARM_PROTOCOL_VERSION: u32 = 2;
 
-/// Ceiling on how long the warm path waits for the server to answer before
+/// Pool geometry. Eight workers bound both the pod's function concurrency and
+/// its warm memory (a worker is one bun process, ~50-100MB with its imported
+/// working set). The first BASE_SLOTS keep a long idle so a lightly-used pod
+/// stays warm; the rest are burst capacity that drains within seconds of load
+/// dropping.
+const POOL_SLOTS: u32 = 8;
+const BASE_SLOTS: u32 = 2;
+const BASE_IDLE_TIMEOUT_MS: u64 = 120_000;
+const BURST_IDLE_TIMEOUT_MS: u64 = 15_000;
+
+/// Ceiling on how long the warm path waits for a worker to answer before
 /// giving up. Generous on purpose: the function itself runs inside this
 /// window, and the caller (front) enforces the real invocation timeout by
-/// killing dsbx. This only bounds a wedged server.
+/// killing dsbx. This only bounds a wedged worker.
 const WARM_RESPONSE_TIMEOUT: Duration = Duration::from_secs(120);
 
-/// Connect timeout: the server is either listening or it is not.
+/// Connect timeout: the worker is either listening or it is not.
 const WARM_CONNECT_TIMEOUT: Duration = Duration::from_millis(250);
 
 #[derive(Debug, Deserialize)]
@@ -52,6 +74,8 @@ struct WarmFrame {
     ack: bool,
     #[serde(default)]
     outcome: Option<serde_json::Value>,
+    #[serde(default, rename = "importKind")]
+    import_kind: Option<ImportKind>,
     #[serde(default)]
     stale: bool,
     #[serde(default)]
@@ -60,24 +84,25 @@ struct WarmFrame {
     error: Option<String>,
 }
 
-/// The outcome of asking the warm server to run an invocation.
+/// The outcome of asking the warm pool to run an invocation.
 pub enum WarmRun {
-    /// The server ran the function; this is the runner `Output` JSON. Also
-    /// carries the synthesized failure outcome when the server acked (the
+    /// A worker ran the function; this is the runner `Output` JSON plus
+    /// whether the worker paid the bundle import on this request. Also
+    /// carries the synthesized failure outcome when a worker acked (the
     /// function started executing) but the outcome was lost: past the ack the
     /// cold path is off the table, because re-running a function that may
     /// already have fired its side effects is worse than failing the
     /// invocation.
-    Outcome(serde_json::Value),
-    /// No usable warm server (not running, busy, stale bundle, protocol
+    Outcome(serde_json::Value, Option<ImportKind>),
+    /// No usable warm worker (none running, all busy, stale bundle, protocol
     /// mismatch, ownership refusal...). Nothing executed; run cold.
     Miss,
 }
 
-/// FNV-1a, inline rather than a hashing crate: these hashes only ever
-/// disambiguate names between runs of the same binary (slug collisions,
-/// runner versions) — nothing security-relevant depends on them, since the
-/// warm directory itself is ownership-verified.
+/// FNV-1a, inline rather than a hashing crate: these hashes only ever pick
+/// slots and disambiguate names between runs of the same binary — nothing
+/// security-relevant depends on them, since the warm directory itself is
+/// ownership-verified.
 fn fnv1a(bytes: &[u8]) -> u64 {
     let mut hash: u64 = 0xcbf29ce484222325;
     for byte in bytes {
@@ -88,7 +113,7 @@ fn fnv1a(bytes: &[u8]) -> u64 {
 }
 
 /// Hash of the embedded runner source: a dsbx upgrade changes the runner and
-/// must never talk to a server built from the old one.
+/// must never talk to a worker built from the old one.
 fn runner_hash8() -> String {
     format!("{:08x}", fnv1a(RUNNER_JS.as_bytes()) as u32)
 }
@@ -127,27 +152,37 @@ fn ensure_trusted_warm_dir() -> Option<PathBuf> {
     Some(dir)
 }
 
-/// Socket path for a function slug. The slug is already validated to
-/// `[A-Za-z0-9_-]+`; it is truncated and suffixed with its own hash so two
-/// long slugs sharing a prefix cannot collide, and with the runner hash so a
-/// dsbx upgrade gets fresh servers. Unix socket paths must stay short
-/// (~104 bytes); with a 20-char slug prefix this stays well under.
-fn socket_path(dir: &Path, name: &str) -> PathBuf {
-    // The functions dir is part of the key: the same slug under a different
-    // DUST_FUNCTIONS_DIR is a different bundle, and the mtime/size staleness
-    // stamp would not catch the swap.
+/// Socket path for a pool slot. Keyed on the functions dir (the same slot
+/// under a different DUST_FUNCTIONS_DIR is a different pod's pool), the
+/// runner hash (a dsbx upgrade gets fresh workers), and the protocol
+/// version. Unix socket paths must stay short (~104 bytes); this stays well
+/// under.
+fn slot_socket_path(dir: &Path, slot: u32) -> PathBuf {
     let functions_dir = std::env::var("DUST_FUNCTIONS_DIR").unwrap_or_default();
-    let key = format!("{functions_dir}\0{name}");
-    let prefix: String = name.chars().take(20).collect();
     dir.join(format!(
-        "{prefix}-{:08x}-{}-v{WARM_PROTOCOL_VERSION}.sock",
-        fnv1a(key.as_bytes()) as u32,
+        "w{:08x}-{}-v{WARM_PROTOCOL_VERSION}.{slot}.sock",
+        fnv1a(functions_dir.as_bytes()) as u32,
         runner_hash8(),
     ))
 }
 
+/// The slot a function's requests try first. Affinity, not assignment: the
+/// same name keeps landing on the same worker (which already imported its
+/// bundle), and contention spills to the following slots.
+fn preferred_slot(name: &str) -> u32 {
+    (fnv1a(name.as_bytes()) % u64::from(POOL_SLOTS)) as u32
+}
+
+fn idle_timeout_ms(slot: u32) -> u64 {
+    if slot < BASE_SLOTS {
+        BASE_IDLE_TIMEOUT_MS
+    } else {
+        BURST_IDLE_TIMEOUT_MS
+    }
+}
+
 /// Stages the embedded runner at a stable content-addressed path inside the
-/// warm dir, so the detached server outlives the dsbx process that spawned
+/// warm dir, so the detached worker outlives the dsbx process that spawned
 /// it (the tempfile used by cold runs is deleted when dsbx exits).
 fn stage_runner(dir: &Path) -> Result<PathBuf> {
     let path = dir.join(format!("runner-{}.js", runner_hash8()));
@@ -166,17 +201,19 @@ fn stage_runner(dir: &Path) -> Result<PathBuf> {
     Ok(path)
 }
 
-/// Tries to run `input` (the raw stdin envelope) against a warm server for
-/// `name`/`handler_hint`. Never errors: every failure is a `Miss`.
+/// Tries to run `input` (the raw stdin envelope) against the pod's warm
+/// worker pool, scanning slots from the function's preferred one. Never
+/// errors: every failure is a `Miss`.
 pub async fn try_warm_run(name: &str, input: &str) -> WarmRun {
-    // The name feeds the socket path before resolve_existing validates it on
-    // the cold path, so it is validated here too.
+    // The name travels in the warm request and feeds the worker's directory
+    // scan, so it is validated here as the cold path's resolve_existing
+    // would.
     if !super::is_valid_name(name) {
         return WarmRun::Miss;
     }
     // Warm serving is for unprivileged runs only: the production fast path
     // execs dsbx as agent-proxied. A root dsbx stays cold — a root client
-    // must not hand invocation env to a workload-owned server it would then
+    // must not hand invocation env to a workload-owned worker it would then
     // have to trust for lifecycle management.
     if rustix::process::geteuid().is_root() {
         return WarmRun::Miss;
@@ -184,23 +221,33 @@ pub async fn try_warm_run(name: &str, input: &str) -> WarmRun {
     let Some(dir) = ensure_trusted_warm_dir() else {
         return WarmRun::Miss;
     };
-    let socket = socket_path(&dir, name);
 
-    let connect = tokio::time::timeout(WARM_CONNECT_TIMEOUT, UnixStream::connect(&socket)).await;
-    let stream = match connect {
-        Ok(Ok(stream)) => stream,
-        _ => return WarmRun::Miss,
-    };
-
-    match tokio::time::timeout(WARM_RESPONSE_TIMEOUT, roundtrip(stream, input)).await {
-        Ok(Ok(run)) => run,
-        // Pre-ack IO error or timeout: nothing executed, run cold. roundtrip
-        // itself converts post-ack losses into a failure Outcome.
-        _ => WarmRun::Miss,
+    let start = preferred_slot(name);
+    for offset in 0..POOL_SLOTS {
+        let slot = (start + offset) % POOL_SLOTS;
+        let socket = slot_socket_path(&dir, slot);
+        let connect =
+            tokio::time::timeout(WARM_CONNECT_TIMEOUT, UnixStream::connect(&socket)).await;
+        let stream = match connect {
+            Ok(Ok(stream)) => stream,
+            // Nothing listening on this slot; try the next.
+            _ => continue,
+        };
+        match tokio::time::timeout(WARM_RESPONSE_TIMEOUT, roundtrip(stream, name, input)).await {
+            Ok(Ok(WarmRun::Outcome(outcome, import_kind))) => {
+                return WarmRun::Outcome(outcome, import_kind);
+            }
+            // Busy, stale, protocol refusal: nothing executed on this
+            // worker; another slot may still serve. Pre-ack IO errors and
+            // timeouts land here too — roundtrip converts post-ack losses
+            // into a failure Outcome, returned above.
+            _ => continue,
+        }
     }
+    WarmRun::Miss
 }
 
-/// The outcome delivered when the server acked (execution started) but the
+/// The outcome delivered when a worker acked (execution started) but the
 /// outcome frame never arrived. Failing the invocation is the only safe call:
 /// the function may already have fired its side effects, so neither the warm
 /// nor the cold path may run it again.
@@ -209,15 +256,15 @@ fn lost_outcome_after_ack() -> serde_json::Value {
         "ok": false,
         "error": {
             "code": "invocation_failed",
-            "message": "The warm function server stopped responding after execution started.",
+            "message": "The warm function worker stopped responding after execution started.",
         }
     })
 }
 
-async fn roundtrip(mut stream: UnixStream, input: &str) -> Result<WarmRun> {
+async fn roundtrip(mut stream: UnixStream, name: &str, input: &str) -> Result<WarmRun> {
     // The request carries the client's full environment: per-invocation
     // values (sandbox token, user identity, pod databases dir) travel in env
-    // vars, and the resident server's own env is stale by definition. This
+    // vars, and the resident worker's own env is stale by definition. This
     // mirrors the env inheritance of the cold path's bun child.
     // vars_os + lossy filtering: std::env::vars() panics on non-unicode
     // values, and a hostile env var must never crash the client.
@@ -228,6 +275,7 @@ async fn roundtrip(mut stream: UnixStream, input: &str) -> Result<WarmRun> {
         "v": WARM_PROTOCOL_VERSION,
         "env": env,
         "input": input,
+        "name": name,
     });
     let mut line = serde_json::to_string(&request)?;
     line.push('\n');
@@ -236,7 +284,8 @@ async fn roundtrip(mut stream: UnixStream, input: &str) -> Result<WarmRun> {
     let mut reader = BufReader::new(stream);
 
     // First frame: ack (execution starting), or a pre-execution refusal
-    // (busy, stale, protocol error) that safely sends the client cold.
+    // (busy, stale, protocol error) that safely sends the client to the next
+    // slot or the cold path.
     let mut first = String::new();
     if reader.read_line(&mut first).await? == 0 {
         return Ok(WarmRun::Miss);
@@ -248,7 +297,7 @@ async fn roundtrip(mut stream: UnixStream, input: &str) -> Result<WarmRun> {
     if let Some(outcome) = frame.outcome {
         // Single-frame outcome: a pre-execution classification such as
         // bad_input, delivered without an ack. Safe either way.
-        return Ok(WarmRun::Outcome(outcome));
+        return Ok(WarmRun::Outcome(outcome, frame.import_kind));
     }
     if !frame.ack {
         return Ok(WarmRun::Miss);
@@ -258,28 +307,28 @@ async fn roundtrip(mut stream: UnixStream, input: &str) -> Result<WarmRun> {
     // a failed invocation, not a cold retry.
     let mut second = String::new();
     match reader.read_line(&mut second).await {
-        Ok(0) | Err(_) => return Ok(WarmRun::Outcome(lost_outcome_after_ack())),
+        Ok(0) | Err(_) => return Ok(WarmRun::Outcome(lost_outcome_after_ack(), None)),
         Ok(_) => {}
     }
     match serde_json::from_str::<WarmFrame>(second.trim()) {
         Ok(WarmFrame {
             v: WARM_PROTOCOL_VERSION,
             outcome: Some(outcome),
+            import_kind,
             ..
-        }) => Ok(WarmRun::Outcome(outcome)),
-        _ => Ok(WarmRun::Outcome(lost_outcome_after_ack())),
+        }) => Ok(WarmRun::Outcome(outcome, import_kind)),
+        _ => Ok(WarmRun::Outcome(lost_outcome_after_ack(), None)),
     }
 }
 
-/// Spawns a detached warm server for `handler` so the *next* invocation of
-/// this function is warm. Fire-and-forget: failures are ignored (the next
-/// run is simply cold again), and the server is its own process group so it
-/// survives dsbx exiting and is not collateral of anything that signals
-/// dsbx's group.
-pub fn spawn_server(name: &str, handler: &Path) {
-    if !super::is_valid_name(name) {
-        return;
-    }
+/// Spawns a detached warm worker on the first free slot, so the *next*
+/// invocation finds one more warm process than this one did — demand-driven
+/// scale-up: a spawn only happens after a cold run, and only persists if a
+/// slot was actually free (a lost bind race exits immediately).
+/// Fire-and-forget: failures are ignored (the next run is simply cold
+/// again), and the worker is its own process group so it survives dsbx
+/// exiting and is not collateral of anything that signals dsbx's group.
+pub fn spawn_worker() {
     if rustix::process::geteuid().is_root() {
         return;
     }
@@ -289,15 +338,16 @@ pub fn spawn_server(name: &str, handler: &Path) {
     let Ok(runner) = stage_runner(&dir) else {
         return;
     };
-    let socket = socket_path(&dir, name);
-    // If a server is already listening, leave it alone: it will serve the
-    // next request or exit stale on its own. Binding a second one would
-    // steal the socket mid-request.
-    if UnixStreamStdCheck::is_listening(&socket) {
+    // First slot with nothing listening. A dead worker's leftover socket
+    // file is fine: the new worker's bind path handles replacing it.
+    let Some(slot) = (0..POOL_SLOTS).find(|slot| !is_listening(&slot_socket_path(&dir, *slot)))
+    else {
+        // Pool full: every slot has a live worker; nothing to add.
         return;
-    }
+    };
+    let socket = slot_socket_path(&dir, slot);
 
-    // The server's stderr goes to a log file in the warm dir rather than
+    // The worker's stderr goes to a log file in the warm dir rather than
     // /dev/null: a warm-served function's console.error output would
     // otherwise vanish, where a cold run's reaches the exec output that
     // front logs on failure.
@@ -310,25 +360,21 @@ pub fn spawn_server(name: &str, handler: &Path) {
     let mut cmd = Command::new("bun");
     cmd.arg(&runner)
         .arg("serve")
-        .arg(handler)
         .arg(&socket)
+        .arg(idle_timeout_ms(slot).to_string())
         .env("NODE_PATH", super::harness_node_path())
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(log.map(Stdio::from).unwrap_or_else(Stdio::null))
         .process_group(0);
     // Spawn and forget: tokio children are not killed on drop by default,
-    // and the server terminates itself on idle/lifetime/staleness.
+    // and the worker terminates itself on idle/lifetime/staleness.
     drop(cmd.spawn());
 }
 
-/// Cheap "is anything listening" probe used to avoid double-spawning.
-struct UnixStreamStdCheck;
-
-impl UnixStreamStdCheck {
-    fn is_listening(socket: &Path) -> bool {
-        std::os::unix::net::UnixStream::connect(socket).is_ok()
-    }
+/// Cheap "is anything listening" probe used to pick a free slot.
+fn is_listening(socket: &Path) -> bool {
+    std::os::unix::net::UnixStream::connect(socket).is_ok()
 }
 
 #[cfg(test)]
@@ -362,13 +408,14 @@ mod tests {
     }
 
     /// Cold-spawn then warm-hit then staleness, against the real runner:
-    /// spawn_server leaves a resident bun process behind, try_warm_run gets an
+    /// spawn_worker leaves a resident bun process behind, try_warm_run gets an
     /// outcome from it without any runner spawn, and a rewritten bundle turns
-    /// the next attempt into a miss.
+    /// the next attempt into a miss (the worker recycles itself).
     #[tokio::test]
-    // The env lock intentionally spans the awaits: the spawned server and the
-    // client both read process-global env (HOME). Each #[tokio::test] runs
-    // its own runtime, so contending tests just block on the mutex.
+    // The env lock intentionally spans the awaits: the spawned worker and the
+    // client both read process-global env (HOME, DUST_FUNCTIONS_DIR). Each
+    // #[tokio::test] runs its own runtime, so contending tests just block on
+    // the mutex.
     #[allow(clippy::await_holding_lock)]
     async fn warm_cycle_end_to_end() {
         let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
@@ -377,38 +424,51 @@ mod tests {
             return;
         }
         let original_home = std::env::var_os("HOME");
+        let original_functions_dir = std::env::var_os("DUST_FUNCTIONS_DIR");
 
         let home = tempfile::tempdir().expect("home tempdir");
         std::env::set_var("HOME", home.path());
         let bundle_dir = tempfile::tempdir().expect("bundle tempdir");
         let handler = bundle_dir.path().join("greet.ts");
         std::fs::write(&handler, HELLO_FIXTURE).expect("fixture");
+        std::env::set_var("DUST_FUNCTIONS_DIR", bundle_dir.path());
 
         let input = serde_json::json!({ "url": "http://localhost/?name=warm" }).to_string();
 
         // Nothing is listening yet: a warm attempt must miss, not error.
         assert!(matches!(try_warm_run("greet", &input).await, WarmRun::Miss));
 
-        spawn_server("greet", &handler);
+        spawn_worker();
 
-        // The server needs a moment to import the bundle and bind the socket.
+        // The worker needs a moment to bind its socket; the first served
+        // request pays the bundle import and reports it.
         let deadline = std::time::Instant::now() + Duration::from_secs(15);
-        let outcome = loop {
+        let (outcome, import_kind) = loop {
             match try_warm_run("greet", &input).await {
-                WarmRun::Outcome(outcome) => break outcome,
+                WarmRun::Outcome(outcome, import_kind) => break (outcome, import_kind),
                 WarmRun::Miss if std::time::Instant::now() < deadline => {
                     tokio::time::sleep(Duration::from_millis(50)).await;
                 }
-                WarmRun::Miss => panic!("warm server never came up"),
+                WarmRun::Miss => panic!("warm worker never came up"),
             }
         };
         assert_eq!(
             outcome,
             serde_json::json!({ "ok": true, "output": { "hello": "warm" } })
         );
+        assert_eq!(import_kind, Some(ImportKind::Fresh));
+
+        // A repeat invocation is served from the cached import.
+        match try_warm_run("greet", &input).await {
+            WarmRun::Outcome(_, import_kind) => {
+                assert_eq!(import_kind, Some(ImportKind::Cached));
+            }
+            WarmRun::Miss => panic!("second warm attempt missed"),
+        }
 
         // A republished bundle (same path, new mtime/size) must not be served
-        // from the stale import: the server refuses and the client misses.
+        // from the stale import: the worker refuses (and recycles itself) and
+        // the client misses.
         std::fs::write(
             &handler,
             format!(
@@ -422,14 +482,15 @@ mod tests {
         loop {
             match try_warm_run("greet", &input).await {
                 WarmRun::Miss => break,
-                WarmRun::Outcome(_) if std::time::Instant::now() < deadline => {
+                WarmRun::Outcome(..) if std::time::Instant::now() < deadline => {
                     tokio::time::sleep(Duration::from_millis(50)).await;
                 }
-                WarmRun::Outcome(_) => panic!("stale bundle kept being served"),
+                WarmRun::Outcome(..) => panic!("stale bundle kept being served"),
             }
         }
 
         restore_env("HOME", original_home);
+        restore_env("DUST_FUNCTIONS_DIR", original_functions_dir);
     }
 
     /// A squatted warm dir (wrong owner is hard to fake unprivileged, but a
@@ -468,36 +529,50 @@ mod tests {
     }
 
     #[test]
-    fn socket_path_is_short_and_stable() {
+    fn slot_socket_paths_are_short_stable_and_distinct() {
         let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
         let dir = PathBuf::from("/home/agent-proxied/.dust-fn");
-        let a = socket_path(&dir, "my-function");
-        let b = socket_path(&dir, "my-function");
+        let a = slot_socket_path(&dir, 0);
+        let b = slot_socket_path(&dir, 0);
         assert_eq!(a, b);
         assert!(a.as_os_str().len() < 100, "socket path too long: {a:?}");
+        assert_ne!(slot_socket_path(&dir, 0), slot_socket_path(&dir, 7));
     }
 
     #[test]
-    fn socket_path_distinguishes_long_slugs_sharing_a_prefix() {
-        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
-        let dir = PathBuf::from("/tmp");
-        let a = socket_path(&dir, "a-very-long-function-name-one");
-        let b = socket_path(&dir, "a-very-long-function-name-two");
-        assert_ne!(a, b);
-    }
-
-    #[test]
-    fn socket_path_distinguishes_functions_dirs() {
+    fn slot_socket_path_distinguishes_functions_dirs() {
         let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
         let original = std::env::var_os("DUST_FUNCTIONS_DIR");
         let dir = PathBuf::from("/tmp");
 
         std::env::set_var("DUST_FUNCTIONS_DIR", "/mnt/functions/space-a");
-        let a = socket_path(&dir, "greet");
+        let a = slot_socket_path(&dir, 0);
         std::env::set_var("DUST_FUNCTIONS_DIR", "/mnt/functions/space-b");
-        let b = socket_path(&dir, "greet");
+        let b = slot_socket_path(&dir, 0);
         assert_ne!(a, b);
 
         restore_env("DUST_FUNCTIONS_DIR", original);
+    }
+
+    #[test]
+    fn preferred_slot_is_stable_and_in_range() {
+        let a = preferred_slot("chatpro-sync");
+        assert_eq!(a, preferred_slot("chatpro-sync"));
+        assert!(a < POOL_SLOTS);
+        // Not a strong property, but the affinity point of the hash: distinct
+        // hot functions should not all pile onto slot 0.
+        let slots: std::collections::HashSet<u32> = ["chatpro-sync", "chess-move", "probe", "list"]
+            .iter()
+            .map(|name| preferred_slot(name))
+            .collect();
+        assert!(slots.len() > 1);
+    }
+
+    #[test]
+    fn burst_slots_get_the_short_idle() {
+        assert_eq!(idle_timeout_ms(0), BASE_IDLE_TIMEOUT_MS);
+        assert_eq!(idle_timeout_ms(BASE_SLOTS - 1), BASE_IDLE_TIMEOUT_MS);
+        assert_eq!(idle_timeout_ms(BASE_SLOTS), BURST_IDLE_TIMEOUT_MS);
+        assert_eq!(idle_timeout_ms(POOL_SLOTS - 1), BURST_IDLE_TIMEOUT_MS);
     }
 }

--- a/cli/dust-sandbox/src/commands/function/warm.rs
+++ b/cli/dust-sandbox/src/commands/function/warm.rs
@@ -58,11 +58,21 @@ const BASE_SLOTS: u32 = 2;
 const BASE_IDLE_TIMEOUT_MS: u64 = 120_000;
 const BURST_IDLE_TIMEOUT_MS: u64 = 15_000;
 
-/// Ceiling on how long the warm path waits for a worker to answer before
-/// giving up. Generous on purpose: the function itself runs inside this
-/// window, and the caller (front) enforces the real invocation timeout by
-/// killing dsbx. This only bounds a wedged worker.
+/// Ceiling on how long the warm path waits, post-ack, for the outcome frame.
+/// Generous on purpose: the function itself runs inside this window, and the
+/// caller (front) enforces the real invocation timeout by killing dsbx. This
+/// only bounds a wedged worker; expiry is a failed invocation, never a
+/// retry.
 const WARM_RESPONSE_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Ceiling on the first frame (claim refusal or ack). A healthy worker
+/// answers in milliseconds — the slowest pre-ack work is a fresh bundle
+/// import — but a worker whose event loop is blocked by another function's
+/// sync CPU-bound code cannot answer at all, and with generic workers that
+/// would stall an unrelated function's scan. Nothing has executed pre-ack,
+/// so abandoning is safe: a worker that answers after the client left writes
+/// its ack into a closed socket and aborts without executing.
+const WARM_FIRST_FRAME_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Connect timeout: the worker is either listening or it is not.
 const WARM_CONNECT_TIMEOUT: Duration = Duration::from_millis(250);
@@ -233,14 +243,15 @@ pub async fn try_warm_run(name: &str, input: &str) -> WarmRun {
             // Nothing listening on this slot; try the next.
             _ => continue,
         };
-        match tokio::time::timeout(WARM_RESPONSE_TIMEOUT, roundtrip(stream, name, input)).await {
-            Ok(Ok(WarmRun::Outcome(outcome, import_kind))) => {
+        // roundtrip owns its timeouts: a short one pre-ack (abandoning is
+        // safe, nothing executed) and the long one post-ack (expiry is a
+        // failed invocation, returned as an Outcome, never retried).
+        match roundtrip(stream, name, input).await {
+            Ok(WarmRun::Outcome(outcome, import_kind)) => {
                 return WarmRun::Outcome(outcome, import_kind);
             }
-            // Busy, stale, protocol refusal: nothing executed on this
-            // worker; another slot may still serve. Pre-ack IO errors and
-            // timeouts land here too — roundtrip converts post-ack losses
-            // into a failure Outcome, returned above.
+            // Busy, stale, protocol refusal, pre-ack IO error or timeout:
+            // nothing executed on this worker; another slot may still serve.
             _ => continue,
         }
     }
@@ -285,10 +296,13 @@ async fn roundtrip(mut stream: UnixStream, name: &str, input: &str) -> Result<Wa
 
     // First frame: ack (execution starting), or a pre-execution refusal
     // (busy, stale, protocol error) that safely sends the client to the next
-    // slot or the cold path.
+    // slot or the cold path. Bounded short: see WARM_FIRST_FRAME_TIMEOUT.
     let mut first = String::new();
-    if reader.read_line(&mut first).await? == 0 {
-        return Ok(WarmRun::Miss);
+    let first_read =
+        tokio::time::timeout(WARM_FIRST_FRAME_TIMEOUT, reader.read_line(&mut first)).await;
+    match first_read {
+        Ok(Ok(0)) | Ok(Err(_)) | Err(_) => return Ok(WarmRun::Miss),
+        Ok(Ok(_)) => {}
     }
     let frame: WarmFrame = serde_json::from_str(first.trim())?;
     if frame.v != WARM_PROTOCOL_VERSION || frame.busy || frame.stale || frame.error.is_some() {
@@ -303,12 +317,16 @@ async fn roundtrip(mut stream: UnixStream, name: &str, input: &str) -> Result<Wa
         return Ok(WarmRun::Miss);
     }
 
-    // Past the ack: never Miss again. A lost or unparsable outcome frame is
-    // a failed invocation, not a cold retry.
+    // Past the ack: never Miss again. A lost, late, or unparsable outcome
+    // frame is a failed invocation, not a cold retry.
     let mut second = String::new();
-    match reader.read_line(&mut second).await {
-        Ok(0) | Err(_) => return Ok(WarmRun::Outcome(lost_outcome_after_ack(), None)),
-        Ok(_) => {}
+    let second_read =
+        tokio::time::timeout(WARM_RESPONSE_TIMEOUT, reader.read_line(&mut second)).await;
+    match second_read {
+        Ok(Ok(0)) | Ok(Err(_)) | Err(_) => {
+            return Ok(WarmRun::Outcome(lost_outcome_after_ack(), None));
+        }
+        Ok(Ok(_)) => {}
     }
     match serde_json::from_str::<WarmFrame>(second.trim()) {
         Ok(WarmFrame {


### PR DESCRIPTION
## Description

Today each function gets one warm server. Under concurrent load that serializes: overlapping calls get busy replies and fall back to a cold run (18% of runs in a real multi-user session), paying the bun spawn and import every time.

This PR replaces it with a pod-scoped pool of up to 8 generic workers (warm protocol v2):

- **Generic workers.** The request names the function; the worker resolves and imports the bundle on first use and caches it. Memory scales with the pool size (~50-100MB per worker), not with the number of functions on the pod. Each worker still runs one invocation at a time, so identity isolation and the serial semantics bundles were written under are unchanged.
- **Hash-affinity routing.** The client scans slots starting at `fnv(name) % 8`, so a function keeps landing on the worker that already has its bundle. Busy → next slot (which warms it for the burst). All 8 busy → cold run.
- **Auto scale-up, no controller.** A cold run spawns a worker on the first free slot. No free slot, or a lost bind race → the spawn just exits.
- **Auto scale-down to zero.** Slots 0-1 idle out after 120s, slots 2-7 after 15s. Workers also self-recycle at 200MB RSS, at the 600s lifetime cap, or when a bundle they imported goes stale (modules can't be evicted, so rebirth is the pruning mechanism — this also keeps republish-then-invoke converging with a full pool).

The ack/busy/stale/never-re-run contract, bundle-hash handshake, warm-dir ownership checks and root refusal are unchanged. The client now bounds the pre-ack wait at 1s, so a worker blocked on another function's sync CPU can't stall an unrelated scan (abandoning pre-ack is safe: a late ack hits a closed socket and aborts). Timings gain an additive `importKind` (cached|fresh) so we can measure whether smarter routing would ever be worth it. v1 and v2 never talk to each other (different socket names); the cold path covers the transition.

Out of scope, noted for later: per-function fairness caps (belong in this scan), per-user/agent/frame fairness (needs caller identity — front or a future per-pod gateway).

## Tests

bun: 106 passing. Notable: the busy claim is taken synchronously before the resolve/import awaits (overlap test with a slow-importing bundle), and the idle exit is busy-guarded so a 15s burst idle can't kill a running invocation. Plus multi-function serving, stale-recycle, hash refusal before import, env isolation, spawn-secret scrubbing. Cargo: 284 passing, including the e2e cycle against real bun (miss → spawn → fresh hit → cached hit → republish → stale → miss). Clippy clean.

## Risk

Inert until a follow-up bumps DSBX_CLI_VERSION and the base image — merges and rolls back freely. Memory worst case is 8 × 200MB = 1.6GB inside the 2GB sandbox (typical ~50-100MB per worker); the RSS check runs after each invocation, so a single import can briefly overshoot. Two behavior deltas: the first request on a spilled-to worker pays the import (~50-150ms, visible as `importKind: fresh`), and a stale bundle recycles a whole worker rather than one function's server.

## Deploy Plan

Ships with the next dsbx patch release + base image bump (same dispatch-then-merge ordering as v0.1.42). Then watch `sandbox.functions.run` by `runner_kind`: cold share under load should drop from ~18% toward zero.
