### PR TITLE
fix(models): gate advanced models on hasAdvancedModelAccess only

### DIFF
--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -38,11 +38,7 @@ export function isModelAvailable(
     region: RegionType;
   }
 ) {
-  // Otherwise, we filter too early.
-  const includeAdvancedModelInPicker =
-    featureFlags.includes("models_picker") && isAdvancedModel(m);
-
-  if (m.largeModel && !isUpgraded(plan) && !includeAdvancedModelInPicker) {
+  if (m.largeModel && !isUpgraded(plan)) {
     return false;
   }
 
@@ -60,10 +56,7 @@ export function isModelAvailable(
 
   const { plansWithAdvancedModels, featureFlag } = m.availableIfOneOf;
 
-  if (
-    plansWithAdvancedModels === true &&
-    (plan?.hasAdvancedModelAccess || includeAdvancedModelInPicker)
-  ) {
+  if (plansWithAdvancedModels === true && plan?.hasAdvancedModelAccess) {
     return true;
   }
 


### PR DESCRIPTION
## Description

Removes the `models_picker` bypass from `isModelAvailable` (`front/lib/assistant.ts`). Previously, when a workspace had the `models_picker` feature flag, advanced models (e.g. Opus 5) were force-included in the picker regardless of `plan.hasAdvancedModelAccess`.

Advanced models are now gated solely on `plan.hasAdvancedModelAccess` (plus the per-model `featureFlag`), making the flag the single source of truth for advanced-model availability.

## Risk

Behavioral change for workspaces on `models_picker`: advanced models that were showing in the picker via the flag will now be filtered out unless the workspace's plan has `hasAdvancedModelAccess = true`. Confirm this is the intended gating before deploy — tier-based selectability (`withModelSelectability`) no longer receives advanced models for workspaces without the flag set.
