### PR TITLE
[dsbx] feat: pod-scoped generic worker pool with app affinity

### DIFF
--- a/cli/dust-sandbox/functions-runner/fixtures/slow-import.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/slow-import.ts
@@ -1,0 +1,9 @@
+// Top-level await delays the IMPORT itself, so tests can pin behaviors that
+// depend on the worker being inside its resolve/hash/import pipeline.
+await new Promise((resolve) => setTimeout(resolve, 400));
+
+export default {
+  async fetch(): Promise<Response> {
+    return Response.json({ imported: true });
+  },
+};

--- a/cli/dust-sandbox/functions-runner/runner.ts
+++ b/cli/dust-sandbox/functions-runner/runner.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env bun
 // Embedded runner for `dsbx function` and `dsbx db`. Subcommands:
 //   runner run <path>                            stdin request envelope -> stdout Output JSON
-//   runner serve <path> <socketPath>             warm server: keep <path> imported, serve
-//                                                invocations over a unix socket until idle
+//   runner serve <functionsDir> <socketPath>     warm worker: serve invocations of any function
+//                                                in <functionsDir> over a unix socket until idle
 //   runner get <path>                            -> stdout FunctionSchema JSON (or {error})
 //   runner build <src> <outBundle> <outSchema>   bundle + extract schema to files
 //   runner db-reconcile <dbPath> <schemaFile>    additive-only DDL reconcile -> stdout envelope
@@ -177,15 +177,15 @@ async function main(): Promise<number> {
     case "get":
       return getHandler(handlerPath);
     case "serve": {
-      const [, socketPath] = rest;
-      if (!socketPath) {
+      const [functionsDir, socketPath] = rest;
+      if (!functionsDir || !socketPath) {
         process.stderr.write(
-          "usage: runner serve <handler-path> <socket-path>\n"
+          "usage: runner serve <functions-dir> <socket-path>\n"
         );
         return 2;
       }
-      // Never returns: the server exits itself (idle, lifetime, staleness).
-      return serve(handlerPath, socketPath);
+      // Never returns: the worker exits itself (idle, lifetime, staleness).
+      return serve(functionsDir, socketPath);
     }
     default:
       process.stderr.write(`runner: unknown command "${command}"\n`);

--- a/cli/dust-sandbox/functions-runner/serve.test.ts
+++ b/cli/dust-sandbox/functions-runner/serve.test.ts
@@ -6,14 +6,15 @@ import { join } from "node:path";
 import {
   MAX_CONCURRENT_INVOCATIONS,
   parseWarmRequest,
+  resolveBundle,
   WARM_PROTOCOL_VERSION,
 } from "./serve.ts";
 
 const runner = join(import.meta.dir, "runner.ts");
-const fx = (n: string) => join(import.meta.dir, "fixtures", n);
+const fixturesDir = join(import.meta.dir, "fixtures");
 
-// Each test gets its own scratch dir holding the socket and a private copy of
-// the fixture (staleness tests rewrite it).
+// Each test gets its own scratch dir holding the socket (and, for staleness
+// tests, a private functions dir whose bundles it rewrites).
 let scratchDirs: string[] = [];
 
 function scratch(): string {
@@ -34,9 +35,9 @@ interface ServerHandle {
   socketPath: string;
 }
 
-async function startServer(handlerPath: string): Promise<ServerHandle> {
+async function startWorker(functionsDir: string): Promise<ServerHandle> {
   const socketPath = join(scratch(), "fn.sock");
-  const proc = Bun.spawn(["bun", runner, "serve", handlerPath, socketPath], {
+  const proc = Bun.spawn(["bun", runner, "serve", functionsDir, socketPath], {
     stdin: "ignore",
     stdout: "ignore",
     stderr: "inherit",
@@ -55,7 +56,7 @@ async function startServer(handlerPath: string): Promise<ServerHandle> {
       await new Promise((resolve) => setTimeout(resolve, 25));
     }
   }
-  throw new Error("warm server did not come up");
+  throw new Error("warm worker did not come up");
 }
 
 interface WarmReply {
@@ -66,11 +67,12 @@ interface WarmReply {
     output?: unknown;
     error?: { code: string };
   };
+  importKind?: string;
   stale?: boolean;
   error?: string;
 }
 
-// Collects every newline-delimited frame until the server closes the
+// Collects every newline-delimited frame until the worker closes the
 // connection: a served invocation is [ack, outcome], every refusal is a
 // single frame.
 async function requestFrames(
@@ -115,29 +117,41 @@ async function request(
 ): Promise<WarmReply> {
   const frames = await requestFrames(socketPath, payload);
   if (frames.length === 0) {
-    throw new Error("server closed without any frame");
+    throw new Error("worker closed without any frame");
   }
   return frames[frames.length - 1]!;
 }
 
-function warmRequest(env: Record<string, string>, input: unknown) {
+function warmRequest(
+  name: string,
+  env: Record<string, string>,
+  input: unknown
+) {
   return {
     v: WARM_PROTOCOL_VERSION,
     env,
     input: JSON.stringify(input),
+    name,
   };
 }
 
 const sleepyRequest = (delayMs: number) =>
-  warmRequest({}, { url: `http://localhost/?delayMs=${delayMs}` });
+  warmRequest("sleepy", {}, { url: `http://localhost/?delayMs=${delayMs}` });
+
+async function sha256Of(path: string): Promise<string> {
+  const bytes = await Bun.file(path).arrayBuffer();
+  return new Bun.CryptoHasher("sha256")
+    .update(new Uint8Array(bytes))
+    .digest("hex");
+}
 
 describe("runner serve", () => {
   test("serves an invocation over the socket", async () => {
-    const { proc, socketPath } = await startServer(fx("hello.ts"));
+    const { proc, socketPath } = await startWorker(fixturesDir);
     try {
       const reply = await request(
         socketPath,
-        warmRequest({}, { url: "http://localhost/?name=warm" })
+        warmRequest("hello", {}, { url: "http://localhost/?name=warm" })
       );
       expect(reply.v).toBe(WARM_PROTOCOL_VERSION);
       expect(reply.outcome?.ok).toBe(true);
@@ -147,23 +161,57 @@ describe("runner serve", () => {
     }
   });
 
-  test("serves repeat invocations from the same process", async () => {
-    const { proc, socketPath } = await startServer(fx("hello.ts"));
+  test("serves multiple functions from one process, reporting import kinds", async () => {
+    const { proc, socketPath } = await startWorker(fixturesDir);
     try {
-      for (const name of ["one", "two", "three"]) {
-        const reply = await request(
-          socketPath,
-          warmRequest({}, { url: `http://localhost/?name=${name}` })
-        );
-        expect(reply.outcome?.output).toEqual({ hello: name });
-      }
+      const first = await requestFrames(
+        socketPath,
+        warmRequest("hello", {}, { url: "http://localhost/?name=one" })
+      );
+      expect(first[1]?.importKind).toBe("fresh");
+
+      const again = await requestFrames(
+        socketPath,
+        warmRequest("hello", {}, { url: "http://localhost/?name=two" })
+      );
+      expect(again[1]?.outcome?.output).toEqual({ hello: "two" });
+      expect(again[1]?.importKind).toBe("cached");
+
+      // A different function on the same worker: its own lazy import, its
+      // own module, no interference.
+      const other = await requestFrames(
+        socketPath,
+        warmRequest("throws", {}, { url: "http://localhost/" })
+      );
+      expect(other[1]?.outcome?.ok).toBe(false);
+      expect(other[1]?.outcome?.error?.code).toBe("threw");
+      expect(other[1]?.importKind).toBe("fresh");
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("an unknown function name is refused without dying", async () => {
+    const { proc, socketPath } = await startWorker(fixturesDir);
+    try {
+      const missing = await request(
+        socketPath,
+        warmRequest("no-such-function", {}, { url: "http://localhost/" })
+      );
+      expect(missing.stale).toBe(true);
+
+      const alive = await request(
+        socketPath,
+        warmRequest("hello", {}, { url: "http://localhost/?name=alive" })
+      );
+      expect(alive.outcome?.output).toEqual({ hello: "alive" });
     } finally {
       proc.kill();
     }
   });
 
   test("serves overlapping invocations concurrently", async () => {
-    const { proc, socketPath } = await startServer(fx("sleepy.ts"));
+    const { proc, socketPath } = await startWorker(fixturesDir);
     try {
       // Three 400ms invocations completing in well under 3 x 400ms proves
       // they shared the event loop instead of serializing.
@@ -187,12 +235,13 @@ describe("runner serve", () => {
     // context-probe.ts reads the invocation context (as @dust/pod does)
     // before and after an await: concurrent invocations with different
     // environments must each observe exactly their own, at both ends.
-    const { proc, socketPath } = await startServer(fx("context-probe.ts"));
+    const { proc, socketPath } = await startWorker(fixturesDir);
     try {
       const probe = (marker: string, delayMs: number) =>
         request(
           socketPath,
           warmRequest(
+            "context-probe",
             { WARM_TEST_MARKER: marker, DUST_SANDBOX_TOKEN: `tok-${marker}` },
             { url: `http://localhost/?delayMs=${delayMs}` }
           )
@@ -214,7 +263,7 @@ describe("runner serve", () => {
       // — in particular not their sandbox tokens.
       const clean = await request(
         socketPath,
-        warmRequest({}, { url: "http://localhost/" })
+        warmRequest("context-probe", {}, { url: "http://localhost/" })
       );
       expect(clean.outcome?.output).toMatchObject({
         before: null,
@@ -227,7 +276,7 @@ describe("runner serve", () => {
   });
 
   test("queues past the concurrency cap and serves once a slot frees", async () => {
-    const { proc, socketPath } = await startServer(fx("sleepy.ts"));
+    const { proc, socketPath } = await startWorker(fixturesDir);
     try {
       // Fill every slot with 300ms invocations, then send one more: it must
       // wait in the queue (no slot is free) and still be served.
@@ -248,7 +297,7 @@ describe("runner serve", () => {
   });
 
   test("a queued request that outwaits the queue deadline is refused as overloaded", async () => {
-    const { proc, socketPath } = await startServer(fx("sleepy.ts"));
+    const { proc, socketPath } = await startWorker(fixturesDir);
     try {
       // Occupy every slot for longer than the queue deadline (2s), then
       // queue one more: it must be refused with a structured overloaded
@@ -276,12 +325,20 @@ describe("runner serve", () => {
     }
   }, 15_000);
 
-  test("reports a rewritten bundle as stale and drains", async () => {
+  test("a rewritten imported bundle is refused as stale and drains the worker", async () => {
     const dir = scratch();
     const bundle = join(dir, "hello.ts");
-    copyFileSync(fx("hello.ts"), bundle);
-    const { proc, socketPath } = await startServer(bundle);
+    copyFileSync(join(fixturesDir, "hello.ts"), bundle);
+    const { proc, socketPath } = await startWorker(dir);
     try {
+      // Import it first: staleness of an already-imported bundle is what
+      // forces the recycle (the module cannot be evicted).
+      const served = await request(
+        socketPath,
+        warmRequest("hello", {}, { url: "http://localhost/?name=first" })
+      );
+      expect(served.outcome?.ok).toBe(true);
+
       // Same content, different mtime — a republish rewrites the object, and
       // mtime/size is the staleness signal.
       const later = new Date(Date.now() + 5_000);
@@ -289,7 +346,7 @@ describe("runner serve", () => {
 
       const reply = await request(
         socketPath,
-        warmRequest({}, { url: "http://localhost/" })
+        warmRequest("hello", {}, { url: "http://localhost/" })
       );
       expect(reply.stale).toBe(true);
       expect(await proc.exited).toBe(0);
@@ -300,10 +357,16 @@ describe("runner serve", () => {
 
   test("a stale-triggered drain lets in-flight invocations finish", async () => {
     const dir = scratch();
-    const bundle = join(dir, "sleepy.ts");
-    copyFileSync(fx("sleepy.ts"), bundle);
-    const { proc, socketPath } = await startServer(bundle);
+    copyFileSync(join(fixturesDir, "sleepy.ts"), join(dir, "sleepy.ts"));
+    const bundle = join(dir, "hello.ts");
+    copyFileSync(join(fixturesDir, "hello.ts"), bundle);
+    const { proc, socketPath } = await startWorker(dir);
     try {
+      // Import hello so its rewrite below recycles the worker.
+      await request(
+        socketPath,
+        warmRequest("hello", {}, { url: "http://localhost/" })
+      );
       const inFlight = request(socketPath, sleepyRequest(600));
       await new Promise((resolve) => setTimeout(resolve, 150));
 
@@ -311,12 +374,12 @@ describe("runner serve", () => {
       utimesSync(bundle, later, later);
       const refused = await request(
         socketPath,
-        warmRequest({}, { url: "http://localhost/" })
+        warmRequest("hello", {}, { url: "http://localhost/" })
       );
       expect(refused.stale).toBe(true);
 
       // The invocation that was already executing still delivers its
-      // outcome; only then does the drained server exit.
+      // outcome; only then does the drained worker exit.
       const served = await inFlight;
       expect(served.outcome?.ok).toBe(true);
       expect(await proc.exited).toBe(0);
@@ -326,15 +389,16 @@ describe("runner serve", () => {
   });
 
   test("serves a request stamped with the matching bundle hash", async () => {
-    const { proc, socketPath } = await startServer(fx("hello.ts"));
+    const { proc, socketPath } = await startWorker(fixturesDir);
     try {
-      const bytes = await Bun.file(fx("hello.ts")).arrayBuffer();
-      const bundleSha256 = new Bun.CryptoHasher("sha256")
-        .update(new Uint8Array(bytes))
-        .digest("hex");
+      const bundleSha256 = await sha256Of(join(fixturesDir, "hello.ts"));
       const reply = await request(
         socketPath,
-        warmRequest({}, { url: "http://localhost/?name=stamped", bundleSha256 })
+        warmRequest(
+          "hello",
+          {},
+          { url: "http://localhost/?name=stamped", bundleSha256 }
+        )
       );
       expect(reply.outcome?.ok).toBe(true);
       expect(reply.outcome?.output).toEqual({ hello: "stamped" });
@@ -343,21 +407,57 @@ describe("runner serve", () => {
     }
   });
 
-  test("refuses a mismatched bundle hash as stale and drains", async () => {
-    // The stat cannot see the rewrite here (the file is untouched), which is
-    // exactly the gcsfuse-cached-metadata case: the request's hash is the
-    // only signal, and it must win.
-    const { proc, socketPath } = await startServer(fx("hello.ts"));
+  test("a mismatched hash on a first request refuses without poisoning the worker", async () => {
+    // The stat cannot see a rewrite (gcsfuse lag): the stamped hash is the
+    // only signal. On a bundle the worker has NOT imported yet, it must
+    // refuse before importing, so a later correctly-stamped request is
+    // still served by the same worker.
+    const { proc, socketPath } = await startWorker(fixturesDir);
     try {
+      const refused = await request(
+        socketPath,
+        warmRequest(
+          "hello",
+          {},
+          { url: "http://localhost/", bundleSha256: "0".repeat(64) }
+        )
+      );
+      expect(refused.stale).toBe(true);
+      expect(refused.outcome).toBeUndefined();
+
+      const bundleSha256 = await sha256Of(join(fixturesDir, "hello.ts"));
+      const served = await request(
+        socketPath,
+        warmRequest(
+          "hello",
+          {},
+          { url: "http://localhost/?name=alive", bundleSha256 }
+        )
+      );
+      expect(served.outcome?.output).toEqual({ hello: "alive" });
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("a mismatched hash on an imported bundle refuses as stale and drains", async () => {
+    const { proc, socketPath } = await startWorker(fixturesDir);
+    try {
+      const served = await request(
+        socketPath,
+        warmRequest("hello", {}, { url: "http://localhost/?name=warm" })
+      );
+      expect(served.outcome?.ok).toBe(true);
+
       const reply = await request(
         socketPath,
         warmRequest(
+          "hello",
           {},
           { url: "http://localhost/", bundleSha256: "0".repeat(64) }
         )
       );
       expect(reply.stale).toBe(true);
-      expect(reply.outcome).toBeUndefined();
       expect(await proc.exited).toBe(0);
     } finally {
       proc.kill();
@@ -365,11 +465,11 @@ describe("runner serve", () => {
   });
 
   test("serves an unstamped request from an older front", async () => {
-    const { proc, socketPath } = await startServer(fx("hello.ts"));
+    const { proc, socketPath } = await startWorker(fixturesDir);
     try {
       const reply = await request(
         socketPath,
-        warmRequest({}, { url: "http://localhost/?name=unstamped" })
+        warmRequest("hello", {}, { url: "http://localhost/?name=unstamped" })
       );
       expect(reply.outcome?.output).toEqual({ hello: "unstamped" });
     } finally {
@@ -378,21 +478,22 @@ describe("runner serve", () => {
   });
 
   test("rejects a protocol version it does not speak without dying", async () => {
-    const { proc, socketPath } = await startServer(fx("hello.ts"));
+    const { proc, socketPath } = await startWorker(fixturesDir);
     try {
       const reply = await request(socketPath, {
         v: 999,
         env: {},
         input: "{}",
+        name: "hello",
       });
       expect(reply.error).toBe("bad warm request");
 
       // Version-suffixed socket names make a mismatched client a bug, not a
-      // rolling-upgrade case; the server must not abandon concurrent work
+      // rolling-upgrade case; the worker must not abandon concurrent work
       // over one bad request.
       const after = await request(
         socketPath,
-        warmRequest({}, { url: "http://localhost/?name=alive" })
+        warmRequest("hello", {}, { url: "http://localhost/?name=alive" })
       );
       expect(after.outcome?.output).toEqual({ hello: "alive" });
     } finally {
@@ -401,11 +502,11 @@ describe("runner serve", () => {
   });
 
   test("acks before the outcome so the client can pin execution start", async () => {
-    const { proc, socketPath } = await startServer(fx("hello.ts"));
+    const { proc, socketPath } = await startWorker(fixturesDir);
     try {
       const frames = await requestFrames(
         socketPath,
-        warmRequest({}, { url: "http://localhost/?name=frames" })
+        warmRequest("hello", {}, { url: "http://localhost/?name=frames" })
       );
       expect(frames.length).toBe(2);
       expect(frames[0]?.ack).toBe(true);
@@ -420,19 +521,16 @@ describe("runner serve", () => {
     const socketPath = join(dir, "fn.sock");
     // Spawned the way dsbx spawns it: with the cold invocation's token in
     // env. Even a bundle reading process.env directly must not observe it.
-    const proc = Bun.spawn(
-      ["bun", runner, "serve", fx("env-probe.ts"), socketPath],
-      {
-        stdin: "ignore",
-        stdout: "ignore",
-        stderr: "inherit",
-        env: {
-          ...process.env,
-          WARM_TEST_MARKER: "from-spawn",
-          DUST_SANDBOX_TOKEN: "spawn-invocation-token",
-        },
-      }
-    );
+    const proc = Bun.spawn(["bun", runner, "serve", fixturesDir, socketPath], {
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "inherit",
+      env: {
+        ...process.env,
+        WARM_TEST_MARKER: "from-spawn",
+        DUST_SANDBOX_TOKEN: "spawn-invocation-token",
+      },
+    });
     try {
       const deadline = Date.now() + 10_000;
       let reply: WarmReply | null = null;
@@ -440,7 +538,7 @@ describe("runner serve", () => {
         try {
           reply = await request(
             socketPath,
-            warmRequest({}, { url: "http://localhost/" })
+            warmRequest("env-probe", {}, { url: "http://localhost/" })
           );
         } catch {
           await new Promise((resolve) => setTimeout(resolve, 25));
@@ -458,40 +556,67 @@ describe("runner serve", () => {
     }
   });
 
-  test("reports runner errors as structured outcomes", async () => {
-    const { proc, socketPath } = await startServer(fx("throws.ts"));
+  test("a bundle rewritten during its import poisons and recycles the worker", async () => {
+    // The hash is taken before the import; if the bytes change in between,
+    // the module registry holds bytes the hash does not describe. The
+    // single-flight import re-stats after importing and must recycle
+    // instead of recording the wrong hash.
+    const dir = scratch();
+    const bundle = join(dir, "slow-import.ts");
+    copyFileSync(join(fixturesDir, "slow-import.ts"), bundle);
+    const { proc, socketPath } = await startWorker(dir);
     try {
-      const reply = await request(
+      const first = request(
         socketPath,
-        warmRequest({}, { url: "http://localhost/" })
+        warmRequest("slow-import", {}, { url: "http://localhost/" })
       );
-      expect(reply.outcome?.ok).toBe(false);
-      expect(reply.outcome?.error?.code).toBe("threw");
+      // The fixture's import takes ~400ms; rewrite the file mid-import.
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await Bun.write(
+        bundle,
+        `${await Bun.file(bundle).text()}// republished\n`
+      );
+
+      const reply = await first;
+      expect(reply.stale).toBe(true);
+      expect(await proc.exited).toBe(0);
     } finally {
       proc.kill();
     }
   });
 
   test("reports malformed envelopes as bad_input without dying", async () => {
-    const { proc, socketPath } = await startServer(fx("hello.ts"));
+    const { proc, socketPath } = await startWorker(fixturesDir);
     try {
       const bad = await request(socketPath, {
         v: WARM_PROTOCOL_VERSION,
         env: {},
         input: "not json",
+        name: "hello",
       });
       expect(bad.outcome?.ok).toBe(false);
       expect(bad.outcome?.error?.code).toBe("bad_input");
 
-      // The server survives a bad envelope: the next request still works.
+      // The worker survives a bad envelope: the next request still works.
       const good = await request(
         socketPath,
-        warmRequest({}, { url: "http://localhost/?name=alive" })
+        warmRequest("hello", {}, { url: "http://localhost/?name=alive" })
       );
       expect(good.outcome?.output).toEqual({ hello: "alive" });
     } finally {
       proc.kill();
     }
+  });
+});
+
+describe("resolveBundle", () => {
+  test("resolves a name to its single matching file", () => {
+    expect(resolveBundle(fixturesDir, "hello")).toBe(
+      join(fixturesDir, "hello.ts")
+    );
+    expect(resolveBundle(fixturesDir, "no-such-function")).toBeNull();
+    // Directories never match, even with a matching stem.
+    expect(resolveBundle(fixturesDir, "databases")).toBeNull();
   });
 });
 
@@ -502,12 +627,14 @@ describe("parseWarmRequest", () => {
         v: WARM_PROTOCOL_VERSION,
         env: { KEEP: "yes", DROP_NUMBER: 3, DROP_NULL: null },
         input: "{}",
+        name: "greet",
       })
     );
     expect(parsed).toEqual({
       v: WARM_PROTOCOL_VERSION,
       env: { KEEP: "yes" },
       input: "{}",
+      name: "greet",
     });
   });
 
@@ -515,21 +642,28 @@ describe("parseWarmRequest", () => {
     expect(parseWarmRequest("not json")).toBeNull();
     expect(parseWarmRequest('"a string"')).toBeNull();
     expect(
-      parseWarmRequest(JSON.stringify({ v: 999, env: {}, input: "{}" }))
-    ).toBeNull();
-    expect(
       parseWarmRequest(
-        JSON.stringify({ v: WARM_PROTOCOL_VERSION, input: "{}" })
+        JSON.stringify({ v: 999, env: {}, input: "{}", name: "x" })
       )
     ).toBeNull();
     expect(
       parseWarmRequest(
-        JSON.stringify({ v: WARM_PROTOCOL_VERSION, env: null, input: "{}" })
+        JSON.stringify({ v: WARM_PROTOCOL_VERSION, input: "{}", name: "x" })
       )
     ).toBeNull();
     expect(
       parseWarmRequest(
-        JSON.stringify({ v: WARM_PROTOCOL_VERSION, env: {}, input: 7 })
+        JSON.stringify({ v: WARM_PROTOCOL_VERSION, env: {}, input: "{}" })
+      )
+    ).toBeNull();
+    expect(
+      parseWarmRequest(
+        JSON.stringify({
+          v: WARM_PROTOCOL_VERSION,
+          env: {},
+          input: "{}",
+          name: "../escape",
+        })
       )
     ).toBeNull();
   });

--- a/cli/dust-sandbox/functions-runner/serve.ts
+++ b/cli/dust-sandbox/functions-runner/serve.ts
@@ -1,23 +1,31 @@
-// Warm function server (protocol v2): keeps one imported function bundle
-// resident in a bun process and serves invocations over a unix socket, so
-// repeat invocations skip process spawn, bundle resolution, and the import of
-// the bundle and its dependencies (the dominant sandbox-side costs of a cold
-// run).
+// Warm function worker (protocol v2): a generic bun process that keeps
+// imported function bundles resident and serves invocations over a unix
+// socket, so repeat invocations skip process spawn, bundle resolution, and
+// the import of the bundle and its dependencies (the dominant sandbox-side
+// costs of a cold run).
 //
-// One server serves exactly one handler path — concurrently. Invocations are
-// IO-bound in the common case (SQL, API calls), so the event loop interleaves
-// many of them at once exactly like a web server would; per-invocation state
-// (user identity, sandbox token) travels in the request and is scoped through
-// the invocation context (see functions-runner/context.ts and @dust/pod),
-// never applied to process.env. Beyond MAX_CONCURRENT_INVOCATIONS requests
-// wait in a FIFO queue; a full or too-slow queue gets a structured
-// `overloaded` outcome instead of sending the client to a cold run —
-// unbounded cold fallback under saturation is exactly the memory blow-up this
-// server exists to prevent.
+// Workers are pod-scoped, not function-scoped: the request names the
+// function, and the worker resolves and imports its bundle on first use (the
+// module cache keeps it). Memory is bounded by the pool size (POOL_SLOTS in
+// warm.rs, times the RSS cap below), not by the number of functions on the
+// pod. The client routes a function to its home worker by hashing the app
+// prefix of its slug, so all of one app's functions accumulate in one
+// worker's module cache and an app pays one process spawn, ever.
+//
+// Invocations run concurrently. They are IO-bound in the common case (SQL,
+// API calls), so the event loop interleaves many of them at once exactly
+// like a web server would; per-invocation state (user identity, sandbox
+// token) travels in the request and is scoped through the invocation context
+// (see functions-runner/context.ts and @dust/pod), never applied to
+// process.env. Beyond MAX_CONCURRENT_INVOCATIONS requests wait in a FIFO
+// queue; a full or too-slow queue gets a structured `overloaded` outcome
+// instead of sending the client to a cold run — unbounded cold fallback
+// under saturation is exactly the memory blow-up this worker exists to
+// prevent.
 //
 // Duplicate executions are the failure mode this protocol is shaped around:
 // pod functions are arbitrary side-effectful code, and front assumes a failed
-// start means nothing ran. The server acks before executing — a synchronous
+// start means nothing ran. The worker acks before executing — a synchronous
 // socket write whose failure proves the client is gone — and the client only
 // falls back to the cold path on failures that precede the ack. After the
 // ack, a lost outcome is reported as a failed invocation, never re-run. (The
@@ -25,15 +33,18 @@
 // sitting behind an HTTP server: response streaming cannot prove the ack
 // reached the client's buffer before execution starts.)
 //
-// The server is disposable. It exits on idle, and it drains (stops
+// The worker is disposable. It exits on idle, and it drains (stops
 // listening, refuses its queue, lets in-flight invocations finish, then
-// exits) at the lifetime cap, when the bundle on disk changes, when its RSS
-// crosses the recycle threshold, or when an invocation outlives its deadline
-// (whose client was killed by front's much shorter exec timeout long ago).
+// exits) at the lifetime cap, when a bundle it imported goes stale (ES
+// modules cannot be evicted, so rebirth is the pruning mechanism), when its
+// RSS crosses the recycle threshold, or when an invocation outlives its
+// deadline (whose client was killed by front's much shorter exec timeout
+// long ago).
 
 import { createHash } from "node:crypto";
-import { unlinkSync } from "node:fs";
+import { readdirSync, unlinkSync } from "node:fs";
 import { stat, unlink } from "node:fs/promises";
+import { join } from "node:path";
 
 import { z } from "zod";
 
@@ -53,16 +64,18 @@ export const MAX_CONCURRENT_INVOCATIONS = 32;
 export const MAX_QUEUED_INVOCATIONS = 128;
 export const QUEUE_WAIT_DEADLINE_MS = 2_000;
 
-// Idle: how long the server waits with nothing running and nothing queued
-// before exiting. Lifetime: hard cap bounding how long a republished bundle
-// can keep being served when the envelope carries no bundle hash and gcsfuse
-// metadata caching hides the change from the per-request stat. Deadline: an
-// invocation that runs this long lost its client to front's much shorter
-// exec timeout ages ago, and its slot is wedged for good (a promise cannot
-// be killed), so the server recycles. Rss: a bloated server trades a one-off
-// import cost for freed memory. Drain flush: how long a drained server waits
-// for its last reply bytes before force-exiting on a client that stopped
-// reading.
+// Idle: how long the worker waits with nothing running and nothing queued
+// before exiting; scale-down to zero is each worker's own idle exit.
+// Lifetime: hard cap bounding both bundle accumulation (imports are
+// permanent for the life of the process) and staleness that gcsfuse metadata
+// caching could hide from unstamped envelopes. Deadline: an invocation that
+// runs this long lost its client to front's much shorter exec timeout ages
+// ago, and its slot is wedged for good (a promise cannot be killed), so the
+// worker recycles. Rss: recycles a worker whose imported working set
+// outgrew its share of the sandbox's memory — sized so a full pool stays
+// bounded well inside the 2GB sandbox. Drain flush: how long a drained
+// worker waits for its last reply bytes before force-exiting on a client
+// that stopped reading.
 const IDLE_TIMEOUT_MS = 120_000;
 // A request older than this must not be acked: the client abandons the wait
 // at 4s (see warm.rs) and falls back cold, and acking into that window is
@@ -76,9 +89,12 @@ const MAX_RSS_BYTES = 300 * 1024 * 1024;
 const DRAIN_FLUSH_TIMEOUT_MS = 5_000;
 
 // Per-invocation env vars inherited from the cold run that spawned this
-// server. Scrubbed at startup: they belong to that invocation, and every
+// worker. Scrubbed at startup: they belong to that invocation, and every
 // request carries its own environment in the request itself.
 const SPAWN_ENV_SCRUB_KEYS = ["DUST_SANDBOX_TOKEN", "DUST_POD_USER_IDENTITY"];
+
+// Mirrors dsbx's function-name validation: the name feeds a directory scan.
+const VALID_NAME = /^[A-Za-z0-9_-]+$/;
 
 const WarmRequestSchema = z.object({
   v: z.literal(WARM_PROTOCOL_VERSION),
@@ -95,6 +111,9 @@ const WarmRequestSchema = z.object({
     return out;
   }),
   input: z.string(),
+  // The function to serve. Workers are generic: the bundle is resolved from
+  // the functions directory and imported on first use.
+  name: z.string().regex(VALID_NAME),
 });
 
 type WarmRequest = z.infer<typeof WarmRequestSchema>;
@@ -102,6 +121,13 @@ type WarmRequest = z.infer<typeof WarmRequestSchema>;
 interface BundleStamp {
   mtimeMs: number;
   size: number;
+}
+
+/** A bundle this worker has imported; the module cache pins it until exit. */
+interface ImportedBundle {
+  handlerPath: string;
+  stamp: BundleStamp;
+  sha256: string;
 }
 
 async function statBundle(handlerPath: string): Promise<BundleStamp | null> {
@@ -126,6 +152,34 @@ async function sha256OfFile(path: string): Promise<string | null> {
   } catch {
     return null;
   }
+}
+
+/**
+ * Resolve a function name to its bundle file, extension-agnostically —
+ * the same contract as dsbx's resolve_existing: exactly one file in the
+ * functions directory whose stem is the name.
+ */
+export function resolveBundle(
+  functionsDir: string,
+  name: string
+): string | null {
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = readdirSync(functionsDir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  const matches = entries.filter((entry) => {
+    if (!entry.isFile()) {
+      return false;
+    }
+    const dot = entry.name.lastIndexOf(".");
+    return (dot <= 0 ? entry.name : entry.name.slice(0, dot)) === name;
+  });
+  if (matches.length !== 1) {
+    return null;
+  }
+  return join(functionsDir, matches[0]!.name);
 }
 
 export function parseWarmRequest(line: string): WarmRequest | null {
@@ -166,47 +220,32 @@ function overloadedFrame(): Record<string, unknown> {
       error: {
         code: "overloaded",
         message:
-          "The function is running at its concurrency limit and the wait " +
-          "queue is saturated; the invocation was not started.",
+          "The function's worker is running at its concurrency limit and " +
+          "the wait queue is saturated; the invocation was not started.",
       },
     },
   };
 }
 
 export async function serve(
-  handlerPath: string,
+  functionsDir: string,
   socketPath: string
 ): Promise<never> {
   for (const key of SPAWN_ENV_SCRUB_KEYS) {
     delete process.env[key];
   }
 
-  // Import eagerly: the server is spawned right after a cold run, so warming
-  // now (rather than on first request) makes the very next invocation fast.
-  // The module cache keyed by path is the whole point of this process. A
-  // static import is impossible here: the bundle to serve is a runtime
-  // argument, a different published function per server.
-  const importedStamp = await statBundle(handlerPath);
-  if (importedStamp === null) {
-    process.exit(1);
-  }
-  // Hash before importing so the hash describes the bytes the import reads;
-  // a write landing between the two is caught by the per-request stat.
-  const importedSha256 = await sha256OfFile(handlerPath);
-  if (importedSha256 === null) {
-    process.exit(1);
-  }
-  try {
-    await import(handlerPath);
-  } catch {
-    // A bundle that fails to import still gets served: invoke() reports the
-    // import error as a structured outcome, exactly like a cold run would.
-  }
+  // name -> imported bundle. Both the resolution and the module are cached
+  // for the life of the worker: a cached resolution that goes bad (bundle
+  // deleted, extension changed, republished) fails its per-request checks
+  // and drains the worker — the module cache cannot be evicted, so rebirth
+  // is the only pruning.
+  const imported = new Map<string, ImportedBundle>();
 
   let boundSocket = false;
   const exit = (code: number): never => {
-    // Remove the socket first so no client connects to a dying server — but
-    // only if this server owns it: a duplicate that lost the bind race must
+    // Remove the socket first so no client connects to a dying worker — but
+    // only if this worker owns it: a duplicate that lost the bind race must
     // not delete the winner's socket on its way out.
     if (boundSocket) {
       try {
@@ -252,9 +291,9 @@ export async function serve(
   }
 
   // `running` counts invocations past admission (including their pre-ack
-  // staleness checks); `hung` counts the subset that blew their deadline and
-  // will never release their slot. The server is fully drained once every
-  // running invocation is hung.
+  // resolve/import phase); `hung` counts the subset that blew their deadline
+  // and will never release their slot. The worker is fully drained once
+  // every running invocation is hung.
   let running = 0;
   let hung = 0;
   let draining = false;
@@ -333,7 +372,7 @@ export async function serve(
     drainExitCode = code;
     clearIdle();
     // Stop accepting and free the socket path immediately: the next cold run
-    // binds a fresh server there while this one finishes its in-flight work.
+    // binds a fresh worker there while this one finishes its in-flight work.
     if (listenerStop !== null) {
       listenerStop();
     }
@@ -346,7 +385,7 @@ export async function serve(
       boundSocket = false;
     }
     // Queued requests never started executing: refuse them as stale so their
-    // clients re-run cold against the successor server. (On a stale-triggered
+    // clients re-run cold against the successor worker. (On a stale-triggered
     // drain, serving them from the old import would be wrong anyway.)
     for (const entry of [...queue]) {
       if (settleQueueEntry(entry)) {
@@ -365,22 +404,141 @@ export async function serve(
     writeThenEnd(socket, `${JSON.stringify(response)}\n`);
   }
 
+  /** Result of the single-flight fuse import of one function's bundle. */
+  type FuseImportResult =
+    | { kind: "ok"; bundle: ImportedBundle }
+    | { kind: "unresolved" }
+    | { kind: "poisoned" };
+
+  // One resolve/stat/hash/import pipeline per name at a time, joined by
+  // concurrent requests. Without it, two overlapping first requests during a
+  // republish window can each hash a different version while import() hands
+  // both the same module — recording one version's hash against the other's
+  // bytes and serving stale code under a fresh stamp from then on.
+  const importsInFlight = new Map<string, Promise<FuseImportResult>>();
+
+  function importFromFunctionsDir(name: string): Promise<FuseImportResult> {
+    const inFlight = importsInFlight.get(name);
+    if (inFlight !== undefined) {
+      return inFlight;
+    }
+    const flight = (async (): Promise<FuseImportResult> => {
+      const handlerPath = resolveBundle(functionsDir, name);
+      if (handlerPath === null) {
+        return { kind: "unresolved" };
+      }
+      const stamp = await statBundle(handlerPath);
+      if (stamp === null) {
+        return { kind: "unresolved" };
+      }
+      // Hash before importing so the hash describes the bytes the import
+      // reads; the re-stat below catches a write landing in between.
+      const sha256 = await sha256OfFile(handlerPath);
+      if (sha256 === null) {
+        return { kind: "unresolved" };
+      }
+      try {
+        // GEN10 exemption: a static import (and a literal specifier) is
+        // structurally impossible here — the module to load is a published
+        // function bundle resolved from the functions directory at request
+        // time. Dynamic import IS this worker's purpose; the path is
+        // produced by resolveBundle from a validated name, never from raw
+        // request input.
+        await import(handlerPath);
+      } catch {
+        // A bundle that fails to import still gets served: invoke() reports
+        // the import error as a structured outcome, exactly like a cold run.
+      }
+      // The module registry now permanently holds whatever bytes import()
+      // read. If the file changed between the hash and the import, the hash
+      // cannot be trusted to describe the module: the worker is poisoned
+      // for this path and must recycle.
+      const after = await statBundle(handlerPath);
+      if (!sameStamp(stamp, after)) {
+        return { kind: "poisoned" };
+      }
+      const bundle: ImportedBundle = { handlerPath, stamp, sha256 };
+      imported.set(name, bundle);
+      return { kind: "ok", bundle };
+    })();
+    // Registered synchronously (before any await runs) and cleared on
+    // settlement so a failed resolution can be retried by a later request.
+    const tracked = flight.finally(() => {
+      importsInFlight.delete(name);
+    });
+    importsInFlight.set(name, tracked);
+    return tracked;
+  }
+
+  /**
+   * Ensure the request's bundle is imported and current. Returns the bundle
+   * and whether this request paid (or joined) the import, or null after a
+   * pre-ack `stale` reply was sent (the client re-runs cold, which reads the
+   * bundle fresh and respawns a worker as needed).
+   */
+  async function ensureBundle(
+    socket: WarmSocket,
+    request: WarmRequest,
+    expectedSha256: string | undefined
+  ): Promise<{
+    bundle: ImportedBundle;
+    importKind: "cached" | "fresh";
+  } | null> {
+    const staleReply = ({ recycle = false }: { recycle?: boolean } = {}) => {
+      reply(socket, { v: WARM_PROTOCOL_VERSION, stale: true });
+      if (recycle) {
+        // The worker holds an import it can never serve again; drain so a
+        // fresh worker replaces it. In-flight invocations finish normally.
+        startDrain(0);
+      }
+      return null;
+    };
+
+    const existing = imported.get(request.name);
+    if (existing) {
+      // A republished bundle must never be served from the old import. One
+      // metadata call per request; any difference (or a vanished file), or a
+      // request stamped with a hash this import does not match, sends the
+      // client down the cold path — and recycles this worker, since the old
+      // module can never be evicted.
+      const current = await statBundle(existing.handlerPath);
+      if (
+        !sameStamp(existing.stamp, current) ||
+        (expectedSha256 !== undefined && expectedSha256 !== existing.sha256)
+      ) {
+        return staleReply({ recycle: true });
+      }
+      return { bundle: existing, importKind: "cached" };
+    }
+
+    const result = await importFromFunctionsDir(request.name);
+    switch (result.kind) {
+      case "unresolved":
+        // Missing or ambiguous bundle: the cold path owes the caller the
+        // structured error, not this worker.
+        return staleReply();
+      case "poisoned":
+        return staleReply({ recycle: true });
+      case "ok":
+        if (
+          expectedSha256 !== undefined &&
+          expectedSha256 !== result.bundle.sha256
+        ) {
+          // The on-disk bundle does not match what the publisher stamped
+          // (gcsfuse lag). The import stays valid for callers of the version
+          // it actually holds; this caller re-runs cold, and the eventual
+          // disk change recycles the worker through the stat check above.
+          return staleReply();
+        }
+        return { bundle: result.bundle, importKind: "fresh" };
+    }
+  }
+
   async function runInvocation(
     socket: WarmSocket,
     request: WarmRequest,
     receivedAtMs: number
   ): Promise<void> {
-    // A republished bundle must never be served from the old import. One
-    // metadata call per invocation start; any difference (or a vanished
-    // file) sends the client down the cold path, which respawns a fresh
-    // server while this one drains.
-    const current = await statBundle(handlerPath);
-    if (!sameStamp(importedStamp, current)) {
-      reply(socket, { v: WARM_PROTOCOL_VERSION, stale: true });
-      startDrain(0);
-      return;
-    }
-
     let input: RequestInput;
     try {
       input = parseInput(request.input);
@@ -395,21 +553,11 @@ export async function serve(
       return;
     }
 
-    // Deterministic republish detection: front stamps each invocation with
-    // the sha256 of the bundle it published, so a server that imported older
-    // bytes is refused even while gcsfuse metadata caching still hides the
-    // rewrite from the stat above. Pre-ack, like every refusal: the client
-    // re-runs cold, which reads the bundle fresh and respawns a matching
-    // server. Unstamped envelopes (older front) keep the stat and lifetime
-    // backstops only.
-    if (
-      input.bundleSha256 !== undefined &&
-      input.bundleSha256 !== importedSha256
-    ) {
-      reply(socket, { v: WARM_PROTOCOL_VERSION, stale: true });
-      startDrain(0);
+    const ensured = await ensureBundle(socket, request, input.bundleSha256);
+    if (ensured === null) {
       return;
     }
+    const { bundle, importKind } = ensured;
 
     // The ack is the point of no return: from here the client must never
     // fall back to the cold path, because the function may have side effects
@@ -438,7 +586,7 @@ export async function serve(
     // An invocation that outlives this deadline lost its client to front's
     // exec timeout long ago, and its slot is wedged for good — a promise
     // cannot be killed. Recycle: drain and let the next cold run spawn a
-    // fresh server. Other in-flight invocations finish normally.
+    // fresh worker. Other in-flight invocations finish normally.
     let deadlineFired = false;
     const deadlineTimer = setTimeout(() => {
       deadlineFired = true;
@@ -448,12 +596,12 @@ export async function serve(
     }, INVOCATION_DEADLINE_MS);
 
     try {
-      const outcome = await invoke(handlerPath, input, request.env);
+      const outcome = await invoke(bundle.handlerPath, input, request.env);
       if (deadlineFired) {
         // The client is long gone; nothing useful to write.
         socket.end();
       } else {
-        reply(socket, { v: WARM_PROTOCOL_VERSION, outcome });
+        reply(socket, { v: WARM_PROTOCOL_VERSION, outcome, importKind });
       }
     } finally {
       clearTimeout(deadlineTimer);
@@ -508,15 +656,15 @@ export async function serve(
   function handleLine(socket: WarmSocket, line: string): void {
     const request = parseWarmRequest(line);
     if (request === null) {
-      // A client this server does not understand. Version-suffixed socket
+      // A client this worker does not understand. Version-suffixed socket
       // names make this a bug rather than a rolling-upgrade case; refusing
-      // the request (the client runs cold) beats killing a server with
+      // the request (the client runs cold) beats killing a worker with
       // concurrent invocations in flight.
       reply(socket, { v: WARM_PROTOCOL_VERSION, error: "bad warm request" });
       return;
     }
     if (draining) {
-      // Send the client cold; its run respawns a fresh server.
+      // Send the client cold; its run respawns a fresh worker.
       reply(socket, { v: WARM_PROTOCOL_VERSION, stale: true });
       return;
     }
@@ -553,8 +701,8 @@ export async function serve(
       socket: {
         open() {
           // Probe connections (the client checks for a listener before
-          // spawning a duplicate server) send no data; the idle timer keeps
-          // running so they cannot pin the server alive.
+          // spawning a duplicate worker) send no data; the idle timer keeps
+          // running so they cannot pin the worker alive.
         },
         data(socket, chunk) {
           const buffered = (socketBuffers.get(socket) ?? "") + chunk.toString();
@@ -599,9 +747,9 @@ export async function serve(
     listenerStop = () => listener.stop();
     boundSocket = true;
   } catch {
-    // The socket path exists. Either a live server owns it — this process is
+    // The socket path exists. Either a live worker owns it — this process is
     // a lost spawn race and must exit without touching the winner's socket —
-    // or it is a stale leftover from a dead server, which is safe to replace.
+    // or it is a stale leftover from a dead worker, which is safe to replace.
     const listening = await new Promise<boolean>((resolve) => {
       Bun.connect({
         unix: socketPath,

--- a/cli/dust-sandbox/src/commands/function/envelope.rs
+++ b/cli/dust-sandbox/src/commands/function/envelope.rs
@@ -32,6 +32,17 @@ pub enum RunnerKind {
     Cold,
 }
 
+/// Whether a warm worker served the invocation from a bundle it had already
+/// imported, or paid the import on this request. Observability for the
+/// pool's affinity routing: a high `fresh` share means functions keep
+/// landing on workers that do not hold their bundle.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum ImportKind {
+    Cached,
+    Fresh,
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TimingsMs {
@@ -41,6 +52,9 @@ pub struct TimingsMs {
     /// treats timingsMs as opaque, so this cannot break the wire contract.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runner_kind: Option<RunnerKind>,
+    /// Additive, warm runs only: see [`ImportKind`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub import_kind: Option<ImportKind>,
 }
 
 impl ResultEnvelope {
@@ -86,6 +100,7 @@ mod tests {
                 total: 12,
                 runner: 8,
                 runner_kind: Some(RunnerKind::Warm),
+                import_kind: Some(ImportKind::Cached),
             }),
         );
 
@@ -96,7 +111,7 @@ mod tests {
                 "protocolVersion": 3,
                 "delivery": "stdout",
                 "outcome": { "ok": true, "output": { "hello": "world" } },
-                "timingsMs": { "total": 12, "runner": 8, "runnerKind": "warm" },
+                "timingsMs": { "total": 12, "runner": 8, "runnerKind": "warm", "importKind": "cached" },
             })
         );
     }

--- a/cli/dust-sandbox/src/commands/function/run.rs
+++ b/cli/dust-sandbox/src/commands/function/run.rs
@@ -36,7 +36,7 @@ pub async fn cmd_function_run(name: &str) -> Result<()> {
         deliver_stdout_envelope(ResultEnvelope::stdout_invocation_failed(err.to_string()), 0);
     }
 
-    if let WarmRun::Outcome(outcome) = warm::try_warm_run(name, &input).await {
+    if let WarmRun::Outcome(outcome, import_kind) = warm::try_warm_run(name, &input).await {
         let runner_ms = started.elapsed().as_millis() as u64;
         deliver_stdout_envelope(
             ResultEnvelope::stdout_outcome(
@@ -45,30 +45,31 @@ pub async fn cmd_function_run(name: &str) -> Result<()> {
                     total: started.elapsed().as_millis() as u64,
                     runner: runner_ms,
                     runner_kind: Some(RunnerKind::Warm),
+                    import_kind,
                 }),
             ),
             0,
         );
     }
 
-    // Cold path. Resolve once: the run below and the warm server spawn both
-    // need the handler path, and resolution lists the (gcsfuse-backed)
-    // functions directory.
-    let (spawned, handler) = match resolve_existing(name) {
+    // Cold path. Resolve once: the run below needs the handler path, and
+    // resolution lists the (gcsfuse-backed) functions directory.
+    let (spawned, resolved) = match resolve_existing(name) {
         Ok(handler) => {
             let spawned = spawn_function_at(&handler, "run", Some(&input), true).await;
-            (spawned, Some(handler))
+            (spawned, true)
         }
         // resolve_existing already emitted the `{error}` line; the message
         // (bad name, unset dir, missing or ambiguous bundle) propagates.
-        Err(e) => (Err(e), None),
+        Err(e) => (Err(e), false),
     };
     let runner_ms = started.elapsed().as_millis() as u64;
 
-    // Leave a warm server behind so the next invocation of this function
-    // skips the spawn. Fire-and-forget; never affects this run's outcome.
-    if let Some(handler) = &handler {
-        warm::spawn_server(name, handler);
+    // Leave a warm worker on this function's home slot so the next
+    // invocation of this function (or its app) skips the spawn.
+    // Fire-and-forget; never affects this run's outcome.
+    if resolved {
+        warm::spawn_worker(name);
     }
 
     deliver_stdout(
@@ -77,6 +78,7 @@ pub async fn cmd_function_run(name: &str) -> Result<()> {
             total: started.elapsed().as_millis() as u64,
             runner: runner_ms,
             runner_kind: Some(RunnerKind::Cold),
+            import_kind: None,
         },
     )
 }
@@ -164,6 +166,7 @@ mod tests {
             total,
             runner,
             runner_kind: Some(RunnerKind::Cold),
+            import_kind: None,
         }
     }
 

--- a/cli/dust-sandbox/src/commands/function/warm.rs
+++ b/cli/dust-sandbox/src/commands/function/warm.rs
@@ -2,17 +2,25 @@
 //!
 //! A cold function run pays process spawn, bundle resolution against the
 //! gcsfuse-backed functions dir, and the import of the bundle and its
-//! dependencies on every invocation. The warm path keeps a per-bundle bun
-//! server (the embedded runner's `serve` subcommand) resident behind a unix
-//! socket and forwards invocations to it, so a repeat invocation costs one
-//! local socket round trip.
+//! dependencies on every invocation. The warm path keeps a pod-scoped pool
+//! of generic bun workers (the embedded runner's `serve` subcommand)
+//! resident behind unix sockets and forwards invocations to them, so a
+//! repeat invocation costs one local socket round trip.
 //!
-//! The server runs invocations concurrently (protocol v2) and queues briefly
-//! when saturated, so overlapping calls of one function no longer fan out
-//! into cold runs. When the server refuses under saturation it answers with
-//! a structured `overloaded` outcome, which is delivered to the caller as
-//! the invocation's result — deliberately not a cold fallback, because
-//! unbounded cold runs under load are what would exhaust the sandbox.
+//! Workers are generic — the request names the function, the worker resolves
+//! and imports its bundle on first use — so memory scales with the pool size
+//! (POOL_SLOTS x one bun process), not with the number of functions on the
+//! pod. Each function has one home worker, picked by hashing the app prefix
+//! of its slug (`myapp__list-notes` publishes are grouped by app folder), so
+//! all of one app's functions share a worker: opening an app pays one
+//! process spawn, ever, and its working set accumulates in one module cache.
+//!
+//! Workers run invocations concurrently (protocol v2) and queue briefly when
+//! saturated, so overlapping calls no longer fan out into cold runs. When a
+//! worker refuses under saturation it answers with a structured `overloaded`
+//! outcome, which is delivered to the caller as the invocation's result —
+//! deliberately not a cold fallback, because unbounded cold runs under load
+//! are what would exhaust the sandbox.
 //!
 //! Everything else is best-effort: any irregularity — missing socket, wrong
 //! directory ownership, protocol mismatch, stale bundle — falls back to the
@@ -39,9 +47,17 @@ use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
 use tokio::net::UnixStream;
 use tokio::process::Command;
 
+use super::envelope::ImportKind;
 use super::RUNNER_JS;
 
 pub const WARM_PROTOCOL_VERSION: u32 = 2;
+
+/// Pool geometry. Four generic workers bound the pod's warm memory (a worker
+/// is one bun process capped at ~300MB RSS with its imported working set,
+/// see serve.ts) regardless of how many functions the pod publishes. Each
+/// worker serves invocations concurrently, so capacity comes from the event
+/// loop, not from the worker count.
+const POOL_SLOTS: u32 = 4;
 
 /// Bound on the wait for the server's first frame (ack or refusal). It must
 /// comfortably exceed the server's admission-queue deadline (~2s, see
@@ -73,24 +89,28 @@ struct WarmFrame {
     ack: bool,
     #[serde(default)]
     outcome: Option<serde_json::Value>,
+    #[serde(default, rename = "importKind")]
+    import_kind: Option<ImportKind>,
     #[serde(default)]
     stale: bool,
     #[serde(default)]
     error: Option<String>,
 }
 
-/// The outcome of asking the warm server to run an invocation.
+/// The outcome of asking the warm pool to run an invocation.
 pub enum WarmRun {
-    /// The server produced this runner `Output` JSON: a served invocation, a
+    /// The worker produced this runner `Output` JSON (plus whether it paid
+    /// the bundle import on this request): a served invocation, a
     /// pre-execution classification (`bad_input`, `overloaded` — delivered as
     /// the result, never retried cold), or the synthesized failure outcome
-    /// when the server acked (the function started executing) but the outcome
+    /// when the worker acked (the function started executing) but the outcome
     /// was lost: past the ack the cold path is off the table, because
     /// re-running a function that may already have fired its side effects is
     /// worse than failing the invocation.
-    Outcome(serde_json::Value),
-    /// No usable warm server (not running, stale bundle, protocol mismatch,
-    /// ownership refusal, first frame overdue...). Nothing executed; run cold.
+    Outcome(serde_json::Value, Option<ImportKind>),
+    /// No usable warm worker (home slot not running, stale bundle, protocol
+    /// mismatch, ownership refusal, first frame overdue...). Nothing
+    /// executed; run cold.
     Miss,
 }
 
@@ -147,23 +167,38 @@ fn ensure_trusted_warm_dir() -> Option<PathBuf> {
     Some(dir)
 }
 
-/// Socket path for a function slug. The slug is already validated to
-/// `[A-Za-z0-9_-]+`; it is truncated and suffixed with its own hash so two
-/// long slugs sharing a prefix cannot collide, and with the runner hash so a
-/// dsbx upgrade gets fresh servers. Unix socket paths must stay short
-/// (~104 bytes); with a 20-char slug prefix this stays well under.
-fn socket_path(dir: &Path, name: &str) -> PathBuf {
-    // The functions dir is part of the key: the same slug under a different
-    // DUST_FUNCTIONS_DIR is a different bundle, and the mtime/size staleness
-    // stamp would not catch the swap.
+/// Socket path for a pool slot. Keyed on the functions dir (the same slot
+/// under a different DUST_FUNCTIONS_DIR is a different pod's pool), the
+/// runner hash (a dsbx upgrade gets fresh workers), and the protocol
+/// version. Unix socket paths must stay short (~104 bytes); this stays well
+/// under.
+fn slot_socket_path(dir: &Path, slot: u32) -> PathBuf {
     let functions_dir = std::env::var("DUST_FUNCTIONS_DIR").unwrap_or_default();
-    let key = format!("{functions_dir}\0{name}");
-    let prefix: String = name.chars().take(20).collect();
     dir.join(format!(
-        "{prefix}-{:08x}-{}-v{WARM_PROTOCOL_VERSION}.sock",
-        fnv1a(key.as_bytes()) as u32,
+        "w{:08x}-{}-v{WARM_PROTOCOL_VERSION}.{slot}.sock",
+        fnv1a(functions_dir.as_bytes()) as u32,
         runner_hash8(),
     ))
+}
+
+/// The affinity key of a slug: its app prefix when it has one, the whole
+/// slug otherwise. Functions published from an app folder get the folder as
+/// a `__`-separated prefix (`myapp__list-notes`), and routing every function
+/// of an app to the same worker means the app pays one worker spawn and
+/// shares one module cache (including its common `lib/` imports). Purely a
+/// routing hint: a wrong key costs a duplicate import, never correctness.
+fn affinity_key(name: &str) -> &str {
+    match name.split_once("__") {
+        Some((app, _)) if !app.is_empty() => app,
+        _ => name,
+    }
+}
+
+/// The home slot a function's requests go to. Affinity, not assignment: the
+/// worker itself is generic, but the same key keeps landing on the same
+/// worker, which already imported the app's bundles.
+fn preferred_slot(name: &str) -> u32 {
+    (fnv1a(affinity_key(name).as_bytes()) % u64::from(POOL_SLOTS)) as u32
 }
 
 /// Stages the embedded runner at a stable content-addressed path inside the
@@ -186,17 +221,18 @@ fn stage_runner(dir: &Path) -> Result<PathBuf> {
     Ok(path)
 }
 
-/// Tries to run `input` (the raw stdin envelope) against a warm server for
-/// `name`/`handler_hint`. Never errors: every failure is a `Miss`.
+/// Tries to run `input` (the raw stdin envelope) against the warm worker on
+/// `name`'s home slot. Never errors: every failure is a `Miss`.
 pub async fn try_warm_run(name: &str, input: &str) -> WarmRun {
-    // The name feeds the socket path before resolve_existing validates it on
-    // the cold path, so it is validated here too.
+    // The name travels in the warm request and feeds the worker's directory
+    // scan, so it is validated here as the cold path's resolve_existing
+    // would.
     if !super::is_valid_name(name) {
         return WarmRun::Miss;
     }
     // Warm serving is for unprivileged runs only: the production fast path
     // execs dsbx as agent-proxied. A root dsbx stays cold — a root client
-    // must not hand invocation env to a workload-owned server it would then
+    // must not hand invocation env to a workload-owned worker it would then
     // have to trust for lifecycle management.
     if rustix::process::geteuid().is_root() {
         return WarmRun::Miss;
@@ -204,7 +240,11 @@ pub async fn try_warm_run(name: &str, input: &str) -> WarmRun {
     let Some(dir) = ensure_trusted_warm_dir() else {
         return WarmRun::Miss;
     };
-    let socket = socket_path(&dir, name);
+    // Home slot only, no scanning: with concurrent workers a live home is
+    // essentially always usable, and always spawning at home (below, via the
+    // cold path) is what keeps an app's functions converging on one worker
+    // instead of piling onto whichever worker happens to be alive.
+    let socket = slot_socket_path(&dir, preferred_slot(name));
 
     let connect = tokio::time::timeout(WARM_CONNECT_TIMEOUT, UnixStream::connect(&socket)).await;
     let stream = match connect {
@@ -217,7 +257,9 @@ pub async fn try_warm_run(name: &str, input: &str) -> WarmRun {
     // (WARM_RESPONSE_TIMEOUT). Any error is a pre-ack condition and a Miss
     // (nothing executed); roundtrip converts post-ack losses into a failure
     // Outcome itself.
-    roundtrip(stream, input).await.unwrap_or(WarmRun::Miss)
+    roundtrip(stream, name, input)
+        .await
+        .unwrap_or(WarmRun::Miss)
 }
 
 /// The outcome delivered when the server acked (execution started) but the
@@ -234,10 +276,10 @@ fn lost_outcome_after_ack() -> serde_json::Value {
     })
 }
 
-async fn roundtrip(mut stream: UnixStream, input: &str) -> Result<WarmRun> {
+async fn roundtrip(mut stream: UnixStream, name: &str, input: &str) -> Result<WarmRun> {
     // The request carries the client's full environment: per-invocation
     // values (sandbox token, user identity, pod databases dir) travel in env
-    // vars, and the resident server's own env is stale by definition. This
+    // vars, and the resident worker's own env is stale by definition. This
     // mirrors the env inheritance of the cold path's bun child.
     // vars_os + lossy filtering: std::env::vars() panics on non-unicode
     // values, and a hostile env var must never crash the client.
@@ -248,6 +290,7 @@ async fn roundtrip(mut stream: UnixStream, input: &str) -> Result<WarmRun> {
         "v": WARM_PROTOCOL_VERSION,
         "env": env,
         "input": input,
+        "name": name,
     });
     let mut line = serde_json::to_string(&request)?;
     line.push('\n');
@@ -283,7 +326,7 @@ async fn roundtrip(mut stream: UnixStream, input: &str) -> Result<WarmRun> {
         // Single-frame outcome: a pre-execution classification such as
         // bad_input or overloaded, delivered without an ack. Nothing
         // executed, and the outcome is the invocation's result.
-        return Ok(WarmRun::Outcome(outcome));
+        return Ok(WarmRun::Outcome(outcome, frame.import_kind));
     }
     if !frame.ack {
         return Ok(WarmRun::Miss);
@@ -293,29 +336,40 @@ async fn roundtrip(mut stream: UnixStream, input: &str) -> Result<WarmRun> {
     // frame is a failed invocation, not a cold retry.
     let mut second = String::new();
     match tokio::time::timeout(WARM_RESPONSE_TIMEOUT, reader.read_line(&mut second)).await {
-        Ok(Ok(0)) | Ok(Err(_)) | Err(_) => return Ok(WarmRun::Outcome(lost_outcome_after_ack())),
+        Ok(Ok(0)) | Ok(Err(_)) | Err(_) => {
+            return Ok(WarmRun::Outcome(lost_outcome_after_ack(), None))
+        }
         Ok(Ok(_)) => {}
     }
     match serde_json::from_str::<WarmFrame>(second.trim()) {
         Ok(WarmFrame {
             v: WARM_PROTOCOL_VERSION,
             outcome: Some(outcome),
+            import_kind,
             ..
-        }) => Ok(WarmRun::Outcome(outcome)),
-        _ => Ok(WarmRun::Outcome(lost_outcome_after_ack())),
+        }) => Ok(WarmRun::Outcome(outcome, import_kind)),
+        _ => Ok(WarmRun::Outcome(lost_outcome_after_ack(), None)),
     }
 }
 
-/// Spawns a detached warm server for `handler` so the *next* invocation of
-/// this function is warm. Fire-and-forget: failures are ignored (the next
-/// run is simply cold again), and the server is its own process group so it
-/// survives dsbx exiting and is not collateral of anything that signals
-/// dsbx's group.
-pub fn spawn_server(name: &str, handler: &Path) {
+/// Spawns a detached generic worker on `name`'s home slot so the *next*
+/// invocation of this function (and of its app) is warm. Fire-and-forget:
+/// failures are ignored (the next run is simply cold again), and the worker
+/// is its own process group so it survives dsbx exiting and is not
+/// collateral of anything that signals dsbx's group.
+pub fn spawn_worker(name: &str) {
     if !super::is_valid_name(name) {
         return;
     }
     if rustix::process::geteuid().is_root() {
+        return;
+    }
+    // The worker resolves bundles against the functions dir itself; without
+    // one there is nothing to serve.
+    let Ok(functions_dir) = std::env::var("DUST_FUNCTIONS_DIR") else {
+        return;
+    };
+    if functions_dir.is_empty() {
         return;
     }
     let Some(dir) = ensure_trusted_warm_dir() else {
@@ -324,15 +378,15 @@ pub fn spawn_server(name: &str, handler: &Path) {
     let Ok(runner) = stage_runner(&dir) else {
         return;
     };
-    let socket = socket_path(&dir, name);
-    // If a server is already listening, leave it alone: it will serve the
-    // next request or exit stale on its own. Binding a second one would
-    // steal the socket mid-request.
-    if UnixStreamStdCheck::is_listening(&socket) {
+    let socket = slot_socket_path(&dir, preferred_slot(name));
+    // If a worker is already listening, leave it alone: it will serve the
+    // next request or drain on its own. Binding a second one would steal the
+    // socket mid-request.
+    if is_listening(&socket) {
         return;
     }
 
-    // The server's stderr goes to a log file in the warm dir rather than
+    // The worker's stderr goes to a log file in the warm dir rather than
     // /dev/null: a warm-served function's console.error output would
     // otherwise vanish, where a cold run's reaches the exec output that
     // front logs on failure.
@@ -345,7 +399,7 @@ pub fn spawn_server(name: &str, handler: &Path) {
     let mut cmd = Command::new("bun");
     cmd.arg(&runner)
         .arg("serve")
-        .arg(handler)
+        .arg(&functions_dir)
         .arg(&socket)
         .env("NODE_PATH", super::harness_node_path())
         .stdin(Stdio::null())
@@ -353,17 +407,13 @@ pub fn spawn_server(name: &str, handler: &Path) {
         .stderr(log.map(Stdio::from).unwrap_or_else(Stdio::null))
         .process_group(0);
     // Spawn and forget: tokio children are not killed on drop by default,
-    // and the server terminates itself on idle/lifetime/staleness.
+    // and the worker terminates itself on idle/lifetime/staleness.
     drop(cmd.spawn());
 }
 
 /// Cheap "is anything listening" probe used to avoid double-spawning.
-struct UnixStreamStdCheck;
-
-impl UnixStreamStdCheck {
-    fn is_listening(socket: &Path) -> bool {
-        std::os::unix::net::UnixStream::connect(socket).is_ok()
-    }
+fn is_listening(socket: &Path) -> bool {
+    std::os::unix::net::UnixStream::connect(socket).is_ok()
 }
 
 #[cfg(test)]
@@ -397,13 +447,14 @@ mod tests {
     }
 
     /// Cold-spawn then warm-hit then staleness, against the real runner:
-    /// spawn_server leaves a resident bun process behind, try_warm_run gets an
+    /// spawn_worker leaves a resident bun process behind, try_warm_run gets an
     /// outcome from it without any runner spawn, and a rewritten bundle turns
-    /// the next attempt into a miss.
+    /// the next attempt into a miss (the worker drains itself).
     #[tokio::test]
-    // The env lock intentionally spans the awaits: the spawned server and the
-    // client both read process-global env (HOME). Each #[tokio::test] runs
-    // its own runtime, so contending tests just block on the mutex.
+    // The env lock intentionally spans the awaits: the spawned worker and the
+    // client both read process-global env (HOME, DUST_FUNCTIONS_DIR). Each
+    // #[tokio::test] runs its own runtime, so contending tests just block on
+    // the mutex.
     #[allow(clippy::await_holding_lock)]
     async fn warm_cycle_end_to_end() {
         let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
@@ -412,38 +463,70 @@ mod tests {
             return;
         }
         let original_home = std::env::var_os("HOME");
+        let original_functions_dir = std::env::var_os("DUST_FUNCTIONS_DIR");
 
         let home = tempfile::tempdir().expect("home tempdir");
         std::env::set_var("HOME", home.path());
         let bundle_dir = tempfile::tempdir().expect("bundle tempdir");
         let handler = bundle_dir.path().join("greet.ts");
         std::fs::write(&handler, HELLO_FIXTURE).expect("fixture");
+        std::env::set_var("DUST_FUNCTIONS_DIR", bundle_dir.path());
 
         let input = serde_json::json!({ "url": "http://localhost/?name=warm" }).to_string();
 
         // Nothing is listening yet: a warm attempt must miss, not error.
         assert!(matches!(try_warm_run("greet", &input).await, WarmRun::Miss));
 
-        spawn_server("greet", &handler);
+        spawn_worker("greet");
 
-        // The server needs a moment to import the bundle and bind the socket.
+        // The worker needs a moment to bind its socket; the first served
+        // request pays the bundle import and reports it.
         let deadline = std::time::Instant::now() + Duration::from_secs(15);
-        let outcome = loop {
+        let (outcome, import_kind) = loop {
             match try_warm_run("greet", &input).await {
-                WarmRun::Outcome(outcome) => break outcome,
+                WarmRun::Outcome(outcome, import_kind) => break (outcome, import_kind),
                 WarmRun::Miss if std::time::Instant::now() < deadline => {
                     tokio::time::sleep(Duration::from_millis(50)).await;
                 }
-                WarmRun::Miss => panic!("warm server never came up"),
+                WarmRun::Miss => panic!("warm worker never came up"),
             }
         };
         assert_eq!(
             outcome,
             serde_json::json!({ "ok": true, "output": { "hello": "warm" } })
         );
+        assert_eq!(import_kind, Some(ImportKind::Fresh));
+
+        // A repeat invocation is served from the cached import.
+        match try_warm_run("greet", &input).await {
+            WarmRun::Outcome(_, import_kind) => {
+                assert_eq!(import_kind, Some(ImportKind::Cached));
+            }
+            WarmRun::Miss => panic!("second warm attempt missed"),
+        }
+
+        // A second function in the same directory is served by the same
+        // worker: its home slot is the same pool, and the worker is generic.
+        let sibling = bundle_dir.path().join("greet__aux.ts");
+        std::fs::write(&sibling, HELLO_FIXTURE).expect("sibling fixture");
+        match try_warm_run("greet__aux", &input).await {
+            WarmRun::Outcome(outcome, import_kind) => {
+                assert_eq!(
+                    outcome,
+                    serde_json::json!({ "ok": true, "output": { "hello": "warm" } })
+                );
+                assert_eq!(import_kind, Some(ImportKind::Fresh));
+            }
+            // Different affinity key, so a different (unspawned) home slot:
+            // also correct. Only assert when the slots coincide.
+            WarmRun::Miss => {
+                assert_ne!(preferred_slot("greet__aux"), preferred_slot("greet"));
+            }
+        }
 
         // A republished bundle (same path, new mtime/size) must not be served
-        // from the stale import: the server refuses and the client misses.
+        // from the stale import: the worker refuses (and drains itself) and
+        // the client misses.
         std::fs::write(
             &handler,
             format!(
@@ -457,14 +540,15 @@ mod tests {
         loop {
             match try_warm_run("greet", &input).await {
                 WarmRun::Miss => break,
-                WarmRun::Outcome(_) if std::time::Instant::now() < deadline => {
+                WarmRun::Outcome(..) if std::time::Instant::now() < deadline => {
                     tokio::time::sleep(Duration::from_millis(50)).await;
                 }
-                WarmRun::Outcome(_) => panic!("stale bundle kept being served"),
+                WarmRun::Outcome(..) => panic!("stale bundle kept being served"),
             }
         }
 
         restore_env("HOME", original_home);
+        restore_env("DUST_FUNCTIONS_DIR", original_functions_dir);
     }
 
     /// A squatted warm dir (wrong owner is hard to fake unprivileged, but a
@@ -503,36 +587,61 @@ mod tests {
     }
 
     #[test]
-    fn socket_path_is_short_and_stable() {
+    fn slot_socket_paths_are_short_stable_and_distinct() {
         let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
         let dir = PathBuf::from("/home/agent-proxied/.dust-fn");
-        let a = socket_path(&dir, "my-function");
-        let b = socket_path(&dir, "my-function");
+        let a = slot_socket_path(&dir, 0);
+        let b = slot_socket_path(&dir, 0);
         assert_eq!(a, b);
         assert!(a.as_os_str().len() < 100, "socket path too long: {a:?}");
+        assert_ne!(
+            slot_socket_path(&dir, 0),
+            slot_socket_path(&dir, POOL_SLOTS - 1)
+        );
     }
 
     #[test]
-    fn socket_path_distinguishes_long_slugs_sharing_a_prefix() {
-        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
-        let dir = PathBuf::from("/tmp");
-        let a = socket_path(&dir, "a-very-long-function-name-one");
-        let b = socket_path(&dir, "a-very-long-function-name-two");
-        assert_ne!(a, b);
-    }
-
-    #[test]
-    fn socket_path_distinguishes_functions_dirs() {
+    fn slot_socket_path_distinguishes_functions_dirs() {
         let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
         let original = std::env::var_os("DUST_FUNCTIONS_DIR");
         let dir = PathBuf::from("/tmp");
 
         std::env::set_var("DUST_FUNCTIONS_DIR", "/mnt/functions/space-a");
-        let a = socket_path(&dir, "greet");
+        let a = slot_socket_path(&dir, 0);
         std::env::set_var("DUST_FUNCTIONS_DIR", "/mnt/functions/space-b");
-        let b = socket_path(&dir, "greet");
+        let b = slot_socket_path(&dir, 0);
         assert_ne!(a, b);
 
         restore_env("DUST_FUNCTIONS_DIR", original);
+    }
+
+    #[test]
+    fn affinity_groups_an_app_and_leaves_root_functions_alone() {
+        // App-prefixed slugs share their app's key; root slugs are their own.
+        assert_eq!(affinity_key("myapp__list-notes"), "myapp");
+        assert_eq!(affinity_key("myapp__post-note"), "myapp");
+        assert_eq!(affinity_key("standalone"), "standalone");
+        // Degenerate prefixes fall back to the whole slug rather than
+        // grouping unrelated functions under an empty key.
+        assert_eq!(affinity_key("__odd"), "__odd");
+
+        assert_eq!(
+            preferred_slot("myapp__list-notes"),
+            preferred_slot("myapp__post-note")
+        );
+    }
+
+    #[test]
+    fn preferred_slot_is_stable_and_in_range() {
+        let a = preferred_slot("chatpro-sync");
+        assert_eq!(a, preferred_slot("chatpro-sync"));
+        assert!(a < POOL_SLOTS);
+        // Not a strong property, but the affinity point of the hash: distinct
+        // hot apps should not all pile onto slot 0.
+        let slots: std::collections::HashSet<u32> = ["chatpro-sync", "chess-move", "probe", "list"]
+            .iter()
+            .map(|name| preferred_slot(name))
+            .collect();
+        assert!(slots.len() > 1);
     }
 }


### PR DESCRIPTION
## Description

The previous PR makes warm servers concurrent but keeps one per function, so warm memory still scales with the number of functions on the pod, which has no ceiling (each bun process is ~40-60MB with no page sharing; dozens of hot functions would out-eat the 2GB sandbox).

This PR replaces per-function servers with a pod-scoped pool of 4 generic workers:

- The request names the function; the worker resolves and imports the bundle lazily and caches it. Warm memory is bounded by the pool (4 x 300MB RSS cap), not by function count.
- Routing hashes the app prefix of the slug (app folders publish as `app__function`, root slugs hash as themselves), so all of one app's functions share a home worker: opening an app pays one process spawn ever, and its working set (shared lib imports included) accumulates in one module cache. The client only talks to the home slot; the cold path spawns it.
- Warm timings gain an additive `importKind` (cached|fresh) to observe affinity effectiveness.

Concurrency, admission, the ack contract and drain semantics are unchanged from the previous PR. A republish now recycles a whole worker rather than one function's server; the next PR in the stack removes that recycle entirely.

## Tests

bun: multi-function serving from one worker with importKind transitions, unknown-name refusal without dying, stamped-hash refusal before import (worker not poisoned), stale drain still lets in-flight work finish. Cargo e2e against real bun: miss, spawn at home slot, fresh then cached hits, a sibling function served by the same worker, republish, stale, miss. Affinity units: app prefixes group, root slugs and degenerate prefixes hash as themselves.

## Risk

Inert until the stack's dsbx release + image bump. Deltas vs per-function: a republish drops one worker's warmth (its app cohort) until the next PR lands, and a CPU-heavy function stalls its own app's siblings during sync bursts (accepted: isolation moved from per-function to per-app-cohort).

## Deploy Plan

Ships with the stack (see the stack's last PR).