### PR TITLE
Persist reconciled agent message consumption credits

### DIFF
--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
@@ -4,6 +4,7 @@ import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assi
 import { computeAndStoreAgentMessageConsumptionAttribution } from "@app/lib/api/assistant/agent_message_consumption_attribution/store";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { tokenCountForTexts } from "@app/lib/tokenization";
@@ -28,6 +29,7 @@ vi.mock("@app/lib/tokenization", () => ({
 const INPUT_TOKENS_COUNT = 100;
 const OUTPUT_TOKENS_COUNT = 20;
 const REASONING_TOKENS_COUNT = 5;
+const BILLED_CREDIT_AMOUNT_MICRO = 10_000_000;
 
 // Every tokenized footprint counts as this many tokens, so tool-call output and tool input
 // footprints are deterministic in the assertions below.
@@ -59,6 +61,10 @@ async function setupSettledMessageWithUsage() {
     conversation,
     agentConfig: agentConfiguration,
     runIds: [run.dustRunId],
+  });
+  await ConversationResource.updateAgentMessageCostCredits(auth, {
+    agentMessageModelId: agentMessage.agentMessageId,
+    costCredits: BILLED_CREDIT_AMOUNT_MICRO / 1_000_000,
   });
 
   return {
@@ -122,9 +128,16 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
 
     for (const item of items) {
       expect(item.grossAttributedCreditAmountMicro).toBeGreaterThan(0);
+      expect(item.reconciledCreditAmountMicro).not.toBeNull();
       expect(item.directCreditAmountMicro).toBeNull();
       expect(item.agentMCPActionId).toBeNull();
     }
+    expect(
+      items.reduce(
+        (total, item) => total + (item.reconciledCreditAmountMicro ?? 0),
+        0
+      )
+    ).toBe(BILLED_CREDIT_AMOUNT_MICRO);
   });
 
   it("is idempotent across repeated runs", async () => {
@@ -154,6 +167,37 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
       "output",
       "reasoning",
     ]);
+  });
+
+  it("rejects an action added after its run usage was attributed", async () => {
+    const {
+      auth,
+      workspace,
+      conversation,
+      run,
+      conversationId,
+      agentMessageId,
+      agentMessageModelId,
+    } = await setupSettledMessageWithUsage();
+
+    await computeAndStoreAgentMessageConsumptionAttribution(auth, {
+      agentMessageId,
+      conversationId,
+    });
+    await AgentMCPActionFactory.create(auth, {
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId,
+      status: "succeeded",
+      dustRunId: run.dustRunId,
+    });
+
+    await expect(
+      computeAndStoreAgentMessageConsumptionAttribution(auth, {
+        agentMessageId,
+        conversationId,
+      })
+    ).rejects.toThrow("An attributed run usage is missing tool evidence");
   });
 
   it("writes a tool row per action and carves the tool output from the assistant output", async () => {
@@ -522,6 +566,17 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
       agentMessageId,
       conversationId,
     });
+    const itemsWhilePending =
+      await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
+        auth,
+        {
+          agentMessageModelIds: [agentMessageModelId],
+          maxAttributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+        }
+      );
+    const pendingInputCreditAmountMicro = itemsWhilePending.find(
+      (item) => item.itemType === "input"
+    )?.reconciledCreditAmountMicro;
 
     // The user approves, the tool executes and succeeds, then the loop finalizes again.
     await AgentMCPActionFactory.setStatus(auth, {
@@ -553,6 +608,25 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
       completedAt: expect.any(Date),
     });
     expect(toolItems[0].directCreditAmountMicro).toBeGreaterThan(0);
+
+    const settledItems =
+      await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
+        auth,
+        {
+          agentMessageModelIds: [agentMessageModelId],
+          maxAttributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+        }
+      );
+    expect(
+      settledItems.reduce(
+        (total, item) => total + (item.reconciledCreditAmountMicro ?? 0),
+        0
+      )
+    ).toBe(BILLED_CREDIT_AMOUNT_MICRO);
+    expect(
+      settledItems.find((item) => item.itemType === "input")
+        ?.reconciledCreditAmountMicro
+    ).toBeLessThan(pendingInputCreditAmountMicro ?? 0);
   });
 
   it("keeps a completed tool single and stable across a redundant re-finalize", async () => {
@@ -577,6 +651,7 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
       agentMessageId,
       conversationId,
     });
+    expect(tokenCountForTexts).toHaveBeenCalledTimes(2);
     await AgentMCPActionFactory.setStatus(auth, {
       action,
       status: "succeeded",
@@ -585,13 +660,17 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
       agentMessageId,
       conversationId,
     });
+    // The completion pass rebuilds only this affected usage, including its shared output-token
+    // partition. It does not revisit any other historical usage.
+    expect(tokenCountForTexts).toHaveBeenCalledTimes(4);
 
     // A redundant finalize (e.g. a Temporal retry) re-upserts the same values. It must not duplicate
-    // the row or change the attributed evidence, and the row stays completed.
+    // the row, change the attributed evidence, or tokenize the completed tool again.
     await computeAndStoreAgentMessageConsumptionAttribution(auth, {
       agentMessageId,
       conversationId,
     });
+    expect(tokenCountForTexts).toHaveBeenCalledTimes(4);
 
     const toolItems = (
       await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
@@ -100,12 +100,12 @@ function selectRunUsagesNeedingEvidence({
 async function buildRunUsageConsumptionEvidence(
   auth: Authenticator,
   {
-    enrichedActionById,
+    enrichedActionByModelId,
     runActions,
     triggeringUserMessageOrigin,
     usage,
   }: {
-    enrichedActionById: ReadonlyMap<ModelId, AgentMCPActionWithOutputType>;
+    enrichedActionByModelId: ReadonlyMap<ModelId, AgentMCPActionWithOutputType>;
     runActions: AgentMCPActionResource[];
     triggeringUserMessageOrigin: UserMessageOrigin | null;
     usage: RunUsageWithRunKeyType;
@@ -129,7 +129,7 @@ async function buildRunUsageConsumptionEvidence(
     isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)
   );
   const modelVisibleRunActionPairs = modelVisibleRunActions.map((action) => {
-    const enrichedAction = enrichedActionById.get(action.id);
+    const enrichedAction = enrichedActionByModelId.get(action.id);
     assert(
       enrichedAction,
       "A selected model-visible action must have an enriched counterpart"
@@ -265,7 +265,7 @@ async function buildRunUsageConsumptionEvidence(
       continue;
     }
 
-    const enrichedAction = enrichedActionById.get(action.id);
+    const enrichedAction = enrichedActionByModelId.get(action.id);
     assert(
       enrichedAction,
       "A completed sandbox child action must have an enriched counterpart"
@@ -497,7 +497,7 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
           ignoreContent: false,
         })
       : [];
-  const enrichedActionById = new Map(
+  const enrichedActionByModelId = new Map(
     enrichedActions.map((action) => [action.id, action])
   );
 
@@ -511,7 +511,7 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
     const dustRunId = dustRunIdByRunModelId.get(usage.runModelId);
     const runActions = (dustRunId && actionsByDustRunId.get(dustRunId)) || [];
     const usageEvidence = await buildRunUsageConsumptionEvidence(auth, {
-      enrichedActionById,
+      enrichedActionByModelId,
       runActions,
       triggeringUserMessageOrigin,
       usage,

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
@@ -1,5 +1,6 @@
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import { isSandboxChildActionInfo } from "@app/lib/actions/types";
+import { buildLatestMessageConsumptionAllocation } from "@app/lib/api/assistant/agent_message_consumption_attribution/allocation";
 import {
   AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
   buildRunUsageAttribution,
@@ -16,11 +17,348 @@ import type {
 } from "@app/lib/resources/agent_message_consumption_item_resource";
 import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { RunUsageWithRunKeyType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
+import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import assert from "assert";
+
+function selectRunUsagesNeedingEvidence({
+  actionsByDustRunId,
+  currentItems,
+  dustRunIdByRunModelId,
+  usages,
+}: {
+  actionsByDustRunId: ReadonlyMap<string, AgentMCPActionResource[]>;
+  currentItems: AgentMessageConsumptionItemResource[];
+  dustRunIdByRunModelId: ReadonlyMap<ModelId, string>;
+  usages: RunUsageWithRunKeyType[];
+}): RunUsageWithRunKeyType[] {
+  const modelItemTypesByRunUsageModelId = new Map<ModelId, Set<string>>();
+  const toolItemByActionModelId = new Map<
+    ModelId,
+    AgentMessageConsumptionItemResource
+  >();
+  const runUsageModelIdsWithEvidence = new Set<ModelId>();
+
+  for (const item of currentItems) {
+    runUsageModelIdsWithEvidence.add(item.runUsageId);
+    if (item.itemType === "tool") {
+      if (item.agentMCPActionId !== null) {
+        toolItemByActionModelId.set(item.agentMCPActionId, item);
+      }
+      continue;
+    }
+    if (item.runUsageId !== null) {
+      const itemTypes =
+        modelItemTypesByRunUsageModelId.get(item.runUsageId) ?? new Set();
+      itemTypes.add(item.itemType);
+      modelItemTypesByRunUsageModelId.set(item.runUsageId, itemTypes);
+    }
+  }
+
+  return usages.filter((usage) => {
+    const dustRunId = dustRunIdByRunModelId.get(usage.runModelId);
+    const runActions = (dustRunId && actionsByDustRunId.get(dustRunId)) || [];
+    const modelItemTypes = modelItemTypesByRunUsageModelId.get(
+      usage.runUsageModelId
+    );
+    const hasMissingActionItem = runActions.some(
+      (action) => !toolItemByActionModelId.has(action.id)
+    );
+    assert(
+      !runUsageModelIdsWithEvidence.has(usage.runUsageModelId) ||
+        !hasMissingActionItem,
+      "An attributed run usage is missing tool evidence"
+    );
+
+    // New usages have no rows. Previously processed usages should have every reported bucket because
+    // model evidence is written atomically. Treating a partial set as incomplete is defensive recovery.
+    const hasCompleteModelItems =
+      modelItemTypes?.has("input") === true &&
+      modelItemTypes.has("output") &&
+      (usage.reasoningTokens === null || modelItemTypes.has("reasoning"));
+
+    // Tool evidence needs another pass only when absent or when a pending row can now be completed.
+    const hasActionNeedingEvidence = runActions.some((action) => {
+      const item = toolItemByActionModelId.get(action.id);
+      return (
+        !item ||
+        (item.completedAt === null && isToolExecutionStatusFinal(action.status))
+      );
+    });
+
+    return !hasCompleteModelItems || hasActionNeedingEvidence;
+  });
+}
+
+async function buildRunUsageConsumptionEvidence(
+  auth: Authenticator,
+  {
+    enrichedActionById,
+    runActions,
+    triggeringUserMessageOrigin,
+    usage,
+  }: {
+    enrichedActionById: ReadonlyMap<ModelId, AgentMCPActionWithOutputType>;
+    runActions: AgentMCPActionResource[];
+    triggeringUserMessageOrigin: UserMessageOrigin | null;
+    usage: RunUsageWithRunKeyType;
+  }
+): Promise<{
+  records: CompletedAgentMessageConsumptionItem[];
+  pendingToolItems: PendingToolConsumptionItem[];
+}> {
+  const records: CompletedAgentMessageConsumptionItem[] = [];
+  const pendingToolItems: PendingToolConsumptionItem[] = [];
+
+  // Sandbox-child actions are invoked by the in-sandbox dsbx CLI, not by the outer model. They
+  // reuse their parent's function-call step content, so measuring them here would tokenize the
+  // parent Computer call a second time and separately count a result already carried in the
+  // Computer output.
+  const modelVisibleRunActions = runActions.filter(
+    (action) =>
+      !isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)
+  );
+  const sandboxChildRunActions = runActions.filter((action) =>
+    isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)
+  );
+  const modelVisibleRunActionPairs = modelVisibleRunActions.map((action) => {
+    const enrichedAction = enrichedActionById.get(action.id);
+    assert(
+      enrichedAction,
+      "A selected model-visible action must have an enriched counterpart"
+    );
+    return { action, enrichedAction };
+  });
+
+  // Selected usages need both sides of every model-visible tool call so their shared provider
+  // output budget is partitioned consistently with the immutable evidence already stored.
+  const footprintsRes = await measureToolCallFootprints(auth, {
+    modelId: usage.modelId,
+    // TODO(2026-07-31 FLAV) Refactor `enrichActionsWithOutputItems` so it still returns the
+    // resource.
+    toolCalls: modelVisibleRunActionPairs.map(({ action, enrichedAction }) => ({
+      action: enrichedAction,
+      functionCallArguments: action.functionCallArguments,
+    })),
+  });
+  if (footprintsRes.isErr()) {
+    throw new Error(
+      `[ConsumptionAttribution] Failed to tokenize tool footprints: ${footprintsRes.error.message}`
+    );
+  }
+  const footprints = footprintsRes.value;
+
+  // Pair each tool call with its enriched form and measured footprint once, here. This is the only
+  // place alignment is assumed: measureToolCallFootprints returns counts positioned by the actions
+  // it received, and modelVisibleRunActionPairs is aligned with the measured footprints, so index i
+  // is the same tool call across both. From here each call carries its own data through the builder,
+  // so nothing downstream re-derives the position.
+  const measuredToolCalls = modelVisibleRunActionPairs.map(
+    ({ action, enrichedAction }, index) => ({
+      action,
+      enrichedAction,
+      footprint: footprints[index],
+    })
+  );
+
+  // A single partition of the usage: the tool calls take their share of the output budget, and the
+  // model buckets take the rest (so the output row here is net of tool emission).
+  const { modelItems, toolCalls } = buildRunUsageAttribution({
+    usage,
+    toolCalls: measuredToolCalls.map((measured) => ({
+      tool: measured,
+      measuredOutputTokensCount: measured.footprint.callOutputTokensCount,
+    })),
+  });
+
+  for (const item of modelItems) {
+    switch (item.itemType) {
+      case "input":
+        records.push({
+          itemType: "input",
+          runUsageModelId: usage.runUsageModelId,
+          inputTokensCount: item.inputTokensCount,
+          grossAttributedCreditAmountMicro:
+            item.grossAttributedCreditAmountMicro,
+        });
+        break;
+
+      case "output":
+      case "reasoning":
+        records.push({
+          itemType: item.itemType,
+          runUsageModelId: usage.runUsageModelId,
+          outputTokensCount: item.outputTokensCount,
+          grossAttributedCreditAmountMicro:
+            item.grossAttributedCreditAmountMicro,
+        });
+        break;
+
+      default:
+        assertNever(item);
+    }
+  }
+
+  for (const toolCall of toolCalls) {
+    const { action, enrichedAction, footprint } = toolCall.tool;
+
+    // A blocked action carries no result and no charge yet, and billing does not charge it. Record
+    // only the emitted call output as a pending row. The rest lands once the action is final.
+    if (!isToolExecutionStatusFinal(action.status)) {
+      pendingToolItems.push({
+        action,
+        runUsageModelId: usage.runUsageModelId,
+        outputTokensCount: toolCall.outputTokensCount,
+        grossAttributedCreditAmountMicro:
+          toolCall.grossAttributedCreditAmountMicro,
+      });
+      continue;
+    }
+
+    // Zero for a denied call, which billing does not charge. Its emitted output tokens stay
+    // attributed here.
+    const directCreditAmountMicro = roundCreditsToMicroCredits(
+      toolAwuFromAction(
+        {
+          toolName: enrichedAction.toolName,
+          internalMCPServerName: enrichedAction.internalMCPServerName,
+          status: action.status,
+        },
+        triggeringUserMessageOrigin
+      )
+    );
+    const toolAttribution = buildToolAttribution({
+      usage,
+      toolCall,
+      inputTokensCount: footprint.inputTokensCount,
+      directCreditAmountMicro,
+    });
+    records.push({
+      itemType: "tool",
+      runUsageModelId: usage.runUsageModelId,
+      action,
+      inputTokensCount: toolAttribution.inputTokensCount,
+      outputTokensCount: toolAttribution.outputTokensCount,
+      directCreditAmountMicro: toolAttribution.directCreditAmountMicro,
+      grossAttributedCreditAmountMicro:
+        toolAttribution.grossAttributedCreditAmountMicro,
+    });
+  }
+
+  for (const action of sandboxChildRunActions) {
+    // A blocked child has not reached the nested tool yet. Unlike a directly model-emitted call,
+    // it contributes no output footprint while pending.
+    if (!isToolExecutionStatusFinal(action.status)) {
+      pendingToolItems.push({
+        action,
+        runUsageModelId: usage.runUsageModelId,
+        outputTokensCount: 0,
+        grossAttributedCreditAmountMicro: 0,
+      });
+      continue;
+    }
+
+    const enrichedAction = enrichedActionById.get(action.id);
+    assert(
+      enrichedAction,
+      "A completed sandbox child action must have an enriched counterpart"
+    );
+    const directCreditAmountMicro = roundCreditsToMicroCredits(
+      toolAwuFromAction(
+        {
+          toolName: enrichedAction.toolName,
+          internalMCPServerName: enrichedAction.internalMCPServerName,
+          status: action.status,
+        },
+        triggeringUserMessageOrigin
+      )
+    );
+
+    records.push({
+      itemType: "tool",
+      runUsageModelId: usage.runUsageModelId,
+      action,
+      inputTokensCount: 0,
+      outputTokensCount: 0,
+      directCreditAmountMicro,
+      grossAttributedCreditAmountMicro: directCreditAmountMicro,
+    });
+  }
+
+  return { records, pendingToolItems };
+}
+
+async function persistMessageConsumptionAttribution(
+  auth: Authenticator,
+  {
+    actions,
+    agentMessageModelId,
+    billedCredits,
+    conversation,
+    dustRunIds,
+    pendingToolItems,
+    records,
+    runs,
+    usages,
+  }: {
+    actions: AgentMCPActionResource[];
+    agentMessageModelId: ModelId;
+    billedCredits: number | null;
+    conversation: ConversationResource;
+    dustRunIds: string[];
+    pendingToolItems: PendingToolConsumptionItem[];
+    records: CompletedAgentMessageConsumptionItem[];
+    runs: RunResource[];
+    usages: RunUsageWithRunKeyType[];
+  }
+): Promise<void> {
+  // Store the immutable evidence first, then materialize the newest complete allocation against the
+  // authoritative bill in the same transaction. An incomplete version keeps its evidence with null
+  // reconciliation and can be completed by a later finalize.
+  await withTransaction(async (transaction) => {
+    await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
+      conversation,
+      agentMessageModelId,
+      attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+      records,
+      pendingToolItems,
+      transaction,
+    });
+
+    const items =
+      await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
+        auth,
+        {
+          agentMessageModelIds: [agentMessageModelId],
+          maxAttributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+          transaction,
+        }
+      );
+    const allocation = buildLatestMessageConsumptionAllocation({
+      actions,
+      billedCredits,
+      dustRunIds,
+      items,
+      runs,
+      usages,
+    });
+    if (!allocation) {
+      return;
+    }
+
+    await AgentMessageConsumptionItemResource.setReconciledCreditAmounts(auth, {
+      reconciledCreditAmountByItem: allocation.reconciledCreditAmounts.byItem,
+      transaction,
+    });
+  });
+}
 
 /**
  * Records the per-run consumption attribution breakdown for one settled agent message.
@@ -35,11 +373,11 @@ import assert from "assert";
  *
  * Runs once the message has settled, launched from the analytics queue by the finalize activities.
  * It is idempotent by (agent message, attribution version, run usage, item type) for model rows and
- * by (agent message, attribution version, action) for tool rows: a re-finalize (interrupt/resume,
- * tool confirmation, Temporal retry) re-inserts the same identities as no-ops and adds rows only for
- * run usages or actions that are new since the last pass. Records are computed for the whole message
- * before any write, so a tokenization failure throws and the retry recomputes from scratch rather
- * than locking in a partial breakdown.
+ * by (agent message, attribution version, action) for tool rows. Before doing any tokenization, a
+ * re-finalize (interrupt/resume, tool confirmation, Temporal retry) reads those identities and only
+ * rebuilds new or incomplete run usages. A usage containing a newly completed tool is rebuilt as a
+ * unit because all its emitted calls share one provider output-token budget. Reconciliation itself
+ * always runs over the full persisted message because the authoritative rounded bill may change.
  *
  * A finalize also fires while the loop is paused on a tool awaiting approval, so an action can be
  * seen here before it is final. Such an action has no result and no charge yet, and billing does not
@@ -69,8 +407,13 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
     return;
   }
 
-  const { agentMessageModelId, status, runIds, triggeringUserMessageOrigin } =
-    creditContext;
+  const {
+    agentMessageModelId,
+    previousCostCredits: billedCredits,
+    status,
+    runIds,
+    triggeringUserMessageOrigin,
+  } = creditContext;
 
   // Attribution only explains what was billed, so it mirrors the billing status gate: an untracked
   // status has no charge to compose.
@@ -102,16 +445,16 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
   // Group the message's tool calls by the run that emitted them. Each action carries its emitting
   // step content, whose dustRunId identifies that run and is the same identifier the run usages are
   // keyed by.
-  const actions = await AgentMCPActionResource.listByAgentMessageIds(auth, [
-    agentMessageModelId,
+  const [actions, existingItems] = await Promise.all([
+    AgentMCPActionResource.listByAgentMessageIds(auth, [agentMessageModelId]),
+    AgentMessageConsumptionItemResource.listByAgentMessageModelIds(auth, {
+      agentMessageModelIds: [agentMessageModelId],
+      maxAttributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+    }),
   ]);
-  const enrichedActions =
-    await AgentMCPActionResource.enrichActionsWithOutputItems(auth, {
-      actions,
-      ignoreContent: false,
-    });
-  const enrichedActionById = new Map(
-    enrichedActions.map((action) => [action.id, action])
+  const currentItems = existingItems.filter(
+    (item) =>
+      item.attributionVersion === AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION
   );
 
   const dustRunIdByRunModelId = new Map(
@@ -131,195 +474,61 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
     actionsByDustRunId.set(dustRunId, runActions);
   }
 
+  const usagesToProcess = selectRunUsagesNeedingEvidence({
+    actionsByDustRunId,
+    currentItems,
+    dustRunIdByRunModelId,
+    usages,
+  });
+  const dustRunIdsToProcess = new Set(
+    usagesToProcess
+      .map((usage) => dustRunIdByRunModelId.get(usage.runModelId))
+      .filter((dustRunId): dustRunId is string => dustRunId !== undefined)
+  );
+  const actionsToEnrich = actions.filter(
+    (action) =>
+      action.stepContent.dustRunId !== null &&
+      dustRunIdsToProcess.has(action.stepContent.dustRunId)
+  );
+  const enrichedActions =
+    actionsToEnrich.length > 0
+      ? await AgentMCPActionResource.enrichActionsWithOutputItems(auth, {
+          actions: actionsToEnrich,
+          ignoreContent: false,
+        })
+      : [];
+  const enrichedActionById = new Map(
+    enrichedActions.map((action) => [action.id, action])
+  );
+
   const records: CompletedAgentMessageConsumptionItem[] = [];
   // Tool calls whose action is still blocked (awaiting approval or authentication). Written pending:
   // only the emitted call output is known, the result footprint and direct charge wait for the
   // action to settle.
   const pendingToolItems: PendingToolConsumptionItem[] = [];
 
-  for (const usage of usages) {
+  for (const usage of usagesToProcess) {
     const dustRunId = dustRunIdByRunModelId.get(usage.runModelId);
     const runActions = (dustRunId && actionsByDustRunId.get(dustRunId)) || [];
-    const runActionPairs = runActions.map((action) => {
-      const enrichedAction = enrichedActionById.get(action.id);
-      assert(enrichedAction, "Every action must have an enriched counterpart");
-      return { action, enrichedAction };
-    });
-    // Sandbox-child actions are invoked by the in-sandbox dsbx CLI, not by the outer model. They
-    // reuse their parent's function-call step content, so measuring them here would tokenize the
-    // parent Computer call a second time and separately count a result already carried in the
-    // Computer output.
-    const modelVisibleRunActionPairs = runActionPairs.filter(
-      ({ action }) =>
-        !isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)
-    );
-    const sandboxChildRunActionPairs = runActionPairs.filter(({ action }) =>
-      isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)
-    );
-
-    // Token footprints of this run's model-visible tool calls: the output the model spent emitting
-    // each call and the input its result occupied. Everything is priced against this one usage below.
-    const footprintsRes = await measureToolCallFootprints(auth, {
-      modelId: usage.modelId,
-      // TODO(2026-07-31 FLAV) Refactor `enrichActionsWithOutputItems` so it still returns the
-      // resource.
-      toolCalls: modelVisibleRunActionPairs.map(
-        ({ action, enrichedAction }) => ({
-          action: enrichedAction,
-          functionCallArguments: action.functionCallArguments,
-        })
-      ),
-    });
-    if (footprintsRes.isErr()) {
-      throw new Error(
-        `[ConsumptionAttribution] Failed to tokenize tool footprints: ${footprintsRes.error.message}`
-      );
-    }
-    const footprints = footprintsRes.value;
-
-    // Pair each tool call with its enriched form and measured footprint once, here. This is the only
-    // place alignment is assumed: measureToolCallFootprints returns counts positioned by the actions
-    // it received, and modelVisibleRunActionPairs is aligned with the measured footprints, so index
-    // i is the same tool call across both. From here each call carries its own data through the
-    // builder, so nothing downstream re-derives the position.
-    const measuredToolCalls = modelVisibleRunActionPairs.map(
-      ({ action, enrichedAction }, index) => ({
-        action,
-        enrichedAction,
-        footprint: footprints[index],
-      })
-    );
-
-    // A single partition of the usage: the tool calls take their share of the output budget, and the
-    // model buckets take the rest (so the output row here is net of tool emission).
-    const { modelItems, toolCalls } = buildRunUsageAttribution({
+    const usageEvidence = await buildRunUsageConsumptionEvidence(auth, {
+      enrichedActionById,
+      runActions,
+      triggeringUserMessageOrigin,
       usage,
-      toolCalls: measuredToolCalls.map((measured) => ({
-        tool: measured,
-        measuredOutputTokensCount: measured.footprint.callOutputTokensCount,
-      })),
     });
-
-    for (const item of modelItems) {
-      switch (item.itemType) {
-        case "input":
-          records.push({
-            itemType: "input",
-            runUsageModelId: usage.runUsageModelId,
-            inputTokensCount: item.inputTokensCount,
-            grossAttributedCreditAmountMicro:
-              item.grossAttributedCreditAmountMicro,
-          });
-          break;
-
-        case "output":
-        case "reasoning":
-          records.push({
-            itemType: item.itemType,
-            runUsageModelId: usage.runUsageModelId,
-            outputTokensCount: item.outputTokensCount,
-            grossAttributedCreditAmountMicro:
-              item.grossAttributedCreditAmountMicro,
-          });
-          break;
-
-        default:
-          assertNever(item);
-      }
-    }
-
-    toolCalls.forEach((toolCall) => {
-      const { action, enrichedAction, footprint } = toolCall.tool;
-
-      // A blocked action carries no result and no charge yet, and billing does not charge it. Record
-      // only the emitted call output as a pending row. The rest lands once the action is final.
-      if (!isToolExecutionStatusFinal(action.status)) {
-        pendingToolItems.push({
-          action,
-          runUsageModelId: usage.runUsageModelId,
-          outputTokensCount: toolCall.outputTokensCount,
-          grossAttributedCreditAmountMicro:
-            toolCall.grossAttributedCreditAmountMicro,
-        });
-        return;
-      }
-
-      // Zero for a denied call, which billing does not charge. Its emitted output tokens stay
-      // attributed here.
-      const directCreditAmountMicro = roundCreditsToMicroCredits(
-        toolAwuFromAction(
-          {
-            toolName: enrichedAction.toolName,
-            internalMCPServerName: enrichedAction.internalMCPServerName,
-            status: action.status,
-          },
-          triggeringUserMessageOrigin
-        )
-      );
-
-      const toolAttribution = buildToolAttribution({
-        usage,
-        toolCall,
-        inputTokensCount: footprint.inputTokensCount,
-        directCreditAmountMicro,
-      });
-
-      records.push({
-        itemType: "tool",
-        runUsageModelId: usage.runUsageModelId,
-        action,
-        inputTokensCount: toolAttribution.inputTokensCount,
-        outputTokensCount: toolAttribution.outputTokensCount,
-        directCreditAmountMicro: toolAttribution.directCreditAmountMicro,
-        grossAttributedCreditAmountMicro:
-          toolAttribution.grossAttributedCreditAmountMicro,
-      });
-    });
-
-    for (const { action, enrichedAction } of sandboxChildRunActionPairs) {
-      // A blocked child has not reached the nested tool yet. Unlike a directly model-emitted call,
-      // it contributes no output footprint while pending.
-      if (!isToolExecutionStatusFinal(action.status)) {
-        pendingToolItems.push({
-          action,
-          runUsageModelId: usage.runUsageModelId,
-          outputTokensCount: 0,
-          grossAttributedCreditAmountMicro: 0,
-        });
-        continue;
-      }
-
-      const directCreditAmountMicro = roundCreditsToMicroCredits(
-        toolAwuFromAction(
-          {
-            toolName: enrichedAction.toolName,
-            internalMCPServerName: enrichedAction.internalMCPServerName,
-            status: action.status,
-          },
-          triggeringUserMessageOrigin
-        )
-      );
-
-      records.push({
-        itemType: "tool",
-        runUsageModelId: usage.runUsageModelId,
-        action,
-        inputTokensCount: 0,
-        outputTokensCount: 0,
-        directCreditAmountMicro,
-        grossAttributedCreditAmountMicro: directCreditAmountMicro,
-      });
-    }
+    records.push(...usageEvidence.records);
+    pendingToolItems.push(...usageEvidence.pendingToolItems);
   }
 
-  // One atomic write for the whole pass. The resource inserts the model buckets and the final tools,
-  // completes in place any tool a prior pass left pending, and records the still-blocked tools as
-  // pending, so this materializer never coordinates a read followed by separate inserts and updates.
-  await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
-    conversation,
+  await persistMessageConsumptionAttribution(auth, {
+    actions,
     agentMessageModelId,
-    attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
-    records,
+    billedCredits,
+    conversation,
+    dustRunIds,
     pendingToolItems,
+    records,
+    runs,
+    usages,
   });
 }

--- a/front/lib/models/agent/agent_message_consumption_item.ts
+++ b/front/lib/models/agent/agent_message_consumption_item.ts
@@ -68,11 +68,11 @@ function validateConsumptionItemShape(
   }
 }
 
-// Each row explains one component of an agent message's cost (a model token bucket or a tool
-// call). The credit amounts here are an attribution breakdown, not the bill: they are un-rounded
-// micro-credits priced cache-naive, whereas the authoritative charge is the Metronome AWU amount
-// rounded up per execution. These rows are not expected to sum to the billed amount. They rank
-// what drove the cost. See attribution_builder.ts for the pricing rationale.
+// Each row explains one component of an agent message's cost (a model token bucket or a tool call).
+// `grossAttributedCreditAmountMicro` is immutable cache-naive evidence and is not expected to sum
+// to the bill. `reconciledCreditAmountMicro` materializes the item's share of the authoritative
+// Metronome AWU charge. It remains null until a complete attribution version can be allocated.
+// See attribution_builder.ts and allocation.ts for the pricing and reconciliation rationale.
 export class AgentMessageConsumptionItemModel extends WorkspaceAwareModel<AgentMessageConsumptionItemModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
@@ -87,6 +87,7 @@ export class AgentMessageConsumptionItemModel extends WorkspaceAwareModel<AgentM
   declare inputTokensCount: number | null;
   declare outputTokensCount: number | null;
   declare grossAttributedCreditAmountMicro: number;
+  declare reconciledCreditAmountMicro: number | null;
   declare directCreditAmountMicro: number | null;
   declare completedAt: Date | null;
 }
@@ -156,6 +157,11 @@ AgentMessageConsumptionItemModel.init(
     grossAttributedCreditAmountMicro: {
       type: DataTypes.BIGINT,
       allowNull: false,
+      validate: { min: 0 },
+    },
+    reconciledCreditAmountMicro: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
       validate: { min: 0 },
     },
     directCreditAmountMicro: {

--- a/front/lib/resources/agent_message_consumption_item_resource.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.ts
@@ -4,6 +4,7 @@ import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { withTransaction } from "@app/lib/utils/sql_utils";
@@ -15,7 +16,7 @@ import { Err } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import assert from "assert";
 import type { Attributes, CreationAttributes, Transaction } from "sequelize";
-import { Op } from "sequelize";
+import { Op, QueryTypes } from "sequelize";
 
 export type ConversationConsumptionMessageFacts = {
   agentConfigurationId: string;
@@ -489,6 +490,58 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
         );
       }
     }, transaction);
+  }
+
+  static async setReconciledCreditAmounts(
+    auth: Authenticator,
+    {
+      reconciledCreditAmountByItem,
+      transaction,
+    }: {
+      reconciledCreditAmountByItem: ReadonlyMap<
+        AgentMessageConsumptionItemResource,
+        number
+      >;
+      transaction?: Transaction;
+    }
+  ): Promise<void> {
+    const changedAllocations = [...reconciledCreditAmountByItem].filter(
+      ([item, reconciledCreditAmountMicro]) =>
+        item.reconciledCreditAmountMicro !== reconciledCreditAmountMicro
+    );
+    if (changedAllocations.length === 0) {
+      return;
+    }
+
+    // `unnest` pairs both arrays by position into rows of item ID and reconciled amount.
+    // biome-ignore lint/plugin/noRawSql: Sequelize cannot bulk-update each row with a distinct value.
+    await frontSequelize.query(
+      `
+        UPDATE agent_message_consumption_items AS item
+        SET
+          "reconciledCreditAmountMicro" = allocation.reconciled_credit_amount_micro,
+          "updatedAt" = $updatedAt
+        FROM unnest(
+          $itemModelIds::bigint[],
+          $reconciledCreditAmountsMicro::bigint[]
+        ) AS allocation(item_model_id, reconciled_credit_amount_micro)
+        WHERE item.id = allocation.item_model_id
+          AND item."workspaceId" = $workspaceModelId
+      `,
+      {
+        bind: {
+          itemModelIds: changedAllocations.map(([item]) => item.id),
+          reconciledCreditAmountsMicro: changedAllocations.map(
+            ([, reconciledCreditAmountMicro]) => reconciledCreditAmountMicro
+          ),
+          // Raw SQL bypasses Sequelize timestamping, so set it explicitly.
+          updatedAt: new Date(),
+          workspaceModelId: auth.getNonNullableWorkspace().id,
+        },
+        transaction,
+        type: QueryTypes.UPDATE,
+      }
+    );
   }
 
   static async listByAgentMessageModelIds(

--- a/front/migrations/pre-deploy/20260810141711_add_reconciled_credit_to_agent_message_consumption_items.sql
+++ b/front/migrations/pre-deploy/20260810141711_add_reconciled_credit_to_agent_message_consumption_items.sql
@@ -1,0 +1,3 @@
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_message_consumption_items" ADD COLUMN "reconciledCreditAmountMicro" bigint;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We already compute a reconciled credit allocation when building consumption analytics documents and message details and in the conversation and message breakdown.

The persisted gross attribution is intentionally cache-naive and does not necessarily sum to the authoritative amount billed on the agent message. The existing reconciliation keeps output, reasoning, and tool amounts unchanged, then distributes the remaining billed credits across input items proportionally. Integer microcredit remainders are allocated deterministically.

This PR does not introduce new billing or reconciliation logic. It reuses the existing allocator and materializes its result on each consumption item as `reconciledCreditAmountMicro`. This makes the additive, authoritative breakdown directly available to downstream consumers without rebuilding it from runs, usages, actions, and attribution evidence on every read.

The existing `grossAttributedCreditAmountMicro` remains unchanged and continues to represent the immutable attribution evidence.

## Why the value is mutable

The reconciled amount cannot be treated as immutable because an agent message may be finalized more than once.

A message can continue with additional run usages after an interruption or tool confirmation. Those usages add attribution items and can change the authoritative `costCredits`. Since input items share the reconciled remainder proportionally, existing input allocations must be updated when a new usage is added (this is the worst case, good for us it does not happen that often).

A tool can first be observed while awaiting approval or authentication. At that point, we only know the output tokens spent emitting the call. If the tool is later approved and completes, its pending row gains the result footprint and direct tool charge. Its reconciled amount increases, while the amount remaining for existing input items decreases.

If the tool is denied, it completes with no direct charge. The allocation is recomputed for consistency, but the resulting amounts are normally unchanged and the update is skipped.

The authoritative agent-message cost may also change between finalizations. Even when the persisted evidence itself is unchanged, the input reconciliation must follow the latest billed amount.

Finally, an incomplete attribution version cannot be reconciled safely. Its evidence is stored with a null reconciled amount. A later finalize can complete the missing model or tool evidence and populate the allocation. Until then, the allocator can continue selecting the newest older version that is complete and self-consistent.

## Implementation

The migration adds a nullable `reconciledCreditAmountMicro` bigint column. It is nullable because evidence may exist before a complete allocation can be built and because existing rows are not synchronously backfilled by this migration.

Evidence persistence and reconciliation now happen in the same transaction. We first insert new attribution rows or complete pending tool rows, then load the full persisted message attribution and run the existing allocator against the authoritative agent-message cost.

Only a complete, self-consistent attribution version is materialized. If the message has no billed cost, has missing model buckets, has incomplete terminal tool evidence, or cannot produce a valid remainder, its reconciled values remain null.

Re-finalization no longer re-tokenizes the entire message. We rebuild only new or incomplete run usages and usages containing a pending tool that has since become terminal. Reconciliation still considers the full persisted message because existing allocations may need to move.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [x] Apply SQL migration
- [ ] Deploy front
