### PR TITLE
[front] Remove the fake outage banner that shipped with #30249

### DIFF
--- a/front/components/navigation/AppStatusBanner.tsx
+++ b/front/components/navigation/AppStatusBanner.tsx
@@ -5,7 +5,6 @@ import {
   isDustCompanyPlan,
   isEnterprisePlanPrefix,
 } from "@app/lib/plans/plan_codes";
-import { useAppRouter } from "@app/lib/platform";
 import { useProgrammaticUsageLimit } from "@app/lib/swr/usage_settings";
 import { useAppStatus } from "@app/lib/swr/useAppStatus";
 import { useWorkspaceUsageStatus } from "@app/lib/swr/user";
@@ -19,7 +18,6 @@ import { isAdmin } from "@app/types/user";
 import { cn, LinkWrapper } from "@dust-tt/sparkle";
 import type { VariantProps } from "class-variance-authority";
 import { cva } from "class-variance-authority";
-import { useMemo } from "react";
 
 const statusBannerVariants = cva(
   "flex flex-col gap-0.5 border-b px-4 py-2 text-sm",
@@ -325,46 +323,9 @@ function WorkspaceUsageStatusBanner({
   return <StatusBanner {...banner} />;
 }
 
-// DEMO ONLY — remove before merging.
-function useDemoAppStatus(): AppStatus | null {
-  const router = useAppRouter();
-  const { demoBanner } = router.query;
-
-  return useMemo(() => {
-    if (demoBanner === "off") {
-      return null;
-    }
-
-    if (demoBanner === "providers") {
-      return {
-        dustStatus: null,
-        providersStatus: {
-          name: "Model provider incident",
-          description:
-            "One of our model providers reports elevated latency. Agents relying on it may be slower than usual.",
-          link: "https://status.dust.tt",
-        },
-      };
-    }
-
-    return {
-      dustStatus: {
-        name: "Degraded performance on conversations",
-        description:
-          "We are investigating elevated error rates on agent conversations. Some messages may fail to send.",
-        link: "https://status.dust.tt",
-      },
-      providersStatus: null,
-    };
-  }, [demoBanner]);
-}
-
 export function StatusBanners() {
   const { workspace: owner, subscription } = useAuth();
-  const { appStatus: liveAppStatus } = useAppStatus();
-  const demoAppStatus = useDemoAppStatus();
-
-  const appStatus = demoAppStatus ?? liveAppStatus;
+  const { appStatus } = useAppStatus();
 
   return (
     <>


### PR DESCRIPTION
## Urgent — user-visible

The demo hook I added to review [#30249](https://github.com/dust-tt/dust/pull/30249) on the deploy preview was merged by mistake. It was meant to be reverted before merge and wasn't.

`useDemoAppStatus` in [AppStatusBanner.tsx](https://github.com/dust-tt/dust/blob/main/front/components/navigation/AppStatusBanner.tsx) returns a fabricated incident **unconditionally**, and it takes precedence over the real data:

```ts
const appStatus = demoAppStatus ?? liveAppStatus;
```

Two consequences on `main`:

1. Every user sees a banner reading "Degraded performance on conversations" — a fake incident.
2. A **genuine** StatusPage incident created via the runbook would be hidden behind the fake one, so the incident-communication path is broken.

## Fix

Removes the demo hook and its wiring, plus the two imports it was the only consumer of (`useAppRouter`, `useMemo`). `StatusBanners` reads `useAppStatus()` directly again, exactly as before #30249.

This is a straight revert of the demo code — no other behaviour from #30249 is touched (the banner keeps its full-width placement at the top of the shell, its orange colors, and its spacing).

## Verification

- No `useDemoAppStatus` / `demoBanner` / `DEMO` reference left in the file.
- `tsgo` clean on `front/components/navigation`.
- After merge, the banner only renders when `/api/app-status` reports an unresolved StatusPage incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)