### PR TITLE
[sparkle] Fix ContentMessage staying light in dark mode

### DIFF
--- a/sparkle/src/components/ContentMessage.tsx
+++ b/sparkle/src/components/ContentMessage.tsx
@@ -24,16 +24,52 @@ const CONTENT_MESSAGE_SIZES = ["sm", "md", "lg"] as const;
 type ContentMessageSizeType = (typeof CONTENT_MESSAGE_SIZES)[number];
 
 const sharedVariantStyles = {
-  primary: "bg-stone-50 border-stone-150",
-  success: "bg-success-50 border-success-200",
-  warning: "bg-red-50 border-rose-100",
-  highlight: "bg-highlight-50 border-highlight-100",
-  info: "bg-orange-50 border-orange-100",
-  green: "bg-success-50 border-success-200",
-  blue: "bg-highlight-50 border-highlight-100",
-  rose: "bg-red-50 border-rose-100",
-  golden: "bg-orange-50 border-orange-100",
-  outline: "bg-transparent border-stone-150",
+  primary: cn(
+    "bg-stone-50 border-stone-150",
+    "dark:bg-stone-950 dark:border-stone-800"
+  ),
+  success: cn(
+    "bg-success-50 border-success-200",
+    "dark:bg-green-950 dark:border-green-900"
+  ),
+  warning: cn(
+    "bg-red-50 border-rose-100",
+    "dark:bg-red-950 dark:border-red-900"
+  ),
+  highlight: cn(
+    "bg-highlight-50 border-highlight-100",
+    "dark:bg-blue-950 dark:border-blue-900"
+  ),
+  info: cn(
+    "bg-orange-50 border-orange-100",
+    "dark:bg-golden-950 dark:border-golden-900"
+  ),
+  green: cn(
+    "bg-success-50 border-success-200",
+    "dark:bg-green-950 dark:border-green-900"
+  ),
+  blue: cn(
+    "bg-highlight-50 border-highlight-100",
+    "dark:bg-blue-950 dark:border-blue-900"
+  ),
+  rose: cn("bg-red-50 border-rose-100", "dark:bg-red-950 dark:border-red-900"),
+  golden: cn(
+    "bg-orange-50 border-orange-100",
+    "dark:bg-golden-950 dark:border-golden-900"
+  ),
+  outline: cn("bg-transparent border-stone-150", "dark:border-stone-750"),
+};
+
+const FOREGROUND_VARIANT_STYLES = {
+  primary: "text-stone-800 dark:text-stone-50",
+  warning: "text-red-800 dark:text-red-100",
+  success: "text-success-800 dark:text-green-100",
+  highlight: "text-highlight-800 dark:text-blue-100",
+  info: "text-orange-800 dark:text-golden-100",
+  green: "text-success-800 dark:text-green-100",
+  blue: "text-highlight-800 dark:text-blue-100",
+  rose: "text-red-800 dark:text-red-100",
+  golden: "text-orange-800 dark:text-golden-100",
 };
 
 const contentMessageVariants = cva("flex flex-col gap-3 border", {
@@ -66,15 +102,7 @@ const contentMessageInlineVariants = cva(
 const iconVariants = cva("shrink-0", {
   variants: {
     variant: {
-      primary: "text-stone-800",
-      warning: "text-red-800",
-      success: "text-success-800",
-      highlight: "text-highlight-800",
-      info: "text-orange-800",
-      green: "text-success-800",
-      blue: "text-highlight-800",
-      rose: "text-red-800",
-      golden: "text-orange-800",
+      ...FOREGROUND_VARIANT_STYLES,
       outline: "text-muted-foreground",
     },
   },
@@ -83,15 +111,7 @@ const iconVariants = cva("shrink-0", {
 const titleVariants = cva("", {
   variants: {
     variant: {
-      primary: "text-stone-800",
-      warning: "text-red-800",
-      success: "text-success-800",
-      highlight: "text-highlight-800",
-      info: "text-orange-800",
-      green: "text-success-800",
-      blue: "text-highlight-800",
-      rose: "text-red-800",
-      golden: "text-orange-800",
+      ...FOREGROUND_VARIANT_STYLES,
       outline: "text-foreground",
     },
   },
@@ -100,15 +120,7 @@ const titleVariants = cva("", {
 const textVariants = cva("", {
   variants: {
     variant: {
-      primary: "text-stone-800",
-      warning: "text-red-800",
-      success: "text-success-800",
-      highlight: "text-highlight-800",
-      info: "text-orange-800",
-      green: "text-success-800",
-      blue: "text-highlight-800",
-      rose: "text-red-800",
-      golden: "text-orange-800",
+      ...FOREGROUND_VARIANT_STYLES,
       outline: "text-muted-foreground",
     },
   },


### PR DESCRIPTION
## Problem

Every `ContentMessage` / `ContentMessageInline` variant built on a raw palette class rendered near-white on the dark canvas. Most visible with `variant="primary"`: the blocked-actions banner above the input bar (`AgentInputBar.tsx:489`) and `ToolValidationCard`.

The Figma redesign (#30172) swapped the semantic tokens for raw palette classes (`bg-stone-50`, `text-red-800`, `bg-orange-50`, ...). In `tokens.css`, only the **semantic** scales are remapped inside `.dark`:

| | light (`:root`) | dark (`.dark`) |
|---|---|---|
| `--color-primary-50` | `stone-50` | `stone-950` ✅ |
| `--color-stone-50` | `stone-50` | `stone-50` ❌ |

## Fix

Dark mode is declared explicitly from the [Figma dark spec](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=13405-36130), the way `Chip.tsx` already does it: one palette family per variant, fixed role per step.

| role | colored variants | neutral |
|---|---|---|
| background | `950` | `950` |
| stroke | `900` | `800` |
| text + icon | `100` | `50` |

| variant | family |
|---|---|
| `primary`, `outline` | stone |
| `warning`, `rose` | red |
| `success`, `green` | green |
| `highlight`, `blue` | blue |
| `info`, `golden` | golden |

`outline` is the one deliberate departure: it has no fill of its own, so it keeps the lighter `stone-750` stroke. It sits on the app or panel surface (`stone-900`/`850`), against which the `stone-800` that reads as a rim on `primary`'s `stone-950` fill would vanish.

### Why not lean on the semantic scales

Two reasons, both measured:

1. Their `.dark` remap lands on different steps than the spec asks for.
2. The orange ramp is **not hue-stable**: 73.7° at step 50, 36.3° at step 950 — and `red-950` is 38.1°. So mirroring `orange-50 → orange-950` produced an `info` banner the same hue as `warning`, which is the red banner reported on this PR.

## Verification

Storybook `Feedback & Status/ContentMessage` → `ColorVariants`, sampling computed background / border / text and converting to sRGB via canvas.

- **Light untouched** — rendered each variant beside a reference element carrying `main`'s original classes: `9/9` identical, zero diffs.
- **Dark** — every background and every text color matches the spec hexes exactly.

### One Figma / token drift to sort out separately

The `highlight`/`blue` stroke is the only value not matching the spec, because the variable and the token have drifted:

| variable | Figma | our token | delta |
|---|---|---|---|
| `Blue/900` | `#063158` | `blue-900` `#07355f` | 8 RGB units |

This PR uses the token rather than hardcoding the hex, so either the Figma variable or the token needs a resync — worth a look independently of this change.

`npx tsgo --noEmit` clean in `sparkle`; `npm run format:changed` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)