### PR TITLE
Bump dsbx to 0.1.45 and dust-base to 0.8.70

### DIFF
--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.69",
+      tag: "0.8.70",
     });
   });
 
@@ -457,7 +457,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.44/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.45/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,8 +26,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.69";
-const DSBX_CLI_VERSION = "0.1.44";
+const DUST_BASE_IMAGE_VERSION = "0.8.70";
+const DSBX_CLI_VERSION = "0.1.45";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
 // the stable identity used when creating the workload account.


### PR DESCRIPTION
## Description

Points the sandbox image at the dsbx that no longer carries callback result delivery (#30268).

Draft on purpose, because the ordering is the whole point: `DSBX_CLI_VERSION` cannot move before the release exists. The image build does `curl -fsSL .../releases/download/dsbx-v${DSBX_CLI_VERSION}/dsbx-linux-x86_64`, and `Release dsbx CLI` is a manual `workflow_dispatch` that reads the version from `cargo metadata` on the default branch. So:

1. Merge #30268 (puts `version = "0.1.45"` on main).
2. Dispatch `Release dsbx CLI` and confirm `dsbx-v0.1.45` has assets.
3. Undraft and merge this.

Merging this before step 2 fails every base image build on a 404.

Once this lands, #30268's leftovers can go: the deprecated `v1/.../sandbox/sandbox-functions/result` route and its test, the callback arm in `normalizeSandboxFunctionResult`, and `--result-delivery` on both sides.

## Tests

Nothing beyond the pinned-version assertions in `registry.test.ts`, which is what this kind of bump is.

## Risk

The base image rebuild is the risk surface, not the diff. Same shape as d223899986.

## Deploy Plan

Standard deploy, after the release exists.