### PR TITLE
[front] fix: stop unlocking premium efforts for merely upgraded plans

### DIFF
--- a/front/components/model_picker/ModelPicker.tsx
+++ b/front/components/model_picker/ModelPicker.tsx
@@ -19,7 +19,6 @@ import {
 import { getModelMakerLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
-import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { useModels } from "@app/lib/swr/models";
 import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
 import { isModelStreamId } from "@app/types/assistant/models/auto";
@@ -95,7 +94,6 @@ export function ModelPicker({
   const hasModelsPicker = hasFeature("models_picker");
   const { subscription } = useAuth();
   const canSelectPremiumModels =
-    isUpgraded(subscription.plan) ||
     isCreditPricedPlan(subscription.plan) ||
     subscription.plan.hasAdvancedModelAccess ||
     hasFeature("claude_4_5_opus_feature");


### PR DESCRIPTION
## Description

Follow-up to `30290`: remove `isUpgraded(subscription.plan)` from the `canSelectPremiumModels` condition in the model picker. Premium efforts now stay locked for plans that are only upgraded — they remain available for credit-priced plans, plans with advanced model access, and workspaces with the `claude_4_5_opus_feature` flag.

## Risk

Low — narrows an over-broad unlock in the model picker UI.

## Deploy Plan

Deploy `front`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)