### PR TITLE
[Activation] Move Frame links to the bottom of isCompactUIView messages 

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.compactUIView.test.tsx
+++ b/front/components/assistant/conversation/AgentMessage.compactUIView.test.tsx
@@ -383,7 +383,7 @@ describe("AgentMessage compact UI view", () => {
   });
 
   describe("Frame link relocation", () => {
-    it("renders one Frame card at the bottom (not the top) for a compact Activation Pod message with one Frame", () => {
+    it("renders one Frame card at the bottom (not the top) for a compact UI message with one Frame", () => {
       const frameFile = buildFrameFile();
       useAutoOpenSidePanelMock.mockReturnValue({
         interactiveFiles: [frameFile],
@@ -408,7 +408,7 @@ describe("AgentMessage compact UI view", () => {
       });
     });
 
-    it("renders one bottom Frame card per Frame for a compact Activation Pod message with multiple Frames", () => {
+    it("renders one bottom Frame card per Frame for a compact UI message with multiple Frames", () => {
       const frameFiles = [
         buildFrameFile({ fileId: "fil_frame_1", title: "First Frame" }),
         buildFrameFile({ fileId: "fil_frame_2", title: "Second Frame" }),
@@ -423,7 +423,7 @@ describe("AgentMessage compact UI view", () => {
       expect(screen.getAllByTestId("bottom-frame-citation")).toHaveLength(2);
     });
 
-    it("renders no Frame container for a compact Activation Pod message without a Frame", () => {
+    it("renders no Frame container for a compact UI message without a Frame", () => {
       useAutoOpenSidePanelMock.mockReturnValue({ interactiveFiles: [] });
 
       renderAgentMessage({ uiView: "compact" });
@@ -434,7 +434,7 @@ describe("AgentMessage compact UI view", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("keeps the Frame link at the top for non-Activation-Pod messages", () => {
+    it("keeps the Frame link at the top for non-compact UI messages", () => {
       const frameFile = buildFrameFile();
       useAutoOpenSidePanelMock.mockReturnValue({
         interactiveFiles: [frameFile],
@@ -450,7 +450,7 @@ describe("AgentMessage compact UI view", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("suppresses the inline Frame preview directive for compact Activation Pod messages", () => {
+    it("suppresses the inline Frame preview directive for compact UI messages", () => {
       renderAgentMessage({
         uiView: "compact",
         agentMessageOverrides: {
@@ -463,7 +463,7 @@ describe("AgentMessage compact UI view", () => {
       expect(screen.queryByText("Quarterly Report")).not.toBeInTheDocument();
     });
 
-    it("keeps the inline Frame preview directive for non-Activation-Pod messages", () => {
+    it("keeps the inline Frame preview directive for non-compact UI messages", () => {
       renderAgentMessage({
         uiView: "standard",
         agentMessageOverrides: {
@@ -476,7 +476,7 @@ describe("AgentMessage compact UI view", () => {
       expect(screen.getByText("Quarterly Report")).toBeInTheDocument();
     });
 
-    it("keeps non-Frame inline file previews for compact Activation Pod messages", () => {
+    it("keeps non-Frame inline file previews for compact UI messages", () => {
       renderAgentMessage({
         uiView: "compact",
         agentMessageOverrides: {

--- a/front/components/assistant/conversation/AgentMessage.compactUIView.test.tsx
+++ b/front/components/assistant/conversation/AgentMessage.compactUIView.test.tsx
@@ -397,8 +397,7 @@ describe("AgentMessage compact UI view", () => {
       expect(cards).toHaveLength(1);
 
       const [card] = cards;
-      expect(card).toHaveTextContent("Frame");
-      expect(card).not.toHaveTextContent(frameFile.title);
+      expect(card).toHaveTextContent(frameFile.title);
       expect(card).toHaveAttribute("aria-label", frameFile.title);
       expect(within(card).getByTestId("frame-icon")).toBeInTheDocument();
 

--- a/front/components/assistant/conversation/AgentMessage.compactUIView.test.tsx
+++ b/front/components/assistant/conversation/AgentMessage.compactUIView.test.tsx
@@ -389,7 +389,7 @@ describe("AgentMessage compact UI view", () => {
         interactiveFiles: [frameFile],
       });
 
-      renderAgentMessage({ isCompactUIView: true });
+      renderAgentMessage({ uiView: "compact" });
 
       expect(screen.queryByTestId("top-frame-link")).not.toBeInTheDocument();
 
@@ -417,7 +417,7 @@ describe("AgentMessage compact UI view", () => {
         interactiveFiles: frameFiles,
       });
 
-      renderAgentMessage({ isCompactUIView: true });
+      renderAgentMessage({ uiView: "compact" });
 
       expect(screen.queryByTestId("top-frame-link")).not.toBeInTheDocument();
       expect(screen.getAllByTestId("bottom-frame-citation")).toHaveLength(2);
@@ -426,7 +426,7 @@ describe("AgentMessage compact UI view", () => {
     it("renders no Frame container for a compact Activation Pod message without a Frame", () => {
       useAutoOpenSidePanelMock.mockReturnValue({ interactiveFiles: [] });
 
-      renderAgentMessage({ isCompactUIView: true });
+      renderAgentMessage({ uiView: "compact" });
 
       expect(screen.queryByTestId("top-frame-link")).not.toBeInTheDocument();
       expect(
@@ -440,7 +440,7 @@ describe("AgentMessage compact UI view", () => {
         interactiveFiles: [frameFile],
       });
 
-      renderAgentMessage({ isCompactUIView: false });
+      renderAgentMessage({ uiView: "standard" });
 
       expect(screen.getByTestId("top-frame-link")).toHaveTextContent(
         frameFile.title
@@ -452,7 +452,7 @@ describe("AgentMessage compact UI view", () => {
 
     it("suppresses the inline Frame preview directive for compact Activation Pod messages", () => {
       renderAgentMessage({
-        isCompactUIView: true,
+        uiView: "compact",
         agentMessageOverrides: {
           content:
             'Here is your frame: :preview_file{path="conv_1/frame.html" title="Quarterly Report" contentType="application/vnd.dust.frame"}',
@@ -465,7 +465,7 @@ describe("AgentMessage compact UI view", () => {
 
     it("keeps the inline Frame preview directive for non-Activation-Pod messages", () => {
       renderAgentMessage({
-        isCompactUIView: false,
+        uiView: "standard",
         agentMessageOverrides: {
           content:
             'Here is your frame: :preview_file{path="conv_1/frame.html" title="Quarterly Report" contentType="application/vnd.dust.frame"}',
@@ -478,7 +478,7 @@ describe("AgentMessage compact UI view", () => {
 
     it("keeps non-Frame inline file previews for compact Activation Pod messages", () => {
       renderAgentMessage({
-        isCompactUIView: true,
+        uiView: "compact",
         agentMessageOverrides: {
           content:
             'See the report: :preview_file{path="conv_1/report.pdf" title="Report.pdf" contentType="application/pdf"}',

--- a/front/components/assistant/conversation/AgentMessage.compactUIView.test.tsx
+++ b/front/components/assistant/conversation/AgentMessage.compactUIView.test.tsx
@@ -6,9 +6,9 @@ import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
 import type { LightAgentMessageWithActionsType } from "@app/types/assistant/conversation";
 import { Ok } from "@app/types/shared/result";
 import type { UserType } from "@app/types/user";
-import { render, screen } from "@testing-library/react";
-import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import type { ComponentType, ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/auth/AuthContext", () => ({
   useAuth: () => ({ vizUrl: null }),
@@ -72,26 +72,88 @@ vi.mock(
   })
 );
 
+const { useAutoOpenSidePanelMock, openPanelMock } = vi.hoisted(() => ({
+  useAutoOpenSidePanelMock: vi.fn(() => ({
+    interactiveFiles: [] as unknown[],
+  })),
+  openPanelMock: vi.fn(),
+}));
+
 vi.mock("@app/components/assistant/conversation/useAutoOpenSidePanel", () => ({
-  useAutoOpenSidePanel: () => ({ interactiveFiles: [] }),
+  useAutoOpenSidePanel: useAutoOpenSidePanelMock,
 }));
 
 vi.mock(
   "@app/components/assistant/conversation/ConversationSidePanelContext",
-  async (importOriginal) => {
-    const actual =
-      await importOriginal<
-        typeof import("@app/components/assistant/conversation/ConversationSidePanelContext")
-      >();
-    return {
-      ...actual,
-      useConversationSidePanelContext: () => ({
-        togglePanel: vi.fn(),
-        openPanel: vi.fn(),
-        currentPanel: null,
-      }),
-    };
-  }
+  () => ({
+    useConversationSidePanelContext: () => ({
+      togglePanel: vi.fn(),
+      openPanel: openPanelMock,
+      currentPanel: null,
+    }),
+  })
+);
+
+// Inline file-preview card (:preview_file{...} directive): stubbed so tests can assert
+// whether FilePreviewBlock decided to render it, without depending on PreviewableCitation's
+// own context wiring (ConversationSidePanelContext, FilePreviewContext, sparkle Tooltip).
+vi.mock(
+  "@app/components/assistant/conversation/attachment/PreviewableCitation",
+  () => ({
+    PreviewableCitation: ({ title }: { title: string }) => (
+      <span data-testid="inline-file-preview">{title}</span>
+    ),
+  })
+);
+
+// Top-of-message Frame renderer: stubbed so tests can assert its presence/absence
+// without depending on the real Citation/CitationGrid markup.
+vi.mock(
+  "@app/components/assistant/conversation/AgentMessageGeneratedFiles",
+  () => ({
+    AgentMessageInteractiveContentGeneratedFiles: ({
+      files,
+    }: {
+      files: { fileId?: string | null; title: string }[];
+    }) =>
+      files.length > 0 ? (
+        <div data-testid="top-frame-link">
+          {files.map((file) => (
+            <span key={file.fileId ?? file.title}>{file.title}</span>
+          ))}
+        </div>
+      ) : null,
+  })
+);
+
+// Bottom citation/source card: stubbed the same way as AttachmentCitation above, so we
+// can assert the visible label, accessible name, icon, and click behavior in isolation.
+vi.mock(
+  "@app/components/assistant/conversation/attachment/FileCitationCard",
+  () => ({
+    FileCitationCard: ({
+      title,
+      tooltipLabel,
+      icon: IconComponent,
+      onClick,
+    }: {
+      title: string;
+      tooltipLabel?: ReactNode;
+      icon?: ComponentType | ReactNode;
+      onClick?: () => void;
+    }) => (
+      <div
+        data-testid="bottom-frame-citation"
+        aria-label={typeof tooltipLabel === "string" ? tooltipLabel : undefined}
+        onClick={onClick}
+      >
+        {typeof IconComponent === "function" ? (
+          <IconComponent data-testid="frame-icon" />
+        ) : null}
+        {title}
+      </div>
+    ),
+  })
 );
 
 vi.mock("@app/components/sparkle/ThemeContext", () => ({
@@ -198,6 +260,17 @@ const messageFeedback: FeedbackSelectorBaseProps = {
   isSubmittingThumb: false,
 };
 
+function buildFrameFile(
+  overrides: Partial<{ fileId: string; title: string }> = {}
+) {
+  return {
+    title: overrides.title ?? "Quarterly Report",
+    contentType: "application/vnd.dust.frame",
+    fileId: overrides.fileId ?? "fil_frame_1",
+    hidden: false,
+  };
+}
+
 function renderAgentMessage({
   uiView,
   agentMessageOverrides,
@@ -225,6 +298,11 @@ function renderAgentMessage({
 }
 
 describe("AgentMessage compact UI view", () => {
+  beforeEach(() => {
+    useAutoOpenSidePanelMock.mockReturnValue({ interactiveFiles: [] });
+    openPanelMock.mockClear();
+  });
+
   describe("bottom citations", () => {
     it("hides the bottom citation list for compact UI conversations but keeps inline citations", () => {
       const { container } = renderAgentMessage({
@@ -301,6 +379,115 @@ describe("AgentMessage compact UI view", () => {
 
       expect(screen.getByText("AGENTS.md")).toBeInTheDocument();
       expect(screen.getByText("session_plan.md")).toBeInTheDocument();
+    });
+  });
+
+  describe("Frame link relocation", () => {
+    it("renders one Frame card at the bottom (not the top) for a compact Activation Pod message with one Frame", () => {
+      const frameFile = buildFrameFile();
+      useAutoOpenSidePanelMock.mockReturnValue({
+        interactiveFiles: [frameFile],
+      });
+
+      renderAgentMessage({ isCompactUIView: true });
+
+      expect(screen.queryByTestId("top-frame-link")).not.toBeInTheDocument();
+
+      const cards = screen.getAllByTestId("bottom-frame-citation");
+      expect(cards).toHaveLength(1);
+
+      const [card] = cards;
+      expect(card).toHaveTextContent("Frame");
+      expect(card).not.toHaveTextContent(frameFile.title);
+      expect(card).toHaveAttribute("aria-label", frameFile.title);
+      expect(within(card).getByTestId("frame-icon")).toBeInTheDocument();
+
+      fireEvent.click(card);
+      expect(openPanelMock).toHaveBeenCalledWith({
+        type: "interactive_content",
+        fileId: frameFile.fileId,
+      });
+    });
+
+    it("renders one bottom Frame card per Frame for a compact Activation Pod message with multiple Frames", () => {
+      const frameFiles = [
+        buildFrameFile({ fileId: "fil_frame_1", title: "First Frame" }),
+        buildFrameFile({ fileId: "fil_frame_2", title: "Second Frame" }),
+      ];
+      useAutoOpenSidePanelMock.mockReturnValue({
+        interactiveFiles: frameFiles,
+      });
+
+      renderAgentMessage({ isCompactUIView: true });
+
+      expect(screen.queryByTestId("top-frame-link")).not.toBeInTheDocument();
+      expect(screen.getAllByTestId("bottom-frame-citation")).toHaveLength(2);
+    });
+
+    it("renders no Frame container for a compact Activation Pod message without a Frame", () => {
+      useAutoOpenSidePanelMock.mockReturnValue({ interactiveFiles: [] });
+
+      renderAgentMessage({ isCompactUIView: true });
+
+      expect(screen.queryByTestId("top-frame-link")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("bottom-frame-citation")
+      ).not.toBeInTheDocument();
+    });
+
+    it("keeps the Frame link at the top for non-Activation-Pod messages", () => {
+      const frameFile = buildFrameFile();
+      useAutoOpenSidePanelMock.mockReturnValue({
+        interactiveFiles: [frameFile],
+      });
+
+      renderAgentMessage({ isCompactUIView: false });
+
+      expect(screen.getByTestId("top-frame-link")).toHaveTextContent(
+        frameFile.title
+      );
+      expect(
+        screen.queryByTestId("bottom-frame-citation")
+      ).not.toBeInTheDocument();
+    });
+
+    it("suppresses the inline Frame preview directive for compact Activation Pod messages", () => {
+      renderAgentMessage({
+        isCompactUIView: true,
+        agentMessageOverrides: {
+          content:
+            'Here is your frame: :preview_file{path="conv_1/frame.html" title="Quarterly Report" contentType="application/vnd.dust.frame"}',
+          citations: {},
+        },
+      });
+
+      expect(screen.queryByText("Quarterly Report")).not.toBeInTheDocument();
+    });
+
+    it("keeps the inline Frame preview directive for non-Activation-Pod messages", () => {
+      renderAgentMessage({
+        isCompactUIView: false,
+        agentMessageOverrides: {
+          content:
+            'Here is your frame: :preview_file{path="conv_1/frame.html" title="Quarterly Report" contentType="application/vnd.dust.frame"}',
+          citations: {},
+        },
+      });
+
+      expect(screen.getByText("Quarterly Report")).toBeInTheDocument();
+    });
+
+    it("keeps non-Frame inline file previews for compact Activation Pod messages", () => {
+      renderAgentMessage({
+        isCompactUIView: true,
+        agentMessageOverrides: {
+          content:
+            'See the report: :preview_file{path="conv_1/report.pdf" title="Report.pdf" contentType="application/pdf"}',
+          citations: {},
+        },
+      });
+
+      expect(screen.getByText("Report.pdf")).toBeInTheDocument();
     });
   });
 });

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1309,13 +1309,7 @@ function AgentMessageContent({
       action_card: getActionCardPlugin(onQuickReplySend, isLastMessage),
       // In the compact UI, the inline Frame preview directive is
       // suppressed here, the Frame is instead rendered as a bottom citation card.
-      ...(uiView === "compact"
-        ? {
-            file_preview: getFilePreviewPlugin({
-              hideInteractiveContent: true,
-            }),
-          }
-        : {}),
+      file_preview: getFilePreviewPlugin({ uiView }),
       ...propsAdditionalMarkdownComponents,
     }),
     [
@@ -1568,7 +1562,7 @@ function getCitations({
   });
 }
 
-// Renders Frame files as bottom citation cards for the compact Activation Pod UI
+// Renders Frame files as bottom citation cards for the compact UI
 function getFrameCitations({
   files,
   openPanel,

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1581,7 +1581,7 @@ function getFrameCitations({
       <FileCitationCard
         key={fileId}
         icon={ActionFrame}
-        title="Frame"
+        title={file.title}
         tooltipLabel={file.title}
         size="sm"
         onClick={() => openPanel({ type: "interactive_content", fileId })}

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -5,9 +5,11 @@ import { AgentHandle } from "@app/components/assistant/conversation/AgentHandle"
 import { AgentMessageInteractiveContentGeneratedFiles } from "@app/components/assistant/conversation/AgentMessageGeneratedFiles";
 import { InlineActivitySteps } from "@app/components/assistant/conversation/actions/inline/InlineActivitySteps";
 import { AttachmentCitation } from "@app/components/assistant/conversation/attachment/AttachmentCitation";
+import { FileCitationCard } from "@app/components/assistant/conversation/attachment/FileCitationCard";
 import { markdownCitationToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
 import { BlockedAction } from "@app/components/assistant/conversation/BlockedAction";
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
+import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { CreditCostPopover } from "@app/components/assistant/conversation/CreditCostPopover";
 import { DeletedMessage } from "@app/components/assistant/conversation/DeletedMessage";
 import { ErrorMessage } from "@app/components/assistant/conversation/ErrorMessage";
@@ -34,6 +36,7 @@ import {
   CitationsContext,
   CiteBlock,
 } from "@app/components/markdown/CiteBlock";
+import { getFilePreviewPlugin } from "@app/components/markdown/FilePreviewBlock";
 import type { MCPReferenceCitation } from "@app/components/markdown/MCPReferenceCitation";
 import { getQuickReplyPlugin } from "@app/components/markdown/QuickReplyBlock";
 import { getToolSetupPlugin } from "@app/components/markdown/tool/tool";
@@ -99,6 +102,7 @@ import type {
 } from "@app/types/user";
 import type { DropdownMenuItemProps } from "@dust-tt/sparkle";
 import {
+  ActionFrame,
   Button,
   ButtonGroupDropdown,
   Chip,
@@ -932,6 +936,17 @@ export function AgentMessage({
     [activeReferences, conversationId, owner]
   );
 
+  const { interactiveFiles } = useAutoOpenSidePanel({
+    agentMessage,
+    isLastMessage,
+  });
+  const { openPanel } = useConversationSidePanelContext();
+
+  const frameCitations = useMemo(
+    () => getFrameCitations({ files: interactiveFiles, openPanel }),
+    [interactiveFiles, openPanel]
+  );
+
   const handleQuickReply = useCallback(
     async (reply: string) => {
       const parsedMention = extractFromString(reply).find(isAgentMention);
@@ -1070,6 +1085,7 @@ export function AgentMessage({
           additionalMarkdownComponents={additionalMarkdownComponents}
           additionalMarkdownPlugins={additionalMarkdownPlugins}
           uiView={uiView}
+          interactiveFiles={isCompactUIView ? [] : interactiveFiles}
         />
       )}
     </ConversationMessageContent>
@@ -1154,6 +1170,7 @@ function AgentMessageContent({
   additionalMarkdownComponents: propsAdditionalMarkdownComponents,
   additionalMarkdownPlugins,
   uiView,
+  interactiveFiles,
 }: {
   onOpenDetails?: (messageId: string, actionId?: string) => void;
   triggeringUser: UserType | null;
@@ -1187,6 +1204,7 @@ function AgentMessageContent({
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
   uiView: UiView;
+  interactiveFiles: AgentMessageWithStreaming["generatedFiles"];
 }) {
   const methods = useVirtuosoMethods<
     VirtuosoMessage,
@@ -1283,6 +1301,15 @@ function AgentMessageContent({
       quickReply: getQuickReplyPlugin(onQuickReplySend, isLastMessage),
       toolSetup: getToolSetupPlugin(owner, handleToolSetupComplete),
       action_card: getActionCardPlugin(onQuickReplySend, isLastMessage),
+      // In the compact Activation Pod UI, the inline Frame preview directive is
+      // suppressed here, the Frame is instead rendered as a bottom citation card.
+      ...(isCompactUIView
+        ? {
+            file_preview: getFilePreviewPlugin({
+              hideInteractiveContent: true,
+            }),
+          }
+        : {}),
       ...propsAdditionalMarkdownComponents,
     }),
     [
@@ -1296,13 +1323,9 @@ function AgentMessageContent({
       handleToolSetupComplete,
       propsAdditionalMarkdownComponents,
       spaceId,
+      isCompactUIView,
     ]
   );
-
-  const { interactiveFiles } = useAutoOpenSidePanel({
-    agentMessage,
-    isLastMessage,
-  });
 
   const blockedActionElement = blockedAction ? (
     <BlockedAction
@@ -1536,5 +1559,33 @@ function getCitations({
         size="sm"
       />
     );
+  });
+}
+
+// Renders Frame files as bottom citation cards for the compact Activation Pod UI
+function getFrameCitations({
+  files,
+  openPanel,
+}: {
+  files: AgentMessageWithStreaming["generatedFiles"];
+  openPanel: ReturnType<typeof useConversationSidePanelContext>["openPanel"];
+}) {
+  return files.flatMap((file) => {
+    if (!file.fileId) {
+      return [];
+    }
+
+    const { fileId } = file;
+
+    return [
+      <FileCitationCard
+        key={fileId}
+        icon={ActionFrame}
+        title="Frame"
+        tooltipLabel={file.title}
+        size="sm"
+        onClick={() => openPanel({ type: "interactive_content", fileId })}
+      />,
+    ];
   });
 }

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1058,7 +1058,13 @@ export function AgentMessage({
 
   const messageContent = (
     <ConversationMessageContent
-      citations={isDeleted || uiView === "compact" ? undefined : citations}
+      citations={
+        isDeleted
+          ? undefined
+          : uiView === "compact"
+            ? frameCitations
+            : citations
+      }
       type="agent"
     >
       {isDeleted ? (
@@ -1085,7 +1091,7 @@ export function AgentMessage({
           additionalMarkdownComponents={additionalMarkdownComponents}
           additionalMarkdownPlugins={additionalMarkdownPlugins}
           uiView={uiView}
-          interactiveFiles={isCompactUIView ? [] : interactiveFiles}
+          interactiveFiles={uiView === "compact" ? [] : interactiveFiles}
         />
       )}
     </ConversationMessageContent>
@@ -1301,9 +1307,9 @@ function AgentMessageContent({
       quickReply: getQuickReplyPlugin(onQuickReplySend, isLastMessage),
       toolSetup: getToolSetupPlugin(owner, handleToolSetupComplete),
       action_card: getActionCardPlugin(onQuickReplySend, isLastMessage),
-      // In the compact Activation Pod UI, the inline Frame preview directive is
+      // In the compact UI, the inline Frame preview directive is
       // suppressed here, the Frame is instead rendered as a bottom citation card.
-      ...(isCompactUIView
+      ...(uiView === "compact"
         ? {
             file_preview: getFilePreviewPlugin({
               hideInteractiveContent: true,
@@ -1323,7 +1329,7 @@ function AgentMessageContent({
       handleToolSetupComplete,
       propsAdditionalMarkdownComponents,
       spaceId,
-      isCompactUIView,
+      uiView,
     ]
   );
 

--- a/front/components/markdown/FilePreviewBlock.test.tsx
+++ b/front/components/markdown/FilePreviewBlock.test.tsx
@@ -234,4 +234,36 @@ describe("getFilePreviewPlugin", () => {
 
     expect(screen.getByText("data.csv")).toBeInTheDocument();
   });
+
+  it("hides Frame files when hideInteractiveContent is set", () => {
+    const FilePreview = getFilePreviewPlugin({ hideInteractiveContent: true });
+
+    render(
+      <FilePreviewProvider owner={mockOwner}>
+        <FilePreview
+          path="conversation-c1/frame.tsx"
+          title="frame.tsx"
+          contentType={frameContentType}
+        />
+      </FilePreviewProvider>
+    );
+
+    expect(screen.queryByText("frame.tsx")).not.toBeInTheDocument();
+  });
+
+  it("still renders non-Frame files when hideInteractiveContent is set", () => {
+    const FilePreview = getFilePreviewPlugin({ hideInteractiveContent: true });
+
+    render(
+      <FilePreviewProvider owner={mockOwner}>
+        <FilePreview
+          path="conversation-c1/reports/report final.pdf"
+          title="report final.pdf"
+          contentType="application/pdf"
+        />
+      </FilePreviewProvider>
+    );
+
+    expect(screen.getByText("report final.pdf")).toBeInTheDocument();
+  });
 });

--- a/front/components/markdown/FilePreviewBlock.test.tsx
+++ b/front/components/markdown/FilePreviewBlock.test.tsx
@@ -235,8 +235,8 @@ describe("getFilePreviewPlugin", () => {
     expect(screen.getByText("data.csv")).toBeInTheDocument();
   });
 
-  it("hides Frame files when hideInteractiveContent is set", () => {
-    const FilePreview = getFilePreviewPlugin({ hideInteractiveContent: true });
+  it("hides Frame files when uiView is compact", () => {
+    const FilePreview = getFilePreviewPlugin({ uiView: "compact" });
 
     render(
       <FilePreviewProvider owner={mockOwner}>
@@ -251,8 +251,8 @@ describe("getFilePreviewPlugin", () => {
     expect(screen.queryByText("frame.tsx")).not.toBeInTheDocument();
   });
 
-  it("still renders non-Frame files when hideInteractiveContent is set", () => {
-    const FilePreview = getFilePreviewPlugin({ hideInteractiveContent: true });
+  it("still renders non-Frame files when uiView is compact", () => {
+    const FilePreview = getFilePreviewPlugin({ uiView: "compact" });
 
     render(
       <FilePreviewProvider owner={mockOwner}>

--- a/front/components/markdown/FilePreviewBlock.tsx
+++ b/front/components/markdown/FilePreviewBlock.tsx
@@ -6,11 +6,14 @@ import {
   getFilePreviewContentType,
   getFilePreviewTypeLabel,
 } from "@app/lib/markdown/file_preview";
+import { isInteractiveContentType } from "@app/types/files";
 import { isString } from "@app/types/shared/utils/general";
 import { visit } from "unist-util-visit";
 
 interface FilePreviewBlockProps {
   contentType?: string;
+  // When true, the compact Activation Pod UI is used
+  hideInteractiveContent?: boolean;
   path: string;
   title?: string;
 }
@@ -40,6 +43,7 @@ function getDirectiveLabelText(children: unknown): string | undefined {
 
 export function FilePreviewBlock({
   contentType,
+  hideInteractiveContent,
   path,
   title,
 }: FilePreviewBlockProps) {
@@ -52,6 +56,11 @@ export function FilePreviewBlock({
     contentType,
     fileName,
   });
+
+  if (hideInteractiveContent && isInteractiveContentType(fileContentType)) {
+    return null;
+  }
+
   const typeLabel = getFilePreviewTypeLabel({
     contentType: fileContentType,
     fileName,
@@ -68,8 +77,16 @@ export function FilePreviewBlock({
   );
 }
 
-export function getFilePreviewPlugin() {
-  return FilePreviewBlock;
+export function getFilePreviewPlugin(options?: {
+  hideInteractiveContent?: boolean;
+}) {
+  if (!options?.hideInteractiveContent) {
+    return FilePreviewBlock;
+  }
+
+  return function CompactFilePreviewBlock(props: FilePreviewBlockProps) {
+    return <FilePreviewBlock {...props} hideInteractiveContent />;
+  };
 }
 
 export function filePreviewDirective() {

--- a/front/components/markdown/FilePreviewBlock.tsx
+++ b/front/components/markdown/FilePreviewBlock.tsx
@@ -1,4 +1,5 @@
 import { PreviewableCitation } from "@app/components/assistant/conversation/attachment/PreviewableCitation";
+import type { UiView } from "@app/components/assistant/conversation/types";
 import {
   FILE_PREVIEW_COMPONENT_NAME,
   FILE_PREVIEW_DIRECTIVE_NAME,
@@ -12,10 +13,9 @@ import { visit } from "unist-util-visit";
 
 interface FilePreviewBlockProps {
   contentType?: string;
-  // When true, the compact Activation Pod UI is used
-  hideInteractiveContent?: boolean;
   path: string;
   title?: string;
+  uiView?: UiView;
 }
 
 function getDirectiveLabelText(children: unknown): string | undefined {
@@ -43,9 +43,9 @@ function getDirectiveLabelText(children: unknown): string | undefined {
 
 export function FilePreviewBlock({
   contentType,
-  hideInteractiveContent,
   path,
   title,
+  uiView,
 }: FilePreviewBlockProps) {
   if (!path) {
     return null;
@@ -57,7 +57,7 @@ export function FilePreviewBlock({
     fileName,
   });
 
-  if (hideInteractiveContent && isInteractiveContentType(fileContentType)) {
+  if (uiView === "compact" && isInteractiveContentType(fileContentType)) {
     return null;
   }
 
@@ -77,15 +77,13 @@ export function FilePreviewBlock({
   );
 }
 
-export function getFilePreviewPlugin(options?: {
-  hideInteractiveContent?: boolean;
-}) {
-  if (!options?.hideInteractiveContent) {
+export function getFilePreviewPlugin(options?: { uiView?: UiView }) {
+  if (options?.uiView !== "compact") {
     return FilePreviewBlock;
   }
 
   return function CompactFilePreviewBlock(props: FilePreviewBlockProps) {
-    return <FilePreviewBlock {...props} hideInteractiveContent />;
+    return <FilePreviewBlock {...props} uiView="compact" />;
   };
 }
 


### PR DESCRIPTION
## Description

Move generated Frame links from the top of compact Activation Pod messages into bottom citation cards, while preserving the existing behavior for standard conversations and non-Frame files.

For compact Activation Pod conversations:

- Collect generated interactive Frame files and render one bottom `FileCitationCard` per Frame.
- Open the corresponding Frame in the conversation side panel when a card is clicked.
- Suppress the top-of-message generated Frame links to avoid duplicate rendering.
- Hide inline `:preview_file` directives for Frame content types, while keeping non-Frame inline file previews available.

For standard conversations, keep generated Frame links at the top of the message and preserve existing inline preview behavior.

![Activation Pod Frame citation cards](https://github.com/user-attachments/assets/021d5a3b-4144-402b-bceb-fc10ddbf81ee)

## Tests

- Expanded `front/components/assistant/conversation/AgentMessage.compactUIView.test.tsx` to cover:
  - One and multiple Frame cards rendered at the bottom for compact conversations.
  - Frame card labels, icons, and opening the correct side-panel file.
  - No Frame card when no Frame is generated.
  - Top-of-message Frame links retained for standard conversations.
  - Inline Frame previews suppressed only in compact conversations.
  - Non-Frame inline file previews retained in compact conversations.
- Updated `front/components/markdown/FilePreviewBlock.test.tsx` to verify that compact conversations hide Frame previews but still render non-Frame files.

## Risk

Low. The behavior change is scoped to Frame rendering in the compact Activation Pod UI. Standard conversations, non-Frame inline previews, accessibility labels, and side-panel navigation remain covered by the existing behavior and focused tests.

## Deploy Plan

Deploy `front`.
