### PR TITLE
[MCP] Implement Shopify export tools

### DIFF
--- a/front/lib/actions/mcp_internal_actions/server_token_labels.ts
+++ b/front/lib/actions/mcp_internal_actions/server_token_labels.ts
@@ -46,6 +46,15 @@ const SERVER_TOKEN_LABELS: Record<string, TokenFieldLabel> = {
     tooltip:
       "You can find your API key by clicking your avatar (bottom left) and selecting API info.",
   },
+  // Preview only: manual access token + shop domain via header. Removed when
+  // Shopify OAuth lands (token + shop come from the connection instead).
+  shopify: {
+    label: "Shopify Admin API access token",
+    placeholder: "Paste your Shopify Admin API access token",
+    tooltip:
+      "Paste the Admin API access token of the Shopify store's custom app to connect the store to Dust.",
+    predefinedHeaders: ["X-Shopify-Shop"],
+  },
 };
 
 const DEFAULT_TOKEN_LABEL: TokenFieldLabel = {

--- a/front/lib/api/actions/servers/shopify/client.ts
+++ b/front/lib/api/actions/servers/shopify/client.ts
@@ -1,0 +1,214 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ExportResult } from "@app/lib/api/actions/servers/shopify/types";
+import { PageInfoSchema } from "@app/lib/api/actions/servers/shopify/types";
+import { untrustedFetch } from "@app/lib/egress/server";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { z } from "zod";
+
+const SHOPIFY_API_VERSION = "2026-07";
+
+// Shopify caps a connection's `first` argument at 250.
+const PAGE_SIZE = 250;
+
+// Hard cap on exported records to keep responses and API usage bounded.
+export const MAX_EXPORT_ITEMS = 1000;
+
+async function shopifyGraphQL<T extends z.ZodTypeAny>(
+  {
+    accessToken,
+    shop,
+    query,
+  }: {
+    accessToken: string;
+    shop: string;
+    query: string;
+  },
+  schema: T
+): Promise<Result<z.infer<T>, MCPError>> {
+  const url = `https://${shop}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`;
+
+  let response: Awaited<ReturnType<typeof untrustedFetch>>;
+  try {
+    response = await untrustedFetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Shopify-Access-Token": accessToken,
+      },
+      body: JSON.stringify({ query }),
+    });
+  } catch (err) {
+    return new Err(
+      new MCPError(
+        `Failed to reach the Shopify API: ${normalizeError(err).message}`
+      )
+    );
+  }
+
+  if (!response.ok) {
+    const body = await response.text();
+    if (response.status === 401 || response.status === 403) {
+      return new Err(
+        new MCPError(
+          "Shopify authentication failed. The access token may be expired or missing the required scope."
+        )
+      );
+    }
+    return new Err(
+      new MCPError(
+        `Shopify API error: ${response.status} ${response.statusText} - ${body.slice(0, 200)}`
+      )
+    );
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(await response.text());
+  } catch (err) {
+    return new Err(
+      new MCPError(
+        `Invalid JSON from the Shopify API: ${normalizeError(err).message}`
+      )
+    );
+  }
+
+  // Shopify returns HTTP 200 with partial `data` and an `errors` array when a
+  // field is redacted (e.g. missing scope / PCD). `data` is validated inline by
+  // the tool schema; `nullish` keeps the "data absent + errors" case parseable
+  // so we can surface the GraphQL error rather than a format error.
+  const parsed = z
+    .object({
+      data: schema.nullish(),
+      errors: z.array(z.object({ message: z.string() })).optional(),
+    })
+    .safeParse(json);
+  if (!parsed.success) {
+    logger.error(
+      { error: parsed.error.message },
+      "[Shopify MCP Server] Response validation failed"
+    );
+    return new Err(
+      new MCPError(`Invalid Shopify response format: ${parsed.error.message}`)
+    );
+  }
+
+  const { data, errors } = parsed.data;
+
+  // Only fail when `data` is absent; otherwise use what we got and log the
+  // redactions.
+  if (data === undefined || data === null) {
+    const message =
+      errors?.map((e) => e.message).join("; ") ?? "Shopify returned no data.";
+    return new Err(new MCPError(`Shopify GraphQL error: ${message}`));
+  }
+  if (errors && errors.length > 0) {
+    logger.warn(
+      { errors: errors.map((e) => e.message) },
+      "[Shopify MCP Server] Partial response with errors (likely redacted fields)"
+    );
+  }
+
+  return new Ok(data);
+}
+
+// One page of a Shopify connection, flattened to the shape `paginate` consumes.
+interface Page<N> {
+  nodes: N[];
+  hasNextPage: boolean;
+  endCursor: string | null;
+}
+
+async function paginate<N>({
+  limit,
+  runPage,
+}: {
+  limit: number;
+  runPage: (cursor: string | null) => Promise<Result<Page<N>, MCPError>>;
+}): Promise<Result<ExportResult<N>, MCPError>> {
+  const cap = Math.min(limit, MAX_EXPORT_ITEMS);
+  const nodes: N[] = [];
+  let cursor: string | null = null;
+
+  while (nodes.length < cap) {
+    const pageRes = await runPage(cursor);
+    if (pageRes.isErr()) {
+      return pageRes;
+    }
+    const page = pageRes.value;
+    nodes.push(...page.nodes);
+    if (!page.hasNextPage || !page.endCursor) {
+      return new Ok({ nodes: nodes.slice(0, cap), truncated: false });
+    }
+    cursor = page.endCursor;
+  }
+
+  return new Ok({ nodes: nodes.slice(0, cap), truncated: true });
+}
+
+// Wrap a value in single quotes for the Shopify search syntax so values with
+// spaces are matched as a whole. Escape backslashes before quotes so the
+// ordering does not double-escape.
+export function quoteSearchValue(value: string): string {
+  return `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+}
+
+// A Shopify connection response, aliased to a fixed `connection` key so a single
+// generic helper can extract it type-safely regardless of the root field.
+function connectionSchema<T extends z.ZodTypeAny>(node: T) {
+  return z.object({
+    connection: z.object({
+      edges: z.array(z.object({ node })),
+      pageInfo: PageInfoSchema,
+    }),
+  });
+}
+
+// Paginate any Shopify connection: build the query from `root` + `fields`,
+// validate each page against `nodeSchema`, and accumulate via `paginate`.
+export async function paginateConnection<T extends z.ZodTypeAny>({
+  accessToken,
+  shop,
+  root,
+  fields,
+  filters,
+  limit,
+  nodeSchema,
+}: {
+  accessToken: string;
+  shop: string;
+  root: "products" | "customers" | "orders";
+  fields: string;
+  filters: string[];
+  limit: number;
+  nodeSchema: T;
+}): Promise<Result<ExportResult<z.infer<T>>, MCPError>> {
+  const schema = connectionSchema(nodeSchema);
+  return paginate<z.infer<T>>({
+    limit,
+    runPage: async (cursor) => {
+      const after = cursor ? `, after: ${JSON.stringify(cursor)}` : "";
+      const search = filters.length
+        ? `, query: ${JSON.stringify(filters.join(" "))}`
+        : "";
+      const query = `{
+        connection: ${root}(first: ${PAGE_SIZE}${after}${search}) {
+          edges { node { ${fields} } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }`;
+      const res = await shopifyGraphQL({ accessToken, shop, query }, schema);
+      if (res.isErr()) {
+        return res;
+      }
+      const { edges, pageInfo } = res.value.connection;
+      return new Ok({
+        nodes: edges.map((e) => e.node),
+        hasNextPage: pageInfo.hasNextPage,
+        endCursor: pageInfo.endCursor,
+      });
+    },
+  });
+}

--- a/front/lib/api/actions/servers/shopify/client.ts
+++ b/front/lib/api/actions/servers/shopify/client.ts
@@ -1,11 +1,25 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import type { ExportResult } from "@app/lib/api/actions/servers/shopify/types";
-import { PageInfoSchema } from "@app/lib/api/actions/servers/shopify/types";
+import { getShopDomain } from "@app/lib/api/actions/servers/shopify/helpers";
+import type {
+  ExportResult,
+  ShopifyCustomer,
+  ShopifyOrder,
+  ShopifyProduct,
+  TopCustomer,
+} from "@app/lib/api/actions/servers/shopify/types";
+import {
+  CustomerNodeSchema,
+  OrderAggNodeSchema,
+  OrderNodeSchema,
+  PageInfoSchema,
+  ProductNodeSchema,
+} from "@app/lib/api/actions/servers/shopify/types";
 import { untrustedFetch } from "@app/lib/egress/server";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { z } from "zod";
 
 const SHOPIFY_API_VERSION = "2026-07";
@@ -16,109 +30,70 @@ const PAGE_SIZE = 250;
 // Hard cap on exported records to keep responses and API usage bounded.
 export const MAX_EXPORT_ITEMS = 1000;
 
-async function shopifyGraphQL<T extends z.ZodTypeAny>(
-  {
-    accessToken,
-    shop,
-    query,
-  }: {
-    accessToken: string;
-    shop: string;
-    query: string;
-  },
-  schema: T
-): Promise<Result<z.infer<T>, MCPError>> {
-  const url = `https://${shop}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`;
-
-  let response: Awaited<ReturnType<typeof untrustedFetch>>;
-  try {
-    response = await untrustedFetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Shopify-Access-Token": accessToken,
-      },
-      body: JSON.stringify({ query }),
-    });
-  } catch (err) {
-    return new Err(
-      new MCPError(
-        `Failed to reach the Shopify API: ${normalizeError(err).message}`
-      )
-    );
+const PRODUCT_FIELDS = `
+  id
+  title
+  handle
+  status
+  vendor
+  productType
+  totalInventory
+  createdAt
+  updatedAt
+  priceRangeV2 {
+    minVariantPrice { amount currencyCode }
+    maxVariantPrice { amount currencyCode }
   }
+`;
 
-  if (!response.ok) {
-    const body = await response.text();
-    if (response.status === 401 || response.status === 403) {
-      return new Err(
-        new MCPError(
-          "Shopify authentication failed. The access token may be expired or missing the required scope."
-        )
-      );
-    }
-    return new Err(
-      new MCPError(
-        `Shopify API error: ${response.status} ${response.statusText} - ${body.slice(0, 200)}`
-      )
-    );
-  }
+const CUSTOMER_FIELDS = `
+  id
+  numberOfOrders
+  amountSpent { amount currencyCode }
+  createdAt
+`;
 
-  let json: unknown;
-  try {
-    json = JSON.parse(await response.text());
-  } catch (err) {
-    return new Err(
-      new MCPError(
-        `Invalid JSON from the Shopify API: ${normalizeError(err).message}`
-      )
-    );
-  }
+const ORDER_FIELDS = `
+  id
+  name
+  createdAt
+  displayFinancialStatus
+  displayFulfillmentStatus
+  totalPriceSet { shopMoney { amount currencyCode } }
+  subtotalPriceSet { shopMoney { amount currencyCode } }
+  totalTaxSet { shopMoney { amount currencyCode } }
+  customer { id }
+`;
 
-  // Shopify returns HTTP 200 with partial `data` and an `errors` array when a
-  // field is redacted (e.g. missing scope / PCD). `data` is validated inline by
-  // the tool schema; `nullish` keeps the "data absent + errors" case parseable
-  // so we can surface the GraphQL error rather than a format error.
-  const parsed = z
-    .object({
-      data: schema.nullish(),
-      errors: z.array(z.object({ message: z.string() })).optional(),
-    })
-    .safeParse(json);
-  if (!parsed.success) {
-    logger.error(
-      { error: parsed.error.message },
-      "[Shopify MCP Server] Response validation failed"
-    );
-    return new Err(
-      new MCPError(`Invalid Shopify response format: ${parsed.error.message}`)
-    );
-  }
-
-  const { data, errors } = parsed.data;
-
-  // Only fail when `data` is absent; otherwise use what we got and log the
-  // redactions.
-  if (data === undefined || data === null) {
-    const message =
-      errors?.map((e) => e.message).join("; ") ?? "Shopify returned no data.";
-    return new Err(new MCPError(`Shopify GraphQL error: ${message}`));
-  }
-  if (errors && errors.length > 0) {
-    logger.warn(
-      { errors: errors.map((e) => e.message) },
-      "[Shopify MCP Server] Partial response with errors (likely redacted fields)"
-    );
-  }
-
-  return new Ok(data);
-}
+const ORDER_AGG_FIELDS = `
+  id
+  totalPriceSet { shopMoney { amount currencyCode } }
+  customer { id }
+`;
 
 // One page of a Shopify connection, flattened to the shape `paginate` consumes.
 interface Page<N> {
   nodes: N[];
   hasNextPage: boolean;
   endCursor: string | null;
+}
+
+// Wrap a value in single quotes for the Shopify search syntax so values with
+// spaces are matched as a whole. Escape backslashes before quotes so the
+// ordering does not double-escape.
+function quoteSearchValue(value: string): string {
+  return `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+}
+
+// A Shopify connection response, aliased to a fixed `connection` key so a single
+// generic helper can extract it type-safely regardless of the root field.
+function connectionSchema<T extends z.ZodTypeAny>(node: T) {
+  return z.object({
+    connection: z.object({
+      edges: z.array(z.object({ node })),
+      pageInfo: PageInfoSchema,
+    }),
+  });
 }
 
 async function paginate<N>({
@@ -145,70 +120,362 @@ async function paginate<N>({
     cursor = page.endCursor;
   }
 
-  return new Ok({ nodes: nodes.slice(0, cap), truncated: true });
-}
-
-// Wrap a value in single quotes for the Shopify search syntax so values with
-// spaces are matched as a whole. Escape backslashes before quotes so the
-// ordering does not double-escape.
-export function quoteSearchValue(value: string): string {
-  return `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
-}
-
-// A Shopify connection response, aliased to a fixed `connection` key so a single
-// generic helper can extract it type-safely regardless of the root field.
-function connectionSchema<T extends z.ZodTypeAny>(node: T) {
-  return z.object({
-    connection: z.object({
-      edges: z.array(z.object({ node })),
-      pageInfo: PageInfoSchema,
-    }),
+  // We stopped with more pages available. Only flag truncation when the hard
+  // cap was the binding constraint; a smaller caller `limit` means the caller
+  // got exactly what they asked for.
+  return new Ok({
+    nodes: nodes.slice(0, cap),
+    truncated: cap === MAX_EXPORT_ITEMS,
   });
 }
 
-// Paginate any Shopify connection: build the query from `root` + `fields`,
-// validate each page against `nodeSchema`, and accumulate via `paginate`.
-export async function paginateConnection<T extends z.ZodTypeAny>({
-  accessToken,
-  shop,
-  root,
-  fields,
-  filters,
-  limit,
-  nodeSchema,
-}: {
-  accessToken: string;
-  shop: string;
-  root: "products" | "customers" | "orders";
-  fields: string;
-  filters: string[];
-  limit: number;
-  nodeSchema: T;
-}): Promise<Result<ExportResult<z.infer<T>>, MCPError>> {
-  const schema = connectionSchema(nodeSchema);
-  return paginate<z.infer<T>>({
-    limit,
-    runPage: async (cursor) => {
-      const after = cursor ? `, after: ${JSON.stringify(cursor)}` : "";
-      const search = filters.length
-        ? `, query: ${JSON.stringify(filters.join(" "))}`
-        : "";
-      const query = `{
-        connection: ${root}(first: ${PAGE_SIZE}${after}${search}) {
-          edges { node { ${fields} } }
-          pageInfo { hasNextPage endCursor }
-        }
-      }`;
-      const res = await shopifyGraphQL({ accessToken, shop, query }, schema);
-      if (res.isErr()) {
-        return res;
-      }
-      const { edges, pageInfo } = res.value.connection;
-      return new Ok({
-        nodes: edges.map((e) => e.node),
-        hasNextPage: pageInfo.hasNextPage,
-        endCursor: pageInfo.endCursor,
+// Owns all outbound interactions with the Shopify Admin API: it holds the access
+// token and shop domain and exposes one method per export. Instantiate it via
+// `createShopifyClient`, which validates the auth information.
+export class ShopifyClient {
+  constructor(
+    private readonly accessToken: string,
+    private readonly shop: string
+  ) {}
+
+  private async graphQL<T extends z.ZodTypeAny>(
+    query: string,
+    schema: T
+  ): Promise<Result<z.infer<T>, MCPError>> {
+    const url = `https://${this.shop}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`;
+
+    let response: Awaited<ReturnType<typeof untrustedFetch>>;
+    try {
+      response = await untrustedFetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Shopify-Access-Token": this.accessToken,
+        },
+        body: JSON.stringify({ query }),
       });
-    },
-  });
+    } catch (err) {
+      return new Err(
+        new MCPError(
+          `Failed to reach the Shopify API: ${normalizeError(err).message}`
+        )
+      );
+    }
+
+    if (!response.ok) {
+      const body = await response.text();
+      // Errors from Shopify's side (bad token, rate limit, their outages): not a
+      // bug on ours, so don't report them to our observability stack.
+      if (response.status === 401 || response.status === 403) {
+        return new Err(
+          new MCPError(
+            "Shopify authentication failed. The access token may be expired or missing the required scope.",
+            { tracked: false }
+          )
+        );
+      }
+      return new Err(
+        new MCPError(
+          `Shopify API error: ${response.status} ${response.statusText} - ${body.slice(0, 200)}`,
+          { tracked: false }
+        )
+      );
+    }
+
+    let json: unknown;
+    try {
+      json = JSON.parse(await response.text());
+    } catch (err) {
+      return new Err(
+        new MCPError(
+          `Invalid JSON from the Shopify API: ${normalizeError(err).message}`,
+          { tracked: false }
+        )
+      );
+    }
+
+    // Shopify returns HTTP 200 with partial `data` and an `errors` array when a
+    // field is redacted (e.g. missing scope / PCD). `data` is validated inline by
+    // the tool schema; `nullish` keeps the "data absent + errors" case parseable
+    // so we can surface the GraphQL error rather than a format error.
+    const parsed = z
+      .object({
+        data: schema.nullish(),
+        errors: z.array(z.object({ message: z.string() })).optional(),
+      })
+      .safeParse(json);
+    if (!parsed.success) {
+      logger.error(
+        { error: parsed.error.message },
+        "[Shopify MCP Server] Response validation failed"
+      );
+      return new Err(
+        new MCPError(`Invalid Shopify response format: ${parsed.error.message}`)
+      );
+    }
+
+    const { data, errors } = parsed.data;
+
+    // Only fail when `data` is absent; otherwise use what we got and log the
+    // redactions.
+    if (data === undefined || data === null) {
+      const message =
+        errors?.map((e) => e.message).join("; ") ?? "Shopify returned no data.";
+      // Comes from Shopify's side (e.g. redacted fields / missing scope), not a
+      // bug on ours: don't report it to our observability stack.
+      return new Err(
+        new MCPError(`Shopify GraphQL error: ${message}`, { tracked: false })
+      );
+    }
+    if (errors && errors.length > 0) {
+      logger.warn(
+        { errors: errors.map((e) => e.message) },
+        "[Shopify MCP Server] Partial response with errors (likely redacted fields)"
+      );
+    }
+
+    return new Ok(data);
+  }
+
+  // Paginate any Shopify connection: build the query from `root` + `fields`,
+  // validate each page against `nodeSchema`, and accumulate via `paginate`.
+  private async paginateConnection<T extends z.ZodTypeAny>({
+    root,
+    fields,
+    filters,
+    limit,
+    nodeSchema,
+  }: {
+    root: "products" | "customers" | "orders";
+    fields: string;
+    filters: string[];
+    limit: number;
+    nodeSchema: T;
+  }): Promise<Result<ExportResult<z.infer<T>>, MCPError>> {
+    const schema = connectionSchema(nodeSchema);
+    return paginate<z.infer<T>>({
+      limit,
+      runPage: async (cursor) => {
+        const after = cursor ? `, after: ${JSON.stringify(cursor)}` : "";
+        const search = filters.length
+          ? `, query: ${JSON.stringify(filters.join(" "))}`
+          : "";
+        const query = `{
+          connection: ${root}(first: ${PAGE_SIZE}${after}${search}) {
+            edges { node { ${fields} } }
+            pageInfo { hasNextPage endCursor }
+          }
+        }`;
+        const res = await this.graphQL(query, schema);
+        if (res.isErr()) {
+          return res;
+        }
+        const { edges, pageInfo } = res.value.connection;
+        return new Ok({
+          nodes: edges.map((e) => e.node),
+          hasNextPage: pageInfo.hasNextPage,
+          endCursor: pageInfo.endCursor,
+        });
+      },
+    });
+  }
+
+  async exportProducts({
+    status,
+    vendor,
+    searchQuery,
+    limit,
+  }: {
+    status?: "ACTIVE" | "DRAFT" | "ARCHIVED";
+    vendor?: string;
+    searchQuery?: string;
+    limit: number;
+  }): Promise<Result<ExportResult<ShopifyProduct>, MCPError>> {
+    const filters: string[] = [];
+    if (status) {
+      filters.push(`status:${status.toLowerCase()}`);
+    }
+    if (vendor) {
+      filters.push(`vendor:${quoteSearchValue(vendor)}`);
+    }
+    if (searchQuery) {
+      filters.push(searchQuery);
+    }
+
+    return this.paginateConnection({
+      root: "products",
+      fields: PRODUCT_FIELDS,
+      filters,
+      limit,
+      nodeSchema: ProductNodeSchema,
+    });
+  }
+
+  async exportCustomerLtv({
+    sortByAmountSpent,
+    minAmountSpentDollars,
+    limit,
+  }: {
+    sortByAmountSpent?: boolean;
+    minAmountSpentDollars?: number;
+    limit: number;
+  }): Promise<Result<ExportResult<ShopifyCustomer>, MCPError>> {
+    const filters: string[] = [];
+    if (minAmountSpentDollars !== undefined) {
+      filters.push(`total_spent:>=${minAmountSpentDollars}`);
+    }
+    const wantsSort = sortByAmountSpent ?? true;
+    // Shopify has no "total spent" sort key, so to return the true top lifetime
+    // spenders we must fetch a wide window and rank locally. Fetching up to the
+    // cap makes the ranking exact when the set fits under it (or is narrowed by
+    // minAmountSpentDollars); beyond the cap it is approximate and flagged as
+    // truncated.
+    const fetchLimit = wantsSort ? MAX_EXPORT_ITEMS : limit;
+
+    const res = await this.paginateConnection({
+      root: "customers",
+      fields: CUSTOMER_FIELDS,
+      filters,
+      limit: fetchLimit,
+      nodeSchema: CustomerNodeSchema,
+    });
+    if (res.isErr()) {
+      return res;
+    }
+
+    if (!wantsSort) {
+      return res;
+    }
+
+    const sorted = [...res.value.nodes].sort(
+      (a, b) => Number(b.amountSpent.amount) - Number(a.amountSpent.amount)
+    );
+    return new Ok({
+      nodes: sorted.slice(0, limit),
+      truncated: res.value.truncated,
+    });
+  }
+
+  async exportSales({
+    startDate,
+    endDate,
+    financialStatus,
+    fulfillmentStatus,
+    limit,
+  }: {
+    startDate?: string;
+    endDate?: string;
+    financialStatus?: string;
+    fulfillmentStatus?: string;
+    limit: number;
+  }): Promise<Result<ExportResult<ShopifyOrder>, MCPError>> {
+    const filters: string[] = [];
+    if (startDate) {
+      filters.push(`created_at:>='${startDate}'`);
+    }
+    if (endDate) {
+      filters.push(`created_at:<='${endDate}'`);
+    }
+    if (financialStatus) {
+      filters.push(`financial_status:${financialStatus.toLowerCase()}`);
+    }
+    if (fulfillmentStatus) {
+      filters.push(`fulfillment_status:${fulfillmentStatus.toLowerCase()}`);
+    }
+
+    return this.paginateConnection({
+      root: "orders",
+      fields: ORDER_FIELDS,
+      filters,
+      limit,
+      nodeSchema: OrderNodeSchema,
+    });
+  }
+
+  async exportTopCustomersByPeriod({
+    startDate,
+    endDate,
+    limit,
+  }: {
+    startDate?: string;
+    endDate?: string;
+    limit: number;
+  }): Promise<Result<ExportResult<TopCustomer>, MCPError>> {
+    const filters: string[] = [];
+    if (startDate) {
+      filters.push(`created_at:>='${startDate}'`);
+    }
+    if (endDate) {
+      filters.push(`created_at:<='${endDate}'`);
+    }
+    // Fetch every order in the window (up to the cap) so the per-customer
+    // aggregation is complete. `limit` only bounds the returned ranking.
+    const res = await this.paginateConnection({
+      root: "orders",
+      fields: ORDER_AGG_FIELDS,
+      filters,
+      limit: MAX_EXPORT_ITEMS,
+      nodeSchema: OrderAggNodeSchema,
+    });
+    if (res.isErr()) {
+      return res;
+    }
+
+    const byCustomer = new Map<
+      string,
+      { amountDollars: number; currencyCode: string; numberOfOrders: number }
+    >();
+    for (const order of res.value.nodes) {
+      // Skip guest orders (no associated customer).
+      if (!order.customer) {
+        continue;
+      }
+      const amountDollars = Number(order.totalPriceSet.shopMoney.amount);
+      const existing = byCustomer.get(order.customer.id);
+      if (existing) {
+        existing.amountDollars += amountDollars;
+        existing.numberOfOrders += 1;
+      } else {
+        byCustomer.set(order.customer.id, {
+          amountDollars,
+          currencyCode: order.totalPriceSet.shopMoney.currencyCode,
+          numberOfOrders: 1,
+        });
+      }
+    }
+
+    const ranked: TopCustomer[] = [...byCustomer.entries()]
+      .map(([customerId, agg]) => ({
+        customerId,
+        numberOfOrders: agg.numberOfOrders,
+        amountSpent: {
+          amount: agg.amountDollars.toFixed(2),
+          currencyCode: agg.currencyCode,
+        },
+      }))
+      .sort(
+        (a, b) => Number(b.amountSpent.amount) - Number(a.amountSpent.amount)
+      )
+      .slice(0, limit);
+
+    // If the order fetch hit the cap, some orders were not counted, so the
+    // ranking is approximate.
+    return new Ok({ nodes: ranked, truncated: res.value.truncated });
+  }
+}
+
+// Instantiate a ShopifyClient from the request auth info. Fails when the access
+// token or a valid shop domain is missing.
+export function createShopifyClient(
+  authInfo?: AuthInfo
+): Result<ShopifyClient, MCPError> {
+  const accessToken = authInfo?.token;
+  if (!accessToken) {
+    return new Err(new MCPError("No Shopify access token found."));
+  }
+  const shopRes = getShopDomain(authInfo);
+  if (shopRes.isErr()) {
+    return shopRes;
+  }
+  return new Ok(new ShopifyClient(accessToken, shopRes.value));
 }

--- a/front/lib/api/actions/servers/shopify/helpers.ts
+++ b/front/lib/api/actions/servers/shopify/helpers.ts
@@ -395,23 +395,24 @@ export async function exportCustomerLtv(
   shop: string,
   {
     sortByAmountSpent,
-    minAmountSpent,
+    minAmountSpentDollars,
     limit,
   }: {
     sortByAmountSpent?: boolean;
-    minAmountSpent?: number;
+    minAmountSpentDollars?: number;
     limit: number;
   }
 ): Promise<Result<ExportResult<ShopifyCustomer>, MCPError>> {
   const filters: string[] = [];
-  if (minAmountSpent !== undefined) {
-    filters.push(`total_spent:>=${minAmountSpent}`);
+  if (minAmountSpentDollars !== undefined) {
+    filters.push(`total_spent:>=${minAmountSpentDollars}`);
   }
   const wantsSort = sortByAmountSpent ?? true;
   // Shopify has no "total spent" sort key, so to return the true top lifetime
   // spenders we must fetch a wide window and rank locally. Fetching up to the
   // cap makes the ranking exact when the set fits under it (or is narrowed by
-  // minAmountSpent); beyond the cap it is approximate and flagged as truncated.
+  // minAmountSpentDollars); beyond the cap it is approximate and flagged as
+  // truncated.
   const fetchLimit = wantsSort ? MAX_EXPORT_ITEMS : limit;
 
   const res = await paginateConnection({
@@ -515,21 +516,21 @@ export async function exportTopCustomersByPeriod(
 
   const byCustomer = new Map<
     string,
-    { amount: number; currencyCode: string; numberOfOrders: number }
+    { amountDollars: number; currencyCode: string; numberOfOrders: number }
   >();
   for (const order of res.value.nodes) {
     // Skip guest orders (no associated customer).
     if (!order.customer) {
       continue;
     }
-    const amount = Number(order.totalPriceSet.shopMoney.amount);
+    const amountDollars = Number(order.totalPriceSet.shopMoney.amount);
     const existing = byCustomer.get(order.customer.id);
     if (existing) {
-      existing.amount += amount;
+      existing.amountDollars += amountDollars;
       existing.numberOfOrders += 1;
     } else {
       byCustomer.set(order.customer.id, {
-        amount,
+        amountDollars,
         currencyCode: order.totalPriceSet.shopMoney.currencyCode,
         numberOfOrders: 1,
       });
@@ -541,7 +542,7 @@ export async function exportTopCustomersByPeriod(
       customerId,
       numberOfOrders: agg.numberOfOrders,
       amountSpent: {
-        amount: agg.amount.toFixed(2),
+        amount: agg.amountDollars.toFixed(2),
         currencyCode: agg.currencyCode,
       },
     }))

--- a/front/lib/api/actions/servers/shopify/helpers.ts
+++ b/front/lib/api/actions/servers/shopify/helpers.ts
@@ -1,70 +1,10 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import {
-  MAX_EXPORT_ITEMS,
-  paginateConnection,
-  quoteSearchValue,
-} from "@app/lib/api/actions/servers/shopify/client";
-import type {
-  ExportResult,
-  ShopifyCustomer,
-  ShopifyOrder,
-  ShopifyProduct,
-  TopCustomer,
-} from "@app/lib/api/actions/servers/shopify/types";
-import {
-  CustomerNodeSchema,
-  OrderAggNodeSchema,
-  OrderNodeSchema,
-  ProductNodeSchema,
-} from "@app/lib/api/actions/servers/shopify/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 
-const PRODUCT_FIELDS = `
-  id
-  title
-  handle
-  status
-  vendor
-  productType
-  totalInventory
-  createdAt
-  updatedAt
-  priceRangeV2 {
-    minVariantPrice { amount currencyCode }
-    maxVariantPrice { amount currencyCode }
-  }
-`;
-
-const CUSTOMER_FIELDS = `
-  id
-  numberOfOrders
-  amountSpent { amount currencyCode }
-  createdAt
-`;
-
-const ORDER_FIELDS = `
-  id
-  name
-  createdAt
-  displayFinancialStatus
-  displayFulfillmentStatus
-  totalPriceSet { shopMoney { amount currencyCode } }
-  subtotalPriceSet { shopMoney { amount currencyCode } }
-  totalTaxSet { shopMoney { amount currencyCode } }
-  customer { id }
-`;
-
-const ORDER_AGG_FIELDS = `
-  id
-  totalPriceSet { shopMoney { amount currencyCode } }
-  customer { id }
-`;
-
-function getShopDomain(authInfo?: AuthInfo): Result<string, MCPError> {
+export function getShopDomain(authInfo?: AuthInfo): Result<string, MCPError> {
   // Preview: no Shopify OAuth provider yet, so the shop domain is read from the
   // `X-Shopify-Shop` custom header set at setup. It will come from the OAuth
   // connection once that lands.
@@ -78,9 +18,20 @@ function getShopDomain(authInfo?: AuthInfo): Result<string, MCPError> {
       )
     );
   }
-  const host = parsed.data["X-Shopify-Shop"]
-    .replace(/^https?:\/\//, "")
-    .replace(/\/.*$/, "");
+  // Accept both bare domains and full URLs by prepending a scheme so the URL
+  // parser can extract the hostname in either case.
+  const raw = parsed.data["X-Shopify-Shop"];
+  const withScheme = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+  let host: string;
+  try {
+    host = new URL(withScheme).hostname;
+  } catch {
+    return new Err(
+      new MCPError(
+        "Invalid Shopify shop domain. Use the store's myshopify.com domain (e.g. my-store.myshopify.com)."
+      )
+    );
+  }
   if (!host.endsWith(".myshopify.com")) {
     return new Err(
       new MCPError(
@@ -89,226 +40,4 @@ function getShopDomain(authInfo?: AuthInfo): Result<string, MCPError> {
     );
   }
   return new Ok(host);
-}
-
-export async function exportProducts(
-  accessToken: string,
-  shop: string,
-  {
-    status,
-    vendor,
-    searchQuery,
-    limit,
-  }: {
-    status?: "ACTIVE" | "DRAFT" | "ARCHIVED";
-    vendor?: string;
-    searchQuery?: string;
-    limit: number;
-  }
-): Promise<Result<ExportResult<ShopifyProduct>, MCPError>> {
-  const filters: string[] = [];
-  if (status) {
-    filters.push(`status:${status.toLowerCase()}`);
-  }
-  if (vendor) {
-    filters.push(`vendor:${quoteSearchValue(vendor)}`);
-  }
-  if (searchQuery) {
-    filters.push(searchQuery);
-  }
-
-  return paginateConnection({
-    accessToken,
-    shop,
-    root: "products",
-    fields: PRODUCT_FIELDS,
-    filters,
-    limit,
-    nodeSchema: ProductNodeSchema,
-  });
-}
-
-export async function exportCustomerLtv(
-  accessToken: string,
-  shop: string,
-  {
-    sortByAmountSpent,
-    minAmountSpentDollars,
-    limit,
-  }: {
-    sortByAmountSpent?: boolean;
-    minAmountSpentDollars?: number;
-    limit: number;
-  }
-): Promise<Result<ExportResult<ShopifyCustomer>, MCPError>> {
-  const filters: string[] = [];
-  if (minAmountSpentDollars !== undefined) {
-    filters.push(`total_spent:>=${minAmountSpentDollars}`);
-  }
-  const wantsSort = sortByAmountSpent ?? true;
-  // Shopify has no "total spent" sort key, so to return the true top lifetime
-  // spenders we must fetch a wide window and rank locally. Fetching up to the
-  // cap makes the ranking exact when the set fits under it (or is narrowed by
-  // minAmountSpentDollars); beyond the cap it is approximate and flagged as
-  // truncated.
-  const fetchLimit = wantsSort ? MAX_EXPORT_ITEMS : limit;
-
-  const res = await paginateConnection({
-    accessToken,
-    shop,
-    root: "customers",
-    fields: CUSTOMER_FIELDS,
-    filters,
-    limit: fetchLimit,
-    nodeSchema: CustomerNodeSchema,
-  });
-  if (res.isErr()) {
-    return res;
-  }
-
-  if (!wantsSort) {
-    return res;
-  }
-
-  const sorted = [...res.value.nodes].sort(
-    (a, b) => Number(b.amountSpent.amount) - Number(a.amountSpent.amount)
-  );
-  return new Ok({
-    nodes: sorted.slice(0, limit),
-    truncated: res.value.truncated,
-  });
-}
-
-export async function exportSales(
-  accessToken: string,
-  shop: string,
-  {
-    startDate,
-    endDate,
-    financialStatus,
-    fulfillmentStatus,
-    limit,
-  }: {
-    startDate?: string;
-    endDate?: string;
-    financialStatus?: string;
-    fulfillmentStatus?: string;
-    limit: number;
-  }
-): Promise<Result<ExportResult<ShopifyOrder>, MCPError>> {
-  const filters: string[] = [];
-  if (startDate) {
-    filters.push(`created_at:>='${startDate}'`);
-  }
-  if (endDate) {
-    filters.push(`created_at:<='${endDate}'`);
-  }
-  if (financialStatus) {
-    filters.push(`financial_status:${financialStatus.toLowerCase()}`);
-  }
-  if (fulfillmentStatus) {
-    filters.push(`fulfillment_status:${fulfillmentStatus.toLowerCase()}`);
-  }
-
-  return paginateConnection({
-    accessToken,
-    shop,
-    root: "orders",
-    fields: ORDER_FIELDS,
-    filters,
-    limit,
-    nodeSchema: OrderNodeSchema,
-  });
-}
-
-export async function exportTopCustomersByPeriod(
-  accessToken: string,
-  shop: string,
-  {
-    startDate,
-    endDate,
-    limit,
-  }: { startDate?: string; endDate?: string; limit: number }
-): Promise<Result<ExportResult<TopCustomer>, MCPError>> {
-  const filters: string[] = [];
-  if (startDate) {
-    filters.push(`created_at:>='${startDate}'`);
-  }
-  if (endDate) {
-    filters.push(`created_at:<='${endDate}'`);
-  }
-  // Fetch every order in the window (up to the cap) so the per-customer
-  // aggregation is complete. `limit` only bounds the returned ranking.
-  const res = await paginateConnection({
-    accessToken,
-    shop,
-    root: "orders",
-    fields: ORDER_AGG_FIELDS,
-    filters,
-    limit: MAX_EXPORT_ITEMS,
-    nodeSchema: OrderAggNodeSchema,
-  });
-  if (res.isErr()) {
-    return res;
-  }
-
-  const byCustomer = new Map<
-    string,
-    { amountDollars: number; currencyCode: string; numberOfOrders: number }
-  >();
-  for (const order of res.value.nodes) {
-    // Skip guest orders (no associated customer).
-    if (!order.customer) {
-      continue;
-    }
-    const amountDollars = Number(order.totalPriceSet.shopMoney.amount);
-    const existing = byCustomer.get(order.customer.id);
-    if (existing) {
-      existing.amountDollars += amountDollars;
-      existing.numberOfOrders += 1;
-    } else {
-      byCustomer.set(order.customer.id, {
-        amountDollars,
-        currencyCode: order.totalPriceSet.shopMoney.currencyCode,
-        numberOfOrders: 1,
-      });
-    }
-  }
-
-  const ranked: TopCustomer[] = [...byCustomer.entries()]
-    .map(([customerId, agg]) => ({
-      customerId,
-      numberOfOrders: agg.numberOfOrders,
-      amountSpent: {
-        amount: agg.amountDollars.toFixed(2),
-        currencyCode: agg.currencyCode,
-      },
-    }))
-    .sort((a, b) => Number(b.amountSpent.amount) - Number(a.amountSpent.amount))
-    .slice(0, limit);
-
-  // If the order fetch hit the cap, some orders were not counted, so the
-  // ranking is approximate.
-  return new Ok({ nodes: ranked, truncated: res.value.truncated });
-}
-
-export async function withShopifyAuth({
-  authInfo,
-  action,
-}: {
-  authInfo?: AuthInfo;
-  action: (
-    accessToken: string,
-    shop: string
-  ) => Promise<Result<CallToolResult["content"], MCPError>>;
-}): Promise<Result<CallToolResult["content"], MCPError>> {
-  const accessToken = authInfo?.token;
-  if (!accessToken) {
-    return new Err(new MCPError("No Shopify access token found."));
-  }
-  const shopRes = getShopDomain(authInfo);
-  if (shopRes.isErr()) {
-    return shopRes;
-  }
-  return action(accessToken, shopRes.value);
 }

--- a/front/lib/api/actions/servers/shopify/helpers.ts
+++ b/front/lib/api/actions/servers/shopify/helpers.ts
@@ -1,316 +1,27 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import { untrustedFetch } from "@app/lib/egress/server";
-import logger from "@app/logger/logger";
+import {
+  MAX_EXPORT_ITEMS,
+  paginateConnection,
+  quoteSearchValue,
+} from "@app/lib/api/actions/servers/shopify/client";
+import type {
+  ExportResult,
+  ShopifyCustomer,
+  ShopifyOrder,
+  ShopifyProduct,
+  TopCustomer,
+} from "@app/lib/api/actions/servers/shopify/types";
+import {
+  CustomerNodeSchema,
+  OrderAggNodeSchema,
+  OrderNodeSchema,
+  ProductNodeSchema,
+} from "@app/lib/api/actions/servers/shopify/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-
-const SHOPIFY_API_VERSION = "2026-07";
-
-// Shopify caps a connection's `first` argument at 250.
-const PAGE_SIZE = 250;
-
-// Hard cap on exported records to keep responses and API usage bounded.
-export const MAX_EXPORT_ITEMS = 1000;
-
-const MoneySchema = z.object({
-  amount: z.string(),
-  currencyCode: z.string(),
-});
-const MoneyBagSchema = z.object({ shopMoney: MoneySchema });
-
-const PageInfoSchema = z.object({
-  hasNextPage: z.boolean(),
-  endCursor: z.string().nullable(),
-});
-
-const ProductNodeSchema = z.object({
-  id: z.string(),
-  title: z.string(),
-  handle: z.string(),
-  status: z.string(),
-  vendor: z.string(),
-  productType: z.string(),
-  totalInventory: z.number(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
-  priceRangeV2: z.object({
-    minVariantPrice: MoneySchema,
-    maxVariantPrice: MoneySchema,
-  }),
-});
-export type ShopifyProduct = z.infer<typeof ProductNodeSchema>;
-
-// Customer lifetime value: level 1 (non-identifying) data only, identified by
-// ID. Name/email/phone are protected customer fields (PCD level 2) and are
-// intentionally not requested.
-const CustomerNodeSchema = z.object({
-  id: z.string(),
-  // Shopify serializes numberOfOrders (UnsignedInt64) as a string.
-  numberOfOrders: z.union([z.string(), z.number()]),
-  amountSpent: MoneySchema,
-  createdAt: z.string(),
-});
-export type ShopifyCustomer = z.infer<typeof CustomerNodeSchema>;
-
-const OrderNodeSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  createdAt: z.string(),
-  displayFinancialStatus: z.string().nullable(),
-  displayFulfillmentStatus: z.string(),
-  totalPriceSet: MoneyBagSchema,
-  subtotalPriceSet: MoneyBagSchema.nullable(),
-  totalTaxSet: MoneyBagSchema.nullable(),
-  // Reference the customer by ID only (no PII).
-  customer: z.object({ id: z.string() }).nullable(),
-});
-export type ShopifyOrder = z.infer<typeof OrderNodeSchema>;
-
-// Minimal order shape used to aggregate spend per customer over a period.
-const OrderAggNodeSchema = z.object({
-  id: z.string(),
-  totalPriceSet: MoneyBagSchema,
-  customer: z.object({ id: z.string() }).nullable(),
-});
-
-export interface TopCustomer {
-  customerId: string;
-  numberOfOrders: number;
-  amountSpent: { amount: string; currencyCode: string };
-}
-
-function getShopDomain(authInfo?: AuthInfo): Result<string, MCPError> {
-  // Phase 1: the shop domain is passed as an `X-Shopify-Shop` custom header set
-  // manually by the merchant. Phase 2 (OAuth) will source it from the connection
-  // metadata instead, so this custom-header path is temporary.
-  const parsed = z
-    .object({ "X-Shopify-Shop": z.string().trim().min(1) })
-    .safeParse(authInfo?.extra?.customHeaders);
-  if (!parsed.success) {
-    return new Err(
-      new MCPError(
-        "Shopify shop domain not found. Set it as an `X-Shopify-Shop` custom header (e.g. my-store.myshopify.com)."
-      )
-    );
-  }
-  const host = parsed.data["X-Shopify-Shop"]
-    .replace(/^https?:\/\//, "")
-    .replace(/\/.*$/, "");
-  return new Ok(
-    host.endsWith(".myshopify.com") ? host : `${host}.myshopify.com`
-  );
-}
-
-async function shopifyGraphQL<T extends z.ZodTypeAny>(
-  {
-    accessToken,
-    shop,
-    query,
-  }: {
-    accessToken: string;
-    shop: string;
-    query: string;
-  },
-  schema: T
-): Promise<Result<z.infer<T>, MCPError>> {
-  const url = `https://${shop}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`;
-
-  let response: Awaited<ReturnType<typeof untrustedFetch>>;
-  try {
-    response = await untrustedFetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Shopify-Access-Token": accessToken,
-      },
-      body: JSON.stringify({ query }),
-    });
-  } catch (err) {
-    return new Err(
-      new MCPError(
-        `Failed to reach the Shopify API: ${normalizeError(err).message}`
-      )
-    );
-  }
-
-  if (!response.ok) {
-    const body = await response.text();
-    if (response.status === 401 || response.status === 403) {
-      return new Err(
-        new MCPError(
-          "Shopify authentication failed. The access token may be expired or missing the required scope."
-        )
-      );
-    }
-    return new Err(
-      new MCPError(
-        `Shopify API error: ${response.status} ${response.statusText} - ${body.slice(0, 200)}`
-      )
-    );
-  }
-
-  let json: unknown;
-  try {
-    json = JSON.parse(await response.text());
-  } catch (err) {
-    return new Err(
-      new MCPError(
-        `Invalid JSON from the Shopify API: ${normalizeError(err).message}`
-      )
-    );
-  }
-
-  const envelope = z
-    .object({
-      data: z.unknown().optional(),
-      errors: z.array(z.object({ message: z.string() })).optional(),
-    })
-    .safeParse(json);
-  if (!envelope.success) {
-    return new Err(new MCPError("Unexpected Shopify API response shape."));
-  }
-
-  const { data, errors } = envelope.data;
-
-  // Shopify returns HTTP 200 with partial `data` and an `errors` array when a
-  // field is redacted (e.g. missing scope / PCD). Only fail when `data` is
-  // absent; otherwise use what we got and log the redactions.
-  if (data === undefined || data === null) {
-    const message =
-      errors?.map((e) => e.message).join("; ") ?? "Shopify returned no data.";
-    return new Err(new MCPError(`Shopify GraphQL error: ${message}`));
-  }
-  if (errors && errors.length > 0) {
-    logger.warn(
-      { errors: errors.map((e) => e.message) },
-      "[Shopify MCP Server] Partial response with errors (likely redacted fields)"
-    );
-  }
-
-  const parsed = schema.safeParse(data);
-  if (!parsed.success) {
-    logger.error(
-      { error: parsed.error.message },
-      "[Shopify MCP Server] Response validation failed"
-    );
-    return new Err(
-      new MCPError(`Invalid Shopify response format: ${parsed.error.message}`)
-    );
-  }
-  return new Ok(parsed.data);
-}
-
-export interface ExportResult<N> {
-  nodes: N[];
-  truncated: boolean;
-}
-
-// One page of a Shopify connection, flattened to the shape `paginate` consumes.
-interface Page<N> {
-  nodes: N[];
-  hasNextPage: boolean;
-  endCursor: string | null;
-}
-
-async function paginate<N>({
-  limit,
-  runPage,
-}: {
-  limit: number;
-  runPage: (cursor: string | null) => Promise<Result<Page<N>, MCPError>>;
-}): Promise<Result<ExportResult<N>, MCPError>> {
-  const cap = Math.min(limit, MAX_EXPORT_ITEMS);
-  const nodes: N[] = [];
-  let cursor: string | null = null;
-
-  while (nodes.length < cap) {
-    const pageRes = await runPage(cursor);
-    if (pageRes.isErr()) {
-      return pageRes;
-    }
-    const page = pageRes.value;
-    nodes.push(...page.nodes);
-    if (!page.hasNextPage || !page.endCursor) {
-      return new Ok({ nodes: nodes.slice(0, cap), truncated: false });
-    }
-    cursor = page.endCursor;
-  }
-
-  return new Ok({ nodes: nodes.slice(0, cap), truncated: true });
-}
-
-function afterArg(cursor: string | null): string {
-  return cursor ? `, after: ${JSON.stringify(cursor)}` : "";
-}
-
-function queryArg(filters: string[]): string {
-  return filters.length ? `, query: ${JSON.stringify(filters.join(" "))}` : "";
-}
-
-// Wrap a value in single quotes for the Shopify search syntax so values with
-// spaces are matched as a whole. Escape backslashes before quotes so the
-// ordering does not double-escape.
-function quoteSearchValue(value: string): string {
-  return `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
-}
-
-// A Shopify connection response, aliased to a fixed `connection` key so a single
-// generic helper can extract it type-safely regardless of the root field.
-function connectionSchema<T extends z.ZodTypeAny>(node: T) {
-  return z.object({
-    connection: z.object({
-      edges: z.array(z.object({ node })),
-      pageInfo: PageInfoSchema,
-    }),
-  });
-}
-
-// Paginate any Shopify connection: build the query from `root` + `fields`,
-// validate each page against `nodeSchema`, and accumulate via `paginate`.
-async function paginateConnection<T extends z.ZodTypeAny>({
-  accessToken,
-  shop,
-  root,
-  fields,
-  filters,
-  limit,
-  nodeSchema,
-}: {
-  accessToken: string;
-  shop: string;
-  root: "products" | "customers" | "orders";
-  fields: string;
-  filters: string[];
-  limit: number;
-  nodeSchema: T;
-}): Promise<Result<ExportResult<z.infer<T>>, MCPError>> {
-  const schema = connectionSchema(nodeSchema);
-  return paginate<z.infer<T>>({
-    limit,
-    runPage: async (cursor) => {
-      const query = `{
-        connection: ${root}(first: ${PAGE_SIZE}${afterArg(cursor)}${queryArg(filters)}) {
-          edges { node { ${fields} } }
-          pageInfo { hasNextPage endCursor }
-        }
-      }`;
-      const res = await shopifyGraphQL({ accessToken, shop, query }, schema);
-      if (res.isErr()) {
-        return res;
-      }
-      const { edges, pageInfo } = res.value.connection;
-      return new Ok({
-        nodes: edges.map((e) => e.node),
-        hasNextPage: pageInfo.hasNextPage,
-        endCursor: pageInfo.endCursor,
-      });
-    },
-  });
-}
 
 const PRODUCT_FIELDS = `
   id
@@ -352,6 +63,33 @@ const ORDER_AGG_FIELDS = `
   totalPriceSet { shopMoney { amount currencyCode } }
   customer { id }
 `;
+
+function getShopDomain(authInfo?: AuthInfo): Result<string, MCPError> {
+  // Preview: no Shopify OAuth provider yet, so the shop domain is read from the
+  // `X-Shopify-Shop` custom header set at setup. It will come from the OAuth
+  // connection once that lands.
+  const parsed = z
+    .object({ "X-Shopify-Shop": z.string().trim().min(1) })
+    .safeParse(authInfo?.extra?.customHeaders);
+  if (!parsed.success) {
+    return new Err(
+      new MCPError(
+        "Shopify shop domain not found. Set it as an `X-Shopify-Shop` custom header (e.g. my-store.myshopify.com)."
+      )
+    );
+  }
+  const host = parsed.data["X-Shopify-Shop"]
+    .replace(/^https?:\/\//, "")
+    .replace(/\/.*$/, "");
+  if (!host.endsWith(".myshopify.com")) {
+    return new Err(
+      new MCPError(
+        "Invalid Shopify shop domain. Use the store's myshopify.com domain (e.g. my-store.myshopify.com)."
+      )
+    );
+  }
+  return new Ok(host);
+}
 
 export async function exportProducts(
   accessToken: string,
@@ -573,17 +311,4 @@ export async function withShopifyAuth({
     return shopRes;
   }
   return action(accessToken, shopRes.value);
-}
-
-export function renderExport<N>(
-  label: string,
-  { nodes, truncated }: ExportResult<N>
-): CallToolResult["content"] {
-  const summary = truncated
-    ? `Exported ${nodes.length} ${label} (truncated at the ${MAX_EXPORT_ITEMS}-record cap).`
-    : `Exported ${nodes.length} ${label}.`;
-  return [
-    { type: "text" as const, text: summary },
-    { type: "text" as const, text: JSON.stringify(nodes, null, 2) },
-  ];
 }

--- a/front/lib/api/actions/servers/shopify/helpers.ts
+++ b/front/lib/api/actions/servers/shopify/helpers.ts
@@ -1,3 +1,588 @@
-// Hard cap on exported records to keep responses and API usage bounded. The
-// export helpers that enforce it land in a follow-up PR.
-export const MAX_EXPORT_ITEMS = 1_000;
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import { untrustedFetch } from "@app/lib/egress/server";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+
+const SHOPIFY_API_VERSION = "2026-07";
+
+// Shopify caps a connection's `first` argument at 250.
+const PAGE_SIZE = 250;
+
+// Hard cap on exported records to keep responses and API usage bounded.
+export const MAX_EXPORT_ITEMS = 1000;
+
+const MoneySchema = z.object({
+  amount: z.string(),
+  currencyCode: z.string(),
+});
+const MoneyBagSchema = z.object({ shopMoney: MoneySchema });
+
+const PageInfoSchema = z.object({
+  hasNextPage: z.boolean(),
+  endCursor: z.string().nullable(),
+});
+
+const ProductNodeSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  handle: z.string(),
+  status: z.string(),
+  vendor: z.string(),
+  productType: z.string(),
+  totalInventory: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  priceRangeV2: z.object({
+    minVariantPrice: MoneySchema,
+    maxVariantPrice: MoneySchema,
+  }),
+});
+export type ShopifyProduct = z.infer<typeof ProductNodeSchema>;
+
+// Customer lifetime value: level 1 (non-identifying) data only, identified by
+// ID. Name/email/phone are protected customer fields (PCD level 2) and are
+// intentionally not requested.
+const CustomerNodeSchema = z.object({
+  id: z.string(),
+  // Shopify serializes numberOfOrders (UnsignedInt64) as a string.
+  numberOfOrders: z.union([z.string(), z.number()]),
+  amountSpent: MoneySchema,
+  createdAt: z.string(),
+});
+export type ShopifyCustomer = z.infer<typeof CustomerNodeSchema>;
+
+const OrderNodeSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  createdAt: z.string(),
+  displayFinancialStatus: z.string().nullable(),
+  displayFulfillmentStatus: z.string(),
+  totalPriceSet: MoneyBagSchema,
+  subtotalPriceSet: MoneyBagSchema.nullable(),
+  totalTaxSet: MoneyBagSchema.nullable(),
+  // Reference the customer by ID only (no PII).
+  customer: z.object({ id: z.string() }).nullable(),
+});
+export type ShopifyOrder = z.infer<typeof OrderNodeSchema>;
+
+// Minimal order shape used to aggregate spend per customer over a period.
+const OrderAggNodeSchema = z.object({
+  id: z.string(),
+  totalPriceSet: MoneyBagSchema,
+  customer: z.object({ id: z.string() }).nullable(),
+});
+
+export interface TopCustomer {
+  customerId: string;
+  numberOfOrders: number;
+  amountSpent: { amount: string; currencyCode: string };
+}
+
+function getShopDomain(authInfo?: AuthInfo): Result<string, MCPError> {
+  // Phase 1: the shop domain is passed as an `X-Shopify-Shop` custom header set
+  // manually by the merchant. Phase 2 (OAuth) will source it from the connection
+  // metadata instead, so this custom-header path is temporary.
+  const parsed = z
+    .object({ "X-Shopify-Shop": z.string().trim().min(1) })
+    .safeParse(authInfo?.extra?.customHeaders);
+  if (!parsed.success) {
+    return new Err(
+      new MCPError(
+        "Shopify shop domain not found. Set it as an `X-Shopify-Shop` custom header (e.g. my-store.myshopify.com)."
+      )
+    );
+  }
+  const host = parsed.data["X-Shopify-Shop"]
+    .replace(/^https?:\/\//, "")
+    .replace(/\/.*$/, "");
+  return new Ok(
+    host.endsWith(".myshopify.com") ? host : `${host}.myshopify.com`
+  );
+}
+
+async function shopifyGraphQL<T extends z.ZodTypeAny>(
+  {
+    accessToken,
+    shop,
+    query,
+  }: {
+    accessToken: string;
+    shop: string;
+    query: string;
+  },
+  schema: T
+): Promise<Result<z.infer<T>, MCPError>> {
+  const url = `https://${shop}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`;
+
+  let response: Awaited<ReturnType<typeof untrustedFetch>>;
+  try {
+    response = await untrustedFetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Shopify-Access-Token": accessToken,
+      },
+      body: JSON.stringify({ query }),
+    });
+  } catch (err) {
+    return new Err(
+      new MCPError(
+        `Failed to reach the Shopify API: ${normalizeError(err).message}`
+      )
+    );
+  }
+
+  if (!response.ok) {
+    const body = await response.text();
+    if (response.status === 401 || response.status === 403) {
+      return new Err(
+        new MCPError(
+          "Shopify authentication failed. The access token may be expired or missing the required scope."
+        )
+      );
+    }
+    return new Err(
+      new MCPError(
+        `Shopify API error: ${response.status} ${response.statusText} - ${body.slice(0, 200)}`
+      )
+    );
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(await response.text());
+  } catch (err) {
+    return new Err(
+      new MCPError(
+        `Invalid JSON from the Shopify API: ${normalizeError(err).message}`
+      )
+    );
+  }
+
+  const envelope = z
+    .object({
+      data: z.unknown().optional(),
+      errors: z.array(z.object({ message: z.string() })).optional(),
+    })
+    .safeParse(json);
+  if (!envelope.success) {
+    return new Err(new MCPError("Unexpected Shopify API response shape."));
+  }
+
+  const { data, errors } = envelope.data;
+
+  // Shopify returns HTTP 200 with partial `data` and an `errors` array when a
+  // field is redacted (e.g. missing scope / PCD). Only fail when `data` is
+  // absent; otherwise use what we got and log the redactions.
+  if (data === undefined || data === null) {
+    const message =
+      errors?.map((e) => e.message).join("; ") ?? "Shopify returned no data.";
+    return new Err(new MCPError(`Shopify GraphQL error: ${message}`));
+  }
+  if (errors && errors.length > 0) {
+    logger.warn(
+      { errors: errors.map((e) => e.message) },
+      "[Shopify MCP Server] Partial response with errors (likely redacted fields)"
+    );
+  }
+
+  const parsed = schema.safeParse(data);
+  if (!parsed.success) {
+    logger.error(
+      { error: parsed.error.message },
+      "[Shopify MCP Server] Response validation failed"
+    );
+    return new Err(
+      new MCPError(`Invalid Shopify response format: ${parsed.error.message}`)
+    );
+  }
+  return new Ok(parsed.data);
+}
+
+export interface ExportResult<N> {
+  nodes: N[];
+  truncated: boolean;
+}
+
+// One page of a Shopify connection, flattened to the shape `paginate` consumes.
+interface Page<N> {
+  nodes: N[];
+  hasNextPage: boolean;
+  endCursor: string | null;
+}
+
+async function paginate<N>({
+  limit,
+  runPage,
+}: {
+  limit: number;
+  runPage: (cursor: string | null) => Promise<Result<Page<N>, MCPError>>;
+}): Promise<Result<ExportResult<N>, MCPError>> {
+  const cap = Math.min(limit, MAX_EXPORT_ITEMS);
+  const nodes: N[] = [];
+  let cursor: string | null = null;
+
+  while (nodes.length < cap) {
+    const pageRes = await runPage(cursor);
+    if (pageRes.isErr()) {
+      return pageRes;
+    }
+    const page = pageRes.value;
+    nodes.push(...page.nodes);
+    if (!page.hasNextPage || !page.endCursor) {
+      return new Ok({ nodes: nodes.slice(0, cap), truncated: false });
+    }
+    cursor = page.endCursor;
+  }
+
+  return new Ok({ nodes: nodes.slice(0, cap), truncated: true });
+}
+
+function afterArg(cursor: string | null): string {
+  return cursor ? `, after: ${JSON.stringify(cursor)}` : "";
+}
+
+function queryArg(filters: string[]): string {
+  return filters.length ? `, query: ${JSON.stringify(filters.join(" "))}` : "";
+}
+
+// Wrap a value in single quotes for the Shopify search syntax so values with
+// spaces are matched as a whole. Escape backslashes before quotes so the
+// ordering does not double-escape.
+function quoteSearchValue(value: string): string {
+  return `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+}
+
+// A Shopify connection response, aliased to a fixed `connection` key so a single
+// generic helper can extract it type-safely regardless of the root field.
+function connectionSchema<T extends z.ZodTypeAny>(node: T) {
+  return z.object({
+    connection: z.object({
+      edges: z.array(z.object({ node })),
+      pageInfo: PageInfoSchema,
+    }),
+  });
+}
+
+// Paginate any Shopify connection: build the query from `root` + `fields`,
+// validate each page against `nodeSchema`, and accumulate via `paginate`.
+async function paginateConnection<T extends z.ZodTypeAny>({
+  accessToken,
+  shop,
+  root,
+  fields,
+  filters,
+  limit,
+  nodeSchema,
+}: {
+  accessToken: string;
+  shop: string;
+  root: "products" | "customers" | "orders";
+  fields: string;
+  filters: string[];
+  limit: number;
+  nodeSchema: T;
+}): Promise<Result<ExportResult<z.infer<T>>, MCPError>> {
+  const schema = connectionSchema(nodeSchema);
+  return paginate<z.infer<T>>({
+    limit,
+    runPage: async (cursor) => {
+      const query = `{
+        connection: ${root}(first: ${PAGE_SIZE}${afterArg(cursor)}${queryArg(filters)}) {
+          edges { node { ${fields} } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }`;
+      const res = await shopifyGraphQL({ accessToken, shop, query }, schema);
+      if (res.isErr()) {
+        return res;
+      }
+      const { edges, pageInfo } = res.value.connection;
+      return new Ok({
+        nodes: edges.map((e) => e.node),
+        hasNextPage: pageInfo.hasNextPage,
+        endCursor: pageInfo.endCursor,
+      });
+    },
+  });
+}
+
+const PRODUCT_FIELDS = `
+  id
+  title
+  handle
+  status
+  vendor
+  productType
+  totalInventory
+  createdAt
+  updatedAt
+  priceRangeV2 {
+    minVariantPrice { amount currencyCode }
+    maxVariantPrice { amount currencyCode }
+  }
+`;
+
+const CUSTOMER_FIELDS = `
+  id
+  numberOfOrders
+  amountSpent { amount currencyCode }
+  createdAt
+`;
+
+const ORDER_FIELDS = `
+  id
+  name
+  createdAt
+  displayFinancialStatus
+  displayFulfillmentStatus
+  totalPriceSet { shopMoney { amount currencyCode } }
+  subtotalPriceSet { shopMoney { amount currencyCode } }
+  totalTaxSet { shopMoney { amount currencyCode } }
+  customer { id }
+`;
+
+const ORDER_AGG_FIELDS = `
+  id
+  totalPriceSet { shopMoney { amount currencyCode } }
+  customer { id }
+`;
+
+export async function exportProducts(
+  accessToken: string,
+  shop: string,
+  {
+    status,
+    vendor,
+    searchQuery,
+    limit,
+  }: {
+    status?: "ACTIVE" | "DRAFT" | "ARCHIVED";
+    vendor?: string;
+    searchQuery?: string;
+    limit: number;
+  }
+): Promise<Result<ExportResult<ShopifyProduct>, MCPError>> {
+  const filters: string[] = [];
+  if (status) {
+    filters.push(`status:${status.toLowerCase()}`);
+  }
+  if (vendor) {
+    filters.push(`vendor:${quoteSearchValue(vendor)}`);
+  }
+  if (searchQuery) {
+    filters.push(searchQuery);
+  }
+
+  return paginateConnection({
+    accessToken,
+    shop,
+    root: "products",
+    fields: PRODUCT_FIELDS,
+    filters,
+    limit,
+    nodeSchema: ProductNodeSchema,
+  });
+}
+
+export async function exportCustomerLtv(
+  accessToken: string,
+  shop: string,
+  {
+    sortByAmountSpent,
+    minAmountSpent,
+    limit,
+  }: {
+    sortByAmountSpent?: boolean;
+    minAmountSpent?: number;
+    limit: number;
+  }
+): Promise<Result<ExportResult<ShopifyCustomer>, MCPError>> {
+  const filters: string[] = [];
+  if (minAmountSpent !== undefined) {
+    filters.push(`total_spent:>=${minAmountSpent}`);
+  }
+  const wantsSort = sortByAmountSpent ?? true;
+  // Shopify has no "total spent" sort key, so to return the true top lifetime
+  // spenders we must fetch a wide window and rank locally. Fetching up to the
+  // cap makes the ranking exact when the set fits under it (or is narrowed by
+  // minAmountSpent); beyond the cap it is approximate and flagged as truncated.
+  const fetchLimit = wantsSort ? MAX_EXPORT_ITEMS : limit;
+
+  const res = await paginateConnection({
+    accessToken,
+    shop,
+    root: "customers",
+    fields: CUSTOMER_FIELDS,
+    filters,
+    limit: fetchLimit,
+    nodeSchema: CustomerNodeSchema,
+  });
+  if (res.isErr()) {
+    return res;
+  }
+
+  if (!wantsSort) {
+    return res;
+  }
+
+  const sorted = [...res.value.nodes].sort(
+    (a, b) => Number(b.amountSpent.amount) - Number(a.amountSpent.amount)
+  );
+  return new Ok({
+    nodes: sorted.slice(0, limit),
+    truncated: res.value.truncated,
+  });
+}
+
+export async function exportSales(
+  accessToken: string,
+  shop: string,
+  {
+    startDate,
+    endDate,
+    financialStatus,
+    fulfillmentStatus,
+    limit,
+  }: {
+    startDate?: string;
+    endDate?: string;
+    financialStatus?: string;
+    fulfillmentStatus?: string;
+    limit: number;
+  }
+): Promise<Result<ExportResult<ShopifyOrder>, MCPError>> {
+  const filters: string[] = [];
+  if (startDate) {
+    filters.push(`created_at:>='${startDate}'`);
+  }
+  if (endDate) {
+    filters.push(`created_at:<='${endDate}'`);
+  }
+  if (financialStatus) {
+    filters.push(`financial_status:${financialStatus.toLowerCase()}`);
+  }
+  if (fulfillmentStatus) {
+    filters.push(`fulfillment_status:${fulfillmentStatus.toLowerCase()}`);
+  }
+
+  return paginateConnection({
+    accessToken,
+    shop,
+    root: "orders",
+    fields: ORDER_FIELDS,
+    filters,
+    limit,
+    nodeSchema: OrderNodeSchema,
+  });
+}
+
+export async function exportTopCustomersByPeriod(
+  accessToken: string,
+  shop: string,
+  {
+    startDate,
+    endDate,
+    limit,
+  }: { startDate?: string; endDate?: string; limit: number }
+): Promise<Result<ExportResult<TopCustomer>, MCPError>> {
+  const filters: string[] = [];
+  if (startDate) {
+    filters.push(`created_at:>='${startDate}'`);
+  }
+  if (endDate) {
+    filters.push(`created_at:<='${endDate}'`);
+  }
+  // Fetch every order in the window (up to the cap) so the per-customer
+  // aggregation is complete. `limit` only bounds the returned ranking.
+  const res = await paginateConnection({
+    accessToken,
+    shop,
+    root: "orders",
+    fields: ORDER_AGG_FIELDS,
+    filters,
+    limit: MAX_EXPORT_ITEMS,
+    nodeSchema: OrderAggNodeSchema,
+  });
+  if (res.isErr()) {
+    return res;
+  }
+
+  const byCustomer = new Map<
+    string,
+    { amount: number; currencyCode: string; numberOfOrders: number }
+  >();
+  for (const order of res.value.nodes) {
+    // Skip guest orders (no associated customer).
+    if (!order.customer) {
+      continue;
+    }
+    const amount = Number(order.totalPriceSet.shopMoney.amount);
+    const existing = byCustomer.get(order.customer.id);
+    if (existing) {
+      existing.amount += amount;
+      existing.numberOfOrders += 1;
+    } else {
+      byCustomer.set(order.customer.id, {
+        amount,
+        currencyCode: order.totalPriceSet.shopMoney.currencyCode,
+        numberOfOrders: 1,
+      });
+    }
+  }
+
+  const ranked: TopCustomer[] = [...byCustomer.entries()]
+    .map(([customerId, agg]) => ({
+      customerId,
+      numberOfOrders: agg.numberOfOrders,
+      amountSpent: {
+        amount: agg.amount.toFixed(2),
+        currencyCode: agg.currencyCode,
+      },
+    }))
+    .sort((a, b) => Number(b.amountSpent.amount) - Number(a.amountSpent.amount))
+    .slice(0, limit);
+
+  // If the order fetch hit the cap, some orders were not counted, so the
+  // ranking is approximate.
+  return new Ok({ nodes: ranked, truncated: res.value.truncated });
+}
+
+export async function withShopifyAuth({
+  authInfo,
+  action,
+}: {
+  authInfo?: AuthInfo;
+  action: (
+    accessToken: string,
+    shop: string
+  ) => Promise<Result<CallToolResult["content"], MCPError>>;
+}): Promise<Result<CallToolResult["content"], MCPError>> {
+  const accessToken = authInfo?.token;
+  if (!accessToken) {
+    return new Err(new MCPError("No Shopify access token found."));
+  }
+  const shopRes = getShopDomain(authInfo);
+  if (shopRes.isErr()) {
+    return shopRes;
+  }
+  return action(accessToken, shopRes.value);
+}
+
+export function renderExport<N>(
+  label: string,
+  { nodes, truncated }: ExportResult<N>
+): CallToolResult["content"] {
+  const summary = truncated
+    ? `Exported ${nodes.length} ${label} (truncated at the ${MAX_EXPORT_ITEMS}-record cap).`
+    : `Exported ${nodes.length} ${label}.`;
+  return [
+    { type: "text" as const, text: summary },
+    { type: "text" as const, text: JSON.stringify(nodes, null, 2) },
+  ];
+}

--- a/front/lib/api/actions/servers/shopify/metadata.ts
+++ b/front/lib/api/actions/servers/shopify/metadata.ts
@@ -136,9 +136,9 @@ export const SHOPIFY_SERVER = {
     version: "1.0.0",
     description:
       "Export product catalog, customer lifetime value, and sales data from a Shopify store.",
-    // Pilot (phase 1) uses a merchant-provided token injected via authInfo; no
-    // Dust OAuth provider yet. Phase 2 will set
-    // `authorization: { provider: "shopify", supported_use_cases: [...] }`.
+    // No Shopify OAuth provider yet (preview): auth uses requiresBearerToken
+    // instead — a merchant access token as bearer + the shop domain via the
+    // `X-Shopify-Shop` custom header. This becomes an OAuth provider later.
     authorization: null,
     icon: "ActionTableIcon",
     documentationUrl: null,

--- a/front/lib/api/actions/servers/shopify/rendering.ts
+++ b/front/lib/api/actions/servers/shopify/rendering.ts
@@ -1,0 +1,16 @@
+import { MAX_EXPORT_ITEMS } from "@app/lib/api/actions/servers/shopify/client";
+import type { ExportResult } from "@app/lib/api/actions/servers/shopify/types";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+export function renderExport<N>(
+  label: string,
+  { nodes, truncated }: ExportResult<N>
+): CallToolResult["content"] {
+  const summary = truncated
+    ? `Exported ${nodes.length} ${label} (truncated at the ${MAX_EXPORT_ITEMS}-record cap).`
+    : `Exported ${nodes.length} ${label}.`;
+  return [
+    { type: "text" as const, text: summary },
+    { type: "text" as const, text: JSON.stringify(nodes, null, 2) },
+  ];
+}

--- a/front/lib/api/actions/servers/shopify/tools/index.ts
+++ b/front/lib/api/actions/servers/shopify/tools/index.ts
@@ -1,15 +1,15 @@
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { MAX_EXPORT_ITEMS } from "@app/lib/api/actions/servers/shopify/client";
 import {
   exportCustomerLtv,
   exportProducts,
   exportSales,
   exportTopCustomersByPeriod,
-  MAX_EXPORT_ITEMS,
-  renderExport,
   withShopifyAuth,
 } from "@app/lib/api/actions/servers/shopify/helpers";
 import { SHOPIFY_TOOLS_METADATA } from "@app/lib/api/actions/servers/shopify/metadata";
+import { renderExport } from "@app/lib/api/actions/servers/shopify/rendering";
 import { Ok } from "@app/types/shared/result";
 
 const handlers: ToolHandlers<typeof SHOPIFY_TOOLS_METADATA> = {

--- a/front/lib/api/actions/servers/shopify/tools/index.ts
+++ b/front/lib/api/actions/servers/shopify/tools/index.ts
@@ -1,19 +1,96 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {
+  exportCustomerLtv,
+  exportProducts,
+  exportSales,
+  exportTopCustomersByPeriod,
+  MAX_EXPORT_ITEMS,
+  renderExport,
+  withShopifyAuth,
+} from "@app/lib/api/actions/servers/shopify/helpers";
 import { SHOPIFY_TOOLS_METADATA } from "@app/lib/api/actions/servers/shopify/metadata";
-import { Err } from "@app/types/shared/result";
-
-// Tool contracts are registered here; the implementations land in a follow-up
-// PR. Until then every handler returns a not-implemented error.
-const notImplemented = () =>
-  Promise.resolve(new Err(new MCPError("Shopify tool not yet implemented.")));
+import { Ok } from "@app/types/shared/result";
 
 const handlers: ToolHandlers<typeof SHOPIFY_TOOLS_METADATA> = {
-  export_products: notImplemented,
-  export_customer_ltv: notImplemented,
-  export_sales: notImplemented,
-  export_top_customers_by_period: notImplemented,
+  export_products: async (
+    { status, vendor, searchQuery, limit },
+    { authInfo }
+  ) =>
+    withShopifyAuth({
+      authInfo,
+      action: async (accessToken, shop) => {
+        const res = await exportProducts(accessToken, shop, {
+          status,
+          vendor,
+          searchQuery,
+          limit: limit ?? MAX_EXPORT_ITEMS,
+        });
+        if (res.isErr()) {
+          return res;
+        }
+        return new Ok(renderExport("products", res.value));
+      },
+    }),
+
+  export_customer_ltv: async (
+    { sortByAmountSpent, minAmountSpent, limit },
+    { authInfo }
+  ) =>
+    withShopifyAuth({
+      authInfo,
+      action: async (accessToken, shop) => {
+        const res = await exportCustomerLtv(accessToken, shop, {
+          sortByAmountSpent,
+          minAmountSpent,
+          limit: limit ?? MAX_EXPORT_ITEMS,
+        });
+        if (res.isErr()) {
+          return res;
+        }
+        return new Ok(renderExport("customers", res.value));
+      },
+    }),
+
+  export_sales: async (
+    { startDate, endDate, financialStatus, fulfillmentStatus, limit },
+    { authInfo }
+  ) =>
+    withShopifyAuth({
+      authInfo,
+      action: async (accessToken, shop) => {
+        const res = await exportSales(accessToken, shop, {
+          startDate,
+          endDate,
+          financialStatus,
+          fulfillmentStatus,
+          limit: limit ?? MAX_EXPORT_ITEMS,
+        });
+        if (res.isErr()) {
+          return res;
+        }
+        return new Ok(renderExport("orders", res.value));
+      },
+    }),
+
+  export_top_customers_by_period: async (
+    { startDate, endDate, limit },
+    { authInfo }
+  ) =>
+    withShopifyAuth({
+      authInfo,
+      action: async (accessToken, shop) => {
+        const res = await exportTopCustomersByPeriod(accessToken, shop, {
+          startDate,
+          endDate,
+          limit: limit ?? MAX_EXPORT_ITEMS,
+        });
+        if (res.isErr()) {
+          return res;
+        }
+        return new Ok(renderExport("top customers", res.value));
+      },
+    }),
 };
 
 export const TOOLS = buildTools(SHOPIFY_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/shopify/tools/index.ts
+++ b/front/lib/api/actions/servers/shopify/tools/index.ts
@@ -1,13 +1,9 @@
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { MAX_EXPORT_ITEMS } from "@app/lib/api/actions/servers/shopify/client";
 import {
-  exportCustomerLtv,
-  exportProducts,
-  exportSales,
-  exportTopCustomersByPeriod,
-  withShopifyAuth,
-} from "@app/lib/api/actions/servers/shopify/helpers";
+  createShopifyClient,
+  MAX_EXPORT_ITEMS,
+} from "@app/lib/api/actions/servers/shopify/client";
 import { SHOPIFY_TOOLS_METADATA } from "@app/lib/api/actions/servers/shopify/metadata";
 import { renderExport } from "@app/lib/api/actions/servers/shopify/rendering";
 import { Ok } from "@app/types/shared/result";
@@ -16,81 +12,81 @@ const handlers: ToolHandlers<typeof SHOPIFY_TOOLS_METADATA> = {
   export_products: async (
     { status, vendor, searchQuery, limit },
     { authInfo }
-  ) =>
-    withShopifyAuth({
-      authInfo,
-      action: async (accessToken, shop) => {
-        const res = await exportProducts(accessToken, shop, {
-          status,
-          vendor,
-          searchQuery,
-          limit: limit ?? MAX_EXPORT_ITEMS,
-        });
-        if (res.isErr()) {
-          return res;
-        }
-        return new Ok(renderExport("products", res.value));
-      },
-    }),
+  ) => {
+    const clientRes = createShopifyClient(authInfo);
+    if (clientRes.isErr()) {
+      return clientRes;
+    }
+    const res = await clientRes.value.exportProducts({
+      status,
+      vendor,
+      searchQuery,
+      limit: limit ?? MAX_EXPORT_ITEMS,
+    });
+    if (res.isErr()) {
+      return res;
+    }
+    return new Ok(renderExport("products", res.value));
+  },
 
   export_customer_ltv: async (
     { sortByAmountSpent, minAmountSpentDollars, limit },
     { authInfo }
-  ) =>
-    withShopifyAuth({
-      authInfo,
-      action: async (accessToken, shop) => {
-        const res = await exportCustomerLtv(accessToken, shop, {
-          sortByAmountSpent,
-          minAmountSpentDollars,
-          limit: limit ?? MAX_EXPORT_ITEMS,
-        });
-        if (res.isErr()) {
-          return res;
-        }
-        return new Ok(renderExport("customers", res.value));
-      },
-    }),
+  ) => {
+    const clientRes = createShopifyClient(authInfo);
+    if (clientRes.isErr()) {
+      return clientRes;
+    }
+    const res = await clientRes.value.exportCustomerLtv({
+      sortByAmountSpent,
+      minAmountSpentDollars,
+      limit: limit ?? MAX_EXPORT_ITEMS,
+    });
+    if (res.isErr()) {
+      return res;
+    }
+    return new Ok(renderExport("customers", res.value));
+  },
 
   export_sales: async (
     { startDate, endDate, financialStatus, fulfillmentStatus, limit },
     { authInfo }
-  ) =>
-    withShopifyAuth({
-      authInfo,
-      action: async (accessToken, shop) => {
-        const res = await exportSales(accessToken, shop, {
-          startDate,
-          endDate,
-          financialStatus,
-          fulfillmentStatus,
-          limit: limit ?? MAX_EXPORT_ITEMS,
-        });
-        if (res.isErr()) {
-          return res;
-        }
-        return new Ok(renderExport("orders", res.value));
-      },
-    }),
+  ) => {
+    const clientRes = createShopifyClient(authInfo);
+    if (clientRes.isErr()) {
+      return clientRes;
+    }
+    const res = await clientRes.value.exportSales({
+      startDate,
+      endDate,
+      financialStatus,
+      fulfillmentStatus,
+      limit: limit ?? MAX_EXPORT_ITEMS,
+    });
+    if (res.isErr()) {
+      return res;
+    }
+    return new Ok(renderExport("orders", res.value));
+  },
 
   export_top_customers_by_period: async (
     { startDate, endDate, limit },
     { authInfo }
-  ) =>
-    withShopifyAuth({
-      authInfo,
-      action: async (accessToken, shop) => {
-        const res = await exportTopCustomersByPeriod(accessToken, shop, {
-          startDate,
-          endDate,
-          limit: limit ?? MAX_EXPORT_ITEMS,
-        });
-        if (res.isErr()) {
-          return res;
-        }
-        return new Ok(renderExport("top customers", res.value));
-      },
-    }),
+  ) => {
+    const clientRes = createShopifyClient(authInfo);
+    if (clientRes.isErr()) {
+      return clientRes;
+    }
+    const res = await clientRes.value.exportTopCustomersByPeriod({
+      startDate,
+      endDate,
+      limit: limit ?? MAX_EXPORT_ITEMS,
+    });
+    if (res.isErr()) {
+      return res;
+    }
+    return new Ok(renderExport("top customers", res.value));
+  },
 };
 
 export const TOOLS = buildTools(SHOPIFY_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/shopify/tools/index.ts
+++ b/front/lib/api/actions/servers/shopify/tools/index.ts
@@ -34,7 +34,7 @@ const handlers: ToolHandlers<typeof SHOPIFY_TOOLS_METADATA> = {
     }),
 
   export_customer_ltv: async (
-    { sortByAmountSpent, minAmountSpent, limit },
+    { sortByAmountSpent, minAmountSpentDollars, limit },
     { authInfo }
   ) =>
     withShopifyAuth({
@@ -42,7 +42,7 @@ const handlers: ToolHandlers<typeof SHOPIFY_TOOLS_METADATA> = {
       action: async (accessToken, shop) => {
         const res = await exportCustomerLtv(accessToken, shop, {
           sortByAmountSpent,
-          minAmountSpent,
+          minAmountSpentDollars,
           limit: limit ?? MAX_EXPORT_ITEMS,
         });
         if (res.isErr()) {

--- a/front/lib/api/actions/servers/shopify/types.ts
+++ b/front/lib/api/actions/servers/shopify/types.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+
+const MoneySchema = z.object({
+  amount: z.string(),
+  currencyCode: z.string(),
+});
+const MoneyBagSchema = z.object({ shopMoney: MoneySchema });
+
+export const PageInfoSchema = z.object({
+  hasNextPage: z.boolean(),
+  endCursor: z.string().nullable(),
+});
+
+export const ProductNodeSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  handle: z.string(),
+  status: z.string(),
+  vendor: z.string(),
+  productType: z.string(),
+  totalInventory: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  priceRangeV2: z.object({
+    minVariantPrice: MoneySchema,
+    maxVariantPrice: MoneySchema,
+  }),
+});
+export type ShopifyProduct = z.infer<typeof ProductNodeSchema>;
+
+// Customer lifetime value: level 1 (non-identifying) data only, identified by
+// ID. Name/email/phone are protected customer fields (PCD level 2) and are
+// intentionally not requested.
+export const CustomerNodeSchema = z.object({
+  id: z.string(),
+  // Shopify serializes numberOfOrders (UnsignedInt64) as a string.
+  numberOfOrders: z.union([z.string(), z.number()]),
+  amountSpent: MoneySchema,
+  createdAt: z.string(),
+});
+export type ShopifyCustomer = z.infer<typeof CustomerNodeSchema>;
+
+export const OrderNodeSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  createdAt: z.string(),
+  displayFinancialStatus: z.string().nullable(),
+  displayFulfillmentStatus: z.string(),
+  totalPriceSet: MoneyBagSchema,
+  subtotalPriceSet: MoneyBagSchema.nullable(),
+  totalTaxSet: MoneyBagSchema.nullable(),
+  // Reference the customer by ID only (no PII).
+  customer: z.object({ id: z.string() }).nullable(),
+});
+export type ShopifyOrder = z.infer<typeof OrderNodeSchema>;
+
+// Minimal order shape used to aggregate spend per customer over a period.
+export const OrderAggNodeSchema = z.object({
+  id: z.string(),
+  totalPriceSet: MoneyBagSchema,
+  customer: z.object({ id: z.string() }).nullable(),
+});
+
+export interface TopCustomer {
+  customerId: string;
+  numberOfOrders: number;
+  amountSpent: { amount: string; currencyCode: string };
+}
+
+export interface ExportResult<N> {
+  nodes: N[];
+  truncated: boolean;
+}


### PR DESCRIPTION
Implement the four Shopify export tools on top of the scaffolding: the Admin GraphQL client, cursor pagination, Zod-validated responses, and the export_products / export_customer_ltv / export_sales / export_top_customers_by_period handlers.

## Description

Implement the four Shopify export tools on top of the scaffolding from #30239: the Admin GraphQL client (per-shop endpoint, `X-Shopify-Access-Token`), cursor pagination, and Zod-validated responses. Handlers: `export_products`, `export_customer_ltv`, `export_sales`, `export_top_customers_by_period`. All read-only. Stacked on #30239, merge #30239 first.

## Tests

Manual, against a real Shopify store

## Risk

Low. Behind `shopify_tool` feature flag

## Deploy Plan

Merge after #30239.
