### PR TITLE
Add team dimension to consumption analytics

### DIFF
--- a/front-api/routes/w/[wId]/analytics/consumption/index.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/index.ts
@@ -5,6 +5,7 @@ import topAgents from "./top-agents";
 import topModels from "./top-models";
 import topSkills from "./top-skills";
 import topSources from "./top-sources";
+import topTeams from "./top-teams";
 import topTools from "./top-tools";
 import topUsers from "./top-users";
 
@@ -16,6 +17,7 @@ app.route("/top-agents", topAgents);
 app.route("/top-models", topModels);
 app.route("/top-skills", topSkills);
 app.route("/top-sources", topSources);
+app.route("/top-teams", topTeams);
 app.route("/top-tools", topTools);
 app.route("/top-users", topUsers);
 

--- a/front-api/routes/w/[wId]/analytics/consumption/top-teams.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-teams.ts
@@ -1,0 +1,59 @@
+import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import {
+  ConsumptionTopQuerySchema,
+  toConsumptionPeriodInput,
+} from "@app/lib/api/analytics/consumption/schema";
+import type { GetConsumptionTopTeamsResponse } from "@app/lib/api/analytics/consumption/top_teams";
+import { fetchConsumptionTopTeams } from "@app/lib/api/analytics/consumption/top_teams";
+import logger from "@app/logger/logger";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsManager } from "@front-api/middlewares/ensure_role";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+
+export type { GetConsumptionTopTeamsResponse };
+
+// Mounted at /api/w/:wId/analytics/consumption/top-teams.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsManager(),
+  validate("query", ConsumptionTopQuerySchema),
+  async (ctx): HandlerResult<GetConsumptionTopTeamsResponse> => {
+    const auth = ctx.get("auth");
+    const { limit, filter, ...periodQuery } = ctx.req.valid("query");
+
+    const period = await resolveConsumptionPeriod(
+      auth,
+      toConsumptionPeriodInput(periodQuery)
+    );
+
+    const result = await fetchConsumptionTopTeams(auth, {
+      period,
+      limit,
+      filter,
+    });
+    if (result.isErr()) {
+      logger.error(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          err: result.error,
+        },
+        "[ConsumptionAnalytics] Failed to retrieve top-teams."
+      );
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to retrieve top teams.",
+        },
+      });
+    }
+
+    return ctx.json(result.value);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
@@ -16,6 +16,10 @@ import {
   type GetConsumptionTopSourcesResponse,
 } from "@app/lib/api/analytics/consumption/top_sources";
 import {
+  fetchConsumptionTopTeams,
+  type GetConsumptionTopTeamsResponse,
+} from "@app/lib/api/analytics/consumption/top_teams";
+import {
   fetchConsumptionTopTools,
   type GetConsumptionTopToolsResponse,
 } from "@app/lib/api/analytics/consumption/top_tools";
@@ -56,6 +60,13 @@ vi.mock(
   async (orig) => {
     const mod = await orig();
     return { ...mod, fetchConsumptionTopSources: vi.fn() };
+  }
+);
+vi.mock(
+  import("@app/lib/api/analytics/consumption/top_teams"),
+  async (orig) => {
+    const mod = await orig();
+    return { ...mod, fetchConsumptionTopTeams: vi.fn() };
   }
 );
 vi.mock(
@@ -136,6 +147,20 @@ const TOP_SOURCES: GetConsumptionTopSourcesResponse = {
   ],
 };
 
+const TOP_TEAMS: GetConsumptionTopTeamsResponse = {
+  period: PERIOD,
+  totalCredits: 5000,
+  teams: [
+    {
+      teamId: "team1",
+      name: "Engineering",
+      credits: 200,
+      messageCount: 4,
+      avgCreditsPerMessage: 50,
+    },
+  ],
+};
+
 const TOP_TOOLS: GetConsumptionTopToolsResponse = {
   period: PERIOD,
   totalCredits: 5000,
@@ -165,7 +190,7 @@ const TOP_SKILLS: GetConsumptionTopSkillsResponse = {
 };
 
 // One entry per ranking endpoint. Each owns its own typed mock plumbing so the
-// table stays type-safe across six different response shapes.
+// table stays type-safe across seven different response shapes.
 const RANKINGS = [
   {
     path: "top-agents",
@@ -200,6 +225,13 @@ const RANKINGS = [
         .mocked(fetchConsumptionTopSources)
         .mockResolvedValue(new Ok(TOP_SOURCES)),
     lastCall: () => vi.mocked(fetchConsumptionTopSources).mock.lastCall,
+  },
+  {
+    path: "top-teams",
+    body: TOP_TEAMS,
+    arrangeOk: () =>
+      vi.mocked(fetchConsumptionTopTeams).mockResolvedValue(new Ok(TOP_TEAMS)),
+    lastCall: () => vi.mocked(fetchConsumptionTopTeams).mock.lastCall,
   },
   {
     path: "top-tools",

--- a/front/components/workspace/analytics/consumption/consumptionDimensions.ts
+++ b/front/components/workspace/analytics/consumption/consumptionDimensions.ts
@@ -8,6 +8,7 @@ export const DEFAULT_CONSUMPTION_DIMENSION: ConsumptionDimension = "agent";
 export const CONSUMPTION_DIMENSIONS: ConsumptionDimension[] = [
   "agent",
   "user",
+  "team",
   "model",
   "tool",
   "skill",
@@ -38,6 +39,12 @@ export const CONSUMPTION_DIMENSION_CONFIG: Record<
     label: "Members",
     breakdownLabel: "member",
     hasAvatar: true,
+    avgLabel: MESSAGE_AVG_LABEL,
+  },
+  team: {
+    label: "Teams",
+    breakdownLabel: "team",
+    hasAvatar: false,
     avgLabel: MESSAGE_AVG_LABEL,
   },
   model: {

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -6,6 +6,7 @@ import type { GetConsumptionTopAgentsResponse } from "@app/lib/api/analytics/con
 import type { GetConsumptionTopModelsResponse } from "@app/lib/api/analytics/consumption/top_models";
 import type { GetConsumptionTopSkillsResponse } from "@app/lib/api/analytics/consumption/top_skills";
 import type { GetConsumptionTopSourcesResponse } from "@app/lib/api/analytics/consumption/top_sources";
+import type { GetConsumptionTopTeamsResponse } from "@app/lib/api/analytics/consumption/top_teams";
 import type { GetConsumptionTopToolsResponse } from "@app/lib/api/analytics/consumption/top_tools";
 import type { GetConsumptionTopUsersResponse } from "@app/lib/api/analytics/consumption/top_users";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
@@ -16,6 +17,7 @@ import type { Fetcher } from "swr";
 const CONSUMPTION_TOP_ENDPOINTS = {
   agent: "top-agents",
   user: "top-users",
+  team: "top-teams",
   model: "top-models",
   tool: "top-tools",
   skill: "top-skills",
@@ -33,6 +35,7 @@ export type ConsumptionTopRow = {
 type ConsumptionTopResponse =
   | GetConsumptionTopAgentsResponse
   | GetConsumptionTopUsersResponse
+  | GetConsumptionTopTeamsResponse
   | GetConsumptionTopModelsResponse
   | GetConsumptionTopToolsResponse
   | GetConsumptionTopSkillsResponse
@@ -56,6 +59,15 @@ function toRows(data: ConsumptionTopResponse): ConsumptionTopRow[] {
       id: row.userId,
       name: row.name,
       pictureUrl: row.pictureUrl,
+      credits: row.credits,
+      avgCredits: row.avgCreditsPerMessage,
+    }));
+  }
+  if ("teams" in data) {
+    return data.teams.map((row) => ({
+      id: row.teamId,
+      name: row.name,
+      pictureUrl: null,
       credits: row.credits,
       avgCredits: row.avgCreditsPerMessage,
     }));

--- a/front/lib/api/analytics/consumption/labels.test.ts
+++ b/front/lib/api/analytics/consumption/labels.test.ts
@@ -5,6 +5,7 @@ import {
 import { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
@@ -105,6 +106,22 @@ describe("resolveDimensionLabels", () => {
     expect(labels.get(agent.sId)).toEqual({
       name: "Analytics agent",
       pictureUrl: agent.pictureUrl,
+    });
+  });
+
+  it("labels teams with their group name", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const team = await GroupFactory.regularManual(workspace, "Engineering");
+
+    const labels = await resolveDimensionLabels(authenticator, "team", [
+      team.sId,
+    ]);
+
+    expect(labels.get(team.sId)).toEqual({
+      name: "Engineering",
+      pictureUrl: null,
     });
   });
 });

--- a/front/lib/api/analytics/consumption/labels.ts
+++ b/front/lib/api/analytics/consumption/labels.ts
@@ -5,8 +5,10 @@ import { getUserDisplayName } from "@app/lib/api/assistant/observability/credit_
 import { resolveServerDisplayNames } from "@app/lib/api/assistant/observability/tool_usage";
 import type { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 /**
@@ -16,6 +18,7 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
  * The expected mapping is:
  * - "agent": agent sIds
  * - "user": user sIds
+ * - "team": group sIds
  * - "model": raw model ids
  * - "tool": MCP server names
  * - "skill": skill sIds
@@ -70,6 +73,16 @@ export async function resolveDimensionLabels(
             },
           ];
         })
+      );
+    }
+
+    case "team": {
+      const groups = await GroupResource.listAllWorkspaceGroups(auth, {
+        groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
+      });
+      const namesById = new Map(groups.map((group) => [group.sId, group.name]));
+      return labelsFromNames(
+        new Map(keys.map((key) => [key, namesById.get(key) ?? key]))
       );
     }
 

--- a/front/lib/api/analytics/consumption/scope.test.ts
+++ b/front/lib/api/analytics/consumption/scope.test.ts
@@ -40,6 +40,7 @@ describe("buildConsumptionScopeQuery", () => {
       filter: {
         agents: ["a1"],
         users: ["u1", "u2"],
+        teams: ["team1"],
         models: ["gpt-5.6-luna"],
         tools: ["web_search_&_browse"],
         skills: ["s1"],
@@ -52,6 +53,7 @@ describe("buildConsumptionScopeQuery", () => {
       expect.objectContaining({ range: expect.anything() }),
       { term: { "agent.id": "a1" } },
       { terms: { "user.id": ["u1", "u2"] } },
+      { term: { "user.group_ids": "team1" } },
       { term: { "model.model_id": "gpt-5.6-luna" } },
       { term: { "tool.server_name": "web_search_&_browse" } },
       { term: { "tool.attributed_skill_ids": "s1" } },

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -9,6 +9,7 @@ export const AGENT_MESSAGE_ID_FIELD = "agent_message_id";
 export const CONSUMPTION_SCOPE_DIMENSIONS = [
   "agent",
   "user",
+  "team",
   "model",
   "tool",
   "skill",
@@ -24,6 +25,8 @@ export const CONSUMPTION_DIMENSION_FIELDS: Record<
 > = {
   agent: "agent.id",
   user: "user.id",
+  // Multi-valued: a member can belong to several teams at once.
+  team: "user.group_ids",
   model: "model.model_id",
   tool: "tool.server_name",
   // Multi-valued: one tool call can be attributed to several skills at once.
@@ -34,6 +37,7 @@ export const CONSUMPTION_DIMENSION_FIELDS: Record<
 export const CONSUMPTION_SCOPE_FILTER_KEYS = [
   "agents",
   "users",
+  "teams",
   "models",
   "tools",
   "skills",
@@ -53,6 +57,7 @@ const CONSUMPTION_DIMENSION_FILTER_KEYS: Record<
 > = {
   agent: "agents",
   user: "users",
+  team: "teams",
   model: "models",
   tool: "tools",
   skill: "skills",

--- a/front/lib/api/analytics/consumption/timeseries.test.ts
+++ b/front/lib/api/analytics/consumption/timeseries.test.ts
@@ -243,6 +243,7 @@ describe("fetchConsumptionTimeseries", () => {
     it.each([
       "agent",
       "user",
+      "team",
       "model",
       "tool",
       "skill",

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -4,6 +4,7 @@ import { fetchConsumptionTopAgents } from "@app/lib/api/analytics/consumption/to
 import { fetchConsumptionTopModels } from "@app/lib/api/analytics/consumption/top_models";
 import { fetchConsumptionTopSkills } from "@app/lib/api/analytics/consumption/top_skills";
 import { fetchConsumptionTopSources } from "@app/lib/api/analytics/consumption/top_sources";
+import { fetchConsumptionTopTeams } from "@app/lib/api/analytics/consumption/top_teams";
 import { fetchConsumptionTopTools } from "@app/lib/api/analytics/consumption/top_tools";
 import { fetchConsumptionTopUsers } from "@app/lib/api/analytics/consumption/top_users";
 import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
@@ -218,7 +219,7 @@ describe("consumption top rankings", () => {
     expect(options?.aggregations?.by_group?.aggs?.messages).toBeUndefined();
   });
 
-  it("ranks users and models per message on their own key", async () => {
+  it("ranks users, teams and models per message on their own key", async () => {
     const { auth } = await setup();
     mockAggs({
       buckets: [
@@ -251,6 +252,26 @@ describe("consumption top rankings", () => {
     });
     expect(lastSearchCall()[1]?.aggregations?.by_group?.terms).toMatchObject({
       field: "user.id",
+    });
+
+    mockLabels({ key1: "Engineering" });
+    const teams = await fetchConsumptionTopTeams(auth, {
+      period: PERIOD,
+      limit: 10,
+    });
+    expect(teams.isOk()).toBe(true);
+    if (!teams.isOk()) {
+      return;
+    }
+    expect(teams.value.teams[0]).toEqual({
+      teamId: "key1",
+      name: "Engineering",
+      credits: 2,
+      messageCount: 4,
+      avgCreditsPerMessage: 0.5,
+    });
+    expect(lastSearchCall()[1]?.aggregations?.by_group?.terms).toMatchObject({
+      field: "user.group_ids",
     });
 
     mockLabels({ key1: "Claude 4 Sonnet" });

--- a/front/lib/api/analytics/consumption/top_teams.ts
+++ b/front/lib/api/analytics/consumption/top_teams.ts
@@ -1,0 +1,78 @@
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import {
+  avgCreditsPerUnit,
+  fetchConsumptionTopGroups,
+} from "@app/lib/api/analytics/consumption/top";
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import { resolveDimensionLabels } from "./labels";
+
+/**
+ * Teams ranked by the credits consumed by their members over the period,
+ * averaged per message. A member can belong to several teams, in which case
+ * their consumption is attributed to each team they belonged to when the
+ * message completed.
+ */
+
+export type ConsumptionTopTeamRow = {
+  teamId: string;
+  name: string;
+  credits: number;
+  messageCount: number;
+  avgCreditsPerMessage: number;
+};
+
+export type ConsumptionTopTeams = {
+  period: ConsumptionPeriod;
+  totalCredits: number;
+  // Highest credits first.
+  teams: ConsumptionTopTeamRow[];
+};
+
+export type GetConsumptionTopTeamsResponse = ConsumptionTopTeams;
+
+export async function fetchConsumptionTopTeams(
+  auth: Authenticator,
+  {
+    period,
+    limit,
+    filter,
+  }: {
+    period: ConsumptionPeriod;
+    limit: number;
+    filter?: ConsumptionScopeFilter;
+  }
+): Promise<Result<ConsumptionTopTeams, ElasticsearchError>> {
+  const result = await fetchConsumptionTopGroups(auth, {
+    dimension: "team",
+    unit: "message",
+    period,
+    limit,
+    filter,
+  });
+  if (result.isErr()) {
+    return result;
+  }
+  const { groups, totalCredits } = result.value;
+
+  const labels = await resolveDimensionLabels(
+    auth,
+    "team",
+    groups.map((group) => group.key)
+  );
+
+  return new Ok({
+    period,
+    totalCredits,
+    teams: groups.map((group) => ({
+      teamId: group.key,
+      name: labels.get(group.key)?.name ?? group.key,
+      credits: group.credits,
+      messageCount: group.count,
+      avgCreditsPerMessage: avgCreditsPerUnit(group.credits, group.count),
+    })),
+  });
+}

--- a/front/lib/api/analytics/consumption/top_teams.ts
+++ b/front/lib/api/analytics/consumption/top_teams.ts
@@ -1,3 +1,4 @@
+import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import {
@@ -8,7 +9,6 @@ import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
-import { resolveDimensionLabels } from "./labels";
 
 /**
  * Teams ranked by the credits consumed by their members over the period,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds the team dimension to the new consumption analytics view. 

<img width="1187" height="850" alt="image" src="https://github.com/user-attachments/assets/c7c528f8-b524-4903-92e0-be76d21f1ba1" />

Will add the plumbing to use it in the filter component in a follow up PR.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
