### PR TITLE
Free usage: rate limit free usage to 5$ per day per user

### DIFF
--- a/front/lib/api/assistant/call_llm.ts
+++ b/front/lib/api/assistant/call_llm.ts
@@ -1,4 +1,5 @@
 import { getStreamLLM } from "@app/lib/api/llm";
+import { isFreeUsageBlocked } from "@app/lib/api/llm/free_usage";
 import { getStreamEndpointFromLegacyModelId } from "@app/lib/api/llm/selectPreferredEndpointForWorkspace";
 import type { LLMTraceContext } from "@app/lib/api/llm/traces/types";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
@@ -66,6 +67,13 @@ export async function runMultiActionsAgent(
   );
   if (!endpoint) {
     return new Err(new Error(`Model ${config.modelId} not supported`));
+  }
+
+  // Enforce the per-user daily free-usage cost cap before running a free call.
+  if (options.context && (await isFreeUsageBlocked(auth, options.context))) {
+    return new Err(
+      new Error("The daily free-usage limit has been reached for this user.")
+    );
   }
 
   const llm = await getStreamLLM(auth, {

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -1,15 +1,12 @@
 import type { Authenticator } from "@app/lib/auth";
-import { awuFromMicroUsd } from "@app/lib/metronome/events";
 import { computeEffectiveMessageLimit } from "@app/lib/plans/usage/limits";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { FixedWindowBounds } from "@app/lib/utils/rate_limiter";
 import {
-  addRateLimiterCount,
   expireRateLimiterKey,
   getRateLimiterCount,
   getTimeframeSecondsFromLiteral,
 } from "@app/lib/utils/rate_limiter";
-import logger from "@app/logger/logger";
 import type {
   MaxAwuCreditsTimeframeType,
   MaxMessagesTimeframeType,
@@ -28,15 +25,6 @@ export const MESSAGE_RATE_LIMIT_PER_ACTOR_PER_HOUR_WINDOW_SECONDS = 60 * 60;
 export const SIDEKICK_MESSAGE_RATE_LIMIT_PER_ACTOR_PER_DAY = 100;
 export const SIDEKICK_MESSAGE_RATE_LIMIT_PER_ACTOR_PER_DAY_WINDOW_SECONDS =
   24 * 60 * 60;
-
-// Per-user cost cap on free (unbilled) LLM usage — utility calls (title/skill
-// suggestions, etc.) and free agent calls (sidekick). Counted in AWU credits.
-// Enforced at the LLM call site: read before each free call, contribute the
-// call's cost after.
-export const FREE_USAGE_COST_WINDOW_SECONDS = 24 * 60 * 60;
-export const FREE_USAGE_AWU_CREDITS_LIMIT_PER_DAY = awuFromMicroUsd(
-  5 * 1_000_000
-);
 
 type MessageRateLimitActor =
   | {
@@ -79,48 +67,6 @@ export const makeSidekickMessageRateLimitKeyForWorkspaceActor = (
 ) => {
   return `${makeMessageRateLimitKeyForWorkspaceActor(owner, actor)}:sidekick_daily`;
 };
-
-export const makeFreeUsageCostRateLimitKeyForUser = (
-  owner: LightWorkspaceType,
-  userId: number
-) => {
-  return `workspace:${owner.id}:user:${userId}:free_usage_cost`;
-};
-
-// Whether the user has hit the daily free-usage cost cap. Fails open (returns
-// false) on a Redis error so a transient failure never blocks usage.
-export async function isFreeUsageCostLimitReachedForUser(
-  owner: LightWorkspaceType,
-  userId: number
-): Promise<boolean> {
-  const result = await getRateLimiterCount({
-    key: makeFreeUsageCostRateLimitKeyForUser(owner, userId),
-    timeframeSeconds: FREE_USAGE_COST_WINDOW_SECONDS,
-  });
-  if (result.isErr()) {
-    return false;
-  }
-  return result.value >= FREE_USAGE_AWU_CREDITS_LIMIT_PER_DAY;
-}
-
-// Contribute a free call's cost (converted to AWU credits) to the user's daily
-// free-usage counter. No-op when the cost rounds to zero credits.
-export async function contributeFreeUsageCostForUser(
-  owner: LightWorkspaceType,
-  userId: number,
-  costMicroUsd: number
-): Promise<void> {
-  const awuCredits = awuFromMicroUsd(costMicroUsd);
-  if (awuCredits <= 0) {
-    return;
-  }
-  await addRateLimiterCount({
-    key: makeFreeUsageCostRateLimitKeyForUser(owner, userId),
-    timeframeSeconds: FREE_USAGE_COST_WINDOW_SECONDS,
-    incrementBy: awuCredits,
-    logger,
-  });
-}
 
 export const makeAgentMentionsRateLimitKeyForWorkspace = (
   owner: LightWorkspaceType,

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -1,12 +1,15 @@
 import type { Authenticator } from "@app/lib/auth";
+import { awuFromMicroUsd } from "@app/lib/metronome/events";
 import { computeEffectiveMessageLimit } from "@app/lib/plans/usage/limits";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { FixedWindowBounds } from "@app/lib/utils/rate_limiter";
 import {
+  addRateLimiterCount,
   expireRateLimiterKey,
   getRateLimiterCount,
   getTimeframeSecondsFromLiteral,
 } from "@app/lib/utils/rate_limiter";
+import logger from "@app/logger/logger";
 import type {
   MaxAwuCreditsTimeframeType,
   MaxMessagesTimeframeType,
@@ -25,6 +28,15 @@ export const MESSAGE_RATE_LIMIT_PER_ACTOR_PER_HOUR_WINDOW_SECONDS = 60 * 60;
 export const SIDEKICK_MESSAGE_RATE_LIMIT_PER_ACTOR_PER_DAY = 100;
 export const SIDEKICK_MESSAGE_RATE_LIMIT_PER_ACTOR_PER_DAY_WINDOW_SECONDS =
   24 * 60 * 60;
+
+// Per-user cost cap on free (unbilled) LLM usage — utility calls (title/skill
+// suggestions, etc.) and free agent calls (sidekick). Counted in AWU credits.
+// Enforced at the LLM call site: read before each free call, contribute the
+// call's cost after.
+export const FREE_USAGE_COST_WINDOW_SECONDS = 24 * 60 * 60;
+export const FREE_USAGE_AWU_CREDITS_LIMIT_PER_DAY = awuFromMicroUsd(
+  5 * 1_000_000
+);
 
 type MessageRateLimitActor =
   | {
@@ -67,6 +79,48 @@ export const makeSidekickMessageRateLimitKeyForWorkspaceActor = (
 ) => {
   return `${makeMessageRateLimitKeyForWorkspaceActor(owner, actor)}:sidekick_daily`;
 };
+
+export const makeFreeUsageCostRateLimitKeyForUser = (
+  owner: LightWorkspaceType,
+  userId: number
+) => {
+  return `workspace:${owner.id}:user:${userId}:free_usage_cost`;
+};
+
+// Whether the user has hit the daily free-usage cost cap. Fails open (returns
+// false) on a Redis error so a transient failure never blocks usage.
+export async function isFreeUsageCostLimitReachedForUser(
+  owner: LightWorkspaceType,
+  userId: number
+): Promise<boolean> {
+  const result = await getRateLimiterCount({
+    key: makeFreeUsageCostRateLimitKeyForUser(owner, userId),
+    timeframeSeconds: FREE_USAGE_COST_WINDOW_SECONDS,
+  });
+  if (result.isErr()) {
+    return false;
+  }
+  return result.value >= FREE_USAGE_AWU_CREDITS_LIMIT_PER_DAY;
+}
+
+// Contribute a free call's cost (converted to AWU credits) to the user's daily
+// free-usage counter. No-op when the cost rounds to zero credits.
+export async function contributeFreeUsageCostForUser(
+  owner: LightWorkspaceType,
+  userId: number,
+  costMicroUsd: number
+): Promise<void> {
+  const awuCredits = awuFromMicroUsd(costMicroUsd);
+  if (awuCredits <= 0) {
+    return;
+  }
+  await addRateLimiterCount({
+    key: makeFreeUsageCostRateLimitKeyForUser(owner, userId),
+    timeframeSeconds: FREE_USAGE_COST_WINDOW_SECONDS,
+    incrementBy: awuCredits,
+    logger,
+  });
+}
 
 export const makeAgentMentionsRateLimitKeyForWorkspace = (
   owner: LightWorkspaceType,

--- a/front/lib/api/llm/free_usage.ts
+++ b/front/lib/api/llm/free_usage.ts
@@ -1,8 +1,29 @@
-import { isFreeUsageCostLimitReachedForUser } from "@app/lib/api/assistant/rate_limits";
 import type { LLMTraceContext } from "@app/lib/api/llm/traces/types";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
-import { isFreeOrigin } from "@app/lib/metronome/events";
+import {
+  awuFromMicroUsd,
+  isFreeOrigin,
+} from "@app/lib/credits/agent_message_billing";
+import {
+  addRateLimiterCount,
+  getRateLimiterCount,
+} from "@app/lib/utils/rate_limiter";
+import logger from "@app/logger/logger";
+import type { LightWorkspaceType } from "@app/types/user";
+
+// Per-user cost cap on free (unbilled) LLM usage — utility calls (title/skill
+// suggestions, etc.) and free agent calls (sidekick). Counted in AWU credits
+// (the fair-use unit; 1 AWU = $0.0085), so $5/day ≈ 589 credits.
+const FREE_USAGE_COST_WINDOW_SECONDS = 24 * 60 * 60;
+const FREE_USAGE_AWU_CREDITS_LIMIT_PER_DAY = awuFromMicroUsd(5 * 1_000_000);
+
+const makeFreeUsageCostRateLimitKeyForUser = (
+  owner: LightWorkspaceType,
+  userId: number
+) => {
+  return `workspace:${owner.id}:user:${userId}:free_usage_cost`;
+};
 
 // Whether an LLM call is free (unbilled). Two cases:
 //   - Utility operations (title/skill suggestions, etc.) — anything other than
@@ -40,8 +61,35 @@ export async function isFreeUsageBlocked(
     return false;
   }
 
-  return isFreeUsageCostLimitReachedForUser(
-    auth.getNonNullableWorkspace(),
-    user.id
-  );
+  // Fails open on a Redis error so a transient failure never blocks usage.
+  const result = await getRateLimiterCount({
+    key: makeFreeUsageCostRateLimitKeyForUser(
+      auth.getNonNullableWorkspace(),
+      user.id
+    ),
+    timeframeSeconds: FREE_USAGE_COST_WINDOW_SECONDS,
+  });
+  if (result.isErr()) {
+    return false;
+  }
+  return result.value >= FREE_USAGE_AWU_CREDITS_LIMIT_PER_DAY;
+}
+
+// Contribute a free call's cost (converted to AWU credits) to the user's daily
+// free-usage counter. No-op when the cost rounds to zero credits.
+export async function contributeFreeUsageCostForUser(
+  owner: LightWorkspaceType,
+  userId: number,
+  costMicroUsd: number
+): Promise<void> {
+  const awuCredits = awuFromMicroUsd(costMicroUsd);
+  if (awuCredits <= 0) {
+    return;
+  }
+  await addRateLimiterCount({
+    key: makeFreeUsageCostRateLimitKeyForUser(owner, userId),
+    timeframeSeconds: FREE_USAGE_COST_WINDOW_SECONDS,
+    incrementBy: awuCredits,
+    logger,
+  });
 }

--- a/front/lib/api/llm/free_usage.ts
+++ b/front/lib/api/llm/free_usage.ts
@@ -1,4 +1,7 @@
+import { isFreeUsageCostLimitReachedForUser } from "@app/lib/api/assistant/rate_limits";
 import type { LLMTraceContext } from "@app/lib/api/llm/traces/types";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { isFreeOrigin } from "@app/lib/metronome/events";
 
 // Whether an LLM call is free (unbilled). Two cases:
@@ -6,9 +9,39 @@ import { isFreeOrigin } from "@app/lib/metronome/events";
 //     the agent conversation itself. They carry no userMessageOrigin, so they
 //     are keyed off operationType.
 //   - Agent conversations triggered by a free origin (e.g. sidekick).
+// This is the single source of truth for classifying free usage at the LLM call
+// site (used for both usage-type tagging and the free-usage cost cap).
 export function isFreeUsageContext(context: LLMTraceContext): boolean {
   return (
     context.operationType !== "agent_conversation" ||
     isFreeOrigin(context.userMessageOrigin ?? null)
+  );
+}
+
+// Whether a free LLM call must be blocked because the triggering user has hit
+// the per-user daily free-usage cost cap. Callers check this *before* invoking
+// the LLM (before getStreamLLM) and surface the block in their own error idiom.
+//
+// Enforcement (this gate) lives above the LLM router; the cost contribution to
+// the counter lives with usage recording in the router. Only authenticated
+// users on free calls are subject to the cap, and the
+// `skip_free_usage_rate_limit` feature flag exempts a workspace entirely.
+export async function isFreeUsageBlocked(
+  auth: Authenticator,
+  context: LLMTraceContext
+): Promise<boolean> {
+  const user = auth.user();
+  if (!user || !isFreeUsageContext(context)) {
+    return false;
+  }
+
+  const featureFlags = await getFeatureFlags(auth);
+  if (featureFlags.includes("skip_free_usage_rate_limit")) {
+    return false;
+  }
+
+  return isFreeUsageCostLimitReachedForUser(
+    auth.getNonNullableWorkspace(),
+    user.id
   );
 }

--- a/front/lib/api/llm/free_usage.ts
+++ b/front/lib/api/llm/free_usage.ts
@@ -1,0 +1,14 @@
+import type { LLMTraceContext } from "@app/lib/api/llm/traces/types";
+import { isFreeOrigin } from "@app/lib/metronome/events";
+
+// Whether an LLM call is free (unbilled). Two cases:
+//   - Utility operations (title/skill suggestions, etc.) — anything other than
+//     the agent conversation itself. They carry no userMessageOrigin, so they
+//     are keyed off operationType.
+//   - Agent conversations triggered by a free origin (e.g. sidekick).
+export function isFreeUsageContext(context: LLMTraceContext): boolean {
+  return (
+    context.operationType !== "agent_conversation" ||
+    isFreeOrigin(context.userMessageOrigin ?? null)
+  );
+}

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -1,4 +1,9 @@
+import {
+  contributeFreeUsageCostForUser,
+  isFreeUsageCostLimitReachedForUser,
+} from "@app/lib/api/assistant/rate_limits";
 import config from "@app/lib/api/config";
+import { isFreeUsageContext } from "@app/lib/api/llm/free_usage";
 import type { LLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import {
   createLLMTraceId,
@@ -24,6 +29,7 @@ import type {
 } from "@app/lib/api/llm/types/options";
 import { emitTokenUsageMetrics } from "@app/lib/api/llm/usage_metrics";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import type { DustBatchEndpointConstructor } from "@app/lib/llms/batch/dust_batch_endpoint";
 import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
 import { USAGE_TYPE_FREE } from "@app/lib/metronome/constants";
@@ -141,6 +147,42 @@ export abstract class LLM<
       yield* this.completeStream(streamParameters, metadata);
       return;
     }
+
+    // Free (unbilled) usage — utility operations and free-origin agent calls
+    // (e.g. sidekick) — is metered per user per day: read the counter before the
+    // call, contribute the call's cost after it completes (see below). Only
+    // authenticated users are metered, and the `skip_free_usage_rate_limit`
+    // feature flag exempts a workspace entirely (escape hatch to unstick legit
+    // heavy free usage).
+    const isFreeUsage = isFreeUsageContext(this.context);
+    const user = this.authenticator.user();
+    let meterFreeUsage = isFreeUsage && Boolean(user);
+    if (meterFreeUsage) {
+      const featureFlags = await getFeatureFlags(this.authenticator);
+      if (featureFlags.includes("skip_free_usage_rate_limit")) {
+        meterFreeUsage = false;
+      }
+    }
+    if (
+      meterFreeUsage &&
+      user &&
+      (await isFreeUsageCostLimitReachedForUser(
+        this.authenticator.getNonNullableWorkspace(),
+        user.id
+      ))
+    ) {
+      yield new EventError(
+        {
+          type: "rate_limit_error",
+          message:
+            "You have reached the daily free-usage limit. Please try again later.",
+          isRetryable: false,
+        },
+        this.metadata
+      );
+      return;
+    }
+
     const { conversation, prompt, specifications, previousMessageId } =
       streamParameters;
 
@@ -362,25 +404,31 @@ export abstract class LLM<
           workspaceId: this.authenticator.getNonNullableWorkspace().id,
         });
 
-        // Classify usage at creation for internal/utility LLM operations
-        // (everything except the agent conversation itself): they are never
-        // billed and never processed by the usage queue, so they are free.
-        // agent_conversation runs are left untagged here and classified
-        // (free/user/programmatic) by the usage queue, which knows the
-        // triggering message origin.
-        const usageType =
-          this.context.operationType === "agent_conversation"
-            ? undefined
-            : USAGE_TYPE_FREE;
+        // Tag free (unbilled) usage at creation — utility operations and
+        // free-origin agent calls (e.g. sidekick). Paid agent_conversation runs
+        // are left untagged here and classified (user/programmatic) by the usage
+        // queue, which knows the triggering message origin.
+        const usageType = isFreeUsage ? USAGE_TYPE_FREE : undefined;
 
         // Run usage is only populated if the run is successful.
         if (buffer.runTokenUsage) {
-          await run.recordTokenUsage(
+          const costMicroUsd = await run.recordTokenUsage(
             this.authenticator,
             buffer.runTokenUsage,
             this.modelId,
             { inferenceRegion: this.metadata.inferenceRegion, usageType }
           );
+
+          // Contribute this free call's cost to the per-user daily free-usage
+          // counter enforced above. Skipped when metering is off (non-free, no
+          // user, or the workspace is exempt via feature flag).
+          if (meterFreeUsage && user && costMicroUsd) {
+            await contributeFreeUsageCostForUser(
+              this.authenticator.getNonNullableWorkspace(),
+              user.id,
+              costMicroUsd
+            );
+          }
         }
 
         const simulatedRunUsages = this.getSimulatedRunUsages();

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -1,6 +1,8 @@
-import { contributeFreeUsageCostForUser } from "@app/lib/api/assistant/rate_limits";
 import config from "@app/lib/api/config";
-import { isFreeUsageContext } from "@app/lib/api/llm/free_usage";
+import {
+  contributeFreeUsageCostForUser,
+  isFreeUsageContext,
+} from "@app/lib/api/llm/free_usage";
 import type { LLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import {
   createLLMTraceId,

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -1,7 +1,4 @@
-import {
-  contributeFreeUsageCostForUser,
-  isFreeUsageCostLimitReachedForUser,
-} from "@app/lib/api/assistant/rate_limits";
+import { contributeFreeUsageCostForUser } from "@app/lib/api/assistant/rate_limits";
 import config from "@app/lib/api/config";
 import { isFreeUsageContext } from "@app/lib/api/llm/free_usage";
 import type { LLMTraceId } from "@app/lib/api/llm/traces/buffer";
@@ -29,7 +26,6 @@ import type {
 } from "@app/lib/api/llm/types/options";
 import { emitTokenUsageMetrics } from "@app/lib/api/llm/usage_metrics";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import type { DustBatchEndpointConstructor } from "@app/lib/llms/batch/dust_batch_endpoint";
 import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
 import { USAGE_TYPE_FREE } from "@app/lib/metronome/constants";
@@ -149,39 +145,11 @@ export abstract class LLM<
     }
 
     // Free (unbilled) usage — utility operations and free-origin agent calls
-    // (e.g. sidekick) — is metered per user per day: read the counter before the
-    // call, contribute the call's cost after it completes (see below). Only
-    // authenticated users are metered, and the `skip_free_usage_rate_limit`
-    // feature flag exempts a workspace entirely (escape hatch to unstick legit
-    // heavy free usage).
+    // (e.g. sidekick). Enforcement of the per-user daily cost cap happens above
+    // the router (before getStreamLLM); here we only record the call's cost into
+    // the counter after it completes (see below), alongside usage recording.
     const isFreeUsage = isFreeUsageContext(this.context);
     const user = this.authenticator.user();
-    let meterFreeUsage = isFreeUsage && Boolean(user);
-    if (meterFreeUsage) {
-      const featureFlags = await getFeatureFlags(this.authenticator);
-      if (featureFlags.includes("skip_free_usage_rate_limit")) {
-        meterFreeUsage = false;
-      }
-    }
-    if (
-      meterFreeUsage &&
-      user &&
-      (await isFreeUsageCostLimitReachedForUser(
-        this.authenticator.getNonNullableWorkspace(),
-        user.id
-      ))
-    ) {
-      yield new EventError(
-        {
-          type: "rate_limit_error",
-          message:
-            "You have reached the daily free-usage limit. Please try again later.",
-          isRetryable: false,
-        },
-        this.metadata
-      );
-      return;
-    }
 
     const { conversation, prompt, specifications, previousMessageId } =
       streamParameters;
@@ -419,10 +387,9 @@ export abstract class LLM<
             { inferenceRegion: this.metadata.inferenceRegion, usageType }
           );
 
-          // Contribute this free call's cost to the per-user daily free-usage
-          // counter enforced above. Skipped when metering is off (non-free, no
-          // user, or the workspace is exempt via feature flag).
-          if (meterFreeUsage && user && costMicroUsd) {
+          // Record this free call's cost into the per-user daily free-usage
+          // counter (enforced above the router, before the call).
+          if (isFreeUsage && user && costMicroUsd) {
             await contributeFreeUsageCostForUser(
               this.authenticator.getNonNullableWorkspace(),
               user.id,

--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -1,5 +1,6 @@
 import type { TokenUsage, ToolCall } from "@app/lib/api/llm/types/events";
 import type { SystemPromptInput } from "@app/lib/api/llm/types/options";
+import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import type {
   ModelIdType,
@@ -43,6 +44,11 @@ interface LLMTraceContextBase {
   workspaceId?: string;
   /** User who triggered the operation */
   userId?: string;
+  /**
+   * Origin of the triggering user message, set for agent_conversation calls.
+   * Used to classify free (unbilled) usage at the LLM call site.
+   */
+  userMessageOrigin?: UserMessageOrigin;
 }
 
 export type LLMTraceContext = LLMTraceContextBase & {

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -507,7 +507,7 @@ export class RunResource extends BaseResource<RunModel> {
       inferenceRegion,
     });
 
-    return this.recordRunUsage(
+    await this.recordRunUsage(
       auth,
       [
         {
@@ -524,6 +524,10 @@ export class RunResource extends BaseResource<RunModel> {
       ],
       { usageType }
     );
+
+    // Return the computed cost so callers can meter it (e.g. the free-usage cost
+    // cap); undefined above when the model is unknown and nothing was recorded.
+    return usageCostMicroUsd;
   }
 
   async listRunUsages(auth: Authenticator): Promise<RunUsageType[]> {

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -784,6 +784,9 @@ export async function runModel(
     conversationId: conversation.sId,
     userId: auth.user()?.sId,
     workspaceId: conversation.owner.sId,
+    // Lets the LLM call site classify free usage (e.g. sidekick) and enforce the
+    // per-user free-usage cost cap.
+    userMessageOrigin: userMessage.context.origin,
   };
 
   const credentials = await getLlmCredentials(auth, {

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -43,6 +43,7 @@ import {
   emitAuditLogEventDirect,
 } from "@app/lib/api/audit/workos_audit";
 import { getStreamLLM } from "@app/lib/api/llm";
+import { isFreeUsageBlocked } from "@app/lib/api/llm/free_usage";
 import type { LLMTraceContext } from "@app/lib/api/llm/traces/types";
 import {
   getByokUserFacingLLMErrorMessage,
@@ -788,6 +789,18 @@ export async function runModel(
     // per-user free-usage cost cap.
     userMessageOrigin: userMessage.context.origin,
   };
+
+  // Enforce the per-user daily free-usage cost cap before running a free call
+  // (e.g. sidekick). Runs per step, so a runaway free loop is stopped mid-run.
+  if (await isFreeUsageBlocked(auth, traceContext)) {
+    await publishAgentError({
+      code: "free_usage_limit_reached",
+      message:
+        "The daily free-usage limit has been reached. Please try again later.",
+      metadata: null,
+    });
+    return null;
+  }
 
   const credentials = await getLlmCredentials(auth, {
     skipEmbeddingApiKeyRequirement: true,

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -9,6 +9,7 @@ import {
   sendBatchCallToLlm,
   storeLlmResult,
 } from "@app/lib/api/llm/batch_llm";
+import { isFreeUsageBlocked } from "@app/lib/api/llm/free_usage";
 import { getStreamEndpointFromLegacyModelId } from "@app/lib/api/llm/selectPreferredEndpointForWorkspace";
 import type { BatchStatus } from "@app/lib/api/llm/types/batch";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
@@ -261,6 +262,22 @@ async function runReinforcedSkillsStep({
       userId: auth.user()?.sId,
     },
   };
+
+  // Enforce the per-user daily free-usage cost cap before running this free call.
+  if (
+    llmParameters.context &&
+    (await isFreeUsageBlocked(auth, llmParameters.context))
+  ) {
+    logger.info(
+      { contextId, workspaceId: owner.sId },
+      "ReinforcedSkills: free-usage limit reached, stopping"
+    );
+    return {
+      isTerminal: true,
+      suggestionsCreated: 0,
+      approvedSourceSuggestionIds: [],
+    };
+  }
 
   const llm = await getStreamLLM(auth, llmParameters);
   if (!llm) {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -355,6 +355,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Allow editing tool inputs before approving a tool call in the tool validation UI.",
     stage: "dust_only",
   },
+  skip_free_usage_rate_limit: {
+    description:
+      "Skip the per-user daily free-usage cost cap enforced at the LLM call site. Escape hatch to unstick legitimate workspaces that legitimately exceed the free-usage limit.",
+    stage: "on_demand",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -812,6 +812,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "similar_agents_check"
   | "enforce_user_spend_limit_rate_cap"
   | "editable_tool_inputs"
+  | "skip_free_usage_rate_limit"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Track the free usage (sidekick, utility call like title generation...) into a 24h rate limiter.
Throw before running the LLM calls if the limit is reach.
Add a feature flag to escape this check entirely if needed for some workspaces

## Tests

tested locally:
 - the limiter is correctly incremented.
 - when reached we are stuck

<img width="532" height="216" alt="image" src="https://github.com/user-attachments/assets/e1097e98-f5b0-4253-bd06-359fb45e3691" />

<img width="1220" height="270" alt="image" src="https://github.com/user-attachments/assets/9b0f1939-1006-4b6b-9999-5e78a20459e8" />


## Risk

low, may block some legit very advanced users but 
 - it's only 24h
 - there is a feature flag to escape if really needed

## Deploy Plan

deploy front
