### PR TITLE
[front] fix: bound the kill-requested pre-destroy flush retry

### DIFF
--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -68,7 +68,7 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { encrypt } from "@app/types/shared/utils/encryption";
 import type { WhereOptions } from "sequelize";
 
@@ -403,6 +403,104 @@ describe("ConversationSandboxAdapter.dangerouslyDestroySandboxIfKillRequested", 
 
     expect(result.isOk()).toBe(true);
     expect(mockProviderDestroy).not.toHaveBeenCalled();
+  });
+});
+
+describe("SandboxResource.dangerouslyDestroyIfKillRequested pre-destroy flush", () => {
+  let authenticator: Authenticator;
+  let conversationResource: ConversationResource;
+
+  // A flush that can never pass — e.g. a pod database the litestream user
+  // cannot write, which fails identically on every sweep.
+  const alwaysFailingCheck = () =>
+    Promise.resolve(new Err(new Error("litestream sync of arena failed")));
+
+  const lifecycleOwner = () => ({
+    lockKey: conversationResource.sId,
+    fetchSandbox: () =>
+      ConversationSandboxAdapter.fetchSandbox(
+        authenticator,
+        conversationResource.toJSON()
+      ),
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockExecuteWithLock.mockImplementation(
+      async (_key: string, fn: () => Promise<unknown>) => fn()
+    );
+    mockGetSandboxProvider.mockReturnValue({ destroy: mockProviderDestroy });
+    mockProviderDestroy.mockResolvedValue(new Ok(undefined));
+    mockDeleteLegacySandboxPolicy.mockResolvedValue(new Ok(undefined));
+    mockRevokeAllExecTokensForSandbox.mockResolvedValue(undefined);
+
+    const testSetup = await createResourceTest({ role: "admin" });
+    authenticator = testSetup.authenticator;
+
+    const agentConfig =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    const fetched = await ConversationResource.fetchById(
+      authenticator,
+      conversation.sId
+    );
+    if (!fetched) {
+      throw new Error("Conversation not found.");
+    }
+    conversationResource = fetched;
+  });
+
+  it("skips the destroy while the kill request is within the grace period", async () => {
+    await SandboxFactory.create(authenticator, conversationResource.toJSON(), {
+      status: "running",
+      killRequestedAt: new Date(),
+    });
+
+    const result = await SandboxResource.dangerouslyDestroyIfKillRequested(
+      authenticator,
+      lifecycleOwner(),
+      { beforeSleep: alwaysFailingCheck }
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(mockProviderDestroy).not.toHaveBeenCalled();
+
+    const reloaded = await ConversationSandboxAdapter.fetchSandbox(
+      authenticator,
+      conversationResource.toJSON()
+    );
+    expect(reloaded?.status).toBe("running");
+  });
+
+  it("destroys anyway once the kill request is older than the grace period", async () => {
+    const sandbox = await SandboxFactory.create(
+      authenticator,
+      conversationResource.toJSON(),
+      {
+        status: "running",
+        killRequestedAt: new Date(Date.now() - 2 * 60 * 60 * 1000),
+      }
+    );
+
+    const result = await SandboxResource.dangerouslyDestroyIfKillRequested(
+      authenticator,
+      lifecycleOwner(),
+      { beforeSleep: alwaysFailingCheck }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockProviderDestroy).toHaveBeenCalledWith(sandbox.providerId, {
+      workspaceId: authenticator.getNonNullableWorkspace().sId,
+    });
+
+    const reloaded = await ConversationSandboxAdapter.fetchSandbox(
+      authenticator,
+      conversationResource.toJSON()
+    );
+    expect(reloaded?.status).toBe("deleted");
   });
 });
 

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -101,6 +101,15 @@ export type SandboxDeleteOwner = SandboxLifecycleOwner & {
 // indistinguishable to it.
 const LAST_ACTIVITY_WRITE_INTERVAL_MS = 30_000;
 
+// How long a kill-requested sandbox may keep failing its pre-destroy flush
+// before the destroy proceeds anyway. The flush is best-effort durability, not
+// a precondition: a sandbox whose state cannot be replicated (e.g. a database
+// file the litestream user cannot write) fails the check identically on every
+// sweep, and without a deadline it pins a running VM and blocks the image
+// rollout forever. Generous enough that a transient GCS or daemon hiccup still
+// resolves on a later sweep — the reaper sweeps every 5 minutes.
+const KILL_REQUESTED_FLUSH_GRACE_MS = 60 * 60 * 1000;
+
 // Owner identity env vars are reserved for owner adapters. SandboxResource
 // only enforces the env contract and does not interpret owner types.
 const SANDBOX_OWNER_ENV_VAR_CONTRACT_NAMES = new Set([
@@ -1121,7 +1130,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    * `SandboxNotFoundError` as success.
    *
    * An `opts.beforeSleep` Err skips the destroy for this sweep: the row keeps
-   * its `killRequestedAt`, so the reaper retries next cycle.
+   * its `killRequestedAt`, so the reaper retries next cycle. Once the kill
+   * request is older than `KILL_REQUESTED_FLUSH_GRACE_MS` the destroy proceeds
+   * despite the failing flush, matching what the destroy-and-recreate path
+   * already does — an unflushable sandbox must not pin a VM forever.
    */
   static async dangerouslyDestroyIfKillRequested(
     auth: Authenticator,
@@ -1147,16 +1159,31 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         sandbox
       );
       if (checkResult.isErr()) {
-        // TODO(@jd 20260730: remove the panic true)
+        const killRequestedForMs =
+          Date.now() - sandbox.killRequestedAt.getTime();
+        if (killRequestedForMs < KILL_REQUESTED_FLUSH_GRACE_MS) {
+          // TODO(@jd 20260730: remove the panic true)
+          logger.error(
+            {
+              sandbox: sandbox.toLogJSON(),
+              err: checkResult.error,
+              killRequestedForMs,
+              panic: true,
+            },
+            "Kill-requested destroy: pre-destroy health check failed — skipping destroy this sweep."
+          );
+          return checkResult;
+        }
+
         logger.error(
           {
             sandbox: sandbox.toLogJSON(),
             err: checkResult.error,
+            killRequestedForMs,
             panic: true,
           },
-          "Kill-requested destroy: pre-destroy health check failed — skipping destroy this sweep."
+          "Kill-requested destroy: pre-destroy health check still failing past the grace period — destroying anyway, unreplicated pod state is lost."
         );
-        return checkResult;
       }
 
       const result = await provider.destroy(sandbox.providerId, tracingOpts);


### PR DESCRIPTION
## Description

A sandbox with `killRequestedAt` set whose pre-destroy flush can never succeed is retried forever. `dangerouslyDestroyIfKillRequested` runs `ensurePodStateHealthOnSleep`, and on failure returns `Err` and skips the destroy — the row keeps its `killRequestedAt`, so the next reaper sweep does exactly the same thing.

This happened in production today. A pod database created by workload function code landed at mode `0640` owned `agent-proxied:agent`, so litestream (`dust-state`, in group `agent`) could read but not write it:

```
litestream sync of arena failed (exit 1): sync failed: sync database: db sync:
create _litestream_seq table: attempt to write a readonly database (8)
```

The sandbox never slept for three days, and once a kill was requested for the image rollout it logged `panic: true` every ~90s and could never be destroyed. It was the last sandbox blocking the rollout.

The flush is best-effort durability, not a precondition — and `dangerouslyDestroyAndRecreate` already treats it that way, logging the failed flush and proceeding with the destroy. The reaper path was the inconsistent one.

This gives the flush a one hour grace period, measured from `killRequestedAt`:

- Within the grace period, behaviour is unchanged — skip the destroy and retry on the next sweep, so a transient GCS credential or daemon hiccup still resolves on its own (the reaper sweeps every 5 minutes, so that is ~12 attempts).
- Past it, destroy anyway and log that unreplicated pod state is being dropped.

Companion PR: #30271 stops these databases from being created unwritable in the first place.

## Tests

- Two new cases in `sandbox_resource.test.ts` drive `dangerouslyDestroyIfKillRequested` with a `beforeSleep` check that always fails, and assert both sides of the deadline: within the grace period the provider destroy is never called and the row stays `running`; past it the destroy runs and the row goes `deleted`. Both fail on `main` (the second one hangs on the old always-skip path).
- `npm test lib/resources/sandbox_resource.test.ts` — 42 passed.
- `npx tsgo --noEmit` clean.
- The production scenario itself was resolved by repairing the file mode by hand, which let the existing path destroy the sandbox cleanly — so the new branch has not been exercised in prod, only in tests.

## Risk

The meaningful risk is that this deliberately converts a wedge into data loss, and that trade should be made consciously.

- Before: an unflushable sandbox pins a running VM indefinitely, but the unreplicated pod state survives on that VM. After: it is destroyed an hour later and that state is gone for good. This is the right trade for fleet health — a pinned VM blocks image rollouts fleet-wide and bills continuously — but it is strictly worse for the affected pod's data, and nothing currently notifies the owner that it happened.
- The one hour window is the main tunable. Too short and a genuine transient (expired mount credential, litestream restart loop, slow gcsfuse) could lose state that would have flushed on a later sweep; one hour is ~12 reaper sweeps, well past any transient we have observed. Too long and a wedged sandbox keeps blocking a rollout, which is the status quo.
- Scope is narrow: only the kill-requested destroy path changes. The reaper sleep path and `pauseForApproval` still refuse to pause on a failed flush, so a healthy sandbox is never paused with unflushed state.
- No schema change, no data migration, no persisted state. Rollback is a plain revert.
- The `panic: true` log is kept on both branches, so existing monitors still fire — the new branch is distinguishable by its message and the added `killRequestedForMs` field.

## Deploy Plan

Standard `front` deploy, no ordering constraints and no coordination with #30271 — the two are independent and either can ship first.

The change only takes effect for sandboxes whose kill request is already an hour old, so nothing happens at deploy time unless a wedged sandbox exists. There is none right now (today's was repaired and destroyed), so expect this to be a no-op until the next occurrence.

After deploy, the log line to watch is `pre-destroy health check still failing past the grace period` — every occurrence is a pod that lost unreplicated state and is worth following up on individually, not just as a fleet metric.
