### PR TITLE
[front] feat: emit structured JSON output from Fathom tools

### DIFF
--- a/front/lib/api/actions/servers/fathom/metadata.ts
+++ b/front/lib/api/actions/servers/fathom/metadata.ts
@@ -5,13 +5,13 @@ export const FATHOM_TOOLS_METADATA = [
   {
     name: "list_meetings",
     description:
-      "List and browse your Fathom meeting and call recordings with optional filters for date range, team, attendee domain, recorded-by email, and CRM data. Returns each Fathom recording with its summary, action items, and metadata.",
+      "List and browse your Fathom meeting and call recordings with optional filters for date range, team, attendee domain, recorded-by email, and CRM data. Returns each Fathom recording with its summary, action items, and metadata, along with a machine-readable JSON block of the form {meetings, nextCursor}.",
     schema: {
       cursor: z
         .string()
         .optional()
         .describe(
-          "Pagination cursor returned as next_cursor in a previous response. Omit to start from the beginning."
+          "Pagination cursor returned as nextCursor in a previous response. Omit to start from the beginning."
         ),
       start_date: z
         .string()

--- a/front/lib/api/actions/servers/fathom/rendering.test.ts
+++ b/front/lib/api/actions/servers/fathom/rendering.test.ts
@@ -1,0 +1,194 @@
+import type { EnrichedMeeting } from "@app/lib/api/actions/servers/fathom/rendering";
+import {
+  makeMeetingRecord,
+  makeMeetingsListPayload,
+  makeTranscriptPayload,
+} from "@app/lib/api/actions/servers/fathom/rendering";
+import { describe, expect, it } from "vitest";
+
+function makeMeeting(overrides: Partial<EnrichedMeeting> = {}): EnrichedMeeting {
+  return {
+    title: "Quarterly sync",
+    meetingTitle: "Quarterly sync",
+    recordingId: 12345,
+    url: "https://fathom.video/calls/12345",
+    shareUrl: "https://fathom.video/share/abc",
+    createdAt: new Date("2026-08-01T10:00:00.000Z"),
+    scheduledStartTime: new Date("2026-08-01T10:00:00.000Z"),
+    scheduledEndTime: new Date("2026-08-01T11:00:00.000Z"),
+    recordingStartTime: new Date("2026-08-01T10:01:00.000Z"),
+    recordingEndTime: new Date("2026-08-01T10:59:00.000Z"),
+    calendarInviteesDomainsType: "only_internal",
+    transcriptLanguage: "en",
+    calendarInvitees: [
+      {
+        name: "Ada Lovelace",
+        email: "ada@acme.com",
+        emailDomain: "acme.com",
+        isExternal: false,
+      },
+    ],
+    recordedBy: {
+      name: "Grace Hopper",
+      email: "grace@acme.com",
+      emailDomain: "acme.com",
+      team: "Sales",
+    },
+    ...overrides,
+  };
+}
+
+describe("makeMeetingRecord", () => {
+  it("serializes dates as ISO 8601 strings and defaults optional fields to null", () => {
+    const record = makeMeetingRecord(makeMeeting());
+
+    expect(record).toEqual({
+      recordingId: 12345,
+      title: "Quarterly sync",
+      meetingTitle: "Quarterly sync",
+      url: "https://fathom.video/calls/12345",
+      shareUrl: "https://fathom.video/share/abc",
+      createdAt: "2026-08-01T10:00:00.000Z",
+      scheduledStartTime: "2026-08-01T10:00:00.000Z",
+      scheduledEndTime: "2026-08-01T11:00:00.000Z",
+      recordingStartTime: "2026-08-01T10:01:00.000Z",
+      recordingEndTime: "2026-08-01T10:59:00.000Z",
+      transcriptLanguage: "en",
+      recordedBy: {
+        name: "Grace Hopper",
+        email: "grace@acme.com",
+        emailDomain: "acme.com",
+        team: "Sales",
+      },
+      calendarInvitees: [
+        {
+          name: "Ada Lovelace",
+          email: "ada@acme.com",
+          emailDomain: "acme.com",
+          isExternal: false,
+        },
+      ],
+      actionItems: null,
+      summary: null,
+      crmMatches: null,
+    });
+  });
+
+  it("falls back to the default summary when no fetched summary is present", () => {
+    const record = makeMeetingRecord(
+      makeMeeting({
+        defaultSummary: { templateName: "General", markdownFormatted: "- ok" },
+      })
+    );
+
+    expect(record.summary).toEqual({
+      templateName: "General",
+      markdownFormatted: "- ok",
+    });
+  });
+
+  it("prefers the fetched summary over the default summary", () => {
+    const record = makeMeetingRecord(
+      makeMeeting({
+        defaultSummary: { templateName: "General", markdownFormatted: "- ok" },
+        fetchedSummary: {
+          templateName: "Sales",
+          markdownFormatted: "- detailed",
+        },
+      })
+    );
+
+    expect(record.summary).toEqual({
+      templateName: "Sales",
+      markdownFormatted: "- detailed",
+    });
+  });
+
+  it("passes through action items and CRM matches", () => {
+    const record = makeMeetingRecord(
+      makeMeeting({
+        actionItems: [
+          {
+            description: "Send the proposal",
+            userGenerated: false,
+            completed: false,
+            recordingTimestamp: "00:12:34",
+            recordingPlaybackUrl: "https://fathom.video/calls/12345?t=754",
+            assignee: {
+              name: "Ada Lovelace",
+              email: "ada@acme.com",
+              team: null,
+            },
+          },
+        ],
+        crmMatches: {
+          contacts: [],
+          companies: [
+            { name: "Acme", recordUrl: "https://crm.example.com/acme" },
+          ],
+          deals: [],
+        },
+      })
+    );
+
+    expect(record.actionItems).toHaveLength(1);
+    expect(record.actionItems?.[0].description).toBe("Send the proposal");
+    expect(record.crmMatches?.companies).toEqual([
+      { name: "Acme", recordUrl: "https://crm.example.com/acme" },
+    ]);
+  });
+});
+
+describe("makeMeetingsListPayload", () => {
+  it("wraps meeting records with the pagination cursor", () => {
+    const payload = makeMeetingsListPayload({
+      meetings: [makeMeeting()],
+      nextCursor: "cursor-123",
+    });
+
+    expect(payload.meetings).toHaveLength(1);
+    expect(payload.meetings[0].recordingId).toBe(12345);
+    expect(payload.nextCursor).toBe("cursor-123");
+  });
+
+  it("returns a null cursor on the last page", () => {
+    const payload = makeMeetingsListPayload({
+      meetings: [],
+      nextCursor: null,
+    });
+
+    expect(payload).toEqual({ meetings: [], nextCursor: null });
+  });
+});
+
+describe("makeTranscriptPayload", () => {
+  it("flattens transcript items into timestamp/speaker/text records", () => {
+    const payload = makeTranscriptPayload({
+      recordingId: 12345,
+      transcript: [
+        {
+          speaker: { displayName: "Grace Hopper" },
+          text: "Hello everyone.",
+          timestamp: "00:00:05",
+        },
+        {
+          speaker: { displayName: "Ada Lovelace" },
+          text: "Hi Grace.",
+          timestamp: "00:00:09",
+        },
+      ],
+    });
+
+    expect(payload).toEqual({
+      recordingId: 12345,
+      transcript: [
+        {
+          timestamp: "00:00:05",
+          speaker: "Grace Hopper",
+          text: "Hello everyone.",
+        },
+        { timestamp: "00:00:09", speaker: "Ada Lovelace", text: "Hi Grace." },
+      ],
+    });
+  });
+});

--- a/front/lib/api/actions/servers/fathom/rendering.test.ts
+++ b/front/lib/api/actions/servers/fathom/rendering.test.ts
@@ -6,7 +6,9 @@ import {
 } from "@app/lib/api/actions/servers/fathom/rendering";
 import { describe, expect, it } from "vitest";
 
-function makeMeeting(overrides: Partial<EnrichedMeeting> = {}): EnrichedMeeting {
+function makeMeeting(
+  overrides: Partial<EnrichedMeeting> = {}
+): EnrichedMeeting {
   return {
     title: "Quarterly sync",
     meetingTitle: "Quarterly sync",

--- a/front/lib/api/actions/servers/fathom/rendering.ts
+++ b/front/lib/api/actions/servers/fathom/rendering.ts
@@ -1,0 +1,100 @@
+import type {
+  ActionItem,
+  CRMMatches,
+  FathomUser,
+  Invitee,
+  Meeting,
+  MeetingSummary,
+  TranscriptItem,
+} from "fathom-typescript/sdk/models/shared";
+
+export type EnrichedMeeting = Meeting & {
+  fetchedSummary?: MeetingSummary | null;
+};
+
+// Stable machine-readable shapes emitted as a JSON content block alongside the human-readable
+// rendering, so programmatic consumers do not have to parse prose. Dates are ISO 8601 strings.
+
+export interface FathomMeetingRecord {
+  recordingId: number;
+  title: string;
+  meetingTitle: string | null;
+  url: string;
+  shareUrl: string;
+  createdAt: string;
+  scheduledStartTime: string;
+  scheduledEndTime: string;
+  recordingStartTime: string;
+  recordingEndTime: string;
+  transcriptLanguage: string;
+  recordedBy: FathomUser;
+  calendarInvitees: Invitee[];
+  actionItems: ActionItem[] | null;
+  summary: MeetingSummary | null;
+  crmMatches: CRMMatches | null;
+}
+
+export interface FathomMeetingsListPayload {
+  meetings: FathomMeetingRecord[];
+  nextCursor: string | null;
+}
+
+export function makeMeetingRecord(meeting: EnrichedMeeting): FathomMeetingRecord {
+  return {
+    recordingId: meeting.recordingId,
+    title: meeting.title,
+    meetingTitle: meeting.meetingTitle,
+    url: meeting.url,
+    shareUrl: meeting.shareUrl,
+    createdAt: meeting.createdAt.toISOString(),
+    scheduledStartTime: meeting.scheduledStartTime.toISOString(),
+    scheduledEndTime: meeting.scheduledEndTime.toISOString(),
+    recordingStartTime: meeting.recordingStartTime.toISOString(),
+    recordingEndTime: meeting.recordingEndTime.toISOString(),
+    transcriptLanguage: meeting.transcriptLanguage,
+    recordedBy: meeting.recordedBy,
+    calendarInvitees: meeting.calendarInvitees,
+    actionItems: meeting.actionItems ?? null,
+    summary: meeting.fetchedSummary ?? meeting.defaultSummary ?? null,
+    crmMatches: meeting.crmMatches ?? null,
+  };
+}
+
+export function makeMeetingsListPayload({
+  meetings,
+  nextCursor,
+}: {
+  meetings: EnrichedMeeting[];
+  nextCursor: string | null;
+}): FathomMeetingsListPayload {
+  return {
+    meetings: meetings.map(makeMeetingRecord),
+    nextCursor,
+  };
+}
+
+export interface FathomTranscriptPayload {
+  recordingId: number;
+  transcript: {
+    timestamp: string;
+    speaker: string;
+    text: string;
+  }[];
+}
+
+export function makeTranscriptPayload({
+  recordingId,
+  transcript,
+}: {
+  recordingId: number;
+  transcript: TranscriptItem[];
+}): FathomTranscriptPayload {
+  return {
+    recordingId,
+    transcript: transcript.map((item) => ({
+      timestamp: item.timestamp,
+      speaker: item.speaker.displayName,
+      text: item.text,
+    })),
+  };
+}

--- a/front/lib/api/actions/servers/fathom/rendering.ts
+++ b/front/lib/api/actions/servers/fathom/rendering.ts
@@ -39,7 +39,9 @@ export interface FathomMeetingsListPayload {
   nextCursor: string | null;
 }
 
-export function makeMeetingRecord(meeting: EnrichedMeeting): FathomMeetingRecord {
+export function makeMeetingRecord(
+  meeting: EnrichedMeeting
+): FathomMeetingRecord {
   return {
     recordingId: meeting.recordingId,
     title: meeting.title,

--- a/front/lib/api/actions/servers/fathom/tools/index.ts
+++ b/front/lib/api/actions/servers/fathom/tools/index.ts
@@ -3,19 +3,19 @@ import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { FathomMCPClient } from "@app/lib/api/actions/servers/fathom/client";
 import { FATHOM_TOOLS_METADATA } from "@app/lib/api/actions/servers/fathom/metadata";
+import type { EnrichedMeeting } from "@app/lib/api/actions/servers/fathom/rendering";
+import {
+  makeMeetingsListPayload,
+  makeTranscriptPayload,
+} from "@app/lib/api/actions/servers/fathom/rendering";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { Err, Ok } from "@app/types/shared/result";
 import type {
   ActionItem,
   CRMMatches,
-  Meeting,
   MeetingSummary,
   TranscriptItem,
 } from "fathom-typescript/sdk/models/shared";
-
-type EnrichedMeeting = Meeting & {
-  fetchedSummary?: MeetingSummary | null;
-};
 
 function formatMeeting(meeting: EnrichedMeeting): string {
   const lines = [
@@ -158,6 +158,14 @@ const handlers: ToolHandlers<typeof FATHOM_TOOLS_METADATA> = {
               ? `Meeting with recording ID ${recording_id} not found on this page.${nextCursor ? ` Use cursor="${nextCursor}" to check the next page.` : ""}`
               : "No meetings found for the given filters.",
         },
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            makeMeetingsListPayload({ meetings: [], nextCursor }),
+            null,
+            2
+          ),
+        },
       ]);
     }
 
@@ -188,6 +196,14 @@ const handlers: ToolHandlers<typeof FATHOM_TOOLS_METADATA> = {
         type: "text" as const,
         text: `Found ${enriched.length} meeting(s):\n\n${enriched.map(formatMeeting).join("\n\n---\n\n")}${paginationNote}`,
       },
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          makeMeetingsListPayload({ meetings: enriched, nextCursor }),
+          null,
+          2
+        ),
+      },
     ]);
   },
 
@@ -205,7 +221,20 @@ const handlers: ToolHandlers<typeof FATHOM_TOOLS_METADATA> = {
     }
 
     const fullText = formatTranscript(result.value);
-    return new Ok([{ type: "text" as const, text: fullText }]);
+    return new Ok([
+      { type: "text" as const, text: fullText },
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          makeTranscriptPayload({
+            recordingId: recording_id,
+            transcript: result.value,
+          }),
+          null,
+          2
+        ),
+      },
+    ]);
   },
 };
 


### PR DESCRIPTION
## Description

Fathom's `list_meetings` holds typed Meeting objects but flattens everything into `--Title--` prose, with the pagination cursor delivered as advice text (`Use cursor="..."`). Anything consuming the output programmatically has to parse prose.

This keeps the human rendering unchanged and appends a machine-readable JSON block:

- `list_meetings`: `{meetings, nextCursor}` (dates as ISO 8601, summary resolved to the fetched one when requested, falling back to the default one)
- `get_transcript`: `{recordingId, transcript: [{timestamp, speaker, text}]}`

Serialization lives in a new `rendering.ts`. Additive only, no existing block is modified.

## Tests

Added unit tests for the new serializers (date serialization, summary fallback, cursor passthrough).

## Risk

Low. Existing content blocks are untouched, the JSON block is appended. Larger tool outputs fall under the existing file-offload path.

## Deploy Plan

Standard deploy.