### PR TITLE
fix(sidekick): reject run_agent via suggest_tools and hide block IDs in chat

### DIFF
--- a/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
@@ -1346,6 +1346,48 @@ describe("agent_sidekick_context tools", () => {
         expect(result.error.message).toContain("suggest_knowledge");
       }
     });
+
+    it("returns error when suggesting run_agent instead of using suggest_sub_agent", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+      await MCPServerViewResource.ensureAllAutoToolsAreCreated(authenticator);
+
+      const runAgentView =
+        await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+          authenticator,
+          "run_agent"
+        );
+      expect(runAgentView).not.toBeNull();
+
+      const agentConfiguration =
+        await AgentConfigurationFactory.createTestAgent(authenticator);
+
+      const { getAgentConfigurationIdFromContext } = await import(
+        "@app/lib/api/actions/servers/agent_sidekick_helpers"
+      );
+      vi.mocked(getAgentConfigurationIdFromContext).mockReturnValueOnce(
+        agentConfiguration.sId
+      );
+
+      const tool = getToolByName("suggest_tools");
+      const result = await tool.handler(
+        {
+          suggestions: [
+            {
+              action: "remove",
+              toolId: runAgentView!.sId,
+              analysis: "Removing a sub-agent",
+            },
+          ],
+        },
+        createTestExtra(authenticator)
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("run_agent");
+        expect(result.error.message).toContain("suggest_sub_agent");
+      }
+    });
   });
 
   describe("suggest_knowledge", () => {

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -377,6 +377,17 @@ async function createToolsSuggestions({
     );
   }
 
+  const runAgentTools = tools.filter(
+    (t) => t.toJSON()?.server.name === "run_agent"
+  );
+  if (runAgentTools.length > 0) {
+    const runAgentToolNames = runAgentTools.map((t) => t.sId).join(", ");
+    return new Err(
+      `The following ID(s) are run_agent tools: ${runAgentToolNames}. ` +
+        `Use \`suggest_sub_agent\` instead of \`suggest_tools\` to add or remove a specific sub-agent.`
+    );
+  }
+
   // Fetch pending suggestions and mark duplicates (same toolId) as outdated.
   const pendingSuggestions =
     await AgentSuggestionResource.listByAgentConfigurationId(

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -17,6 +17,7 @@ import type {
 } from "@app/lib/api/actions/servers/agent_sidekick_context/metadata";
 import { AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA } from "@app/lib/api/actions/servers/agent_sidekick_context/metadata";
 import { getAgentConfigurationIdFromContext } from "@app/lib/api/actions/servers/agent_sidekick_helpers";
+import { RUN_AGENT_SERVER_NAME } from "@app/lib/api/actions/servers/run_agent/metadata";
 import { pruneConflictingInstructionSuggestions } from "@app/lib/api/assistant/agent_suggestion_pruning";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
@@ -378,7 +379,7 @@ async function createToolsSuggestions({
   }
 
   const runAgentTools = tools.filter(
-    (t) => t.toJSON()?.server.name === "run_agent"
+    (t) => t.toJSON()?.server.name === RUN_AGENT_SERVER_NAME
   );
   if (runAgentTools.length > 0) {
     const runAgentToolNames = runAgentTools.map((t) => t.sId).join(", ");

--- a/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
@@ -185,6 +185,16 @@ BAD: "Here's the current state of your agent: Config: 'Test', minimal instructio
 GOOD: Jump straight to insights or suggestions based on what you found.
 </dont_echo_config>
 
+<refer_to_visible_text>
+Block IDs (\`data-block-id\` / \`targetBlockId\` values like "a394d144") are internal tooling only.
+Use them exclusively in \`suggest_prompt_edits\` tool arguments. Users cannot see them in the builder UI.
+
+When discussing edits in chat, NEVER cite, quote, or mention block IDs. Identify the target by what the user can see:
+- Section heading (e.g., "the Output Guidelines section")
+- A short quote of the instruction text (e.g., "where it says 'Return results as a bulleted list'")
+- A plain paraphrase of the passage
+</refer_to_visible_text>
+
 <asking_questions>
 Only ask questions that are pinpointed to obtain the information needed to create a good suggestion.
 Proactively make users aware that you can research internal data sources for answers instead of asking.


### PR DESCRIPTION
## Summary
- Prompt fix for https://github.com/dust-tt/tasks/issues/9935
- Added check for https://github.com/dust-tt/tasks/issues/9985

## Testing
Unit test

## Risk
Low

## Deploy
Deploy front