### PR TITLE
[front] fix: hide agent model names in Manage Agents on smaller tables

### DIFF
--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -196,14 +196,19 @@ const getTableColumns = ({
             tooltipTriggerAsChild
             label={modelName}
             trigger={
-              <DataTable.CellContent
-                disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
-                icon={modelIcon}
-                iconClassName="mr-0 @xl:mr-2"
-              >
-                <span className="hidden @xl:inline">{modelName}</span>
-                {!modelIcon && <span className="@xl:hidden">-</span>}
-              </DataTable.CellContent>
+              <div className="inline-flex">
+                <DataTable.CellContent
+                  disabled={isDisabled(
+                    info.row.original.canArchive,
+                    isBatchEdit
+                  )}
+                  icon={modelIcon}
+                  iconClassName="mr-0 @xl:mr-2"
+                >
+                  <span className="hidden @xl:inline">{modelName}</span>
+                  {!modelIcon && <span className="@xl:hidden">-</span>}
+                </DataTable.CellContent>
+              </div>
             }
           />
         );

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -187,16 +187,30 @@ const getTableColumns = ({
     {
       header: "Model",
       accessorKey: "model",
-      cell: (info: CellContext<RowData, string>) => (
-        <DataTable.CellContent
-          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
-          icon={info.row.original.modelIcon}
-        >
-          {info.getValue() || "-"}
-        </DataTable.CellContent>
-      ),
+      cell: (info: CellContext<RowData, string>) => {
+        const modelName = info.getValue() || "-";
+        const modelIcon = info.row.original.modelIcon;
+
+        return (
+          <Tooltip
+            tooltipTriggerAsChild
+            label={modelName}
+            trigger={
+              <DataTable.CellContent
+                className="justify-center @xl:justify-start"
+                disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+                icon={modelIcon}
+                iconClassName="mr-0 @xl:mr-2"
+              >
+                <span className="hidden @xl:inline">{modelName}</span>
+                {!modelIcon && <span className="@xl:hidden">-</span>}
+              </DataTable.CellContent>
+            }
+          />
+        );
+      },
       meta: {
-        className: "hidden @sm:w-48 @sm:table-cell",
+        className: "hidden @sm:w-20 @sm:table-cell @xl:w-48",
       },
     },
     {

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -197,7 +197,6 @@ const getTableColumns = ({
             label={modelName}
             trigger={
               <DataTable.CellContent
-                className="justify-center @xl:justify-start"
                 disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
                 icon={modelIcon}
                 iconClassName="mr-0 @xl:mr-2"


### PR DESCRIPTION
## Description

On laptop-sized screens, model names take too much space in the Manage Agents table and become hard to read.

The Model column now shows only the provider icon while the table is narrow, with the full model name available on hover. The inline name returns on wider tables, and the existing mobile behavior remains unchanged.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
