### PR TITLE
fix(dsbx): create function-authored files group-writable

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.44"
+version = "0.1.45"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/functions-runner/fixtures/file-mode-probe.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/file-mode-probe.ts
@@ -1,0 +1,14 @@
+import { mkdtempSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Creates a file the way a function body would (no explicit mode) and reports
+// the resulting permission bits, so the runner's umask can be asserted.
+export default {
+  async fetch(): Promise<Response> {
+    const dir = mkdtempSync(join(tmpdir(), "dsbx-mode-"));
+    const path = join(dir, "probe.db");
+    await Bun.write(path, "");
+    return Response.json({ mode: statSync(path).mode & 0o777 });
+  },
+};

--- a/cli/dust-sandbox/functions-runner/runner.test.ts
+++ b/cli/dust-sandbox/functions-runner/runner.test.ts
@@ -28,6 +28,17 @@ describe("runner run", () => {
     expect(out.output).toEqual({ hello: "r" });
   });
 
+  test("creates function-authored files group-writable (umask 007)", async () => {
+    // A pod database a function opens directly must stay writable by group
+    // `agent`, or litestream can never replicate it.
+    const { stdout, code } = await run(
+      ["run", fx("file-mode-probe.ts")],
+      JSON.stringify({ url: "http://localhost/" })
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout).output.mode).toBe(0o660);
+  });
+
   test("exits 1 with ok:false when handler throws", async () => {
     const { stdout, code } = await run(
       ["run", fx("throws.ts")],

--- a/cli/dust-sandbox/functions-runner/runner.ts
+++ b/cli/dust-sandbox/functions-runner/runner.ts
@@ -21,6 +21,19 @@ import { BadInputError, parseInput, type RequestInput } from "./protocol.ts";
 import { getFunctionSchema } from "./schema.ts";
 import { serve } from "./serve.ts";
 
+// Everything this process creates — including files the function body creates
+// itself — must stay group-writable. The shared sandbox directories are setgid
+// with a `g::rwx` default ACL (`/pod-state/databases`, `/files`), but a default
+// ACL only masks the mode a process asks for; it cannot add bits the umask
+// stripped. With the inherited 022/027 umask, a SQLite database a function
+// opens directly lands at 0644/0640 owned by `agent-proxied:agent`, and
+// litestream (user `dust-state`, group `agent`) can then read but never write
+// it — every replication sync fails with SQLITE_READONLY, forever. `dsbx db
+// reconcile` already chmods 0660 for exactly this reason; the umask extends the
+// same guarantee to files it did not create. 007 keeps `other` empty: group
+// `agent` is the sandbox's own trust boundary, everyone else stays out.
+process.umask(0o007);
+
 async function runHandler(handlerPath: string): Promise<number> {
   const raw = await Bun.stdin.text();
   let input: RequestInput;

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.69",
+      tag: "0.8.70",
     });
   });
 
@@ -457,7 +457,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.44/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.45/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,8 +26,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.69";
-const DSBX_CLI_VERSION = "0.1.44";
+const DUST_BASE_IMAGE_VERSION = "0.8.70";
+const DSBX_CLI_VERSION = "0.1.45";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
 // the stable identity used when creating the workload account.


### PR DESCRIPTION
## Description

`/pod-state/databases` is workload-writable by design, and litestream replicates whatever SQLite file lands there. `dsbx db reconcile` chmods the databases it creates to `0660` precisely so litestream (user `dust-state`, group `agent`) can write them — but a function that opens a database directly, without going through reconcile, bypasses that.

Those files land at the process umask. In production today:

```
-rw-r-----  1 1003 1002   4096  arena.db        # agent-proxied:agent, 0640
-rw-r-----  1 1003 1002  32768  arena.db-shm
-rw-r-----  1 1003 1002 288432  arena.db-wal
```

`dust-state` is in group `agent`, so it could read the file but never write it. Litestream needs to write the source database (it creates a `_litestream_seq` table), so every sync failed:

```
sync failed: sync database: db sync: create _litestream_seq table:
attempt to write a readonly database (8)
```

That database therefore never replicated at all, and the sandbox failed its pre-sleep flush on every reaper sweep — it never slept for three days, and once a kill was requested for the image rollout it could not be destroyed either, blocking the rollout.

The image already sets the directory up to make this work: `install -d -o dust-state -g agent -m 2770` plus `setfacl -R -d -m g::rwx`. The setgid bit gives new files group `agent`, but a default ACL only *masks* the mode the process requests — it cannot add back bits the umask stripped. So the `g::rwx` intent silently never took effect for function-created files.

This sets `process.umask(0o007)` in the functions runner, the single entry point for `dsbx function run/serve` and every `dsbx db` subcommand, and the process the untrusted function bundle is imported into. Everything a function creates is then group-writable, matching what reconcile already does by hand.

`007` rather than `002`: `other` stays empty. Group `agent` (`agent`, `agent-proxied`, `dust-state`) is the sandbox's existing trust boundary — and since the directory is `2770` and group-writable, the `agent` user could already unlink and replace any file in it, so this widens no boundary that was actually closed.

Bumps dsbx to 0.1.45 and dust-base to 0.8.70 so the change ships in the image.

Companion PR: #30269 stops an unflushable sandbox from blocking a rollout forever.

## Tests

- New `runner.test.ts` case runs a fixture function that creates a file with no explicit mode and asserts it comes out `0660` — it fails on `main` (`0644`).
- `bun test functions-runner/` — 109 passed.
- `npm test lib/api/sandbox/image/registry.test.ts` — 20 passed (version-bump assertions).
- Verified against the live sandbox: root `chmod 660` on the three `arena.db*` files made litestream log `sync recovered` and upload its first LTX file, and the next reaper sweep destroyed the sandbox cleanly.

## Risk

Low, and the blast radius is limited to files created inside a sandbox.

- The umask only widens the group bit, and only for the runner process. It does not touch existing files, does not run as root, and cannot make anything world-readable.
- Group `agent` already had directory-level write on both shared directories (`2770`), so a group-writable file grants the workload nothing it could not already do by unlinking and replacing the file.
- Files the runner writes outside `/pod-state/databases` (e.g. under `/files`) also become group-writable. Same trust group, same setgid + `g::rwx` ACL intent, so this is the designed behaviour rather than a new exposure.
- The riskiest part is not the one-line umask but the version bump: shipping 0.8.70 kill-requests every sandbox on 0.8.69 and recycles the fleet. That path runs on every image release and ran today.
- Rollback is a revert plus a version bump back; no data migration, no persisted state depends on the mode.

Not fixed by this PR: databases already created at `0640` inside a live sandbox stay unwritable until that sandbox is recycled. Fleet-wide there are currently none — a 30-day sweep of litestream errors found four sandboxes, all the same `arena.db` in workspace `0ec9852c2f`, three already destroyed and the fourth repaired by hand today.

## Deploy Plan

1. Merge, then run the **Release dsbx CLI** workflow to publish the `dsbx-v0.1.45` release artifacts. The image build pulls the binary from that release tag, so it must exist before the image is built.
2. Build and publish the `dust-base` 0.8.70 image.
3. Deploy `front`. The kill-requester marks every sandbox whose version differs from 0.8.70, and the reaper recycles them over subsequent sweeps — the same rollout path as any image bump.
4. Watch `@source:litestream @status:error` and the pod-state health metric during the rollout. A recurrence of `readonly database (8)` on a sandbox already running 0.8.70 would mean the umask did not take effect and should be investigated before the rollout completes.

Ordering matters between steps 1 and 2 only; step 3 is safe at any point after, since older sandboxes keep running their existing image until recycled.
