### PR TITLE
[front] fix: validate MCP view names on rename

### DIFF
--- a/front-api/routes/w/[wId]/mcp/views/[viewId]/index.test.ts
+++ b/front-api/routes/w/[wId]/mcp/views/[viewId]/index.test.ts
@@ -289,6 +289,37 @@ describe("PATCH /api/w/:wId/mcp/views/:viewId", () => {
     expect(data.error.message).toContain("server-two");
   });
 
+  it("should return 400 when renaming generates a duplicate cropped tool name", async () => {
+    const { workspace, auth } = await setup("admin");
+    const sharedPrefix = "a".repeat(80);
+    const existingName = `${sharedPrefix}-existing`;
+    const candidateName = `${sharedPrefix}-candidate`;
+
+    const server1 = await RemoteMCPServerFactory.create(workspace, {
+      name: "server-one",
+    });
+    await RemoteMCPServerFactory.create(workspace, {
+      name: existingName,
+    });
+
+    const systemView1 =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        auth,
+        server1.sId
+      );
+    expect(systemView1).toBeDefined();
+
+    const response = await patchView(workspace.sId, systemView1!.sId, {
+      name: candidateName,
+      description: "updated",
+    });
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error.type).toBe("invalid_request_error");
+    expect(data.error.message).toContain(candidateName);
+  });
+
   it("should allow renaming when the new name is unique", async () => {
     const { workspace, auth } = await setup("admin");
 

--- a/front/lib/api/mcp/views.ts
+++ b/front/lib/api/mcp/views.ts
@@ -117,7 +117,7 @@ export async function updateNameAndDescriptionForMCPServerViews(
           name,
           systemView.space,
           systemView.getServerTools(),
-          systemView.sId
+          { excludedMCPServerViewId: systemView.sId }
         );
 
       if (hasConflict) {

--- a/front/lib/api/mcp/views.ts
+++ b/front/lib/api/mcp/views.ts
@@ -117,7 +117,7 @@ export async function updateNameAndDescriptionForMCPServerViews(
           name,
           systemView.space,
           systemView.getServerTools(),
-          mcpServerId
+          systemView.sId
         );
 
       if (hasConflict) {

--- a/front/lib/api/mcp/views.ts
+++ b/front/lib/api/mcp/views.ts
@@ -106,16 +106,19 @@ export async function updateNameAndDescriptionForMCPServerViews(
   if (name) {
     const systemView = views.find((v) => v.space.kind === "system");
     if (systemView) {
-      const systemViews = await MCPServerViewResource.listBySpace(
+      await MCPServerViewResource.hydrateRemoteServerHeavyAttributes(
         auth,
-        systemView.space
+        [systemView],
+        ["cachedTools"]
       );
-      const hasConflict = systemViews.some((v) => {
-        if (v.mcpServerId === mcpServerId) {
-          return false;
-        }
-        return (v.name ?? v.getServerDisplayMetadata().name) === name;
-      });
+      const { hasConflict } =
+        await MCPServerViewResource.hasNameConflictInSpaceByName(
+          auth,
+          name,
+          systemView.space,
+          systemView.getServerTools(),
+          mcpServerId
+        );
 
       if (hasConflict) {
         return new Err(

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -249,7 +249,8 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     auth: Authenticator,
     name: string,
     space: SpaceResource,
-    tools: readonly MCPToolType[] = []
+    tools: readonly MCPToolType[] = [],
+    excludedMCPServerId?: string
   ): Promise<{ hasConflict: boolean; name: string }> {
     const candidateToolNames = removeNulls(
       tools.map((tool) => {
@@ -261,6 +262,10 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     );
     const existingViews = await this.listBySpace(auth, space);
     const hasConflict = existingViews.some((view) => {
+      if (view.mcpServerId === excludedMCPServerId) {
+        return false;
+      }
+
       const existingName = view.name ?? view.getServerDisplayMetadata().name;
       if (existingName === name) {
         return true;

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -250,7 +250,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     name: string,
     space: SpaceResource,
     tools: readonly MCPToolType[] = [],
-    excludedMCPServerViewId?: string
+    { excludedMCPServerViewId }: { excludedMCPServerViewId?: string } = {}
   ): Promise<{ hasConflict: boolean; name: string }> {
     const candidateToolNames = removeNulls(
       tools.map((tool) => {

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -250,7 +250,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     name: string,
     space: SpaceResource,
     tools: readonly MCPToolType[] = [],
-    excludedMCPServerId?: string
+    excludedMCPServerViewId?: string
   ): Promise<{ hasConflict: boolean; name: string }> {
     const candidateToolNames = removeNulls(
       tools.map((tool) => {
@@ -262,7 +262,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     );
     const existingViews = await this.listBySpace(auth, space);
     const hasConflict = existingViews.some((view) => {
-      if (view.mcpServerId === excludedMCPServerId) {
+      if (view.sId === excludedMCPServerViewId) {
         return false;
       }
 


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/9068

Renaming an MCP server view only rejected exact duplicate view names, so distinct names could still generate the same model-facing tool name after the server prefix was cropped.

This PR reuses the creation-time conflict check during rename, loading the renamed server tools and excluding the server itself from the comparison.

## Tests

- Added a test.

## Risk

- Low.

## Deploy Plan

- Deploy front.
