### PR TITLE
Polish analytics table alignment and sorting

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -63,11 +63,11 @@ function buildColumns({
       id: "name",
       accessorKey: "name",
       header: "Name",
-      meta: { sizeRatio: 34 },
+      meta: { sizeRatio: 34, headerAlign: "left" },
       cell: (info) => {
         const { name, pictureUrl } = info.row.original;
         return (
-          <DataTable.CellContent>
+          <DataTable.CellContent className="w-full justify-start text-left">
             {hasAvatar ? (
               <AvatarNameCell name={name} imageUrl={pictureUrl} />
             ) : (
@@ -80,9 +80,9 @@ function buildColumns({
     {
       id: "costShare",
       header: "Cost share",
-      meta: { sizeRatio: 22 },
+      meta: { sizeRatio: 22, headerAlign: "left" },
       cell: (info) => (
-        <DataTable.CellContent>
+        <DataTable.CellContent className="w-full justify-start">
           <CostShareCell
             share={
               totalCredits > 0 ? info.row.original.credits / totalCredits : 0
@@ -95,9 +95,10 @@ function buildColumns({
       id: "credits",
       accessorKey: "credits",
       header: "Total credits",
-      meta: { sizeRatio: 22 },
+      meta: { sizeRatio: 22, headerAlign: "right" },
       cell: (info) => (
         <DataTable.BasicCellContent
+          className="justify-end text-right tabular-nums"
           label={formatCredits(info.row.original.credits)}
         />
       ),
@@ -106,9 +107,10 @@ function buildColumns({
       id: "avgCredits",
       accessorKey: "avgCredits",
       header: avgLabel,
-      meta: { sizeRatio: 22 },
+      meta: { sizeRatio: 22, headerAlign: "right" },
       cell: (info) => (
         <DataTable.BasicCellContent
+          className="justify-end text-right tabular-nums"
           label={formatCredits(info.row.original.avgCredits)}
         />
       ),

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -28,6 +28,7 @@ import { useCopyToClipboard } from "@sparkle/hooks";
 import {
   ArrowDown,
   ArrowUp,
+  ChevronSelectorVertical,
   Clipboard,
   ClipboardCheck,
   DotsHorizontal,
@@ -268,15 +269,12 @@ export function DataTable<TData extends TBaseData>({
                           visual={
                             header.column.getIsSorted() === "asc"
                               ? ArrowUp
-                              : ArrowDown
+                              : header.column.getIsSorted() === "desc"
+                                ? ArrowDown
+                                : ChevronSelectorVertical
                           }
                           size="xs"
-                          className={cn(
-                            "ml-1",
-                            header.column.getIsSorted()
-                              ? "opacity-100"
-                              : "opacity-0"
-                          )}
+                          className="ml-1"
                         />
                       )}
                     </div>
@@ -620,15 +618,12 @@ export function ScrollableDataTable<TData extends TBaseData>({
                             visual={
                               header.column.getIsSorted() === "asc"
                                 ? ArrowUp
-                                : ArrowDown
+                                : header.column.getIsSorted() === "desc"
+                                  ? ArrowDown
+                                  : ChevronSelectorVertical
                             }
                             size="xs"
-                            className={cn(
-                              "ml-1",
-                              header.column.getIsSorted()
-                                ? "opacity-100"
-                                : "opacity-0"
-                            )}
+                            className="ml-1"
                           />
                         )}
                       </div>


### PR DESCRIPTION
## Description

Aligns the consumption attribution table by content type. Names and cost-share content remain left aligned, credit values are right aligned with tabular numerals, and each header follows its cell alignment.

It also replaces the invisible unsorted DataTable arrow with a neutral sort selector icon, avoiding unexplained empty spacing while preserving ascending and descending arrows after sorting.