### PR TITLE
Bump dsbx to 0.1.47 and dust-base to 0.8.72

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.46"
+version = "0.1.47"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.46"
+version = "0.1.47"
 edition = "2021"
 
 [[bin]]

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.71",
+      tag: "0.8.72",
     });
   });
 
@@ -457,7 +457,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.46/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.47/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,8 +26,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.71";
-const DSBX_CLI_VERSION = "0.1.46";
+const DUST_BASE_IMAGE_VERSION = "0.8.72";
+const DSBX_CLI_VERSION = "0.1.47";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
 // the stable identity used when creating the workload account.


### PR DESCRIPTION
## Description

Deploy PR for the warm worker pool stack (#30234, #30235, #30293, #30236): bumps dsbx to 0.1.47 and the base image to 0.8.72 so sandboxes pick up the concurrent generic workers, the per-invocation context in @dust/pod, and the bundle cache.

## Tests

The stack's own suites (cargo + bun) cover the shipped behavior; this PR only moves version pins.

## Risk

Low: the code is inert until this rolls, and rolling back is re-pinning the previous versions. Memory worst case is 4 workers x 300MB RSS cap inside the 2GB sandbox.

## Deploy Plan

1. dsbx release dispatched from this branch before merge (release-dsbx-cli.yml), so the binary exists when the image builds.
2. Merge; sandbox-img-registry builds dust-base 0.8.72.
3. After deploy, /poke/kill sandboxes on older image versions.
4. Watch `sandbox.functions.run` by `runner_kind`/`importKind`: cold share under load should drop toward zero, `overloaded` only under real saturation.