### PR TITLE
Pluzalize scope filters for clarity

### DIFF
--- a/front-api/routes/w/[wId]/analytics/consumption/overview.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/overview.test.ts
@@ -73,7 +73,7 @@ describe("GET /api/w/:wId/analytics/consumption/overview", () => {
     const response = await getOverviewRequest(workspace.sId, {
       period: "days",
       days: "7",
-      filter: JSON.stringify({ agent: ["a1"], user: ["u1", "u2"] }),
+      filter: JSON.stringify({ agents: ["a1"], users: ["u1", "u2"] }),
     });
 
     expect(response.status).toBe(200);
@@ -81,7 +81,7 @@ describe("GET /api/w/:wId/analytics/consumption/overview", () => {
       expect.anything(),
       expect.objectContaining({
         periodInput: { kind: "days", days: 7 },
-        filter: { agent: ["a1"], user: ["u1", "u2"] },
+        filter: { agents: ["a1"], users: ["u1", "u2"] },
       })
     );
   });

--- a/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
@@ -278,7 +278,7 @@ describe("GET /api/w/:wId/analytics/consumption/top-*", () => {
       limit: "5",
       period: "days",
       days: "7",
-      filter: JSON.stringify({ source: ["slack"] }),
+      filter: JSON.stringify({ sources: ["slack"] }),
     });
 
     expect(response.status).toBe(200);
@@ -286,7 +286,7 @@ describe("GET /api/w/:wId/analytics/consumption/top-*", () => {
       expect.anything(),
       expect.objectContaining({
         limit: 5,
-        filter: { source: ["slack"] },
+        filter: { sources: ["slack"] },
       })
     );
   });

--- a/front/components/workspace/analytics/usageFilter.ts
+++ b/front/components/workspace/analytics/usageFilter.ts
@@ -162,5 +162,5 @@ export function toConsumptionScopeFilter(
   filter: UsageFilter
 ): ConsumptionScopeFilter {
   const memberIds = filter.member?.map((entity) => entity.id);
-  return memberIds && memberIds.length > 0 ? { user: memberIds } : {};
+  return memberIds && memberIds.length > 0 ? { users: memberIds } : {};
 }

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -1,5 +1,5 @@
 import type { ConsumptionPeriodInput } from "@app/lib/api/analytics/consumption/period";
-import { CONSUMPTION_SCOPE_DIMENSIONS } from "@app/lib/api/analytics/consumption/scope";
+import { CONSUMPTION_SCOPE_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
 import { z } from "zod";
 
 /**
@@ -12,7 +12,7 @@ export const DEFAULT_CONSUMPTION_PERIOD_DAYS = 30;
 export const DEFAULT_CONSUMPTION_TOP_LIMIT = 10;
 
 const ConsumptionFilterSchema = z.record(
-  z.enum(CONSUMPTION_SCOPE_DIMENSIONS),
+  z.enum(CONSUMPTION_SCOPE_FILTER_KEYS),
   z.string().array()
 );
 

--- a/front/lib/api/analytics/consumption/scope.test.ts
+++ b/front/lib/api/analytics/consumption/scope.test.ts
@@ -38,12 +38,12 @@ describe("buildConsumptionScopeQuery", () => {
       auth: authenticator,
       ...WINDOW,
       filter: {
-        agent: ["a1"],
-        user: ["u1", "u2"],
-        model: ["gpt-5.6-luna"],
-        tool: ["web_search_&_browse"],
-        skill: ["s1"],
-        source: ["web"],
+        agents: ["a1"],
+        users: ["u1", "u2"],
+        models: ["gpt-5.6-luna"],
+        tools: ["web_search_&_browse"],
+        skills: ["s1"],
+        sources: ["web"],
       },
     });
 
@@ -66,7 +66,7 @@ describe("buildConsumptionScopeQuery", () => {
     const query = buildConsumptionScopeQuery({
       auth: authenticator,
       ...WINDOW,
-      filter: { agent: [], user: [""] },
+      filter: { agents: [], users: [""] },
     });
 
     expect(query.bool?.filter).toHaveLength(2);

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -31,9 +31,33 @@ export const CONSUMPTION_DIMENSION_FIELDS: Record<
   source: "context_origin",
 };
 
+export const CONSUMPTION_SCOPE_FILTER_KEYS = [
+  "agents",
+  "users",
+  "models",
+  "tools",
+  "skills",
+  "sources",
+] as const;
+
+export type ConsumptionScopeFilterKey =
+  (typeof CONSUMPTION_SCOPE_FILTER_KEYS)[number];
+
 export type ConsumptionScopeFilter = Partial<
-  Record<ConsumptionScopeDimension, string[]>
+  Record<ConsumptionScopeFilterKey, string[]>
 >;
+
+export const CONSUMPTION_DIMENSION_FILTER_KEYS: Record<
+  ConsumptionScopeDimension,
+  ConsumptionScopeFilterKey
+> = {
+  agent: "agents",
+  user: "users",
+  model: "models",
+  tool: "tools",
+  skill: "skills",
+  source: "sources",
+};
 
 export const CONSUMPTION_METRICS = ["credit_micro"] as const;
 
@@ -119,7 +143,10 @@ export function buildConsumptionScopeQuery({
 
   for (const dimension of CONSUMPTION_SCOPE_DIMENSIONS) {
     filters.push(
-      ...termFilter(CONSUMPTION_DIMENSION_FIELDS[dimension], filter[dimension])
+      ...termFilter(
+        CONSUMPTION_DIMENSION_FIELDS[dimension],
+        filter[CONSUMPTION_DIMENSION_FILTER_KEYS[dimension]]
+      )
     );
   }
 

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -47,7 +47,7 @@ export type ConsumptionScopeFilter = Partial<
   Record<ConsumptionScopeFilterKey, string[]>
 >;
 
-export const CONSUMPTION_DIMENSION_FILTER_KEYS: Record<
+const CONSUMPTION_DIMENSION_FILTER_KEYS: Record<
   ConsumptionScopeDimension,
   ConsumptionScopeFilterKey
 > = {

--- a/front/lib/api/analytics/consumption/timeseries.test.ts
+++ b/front/lib/api/analytics/consumption/timeseries.test.ts
@@ -184,7 +184,7 @@ describe("fetchConsumptionTimeseries", () => {
       period,
       granularity: "day",
       mode: "daily",
-      filter: { agent: ["a1"], source: ["web", "slack"], skill: ["s1"] },
+      filter: { agents: ["a1"], sources: ["web", "slack"], skills: ["s1"] },
     });
 
     const [query] = vi.mocked(searchConsumptionAnalytics).mock.calls[0];

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -318,7 +318,7 @@ describe("consumption top rankings", () => {
     await fetchConsumptionTopAgents(auth, {
       period: PERIOD,
       limit: 10,
-      filter: { source: ["slack"], user: ["u1", "u2"] },
+      filter: { sources: ["slack"], users: ["u1", "u2"] },
     });
 
     const [query] = lastSearchCall();


### PR DESCRIPTION
## Description

Pluralizes the `ConsumptionScopeFilter` keys (`agent` → `agents`, `user` → `users`, `model` → `models`, `tool` → `tools`, `skill` → `skills`, `source` → `sources`), since every one of these keys already typed to `string[]`. Adds `CONSUMPTION_SCOPE_FILTER_KEYS` / `ConsumptionScopeFilterKey` and a `CONSUMPTION_DIMENSION_FILTER_KEYS` mapping to bridge the singular `ConsumptionScopeDimension` values to the new plural filter keys.

This addresses [this review comment](https://github.com/dust-tt/dust/pull/30212#discussion_r3748533349) on #30212, where singular naming on an array-valued field read as inconsistent. Done purely for clarity, no behavior change.

## Tests

Updated existing unit tests (`scope.test.ts`, `timeseries.test.ts`, `top.test.ts`) to use the new plural filter keys.

## Risk

Low — internal type/key rename only, no runtime behavior change.

## Deploy Plan

Standard deploy.