### PR TITLE
[marketing] feat: make the landing-page skip on dust.tt/ opt-in

### DIFF
--- a/marketing/components/home/LandingLayout.tsx
+++ b/marketing/components/home/LandingLayout.tsx
@@ -11,6 +11,7 @@ import { OpenDustButton } from "@marketing/components/home/OpenDustButton";
 import { PromoBanner } from "@marketing/components/home/PromoBanner";
 import { PublicWebsiteLogo } from "@marketing/components/home/PublicWebsiteLogo";
 import ScrollingHeader from "@marketing/components/home/ScrollingHeader";
+import { SkipLandingPrompt } from "@marketing/components/home/SkipLandingPrompt";
 import UTMButton from "@marketing/components/UTMButton";
 import { useStripUtmParams } from "@marketing/hooks/useStripUtmParams";
 import {
@@ -168,14 +169,19 @@ export default function LandingLayout({
                 <PublicWebsiteLogo />
               </div>
               <MainNavigation />
-              <div className="flex flex-grow items-center justify-end gap-1 xs:gap-4">
+              <div className="relative flex flex-grow items-center justify-end gap-1 xs:gap-4">
                 {hasSession && (isAuthLoading || isAuthenticated) ? (
-                  <OpenDustButton
-                    variant="highlight"
-                    size="sm"
-                    trackingArea={TRACKING_AREAS.NAVIGATION}
-                    trackingObject="go_to_app"
-                  />
+                  <>
+                    <OpenDustButton
+                      variant="highlight"
+                      size="sm"
+                      trackingArea={TRACKING_AREAS.NAVIGATION}
+                      trackingObject="go_to_app"
+                    />
+                    {/* The opt-in only affects the root, which is the only page
+                        that redirects to the app. */}
+                    {router.pathname === "/" && <SkipLandingPrompt />}
+                  </>
                 ) : (
                   <>
                     <Button

--- a/marketing/components/home/OpenDustButton.tsx
+++ b/marketing/components/home/OpenDustButton.tsx
@@ -1,11 +1,6 @@
-import config from "@marketing/lib/api/config";
-import { DUST_HAS_SESSION, hasSessionIndicator } from "@marketing/lib/cookies";
-import { useLandingAuthContext } from "@marketing/lib/swr/website";
+import { useOpenDustTarget } from "@marketing/hooks/useOpenDustTarget";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
-import { appendUTMParams } from "@marketing/lib/utils/utm";
 import { ArrowRight, LegacyButton as Button } from "@dust-tt/sparkle";
-import { useEffect, useState } from "react";
-import { useCookies } from "react-cookie";
 
 interface OpenDustButtonProps {
   variant?: "highlight" | "outline";
@@ -22,17 +17,8 @@ export function OpenDustButton({
   trackingObject = "open_dust",
   showWelcome = false,
 }: OpenDustButtonProps) {
-  const [cookies] = useCookies([DUST_HAS_SESSION], { doNotParse: true });
-  const [hasSession, setHasSession] = useState(false);
-
-  useEffect(() => {
-    setHasSession(hasSessionIndicator(cookies[DUST_HAS_SESSION]));
-  }, [cookies]);
-
-  const { user, defaultWorkspaceId, isLoading, isAuthenticated } =
-    useLandingAuthContext({
-      hasSessionCookie: hasSession,
-    });
+  const { hasSession, user, isLoading, isAuthenticated, target } =
+    useOpenDustTarget();
 
   if (!hasSession) {
     return null;
@@ -53,14 +39,6 @@ export function OpenDustButton({
   if (!isAuthenticated) {
     return null;
   }
-
-  // When we already know the user's workspace, navigate straight to the app to
-  // skip the slow server-side `/api/login` round-trip. Fall back to `/api/login`
-  // when there is no default workspace (no-workspace / first-login / invite / SSO
-  // edge cases that need the full login flow).
-  const target = defaultWorkspaceId
-    ? appendUTMParams(`${config.getAppUrl()}/w/${defaultWorkspaceId}`)
-    : appendUTMParams("/api/login");
 
   const button = (
     <Button

--- a/marketing/components/home/SkipLandingPrompt.tsx
+++ b/marketing/components/home/SkipLandingPrompt.tsx
@@ -1,0 +1,89 @@
+import { useOpenDustTarget } from "@marketing/hooks/useOpenDustTarget";
+import {
+  DUST_SKIP_LANDING,
+  DUST_SKIP_LANDING_PROMPT_DISMISSED,
+  isSkipLandingPromptDismissed,
+  shouldSkipLanding,
+  SKIP_LANDING_COOKIE_OPTIONS,
+} from "@marketing/lib/cookies";
+import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
+import { ArrowRight, LegacyButton as Button, XClose } from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
+import { useCookies } from "react-cookie";
+
+/**
+ * Offers a logged-in visitor on the marketing root the option to go straight to
+ * the app on subsequent visits. Opting in sets `dust-skip-landing`, which the
+ * root page reads server-side to redirect before rendering.
+ *
+ * Rendered inside the header's CTA cluster, which must be `relative` for the
+ * card to anchor under the "Open Dust" button.
+ */
+export function SkipLandingPrompt() {
+  const [cookies, setCookie] = useCookies(
+    [DUST_SKIP_LANDING, DUST_SKIP_LANDING_PROMPT_DISMISSED],
+    { doNotParse: true }
+  );
+  const { hasSession, isAuthenticated, target } = useOpenDustTarget();
+
+  // Read the preference cookies on the client only, to avoid a hydration
+  // mismatch: the root page is server-rendered for everyone who has not opted
+  // in, so the card can never be part of that HTML.
+  const [showPrompt, setShowPrompt] = useState(false);
+  useEffect(() => {
+    setShowPrompt(
+      !shouldSkipLanding(cookies[DUST_SKIP_LANDING]) &&
+        !isSkipLandingPromptDismissed(
+          cookies[DUST_SKIP_LANDING_PROMPT_DISMISSED]
+        )
+    );
+  }, [cookies]);
+
+  if (!showPrompt || !hasSession || !isAuthenticated) {
+    return null;
+  }
+
+  return (
+    <div className="absolute right-0 top-full z-20 mt-3 hidden xs:block">
+      <div className="flex w-max flex-col items-start gap-1 rounded-2xl border border-border bg-background p-4 shadow-lg">
+        <div className="flex w-full items-center justify-between gap-6">
+          <span className="text-sm font-medium text-foreground">
+            Skip this page next time?
+          </span>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            icon={XClose}
+            tooltip="Dismiss"
+            onClick={withTracking(
+              TRACKING_AREAS.NAVIGATION,
+              "dismiss_skip_landing_prompt",
+              () => {
+                setCookie(
+                  DUST_SKIP_LANDING_PROMPT_DISMISSED,
+                  "1",
+                  SKIP_LANDING_COOKIE_OPTIONS
+                );
+              }
+            )}
+          />
+        </div>
+        <Button
+          variant="highlight-secondary"
+          size="sm"
+          label="Always open Dust"
+          icon={ArrowRight}
+          onClick={withTracking(
+            TRACKING_AREAS.NAVIGATION,
+            "always_open_dust",
+            () => {
+              setCookie(DUST_SKIP_LANDING, "1", SKIP_LANDING_COOKIE_OPTIONS);
+              // eslint-disable-next-line react-hooks/immutability
+              window.location.href = target;
+            }
+          )}
+        />
+      </div>
+    </div>
+  );
+}

--- a/marketing/hooks/useOpenDustTarget.ts
+++ b/marketing/hooks/useOpenDustTarget.ts
@@ -1,0 +1,41 @@
+import config from "@marketing/lib/api/config";
+import { DUST_HAS_SESSION, hasSessionIndicator } from "@marketing/lib/cookies";
+import { useLandingAuthContext } from "@marketing/lib/swr/website";
+import { appendUTMParams } from "@marketing/lib/utils/utm";
+import { useEffect, useState } from "react";
+import { useCookies } from "react-cookie";
+
+/**
+ * Resolves where a logged-in visitor should be sent when they choose to open the
+ * app from the public website, along with the auth state needed to decide
+ * whether to offer that at all.
+ *
+ * Shared by every header affordance that opens the app, so the `/api/login`
+ * fallback stays in one place. SWR deduplicates the underlying auth-context
+ * request across call sites, so using this hook more than once on a page costs
+ * no extra network round-trip.
+ */
+export function useOpenDustTarget() {
+  const [cookies] = useCookies([DUST_HAS_SESSION], { doNotParse: true });
+  const [hasSession, setHasSession] = useState(false);
+
+  // Check session cookie only on client to avoid hydration mismatch.
+  useEffect(() => {
+    setHasSession(hasSessionIndicator(cookies[DUST_HAS_SESSION]));
+  }, [cookies]);
+
+  const { user, defaultWorkspaceId, isLoading, isAuthenticated } =
+    useLandingAuthContext({
+      hasSessionCookie: hasSession,
+    });
+
+  // When we already know the user's workspace, navigate straight to the app to
+  // skip the slow server-side `/api/login` round-trip. Fall back to `/api/login`
+  // when there is no default workspace (no-workspace / first-login / invite / SSO
+  // edge cases that need the full login flow).
+  const target = defaultWorkspaceId
+    ? appendUTMParams(`${config.getAppUrl()}/w/${defaultWorkspaceId}`)
+    : appendUTMParams("/api/login");
+
+  return { hasSession, user, isLoading, isAuthenticated, target };
+}

--- a/marketing/lib/cookies.ts
+++ b/marketing/lib/cookies.ts
@@ -3,10 +3,46 @@ import type { UserType } from "@marketing/types/user";
 export const DUST_COOKIES_ACCEPTED = "dust-cookies-accepted";
 export const DUST_HAS_SESSION = "dust-has-session";
 
-export function hasSessionIndicator(
+// Set when the visitor opts into going straight to the app from the marketing
+// root. Read server-side in the root page's `getServerSideProps`.
+export const DUST_SKIP_LANDING = "dust-skip-landing";
+// Set when the visitor dismisses the opt-in prompt without opting in, so it
+// stops being offered. Client-side only.
+export const DUST_SKIP_LANDING_PROMPT_DISMISSED =
+  "dust-skip-landing-prompt-dismissed";
+
+const SKIP_LANDING_COOKIE_MAX_AGE_SECONDS = 365 * 24 * 60 * 60; // 1 year
+
+// Host-only (no `domain`) on purpose: the preference is per-region, so opting in
+// on dust.tt must not silently opt the visitor in on eu.dust.tt.
+export const SKIP_LANDING_COOKIE_OPTIONS = {
+  path: "/",
+  maxAge: SKIP_LANDING_COOKIE_MAX_AGE_SECONDS,
+  sameSite: "lax",
+} as const;
+
+function isCookieFlagSet(
   cookieValue: string | number | boolean | undefined
 ): boolean {
   return cookieValue === "1" || cookieValue === 1 || cookieValue === true;
+}
+
+export function hasSessionIndicator(
+  cookieValue: string | number | boolean | undefined
+): boolean {
+  return isCookieFlagSet(cookieValue);
+}
+
+export function shouldSkipLanding(
+  cookieValue: string | number | boolean | undefined
+): boolean {
+  return isCookieFlagSet(cookieValue);
+}
+
+export function isSkipLandingPromptDismissed(
+  cookieValue: string | number | boolean | undefined
+): boolean {
+  return isCookieFlagSet(cookieValue);
 }
 
 export function hasCookiesAccepted(

--- a/marketing/pages/index.tsx
+++ b/marketing/pages/index.tsx
@@ -5,6 +5,7 @@ import {
   fetchAuthContext,
   hasWorkosSessionCookie,
 } from "@marketing/lib/api/authContext";
+import { DUST_SKIP_LANDING, shouldSkipLanding } from "@marketing/lib/cookies";
 import type { NewsItem } from "@marketing/lib/homepage_news";
 import { fetchHomepageNews } from "@marketing/lib/homepage_news";
 import { extractUTMParams } from "@marketing/lib/utils/utm";
@@ -24,8 +25,8 @@ interface HomeProps {
 /**
  * Resolve where an already-authenticated visitor should be sent, server-side.
  *
- * Mirrors the old `front` behaviour (`front/pages/index.tsx` `getServerSideProps`,
- * which called `getSession` and redirected before rendering).
+ * Only called for visitors who opted into skipping the landing page; the caller
+ * owns that gate.
  *
  * `/api/auth-context` already returns the default workspace, so we redirect
  * straight to the app (`/w/<id>`) rather than bouncing through `/api/login`,
@@ -71,14 +72,19 @@ export const getServerSideProps: GetServerSideProps<HomeProps> = async (
 ) => {
   const { inviteToken } = context.query;
 
-  // On the marketing root, an authenticated user's intent is to open the
-  // product, not browse the homepage — so redirect them server-side, before
-  // rendering, to avoid the render + hydrate + client fetch round-trip. Gated on
-  // the session cookie so anonymous SSR stays a no-op. We do NOT forward
-  // inviteToken: an expired/invalid one makes /api/login 400, and the redirect
-  // intent doesn't depend on it.
+  // On the marketing root, redirect straight to the product only for visitors
+  // who explicitly asked for it via the "Always open Dust" prompt. Everyone else
+  // gets the landing page. Doing it server-side, before rendering, avoids the
+  // render + hydrate + client fetch round-trip. The skip-preference check comes
+  // first because it is a plain cookie lookup, which keeps the auth-context
+  // round-trip off the path of every logged-in visitor who has not opted in. We
+  // do NOT forward inviteToken: an expired/invalid one makes /api/login 400, and
+  // the redirect intent doesn't depend on it.
   const cookieHeader = context.req.headers.cookie ?? "";
-  if (hasWorkosSessionCookie(cookieHeader)) {
+  if (
+    shouldSkipLanding(context.req.cookies[DUST_SKIP_LANDING]) &&
+    hasWorkosSessionCookie(cookieHeader)
+  ) {
     const destination = await resolveAuthedRedirectDestination(
       cookieHeader,
       context.query


### PR DESCRIPTION
## Description

Today `dust.tt/` redirects **every** logged-in visitor straight to the app — the marketing homepage is unreachable for them unless they know about `dust.tt/home`. This flips the default: logged-in visitors get the landing page, and opt into the redirect themselves.

The opt-in is a prompt anchored under the existing "Open Dust" button:

```
┌─────────────────────────────────┐
│  Skip this page next time?   ×  │
│  Always open Dust  →            │
└─────────────────────────────────┘
```

"Always open Dust" sets the preference *and* opens the app. `×` dismisses the prompt for good without opting in. The prompt only shows on `/`, since that is the only page that redirects.

## Implementation

**`lib/cookies.ts`** — two new cookies alongside the existing ones: `dust-skip-landing` (the opt-in, read server-side) and `dust-skip-landing-prompt-dismissed` (client-only). Both `path=/`, `SameSite=Lax`, 1-year max-age, and deliberately **host-only** so opting in on `dust.tt` does not silently opt the visitor in on `eu.dust.tt`. The three predicates delegate to a shared `isCookieFlagSet`, which `hasSessionIndicator` now uses too.

**`pages/index.tsx`** — the redirect is gated on the preference:

```ts
if (
  shouldSkipLanding(context.req.cookies[DUST_SKIP_LANDING]) &&
  hasWorkosSessionCookie(cookieHeader)
) {
```

The cookie lookup comes first on purpose: it is a plain map read, so logged-in visitors who have not opted in no longer pay for the blocking `/api/auth-context` round-trip (1500ms timeout) on every SSR of the root. Everything downstream is unchanged — UTM forwarding, the `/api/login` fallback when there is no default workspace, and the "auth-context failed → render the landing page" behaviour.

**`hooks/useOpenDustTarget.ts`** (new) — extracts the `dust-has-session` read, the auth-context lookup, and the destination resolution that `OpenDustButton` owned, so the button and the prompt cannot drift on the `/api/login` fallback. SWR already dedupes the underlying request, so using the hook twice on a page costs no extra network call.

**`components/home/SkipLandingPrompt.tsx`** (new) — renders only when the visitor is authenticated and neither cookie is set. Cookie reads happen in a `useEffect` (matching the existing hydration-mismatch handling in `LandingLayout` and `OpenDustButton`), so the card is never part of the server-rendered HTML. Both actions are tracked via the existing `withTracking` helper (`always_open_dust`, `dismiss_skip_landing_prompt`). Hidden below the `xs` breakpoint, consistent with how "Contact sales" is handled in the same cluster.

**`components/home/LandingLayout.tsx`** — the CTA cluster gets `relative` so the card anchors under the button and tracks the header as it shrinks on scroll.

These are functional preference cookies set by an explicit user action, so they are not gated on the consent banner — same reasoning that applies to `dust-has-session` today.

## Risk

- **No undo.** Once opted in, `dust.tt/` redirects for good on that browser. `dust.tt/home` still serves the same landing page and the logo links there, so the content is never unreachable, but there is no in-product way to clear the preference. This was a deliberate call to keep the change small.
- **Logged-in visitors get an extra click** on `dust.tt/` until they opt in. That is the intended trade-off.
- **Marketing analytics will move.** Logged-in visitors currently never render `/`, so GTM/PostHog never fire for them there. After this they will — landing pageviews go up and the funnel mix shifts until opt-in rates settle. Worth a heads-up to whoever watches those dashboards so the jump is not read as a data bug.

## Tests

`marketing` has no test runner (no vitest/jest, no test files), so this is verified by `npm run tsgo`, `npx biome check`, and `npm run build` — all clean.

