### PR TITLE
Poke plugin delete frame

### DIFF
--- a/front/admin/audit_log_schemas/frame.deleted_admin.json
+++ b/front/admin/audit_log_schemas/frame.deleted_admin.json
@@ -1,0 +1,12 @@
+{
+  "action": "frame.deleted_admin",
+  "targets": [
+    { "type": "workspace" },
+    { "type": "frame" }
+  ],
+  "metadata": {
+    "frame_name": "string",
+    "source": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/components/poke/pages/FramePage.tsx
+++ b/front/components/poke/pages/FramePage.tsx
@@ -1,3 +1,4 @@
+import { PluginList } from "@app/components/poke/plugins/PluginList";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useRequiredPathParam } from "@app/lib/platform";
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
@@ -99,6 +100,14 @@ export function FramePage() {
             size="sm"
           />
         </div>
+
+        <PluginList
+          pluginResourceTarget={{
+            resourceId: file.sId,
+            resourceType: "files",
+            workspace: owner,
+          }}
+        />
 
         {/* Metadata Card */}
         <div className="rounded-lg border">

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -30,6 +30,7 @@
   "dust_mcp_server.settings_updated": 1,
   "file.moved": 1,
   "frame.authorized_files_updated": 1,
+  "frame.deleted_admin": 1,
   "frame.email_grant_added": 2,
   "frame.email_grant_revoked": 3,
   "frame.share_scope_updated": 2,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -169,6 +169,7 @@ export const AUDIT_ACTIONS = [
   // Files.
   "file.moved",
   "frame.authorized_files_updated",
+  "frame.deleted_admin",
   "frame.email_grant_added",
   "frame.email_grant_revoked",
   "frame.share_scope_updated",

--- a/front/lib/api/poke/plugins/files/delete_frame.test.ts
+++ b/front/lib/api/poke/plugins/files/delete_frame.test.ts
@@ -1,13 +1,10 @@
 import { deleteFramePlugin } from "@app/lib/api/poke/plugins/files/delete_frame";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
-import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
-import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { frameContentType } from "@app/types/files";
 import { DEFAULT_POD_FRAME_TAB_ICON } from "@app/types/pod_frame_tab";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -30,31 +27,6 @@ beforeEach(() => {
 });
 
 describe("deleteFramePlugin", () => {
-  it("requires an exact confirmation before deleting", async () => {
-    const { authenticator: auth } = await createResourceTest({ role: "admin" });
-    const conversation = await ConversationFactory.create(auth, {
-      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-      messagesCreatedAt: [new Date()],
-    });
-    const frame = await FileFactory.create(auth, null, {
-      contentType: frameContentType,
-      fileName: "Dashboard.tsx",
-      fileSize: 100,
-      status: "ready",
-      useCase: "conversation",
-      useCaseMetadata: { conversationId: conversation.sId },
-    });
-
-    const result = await deleteFramePlugin.execute(auth, frame, {
-      confirmation: "delete",
-    });
-
-    expect(result.isErr()).toBe(true);
-    await expect(
-      FileResource.fetchById(auth, frame.sId)
-    ).resolves.not.toBeNull();
-  });
-
   it("deletes a Pod Frame and removes its banner and tab references", async () => {
     const {
       authenticator: auth,

--- a/front/lib/api/poke/plugins/files/delete_frame.test.ts
+++ b/front/lib/api/poke/plugins/files/delete_frame.test.ts
@@ -1,0 +1,113 @@
+import { deleteFramePlugin } from "@app/lib/api/poke/plugins/files/delete_frame";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { frameContentType } from "@app/types/files";
+import { DEFAULT_POD_FRAME_TAB_ICON } from "@app/types/pod_frame_tab";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEmitAuditLogEvent } = vi.hoisted(() => ({
+  mockEmitAuditLogEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/audit/workos_audit")>();
+  return { ...actual, emitAuditLogEvent: mockEmitAuditLogEvent };
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  fileStorageMock.reset();
+  mockEmitAuditLogEvent.mockReset();
+  mockEmitAuditLogEvent.mockResolvedValue(undefined);
+});
+
+describe("deleteFramePlugin", () => {
+  it("requires an exact confirmation before deleting", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameContentType,
+      fileName: "Dashboard.tsx",
+      fileSize: 100,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    const result = await deleteFramePlugin.execute(auth, frame, {
+      confirmation: "delete",
+    });
+
+    expect(result.isErr()).toBe(true);
+    await expect(
+      FileResource.fetchById(auth, frame.sId)
+    ).resolves.not.toBeNull();
+  });
+
+  it("deletes a Pod Frame and removes its banner and tab references", async () => {
+    const {
+      authenticator: auth,
+      user,
+      workspace,
+    } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace, user.id);
+    const frame = await ProjectFileFactory.create(auth, user, pod, {
+      contentType: frameContentType,
+      fileName: "Dashboard.tsx",
+      fileSize: 100,
+      status: "ready",
+    });
+    const framePath = frame.toScopedPath(auth);
+    expect(framePath).not.toBeNull();
+    if (!framePath) {
+      throw new Error("Expected a scoped Pod Frame path.");
+    }
+
+    await ProjectMetadataResource.makeNew(auth, pod, {
+      description: null,
+      pinnedFramePath: framePath,
+      frameTabs: [
+        {
+          path: framePath,
+          title: "Dashboard",
+          icon: DEFAULT_POD_FRAME_TAB_ICON,
+        },
+      ],
+      tabsOrder: [framePath],
+    });
+
+    const result = await deleteFramePlugin.execute(auth, frame, {
+      confirmation: "DELETE",
+    });
+
+    expect(result.isOk()).toBe(true);
+    await expect(FileResource.fetchById(auth, frame.sId)).resolves.toBeNull();
+
+    const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+    expect(metadata?.pinnedFramePath).toBeNull();
+    expect(metadata?.frameTabs).toEqual([]);
+    expect(metadata?.tabsOrder).not.toContain(framePath);
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "frame.deleted_admin",
+        metadata: {
+          frame_name: "Dashboard.tsx",
+          source: "poke",
+        },
+      })
+    );
+  });
+});

--- a/front/lib/api/poke/plugins/files/delete_frame.ts
+++ b/front/lib/api/poke/plugins/files/delete_frame.ts
@@ -1,0 +1,121 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
+import { createPlugin } from "@app/lib/api/poke/types";
+import { removeFileFromProject } from "@app/lib/api/projects/context";
+import type { Authenticator } from "@app/lib/auth";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+async function deleteFrame(
+  auth: Authenticator,
+  file: FileResource
+): Promise<Result<void, Error>> {
+  if (file.useCase !== "project_context") {
+    return file.delete(auth);
+  }
+
+  const podId = file.useCaseMetadata?.spaceId;
+  const pod = podId ? await SpaceResource.fetchById(auth, podId) : null;
+  if (!pod?.isProject()) {
+    return new Err(new Error("Pod not found for this Frame."));
+  }
+
+  const scopedPath = file.toScopedPath(auth);
+  if (!scopedPath) {
+    return new Err(new Error("Canonical Pod path not found for this Frame."));
+  }
+
+  const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+  // Cleans up project references, then delegates GCS and DB deletion to FileResource.delete().
+  const deleteResult = await removeFileFromProject(auth, {
+    space: pod,
+    fileId: file.sId,
+  });
+  if (deleteResult.isErr()) {
+    return new Err(deleteResult.error);
+  }
+
+  if (metadata && scopedPath) {
+    try {
+      await metadata.removeFramePath(scopedPath);
+    } catch (error) {
+      // The Frame is already deleted at this point, so do not report a failed
+      // operation that cannot safely be retried. Keep the metadata cleanup
+      // best-effort and retain enough context to repair stale tabs manually.
+      logger.warn(
+        {
+          error,
+          fileId: file.sId,
+          framePath: scopedPath,
+          spaceId: pod.sId,
+          workspaceId: auth.getNonNullableWorkspace().sId,
+        },
+        "[Poke Plugin] Deleted Frame but failed to clean up Pod metadata"
+      );
+    }
+  }
+
+  return new Ok(undefined);
+}
+
+export const deleteFramePlugin = createPlugin({
+  manifest: {
+    id: "delete-frame",
+    name: "Delete Frame",
+    description: "Permanently delete this Frame and invalidate its share URL.",
+    warning: "This is permanent and cannot be undone.",
+    resourceTypes: ["files"],
+    args: {
+      confirmation: {
+        type: "string",
+        label: "Type DELETE to confirm",
+        description: "Deletion cannot be undone.",
+      },
+    },
+    requiredRoles: ["engineering", "support"],
+  },
+  execute: async (auth, file, args) => {
+    if (!file?.isInteractiveContent) {
+      return new Err(new Error("Frame not found."));
+    }
+    if (args.confirmation !== "DELETE") {
+      return new Err(new Error("Type DELETE to confirm deletion."));
+    }
+
+    const frameName = file.fileName ?? file.sId;
+    const deleteResult = await deleteFrame(auth, file);
+    if (deleteResult.isErr()) {
+      return deleteResult;
+    }
+
+    void emitAuditLogEvent({
+      auth,
+      action: "frame.deleted_admin",
+      targets: [
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        buildAuditLogTarget("frame", {
+          sId: file.sId,
+          name: frameName,
+        }),
+      ],
+      context: getAuditLogContext(auth),
+      metadata: {
+        frame_name: frameName,
+        source: "poke",
+      },
+    });
+
+    return new Ok({
+      display: "text",
+      value: `Frame "${frameName}" was permanently deleted.`,
+    });
+  },
+  isApplicableTo: (auth, file) => file?.isInteractiveContent === true,
+});

--- a/front/lib/api/poke/plugins/files/index.ts
+++ b/front/lib/api/poke/plugins/files/index.ts
@@ -1,0 +1,1 @@
+export * from "./delete_frame";

--- a/front/lib/api/poke/plugins/index.ts
+++ b/front/lib/api/poke/plugins/index.ts
@@ -3,6 +3,7 @@ export * from "./apps";
 export * from "./conversations";
 export * from "./data_source_views";
 export * from "./data_sources";
+export * from "./files";
 export * from "./global";
 export * from "./mcp_server_views";
 export * from "./skills";

--- a/front/lib/api/poke/utils.ts
+++ b/front/lib/api/poke/utils.ts
@@ -5,6 +5,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -21,6 +22,7 @@ export type ResourceTypeMap = {
   conversations: ConversationType;
   workspaces: LightWorkspaceType;
   data_sources: DataSourceResource;
+  files: FileResource;
   mcp_server_views: MCPServerViewResource;
   skills: SkillResource;
   spaces: SpaceResource;
@@ -60,6 +62,9 @@ export async function fetchPluginResource<T extends SupportedResourceType>(
       break;
     case "data_source_views":
       result = await DataSourceViewResource.fetchById(auth, resourceId);
+      break;
+    case "files":
+      result = await FileResource.fetchById(auth, resourceId);
       break;
     case "mcp_server_views":
       result = await MCPServerViewResource.fetchById(auth, resourceId);

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -233,6 +233,29 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
     await this.update({ frameTabs, tabsOrder }, transaction);
   }
 
+  async removeFramePath(
+    framePath: string,
+    transaction?: Transaction
+  ): Promise<void> {
+    const frameTabs = (this.frameTabs ?? []).filter(
+      (tab) => tab.path !== framePath
+    );
+    const tabsOrder = normalizeTabsOrder(
+      (this.tabsOrder ?? []).filter((entry) => entry !== framePath),
+      frameTabs.map((tab) => tab.path)
+    );
+
+    await this.update(
+      {
+        pinnedFramePath:
+          this.pinnedFramePath === framePath ? null : this.pinnedFramePath,
+        frameTabs,
+        tabsOrder,
+      },
+      transaction
+    );
+  }
+
   async updateDefaultAgentId(
     defaultAgentId: string | null,
     transaction?: Transaction

--- a/front/types/poke/plugins.ts
+++ b/front/types/poke/plugins.ts
@@ -225,6 +225,7 @@ export const supportedResourceTypes = [
   "conversations",
   "data_source_views",
   "data_sources",
+  "files",
   "mcp_server_views",
   "skills",
   "spaces",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread [here](https://dust4ai.slack.com/archives/C09C8L42C8M/p1786383163897329). 

This PR adds a Poke plugin to permanently delete a frame. Pod Frames use the project-aware deletion path, removing their GCS files, database records, project references, pinned banner, and tab metadata. Deletions require explicit confirmation and emit a WorkOS audit event.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
