### PR TITLE
Admin governance: allow to list members of provisioned groups in admin page

### DIFF
--- a/front-api/routes/w/[wId]/groups/[groupId]/index.test.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/index.test.ts
@@ -1,0 +1,103 @@
+import { Authenticator } from "@app/lib/auth";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function getGroupRequest(wId: string, groupId: string) {
+  return honoApp.request(`/api/w/${wId}/groups/${groupId}`);
+}
+
+function patchGroupRequest(
+  wId: string,
+  groupId: string,
+  body: Record<string, unknown>
+) {
+  return honoApp.request(`/api/w/${wId}/groups/${groupId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("GET /api/w/:wId/groups/:groupId", () => {
+  it("returns the members of a manually-managed group", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const alice = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, alice, { role: "user" });
+    const sales = await GroupFactory.regularManual(workspace, "Sales");
+    await GroupFactory.withMembers(adminAuth, sales, [alice]);
+
+    const response = await getGroupRequest(workspace.sId, sales.sId);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.group).toEqual(
+      expect.objectContaining({ sId: sales.sId, name: "Sales", memberCount: 1 })
+    );
+    expect(body.members).toEqual([expect.objectContaining({ sId: alice.sId })]);
+  });
+
+  it("returns the members of a provisioned group", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const bob = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, bob, { role: "user" });
+    const engineering = await GroupFactory.provisioned(
+      workspace,
+      "Engineering"
+    );
+    await GroupFactory.withMembers(adminAuth, engineering, [bob]);
+
+    const response = await getGroupRequest(workspace.sId, engineering.sId);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.group).toEqual(
+      expect.objectContaining({
+        sId: engineering.sId,
+        name: "Engineering",
+        kind: "provisioned",
+        memberCount: 1,
+      })
+    );
+    expect(body.members).toEqual([expect.objectContaining({ sId: bob.sId })]);
+  });
+
+  it("returns 404 on a group that is not surfaced in admin UIs", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
+    const spaceGroup = await GroupFactory.regularAuto(workspace, "Space group");
+
+    const response = await getGroupRequest(workspace.sId, spaceGroup.sId);
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).error.type).toBe("group_not_found");
+  });
+});
+
+describe("PATCH /api/w/:wId/groups/:groupId", () => {
+  it("returns 404 when editing a provisioned group", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const engineering = await GroupFactory.provisioned(
+      workspace,
+      "Engineering"
+    );
+
+    const response = await patchGroupRequest(workspace.sId, engineering.sId, {
+      name: "Engineering renamed",
+    });
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).error.type).toBe("group_not_found");
+  });
+});

--- a/front-api/routes/w/[wId]/groups/[groupId]/index.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/index.ts
@@ -6,6 +6,7 @@ import type {
   PatchGroupResponseBody,
 } from "@app/types/api/groups/manage";
 import { PatchGroupBodySchema } from "@app/types/api/groups/manage";
+import { isManageableGroupKind } from "@app/types/groups";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
@@ -63,8 +64,9 @@ app.get(
 
     const group = groupRes.value;
 
-    // This management API only surfaces manually-managed groups.
-    if (!group.isRegularManual()) {
+    // This management API only surfaces groups exposed in workspace admin UIs: manually-managed
+    // ones (editable) and provisioned ones (read-only).
+    if (!isManageableGroupKind(group.kind)) {
       return apiError(ctx, {
         status_code: 404,
         api_error: {

--- a/front/components/groups/ProvisionedGroupDialog.tsx
+++ b/front/components/groups/ProvisionedGroupDialog.tsx
@@ -1,0 +1,121 @@
+import { PROVISIONED_GROUP_TOOLTIP } from "@app/components/groups/GroupKinds";
+import type { MemberRowData } from "@app/components/members/MemberSelectionTable";
+import { useGroup } from "@app/lib/swr/groups";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Avatar,
+  DataTable,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  Spinner,
+} from "@dust-tt/sparkle";
+import type { ColumnDef, PaginationState } from "@tanstack/react-table";
+import { useState } from "react";
+
+const DEFAULT_PAGE_SIZE = 25;
+
+const columns: ColumnDef<MemberRowData>[] = [
+  {
+    id: "fullName",
+    accessorKey: "fullName",
+    header: "Name",
+    sortingFn: "text",
+    meta: { className: "w-full" },
+    cell: ({ row }) => {
+      const { fullName, email, image } = row.original;
+      return (
+        <DataTable.CellContent>
+          <div className="flex items-center gap-2">
+            <Avatar
+              name={fullName}
+              visual={image || undefined}
+              size="xs"
+              isRounded
+            />
+            <div className="flex flex-col">
+              <span className="text-sm">{fullName}</span>
+              {email && (
+                <span className="text-xs text-muted-foreground">{email}</span>
+              )}
+            </div>
+          </div>
+        </DataTable.CellContent>
+      );
+    },
+  },
+];
+
+interface ProvisionedGroupDialogProps {
+  owner: LightWorkspaceType;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  groupId: string | null;
+  groupName: string;
+}
+
+/**
+ * Read-only view of a provisioned group: membership is owned by the identity provider, so members
+ * are only listed, never edited.
+ */
+export function ProvisionedGroupDialog({
+  owner,
+  isOpen,
+  onOpenChange,
+  groupId,
+  groupName,
+}: ProvisionedGroupDialogProps) {
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: DEFAULT_PAGE_SIZE,
+  });
+
+  const { members, isGroupLoading } = useGroup({
+    owner,
+    groupId,
+    disabled: !isOpen,
+  });
+
+  const rows: MemberRowData[] = members.map((member) => ({
+    sId: member.sId,
+    fullName: member.fullName,
+    email: member.email,
+    image: member.image ?? "",
+  }));
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent size="xl" height="lg">
+        <DialogHeader>
+          <DialogTitle>{groupName}</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          <div className="flex flex-col gap-4">
+            <p className="text-sm italic text-muted-foreground">
+              {PROVISIONED_GROUP_TOOLTIP}
+            </p>
+            {isGroupLoading ? (
+              <div className="flex items-center justify-center py-8">
+                <Spinner size="lg" />
+              </div>
+            ) : rows.length > 0 ? (
+              <DataTable
+                data={rows}
+                columns={columns}
+                pagination={pagination}
+                setPagination={setPagination}
+                getRowId={(row) => row.sId}
+              />
+            ) : (
+              <div className="text-sm text-muted-foreground">
+                This group has no members.
+              </div>
+            )}
+          </div>
+        </DialogContainer>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/groups/WorkspaceGroupsList.tsx
+++ b/front/components/groups/WorkspaceGroupsList.tsx
@@ -1,6 +1,7 @@
 import { ConfirmContext } from "@app/components/Confirm";
 import { GroupDialog } from "@app/components/groups/GroupDialog";
 import { getGroupKindChip } from "@app/components/groups/GroupKinds";
+import { ProvisionedGroupDialog } from "@app/components/groups/ProvisionedGroupDialog";
 import { LinkedSectionNotice } from "@app/components/workspace/LinkedSectionNotice";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { isSCIMEnabled } from "@app/lib/plans/scim";
@@ -137,6 +138,11 @@ export function WorkspaceGroupsList({ owner }: WorkspaceGroupsListProps) {
   });
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [editedGroupId, setEditedGroupId] = useState<string | null>(null);
+  const [isProvisionedDialogOpen, setIsProvisionedDialogOpen] = useState(false);
+  const [viewedProvisionedGroup, setViewedProvisionedGroup] = useState<{
+    groupId: string;
+    name: string;
+  } | null>(null);
 
   const confirm = useContext(ConfirmContext);
   const { doDeleteGroup } = useDeleteGroup({ owner });
@@ -176,7 +182,14 @@ export function WorkspaceGroupsList({ owner }: WorkspaceGroupsListProps) {
               setEditedGroupId(group.sId);
               setIsDialogOpen(true);
             }
-          : undefined,
+          : // Provisioned groups open a read-only member list.
+            () => {
+              setViewedProvisionedGroup({
+                groupId: group.sId,
+                name: group.name,
+              });
+              setIsProvisionedDialogOpen(true);
+            },
         onDelete: isManual
           ? () => handleDeleteGroup(group.sId, group.name)
           : undefined,
@@ -243,6 +256,13 @@ export function WorkspaceGroupsList({ owner }: WorkspaceGroupsListProps) {
         isOpen={isDialogOpen}
         onOpenChange={setIsDialogOpen}
         groupId={editedGroupId}
+      />
+      <ProvisionedGroupDialog
+        owner={owner}
+        isOpen={isProvisionedDialogOpen}
+        onOpenChange={setIsProvisionedDialogOpen}
+        groupId={viewedProvisionedGroup?.groupId ?? null}
+        groupName={viewedProvisionedGroup?.name ?? ""}
       />
     </div>
   );

--- a/front/tests/utils/GroupFactory.ts
+++ b/front/tests/utils/GroupFactory.ts
@@ -40,6 +40,8 @@ export class GroupFactory {
   ) {
     return group.dangerouslyAddMembers(auth, {
       users: users.map((u) => u.toJSON()),
+      // Provisioned membership is owned by the IdP in production; tests seed it directly.
+      allowProvisionedGroups: true,
     });
   }
 }


### PR DESCRIPTION
## Description

Before that, only manual groups were clickable to display the list of members.
This adds a similar pop-up for provisioned group with a message that members cannot be managed from here.

<img width="1856" height="1446" alt="image" src="https://github.com/user-attachments/assets/4a8d1da0-4c49-44b6-86d0-403fa19ae35b" />


## Tests

tested locally


https://github.com/user-attachments/assets/1b0856ea-b7d4-4392-9370-b9c830cfac0c

also add unit tests to the endpoint

## Risk

low

## Deploy Plan

deploy front
