### PR TITLE
Pricing: allow to override plan seat limits per workspace

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -152,6 +152,7 @@ import { UserProjectPreferencesModel } from "@app/lib/resources/storage/models/u
 import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
+import { WorkspacePlanLimitOverrideModel } from "@app/lib/resources/storage/models/workspace_plan_limit_override";
 import { WorkspaceSeatLimitModel } from "@app/lib/resources/storage/models/workspace_seat_limit";
 import { WorkspaceVerificationAttemptModel } from "@app/lib/resources/storage/models/workspace_verification_attempt";
 import { isDevelopment, isTest } from "@app/types/shared/env";
@@ -285,6 +286,7 @@ export function loadAllModels() {
     WorkspaceSensitivityLabelConfigModel,
     SandboxEnvVarModel,
     WorkspaceSeatLimitModel,
+    WorkspacePlanLimitOverrideModel,
     ActivationPodModel,
     ActivationRecommendationModel,
     ActivationNudgeModel,

--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -135,6 +135,7 @@ export function WorkspacePage() {
     membersCount,
     metronomeCustomerId,
     pendingSubscription,
+    planLimitOverride,
     poolCreditState,
     poolAlert,
     programmaticAlerts,
@@ -258,7 +259,10 @@ export function WorkspacePage() {
                 />
               </TabsContent>
               <TabsContent value="planlimitations">
-                <PlanLimitationsTable subscription={activeSubscription} />
+                <PlanLimitationsTable
+                  subscription={activeSubscription}
+                  planLimitOverride={planLimitOverride}
+                />
               </TabsContent>
             </Tabs>
 

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -17,6 +17,7 @@ import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
 import { getMetronomeContractUrl } from "@app/lib/metronome/urls";
 import { FREE_NO_PLAN_CODE, isProPlanPrefix } from "@app/lib/plans/plan_codes";
+import type { PlanLimitOverride } from "@app/lib/plans/plan_limit_overrides";
 import { useAppRouter } from "@app/lib/platform";
 import { usePokeCancelPendingContract, usePokePlans } from "@app/lib/swr/poke";
 import type { PlanType, SubscriptionType } from "@app/types/plan";
@@ -436,11 +437,34 @@ export function ActiveSubscriptionTable({
   );
 }
 
+interface PlanLimitValueProps {
+  value: number;
+  isOverridden: boolean;
+}
+
+// A plan limit as it applies to this workspace. Overridden limits are flagged so
+// that a value that does not match the plan is never silently displayed as if it
+// came from the plan.
+function PlanLimitValue({ value, isOverridden }: PlanLimitValueProps) {
+  return (
+    <span>
+      {value === -1 ? "unlimited" : value}
+      {isOverridden && (
+        <span className="text-warning-500 pl-1 font-bold">(overridden)</span>
+      )}
+    </span>
+  );
+}
+
+interface PlanLimitationsTableProps {
+  subscription: SubscriptionType;
+  planLimitOverride: PlanLimitOverride | null;
+}
+
 export function PlanLimitationsTable({
   subscription,
-}: {
-  subscription: SubscriptionType;
-}) {
+  planLimitOverride,
+}: PlanLimitationsTableProps) {
   const activePlan = subscription.plan;
 
   return (
@@ -500,9 +524,36 @@ export function PlanLimitationsTable({
               <PokeTableRow>
                 <PokeTableCell>Max number of users</PokeTableCell>
                 <PokeTableCell>
-                  {activePlan.limits.users.maxUsers === -1
-                    ? "unlimited"
-                    : activePlan.limits.users.maxUsers}
+                  <PlanLimitValue
+                    value={activePlan.limits.users.maxUsers}
+                    isOverridden={
+                      planLimitOverride?.maxUsersInWorkspace != null
+                    }
+                  />
+                </PokeTableCell>
+              </PokeTableRow>
+
+              <PokeTableRow>
+                <PokeTableCell>Max number of free seats</PokeTableCell>
+                <PokeTableCell>
+                  <PlanLimitValue
+                    value={activePlan.limits.users.maxFreeUsers}
+                    isOverridden={
+                      planLimitOverride?.maxFreeUsersInWorkspace != null
+                    }
+                  />
+                </PokeTableCell>
+              </PokeTableRow>
+
+              <PokeTableRow>
+                <PokeTableCell>Max number of lifetime free seats</PokeTableCell>
+                <PokeTableCell>
+                  <PlanLimitValue
+                    value={activePlan.limits.users.maxLifetimeFreeUsers}
+                    isOverridden={
+                      planLimitOverride?.maxLifetimeFreeUsersInWorkspace != null
+                    }
+                  />
                 </PokeTableCell>
               </PokeTableRow>
 

--- a/front/lib/api/plan_compatibility.ts
+++ b/front/lib/api/plan_compatibility.ts
@@ -3,6 +3,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { doesConnectorProviderCountTowardConnectionsLimit } from "@app/lib/data_sources";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { WorkspacePlanLimitOverrideResource } from "@app/lib/resources/workspace_plan_limit_override_resource";
 import type { PlanType } from "@app/types/plan";
 
 type PlanFitResult = {
@@ -20,6 +21,9 @@ type PlanFitResult = {
  * migration: active seats, regular spaces, and data sources. A limit of -1
  * (unlimited) is never a violation. Feature gates (SSO/SCIM/audit logs) are
  * intentionally not checked here.
+ *
+ * The workspace's plan-limit overrides apply to `plan` as well (they are
+ * workspace-scoped, not plan-scoped), so the seat check uses the effective cap.
  */
 export async function checkWorkspaceFitsPlanLimits(
   auth: Authenticator,
@@ -29,13 +33,18 @@ export async function checkWorkspaceFitsPlanLimits(
   const { limits } = plan;
   const violations: string[] = [];
 
-  if (limits.users.maxUsers !== -1) {
+  const planLimitOverride =
+    await WorkspacePlanLimitOverrideResource.fetchByWorkspace({ workspace });
+  const maxUsers =
+    planLimitOverride?.maxUsersInWorkspace ?? limits.users.maxUsers;
+
+  if (maxUsers !== -1) {
     const activeSeats = await MembershipResource.countActiveSeatsInWorkspace(
       workspace.sId
     );
-    if (activeSeats > limits.users.maxUsers) {
+    if (activeSeats > maxUsers) {
       violations.push(
-        `active seats (${activeSeats}) exceed plan maxUsers (${limits.users.maxUsers})`
+        `active seats (${activeSeats}) exceed plan maxUsers (${maxUsers})`
       );
     }
   }

--- a/front/lib/api/plan_limit_overrides.test.ts
+++ b/front/lib/api/plan_limit_overrides.test.ts
@@ -1,0 +1,141 @@
+import {
+  getWorkspacePlanLimitOverrides,
+  setWorkspacePlanLimitOverrides,
+} from "@app/lib/api/plan_limit_overrides";
+import { evaluateWorkspaceSeatAvailability } from "@app/lib/api/workspace";
+import { Authenticator } from "@app/lib/auth";
+import type { PlanLimitOverride } from "@app/lib/plans/plan_limit_overrides";
+import { EMPTY_PLAN_LIMIT_OVERRIDE } from "@app/lib/plans/plan_limit_overrides";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { PlanFactory } from "@app/tests/utils/PlanFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { LightWorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
+
+function override(partial: Partial<PlanLimitOverride>): PlanLimitOverride {
+  return { ...EMPTY_PLAN_LIMIT_OVERRIDE, ...partial };
+}
+
+// The plan the workspace is subscribed to, so tests can assert against the
+// values the override replaces.
+const PLAN_MAX_USERS = 4;
+const PLAN_MAX_FREE_USERS = 2;
+const PLAN_MAX_LIFETIME_FREE_USERS = 3;
+
+describe("workspace plan limit overrides", () => {
+  let workspace: LightWorkspaceType;
+  let auth: Authenticator;
+
+  beforeEach(async () => {
+    const plan = await PlanFactory.enterprise("ENT_PLAN_LIMIT_OVERRIDE_TEST", {
+      maxUsersInWorkspace: PLAN_MAX_USERS,
+      maxFreeUsersInWorkspace: PLAN_MAX_FREE_USERS,
+      maxLifetimeFreeUsersInWorkspace: PLAN_MAX_LIFETIME_FREE_USERS,
+    });
+    workspace = await WorkspaceFactory.fromPlan(plan);
+    auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  });
+
+  async function activeSubscription() {
+    const subscription =
+      await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
+    return subscription.toJSON();
+  }
+
+  async function effectiveUserLimits() {
+    return (await activeSubscription()).plan.limits.users;
+  }
+
+  it("uses the plan values when the workspace has no override", async () => {
+    expect(await getWorkspacePlanLimitOverrides(auth)).toBeNull();
+
+    const limits = await effectiveUserLimits();
+    expect(limits.maxUsers).toBe(PLAN_MAX_USERS);
+    expect(limits.maxFreeUsers).toBe(PLAN_MAX_FREE_USERS);
+    expect(limits.maxLifetimeFreeUsers).toBe(PLAN_MAX_LIFETIME_FREE_USERS);
+  });
+
+  it("applies the override to the effective plan limits", async () => {
+    const res = await setWorkspacePlanLimitOverrides(
+      auth,
+      override({ maxUsersInWorkspace: 500, maxFreeUsersInWorkspace: -1 })
+    );
+    expect(res.isOk()).toBe(true);
+
+    const limits = await effectiveUserLimits();
+    expect(limits.maxUsers).toBe(500);
+    expect(limits.maxFreeUsers).toBe(-1);
+    // Not overridden: still the plan value.
+    expect(limits.maxLifetimeFreeUsers).toBe(PLAN_MAX_LIFETIME_FREE_USERS);
+  });
+
+  it("clears the override and falls back to the plan values", async () => {
+    await setWorkspacePlanLimitOverrides(
+      auth,
+      override({ maxUsersInWorkspace: 500 })
+    );
+    expect(await getWorkspacePlanLimitOverrides(auth)).not.toBeNull();
+
+    await setWorkspacePlanLimitOverrides(auth, EMPTY_PLAN_LIMIT_OVERRIDE);
+
+    expect(await getWorkspacePlanLimitOverrides(auth)).toBeNull();
+    expect((await effectiveUserLimits()).maxUsers).toBe(PLAN_MAX_USERS);
+  });
+
+  it("rejects a limit below -1 and writes nothing", async () => {
+    const res = await setWorkspacePlanLimitOverrides(
+      auth,
+      override({ maxUsersInWorkspace: -2 })
+    );
+
+    expect(res.isErr()).toBe(true);
+    expect(await getWorkspacePlanLimitOverrides(auth)).toBeNull();
+  });
+
+  it("rejects a non-integer limit", async () => {
+    const res = await setWorkspacePlanLimitOverrides(
+      auth,
+      override({ maxFreeUsersInWorkspace: 2.5 })
+    );
+
+    expect(res.isErr()).toBe(true);
+    expect(await getWorkspacePlanLimitOverrides(auth)).toBeNull();
+  });
+
+  it("does not clobber an existing override when the new value is invalid", async () => {
+    await setWorkspacePlanLimitOverrides(
+      auth,
+      override({ maxUsersInWorkspace: 500 })
+    );
+
+    const res = await setWorkspacePlanLimitOverrides(
+      auth,
+      override({ maxUsersInWorkspace: -2 })
+    );
+
+    expect(res.isErr()).toBe(true);
+    expect((await effectiveUserLimits()).maxUsers).toBe(500);
+  });
+
+  it("is honored by the workspace seat-availability check", async () => {
+    // The workspace has no member yet, so it is under the plan cap.
+    expect(
+      await evaluateWorkspaceSeatAvailability(
+        workspace,
+        await activeSubscription()
+      )
+    ).toBe(true);
+
+    await setWorkspacePlanLimitOverrides(
+      auth,
+      override({ maxUsersInWorkspace: 0 })
+    );
+
+    expect(
+      await evaluateWorkspaceSeatAvailability(
+        workspace,
+        await activeSubscription()
+      )
+    ).toBe(false);
+  });
+});

--- a/front/lib/api/plan_limit_overrides.ts
+++ b/front/lib/api/plan_limit_overrides.ts
@@ -1,0 +1,51 @@
+import type { Authenticator } from "@app/lib/auth";
+import type { PlanLimitOverride } from "@app/lib/plans/plan_limit_overrides";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspacePlanLimitOverrideResource } from "@app/lib/resources/workspace_plan_limit_override_resource";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+
+/**
+ * Returns the plan-limit overrides configured for the workspace, or `null` when
+ * it has none.
+ */
+export async function getWorkspacePlanLimitOverrides(
+  auth: Authenticator
+): Promise<PlanLimitOverride | null> {
+  return WorkspacePlanLimitOverrideResource.fetchByWorkspace({
+    workspace: auth.getNonNullableWorkspace(),
+  });
+}
+
+/**
+ * Sets the plan-limit overrides for the workspace. Fields passed as `null` are
+ * cleared, so the workspace falls back to its plan value.
+ *
+ * This is the only entry point that should be used to write overrides: the
+ * rendered plan (and therefore the effective limits) is part of the Redis-cached
+ * subscription, so the cache must be invalidated for the change to take effect.
+ */
+export async function setWorkspacePlanLimitOverrides(
+  auth: Authenticator,
+  override: PlanLimitOverride
+): Promise<Result<undefined, Error>> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const res = await WorkspacePlanLimitOverrideResource.upsert({
+    workspace,
+    override,
+  });
+  if (res.isErr()) {
+    return res;
+  }
+
+  await SubscriptionResource.invalidateSubscriptionCache(workspace.id);
+
+  logger.info(
+    { workspaceId: workspace.sId, override },
+    "[PlanLimitOverrides] Updated workspace plan limit overrides"
+  );
+
+  return new Ok(undefined);
+}

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -27,6 +27,7 @@ export * from "./manage_credit_usage_configuration";
 export * from "./manage_programmatic_usage_configuration";
 export * from "./manage_seat_limits";
 export * from "./manage_workspace_kill_switch";
+export * from "./override_plan_seat_limits";
 export * from "./project_task_details";
 export * from "./reconcile_credit_state";
 export * from "./reinforcement_workflow";

--- a/front/lib/api/poke/plugins/workspaces/override_plan_seat_limits.ts
+++ b/front/lib/api/poke/plugins/workspaces/override_plan_seat_limits.ts
@@ -1,0 +1,173 @@
+import {
+  getWorkspacePlanLimitOverrides,
+  setWorkspacePlanLimitOverrides,
+} from "@app/lib/api/plan_limit_overrides";
+import { createPlugin } from "@app/lib/api/poke/types";
+import type { PlanLimitOverride } from "@app/lib/plans/plan_limit_overrides";
+import { Err, Ok } from "@app/types/shared/result";
+import { z } from "zod";
+
+const UNLIMITED = -1;
+
+const SeatLimitOverridesSchema = z.object({
+  overrideMaxUsers: z.boolean(),
+  maxUsers: z.number().int().min(UNLIMITED).optional(),
+  overrideMaxFreeUsers: z.boolean(),
+  maxFreeUsers: z.number().int().min(UNLIMITED).optional(),
+  overrideMaxLifetimeFreeUsers: z.boolean(),
+  maxLifetimeFreeUsers: z.number().int().min(UNLIMITED).optional(),
+});
+
+function resolveOverride(
+  enabled: boolean,
+  value: number | undefined
+): number | null {
+  return enabled && value !== undefined ? value : null;
+}
+
+function describeLimit(value: number | null): string {
+  if (value === null) {
+    return "plan value";
+  }
+  return value === UNLIMITED ? "unlimited" : `${value}`;
+}
+
+export const overridePlanSeatLimitsPlugin = createPlugin({
+  manifest: {
+    id: "override-plan-seat-limits",
+    name: "Override Plan Seat Limits",
+    description:
+      "Override this workspace's seat limits without creating a dedicated plan. " +
+      "Each limit falls back to the plan value when its toggle is off. Use -1 for unlimited.",
+    explanation:
+      "Overrides are workspace-scoped: they survive plan changes and renewals, and they " +
+      "also win over the trial limits. They cap seat assignment and what the product " +
+      "displays — they do not change what is billed (see 'Manage Seat Limits' for billing " +
+      "floors). Raising the lifetime free-seat cap only affects users onboarded from now " +
+      "on; lowering a cap never revokes existing seats.",
+    resourceTypes: ["workspaces"],
+    args: {
+      overrideMaxUsers: {
+        type: "boolean",
+        variant: "toggle",
+        label: "Override max users",
+        async: true,
+        asyncDescription: true,
+      },
+      maxUsers: {
+        type: "number",
+        variant: "text",
+        label: "Max users",
+        description:
+          "Maximum active members + pending invitations in the workspace. -1 for unlimited.",
+        async: true,
+        dependsOn: { field: "overrideMaxUsers", value: true },
+      },
+      overrideMaxFreeUsers: {
+        type: "boolean",
+        variant: "toggle",
+        label: "Override max free seats",
+        async: true,
+        asyncDescription: true,
+      },
+      maxFreeUsers: {
+        type: "number",
+        variant: "text",
+        label: "Max free seats",
+        description:
+          "Maximum simultaneously-active `free` seats. -1 for unlimited.",
+        async: true,
+        dependsOn: { field: "overrideMaxFreeUsers", value: true },
+      },
+      overrideMaxLifetimeFreeUsers: {
+        type: "boolean",
+        variant: "toggle",
+        label: "Override max lifetime free seats",
+        async: true,
+        asyncDescription: true,
+      },
+      maxLifetimeFreeUsers: {
+        type: "number",
+        variant: "text",
+        label: "Max lifetime free seats",
+        description:
+          "Maximum distinct users ever assigned a `free` seat (active + revoked). -1 for unlimited.",
+        async: true,
+        dependsOn: { field: "overrideMaxLifetimeFreeUsers", value: true },
+      },
+    },
+    requiredRoles: ["billing"],
+  },
+
+  populateAsyncArgs: async (auth) => {
+    // These limits are already the effective ones: the override is applied when
+    // the plan is resolved for the workspace. So prefilling the number fields
+    // with them is correct whether or not an override is in place.
+    const planLimits = auth.getNonNullablePlan().limits.users;
+    const override = await getWorkspacePlanLimitOverrides(auth);
+
+    return new Ok({
+      overrideMaxUsers: override?.maxUsersInWorkspace != null,
+      overrideMaxUsersDescription:
+        "Override the plan's max-users cap for this workspace only.",
+      maxUsers: planLimits.maxUsers,
+      overrideMaxFreeUsers: override?.maxFreeUsersInWorkspace != null,
+      overrideMaxFreeUsersDescription:
+        "Override the plan's active free-seat cap for this workspace only.",
+      maxFreeUsers: planLimits.maxFreeUsers,
+      overrideMaxLifetimeFreeUsers:
+        override?.maxLifetimeFreeUsersInWorkspace != null,
+      overrideMaxLifetimeFreeUsersDescription:
+        "Override the plan's lifetime free-seat cap for this workspace only.",
+      maxLifetimeFreeUsers: planLimits.maxLifetimeFreeUsers,
+    });
+  },
+
+  execute: async (auth, _, args) => {
+    const parseResult = SeatLimitOverridesSchema.safeParse(args);
+    if (!parseResult.success) {
+      return new Err(
+        new Error(
+          `Invalid arguments: ${parseResult.error.errors
+            .map((e) => `${e.path.join(".")}: ${e.message}`)
+            .join(", ")}`
+        )
+      );
+    }
+
+    const {
+      overrideMaxUsers,
+      maxUsers,
+      overrideMaxFreeUsers,
+      maxFreeUsers,
+      overrideMaxLifetimeFreeUsers,
+      maxLifetimeFreeUsers,
+    } = parseResult.data;
+
+    const override: PlanLimitOverride = {
+      maxUsersInWorkspace: resolveOverride(overrideMaxUsers, maxUsers),
+      maxFreeUsersInWorkspace: resolveOverride(
+        overrideMaxFreeUsers,
+        maxFreeUsers
+      ),
+      maxLifetimeFreeUsersInWorkspace: resolveOverride(
+        overrideMaxLifetimeFreeUsers,
+        maxLifetimeFreeUsers
+      ),
+    };
+
+    const res = await setWorkspacePlanLimitOverrides(auth, override);
+    if (res.isErr()) {
+      return res;
+    }
+
+    return new Ok({
+      display: "text",
+      value: [
+        `Max users: ${describeLimit(override.maxUsersInWorkspace)}.`,
+        `Max free seats: ${describeLimit(override.maxFreeUsersInWorkspace)}.`,
+        `Max lifetime free seats: ${describeLimit(override.maxLifetimeFreeUsersInWorkspace)}.`,
+      ].join(" "),
+    });
+  },
+});

--- a/front/lib/api/poke/workspace_info.ts
+++ b/front/lib/api/poke/workspace_info.ts
@@ -1,6 +1,7 @@
 import config from "@app/lib/api/config";
 import type { SeatPlanResponseBody } from "@app/lib/api/credits/seat_plan";
 import { getSeatPlan } from "@app/lib/api/credits/seat_plan";
+import { getWorkspacePlanLimitOverrides } from "@app/lib/api/plan_limit_overrides";
 import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import { getWorkspaceCreationDate } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
@@ -10,6 +11,7 @@ import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
 import { getCachedWorkspaceMetronomeAlerts } from "@app/lib/metronome/alerts/workspace_alerts";
 import { getMetronomeCustomerStripeCustomerId } from "@app/lib/metronome/client";
 import { isWorkspaceProgrammaticWarningReached } from "@app/lib/metronome/user_block";
+import type { PlanLimitOverride } from "@app/lib/plans/plan_limit_overrides";
 import { getCustomerId, getStripeSubscription } from "@app/lib/plans/stripe";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
@@ -68,6 +70,10 @@ export type PokeWorkspaceInfo = {
   membersCount: number;
   metronomeCustomerId: string | null;
   pendingSubscription: SubscriptionType | null;
+  // Per-workspace overrides of the plan seat limits, or null when the workspace
+  // has none. `activeSubscription.plan` already carries the effective values;
+  // this tells Poke which of them are overridden rather than plan-given.
+  planLimitOverride: PlanLimitOverride | null;
   poolCreditState: WorkspacePoolCreditState;
   seatPlan: SeatPlanResponseBody | null;
   // The Metronome alerts backing each credit dimension — id and current status —
@@ -180,6 +186,8 @@ export async function getPokeWorkspaceInfo(
     );
   const pendingSubscription = pendingSubscriptionResource?.toJSON() ?? null;
 
+  const planLimitOverride = await getWorkspacePlanLimitOverrides(auth);
+
   const [membersCount, seatPlanResult] = await Promise.all([
     MembershipResource.getMembersCountForWorkspace({
       workspace: owner,
@@ -225,6 +233,7 @@ export async function getPokeWorkspaceInfo(
     metronomeCustomerId: workspaceResource.metronomeCustomerId ?? null,
     seatPlan,
     pendingSubscription,
+    planLimitOverride,
     poolCreditState: workspaceResource.poolCreditState,
     poolAlert,
     programmaticAlerts,

--- a/front/lib/plans/plan_limit_overrides.test.ts
+++ b/front/lib/plans/plan_limit_overrides.test.ts
@@ -1,0 +1,82 @@
+import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
+import type { PlanLimitOverride } from "@app/lib/plans/plan_limit_overrides";
+import {
+  applyPlanLimitOverrides,
+  EMPTY_PLAN_LIMIT_OVERRIDE,
+  hasAnyPlanLimitOverride,
+} from "@app/lib/plans/plan_limit_overrides";
+import { describe, expect, it } from "vitest";
+
+const PLAN = {
+  ...FREE_NO_PLAN_DATA,
+  maxUsersInWorkspace: 10,
+  maxFreeUsersInWorkspace: 3,
+  maxLifetimeFreeUsersInWorkspace: 5,
+};
+
+function override(partial: Partial<PlanLimitOverride>): PlanLimitOverride {
+  return { ...EMPTY_PLAN_LIMIT_OVERRIDE, ...partial };
+}
+
+describe("applyPlanLimitOverrides", () => {
+  it("returns the plan untouched when there is no override", () => {
+    expect(applyPlanLimitOverrides(PLAN, null)).toEqual(PLAN);
+    expect(applyPlanLimitOverrides(PLAN, EMPTY_PLAN_LIMIT_OVERRIDE)).toEqual(
+      PLAN
+    );
+  });
+
+  it("overrides only the fields that are set", () => {
+    const res = applyPlanLimitOverrides(
+      PLAN,
+      override({ maxUsersInWorkspace: 500 })
+    );
+
+    expect(res.maxUsersInWorkspace).toBe(500);
+    expect(res.maxFreeUsersInWorkspace).toBe(3);
+    expect(res.maxLifetimeFreeUsersInWorkspace).toBe(5);
+  });
+
+  it("supports raising a limit to unlimited and lowering it to zero", () => {
+    expect(
+      applyPlanLimitOverrides(PLAN, override({ maxUsersInWorkspace: -1 }))
+        .maxUsersInWorkspace
+    ).toBe(-1);
+    expect(
+      applyPlanLimitOverrides(PLAN, override({ maxFreeUsersInWorkspace: 0 }))
+        .maxFreeUsersInWorkspace
+    ).toBe(0);
+  });
+
+  it("does not mutate the plan it is given", () => {
+    applyPlanLimitOverrides(PLAN, override({ maxUsersInWorkspace: 500 }));
+
+    expect(PLAN.maxUsersInWorkspace).toBe(10);
+  });
+
+  it("overrides the trial limits, since it is applied last", () => {
+    // `getTrialVersionForPlan` caps maxUsersInWorkspace at 5; the override is
+    // merged on top of that result.
+    const trialPlan = { ...PLAN, maxUsersInWorkspace: 5 };
+
+    expect(
+      applyPlanLimitOverrides(trialPlan, override({ maxUsersInWorkspace: 50 }))
+        .maxUsersInWorkspace
+    ).toBe(50);
+  });
+});
+
+describe("hasAnyPlanLimitOverride", () => {
+  it("is false when every field is null", () => {
+    expect(hasAnyPlanLimitOverride(EMPTY_PLAN_LIMIT_OVERRIDE)).toBe(false);
+  });
+
+  it("is true as soon as one field is set, including 0 and -1", () => {
+    expect(
+      hasAnyPlanLimitOverride(override({ maxLifetimeFreeUsersInWorkspace: 0 }))
+    ).toBe(true);
+    expect(hasAnyPlanLimitOverride(override({ maxUsersInWorkspace: -1 }))).toBe(
+      true
+    );
+  });
+});

--- a/front/lib/plans/plan_limit_overrides.ts
+++ b/front/lib/plans/plan_limit_overrides.ts
@@ -1,0 +1,53 @@
+import type { PlanAttributes } from "@app/lib/plans/free_plans";
+
+/**
+ * The plan limits that can be overridden per workspace. Keys are `PlanModel`
+ * column names so that merging is a plain field copy.
+ */
+export const OVERRIDABLE_PLAN_LIMITS = [
+  "maxUsersInWorkspace",
+  "maxFreeUsersInWorkspace",
+  "maxLifetimeFreeUsersInWorkspace",
+] as const satisfies readonly (keyof PlanAttributes)[];
+
+export type OverridablePlanLimit = (typeof OVERRIDABLE_PLAN_LIMITS)[number];
+
+/**
+ * A per-workspace override of the plan limits. `null` means "not overridden,
+ * use the plan value"; `-1` keeps its plan meaning (unlimited).
+ */
+export type PlanLimitOverride = Record<OverridablePlanLimit, number | null>;
+
+export const EMPTY_PLAN_LIMIT_OVERRIDE: PlanLimitOverride = {
+  maxUsersInWorkspace: null,
+  maxFreeUsersInWorkspace: null,
+  maxLifetimeFreeUsersInWorkspace: null,
+};
+
+export function hasAnyPlanLimitOverride(override: PlanLimitOverride): boolean {
+  return OVERRIDABLE_PLAN_LIMITS.some((key) => override[key] !== null);
+}
+
+/**
+ * Applies a workspace's plan-limit overrides on top of the plan attributes.
+ * Applied last when resolving the plan for a workspace — after the trial limits
+ * of `getTrialVersionForPlan` — so an explicit override always wins.
+ */
+export function applyPlanLimitOverrides(
+  plan: PlanAttributes,
+  override: PlanLimitOverride | null
+): PlanAttributes {
+  if (!override) {
+    return plan;
+  }
+
+  const overridden = { ...plan };
+  for (const key of OVERRIDABLE_PLAN_LIMITS) {
+    const value = override[key];
+    if (value !== null) {
+      overridden[key] = value;
+    }
+  }
+
+  return overridden;
+}

--- a/front/lib/resources/storage/models/workspace_plan_limit_override.ts
+++ b/front/lib/resources/storage/models/workspace_plan_limit_override.ts
@@ -1,0 +1,75 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional } from "sequelize";
+
+/**
+ * Per-workspace overrides of numeric plan limits.
+ *
+ * A `PlanModel` row is shared by every workspace subscribed to it, so raising a
+ * limit for a single customer would otherwise mean creating a dedicated plan. A
+ * row here overrides the matching `PlanModel` column for one workspace only. It
+ * is applied when the plan is resolved for that workspace (see
+ * `SubscriptionResource.determinePlanFromSubscription`), so every consumer of
+ * `PlanType.limits` — enforcement and UI alike — sees the effective value.
+ *
+ * `null` means "not overridden, use the plan value". `-1` keeps its plan meaning
+ * (unlimited), so raising a workspace to unlimited is expressible.
+ *
+ * Columns are named exactly like their `PlanModel` counterparts so that the
+ * merge in `applyPlanLimitOverrides` stays mechanical.
+ */
+export class WorkspacePlanLimitOverrideModel extends WorkspaceAwareModel<WorkspacePlanLimitOverrideModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare maxUsersInWorkspace: CreationOptional<number | null>;
+  declare maxFreeUsersInWorkspace: CreationOptional<number | null>;
+  declare maxLifetimeFreeUsersInWorkspace: CreationOptional<number | null>;
+}
+
+WorkspacePlanLimitOverrideModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    // Range is enforced by `WorkspacePlanLimitOverrideResource.upsert`, the only
+    // write path.
+    maxUsersInWorkspace: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
+    },
+    maxFreeUsersInWorkspace: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
+    },
+    maxLifetimeFreeUsersInWorkspace: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
+    },
+  },
+  {
+    modelName: "workspace_plan_limit_override",
+    sequelize: frontSequelize,
+    indexes: [
+      // Enforce 1:1 relationship with workspace.
+      { unique: true, fields: ["workspaceId"] },
+    ],
+    relationship: "hasOne",
+  }
+);
+
+WorkspacePlanLimitOverrideModel.belongsTo(WorkspaceModel, {
+  foreignKey: { name: "workspaceId", allowNull: false },
+});

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -31,6 +31,8 @@ import {
   POKE_PLAN_TYPE_FILTERS,
   PRO_PLAN_SEAT_39_CODE,
 } from "@app/lib/plans/plan_codes";
+import type { PlanLimitOverride } from "@app/lib/plans/plan_limit_overrides";
+import { applyPlanLimitOverrides } from "@app/lib/plans/plan_limit_overrides";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import {
   cancelSubscriptionImmediately,
@@ -48,6 +50,7 @@ import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { WorkspacePlanLimitOverrideResource } from "@app/lib/resources/workspace_plan_limit_override_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -434,9 +437,16 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       return null;
     }
 
+    const planLimitOverride =
+      await WorkspacePlanLimitOverrideResource.fetchByWorkspace({
+        workspace,
+        transaction,
+      });
+
     const plan = this.determinePlanFromSubscription(
       lastSubscription,
-      workspace.sId
+      workspace.sId,
+      planLimitOverride
     );
 
     return new SubscriptionResource(
@@ -501,6 +511,12 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       "workspaceId"
     );
 
+    const planLimitOverrideByWorkspaceModelId =
+      await WorkspacePlanLimitOverrideResource.fetchByWorkspaceModelIds(
+        workspaceModelIds,
+        transaction
+      );
+
     const subscriptionResourceByWorkspaceModelId: Record<
       ModelId,
       SubscriptionResource
@@ -512,7 +528,8 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
 
       const plan = this.determinePlanFromSubscription(
         activeSubscription ?? null,
-        workspaceModelId.toString()
+        workspaceModelId.toString(),
+        planLimitOverrideByWorkspaceModelId.get(workspaceModelId) ?? null
       );
 
       subscriptionResourceByWorkspaceModelId[workspaceModelId] =
@@ -847,13 +864,18 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
 
     await this.endActiveSubscription(workspace);
 
-    // No plan anymore: clear billed seat assignments and plan-level seat caps.
+    // No plan anymore: clear billed seat assignments, plan-level seat caps and
+    // any negotiated plan-limit override.
     await withTransaction(async (t) => {
       await MembershipResource.resetAllSeatsToNoneForWorkspace({
         workspace,
         transaction: t,
       });
       await WorkspaceSeatLimitResource.deleteAllForWorkspace({
+        workspace,
+        transaction: t,
+      });
+      await WorkspacePlanLimitOverrideResource.deleteAllForWorkspace({
         workspace,
         transaction: t,
       });
@@ -902,12 +924,18 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       );
     }
 
-    // Prevent subscribing if the new plan has less users allowed then the current one on the workspace
-    if (newPlan.maxUsersInWorkspace !== -1) {
+    // Prevent subscribing if the new plan has less users allowed then the current one on the
+    // workspace. The workspace's own plan-limit overrides apply to the new plan too, so compare
+    // against the effective cap.
+    const { maxUsersInWorkspace } = applyPlanLimitOverrides(
+      newPlan.get(),
+      await WorkspacePlanLimitOverrideResource.fetchByWorkspace({ workspace })
+    );
+    if (maxUsersInWorkspace !== -1) {
       const activeSeats = await MembershipResource.countActiveSeatsInWorkspace(
         workspace.sId
       );
-      if (activeSeats > newPlan.maxUsersInWorkspace) {
+      if (activeSeats > maxUsersInWorkspace) {
         throw new Error(
           `Cannot subscribe to plan ${planCode}: new plan has less users allowed than currently in workspace.`
         );
@@ -1589,7 +1617,8 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
 
   private static determinePlanFromSubscription(
     subscription: SubscriptionModel | null,
-    workspaceId: string
+    workspaceId: string,
+    planLimitOverride: PlanLimitOverride | null
   ): PlanAttributes {
     let plan: PlanAttributes = DEFAULT_PLAN_WHEN_NO_SUBSCRIPTION;
 
@@ -1598,7 +1627,9 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       if (isTrial(subscription)) {
         plan = getTrialVersionForPlan(subscription.plan);
       } else if (subscription.plan) {
-        plan = subscription.plan;
+        // `.get()` so that `plan` is always plain attributes: spreading a
+        // Sequelize instance would drop every attribute.
+        plan = subscription.plan.get();
       } else {
         logger.error(
           {
@@ -1610,7 +1641,9 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       }
     }
 
-    return plan;
+    // Applied last: a per-workspace override wins over the plan value and over
+    // the trial limits above.
+    return applyPlanLimitOverrides(plan, planLimitOverride);
   }
 
   private static async findPlanOrThrow(planCode: string): Promise<PlanModel> {

--- a/front/lib/resources/workspace_plan_limit_override_resource.ts
+++ b/front/lib/resources/workspace_plan_limit_override_resource.ts
@@ -1,0 +1,150 @@
+import type { PlanLimitOverride } from "@app/lib/plans/plan_limit_overrides";
+import {
+  hasAnyPlanLimitOverride,
+  OVERRIDABLE_PLAN_LIMITS,
+} from "@app/lib/plans/plan_limit_overrides";
+import { WorkspacePlanLimitOverrideModel } from "@app/lib/resources/storage/models/workspace_plan_limit_override";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { Transaction } from "sequelize";
+
+function toPlanLimitOverride(
+  row: WorkspacePlanLimitOverrideModel
+): PlanLimitOverride {
+  return {
+    maxUsersInWorkspace: row.maxUsersInWorkspace,
+    maxFreeUsersInWorkspace: row.maxFreeUsersInWorkspace,
+    maxLifetimeFreeUsersInWorkspace: row.maxLifetimeFreeUsersInWorkspace,
+  };
+}
+
+// A limit is `null` (not overridden), `-1` (unlimited) or a non-negative count,
+// matching the plan convention.
+function validatePlanLimitOverride(
+  override: PlanLimitOverride
+): Result<undefined, Error> {
+  for (const key of OVERRIDABLE_PLAN_LIMITS) {
+    const value = override[key];
+    if (value !== null && (!Number.isInteger(value) || value < -1)) {
+      return new Err(
+        new Error(
+          `${key} must be -1 (unlimited) or a non-negative integer, got ${value}.`
+        )
+      );
+    }
+  }
+
+  return new Ok(undefined);
+}
+
+/**
+ * A workspace has at most one override row, and callers only ever need its
+ * values — never a row identity — so this resource exposes statics returning
+ * plain {@link PlanLimitOverride} objects and never instantiates itself.
+ */
+export class WorkspacePlanLimitOverrideResource {
+  static model: ModelStaticWorkspaceAware<WorkspacePlanLimitOverrideModel> =
+    WorkspacePlanLimitOverrideModel;
+
+  /**
+   * Returns the plan-limit overrides for a workspace, or `null` when the
+   * workspace has none. Used by `SubscriptionResource` when resolving the plan.
+   */
+  static async fetchByWorkspace({
+    workspace,
+    transaction,
+  }: {
+    workspace: LightWorkspaceType;
+    transaction?: Transaction;
+  }): Promise<PlanLimitOverride | null> {
+    const row = await this.model.findOne({
+      where: { workspaceId: workspace.id },
+      transaction,
+    });
+
+    return row ? toPlanLimitOverride(row) : null;
+  }
+
+  /**
+   * Batched variant of {@link fetchByWorkspace}: returns one entry per
+   * workspace that has overrides (workspaces without any are simply absent).
+   */
+  static async fetchByWorkspaceModelIds(
+    workspaceModelIds: ModelId[],
+    transaction?: Transaction
+  ): Promise<Map<ModelId, PlanLimitOverride>> {
+    if (workspaceModelIds.length === 0) {
+      return new Map();
+    }
+
+    const rows = await this.model.findAll({
+      where: { workspaceId: workspaceModelIds },
+      transaction,
+      // WORKSPACE_ISOLATION_BYPASS: Plans are resolved for several workspaces at
+      // once (`SubscriptionResource.fetchActiveByWorkspacesModelId`); the query
+      // is scoped to exactly the requested workspaces.
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+    });
+
+    return new Map(
+      rows.map((row) => [row.workspaceId, toPlanLimitOverride(row)])
+    );
+  }
+
+  /**
+   * Sets the overrides for a workspace. Fields set to `null` are cleared, so the
+   * workspace falls back to its plan value. When no override remains, the row is
+   * deleted rather than kept fully null. Rejects out-of-range limits.
+   *
+   * The caller is responsible for invalidating the subscription cache — see
+   * `setWorkspacePlanLimitOverrides`, which is the entry point to use.
+   */
+  static async upsert({
+    workspace,
+    override,
+  }: {
+    workspace: LightWorkspaceType;
+    override: PlanLimitOverride;
+  }): Promise<Result<undefined, Error>> {
+    const validation = validatePlanLimitOverride(override);
+    if (validation.isErr()) {
+      return validation;
+    }
+
+    if (!hasAnyPlanLimitOverride(override)) {
+      await this.model.destroy({
+        where: { workspaceId: workspace.id },
+      });
+      return new Ok(undefined);
+    }
+
+    const existing = await this.model.findOne({
+      where: { workspaceId: workspace.id },
+    });
+
+    if (existing) {
+      await existing.update(override);
+    } else {
+      await this.model.create({ ...override, workspaceId: workspace.id });
+    }
+
+    return new Ok(undefined);
+  }
+
+  static async deleteAllForWorkspace({
+    workspace,
+    transaction,
+  }: {
+    workspace: LightWorkspaceType;
+    transaction?: Transaction;
+  }): Promise<void> {
+    await this.model.destroy({
+      where: { workspaceId: workspace.id },
+      transaction,
+    });
+  }
+}

--- a/front/migrations/pre-deploy/20260811104625_create_workspace_plan_limit_overrides.sql
+++ b/front/migrations/pre-deploy/20260811104625_create_workspace_plan_limit_overrides.sql
@@ -1,0 +1,69 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE SEQUENCE "public"."workspace_plan_limit_overrides_id_seq"
+	AS bigint
+	INCREMENT BY 1
+	MINVALUE 1 MAXVALUE 9223372036854775807
+	START WITH 1 CACHE 1 NO CYCLE
+;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE TABLE "public"."workspace_plan_limit_overrides" (
+	"createdAt" timestamp with time zone NOT NULL,
+	"updatedAt" timestamp with time zone NOT NULL,
+	"workspaceId" bigint NOT NULL,
+	"id" bigint DEFAULT nextval('workspace_plan_limit_overrides_id_seq'::regclass) NOT NULL,
+	"maxUsersInWorkspace" integer,
+	"maxFreeUsersInWorkspace" integer,
+	"maxLifetimeFreeUsersInWorkspace" integer
+);
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY workspace_plan_limit_overrides_pkey ON public.workspace_plan_limit_overrides USING btree (id);
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."workspace_plan_limit_overrides" ADD CONSTRAINT "workspace_plan_limit_overrides_pkey" PRIMARY KEY USING INDEX "workspace_plan_limit_overrides_pkey";
+
+/*
+Statement 4
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY workspace_plan_limit_overrides_workspace_id ON public.workspace_plan_limit_overrides USING btree ("workspaceId");
+
+/*
+Statement 5
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER SEQUENCE "public"."workspace_plan_limit_overrides_id_seq" OWNED BY "public"."workspace_plan_limit_overrides"."id";
+
+/*
+Statement 6
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."workspace_plan_limit_overrides" ADD CONSTRAINT "workspace_plan_limit_overrides_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES workspaces(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 7
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."workspace_plan_limit_overrides" VALIDATE CONSTRAINT "workspace_plan_limit_overrides_workspaceId_fkey";

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -83,6 +83,7 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
+import { WorkspacePlanLimitOverrideResource } from "@app/lib/resources/workspace_plan_limit_override_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
 import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspace_verification_attempt_resource";
@@ -863,6 +864,7 @@ export async function deleteWorkspaceActivity({
   await SelfImprovingSkillsUsageResource.deleteAllForWorkspace(auth);
   await WorkspaceVerificationAttemptResource.deleteAllForWorkspace(auth);
   await WorkspaceSeatLimitResource.deleteAllForWorkspace({ workspace });
+  await WorkspacePlanLimitOverrideResource.deleteAllForWorkspace({ workspace });
 
   hardDeleteLogger.info({ workspaceId }, "Deleting Workspace");
 

--- a/front/tests/utils/WorkspaceFactory.ts
+++ b/front/tests/utils/WorkspaceFactory.ts
@@ -43,6 +43,15 @@ export class WorkspaceFactory {
     return this.createWithPlan(plan, overrides);
   }
 
+  // Subscribe a fresh workspace to a plan built by the caller — use when the
+  // test needs specific plan limits rather than one of the seeded plans.
+  static async fromPlan(
+    plan: PlanModel,
+    overrides?: WorkspaceOverrides
+  ): Promise<WorkspaceType> {
+    return this.createWithPlan(plan, overrides);
+  }
+
   static async freeNoProductAccess(
     overrides?: WorkspaceOverrides
   ): Promise<WorkspaceType> {


### PR DESCRIPTION
## Description

related to https://github.com/dust-tt/tasks/issues/9961

The purpose is to avoid creating a lot of custom plans which are hard to maintain just to bypass one limit of the plan.
The main reason to create custom plans was the max number of seats and free seats.

Limits override are store in a new table and injected into the plan so every reader correctly use the overriden limits.
Note: -1 means unlimited, same as in the actual plans.

Add a poke plugin to set these overrides

<img width="1752" height="902" alt="image" src="https://github.com/user-attachments/assets/67c1bbe7-bce5-4d47-b7cc-ed6ba440d955" />

The overrides are displayed in the plan description:

<img width="1042" height="244" alt="image" src="https://github.com/user-attachments/assets/a4c2ea66-8e3c-4b78-b1f0-9ff5cac8487f" />


## Tests

tested locally + unit tests

## Risk

low

## Deploy Plan

lock front
merge
apply migration 
deploy front
unlock front
