### PR TITLE
[front] enh: namespace pod databases by app

### DIFF
--- a/cli/dust-sandbox/pod/db.ts
+++ b/cli/dust-sandbox/pod/db.ts
@@ -1,5 +1,6 @@
 import type { Changes, SQLQueryBindings, Statement } from "bun:sqlite";
 import { Database } from "bun:sqlite";
+import { existsSync } from "node:fs";
 import type { BunSQLiteDatabase } from "drizzle-orm/bun-sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
@@ -9,10 +10,17 @@ import { podEnv } from "./context.ts";
  * Pod state databases.
  *
  * `db(name)` returns a cached Drizzle instance over the pod's live SQLite
- * database at `${DUST_POD_DATABASES_DIR}/{name}.db`. Databases are created by
- * `dsbx db reconcile` (the db_reconcile tool), never here: the file is opened
- * must-exist so a typo'd name errors clearly instead of minting an empty
- * database. Functions that never call `db()` pay nothing.
+ * database at `${DUST_POD_DATABASES_DIR}/{prefix}{name}.db`. Databases are
+ * created by `dsbx db reconcile` (the db_reconcile tool), never here: the file
+ * is opened must-exist so a typo'd name errors clearly instead of minting an
+ * empty database. Functions that never call `db()` pay nothing.
+ *
+ * `name` is the app-relative name the function's source writes, and the app
+ * prefix comes from the environment ({@link POD_DATABASE_PREFIX_ENV}) rather
+ * than the source. That is what lets a whole app folder be copied within a pod
+ * without editing any source: the copy publishes under its own prefix and
+ * therefore resolves `db("chat")` to its own database. See
+ * {@link resolveDatabasePath} for the resolution order.
  *
  * Disk guardrails — pod state must not fill the sandbox disk by accident:
  *
@@ -60,6 +68,21 @@ export const POD_SPACE_ID_ENV = "SPACE_ID";
  */
 export const POD_DATABASE_MAX_SIZE_BYTES_ENV =
   "DUST_POD_DATABASE_MAX_SIZE_BYTES";
+
+/**
+ * Env var carrying the app prefix (separator included, e.g. `"myapp__"`) that
+ * namespaces this function's databases inside the pod's flat databases
+ * directory. Optional: empty or absent means unprefixed names, which is what
+ * functions published outside an app folder get.
+ *
+ * Front owns the value and derives it from the invoked function's slug, so no
+ * layer below front knows how a prefix is built. Like the size quota, it lives
+ * in the untrusted workload's own process and workload code can rewrite it —
+ * acceptable because it is not a security boundary: the databases directory is
+ * local disk the workload can read and write directly, so app prefixing
+ * prevents accidental collisions between apps, it does not isolate them.
+ */
+export const POD_DATABASE_PREFIX_ENV = "DUST_POD_DATABASE_PREFIX";
 
 /** How long a connection waits on a locked database before failing. */
 export const POD_DATABASE_BUSY_TIMEOUT_MS = 5000;
@@ -247,6 +270,38 @@ function podDatabasesDir(): string {
   return dir;
 }
 
+/**
+ * Resolve the app-relative `name` to a database file path.
+ *
+ * Order, and why: the app-prefixed file wins when it exists, so an app that has
+ * been reconciled under app namespacing always gets its own database. Otherwise
+ * the bare name is used, which covers two cases — functions published outside an
+ * app folder (no prefix at all), and databases created before app namespacing
+ * existed, whose files are still on disk under their bare names.
+ *
+ * That bare-name branch is transitional. While it is in place, two apps that
+ * both reconcile a name which already exists unprefixed keep sharing that one
+ * legacy database, exactly as they do today; only databases created from here on
+ * are namespaced. Reconcile applies the same order (in front), so the file
+ * db() opens is always the file reconcile applied the schema to.
+ */
+function resolveDatabasePath(dir: string, name: string): string {
+  const prefix = process.env[POD_DATABASE_PREFIX_ENV] ?? "";
+  if (prefix.length > 0) {
+    const prefixedName = `${prefix}${name}`;
+    // A prefix long enough to push the qualified name past the name contract
+    // means this app cannot namespace this database; fall through to the bare
+    // name rather than looking for a file reconcile could never have created.
+    if (POD_DATABASE_NAME_REGEX.test(prefixedName)) {
+      const prefixedPath = `${dir}/${prefixedName}.db`;
+      if (existsSync(prefixedPath)) {
+        return prefixedPath;
+      }
+    }
+  }
+  return `${dir}/${name}.db`;
+}
+
 function podDatabaseMaxSizeBytes(): number {
   const raw = podEnv(POD_DATABASE_MAX_SIZE_BYTES_ENV);
   if (raw === undefined || raw.length === 0) {
@@ -311,7 +366,9 @@ function applyPragmas(sqlite: PodSqliteDatabase, maxSizeBytes: number): void {
 const instances = new Map<string, PodDatabase>();
 
 /**
- * Get the pod's Drizzle handle for database `name`.
+ * Get the pod's Drizzle handle for database `name`, where `name` is the app's
+ * own name for it (`db("chat")`) and the app prefix is applied by
+ * {@link resolveDatabasePath} from the environment.
  *
  * @throws PodDatabaseInvalidNameError when `name` does not match the contract.
  * @throws PodDatabasesUnavailableError when SPACE_ID is absent — this sandbox
@@ -331,7 +388,7 @@ export function db(name: string): PodDatabase {
   if (spaceId === undefined || spaceId.length === 0) {
     throw new PodDatabasesUnavailableError();
   }
-  const path = `${podDatabasesDir()}/${name}.db`;
+  const path = resolveDatabasePath(podDatabasesDir(), name);
   const cached = instances.get(path);
   if (cached !== undefined) {
     return cached;

--- a/cli/dust-sandbox/pod/db.ts
+++ b/cli/dust-sandbox/pod/db.ts
@@ -288,15 +288,12 @@ function podDatabasesDir(): string {
 function resolveDatabasePath(dir: string, name: string): string {
   const prefix = process.env[POD_DATABASE_PREFIX_ENV] ?? "";
   if (prefix.length > 0) {
-    const prefixedName = `${prefix}${name}`;
-    // A prefix long enough to push the qualified name past the name contract
-    // means this app cannot namespace this database; fall through to the bare
-    // name rather than looking for a file reconcile could never have created.
-    if (POD_DATABASE_NAME_REGEX.test(prefixedName)) {
-      const prefixedPath = `${dir}/${prefixedName}.db`;
-      if (existsSync(prefixedPath)) {
-        return prefixedPath;
-      }
+    // No need to re-check the name contract here: a prefix long enough to push
+    // the qualified name past it is one reconcile refuses to create a file for,
+    // so the existence check below is what rejects it.
+    const prefixedPath = `${dir}/${prefix}${name}.db`;
+    if (existsSync(prefixedPath)) {
+      return prefixedPath;
     }
   }
   return `${dir}/${name}.db`;

--- a/cli/dust-sandbox/pod/db.ts
+++ b/cli/dust-sandbox/pod/db.ts
@@ -76,11 +76,13 @@ export const POD_DATABASE_MAX_SIZE_BYTES_ENV =
  * functions published outside an app folder get.
  *
  * Front owns the value and derives it from the invoked function's slug, so no
- * layer below front knows how a prefix is built. Like the size quota, it lives
- * in the untrusted workload's own process and workload code can rewrite it —
- * acceptable because it is not a security boundary: the databases directory is
- * local disk the workload can read and write directly, so app prefixing
- * prevents accidental collisions between apps, it does not isolate them.
+ * layer below front knows how a prefix is built. Read through `podEnv`, so a
+ * resident server serving two apps resolves each invocation against its own
+ * prefix rather than a process-wide one.
+ *
+ * Not a security boundary: the databases directory is local disk the workload
+ * can read and write directly, so app prefixing prevents accidental collisions
+ * between apps, it does not isolate them.
  */
 export const POD_DATABASE_PREFIX_ENV = "DUST_POD_DATABASE_PREFIX";
 
@@ -286,7 +288,11 @@ function podDatabasesDir(): string {
  * db() opens is always the file reconcile applied the schema to.
  */
 function resolveDatabasePath(dir: string, name: string): string {
-  const prefix = process.env[POD_DATABASE_PREFIX_ENV] ?? "";
+  // Through podEnv, like every other env read here: a resident server runs
+  // concurrent invocations from different apps, and their prefixes differ. Read
+  // straight from process.env and every warm invocation would resolve against
+  // whichever prefix the cold run happened to leave there.
+  const prefix = podEnv(POD_DATABASE_PREFIX_ENV) ?? "";
   if (prefix.length > 0) {
     // No need to re-check the name contract here: a prefix long enough to push
     // the qualified name past it is one reconcile refuses to create a file for,

--- a/cli/dust-sandbox/pod/index.test.ts
+++ b/cli/dust-sandbox/pod/index.test.ts
@@ -7,6 +7,7 @@ import {
   db,
   POD_DATABASE_BUSY_TIMEOUT_MS,
   POD_DATABASE_MAX_SIZE_BYTES_ENV,
+  POD_DATABASE_PREFIX_ENV,
   POD_DATABASES_DIR_ENV,
   POD_SPACE_ID_ENV,
   PodDatabaseError,
@@ -68,6 +69,7 @@ beforeEach(() => {
 afterEach(() => {
   delete process.env[POD_DATABASES_DIR_ENV];
   delete process.env[POD_DATABASE_MAX_SIZE_BYTES_ENV];
+  delete process.env[POD_DATABASE_PREFIX_ENV];
   if (originalSpaceId === undefined) {
     delete process.env[POD_SPACE_ID_ENV];
   } else {
@@ -163,6 +165,97 @@ describe("must-exist open", () => {
     const name = uniqueName("nodir");
     expect(() => db(name)).toThrow(PodDatabaseError);
     expect(() => db(name)).toThrow(/DUST_POD_DATABASES_DIR is not set/);
+  });
+});
+
+describe("app prefix resolution", () => {
+  // Each database gets a table named after the app that owns it, so the assertions can tell
+  // which FILE db() opened rather than trusting the name it was asked for.
+  function createDatabaseOwnedBy(fileName: string, owner: string): void {
+    createDatabaseFile(fileName, `CREATE TABLE ${owner}_marker (id INTEGER)`);
+  }
+
+  function ownerOf(name: string): string {
+    const row = db(name)
+      .$client.query<{ name: string }, []>(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE '%_marker'"
+      )
+      .get();
+    if (row === null) {
+      throw new Error(`No marker table in database ${name}`);
+    }
+    return row.name.replace(/_marker$/, "");
+  }
+
+  test("opens the app-prefixed database when it exists", () => {
+    const name = uniqueName("chat");
+    process.env[POD_DATABASE_PREFIX_ENV] = "myapp__";
+    createDatabaseOwnedBy(`myapp__${name}`, "myapp");
+
+    expect(ownerOf(name)).toBe("myapp");
+  });
+
+  test("prefers the app-prefixed database over a same-named legacy one", () => {
+    const name = uniqueName("chat");
+    process.env[POD_DATABASE_PREFIX_ENV] = "myapp__";
+    createDatabaseOwnedBy(name, "legacy");
+    createDatabaseOwnedBy(`myapp__${name}`, "myapp");
+
+    expect(ownerOf(name)).toBe("myapp");
+  });
+
+  test("falls back to a legacy unprefixed database", () => {
+    // Transitional: databases created before app namespacing keep their bare filenames, and
+    // litestream replicates them under a prefix keyed on that filename.
+    const name = uniqueName("chat");
+    process.env[POD_DATABASE_PREFIX_ENV] = "myapp__";
+    createDatabaseOwnedBy(name, "legacy");
+
+    expect(ownerOf(name)).toBe("legacy");
+  });
+
+  test("two apps asking for the same name get their own databases", () => {
+    const name = uniqueName("chat");
+    createDatabaseOwnedBy(`myapp__${name}`, "myapp");
+    createDatabaseOwnedBy(`otherapp__${name}`, "otherapp");
+
+    process.env[POD_DATABASE_PREFIX_ENV] = "myapp__";
+    expect(ownerOf(name)).toBe("myapp");
+    process.env[POD_DATABASE_PREFIX_ENV] = "otherapp__";
+    expect(ownerOf(name)).toBe("otherapp");
+  });
+
+  test("uses the bare name when no prefix is set", () => {
+    const name = uniqueName("chat");
+    createDatabaseOwnedBy(name, "bare");
+
+    expect(ownerOf(name)).toBe("bare");
+  });
+
+  test("an empty prefix means unprefixed", () => {
+    // front passes "" for functions published outside an app folder.
+    const name = uniqueName("chat");
+    process.env[POD_DATABASE_PREFIX_ENV] = "";
+    createDatabaseOwnedBy(name, "bare");
+
+    expect(ownerOf(name)).toBe("bare");
+  });
+
+  test("falls back to the bare name when the prefix breaks the name contract", () => {
+    // A prefix this long cannot produce a valid qualified name, so reconcile could never have
+    // created one; looking for it would only mask the database that does exist.
+    const name = uniqueName("chat");
+    process.env[POD_DATABASE_PREFIX_ENV] = `${"a".repeat(60)}__`;
+    createDatabaseOwnedBy(name, "bare");
+
+    expect(ownerOf(name)).toBe("bare");
+  });
+
+  test("still throws when neither the prefixed nor the bare database exists", () => {
+    const name = uniqueName("missing");
+    process.env[POD_DATABASE_PREFIX_ENV] = "myapp__";
+
+    expect(() => db(name)).toThrow(PodDatabaseNotDeclaredError);
   });
 });
 

--- a/cli/dust-sandbox/pod/index.test.ts
+++ b/cli/dust-sandbox/pod/index.test.ts
@@ -15,6 +15,7 @@ import {
   PodDatabaseInvalidNameError,
   PodDatabaseNotDeclaredError,
   PodDatabasesUnavailableError,
+  runWithInvocationEnv,
 } from "@dust/pod";
 import { blob, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
@@ -256,6 +257,48 @@ describe("app prefix resolution", () => {
     process.env[POD_DATABASE_PREFIX_ENV] = "myapp__";
 
     expect(() => db(name)).toThrow(PodDatabaseNotDeclaredError);
+  });
+
+  // A resident server serves concurrent invocations from different apps without
+  // touching process.env, so the prefix has to come from the invocation context.
+  describe("inside an invocation context", () => {
+    const contextEnv = (prefix: string) => ({
+      [POD_DATABASES_DIR_ENV]: databasesDir,
+      [POD_DATABASE_MAX_SIZE_BYTES_ENV]: String(ONE_GIB_BYTES),
+      [POD_SPACE_ID_ENV]: "spc_test_pod",
+      [POD_DATABASE_PREFIX_ENV]: prefix,
+    });
+
+    test("reads the prefix from the context env", () => {
+      const name = uniqueName("chat");
+      createDatabaseOwnedBy(`myapp__${name}`, "myapp");
+
+      expect(
+        runWithInvocationEnv(contextEnv("myapp__"), () => ownerOf(name))
+      ).toBe("myapp");
+    });
+
+    test("the context's prefix wins over the one in process.env", () => {
+      const name = uniqueName("chat");
+      createDatabaseOwnedBy(`myapp__${name}`, "myapp");
+      createDatabaseOwnedBy(`otherapp__${name}`, "otherapp");
+      process.env[POD_DATABASE_PREFIX_ENV] = "myapp__";
+
+      expect(
+        runWithInvocationEnv(contextEnv("otherapp__"), () => ownerOf(name))
+      ).toBe("otherapp");
+    });
+
+    test("a context without a prefix ignores the one in process.env", () => {
+      const name = uniqueName("chat");
+      createDatabaseOwnedBy(name, "bare");
+      createDatabaseOwnedBy(`myapp__${name}`, "myapp");
+      process.env[POD_DATABASE_PREFIX_ENV] = "myapp__";
+
+      expect(runWithInvocationEnv(contextEnv(""), () => ownerOf(name))).toBe(
+        "bare"
+      );
+    });
   });
 });
 

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -238,8 +238,7 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
         .regex(POD_DATABASE_NAME_REGEX)
         .describe(
           "The database's short name as declared by the schema file (e.g. `chat`), without " +
-            "the app prefix: the app folder in `path` namespaces it, and the reply reports " +
-            "the resulting on-disk name."
+            "the app prefix."
         ),
       path: z
         .string()

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -236,7 +236,11 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
       database: z
         .string()
         .regex(POD_DATABASE_NAME_REGEX)
-        .describe("The database name declared by the schema file."),
+        .describe(
+          "The database's short name as declared by the schema file (e.g. `chat`), without " +
+            "the app prefix: the app folder in `path` namespaces it, and the reply reports " +
+            "the resulting on-disk name."
+        ),
       path: z
         .string()
         .min(1)

--- a/front/lib/api/actions/servers/sandbox_functions/tools/db_reconcile.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/db_reconcile.test.ts
@@ -3,7 +3,8 @@ import { describe, expect, it } from "vitest";
 
 describe("formatReconcileResult", () => {
   it("renders a first claim with the applied statements", () => {
-    const out = formatReconcileResult("chat", {
+    const out = formatReconcileResult({
+      database: "chat",
       created: true,
       statements: ["CREATE TABLE `messages` (...)"],
     });
@@ -13,12 +14,23 @@ describe("formatReconcileResult", () => {
   });
 
   it("renders an in-sync reconcile with no statements", () => {
-    const out = formatReconcileResult("chat", {
+    const out = formatReconcileResult({
+      database: "chat",
       created: false,
       statements: [],
     });
 
     expect(out).toContain('Database "chat" reconciled.');
     expect(out).toContain("No schema changes to apply.");
+  });
+
+  it("reports the app-qualified name the database was reconciled under", () => {
+    const out = formatReconcileResult({
+      database: "myapp__chat",
+      created: true,
+      statements: [],
+    });
+
+    expect(out).toContain('Database "myapp__chat" created.');
   });
 });

--- a/front/lib/api/actions/servers/sandbox_functions/tools/db_reconcile.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/db_reconcile.ts
@@ -8,10 +8,8 @@ import type { ReconcileDatabaseResult } from "@app/lib/api/sandbox_functions/dsb
 import { reconcileDatabaseFromPodPath } from "@app/lib/api/sandbox_functions/dsbx_db";
 import { Err, Ok } from "@app/types/shared/result";
 
-export function formatReconcileResult(
-  database: string,
-  result: ReconcileDatabaseResult
-): string {
+export function formatReconcileResult(result: ReconcileDatabaseResult): string {
+  const { database } = result;
   const header = result.created
     ? `Database "${database}" created.`
     : `Database "${database}" reconciled.`;
@@ -42,7 +40,7 @@ export async function dbReconcileHandler(
     return new Err(toDbMCPError(result.error));
   }
 
-  return new Ok([
-    { type: "text", text: formatReconcileResult(database, result.value) },
-  ]);
+  // The name in the message is the resolved on-disk one, which is what db_query and db_schema
+  // address the database by; it carries the app prefix the caller's name did not.
+  return new Ok([{ type: "text", text: formatReconcileResult(result.value) }]);
 }

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -123,16 +123,28 @@ const POD_SANDBOX_DATABASE_MAX_SIZE_BYTES = 1024 * 1024 * 1024;
  * The env vars every pod-database exec (`dsbx function run` and every `dsbx db` subcommand)
  * must carry so the bun child resolves the databases dir and the size quota. Returned as a
  * fresh object so callers can spread it into their own env without sharing a reference.
+ *
+ * `databasePrefix` is the app prefix that namespaces the databases the exec resolves by their
+ * app-relative name, i.e. `@dust/pod`'s `db("chat")` inside a published function (see
+ * `podDatabasePrefixFromSlug`). Omit it for execs that address databases by their on-disk name —
+ * every `dsbx db` subcommand does, since front resolves the name before running them.
  */
-export function podDatabaseExecEnvVars(): {
+export function podDatabaseExecEnvVars({
+  databasePrefix,
+}: {
+  databasePrefix?: string | null;
+} = {}): {
   DUST_POD_DATABASES_DIR: string;
   DUST_POD_DATABASE_MAX_SIZE_BYTES: string;
+  DUST_POD_DATABASE_PREFIX: string;
 } {
   return {
     DUST_POD_DATABASES_DIR: POD_SANDBOX_DATABASES_DIR,
     DUST_POD_DATABASE_MAX_SIZE_BYTES: String(
       POD_SANDBOX_DATABASE_MAX_SIZE_BYTES
     ),
+    // Empty means unprefixed, which is what the shim reads an absent value as.
+    DUST_POD_DATABASE_PREFIX: databasePrefix ?? "",
   };
 }
 

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.72",
+      tag: "0.8.73",
     });
   });
 

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,7 +26,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.72";
+const DUST_BASE_IMAGE_VERSION = "0.8.73";
 const DSBX_CLI_VERSION = "0.1.47";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is

--- a/front/lib/api/sandbox_functions/db_naming.test.ts
+++ b/front/lib/api/sandbox_functions/db_naming.test.ts
@@ -1,0 +1,163 @@
+import {
+  podDatabasePrefixFromPodPath,
+  podDatabasePrefixFromSlug,
+  qualifyPodDatabaseName,
+  resolvePodDatabaseName,
+  stripPodDatabasePrefix,
+} from "@app/lib/api/sandbox_functions/db_naming";
+import { POD_DATABASE_NAME_REGEX } from "@app/types/api/sandbox_functions";
+import { describe, expect, it } from "vitest";
+
+const POD_ID = "vlt_abc123";
+
+function prefixForPath(sourcePath: string) {
+  const result = podDatabasePrefixFromPodPath({ sourcePath, podId: POD_ID });
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+}
+
+describe("podDatabasePrefixFromPodPath", () => {
+  it("derives the prefix from the app folder", () => {
+    expect(prefixForPath(`pod-${POD_ID}/MyApp/databases/chat.db.ts`)).toBe(
+      "myapp__"
+    );
+  });
+
+  it("uses underscores where the slug prefix would use hyphens", () => {
+    // Database names admit [a-z0-9_] only, so `Task List` cannot become `task-list`.
+    const prefix = prefixForPath(
+      `pod-${POD_ID}/Task List/databases/chat.db.ts`
+    );
+
+    expect(prefix).toBe("task_list__");
+    expect(POD_DATABASE_NAME_REGEX.test(`${prefix}chat`)).toBe(true);
+  });
+
+  it("has no prefix for a schema file at the pod root", () => {
+    expect(prefixForPath(`pod-${POD_ID}/chat.db.ts`)).toBeNull();
+  });
+
+  it("has no prefix when the app folder cannot start a database name", () => {
+    // `2048game__chat` would fail the leading-letter contract, so this app keeps bare names.
+    expect(
+      prefixForPath(`pod-${POD_ID}/2048Game/databases/chat.db.ts`)
+    ).toBeNull();
+  });
+
+  it("rejects a path outside the pod file system", () => {
+    const result = podDatabasePrefixFromPodPath({
+      sourcePath: "conversation-abc/databases/chat.db.ts",
+      podId: POD_ID,
+    });
+
+    expect(result.isErr()).toBe(true);
+  });
+});
+
+describe("podDatabasePrefixFromSlug", () => {
+  it("agrees with the path derivation for the same app", () => {
+    expect(podDatabasePrefixFromSlug("myapp__post-message")).toBe(
+      prefixForPath(`pod-${POD_ID}/MyApp/databases/chat.db.ts`)
+    );
+  });
+
+  it("converts the slug's hyphens to underscores", () => {
+    expect(podDatabasePrefixFromSlug("task-list__add-task")).toBe(
+      "task_list__"
+    );
+  });
+
+  it("has no prefix for a function published outside an app folder", () => {
+    expect(podDatabasePrefixFromSlug("greet")).toBeNull();
+  });
+});
+
+describe("qualifyPodDatabaseName", () => {
+  it("qualifies with the prefix", () => {
+    expect(qualifyPodDatabaseName({ prefix: "myapp__", name: "chat" })).toBe(
+      "myapp__chat"
+    );
+  });
+
+  it("returns the bare name when there is no prefix", () => {
+    expect(qualifyPodDatabaseName({ prefix: null, name: "chat" })).toBe("chat");
+  });
+
+  it("falls back to the bare name when the prefix would break the length cap", () => {
+    const prefix = `${"a".repeat(60)}__`;
+
+    expect(qualifyPodDatabaseName({ prefix, name: "chat" })).toBe("chat");
+  });
+});
+
+describe("stripPodDatabasePrefix", () => {
+  it("makes qualifying idempotent for an already-qualified name", () => {
+    const prefix = "myapp__";
+    const stripped = stripPodDatabasePrefix({ prefix, name: "myapp__chat" });
+
+    expect(qualifyPodDatabaseName({ prefix, name: stripped })).toBe(
+      "myapp__chat"
+    );
+  });
+
+  it("leaves another app's prefix in place", () => {
+    expect(
+      stripPodDatabasePrefix({ prefix: "myapp__", name: "other__chat" })
+    ).toBe("other__chat");
+  });
+});
+
+describe("resolvePodDatabaseName", () => {
+  const prefix = "myapp__";
+
+  it("creates a new database under the app prefix", () => {
+    expect(
+      resolvePodDatabaseName({ prefix, name: "chat", existingNames: [] })
+    ).toBe("myapp__chat");
+  });
+
+  it("keeps using an app-prefixed database that already exists", () => {
+    expect(
+      resolvePodDatabaseName({
+        prefix,
+        name: "chat",
+        existingNames: ["myapp__chat", "chat"],
+      })
+    ).toBe("myapp__chat");
+  });
+
+  it("falls back to an existing unprefixed database", () => {
+    // Transitional: databases created before app namespacing keep their bare filenames, and
+    // their litestream replica prefixes are keyed on those.
+    expect(
+      resolvePodDatabaseName({
+        prefix,
+        name: "chat",
+        existingNames: ["chat"],
+      })
+    ).toBe("chat");
+  });
+
+  it("does not prefix when the source has no app folder", () => {
+    expect(
+      resolvePodDatabaseName({
+        prefix: null,
+        name: "chat",
+        existingNames: ["chat"],
+      })
+    ).toBe("chat");
+  });
+
+  it("gives a copied app its own database rather than the original's", () => {
+    // The copy's source is unchanged and still says db("chat"); only its prefix differs.
+    expect(
+      resolvePodDatabaseName({
+        prefix: "myappcopy__",
+        name: "chat",
+        existingNames: ["myapp__chat"],
+      })
+    ).toBe("myappcopy__chat");
+  });
+});

--- a/front/lib/api/sandbox_functions/db_naming.test.ts
+++ b/front/lib/api/sandbox_functions/db_naming.test.ts
@@ -1,9 +1,7 @@
 import {
   podDatabasePrefixFromPodPath,
   podDatabasePrefixFromSlug,
-  qualifyPodDatabaseName,
   resolvePodDatabaseName,
-  stripPodDatabasePrefix,
 } from "@app/lib/api/sandbox_functions/db_naming";
 import { POD_DATABASE_NAME_REGEX } from "@app/types/api/sandbox_functions";
 import { describe, expect, it } from "vitest";
@@ -74,43 +72,39 @@ describe("podDatabasePrefixFromSlug", () => {
   });
 });
 
-describe("qualifyPodDatabaseName", () => {
-  it("qualifies with the prefix", () => {
-    expect(qualifyPodDatabaseName({ prefix: "myapp__", name: "chat" })).toBe(
-      "myapp__chat"
-    );
+describe("resolvePodDatabaseName", () => {
+  const prefix = "myapp__";
+
+  it("is idempotent for an already-qualified name", () => {
+    // db_list reports on-disk names, so the model may hand one straight back to db_reconcile.
+    expect(
+      resolvePodDatabaseName({
+        prefix,
+        name: "myapp__chat",
+        existingNames: ["myapp__chat"],
+      })
+    ).toBe("myapp__chat");
   });
 
-  it("returns the bare name when there is no prefix", () => {
-    expect(qualifyPodDatabaseName({ prefix: null, name: "chat" })).toBe("chat");
+  it("treats another app's prefix as part of the name", () => {
+    expect(
+      resolvePodDatabaseName({
+        prefix,
+        name: "other__chat",
+        existingNames: [],
+      })
+    ).toBe("myapp__other__chat");
   });
 
   it("falls back to the bare name when the prefix would break the length cap", () => {
-    const prefix = `${"a".repeat(60)}__`;
-
-    expect(qualifyPodDatabaseName({ prefix, name: "chat" })).toBe("chat");
-  });
-});
-
-describe("stripPodDatabasePrefix", () => {
-  it("makes qualifying idempotent for an already-qualified name", () => {
-    const prefix = "myapp__";
-    const stripped = stripPodDatabasePrefix({ prefix, name: "myapp__chat" });
-
-    expect(qualifyPodDatabaseName({ prefix, name: stripped })).toBe(
-      "myapp__chat"
-    );
-  });
-
-  it("leaves another app's prefix in place", () => {
     expect(
-      stripPodDatabasePrefix({ prefix: "myapp__", name: "other__chat" })
-    ).toBe("other__chat");
+      resolvePodDatabaseName({
+        prefix: `${"a".repeat(60)}__`,
+        name: "chat",
+        existingNames: [],
+      })
+    ).toBe("chat");
   });
-});
-
-describe("resolvePodDatabaseName", () => {
-  const prefix = "myapp__";
 
   it("creates a new database under the app prefix", () => {
     expect(

--- a/front/lib/api/sandbox_functions/db_naming.ts
+++ b/front/lib/api/sandbox_functions/db_naming.ts
@@ -40,7 +40,7 @@ const POD_DATABASE_PREFIX_SEPARATOR = SANDBOX_FUNCTION_SLUG_SEPARATOR;
  * unprefixed database names, which is how every pod behaved before namespacing — deliberately not
  * an error, since refusing would leave the app unable to create any database at all.
  */
-export function podDatabasePrefixFromAppPrefix(
+function podDatabasePrefixFromAppPrefix(
   appPrefix: string | null
 ): string | null {
   if (appPrefix === null) {
@@ -85,45 +85,11 @@ export function podDatabasePrefixFromPodPath({
 }
 
 /**
- * Qualify an app-relative database name with its app prefix, or return it unchanged when there is
- * no prefix or the result would break the name contract (a long app folder plus a long database
- * name can exceed the 64-character cap). Falling back rather than erroring keeps this total, so
- * reconcile and the runtime always agree on the name without either having to handle a failure.
- */
-export function qualifyPodDatabaseName({
-  prefix,
-  name,
-}: {
-  prefix: string | null;
-  name: string;
-}): string {
-  if (prefix === null) {
-    return name;
-  }
-  const qualified = `${prefix}${name}`;
-  return POD_DATABASE_NAME_REGEX.test(qualified) ? qualified : name;
-}
-
-/**
- * Strip an app prefix the caller already applied, so qualifying is idempotent. `db_list` reports
- * on-disk names, so a model that copies `myapp__chat` from it into `db_reconcile` must not end up
- * reconciling `myapp__myapp__chat`.
- */
-export function stripPodDatabasePrefix({
-  prefix,
-  name,
-}: {
-  prefix: string | null;
-  name: string;
-}): string {
-  if (prefix !== null && name.startsWith(prefix)) {
-    return name.slice(prefix.length);
-  }
-  return name;
-}
-
-/**
- * Pick the database file an app-relative `name` refers to, given the names currently on disk.
+ * Pick the database file `name` refers to, given the names currently on disk.
+ *
+ * `name` is the database's app-relative name as the schema file declares it (`chat`). An
+ * already-qualified name is accepted too and re-qualified to itself, because `db_list` reports
+ * on-disk names and a model may well copy `myapp__chat` from it straight into `db_reconcile`.
  *
  * Mirrors `resolveDatabasePath` in cli/dust-sandbox/pod/db.ts so reconcile applies schema changes
  * to exactly the file `db()` will open:
@@ -137,6 +103,10 @@ export function stripPodDatabasePrefix({
  * The step 2 fallback is temporary. While it stands, two apps that each reconcile a name which
  * already exists unprefixed keep sharing that one legacy database, exactly as they do today;
  * removing the fallback requires renaming those files and their litestream replica prefixes.
+ *
+ * A prefix that would push the qualified name past the name contract's 64-character cap yields the
+ * bare name instead of an error, which keeps this total: reconcile and the runtime always agree
+ * without either having to handle a failure.
  */
 export function resolvePodDatabaseName({
   prefix,
@@ -147,13 +117,20 @@ export function resolvePodDatabaseName({
   name: string;
   existingNames: string[];
 }): string {
-  const qualified = qualifyPodDatabaseName({ prefix, name });
-  if (qualified === name) {
+  if (prefix === null) {
     return name;
   }
+  const appRelativeName = name.startsWith(prefix)
+    ? name.slice(prefix.length)
+    : name;
+  const qualified = `${prefix}${appRelativeName}`;
+  if (!POD_DATABASE_NAME_REGEX.test(qualified)) {
+    return appRelativeName;
+  }
+
   const existing = new Set(existingNames);
   if (existing.has(qualified)) {
     return qualified;
   }
-  return existing.has(name) ? name : qualified;
+  return existing.has(appRelativeName) ? appRelativeName : qualified;
 }

--- a/front/lib/api/sandbox_functions/db_naming.ts
+++ b/front/lib/api/sandbox_functions/db_naming.ts
@@ -1,0 +1,159 @@
+import {
+  deriveAppPrefix,
+  SANDBOX_FUNCTION_SLUG_SEPARATOR,
+} from "@app/lib/api/sandbox_functions/slug";
+import { POD_DATABASE_NAME_REGEX } from "@app/types/api/sandbox_functions";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+/**
+ * App namespacing for pod databases.
+ *
+ * A pod's databases live in one flat directory, `{name}.db` files replicated to GCS by litestream
+ * under a prefix keyed on that filename. So an app's databases are namespaced by prefixing the
+ * FILE name (`myapp__chat.db`), never by nesting them in a per-app subdirectory: subdirectories
+ * would make two apps' `chat.db` share one replica prefix.
+ *
+ * The app prefix is never written in the function's source. Source code says `db("chat")`, and the
+ * prefix is derived from where the code lives — the schema file's app folder when reconciling, the
+ * function's slug when invoking. That is what makes an app folder copyable inside a pod: the copy
+ * publishes under its own prefix and so gets its own databases, with no source edit.
+ *
+ * Databases created before app namespacing existed keep their bare filenames. Both resolution
+ * paths (`resolvePodDatabaseName` here, `resolveDatabasePath` in cli/dust-sandbox/pod/db.ts) prefer
+ * the prefixed file when it exists and fall back to the bare one, so those keep working untouched.
+ */
+
+/** The separator between an app prefix and a database name; shared with function slugs. */
+const POD_DATABASE_PREFIX_SEPARATOR = SANDBOX_FUNCTION_SLUG_SEPARATOR;
+
+/**
+ * Convert an app prefix (function-slug form, hyphen-separated) into a pod database prefix,
+ * separator included: `my-app` becomes `my_app__`.
+ *
+ * Hyphens become underscores because database names admit `[a-z0-9_]` only, while slug segments use
+ * hyphens. The mapping is injective over the prefixes `deriveAppPrefix` can produce, since it never
+ * emits an underscore — so two apps can never normalize onto the same database prefix.
+ *
+ * Returns `null` when the app name cannot start a database name (the contract requires a leading
+ * letter, but a folder like `2048Game` normalizes to `2048game`). Such an app falls back to
+ * unprefixed database names, which is how every pod behaved before namespacing — deliberately not
+ * an error, since refusing would leave the app unable to create any database at all.
+ */
+export function podDatabasePrefixFromAppPrefix(
+  appPrefix: string | null
+): string | null {
+  if (appPrefix === null) {
+    return null;
+  }
+  const normalized = appPrefix.replace(/-/g, "_");
+  if (!/^[a-z]/.test(normalized)) {
+    return null;
+  }
+  return `${normalized}${POD_DATABASE_PREFIX_SEPARATOR}`;
+}
+
+/**
+ * The database prefix for a published function, derived from its slug's app segment. Used at
+ * invocation time, where the slug is all the app identity front has — the source path is not
+ * involved in running a published bundle.
+ */
+export function podDatabasePrefixFromSlug(slug: string): string | null {
+  const separatorIndex = slug.indexOf(POD_DATABASE_PREFIX_SEPARATOR);
+  if (separatorIndex <= 0) {
+    return null;
+  }
+  return podDatabasePrefixFromAppPrefix(slug.slice(0, separatorIndex));
+}
+
+/**
+ * The database prefix for a source file in the pod, derived from its app folder. Used when
+ * reconciling, where the schema file's path is what identifies the app.
+ */
+export function podDatabasePrefixFromPodPath({
+  sourcePath,
+  podId,
+}: {
+  sourcePath: string;
+  podId: string;
+}): Result<string | null, Error> {
+  const appPrefixResult = deriveAppPrefix({ sourcePath, podId });
+  if (appPrefixResult.isErr()) {
+    return new Err(appPrefixResult.error);
+  }
+  return new Ok(podDatabasePrefixFromAppPrefix(appPrefixResult.value));
+}
+
+/**
+ * Qualify an app-relative database name with its app prefix, or return it unchanged when there is
+ * no prefix or the result would break the name contract (a long app folder plus a long database
+ * name can exceed the 64-character cap). Falling back rather than erroring keeps this total, so
+ * reconcile and the runtime always agree on the name without either having to handle a failure.
+ */
+export function qualifyPodDatabaseName({
+  prefix,
+  name,
+}: {
+  prefix: string | null;
+  name: string;
+}): string {
+  if (prefix === null) {
+    return name;
+  }
+  const qualified = `${prefix}${name}`;
+  return POD_DATABASE_NAME_REGEX.test(qualified) ? qualified : name;
+}
+
+/**
+ * Strip an app prefix the caller already applied, so qualifying is idempotent. `db_list` reports
+ * on-disk names, so a model that copies `myapp__chat` from it into `db_reconcile` must not end up
+ * reconciling `myapp__myapp__chat`.
+ */
+export function stripPodDatabasePrefix({
+  prefix,
+  name,
+}: {
+  prefix: string | null;
+  name: string;
+}): string {
+  if (prefix !== null && name.startsWith(prefix)) {
+    return name.slice(prefix.length);
+  }
+  return name;
+}
+
+/**
+ * Pick the database file an app-relative `name` refers to, given the names currently on disk.
+ *
+ * Mirrors `resolveDatabasePath` in cli/dust-sandbox/pod/db.ts so reconcile applies schema changes
+ * to exactly the file `db()` will open:
+ *
+ * 1. the app-prefixed name when that database already exists — an app that has been namespaced
+ *    stays namespaced;
+ * 2. otherwise the bare name when THAT database already exists — the transitional case, covering
+ *    databases created before namespacing;
+ * 3. otherwise the app-prefixed name, creating it — every new database is namespaced.
+ *
+ * The step 2 fallback is temporary. While it stands, two apps that each reconcile a name which
+ * already exists unprefixed keep sharing that one legacy database, exactly as they do today;
+ * removing the fallback requires renaming those files and their litestream replica prefixes.
+ */
+export function resolvePodDatabaseName({
+  prefix,
+  name,
+  existingNames,
+}: {
+  prefix: string | null;
+  name: string;
+  existingNames: string[];
+}): string {
+  const qualified = qualifyPodDatabaseName({ prefix, name });
+  if (qualified === name) {
+    return name;
+  }
+  const existing = new Set(existingNames);
+  if (existing.has(qualified)) {
+    return qualified;
+  }
+  return existing.has(name) ? name : qualified;
+}

--- a/front/lib/api/sandbox_functions/dsbx_db.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.ts
@@ -9,6 +9,11 @@ import {
 import { getRedisStreamClient } from "@app/lib/api/redis";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
+import {
+  podDatabasePrefixFromPodPath,
+  resolvePodDatabaseName,
+  stripPodDatabasePrefix,
+} from "@app/lib/api/sandbox_functions/db_naming";
 import type { SandboxFunctionErrorCode } from "@app/lib/api/sandbox_functions/errors";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import type { StagingHashes } from "@app/lib/api/sandbox_functions/staging_integrity";
@@ -169,6 +174,12 @@ const reconcileEnvelopeSchema = z.union([
 ]);
 
 export interface ReconcileDatabaseResult {
+  /**
+   * The on-disk database name that was reconciled: the app-relative name qualified with the app
+   * prefix (see resolvePodDatabaseName). Reported back because it is what `db_list`, `db_query` and
+   * `db_schema` address the database by, and it is not what the caller passed in.
+   */
+  database: string;
   created: boolean;
   statements: string[];
 }
@@ -215,6 +226,7 @@ async function reconcileDatabaseOnSandbox(
       );
     }
     return new Ok({
+      database,
       created: envelope.created,
       statements: envelope.statements,
     });
@@ -229,10 +241,15 @@ async function reconcileDatabaseOnSandbox(
 const RECONCILE_LOCK_ACQUIRE_TIMEOUT_MS = 30_000;
 
 /**
- * Resolve a model-supplied scoped schema-file path (e.g. `pod-{id}/databases/chat.db.ts`) to its
- * in-sandbox path and reconcile against it. The only path that applies schema changes to a live
+ * Resolve a model-supplied scoped schema-file path (e.g. `pod-{id}/MyApp/databases/chat.db.ts`) to
+ * its in-sandbox path and reconcile against it. The only path that applies schema changes to a live
  * database (publish validates but never applies); concurrent reconciles of one pod are serialized
  * under a per-pod lock.
+ *
+ * `database` is the app-relative name the schema file declares (`chat`); the on-disk name is that
+ * name qualified with the app prefix taken from the schema file's own app folder. The live database
+ * set is read inside the lock, because which name wins depends on what already exists (see
+ * resolvePodDatabaseName) and a concurrent reconcile could otherwise create it in between.
  */
 export async function reconcileDatabaseFromPodPath(
   auth: Authenticator,
@@ -254,6 +271,19 @@ export async function reconcileDatabaseFromPodPath(
       new SandboxFunctionError("invalid_path", resolved.error.message)
     );
   }
+
+  const prefixResult = podDatabasePrefixFromPodPath({
+    sourcePath: scopedPath,
+    podId: space.sId,
+  });
+  if (prefixResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError("invalid_path", prefixResult.error.message)
+    );
+  }
+  const prefix = prefixResult.value;
+  // db_list reports on-disk names, so the model may hand back an already-qualified one.
+  const appRelativeName = stripPodDatabasePrefix({ prefix, name: database });
 
   // Acquire the per-pod lock directly (not via executeWithLock) so a timeout surfaces as a
   // retryable publish_conflict Result instead of a thrown error.
@@ -283,9 +313,18 @@ export async function reconcileDatabaseFromPodPath(
     );
   }
   try {
+    const existingResult = await listDatabasesOnSandbox(auth, { space });
+    if (existingResult.isErr()) {
+      return new Err(existingResult.error);
+    }
+
     return await reconcileDatabaseOnSandbox(auth, {
       space,
-      database,
+      database: resolvePodDatabaseName({
+        prefix,
+        name: appRelativeName,
+        existingNames: existingResult.value.map((entry) => entry.name),
+      }),
       schemaFileSandboxPath: resolved.value,
     });
   } finally {

--- a/front/lib/api/sandbox_functions/dsbx_db.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.ts
@@ -12,7 +12,6 @@ import { shellEscape } from "@app/lib/api/sandbox/shell";
 import {
   podDatabasePrefixFromPodPath,
   resolvePodDatabaseName,
-  stripPodDatabasePrefix,
 } from "@app/lib/api/sandbox_functions/db_naming";
 import type { SandboxFunctionErrorCode } from "@app/lib/api/sandbox_functions/errors";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
@@ -282,8 +281,6 @@ export async function reconcileDatabaseFromPodPath(
     );
   }
   const prefix = prefixResult.value;
-  // db_list reports on-disk names, so the model may hand back an already-qualified one.
-  const appRelativeName = stripPodDatabasePrefix({ prefix, name: database });
 
   // Acquire the per-pod lock directly (not via executeWithLock) so a timeout surfaces as a
   // retryable publish_conflict Result instead of a thrown error.
@@ -322,7 +319,7 @@ export async function reconcileDatabaseFromPodPath(
       space,
       database: resolvePodDatabaseName({
         prefix,
-        name: appRelativeName,
+        name: database,
         existingNames: existingResult.value.map((entry) => entry.name),
       }),
       schemaFileSandboxPath: resolved.value,

--- a/front/lib/api/sandbox_functions/slug.ts
+++ b/front/lib/api/sandbox_functions/slug.ts
@@ -22,39 +22,23 @@ function normalizeAppPrefix(folderName: string): string {
 }
 
 /**
- * Compose a published function's slug as `<appPrefix>__<name>`, where the prefix comes from the app
- * folder the source lives in: the first path segment under the pod root.
+ * Derive the app prefix a pod path belongs to: the normalized first path segment under the pod
+ * root, or `null` for a path sitting directly at the pod root (no app folder).
  *
- * Only that folder contributes. Folders between it and the source (the conventional `functions/`,
- * and anything nested below it) are the app's own business, so moving a source inside its app never
- * renames the published function and never orphans a Frame's `<podId>/<slug>` reference.
- *
- * A source sitting directly at the pod root has no app folder and keeps the bare name. That cannot
- * collide with an app's function: `name` is a single segment so it carries no `__`, and a prefix
- * never contains one either, so a prefixed slug always has exactly one and the two namespaces stay
- * disjoint. Moving such a source into an app folder does rename its function, which is the one
- * rename this scheme does not absorb.
+ * Shared by the two things an app namespaces — its published function slugs (below) and its
+ * databases (`derivePodDatabasePrefix` in db_naming.ts) — so both always agree on which app a
+ * source file belongs to.
  *
  * This checks shape, not access: callers resolve `sourcePath` through `DustFileSystem`, which is
  * what rejects traversal, foreign pods and scopes that are not sandbox-mounted.
  */
-export function deriveSandboxFunctionSlug({
+export function deriveAppPrefix({
   sourcePath,
   podId,
-  name,
 }: {
   sourcePath: string;
   podId: string;
-  name: string;
-}): Result<string, Error> {
-  if (!SANDBOX_FUNCTION_SLUG_SEGMENT_REGEX.test(name)) {
-    return new Err(
-      new Error(
-        `Function name must be lowercase alphanumeric with single hyphen separators: got '${name}'.`
-      )
-    );
-  }
-
+}): Result<string | null, Error> {
   const canonicalPath = resolveCanonicalScopedPath(sourcePath, {
     conversationId: null,
     spaceId: podId,
@@ -75,7 +59,7 @@ export function deriveSandboxFunctionSlug({
     );
   }
   if (segments.length === 1) {
-    return new Ok(name);
+    return new Ok(null);
   }
 
   const prefix = normalizeAppPrefix(segments[0]);
@@ -85,6 +69,49 @@ export function deriveSandboxFunctionSlug({
         `App folder '${segments[0]}' has no alphanumeric characters to derive a function prefix from.`
       )
     );
+  }
+
+  return new Ok(prefix);
+}
+
+/**
+ * Compose a published function's slug as `<appPrefix>__<name>`, where the prefix comes from the app
+ * folder the source lives in: the first path segment under the pod root.
+ *
+ * Only that folder contributes. Folders between it and the source (the conventional `functions/`,
+ * and anything nested below it) are the app's own business, so moving a source inside its app never
+ * renames the published function and never orphans a Frame's `<podId>/<slug>` reference.
+ *
+ * A source sitting directly at the pod root has no app folder and keeps the bare name. That cannot
+ * collide with an app's function: `name` is a single segment so it carries no `__`, and a prefix
+ * never contains one either, so a prefixed slug always has exactly one and the two namespaces stay
+ * disjoint. Moving such a source into an app folder does rename its function, which is the one
+ * rename this scheme does not absorb.
+ */
+export function deriveSandboxFunctionSlug({
+  sourcePath,
+  podId,
+  name,
+}: {
+  sourcePath: string;
+  podId: string;
+  name: string;
+}): Result<string, Error> {
+  if (!SANDBOX_FUNCTION_SLUG_SEGMENT_REGEX.test(name)) {
+    return new Err(
+      new Error(
+        `Function name must be lowercase alphanumeric with single hyphen separators: got '${name}'.`
+      )
+    );
+  }
+
+  const prefixResult = deriveAppPrefix({ sourcePath, podId });
+  if (prefixResult.isErr()) {
+    return new Err(prefixResult.error);
+  }
+  const prefix = prefixResult.value;
+  if (prefix === null) {
+    return new Ok(name);
   }
 
   return new Ok(`${prefix}${SANDBOX_FUNCTION_SLUG_SEPARATOR}${name}`);

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -106,7 +106,8 @@ beforeEach(() => {
 async function setupExecutionTest(
   userIdentity: SandboxFunctionUserIdentityPolicy = "optional",
   origin: SandboxFunctionInvocationOrigin = "delegated",
-  executionMode: SandboxFunctionExecutionMode = "durable"
+  executionMode: SandboxFunctionExecutionMode = "durable",
+  slug: string = "add-comment"
 ) {
   const { authenticator, workspace } = await createResourceTest({
     role: "admin",
@@ -123,7 +124,7 @@ async function setupExecutionTest(
   const sandboxFunction = await SandboxFunctionResource.makeNew(authenticator, {
     space,
     file,
-    slug: "add-comment",
+    slug,
     description: "Add a comment.",
     userIdentity,
     executionMode,
@@ -731,6 +732,8 @@ describe("SandboxFunctionInvocationResource", () => {
       DUST_FUNCTIONS_DIR: `/sandbox-functions/pods/${space.sId}`,
       DUST_POD_DATABASES_DIR: "/pod-state/databases",
       DUST_POD_DATABASE_MAX_SIZE_BYTES: "1073741824",
+      // Published outside an app folder, so its databases are unprefixed.
+      DUST_POD_DATABASE_PREFIX: "",
       DUST_SANDBOX_TOKEN: "sbt-function-token",
     });
     expect(
@@ -760,6 +763,34 @@ describe("SandboxFunctionInvocationResource", () => {
       body: JSON.stringify({ message: "hello" }),
       encoding: "utf8",
       bundleSha256: TEST_BUNDLE_SHA256,
+    });
+  });
+
+  it("passes the app's database prefix, derived from the function slug", async () => {
+    // This is what lets the bundle's `db("chat")` resolve to the app's own database without the
+    // app name appearing anywhere in the function's source.
+    const { authenticator, sandbox, invocation } = await setupExecutionTest(
+      "optional",
+      "delegated",
+      "durable",
+      "task-list__add-comment"
+    );
+    const execSpy = vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout: "hello world\n",
+        stderr: "",
+      })
+    );
+
+    const executionResult = await invocation.execute(authenticator);
+    if (executionResult.isErr()) {
+      throw executionResult.error;
+    }
+
+    const opts = execSpy.mock.calls[0]?.[2];
+    expect(opts?.envVars).toMatchObject({
+      DUST_POD_DATABASE_PREFIX: "task_list__",
     });
   });
 

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -16,6 +16,7 @@ import { isSandboxNotRunningError } from "@app/lib/api/sandbox/errors";
 import { recordSandboxFunctionRun } from "@app/lib/api/sandbox/instrumentation";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
+import { podDatabasePrefixFromSlug } from "@app/lib/api/sandbox_functions/db_naming";
 import { SandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
 import { parseStdoutResultEnvelope } from "@app/lib/api/sandbox_functions/result_delivery";
@@ -679,7 +680,11 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
           DUST_FUNCTIONS_DIR: getPodSandboxFunctionsMountPoint(
             sandboxFunction.space.sId
           ),
-          ...podDatabaseExecEnvVars(),
+          // The app prefix comes from the slug, so `db("chat")` in the bundle resolves to this
+          // app's own database without the source naming the app.
+          ...podDatabaseExecEnvVars({
+            databasePrefix: podDatabasePrefixFromSlug(sandboxFunction.slug),
+          }),
           DUST_SANDBOX_TOKEN: token,
           // Set this for every invocation so userless calls cannot inherit a sandbox-level value.
           [POD_USER_IDENTITY_ENV]: userIdentity

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -93,6 +93,14 @@ skill covers creating it and moving it into the app folder with \`${FILES_MOVE_T
 
 Functions that no Frame calls still get an app folder, named after what they do together.
 
+**Copying an app folder does not finish the job.** The databases and the published slugs follow the
+new folder on their own, but a Frame addresses its functions by \`<podId>/<slug>\` written into its
+source, so the copy's Frame still calls the ORIGINAL app's functions and therefore reads and writes
+the original's data. After copying \`MyApp/\` to \`MyAppCopy/\`: publish the copy's functions, reconcile
+its databases, then edit the copy's Frame so every function reference carries the new prefix
+(\`myappcopy__list-notes\`, not \`myapp__list-notes\`) and re-publish it. The same applies to renaming
+an app folder.
+
 #### Authoring a function
 
 Write the source as a TypeScript file in the app's \`functions\` folder, at
@@ -155,10 +163,10 @@ Functions of the same Pod can share durable SQLite databases (via \`drizzle-orm\
   its table objects from it as \`../databases/{db}.db.ts\` (never hand-write tables in a function
   file), so functions sharing a database belong to the same app. Name the database for what it
   holds within the app (\`chat\`, \`notes\`), not for the app: the app folder namespaces it, so two
-  apps can each own a \`chat\` without colliding. Never write the app name in the source — that is
-  what lets an app folder be copied and get its own databases with no edit. \`${toolName("db_list")}\`
-  shows the resulting on-disk names (\`myapp__chat\`), which is how the db tools address a database;
-  \`db()\` and the schema file always use the short name.
+  apps can each own a \`chat\` without colliding. Never write the app name in \`db()\` or the schema
+  file — the prefix is applied for you from the app folder. \`${toolName("db_list")}\` shows the
+  resulting on-disk names (\`myapp__chat\`), which is how the db tools address a database; \`db()\`
+  and the schema file always use the short name.
 - **Name functions that use this db.ts by writting a comment a the top** 
 - **Apply the schema file with \`${toolName("db_reconcile")}\`**; it creates the database and
   applies additive DDL after edits, and enforces the rules below. Publishing does not touch

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -153,9 +153,12 @@ Functions of the same Pod can share durable SQLite databases (via \`drizzle-orm\
 - **One schema file per database** at \`<AppName>/databases/{db}.db.ts\`: the single source of truth
   declaring that database's full schema with drizzle's \`sqliteTable\` DSL. Every function imports
   its table objects from it as \`../databases/{db}.db.ts\` (never hand-write tables in a function
-  file), so functions sharing a database belong to the same app. The database name itself is
-  Pod-wide rather than app-scoped, so pick one that will not collide with another app's
-  (\`${toolName("db_list")}\` shows what the Pod already has).
+  file), so functions sharing a database belong to the same app. Name the database for what it
+  holds within the app (\`chat\`, \`notes\`), not for the app: the app folder namespaces it, so two
+  apps can each own a \`chat\` without colliding. Never write the app name in the source — that is
+  what lets an app folder be copied and get its own databases with no edit. \`${toolName("db_list")}\`
+  shows the resulting on-disk names (\`myapp__chat\`), which is how the db tools address a database;
+  \`db()\` and the schema file always use the short name.
 - **Name functions that use this db.ts by writting a comment a the top** 
 - **Apply the schema file with \`${toolName("db_reconcile")}\`**; it creates the database and
   applies additive DDL after edits, and enforces the rules below. Publishing does not touch
@@ -435,7 +438,7 @@ one \`notes\` function taking an \`action\` field is not. If a capability must b
 subset of members, keep that list in the database and check it against \`currentUser().sId\` —
 the platform only tells you the caller is a workspace member, not what they are allowed to do.`,
   mcpServers: [{ name: SANDBOX_FUNCTIONS_SERVER_NAME }],
-  version: 5,
+  version: 6,
   icon: "PuzzleIcon",
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);


### PR DESCRIPTION
## Why

A pod's databases are one flat namespace. Two apps in the same pod cannot both own a `chat`, and the `pod_functions` skill had to work around it by telling the model: *"The database name itself is Pod-wide rather than app-scoped, so pick one that will not collide with another app's."*

Published function slugs are already app-namespaced (`myapp__list-notes`). This does the same for databases.

## Approach

The app prefix is **never written in the function's source**. Source says `db("chat")`; the prefix is derived from where the code lives — the schema file's app folder when reconciling, the function's slug when invoking — and reaches the runtime as a new `DUST_POD_DATABASE_PREFIX` env var on the existing per-exec paths-env contract.

That property is the point for the storage layer: copy `MyApp/` to `MyAppCopy/`, republish, and the copy reconciles and opens its own databases with no edit to any function source. Both derivations go through one shared `deriveAppPrefix` helper (extracted from `slug.ts`) so they cannot drift apart.

**It does not make an app wholly copyable, and the skill text now says so.** A Frame addresses its functions by `<podId>/<slug>` written into its own source, so a copied folder's Frame still calls the *original* app's functions and therefore reads and writes the original's data, while the copy's functions and database sit published, reconciled and unused. Verified on a real pod: after copying `PeopleTracker` to `PeopleTracker2`, `peopletracker__people.db` held 6 rows and `peopletracker2__people.db` held 0. Repointing a copied Frame is a manual step; making Frame references app-relative would fix it properly and is not attempted here.

**Prefixing the filename (`myapp__chat.db`) rather than nesting per-app subdirectories is deliberate.** Litestream names replica subdirectories after the database *filename*, so `myapp/chat.db` and `other/chat.db` would replicate into the same `replica/chat.db/` prefix — two databases writing one replica. Keeping the directory flat also means no Rust changes, no litestream config changes, and no changes to `db_list`/`db_query`/`db_schema`: `myapp__chat` already satisfies `POD_DATABASE_NAME_REGEX`, and those tools already address databases by on-disk name.

## The transitional fallback

Databases created before this keep their bare filenames. Both resolution paths prefer the prefixed file when it exists and fall back to the bare one, so existing databases keep working untouched. Reconcile reads the live database set **inside its per-pod lock** and applies the same three-step rule, so the file it applies DDL to is always the file `db()` will open.

Known limitation, called out in the code: while the fallback stands, two apps that each reconcile a name which *already exists unprefixed* keep sharing that one legacy database — exactly as they do today. Only databases created from here on are namespaced. Retiring the fallback means renaming those files along with their litestream replica prefixes, which is data-bearing and out of scope here.

## Reviewer notes

- `db_list` reports on-disk names while the schema file and `db()` use short names. `resolvePodDatabaseName` is idempotent for an already-qualified name, so a model pasting `myapp__chat` from `db_list` into `db_reconcile` doesn't get `myapp__myapp__chat`. The skill prose and the `db_reconcile` tool description both explain the split.
- `DUST_BASE_IMAGE_VERSION` goes to **0.8.71** because `@dust/pod` is vendored into the sandbox image — the front-side prefixing is only correct against an image carrying the matching resolver. Note this branch originally set 0.8.70, but main took that tag for the group-writable-files fix while this was open, so a rebase collapsed the bump into a no-op; rebumping is what keeps the resolver and the image tag together. `DSBX_CLI_VERSION` is deliberately **not** bumped: it names a GitHub release artifact, and nothing in dsbx or the runner changed.
- **The prefix is read through `podEnv`, not `process.env`.** `@dust/pod` consults a per-invocation `AsyncLocalStorage` context first, which exists so a resident server can serve concurrent invocations from different apps without touching `process.env` — precisely where a process-wide prefix is wrong. Today `serve.ts` still applies request env to `process.env`, so a direct read would happen to work; the moment it passes `invocationEnv` the prefix would go stale while the databases dir and quota beside it stayed correct, giving a silently wrong database. Covered by three tests inside `runWithInvocationEnv` — the earlier prefix tests could not catch it, since outside a context `podEnv` falls back to `process.env` and they passed either way.
- Warm servers are also keyed per slug, so a given server's prefix is constant for its lifetime.

## Testing

- New coverage: `db_naming.test.ts` (18 tests) for the derivation/qualification/resolution rules including the copied-app case; 8 shim tests for prefix resolution and the legacy fallback; one invocation-resource test asserting the prefix actually reaches the exec env.
