### PR TITLE
fix(model-picker): unlock premium efforts for upgraded and advanced-access plans

### DIFF
--- a/front/components/model_picker/ModelPicker.tsx
+++ b/front/components/model_picker/ModelPicker.tsx
@@ -19,6 +19,7 @@ import {
 import { getModelMakerLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { useModels } from "@app/lib/swr/models";
 import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
 import { isModelStreamId } from "@app/types/assistant/models/auto";
@@ -93,7 +94,12 @@ export function ModelPicker({
   const { hasFeature } = useFeatureFlags();
   const hasModelsPicker = hasFeature("models_picker");
   const { subscription } = useAuth();
-  const lockPremiumEfforts = !isCreditPricedPlan(subscription.plan);
+  const canSelectPremiumModels =
+    isUpgraded(subscription.plan) ||
+    isCreditPricedPlan(subscription.plan) ||
+    subscription.plan.hasAdvancedModelAccess ||
+    hasFeature("claude_4_5_opus_feature");
+  const lockPremiumEfforts = !canSelectPremiumModels;
 
   const { isDark } = useTheme();
 


### PR DESCRIPTION
## Description

Broaden which plans can select premium reasoning efforts in the model picker.

Previously premium efforts were only unlocked for credit-priced plans (`!isCreditPricedPlan` was the sole gate). Upgraded plans, plans with `hasAdvancedModelAccess`, and workspaces with the `claude_4_5_opus_feature` flag were incorrectly locked out.

The gate is now expressed as an explicit `canSelectPremiumModels` predicate that unlocks premium efforts when any of the following holds:

- the plan is upgraded (`isUpgraded`)
- the plan is credit-priced (`isCreditPricedPlan`, existing behavior)
- the plan has `hasAdvancedModelAccess`
- the workspace has the `claude_4_5_opus_feature` flag
