### PR TITLE
[dsbx] chore: script to push @dust/pod into a running sandbox

### DIFF
--- a/cli/dust-sandbox/README.md
+++ b/cli/dust-sandbox/README.md
@@ -94,3 +94,17 @@ compiling `dsbx`; `build.rs` fails early with instructions if it is missing. CI,
 the release workflow, and `upsert_dsbx_to_sandbox.sh` build it on the host
 first. Rebuild it after changing any runner source (`protocol.ts`, `invoke.ts`,
 `schema.ts`, `runner.ts`).
+
+## The `@dust/pod` runtime package
+
+`pod/` is the runtime library sandbox function code imports (`db()`,
+`currentUser()`). It is not part of `dsbx`: the image vendors it into
+`/opt/npm-global/lib/node_modules/@dust/pod` at image build time (see
+`front/lib/api/sandbox/image/pod_package.ts`), and published bundles keep it as
+an external import. So neither rebuilding `dsbx` nor republishing a function
+picks up a change to it — only a new image does, gated by
+`DUST_BASE_IMAGE_VERSION`.
+
+For the dev loop, `upsert_pod_package_to_sandbox.sh` builds it and pushes it
+into one running sandbox, then drops the warm function servers so the next
+invocation re-imports it (a resident server holds the module it started with).

--- a/cli/dust-sandbox/upsert_pod_package_to_sandbox.sh
+++ b/cli/dust-sandbox/upsert_pod_package_to_sandbox.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Build the @dust/pod runtime package and push it to an e2b sandbox.
+#
+# @dust/pod is vendored into the sandbox image at build time (see
+# front/lib/api/sandbox/image/pod_package.ts), and published function bundles keep it as an
+# external import, so neither republishing a function nor pushing a new dsbx picks up a change
+# to it. This script is the dev loop for iterating on it without rebuilding the image.
+#
+# Usage:
+#   ./upsert_pod_package_to_sandbox.sh              # interactive sandbox picker (requires fzf)
+#   ./upsert_pod_package_to_sandbox.sh <sandbox-id> # push directly to a specific sandbox
+#   ./upsert_pod_package_to_sandbox.sh --no-build <sandbox-id>  # skip build, just push
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUNDLE="$SCRIPT_DIR/pod/dist/index.js"
+# Mirrors POD_PACKAGE_IMAGE_DIR in front/lib/api/sandbox/image/pod_package.ts. Only index.js is
+# pushed: the package.json the image generates alongside it does not change.
+REMOTE_PATH="/opt/npm-global/lib/node_modules/@dust/pod/index.js"
+# $HOME of the agent-proxied user, where warm servers keep their sockets (warm_dir in
+# src/commands/function/warm.rs).
+WARM_DIR="/home/agent-proxied/.dust-fn"
+
+NO_BUILD=false
+
+# Parse flags.
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-build)
+      NO_BUILD=true
+      shift
+      ;;
+    -h|--help)
+      echo "Usage: $0 [--no-build] [sandbox-id]"
+      echo ""
+      echo "Build the @dust/pod package and push it to a running e2b sandbox."
+      echo ""
+      echo "Options:"
+      echo "  --no-build    Skip the build step (use existing bundle)"
+      echo "  -h, --help    Show this help"
+      echo ""
+      echo "If no sandbox-id is given, an interactive picker is shown (requires fzf)."
+      exit 0
+      ;;
+    *)
+      SANDBOX_ID="$1"
+      shift
+      ;;
+  esac
+done
+
+# --- Build ---
+if [[ "$NO_BUILD" == false ]]; then
+  if ! command -v bun &>/dev/null; then
+    echo "Error: 'bun' is not installed (needed to build the @dust/pod bundle)."
+    echo "Install it from https://bun.com/ (or: curl -fsSL https://bun.sh/install | bash)"
+    exit 1
+  fi
+  # Same bun flags the image build uses (buildPodPackage), so what lands here is byte-identical
+  # to what a rebuilt image would ship.
+  echo "==> Building @dust/pod bundle..."
+  (cd "$SCRIPT_DIR/pod" && bun install --frozen-lockfile && bun run build)
+  echo "==> Build complete: $BUNDLE"
+else
+  echo "==> Skipping build (--no-build)"
+fi
+
+if [[ ! -f "$BUNDLE" ]]; then
+  echo "Error: Bundle not found at $BUNDLE"
+  echo "Run without --no-build to build it first."
+  exit 1
+fi
+
+# --- Select sandbox ---
+if [[ -z "${SANDBOX_ID:-}" ]]; then
+  if ! command -v fzf &>/dev/null; then
+    echo "Error: fzf is required for interactive sandbox selection."
+    echo "Install it with: brew install fzf"
+    echo "Or pass a sandbox ID directly: $0 <sandbox-id>"
+    exit 1
+  fi
+
+  echo "==> Fetching running sandboxes..."
+  SANDBOXES_JSON=$(e2b sandbox list -f json 2>/dev/null)
+  COUNT=$(echo "$SANDBOXES_JSON" | jq length)
+
+  if [[ "$COUNT" -eq 0 ]]; then
+    echo "No running sandboxes found."
+    exit 1
+  fi
+
+  # Format for fzf: "sandboxId | name | startedAt | cpus | ram"
+  SANDBOX_ID=$(echo "$SANDBOXES_JSON" | jq -r '.[] | "\(.sandboxId)\t\(.name)\tstarted: \(.startedAt)\tcpus: \(.cpuCount)\tram: \(.memoryMB)MB"' \
+    | fzf --prompt="Select sandbox> " \
+           --header="ID                     TEMPLATE            STARTED                   RESOURCES" \
+           --delimiter=$'\t' \
+           --with-nth=1.. \
+    | cut -f1)
+
+  if [[ -z "$SANDBOX_ID" ]]; then
+    echo "No sandbox selected."
+    exit 1
+  fi
+fi
+
+echo "==> Pushing @dust/pod to sandbox $SANDBOX_ID at $REMOTE_PATH..."
+
+BUNDLE_SIZE=$(wc -c < "$BUNDLE" | tr -d ' ')
+echo "    Bundle size: $(( BUNDLE_SIZE / 1024 ))KB"
+
+# 644 root:root, matching what the image's root-owned copy leaves behind: the workload users must
+# be able to import it and must not be able to rewrite it.
+e2b sandbox exec "$SANDBOX_ID" -u root "mkdir -p '$(dirname "$REMOTE_PATH")'"
+base64 -i "$BUNDLE" | e2b sandbox exec "$SANDBOX_ID" -u root \
+  "base64 -d > '$REMOTE_PATH' && chown root:root '$REMOTE_PATH' && chmod 644 '$REMOTE_PATH'"
+
+# A resident warm server imported the old module at startup, so replacing the file on disk does
+# nothing for it (see the warm path in src/commands/function/warm.rs). Drop the servers and their
+# sockets; the next invocation takes the cold path and re-imports.
+echo "==> Restarting warm function servers..."
+e2b sandbox exec "$SANDBOX_ID" -u root \
+  "pkill -f '$WARM_DIR/' || true; rm -f '$WARM_DIR'/*.sock"
+
+echo "==> Verifying..."
+LOCAL_SHA=$(shasum -a 256 "$BUNDLE" | cut -d' ' -f1)
+e2b sandbox exec "$SANDBOX_ID" -u root \
+  "echo '$LOCAL_SHA  $REMOTE_PATH' | sha256sum -c -" 2>&1 || true
+
+echo "==> Done! @dust/pod deployed to sandbox $SANDBOX_ID"


### PR DESCRIPTION
## Why

`@dust/pod` (the runtime library sandbox function code imports for `db()` and `currentUser()`) is vendored into the sandbox image at image build time by `buildPodPackage`, and published function bundles keep it as an external import (`packages: "external"`). So **neither rebuilding `dsbx` nor republishing a function picks up a change to it** — only a new image does, gated by `DUST_BASE_IMAGE_VERSION`.

That makes iterating on the package slower than it needs to be, and the reason isn't written down anywhere, so the natural moves (rebuild dsbx, republish the function) both silently do nothing.

## What

`upsert_pod_package_to_sandbox.sh`, a sibling of the existing `upsert_dsbx_to_sandbox.sh`: same flags (`--no-build`, `-h`), same `fzf` sandbox picker, same `e2b sandbox exec` + base64 push. Plus a README section explaining why the package is invisible to the other two rebuild paths.

Two details worth a look in review:

- **The build uses the same bun flags as `buildPodPackage`** (`--bundle --target=bun --packages=external`), so what lands is byte-identical to what a rebuilt image would ship. It writes only `index.js` — the `package.json` the image generates alongside it doesn't change — as `644 root:root`, matching the image's root-owned copy: importable by the workload users, not writable by them.
- **The push is followed by dropping the warm function servers.** A resident warm server holds the module it imported at startup, so replacing the file on disk alone changes nothing for it — the push looks successful while doing nothing. The script kills the servers and removes their sockets in `/home/agent-proxied/.dust-fn`, so the next invocation takes the cold path and re-imports.

Verification ends with `sha256sum -c -` against the locally computed hash, the same pattern `registry.ts` uses for the dsbx release download.

## Testing

Dev tooling only — no product code, no tests. Checked: `bash -n` passes; `--help` renders; the missing-bundle guard exits 1 before touching `e2b`; the build step produces `pod/dist/index.js`. I have **not** exercised the actual push against a live sandbox, so that's worth confirming before relying on it.