### PR TITLE
[dsbx] feat: concurrent warm function server with bounded admission

### DIFF
--- a/cli/dust-sandbox/functions-runner/fixtures/sleepy.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/sleepy.ts
@@ -1,0 +1,10 @@
+// Sleeps for a caller-chosen duration so concurrency tests can control how
+// long an invocation occupies its slot.
+export default {
+  async fetch(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+    const delayMs = Number(url.searchParams.get("delayMs") ?? "100");
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    return Response.json({ done: true });
+  },
+};

--- a/cli/dust-sandbox/functions-runner/fixtures/slow.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/slow.ts
@@ -1,7 +1,0 @@
-// Sleeps briefly so warm-server tests can observe the busy reply.
-export default {
-  async fetch(): Promise<Response> {
-    await new Promise((resolve) => setTimeout(resolve, 400));
-    return Response.json({ done: true });
-  },
-};

--- a/cli/dust-sandbox/functions-runner/protocol.ts
+++ b/cli/dust-sandbox/functions-runner/protocol.ts
@@ -23,6 +23,10 @@ export const RUNNER_ERROR_CODES = [
   "bad_return",
   "http_error",
   "invalid_output",
+  // Emitted by the warm server's admission layer (serve.ts), never by
+  // invoke(): the function is at its concurrency limit and the invocation
+  // was refused before anything executed.
+  "overloaded",
 ] as const;
 
 export type ErrorCode = (typeof RUNNER_ERROR_CODES)[number];

--- a/cli/dust-sandbox/functions-runner/serve.test.ts
+++ b/cli/dust-sandbox/functions-runner/serve.test.ts
@@ -4,8 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
-  applyRequestEnv,
-  clearAppliedEnv,
+  MAX_CONCURRENT_INVOCATIONS,
   parseWarmRequest,
   WARM_PROTOCOL_VERSION,
 } from "./serve.ts";
@@ -62,9 +61,12 @@ async function startServer(handlerPath: string): Promise<ServerHandle> {
 interface WarmReply {
   v: number;
   ack?: boolean;
-  outcome?: { ok: boolean; output?: unknown; error?: { code: string } };
+  outcome?: {
+    ok: boolean;
+    output?: unknown;
+    error?: { code: string };
+  };
   stale?: boolean;
-  busy?: boolean;
   error?: string;
 }
 
@@ -126,6 +128,9 @@ function warmRequest(env: Record<string, string>, input: unknown) {
   };
 }
 
+const sleepyRequest = (delayMs: number) =>
+  warmRequest({}, { url: `http://localhost/?delayMs=${delayMs}` });
+
 describe("runner serve", () => {
   test("serves an invocation over the socket", async () => {
     const { proc, socketPath } = await startServer(fx("hello.ts"));
@@ -157,39 +162,121 @@ describe("runner serve", () => {
     }
   });
 
-  test("applies per-request env and clears it between requests", async () => {
-    // env-probe.ts echoes process.env.WARM_TEST_MARKER, so the reply proves
-    // which env the invocation ran under.
-    const { proc, socketPath } = await startServer(fx("env-probe.ts"));
+  test("serves overlapping invocations concurrently", async () => {
+    const { proc, socketPath } = await startServer(fx("sleepy.ts"));
     try {
-      const first = await request(
-        socketPath,
-        warmRequest(
-          { WARM_TEST_MARKER: "alpha", DUST_SANDBOX_TOKEN: "tok-alpha" },
-          { url: "http://localhost/" }
-        )
-      );
-      expect(first.outcome?.output).toEqual({
-        marker: "alpha",
-        token: "tok-alpha",
+      // Three 400ms invocations completing in well under 3 x 400ms proves
+      // they shared the event loop instead of serializing.
+      const startedAtMs = Date.now();
+      const replies = await Promise.all([
+        request(socketPath, sleepyRequest(400)),
+        request(socketPath, sleepyRequest(400)),
+        request(socketPath, sleepyRequest(400)),
+      ]);
+      const elapsedMs = Date.now() - startedAtMs;
+      for (const reply of replies) {
+        expect(reply.outcome?.ok).toBe(true);
+      }
+      expect(elapsedMs).toBeLessThan(1_000);
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("per-invocation env is scoped to its invocation, concurrently", async () => {
+    // context-probe.ts reads the invocation context (as @dust/pod does)
+    // before and after an await: concurrent invocations with different
+    // environments must each observe exactly their own, at both ends.
+    const { proc, socketPath } = await startServer(fx("context-probe.ts"));
+    try {
+      const probe = (marker: string, delayMs: number) =>
+        request(
+          socketPath,
+          warmRequest(
+            { WARM_TEST_MARKER: marker, DUST_SANDBOX_TOKEN: `tok-${marker}` },
+            { url: `http://localhost/?delayMs=${delayMs}` }
+          )
+        );
+      const [a, b] = await Promise.all([
+        probe("alpha", 120),
+        probe("beta", 30),
+      ]);
+      expect(a.outcome?.output).toMatchObject({
+        before: "alpha",
+        after: "alpha",
+      });
+      expect(b.outcome?.output).toMatchObject({
+        before: "beta",
+        after: "beta",
       });
 
-      // The second request carries neither: nothing may leak over from the
-      // first invocation — in particular not its sandbox token.
-      const second = await request(
+      // A request carrying no env observes nothing from earlier invocations
+      // — in particular not their sandbox tokens.
+      const clean = await request(
         socketPath,
         warmRequest({}, { url: "http://localhost/" })
       );
-      expect(second.outcome?.output).toEqual({
-        marker: "unset",
-        token: "unset",
+      expect(clean.outcome?.output).toMatchObject({
+        before: null,
+        after: null,
+        identity: null,
       });
     } finally {
       proc.kill();
     }
   });
 
-  test("reports a rewritten bundle as stale and exits", async () => {
+  test("queues past the concurrency cap and serves once a slot frees", async () => {
+    const { proc, socketPath } = await startServer(fx("sleepy.ts"));
+    try {
+      // Fill every slot with 300ms invocations, then send one more: it must
+      // wait in the queue (no slot is free) and still be served.
+      const filling = Array.from({ length: MAX_CONCURRENT_INVOCATIONS }, () =>
+        request(socketPath, sleepyRequest(300))
+      );
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const queued = await request(socketPath, sleepyRequest(10));
+      expect(queued.outcome?.ok).toBe(true);
+
+      const replies = await Promise.all(filling);
+      for (const reply of replies) {
+        expect(reply.outcome?.ok).toBe(true);
+      }
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("a queued request that outwaits the queue deadline is refused as overloaded", async () => {
+    const { proc, socketPath } = await startServer(fx("sleepy.ts"));
+    try {
+      // Occupy every slot for longer than the queue deadline (2s), then
+      // queue one more: it must be refused with a structured overloaded
+      // outcome rather than executed late or sent cold.
+      const filling = Array.from({ length: MAX_CONCURRENT_INVOCATIONS }, () =>
+        request(socketPath, sleepyRequest(2_800))
+      );
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      const startedAtMs = Date.now();
+      const refused = await request(socketPath, sleepyRequest(10));
+      const waitedMs = Date.now() - startedAtMs;
+      expect(refused.outcome?.ok).toBe(false);
+      expect(refused.outcome?.error?.code).toBe("overloaded");
+      expect(refused.ack).toBeUndefined();
+      // Refused at the queue deadline, not at the caller's leisure.
+      expect(waitedMs).toBeGreaterThanOrEqual(1_500);
+      expect(waitedMs).toBeLessThan(2_800);
+
+      const replies = await Promise.all(filling);
+      for (const reply of replies) {
+        expect(reply.outcome?.ok).toBe(true);
+      }
+    } finally {
+      proc.kill();
+    }
+  }, 15_000);
+
+  test("reports a rewritten bundle as stale and drains", async () => {
     const dir = scratch();
     const bundle = join(dir, "hello.ts");
     copyFileSync(fx("hello.ts"), bundle);
@@ -205,6 +292,33 @@ describe("runner serve", () => {
         warmRequest({}, { url: "http://localhost/" })
       );
       expect(reply.stale).toBe(true);
+      expect(await proc.exited).toBe(0);
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("a stale-triggered drain lets in-flight invocations finish", async () => {
+    const dir = scratch();
+    const bundle = join(dir, "sleepy.ts");
+    copyFileSync(fx("sleepy.ts"), bundle);
+    const { proc, socketPath } = await startServer(bundle);
+    try {
+      const inFlight = request(socketPath, sleepyRequest(600));
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      const later = new Date(Date.now() + 5_000);
+      utimesSync(bundle, later, later);
+      const refused = await request(
+        socketPath,
+        warmRequest({}, { url: "http://localhost/" })
+      );
+      expect(refused.stale).toBe(true);
+
+      // The invocation that was already executing still delivers its
+      // outcome; only then does the drained server exit.
+      const served = await inFlight;
+      expect(served.outcome?.ok).toBe(true);
       expect(await proc.exited).toBe(0);
     } finally {
       proc.kill();
@@ -229,7 +343,7 @@ describe("runner serve", () => {
     }
   });
 
-  test("refuses a mismatched bundle hash as stale and exits", async () => {
+  test("refuses a mismatched bundle hash as stale and drains", async () => {
     // The stat cannot see the rewrite here (the file is untouched), which is
     // exactly the gcsfuse-cached-metadata case: the request's hash is the
     // only signal, and it must win.
@@ -263,7 +377,7 @@ describe("runner serve", () => {
     }
   });
 
-  test("rejects a protocol version it does not speak and exits", async () => {
+  test("rejects a protocol version it does not speak without dying", async () => {
     const { proc, socketPath } = await startServer(fx("hello.ts"));
     try {
       const reply = await request(socketPath, {
@@ -272,7 +386,15 @@ describe("runner serve", () => {
         input: "{}",
       });
       expect(reply.error).toBe("bad warm request");
-      expect(await proc.exited).toBe(0);
+
+      // Version-suffixed socket names make a mismatched client a bug, not a
+      // rolling-upgrade case; the server must not abandon concurrent work
+      // over one bad request.
+      const after = await request(
+        socketPath,
+        warmRequest({}, { url: "http://localhost/?name=alive" })
+      );
+      expect(after.outcome?.output).toEqual({ hello: "alive" });
     } finally {
       proc.kill();
     }
@@ -293,44 +415,11 @@ describe("runner serve", () => {
     }
   });
 
-  test("replies busy instead of queueing behind a running invocation", async () => {
-    const { proc, socketPath } = await startServer(fx("slow.ts"));
-    try {
-      const slow = request(
-        socketPath,
-        warmRequest({}, { url: "http://localhost/" })
-      );
-      // Give the slow request time to reach the server and start executing.
-      await new Promise((resolve) => setTimeout(resolve, 150));
-
-      const overlapped = await request(
-        socketPath,
-        warmRequest({}, { url: "http://localhost/" })
-      );
-      // Queueing would run this request for a client whose front-side
-      // timeout may already have fired; busy sends it cold immediately.
-      expect(overlapped.busy).toBe(true);
-      expect(overlapped.outcome).toBeUndefined();
-
-      const first = await slow;
-      expect(first.outcome?.output).toEqual({ done: true });
-
-      // The server survives and serves again once free.
-      const after = await request(
-        socketPath,
-        warmRequest({}, { url: "http://localhost/" })
-      );
-      expect(after.outcome?.output).toEqual({ done: true });
-    } finally {
-      proc.kill();
-    }
-  });
-
   test("scrubs the spawn-time invocation secrets from its own environment", async () => {
     const dir = scratch();
     const socketPath = join(dir, "fn.sock");
     // Spawned the way dsbx spawns it: with the cold invocation's token in
-    // env. The server must not serve requests under that inherited value.
+    // env. Even a bundle reading process.env directly must not observe it.
     const proc = Bun.spawn(
       ["bun", runner, "serve", fx("env-probe.ts"), socketPath],
       {
@@ -443,26 +532,5 @@ describe("parseWarmRequest", () => {
         JSON.stringify({ v: WARM_PROTOCOL_VERSION, env: {}, input: 7 })
       )
     ).toBeNull();
-  });
-});
-
-describe("applyRequestEnv", () => {
-  test("applies for the invocation and clears afterwards", () => {
-    const original = process.env.SERVE_TEST_KEY;
-    try {
-      const applied = applyRequestEnv({ SERVE_TEST_KEY: "one" });
-      expect(process.env.SERVE_TEST_KEY).toBe("one");
-
-      // Cleared after the invocation: per-request secrets (the sandbox
-      // token travels in env) must not sit in the idle server's environment.
-      clearAppliedEnv(applied);
-      expect(process.env.SERVE_TEST_KEY).toBeUndefined();
-    } finally {
-      if (original === undefined) {
-        delete process.env.SERVE_TEST_KEY;
-      } else {
-        process.env.SERVE_TEST_KEY = original;
-      }
-    }
   });
 });

--- a/cli/dust-sandbox/functions-runner/serve.ts
+++ b/cli/dust-sandbox/functions-runner/serve.ts
@@ -252,7 +252,11 @@ export async function serve(
   let draining = false;
   let drainExitCode = 0;
   let drainFlushTimer: ReturnType<typeof setTimeout> | null = null;
-  const queue: QueueEntry[] = [];
+  // Settled entries linger in the array until dequeued or compacted;
+  // queuedLive is the number of live ones and the number that matters for
+  // admission, idling and drain.
+  let queue: QueueEntry[] = [];
+  let queuedLive = 0;
   const queuedBySocket = new Map<object, QueueEntry>();
 
   let idleTimer: ReturnType<typeof setTimeout> | null = null;
@@ -267,7 +271,7 @@ export async function serve(
     idleTimer = setTimeout(() => {
       // Guarded: the timer is cleared on every start, but never trust a
       // timer alone with killing a process that might be serving.
-      if (running === 0 && queue.length === 0 && !draining) {
+      if (running === 0 && queuedLive === 0 && !draining) {
         exit(0);
       }
     }, IDLE_TIMEOUT_MS);
@@ -278,13 +282,24 @@ export async function serve(
       return false;
     }
     entry.settled = true;
+    queuedLive -= 1;
     clearTimeout(entry.expireTimer);
     queuedBySocket.delete(entry.socket);
+    // pump() only reclaims settled entries as they reach the front, which
+    // never happens while every slot stays busy with long invocations; the
+    // occasional compaction keeps the array proportional to the live count
+    // under that kind of churn.
+    if (
+      queue.length > MAX_QUEUED_INVOCATIONS &&
+      queuedLive < queue.length / 2
+    ) {
+      queue = queue.filter((queued) => !queued.settled);
+    }
     return true;
   }
 
   function exitIfDrained(): void {
-    if (!draining || queue.length > 0 || running !== hung) {
+    if (!draining || queuedLive > 0 || running !== hung) {
       return;
     }
     if (pendingWrites.size === 0) {
@@ -325,12 +340,12 @@ export async function serve(
     // Queued requests never started executing: refuse them as stale so their
     // clients re-run cold against the successor server. (On a stale-triggered
     // drain, serving them from the old import would be wrong anyway.)
-    for (const entry of queue) {
+    for (const entry of [...queue]) {
       if (settleQueueEntry(entry)) {
         reply(entry.socket, { v: WARM_PROTOCOL_VERSION, stale: true });
       }
     }
-    queue.length = 0;
+    queue = [];
     exitIfDrained();
   }
 
@@ -447,7 +462,7 @@ export async function serve(
           startDrain(0);
         }
         pump();
-        if (running === 0 && queue.length === 0 && !draining) {
+        if (running === 0 && queuedLive === 0 && !draining) {
           armIdle();
         }
         exitIfDrained();
@@ -465,18 +480,6 @@ export async function serve(
       }
       start(entry.socket, entry.request);
     }
-  }
-
-  function queuedCount(): number {
-    // Settled entries linger in the array until dequeued; count live ones.
-    // O(queue length), bounded by MAX_QUEUED_INVOCATIONS.
-    let count = 0;
-    for (const entry of queue) {
-      if (!entry.settled) {
-        count += 1;
-      }
-    }
-    return count;
   }
 
   function handleLine(socket: WarmSocket, line: string): void {
@@ -498,7 +501,7 @@ export async function serve(
       start(socket, request);
       return;
     }
-    if (queuedCount() >= MAX_QUEUED_INVOCATIONS) {
+    if (queuedLive >= MAX_QUEUED_INVOCATIONS) {
       reply(socket, overloadedFrame());
       return;
     }
@@ -515,6 +518,7 @@ export async function serve(
       }, QUEUE_WAIT_DEADLINE_MS),
     };
     queue.push(entry);
+    queuedLive += 1;
     queuedBySocket.set(socket, entry);
   }
 

--- a/cli/dust-sandbox/functions-runner/serve.ts
+++ b/cli/dust-sandbox/functions-runner/serve.ts
@@ -64,6 +64,12 @@ export const QUEUE_WAIT_DEADLINE_MS = 2_000;
 // for its last reply bytes before force-exiting on a client that stopped
 // reading.
 const IDLE_TIMEOUT_MS = 120_000;
+// A request older than this must not be acked: the client abandons the wait
+// at 4s (see warm.rs) and falls back cold, and acking into that window is
+// the one race that could double-execute. Refusing pre-ack is always safe,
+// so past this age the server sends `stale` instead of starting work, and
+// the ack-vs-abandon race shrinks to clock slop.
+const PRE_ACK_DEADLINE_MS = 3_000;
 const MAX_LIFETIME_MS = 600_000;
 const INVOCATION_DEADLINE_MS = 120_000;
 const MAX_RSS_BYTES = 300 * 1024 * 1024;
@@ -140,42 +146,11 @@ interface WarmSocket {
   end(): void;
 }
 
-/**
- * Backpressure-aware write: Bun's socket.write returns how many bytes it
- * accepted, and a large outcome can exceed the kernel buffer. The remainder
- * is retried from the drain callback via the pending map; end() only happens
- * once everything is flushed, so the client never sees a truncated JSON line.
- */
-const pendingWrites = new Map<object, Uint8Array>();
-
-function writeThenEnd(socket: WarmSocket, payload: string): void {
-  const bytes = new TextEncoder().encode(payload);
-  const written = socket.write(bytes);
-  if (written >= bytes.length) {
-    socket.end();
-    return;
-  }
-  pendingWrites.set(socket, bytes.subarray(Math.max(written, 0)));
-}
-
-function drainPending(socket: WarmSocket): void {
-  const remaining = pendingWrites.get(socket);
-  if (!remaining) {
-    return;
-  }
-  const written = socket.write(remaining);
-  if (written >= remaining.length) {
-    pendingWrites.delete(socket);
-    socket.end();
-    return;
-  }
-  pendingWrites.set(socket, remaining.subarray(Math.max(written, 0)));
-}
-
 /** A request waiting for a free invocation slot, in FIFO order. */
 interface QueueEntry {
   socket: WarmSocket;
   request: WarmRequest;
+  receivedAtMs: number;
   // Settled entries (reply already sent, or client gone) stay in the array
   // and are skipped at dequeue time: O(1) removal without scanning the queue
   // on every socket close.
@@ -242,6 +217,39 @@ export async function serve(
     }
     process.exit(code);
   };
+
+  /**
+   * Backpressure-aware write: Bun's socket.write returns how many bytes it
+   * accepted, and a large outcome can exceed the kernel buffer. The
+   * remainder is retried from the drain callback via the pending map; end()
+   * only happens once everything is flushed, so the client never sees a
+   * truncated JSON line.
+   */
+  const pendingWrites = new Map<object, Uint8Array>();
+
+  function writeThenEnd(socket: WarmSocket, payload: string): void {
+    const bytes = new TextEncoder().encode(payload);
+    const written = socket.write(bytes);
+    if (written >= bytes.length) {
+      socket.end();
+      return;
+    }
+    pendingWrites.set(socket, bytes.subarray(Math.max(written, 0)));
+  }
+
+  function drainPending(socket: WarmSocket): void {
+    const remaining = pendingWrites.get(socket);
+    if (!remaining) {
+      return;
+    }
+    const written = socket.write(remaining);
+    if (written >= remaining.length) {
+      pendingWrites.delete(socket);
+      socket.end();
+      return;
+    }
+    pendingWrites.set(socket, remaining.subarray(Math.max(written, 0)));
+  }
 
   // `running` counts invocations past admission (including their pre-ack
   // staleness checks); `hung` counts the subset that blew their deadline and
@@ -359,7 +367,8 @@ export async function serve(
 
   async function runInvocation(
     socket: WarmSocket,
-    request: WarmRequest
+    request: WarmRequest,
+    receivedAtMs: number
   ): Promise<void> {
     // A republished bundle must never be served from the old import. One
     // metadata call per invocation start; any difference (or a vanished
@@ -408,10 +417,20 @@ export async function serve(
     // a retried one. The write is synchronous into the kernel buffer: its
     // failure proves the client is gone, so nothing executes for a client
     // that already gave up (e.g. one that timed out while queued).
-    const ackWritten = socket.write(
+    if (Date.now() - receivedAtMs > PRE_ACK_DEADLINE_MS) {
+      // The pre-ack work (queue wait, gcsfuse metadata) outlived the
+      // client's patience budget; it is walking away or about to.
+      reply(socket, { v: WARM_PROTOCOL_VERSION, stale: true });
+      return;
+    }
+    const ackBytes = new TextEncoder().encode(
       `${JSON.stringify({ v: WARM_PROTOCOL_VERSION, ack: true })}\n`
     );
-    if (ackWritten <= 0) {
+    const ackWritten = socket.write(ackBytes);
+    if (ackWritten < ackBytes.length) {
+      // Failed or partial: the client is gone, or would read a truncated
+      // frame and treat the connection as dead pre-ack. Either way nothing
+      // has executed, so not executing is the only safe continuation.
       socket.end();
       return;
     }
@@ -444,10 +463,14 @@ export async function serve(
     }
   }
 
-  function start(socket: WarmSocket, request: WarmRequest): void {
+  function start(
+    socket: WarmSocket,
+    request: WarmRequest,
+    receivedAtMs: number
+  ): void {
     running += 1;
     clearIdle();
-    void runInvocation(socket, request)
+    void runInvocation(socket, request, receivedAtMs)
       .catch(() => {
         // runInvocation reports failures as structured outcomes; a throw
         // here is a runner bug, and the client's timeout classifies it.
@@ -478,7 +501,7 @@ export async function serve(
       if (!settleQueueEntry(entry)) {
         continue;
       }
-      start(entry.socket, entry.request);
+      start(entry.socket, entry.request, entry.receivedAtMs);
     }
   }
 
@@ -497,8 +520,9 @@ export async function serve(
       reply(socket, { v: WARM_PROTOCOL_VERSION, stale: true });
       return;
     }
+    const receivedAtMs = Date.now();
     if (running < MAX_CONCURRENT_INVOCATIONS) {
-      start(socket, request);
+      start(socket, request, receivedAtMs);
       return;
     }
     if (queuedLive >= MAX_QUEUED_INVOCATIONS) {
@@ -508,6 +532,7 @@ export async function serve(
     const entry: QueueEntry = {
       socket,
       request,
+      receivedAtMs,
       settled: false,
       expireTimer: setTimeout(() => {
         // Waited too long: refuse rather than executing for a caller whose

--- a/cli/dust-sandbox/functions-runner/serve.ts
+++ b/cli/dust-sandbox/functions-runner/serve.ts
@@ -1,25 +1,35 @@
-// Warm function server: keeps one imported function bundle resident in a bun
-// process and serves invocations over a unix socket, so repeat invocations skip
-// process spawn, bundle resolution, and the import of the bundle and its
-// dependencies (the dominant sandbox-side costs of a cold run).
+// Warm function server (protocol v2): keeps one imported function bundle
+// resident in a bun process and serves invocations over a unix socket, so
+// repeat invocations skip process spawn, bundle resolution, and the import of
+// the bundle and its dependencies (the dominant sandbox-side costs of a cold
+// run).
 //
-// One server serves exactly one handler path, one invocation at a time. The
-// per-invocation environment (sandbox token, user identity) travels in the
-// request and is applied to process.env for the duration of the invocation,
-// then cleared — concurrency would race those swaps, so a request arriving
-// while one is running gets an immediate `busy` reply and the client runs
-// cold instead of queueing behind work of unknown duration.
+// One server serves exactly one handler path — concurrently. Invocations are
+// IO-bound in the common case (SQL, API calls), so the event loop interleaves
+// many of them at once exactly like a web server would; per-invocation state
+// (user identity, sandbox token) travels in the request and is scoped through
+// the invocation context (see functions-runner/context.ts and @dust/pod),
+// never applied to process.env. Beyond MAX_CONCURRENT_INVOCATIONS requests
+// wait in a FIFO queue; a full or too-slow queue gets a structured
+// `overloaded` outcome instead of sending the client to a cold run —
+// unbounded cold fallback under saturation is exactly the memory blow-up this
+// server exists to prevent.
 //
 // Duplicate executions are the failure mode this protocol is shaped around:
 // pod functions are arbitrary side-effectful code, and front assumes a failed
-// start means nothing ran. The server acks before executing; the client only
+// start means nothing ran. The server acks before executing — a synchronous
+// socket write whose failure proves the client is gone — and the client only
 // falls back to the cold path on failures that precede the ack. After the
-// ack, a lost outcome is reported as a failed invocation, never re-run.
+// ack, a lost outcome is reported as a failed invocation, never re-run. (The
+// synchronous-ack guarantee is why this stays a raw line protocol instead of
+// sitting behind an HTTP server: response streaming cannot prove the ack
+// reached the client's buffer before execution starts.)
 //
-// The server is disposable. It exits on idle, at a hard lifetime cap (drained,
-// never mid-invocation), when the bundle on disk changes, on any malformed
-// request, or when an invocation outlives its deadline (without replying: the
-// client's front-side timeout killed it long before).
+// The server is disposable. It exits on idle, and it drains (stops
+// listening, refuses its queue, lets in-flight invocations finish, then
+// exits) at the lifetime cap, when the bundle on disk changes, when its RSS
+// crosses the recycle threshold, or when an invocation outlives its deadline
+// (whose client was killed by front's much shorter exec timeout long ago).
 
 import { createHash } from "node:crypto";
 import { unlinkSync } from "node:fs";
@@ -31,28 +41,44 @@ import { invoke } from "./invoke.ts";
 import type { RequestInput } from "./protocol.ts";
 import { BadInputError, parseInput } from "./protocol.ts";
 
-export const WARM_PROTOCOL_VERSION = 1;
+export const WARM_PROTOCOL_VERSION = 2;
 
-// Idle: how long the server waits for another invocation before exiting.
-// Lifetime: hard cap bounding how long a republished bundle can keep being
-// served when the envelope carries no bundle hash and gcsfuse metadata
-// caching hides the change from the per-request stat. Deadline: an
+// Concurrency: in-flight invocations share the event loop, so the cap bounds
+// per-invocation memory and downstream pressure (sqlite, egress), not CPU —
+// CPU-bound work serializes on the single JS thread regardless. The queue
+// deadline stays comfortably under front's 10s inline exec timeout so a
+// queued invocation either starts or is refused while its caller still
+// listens; the client's own pre-ack timeout must exceed it (see warm.rs).
+export const MAX_CONCURRENT_INVOCATIONS = 32;
+export const MAX_QUEUED_INVOCATIONS = 128;
+export const QUEUE_WAIT_DEADLINE_MS = 2_000;
+
+// Idle: how long the server waits with nothing running and nothing queued
+// before exiting. Lifetime: hard cap bounding how long a republished bundle
+// can keep being served when the envelope carries no bundle hash and gcsfuse
+// metadata caching hides the change from the per-request stat. Deadline: an
 // invocation that runs this long lost its client to front's much shorter
-// exec timeout ages ago; exit and free the socket.
+// exec timeout ages ago, and its slot is wedged for good (a promise cannot
+// be killed), so the server recycles. Rss: a bloated server trades a one-off
+// import cost for freed memory. Drain flush: how long a drained server waits
+// for its last reply bytes before force-exiting on a client that stopped
+// reading.
 const IDLE_TIMEOUT_MS = 120_000;
 const MAX_LIFETIME_MS = 600_000;
 const INVOCATION_DEADLINE_MS = 120_000;
+const MAX_RSS_BYTES = 300 * 1024 * 1024;
+const DRAIN_FLUSH_TIMEOUT_MS = 5_000;
 
 // Per-invocation env vars inherited from the cold run that spawned this
 // server. Scrubbed at startup: they belong to that invocation, and every
-// request carries its own.
+// request carries its own environment in the request itself.
 const SPAWN_ENV_SCRUB_KEYS = ["DUST_SANDBOX_TOKEN", "DUST_POD_USER_IDENTITY"];
 
 const WarmRequestSchema = z.object({
   v: z.literal(WARM_PROTOCOL_VERSION),
-  // Non-string values are dropped rather than refused: only strings can be
-  // applied to process.env, and the request must not die for an ignorable
-  // field.
+  // Non-string values are dropped rather than refused: only strings are
+  // meaningful environment values, and the request must not die for an
+  // ignorable field.
   env: z.record(z.string(), z.unknown()).transform((env) => {
     const out: Record<string, string> = {};
     for (const [key, value] of Object.entries(env)) {
@@ -107,28 +133,6 @@ export function parseWarmRequest(line: string): WarmRequest | null {
   return result.success ? result.data : null;
 }
 
-/**
- * Applies a request's environment on top of process.env and returns the keys
- * it set, so the caller can clear them once the invocation completes. The
- * request carries the client's full environment, so the invocation sees
- * exactly what a cold run's child would have inherited; clearing afterwards
- * keeps per-invocation secrets out of the idle server's environment.
- */
-export function applyRequestEnv(env: Record<string, string>): Set<string> {
-  const applied = new Set<string>();
-  for (const [key, value] of Object.entries(env)) {
-    process.env[key] = value;
-    applied.add(key);
-  }
-  return applied;
-}
-
-export function clearAppliedEnv(applied: Set<string>): void {
-  for (const key of applied) {
-    delete process.env[key];
-  }
-}
-
 // Minimal surface of Bun's unix socket needed here, typed so the write path
 // can honor partial writes.
 interface WarmSocket {
@@ -166,6 +170,32 @@ function drainPending(socket: WarmSocket): void {
     return;
   }
   pendingWrites.set(socket, remaining.subarray(Math.max(written, 0)));
+}
+
+/** A request waiting for a free invocation slot, in FIFO order. */
+interface QueueEntry {
+  socket: WarmSocket;
+  request: WarmRequest;
+  // Settled entries (reply already sent, or client gone) stay in the array
+  // and are skipped at dequeue time: O(1) removal without scanning the queue
+  // on every socket close.
+  settled: boolean;
+  expireTimer: ReturnType<typeof setTimeout>;
+}
+
+function overloadedFrame(): Record<string, unknown> {
+  return {
+    v: WARM_PROTOCOL_VERSION,
+    outcome: {
+      ok: false,
+      error: {
+        code: "overloaded",
+        message:
+          "The function is running at its concurrency limit and the wait " +
+          "queue is saturated; the invocation was not started.",
+      },
+    },
+  };
 }
 
 export async function serve(
@@ -213,36 +243,103 @@ export async function serve(
     process.exit(code);
   };
 
-  let busy = false;
+  // `running` counts invocations past admission (including their pre-ack
+  // staleness checks); `hung` counts the subset that blew their deadline and
+  // will never release their slot. The server is fully drained once every
+  // running invocation is hung.
+  let running = 0;
+  let hung = 0;
   let draining = false;
-  let idleTimer = setTimeout(() => exit(0), IDLE_TIMEOUT_MS);
-  const armIdle = () => {
-    clearTimeout(idleTimer);
-    idleTimer = setTimeout(() => exit(0), IDLE_TIMEOUT_MS);
-  };
-  setTimeout(() => {
-    // Never exit mid-invocation: the in-flight request finishes and replies,
-    // then the drained server exits. New requests get `busy` meanwhile.
-    if (busy) {
-      draining = true;
-    } else {
-      exit(0);
+  let drainExitCode = 0;
+  let drainFlushTimer: ReturnType<typeof setTimeout> | null = null;
+  const queue: QueueEntry[] = [];
+  const queuedBySocket = new Map<object, QueueEntry>();
+
+  let idleTimer: ReturnType<typeof setTimeout> | null = null;
+  const clearIdle = () => {
+    if (idleTimer !== null) {
+      clearTimeout(idleTimer);
+      idleTimer = null;
     }
-  }, MAX_LIFETIME_MS);
+  };
+  const armIdle = () => {
+    clearIdle();
+    idleTimer = setTimeout(() => {
+      // Guarded: the timer is cleared on every start, but never trust a
+      // timer alone with killing a process that might be serving.
+      if (running === 0 && queue.length === 0 && !draining) {
+        exit(0);
+      }
+    }, IDLE_TIMEOUT_MS);
+  };
+
+  function settleQueueEntry(entry: QueueEntry): boolean {
+    if (entry.settled) {
+      return false;
+    }
+    entry.settled = true;
+    clearTimeout(entry.expireTimer);
+    queuedBySocket.delete(entry.socket);
+    return true;
+  }
+
+  function exitIfDrained(): void {
+    if (!draining || queue.length > 0 || running !== hung) {
+      return;
+    }
+    if (pendingWrites.size === 0) {
+      exit(drainExitCode);
+    }
+    // Some reply bytes are still buffered toward a slow reader; give the
+    // flush a bounded window, then exit anyway — the reader had its chance.
+    if (drainFlushTimer === null) {
+      drainFlushTimer = setTimeout(
+        () => exit(drainExitCode),
+        DRAIN_FLUSH_TIMEOUT_MS
+      );
+    }
+  }
+
+  let listenerStop: (() => void) | null = null;
+
+  function startDrain(code: number): void {
+    if (draining) {
+      return;
+    }
+    draining = true;
+    drainExitCode = code;
+    clearIdle();
+    // Stop accepting and free the socket path immediately: the next cold run
+    // binds a fresh server there while this one finishes its in-flight work.
+    if (listenerStop !== null) {
+      listenerStop();
+    }
+    if (boundSocket) {
+      try {
+        unlinkSync(socketPath);
+      } catch {
+        // Best effort.
+      }
+      boundSocket = false;
+    }
+    // Queued requests never started executing: refuse them as stale so their
+    // clients re-run cold against the successor server. (On a stale-triggered
+    // drain, serving them from the old import would be wrong anyway.)
+    for (const entry of queue) {
+      if (settleQueueEntry(entry)) {
+        reply(entry.socket, { v: WARM_PROTOCOL_VERSION, stale: true });
+      }
+    }
+    queue.length = 0;
+    exitIfDrained();
+  }
+
+  setTimeout(() => startDrain(0), MAX_LIFETIME_MS);
 
   const socketBuffers = new Map<object, string>();
 
-  function reply(
-    socket: WarmSocket,
-    response: Record<string, unknown>,
-    { exitAfter = false }: { exitAfter?: boolean } = {}
-  ): void {
+  function reply(socket: WarmSocket, response: Record<string, unknown>): void {
     writeThenEnd(socket, `${JSON.stringify(response)}\n`);
-    if (exitAfter) {
-      // The flush of a tiny control frame cannot realistically backpressure;
-      // exit on the next tick so the write callbacks run.
-      setTimeout(() => exit(0), 0);
-    }
   }
 
   async function runInvocation(
@@ -250,15 +347,13 @@ export async function serve(
     request: WarmRequest
   ): Promise<void> {
     // A republished bundle must never be served from the old import. One
-    // metadata call per request; any difference (or a vanished file) sends
-    // the client down the cold path, which respawns a fresh server.
+    // metadata call per invocation start; any difference (or a vanished
+    // file) sends the client down the cold path, which respawns a fresh
+    // server while this one drains.
     const current = await statBundle(handlerPath);
     if (!sameStamp(importedStamp, current)) {
-      reply(
-        socket,
-        { v: WARM_PROTOCOL_VERSION, stale: true },
-        { exitAfter: true }
-      );
+      reply(socket, { v: WARM_PROTOCOL_VERSION, stale: true });
+      startDrain(0);
       return;
     }
 
@@ -287,71 +382,140 @@ export async function serve(
       input.bundleSha256 !== undefined &&
       input.bundleSha256 !== importedSha256
     ) {
-      reply(
-        socket,
-        { v: WARM_PROTOCOL_VERSION, stale: true },
-        { exitAfter: true }
-      );
+      reply(socket, { v: WARM_PROTOCOL_VERSION, stale: true });
+      startDrain(0);
       return;
     }
 
     // The ack is the point of no return: from here the client must never
     // fall back to the cold path, because the function may have side effects
     // in flight. A lost outcome after this frame is a failed invocation, not
-    // a retried one.
-    busy = true;
+    // a retried one. The write is synchronous into the kernel buffer: its
+    // failure proves the client is gone, so nothing executes for a client
+    // that already gave up (e.g. one that timed out while queued).
     const ackWritten = socket.write(
       `${JSON.stringify({ v: WARM_PROTOCOL_VERSION, ack: true })}\n`
     );
     if (ackWritten <= 0) {
-      // The client is already gone; do not execute for a dead client.
-      busy = false;
       socket.end();
       return;
     }
 
     // An invocation that outlives this deadline lost its client to front's
-    // exec timeout long ago. Exit without replying and free the socket; the
-    // hung function was never going to produce an outcome anyway.
-    const deadline = setTimeout(() => exit(1), INVOCATION_DEADLINE_MS);
+    // exec timeout long ago, and its slot is wedged for good — a promise
+    // cannot be killed. Recycle: drain and let the next cold run spawn a
+    // fresh server. Other in-flight invocations finish normally.
+    let deadlineFired = false;
+    const deadlineTimer = setTimeout(() => {
+      deadlineFired = true;
+      hung += 1;
+      startDrain(1);
+      exitIfDrained();
+    }, INVOCATION_DEADLINE_MS);
 
-    const applied = applyRequestEnv(request.env);
     try {
-      const outcome = await invoke(handlerPath, input);
-      reply(
-        socket,
-        { v: WARM_PROTOCOL_VERSION, outcome },
-        { exitAfter: draining }
-      );
+      const outcome = await invoke(handlerPath, input, request.env);
+      if (deadlineFired) {
+        // The client is long gone; nothing useful to write.
+        socket.end();
+      } else {
+        reply(socket, { v: WARM_PROTOCOL_VERSION, outcome });
+      }
     } finally {
-      clearTimeout(deadline);
-      clearAppliedEnv(applied);
-      busy = false;
-      armIdle();
+      clearTimeout(deadlineTimer);
+      if (deadlineFired) {
+        hung -= 1;
+      }
     }
   }
 
-  function handleLine(socket: WarmSocket, line: string): void {
-    if (busy || draining) {
-      // Never queue: the caller's timeout is shorter than any queue wait
-      // guarantee this server could make, and a queued request would execute
-      // for a client that already gave up. An immediate busy reply sends the
-      // client down the cold path before anything ran.
-      reply(socket, { v: WARM_PROTOCOL_VERSION, busy: true });
-      return;
+  function start(socket: WarmSocket, request: WarmRequest): void {
+    running += 1;
+    clearIdle();
+    void runInvocation(socket, request)
+      .catch(() => {
+        // runInvocation reports failures as structured outcomes; a throw
+        // here is a runner bug, and the client's timeout classifies it.
+        // Never let it take down concurrent invocations.
+      })
+      .finally(() => {
+        running -= 1;
+        if (!draining && process.memoryUsage.rss() > MAX_RSS_BYTES) {
+          // Trade a one-off re-import for freed memory. Checked between
+          // invocation completions only, so a single greedy invocation can
+          // briefly overshoot.
+          startDrain(0);
+        }
+        pump();
+        if (running === 0 && queue.length === 0 && !draining) {
+          armIdle();
+        }
+        exitIfDrained();
+      });
+  }
+
+  function pump(): void {
+    while (!draining && running < MAX_CONCURRENT_INVOCATIONS) {
+      const entry = queue.shift();
+      if (entry === undefined) {
+        return;
+      }
+      if (!settleQueueEntry(entry)) {
+        continue;
+      }
+      start(entry.socket, entry.request);
     }
+  }
+
+  function queuedCount(): number {
+    // Settled entries linger in the array until dequeued; count live ones.
+    // O(queue length), bounded by MAX_QUEUED_INVOCATIONS.
+    let count = 0;
+    for (const entry of queue) {
+      if (!entry.settled) {
+        count += 1;
+      }
+    }
+    return count;
+  }
+
+  function handleLine(socket: WarmSocket, line: string): void {
     const request = parseWarmRequest(line);
     if (request === null) {
-      // A client this server does not understand; dying lets the cold path
-      // respawn a matching one.
-      reply(
-        socket,
-        { v: WARM_PROTOCOL_VERSION, error: "bad warm request" },
-        { exitAfter: true }
-      );
+      // A client this server does not understand. Version-suffixed socket
+      // names make this a bug rather than a rolling-upgrade case; refusing
+      // the request (the client runs cold) beats killing a server with
+      // concurrent invocations in flight.
+      reply(socket, { v: WARM_PROTOCOL_VERSION, error: "bad warm request" });
       return;
     }
-    void runInvocation(socket, request);
+    if (draining) {
+      // Send the client cold; its run respawns a fresh server.
+      reply(socket, { v: WARM_PROTOCOL_VERSION, stale: true });
+      return;
+    }
+    if (running < MAX_CONCURRENT_INVOCATIONS) {
+      start(socket, request);
+      return;
+    }
+    if (queuedCount() >= MAX_QUEUED_INVOCATIONS) {
+      reply(socket, overloadedFrame());
+      return;
+    }
+    const entry: QueueEntry = {
+      socket,
+      request,
+      settled: false,
+      expireTimer: setTimeout(() => {
+        // Waited too long: refuse rather than executing for a caller whose
+        // own timeout budget is nearly spent. Pre-ack, so nothing ran.
+        if (settleQueueEntry(entry)) {
+          reply(socket, overloadedFrame());
+        }
+      }, QUEUE_WAIT_DEADLINE_MS),
+    };
+    queue.push(entry);
+    queuedBySocket.set(socket, entry);
   }
 
   const bind = () =>
@@ -375,20 +539,35 @@ export async function serve(
         },
         drain(socket) {
           drainPending(socket);
+          exitIfDrained();
         },
         close(socket) {
           socketBuffers.delete(socket);
           pendingWrites.delete(socket);
+          // A queued client that hung up is settled here so its slot is
+          // never handed an execution; the ack-write failure would catch it
+          // anyway, but settling keeps the queue honest.
+          const entry = queuedBySocket.get(socket);
+          if (entry !== undefined) {
+            settleQueueEntry(entry);
+          }
+          exitIfDrained();
         },
         error(socket) {
           socketBuffers.delete(socket);
           pendingWrites.delete(socket);
+          const entry = queuedBySocket.get(socket);
+          if (entry !== undefined) {
+            settleQueueEntry(entry);
+          }
+          exitIfDrained();
         },
       },
     });
 
   try {
-    bind();
+    const listener = bind();
+    listenerStop = () => listener.stop();
     boundSocket = true;
   } catch {
     // The socket path exists. Either a live server owns it — this process is
@@ -416,9 +595,12 @@ export async function serve(
       process.exit(0);
     }
     await unlink(socketPath).catch(() => {});
-    bind();
+    const listener = bind();
+    listenerStop = () => listener.stop();
     boundSocket = true;
   }
+
+  armIdle();
 
   // The process stays alive on the event loop; exits go through exit() above.
   return new Promise<never>(() => {});

--- a/cli/dust-sandbox/src/commands/function/warm.rs
+++ b/cli/dust-sandbox/src/commands/function/warm.rs
@@ -49,6 +49,12 @@ pub const WARM_PROTOCOL_VERSION: u32 = 2;
 /// refused. On breach the stream is dropped, which closes the socket and
 /// makes the server's eventual ack write fail — so abandoning a wedged or
 /// queued server pre-ack can never race into a duplicate execution.
+///
+/// Accepted residual: an ack the server buffers within a hair of this
+/// deadline can go unread while the client walks away cold. The 2s server
+/// queue deadline keeps every normal ack far from this boundary; only a
+/// multi-second server-side stall (e.g. a gcsfuse stat hang) could put an
+/// ack near it, which is judged rare enough to accept.
 const WARM_FIRST_FRAME_TIMEOUT: Duration = Duration::from_secs(4);
 
 /// Ceiling on the wait for the outcome once the server acked. Generous on

--- a/cli/dust-sandbox/src/commands/function/warm.rs
+++ b/cli/dust-sandbox/src/commands/function/warm.rs
@@ -7,7 +7,14 @@
 //! socket and forwards invocations to it, so a repeat invocation costs one
 //! local socket round trip.
 //!
-//! Everything here is best-effort: any irregularity — missing socket, wrong
+//! The server runs invocations concurrently (protocol v2) and queues briefly
+//! when saturated, so overlapping calls of one function no longer fan out
+//! into cold runs. When the server refuses under saturation it answers with
+//! a structured `overloaded` outcome, which is delivered to the caller as
+//! the invocation's result — deliberately not a cold fallback, because
+//! unbounded cold runs under load are what would exhaust the sandbox.
+//!
+//! Everything else is best-effort: any irregularity — missing socket, wrong
 //! directory ownership, protocol mismatch, stale bundle — falls back to the
 //! cold path, which is exactly today's behavior. The warm path can only ever
 //! be a fast alternative, never a new failure mode.
@@ -34,12 +41,20 @@ use tokio::process::Command;
 
 use super::RUNNER_JS;
 
-pub const WARM_PROTOCOL_VERSION: u32 = 1;
+pub const WARM_PROTOCOL_VERSION: u32 = 2;
 
-/// Ceiling on how long the warm path waits for the server to answer before
-/// giving up. Generous on purpose: the function itself runs inside this
-/// window, and the caller (front) enforces the real invocation timeout by
-/// killing dsbx. This only bounds a wedged server.
+/// Bound on the wait for the server's first frame (ack or refusal). It must
+/// comfortably exceed the server's admission-queue deadline (~2s, see
+/// serve.ts): a queued request receives nothing until it is started or
+/// refused. On breach the stream is dropped, which closes the socket and
+/// makes the server's eventual ack write fail — so abandoning a wedged or
+/// queued server pre-ack can never race into a duplicate execution.
+const WARM_FIRST_FRAME_TIMEOUT: Duration = Duration::from_secs(4);
+
+/// Ceiling on the wait for the outcome once the server acked. Generous on
+/// purpose: the function itself runs inside this window, and the caller
+/// (front) enforces the real invocation timeout by killing dsbx. This only
+/// bounds a wedged server.
 const WARM_RESPONSE_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Connect timeout: the server is either listening or it is not.
@@ -55,22 +70,21 @@ struct WarmFrame {
     #[serde(default)]
     stale: bool,
     #[serde(default)]
-    busy: bool,
-    #[serde(default)]
     error: Option<String>,
 }
 
 /// The outcome of asking the warm server to run an invocation.
 pub enum WarmRun {
-    /// The server ran the function; this is the runner `Output` JSON. Also
-    /// carries the synthesized failure outcome when the server acked (the
-    /// function started executing) but the outcome was lost: past the ack the
-    /// cold path is off the table, because re-running a function that may
-    /// already have fired its side effects is worse than failing the
-    /// invocation.
+    /// The server produced this runner `Output` JSON: a served invocation, a
+    /// pre-execution classification (`bad_input`, `overloaded` — delivered as
+    /// the result, never retried cold), or the synthesized failure outcome
+    /// when the server acked (the function started executing) but the outcome
+    /// was lost: past the ack the cold path is off the table, because
+    /// re-running a function that may already have fired its side effects is
+    /// worse than failing the invocation.
     Outcome(serde_json::Value),
-    /// No usable warm server (not running, busy, stale bundle, protocol
-    /// mismatch, ownership refusal...). Nothing executed; run cold.
+    /// No usable warm server (not running, stale bundle, protocol mismatch,
+    /// ownership refusal, first frame overdue...). Nothing executed; run cold.
     Miss,
 }
 
@@ -192,12 +206,12 @@ pub async fn try_warm_run(name: &str, input: &str) -> WarmRun {
         _ => return WarmRun::Miss,
     };
 
-    match tokio::time::timeout(WARM_RESPONSE_TIMEOUT, roundtrip(stream, input)).await {
-        Ok(Ok(run)) => run,
-        // Pre-ack IO error or timeout: nothing executed, run cold. roundtrip
-        // itself converts post-ack losses into a failure Outcome.
-        _ => WarmRun::Miss,
-    }
+    // roundtrip owns its own timeouts: the first frame is bounded tightly
+    // (WARM_FIRST_FRAME_TIMEOUT), the post-ack outcome generously
+    // (WARM_RESPONSE_TIMEOUT). Any error is a pre-ack condition and a Miss
+    // (nothing executed); roundtrip converts post-ack losses into a failure
+    // Outcome itself.
+    roundtrip(stream, input).await.unwrap_or(WarmRun::Miss)
 }
 
 /// The outcome delivered when the server acked (execution started) but the
@@ -231,35 +245,50 @@ async fn roundtrip(mut stream: UnixStream, input: &str) -> Result<WarmRun> {
     });
     let mut line = serde_json::to_string(&request)?;
     line.push('\n');
-    stream.write_all(line.as_bytes()).await?;
-
-    let mut reader = BufReader::new(stream);
 
     // First frame: ack (execution starting), or a pre-execution refusal
-    // (busy, stale, protocol error) that safely sends the client cold.
-    let mut first = String::new();
-    if reader.read_line(&mut first).await? == 0 {
+    // (stale, overloaded, protocol error). The wait is bounded: the server
+    // may queue the request behind its concurrency cap, and a first frame
+    // that outlives the server's own queue deadline means a wedged server.
+    // Timing out here drops the stream, which closes the socket and makes
+    // the server's eventual ack write fail — nothing executes for us after
+    // we walk away, so the cold fallback below stays safe.
+    let first_frame = tokio::time::timeout(WARM_FIRST_FRAME_TIMEOUT, async {
+        stream.write_all(line.as_bytes()).await?;
+        let mut reader = BufReader::new(stream);
+        let mut first = String::new();
+        let read = reader.read_line(&mut first).await?;
+        Ok::<_, std::io::Error>((reader, first, read))
+    })
+    .await;
+    let (mut reader, first, read) = match first_frame {
+        Ok(Ok(parts)) => parts,
+        // Timeout or pre-ack IO error: nothing executed, run cold.
+        _ => return Ok(WarmRun::Miss),
+    };
+    if read == 0 {
         return Ok(WarmRun::Miss);
     }
     let frame: WarmFrame = serde_json::from_str(first.trim())?;
-    if frame.v != WARM_PROTOCOL_VERSION || frame.busy || frame.stale || frame.error.is_some() {
+    if frame.v != WARM_PROTOCOL_VERSION || frame.stale || frame.error.is_some() {
         return Ok(WarmRun::Miss);
     }
     if let Some(outcome) = frame.outcome {
         // Single-frame outcome: a pre-execution classification such as
-        // bad_input, delivered without an ack. Safe either way.
+        // bad_input or overloaded, delivered without an ack. Nothing
+        // executed, and the outcome is the invocation's result.
         return Ok(WarmRun::Outcome(outcome));
     }
     if !frame.ack {
         return Ok(WarmRun::Miss);
     }
 
-    // Past the ack: never Miss again. A lost or unparsable outcome frame is
-    // a failed invocation, not a cold retry.
+    // Past the ack: never Miss again. A lost, overdue or unparsable outcome
+    // frame is a failed invocation, not a cold retry.
     let mut second = String::new();
-    match reader.read_line(&mut second).await {
-        Ok(0) | Err(_) => return Ok(WarmRun::Outcome(lost_outcome_after_ack())),
-        Ok(_) => {}
+    match tokio::time::timeout(WARM_RESPONSE_TIMEOUT, reader.read_line(&mut second)).await {
+        Ok(Ok(0)) | Ok(Err(_)) | Err(_) => return Ok(WarmRun::Outcome(lost_outcome_after_ack())),
+        Ok(Ok(_)) => {}
     }
     match serde_json::from_str::<WarmFrame>(second.trim()) {
         Ok(WarmFrame {

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -96,6 +96,9 @@ export const SANDBOX_FUNCTION_RUNNER_ERROR_CODES = [
   "bad_return",
   "http_error",
   "invalid_output",
+  // Emitted by the warm server's admission layer when the function is at its
+  // concurrency limit and the invocation was refused before anything ran.
+  "overloaded",
 ] as const;
 
 // Codes minted by front, for failures that happen outside the runner and therefore have no


### PR DESCRIPTION
## Description

The per-function warm server serves one invocation at a time: overlapping calls get a busy reply and fall back to a cold run each (18% of runs in a real multi-user session), paying a fresh bun spawn and import under exactly the load where that hurts most.

This PR makes the server concurrent. Pod function calls are mostly IO-bound (SQL, API calls), so one bun process interleaves many of them on its event loop like a web server:

- Up to 32 invocations in flight, then a FIFO queue (128 max, 2s wait max), then a structured `overloaded` outcome. Refusing is deliberate: cold-run fan-out under saturation is what would OOM the sandbox. Front learns the `overloaded` code so it surfaces as itself.
- Caller identity rides the invocation context from the previous PR instead of a process.env swap, which is what makes concurrency safe. Concurrent requests with different users observe only their own env (pinned by test).
- The ack-before-execute contract is unchanged, and is why this stays a raw line protocol instead of moving behind an HTTP server: the ack is a synchronous socket write whose failure proves the client is gone, so an abandoned queued request can never race into a duplicate execution.
- Staleness, the lifetime cap, an RSS threshold and hung invocations now drain the server (stop listening, free the socket for the successor, finish in-flight work, exit) instead of killing it mid-flight. The client bounds its pre-ack wait at 4s (covering the 2s queue deadline); post-ack losses remain failed invocations, never re-runs.

v1 and v2 never talk to each other (version-suffixed socket names); the cold path covers the transition.

## Tests

bun, against the real server process: overlapping invocations complete concurrently (3x400ms in <1s), queueing serves once a slot frees, a queued request outwaiting the 2s deadline gets `overloaded` with no ack, concurrent invocations with different envs observe only their own across awaits, a stale-triggered drain lets in-flight work finish before exit. Cargo e2e against real bun covers the full miss/spawn/hit/republish cycle.

## Risk

Inert until the stack's dsbx release + image bump. One behavior delta vs v1: saturation yields `overloaded` outcomes instead of cold runs (intended; front surfaces it as a failed invocation).

## Deploy Plan

Ships with the stack (see the stack's last PR). Watch `sandbox.functions.run` by `runner_kind`: cold share under load should drop toward zero, with `overloaded` only under genuine saturation.