### PR TITLE
[front] enh: add notification on skill favorites setting

### DIFF
--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -54,7 +54,6 @@ export function SkillDetailsButtonBar({
         {onFavoriteChange && (
           <SkillFavoriteButton
             isFavorite={skill.isFavorite ?? false}
-            skill={skill}
             variant="outline"
             onFavoriteChange={(isFavorite) =>
               onFavoriteChange(skill, isFavorite)

--- a/front/components/skills/SkillFavoriteButton.tsx
+++ b/front/components/skills/SkillFavoriteButton.tsx
@@ -1,4 +1,3 @@
-import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { ButtonVariantType } from "@dust-tt/sparkle";
 import { Button, Star01, StarFilled } from "@dust-tt/sparkle";
 import type { MouseEvent } from "react";
@@ -7,7 +6,6 @@ import { useState } from "react";
 type SkillFavoriteButtonProps = {
   isFavorite: boolean;
   onFavoriteChange: (isFavorite: boolean) => Promise<void>;
-  skill: SkillWithoutInstructionsAndToolsType;
   size?: "icon" | "icon-xs";
   variant?: ButtonVariantType;
 };
@@ -15,7 +13,6 @@ type SkillFavoriteButtonProps = {
 export function SkillFavoriteButton({
   isFavorite,
   onFavoriteChange,
-  skill,
   size = "icon",
   variant = "ghost-secondary",
 }: SkillFavoriteButtonProps) {
@@ -39,7 +36,7 @@ export function SkillFavoriteButton({
       icon={isFavorite ? StarFilled : Star01}
       isLoading={isUpdating}
       aria-pressed={isFavorite}
-      tooltip={`${nextIsFavorite ? "Favorite" : "Unfavorite"} ${skill.name}`}
+      tooltip={nextIsFavorite ? "Add to favorites" : "Remove from favorites"}
       onClick={handleClick}
     />
   );

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -8,6 +8,7 @@ import type {
 } from "@app/lib/skill_detection";
 import { parseGitHubRepoUrl } from "@app/lib/skill_detection";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { getManageSkillsRoute } from "@app/lib/utils/router";
 import type { GetSkillHistoryResponseBody } from "@app/types/api/assistant/skills/history";
 import type {
   GetSkillResponseBody,
@@ -434,6 +435,18 @@ export function useUpdateSkillFavorite({
 
         void mutateActiveSkills();
         void mutateActiveSkillsWithRelations();
+
+        if (isFavorite) {
+          sendNotification({
+            type: "success",
+            title: "Added to favorites",
+            description: skill.name,
+            action: {
+              label: "View",
+              href: `${getManageSkillsRoute(owner.sId)}#?selectedTab=favorites`,
+            },
+          });
+        }
         return true;
       } catch (err) {
         sendNotification({

--- a/sparkle/src/components/Notification.tsx
+++ b/sparkle/src/components/Notification.tsx
@@ -11,11 +11,17 @@ import { cn } from "@sparkle/lib/utils";
 import React from "react";
 import { Toaster, toast } from "sonner";
 
+import { Button } from "./Button";
 import { Icon } from "./Icon";
 
 const NOTIFICATION_DELAY_MS = 5000;
 
 export type NotificationType = {
+  action?: {
+    href?: string;
+    label: string;
+    onClick?: () => void;
+  };
   title?: string;
   description?: string;
   type: "success" | "error" | "info" | "warning" | "hello";
@@ -63,6 +69,7 @@ export function NotificationContent({
   type,
   title,
   description,
+  action,
   onDismiss,
 }: NotificationType & { onDismiss?: () => void }) {
   const icon = resolveIcon(type);
@@ -114,6 +121,20 @@ export function NotificationContent({
           </button>
         )}
       </div>
+      {action && (
+        <div className="mt-1 pl-5">
+          <Button
+            size="xs"
+            variant="ghost"
+            label={action.label}
+            href={action.href}
+            onClick={() => {
+              action.onClick?.();
+              onDismiss?.();
+            }}
+          />
+        </div>
+      )}
     </div>
   );
 }
@@ -128,6 +149,7 @@ export const Notification = {
               type={notification.type}
               title={notification.title}
               description={notification.description}
+              action={notification.action}
               onDismiss={() => toast.dismiss(t)}
             />
           ),

--- a/sparkle/src/stories/Notification.stories.tsx
+++ b/sparkle/src/stories/Notification.stories.tsx
@@ -58,6 +58,12 @@ export const Inline = () => {
         title="You have a message"
         description="A friendly notification"
       />
+      <NotificationContent
+        type="success"
+        title="Added to favorites"
+        description="Research assistant"
+        action={{ label: "View", href: "#favorites" }}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Description

Favoriting a skill currently updates the star without showing where the skill can be found again.

This PR adds optional actions to notifications and shows an Added to favorites confirmation with a View action linking directly to the Favorites tab. It also changes the toggle tooltip to Add to favorites or Remove from favorites.

## Tests

- Tested locally.

## Risk

- Low. The favorite UI remains behind the `skill_favorites` feature flag.

## Deploy Plan

- Deploy front.