### PR TITLE
feat: Add requireUpgradeRequestReason field to credit usage configuration

### DIFF
--- a/front-api/routes/w/[wId]/credits/usage-configuration.test.ts
+++ b/front-api/routes/w/[wId]/credits/usage-configuration.test.ts
@@ -69,6 +69,7 @@ describe("/api/w/[wId]/credits/usage-configuration", () => {
     const { configuration } = await response.json();
     expect(configuration.allowMemberUpgradeRequests).toBe(true);
     expect(configuration.upgradeRequestEmailEnabled).toBe(true);
+    expect(configuration.requireUpgradeRequestReason).toBe(false);
     expect(configuration.autoSeatUpgradeEnabled).toBe(false);
     // The default mock workspace is on a free (non-Metronome) plan, so
     // auto-upgrade is not available — the UI disables the toggle.
@@ -112,6 +113,38 @@ describe("/api/w/[wId]/credits/usage-configuration", () => {
     const getBody = await getResponse.json();
     expect(getBody.configuration.allowMemberUpgradeRequests).toBe(false);
     expect(getBody.configuration.upgradeRequestEmailEnabled).toBe(false);
+  });
+
+  it("PATCH persists requireUpgradeRequestReason and GET reflects it", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+
+    const patchResponse = await honoApp.request(
+      usageConfigurationUrl(workspace.sId),
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ requireUpgradeRequestReason: true }),
+      }
+    );
+
+    expect(patchResponse.status).toBe(200);
+    const { configuration } = await patchResponse.json();
+    expect(configuration.requireUpgradeRequestReason).toBe(true);
+
+    await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+      workspace,
+    });
+
+    const getResponse = await honoApp.request(
+      usageConfigurationUrl(workspace.sId)
+    );
+    const getBody = await getResponse.json();
+    expect(getBody.configuration.requireUpgradeRequestReason).toBe(true);
   });
 
   it("PATCH persists autoSeatUpgradeEnabled and GET reflects it", async () => {

--- a/front/lib/api/credits/usage_configuration.ts
+++ b/front/lib/api/credits/usage_configuration.ts
@@ -7,6 +7,7 @@ import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usag
 import {
   DEFAULT_ALLOW_MEMBER_UPGRADE_REQUESTS,
   DEFAULT_AUTO_SEAT_UPGRADE_ENABLED,
+  DEFAULT_REQUIRE_UPGRADE_REQUEST_REASON,
   DEFAULT_TOP_UP_ENABLED,
   DEFAULT_UPGRADE_REQUEST_EMAIL_ENABLED,
 } from "@app/lib/resources/storage/models/credit_usage_configurations";
@@ -39,6 +40,9 @@ export async function getUsageConfiguration(
     upgradeRequestEmailEnabled:
       config?.upgradeRequestEmailEnabled ??
       DEFAULT_UPGRADE_REQUEST_EMAIL_ENABLED,
+    requireUpgradeRequestReason:
+      config?.requireUpgradeRequestReason ??
+      DEFAULT_REQUIRE_UPGRADE_REQUEST_REASON,
     autoSeatUpgradeEnabled:
       config?.autoSeatUpgradeEnabled ?? DEFAULT_AUTO_SEAT_UPGRADE_ENABLED,
     autoSeatUpgradeAvailable: subscription
@@ -60,6 +64,7 @@ async function setConfigurationToggles(
   toggles: {
     allowMemberUpgradeRequests?: boolean;
     upgradeRequestEmailEnabled?: boolean;
+    requireUpgradeRequestReason?: boolean;
     autoSeatUpgradeEnabled?: boolean;
   }
 ): Promise<Result<undefined, Error>> {
@@ -80,6 +85,9 @@ async function setConfigurationToggles(
     upgradeRequestEmailEnabled:
       toggles.upgradeRequestEmailEnabled ??
       DEFAULT_UPGRADE_REQUEST_EMAIL_ENABLED,
+    requireUpgradeRequestReason:
+      toggles.requireUpgradeRequestReason ??
+      DEFAULT_REQUIRE_UPGRADE_REQUEST_REASON,
     autoSeatUpgradeEnabled:
       toggles.autoSeatUpgradeEnabled ?? DEFAULT_AUTO_SEAT_UPGRADE_ENABLED,
   });
@@ -127,11 +135,13 @@ export async function updateUsageConfiguration(
   if (
     patch.allowMemberUpgradeRequests !== undefined ||
     patch.upgradeRequestEmailEnabled !== undefined ||
+    patch.requireUpgradeRequestReason !== undefined ||
     patch.autoSeatUpgradeEnabled !== undefined
   ) {
     const toggleResult = await setConfigurationToggles(auth, {
       allowMemberUpgradeRequests: patch.allowMemberUpgradeRequests,
       upgradeRequestEmailEnabled: patch.upgradeRequestEmailEnabled,
+      requireUpgradeRequestReason: patch.requireUpgradeRequestReason,
       autoSeatUpgradeEnabled: patch.autoSeatUpgradeEnabled,
     });
     if (toggleResult.isErr()) {

--- a/front/lib/resources/credit_usage_configuration_resource.ts
+++ b/front/lib/resources/credit_usage_configuration_resource.ts
@@ -124,6 +124,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       usageCapCredits: number | null;
       allowMemberUpgradeRequests: boolean;
       upgradeRequestEmailEnabled: boolean;
+      requireUpgradeRequestReason: boolean;
       defaultPoolCapAwuCredits: number;
       programmaticMonthlyCapAwuCredits: number;
       autoSeatUpgradeEnabled: boolean;
@@ -191,6 +192,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       usageCapCredits: this.usageCapCredits,
       allowMemberUpgradeRequests: this.allowMemberUpgradeRequests,
       upgradeRequestEmailEnabled: this.upgradeRequestEmailEnabled,
+      requireUpgradeRequestReason: this.requireUpgradeRequestReason,
       defaultPoolCapAwuCredits: this.defaultPoolCapAwuCredits,
       programmaticMonthlyCapAwuCredits: this.programmaticMonthlyCapAwuCredits,
       balanceThresholdAwuCredits: this.balanceThresholdAwuCredits,
@@ -207,6 +209,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       usageCapCredits: this.usageCapCredits,
       allowMemberUpgradeRequests: String(this.allowMemberUpgradeRequests),
       upgradeRequestEmailEnabled: String(this.upgradeRequestEmailEnabled),
+      requireUpgradeRequestReason: String(this.requireUpgradeRequestReason),
       defaultPoolCapAwuCredits: this.defaultPoolCapAwuCredits,
       programmaticMonthlyCapAwuCredits: this.programmaticMonthlyCapAwuCredits,
       balanceThresholdAwuCredits: this.balanceThresholdAwuCredits,

--- a/front/lib/resources/storage/models/credit_usage_configurations.ts
+++ b/front/lib/resources/storage/models/credit_usage_configurations.ts
@@ -1,5 +1,6 @@
 export const DEFAULT_ALLOW_MEMBER_UPGRADE_REQUESTS = true;
 export const DEFAULT_UPGRADE_REQUEST_EMAIL_ENABLED = true;
+export const DEFAULT_REQUIRE_UPGRADE_REQUEST_REASON = false;
 export const DEFAULT_AUTO_SEAT_UPGRADE_ENABLED = false;
 export const DEFAULT_TOP_UP_ENABLED = false;
 export const DEFAULT_AUTO_INVOICE_FINALIZATION_ENABLED = true;
@@ -31,6 +32,8 @@ import type { CreationOptional } from "sequelize";
  *   Defaults to true.
  * - upgradeRequestEmailEnabled: Whether workspace admins are emailed when a
  *   member requests an upgrade. Defaults to true.
+ * - requireUpgradeRequestReason: Whether a member submitting an upgrade
+ *   request must provide a non-empty reason. Defaults to false.
  * - defaultPoolCapAwuCredits: Workspace-wide default per-user cap on
  *   workspace-pool AWU consumption, in AWU credits, excluding the seat
  *   allowance. Non-nullable, defaults to 0: 0 removes pool access; a positive
@@ -70,6 +73,7 @@ export class CreditUsageConfigurationModel extends WorkspaceAwareModel<CreditUsa
   declare usageCapCredits: number | null;
   declare allowMemberUpgradeRequests: CreationOptional<boolean>;
   declare upgradeRequestEmailEnabled: CreationOptional<boolean>;
+  declare requireUpgradeRequestReason: CreationOptional<boolean>;
   declare defaultPoolCapAwuCredits: CreationOptional<number>;
   declare programmaticMonthlyCapAwuCredits: CreationOptional<number>;
   declare autoSeatUpgradeEnabled: CreationOptional<boolean>;
@@ -127,6 +131,11 @@ CreditUsageConfigurationModel.init(
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: DEFAULT_UPGRADE_REQUEST_EMAIL_ENABLED,
+    },
+    requireUpgradeRequestReason: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: DEFAULT_REQUIRE_UPGRADE_REQUEST_REASON,
     },
     defaultPoolCapAwuCredits: {
       type: DataTypes.INTEGER,

--- a/front/migrations/pre-deploy/20260731152015_add_require_upgrade_request_reason_to_credit_usage_configuration.sql
+++ b/front/migrations/pre-deploy/20260731152015_add_require_upgrade_request_reason_to_credit_usage_configuration.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."credit_usage_configurations" ADD COLUMN "requireUpgradeRequestReason" boolean DEFAULT false NOT NULL;

--- a/front/types/api/credits/usage_configuration.ts
+++ b/front/types/api/credits/usage_configuration.ts
@@ -9,6 +9,9 @@ export type CreditUsageConfigurationBody = {
   allowMemberUpgradeRequests: boolean;
   // Whether workspace admins are emailed when a member requests an upgrade.
   upgradeRequestEmailEnabled: boolean;
+  // Whether a member submitting an upgrade request must provide a non-empty
+  // reason.
+  requireUpgradeRequestReason: boolean;
   // Whether members who hit their per-user credit limit are automatically bumped
   // to the next entitled seat tier instead of being blocked.
   autoSeatUpgradeEnabled: boolean;
@@ -30,6 +33,7 @@ export const PatchCreditUsageConfigurationRequestBody = z.object({
   balanceThresholdCredits: z.number().int().min(0).nullable().optional(),
   allowMemberUpgradeRequests: z.boolean().optional(),
   upgradeRequestEmailEnabled: z.boolean().optional(),
+  requireUpgradeRequestReason: z.boolean().optional(),
   autoSeatUpgradeEnabled: z.boolean().optional(),
 });
 


### PR DESCRIPTION
## Description

This PR adds `requireUpgradeRequestReason` to workspace credit usage configuration.

Until now, the configuration had no persisted setting or API field for requiring members to provide a reason when submitting an upgrade request. This PR adds a non-nullable boolean column with a default of `false`, wires the field through the Sequelize model and resource, and exposes it through the usage-configuration GET and optional PATCH APIs.

The default preserves the existing behavior for all workspaces. Request validation and UI exposure are deliberately out of scope; this PR only adds the storage and API plumbing needed by follow-up changes.

This PR is part of the stacked change sequence containing #30315 and #29858.

## Tests

Added API regression coverage for:

- The default value of `requireUpgradeRequestReason`.
- Persisting the setting through PATCH and reading it back through GET.

## Risk

Low. The database change is additive and defaults to `false`, so existing upgrade-request behavior remains unchanged.

## Deploy Plan

Apply the new pre-deploy migration adding `requireUpgradeRequestReason` before deploying application code that depends on the new column. Add the `migration-ack` and `documentation-ack` labels required by CI. No feature-flag activation or UI rollout is required for this PR; enforcement and presentation will be handled by follow-up changes.