### PR TITLE
fix: apply the Datadog status check to the browser logger

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -519,7 +519,7 @@ function AgentBuilderForm({
           setPendingAgentId(data.sId);
         } else {
           datadogLogger.error(
-            { status: response.status },
+            { statusCode: response.status },
             "[Agent builder] - Failed to create pending agent"
           );
         }

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -532,7 +532,7 @@ export function AgentMessage({
         {
           messageId: agentMessage.sId,
           conversationId,
-          status: agentMessage.status,
+          messageStatus: agentMessage.status,
         },
         "handleCopyToClipboard: message content is null"
       );

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -138,7 +138,7 @@ const sendErrorToIframe = (
     errorMessage: error.message,
     fileId: request.identifier,
     functionIdOrSlug: request.params.functionIdOrSlug,
-    status: error.status,
+    statusCode: error.status,
     workspaceId,
   });
 

--- a/front/components/labs/transcripts/ProviderSelection.tsx
+++ b/front/components/labs/transcripts/ProviderSelection.tsx
@@ -143,7 +143,7 @@ export function ProviderSelection({
         const errorText = await response.text();
         datadogLogger.error(
           {
-            status: response.status,
+            statusCode: response.status,
             error: errorText,
             workspaceId: owner.sId,
           },

--- a/front/logger/datadogLogger.test.ts
+++ b/front/logger/datadogLogger.test.ts
@@ -1,0 +1,31 @@
+import datadogLogger from "@app/logger/datadogLogger";
+import { describe, expectTypeOf, it } from "vitest";
+
+describe("datadog logger status typing", () => {
+  it("accepts a real Datadog severity as status", () => {
+    expectTypeOf(datadogLogger.info).toBeCallableWith(
+      { status: "critical" },
+      "message"
+    );
+  });
+
+  it("accepts payloads without a status", () => {
+    expectTypeOf(datadogLogger.info).toBeCallableWith(
+      { itemId: "1" },
+      "message"
+    );
+    expectTypeOf(datadogLogger.info).toBeCallableWith("message");
+  });
+
+  it("rejects a status Datadog would misread as a severity", () => {
+    expectTypeOf(datadogLogger.info).toBeCallableWith(
+      // @ts-expect-error - "completed" is prefix-matched to critical by Datadog.
+      { status: "completed" },
+      "msg"
+    );
+    expectTypeOf(datadogLogger.child).toBeCallableWith({
+      // @ts-expect-error - child bindings are logged as a top-level status too.
+      status: "completed",
+    });
+  });
+});

--- a/front/logger/datadogLogger.ts
+++ b/front/logger/datadogLogger.ts
@@ -1,7 +1,10 @@
 import { datadogLogs } from "@datadog/browser-logs";
 
-// Keep the exported Logger type for compatibility with existing imports.
-export type { Logger } from "pino";
+import type { DatadogLogStatus } from "./logger";
+
+// Keep the exported Logger type for compatibility with existing imports. Type-only, so the
+// pino-backed module is erased from the browser bundle.
+export type { Logger } from "./logger";
 
 // Benign error messages that should not be forwarded to Datadog.
 // - ResizeObserver: https://github.com/DataDog/browser-sdk/issues/1616
@@ -87,7 +90,10 @@ function toMessageAndContext(
 
 type LogContext = Record<string, unknown>;
 type LogMessage = string;
-type LogArg = LogContext | LogMessage;
+// Datadog reads a top-level `status` as the log severity, prefix-matched on its value, so
+// `status: "completed"` reads as critical. Same check as the server-side logger.
+type CheckedLogContext = { status?: DatadogLogStatus } & LogContext;
+type LogArg = CheckedLogContext | LogMessage;
 
 function makeLogger(baseBindings?: LogContext) {
   const call = (level: Level, arg1?: LogArg, arg2?: LogArg) => {
@@ -135,7 +141,7 @@ function makeLogger(baseBindings?: LogContext) {
     error: (a?: LogArg, b?: LogArg) => call("error", a, b),
 
     // Pino-like child logger to bind persistent context
-    child: (bindings?: LogContext) =>
+    child: (bindings?: CheckedLogContext) =>
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       makeLogger({ ...(baseBindings || {}), ...(bindings || {}) }),
   };

--- a/marketing/logger/datadogLogger.ts
+++ b/marketing/logger/datadogLogger.ts
@@ -1,7 +1,10 @@
 import { datadogLogs } from "@datadog/browser-logs";
 
-// Keep the exported Logger type for compatibility with existing imports.
-export type { Logger } from "pino";
+import type { DatadogLogStatus } from "./logger";
+
+// Keep the exported Logger type for compatibility with existing imports. Type-only, so the
+// pino-backed module is erased from the browser bundle.
+export type { Logger } from "./logger";
 
 // Benign error messages that should not be forwarded to Datadog.
 export const IGNORED_LOG_MESSAGES = [
@@ -75,7 +78,10 @@ function toMessageAndContext(
 
 type LogContext = Record<string, unknown>;
 type LogMessage = string;
-type LogArg = LogContext | LogMessage;
+// Datadog reads a top-level `status` as the log severity, prefix-matched on its value, so
+// `status: "completed"` reads as critical. Same check as the server-side logger.
+type CheckedLogContext = { status?: DatadogLogStatus } & LogContext;
+type LogArg = CheckedLogContext | LogMessage;
 
 function makeLogger(baseBindings?: LogContext) {
   const call = (level: Level, arg1?: LogArg, arg2?: LogArg) => {
@@ -117,7 +123,7 @@ function makeLogger(baseBindings?: LogContext) {
     warn: (a?: LogArg, b?: LogArg) => call("warn", a, b),
     error: (a?: LogArg, b?: LogArg) => call("error", a, b),
 
-    child: (bindings?: LogContext) =>
+    child: (bindings?: CheckedLogContext) =>
       makeLogger({ ...(baseBindings ?? {}), ...(bindings ?? {}) }),
   };
 }


### PR DESCRIPTION
## Description

Follow-up to #30028, which missed front-spa. The SPA aliases `@app/logger/logger` to `front/logger/datadogLogger.ts` (`front-spa/vite.config.ts`), and that module kept the old log payload type and re-exported pino's unchecked `Logger`, so anything logged from the SPA could still ship a `status` that Datadog reads as the severity.

## Tests

Added `front/logger/datadogLogger.test.ts`, mirroring the existing `logger.test.ts` type test with an extra case for `child()` bindings.

## Risk

Low.

## Deploy Plan

Regular deploy.