### PR TITLE
[dsbx] feat: per-invocation context for pod runtime env

### DIFF
--- a/cli/dust-sandbox/functions-runner/context.ts
+++ b/cli/dust-sandbox/functions-runner/context.ts
@@ -1,0 +1,42 @@
+// Enter side of the per-invocation context contract shared with @dust/pod
+// (pod/context.ts — see the module doc there for the full story).
+//
+// The runner and @dust/pod are distinct module graphs (the runner is a
+// pre-bundled artifact, @dust/pod resolves through NODE_PATH), so the
+// AsyncLocalStorage instance is shared through the process-wide `Symbol.for`
+// registry rather than an import both sides would duplicate. This file
+// mirrors pod/context.ts's get-or-create; the registry key is the contract
+// and must match exactly.
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export interface InvocationContext {
+  readonly env: Readonly<Record<string, string>>;
+}
+
+/** Must match pod/context.ts. Versioned: a breaking change to the store
+ * shape must change the key so mismatched runner/SDK builds ignore each
+ * other instead of misreading the store. */
+export const INVOCATION_CONTEXT_KEY = "dust.pod.invocation-context.v1";
+
+function contextStorage(): AsyncLocalStorage<InvocationContext> {
+  const key = Symbol.for(INVOCATION_CONTEXT_KEY);
+  const existing: unknown = Reflect.get(globalThis, key);
+  if (existing instanceof AsyncLocalStorage) {
+    return existing;
+  }
+  const storage = new AsyncLocalStorage<InvocationContext>();
+  Reflect.set(globalThis, key, storage);
+  return storage;
+}
+
+/** Run `fn` inside an invocation context whose environment is `env`. */
+export function runWithInvocationEnv<T>(
+  env: Readonly<Record<string, string>>,
+  fn: () => T
+): T {
+  return contextStorage().run(
+    Object.freeze({ env: Object.freeze({ ...env }) }),
+    fn
+  );
+}

--- a/cli/dust-sandbox/functions-runner/fixtures/context-probe.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/context-probe.ts
@@ -1,0 +1,25 @@
+// Reads the invocation environment through @dust/pod's accessor, imported
+// from the pod package source directly. In tests this exercises the real
+// cross-module-graph contract: this fixture's copy of the context module and
+// the runner's own (functions-runner/context.ts) only share state through the
+// Symbol.for registry, exactly like the vendored @dust/pod does in the
+// sandbox. An optional delayMs query param spans the reads across an await so
+// tests can prove concurrent invocations do not leak into each other.
+import { podEnv } from "../../pod/context.ts";
+
+export default {
+  async fetch(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+    const delayMs = Number(url.searchParams.get("delayMs") ?? "0");
+    const before = podEnv("WARM_TEST_MARKER") ?? null;
+    if (delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+    const after = podEnv("WARM_TEST_MARKER") ?? null;
+    return Response.json({
+      before,
+      after,
+      identity: podEnv("DUST_POD_USER_IDENTITY") ?? null,
+    });
+  },
+};

--- a/cli/dust-sandbox/functions-runner/invoke.test.ts
+++ b/cli/dust-sandbox/functions-runner/invoke.test.ts
@@ -136,3 +136,68 @@ describe("invoke", () => {
     }
   });
 });
+
+describe("invoke with invocationEnv", () => {
+  const outputOf = async (
+    input: RequestInput,
+    env?: Readonly<Record<string, string>>
+  ): Promise<Record<string, unknown>> => {
+    const out = await invoke(fx("context-probe.ts"), input, env);
+    expect(out.ok).toBe(true);
+    if (!out.ok) {
+      throw new Error("probe invocation failed");
+    }
+    expect(typeof out.output).toBe("object");
+    return Object(out.output);
+  };
+
+  test("the handler reads the invocation env, not process.env", async () => {
+    process.env.WARM_TEST_MARKER = "from-process";
+    try {
+      const output = await outputOf(req(), {
+        WARM_TEST_MARKER: "from-context",
+        DUST_POD_USER_IDENTITY: "ctx-identity",
+      });
+      expect(output.before).toBe("from-context");
+      expect(output.identity).toBe("ctx-identity");
+    } finally {
+      delete process.env.WARM_TEST_MARKER;
+    }
+  });
+
+  test("a key absent from the invocation env stays absent", async () => {
+    process.env.WARM_TEST_MARKER = "from-process";
+    try {
+      const output = await outputOf(req(), {});
+      expect(output.before).toBeNull();
+    } finally {
+      delete process.env.WARM_TEST_MARKER;
+    }
+  });
+
+  test("without an invocation env the handler falls back to process.env", async () => {
+    process.env.WARM_TEST_MARKER = "from-process";
+    try {
+      const output = await outputOf(req());
+      expect(output.before).toBe("from-process");
+    } finally {
+      delete process.env.WARM_TEST_MARKER;
+    }
+  });
+
+  test("concurrent invocations with different envs never observe each other", async () => {
+    const probe = (marker: string, delayMs: number) =>
+      outputOf(req({ url: `http://localhost/?delayMs=${delayMs}` }), {
+        WARM_TEST_MARKER: marker,
+      });
+    // Staggered delays force the invocations to interleave across awaits.
+    const [a, b, c] = await Promise.all([
+      probe("alpha", 60),
+      probe("beta", 20),
+      probe("gamma", 40),
+    ]);
+    expect(a).toMatchObject({ before: "alpha", after: "alpha" });
+    expect(b).toMatchObject({ before: "beta", after: "beta" });
+    expect(c).toMatchObject({ before: "gamma", after: "gamma" });
+  });
+});

--- a/cli/dust-sandbox/functions-runner/invoke.ts
+++ b/cli/dust-sandbox/functions-runner/invoke.ts
@@ -1,5 +1,6 @@
 // Import a function handler, validate its input and output, and call its default fetch.
 
+import { runWithInvocationEnv } from "./context.ts";
 import {
   decodeRequestBody,
   type InvocationError,
@@ -45,7 +46,31 @@ function getProperty(value: unknown, property: string): unknown {
   return value[property];
 }
 
+/**
+ * Import a function handler and run one invocation.
+ *
+ * When `invocationEnv` is provided, the whole invocation (import included:
+ * module top-level code runs on first import) executes inside a per-invocation
+ * context carrying that environment, which @dust/pod reads through `podEnv()`.
+ * This is how a resident server runs concurrent invocations with different
+ * callers without touching process.env. Without it (cold runs, where the
+ * process environment IS the invocation's), no context is entered and
+ * @dust/pod falls back to process.env.
+ */
 export async function invoke(
+  handlerPath: string,
+  input: RequestInput,
+  invocationEnv?: Readonly<Record<string, string>>
+): Promise<Output> {
+  if (invocationEnv !== undefined) {
+    return runWithInvocationEnv(invocationEnv, () =>
+      invokeInContext(handlerPath, input)
+    );
+  }
+  return invokeInContext(handlerPath, input);
+}
+
+async function invokeInContext(
   handlerPath: string,
   input: RequestInput
 ): Promise<Output> {

--- a/cli/dust-sandbox/pod/context.test.ts
+++ b/cli/dust-sandbox/pod/context.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import {
+  INVOCATION_CONTEXT_KEY,
+  podEnv,
+  runWithInvocationEnv,
+} from "@dust/pod";
+
+const MARKER = "POD_CONTEXT_TEST_MARKER";
+
+afterEach(() => {
+  delete process.env[MARKER];
+});
+
+describe("podEnv", () => {
+  test("reads process.env outside any invocation context", () => {
+    process.env[MARKER] = "from-process";
+    expect(podEnv(MARKER)).toBe("from-process");
+  });
+
+  test("reads only the context env inside an invocation context", () => {
+    process.env[MARKER] = "from-process";
+    const seen = runWithInvocationEnv({ [MARKER]: "from-context" }, () =>
+      podEnv(MARKER)
+    );
+    expect(seen).toBe("from-context");
+  });
+
+  test("a key absent from the context env stays absent", () => {
+    process.env[MARKER] = "from-process";
+    const seen = runWithInvocationEnv({}, () => podEnv(MARKER));
+    expect(seen).toBeUndefined();
+  });
+
+  test("the context survives awaits and does not leak across concurrent flows", async () => {
+    const flow = async (value: string, delayMs: number) =>
+      runWithInvocationEnv({ [MARKER]: value }, async () => {
+        const before = podEnv(MARKER);
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        const after = podEnv(MARKER);
+        return { before, after };
+      });
+    const [a, b] = await Promise.all([flow("alpha", 40), flow("beta", 10)]);
+    expect(a).toEqual({ before: "alpha", after: "alpha" });
+    expect(b).toEqual({ before: "beta", after: "beta" });
+  });
+
+  test("the context env is a frozen copy taken at entry", () => {
+    const source: Record<string, string> = { [MARKER]: "original" };
+    runWithInvocationEnv(source, () => {
+      source[MARKER] = "mutated-after-entry";
+      expect(podEnv(MARKER)).toBe("original");
+    });
+  });
+
+  test("the storage is published in the Symbol.for registry", () => {
+    // Force the get-or-create, then look the storage up the way the runner's
+    // own copy of the context module does.
+    runWithInvocationEnv({}, () => undefined);
+    const shared: unknown = Reflect.get(
+      globalThis,
+      Symbol.for(INVOCATION_CONTEXT_KEY)
+    );
+    expect(shared instanceof AsyncLocalStorage).toBe(true);
+  });
+});

--- a/cli/dust-sandbox/pod/context.ts
+++ b/cli/dust-sandbox/pod/context.ts
@@ -1,0 +1,67 @@
+// Per-invocation context.
+//
+// The function runner executes every invocation inside an AsyncLocalStorage
+// context carrying that invocation's environment (user identity, sandbox
+// token, pod paths), so one process can serve concurrent invocations without
+// mutating process.env. Runtime code reads the environment through podEnv():
+// the active context's env inside an invocation, process.env otherwise (cold
+// runs and local use, where the process environment IS the invocation's).
+//
+// The storage instance is shared with the runner through the process-wide
+// `Symbol.for` registry rather than a module-level singleton: the runner is a
+// pre-bundled artifact and @dust/pod resolves through NODE_PATH, so the two
+// are distinct module graphs that would each get their own module state. The
+// runner's enter side of this contract lives in
+// functions-runner/context.ts and must use the same key.
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export interface InvocationContext {
+  readonly env: Readonly<Record<string, string>>;
+}
+
+/** Registry key of the shared storage. Versioned: a breaking change to the
+ * store shape must change the key so mismatched runner/SDK builds ignore
+ * each other instead of misreading the store. */
+export const INVOCATION_CONTEXT_KEY = "dust.pod.invocation-context.v1";
+
+function contextStorage(): AsyncLocalStorage<InvocationContext> {
+  const key = Symbol.for(INVOCATION_CONTEXT_KEY);
+  const existing: unknown = Reflect.get(globalThis, key);
+  if (existing instanceof AsyncLocalStorage) {
+    return existing;
+  }
+  const storage = new AsyncLocalStorage<InvocationContext>();
+  Reflect.set(globalThis, key, storage);
+  return storage;
+}
+
+/**
+ * Run `fn` inside an invocation context whose environment is `env`.
+ * Called by the runner around each invocation; user code never calls this.
+ */
+export function runWithInvocationEnv<T>(
+  env: Readonly<Record<string, string>>,
+  fn: () => T
+): T {
+  return contextStorage().run(
+    Object.freeze({ env: Object.freeze({ ...env }) }),
+    fn
+  );
+}
+
+/**
+ * Read an environment variable as seen by the current invocation.
+ *
+ * Inside an invocation context, only the context's env is consulted — a key
+ * absent there stays absent even when process.env has a value, so one
+ * invocation's environment can never leak into another. Outside any context
+ * (cold runs, local use), this is plain process.env.
+ */
+export function podEnv(name: string): string | undefined {
+  const context = contextStorage().getStore();
+  if (context !== undefined) {
+    return context.env[name];
+  }
+  return process.env[name];
+}

--- a/cli/dust-sandbox/pod/db.ts
+++ b/cli/dust-sandbox/pod/db.ts
@@ -3,6 +3,8 @@ import { Database } from "bun:sqlite";
 import type { BunSQLiteDatabase } from "drizzle-orm/bun-sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
+import { podEnv } from "./context.ts";
+
 /**
  * Pod state databases.
  *
@@ -234,7 +236,7 @@ class PodSqliteDatabase extends Database {
 }
 
 function podDatabasesDir(): string {
-  const dir = process.env[POD_DATABASES_DIR_ENV];
+  const dir = podEnv(POD_DATABASES_DIR_ENV);
   if (dir === undefined || dir.length === 0) {
     throw new PodDatabaseError(
       `${POD_DATABASES_DIR_ENV} is not set: the databases directory is ` +
@@ -246,7 +248,7 @@ function podDatabasesDir(): string {
 }
 
 function podDatabaseMaxSizeBytes(): number {
-  const raw = process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV];
+  const raw = podEnv(POD_DATABASE_MAX_SIZE_BYTES_ENV);
   if (raw === undefined || raw.length === 0) {
     throw new PodDatabaseError(
       `${POD_DATABASE_MAX_SIZE_BYTES_ENV} is not set: the per-database size ` +
@@ -325,7 +327,7 @@ export function db(name: string): PodDatabase {
   if (!POD_DATABASE_NAME_REGEX.test(name)) {
     throw new PodDatabaseInvalidNameError(name);
   }
-  const spaceId = process.env[POD_SPACE_ID_ENV];
+  const spaceId = podEnv(POD_SPACE_ID_ENV);
   if (spaceId === undefined || spaceId.length === 0) {
     throw new PodDatabasesUnavailableError();
   }

--- a/cli/dust-sandbox/pod/identity.test.ts
+++ b/cli/dust-sandbox/pod/identity.test.ts
@@ -4,6 +4,7 @@ import {
   POD_USER_IDENTITY_ENV,
   POD_WORKSPACE_ID_ENV,
   PodUserIdentityError,
+  runWithInvocationEnv,
 } from "@dust/pod";
 
 const identity = {
@@ -53,5 +54,52 @@ describe("currentUser", () => {
     });
 
     expect(() => currentUser()).toThrow(PodUserIdentityError);
+  });
+});
+
+describe("currentUser inside an invocation context", () => {
+  const contextEnv = (identityValue: string | undefined) => ({
+    [POD_WORKSPACE_ID_ENV]: "w_current",
+    ...(identityValue === undefined
+      ? {}
+      : { [POD_USER_IDENTITY_ENV]: identityValue }),
+  });
+
+  test("reads the identity from the context env", () => {
+    const user = runWithInvocationEnv(
+      contextEnv(JSON.stringify(identity)),
+      () => currentUser()
+    );
+    expect(user).toEqual(identity.user);
+  });
+
+  test("a userless context returns null even when process.env has an identity", () => {
+    process.env[POD_WORKSPACE_ID_ENV] = "w_current";
+    process.env[POD_USER_IDENTITY_ENV] = JSON.stringify(identity);
+
+    expect(
+      runWithInvocationEnv(contextEnv(""), () => currentUser())
+    ).toBeNull();
+    expect(
+      runWithInvocationEnv(contextEnv(undefined), () => currentUser())
+    ).toBeNull();
+  });
+
+  test("concurrent invocations resolve their own callers", async () => {
+    const otherIdentity = {
+      workspaceId: "w_current",
+      user: { ...identity.user, sId: "usr_456", firstName: "Grace" },
+    };
+    const call = async (raw: string, delayMs: number) =>
+      runWithInvocationEnv(contextEnv(raw), async () => {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        return currentUser();
+      });
+    const [a, b] = await Promise.all([
+      call(JSON.stringify(identity), 30),
+      call(JSON.stringify(otherIdentity), 5),
+    ]);
+    expect(a?.sId).toBe("usr_123");
+    expect(b?.sId).toBe("usr_456");
   });
 });

--- a/cli/dust-sandbox/pod/identity.ts
+++ b/cli/dust-sandbox/pod/identity.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { podEnv } from "./context.ts";
+
 export const POD_USER_IDENTITY_ENV = "DUST_POD_USER_IDENTITY";
 export const POD_WORKSPACE_ID_ENV = "WORKSPACE_ID";
 
@@ -38,7 +40,7 @@ export class PodUserIdentityError extends Error {
  * Userless invocations return null.
  */
 export function currentUser(): WorkspaceUserIdentity | null {
-  const rawIdentity = process.env[POD_USER_IDENTITY_ENV];
+  const rawIdentity = podEnv(POD_USER_IDENTITY_ENV);
   if (!rawIdentity) {
     return null;
   }
@@ -56,7 +58,7 @@ export function currentUser(): WorkspaceUserIdentity | null {
   }
   const value: WorkspaceUserIdentityEnvelope = parsedIdentity.data;
 
-  const workspaceId = process.env[POD_WORKSPACE_ID_ENV];
+  const workspaceId = podEnv(POD_WORKSPACE_ID_ENV);
   if (!workspaceId || value.workspaceId !== workspaceId) {
     throw new PodUserIdentityError(
       "The Pod user identity does not match the current workspace."

--- a/cli/dust-sandbox/pod/index.ts
+++ b/cli/dust-sandbox/pod/index.ts
@@ -4,6 +4,8 @@
  * Surfaces:
  * - `db(name)`: the pod's SQLite state databases, through Drizzle (./db.ts).
  * - `currentUser()`: the workspace-scoped user attributed to this invocation.
+ * - `podEnv(name)`: the invocation's environment (./context.ts).
  */
+export * from "./context.ts";
 export * from "./db.ts";
 export * from "./identity.ts";


### PR DESCRIPTION
## Description

First PR of a stack that makes warm function servers serve invocations concurrently (like a web server) instead of one at a time.

Today the warm server injects per-invocation state (user identity, sandbox token) by swapping process.env around each invocation, which forces strict serialization. This PR moves that state into an AsyncLocalStorage invocation context:

- New pod SDK surface: `podEnv(name)` reads the active invocation's env; `currentUser()` and `db()` now go through it. Outside any context (cold runs, local use) it reads process.env, unchanged behavior.
- Inside a context, only the context env is consulted. A key absent there stays absent even if process.env has a value, so one invocation's environment can never leak into another.
- The storage is shared between the runner bundle and the vendored `@dust/pod` through the `Symbol.for` registry: they are distinct module graphs (the runner is pre-bundled, the package resolves via NODE_PATH), so a module-level singleton would not be shared.
- `invoke()` takes the per-invocation env as an optional argument. The v1 warm server still swaps process.env, so nothing changes until the concurrent server lands on top.

## Tests

Unit tests for the context (isolation across concurrent flows, no fallback leakage), context-aware `currentUser()`, and `invoke()` with an invocation env. The runner-side test fixture imports the pod package's copy of the context module, so the cross-module-graph Symbol.for contract is exercised for real.

## Risk

No behavior change on its own: the cold path reads process.env as before and the v1 server still swaps env. The SDK change ships with the next base image bump.

## Deploy Plan

Merges freely; takes effect with the stack's dsbx release + base image bump (last PR of the stack).