### PR TITLE
[front] fix: steer fast-function tool-call 403 to a retry, add stable error type

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/actions/call.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/call.test.ts
@@ -113,7 +113,12 @@ describe("POST /api/v1/w/[wId]/sandbox/actions/call (function invocation)", () =
 
     expect(response.status).toBe(403);
     const body = await response.json();
+    expect(body.error.type).toBe("fast_function_called_tools");
+    // Prod frames string-match this phrase to classify the refusal; keep it stable.
     expect(body.error.message).toContain("published as fast");
+    // Self-heal has already recorded the function as durable by the time the refusal is built,
+    // so the copy must steer the caller to a retry, not a republish.
+    expect(body.error.message).toContain("retrying the invocation will work");
     expect(vi.mocked(launchSandboxFunctionToolWorkflow)).not.toHaveBeenCalled();
   });
 

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
@@ -70,10 +70,12 @@ app.post(
         return apiError(ctx, {
           status_code: 403,
           api_error: {
-            type: "invalid_request_error",
+            type: "fast_function_called_tools",
             message:
-              "This Pod function is published as fast and cannot call tools. Publish it with " +
-              "executionMode `durable` to let it call tools.",
+              "This Pod function was published as fast, which cannot call tools, so this call " +
+              "was refused. The function is now recorded as durable: retrying the invocation " +
+              "will work without a republish. Republish with executionMode `durable` only to " +
+              "make the source's declaration match.",
           },
         });
       }

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -167,6 +167,7 @@ const API_ERROR_TYPES = [
   "skill_github_repository_not_found",
   "sandbox_function_not_found",
   "sandbox_function_invocation_not_found",
+  "fast_function_called_tools",
   // Projects
   "project_metadata_not_found",
   // Suggestions


### PR DESCRIPTION
## Description

When a fast Pod function calls a tool, the platform self-heals: it records the function as durable before building the 403. The refusal copy still said "Publish it with executionMode `durable`", which sends agents into a republish cycle when simply retrying the invocation already works. This rewords the message to say retrying works (republish only to make the source declaration match) and gives the refusal a stable error type, `fast_function_called_tools`, instead of the generic `invalid_request_error`.

The "published as fast" phrase is kept verbatim: live frames string-match it to classify the refusal.

## Tests

Extended the existing 403 test to pin the new error type, the "published as fast" phrase, and the retry wording.

## Risk

Low. Message and error-type change on one refusal path; status code and self-heal behavior unchanged.

## Deploy Plan

Standard deploy.