### PR TITLE
[MCP] Add Shopify internal MCP server (preview)

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2133,6 +2133,24 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "toolCostCategory": "advanced",
     },
   },
+  "shopify": {
+    "export_customer_ltv": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "export_products": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "export_sales": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "export_top_customers_by_period": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+  },
   "skill_authoring": {
     "create_skill": {
       "freeUsage": true,
@@ -3286,6 +3304,12 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_incident": "never_ask",
     "list_incidents": "never_ask",
     "update_incident": "low",
+  },
+  "shopify": {
+    "export_customer_ltv": "never_ask",
+    "export_products": "never_ask",
+    "export_sales": "never_ask",
+    "export_top_customers_by_period": "never_ask",
   },
   "skill_authoring": {
     "create_skill": "high",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1280,7 +1280,7 @@ export const INTERNAL_MCP_SERVERS = ensureUniqueToolNames({
     metadata: SERVICENOW_SERVER,
   },
   shopify: {
-    id: 1044,
+    id: 1046,
     availability: "manual",
     allowMultipleInstances: true,
     isRestricted: ({ featureFlags }) => {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -79,6 +79,7 @@ import {
 import { SANDBOX_FUNCTIONS_SERVER } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 import { SEARCH_SERVER } from "@app/lib/api/actions/servers/search/metadata";
 import { SERVICENOW_SERVER } from "@app/lib/api/actions/servers/servicenow/metadata";
+import { SHOPIFY_SERVER } from "@app/lib/api/actions/servers/shopify/metadata";
 import { SKILL_AUTHORING_SERVER } from "@app/lib/api/actions/servers/skill_authoring/metadata";
 import { SKILL_MANAGEMENT_SERVER } from "@app/lib/api/actions/servers/skill_management/metadata";
 import { SLAB_SERVER } from "@app/lib/api/actions/servers/slab/metadata";
@@ -212,6 +213,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "salesforce",
   "salesloft",
   "servicenow",
+  "shopify",
   "slab",
   "slack",
   "slack_bot",
@@ -1276,6 +1278,22 @@ export const INTERNAL_MCP_SERVERS = ensureUniqueToolNames({
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     metadata: SERVICENOW_SERVER,
+  },
+  shopify: {
+    id: 1044,
+    availability: "manual",
+    allowMultipleInstances: true,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("shopify_tool");
+    },
+    isPreview: true,
+    // Pilot (phase 1): no OAuth provider yet. The merchant token is provided as
+    // a bearer token and the shop domain as an `X-Shopify-Shop` custom header.
+    requiresBearerToken: true,
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    metadata: SHOPIFY_SERVER,
   },
   user_memory: {
     id: 1043,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1287,8 +1287,8 @@ export const INTERNAL_MCP_SERVERS = ensureUniqueToolNames({
       return !featureFlags.includes("shopify_tool");
     },
     isPreview: true,
-    // Pilot (phase 1): no OAuth provider yet. The merchant token is provided as
-    // a bearer token and the shop domain as an `X-Shopify-Shop` custom header.
+    // no Shopify OAuth provider yet (preview), so auth uses requiresBearerToken
+    // (we are using an access token from a client as bearer + shop domain via X-Shopify-Shop header)
     requiresBearerToken: true,
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,

--- a/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
+++ b/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
@@ -86,6 +86,6 @@
     { "name": "clari_copilot", "id": 1030 },
     { "name": "workday", "id": 1038 },
     { "name": "servicenow", "id": 1042 },
-    { "name": "shopify", "id": 1044 }
+    { "name": "shopify", "id": 1046 }
   ]
 }

--- a/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
+++ b/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
@@ -85,6 +85,7 @@
     { "name": "poke", "id": 1027 },
     { "name": "clari_copilot", "id": 1030 },
     { "name": "workday", "id": 1038 },
-    { "name": "servicenow", "id": 1042 }
+    { "name": "servicenow", "id": 1042 },
+    { "name": "shopify", "id": 1044 }
   ]
 }

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -67,6 +67,7 @@ import { default as sandboxServer } from "@app/lib/api/actions/servers/sandbox";
 import { default as sandboxFunctionsServer } from "@app/lib/api/actions/servers/sandbox_functions";
 import { default as searchServer } from "@app/lib/api/actions/servers/search";
 import { default as servicenowServer } from "@app/lib/api/actions/servers/servicenow";
+import { default as shopifyServer } from "@app/lib/api/actions/servers/shopify";
 import { default as skillAuthoringServer } from "@app/lib/api/actions/servers/skill_authoring";
 import { default as skillManagementServer } from "@app/lib/api/actions/servers/skill_management";
 import { default as slabServer } from "@app/lib/api/actions/servers/slab";
@@ -210,6 +211,8 @@ export async function getInternalMCPServer(
       return databricksServer(auth, toolContext);
     case "servicenow":
       return servicenowServer(auth, toolContext);
+    case "shopify":
+      return shopifyServer(auth, toolContext);
     case "jira":
       return jiraServer(auth, toolContext);
     case "luma":

--- a/front/lib/api/actions/servers/shopify/helpers.ts
+++ b/front/lib/api/actions/servers/shopify/helpers.ts
@@ -1,0 +1,3 @@
+// Hard cap on exported records to keep responses and API usage bounded. The
+// export helpers that enforce it land in a follow-up PR.
+export const MAX_EXPORT_ITEMS = 1_000;

--- a/front/lib/api/actions/servers/shopify/index.ts
+++ b/front/lib/api/actions/servers/shopify/index.ts
@@ -1,0 +1,24 @@
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { ToolContext } from "@app/lib/actions/types";
+import { SHOPIFY_SERVER_NAME } from "@app/lib/api/actions/servers/shopify/metadata";
+import { TOOLS } from "@app/lib/api/actions/servers/shopify/tools";
+import type { Authenticator } from "@app/lib/auth";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+function createServer(
+  auth: Authenticator,
+  toolContext?: ToolContext
+): McpServer {
+  const server = makeInternalMCPServer(SHOPIFY_SERVER_NAME);
+
+  for (const tool of TOOLS) {
+    registerTool(auth, toolContext, server, tool, {
+      monitoringName: SHOPIFY_SERVER_NAME,
+    });
+  }
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/actions/servers/shopify/metadata.ts
+++ b/front/lib/api/actions/servers/shopify/metadata.ts
@@ -46,9 +46,9 @@ export const SHOPIFY_TOOLS_METADATA = [
         .boolean()
         .optional()
         .describe(
-          "Rank customers by lifetime amount spent, highest first (default: true). Exact for up to 1000 customers; use minAmountSpent to narrow beyond that."
+          "Rank customers by lifetime amount spent, highest first (default: true). Exact for up to 1000 customers; use minAmountSpentDollars to narrow beyond that."
         ),
-      minAmountSpent: z
+      minAmountSpentDollars: z
         .number()
         .nonnegative()
         .optional()

--- a/front/lib/api/actions/servers/shopify/metadata.ts
+++ b/front/lib/api/actions/servers/shopify/metadata.ts
@@ -1,0 +1,147 @@
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { z } from "zod";
+
+export const SHOPIFY_SERVER_NAME = "shopify" as const;
+
+const limitSchema = (noun: string) =>
+  z
+    .number()
+    .int()
+    .positive()
+    .max(1000)
+    .optional()
+    .describe(`Maximum number of ${noun} to return (max 1000).`);
+
+export const SHOPIFY_TOOLS_METADATA = [
+  {
+    name: "export_products",
+    description:
+      "Export the Shopify product catalog with title, status, vendor, type, inventory, and price range.",
+    schema: {
+      status: z
+        .enum(["ACTIVE", "DRAFT", "ARCHIVED"])
+        .optional()
+        .describe("Filter by product status."),
+      vendor: z.string().optional().describe("Filter by exact vendor name."),
+      searchQuery: z
+        .string()
+        .optional()
+        .describe("Free text search over the catalog (title, SKU, tag)."),
+      limit: limitSchema("products"),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Exporting Shopify products",
+      done: "Export Shopify products",
+    },
+    toolCostCategory: "advanced",
+    freeUsage: false,
+  },
+  {
+    name: "export_customer_ltv",
+    description:
+      "Export customer lifetime value: total amount spent and order count per customer, identified by ID.",
+    schema: {
+      sortByAmountSpent: z
+        .boolean()
+        .optional()
+        .describe(
+          "Rank customers by lifetime amount spent, highest first (default: true). Exact for up to 1000 customers; use minAmountSpent to narrow beyond that."
+        ),
+      minAmountSpent: z
+        .number()
+        .nonnegative()
+        .optional()
+        .describe(
+          "Keep only customers whose lifetime spend is at least this amount, in store currency."
+        ),
+      limit: limitSchema("customers"),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Exporting Shopify customer LTV",
+      done: "Export Shopify customer LTV",
+    },
+    toolCostCategory: "advanced",
+    freeUsage: false,
+  },
+  {
+    name: "export_sales",
+    description:
+      "Export Shopify orders for a date range, with totals, taxes, and payment and fulfillment status. Without the read_all_orders scope, only the last 60 days are available.",
+    schema: {
+      startDate: z
+        .string()
+        .optional()
+        .describe("ISO 8601 lower bound for order creation date (inclusive)."),
+      endDate: z
+        .string()
+        .optional()
+        .describe("ISO 8601 upper bound for order creation date (inclusive)."),
+      financialStatus: z
+        .enum([
+          "PAID",
+          "PENDING",
+          "AUTHORIZED",
+          "PARTIALLY_PAID",
+          "PARTIALLY_REFUNDED",
+          "REFUNDED",
+          "VOIDED",
+          "EXPIRED",
+        ])
+        .optional()
+        .describe("Filter by payment status."),
+      fulfillmentStatus: z
+        .enum(["UNFULFILLED", "FULFILLED", "PARTIAL", "SCHEDULED", "ON_HOLD"])
+        .optional()
+        .describe("Filter by fulfillment status."),
+      limit: limitSchema("orders"),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Exporting Shopify sales",
+      done: "Export Shopify sales",
+    },
+    toolCostCategory: "advanced",
+    freeUsage: false,
+  },
+  {
+    name: "export_top_customers_by_period",
+    description:
+      "Rank the top customers by total spend over a date range, aggregated from their orders. Without the read_all_orders scope, only the last 60 days are available.",
+    schema: {
+      startDate: z
+        .string()
+        .optional()
+        .describe("ISO 8601 lower bound for order creation date (inclusive)."),
+      endDate: z
+        .string()
+        .optional()
+        .describe("ISO 8601 upper bound for order creation date (inclusive)."),
+      limit: limitSchema("customers"),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Ranking Shopify top customers",
+      done: "Rank Shopify top customers",
+    },
+    toolCostCategory: "advanced",
+    freeUsage: false,
+  },
+] as const;
+
+export const SHOPIFY_SERVER = {
+  serverInfo: {
+    name: SHOPIFY_SERVER_NAME,
+    version: "1.0.0",
+    description:
+      "Export product catalog, customer lifetime value, and sales data from a Shopify store.",
+    // Pilot (phase 1) uses a merchant-provided token injected via authInfo; no
+    // Dust OAuth provider yet. Phase 2 will set
+    // `authorization: { provider: "shopify", supported_use_cases: [...] }`.
+    authorization: null,
+    icon: "ActionTableIcon",
+    documentationUrl: null,
+  },
+  tools: SHOPIFY_TOOLS_METADATA,
+} as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/shopify/tools/index.ts
+++ b/front/lib/api/actions/servers/shopify/tools/index.ts
@@ -1,0 +1,19 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { SHOPIFY_TOOLS_METADATA } from "@app/lib/api/actions/servers/shopify/metadata";
+import { Err } from "@app/types/shared/result";
+
+// Tool contracts are registered here; the implementations land in a follow-up
+// PR. Until then every handler returns a not-implemented error.
+const notImplemented = () =>
+  Promise.resolve(new Err(new MCPError("Shopify tool not yet implemented.")));
+
+const handlers: ToolHandlers<typeof SHOPIFY_TOOLS_METADATA> = {
+  export_products: notImplemented,
+  export_customer_ltv: notImplemented,
+  export_sales: notImplemented,
+  export_top_customers_by_period: notImplemented,
+};
+
+export const TOOLS = buildTools(SHOPIFY_TOOLS_METADATA, handlers);

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -204,6 +204,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "ServiceNow MCP tool",
     stage: "on_demand",
   },
+  shopify_tool: {
+    description: "Shopify MCP tool",
+    stage: "on_demand",
+  },
   workday_mcp: {
     description: "Workday MCP tool",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -786,6 +786,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "sandbox_functions"
   | "self_created_slack_app_connector_rollout"
   | "servicenow_tool"
+  | "shopify_tool"
   | "show_debug_tools"
   | "slack_enhanced_default_agent"
   | "slack_message_splitting"


### PR DESCRIPTION
## Description

Register a Shopify internal MCP server behind the `shopify_tool` feature flag (`isPreview`, no OAuth yet, uses a merchant-provided token). This PR is the scaffolding only: tool contracts (metadata), server registration, and the feature flag. Every tool handler is a not-implemented stub; the implementations land in a follow-up PR.

## Tests

Manual, against a real Shopify store.

## Risk

Low. Gated behind shopify_tool.

## Deploy Plan

