### PR TITLE
feat(poke): show region in global feature flag toggle and preserve description line breaks

### DIFF
--- a/front/components/poke/plugins/RunPluginDialog.tsx
+++ b/front/components/poke/plugins/RunPluginDialog.tsx
@@ -173,7 +173,9 @@ export function RunPluginDialog({
       >
         <DialogHeader className="bg-structure-100 rounded-t-2xl pb-4">
           <DialogTitle>Run {plugin.name} plugin</DialogTitle>
-          <DialogDescription>{plugin.description}</DialogDescription>
+          <DialogDescription className="whitespace-pre-line">
+            {plugin.description}
+          </DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-2 px-5 py-4 text-foreground">
           {isLoading || (hasAsyncArgs && isLoadingAsyncArgs) ? (

--- a/front/lib/api/poke/plugins/global/toggle_global_feature_flag.ts
+++ b/front/lib/api/poke/plugins/global/toggle_global_feature_flag.ts
@@ -1,4 +1,6 @@
 import { createPlugin } from "@app/lib/api/poke/types";
+import { config } from "@app/lib/api/regions/config";
+import { getRegionDisplay } from "@app/lib/poke/regions";
 import { GlobalFeatureFlagResource } from "@app/lib/resources/global_feature_flag_resource";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import {
@@ -14,9 +16,11 @@ export const toggleGlobalFeatureFlagPlugin = createPlugin({
     id: "toggle-global-feature-flag",
     name: "Toggle Global Feature Flag",
     description:
-      "Set a global feature flag with a rollout percentage (0-100). " +
+      "Set a global feature flag with a rollout percentage (0-100) " +
+      `in ${getRegionDisplay(config.getCurrentRegion())}. ` +
       "Setting 0 removes the global flag. Setting 100 enables it for all workspaces. " +
-      "Workspace-level flags always take precedence.",
+      "Workspace-level flags always take precedence.\n" +
+      "WARNING: Don't forget to apply for all regions!",
     resourceTypes: ["global"],
     args: {
       feature: {


### PR DESCRIPTION
## Description

Small improvements to the Poke "Toggle Global Feature Flag" plugin dialog:

- The plugin description now shows the **current region** (via `getRegionDisplay(config.getCurrentRegion())`) and includes a reminder to apply the change across all regions, so operators don't forget global flags are region-scoped.
- `RunPluginDialog` now renders plugin descriptions with `whitespace-pre-line`, so the newline in the updated description (and any other multi-line plugin description) is preserved instead of collapsing to a single line.

## Tests

Manually verified in Poke: the toggle-global-feature-flag dialog displays the current region and the multi-line description renders with line breaks preserved.
