### PR TITLE
[front] test: update FF settings in complex model choice

### DIFF
--- a/front/lib/model_tiers/enabled_models.test.ts
+++ b/front/lib/model_tiers/enabled_models.test.ts
@@ -10,7 +10,7 @@ import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import {
   CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
-  CLAUDE_OPUS_5_MODEL_ID,
+  CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
 import { MODEL_STREAMS } from "@app/types/assistant/models/auto";
@@ -201,7 +201,7 @@ describe("getModelForStream", () => {
     const resolved = await getModelForStream(adminAuth, "auto_complex");
 
     expect(resolved).not.toBeNull();
-    expect(resolved?.model.modelId).toBe(CLAUDE_OPUS_5_MODEL_ID);
+    expect(resolved?.model.modelId).toBe(CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG.modelId);
     expect(resolved?.reasoningEffort).toBe("high");
   });
 
@@ -215,7 +215,7 @@ describe("getModelForStream", () => {
 
     expect(resolved).not.toBeNull();
     expect(resolved?.model.modelId).toBe(
-      CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId
+      CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG.modelId
     );
     expect(resolved?.reasoningEffort).toBe("light");
   });

--- a/front/lib/model_tiers/enabled_models.test.ts
+++ b/front/lib/model_tiers/enabled_models.test.ts
@@ -163,7 +163,7 @@ describe("getModelForStream", () => {
   beforeEach(async () => {
     workspace = await WorkspaceFactory.basic();
     adminAuth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-    await FeatureFlagFactory.basic(adminAuth, "models_picker");
+    await FeatureFlagFactory.basic(adminAuth, "claude_4_5_opus_feature");
   });
 
   async function userAuthForTierCap(tierName: "cost_efficient" | "balanced") {

--- a/front/lib/model_tiers/enabled_models.test.ts
+++ b/front/lib/model_tiers/enabled_models.test.ts
@@ -201,7 +201,9 @@ describe("getModelForStream", () => {
     const resolved = await getModelForStream(adminAuth, "auto_complex");
 
     expect(resolved).not.toBeNull();
-    expect(resolved?.model.modelId).toBe(CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG.modelId);
+    expect(resolved?.model.modelId).toBe(
+      CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG.modelId
+    );
     expect(resolved?.reasoningEffort).toBe("high");
   });
 

--- a/front/lib/model_tiers/enabled_models.test.ts
+++ b/front/lib/model_tiers/enabled_models.test.ts
@@ -219,7 +219,7 @@ describe("getModelForStream", () => {
     expect(resolved?.model.modelId).toBe(
       CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG.modelId
     );
-    expect(resolved?.reasoningEffort).toBe("light");
+    expect(resolved?.reasoningEffort).toBe("high");
   });
 
   it("only ever resolves to a candidate declared in the stream", async () => {


### PR DESCRIPTION
## Description

Follow up on https://github.com/dust-tt/dust/pull/30248
This PR fixes the test `routes the Complex stream to its first available candidate + effort`.
The test relied on an undesired behavior, where the `models_picker` feature flag would allow to bypass model gating.

## Tests

Yes

## Risk

- N/A.

## Deploy Plan

- N/A.
