### PR TITLE
Backfill agent message consumption analytics

### DIFF
--- a/front/scripts/backfill_agent_message_consumption_analytics.ts
+++ b/front/scripts/backfill_agent_message_consumption_analytics.ts
@@ -1,0 +1,298 @@
+/**
+ * Enqueue the consumption attribution + Elasticsearch indexing workflow for historical agent
+ * messages. Run once in each region after the consumption analytics index and V3 analytics worker
+ * have been deployed.
+ *
+ * Dry run:
+ *   npx tsx scripts/backfill_agent_message_consumption_analytics.ts \
+ *     --fromDate 2026-08-01T00:00:00.000Z
+ *
+ * Execute:
+ *   npx tsx scripts/backfill_agent_message_consumption_analytics.ts \
+ *     --fromDate 2026-08-01T00:00:00.000Z \
+ *     --execute
+ */
+import {
+  CONSUMPTION_ANALYTICS_ALIAS_NAME,
+  withEs,
+} from "@app/lib/api/elasticsearch";
+import { Authenticator } from "@app/lib/auth";
+import {
+  AgentMessageModel,
+  ConversationModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import { launchStoreAgentMessageConsumptionAttributionWorkflow } from "@app/temporal/analytics_queue/client";
+import type { AgentMessageRef } from "@app/types/assistant/agent_run";
+import {
+  AGENT_MESSAGE_STATUSES_TO_TRACK,
+  isTerminalAgentMessageStatus,
+} from "@app/types/assistant/conversation";
+import type { LightWorkspaceType } from "@app/types/user";
+import assert from "assert";
+import { Op } from "sequelize";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const DEFAULT_BATCH_SIZE = 100;
+const DEFAULT_CONCURRENCY = 4;
+const TERMINAL_TRACKED_STATUSES = AGENT_MESSAGE_STATUSES_TO_TRACK.filter(
+  isTerminalAgentMessageStatus
+);
+const TimestampSchema = z.string().datetime({ offset: true });
+
+function parseTimestamp(value: string, argumentName: string): Date {
+  const result = TimestampSchema.safeParse(value);
+  if (!result.success) {
+    throw new Error(
+      `Invalid --${argumentName}: ${fromError(result.error).toString()}`
+    );
+  }
+
+  return new Date(result.data);
+}
+
+async function assertConsumptionAnalyticsIndexExists(): Promise<void> {
+  const result = await withEs((client) =>
+    client.indices.exists({ index: CONSUMPTION_ANALYTICS_ALIAS_NAME })
+  );
+  if (result.isErr()) {
+    throw result.error;
+  }
+  if (!result.value) {
+    throw new Error(
+      `Elasticsearch index alias does not exist: ${CONSUMPTION_ANALYTICS_ALIAS_NAME}`
+    );
+  }
+}
+
+async function listAgentMessageRefs({
+  afterAgentMessageModelId,
+  batchSize,
+  fromDate,
+  toDate,
+  workspace,
+}: {
+  afterAgentMessageModelId: number;
+  batchSize: number;
+  fromDate: Date;
+  toDate: Date;
+  workspace: LightWorkspaceType;
+}): Promise<Array<{ agentMessageModelId: number; message: AgentMessageRef }>> {
+  const agentMessages = await AgentMessageModel.findAll({
+    attributes: ["id"],
+    where: {
+      id: { [Op.gt]: afterAgentMessageModelId },
+      workspaceId: workspace.id,
+      status: { [Op.in]: TERMINAL_TRACKED_STATUSES },
+      completedAt: { [Op.gte]: fromDate, [Op.lt]: toDate },
+      costCredits: { [Op.ne]: null },
+      runIds: { [Op.ne]: null },
+    },
+    include: [
+      {
+        model: MessageModel,
+        as: "message",
+        attributes: ["sId"],
+        required: true,
+        include: [
+          {
+            model: ConversationModel,
+            as: "conversation",
+            attributes: ["sId"],
+            required: true,
+          },
+        ],
+      },
+    ],
+    order: [["id", "ASC"]],
+    limit: batchSize,
+  });
+
+  return agentMessages.map((agentMessage) => {
+    const message = agentMessage.message;
+    const conversation = message?.conversation;
+    assert(message && conversation, "Agent message context was not joined");
+
+    return {
+      agentMessageModelId: agentMessage.id,
+      message: {
+        agentMessageId: message.sId,
+        conversationId: conversation.sId,
+      },
+    };
+  });
+}
+
+makeScript(
+  {
+    fromDate: {
+      type: "string",
+      required: true,
+      description: "Inclusive ISO-8601 completion timestamp.",
+    },
+    toDate: {
+      type: "string",
+      required: false,
+      description:
+        "Exclusive ISO-8601 completion timestamp (defaults to script start).",
+    },
+    workspaceId: {
+      type: "string",
+      required: false,
+      description: "Single workspace sId to process (all if omitted).",
+    },
+    fromWorkspaceId: {
+      type: "number",
+      required: false,
+      description: "Resume from this workspace model id.",
+    },
+    batchSize: {
+      type: "number",
+      default: DEFAULT_BATCH_SIZE,
+      description: "Number of agent messages to fetch per database query.",
+    },
+    concurrency: {
+      type: "number",
+      default: DEFAULT_CONCURRENCY,
+      description: "Maximum concurrent Temporal workflow launches.",
+    },
+  },
+  async (
+    {
+      batchSize,
+      concurrency,
+      execute,
+      fromDate,
+      fromWorkspaceId,
+      toDate,
+      workspaceId,
+    },
+    logger
+  ) => {
+    const parsedFromDate = parseTimestamp(fromDate, "fromDate");
+    const parsedToDate = toDate ? parseTimestamp(toDate, "toDate") : new Date();
+    assert(parsedFromDate < parsedToDate, "--fromDate must precede --toDate");
+    assert(batchSize > 0, "--batchSize must be positive");
+    assert(concurrency > 0, "--concurrency must be positive");
+
+    if (execute) {
+      await assertConsumptionAnalyticsIndexExists();
+    }
+
+    let totalCandidates = 0;
+    let totalEnqueued = 0;
+    let totalFailed = 0;
+
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        const auth = await Authenticator.internalBuilderForWorkspace(
+          workspace.sId
+        );
+
+        let afterAgentMessageModelId = 0;
+        let workspaceCandidates = 0;
+        let workspaceEnqueued = 0;
+        let workspaceFailed = 0;
+
+        while (true) {
+          const candidates = await listAgentMessageRefs({
+            afterAgentMessageModelId,
+            batchSize,
+            fromDate: parsedFromDate,
+            toDate: parsedToDate,
+            workspace,
+          });
+          if (candidates.length === 0) {
+            break;
+          }
+
+          afterAgentMessageModelId =
+            candidates[candidates.length - 1].agentMessageModelId;
+          workspaceCandidates += candidates.length;
+
+          if (!execute) {
+            continue;
+          }
+
+          const results = await concurrentExecutor(
+            candidates,
+            async ({ message }) => {
+              const result =
+                await launchStoreAgentMessageConsumptionAttributionWorkflow({
+                  authType: auth.toJSON(),
+                  message,
+                });
+              if (result.isErr()) {
+                logger.error(
+                  {
+                    error: result.error,
+                    workspaceId: workspace.sId,
+                    ...message,
+                  },
+                  "[ConsumptionAnalyticsBackfill] Failed to enqueue workflow"
+                );
+                return false;
+              }
+
+              return true;
+            },
+            { concurrency }
+          );
+          workspaceEnqueued += results.filter(Boolean).length;
+          workspaceFailed += results.filter((succeeded) => !succeeded).length;
+
+          logger.info(
+            {
+              workspaceId: workspace.sId,
+              workspaceCandidates,
+              workspaceEnqueued,
+              workspaceFailed,
+              afterAgentMessageModelId,
+            },
+            "[ConsumptionAnalyticsBackfill] Batch complete"
+          );
+        }
+
+        totalCandidates += workspaceCandidates;
+        totalEnqueued += workspaceEnqueued;
+        totalFailed += workspaceFailed;
+
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            workspaceCandidates,
+            workspaceEnqueued,
+            workspaceFailed,
+            execute,
+          },
+          "[ConsumptionAnalyticsBackfill] Workspace complete"
+        );
+      },
+      { wId: workspaceId, fromWorkspaceId }
+    );
+
+    logger.info(
+      {
+        fromDate: parsedFromDate.toISOString(),
+        toDate: parsedToDate.toISOString(),
+        totalCandidates,
+        totalEnqueued,
+        totalFailed,
+        execute,
+      },
+      execute
+        ? "[ConsumptionAnalyticsBackfill] Enqueue complete"
+        : "[ConsumptionAnalyticsBackfill] Dry run complete"
+    );
+
+    if (totalFailed > 0) {
+      throw new Error(
+        `${totalFailed} consumption analytics workflow launches failed`
+      );
+    }
+  }
+);

--- a/front/temporal/agent_loop/activities/analytics.ts
+++ b/front/temporal/agent_loop/activities/analytics.ts
@@ -39,7 +39,7 @@ export async function launchAgentMessageConsumptionAttribution(
 ): Promise<void> {
   const result = await launchStoreAgentMessageConsumptionAttributionWorkflow({
     authType: auth.toJSON(),
-    agentLoopArgs,
+    message: agentLoopArgs,
   });
 
   if (result.isErr()) {

--- a/front/temporal/analytics_queue/activities/consumption_attribution.test.ts
+++ b/front/temporal/analytics_queue/activities/consumption_attribution.test.ts
@@ -3,7 +3,7 @@ import { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { storeAgentMessageConsumptionAnalyticsActivity } from "@app/temporal/analytics_queue/activities/consumption_attribution";
-import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+import type { AgentMessageRef } from "@app/types/assistant/agent_run";
 import { Err, Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -19,9 +19,10 @@ vi.mock(
 );
 
 const authType = {} as AuthenticatorType;
-const agentLoopArgs = {
+const message: AgentMessageRef = {
   agentMessageId: "agent_message_1",
-} as AgentLoopArgs;
+  conversationId: "conversation_1",
+};
 
 describe("storeAgentMessageConsumptionAnalyticsActivity", () => {
   beforeEach(() => {
@@ -38,7 +39,7 @@ describe("storeAgentMessageConsumptionAnalyticsActivity", () => {
 
     await expect(
       storeAgentMessageConsumptionAnalyticsActivity(authType, {
-        agentLoopArgs,
+        message,
       })
     ).resolves.toBeUndefined();
   });
@@ -51,7 +52,7 @@ describe("storeAgentMessageConsumptionAnalyticsActivity", () => {
 
     await expect(
       storeAgentMessageConsumptionAnalyticsActivity(authType, {
-        agentLoopArgs,
+        message,
       })
     ).rejects.toBe(error);
   });

--- a/front/temporal/analytics_queue/activities/consumption_attribution.ts
+++ b/front/temporal/analytics_queue/activities/consumption_attribution.ts
@@ -3,7 +3,19 @@ import { computeAndStoreAgentMessageConsumptionAttribution } from "@app/lib/api/
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+import type {
+  AgentLoopArgs,
+  AgentMessageRef,
+} from "@app/types/assistant/agent_run";
+
+async function storeAgentMessageConsumptionAttribution(
+  authType: AuthenticatorType,
+  message: AgentMessageRef
+): Promise<void> {
+  const auth = await Authenticator.fromJSON(authType);
+
+  await computeAndStoreAgentMessageConsumptionAttribution(auth, message);
+}
 
 export async function storeAgentMessageConsumptionAttributionActivity(
   authType: AuthenticatorType,
@@ -13,27 +25,26 @@ export async function storeAgentMessageConsumptionAttributionActivity(
     agentLoopArgs: AgentLoopArgs;
   }
 ): Promise<void> {
-  const auth = await Authenticator.fromJSON(authType);
-  const { agentMessageId, conversationId } = agentLoopArgs;
+  await storeAgentMessageConsumptionAttribution(authType, agentLoopArgs);
+}
 
-  await computeAndStoreAgentMessageConsumptionAttribution(auth, {
-    agentMessageId,
-    conversationId,
-  });
+// V1/V2 keep their original AgentLoopArgs activity payload for replay. V3 only needs this stable
+// message reference, which also lets historical backfills use the same durable workflow.
+export async function storeAgentMessageConsumptionAttributionForMessageActivity(
+  authType: AuthenticatorType,
+  { message }: { message: AgentMessageRef }
+): Promise<void> {
+  await storeAgentMessageConsumptionAttribution(authType, message);
 }
 
 /** Builds and bulk-upserts every billed consumption unit for one settled agent message. */
 export async function storeAgentMessageConsumptionAnalyticsActivity(
   authType: AuthenticatorType,
-  {
-    agentLoopArgs,
-  }: {
-    agentLoopArgs: AgentLoopArgs;
-  }
+  { message }: { message: AgentMessageRef }
 ): Promise<void> {
   const auth = await Authenticator.fromJSON(authType);
   const result = await indexAgentMessageConsumptionAnalytics(auth, {
-    agentMessageId: agentLoopArgs.agentMessageId,
+    agentMessageId: message.agentMessageId,
   });
 
   if (result.isErr()) {
@@ -44,7 +55,7 @@ export async function storeAgentMessageConsumptionAnalyticsActivity(
       {
         error,
         workspaceId,
-        agentMessageId: agentLoopArgs.agentMessageId,
+        agentMessageId: message.agentMessageId,
       },
       "[ConsumptionAnalytics] Failed to upsert consumption documents in ES"
     );

--- a/front/temporal/analytics_queue/client.test.ts
+++ b/front/temporal/analytics_queue/client.test.ts
@@ -40,11 +40,11 @@ describe("launchStoreAgentMessageConsumptionAttributionWorkflow", () => {
 
     const first = await launchStoreAgentMessageConsumptionAttributionWorkflow({
       authType,
-      agentLoopArgs,
+      message: agentLoopArgs,
     });
     const second = await launchStoreAgentMessageConsumptionAttributionWorkflow({
       authType,
-      agentLoopArgs,
+      message: agentLoopArgs,
     });
 
     expect(first.isOk()).toBe(true);
@@ -53,7 +53,15 @@ describe("launchStoreAgentMessageConsumptionAttributionWorkflow", () => {
     expect(mockSignalWithStart).toHaveBeenCalledWith(
       storeAgentMessageConsumptionAttributionV3Workflow,
       expect.objectContaining({
-        args: [authType, { agentLoopArgs }],
+        args: [
+          authType,
+          {
+            message: {
+              agentMessageId: agentLoopArgs.agentMessageId,
+              conversationId: agentLoopArgs.conversationId,
+            },
+          },
+        ],
         taskQueue: QUEUE_NAME,
         workflowId: `${makeAgentMessageAnalyticsWorkflowId({
           agentMessageId: agentLoopArgs.agentMessageId,

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -101,14 +101,15 @@ export async function launchStoreAgentAnalyticsWorkflow({
 
 export async function launchStoreAgentMessageConsumptionAttributionWorkflow({
   authType,
-  agentLoopArgs,
+  message,
 }: {
   authType: AuthenticatorType;
-  agentLoopArgs: AgentLoopArgs;
+  message: AgentMessageRef;
 }): Promise<Result<undefined, Error>> {
   const { workspaceId } = authType;
 
-  const { agentMessageId, conversationId } = agentLoopArgs;
+  const { agentMessageId, conversationId } = message;
+  const messageRef = { agentMessageId, conversationId };
 
   const client = await getTemporalClientForFrontNamespace();
 
@@ -127,7 +128,7 @@ export async function launchStoreAgentMessageConsumptionAttributionWorkflow({
     await client.workflow.signalWithStart(
       storeAgentMessageConsumptionAttributionV3Workflow,
       {
-        args: [authType, { agentLoopArgs }],
+        args: [authType, { message: messageRef }],
         taskQueue: QUEUE_NAME,
         workflowId,
         signal: storeAgentMessageConsumptionAttributionV3Signal,

--- a/front/temporal/analytics_queue/workflows.ts
+++ b/front/temporal/analytics_queue/workflows.ts
@@ -14,6 +14,7 @@ const {
   storeAgentAnalyticsActivity,
   storeAgentMessageFeedbackActivity,
   storeAgentMessageConsumptionAttributionActivity,
+  storeAgentMessageConsumptionAttributionForMessageActivity,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
   retry: {
@@ -101,11 +102,7 @@ export async function storeAgentMessageConsumptionAttributionV2Workflow(
 // unchanged above so executions started before this deployment can replay deterministically.
 export async function storeAgentMessageConsumptionAttributionV3Workflow(
   authType: AuthenticatorType,
-  {
-    agentLoopArgs,
-  }: {
-    agentLoopArgs: AgentLoopArgs;
-  }
+  { message }: { message: AgentMessageRef }
 ): Promise<void> {
   let pendingRecompute = true;
 
@@ -116,12 +113,12 @@ export async function storeAgentMessageConsumptionAttributionV3Workflow(
   while (pendingRecompute) {
     pendingRecompute = false;
 
-    await storeAgentMessageConsumptionAttributionActivity(authType, {
-      agentLoopArgs,
+    await storeAgentMessageConsumptionAttributionForMessageActivity(authType, {
+      message,
     });
 
     await storeAgentMessageConsumptionAnalyticsActivity(authType, {
-      agentLoopArgs,
+      message,
     });
   }
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds a resumable, dry-run-first script that enqueues historical consumption analytics through Temporal using a minimal `AgentMessageRef` payload for V3 so live ingestion and backfills share the same workflow.

> [!WARNING]
> This changes V3’s serialized workflow/activity input. It must be deployed as the same time asV3 from #30203

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
