### PR TITLE
fix: don't create WorkOS users on dsync deprovisioning paths

### DIFF
--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -502,6 +502,68 @@ export async function addUserToWorkOSOrganization(
   );
 }
 
+function getEmailFromWorkOSDirectoryUser(
+  workOSUser: WorkOSDirectoryUser
+): string | null {
+  if (workOSUser.email) {
+    return workOSUser.email;
+  }
+
+  return (
+    workOSUser.rawAttributes.emails.find(
+      (e: unknown): e is { address: string; primary: true } =>
+        typeof e === "object" &&
+        e !== null &&
+        "primary" in e &&
+        e.primary === true &&
+        "address" in e &&
+        isString(e.address)
+    )?.address ?? null
+  );
+}
+
+async function fetchWorkOSUserByEmail(email: string) {
+  const workOSUserResponse = await getWorkOS().userManagement.listUsers({
+    email,
+  });
+
+  const [existingUser] = workOSUserResponse.data;
+
+  return existingUser ?? null;
+}
+
+/**
+ * Fetch-only counterpart of `fetchOrCreateWorkOSUserWithEmail`. Deprovisioning
+ * paths must use this one: creating a WorkOS user while handling a removal
+ * provisions the very user we are removing.
+ */
+export async function fetchWorkOSUserWithEmail({
+  workOSUser,
+  workspace,
+}: {
+  workspace: LightWorkspaceType;
+  workOSUser: WorkOSDirectoryUser;
+}): Promise<Result<WorkOSUser | null, Error>> {
+  const localLogger = logger.child({
+    directoryUserId: workOSUser.id,
+    workspaceId: workspace.sId,
+  });
+
+  const email = getEmailFromWorkOSDirectoryUser(workOSUser);
+  if (!email) {
+    return new Err(new Error("Missing email"));
+  }
+
+  const existingUser = await fetchWorkOSUserByEmail(email);
+  if (!existingUser) {
+    return new Ok(null);
+  }
+
+  localLogger.info("Found WorkOS user for webhook event.");
+
+  return new Ok(existingUser);
+}
+
 export async function fetchOrCreateWorkOSUserWithEmail({
   workOSUser,
   workspace,
@@ -514,28 +576,12 @@ export async function fetchOrCreateWorkOSUserWithEmail({
     workspaceId: workspace.sId,
   });
 
-  let email = workOSUser.email;
+  const email = getEmailFromWorkOSDirectoryUser(workOSUser);
   if (!email) {
-    email =
-      workOSUser.rawAttributes.emails.find(
-        (e: unknown): e is { address: string; primary: true } =>
-          typeof e === "object" &&
-          e !== null &&
-          "primary" in e &&
-          e.primary === true &&
-          "address" in e &&
-          isString(e.address)
-      )?.address ?? null;
-    if (!email) {
-      return new Err(new Error("Missing email"));
-    }
+    return new Err(new Error("Missing email"));
   }
 
-  const workOSUserResponse = await getWorkOS().userManagement.listUsers({
-    email,
-  });
-
-  const [existingUser] = workOSUserResponse.data;
+  const existingUser = await fetchWorkOSUserByEmail(email);
   if (!existingUser) {
     const createdUser = await getWorkOS().userManagement.createUser({
       email,

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -15,6 +15,7 @@ import {
 } from "@app/lib/api/workos/organization";
 import {
   fetchOrCreateWorkOSUserWithEmail,
+  fetchWorkOSUserWithEmail,
   getUserNicknameFromEmail,
 } from "@app/lib/api/workos/user";
 import {
@@ -1004,7 +1005,7 @@ async function handleUserRemovedFromGroup(
     return;
   }
 
-  const workOSUserRes = await fetchOrCreateWorkOSUserWithEmail({
+  const workOSUserRes = await fetchWorkOSUserWithEmail({
     workspace,
     workOSUser: eventData.user,
   });
@@ -1013,9 +1014,20 @@ async function handleUserRemovedFromGroup(
   }
   const workOSUser = workOSUserRes.value;
 
-  const user = await UserResource.fetchByWorkOSUserId(workOSUser.id);
+  // Nothing to deprovision. Removing them from a group is a no-op.
+  const user = workOSUser
+    ? await UserResource.fetchByWorkOSUserId(workOSUser.id)
+    : null;
   if (!user) {
-    throw new Error(`User not found with workOSId "${workOSUser.id}"`);
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        directoryUserId: eventData.user.id,
+        workOSUserId: workOSUser?.id,
+      },
+      "User to remove from group not found, skipping group removal"
+    );
+    return;
   }
 
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
@@ -1140,6 +1152,44 @@ async function handleCreateOrUpdateWorkOSUser(
 ) {
   const { data: eventData } = event;
 
+  // Entra (and other IdPs) disable users via SCIM PATCH active=false, which WorkOS translates
+  // into dsync.user.updated with state='inactive' rather than dsync.user.deleted. Treat this
+  // the same as deletion: revoke membership and remove from all groups. Being a deprovisioning
+  // path, it must not create the WorkOS user it fails to find.
+  if (eventData.state === "inactive") {
+    const inactiveWorkOSUserRes = await fetchWorkOSUserWithEmail({
+      workspace,
+      workOSUser: eventData,
+    });
+    if (inactiveWorkOSUserRes.isErr()) {
+      throw inactiveWorkOSUserRes.error;
+    }
+    const inactiveWorkOSUser = inactiveWorkOSUserRes.value;
+
+    const inactiveUser = inactiveWorkOSUser
+      ? await UserResource.fetchByWorkOSUserId(inactiveWorkOSUser.id)
+      : null;
+    if (!inactiveUser) {
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          directoryUserId: eventData.id,
+          workOSUserId: inactiveWorkOSUser?.id,
+        },
+        "Inactive user not found in workspace, skipping revocation"
+      );
+      return;
+    }
+
+    await revokeWorkOSUserMembership(
+      workspace,
+      inactiveUser,
+      eventData.directoryId,
+      false
+    );
+    return;
+  }
+
   const workOSUserRes = await fetchOrCreateWorkOSUserWithEmail({
     workspace,
     workOSUser: eventData,
@@ -1151,25 +1201,6 @@ async function handleCreateOrUpdateWorkOSUser(
 
   const user = await UserResource.fetchByWorkOSUserId(workOSUser.id);
 
-  // Entra (and other IdPs) disable users via SCIM PATCH active=false, which WorkOS translates
-  // into dsync.user.updated with state='inactive' rather than dsync.user.deleted. Treat this
-  // the same as deletion: revoke membership and remove from all groups.
-  if (eventData.state === "inactive") {
-    if (!user) {
-      logger.info(
-        { workspaceId: workspace.sId, workOSUserId: workOSUser.id },
-        "Inactive user not found in workspace, skipping revocation"
-      );
-      return;
-    }
-    await revokeWorkOSUserMembership(
-      workspace,
-      user,
-      eventData.directoryId,
-      false
-    );
-    return;
-  }
   const externalUser: ExternalUser = {
     email: workOSUser.email,
     email_verified: true,
@@ -1376,7 +1407,7 @@ async function handleDeleteWorkOSUser(
   event: DsyncUserDeletedEvent
 ) {
   const { data: eventData } = event;
-  const workOSUserRes = await fetchOrCreateWorkOSUserWithEmail({
+  const workOSUserRes = await fetchWorkOSUserWithEmail({
     workspace,
     workOSUser: eventData,
   });
@@ -1385,11 +1416,19 @@ async function handleDeleteWorkOSUser(
   }
   const workOSUser = workOSUserRes.value;
 
-  const user = await UserResource.fetchByWorkOSUserId(workOSUser.id);
+  const user = workOSUser
+    ? await UserResource.fetchByWorkOSUserId(workOSUser.id)
+    : null;
   if (!user) {
-    throw new Error(
-      `Did not find user to delete for workOSUserId "${workOSUser.id}" in workspace "${workspace.sId}"`
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        directoryUserId: eventData.id,
+        workOSUserId: workOSUser?.id,
+      },
+      "User to delete not found, likely already deleted"
     );
+    return;
   }
 
   // Clear WorkOS custom attributes before revoking membership.

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -1014,20 +1014,20 @@ async function handleUserRemovedFromGroup(
   }
   const workOSUser = workOSUserRes.value;
 
-  // Nothing to deprovision. Removing them from a group is a no-op.
-  const user = workOSUser
-    ? await UserResource.fetchByWorkOSUserId(workOSUser.id)
-    : null;
-  if (!user) {
+  // Unknown to WorkOS and to us: nothing to deprovision, removing them from a
+  // group is a no-op.
+  if (!workOSUser) {
     logger.info(
-      {
-        workspaceId: workspace.sId,
-        directoryUserId: eventData.user.id,
-        workOSUserId: workOSUser?.id,
-      },
-      "User to remove from group not found, skipping group removal"
+      { workspaceId: workspace.sId, directoryUserId: eventData.user.id },
+      "User to remove from group not found in WorkOS, skipping group removal"
     );
     return;
+  }
+
+  // Known to WorkOS but not to us: provisioning never went through, so surface it.
+  const user = await UserResource.fetchByWorkOSUserId(workOSUser.id);
+  if (!user) {
+    throw new Error(`User not found with workOSId "${workOSUser.id}"`);
   }
 
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
@@ -1166,19 +1166,22 @@ async function handleCreateOrUpdateWorkOSUser(
     }
     const inactiveWorkOSUser = inactiveWorkOSUserRes.value;
 
-    const inactiveUser = inactiveWorkOSUser
-      ? await UserResource.fetchByWorkOSUserId(inactiveWorkOSUser.id)
-      : null;
-    if (!inactiveUser) {
+    if (!inactiveWorkOSUser) {
       logger.info(
-        {
-          workspaceId: workspace.sId,
-          directoryUserId: eventData.id,
-          workOSUserId: inactiveWorkOSUser?.id,
-        },
-        "Inactive user not found in workspace, skipping revocation"
+        { workspaceId: workspace.sId, directoryUserId: eventData.id },
+        "Inactive user not found in WorkOS, skipping revocation"
       );
       return;
+    }
+
+    // Known to WorkOS but not to us: provisioning never went through, so surface it.
+    const inactiveUser = await UserResource.fetchByWorkOSUserId(
+      inactiveWorkOSUser.id
+    );
+    if (!inactiveUser) {
+      throw new Error(
+        `User not found with workOSId "${inactiveWorkOSUser.id}"`
+      );
     }
 
     await revokeWorkOSUserMembership(
@@ -1416,19 +1419,21 @@ async function handleDeleteWorkOSUser(
   }
   const workOSUser = workOSUserRes.value;
 
-  const user = workOSUser
-    ? await UserResource.fetchByWorkOSUserId(workOSUser.id)
-    : null;
-  if (!user) {
+  // Unknown to WorkOS and to us: nothing to delete.
+  if (!workOSUser) {
     logger.info(
-      {
-        workspaceId: workspace.sId,
-        directoryUserId: eventData.id,
-        workOSUserId: workOSUser?.id,
-      },
-      "User to delete not found, likely already deleted"
+      { workspaceId: workspace.sId, directoryUserId: eventData.id },
+      "User to delete not found in WorkOS, likely already deleted"
     );
     return;
+  }
+
+  // Known to WorkOS but not to us: provisioning never went through, so surface it.
+  const user = await UserResource.fetchByWorkOSUserId(workOSUser.id);
+  if (!user) {
+    throw new Error(
+      `Did not find user to delete for workOSUserId "${workOSUser.id}" in workspace "${workspace.sId}"`
+    );
   }
 
   // Clear WorkOS custom attributes before revoking membership.


### PR DESCRIPTION
## Description

Three dsync workflows have been retrying since this morning on workspace `Dr71zx5s38`:

```
group.user_removed  -> User not found with workOSId "user_01KZNHJGR6TPFSANFQYG82X501"
group.user_removed  -> User not found with workOSId "user_01KZNHJGR6TPFSANFQYG82X501"
user.deleted        -> Did not find user to delete for workOSUserId "user_01KZNHJGR6..."
```

I suspect a double emission of the event by WorkOS, which would have first removed the User, then tried to remove it but couldn't find it, creating a new user at the same time. There's no result to `SELECT * FROM users WHERE "workOSUserId" = 'user_01KZNHJGR6TPFSANFQYG82X501'` in the prod DB.

That WorkOS id was created in WorkOS at 09:55:29, *after* the three events were emitted. All three handlers resolved the WorkOS user through `fetchOrCreateWorkOSUserWithEmail`, so the helper created one and added it to the organization.

So: the second emission of the removal event provisioned the user it was supposed to remove.

- Add `fetchWorkOSUserWithEmail`, a fetch-only counterpart returning `Ok(null)` when WorkOS doesn't know the email. Both variants now share the email resolution and lookup helpers; `fetchOrCreateWorkOSUserWithEmail` behaviour is unchanged.
- Use it in `handleUserRemovedFromGroup`, `handleDeleteWorkOSUser`, and the `state === "inactive"` branch of `handleCreateOrUpdateWorkOSUser`, and no-op with a log when there's no local user, same way as `handleGroupDelete` already does.

## Tests

Typechecks clean.

## Risk

Low. 

## Deploy Plan

Normal deploy. Afterwards:
- terminate the three stuck workflows, they predate this and won't pick it up
- clean up the orphan `user_01KZNHJGR6TPFSANFQYG82X501` added to WorkOS org `Dr71zx5s38` at 09:55:30