### PR TITLE
chore: bump seat count sync activity timeouts

### DIFF
--- a/front/temporal/usage_queue/workflows.ts
+++ b/front/temporal/usage_queue/workflows.ts
@@ -32,8 +32,8 @@ const { emitMetronomeUsageEventsActivity } = proxyActivities<typeof activities>(
 );
 
 const { syncMetronomeSeatCountActivity } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "10 minutes",
-  heartbeatTimeout: "1 minute",
+  startToCloseTimeout: "15 minutes",
+  heartbeatTimeout: "2 minutes",
 });
 
 const { reconcileApiKeyCreditStateActivity } = proxyActivities<


### PR DESCRIPTION
## Description

`syncMetronomeSeatCountActivity` was running longer than its timeouts allowed on some workspaces, so it kept getting cancelled and retried. Bumped the heartbeat timeout to 2 minutes and the start-to-close timeout to 15 minutes.

## Tests

Typecheck + existing tests.

## Risk

Low. A stuck activity now holds a worker slot for up to 15 minutes instead of 10. Rollback is reverting the two values.

## Deploy Plan

Deploy `front`.