### PR TITLE
[front] fix: let `pod_manager` tools move its current conversation

### DIFF
--- a/front/lib/api/actions/servers/pod_manager/tools/index.test.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.test.ts
@@ -1,3 +1,4 @@
+import { makePodConfigurationURI } from "@app/lib/actions/mcp_internal_actions/pod_configuration_uri";
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { AgentLoopRunContext } from "@app/lib/actions/types";
 import { createProjectManagerTools } from "@app/lib/api/actions/servers/pod_manager/tools";
@@ -12,6 +13,7 @@ import {
   isAgentMessageType,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import assert from "assert";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
@@ -121,7 +123,17 @@ async function createConversationFromNestedAgent() {
   );
   assert(createdConversation);
 
-  return { createdConversation, extra, pod, tools };
+  return {
+    agent,
+    auth,
+    createdConversation,
+    extra,
+    parentConversation,
+    pod,
+    tools,
+    user,
+    workspace,
+  };
 }
 
 describe("pod_manager create_conversation", () => {
@@ -151,5 +163,75 @@ describe("pod_manager create_conversation", () => {
     expect(
       output.conversations.map((conversation) => conversation.sId)
     ).toContain(createdConversation.sId);
+  });
+});
+
+describe("pod_manager move_conversation", () => {
+  it("moves the current conversation while its agent loop is running", async () => {
+    const { auth, extra, parentConversation, tools, user, workspace } =
+      await createConversationFromNestedAgent();
+    const targetPod = await SpaceFactory.project(workspace, user.id);
+    await auth.refresh();
+    await ConversationResource.setIsRunningAgentLoop(auth, {
+      conversation: parentConversation,
+      isRunningAgentLoop: true,
+    });
+
+    const result = await getTool(tools, "move_conversation").handler(
+      {
+        destination: "pod",
+        dustPod: {
+          uri: makePodConfigurationURI(workspace.sId, targetPod.sId),
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD,
+        },
+      },
+      extra
+    );
+
+    expect(result.isOk()).toBe(true);
+    const movedConversation = await ConversationResource.fetchById(
+      auth,
+      parentConversation.sId
+    );
+    expect(movedConversation?.toJSON().spaceId).toBe(targetPod.sId);
+  });
+
+  it("still rejects another conversation whose agent loop is running", async () => {
+    const { agent, auth, extra, tools, user, workspace } =
+      await createConversationFromNestedAgent();
+    const targetPod = await SpaceFactory.project(workspace, user.id);
+    const otherConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+    await auth.refresh();
+    await ConversationResource.setIsRunningAgentLoop(auth, {
+      conversation: otherConversation,
+      isRunningAgentLoop: true,
+    });
+
+    const result = await getTool(tools, "move_conversation").handler(
+      {
+        destination: "pod",
+        conversationId: otherConversation.sId,
+        dustPod: {
+          uri: makePodConfigurationURI(workspace.sId, targetPod.sId),
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD,
+        },
+      },
+      extra
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        "Wait for the agent to finish before moving this conversation."
+      );
+    }
+    const unmovedConversation = await ConversationResource.fetchById(
+      auth,
+      otherConversation.sId
+    );
+    expect(unmovedConversation?.toJSON().spaceId).toBeNull();
   });
 });

--- a/front/lib/api/actions/servers/pod_manager/tools/index.test.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.test.ts
@@ -3,12 +3,14 @@ import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/too
 import type { AgentLoopRunContext } from "@app/lib/actions/types";
 import { createProjectManagerTools } from "@app/lib/api/actions/servers/pod_manager/tools";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { processEventForDatabase } from "@app/temporal/agent_loop/activities/common";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { getTestStreamEndpoint } from "@app/tests/utils/models";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { getAgentLoopData } from "@app/types/assistant/agent_run";
 import {
   isAgentMessageType,
   isUserMessageType,
@@ -130,6 +132,7 @@ async function createConversationFromNestedAgent() {
     extra,
     parentConversation,
     pod,
+    runContext,
     tools,
     user,
     workspace,
@@ -167,9 +170,16 @@ describe("pod_manager create_conversation", () => {
 });
 
 describe("pod_manager move_conversation", () => {
-  it("moves the current conversation while its agent loop is running", async () => {
-    const { auth, extra, parentConversation, tools, user, workspace } =
-      await createConversationFromNestedAgent();
+  it("moves the current conversation and lets its agent loop complete", async () => {
+    const {
+      auth,
+      extra,
+      parentConversation,
+      runContext,
+      tools,
+      user,
+      workspace,
+    } = await createConversationFromNestedAgent();
     const targetPod = await SpaceFactory.project(workspace, user.id);
     await auth.refresh();
     await ConversationResource.setIsRunningAgentLoop(auth, {
@@ -194,6 +204,40 @@ describe("pod_manager move_conversation", () => {
       parentConversation.sId
     );
     expect(movedConversation?.toJSON().spaceId).toBe(targetPod.sId);
+
+    const agentLoopArgs = {
+      agentMessageId: runContext.agentMessage.sId,
+      agentMessageVersion: runContext.agentMessage.version,
+      conversationId: parentConversation.sId,
+      conversationTitle: parentConversation.title,
+      userMessageId: runContext.userMessage.sId,
+      userMessageVersion: runContext.userMessage.version,
+      userMessageOrigin: runContext.userMessage.context.origin,
+    };
+    const agentLoopData = await getAgentLoopData(auth.toJSON(), agentLoopArgs);
+    assert(agentLoopData.isOk());
+    expect(agentLoopData.value.conversation.spaceId).toBe(targetPod.sId);
+
+    const shouldPublish = await processEventForDatabase(auth, {
+      event: {
+        type: "agent_message_success",
+        created: Date.now(),
+        configurationId: agentLoopData.value.agentConfiguration.sId,
+        messageId: agentLoopData.value.agentMessage.sId,
+        message: agentLoopData.value.agentMessage,
+        runIds: [],
+      },
+      agentMessage: agentLoopData.value.agentMessage,
+      conversation: agentLoopData.value.conversation,
+      step: 1,
+    });
+    expect(shouldPublish).toBe(true);
+
+    const completedConversation = await ConversationResource.fetchById(
+      auth,
+      parentConversation.sId
+    );
+    expect(completedConversation?.isRunningAgentLoop).toBe(false);
   });
 
   it("still rejects another conversation whose agent loop is running", async () => {

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -1705,6 +1705,11 @@ export function createProjectManagerTools(
           const { pod } = contextRes.value;
           const moveRes = await moveConversationToProject(auth, {
             conversation,
+            currentAgentConversationId: isAgentLoopRunContext(
+              toolContext?.runContext
+            )
+              ? toolContext.runContext.conversation.sId
+              : undefined,
             spaceId: pod.sId,
           });
 

--- a/front/lib/api/projects/conversations.ts
+++ b/front/lib/api/projects/conversations.ts
@@ -34,10 +34,12 @@ export async function moveConversationToProject(
   auth: Authenticator,
   {
     conversation,
+    currentAgentConversationId,
     spaceId,
     transaction,
   }: {
     conversation: ConversationWithoutContentType;
+    currentAgentConversationId?: string;
     spaceId: string;
     transaction?: Transaction;
   }
@@ -53,7 +55,10 @@ export async function moveConversationToProject(
     >
   >
 > {
-  if (conversation.isRunningAgentLoop) {
+  if (
+    conversation.isRunningAgentLoop &&
+    conversation.sId !== currentAgentConversationId
+  ) {
     return new Err(
       new DustError(
         "conversation_agent_running",


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/9992

The `pod_manager.move_conversation` tool always fails when targeting the current conversation as we error when the agent loop is running.

The running-agent guard was introduced in https://github.com/dust-tt/dust/pull/26227 to prevent another caller from moving a conversation somewhere the active loop could no longer access, which could leave the agent message and `isRunningAgentLoop` state stuck.

This PR preserves that protection for UI and cross-conversation moves. It allows the move only when the target ID matches the agent-loop conversation in the tool execution context. In that case the move runs with the same authentication as the active loop and still validates membership in the destination Pod, so subsequent loop activities can rehydrate that authentication and access the moved conversation.

## Tests

- Added test that the moved conversation remains readable to the original agent loop and that its normal success path clears `isRunningAgentLoop`.
- Added test that moving another running conversation remains rejected.

## Risk

- Low.

## Deploy Plan

- Deploy front.
