### PR TITLE
[front] Show poke plugin running feedback for long runs

### DIFF
--- a/front/components/poke/plugins/PluginForm.tsx
+++ b/front/components/poke/plugins/PluginForm.tsx
@@ -35,6 +35,7 @@ interface PluginFormProps {
     Record<string, string | number | boolean | AsyncEnumValues | EnumValues>
   > | null;
   disabled?: boolean;
+  isRunning?: boolean;
   manifest: PokeGetPluginDetailsResponseBody["manifest"];
   onSubmit: (args: FormValues<any>) => Promise<void>;
   pluginResourceTarget: PluginResourceTarget;
@@ -43,11 +44,12 @@ interface PluginFormProps {
 export function PluginForm({
   asyncArgs,
   disabled,
+  isRunning = false,
   manifest,
   onSubmit,
   pluginResourceTarget,
 }: PluginFormProps) {
-  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const argsSchema = useMemo(() => {
     if (!manifest) {
@@ -149,10 +151,16 @@ export function PluginForm({
   });
 
   async function handleSubmit(values: FormValues<typeof argsSchema>) {
-    // Lock the form to prevent multiple submissions.
-    setIsSubmitted(true);
+    if (isSubmitting || isRunning || disabled) {
+      return;
+    }
 
-    await onSubmit(values);
+    setIsSubmitting(true);
+    try {
+      await onSubmit(values);
+    } finally {
+      setIsSubmitting(false);
+    }
   }
 
   if (!manifest) {
@@ -314,8 +322,8 @@ export function PluginForm({
         <Button
           type="submit"
           variant="outline"
-          disabled={isSubmitted}
-          label="Run"
+          disabled={disabled || isRunning || isSubmitting}
+          label={isRunning || isSubmitting ? "Running..." : "Run"}
         />
       </form>
     </PokeForm>

--- a/front/components/poke/plugins/RunPluginDialog.tsx
+++ b/front/components/poke/plugins/RunPluginDialog.tsx
@@ -27,7 +27,16 @@ import {
   useCopyToClipboard,
 } from "@dust-tt/sparkle";
 import { AlertCircle } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+
+function formatElapsed(seconds: number): string {
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes}m ${remainingSeconds}s`;
+}
 
 function pluginResponseToCopyText(result: PluginResponse): string {
   switch (result.display) {
@@ -75,6 +84,8 @@ export function RunPluginDialog({
 }: ExecutePluginDialogProps) {
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<PluginResponse | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
 
   const { isLoading, manifest } = usePokePluginManifest({
     disabled: false,
@@ -99,6 +110,24 @@ export function RunPluginDialog({
 
   const [isCopied, copyToClipboard] = useCopyToClipboard();
 
+  // Tick an elapsed timer every 5s while the plugin runs so long jobs don't
+  // look stalled. Hidden until the first tick so fast plugins stay quiet.
+  useEffect(() => {
+    if (!isRunning) {
+      return;
+    }
+
+    setElapsedSeconds(0);
+    const startedAt = Date.now();
+    const intervalId = window.setInterval(() => {
+      setElapsedSeconds(Math.floor((Date.now() - startedAt) / 1000));
+    }, 5000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [isRunning]);
+
   const handleCopyResult = useCallback(() => {
     if (result) {
       void copyToClipboard(pluginResponseToCopyText(result));
@@ -108,6 +137,7 @@ export function RunPluginDialog({
   const handleClose = () => {
     setError(null);
     setResult(null);
+    setElapsedSeconds(0);
     onClose();
   };
 
@@ -115,12 +145,17 @@ export function RunPluginDialog({
     async (args: object) => {
       setError(null);
       setResult(null);
+      setIsRunning(true);
 
-      const runRes = await doRunPlugin(args);
-      if (runRes.isErr()) {
-        setError(runRes.error);
-      } else {
-        setResult(runRes.value);
+      try {
+        const runRes = await doRunPlugin(args);
+        if (runRes.isErr()) {
+          setError(runRes.error);
+        } else {
+          setResult(runRes.value);
+        }
+      } finally {
+        setIsRunning(false);
       }
     },
     [doRunPlugin]
@@ -153,6 +188,23 @@ export function RunPluginDialog({
             </PokeAlert>
           ) : (
             <>
+              {isRunning && (
+                <PokeAlert>
+                  <div className="flex items-center gap-3">
+                    <Spinner size="sm" />
+                    <div>
+                      <PokeAlertTitle>Running…</PokeAlertTitle>
+                      <PokeAlertDescription>
+                        Still working
+                        {elapsedSeconds >= 5
+                          ? ` · ${formatElapsed(elapsedSeconds)}`
+                          : ""}
+                        . Leave this dialog open until it finishes.
+                      </PokeAlertDescription>
+                    </div>
+                  </div>
+                </PokeAlert>
+              )}
               {error && (
                 <PokeAlert variant="destructive">
                   <PokeAlertTitle>Error</PokeAlertTitle>
@@ -211,7 +263,8 @@ export function RunPluginDialog({
                 </div>
               )}
               <PluginForm
-                disabled={result !== null}
+                disabled={result !== null || isRunning}
+                isRunning={isRunning}
                 manifest={manifest}
                 asyncArgs={asyncArgs}
                 onSubmit={onSubmit}

--- a/front/lib/api/poke/plugins/spaces/activation_management.ts
+++ b/front/lib/api/poke/plugins/spaces/activation_management.ts
@@ -25,6 +25,7 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { startActivationWorkspaceSchedule } from "@app/temporal/activation_scheduler/client";
 import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
@@ -33,6 +34,10 @@ import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 
 const LEARNING_SPACE_NAME_SUFFIX = "'s Learning Space";
+
+// Light parallelism for group runs: enough to cut wall time without
+// stampeding the DB pool / nudge path on a large selection.
+const ACTIVATION_MANAGEMENT_CONCURRENCY = 3;
 
 const activationManagementLogger = logger.child({
   activity: "activation-management",
@@ -267,6 +272,9 @@ export const activationManagementPlugin = createPlugin({
       "Work Areas for the first conversation. Check 'Force " +
       "recreate' to delete and rebuild an existing Pod from scratch.",
     resourceTypes: ["workspaces"],
+    warning:
+      "Large groups can take several minutes — the dialog shows Running… " +
+      "with a timer. Leave it open until it finishes.",
     args: {
       targetUserIds: {
         type: "enum",
@@ -495,107 +503,101 @@ export const activationManagementPlugin = createPlugin({
         ? trimmedPodName
         : null;
 
-    const outcomes: TargetOutcome[] = [];
-    // Sequential to avoid straining the connection pool: provisioning a pod is
-    // a multi-step write and a whole group may be selected at once.
-    for (const user of users) {
-      const name = user.fullName() || user.email;
+    const outcomes = await concurrentExecutor(
+      users,
+      async (user): Promise<TargetOutcome> => {
+        const name = user.fullName() || user.email;
+        const existing = existingPodsByUser.get(user.id);
 
-      const existing = existingPodsByUser.get(user.id);
+        // Reuse path: the user already has a Pod and we're not recreating it —
+        // just nudge it. Never fails on an existing Pod.
+        if (existing && !forceRecreate) {
+          if (!existing.trigger) {
+            return {
+              name,
+              status: "failed",
+              message:
+                "Pod exists but trigger was deleted — use forceRecreate to rebuild it.",
+            };
+          }
+          const nudgeResult = await fireActivationNudge(adminAuth, {
+            pod: existing.pod,
+            trigger: existing.trigger,
+            targetUserId: user.sId,
+            context,
+          });
+          if (nudgeResult.isErr()) {
+            return {
+              name,
+              status: "failed",
+              message: nudgeResult.error.message,
+            };
+          }
+          return {
+            name,
+            status: "nudged",
+            podLink: podLink(existing.pod),
+          };
+        }
 
-      // Reuse path: the user already has a Pod and we're not recreating it —
-      // just nudge it. Never fails on an existing Pod.
-      if (existing && !forceRecreate) {
-        if (!existing.trigger) {
-          outcomes.push({
+        // Force-recreate path: tear down the existing Pod before provisioning a
+        // fresh one. Soft-deleting the space launches the scrub workflow, which
+        // removes the ActivationPod row, nudges, and trigger; the soft-deleted
+        // space is excluded from future lookups so it won't shadow the new Pod.
+        const recreated = Boolean(existing);
+        if (existing) {
+          const deleteResult = await softDeleteSpaceAndLaunchScrubWorkflow(
+            adminAuth,
+            existing.pod,
+            true
+          );
+          if (deleteResult.isErr()) {
+            return {
+              name,
+              status: "failed",
+              message: `failed to delete existing Pod: ${deleteResult.error.message}`,
+            };
+          }
+        }
+
+        const otherUsers = users.filter((u) => u.sId !== user.sId);
+        const provisionResult = await provisionTrainingPod(auth, adminAuth, {
+          creator: user,
+          otherUsers,
+          podNameOverride,
+        });
+        if (provisionResult.isErr()) {
+          return {
             name,
             status: "failed",
-            message:
-              "Pod exists but trigger was deleted — use forceRecreate to rebuild it.",
-          });
-          continue;
+            message: provisionResult.error.message,
+          };
         }
+
+        const { pod, trigger } = provisionResult.value;
         const nudgeResult = await fireActivationNudge(adminAuth, {
-          pod: existing.pod,
-          trigger: existing.trigger,
+          pod,
+          trigger,
           targetUserId: user.sId,
           context,
         });
         if (nudgeResult.isErr()) {
-          outcomes.push({
+          return {
             name,
             status: "failed",
-            message: nudgeResult.error.message,
-          });
-        } else {
-          outcomes.push({
-            name,
-            status: "nudged",
-            podLink: podLink(existing.pod),
-          });
+            message: `${recreated ? "recreated" : "provisioned"} but failed to nudge: ${nudgeResult.error.message}`,
+            podLink: podLink(pod),
+          };
         }
-        continue;
-      }
 
-      // Force-recreate path: tear down the existing Pod before provisioning a
-      // fresh one. Soft-deleting the space launches the scrub workflow, which
-      // removes the ActivationPod row, nudges, and trigger; the soft-deleted
-      // space is excluded from future lookups so it won't shadow the new Pod.
-      const recreated = Boolean(existing);
-      if (existing) {
-        const deleteResult = await softDeleteSpaceAndLaunchScrubWorkflow(
-          adminAuth,
-          existing.pod,
-          true
-        );
-        if (deleteResult.isErr()) {
-          outcomes.push({
-            name,
-            status: "failed",
-            message: `failed to delete existing Pod: ${deleteResult.error.message}`,
-          });
-          continue;
-        }
-      }
-
-      const otherUsers = users.filter((u) => u.sId !== user.sId);
-      const provisionResult = await provisionTrainingPod(auth, adminAuth, {
-        creator: user,
-        otherUsers,
-        podNameOverride,
-      });
-      if (provisionResult.isErr()) {
-        outcomes.push({
+        return {
           name,
-          status: "failed",
-          message: provisionResult.error.message,
-        });
-        continue;
-      }
-
-      const { pod, trigger } = provisionResult.value;
-      const nudgeResult = await fireActivationNudge(adminAuth, {
-        pod,
-        trigger,
-        targetUserId: user.sId,
-        context,
-      });
-      if (nudgeResult.isErr()) {
-        outcomes.push({
-          name,
-          status: "failed",
-          message: `${recreated ? "recreated" : "provisioned"} but failed to nudge: ${nudgeResult.error.message}`,
+          status: recreated ? "recreated" : "provisioned",
           podLink: podLink(pod),
-        });
-        continue;
-      }
-
-      outcomes.push({
-        name,
-        status: recreated ? "recreated" : "provisioned",
-        podLink: podLink(pod),
-      });
-    }
+        };
+      },
+      { concurrency: ACTIVATION_MANAGEMENT_CONCURRENCY }
+    );
 
     const provisioned = outcomes.filter((o) => o.status === "provisioned");
     const recreated = outcomes.filter((o) => o.status === "recreated");

--- a/front/lib/api/poke/plugins/spaces/activation_management.ts
+++ b/front/lib/api/poke/plugins/spaces/activation_management.ts
@@ -25,7 +25,6 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { startActivationWorkspaceSchedule } from "@app/temporal/activation_scheduler/client";
 import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
@@ -34,10 +33,6 @@ import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 
 const LEARNING_SPACE_NAME_SUFFIX = "'s Learning Space";
-
-// Light parallelism for group runs: enough to cut wall time without
-// stampeding the DB pool / nudge path on a large selection.
-const ACTIVATION_MANAGEMENT_CONCURRENCY = 3;
 
 const activationManagementLogger = logger.child({
   activity: "activation-management",
@@ -272,9 +267,7 @@ export const activationManagementPlugin = createPlugin({
       "Work Areas for the first conversation. Check 'Force " +
       "recreate' to delete and rebuild an existing Pod from scratch.",
     resourceTypes: ["workspaces"],
-    warning:
-      "Large groups can take several minutes — the dialog shows Running… " +
-      "with a timer. Leave it open until it finishes.",
+    warning: "Large groups can take several minutes.",
     args: {
       targetUserIds: {
         type: "enum",
@@ -503,101 +496,107 @@ export const activationManagementPlugin = createPlugin({
         ? trimmedPodName
         : null;
 
-    const outcomes = await concurrentExecutor(
-      users,
-      async (user): Promise<TargetOutcome> => {
-        const name = user.fullName() || user.email;
-        const existing = existingPodsByUser.get(user.id);
+    const outcomes: TargetOutcome[] = [];
+    // Sequential to avoid straining the connection pool: provisioning a pod is
+    // a multi-step write and a whole group may be selected at once.
+    for (const user of users) {
+      const name = user.fullName() || user.email;
 
-        // Reuse path: the user already has a Pod and we're not recreating it —
-        // just nudge it. Never fails on an existing Pod.
-        if (existing && !forceRecreate) {
-          if (!existing.trigger) {
-            return {
-              name,
-              status: "failed",
-              message:
-                "Pod exists but trigger was deleted — use forceRecreate to rebuild it.",
-            };
-          }
-          const nudgeResult = await fireActivationNudge(adminAuth, {
-            pod: existing.pod,
-            trigger: existing.trigger,
-            targetUserId: user.sId,
-            context,
-          });
-          if (nudgeResult.isErr()) {
-            return {
-              name,
-              status: "failed",
-              message: nudgeResult.error.message,
-            };
-          }
-          return {
-            name,
-            status: "nudged",
-            podLink: podLink(existing.pod),
-          };
-        }
+      const existing = existingPodsByUser.get(user.id);
 
-        // Force-recreate path: tear down the existing Pod before provisioning a
-        // fresh one. Soft-deleting the space launches the scrub workflow, which
-        // removes the ActivationPod row, nudges, and trigger; the soft-deleted
-        // space is excluded from future lookups so it won't shadow the new Pod.
-        const recreated = Boolean(existing);
-        if (existing) {
-          const deleteResult = await softDeleteSpaceAndLaunchScrubWorkflow(
-            adminAuth,
-            existing.pod,
-            true
-          );
-          if (deleteResult.isErr()) {
-            return {
-              name,
-              status: "failed",
-              message: `failed to delete existing Pod: ${deleteResult.error.message}`,
-            };
-          }
-        }
-
-        const otherUsers = users.filter((u) => u.sId !== user.sId);
-        const provisionResult = await provisionTrainingPod(auth, adminAuth, {
-          creator: user,
-          otherUsers,
-          podNameOverride,
-        });
-        if (provisionResult.isErr()) {
-          return {
+      // Reuse path: the user already has a Pod and we're not recreating it —
+      // just nudge it. Never fails on an existing Pod.
+      if (existing && !forceRecreate) {
+        if (!existing.trigger) {
+          outcomes.push({
             name,
             status: "failed",
-            message: provisionResult.error.message,
-          };
+            message:
+              "Pod exists but trigger was deleted — use forceRecreate to rebuild it.",
+          });
+          continue;
         }
-
-        const { pod, trigger } = provisionResult.value;
         const nudgeResult = await fireActivationNudge(adminAuth, {
-          pod,
-          trigger,
+          pod: existing.pod,
+          trigger: existing.trigger,
           targetUserId: user.sId,
           context,
         });
         if (nudgeResult.isErr()) {
-          return {
+          outcomes.push({
             name,
             status: "failed",
-            message: `${recreated ? "recreated" : "provisioned"} but failed to nudge: ${nudgeResult.error.message}`,
-            podLink: podLink(pod),
-          };
+            message: nudgeResult.error.message,
+          });
+        } else {
+          outcomes.push({
+            name,
+            status: "nudged",
+            podLink: podLink(existing.pod),
+          });
         }
+        continue;
+      }
 
-        return {
+      // Force-recreate path: tear down the existing Pod before provisioning a
+      // fresh one. Soft-deleting the space launches the scrub workflow, which
+      // removes the ActivationPod row, nudges, and trigger; the soft-deleted
+      // space is excluded from future lookups so it won't shadow the new Pod.
+      const recreated = Boolean(existing);
+      if (existing) {
+        const deleteResult = await softDeleteSpaceAndLaunchScrubWorkflow(
+          adminAuth,
+          existing.pod,
+          true
+        );
+        if (deleteResult.isErr()) {
+          outcomes.push({
+            name,
+            status: "failed",
+            message: `failed to delete existing Pod: ${deleteResult.error.message}`,
+          });
+          continue;
+        }
+      }
+
+      const otherUsers = users.filter((u) => u.sId !== user.sId);
+      const provisionResult = await provisionTrainingPod(auth, adminAuth, {
+        creator: user,
+        otherUsers,
+        podNameOverride,
+      });
+      if (provisionResult.isErr()) {
+        outcomes.push({
           name,
-          status: recreated ? "recreated" : "provisioned",
+          status: "failed",
+          message: provisionResult.error.message,
+        });
+        continue;
+      }
+
+      const { pod, trigger } = provisionResult.value;
+      const nudgeResult = await fireActivationNudge(adminAuth, {
+        pod,
+        trigger,
+        targetUserId: user.sId,
+        context,
+      });
+      if (nudgeResult.isErr()) {
+        outcomes.push({
+          name,
+          status: "failed",
+          message: `${recreated ? "recreated" : "provisioned"} but failed to nudge: ${nudgeResult.error.message}`,
           podLink: podLink(pod),
-        };
-      },
-      { concurrency: ACTIVATION_MANAGEMENT_CONCURRENCY }
-    );
+        });
+        continue;
+      }
+
+      outcomes.push({
+        name,
+        status: recreated ? "recreated" : "provisioned",
+        podLink: podLink(pod),
+      });
+    }
 
     const provisioned = outcomes.filter((o) => o.status === "provisioned");
     const recreated = outcomes.filter((o) => o.status === "recreated");


### PR DESCRIPTION
## Summary
-Purpose is to avoid poke tools looking like they stalled mid run
- Show a Running… spinner in the poke plugin dialog while a plugin executes, with an elapsed timer that appears after 5s and updates every 5s

## Test plan
<img width="585" height="742" alt="Screenshot 2026-08-10 at 12 53 10 PM" src="https://github.com/user-attachments/assets/f512b63a-f913-40c6-b7f6-d56b7a934762" />

## Risk
Low

## Deploy
1.Deploy front
