### PR TITLE
Remove legacy consumption analytics workflows

### DIFF
--- a/front/temporal/analytics_queue/activities/consumption_attribution.ts
+++ b/front/temporal/analytics_queue/activities/consumption_attribution.ts
@@ -3,10 +3,7 @@ import { computeAndStoreAgentMessageConsumptionAttribution } from "@app/lib/api/
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import type {
-  AgentLoopArgs,
-  AgentMessageRef,
-} from "@app/types/assistant/agent_run";
+import type { AgentMessageRef } from "@app/types/assistant/agent_run";
 
 async function storeAgentMessageConsumptionAttribution(
   authType: AuthenticatorType,
@@ -17,19 +14,6 @@ async function storeAgentMessageConsumptionAttribution(
   await computeAndStoreAgentMessageConsumptionAttribution(auth, message);
 }
 
-export async function storeAgentMessageConsumptionAttributionActivity(
-  authType: AuthenticatorType,
-  {
-    agentLoopArgs,
-  }: {
-    agentLoopArgs: AgentLoopArgs;
-  }
-): Promise<void> {
-  await storeAgentMessageConsumptionAttribution(authType, agentLoopArgs);
-}
-
-// V1/V2 keep their original AgentLoopArgs activity payload for replay. V3 only needs this stable
-// message reference, which also lets historical backfills use the same durable workflow.
 export async function storeAgentMessageConsumptionAttributionForMessageActivity(
   authType: AuthenticatorType,
   { message }: { message: AgentMessageRef }

--- a/front/temporal/analytics_queue/signals.ts
+++ b/front/temporal/analytics_queue/signals.ts
@@ -1,13 +1,5 @@
 import { defineSignal } from "@temporalio/workflow";
 
-// Signals a running consumption-attribution workflow that the message settled further (a tool was
-// approved, a retry landed) and its breakdown must be recomputed. A finalize fires this on every
-// pass, including while the loop is paused for approval, so a run in flight when a later pass arrives
-// reruns rather than dropping it.
-export const storeAgentMessageConsumptionAttributionV2Signal = defineSignal<
-  [void]
->("store_agent_message_consumption_attribution_v2_signal");
-
 export const storeAgentMessageConsumptionAttributionV3Signal = defineSignal<
   [void]
 >("store_agent_message_consumption_attribution_v3_signal");

--- a/front/temporal/analytics_queue/workflows.ts
+++ b/front/temporal/analytics_queue/workflows.ts
@@ -1,9 +1,6 @@
 import type { AuthenticatorType } from "@app/lib/auth";
 import type * as activities from "@app/temporal/analytics_queue/activities";
-import {
-  storeAgentMessageConsumptionAttributionV2Signal,
-  storeAgentMessageConsumptionAttributionV3Signal,
-} from "@app/temporal/analytics_queue/signals";
+import { storeAgentMessageConsumptionAttributionV3Signal } from "@app/temporal/analytics_queue/signals";
 import type {
   AgentLoopArgs,
   AgentMessageRef,
@@ -13,7 +10,6 @@ import { proxyActivities, setHandler } from "@temporalio/workflow";
 const {
   storeAgentAnalyticsActivity,
   storeAgentMessageFeedbackActivity,
-  storeAgentMessageConsumptionAttributionActivity,
   storeAgentMessageConsumptionAttributionForMessageActivity,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
@@ -58,48 +54,7 @@ export async function storeAgentMessageFeedbackWorkflow(
   });
 }
 
-// Kept unchanged for executions started before the V2 signal workflow was deployed.
-export async function storeAgentMessageConsumptionAttributionWorkflow(
-  authType: AuthenticatorType,
-  {
-    agentLoopArgs,
-  }: {
-    agentLoopArgs: AgentLoopArgs;
-  }
-): Promise<void> {
-  await storeAgentMessageConsumptionAttributionActivity(authType, {
-    agentLoopArgs,
-  });
-}
-
-// Durable recompute of one message's consumption breakdown. New launches use this versioned
-// workflow, while the original workflow above remains available for replay. A finalize signals this
-// on every pass. A signal received while the activity runs requests one more pass, and a signal
-// received before it runs is covered by the activity reading the latest message state from the DB.
-export async function storeAgentMessageConsumptionAttributionV2Workflow(
-  authType: AuthenticatorType,
-  {
-    agentLoopArgs,
-  }: {
-    agentLoopArgs: AgentLoopArgs;
-  }
-): Promise<void> {
-  let pendingRecompute = true;
-
-  setHandler(storeAgentMessageConsumptionAttributionV2Signal, () => {
-    pendingRecompute = true;
-  });
-
-  while (pendingRecompute) {
-    pendingRecompute = false;
-    await storeAgentMessageConsumptionAttributionActivity(authType, {
-      agentLoopArgs,
-    });
-  }
-}
-
-// V3 adds consumption analytics indexation after each committed attribution pass. V2 remains
-// unchanged above so executions started before this deployment can replay deterministically.
+// Recomputes attribution and indexes consumption analytics after each committed pass.
 export async function storeAgentMessageConsumptionAttributionV3Workflow(
   authType: AuthenticatorType,
   { message }: { message: AgentMessageRef }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR removes the two legacy workflows for analytics consumption. I checked both regions and all those workflows have been drained.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
