### PR TITLE
Drop callback result delivery from dsbx, bump to 0.1.46

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.45"
+version = "0.1.46"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.45"
+version = "0.1.46"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/README.md
+++ b/cli/dust-sandbox/README.md
@@ -49,8 +49,9 @@ cargo build
 Functions are self-contained Bun bundles in `$DUST_FUNCTIONS_DIR`, named
 `<name>.ts`. `dsbx` executes them via an embedded runner (`bun` required).
 
-- `dsbx function run <name>` — request envelope JSON on stdin → parsed output or error envelope
-  on stdout (`{ok, response}` / `{ok:false, error}`).
+- `dsbx function run <name>` — request envelope JSON on stdin → a protocol v3 result envelope
+  on stdout (`{protocolVersion, delivery, outcome, timingsMs?}`), exit 0 whenever an envelope
+  was written, so the caller classifies from `outcome` rather than the exit code.
 - `dsbx function get <name>` — prints `{name, description, userIdentity,
   input_schema, output_schema}` (JSON Schema).
 

--- a/cli/dust-sandbox/src/api/client.rs
+++ b/cli/dust-sandbox/src/api/client.rs
@@ -234,32 +234,4 @@ impl DustApiClient {
 
         self.poll_action_result(&action_id).await
     }
-
-    /// Deliver a completed function's response to the sandbox-functions result
-    /// endpoint (`/api/v1/sandbox/sandbox-functions/result`, relative to
-    /// `DUST_API_URL`). The body carries the function name and the runner's
-    /// response JSON. Returns `Ok` on a 2xx; the response body is ignored, so an
-    /// empty/ack response is fine.
-    pub async fn post_function_result(
-        &self,
-        function: &str,
-        result: &serde_json::Value,
-    ) -> anyhow::Result<()> {
-        let url = self.url("sandbox/sandbox-functions/result");
-        let body = serde_json::json!({ "function": function, "result": result });
-        let resp = self
-            .client
-            .post(&url)
-            .json(&body)
-            .send()
-            .await
-            .context(format!("POST {url}"))?;
-
-        let status = resp.status();
-        if !status.is_success() {
-            let text = resp.text().await.unwrap_or_default();
-            bail!("POST {url} returned {status}: {text}");
-        }
-        Ok(())
-    }
 }

--- a/cli/dust-sandbox/src/commands/function/envelope.rs
+++ b/cli/dust-sandbox/src/commands/function/envelope.rs
@@ -2,11 +2,13 @@ use serde::{Deserialize, Serialize};
 
 pub const RESULT_PROTOCOL_VERSION: u32 = 3;
 
+/// How a function result reaches Dust. Stdout is the only mode: the worker that
+/// started the command reads a protocol v3 envelope off the exec's own stdout.
+/// Kept as an enum because it is also the envelope's `delivery` wire field.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum, Serialize, Deserialize)]
 #[value(rename_all = "lowercase")]
 #[serde(rename_all = "lowercase")]
 pub enum ResultDelivery {
-    Callback,
     Stdout,
 }
 

--- a/cli/dust-sandbox/src/commands/function/mod.rs
+++ b/cli/dust-sandbox/src/commands/function/mod.rs
@@ -49,10 +49,12 @@ pub enum FunctionCommand {
     /// via `--result-delivery` (HTTP callback by default, or a protocol v3
     /// envelope on stdout).
     Run {
-        /// How to deliver the function result. Default remains the in-sandbox
-        /// HTTP callback; `stdout` returns a protocol v3 envelope on stdout for
-        /// the worker that started the command.
-        #[arg(long, value_enum, default_value_t = ResultDelivery::Callback)]
+        /// Accepted and ignored: `stdout` is the only delivery mode. The flag
+        /// stays because front still passes `--result-delivery stdout`, and
+        /// dsbx is pinned by release, so a binary that rejected it would break
+        /// every invocation the moment DSBX_CLI_VERSION moved. Remove it with
+        /// front's argument, not before.
+        #[arg(long, value_enum, default_value_t = ResultDelivery::Stdout)]
         result_delivery: ResultDelivery,
         /// Function name (resolved to a <name>.<ext> bundle in ${DUST_FUNCTIONS_DIR})
         name: String,

--- a/cli/dust-sandbox/src/commands/function/mod.rs
+++ b/cli/dust-sandbox/src/commands/function/mod.rs
@@ -45,9 +45,8 @@ const DEFAULT_FUNCTION_WORKING_DIR: &str = "/home/agent";
 
 #[derive(Subcommand)]
 pub enum FunctionCommand {
-    /// Execute a function. Request envelope JSON on stdin; deliver the result
-    /// via `--result-delivery` (HTTP callback by default, or a protocol v3
-    /// envelope on stdout).
+    /// Execute a function. Request envelope JSON on stdin, protocol v3 result
+    /// envelope on stdout.
     Run {
         /// Accepted and ignored: `stdout` is the only delivery mode. The flag
         /// stays because front still passes `--result-delivery stdout`, and

--- a/cli/dust-sandbox/src/commands/function/run.rs
+++ b/cli/dust-sandbox/src/commands/function/run.rs
@@ -3,12 +3,10 @@ use std::time::Instant;
 use anyhow::{anyhow, Result};
 use tokio::io::AsyncReadExt as _;
 
-use super::envelope::{ResultDelivery, ResultEnvelope, RunnerKind, TimingsMs};
+use super::envelope::{ResultEnvelope, RunnerKind, TimingsMs};
 use super::warm::{self, WarmRun};
 use super::{emit_error, resolve_existing, spawn_function_at};
-use crate::api::DustApiClient;
 
-const SANDBOX_TOKEN_ENV: &str = "DUST_SANDBOX_TOKEN";
 const NON_JSON_SNIPPET_MAX_CHARS: usize = 512;
 
 /// Execute a function and deliver its response.
@@ -21,16 +19,10 @@ const NON_JSON_SNIPPET_MAX_CHARS: usize = 512;
 /// spawn. A cold run additionally leaves a warm server behind for the next
 /// invocation. Both paths produce the same runner `Output` JSON.
 ///
-/// Delivery modes:
-/// - `callback` (default): POST the runner response to the Dust result API when
-///   `DUST_SANDBOX_TOKEN` is set. As a testing/local convenience, when there is
-///   no sandbox token the API call is skipped and the bare runner response is
-///   written to dsbx's stdout instead (previous behavior).
-/// - `stdout`: print a protocol v3 envelope on stdout and exit 0, including for
-///   runner `ok:false` and for failures that keep the function from being
-///   spawned at all, so the worker keeps structured errors. Never POSTs the
-///   callback.
-pub async fn cmd_function_run(name: &str, result_delivery: ResultDelivery) -> Result<()> {
+/// The result is always a protocol v3 envelope on stdout, exit 0, including for
+/// runner `ok:false` and for failures that keep the function from being spawned
+/// at all, so the worker keeps structured errors.
+pub async fn cmd_function_run(name: &str) -> Result<()> {
     let started = Instant::now();
 
     // The envelope is consumed here rather than inherited by the runner child:
@@ -38,31 +30,22 @@ pub async fn cmd_function_run(name: &str, result_delivery: ResultDelivery) -> Re
     let mut input = String::new();
     if let Err(e) = tokio::io::stdin().read_to_string(&mut input).await {
         let err = emit_error(anyhow!("failed to read request envelope: {e}"));
-        return match result_delivery {
-            ResultDelivery::Callback => Err(err),
-            ResultDelivery::Stdout => deliver_stdout_envelope(
-                ResultEnvelope::stdout_invocation_failed(err.to_string()),
-                0,
-            ),
-        };
+        deliver_stdout_envelope(ResultEnvelope::stdout_invocation_failed(err.to_string()), 0);
     }
 
     if let WarmRun::Outcome(outcome) = warm::try_warm_run(name, &input).await {
         let runner_ms = started.elapsed().as_millis() as u64;
-        return match result_delivery {
-            ResultDelivery::Callback => deliver_callback_outcome(name, outcome).await,
-            ResultDelivery::Stdout => deliver_stdout_envelope(
-                ResultEnvelope::stdout_outcome(
-                    outcome,
-                    Some(TimingsMs {
-                        total: started.elapsed().as_millis() as u64,
-                        runner: runner_ms,
-                        runner_kind: Some(RunnerKind::Warm),
-                    }),
-                ),
-                0,
+        deliver_stdout_envelope(
+            ResultEnvelope::stdout_outcome(
+                outcome,
+                Some(TimingsMs {
+                    total: started.elapsed().as_millis() as u64,
+                    runner: runner_ms,
+                    runner_kind: Some(RunnerKind::Warm),
+                }),
             ),
-        };
+            0,
+        );
     }
 
     // Cold path. Resolve once: the run below and the warm server spawn both
@@ -85,90 +68,14 @@ pub async fn cmd_function_run(name: &str, result_delivery: ResultDelivery) -> Re
         warm::spawn_server(name, handler);
     }
 
-    match result_delivery {
-        // Spawn failures keep propagating: the bare `{error}` line emit_error
-        // printed is the contract here, and the exit code stays non-zero.
-        ResultDelivery::Callback => {
-            let (code, captured) = spawned?;
-            deliver_callback(name, code, &captured.unwrap_or_default()).await
-        }
-        ResultDelivery::Stdout => deliver_stdout(
-            spawned,
-            TimingsMs {
-                total: started.elapsed().as_millis() as u64,
-                runner: runner_ms,
-                runner_kind: Some(RunnerKind::Cold),
-            },
-        ),
-    }
-}
-
-/// Callback delivery for a warm outcome: the runner `Output` is already
-/// parsed, so it goes straight to the result API (or to stdout in the
-/// local/no-token case, mirroring the cold path's convenience behavior).
-async fn deliver_callback_outcome(name: &str, outcome: serde_json::Value) -> Result<()> {
-    let have_token = std::env::var(SANDBOX_TOKEN_ENV)
-        .map(|t| !t.is_empty())
-        .unwrap_or(false);
-
-    if !have_token {
-        // Exit-code parity with the cold runner: 0 for ok, 2 for bad_input,
-        // 1 for every other failure.
-        let ok = outcome
-            .get("ok")
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false);
-        let bad_input = outcome
-            .pointer("/error/code")
-            .and_then(serde_json::Value::as_str)
-            == Some("bad_input");
-        println!("{outcome}");
-        std::process::exit(if ok {
-            0
-        } else if bad_input {
-            2
-        } else {
-            1
-        });
-    }
-
-    let client = DustApiClient::from_env()?;
-    client
-        .post_function_result(name, &outcome)
-        .await
-        .map_err(emit_error)?;
-    std::process::exit(0);
-}
-
-async fn deliver_callback(name: &str, code: i32, response: &str) -> Result<()> {
-    let have_token = std::env::var(SANDBOX_TOKEN_ENV)
-        .map(|t| !t.is_empty())
-        .unwrap_or(false);
-
-    // No sandbox token: local/testing — emit the response on stdout, as before.
-    if !have_token {
-        print!("{response}");
-        std::process::exit(code);
-    }
-
-    let line = last_non_empty_line(response);
-    // Sandbox: deliver the response to the Dust result API instead of stdout.
-    if line.is_empty() {
-        return Err(emit_error(anyhow!(
-            "function produced no output to deliver to the result API"
-        )));
-    }
-    // The runner emits a JSON line; take the last non-empty line so incidental
-    // console.log output on the same fd does not poison the callback body.
-    let result: serde_json::Value =
-        serde_json::from_str(line).unwrap_or_else(|_| serde_json::Value::String(line.to_string()));
-
-    let client = DustApiClient::from_env()?;
-    client
-        .post_function_result(name, &result)
-        .await
-        .map_err(emit_error)?;
-    std::process::exit(0);
+    deliver_stdout(
+        spawned,
+        TimingsMs {
+            total: started.elapsed().as_millis() as u64,
+            runner: runner_ms,
+            runner_kind: Some(RunnerKind::Cold),
+        },
+    )
 }
 
 fn deliver_stdout(spawned: Result<(i32, Option<String>)>, timings_ms: TimingsMs) -> ! {
@@ -246,6 +153,7 @@ fn truncate_chars(value: &str, max_chars: usize) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::super::envelope::ResultDelivery;
     use super::*;
 
     fn timings(total: u64, runner: u64) -> TimingsMs {

--- a/cli/dust-sandbox/src/commands/function/run.rs
+++ b/cli/dust-sandbox/src/commands/function/run.rs
@@ -22,6 +22,9 @@ const NON_JSON_SNIPPET_MAX_CHARS: usize = 512;
 /// The result is always a protocol v3 envelope on stdout, exit 0, including for
 /// runner `ok:false` and for failures that keep the function from being spawned
 /// at all, so the worker keeps structured errors.
+///
+/// Never actually returns: every path ends in a `deliver_stdout*` call, which
+/// writes the envelope and exits. The `Result` is what the dispatch expects.
 pub async fn cmd_function_run(name: &str) -> Result<()> {
     let started = Instant::now();
 

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -73,8 +73,8 @@ async fn run() -> anyhow::Result<()> {
         Commands::Function { command } => match command {
             commands::function::FunctionCommand::Run {
                 name,
-                result_delivery,
-            } => commands::cmd_function_run(&name, result_delivery).await?,
+                result_delivery: _,
+            } => commands::cmd_function_run(&name).await?,
             commands::function::FunctionCommand::Get { name } => {
                 commands::cmd_function_get(&name).await?
             }
@@ -191,10 +191,7 @@ mod tests {
                     result_delivery,
                 } => {
                     assert_eq!(name, "greet");
-                    assert_eq!(
-                        result_delivery,
-                        commands::function::ResultDelivery::Callback
-                    );
+                    assert_eq!(result_delivery, commands::function::ResultDelivery::Stdout);
                 }
                 _ => panic!("expected run"),
             },
@@ -202,8 +199,9 @@ mod tests {
         }
     }
 
+    // front still sends the flag. Parsing it must keep working until front stops.
     #[test]
-    fn function_run_parses_stdout_result_delivery() {
+    fn function_run_still_accepts_the_result_delivery_flag() {
         let cli = Cli::try_parse_from([
             "dsbx",
             "function",
@@ -215,12 +213,8 @@ mod tests {
         .expect("parse");
         match cli.command {
             Commands::Function { command } => match command {
-                commands::function::FunctionCommand::Run {
-                    name,
-                    result_delivery,
-                } => {
+                commands::function::FunctionCommand::Run { name, .. } => {
                     assert_eq!(name, "greet");
-                    assert_eq!(result_delivery, commands::function::ResultDelivery::Stdout);
                 }
                 _ => panic!("expected run"),
             },

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
@@ -25,9 +25,10 @@ const PostSandboxFunctionResultRequestBodySchema = z
 // `--result-delivery stdout` since Pod function stdout delivery became the
 // default. The only callers left are dsbx binaries baked into images still
 // pinned below 0.1.45 (DSBX_CLI_VERSION in front/lib/api/sandbox/image/registry.ts),
-// and only for a hand-run `dsbx function run` that omits the flag. Delete this
-// route, its test, and the sandbox-functions result client once that pin has
-// moved and no running sandbox predates it.
+// and only for a hand-run `dsbx function run` that omits the flag. Once that pin
+// has moved and no running sandbox predates it, delete this route and its test,
+// along with the callback arm normalizeSandboxFunctionResult still accepts in
+// lib/api/sandbox_functions/result_envelope.ts.
 const app = sandboxApp();
 
 /**

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
@@ -20,11 +20,11 @@ const PostSandboxFunctionResultRequestBodySchema = z
 // applied by the parent sandbox sub-app, so ctx.get("auth") and
 // ctx.get("sandboxClaims") are always available here.
 //
-// DEPRECATED 2026-08-10, pending removal. dsbx 0.1.45 dropped callback delivery:
+// DEPRECATED 2026-08-10, pending removal. dsbx 0.1.46 dropped callback delivery:
 // every result now comes back on the exec's own stdout, and front has passed
 // `--result-delivery stdout` since Pod function stdout delivery became the
 // default. The only callers left are dsbx binaries baked into images still
-// pinned below 0.1.45 (DSBX_CLI_VERSION in front/lib/api/sandbox/image/registry.ts),
+// pinned below 0.1.46 (DSBX_CLI_VERSION in front/lib/api/sandbox/image/registry.ts),
 // and only for a hand-run `dsbx function run` that omits the flag. Once that pin
 // has moved and no running sandbox predates it, delete this route and its test,
 // along with the callback arm normalizeSandboxFunctionResult still accepts in

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
@@ -19,6 +19,15 @@ const PostSandboxFunctionResultRequestBodySchema = z
 // Mounted at /api/v1/w/:wId/sandbox/sandbox-functions/result. sandboxAuth is
 // applied by the parent sandbox sub-app, so ctx.get("auth") and
 // ctx.get("sandboxClaims") are always available here.
+//
+// DEPRECATED 2026-08-10, pending removal. dsbx 0.1.45 dropped callback delivery:
+// every result now comes back on the exec's own stdout, and front has passed
+// `--result-delivery stdout` since Pod function stdout delivery became the
+// default. The only callers left are dsbx binaries baked into images still
+// pinned below 0.1.45 (DSBX_CLI_VERSION in front/lib/api/sandbox/image/registry.ts),
+// and only for a hand-run `dsbx function run` that omits the flag. Delete this
+// route, its test, and the sandbox-functions result client once that pin has
+// moved and no running sandbox predates it.
 const app = sandboxApp();
 
 /**

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.70",
+      tag: "0.8.71",
     });
   });
 
@@ -457,7 +457,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.45/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.46/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,8 +26,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.70";
-const DSBX_CLI_VERSION = "0.1.45";
+const DUST_BASE_IMAGE_VERSION = "0.8.71";
+const DSBX_CLI_VERSION = "0.1.46";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
 // the stable identity used when creating the workload account.


### PR DESCRIPTION
## Description

Follow-up to #30261. Now that front always runs functions with `--result-delivery stdout` and `dsbx function run` has no other invoker, callback delivery is dead code. Removes `ResultDelivery::Callback`, `deliver_callback` / `deliver_callback_outcome`, and the `post_function_result` client. Bumps dsbx to 0.1.46 and dust-base to 0.8.71, so the pin ships with the change it points at. (0.1.45 went out from main while this was open, so this takes the next version.)

Two things deliberately left in place:

- `--result-delivery` still parses (accepted, ignored, `stdout` the only value). dsbx ships as a pinned release, so a binary that rejected the flag would break every invocation the moment the pin moved. It gets removed together with front's argument.
- The v1 result route is marked deprecated, not deleted. Sandboxes still running an image built below 0.1.46 carry a dsbx that defaults to callback, so a hand-run `dsbx function run` without the flag can reach it. Deleting it now would be a [BACK12] violation for no gain.

**Before the next front deploy**, dispatch `Release dsbx CLI` so `dsbx-v0.1.46` exists. Nothing builds images on merge (`sandbox-img-registry` only runs via `ensure-sandbox-images` inside the manual `Deploy` workflow), but a front deploy without the release fails at the image build's `curl`.

Once deployed sandboxes have all cycled onto 0.1.46, the leftovers can go: the deprecated route and its test, the callback arm in `normalizeSandboxFunctionResult`, and `--result-delivery` on both sides.

## Tests

`cargo test` (283), clippy with `-D warnings`, and `cargo fmt --check` all clean locally, plus the registry and result-route tests after the rebase. Also checked the local no-token path changes shape: a bare `dsbx function run` now prints the v3 envelope and exits 0 instead of the raw runner response with the runner's exit code.

## Risk

Low. No production path selected callback. The behavior change is confined to running dsbx by hand: previously the no-token case printed the bare runner response and mirrored the runner's exit code, now it prints the envelope and exits 0.

One ordering note: since `callback` is gone from the value enum, `--result-delivery callback` is a usage error rather than an ignored value. If #30261 ever needs reverting after this deploys, the revert has to move the pin back too, or every invocation fails to parse.

## Deploy Plan

Cut the dsbx release first, then a standard front deploy, which rebuilds dust-base 0.8.71 on the way through.