### PR TITLE
[marketing] Promote the August 20 and 27 online events

### DIFF
--- a/marketing/components/home/PromoBanner.tsx
+++ b/marketing/components/home/PromoBanner.tsx
@@ -1,21 +1,44 @@
-import { Clock, User01, XClose } from "@dust-tt/sparkle";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Clock,
+  User01,
+  XClose,
+} from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
 // =============================================================================
-// PROMO CONFIG — Update this object to promote a new event.
-// Set to null when there's nothing to promote.
+// PROMO SCHEDULE — Ordered list of events to promote.
+// Every entry that hasn't expired yet is shown, as a carousel the visitor can
+// page through. Expired entries drop out on their own, so the banner needs no
+// deploy to stay current. Keep it ordered by `expiresAt` (soonest first) —
+// that's the order visitors page through. Empty it when there's nothing to
+// promote.
 // =============================================================================
-const CURRENT_PROMO: PromoConfig | null = {
-  id: "the-governance-of-ai-aug10",
-  image: "/static/landing/Webinar_Banner.jpeg",
-  link: "https://watch.getcontrast.io/register/dust-the-governance-of-ai?utm_source=website",
-  badge: "Online Event",
-  title: "The Governance of AI",
-  time: "August 10 · 9:00am PT / 6:00pm CET",
-  linkLabel: "Register Now",
-  // Banner auto-hides after this date (a few hours after the August 10th event).
-  expiresAt: new Date("2026-08-10T13:00:00-07:00"),
-};
+const PROMO_SCHEDULE: PromoConfig[] = [
+  {
+    id: "use-gamma-in-dust-aug20",
+    image: "/static/landing/Webinar_Banner.jpeg",
+    link: "https://watch.getcontrast.io/register/dust-gamma-in-dust?utm_source=website",
+    badge: "Online Event",
+    title: "How to use Gamma in Dust",
+    time: "August 20 · 9:00am PT / 6:00pm CET",
+    linkLabel: "Register Now",
+    // Drops out of the carousel an hour after the August 20th event.
+    expiresAt: new Date("2026-08-20T10:00:00-07:00"),
+  },
+  {
+    id: "build-your-gtm-cockpit-aug27",
+    image: "/static/landing/GTM_Engineers_Webinar_Banner.png",
+    link: "https://watch.getcontrast.io/register/dust-build-your-gtm-cockpit?utm_source=website",
+    badge: "Online Event",
+    title: "Build your GTM cockpit",
+    time: "August 27 · 9:00am PT / 6:00pm CET",
+    linkLabel: "Register Now",
+    // Banner auto-hides after this date (a few hours after the August 27th event).
+    expiresAt: new Date("2026-08-27T22:00:00+02:00"),
+  },
+];
 // =============================================================================
 
 interface PromoConfig {
@@ -37,31 +60,45 @@ interface PromoConfig {
   expiresAt?: Date;
 }
 
-function storageKey(id: string) {
-  return `promo-banner-dismissed-${id}`;
+/** Dismissal covers the whole carousel, so the key spans every promo shown. */
+function storageKey(promos: PromoConfig[]) {
+  return `promo-banner-dismissed-${promos.map((promo) => promo.id).join("+")}`;
+}
+
+/** Promos that haven't expired yet, in schedule order. */
+function getActivePromos(now: Date): PromoConfig[] {
+  return PROMO_SCHEDULE.filter(
+    (promo) => !promo.expiresAt || now <= promo.expiresAt
+  );
 }
 
 export function PromoBanner() {
-  const [isVisible, setIsVisible] = useState(false);
+  // Resolved on mount only: the schedule is picked from the visitor's clock, so
+  // it must not run during SSR (the server would bake in a stale promo).
+  const [promos, setPromos] = useState<PromoConfig[]>([]);
+  const [index, setIndex] = useState(0);
 
   useEffect(() => {
-    if (!CURRENT_PROMO) {
+    const activePromos = getActivePromos(new Date());
+    if (activePromos.length === 0) {
       return;
     }
-    if (CURRENT_PROMO.expiresAt && new Date() > CURRENT_PROMO.expiresAt) {
-      return;
-    }
-    if (sessionStorage.getItem(storageKey(CURRENT_PROMO.id)) !== "true") {
-      setIsVisible(true);
+    if (sessionStorage.getItem(storageKey(activePromos)) !== "true") {
+      setPromos(activePromos);
     }
   }, []);
 
-  if (!isVisible || !CURRENT_PROMO) {
+  if (promos.length === 0) {
     return null;
   }
 
-  const { link, badge, title, time, host, linkLabel, id } = CURRENT_PROMO;
+  const hasMultiplePromos = promos.length > 1;
+  // Wraps around, so two events stay one click apart in either direction.
+  const step = (offset: number) =>
+    setIndex((current) => (current + offset + promos.length) % promos.length);
 
+  // Below `sm` the card keeps its width but loses vertical padding, so it
+  // covers less of the hero on a phone.
   return (
     <div className="fixed bottom-4 right-4 z-40 w-[264px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-xl ring-1 ring-black/5">
       <button
@@ -69,50 +106,107 @@ export function PromoBanner() {
         aria-label="Dismiss"
         className="absolute right-1.5 top-1.5 z-10 flex h-8 w-8 items-center justify-center rounded-full text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600"
         onClick={() => {
-          sessionStorage.setItem(storageKey(id), "true");
-          setIsVisible(false);
+          sessionStorage.setItem(storageKey(promos), "true");
+          setPromos([]);
         }}
       >
         <XClose className="h-4 w-4" />
       </button>
-      <a
-        href={link}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="group block p-4"
-      >
-        <div className="mb-2.5 flex items-center gap-2 pr-6 text-[11px] font-semibold uppercase tracking-wide text-blue-600">
-          <span className="relative flex h-2 w-2">
-            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-400 opacity-75" />
-            <span className="relative inline-flex h-2 w-2 rounded-full bg-blue-500" />
-          </span>
-          {badge}
+      {/* Slides sit side by side on one row; paging slides the row rather than
+          swapping the content, so the movement reads as continuous. */}
+      <div className="overflow-hidden">
+        <div
+          className="flex transition-transform duration-500 ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none"
+          style={{ transform: `translateX(-${index * 100}%)` }}
+        >
+          {promos.map((promo, promoIndex) => {
+            const isActive = promoIndex === index;
+
+            return (
+              <a
+                key={promo.id}
+                href={promo.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group block w-full shrink-0 px-4 py-3 sm:p-4"
+                // Off-screen slides stay out of the tab order and the a11y tree.
+                aria-hidden={!isActive}
+                tabIndex={isActive ? undefined : -1}
+              >
+                <div className="mb-1.5 flex items-center gap-2 pr-6 text-[11px] font-semibold uppercase tracking-wide text-blue-600 sm:mb-2.5">
+                  <span className="relative flex h-2 w-2">
+                    <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-400 opacity-75" />
+                    <span className="relative inline-flex h-2 w-2 rounded-full bg-blue-500" />
+                  </span>
+                  {promo.badge}
+                </div>
+                <div className="text-sm font-semibold leading-snug text-slate-900">
+                  {promo.title}
+                </div>
+                <div className="mt-1.5 space-y-1 text-[11px] leading-relaxed text-slate-500 sm:mt-2">
+                  <div className="flex items-start gap-1.5">
+                    <Clock className="mt-px h-3.5 w-3.5 shrink-0 text-slate-400" />
+                    <span>{promo.time}</span>
+                  </div>
+                  {promo.host && (
+                    <div className="flex items-start gap-1.5">
+                      <User01 className="mt-px h-3.5 w-3.5 shrink-0 text-slate-400" />
+                      <span>{promo.host}</span>
+                    </div>
+                  )}
+                </div>
+                <div className="mt-2 flex items-center gap-1 text-[11px] font-medium text-blue-600 group-hover:underline sm:mt-3">
+                  {promo.linkLabel}
+                  <span
+                    aria-hidden
+                    className="transition-transform group-hover:translate-x-0.5"
+                  >
+                    →
+                  </span>
+                </div>
+              </a>
+            );
+          })}
         </div>
-        <div className="text-sm font-semibold leading-snug text-slate-900">
-          {title}
-        </div>
-        <div className="mt-2 space-y-1 text-[11px] leading-relaxed text-slate-500">
-          <div className="flex items-start gap-1.5">
-            <Clock className="mt-px h-3.5 w-3.5 shrink-0 text-slate-400" />
-            <span>{time}</span>
-          </div>
-          {host && (
-            <div className="flex items-start gap-1.5">
-              <User01 className="mt-px h-3.5 w-3.5 shrink-0 text-slate-400" />
-              <span>{host}</span>
-            </div>
-          )}
-        </div>
-        <div className="mt-3 flex items-center gap-1 text-[11px] font-medium text-blue-600 group-hover:underline">
-          {linkLabel}
-          <span
-            aria-hidden
-            className="transition-transform group-hover:translate-x-0.5"
+      </div>
+      {/* Kept outside the <a> — nesting buttons in a link is invalid markup and
+          every arrow click would also open the registration page. */}
+      {hasMultiplePromos && (
+        <div className="flex items-center justify-between border-t border-slate-100 px-1.5 py-0.5 sm:py-1">
+          <button
+            type="button"
+            aria-label="Previous event"
+            className="flex h-5 w-5 items-center justify-center rounded-full text-slate-300 transition-colors hover:bg-slate-100 hover:text-slate-500"
+            onClick={() => step(-1)}
           >
-            →
-          </span>
+            <ChevronLeft className="h-3 w-3" />
+          </button>
+          <div className="flex items-center gap-1">
+            {promos.map((promo, promoIndex) => (
+              <button
+                key={promo.id}
+                type="button"
+                aria-label={`Show ${promo.title}`}
+                aria-current={promoIndex === index}
+                className={`h-1 w-1 rounded-full transition-colors ${
+                  promoIndex === index
+                    ? "bg-blue-500"
+                    : "bg-slate-300 hover:bg-slate-400"
+                }`}
+                onClick={() => setIndex(promoIndex)}
+              />
+            ))}
+          </div>
+          <button
+            type="button"
+            aria-label="Next event"
+            className="flex h-5 w-5 items-center justify-center rounded-full text-slate-300 transition-colors hover:bg-slate-100 hover:text-slate-500"
+            onClick={() => step(1)}
+          >
+            <ChevronRight className="h-3 w-3" />
+          </button>
         </div>
-      </a>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Description

Replaces the single `CURRENT_PROMO` config in the marketing `PromoBanner` with an ordered `PROMO_SCHEDULE` array, enabling multiple upcoming events to be promoted simultaneously as a carousel. Active promos are filtered client-side (on mount, not during SSR) based on their `expiresAt` date, so expired entries drop out automatically without a redeploy. Dismissal covers the entire carousel via a combined session-storage key. Two events are added: "How to use Gamma in Dust" (Aug 20) and "Build your GTM cockpit" (Aug 27). Also reduces vertical padding below `sm` breakpoint so the card covers less of the hero on mobile.

## Tests

Tested manually: verify the carousel renders both events, pagination wraps correctly, and dismissing hides the full banner. Verify that expiring the first event (mocking the date past Aug 20) leaves only the second card with no carousel controls.

## Risk

Low — marketing-only UI change with no backend or data impact. The SSR-safe `useEffect` pattern avoids hydration mismatches.

## Deploy Plan

Deploy `marketing`.