### PR TITLE
Backfill agent step content run IDs

### DIFF
--- a/front/lib/api/programmatic_usage/common.ts
+++ b/front/lib/api/programmatic_usage/common.ts
@@ -55,6 +55,21 @@ const PROGRAMMATIC_USAGE_ORIGINS = Object.keys(
     USAGE_ORIGINS_CLASSIFICATION[origin as UserMessageOrigin] === "programmatic"
 );
 
+export function isProgrammaticUsageFromContext({
+  authMethod,
+  userMessageOrigin,
+}: {
+  // Persisted historical values predate the AuthMethodType union, so keep the input broad and
+  // reproduce the live rule by recognizing the one auth method that changes classification.
+  authMethod: string | null;
+  userMessageOrigin: UserMessageOrigin;
+}): boolean {
+  return (
+    authMethod === "api_key" ||
+    USAGE_ORIGINS_CLASSIFICATION[userMessageOrigin] === "programmatic"
+  );
+}
+
 // Markup multiplier to convert raw ES costs to costs with Dust markup.
 export const MARKUP_MULTIPLIER = 1 + DUST_MARKUP_PERCENT / 100;
 

--- a/front/lib/api/programmatic_usage/tracking.test.ts
+++ b/front/lib/api/programmatic_usage/tracking.test.ts
@@ -1,3 +1,4 @@
+import { isProgrammaticUsageFromContext } from "@app/lib/api/programmatic_usage/common";
 import {
   checkProgrammaticUsageLimits,
   compareCreditsForConsumption,
@@ -162,6 +163,30 @@ describe("isProgrammaticUsage", () => {
     expect(isProgrammaticUsage(auth, { userMessageOrigin: "wakeup" })).toBe(
       false
     );
+  });
+
+  it("reconstructs API-key usage from persisted message context", () => {
+    expect(
+      isProgrammaticUsageFromContext({
+        authMethod: "api_key",
+        userMessageOrigin: "web",
+      })
+    ).toBe(true);
+  });
+
+  it("reconstructs programmatic origins from persisted message context", () => {
+    expect(
+      isProgrammaticUsageFromContext({
+        authMethod: "session",
+        userMessageOrigin: "zapier",
+      })
+    ).toBe(true);
+    expect(
+      isProgrammaticUsageFromContext({
+        authMethod: "session",
+        userMessageOrigin: "web",
+      })
+    ).toBe(false);
   });
 
   it("should return credits_exhausted when no active credits are available", async () => {

--- a/front/lib/api/programmatic_usage/tracking.ts
+++ b/front/lib/api/programmatic_usage/tracking.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 
 import { DUST_MARKUP_PERCENT } from "@app/lib/api/assistant/token_pricing";
-import { USAGE_ORIGINS_CLASSIFICATION } from "@app/lib/api/programmatic_usage/common";
+import { isProgrammaticUsageFromContext } from "@app/lib/api/programmatic_usage/common";
 import {
   hasReachedDailyUsageCap,
   incrementDailyUsageMicroUsd,
@@ -40,14 +40,10 @@ export function isProgrammaticUsage(
   auth: Authenticator,
   { userMessageOrigin }: { userMessageOrigin: UserMessageOrigin }
 ): boolean {
-  if (
-    auth.authMethod() === "api_key" ||
-    USAGE_ORIGINS_CLASSIFICATION[userMessageOrigin] === "programmatic"
-  ) {
-    return true;
-  }
-
-  return false;
+  return isProgrammaticUsageFromContext({
+    authMethod: auth.authMethod(),
+    userMessageOrigin,
+  });
 }
 
 async function hasReachedProgrammaticUsageLimits(

--- a/front/lib/resources/agent_step_content/cache.ts
+++ b/front/lib/resources/agent_step_content/cache.ts
@@ -52,6 +52,7 @@ type AgentStepContentCacheMetadata = {
   index: number;
   version: number;
   type: AgentContentItemType["type"];
+  dustRunId: string | null;
 };
 
 /**
@@ -167,7 +168,9 @@ function isCachedAgentStepContent(
 /**
  * Given latest-version metadata from PG (no `value` column), try to hydrate
  * full rows from the per-agentMessage Redis Hash. A message is a hit only when
- * every expected `(step, index)` field is present and matches `id` + `version`.
+ * every expected `(step, index)` field is present and matches `id`, `version`, and `dustRunId`.
+ * Comparing dustRunId makes raw database backfills self-invalidating without coordinating a Redis
+ * delete with the Postgres update.
  *
  * Returns null if Redis itself fails — caller should treat all ids as misses.
  */
@@ -245,6 +248,7 @@ export async function tryHydrateAgentStepContentsFromCache({
           !isCachedAgentStepContent(parsed) ||
           parsed.id !== meta.id ||
           parsed.version !== meta.version ||
+          parsed.dustRunId !== meta.dustRunId ||
           parsed.agentMessageId !== meta.agentMessageId
         ) {
           complete = false;

--- a/front/lib/resources/agent_step_content_resource.test.ts
+++ b/front/lib/resources/agent_step_content_resource.test.ts
@@ -234,6 +234,34 @@ describe("AgentStepContentResource Redis cache", () => {
     expect(fetched.map((c) => c.id).includes(created.id)).toBe(true);
   });
 
+  it("falls back to Postgres when a backfill changes dustRunId behind the cache", async () => {
+    const created = await AgentStepContentResource.createNewVersion({
+      workspaceId,
+      agentMessageId: agentMessage.id,
+      step: 0,
+      index: 0,
+      type: "text_content",
+      value: makeTextContent("cached before backfill"),
+    });
+
+    await AgentStepContentModel.update(
+      { dustRunId: "backfilled-run-id" },
+      {
+        where: { id: created.id, workspaceId },
+        fields: ["dustRunId"],
+        silent: true,
+      }
+    );
+
+    const fetched = await AgentStepContentResource.fetchByAgentMessages(
+      authenticator,
+      { agentMessageIds: [agentMessage.id] }
+    );
+
+    expect(fetched).toHaveLength(1);
+    expect(fetched[0].dustRunId).toBe("backfilled-run-id");
+  });
+
   it("overwrites the hash field when creating a new version of the same step/index", async () => {
     await AgentStepContentResource.createNewVersion({
       workspaceId,

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -46,6 +46,7 @@ const METADATA_ATTRIBUTES = [
   "index",
   "version",
   "type",
+  "dustRunId",
 ] as const;
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
@@ -283,6 +284,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       index: number;
       version: number;
       type: AgentStepContentModel["type"];
+      dustRunId: string | null;
     }>
   > {
     const owner = auth.getNonNullableWorkspace();
@@ -323,6 +325,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       index: row.index,
       version: row.version,
       type: row.type,
+      dustRunId: row.dustRunId,
     }));
   }
 

--- a/front/scripts/backfill_agent_message_consumption_analytics.ts
+++ b/front/scripts/backfill_agent_message_consumption_analytics.ts
@@ -1,7 +1,12 @@
 /**
  * Enqueue the consumption attribution + Elasticsearch indexing workflow for historical agent
  * messages. Run once in each region after the consumption analytics index and V3 analytics worker
- * have been deployed.
+ * have been deployed, and after agent step content dustRunIds have been backfilled.
+ *
+ * Before enqueueing each batch, the script classifies any run usages whose usageType is still null.
+ * It reconstructs the same billing classification as the live path from the triggering user
+ * message's persisted origin and auth method. This is required because the analytics loader rejects
+ * unclassified usage rather than risking that free, user, and programmatic consumption are mixed.
  *
  * Dry run:
  *   npx tsx scripts/backfill_agent_message_consumption_analytics.ts \
@@ -16,12 +21,20 @@ import {
   CONSUMPTION_ANALYTICS_ALIAS_NAME,
   withEs,
 } from "@app/lib/api/elasticsearch";
+import { isProgrammaticUsageFromContext } from "@app/lib/api/programmatic_usage/common";
 import { Authenticator } from "@app/lib/auth";
+import { getUsageType } from "@app/lib/metronome/events";
+import type { UsageType } from "@app/lib/metronome/types";
 import {
   AgentMessageModel,
   ConversationModel,
   MessageModel,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
+import {
+  RunModel,
+  RunUsageModel,
+} from "@app/lib/resources/storage/models/runs";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
@@ -31,6 +44,7 @@ import {
   AGENT_MESSAGE_STATUSES_TO_TRACK,
   isTerminalAgentMessageStatus,
 } from "@app/types/assistant/conversation";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { LightWorkspaceType } from "@app/types/user";
 import assert from "assert";
 import { Op } from "sequelize";
@@ -43,6 +57,13 @@ const TERMINAL_TRACKED_STATUSES = AGENT_MESSAGE_STATUSES_TO_TRACK.filter(
   isTerminalAgentMessageStatus
 );
 const TimestampSchema = z.string().datetime({ offset: true });
+
+type AgentMessageBackfillCandidate = {
+  agentMessageModelId: ModelId;
+  dustRunIds: string[];
+  message: AgentMessageRef;
+  usageType: UsageType;
+};
 
 function parseTimestamp(value: string, argumentName: string): Date {
   const result = TimestampSchema.safeParse(value);
@@ -81,9 +102,9 @@ async function listAgentMessageRefs({
   fromDate: Date;
   toDate: Date;
   workspace: LightWorkspaceType;
-}): Promise<Array<{ agentMessageModelId: number; message: AgentMessageRef }>> {
+}): Promise<AgentMessageBackfillCandidate[]> {
   const agentMessages = await AgentMessageModel.findAll({
-    attributes: ["id"],
+    attributes: ["id", "runIds"],
     where: {
       id: { [Op.gt]: afterAgentMessageModelId },
       workspaceId: workspace.id,
@@ -96,7 +117,7 @@ async function listAgentMessageRefs({
       {
         model: MessageModel,
         as: "message",
-        attributes: ["sId"],
+        attributes: ["sId", "parentId"],
         required: true,
         include: [
           {
@@ -112,19 +133,115 @@ async function listAgentMessageRefs({
     limit: batchSize,
   });
 
+  const triggeringMessages = await MessageModel.findAll({
+    attributes: ["id"],
+    where: {
+      id: {
+        [Op.in]: agentMessages.map((agentMessage) => {
+          assert(agentMessage.message?.parentId, "Agent message has no parent");
+          return agentMessage.message.parentId;
+        }),
+      },
+      workspaceId: workspace.id,
+    },
+    include: [
+      {
+        model: UserMessageModel,
+        as: "userMessage",
+        attributes: ["userContextAuthMethod", "userContextOrigin"],
+        required: true,
+      },
+    ],
+  });
+  const triggeringMessageById = new Map(
+    triggeringMessages.map((message) => [message.id, message])
+  );
+
   return agentMessages.map((agentMessage) => {
     const message = agentMessage.message;
     const conversation = message?.conversation;
     assert(message && conversation, "Agent message context was not joined");
+    assert(message.parentId, "Agent message has no parent");
+    const triggeringUserMessage = triggeringMessageById.get(
+      message.parentId
+    )?.userMessage;
+    assert(triggeringUserMessage, "Triggering user message was not joined");
+    const dustRunIds = [...new Set(agentMessage.runIds ?? [])];
+    const origin = triggeringUserMessage.userContextOrigin;
 
     return {
       agentMessageModelId: agentMessage.id,
+      dustRunIds,
       message: {
         agentMessageId: message.sId,
         conversationId: conversation.sId,
       },
+      usageType: getUsageType(
+        isProgrammaticUsageFromContext({
+          authMethod: triggeringUserMessage.userContextAuthMethod,
+          userMessageOrigin: origin,
+        }),
+        origin
+      ),
     };
   });
+}
+
+async function backfillMissingRunUsageTypes({
+  candidates,
+  workspace,
+}: {
+  candidates: AgentMessageBackfillCandidate[];
+  workspace: LightWorkspaceType;
+}): Promise<number> {
+  const usageTypeByDustRunId = new Map<string, UsageType>();
+  for (const candidate of candidates) {
+    for (const dustRunId of candidate.dustRunIds) {
+      const existingUsageType = usageTypeByDustRunId.get(dustRunId);
+      assert(
+        !existingUsageType || existingUsageType === candidate.usageType,
+        `Run ${dustRunId} has conflicting usage classifications`
+      );
+      usageTypeByDustRunId.set(dustRunId, candidate.usageType);
+    }
+  }
+  if (usageTypeByDustRunId.size === 0) {
+    return 0;
+  }
+
+  const runs = await RunModel.findAll({
+    attributes: ["id", "dustRunId"],
+    where: {
+      dustRunId: { [Op.in]: [...usageTypeByDustRunId.keys()] },
+      workspaceId: workspace.id,
+    },
+  });
+  const runModelIdsByUsageType = new Map<UsageType, ModelId[]>();
+  for (const run of runs) {
+    const usageType = usageTypeByDustRunId.get(run.dustRunId);
+    assert(usageType, "Fetched run has no usage classification");
+    const runModelIds = runModelIdsByUsageType.get(usageType) ?? [];
+    runModelIds.push(run.id);
+    runModelIdsByUsageType.set(usageType, runModelIds);
+  }
+
+  const updateCounts = await Promise.all(
+    [...runModelIdsByUsageType].map(async ([usageType, runModelIds]) => {
+      const [updatedCount] = await RunUsageModel.update(
+        { usageType },
+        {
+          where: {
+            runId: { [Op.in]: runModelIds },
+            usageType: null,
+            workspaceId: workspace.id,
+          },
+        }
+      );
+      return updatedCount;
+    })
+  );
+
+  return updateCounts.reduce((total, count) => total + count, 0);
 }
 
 makeScript(
@@ -186,6 +303,7 @@ makeScript(
     let totalCandidates = 0;
     let totalEnqueued = 0;
     let totalFailed = 0;
+    let totalUsageTypesBackfilled = 0;
 
     await runOnAllWorkspaces(
       async (workspace) => {
@@ -197,6 +315,7 @@ makeScript(
         let workspaceCandidates = 0;
         let workspaceEnqueued = 0;
         let workspaceFailed = 0;
+        let workspaceUsageTypesBackfilled = 0;
 
         while (true) {
           const candidates = await listAgentMessageRefs({
@@ -217,6 +336,11 @@ makeScript(
           if (!execute) {
             continue;
           }
+
+          workspaceUsageTypesBackfilled += await backfillMissingRunUsageTypes({
+            candidates,
+            workspace,
+          });
 
           const results = await concurrentExecutor(
             candidates,
@@ -251,6 +375,7 @@ makeScript(
               workspaceCandidates,
               workspaceEnqueued,
               workspaceFailed,
+              workspaceUsageTypesBackfilled,
               afterAgentMessageModelId,
             },
             "[ConsumptionAnalyticsBackfill] Batch complete"
@@ -260,6 +385,7 @@ makeScript(
         totalCandidates += workspaceCandidates;
         totalEnqueued += workspaceEnqueued;
         totalFailed += workspaceFailed;
+        totalUsageTypesBackfilled += workspaceUsageTypesBackfilled;
 
         logger.info(
           {
@@ -267,6 +393,7 @@ makeScript(
             workspaceCandidates,
             workspaceEnqueued,
             workspaceFailed,
+            workspaceUsageTypesBackfilled,
             execute,
           },
           "[ConsumptionAnalyticsBackfill] Workspace complete"
@@ -282,6 +409,7 @@ makeScript(
         totalCandidates,
         totalEnqueued,
         totalFailed,
+        totalUsageTypesBackfilled,
         execute,
       },
       execute

--- a/front/scripts/backfill_agent_step_content_dust_run_ids.test.ts
+++ b/front/scripts/backfill_agent_step_content_dust_run_ids.test.ts
@@ -1,0 +1,88 @@
+import {
+  getChronologicalRunsForAgentMessage,
+  inferDustRunIdForStepContent,
+} from "@app/scripts/backfill_agent_step_content_dust_run_ids";
+import { describe, expect, it } from "vitest";
+
+describe("inferDustRunIdForStepContent", () => {
+  const runs = [
+    {
+      dustRunId: "run-0",
+      createdAt: new Date("2026-08-01T00:00:00.000Z"),
+      runModelId: 10,
+    },
+    {
+      dustRunId: "run-1",
+      createdAt: new Date("2026-08-01T00:01:00.000Z"),
+      runModelId: 11,
+    },
+    {
+      dustRunId: "run-2",
+      createdAt: new Date("2026-08-01T00:02:00.000Z"),
+      runModelId: 12,
+    },
+  ];
+  const runByDustRunId = new Map(runs.map((run) => [run.dustRunId, run]));
+
+  it("orders and deduplicates the message run ids", () => {
+    expect(
+      getChronologicalRunsForAgentMessage(
+        ["run-2", "run-0", "run-1", "run-1"],
+        runByDustRunId
+      )?.map((run) => run.dustRunId)
+    ).toEqual(["run-0", "run-1", "run-2"]);
+  });
+
+  it("does not infer when an in-progress message references a run that is not persisted yet", () => {
+    expect(
+      getChronologicalRunsForAgentMessage(
+        ["run-0", "run-not-persisted-yet"],
+        runByDustRunId
+      )
+    ).toBeNull();
+  });
+
+  it("matches the run at the content step within its timestamp bounds", () => {
+    expect(
+      inferDustRunIdForStepContent(
+        {
+          step: 1,
+          createdAt: new Date("2026-08-01T00:01:30.000Z"),
+        },
+        runs
+      )
+    ).toBe("run-1");
+  });
+
+  it("does not guess when the step and run chronology disagree", () => {
+    expect(
+      inferDustRunIdForStepContent(
+        {
+          step: 1,
+          createdAt: new Date("2026-08-01T00:00:30.000Z"),
+        },
+        runs
+      )
+    ).toBeNull();
+
+    expect(
+      inferDustRunIdForStepContent(
+        {
+          step: 1,
+          createdAt: new Date("2026-08-01T00:02:30.000Z"),
+        },
+        runs
+      )
+    ).toBeNull();
+
+    expect(
+      inferDustRunIdForStepContent(
+        {
+          step: 3,
+          createdAt: new Date("2026-08-01T00:03:30.000Z"),
+        },
+        runs
+      )
+    ).toBeNull();
+  });
+});

--- a/front/scripts/backfill_agent_step_content_dust_run_ids.ts
+++ b/front/scripts/backfill_agent_step_content_dust_run_ids.ts
@@ -1,0 +1,448 @@
+/**
+ * Backfill the dustRunId stamped on model-produced agent step contents. This must run before the
+ * agent message consumption analytics backfill so historical tool calls can be attributed to the
+ * run usage that emitted them.
+ *
+ * Inference:
+ * - AgentMessage.runIds is an unordered set, so the script fetches the corresponding Run rows and
+ *   orders them by createdAt, then model id.
+ * - Agent-loop step N is matched to chronological run N.
+ * - The content timestamp must fall at or after run N and before run N+1. If a run is missing or
+ *   the chronology does not agree, the content is skipped rather than assigned speculatively.
+ *
+ * The script considers every agent-message status and only updates null dustRunId values, making
+ * reruns safe. An in-progress message may be skipped until its newest run id has been persisted;
+ * rerunning after it settles will pick it up. Cache reads compare dustRunId with Postgres metadata,
+ * so an entry cached before this backfill is rejected and refreshed rather than serving stale null.
+ *
+ * Run once in each region.
+ *
+ * Dry run:
+ *   npx tsx scripts/backfill_agent_step_content_dust_run_ids.ts \
+ *     --fromDate 2026-08-01T00:00:00.000Z
+ *
+ * Execute:
+ *   npx tsx scripts/backfill_agent_step_content_dust_run_ids.ts \
+ *     --fromDate 2026-08-01T00:00:00.000Z \
+ *     --execute
+ */
+import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
+import { AgentMessageModel } from "@app/lib/models/agent/conversation";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { RunModel } from "@app/lib/resources/storage/models/runs";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { LightWorkspaceType } from "@app/types/user";
+import assert from "assert";
+import type { WhereOptions } from "sequelize";
+import { Op, QueryTypes } from "sequelize";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const DEFAULT_BATCH_SIZE = 500;
+const TimestampSchema = z.string().datetime({ offset: true });
+
+type RunCandidate = {
+  dustRunId: string;
+  createdAt: Date;
+  runModelId: ModelId;
+};
+
+type StepContentCandidate = {
+  createdAt: Date;
+  step: number;
+};
+
+type StepContentUpdate = {
+  dustRunId: string;
+  stepContentModelId: ModelId;
+};
+
+type StepContentCursor = {
+  agentMessageModelId: ModelId;
+  index: number;
+  step: number;
+  version: number;
+};
+
+function parseTimestamp(value: string, argumentName: string): Date {
+  const result = TimestampSchema.safeParse(value);
+  if (!result.success) {
+    throw new Error(
+      `Invalid --${argumentName}: ${fromError(result.error).toString()}`
+    );
+  }
+
+  return new Date(result.data);
+}
+
+/**
+ * Agent message runIds are a set and do not preserve chronological order. Once sorted by the run
+ * rows themselves, run position and step number advance together in the agent loop. The timestamp
+ * bounds prevent assigning content to a run when missing/duplicate historical data has broken that
+ * invariant.
+ */
+export function inferDustRunIdForStepContent(
+  content: StepContentCandidate,
+  chronologicalRuns: RunCandidate[]
+): string | null {
+  const run = chronologicalRuns[content.step];
+  if (!run || run.createdAt > content.createdAt) {
+    return null;
+  }
+
+  const nextRun = chronologicalRuns[content.step + 1];
+  if (nextRun && nextRun.createdAt <= content.createdAt) {
+    return null;
+  }
+
+  return run.dustRunId;
+}
+
+export function getChronologicalRunsForAgentMessage(
+  dustRunIds: string[],
+  runByDustRunId: Map<string, RunCandidate>
+): RunCandidate[] | null {
+  const uniqueDustRunIds = [...new Set(dustRunIds)];
+  const messageRuns = uniqueDustRunIds.flatMap((dustRunId) => {
+    const run = runByDustRunId.get(dustRunId);
+    return run ? [run] : [];
+  });
+
+  // A missing run shifts every later positional match, so do not infer any row for the message.
+  if (messageRuns.length !== uniqueDustRunIds.length) {
+    return null;
+  }
+
+  return messageRuns.toSorted(
+    (left, right) =>
+      left.createdAt.getTime() - right.createdAt.getTime() ||
+      left.runModelId - right.runModelId
+  );
+}
+
+async function listStepContentCandidates({
+  afterCursor,
+  batchSize,
+  fromDate,
+  toDate,
+  workspace,
+}: {
+  afterCursor: StepContentCursor | null;
+  batchSize: number;
+  fromDate: Date;
+  toDate: Date;
+  workspace: LightWorkspaceType;
+}): Promise<AgentStepContentModel[]> {
+  const afterCursorWhere: WhereOptions<AgentStepContentModel> = afterCursor
+    ? {
+        [Op.or]: [
+          {
+            agentMessageId: { [Op.gt]: afterCursor.agentMessageModelId },
+          },
+          {
+            agentMessageId: afterCursor.agentMessageModelId,
+            step: { [Op.gt]: afterCursor.step },
+          },
+          {
+            agentMessageId: afterCursor.agentMessageModelId,
+            step: afterCursor.step,
+            index: { [Op.gt]: afterCursor.index },
+          },
+          {
+            agentMessageId: afterCursor.agentMessageModelId,
+            step: afterCursor.step,
+            index: afterCursor.index,
+            version: { [Op.gt]: afterCursor.version },
+          },
+        ],
+      }
+    : {};
+
+  return AgentStepContentModel.findAll({
+    attributes: [
+      "id",
+      "agentMessageId",
+      "createdAt",
+      "step",
+      "index",
+      "version",
+    ],
+    where: {
+      ...afterCursorWhere,
+      createdAt: { [Op.gte]: fromDate, [Op.lt]: toDate },
+      workspaceId: workspace.id,
+      dustRunId: null,
+    },
+    include: [
+      {
+        model: AgentMessageModel,
+        as: "agentMessage",
+        attributes: ["id", "runIds"],
+        required: true,
+        where: {
+          workspaceId: workspace.id,
+          runIds: { [Op.ne]: null },
+        },
+      },
+    ],
+    order: [
+      ["agentMessageId", "ASC"],
+      ["step", "ASC"],
+      ["index", "ASC"],
+      ["version", "ASC"],
+    ],
+    limit: batchSize,
+  });
+}
+
+async function inferStepContentUpdates({
+  candidates,
+  workspace,
+}: {
+  candidates: AgentStepContentModel[];
+  workspace: LightWorkspaceType;
+}): Promise<StepContentUpdate[]> {
+  const dustRunIds = [
+    ...new Set(
+      candidates.flatMap((candidate) => candidate.agentMessage?.runIds ?? [])
+    ),
+  ];
+  if (dustRunIds.length === 0) {
+    return [];
+  }
+
+  const runs = await RunModel.findAll({
+    attributes: ["id", "dustRunId", "createdAt"],
+    where: {
+      workspaceId: workspace.id,
+      dustRunId: { [Op.in]: dustRunIds },
+    },
+  });
+  const runByDustRunId = new Map(
+    runs.map((run) => [
+      run.dustRunId,
+      {
+        dustRunId: run.dustRunId,
+        createdAt: run.createdAt,
+        runModelId: run.id,
+      },
+    ])
+  );
+
+  const chronologicalRunsByAgentMessageModelId = new Map<
+    ModelId,
+    RunCandidate[]
+  >();
+
+  for (const candidate of candidates) {
+    const agentMessage = candidate.agentMessage;
+    assert(agentMessage, "Agent message context was not joined");
+
+    if (!chronologicalRunsByAgentMessageModelId.has(agentMessage.id)) {
+      chronologicalRunsByAgentMessageModelId.set(
+        agentMessage.id,
+        getChronologicalRunsForAgentMessage(
+          agentMessage.runIds ?? [],
+          runByDustRunId
+        ) ?? []
+      );
+    }
+  }
+
+  return candidates.flatMap((candidate) => {
+    const agentMessage = candidate.agentMessage;
+    assert(agentMessage, "Agent message context was not joined");
+
+    const dustRunId = inferDustRunIdForStepContent(
+      candidate,
+      chronologicalRunsByAgentMessageModelId.get(agentMessage.id) ?? []
+    );
+    return dustRunId
+      ? [
+          {
+            dustRunId,
+            stepContentModelId: candidate.id,
+          },
+        ]
+      : [];
+  });
+}
+
+async function applyStepContentUpdates({
+  updates,
+  workspace,
+}: {
+  updates: StepContentUpdate[];
+  workspace: LightWorkspaceType;
+}): Promise<number> {
+  if (updates.length === 0) {
+    return 0;
+  }
+
+  const bind: Record<string, number | string> = {
+    workspaceModelId: workspace.id,
+  };
+  const values = updates.map((update, index) => {
+    bind[`stepContentModelId${index}`] = update.stepContentModelId;
+    bind[`dustRunId${index}`] = update.dustRunId;
+    return `($stepContentModelId${index}::bigint, $dustRunId${index}::text)`;
+  });
+
+  // biome-ignore lint/plugin/noRawSql: one bound VALUES query avoids an update query per run.
+  const updatedRows = await frontSequelize.query<{ id: string }>(
+    `
+      WITH mapping("stepContentModelId", "dustRunId") AS (
+        VALUES ${values.join(", ")}
+      )
+      UPDATE "agent_step_contents" AS content
+      SET "dustRunId" = mapping."dustRunId"
+      FROM mapping
+      WHERE content.id = mapping."stepContentModelId"
+        AND content."workspaceId" = $workspaceModelId
+        AND content."dustRunId" IS NULL
+      RETURNING content.id
+    `,
+    { bind, type: QueryTypes.SELECT }
+  );
+
+  return updatedRows.length;
+}
+
+function runScript(): void {
+  makeScript(
+    {
+      fromDate: {
+        type: "string",
+        required: true,
+        description: "Inclusive ISO-8601 step content creation timestamp.",
+      },
+      toDate: {
+        type: "string",
+        required: false,
+        description:
+          "Exclusive ISO-8601 step content creation timestamp (defaults to script start).",
+      },
+      workspaceId: {
+        type: "string",
+        required: false,
+        description: "Single workspace sId to process (all if omitted).",
+      },
+      fromWorkspaceId: {
+        type: "number",
+        required: false,
+        description: "Resume from this workspace model id.",
+      },
+      batchSize: {
+        type: "number",
+        default: DEFAULT_BATCH_SIZE,
+        description: "Number of null step content rows to fetch per query.",
+      },
+    },
+    async (
+      { batchSize, execute, fromDate, fromWorkspaceId, toDate, workspaceId },
+      logger
+    ) => {
+      const parsedFromDate = parseTimestamp(fromDate, "fromDate");
+      const parsedToDate = toDate
+        ? parseTimestamp(toDate, "toDate")
+        : new Date();
+      assert(parsedFromDate < parsedToDate, "--fromDate must precede --toDate");
+      assert(batchSize > 0, "--batchSize must be positive");
+
+      let totalCandidates = 0;
+      let totalInferred = 0;
+      let totalUpdated = 0;
+
+      await runOnAllWorkspaces(
+        async (workspace) => {
+          let afterCursor: StepContentCursor | null = null;
+          let workspaceCandidates = 0;
+          let workspaceInferred = 0;
+          let workspaceUpdated = 0;
+
+          while (true) {
+            const candidates = await listStepContentCandidates({
+              afterCursor,
+              batchSize,
+              fromDate: parsedFromDate,
+              toDate: parsedToDate,
+              workspace,
+            });
+            if (candidates.length === 0) {
+              break;
+            }
+
+            const lastCandidate = candidates[candidates.length - 1];
+            afterCursor = {
+              agentMessageModelId: lastCandidate.agentMessageId,
+              step: lastCandidate.step,
+              index: lastCandidate.index,
+              version: lastCandidate.version,
+            };
+            const updates = await inferStepContentUpdates({
+              candidates,
+              workspace,
+            });
+
+            workspaceCandidates += candidates.length;
+            workspaceInferred += updates.length;
+            if (execute) {
+              workspaceUpdated += await applyStepContentUpdates({
+                updates,
+                workspace,
+              });
+            }
+
+            logger.info(
+              {
+                workspaceId: workspace.sId,
+                afterCursor,
+                workspaceCandidates,
+                workspaceInferred,
+                workspaceSkipped: workspaceCandidates - workspaceInferred,
+                workspaceUpdated,
+              },
+              "[StepContentDustRunIdBackfill] Batch complete"
+            );
+          }
+
+          totalCandidates += workspaceCandidates;
+          totalInferred += workspaceInferred;
+          totalUpdated += workspaceUpdated;
+
+          logger.info(
+            {
+              workspaceId: workspace.sId,
+              workspaceCandidates,
+              workspaceInferred,
+              workspaceSkipped: workspaceCandidates - workspaceInferred,
+              workspaceUpdated,
+              execute,
+            },
+            "[StepContentDustRunIdBackfill] Workspace complete"
+          );
+        },
+        { wId: workspaceId, fromWorkspaceId }
+      );
+
+      logger.info(
+        {
+          fromDate: parsedFromDate.toISOString(),
+          toDate: parsedToDate.toISOString(),
+          totalCandidates,
+          totalInferred,
+          totalSkipped: totalCandidates - totalInferred,
+          totalUpdated,
+          execute,
+        },
+        "[StepContentDustRunIdBackfill] Backfill complete"
+      );
+    }
+  );
+}
+
+if (process.argv[1]?.endsWith("backfill_agent_step_content_dust_run_ids.ts")) {
+  runScript();
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This adds a dry-run-first script that backfills `dustRunId` on historical agent step contents across all message statuses. It reconstructs the association by ordering each message’s runs chronologically and matching them to agent-loop steps, skipping inconsistent data rather than guessing.

The script updates Postgres directly, so it also makes `AgentStepContentResource` compare cached `dustRunId` values with Postgres metadata. Stale Redis entries are automatically treated as cache misses and refreshed on the next read.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
