### PR TITLE
[dsbx] perf: content-addressed bundle cache, hash-addressed warm imports

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -326,6 +326,7 @@ dependencies = [
  "lru",
  "rcgen",
  "reqwest",
+ "ring",
  "rustix",
  "rustls",
  "rustls-native-certs",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -21,6 +21,8 @@ httparse = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
+# Already in the tree through rustls/rcgen; used directly for bundle hashing.
+ring = "0.17"
 rustix = { version = "1", features = ["process"] }
 rustls = { version = "0.23", features = ["ring"] }
 rustls-native-certs = "0.8"

--- a/cli/dust-sandbox/functions-runner/serve.test.ts
+++ b/cli/dust-sandbox/functions-runner/serve.test.ts
@@ -35,12 +35,16 @@ interface ServerHandle {
   socketPath: string;
 }
 
-async function startWorker(functionsDir: string): Promise<ServerHandle> {
+async function startWorker(
+  functionsDir: string,
+  env?: Record<string, string>
+): Promise<ServerHandle> {
   const socketPath = join(scratch(), "fn.sock");
   const proc = Bun.spawn(["bun", runner, "serve", functionsDir, socketPath], {
     stdin: "ignore",
     stdout: "ignore",
     stderr: "inherit",
+    ...(env === undefined ? {} : { env: { ...process.env, ...env } }),
   });
   // Wait for the socket to accept connections.
   const deadline = Date.now() + 10_000;
@@ -440,7 +444,7 @@ describe("runner serve", () => {
     }
   });
 
-  test("a mismatched hash on an imported bundle refuses as stale and drains", async () => {
+  test("a mismatched hash on an imported bundle refuses without draining when uncached", async () => {
     const { proc, socketPath } = await startWorker(fixturesDir);
     try {
       const served = await request(
@@ -449,6 +453,8 @@ describe("runner serve", () => {
       );
       expect(served.outcome?.ok).toBe(true);
 
+      // Republished but not yet in the cache: the client goes cold (which
+      // populates the cache), and the worker keeps serving everything else.
       const reply = await request(
         socketPath,
         warmRequest(
@@ -458,7 +464,71 @@ describe("runner serve", () => {
         )
       );
       expect(reply.stale).toBe(true);
-      expect(await proc.exited).toBe(0);
+
+      const alive = await request(
+        socketPath,
+        warmRequest("sleepy", {}, { url: "http://localhost/?delayMs=10" })
+      );
+      expect(alive.outcome?.ok).toBe(true);
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("a stamped republish is served from the bundle cache without recycling", async () => {
+    // The worker gets its own HOME so the test controls the cache dir.
+    const home = scratch();
+    const dir = scratch();
+    copyFileSync(join(fixturesDir, "hello.ts"), join(dir, "hello.ts"));
+    copyFileSync(join(fixturesDir, "sleepy.ts"), join(dir, "sleepy.ts"));
+    const { proc, socketPath } = await startWorker(dir, { HOME: home });
+    try {
+      // Warm both functions on the old versions.
+      const before = await request(
+        socketPath,
+        warmRequest("hello", {}, { url: "http://localhost/?name=v1" })
+      );
+      expect(before.outcome?.output).toEqual({ hello: "v1" });
+      await request(socketPath, sleepyRequest(10));
+
+      // "Republish" hello: a cold run would read the new bytes and populate
+      // the content-addressed cache. Simulate exactly that.
+      const republished =
+        "export default { async fetch() { return Response.json({ hello: 'republished' }); } };\n";
+      const newSha = new Bun.CryptoHasher("sha256")
+        .update(new TextEncoder().encode(republished))
+        .digest("hex");
+      const cacheDir = join(home, ".dust-fn", "bundles");
+      await Bun.write(join(cacheDir, `${newSha}.js`), republished);
+
+      // The stamped request is served from the cache: new version, fresh
+      // import, and nothing recycles.
+      const frames = await requestFrames(
+        socketPath,
+        warmRequest(
+          "hello",
+          {},
+          { url: "http://localhost/", bundleSha256: newSha }
+        )
+      );
+      expect(frames[1]?.outcome?.output).toEqual({ hello: "republished" });
+      expect(frames[1]?.importKind).toBe("fresh");
+
+      // Served from the module cache from now on.
+      const again = await requestFrames(
+        socketPath,
+        warmRequest(
+          "hello",
+          {},
+          { url: "http://localhost/", bundleSha256: newSha }
+        )
+      );
+      expect(again[1]?.importKind).toBe("cached");
+
+      // The sibling function never lost its warmth.
+      const sibling = await requestFrames(socketPath, sleepyRequest(10));
+      expect(sibling[1]?.outcome?.ok).toBe(true);
+      expect(sibling[1]?.importKind).toBe("cached");
     } finally {
       proc.kill();
     }

--- a/cli/dust-sandbox/functions-runner/serve.ts
+++ b/cli/dust-sandbox/functions-runner/serve.ts
@@ -35,14 +35,16 @@
 //
 // The worker is disposable. It exits on idle, and it drains (stops
 // listening, refuses its queue, lets in-flight invocations finish, then
-// exits) at the lifetime cap, when a bundle it imported goes stale (ES
-// modules cannot be evicted, so rebirth is the pruning mechanism), when its
+// exits) at the lifetime cap, when an unstamped request finds a bundle it
+// imported rewritten on disk (ES modules cannot be evicted, so rebirth is
+// the pruning mechanism there; stamped republishes instead import the new
+// version from the content-addressed cache, recycling nothing), when its
 // RSS crosses the recycle threshold, or when an invocation outlives its
 // deadline (whose client was killed by front's much shorter exec timeout
 // long ago).
 
 import { createHash } from "node:crypto";
-import { readdirSync, unlinkSync } from "node:fs";
+import { readdirSync, statSync, unlinkSync } from "node:fs";
 import { stat, unlink } from "node:fs/promises";
 import { join } from "node:path";
 
@@ -180,6 +182,35 @@ export function resolveBundle(
     return null;
   }
   return join(functionsDir, matches[0]!.name);
+}
+
+// Publish-time bundle hashes are lowercase hex sha256; anything else must
+// not touch the filesystem.
+const BUNDLE_SHA256_REGEX = /^[0-9a-f]{64}$/;
+
+/**
+ * Path of the locally cached copy of a bundle in the content-addressed cache
+ * shared with dsbx (`~/.dust-fn/bundles/<sha256>.js`, populated by cold runs
+ * from verified bytes — see warm.rs), when one exists. Same trust model as
+ * the socket this worker serves: the warm dir is 0700 and owned by this uid.
+ */
+export function cachedBundlePath(sha256: string): string | null {
+  if (!BUNDLE_SHA256_REGEX.test(sha256)) {
+    return null;
+  }
+  const home = process.env.HOME;
+  if (!home) {
+    return null;
+  }
+  const path = join(home, ".dust-fn", "bundles", `${sha256}.js`);
+  try {
+    if (!statSync(path).isFile()) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+  return path;
 }
 
 export function parseWarmRequest(line: string): WarmRequest | null {
@@ -475,6 +506,15 @@ export async function serve(
    * and whether this request paid (or joined) the import, or null after a
    * pre-ack `stale` reply was sent (the client re-runs cold, which reads the
    * bundle fresh and respawns a worker as needed).
+   *
+   * Stamped requests are served by content hash: the module cache is keyed
+   * by path, so importing a republished bundle from its content-addressed
+   * cache path (`bundles/<sha256>.js`, populated by cold runs) loads the new
+   * version alongside the old one — no recycle, and the worker's other
+   * bundles keep their warmth. The abandoned module lingers as unreachable
+   * memory until the routine RSS recycle, which is fine for dev-time-rate
+   * republishes. Only unstamped (legacy) staleness still drains the worker:
+   * same path, new bytes, and the old module cannot be evicted.
    */
   async function ensureBundle(
     socket: WarmSocket,
@@ -494,18 +534,66 @@ export async function serve(
       return null;
     };
 
+    /** Import the stamped bytes from the content-addressed cache, if the
+     * cold path has populated them. Immutable content: no stat, no
+     * staleness — the path IS the version. */
+    const importFromCache = async (
+      sha256: string
+    ): Promise<{ bundle: ImportedBundle; importKind: "fresh" } | null> => {
+      const cachePath = cachedBundlePath(sha256);
+      if (cachePath === null) {
+        return null;
+      }
+      const stamp = await statBundle(cachePath);
+      if (stamp === null) {
+        return null;
+      }
+      try {
+        // GEN10 exemption: like the fuse import below, the module to load
+        // is resolved at request time (here from a validated content hash);
+        // a literal specifier is structurally impossible.
+        await import(cachePath);
+      } catch {
+        // A bundle that fails to import still gets served: invoke() reports
+        // the import error as a structured outcome, exactly like a cold run.
+      }
+      const bundle: ImportedBundle = { handlerPath: cachePath, stamp, sha256 };
+      imported.set(request.name, bundle);
+      return { bundle, importKind: "fresh" };
+    };
+
     const existing = imported.get(request.name);
-    if (existing) {
-      // A republished bundle must never be served from the old import. One
-      // metadata call per request; any difference (or a vanished file), or a
-      // request stamped with a hash this import does not match, sends the
-      // client down the cold path — and recycles this worker, since the old
-      // module can never be evicted.
+
+    if (expectedSha256 !== undefined) {
+      // Stamped: the hash is authoritative, and content-addressing makes
+      // every check exact. Matching import -> serve it, no stat needed (the
+      // stamp says the caller wants exactly the bytes this import holds).
+      if (existing && existing.sha256 === expectedSha256) {
+        return { bundle: existing, importKind: "cached" };
+      }
+      // Republish (or first sight of this function): import the stamped
+      // version from the cache, next to whatever old import may exist.
+      const fromCache = await importFromCache(expectedSha256);
+      if (fromCache !== null) {
+        return fromCache;
+      }
+      if (existing) {
+        // Republished but not yet in the cache: refuse; the cold run reads
+        // the fuse fresh and populates the cache, and the next warm request
+        // imports it here. The old import stays valid for nothing, but
+        // draining over it would cost every other bundle's warmth.
+        return staleReply();
+      }
+      // Never imported and not cached: fall through to the fuse below.
+    } else if (existing) {
+      // Unstamped (legacy front): mtime/size against the path we imported
+      // is the only signal, and a mismatch can only be cured by rebirth.
+      // When the import came from the immutable cache path this stat can
+      // never fire; a mixed-front-version window during a rolling deploy
+      // could then serve an unstamped caller a superseded version, bounded
+      // by the lifetime cap. Accepted: fronts stamp everything post-deploy.
       const current = await statBundle(existing.handlerPath);
-      if (
-        !sameStamp(existing.stamp, current) ||
-        (expectedSha256 !== undefined && expectedSha256 !== existing.sha256)
-      ) {
+      if (!sameStamp(existing.stamp, current)) {
         return staleReply({ recycle: true });
       }
       return { bundle: existing, importKind: "cached" };

--- a/cli/dust-sandbox/src/commands/function/run.rs
+++ b/cli/dust-sandbox/src/commands/function/run.rs
@@ -52,23 +52,46 @@ pub async fn cmd_function_run(name: &str) -> Result<()> {
         );
     }
 
-    // Cold path. Resolve once: the run below needs the handler path, and
-    // resolution lists the (gcsfuse-backed) functions directory.
-    let (spawned, resolved) = match resolve_existing(name) {
+    // Cold path. A stamped invocation whose bundle already sits in the local
+    // content-addressed cache runs from the cached copy, skipping the
+    // gcsfuse-backed functions dir entirely (both the resolution readdir and
+    // the bundle read) — the dominant cost of a first invocation. The cache
+    // key is the publish-time hash, so it can never serve a republished
+    // function's old bytes. A cache hit also skips resolve_existing's
+    // existence check, so an invocation stamped just before its function was
+    // deleted can still execute: acceptable, front only stamps invocations
+    // for functions that exist at dispatch time, and that window is the one
+    // in-flight request. Everything else resolves as before.
+    let stamped_sha256 = stamped_bundle_sha256(&input);
+    let resolved = match stamped_sha256
+        .as_deref()
+        .filter(|_| super::is_valid_name(name))
+        .and_then(warm::cached_bundle_path)
+    {
+        Some(cached) => Ok(cached),
+        None => resolve_existing(name),
+    };
+    let (spawned, handler) = match resolved {
         Ok(handler) => {
             let spawned = spawn_function_at(&handler, "run", Some(&input), true).await;
-            (spawned, true)
+            (spawned, Some(handler))
         }
         // resolve_existing already emitted the `{error}` line; the message
         // (bad name, unset dir, missing or ambiguous bundle) propagates.
-        Err(e) => (Err(e), false),
+        Err(e) => (Err(e), None),
     };
     let runner_ms = started.elapsed().as_millis() as u64;
 
-    // Leave a warm worker on this function's home slot so the next
-    // invocation of this function (or its app) skips the spawn.
-    // Fire-and-forget; never affects this run's outcome.
-    if resolved {
+    if let Some(handler) = &handler {
+        // Cache the bundle this run just read so the next cold run of this
+        // publish skips gcsfuse. No-op when the run already came from the
+        // cache. Best-effort; never affects this run's outcome.
+        if let Some(sha256) = stamped_sha256.as_deref() {
+            warm::populate_bundle_cache(handler, sha256);
+        }
+        // Leave a warm worker on this function's home slot so the next
+        // invocation of this function (or its app) skips the spawn.
+        // Fire-and-forget; never affects this run's outcome.
         warm::spawn_worker(name);
     }
 
@@ -81,6 +104,14 @@ pub async fn cmd_function_run(name: &str) -> Result<()> {
             import_kind: None,
         },
     )
+}
+
+/// The publish-time bundle hash front stamps into the request envelope, when
+/// present. Extraction only — `cached_bundle_path` and
+/// `populate_bundle_cache` validate the value before it touches any path.
+fn stamped_bundle_sha256(input: &str) -> Option<String> {
+    let envelope: serde_json::Value = serde_json::from_str(input).ok()?;
+    Some(envelope.get("bundleSha256")?.as_str()?.to_string())
 }
 
 fn deliver_stdout(spawned: Result<(i32, Option<String>)>, timings_ms: TimingsMs) -> ! {
@@ -224,5 +255,16 @@ mod tests {
     fn last_non_empty_line_skips_trailing_blank_lines() {
         assert_eq!(last_non_empty_line("a\n\n"), "a");
         assert_eq!(last_non_empty_line("   \n"), "");
+    }
+
+    #[test]
+    fn stamped_bundle_sha256_extracts_only_a_string_stamp() {
+        assert_eq!(
+            stamped_bundle_sha256(r#"{"url":"http://x/","bundleSha256":"abc123"}"#),
+            Some("abc123".to_string())
+        );
+        assert_eq!(stamped_bundle_sha256(r#"{"url":"http://x/"}"#), None);
+        assert_eq!(stamped_bundle_sha256(r#"{"bundleSha256":42}"#), None);
+        assert_eq!(stamped_bundle_sha256("not json"), None);
     }
 }

--- a/cli/dust-sandbox/src/commands/function/warm.rs
+++ b/cli/dust-sandbox/src/commands/function/warm.rs
@@ -221,6 +221,123 @@ fn stage_runner(dir: &Path) -> Result<PathBuf> {
     Ok(path)
 }
 
+/// How long an unused cached bundle survives before opportunistic pruning
+/// removes it. Content-addressed entries never go stale, only unused: a
+/// republish changes the stamped hash, so old entries simply stop being
+/// looked up.
+const BUNDLE_CACHE_MAX_AGE: Duration = Duration::from_secs(7 * 24 * 3600);
+
+/// A stamped bundle hash is exactly the lowercase hex sha256 front computes
+/// at publish time; anything else must not touch the filesystem.
+fn is_valid_bundle_sha256(sha256: &str) -> bool {
+    sha256.len() == 64
+        && sha256
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+fn bundle_cache_dir() -> Option<PathBuf> {
+    // Same trust model as the rest of the warm dir (and the same root
+    // refusal): only the invoking unprivileged user can write here, so a
+    // cached bundle is exactly what this user previously read and verified.
+    if rustix::process::geteuid().is_root() {
+        return None;
+    }
+    let dir = ensure_trusted_warm_dir()?.join("bundles");
+    let mut builder = std::fs::DirBuilder::new();
+    builder.mode(0o700);
+    match builder.create(&dir) {
+        Ok(()) => {}
+        Err(e) if e.kind() == ErrorKind::AlreadyExists => {}
+        Err(_) => return None,
+    }
+    Some(dir)
+}
+
+/// Path of the locally cached copy of the bundle whose publish-time sha256 is
+/// `sha256`, when one exists. A hit means the cold run can skip the
+/// gcsfuse-backed functions dir entirely — both the resolution readdir and
+/// the bundle read — which is the dominant cost of a first invocation. The
+/// cache can never serve a stale bundle: a republish changes the stamped
+/// hash, which is the lookup key.
+pub fn cached_bundle_path(sha256: &str) -> Option<PathBuf> {
+    if !is_valid_bundle_sha256(sha256) {
+        return None;
+    }
+    let path = bundle_cache_dir()?.join(format!("{sha256}.js"));
+    if std::fs::metadata(&path)
+        .map(|m| m.is_file())
+        .unwrap_or(false)
+    {
+        Some(path)
+    } else {
+        None
+    }
+}
+
+/// Copies `handler` (just read from the functions dir) into the cache under
+/// its stamped hash, so the next cold run of this publish skips gcsfuse.
+/// Best-effort and silent: a failed populate only means the next run stays
+/// on today's path. The bytes are re-hashed before caching — when gcsfuse
+/// caching serves bytes older than the stamp, caching them under the stamp
+/// would wrongly pin the stale version, so a mismatch caches nothing.
+pub fn populate_bundle_cache(handler: &Path, sha256: &str) {
+    if !is_valid_bundle_sha256(sha256) {
+        return;
+    }
+    let Some(dir) = bundle_cache_dir() else {
+        return;
+    };
+    let target = dir.join(format!("{sha256}.js"));
+    if std::fs::metadata(&target).is_ok() {
+        return;
+    }
+    let Ok(bytes) = std::fs::read(handler) else {
+        return;
+    };
+    let digest = ring::digest::digest(&ring::digest::SHA256, &bytes);
+    let actual: String = digest.as_ref().iter().map(|b| format!("{b:02x}")).collect();
+    if actual != sha256 {
+        return;
+    }
+    // Write-then-rename so a concurrent dsbx never observes (or imports) a
+    // half-written bundle.
+    let tmp = dir.join(format!("{sha256}.js.tmp-{}", std::process::id()));
+    if std::fs::write(&tmp, &bytes).is_err() {
+        return;
+    }
+    let _ = std::fs::rename(&tmp, &target);
+    // A populate happens once per publish per sandbox: cheap enough a spot
+    // to keep the cache bounded.
+    prune_bundle_cache(&dir, BUNDLE_CACHE_MAX_AGE);
+}
+
+/// Removes cache entries whose mtime is older than `max_age`. Best-effort.
+fn prune_bundle_cache(dir: &Path, max_age: Duration) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let now = std::time::SystemTime::now();
+    for entry in entries.flatten() {
+        let Ok(meta) = entry.metadata() else {
+            continue;
+        };
+        if !meta.is_file() {
+            continue;
+        }
+        let Ok(modified) = meta.modified() else {
+            continue;
+        };
+        if now
+            .duration_since(modified)
+            .map(|age| age > max_age)
+            .unwrap_or(false)
+        {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
 /// Tries to run `input` (the raw stdin envelope) against the warm worker on
 /// `name`'s home slot. Never errors: every failure is a `Miss`.
 pub async fn try_warm_run(name: &str, input: &str) -> WarmRun {
@@ -643,5 +760,103 @@ mod tests {
             .map(|name| preferred_slot(name))
             .collect();
         assert!(slots.len() > 1);
+    }
+
+    fn sha256_hex(bytes: &[u8]) -> String {
+        ring::digest::digest(&ring::digest::SHA256, bytes)
+            .as_ref()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect()
+    }
+
+    #[test]
+    fn bundle_cache_populates_and_serves_matching_bytes() {
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
+        let original_home = std::env::var_os("HOME");
+        let home = tempfile::tempdir().expect("home tempdir");
+        std::env::set_var("HOME", home.path());
+
+        let bundle_dir = tempfile::tempdir().expect("bundle tempdir");
+        let handler = bundle_dir.path().join("greet.ts");
+        std::fs::write(&handler, b"export default {};").expect("bundle");
+        let sha256 = sha256_hex(b"export default {};");
+
+        assert!(cached_bundle_path(&sha256).is_none());
+        populate_bundle_cache(&handler, &sha256);
+        let cached = cached_bundle_path(&sha256).expect("cache hit after populate");
+        assert_eq!(
+            std::fs::read(&cached).expect("cached bytes"),
+            b"export default {};"
+        );
+
+        restore_env("HOME", original_home);
+    }
+
+    #[test]
+    fn bundle_cache_refuses_bytes_that_do_not_match_the_stamp() {
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
+        let original_home = std::env::var_os("HOME");
+        let home = tempfile::tempdir().expect("home tempdir");
+        std::env::set_var("HOME", home.path());
+
+        let bundle_dir = tempfile::tempdir().expect("bundle tempdir");
+        let handler = bundle_dir.path().join("greet.ts");
+        std::fs::write(&handler, b"current bytes").expect("bundle");
+
+        // The gcsfuse-served-stale-bytes case: the stamp describes different
+        // content than what was read, so nothing may be cached under it.
+        let stamp_of_other_bytes = sha256_hex(b"republished bytes");
+        populate_bundle_cache(&handler, &stamp_of_other_bytes);
+        assert!(cached_bundle_path(&stamp_of_other_bytes).is_none());
+
+        restore_env("HOME", original_home);
+    }
+
+    #[test]
+    fn bundle_cache_refuses_malformed_hashes() {
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
+        let original_home = std::env::var_os("HOME");
+        let home = tempfile::tempdir().expect("home tempdir");
+        std::env::set_var("HOME", home.path());
+
+        for bad in [
+            "",
+            "short",
+            &"Z".repeat(64),
+            &"A".repeat(64), // uppercase hex is not what front stamps
+            "../../../../etc/passwd\0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ] {
+            assert!(cached_bundle_path(bad).is_none());
+            // Must also not create anything on disk.
+            populate_bundle_cache(Path::new("/nonexistent"), bad);
+        }
+        assert!(
+            !home.path().join(".dust-fn/bundles").exists() || {
+                std::fs::read_dir(home.path().join(".dust-fn/bundles"))
+                    .map(|entries| entries.count() == 0)
+                    .unwrap_or(true)
+            }
+        );
+
+        restore_env("HOME", original_home);
+    }
+
+    #[test]
+    fn bundle_cache_prunes_old_entries_only() {
+        let dir = tempfile::tempdir().expect("cache tempdir");
+        let old = dir.path().join("old.js");
+        let fresh = dir.path().join("fresh.js");
+        std::fs::write(&old, b"old").expect("old");
+        std::fs::write(&fresh, b"fresh").expect("fresh");
+        std::thread::sleep(Duration::from_millis(20));
+
+        // Everything written before the sleep is older than 1ms; a 7-day
+        // horizon keeps both.
+        prune_bundle_cache(dir.path(), BUNDLE_CACHE_MAX_AGE);
+        assert!(old.exists() && fresh.exists());
+
+        prune_bundle_cache(dir.path(), Duration::from_millis(1));
+        assert!(!old.exists() && !fresh.exists());
     }
 }


### PR DESCRIPTION
## Description

Front stamps every invocation with the publish-time bundle sha256. This PR turns that stamp into a content-addressed local cache (`~/.dust-fn/bundles/<sha256>.js`) with two payoffs:

- Cold runs: a stamped invocation whose bundle is cached skips the gcsfuse readdir and read entirely, the dominant cost of a first invocation. Population happens after a resolved cold run and re-hashes the bytes it just read, so gcsfuse serving stale bytes cannot pin the stale version under the new hash. Entries unused for 7 days are pruned. The fuse mount's deliberate no-cache config stays untouched.
- Warm republishes stop recycling workers: the module cache is keyed by path, so importing a republished bundle from its cache path loads the new version alongside the old module. The worker's other bundles (the rest of the app) keep their warmth; the abandoned module lingers until the routine RSS recycle. A stamped mismatch with no cache entry refuses without draining: the cold run populates the cache and the next warm request imports it. Only unstamped legacy staleness still drains.

Correct by construction: the cache key is the publish-time hash, so a republish (new hash) can never be served old bytes.

## Tests

Cargo: populate/lookup roundtrip, refusal of bytes not matching the stamp, malformed and path-traversal hashes touch nothing on disk, prune removes only old entries. bun, against the real worker: a stamped republish is served from the cache with a fresh import while the sibling function stays warm and nothing exits; a stamped mismatch without a cache entry refuses and the worker keeps serving.

## Risk

Best-effort everywhere: any cache irregularity falls back to today's fuse path. Disk bounded by pruning and one entry per publish; abandoned modules from republishes are bounded by the RSS recycle.

## Deploy Plan

Ships with the stack (see #30235).