### PR TITLE
[front] fix: refresh blocked actions client-side after personal auth

### DIFF
--- a/front/components/assistant/conversation/BlockedActionsProvider.test.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.test.tsx
@@ -86,8 +86,11 @@ function makeAuthBlockedAction(
 }
 
 function Consumer() {
-  const { getFirstBlockedActionForMessage, removeCompletedAction } =
-    useBlockedActionsContext();
+  const {
+    getFirstBlockedActionForMessage,
+    refreshBlockedActions,
+    removeCompletedAction,
+  } = useBlockedActionsContext();
 
   const firstAction = getFirstBlockedActionForMessage("msg_1");
 
@@ -103,6 +106,14 @@ function Consumer() {
         }}
       >
         resolve
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void refreshBlockedActions();
+        }}
+      >
+        refresh
       </button>
     </div>
   );
@@ -147,6 +158,15 @@ describe("BlockedActionsProvider", () => {
     await user.click(screen.getByRole("button", { name: "resolve" }));
 
     expect(screen.getByTestId("first-action")).toHaveTextContent("none");
+    expect(mutateBlockedActionsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes blocked actions on demand", async () => {
+    const user = userEvent.setup();
+
+    renderProvider();
+    await user.click(screen.getByRole("button", { name: "refresh" }));
+
     expect(mutateBlockedActionsMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -28,6 +28,7 @@ type BlockedActionsContextType = {
     messageId: string;
     blockedAction: AgentLoopBlockedToolExecution;
   }) => void;
+  refreshBlockedActions: () => Promise<void>;
   removeCompletedAction: (actionId: string) => void;
   removeAllBlockedActionsForMessage: (params: {
     messageId: string;
@@ -204,6 +205,10 @@ export function BlockedActionsProvider({
     [stopPulsingAction, mutateBlockedActions]
   );
 
+  const refreshBlockedActions = useCallback(async () => {
+    await mutateBlockedActions();
+  }, [mutateBlockedActions]);
+
   const hasPendingValidations = useCallback(
     (userId: string) => {
       return blockedActionsQueue.some(
@@ -285,6 +290,7 @@ export function BlockedActionsProvider({
   const value = useMemo(
     () => ({
       enqueueBlockedAction,
+      refreshBlockedActions,
       removeCompletedAction,
       removeAllBlockedActionsForMessage,
       hasPendingValidations,
@@ -296,6 +302,7 @@ export function BlockedActionsProvider({
     }),
     [
       enqueueBlockedAction,
+      refreshBlockedActions,
       removeCompletedAction,
       removeAllBlockedActionsForMessage,
       hasPendingValidations,

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.test.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.test.tsx
@@ -9,7 +9,7 @@ import { MCPServerPersonalAuthenticationRequired } from "./MCPServerPersonalAuth
 
 const createPersonalConnectionMock = vi.fn();
 const resolveAuthenticationMock = vi.fn();
-const removeCompletedActionMock = vi.fn();
+const refreshBlockedActionsMock = vi.fn();
 
 vi.mock("@app/lib/auth/AuthContext", () => ({
   useAuth: () => ({ user: { sId: "user_1" } }),
@@ -19,7 +19,7 @@ vi.mock(
   "@app/components/assistant/conversation/BlockedActionsProvider",
   () => ({
     useBlockedActionsContext: () => ({
-      removeCompletedAction: removeCompletedActionMock,
+      refreshBlockedActions: refreshBlockedActionsMock,
     }),
   })
 );
@@ -170,16 +170,20 @@ describe("MCPServerPersonalAuthenticationRequired", () => {
     vi.clearAllMocks();
     createPersonalConnectionMock.mockResolvedValue({ success: true });
     resolveAuthenticationMock.mockResolvedValue({ success: true });
+    refreshBlockedActionsMock.mockResolvedValue(undefined);
   });
 
-  it("resolves the action as completed on a successful connection", async () => {
+  it("refreshes blocked actions after resolving a successful connection", async () => {
     const user = userEvent.setup();
     renderCard();
 
     await user.click(screen.getByRole("button", { name: /Connect/i }));
 
     expect(outcomesPassedToResolve()).toContain("completed");
-    expect(removeCompletedActionMock).toHaveBeenCalledWith("action_1");
+    expect(refreshBlockedActionsMock).toHaveBeenCalledTimes(1);
+    expect(resolveAuthenticationMock.mock.invocationCallOrder[0]).toBeLessThan(
+      refreshBlockedActionsMock.mock.invocationCallOrder[0]
+    );
   });
 
   it("keeps Skip enabled while a connection attempt is in flight", async () => {

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.test.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.test.tsx
@@ -10,6 +10,7 @@ import { MCPServerPersonalAuthenticationRequired } from "./MCPServerPersonalAuth
 const createPersonalConnectionMock = vi.fn();
 const resolveAuthenticationMock = vi.fn();
 const refreshBlockedActionsMock = vi.fn();
+const removeCompletedActionMock = vi.fn();
 
 vi.mock("@app/lib/auth/AuthContext", () => ({
   useAuth: () => ({ user: { sId: "user_1" } }),
@@ -20,6 +21,7 @@ vi.mock(
   () => ({
     useBlockedActionsContext: () => ({
       refreshBlockedActions: refreshBlockedActionsMock,
+      removeCompletedAction: removeCompletedActionMock,
     }),
   })
 );
@@ -173,15 +175,19 @@ describe("MCPServerPersonalAuthenticationRequired", () => {
     refreshBlockedActionsMock.mockResolvedValue(undefined);
   });
 
-  it("refreshes blocked actions after resolving a successful connection", async () => {
+  it("removes the completed action before refreshing blocked actions", async () => {
     const user = userEvent.setup();
     renderCard();
 
     await user.click(screen.getByRole("button", { name: /Connect/i }));
 
     expect(outcomesPassedToResolve()).toContain("completed");
+    expect(removeCompletedActionMock).toHaveBeenCalledWith("action_1");
     expect(refreshBlockedActionsMock).toHaveBeenCalledTimes(1);
     expect(resolveAuthenticationMock.mock.invocationCallOrder[0]).toBeLessThan(
+      removeCompletedActionMock.mock.invocationCallOrder[0]
+    );
+    expect(removeCompletedActionMock.mock.invocationCallOrder[0]).toBeLessThan(
       refreshBlockedActionsMock.mock.invocationCallOrder[0]
     );
   });

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -25,7 +25,8 @@ export function MCPServerPersonalAuthenticationRequired({
   scope,
 }: MCPServerPersonalAuthenticationRequiredProps) {
   const { user } = useAuth();
-  const { refreshBlockedActions } = useBlockedActionsContext();
+  const { refreshBlockedActions, removeCompletedAction } =
+    useBlockedActionsContext();
 
   const { resolveAuthentication, isResolving } = useResolveAuthentication({
     owner,
@@ -47,6 +48,7 @@ export function MCPServerPersonalAuthenticationRequired({
       return false;
     }
 
+    removeCompletedAction(blockedAction.actionId);
     await refreshBlockedActions();
     return true;
   };

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -25,7 +25,7 @@ export function MCPServerPersonalAuthenticationRequired({
   scope,
 }: MCPServerPersonalAuthenticationRequiredProps) {
   const { user } = useAuth();
-  const { removeCompletedAction } = useBlockedActionsContext();
+  const { refreshBlockedActions } = useBlockedActionsContext();
 
   const { resolveAuthentication, isResolving } = useResolveAuthentication({
     owner,
@@ -47,7 +47,7 @@ export function MCPServerPersonalAuthenticationRequired({
       return false;
     }
 
-    removeCompletedAction(blockedAction.actionId);
+    await refreshBlockedActions();
     return true;
   };
 

--- a/front/lib/api/assistant/conversation/resolve_authentication.ts
+++ b/front/lib/api/assistant/conversation/resolve_authentication.ts
@@ -1,5 +1,5 @@
+import type { AgentLoopBlockedToolExecution } from "@app/lib/actions/mcp";
 import {
-  type AgentLoopBlockedToolExecution,
   isToolFileAuthRequiredEvent,
   isToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp";


### PR DESCRIPTION
## Description

Follow-up to #30007. When one personal authentication resolves several other blocked tool calls on the same server, these ones are not cleared client-side, until revalidation kicks in.

This PR mutates the blocked actions to clear the other ones that were able to advance using the new auth.

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
