### PR TITLE
feat(agents): run @dust on Auto and lead Standard stream with Luna high

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -88,8 +88,6 @@ interface DustLikeGlobalAgentArgs {
   // same model availability check that is enforced when a message is posted.
   featureFlags: WhitelistableFeature[];
   // When set, the @dust agent defaults to the Auto (Standard) meta-model. This
-  // is passed unconditionally so @dust runs on Auto for everyone, taking
-  // priority over the per-model default flags below.
   preferAutoDefaultModel?: boolean;
   // When set, the @dust agent defaults to GPT 5.6 Luna (high reasoning) instead
   // of Claude Sonnet 4.6. Gated by the `dust_agent_gpt_5_6_luna_default` flag.

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -87,6 +87,10 @@ interface DustLikeGlobalAgentArgs {
   // Workspace feature flags, forwarded to model selection so it runs the exact
   // same model availability check that is enforced when a message is posted.
   featureFlags: WhitelistableFeature[];
+  // When set, the @dust agent defaults to the Auto (Standard) meta-model. This
+  // is passed unconditionally so @dust runs on Auto for everyone, taking
+  // priority over the per-model default flags below.
+  preferAutoDefaultModel?: boolean;
   // When set, the @dust agent defaults to GPT 5.6 Luna (high reasoning) instead
   // of Claude Sonnet 4.6. Gated by the `dust_agent_gpt_5_6_luna_default` flag.
   preferGpt56LunaDefaultModel?: boolean;
@@ -477,15 +481,15 @@ export function _getDustGlobalAgent(
     CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG;
   let preferredReasoningEffort: ReasoningEffort = "medium";
 
-  if (args.preferSonnet5DefaultModel) {
+  if (args.preferAutoDefaultModel) {
+    preferredModelConfiguration = AUTO_MODEL_CONFIG;
+    preferredReasoningEffort = "none";
+  } else if (args.preferSonnet5DefaultModel) {
     preferredModelConfiguration = CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG;
     preferredReasoningEffort = "medium";
   } else if (args.preferGpt56LunaDefaultModel) {
     preferredModelConfiguration = GPT_5_6_LUNA_MODEL_CONFIG;
     preferredReasoningEffort = "high";
-  } else if (args.featureFlags.includes("models_picker")) {
-    preferredModelConfiguration = AUTO_MODEL_CONFIG;
-    preferredReasoningEffort = "none";
   }
   return _getDustLikeGlobalAgent(auth, args, {
     agentId: GLOBAL_AGENTS_SID.DUST,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -146,6 +146,7 @@ function getGlobalAgent({
   hasSandbox,
   globalAgentContext,
   excludeProviders,
+  preferAutoDefaultModel,
   preferGpt56LunaDefaultModel,
   preferSonnet5DefaultModel,
   featureFlags,
@@ -160,6 +161,7 @@ function getGlobalAgent({
   hasSandbox: boolean;
   globalAgentContext?: GlobalAgentContext;
   excludeProviders: ReadonlySet<ModelProviderIdType>;
+  preferAutoDefaultModel: boolean;
   preferGpt56LunaDefaultModel: boolean;
   preferSonnet5DefaultModel: boolean;
   featureFlags: WhitelistableFeature[];
@@ -381,6 +383,7 @@ function getGlobalAgent({
         featureFlags,
         globalAgentContext,
         excludeProviders,
+        preferAutoDefaultModel,
         preferGpt56LunaDefaultModel,
         preferSonnet5DefaultModel,
       });
@@ -1211,6 +1214,7 @@ export async function getGlobalAgents(
       hasSandbox: isComputerFeatureEnabled(flags),
       globalAgentContext: options?.globalAgentContext,
       excludeProviders,
+      preferAutoDefaultModel: flags.includes("models_picker"),
       preferGpt56LunaDefaultModel: flags.includes(
         "dust_agent_gpt_5_6_luna_default"
       ),

--- a/front/lib/api/assistant/models.test.ts
+++ b/front/lib/api/assistant/models.test.ts
@@ -284,15 +284,15 @@ describe("resolveModel", () => {
     });
 
     // `auto` is a stream like `auto_fast` / `auto_complex`: it routes through
-    // getModelForStream and resolves to its first available candidate.
+    // getModelForStream and resolves to its first available candidate, which
+    // is Luna at `high` reasoning.
     expect(getModelForStreamSpy).toHaveBeenCalledWith(auth, AUTO_MODEL_ID);
     expect(modelResolutionMethod).toBe("auto");
     expect(resolvedModel.modelId).not.toBe(AUTO_MODEL_ID);
     expect(resolvedModel).toEqual({
-      providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
-      modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
-      reasoningEffort:
-        CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort,
+      providerId: GPT_5_6_LUNA_MODEL_CONFIG.providerId,
+      modelId: GPT_5_6_LUNA_MODEL_CONFIG.modelId,
+      reasoningEffort: "high",
     });
   });
 
@@ -319,10 +319,9 @@ describe("resolveModel", () => {
     expect(modelResolutionMethod).toBe("auto");
     expect(resolvedModel.modelId).not.toBe(AUTO_MODEL_ID);
     expect(resolvedModel).toEqual({
-      providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
-      modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
-      reasoningEffort:
-        CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort,
+      providerId: GPT_5_6_LUNA_MODEL_CONFIG.providerId,
+      modelId: GPT_5_6_LUNA_MODEL_CONFIG.modelId,
+      reasoningEffort: "high",
     });
   });
 

--- a/front/lib/model_tiers/enabled_models.test.ts
+++ b/front/lib/model_tiers/enabled_models.test.ts
@@ -182,10 +182,8 @@ describe("getModelForStream", () => {
 
     expect(resolved).not.toBeNull();
     // In a full workspace every candidate is available, so the first one wins.
-    expect(resolved?.model.modelId).toBe(
-      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId
-    );
-    expect(resolved?.reasoningEffort).toBe("medium");
+    expect(resolved?.model.modelId).toBe(GPT_5_6_LUNA_MODEL_ID);
+    expect(resolved?.reasoningEffort).toBe("high");
   });
 
   it("routes the Fast stream to its first available candidate + effort", async () => {

--- a/front/migrations/20260810_migrate_sonnet46_medium_to_auto.ts
+++ b/front/migrations/20260810_migrate_sonnet46_medium_to_auto.ts
@@ -1,0 +1,53 @@
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { makeScript } from "@app/scripts/helpers";
+import { CLAUDE_SONNET_4_6_MODEL_ID } from "@app/types/assistant/models/anthropic";
+import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
+
+// Migrate active agents running on Claude Sonnet 4.6 with medium reasoning to
+// the Standard (Auto) meta-model, which routes across the preferred catalog at
+// message-send time.
+const FROM_MODEL_ID = CLAUDE_SONNET_4_6_MODEL_ID;
+const FROM_REASONING_EFFORT = "medium";
+
+const AgentConfigurationModelWithBypass: ModelStaticWorkspaceAware<AgentConfigurationModel> =
+  AgentConfigurationModel;
+
+makeScript({}, async ({ execute }, logger) => {
+  const agents = await AgentConfigurationModelWithBypass.findAll({
+    where: {
+      modelId: FROM_MODEL_ID,
+      reasoningEffort: FROM_REASONING_EFFORT,
+      status: "active",
+    },
+    // WORKSPACE_ISOLATION_BYPASS: Migration runs across all workspaces.
+    // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+    dangerouslyBypassWorkspaceIsolationSecurity: true,
+  });
+
+  logger.info(
+    { count: agents.length, from: FROM_MODEL_ID, to: AUTO_MODEL_ID },
+    `Found ${agents.length} active agents on ${FROM_MODEL_ID} (${FROM_REASONING_EFFORT} reasoning), migrating to ${AUTO_MODEL_ID}.`
+  );
+
+  for (const agent of agents) {
+    if (execute) {
+      logger.info(
+        {
+          sId: agent.sId,
+          version: agent.version,
+          workspaceId: agent.workspaceId,
+        },
+        `Migrating agent ${agent.sId} (version ${agent.version}) from ${FROM_MODEL_ID} to ${AUTO_MODEL_ID}.`
+      );
+
+      await agent.update({
+        providerId: AUTO_MODEL_ID,
+        modelId: AUTO_MODEL_ID,
+        reasoningEffort: "none",
+      });
+    }
+  }
+
+  logger.info("Migration complete.");
+});

--- a/front/types/assistant/models/auto.ts
+++ b/front/types/assistant/models/auto.ts
@@ -61,6 +61,11 @@ export const MODEL_STREAMS: Record<ModelStreamIdType, ModelStreamCandidate[]> =
     // cost-effective floor so tier-capped users still resolve within the stream.
     [AUTO_MODEL_ID]: [
       {
+        providerId: "openai",
+        modelId: GPT_5_6_LUNA_MODEL_ID,
+        reasoningEffort: "high",
+      },
+      {
         providerId: "anthropic",
         modelId: CLAUDE_SONNET_4_6_MODEL_ID,
         reasoningEffort: "medium",
@@ -68,11 +73,6 @@ export const MODEL_STREAMS: Record<ModelStreamIdType, ModelStreamCandidate[]> =
       {
         providerId: "openai",
         modelId: GPT_5_5_MODEL_ID,
-        reasoningEffort: "medium",
-      },
-      {
-        providerId: "openai",
-        modelId: GPT_5_6_LUNA_MODEL_ID,
         reasoningEffort: "medium",
       },
       {


### PR DESCRIPTION
## Description

Makes `@dust` route through the Auto (Standard) meta-model and tunes the Standard stream.

- **`@dust` runs on Auto (Standard).** Adds a `preferAutoDefaultModel` arg to the dust global-agent builder and makes it the highest-priority branch in `_getDustGlobalAgent`. It is passed from `global_agents.ts` gated on the `models_picker` feature flag, so wherever the models picker is enabled `@dust` defaults to Auto. The existing `dust_agent_sonnet_5_default` and `dust_agent_gpt_5_6_luna_default` flags remain as lower-priority fallbacks.
- **Standard stream leads with GPT 5.6 Luna (high).** `GPT_5_6_LUNA_MODEL_ID` at `high` reasoning becomes the first candidate of the `auto` stream; the rest of the pool follows unchanged as fallback.
- **Migration.** Adds `20260810_migrate_sonnet46_medium_to_auto.ts` to move active agents on `claude-sonnet-4-6` with `medium` reasoning to the Auto meta-model (provider/model `auto`, reasoning `none`).

## Tests

Type-check and biome pass on the changed files. Run the migration in dry-run first (without `--execute`) to review the affected agent count before executing.

## Deploy Plan

After deploy, run the migration to move existing Sonnet 4.6 / medium agents onto Auto:

```
npx tsx front/migrations/20260810_migrate_sonnet46_medium_to_auto.ts --execute
```
