### PR TITLE
[dsbx] perf: eager import and app sibling prefetch in warm workers

### DIFF
--- a/cli/dust-sandbox/functions-runner/runner.ts
+++ b/cli/dust-sandbox/functions-runner/runner.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env bun
 // Embedded runner for `dsbx function` and `dsbx db`. Subcommands:
 //   runner run <path>                            stdin request envelope -> stdout Output JSON
-//   runner serve <functionsDir> <socketPath>     warm worker: serve invocations of any function
-//                                                in <functionsDir> over a unix socket until idle
+//   runner serve <functionsDir> <socketPath> [eagerName]
+//                                                warm worker: serve invocations of any function
+//                                                in <functionsDir> over a unix socket until idle,
+//                                                eagerly importing [eagerName] and its app first
 //   runner get <path>                            -> stdout FunctionSchema JSON (or {error})
 //   runner build <src> <outBundle> <outSchema>   bundle + extract schema to files
 //   runner db-reconcile <dbPath> <schemaFile>    additive-only DDL reconcile -> stdout envelope
@@ -177,15 +179,15 @@ async function main(): Promise<number> {
     case "get":
       return getHandler(handlerPath);
     case "serve": {
-      const [functionsDir, socketPath] = rest;
+      const [functionsDir, socketPath, eagerName] = rest;
       if (!functionsDir || !socketPath) {
         process.stderr.write(
-          "usage: runner serve <functions-dir> <socket-path>\n"
+          "usage: runner serve <functions-dir> <socket-path> [eager-name]\n"
         );
         return 2;
       }
       // Never returns: the worker exits itself (idle, lifetime, staleness).
-      return serve(functionsDir, socketPath);
+      return serve(functionsDir, socketPath, eagerName);
     }
     default:
       process.stderr.write(`runner: unknown command "${command}"\n`);

--- a/cli/dust-sandbox/functions-runner/serve.test.ts
+++ b/cli/dust-sandbox/functions-runner/serve.test.ts
@@ -679,6 +679,100 @@ describe("runner serve", () => {
   });
 });
 
+describe("sibling prefetch", () => {
+  const appDir = () => {
+    const dir = scratch();
+    for (const stem of [
+      "myapp__alpha",
+      "myapp__beta",
+      "myapp__gamma",
+      "solo",
+    ]) {
+      copyFileSync(join(fixturesDir, "hello.ts"), join(dir, `${stem}.ts`));
+    }
+    return dir;
+  };
+
+  // Polls until a request for `name` is served from the module cache.
+  async function untilCached(
+    socketPath: string,
+    name: string,
+    deadlineMs: number
+  ): Promise<boolean> {
+    const deadline = Date.now() + deadlineMs;
+    while (Date.now() < deadline) {
+      const frames = await requestFrames(
+        socketPath,
+        warmRequest(name, {}, { url: "http://localhost/" })
+      );
+      if (frames[1]?.importKind === "cached") {
+        return true;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    return false;
+  }
+
+  test("the first import of an app warms its siblings in the background", async () => {
+    const dir = appDir();
+    const { proc, socketPath } = await startWorker(dir);
+    try {
+      const first = await requestFrames(
+        socketPath,
+        warmRequest("myapp__alpha", {}, { url: "http://localhost/?name=a" })
+      );
+      expect(first[1]?.importKind).toBe("fresh");
+
+      // Both siblings become cached without ever being requested fresh
+      // first... their first request may race the prefetch, so poll.
+      expect(await untilCached(socketPath, "myapp__beta", 5_000)).toBe(true);
+      expect(await untilCached(socketPath, "myapp__gamma", 5_000)).toBe(true);
+
+      // The root-level function shares the worker but not the app: it is
+      // not prefetched and pays its own import on first request.
+      const solo = await requestFrames(
+        socketPath,
+        warmRequest("solo", {}, { url: "http://localhost/" })
+      );
+      expect(solo[1]?.importKind).toBe("fresh");
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("an eager-name spawn imports the function and its app before any request", async () => {
+    const dir = appDir();
+    const socketPath = join(scratch(), "fn.sock");
+    const proc = Bun.spawn(
+      ["bun", runner, "serve", dir, socketPath, "myapp__alpha"],
+      { stdin: "ignore", stdout: "ignore", stderr: "inherit" }
+    );
+    try {
+      // Wait for the socket, then for the eager import + prefetch to land:
+      // every function of the app ends up cached without a fresh request.
+      const deadline = Date.now() + 10_000;
+      let up = false;
+      while (Date.now() < deadline && !up) {
+        try {
+          const probe = await Bun.connect({
+            unix: socketPath,
+            socket: { data() {} },
+          });
+          probe.end();
+          up = true;
+        } catch {
+          await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+      }
+      expect(up).toBe(true);
+      expect(await untilCached(socketPath, "myapp__alpha", 5_000)).toBe(true);
+      expect(await untilCached(socketPath, "myapp__beta", 5_000)).toBe(true);
+    } finally {
+      proc.kill();
+    }
+  });
+});
+
 describe("resolveBundle", () => {
   test("resolves a name to its single matching file", () => {
     expect(resolveBundle(fixturesDir, "hello")).toBe(

--- a/cli/dust-sandbox/functions-runner/serve.test.ts
+++ b/cli/dust-sandbox/functions-runner/serve.test.ts
@@ -693,25 +693,11 @@ describe("sibling prefetch", () => {
     return dir;
   };
 
-  // Polls until a request for `name` is served from the module cache.
-  async function untilCached(
-    socketPath: string,
-    name: string,
-    deadlineMs: number
-  ): Promise<boolean> {
-    const deadline = Date.now() + deadlineMs;
-    while (Date.now() < deadline) {
-      const frames = await requestFrames(
-        socketPath,
-        warmRequest(name, {}, { url: "http://localhost/" })
-      );
-      if (frames[1]?.importKind === "cached") {
-        return true;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    }
-    return false;
-  }
+  // The fixtures import in milliseconds and the prefetch loop re-checks
+  // quiet every 100ms, so this settle window makes the background imports
+  // deterministic: after it, a sibling's FIRST request must already be
+  // cached — polling would be vacuous, since the poll itself imports.
+  const PREFETCH_SETTLE_MS = 2_000;
 
   test("the first import of an app warms its siblings in the background", async () => {
     const dir = appDir();
@@ -723,10 +709,20 @@ describe("sibling prefetch", () => {
       );
       expect(first[1]?.importKind).toBe("fresh");
 
-      // Both siblings become cached without ever being requested fresh
-      // first... their first request may race the prefetch, so poll.
-      expect(await untilCached(socketPath, "myapp__beta", 5_000)).toBe(true);
-      expect(await untilCached(socketPath, "myapp__gamma", 5_000)).toBe(true);
+      await new Promise((resolve) => setTimeout(resolve, PREFETCH_SETTLE_MS));
+
+      // The very first request for each sibling is served from the module
+      // cache: the prefetch paid the import, not this request.
+      const beta = await requestFrames(
+        socketPath,
+        warmRequest("myapp__beta", {}, { url: "http://localhost/" })
+      );
+      expect(beta[1]?.importKind).toBe("cached");
+      const gamma = await requestFrames(
+        socketPath,
+        warmRequest("myapp__gamma", {}, { url: "http://localhost/" })
+      );
+      expect(gamma[1]?.importKind).toBe("cached");
 
       // The root-level function shares the worker but not the app: it is
       // not prefetched and pays its own import on first request.
@@ -738,7 +734,7 @@ describe("sibling prefetch", () => {
     } finally {
       proc.kill();
     }
-  });
+  }, 15_000);
 
   test("an eager-name spawn imports the function and its app before any request", async () => {
     const dir = appDir();
@@ -748,8 +744,6 @@ describe("sibling prefetch", () => {
       { stdin: "ignore", stdout: "ignore", stderr: "inherit" }
     );
     try {
-      // Wait for the socket, then for the eager import + prefetch to land:
-      // every function of the app ends up cached without a fresh request.
       const deadline = Date.now() + 10_000;
       let up = false;
       while (Date.now() < deadline && !up) {
@@ -765,12 +759,24 @@ describe("sibling prefetch", () => {
         }
       }
       expect(up).toBe(true);
-      expect(await untilCached(socketPath, "myapp__alpha", 5_000)).toBe(true);
-      expect(await untilCached(socketPath, "myapp__beta", 5_000)).toBe(true);
+      await new Promise((resolve) => setTimeout(resolve, PREFETCH_SETTLE_MS));
+
+      // No request has been made yet: the eager import covered the named
+      // function and the prefetch covered its sibling.
+      const alpha = await requestFrames(
+        socketPath,
+        warmRequest("myapp__alpha", {}, { url: "http://localhost/" })
+      );
+      expect(alpha[1]?.importKind).toBe("cached");
+      const beta = await requestFrames(
+        socketPath,
+        warmRequest("myapp__beta", {}, { url: "http://localhost/" })
+      );
+      expect(beta[1]?.importKind).toBe("cached");
     } finally {
       proc.kill();
     }
-  });
+  }, 15_000);
 });
 
 describe("resolveBundle", () => {

--- a/cli/dust-sandbox/functions-runner/serve.ts
+++ b/cli/dust-sandbox/functions-runner/serve.ts
@@ -260,7 +260,8 @@ function overloadedFrame(): Record<string, unknown> {
 
 export async function serve(
   functionsDir: string,
-  socketPath: string
+  socketPath: string,
+  eagerName?: string
 ): Promise<never> {
   for (const key of SPAWN_ENV_SCRUB_KEYS) {
     delete process.env[key];
@@ -501,6 +502,94 @@ export async function serve(
     return tracked;
   }
 
+  // Sibling prefetch: the first import of an app's function warms the rest
+  // of the app in the background, restoring what per-function servers used
+  // to get by importing in parallel processes — without it, an app opening
+  // through a Frame pays its bundles' imports serially, each first request
+  // stalling behind the previous function's import. Best-effort and polite:
+  // one bundle at a time, only while nothing is running or queued (module
+  // evaluation is synchronous and would stall live requests), stopping at a
+  // soft RSS ceiling, and one attempt per app per worker lifetime.
+  const PREFETCH_MAX_SIBLINGS = 16;
+  const PREFETCH_RSS_CEILING_BYTES = Math.floor(MAX_RSS_BYTES * 0.8);
+  const PREFETCH_QUIET_RECHECK_MS = 100;
+  const prefetchedApps = new Set<string>();
+
+  /** The app-folder prefix of a slug (`myapp__list-notes` -> `myapp`), or
+   * null for root-level functions, which have no app to prefetch. Mirrors
+   * the affinity key in warm.rs. */
+  function appPrefix(name: string): string | null {
+    const separator = name.indexOf("__");
+    return separator > 0 ? name.slice(0, separator) : null;
+  }
+
+  function listUnimportedAppSiblings(prefix: string): string[] {
+    let entries: import("node:fs").Dirent[];
+    try {
+      entries = readdirSync(functionsDir, { withFileTypes: true });
+    } catch {
+      return [];
+    }
+    const siblings: string[] = [];
+    for (const entry of entries) {
+      if (!entry.isFile()) {
+        continue;
+      }
+      const dot = entry.name.lastIndexOf(".");
+      const stem = dot <= 0 ? entry.name : entry.name.slice(0, dot);
+      if (
+        stem.startsWith(`${prefix}__`) &&
+        VALID_NAME.test(stem) &&
+        !imported.has(stem)
+      ) {
+        siblings.push(stem);
+      }
+    }
+    return siblings;
+  }
+
+  function schedulePrefetch(name: string): void {
+    const prefix = appPrefix(name);
+    if (prefix === null || prefetchedApps.has(prefix)) {
+      return;
+    }
+    prefetchedApps.add(prefix);
+    void prefetchApp(prefix);
+  }
+
+  async function prefetchApp(prefix: string): Promise<void> {
+    const siblings = listUnimportedAppSiblings(prefix).slice(
+      0,
+      PREFETCH_MAX_SIBLINGS
+    );
+    for (const sibling of siblings) {
+      // Yield to live traffic: a prefetch import runs only on a fully quiet
+      // worker, so at most one background import ever stands in front of a
+      // request.
+      while (running > 0 || queuedLive > 0) {
+        if (draining) {
+          return;
+        }
+        await new Promise((resolve) =>
+          setTimeout(resolve, PREFETCH_QUIET_RECHECK_MS)
+        );
+      }
+      if (draining) {
+        return;
+      }
+      if (process.memoryUsage.rss() > PREFETCH_RSS_CEILING_BYTES) {
+        return;
+      }
+      if (imported.has(sibling)) {
+        continue;
+      }
+      // Failures (unresolved, poisoned) are ignored: prefetch is an
+      // optimization, and the request path re-runs the pipeline with full
+      // handling when the function is actually called.
+      await importFromFunctionsDir(sibling);
+    }
+  }
+
   /**
    * Ensure the request's bundle is imported and current. Returns the bundle
    * and whether this request paid (or joined) the import, or null after a
@@ -559,6 +648,7 @@ export async function serve(
       }
       const bundle: ImportedBundle = { handlerPath: cachePath, stamp, sha256 };
       imported.set(request.name, bundle);
+      schedulePrefetch(request.name);
       return { bundle, importKind: "fresh" };
     };
 
@@ -618,6 +708,7 @@ export async function serve(
           // disk change recycles the worker through the stat check above.
           return staleReply();
         }
+        schedulePrefetch(request.name);
         return { bundle: result.bundle, importKind: "fresh" };
     }
   }
@@ -866,6 +957,17 @@ export async function serve(
   }
 
   armIdle();
+
+  // Eager warm-up: the worker is spawned right after a cold run of one
+  // function, so importing that bundle now (and prefetching its app) makes
+  // the very next invocation fast instead of paying the import on its first
+  // request. Best-effort; a request arriving mid-import joins the
+  // single-flight pipeline.
+  if (eagerName !== undefined && VALID_NAME.test(eagerName)) {
+    void importFromFunctionsDir(eagerName).then(() => {
+      schedulePrefetch(eagerName);
+    });
+  }
 
   // The process stays alive on the event loop; exits go through exit() above.
   return new Promise<never>(() => {});

--- a/cli/dust-sandbox/functions-runner/serve.ts
+++ b/cli/dust-sandbox/functions-runner/serve.ts
@@ -449,10 +449,22 @@ export async function serve(
   // bytes and serving stale code under a fresh stamp from then on.
   const importsInFlight = new Map<string, Promise<FuseImportResult>>();
 
+  // Poison is sticky: once a name's import was caught racing a rewrite, the
+  // module registry permanently holds bytes whose hash is unknown, and NO
+  // later fuse run can fix that — import() would return the already-evaluated
+  // module while the pipeline hashes the new on-disk bytes, silently pairing
+  // a fresh hash with stale code. A background (prefetch) import that
+  // discovers poison ignores the result, so the set is what guarantees the
+  // next real request still takes the stale-and-recycle path.
+  const poisonedNames = new Set<string>();
+
   function importFromFunctionsDir(name: string): Promise<FuseImportResult> {
     const inFlight = importsInFlight.get(name);
     if (inFlight !== undefined) {
       return inFlight;
+    }
+    if (poisonedNames.has(name)) {
+      return Promise.resolve({ kind: "poisoned" });
     }
     const flight = (async (): Promise<FuseImportResult> => {
       const handlerPath = resolveBundle(functionsDir, name);
@@ -487,10 +499,17 @@ export async function serve(
       // for this path and must recycle.
       const after = await statBundle(handlerPath);
       if (!sameStamp(stamp, after)) {
+        poisonedNames.add(name);
         return { kind: "poisoned" };
       }
       const bundle: ImportedBundle = { handlerPath, stamp, sha256 };
-      imported.set(name, bundle);
+      // An entry appearing mid-flight came from a stamped cache import and
+      // is at least as current as the fuse's read (gcsfuse can lag); never
+      // clobber it. Request callers only run this pipeline when the entry
+      // was absent.
+      if (!imported.has(name)) {
+        imported.set(name, bundle);
+      }
       return { kind: "ok", bundle };
     })();
     // Registered synchronously (before any await runs) and cleared on
@@ -554,7 +573,10 @@ export async function serve(
       return;
     }
     prefetchedApps.add(prefix);
-    void prefetchApp(prefix);
+    // The chain is written to never reject; the catch keeps a runner bug in
+    // background work from becoming an unhandled rejection that kills a
+    // serving worker.
+    prefetchApp(prefix).catch(() => {});
   }
 
   async function prefetchApp(prefix: string): Promise<void> {
@@ -964,9 +986,13 @@ export async function serve(
   // request. Best-effort; a request arriving mid-import joins the
   // single-flight pipeline.
   if (eagerName !== undefined && VALID_NAME.test(eagerName)) {
-    void importFromFunctionsDir(eagerName).then(() => {
-      schedulePrefetch(eagerName);
-    });
+    // The catch mirrors prefetchApp's: background work must never become an
+    // unhandled rejection.
+    importFromFunctionsDir(eagerName)
+      .then(() => {
+        schedulePrefetch(eagerName);
+      })
+      .catch(() => {});
   }
 
   // The process stays alive on the event loop; exits go through exit() above.

--- a/cli/dust-sandbox/src/commands/function/warm.rs
+++ b/cli/dust-sandbox/src/commands/function/warm.rs
@@ -518,6 +518,10 @@ pub fn spawn_worker(name: &str) {
         .arg("serve")
         .arg(&functions_dir)
         .arg(&socket)
+        // Eager warm-up hint: the worker imports this function's bundle (and
+        // prefetches its app's siblings) immediately instead of on first
+        // request. The name is already validated by the caller.
+        .arg(name)
         .env("NODE_PATH", super::harness_node_path())
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -596,8 +600,10 @@ mod tests {
 
         spawn_worker("greet");
 
-        // The worker needs a moment to bind its socket; the first served
-        // request pays the bundle import and reports it.
+        // The worker needs a moment to bind its socket. The spawn carries an
+        // eager-import hint, so the first served request is usually already
+        // cached; a fast enough client can still race the eager import and
+        // join it as fresh. Either way the outcome must be correct.
         let deadline = std::time::Instant::now() + Duration::from_secs(15);
         let (outcome, import_kind) = loop {
             match try_warm_run("greet", &input).await {
@@ -612,7 +618,7 @@ mod tests {
             outcome,
             serde_json::json!({ "ok": true, "output": { "hello": "warm" } })
         );
-        assert_eq!(import_kind, Some(ImportKind::Fresh));
+        assert!(import_kind.is_some());
 
         // A repeat invocation is served from the cached import.
         match try_warm_run("greet", &input).await {

--- a/cli/dust-sandbox/src/commands/function/warm.rs
+++ b/cli/dust-sandbox/src/commands/function/warm.rs
@@ -520,7 +520,7 @@ pub fn spawn_worker(name: &str) {
         .arg(&socket)
         // Eager warm-up hint: the worker imports this function's bundle (and
         // prefetches its app's siblings) immediately instead of on first
-        // request. The name is already validated by the caller.
+        // request. The name was validated at the top of this function.
         .arg(name)
         .env("NODE_PATH", super::harness_node_path())
         .stdin(Stdio::null())


### PR DESCRIPTION
## Description

First-load of an app regressed with the generic pool: bundles import serially on the home worker's event loop (module evaluation is synchronous), each function's first request stalling behind the previous import. Per-function servers used to pay these imports in parallel across processes. Prod shows it: warm runs mean 122ms (fine), cold runs mean ~1.5s vs ~400ms pre-pool, concentrated right after sandbox wake.

- The cold run's spawn now passes the function name; the worker imports that bundle eagerly at startup instead of on first request (what v1 did).
- Any fresh import of an `app__function` slug prefetches the app's remaining bundles in the background: one at a time, only while the worker is fully quiet (so at most one background import ever stands in front of a live request), capped at 16 siblings, stopping at 80% of the RSS recycle threshold, once per app per worker lifetime. Root-level slugs prefetch nothing.

Prefetch failures are ignored; the request path re-runs the full import pipeline (single-flight, hash checks) when the function is actually called.

## Tests

bun, against the real worker: first import of an app warms its siblings to `cached` without any fresh request while a root-level function on the same worker stays un-prefetched; an eager-name spawn serves the whole app cached before any fresh request. Cargo e2e updated: the first warm hit may now be cached (eager import) or fresh (racing it).

## Risk

Low: everything is best-effort and yields to live traffic. Worst case is importing bundles nobody calls, bounded by the sibling cap and the RSS ceiling.

## Deploy Plan

Next dsbx patch release + image bump.