### PR TITLE
Fix Complex stream test after advanced model access cleanup

### DIFF
--- a/front/lib/model_tiers/enabled_models.test.ts
+++ b/front/lib/model_tiers/enabled_models.test.ts
@@ -164,6 +164,10 @@ describe("getModelForStream", () => {
     workspace = await WorkspaceFactory.basic();
     adminAuth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     await FeatureFlagFactory.basic(adminAuth, "models_picker");
+    // The Complex stream leads with Opus, which the basic plan does not have
+    // advanced model access for. These tests exercise stream ordering and tier
+    // caps on a full catalog, so unlock the frontier models explicitly.
+    await FeatureFlagFactory.basic(adminAuth, "claude_4_5_opus_feature");
   });
 
   async function userAuthForTierCap(tierName: "cost_efficient" | "balanced") {


### PR DESCRIPTION
`lib/model_tiers/enabled_models.test.ts > getModelForStream > routes the Complex stream to its first available candidate + effort` is currently red on `main`:

```
AssertionError: expected 'gemini-3.1-pro-preview' to be 'claude-opus-5'
```

## Root cause

Not a bug in `getModelForStream`, and not the Opus 5 rollout. #30248 deliberately removed the `models_picker` escape hatch in `lib/assistant.ts` that used to make advanced models available regardless of plan:

```ts
// before
const includeAdvancedModelInPicker =
  featureFlags.includes("models_picker") && isAdvancedModel(m);
```

That removal is intentional and covered by `lib/assistant.test.ts` → `"should not grant advanced model access through models_picker"`.

The consequence for this test: `WorkspaceFactory.basic()` creates a `PRO_PLAN_SEAT_29` workspace with `hasAdvancedModelAccess: false` and no `claude_4_5_opus_feature` flag. `getAvailableModelsForWorkspace` therefore returns only `claude-haiku-4-5`, `claude-sonnet-5` and `claude-sonnet-4-6` for Anthropic — Opus 5, Opus 4.8 *and* GPT 5.6 Sol (which gained the same gate in #30248) are all filtered out. The Complex stream correctly falls through to its 4th candidate, Gemini 3.1 Pro. The test's premise — "In a full workspace every candidate is available, so the first one wins" — no longer held for its fixture.

## Fix

Restore the premise rather than assert the accident: enable `claude_4_5_opus_feature` alongside `models_picker` in the `getModelForStream` `beforeEach`.

Side benefit: the `cost_efficient`-capped test now genuinely exercises what its comment claims. Previously Opus/Sol weren't in the catalog at all so it passed trivially; now they are present and the tier cap is what makes them non-selectable, leaving Sonnet at `light` as the cost-effective floor.

## Test plan

`npm run test -- lib/model_tiers/` — 24 tests pass (11/11 in `enabled_models.test.ts`).