### PR TITLE
[front] fix: compact Manage Agents actions on mobile

### DIFF
--- a/front/components/assistant/CreateDropdown.tsx
+++ b/front/components/assistant/CreateDropdown.tsx
@@ -27,11 +27,13 @@ import { useState } from "react";
 interface CreateDropdownProps {
   owner: LightWorkspaceType;
   dataGtmLocation: string;
+  isCompact?: boolean;
 }
 
 export const CreateDropdown = ({
   owner,
   dataGtmLocation,
+  isCompact = false,
 }: CreateDropdownProps) => {
   const router = useAppRouter();
   const [isLoading, setIsLoading] = useState(false);
@@ -59,7 +61,8 @@ export const CreateDropdown = ({
         <Button
           variant="primary"
           icon={Plus}
-          label="Create"
+          label={isCompact ? undefined : "Create"}
+          tooltip={isCompact ? "Create" : undefined}
           data-gtm-label="assistantCreationButton"
           data-gtm-location={dataGtmLocation}
           onClick={withTracking(TRACKING_AREAS.BUILDER, "create_menu")}

--- a/front/components/assistant/ModelsFilterMenu.tsx
+++ b/front/components/assistant/ModelsFilterMenu.tsx
@@ -17,16 +17,18 @@ export type AgentModelFilterType = {
   displayName: string;
 };
 
-type ModelsFilterMenuProps = {
+interface ModelsFilterMenuProps {
   models: AgentModelFilterType[];
   selectedModels: AgentModelFilterType[];
   setSelectedModels: (models: AgentModelFilterType[]) => void;
-};
+  isCompact?: boolean;
+}
 
 export const ModelsFilterMenu = ({
   models,
   selectedModels,
   setSelectedModels,
+  isCompact = false,
 }: ModelsFilterMenuProps) => {
   const { isDark } = useTheme();
   const [isDropdownOpen, setDropdownOpen] = useState(false);
@@ -58,7 +60,8 @@ export const ModelsFilterMenu = ({
         <Button
           variant="outline"
           icon={CpuChip01}
-          label="Models"
+          label={isCompact ? undefined : "Models"}
+          tooltip={isCompact ? "Models" : undefined}
           counterValue={selectedModels.length.toString()}
           isCounter={selectedModels.length > 0}
         />

--- a/front/components/assistant/TagsFilterMenu.tsx
+++ b/front/components/assistant/TagsFilterMenu.tsx
@@ -16,18 +16,20 @@ import { useState } from "react";
 
 import { TagsManager } from "./TagsManager";
 
-type TagsFilterMenuProps = {
+interface TagsFilterMenuProps {
   tags: TagType[];
   selectedTags: TagType[];
   setSelectedTags: (tags: TagType[]) => void;
   owner: WorkspaceType;
-};
+  isCompact?: boolean;
+}
 
 export const TagsFilterMenu = ({
   tags,
   selectedTags,
   setSelectedTags,
   owner,
+  isCompact = false,
 }: TagsFilterMenuProps) => {
   const [isTagManagerOpen, setTagManagerOpen] = useState(false);
   const [isDropdownOpen, setDropdownOpen] = useState(false);
@@ -61,7 +63,8 @@ export const TagsFilterMenu = ({
           <Button
             variant="outline"
             icon={Tag01}
-            label="Tags"
+            label={isCompact ? undefined : "Tags"}
+            tooltip={isCompact ? "Tags" : undefined}
             counterValue={selectedTags.length.toString()}
             isCounter={selectedTags.length > 0}
           />

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -19,6 +19,7 @@ import { clientFetch } from "@app/lib/egress/client";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import {
   compareForFuzzySort,
   getAgentSearchString,
@@ -87,6 +88,7 @@ export function ManageAgentsPage() {
   );
   const [isBatchEdit, setIsBatchEdit] = useState(false);
   const [selection, setSelection] = useState<string[]>([]);
+  const isMobile = useIsMobile();
 
   const { isDark } = useTheme();
 
@@ -301,7 +303,8 @@ export function ManageAgentsPage() {
                   <Button
                     variant="outline"
                     icon={ListSelect}
-                    label="Batch edit"
+                    label={isMobile ? undefined : "Batch edit"}
+                    tooltip={isMobile ? "Batch edit" : undefined}
                     onClick={() => {
                       setIsBatchEdit(true);
                     }}
@@ -311,17 +314,20 @@ export function ManageAgentsPage() {
                   models={uniqueModels}
                   selectedModels={selectedModels}
                   setSelectedModels={setSelectedModels}
+                  isCompact={isMobile}
                 />
                 <TagsFilterMenu
                   tags={uniqueTags}
                   selectedTags={selectedTags}
                   setSelectedTags={setSelectedTags}
                   owner={owner}
+                  isCompact={isMobile}
                 />
                 {canCreateAgent && (
                   <CreateDropdown
                     owner={owner}
                     dataGtmLocation="assistantsWorkspace"
+                    isCompact={isMobile}
                   />
                 )}
               </div>


### PR DESCRIPTION
## Description

The Manage Agents buttons crowd out the search field on narrow screens and take most of the horizontal space.

This PR changes the mobile behavior so that Batch edit, Models, Tags, and Create now use compact icon buttons while preserving tooltips, accessible labels, and selected filter counters.

Only affects the mobile version.

Before 
<img width="411" height="308" alt="image" src="https://github.com/user-attachments/assets/c9db55dc-c346-4615-9ba1-d170e15f6849" />

After
<img width="405" height="311" alt="image" src="https://github.com/user-attachments/assets/4435652c-04d5-4961-92da-be4d32273cee" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
