### PR TITLE
Include deleted conversations in consumption analytics ancestry

### DIFF
--- a/front/lib/analytics/agent_message_consumption/load.test.ts
+++ b/front/lib/analytics/agent_message_consumption/load.test.ts
@@ -316,6 +316,36 @@ describe("loadAgentMessageConsumptionAnalyticsInput", () => {
     });
   });
 
+  it("preserves the agent chain when the parent conversation was deleted", async () => {
+    const testContext = await createResourceTest({ role: "admin" });
+    const parent = await createAgenticMessage({
+      auth: testContext.authenticator,
+      workspace: testContext.workspace,
+      depth: 0,
+      agentName: "Deleted parent agent",
+    });
+    const child = await setupSettledMessage({
+      testContext,
+      depth: 1,
+      agenticOriginMessageId: parent.agentMessage.sId,
+      agentName: "Child agent",
+    });
+    await parent.conversation.updateVisibilityToDeleted(
+      testContext.authenticator
+    );
+
+    const input = await loadAgentMessageConsumptionAnalyticsInput(child.auth, {
+      agentMessageId: child.agentMessage.sId,
+    });
+
+    expect(input?.agent).toMatchObject({
+      parent_ids: [parent.agent.sId],
+      direct_parent_id: parent.agent.sId,
+      root_id: parent.agent.sId,
+      depth: 1,
+    });
+  });
+
   it("includes usage explicitly classified as programmatic", async () => {
     const context = await setupSettledMessage({
       usageType: USAGE_TYPE_PROGRAMMATIC,

--- a/front/lib/analytics/agent_message_consumption/load.ts
+++ b/front/lib/analytics/agent_message_consumption/load.ts
@@ -248,7 +248,10 @@ export async function loadAgentMessageConsumptionAnalyticsInput(
     { withToolMetadata: true }
   );
   const ancestorAgentIds = (
-    await listAgenticAncestors(auth, messageConversation, { agentMessageId })
+    await listAgenticAncestors(auth, messageConversation, {
+      agentMessageId,
+      includeDeleted: true,
+    })
   )
     .map((ancestor) => ancestor.agentConfigurationId)
     .reverse();

--- a/front/lib/api/assistant/conversation/agentic_ancestors.ts
+++ b/front/lib/api/assistant/conversation/agentic_ancestors.ts
@@ -15,8 +15,13 @@ export async function listAgenticAncestors(
   conversation: ConversationResource,
   {
     agentMessageId,
+    includeDeleted = false,
     maxAncestors,
-  }: { agentMessageId: string; maxAncestors?: number }
+  }: {
+    agentMessageId: string;
+    includeDeleted?: boolean;
+    maxAncestors?: number;
+  }
 ): Promise<AgenticAncestor[]> {
   const ancestors: AgenticAncestor[] = [];
   const visitedAgentMessageIds = new Set([agentMessageId]);
@@ -37,7 +42,7 @@ export async function listAgenticAncestors(
     const [parentConversation] = await ConversationResource.fetchByModelIds(
       auth,
       [parentAgentMessage.conversationModelId],
-      { loadSpaces: true }
+      { includeDeleted, loadSpaces: true }
     );
     if (!parentConversation) {
       break;

--- a/front/lib/api/assistant/conversation/resume_ancestor_conversations.test.ts
+++ b/front/lib/api/assistant/conversation/resume_ancestor_conversations.test.ts
@@ -159,6 +159,20 @@ describe("resumeAncestorConversations", () => {
     expect(retryBlockedActions).not.toHaveBeenCalled();
   });
 
+  it("does not retry a deleted ancestor conversation", async () => {
+    const parent = await createAgenticConversation(auth, workspace);
+    const child = await createAgenticConversation(auth, workspace, {
+      agenticParentMessageId: parent.agentMessageId,
+    });
+    await parent.conversation.updateVisibilityToDeleted(auth);
+
+    await resumeAncestorConversations(auth, child.conversation, {
+      agentMessageId: child.agentMessageId,
+    });
+
+    expect(retryBlockedActions).not.toHaveBeenCalled();
+  });
+
   it("walks up multiple ancestors when each resumes successfully", async () => {
     const grandParent = await createAgenticConversation(auth, workspace);
     const parent = await createAgenticConversation(auth, workspace, {

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -318,12 +318,14 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       transaction,
       excludeTest,
       updatedAfter,
+      includeDeleted,
       includeForkingData,
       loadSpaces,
     }: {
       transaction?: Transaction;
       excludeTest?: boolean;
       updatedAfter?: Date;
+      includeDeleted?: boolean;
       includeForkingData?: boolean;
       loadSpaces?: boolean;
     } = {}
@@ -334,7 +336,11 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     const workspace = auth.getNonNullableWorkspace();
 
-    const excludedVisibilities: ConversationVisibility[] = ["deleted"];
+    const excludedVisibilities: ConversationVisibility[] = [];
+
+    if (!includeDeleted) {
+      excludedVisibilities.push("deleted");
+    }
 
     if (excludeTest) {
       excludedVisibilities.push("test");
@@ -344,7 +350,9 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       where: {
         workspaceId: workspace.id,
         id: ids,
-        visibility: { [Op.notIn]: excludedVisibilities },
+        ...(excludedVisibilities.length > 0
+          ? { visibility: { [Op.notIn]: excludedVisibilities } }
+          : {}),
         ...(updatedAfter ? { updatedAt: { [Op.gte]: updatedAfter } } : {}),
       } as WhereOptions<ConversationModel>,
       ...(includeForkingData ? { include: this.getForkedFromInclude() } : {}),
@@ -360,6 +368,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         uniqueSpaceIds.length === 0
           ? []
           : await SpaceResource.fetchByModelIds(auth, uniqueSpaceIds, {
+              includeDeleted,
               transaction,
             });
       spaceIdToSpaceMap = new Map(spaces.map((s) => [s.id, s]));


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up from https://github.com/dust-tt/dust/pull/30305#discussion_r3756398606. This PR preserves the full agent ancestry when a parent conversation has been deleted, ensuring historical consumption analytics retain the correct parent, direct parent, and root agent attribution.

Deleted conversations remain excluded by default from operational ancestor traversal, preventing resume attempts for
deleted conversations.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
