### PR TITLE
[front] enh: add public skill archive endpoint

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -3397,6 +3397,72 @@
         }
       }
     },
+    "/api/v1/w/{wId}/skills/{skillId}": {
+      "delete": {
+        "summary": "Archive a skill",
+        "description": "Soft-archives a custom skill in the workspace.",
+        "tags": [
+          "Skills"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "Unique string identifier for the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "skillId",
+            "required": true,
+            "description": "Unique string identifier for the custom skill",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Skill archived successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized. Invalid or missing authentication token."
+          },
+          "403": {
+            "description": "Forbidden. The caller is not allowed to archive skills."
+          },
+          "404": {
+            "description": "Skill not found."
+          },
+          "500": {
+            "description": "Internal Server Error."
+          }
+        }
+      }
+    },
     "/api/v1/w/{wId}/skills": {
       "get": {
         "summary": "List skills",

--- a/front-api/routes/v1/w/[wId]/skills/[skillId].test.ts
+++ b/front-api/routes/v1/w/[wId]/skills/[skillId].test.ts
@@ -1,0 +1,91 @@
+import { Authenticator } from "@app/lib/auth";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+async function setupTest({ role }: { role: "user" | "builder" }) {
+  const { workspace, key } = await createPublicApiMockRequest({ role });
+  await SpaceFactory.defaults(
+    await Authenticator.internalAdminForWorkspace(workspace.sId)
+  );
+
+  const user = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, user, { role: "builder" });
+  const skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+  const skill = await SkillFactory.create(skillOwnerAuth, {
+    name: "Skill to archive through the public API",
+  });
+
+  return { key, skill, skillOwnerAuth, workspace };
+}
+
+function archiveSkill(
+  workspace: { sId: string },
+  key: { secret: string },
+  skillId: string
+) {
+  return honoApp.request(`/api/v1/w/${workspace.sId}/skills/${skillId}`, {
+    method: "DELETE",
+    headers: { authorization: `Bearer ${key.secret}` },
+  });
+}
+
+describe("DELETE /api/v1/w/[wId]/skills/[skillId]", () => {
+  it("archives a custom skill", async () => {
+    const { key, skill, skillOwnerAuth, workspace } = await setupTest({
+      role: "builder",
+    });
+
+    const response = await archiveSkill(workspace, key, skill.sId);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+
+    const archivedSkill = await SkillResource.fetchById(
+      skillOwnerAuth,
+      skill.sId
+    );
+    expect(archivedSkill?.status).toBe("archived");
+  });
+
+  it("returns 404 when the skill does not exist", async () => {
+    const { key, workspace } = await setupTest({ role: "builder" });
+
+    const response = await archiveSkill(
+      workspace,
+      key,
+      "non_existent_skill_id"
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "skill_not_found",
+        message: "The skill you requested was not found.",
+      },
+    });
+  });
+
+  it("rejects a non-builder API key", async () => {
+    const { key, skill, skillOwnerAuth, workspace } = await setupTest({
+      role: "user",
+    });
+
+    const response = await archiveSkill(workspace, key, skill.sId);
+
+    expect(response.status).toBe(403);
+    const unchangedSkill = await SkillResource.fetchById(
+      skillOwnerAuth,
+      skill.sId
+    );
+    expect(unchangedSkill?.status).toBe("active");
+  });
+});

--- a/front-api/routes/v1/w/[wId]/skills/[skillId].ts
+++ b/front-api/routes/v1/w/[wId]/skills/[skillId].ts
@@ -1,0 +1,100 @@
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { isResourceSId } from "@app/lib/resources/string_ids";
+import type { DeleteSkillResponseBody } from "@app/types/api/skills";
+import { publicApiApp } from "@front-api/middlewares/ctx";
+import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  skillId: z.string(),
+});
+
+// Mounted at /api/v1/w/:wId/skills/:skillId.
+const app = publicApiApp();
+
+/**
+ * @swagger
+ * /api/v1/w/{wId}/skills/{skillId}:
+ *   delete:
+ *     summary: Archive a skill
+ *     description: Soft-archives a custom skill in the workspace.
+ *     tags:
+ *       - Skills
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: Unique string identifier for the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: skillId
+ *         required: true
+ *         description: Unique string identifier for the custom skill
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Skill archived successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required:
+ *                 - success
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *       401:
+ *         description: Unauthorized. Invalid or missing authentication token.
+ *       403:
+ *         description: Forbidden. The caller is not allowed to archive skills.
+ *       404:
+ *         description: Skill not found.
+ *       500:
+ *         description: Internal Server Error.
+ */
+app.delete(
+  "/",
+  ensureIsBuilder(),
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<DeleteSkillResponseBody> => {
+    const auth = ctx.get("auth");
+    const { skillId } = ctx.req.valid("param");
+
+    const skill = isResourceSId("skill", skillId)
+      ? await SkillResource.fetchById(auth, skillId)
+      : null;
+
+    if (!skill) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "skill_not_found",
+          message: "The skill you requested was not found.",
+        },
+      });
+    }
+
+    if (!skill.canAdministrate(auth)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message: "Only admins and editors can archive this skill.",
+        },
+      });
+    }
+
+    await skill.archive(auth);
+
+    return ctx.json({ success: true });
+  }
+);
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/skills/index.ts
+++ b/front-api/routes/v1/w/[wId]/skills/index.ts
@@ -17,6 +17,8 @@ import type { HttpBindings } from "@hono/node-server";
 import formidable from "formidable";
 import { z } from "zod";
 
+import skill from "./[skillId]";
+
 export type GetPublicSkillsResponseBody = {
   skills: SkillType[];
 };
@@ -35,6 +37,8 @@ const SkillAvailabilitiesSchema = z
 // underlying Node `IncomingMessage` via `ctx.env.incoming` and hand it to
 // `formidable.parse(...)` for multipart parsing in the POST handler.
 const app = createHono<PublicApiCtx & { Bindings: HttpBindings }>();
+
+app.route("/:skillId", skill);
 
 /**
  * @swagger


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/9972#issuecomment-5242209812.

The public API can list and import skills, but it cannot archive an existing skill. This PR adds a `DELETE /api/v1/w/{wId}/skills/{skillId}` endpoint.

## Tests

- Added tests.

## Risk

- Low. Purely additive.

## Deploy Plan

- Deploy front.
