### PR TITLE
[viz] fix: prevent empty pages in slideshow PDF exports

### DIFF
--- a/viz/components/dust/slideshow/v2/index.tsx
+++ b/viz/components/dust/slideshow/v2/index.tsx
@@ -15,10 +15,11 @@ export function Slide({ children, className }: SlideProps) {
   return (
     <div
       className={cn(
+        // relative keeps absolutely positioned content scoped to its slide during PDF export.
         // [&>*]:min-h-0 overrides the default flex-item `min-height: auto` so  that LLM-generated
         // children with tall intrinsic heights (e.g. an SVG with height="2147") shrink to fit the
         // slide instead of overflowing.
-        "w-full h-full flex flex-col items-center justify-center overflow-hidden p-4 [&>*]:min-h-0",
+        "relative w-full h-full flex flex-col items-center justify-center overflow-hidden p-4 [&>*]:min-h-0",
         className
       )}
     >


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9974.

In the issue there's a Frame that breaks when exported: we only see the first and last slides, the other ones are empty (just have the background color).
The Frame is available in a conversation linked in the issue.

Here's my understanding of the problem: the slides in the Frame use `position: absolute; inset: 0`, during the PDF export we render all the slides inside one tall visualization document. Because the `Slide` component was not positioned, the content that is absolutely positioned is positioned relatively to the overall document rather than within its own slide.

This PR fixes that by making each `Slide` a positioning context. If smth is absolutely positioned, it is now only done so  within its own slide, which should not change anything for the preview because we see one slide at a time, and fixes the PDF export.

## Tests

Reproduced locally with the Frame found in the issue (bundled the frame with `esbuild` after inlining the components from v2 slideshow in one big js file, ran gotenberg locally and curled it directly).

## Risk

- Low.

## Deploy Plan

- Deploy viz.
