### PR TITLE
[front] fix: pass down `offline_access` if requested in remote MCP OAuth flow

### DIFF
--- a/core/src/oauth/providers/mcp.rs
+++ b/core/src/oauth/providers/mcp.rs
@@ -279,6 +279,10 @@ impl Provider for MCPConnectionProvider {
             form_data.push(("resource", resource));
         }
 
+        if let Some(ref scope) = metadata.scope {
+            form_data.push(("scope", scope));
+        }
+
         let client = self.client_for(use_static_ip)?;
         let mut req = client
             .post(metadata.token_endpoint)

--- a/front/lib/resources/remote_mcp_servers_resource.test.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.test.ts
@@ -1,11 +1,34 @@
 import type { MCPToolType } from "@app/lib/api/mcp";
 import { Authenticator } from "@app/lib/auth";
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
-import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
+import {
+  getMCPAuthorizationScope,
+  RemoteMCPServerResource,
+} from "@app/lib/resources/remote_mcp_servers_resource";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { describe, expect, it } from "vitest";
+
+describe("getMCPAuthorizationScope", () => {
+  it("requests offline access when the authorization server supports it", () => {
+    expect(
+      getMCPAuthorizationScope({
+        extraScopes: "files.read",
+        authorizationServerScopes: ["files.read", "offline_access"],
+      })
+    ).toBe("files.read offline_access");
+  });
+
+  it("omits offline access when the authorization server does not support it", () => {
+    expect(
+      getMCPAuthorizationScope({
+        extraScopes: "files.read offline_access",
+        authorizationServerScopes: ["files.read"],
+      })
+    ).toBe("files.read");
+  });
+});
 
 describe("RemoteMCPServerResource.updateUrl", () => {
   it("updates the URL of a remote MCP server", async () => {

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -59,6 +59,30 @@ import { Op } from "sequelize";
 
 const SECRET_REDACTION_COOLDOWN_IN_MINUTES = 10;
 
+export function getMCPAuthorizationScope({
+  extraScopes,
+  resourceScopes,
+  authorizationServerScopes,
+}: {
+  extraScopes?: string;
+  resourceScopes?: string[];
+  authorizationServerScopes?: string[];
+}): string | undefined {
+  const scopes = new Set(
+    extraScopes?.trim()
+      ? extraScopes.trim().split(/\s+/)
+      : (resourceScopes ?? authorizationServerScopes ?? [])
+  );
+
+  if (authorizationServerScopes?.includes("offline_access")) {
+    scopes.add("offline_access");
+  } else {
+    scopes.delete("offline_access");
+  }
+
+  return scopes.size > 0 ? [...scopes].join(" ") : undefined;
+}
+
 // Unbounded columns (large JSONB/TEXT values) excluded from the base fetch. Callers opt into
 // the ones they need via `includeHeavyAttributes`, or hydrate later via `hydrateHeavyAttributes`.
 const REMOTE_MCP_SERVER_HEAVY_ATTRIBUTES = [
@@ -727,16 +751,11 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     // Dynamic client registration
     const clientMetadata = provider.clientMetadata;
 
-    // Priority: user-provided scope > discovered scopes
-    if (!extraScopes || extraScopes.trim() === "") {
-      // Prefer scopes from resource metadata if available
-      const scopesSupported =
-        resourceMetadata?.scopes_supported ?? metadata.scopes_supported;
-      // Add all supported scopes to client registration
-      if (scopesSupported) {
-        clientMetadata.scope = scopesSupported.join(" ");
-      }
-    }
+    clientMetadata.scope = getMCPAuthorizationScope({
+      extraScopes,
+      resourceScopes: resourceMetadata?.scopes_supported,
+      authorizationServerScopes: metadata.scopes_supported,
+    });
 
     try {
       // Try DCR.


### PR DESCRIPTION
## Description

2nd tentative fix for https://github.com/dust-tt/tasks/issues/9989

Some remote MCP authorization servers only issue refresh tokens when the client requests `offline_access` (Ashby for instance). Our dynamic OAuth flow advertises the refresh-token grant, but did not request that scope when the server supported it.

When authorization-server metadata advertises `offline_access`, this PR adds it to the selected scopes and sends the same scope in both the authorization request and authorization-code token exchange. The authorization server may still choose not to issue a refresh token, and existing connections are unchanged until they reconnect.

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
- Deploy oauth.
