### PR TITLE
feat(front): replace models_picker feature flag with a global kill switch

### DIFF
--- a/front-api/lib/api/assistant/conversation/model_selection.ts
+++ b/front-api/lib/api/assistant/conversation/model_selection.ts
@@ -1,6 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
-import { hasFeatureFlag } from "@app/lib/auth";
 import { getEnabledModelsForAuth } from "@app/lib/model_tiers/enabled_models";
+import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import { ModelSelectionSchema } from "@app/types/assistant/models/types";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
@@ -30,14 +30,14 @@ export async function validatePublicModelSelection(
   }
   const modelSelection = parsed.data;
 
-  if (!(await hasFeatureFlag(auth, "models_picker"))) {
+  if (
+    await KillSwitchResource.isKillSwitchEnabled("global_disable_models_picker")
+  ) {
     return new Err({
       status_code: 403,
       api_error: {
         type: "feature_flag_not_found",
-        message:
-          "Per-message model selection requires the 'models_picker' feature, " +
-          "which is not enabled for this workspace.",
+        message: "Per-message model selection is currently disabled.",
       },
     });
   }

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
@@ -1,6 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -177,7 +176,6 @@ describe("POST /api/v1/w/[wId]/assistant/conversations/[cId]/messages", () => {
       user.sId,
       workspace.sId
     );
-    await FeatureFlagFactory.basic(userAuth, "models_picker");
     const conversation = await ConversationFactory.create(userAuth, {
       agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
       messagesCreatedAt: [new Date()],

--- a/front/components/agent_builder/instructions/AdvancedSettings.tsx
+++ b/front/components/agent_builder/instructions/AdvancedSettings.tsx
@@ -5,7 +5,7 @@ import { ReasoningEffortSubmenu } from "@app/components/agent_builder/instructio
 import { ModelPicker } from "@app/components/model_picker/ModelPicker";
 import { SuspensedCodeEditor } from "@app/components/SuspensedCodeEditor";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useKillSwitches } from "@app/lib/swr/kill";
 import { useModels } from "@app/lib/swr/models";
 import { isSupportingResponseFormat } from "@app/types/assistant/assistant";
 import { isModelStreamId } from "@app/types/assistant/models/auto";
@@ -211,8 +211,10 @@ function AdvancedSettingsLegacy({
 
 export function AdvancedSettings() {
   const { owner } = useAgentBuilderContext();
-  const { hasFeature } = useFeatureFlags();
-  const hasModelsPicker = hasFeature("models_picker");
+  const { killSwitches } = useKillSwitches();
+  const hasModelsPicker = !killSwitches?.includes(
+    "global_disable_models_picker"
+  );
 
   const [isResponseFormatDialogOpen, setIsResponseFormatDialogOpen] =
     React.useState(false);

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -53,6 +53,7 @@ import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isNodeCandidate } from "@app/lib/connectors";
 import { useClientType } from "@app/lib/context/clientType";
 import { getSpaceIcon } from "@app/lib/spaces";
+import { useKillSwitches } from "@app/lib/swr/kill";
 import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
 import { useIsMobile, useIsWidthConstrained } from "@app/lib/swr/useIsMobile";
 import { classNames } from "@app/lib/utils";
@@ -426,9 +427,11 @@ const InputBarContainer = ({
   const includeAttachKnowledgeRef = useRef(actions.includes("attachment"));
   includeAttachKnowledgeRef.current = actions.includes("attachment");
   const { hasFeature } = useFeatureFlags();
+  const { killSwitches } = useKillSwitches();
   const includePickModelRef = useRef(false);
   includePickModelRef.current =
-    hasFeature("models_picker") && actions.includes("model-picker");
+    !killSwitches?.includes("global_disable_models_picker") &&
+    actions.includes("model-picker");
   const modelSelectionCommitRef = useRef<
     ((selection: Selection) => void) | null
   >(null);

--- a/front/components/editor/extensions/shared/slash_suggestion/PickModelSubMenuDropdown.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/PickModelSubMenuDropdown.tsx
@@ -6,7 +6,8 @@ import type { SlashMenuStackFrame } from "@app/components/editor/extensions/shar
 import type { Selection } from "@app/components/model_picker/modelPickerUtils";
 import { getModelMakerLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import { useKillSwitches } from "@app/lib/swr/kill";
 import { useModels } from "@app/lib/swr/models";
 import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
 import { getModelMaker } from "@app/types/assistant/models/providers";
@@ -42,8 +43,10 @@ export const PickModelSubMenuDropdown = forwardRef<
     const dropdownRef = useRef<{
       onKeyDown: (props: { event: KeyboardEvent }) => boolean;
     }>(null);
-    const { hasFeature } = useFeatureFlags();
-    const hasModelsPicker = hasFeature("models_picker");
+    const { killSwitches } = useKillSwitches();
+    const hasModelsPicker = !killSwitches?.includes(
+      "global_disable_models_picker"
+    );
     const { subscription } = useAuth();
     const lockPremiumEfforts = !isCreditPricedPlan(subscription.plan);
     const { isDark } = useTheme();

--- a/front/components/model_picker/ModelPicker.tsx
+++ b/front/components/model_picker/ModelPicker.tsx
@@ -18,7 +18,8 @@ import {
 } from "@app/components/model_picker/modelPickerUtils";
 import { getModelMakerLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import { useKillSwitches } from "@app/lib/swr/kill";
 import { useModels } from "@app/lib/swr/models";
 import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
 import { isModelStreamId } from "@app/types/assistant/models/auto";
@@ -90,8 +91,10 @@ export function ModelPicker({
   setStickyModelOverride,
   commitApiRef,
 }: ModelPickerProps) {
-  const { hasFeature } = useFeatureFlags();
-  const hasModelsPicker = hasFeature("models_picker");
+  const { killSwitches } = useKillSwitches();
+  const hasModelsPicker = !killSwitches?.includes(
+    "global_disable_models_picker"
+  );
   const { subscription } = useAuth();
   const lockPremiumEfforts = !isCreditPricedPlan(subscription.plan);
 

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -55,6 +55,7 @@ import {
   useSeatPlan,
 } from "@app/lib/swr/credits";
 import { useGroups } from "@app/lib/swr/groups";
+import { useKillSwitches } from "@app/lib/swr/kill";
 import type { BulkMemberSelectionBody } from "@app/lib/swr/memberships";
 import {
   useBulkChangeSeatType,
@@ -161,6 +162,7 @@ export function UsagePage() {
   const { subscription } = useAuth();
   const router = useAppRouter();
   const { hasFeature } = useFeatureFlags();
+  const { killSwitches } = useKillSwitches();
   const isCreditPriced = isCreditPricedPlan(subscription.plan);
   // Legacy-contract workspaces can view this page in read-only mode behind a
   // flag: analytics and member spend render as usual, but every action (top up,
@@ -260,7 +262,8 @@ export function UsagePage() {
     []
   );
   const isWorkspaceAdmin = isAdmin(owner);
-  const modelsPickerEnabled = hasFeature("models_picker") && isWorkspaceAdmin;
+  const modelsPickerEnabled =
+    !killSwitches?.includes("global_disable_models_picker") && isWorkspaceAdmin;
   const [membersTab, setMembersTab] = useState<"members" | "requests">(
     "members"
   );

--- a/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
@@ -8,6 +8,7 @@ import { isModelAvailable } from "@app/lib/assistant";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { useAppRouter } from "@app/lib/platform";
+import { useKillSwitches } from "@app/lib/swr/kill";
 import { isModelStreamId } from "@app/types/assistant/models/auto";
 import type {
   ModelConfigurationType,
@@ -37,7 +38,8 @@ export function ModelProvidersPageContent({
 }: ModelProvidersPageContentProps) {
   const { subscription } = useAuth();
   const { plan } = subscription;
-  const { featureFlags, hasFeature } = useFeatureFlags();
+  const { featureFlags } = useFeatureFlags();
+  const { killSwitches } = useKillSwitches();
   const { regionInfo } = useRegionContext();
   const router = useAppRouter();
 
@@ -85,7 +87,7 @@ export function ModelProvidersPageContent({
         </>
       )}
       <EmbeddingModelSelect workspace={workspace} />
-      {hasFeature("models_picker") && (
+      {!killSwitches?.includes("global_disable_models_picker") && (
         <div className="flex flex-col gap-2 p-3">
           <div className="font-semibold">Model access tiers</div>
           <div className="flex items-center justify-between gap-4">

--- a/front/components/poke/pages/KillPage.tsx
+++ b/front/components/poke/pages/KillPage.tsx
@@ -19,6 +19,7 @@ import {
   OpenaiLogo,
   PauseCircle,
   RefreshCw02,
+  Robot,
   Settings01,
   SliderToggle,
   Spinner,
@@ -75,6 +76,13 @@ const KILL_SWITCH_DEFINITIONS: Record<KillSwitchType, KillSwitchDefinition> = {
       "Pause the document upsert queue: parked upserts retry every 5 minutes until the switch is disabled.",
     note: "Enqueues keep succeeding and in-flight upserts finish. Use to shed Qdrant write load (e.g. during resharding).",
     icon: PauseCircle,
+  },
+  global_disable_models_picker: {
+    title: "Model Picker",
+    description:
+      "Disable the conversation model picker globally: hide the input-bar model/effort picker, reject per-message model selection, and stop enforcing model access tiers.",
+    note: "Advanced models and the Auto/Standard/Fast/Complex models stay available; only the user-facing picker and tier enforcement are turned off.",
+    icon: Robot,
   },
 };
 

--- a/front/lib/api/assistant/configuration/create_or_upgrade.ts
+++ b/front/lib/api/assistant/configuration/create_or_upgrade.ts
@@ -12,7 +12,6 @@ import {
 } from "@app/lib/api/assistant/configuration/agent";
 import { getAgentConfigurationRequirementsFromCapabilities } from "@app/lib/api/assistant/permissions";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { getModelTierAccessErrorForAgentConfiguration } from "@app/lib/model_tiers/access";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -156,7 +155,6 @@ export async function createOrUpgradeAgentConfiguration({
     );
   }
 
-  const featureFlags = await getFeatureFlags(auth);
   const modelConfig = getSupportedModelConfig(assistant.model);
   if (!modelConfig) {
     return new Err(
@@ -171,7 +169,6 @@ export async function createOrUpgradeAgentConfiguration({
     agentName: assistant.name,
     model: modelConfig,
     reasoningEffort: assistant.model.reasoningEffort,
-    featureFlags,
   });
   if (accessError) {
     return new Err(new Error(accessError.message));

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -87,6 +87,10 @@ interface DustLikeGlobalAgentArgs {
   // Workspace feature flags, forwarded to model selection so it runs the exact
   // same model availability check that is enforced when a message is posted.
   featureFlags: WhitelistableFeature[];
+  // When set, the @dust agent defaults to the Auto meta-model (dynamically
+  // routed at message-send time). Takes precedence over the other default-model
+  // preferences below.
+  preferAutoDefaultModel?: boolean;
   // When set, the @dust agent defaults to GPT 5.6 Luna (high reasoning) instead
   // of Claude Sonnet 4.6. Gated by the `dust_agent_gpt_5_6_luna_default` flag.
   preferGpt56LunaDefaultModel?: boolean;
@@ -477,15 +481,17 @@ export function _getDustGlobalAgent(
     CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG;
   let preferredReasoningEffort: ReasoningEffort = "medium";
 
-  if (args.preferSonnet5DefaultModel) {
+  // @dust runs on Auto first: it defaults to the Auto meta-model, which routes
+  // to the best available model (GPT 5.6 Luna high first) at message-send time.
+  if (args.preferAutoDefaultModel) {
+    preferredModelConfiguration = AUTO_MODEL_CONFIG;
+    preferredReasoningEffort = "none";
+  } else if (args.preferSonnet5DefaultModel) {
     preferredModelConfiguration = CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG;
     preferredReasoningEffort = "medium";
   } else if (args.preferGpt56LunaDefaultModel) {
     preferredModelConfiguration = GPT_5_6_LUNA_MODEL_CONFIG;
     preferredReasoningEffort = "high";
-  } else if (args.featureFlags.includes("models_picker")) {
-    preferredModelConfiguration = AUTO_MODEL_CONFIG;
-    preferredReasoningEffort = "none";
   }
   return _getDustLikeGlobalAgent(auth, args, {
     agentId: GLOBAL_AGENTS_SID.DUST,

--- a/front/lib/api/assistant/global_agents/global_agents.test.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.test.ts
@@ -8,6 +8,7 @@ import {
   CLAUDE_OPUS_5_MODEL_ID,
   CLAUDE_SONNET_5_MODEL_ID,
 } from "@app/types/assistant/models/anthropic";
+import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
 import { GEMINI_3_1_PRO_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 import {
   GPT_5_6_LUNA_MODEL_ID,
@@ -250,10 +251,8 @@ describe("getGlobalAgents custom model agents", () => {
 });
 
 describe("getGlobalAgents OpenAI Dust agents", () => {
-  it("uses GPT 5.6 Luna with high reasoning as the flagged Dust default", async () => {
-    const auth = await createAuthenticatorWithFlags([
-      "dust_agent_gpt_5_6_luna_default",
-    ]);
+  it("uses the Auto meta-model as the Dust default", async () => {
+    const auth = await createAuthenticatorWithFlags([]);
 
     const agents = await getGlobalAgents(
       auth,
@@ -263,13 +262,13 @@ describe("getGlobalAgents OpenAI Dust agents", () => {
 
     expect(agents).toHaveLength(1);
     expect(agents[0].model).toMatchObject({
-      providerId: "openai",
-      modelId: GPT_5_6_LUNA_MODEL_ID,
-      reasoningEffort: "high",
+      providerId: AUTO_MODEL_ID,
+      modelId: AUTO_MODEL_ID,
+      reasoningEffort: "none",
     });
   });
 
-  it("keeps Sonnet 5 at medium reasoning when both default flags are set", async () => {
+  it("keeps @dust on Auto even when the legacy default-model flags are set", async () => {
     const auth = await createAuthenticatorWithFlags([
       "dust_agent_gpt_5_6_luna_default",
       "dust_agent_sonnet_5_default",
@@ -283,9 +282,9 @@ describe("getGlobalAgents OpenAI Dust agents", () => {
 
     expect(agents).toHaveLength(1);
     expect(agents[0].model).toMatchObject({
-      providerId: "anthropic",
-      modelId: CLAUDE_SONNET_5_MODEL_ID,
-      reasoningEffort: "medium",
+      providerId: AUTO_MODEL_ID,
+      modelId: AUTO_MODEL_ID,
+      reasoningEffort: "none",
     });
   });
 

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -146,6 +146,7 @@ function getGlobalAgent({
   hasSandbox,
   globalAgentContext,
   excludeProviders,
+  preferAutoDefaultModel,
   preferGpt56LunaDefaultModel,
   preferSonnet5DefaultModel,
   featureFlags,
@@ -160,6 +161,7 @@ function getGlobalAgent({
   hasSandbox: boolean;
   globalAgentContext?: GlobalAgentContext;
   excludeProviders: ReadonlySet<ModelProviderIdType>;
+  preferAutoDefaultModel: boolean;
   preferGpt56LunaDefaultModel: boolean;
   preferSonnet5DefaultModel: boolean;
   featureFlags: WhitelistableFeature[];
@@ -381,6 +383,7 @@ function getGlobalAgent({
         featureFlags,
         globalAgentContext,
         excludeProviders,
+        preferAutoDefaultModel,
         preferGpt56LunaDefaultModel,
         preferSonnet5DefaultModel,
       });
@@ -1088,7 +1091,13 @@ export async function getGlobalAgents(
     );
   }
 
-  if (agentIds === undefined && flags.includes("models_picker")) {
+  // With the model picker shipped to everyone, model-only global agents are
+  // hidden by default. They resurface when the picker is disabled globally via
+  // the kill switch.
+  const isModelsPickerDisabled = await KillSwitchResource.isKillSwitchEnabled(
+    "global_disable_models_picker"
+  );
+  if (agentIds === undefined && !isModelsPickerDisabled) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
       (sId) =>
         !isGlobalAgentId(sId) || !MODEL_ONLY_GLOBAL_AGENTS_SID.includes(sId)
@@ -1211,6 +1220,7 @@ export async function getGlobalAgents(
       hasSandbox: isComputerFeatureEnabled(flags),
       globalAgentContext: options?.globalAgentContext,
       excludeProviders,
+      preferAutoDefaultModel: true,
       preferGpt56LunaDefaultModel: flags.includes(
         "dust_agent_gpt_5_6_luna_default"
       ),

--- a/front/lib/api/assistant/models.test.ts
+++ b/front/lib/api/assistant/models.test.ts
@@ -4,7 +4,6 @@ import { resolveModel } from "@app/lib/api/assistant/resolve_model";
 import { Authenticator } from "@app/lib/auth";
 import * as enabledModels from "@app/lib/model_tiers/enabled_models";
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
@@ -28,6 +27,13 @@ import {
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/resources/provider_credential_resource");
+
+vi.mock("@app/lib/resources/kill_switch_resource", () => ({
+  KillSwitchResource: {
+    isKillSwitchEnabled: vi.fn().mockResolvedValue(false),
+    listEnabledKillSwitches: vi.fn().mockResolvedValue([]),
+  },
+}));
 
 function mockCredentials(
   credentials: Array<{
@@ -268,10 +274,9 @@ describe("resolveModel", () => {
     );
   });
 
-  it("resolves an auto agent configuration to a concrete model when models_picker is enabled", async () => {
+  it("resolves an auto agent configuration to a concrete model", async () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-    await FeatureFlagFactory.basic(auth, "models_picker");
 
     const getModelForStreamSpy = vi.spyOn(enabledModels, "getModelForStream");
 
@@ -280,26 +285,25 @@ describe("resolveModel", () => {
         providerId: AUTO_MODEL_ID,
         modelId: AUTO_MODEL_ID,
       }),
-      featureFlags: ["models_picker"],
+      featureFlags: [],
     });
 
     // `auto` is a stream like `auto_fast` / `auto_complex`: it routes through
-    // getModelForStream and resolves to its first available candidate.
+    // getModelForStream and resolves to its first available candidate (GPT 5.6
+    // Luna at high reasoning).
     expect(getModelForStreamSpy).toHaveBeenCalledWith(auth, AUTO_MODEL_ID);
     expect(modelResolutionMethod).toBe("auto");
     expect(resolvedModel.modelId).not.toBe(AUTO_MODEL_ID);
     expect(resolvedModel).toEqual({
-      providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
-      modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
-      reasoningEffort:
-        CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort,
+      providerId: GPT_5_6_LUNA_MODEL_CONFIG.providerId,
+      modelId: GPT_5_6_LUNA_MODEL_CONFIG.modelId,
+      reasoningEffort: "high",
     });
   });
 
-  it("resolves an auto user selection to a concrete model when models_picker is enabled", async () => {
+  it("resolves an auto user selection to a concrete model", async () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-    await FeatureFlagFactory.basic(auth, "models_picker");
 
     const getModelForStreamSpy = vi.spyOn(enabledModels, "getModelForStream");
 
@@ -312,41 +316,16 @@ describe("resolveModel", () => {
         providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
         modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
       }),
-      featureFlags: ["models_picker"],
+      featureFlags: [],
     });
 
     expect(getModelForStreamSpy).toHaveBeenCalledWith(auth, AUTO_MODEL_ID);
     expect(modelResolutionMethod).toBe("auto");
     expect(resolvedModel.modelId).not.toBe(AUTO_MODEL_ID);
     expect(resolvedModel).toEqual({
-      providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
-      modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
-      reasoningEffort:
-        CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort,
-    });
-  });
-
-  it("falls back to a preferred large model when the agent is on auto without models_picker", async () => {
-    const workspace = await WorkspaceFactory.basic();
-    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
-    const getAutoModelSpy = vi.spyOn(enabledModels, "getAutoModelForAuth");
-
-    const { resolvedModel, modelResolutionMethod } = await resolveModel(auth, {
-      configuration: makeAgentConfiguration({
-        providerId: AUTO_MODEL_ID,
-        modelId: AUTO_MODEL_ID,
-      }),
-      featureFlags: [],
-    });
-
-    expect(getAutoModelSpy).not.toHaveBeenCalled();
-    expect(modelResolutionMethod).toBe("agent");
-    expect(resolvedModel).toEqual({
-      providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
-      modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
-      reasoningEffort:
-        CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort,
+      providerId: GPT_5_6_LUNA_MODEL_CONFIG.providerId,
+      modelId: GPT_5_6_LUNA_MODEL_CONFIG.modelId,
+      reasoningEffort: "high",
     });
   });
 });

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -257,25 +257,6 @@ describe("isModelAvailable", () => {
     ).toBe(false);
   });
 
-  it("should return true for advanced models when models_picker is enabled without plan access", () => {
-    const model = createMockModel({
-      availableIfOneOf: { plansWithAdvancedModels: true },
-      largeModel: false,
-    });
-    const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE, {
-      hasAdvancedModelAccess: false,
-    });
-
-    expect(
-      isModelAvailable(model, {
-        featureFlags: ["models_picker"],
-        plan,
-        regionalModelsOnly: owner.regionalModelsOnly,
-        region: TEST_REGION,
-      })
-    ).toBe(true);
-  });
-
   it("should return true when both plansWithAdvancedModels and featureFlag are set, with advanced model access", () => {
     const model = createMockModel({
       availableIfOneOf: {
@@ -356,7 +337,7 @@ describe("isModelReleased", () => {
 });
 
 describe("filterEnabledModels", () => {
-  it("includes advanced models when models_picker is enabled without plan access", async () => {
+  it("includes advanced models when the plan has advanced model access", async () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     const model = createMockModel({
@@ -366,8 +347,8 @@ describe("filterEnabledModels", () => {
     });
 
     const result = filterEnabledModels([model], {
-      featureFlags: ["models_picker"],
-      plan: { ...auth.plan()!, hasAdvancedModelAccess: false },
+      featureFlags: [],
+      plan: { ...auth.plan()!, hasAdvancedModelAccess: true },
       regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
       region: TEST_REGION,
       whitelistedProviders: getWhitelistedProviders(auth),

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -38,11 +38,7 @@ export function isModelAvailable(
     region: RegionType;
   }
 ) {
-  // Otherwise, we filter too early.
-  const includeAdvancedModelInPicker =
-    featureFlags.includes("models_picker") && isAdvancedModel(m);
-
-  if (m.largeModel && !isUpgraded(plan) && !includeAdvancedModelInPicker) {
+  if (m.largeModel && !isUpgraded(plan)) {
     return false;
   }
 
@@ -60,10 +56,7 @@ export function isModelAvailable(
 
   const { plansWithAdvancedModels, featureFlag } = m.availableIfOneOf;
 
-  if (
-    plansWithAdvancedModels === true &&
-    (plan?.hasAdvancedModelAccess || includeAdvancedModelInPicker)
-  ) {
+  if (plansWithAdvancedModels === true && plan?.hasAdvancedModelAccess) {
     return true;
   }
 

--- a/front/lib/model_tiers/access.test.ts
+++ b/front/lib/model_tiers/access.test.ts
@@ -6,13 +6,22 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const isKillSwitchEnabled = vi.hoisted(() => vi.fn().mockResolvedValue(false));
+vi.mock("@app/lib/resources/kill_switch_resource", () => ({
+  KillSwitchResource: {
+    isKillSwitchEnabled,
+    listEnabledKillSwitches: vi.fn().mockResolvedValue([]),
+  },
+}));
 
 describe("getModelTierAccessErrorForAgentConfiguration", () => {
   let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
   let adminAuth: Authenticator;
 
   beforeEach(async () => {
+    isKillSwitchEnabled.mockResolvedValue(false);
     workspace = await WorkspaceFactory.basic();
     adminAuth = await Authenticator.internalAdminForWorkspace(workspace.sId);
   });
@@ -45,7 +54,6 @@ describe("getModelTierAccessErrorForAgentConfiguration", () => {
     return getModelTierAccessErrorForAgentConfiguration(auth, {
       agentName: "test-agent",
       model: CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
-      featureFlags: ["models_picker"],
       agentScope,
     });
   }
@@ -85,13 +93,13 @@ describe("getModelTierAccessErrorForAgentConfiguration", () => {
     expect(error?.code).toBe("model_tier_not_enabled");
   });
 
-  it("does not block when models_picker is disabled", async () => {
+  it("does not block when the model picker is disabled via kill switch", async () => {
+    isKillSwitchEnabled.mockResolvedValue(true);
     const auth = await restrictedUserAuth();
 
     const error = await getModelTierAccessErrorForAgentConfiguration(auth, {
       agentName: "test-agent",
       model: CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
-      featureFlags: [],
       agentScope: "visible",
     });
 

--- a/front/lib/model_tiers/access.ts
+++ b/front/lib/model_tiers/access.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
+import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
 import type {
   AgentConfigurationScope,
@@ -9,7 +10,6 @@ import type {
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
 import { getMinimumReasoningEffort } from "@app/types/assistant/models/types";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import { areRestrictedModelsAllowedForPublishedAgents } from "@app/types/user";
 
 const MODEL_TIER_NOT_ENABLED_ERROR_CODE = "model_tier_not_enabled";
@@ -35,17 +35,19 @@ export async function getModelTierAccessErrorForAgentConfiguration(
     agentName,
     model,
     reasoningEffort,
-    featureFlags,
     agentScope,
   }: {
     agentName: string;
     model: ModelConfigurationType;
     reasoningEffort?: ReasoningEffort;
-    featureFlags: WhitelistableFeature[];
     agentScope?: AgentConfigurationScope;
   }
 ): Promise<GenericErrorContent | null> {
-  if (!featureFlags.includes("models_picker")) {
+  // Model access tiers are only enforced while the model picker is enabled.
+  // The picker can be turned off globally via a kill switch.
+  if (
+    await KillSwitchResource.isKillSwitchEnabled("global_disable_models_picker")
+  ) {
     return null;
   }
 

--- a/front/lib/model_tiers/enabled_models.test.ts
+++ b/front/lib/model_tiers/enabled_models.test.ts
@@ -4,19 +4,28 @@ import {
   withModelSelectability,
 } from "@app/lib/model_tiers/enabled_models";
 import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import {
   CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
-  CLAUDE_OPUS_5_MODEL_ID,
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
 import { MODEL_STREAMS } from "@app/types/assistant/models/auto";
-import { GPT_5_6_LUNA_MODEL_ID } from "@app/types/assistant/models/openai";
+import {
+  GPT_5_6_LUNA_MODEL_ID,
+  GPT_5_6_SOL_MODEL_ID,
+} from "@app/types/assistant/models/openai";
 import type { ModelIdType } from "@app/types/assistant/models/types";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const isKillSwitchEnabled = vi.hoisted(() => vi.fn().mockResolvedValue(false));
+vi.mock("@app/lib/resources/kill_switch_resource", () => ({
+  KillSwitchResource: {
+    isKillSwitchEnabled,
+    listEnabledKillSwitches: vi.fn().mockResolvedValue([]),
+  },
+}));
 
 const CUSTOM_MODEL_CONFIG = {
   ...CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
@@ -29,6 +38,7 @@ describe("withModelSelectability", () => {
   let adminAuth: Authenticator;
 
   beforeEach(async () => {
+    isKillSwitchEnabled.mockResolvedValue(false);
     workspace = await WorkspaceFactory.basic();
     adminAuth = await Authenticator.internalAdminForWorkspace(workspace.sId);
   });
@@ -44,18 +54,16 @@ describe("withModelSelectability", () => {
     return Authenticator.fromUserIdAndWorkspaceId(user.sId, workspace.sId);
   }
 
-  it("keeps full reasoning efforts when models_picker is disabled", async () => {
-    const user = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, user, { role: "user" });
-    const auth = await Authenticator.fromUserIdAndWorkspaceId(
-      user.sId,
-      workspace.sId
-    );
+  it("keeps everything selectable when the model picker is disabled via kill switch", async () => {
+    isKillSwitchEnabled.mockResolvedValue(true);
+    const auth = await userAuthForTierCap("cost_efficient");
 
     const [model] = await withModelSelectability(auth, {
       models: [CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG],
     });
 
+    // With the picker disabled we stop enforcing tiers: the model is fully
+    // selectable with its efforts untouched even though the user is tier-capped.
     expect(model.isSelectable).toBe(true);
     expect(model.supportedReasoningEfforts).toEqual(
       CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.supportedReasoningEfforts
@@ -65,14 +73,13 @@ describe("withModelSelectability", () => {
     );
   });
 
-  it("keeps full reasoning efforts when models_picker is enabled and user has no tier cap", async () => {
+  it("keeps full reasoning efforts when the user has no tier cap", async () => {
     const user = await UserFactory.basic();
     await MembershipFactory.associate(workspace, user, { role: "user" });
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
       workspace.sId
     );
-    await FeatureFlagFactory.basic(auth, "models_picker");
 
     const [model] = await withModelSelectability(auth, {
       models: [CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG],
@@ -88,7 +95,6 @@ describe("withModelSelectability", () => {
   });
 
   it("filters reasoning efforts to those allowed by the user's tier cap", async () => {
-    await FeatureFlagFactory.basic(adminAuth, "models_picker");
     const auth = await userAuthForTierCap("cost_efficient");
 
     const [model] = await withModelSelectability(auth, {
@@ -106,7 +112,6 @@ describe("withModelSelectability", () => {
   });
 
   it("keeps reasoning efforts up to the user's tier cap and drops premium ones", async () => {
-    await FeatureFlagFactory.basic(adminAuth, "models_picker");
     const auth = await userAuthForTierCap("balanced");
 
     const [model] = await withModelSelectability(auth, {
@@ -126,7 +131,6 @@ describe("withModelSelectability", () => {
   });
 
   it("marks frontier-only models as not selectable when capped at balanced", async () => {
-    await FeatureFlagFactory.basic(adminAuth, "models_picker");
     const auth = await userAuthForTierCap("balanced");
 
     const [model] = await withModelSelectability(auth, {
@@ -142,8 +146,7 @@ describe("withModelSelectability", () => {
     });
   });
 
-  it("keeps custom (non-tiered) models selectable when models_picker is enabled and the user is tier-capped", async () => {
-    await FeatureFlagFactory.basic(adminAuth, "models_picker");
+  it("keeps custom (non-tiered) models selectable when the user is tier-capped", async () => {
     const auth = await userAuthForTierCap("cost_efficient");
 
     const [model] = await withModelSelectability(auth, {
@@ -161,9 +164,9 @@ describe("getModelForStream", () => {
   let adminAuth: Authenticator;
 
   beforeEach(async () => {
+    isKillSwitchEnabled.mockResolvedValue(false);
     workspace = await WorkspaceFactory.basic();
     adminAuth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-    await FeatureFlagFactory.basic(adminAuth, "models_picker");
   });
 
   async function userAuthForTierCap(tierName: "cost_efficient" | "balanced") {
@@ -182,10 +185,8 @@ describe("getModelForStream", () => {
 
     expect(resolved).not.toBeNull();
     // In a full workspace every candidate is available, so the first one wins.
-    expect(resolved?.model.modelId).toBe(
-      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId
-    );
-    expect(resolved?.reasoningEffort).toBe("medium");
+    expect(resolved?.model.modelId).toBe(GPT_5_6_LUNA_MODEL_ID);
+    expect(resolved?.reasoningEffort).toBe("high");
   });
 
   it("routes the Fast stream to its first available candidate + effort", async () => {
@@ -201,8 +202,11 @@ describe("getModelForStream", () => {
     const resolved = await getModelForStream(adminAuth, "auto_complex");
 
     expect(resolved).not.toBeNull();
-    expect(resolved?.model.modelId).toBe(CLAUDE_OPUS_5_MODEL_ID);
-    expect(resolved?.reasoningEffort).toBe("high");
+    // The workspace has no advanced-model access, so the Opus candidates at the
+    // top of the Complex stream are unavailable; it resolves to the first
+    // non-advanced candidate (GPT 5.6 Sol at medium).
+    expect(resolved?.model.modelId).toBe(GPT_5_6_SOL_MODEL_ID);
+    expect(resolved?.reasoningEffort).toBe("medium");
   });
 
   it("keeps a cost-effective candidate in the Complex stream for cost_efficient-capped users", async () => {

--- a/front/lib/model_tiers/enabled_models.ts
+++ b/front/lib/model_tiers/enabled_models.ts
@@ -3,7 +3,7 @@ import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers"
 import { STATIC_MODEL_TIERS } from "@app/lib/api/assistant/token_pricing/tiers";
 import { getAvailableModelsForWorkspace } from "@app/lib/api/assistant/workspace_capabilities";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
+import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
 import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
 import type { ModelStreamIdType } from "@app/types/assistant/models/auto";
@@ -73,9 +73,11 @@ export async function withModelSelectability(
   auth: Authenticator,
   { models }: { models: ModelConfigurationType[] }
 ): Promise<EnabledModelConfigurationType[]> {
-  const featureFlags = await getFeatureFlags(auth);
-
-  if (!featureFlags.includes("models_picker")) {
+  // The model picker can be turned off globally via a kill switch, in which
+  // case we stop enforcing model access tiers and everything is selectable.
+  if (
+    await KillSwitchResource.isKillSwitchEnabled("global_disable_models_picker")
+  ) {
     return models.map((model) => ({
       ...model,
       isSelectable: true,

--- a/front/lib/poke/types.ts
+++ b/front/lib/poke/types.ts
@@ -6,6 +6,7 @@ export const KILL_SWITCH_TYPES = [
   "global_disable_firecrawl",
   "global_dust_agents_fallback",
   "pause_upsert_queue",
+  "global_disable_models_picker",
 ] as const;
 export type KillSwitchType = (typeof KILL_SWITCH_TYPES)[number];
 export function isKillSwitchType(type: string): type is KillSwitchType {

--- a/front/migrations/20260810_migrate_sonnet_4_6_medium_to_auto.ts
+++ b/front/migrations/20260810_migrate_sonnet_4_6_medium_to_auto.ts
@@ -1,0 +1,77 @@
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { makeScript } from "@app/scripts/helpers";
+
+// Migrate every active agent explicitly configured on Claude Sonnet 4.6 at
+// `medium` reasoning effort to the "Standard" auto-routing meta-model (`auto`).
+//
+// This moves those agents onto the meta-model so Dust dynamically picks the
+// best available model at message-send time. Note this is NOT behavior-
+// preserving: the `auto` stream's first candidate is GPT 5.6 Luna (high), so
+// migrated agents route there first and fall back through the stream (down to
+// Sonnet 4.6 at `light`) when a candidate isn't available to the workspace.
+//
+// All ids (source and target) are hardcoded on purpose so this migration is a
+// frozen snapshot: it keeps working after the configs move in the codebase and
+// won't silently change target if the meta-model definition evolves later. The
+// `auto` meta-model only supports the `none` reasoning effort, so we clear the
+// stored `medium` effort to match its config.
+const SOURCE_PROVIDER_ID = "anthropic";
+const SOURCE_MODEL_ID = "claude-sonnet-4-6";
+const SOURCE_REASONING_EFFORT = "medium";
+
+const TARGET_PROVIDER_ID = "auto";
+const TARGET_MODEL_ID = "auto";
+const TARGET_REASONING_EFFORT = "none";
+
+const AgentConfigurationModelWithBypass: ModelStaticWorkspaceAware<AgentConfigurationModel> =
+  AgentConfigurationModel;
+
+makeScript({}, async ({ execute }, logger) => {
+  const agents = await AgentConfigurationModelWithBypass.findAll({
+    where: {
+      providerId: SOURCE_PROVIDER_ID,
+      modelId: SOURCE_MODEL_ID,
+      reasoningEffort: SOURCE_REASONING_EFFORT,
+      status: "active",
+    },
+    // WORKSPACE_ISOLATION_BYPASS: Migration runs across all workspaces.
+    // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+    dangerouslyBypassWorkspaceIsolationSecurity: true,
+  });
+
+  logger.info(
+    { count: agents.length, to: TARGET_MODEL_ID },
+    `Found ${agents.length} active agents on ${SOURCE_MODEL_ID} (${SOURCE_REASONING_EFFORT}), migrating to Standard (${TARGET_MODEL_ID}).`
+  );
+
+  for (const agent of agents) {
+    logger.info(
+      {
+        sId: agent.sId,
+        version: agent.version,
+        workspaceId: agent.workspaceId,
+        fromProviderId: agent.providerId,
+        fromModelId: agent.modelId,
+        fromReasoningEffort: agent.reasoningEffort,
+      },
+      `Migrating agent ${agent.sId} (version ${agent.version}) from ${SOURCE_MODEL_ID} (${SOURCE_REASONING_EFFORT}) to Standard (${TARGET_MODEL_ID}).`
+    );
+  }
+
+  if (execute && agents.length > 0) {
+    // Single batched UPDATE instead of one query per row (GEN14). Scoped to the
+    // exact ids gathered above, so no workspace isolation bypass is needed (the
+    // cross-workspace scan happened in the findAll).
+    await AgentConfigurationModelWithBypass.update(
+      {
+        providerId: TARGET_PROVIDER_ID,
+        modelId: TARGET_MODEL_ID,
+        reasoningEffort: TARGET_REASONING_EFFORT,
+      },
+      { where: { id: agents.map((agent) => agent.id) } }
+    );
+  }
+
+  logger.info("Migration complete.");
+});

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -476,7 +476,6 @@ export async function runModel(
         agentName: agentConfiguration.name,
         model: modelInfo.endpoint.modelConfig,
         reasoningEffort: modelInfo.reasoningEffort,
-        featureFlags,
         agentScope: agentConfiguration.scope,
       }
     );

--- a/front/types/assistant/models/auto.ts
+++ b/front/types/assistant/models/auto.ts
@@ -56,10 +56,16 @@ export interface ModelStreamCandidate {
 
 export const MODEL_STREAMS: Record<ModelStreamIdType, ModelStreamCandidate[]> =
   {
-    // Plain `auto` spans the whole preferred catalog at each model's default
-    // reasoning effort. The last candidate (Sonnet at `light`) is the
-    // cost-effective floor so tier-capped users still resolve within the stream.
+    // Plain `auto` spans the whole preferred catalog. GPT 5.6 Luna at `high` is
+    // the first pick; the rest follow at each model's default reasoning effort.
+    // The last candidate (Sonnet at `light`) is the cost-effective floor so
+    // tier-capped users still resolve within the stream.
     [AUTO_MODEL_ID]: [
+      {
+        providerId: "openai",
+        modelId: GPT_5_6_LUNA_MODEL_ID,
+        reasoningEffort: "high",
+      },
       {
         providerId: "anthropic",
         modelId: CLAUDE_SONNET_4_6_MODEL_ID,
@@ -205,9 +211,9 @@ function makeMetaModelConfig(
     },
     defaultReasoningEffort: "none",
     supportsResponseFormat: false,
-    availableIfOneOf: {
-      featureFlag: "models_picker",
-    },
+    // The model picker is shipped to everyone, so the meta-models (Standard /
+    // Fast / Complex) are available to all workspaces (subject to the usual
+    // plan/region gating in isModelAvailable).
     tokenizer: { type: "tiktoken", base: "o200k_base" },
     regionalAvailability: {
       "us-central1": true,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -312,11 +312,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Whitelabel frames: customize the workspace logo, favicon and OG image shown on shared Frames.",
     stage: "on_demand",
   },
-  models_picker: {
-    description:
-      "Model picker in the conversation input bar: keep Auto (the agent's configured model) or pick a specific model and reasoning effort.",
-    stage: "dust_only",
-  },
   activation_skill: {
     description: "Enable the Activation skill for agentic user activation pods",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -764,7 +764,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "labs_mcp_actions_dashboard"
   | "labs_transcripts"
   | "legacy_dust_apps"
-  | "models_picker"
   | "netsuite_mcp"
   | "noop_model_feature"
   | "notion_private_integration"


### PR DESCRIPTION
## Description

Ships the conversation model picker to every workspace and removes the `models_picker` feature flag that used to gate it. The flag is deleted from `WHITELISTABLE_FEATURES_CONFIG` and the `@dust-tt/client` SDK union; stale per-workspace rows are harmless (they're filtered out by `isWhitelistableFeature`).

The feature is split into two concerns:

- **Baseline (now always on for everyone):** the `auto` / `auto_fast` / `auto_complex` meta-models (the Fast/Standard/Complex tiers) are available to all workspaces, and `@dust` now runs on Auto by default (unconditionally, ahead of the `dust_agent_*_default` flags). Advanced/large models keep their existing plan gating (`hasAdvancedModelAccess` / upgraded plan) — this PR does not broaden build-time model availability.
- **Wide kill switch (`global_disable_models_picker`):** a new global kill switch, exposed on the Poke Kill Switches page, that turns the *user-facing* picker off — it hides the input-bar model/effort picker, the agent-builder and editor pickers, the tiers admin UI, rejects per-message model selection on the public API, stops enforcing model access tiers, and re-surfaces the model-only global agents. Auto/meta-model availability is intentionally **not** reverted by the switch, so flipping it is safe and non-destructive.

The `auto` (Standard) stream now routes to **GPT 5.6 Luna (high)** as its first candidate, then falls back through the rest of the pool. Since `@dust` runs on Auto, it resolves to Luna-high first (dynamically, with fallback when unavailable).

Also migrates existing agents explicitly configured on Claude Sonnet 4.6 (`medium`) onto the `auto` meta-model. Note this is **not** behavior-preserving: migrated agents route through the `auto` stream (Luna-high first) rather than staying pinned to Sonnet 4.6.

## Tests

- Updated the affected unit/functional tests (`assistant`, `model_tiers/access`, `model_tiers/enabled_models`, `assistant/models`, and the public-API `messages` route) to cover the new kill-switch behavior and the always-on advanced-model baseline. All pass.
- `tsgo --noEmit` clean across `front`, `front-api`, and `sdks/js`.

## Deploy Plan

After deploy, run the migration to move existing Sonnet 4.6 (`medium`) agents onto Auto:

```
npx tsx front/migrations/20260810_migrate_sonnet_4_6_medium_to_auto.ts --execute
```
