### PR TITLE
[front] enh: support availability in public skill upserts

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -3621,6 +3621,15 @@
                       "format": "email"
                     },
                     "description": "Optional editor email addresses to add to imported or updated skills. Editors must be active workspace builders. Existing skills keep their current editors."
+                  },
+                  "availability": {
+                    "type": "string",
+                    "enum": [
+                      "editors",
+                      "workspace_users",
+                      "users_and_agents"
+                    ],
+                    "description": "Optional availability to apply to imported or updated skills. editors is unpublished, workspace_users is published, and users_and_agents is discoverable. New skills default to editors and existing skills keep their current availability when omitted."
                   }
                 }
               }

--- a/front-api/routes/v1/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/skills/index.test.ts
@@ -14,6 +14,7 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { SkillAvailability } from "@app/types/assistant/skill_configuration";
 import { honoApp } from "@front-api/app";
 import AdmZip from "adm-zip";
 import type formidable from "formidable";
@@ -309,6 +310,102 @@ describe("GET /api/v1/w/[wId]/skills", () => {
 });
 
 describe("POST /api/v1/w/[wId]/skills", () => {
+  it("sets availability when creating and updating imported skills", async () => {
+    const { auth, workspace } = await createPublicApiMockRequest();
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await SpaceFactory.defaults(adminAuth);
+    for (const grantType of [
+      "create",
+      "publish",
+      "make_discoverable",
+    ] as const) {
+      await GroupPermissionResource.setForEverybody(adminAuth, {
+        grantType,
+        resourceType: "skill",
+      });
+    }
+
+    const importWithAvailability = async ({
+      availability,
+      instructions,
+    }: {
+      availability: SkillAvailability;
+      instructions: string;
+    }) => {
+      const result = await importSkillsFromFiles(auth, {
+        uploadedFiles: [
+          await makeSkillZipFile({
+            name: "Imported Skill with Availability",
+            instructions,
+          }),
+        ],
+        availability,
+        source: "api",
+        onConflict: "error",
+      });
+      if (result.isErr()) {
+        throw result.error;
+      }
+      return result.value;
+    };
+
+    const published = await importWithAvailability({
+      availability: "workspace_users",
+      instructions: "Published version.",
+    });
+    expect(published.imported[0]?.availability).toBe("workspace_users");
+
+    const discoverable = await importWithAvailability({
+      availability: "users_and_agents",
+      instructions: "Discoverable version.",
+    });
+    expect(discoverable.updated[0]?.availability).toBe("users_and_agents");
+
+    const unpublished = await importWithAvailability({
+      availability: "editors",
+      instructions: "Unpublished version.",
+    });
+    expect(unpublished.updated[0]?.availability).toBe("editors");
+  });
+
+  it("rejects discoverable imports without the make-discoverable permission", async () => {
+    const { auth, workspace } = await createPublicApiMockRequest();
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await SpaceFactory.defaults(adminAuth);
+    for (const grantType of ["create", "publish"] as const) {
+      await GroupPermissionResource.setForEverybody(adminAuth, {
+        grantType,
+        resourceType: "skill",
+      });
+    }
+
+    const result = await importSkillsFromFiles(auth, {
+      uploadedFiles: [
+        await makeSkillZipFile({
+          name: "Unauthorized Discoverable Skill",
+          instructions: "Should not be imported.",
+        }),
+      ],
+      availability: "users_and_agents",
+      source: "api",
+      onConflict: "error",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe(
+        "You don't have permission to change a skill's auto-discoverable status."
+      );
+    }
+    expect(
+      await SkillResource.fetchByName(auth, "Unauthorized Discoverable Skill")
+    ).toBeNull();
+  });
+
   it("adds provided editors to new and existing imported skills", async () => {
     const { auth, workspace } = await createPublicApiMockRequest();
     const adminAuth = await Authenticator.internalAdminForWorkspace(
@@ -377,6 +474,7 @@ describe("POST /api/v1/w/[wId]/skills", () => {
     if (!updatedSkill) {
       throw new Error("Expected imported skill to be found.");
     }
+    expect(updatedSkill.availability).toBe("editors");
     const updatedEditors = await updatedSkill.listEditors(auth);
     expect(updatedEditors?.map((editor) => editor.email).sort()).toEqual(
       [firstEditor.email, secondEditor.email]

--- a/front-api/routes/v1/w/[wId]/skills/index.ts
+++ b/front-api/routes/v1/w/[wId]/skills/index.ts
@@ -30,6 +30,7 @@ const GetSkillsQuerySchema = z.object({
 const SkillAvailabilitiesSchema = z
   .array(z.enum(SKILL_AVAILABILITIES))
   .optional();
+const SkillAvailabilitySchema = z.enum(SKILL_AVAILABILITIES).optional();
 
 // Mounted at /api/v1/w/:wId/skills.
 //
@@ -143,6 +144,10 @@ app.route("/:skillId", skill);
  *                   type: string
  *                   format: email
  *                 description: Optional editor email addresses to add to imported or updated skills. Editors must be active workspace builders. Existing skills keep their current editors.
+ *               availability:
+ *                 type: string
+ *                 enum: [editors, workspace_users, users_and_agents]
+ *                 description: Optional availability to apply to imported or updated skills. editors is unpublished, workspace_users is published, and users_and_agents is discoverable. New skills default to editors and existing skills keep their current availability when omitted.
  *     responses:
  *       200:
  *         description: Skills import result.
@@ -279,6 +284,20 @@ app.post("/", async (ctx): HandlerResult<ImportSkillsResponseBody> => {
 
   const { editors, names } = fields;
 
+  const availabilityValidation = SkillAvailabilitySchema.safeParse(
+    fields.availability?.[0]
+  );
+  if (!availabilityValidation.success) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          'Invalid availability. Expected "editors", "workspace_users", or "users_and_agents".',
+      },
+    });
+  }
+
   const onConflict = fields.onConflict?.[0] ?? "error";
   if (!isImportConflictStrategy(onConflict)) {
     return apiError(ctx, {
@@ -292,6 +311,7 @@ app.post("/", async (ctx): HandlerResult<ImportSkillsResponseBody> => {
 
   const result = await importSkillsFromFiles(auth, {
     uploadedFiles,
+    availability: availabilityValidation.data,
     editors,
     names,
     source: "api",

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -14,7 +14,10 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import type { SkillSourceType } from "@app/types/assistant/skill_configuration";
+import type {
+  SkillAvailability,
+  SkillSourceType,
+} from "@app/types/assistant/skill_configuration";
 import { DEFAULT_SKILL_AVAILABILITY } from "@app/types/assistant/skill_configuration";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -60,12 +63,14 @@ export async function importSkillsFromFiles(
     uploadedFiles,
     names,
     editors,
+    availability,
     source = "local_file",
     onConflict = "skip",
   }: {
     uploadedFiles: formidable.File[];
     names?: string[];
     editors?: string[];
+    availability?: SkillAvailability;
     source?: FileImportSource;
     onConflict?: ImportConflictStrategyType;
   }
@@ -133,6 +138,54 @@ export async function importSkillsFromFiles(
     return new Err(new Error("No matching importable skills found."));
   }
 
+  const existingSkillsMap = new Map(existingSkills.map((s) => [s.name, s]));
+
+  if (availability !== undefined) {
+    const skillsToUpsert = selectedSkills.filter((skill) => {
+      const existing = existingSkillsMap.get(skill.name);
+      return !(
+        existing &&
+        existing.source !== source &&
+        onConflict !== "override"
+      );
+    });
+    const existingSkillsWithAvailabilityChange = removeNulls(
+      skillsToUpsert.map((skill) => existingSkillsMap.get(skill.name) ?? null)
+    ).filter((skill) => skill.availability !== availability);
+    const createsSkillWithAvailabilityChange =
+      availability !== DEFAULT_SKILL_AVAILABILITY &&
+      skillsToUpsert.some((skill) => !existingSkillsMap.has(skill.name));
+    const availabilityChanged =
+      createsSkillWithAvailabilityChange ||
+      existingSkillsWithAvailabilityChange.length > 0;
+
+    if (
+      availabilityChanged &&
+      !(await auth.hasWorkspacePermission("publish", "skill"))
+    ) {
+      return new Err(
+        new Error("You don't have permission to change skill availability.")
+      );
+    }
+
+    const involvesAutoDiscoverable =
+      availability === "users_and_agents" ||
+      existingSkillsWithAvailabilityChange.some(
+        (skill) => skill.availability === "users_and_agents"
+      );
+    if (
+      availabilityChanged &&
+      involvesAutoDiscoverable &&
+      !(await auth.hasWorkspacePermission("make_discoverable", "skill"))
+    ) {
+      return new Err(
+        new Error(
+          "You don't have permission to change a skill's auto-discoverable status."
+        )
+      );
+    }
+  }
+
   const editorUsersResult = await resolveEditorUsersFromEmails(
     auth,
     editors ?? []
@@ -146,8 +199,6 @@ export async function importSkillsFromFiles(
   const imported: SkillResource[] = [];
   const updated: SkillResource[] = [];
   const skipped: { name: string; message: string }[] = [];
-
-  const existingSkillsMap = new Map(existingSkills.map((s) => [s.name, s]));
 
   for (const skill of selectedSkills) {
     const existing = existingSkillsMap.get(skill.name) ?? null;
@@ -189,6 +240,7 @@ export async function importSkillsFromFiles(
 
       await existing.updateSkill(auth, {
         name: skill.name,
+        availability,
         agentFacingDescription: skill.description,
         userFacingDescription: skill.description,
         instructions: skill.instructions,
@@ -247,7 +299,7 @@ export async function importSkillsFromFiles(
           icon,
           source,
           sourceMetadata: { filePath: skill.skillMdPath },
-          availability: DEFAULT_SKILL_AVAILABILITY,
+          availability: availability ?? DEFAULT_SKILL_AVAILABILITY,
         },
         {
           mcpServerViews: suggestedMCPServerViews,

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -75,7 +75,8 @@ export async function importSkillsFromFiles(
     onConflict?: ImportConflictStrategyType;
   }
 ): Promise<Result<ImportSkillsResult, Error>> {
-  if (!(await auth.hasWorkspacePermission("create", "skill"))) {
+  const canCreateSkills = await auth.hasWorkspacePermission("create", "skill");
+  if (!canCreateSkills) {
     return new Err(new Error("Creating skills is restricted."));
   }
 
@@ -159,13 +160,16 @@ export async function importSkillsFromFiles(
       createsSkillWithAvailabilityChange ||
       existingSkillsWithAvailabilityChange.length > 0;
 
-    if (
-      availabilityChanged &&
-      !(await auth.hasWorkspacePermission("publish", "skill"))
-    ) {
-      return new Err(
-        new Error("You don't have permission to change skill availability.")
+    if (availabilityChanged) {
+      const canPublishSkills = await auth.hasWorkspacePermission(
+        "publish",
+        "skill"
       );
+      if (!canPublishSkills) {
+        return new Err(
+          new Error("You don't have permission to change skill availability.")
+        );
+      }
     }
 
     const involvesAutoDiscoverable =
@@ -173,16 +177,18 @@ export async function importSkillsFromFiles(
       existingSkillsWithAvailabilityChange.some(
         (skill) => skill.availability === "users_and_agents"
       );
-    if (
-      availabilityChanged &&
-      involvesAutoDiscoverable &&
-      !(await auth.hasWorkspacePermission("make_discoverable", "skill"))
-    ) {
-      return new Err(
-        new Error(
-          "You don't have permission to change a skill's auto-discoverable status."
-        )
+    if (availabilityChanged && involvesAutoDiscoverable) {
+      const canMakeSkillsDiscoverable = await auth.hasWorkspacePermission(
+        "make_discoverable",
+        "skill"
       );
+      if (!canMakeSkillsDiscoverable) {
+        return new Err(
+          new Error(
+            "You don't have permission to change a skill's auto-discoverable status."
+          )
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/9972

Public API skill imports always create new skills as unpublished, and changing the availability is not possible.
This PR adds an optional `availability` field to the `POST /api/v1/w/{wId}/skills` endpoint, using the existing `editors`, `workspace_users`, and `users_and_agents` values.

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
