### PR TITLE
Bump maxConcurrentActivityTaskExecutions from 16 to 32 for analytics queue

### DIFF
--- a/front/temporal/analytics_queue/worker.ts
+++ b/front/temporal/analytics_queue/worker.ts
@@ -14,6 +14,8 @@ import { QUEUE_NAME } from "./config";
 // Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
 const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 
+const MAX_CONCURRENT_ACTIVITY_TASK_EXECUTIONS = 32;
+
 export async function runAnalyticsWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
@@ -25,7 +27,8 @@ export async function runAnalyticsWorker() {
     activities,
     taskQueue: QUEUE_NAME,
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
-    maxConcurrentActivityTaskExecutions: 16,
+    maxConcurrentActivityTaskExecutions:
+      MAX_CONCURRENT_ACTIVITY_TASK_EXECUTIONS,
     connection,
     namespace,
     shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Since the analytics queue is not being processed by a dedicated deployment, this PR bumps from 16 to 32 the number of concurrent activities it can run in parallel. as we have quite some backlog.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
