### PR TITLE
[front] fix: populate permalink in slack_personal list_messages results

### DIFF
--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -475,6 +475,50 @@ export async function resolveChannelDisplayName({
   return `#${channelId}`;
 }
 
+// Returns the Slack workspace base URL (e.g. "https://acme.slack.com/") using auth.test.
+// Returns null when the URL cannot be determined (callers should degrade gracefully,
+// e.g. by omitting permalinks).
+export async function getSlackTeamUrl({
+  accessToken,
+}: {
+  accessToken: string;
+}): Promise<string | null> {
+  const slackClient = await getSlackClient(accessToken);
+
+  try {
+    const authResult = await slackClient.auth.test();
+    if (authResult.ok && authResult.url) {
+      return authResult.url;
+    }
+  } catch {
+    // Best effort: return null so callers can omit permalinks.
+  }
+
+  return null;
+}
+
+// Builds a Slack archive permalink for a message, matching the format returned by
+// chat.getPermalink (e.g. "https://acme.slack.com/archives/C012AB3CD/p1234567890123456").
+// For thread replies, pass threadTs so the permalink opens the thread view.
+export function buildSlackPermalink({
+  teamUrl,
+  channelId,
+  messageTs,
+  threadTs,
+}: {
+  teamUrl: string;
+  channelId: string;
+  messageTs: string;
+  threadTs?: string;
+}): string {
+  const base = teamUrl.endsWith("/") ? teamUrl : `${teamUrl}/`;
+  const permalink = `${base}archives/${channelId}/p${messageTs.replace(".", "")}`;
+  if (threadTs && threadTs !== messageTs) {
+    return `${permalink}?thread_ts=${threadTs}&cid=${channelId}`;
+  }
+  return permalink;
+}
+
 // Format users as Markdown.
 function formatUsersAsMarkdown(users: MinimalUserInfo[]): string {
   return users

--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -499,24 +499,17 @@ export async function getSlackTeamUrl({
 
 // Builds a Slack archive permalink for a message, matching the format returned by
 // chat.getPermalink (e.g. "https://acme.slack.com/archives/C012AB3CD/p1234567890123456").
-// For thread replies, pass threadTs so the permalink opens the thread view.
 export function buildSlackPermalink({
   teamUrl,
   channelId,
   messageTs,
-  threadTs,
 }: {
   teamUrl: string;
   channelId: string;
   messageTs: string;
-  threadTs?: string;
 }): string {
   const base = teamUrl.endsWith("/") ? teamUrl : `${teamUrl}/`;
-  const permalink = `${base}archives/${channelId}/p${messageTs.replace(".", "")}`;
-  if (threadTs && threadTs !== messageTs) {
-    return `${permalink}?thread_ts=${threadTs}&cid=${channelId}`;
-  }
-  return permalink;
+  return `${base}archives/${channelId}/p${messageTs.replace(".", "")}`;
 }
 
 // Format users as Markdown.

--- a/front/lib/api/actions/servers/slack/permalink.test.ts
+++ b/front/lib/api/actions/servers/slack/permalink.test.ts
@@ -43,30 +43,6 @@ describe("buildSlackPermalink", () => {
       })
     ).toBe("https://acme.slack.com/archives/C012AB3CD/p1234567890123456");
   });
-
-  it("adds thread parameters for thread replies", () => {
-    expect(
-      buildSlackPermalink({
-        teamUrl: "https://acme.slack.com/",
-        channelId: "C012AB3CD",
-        messageTs: "1234567891.000200",
-        threadTs: "1234567890.123456",
-      })
-    ).toBe(
-      "https://acme.slack.com/archives/C012AB3CD/p1234567891000200?thread_ts=1234567890.123456&cid=C012AB3CD"
-    );
-  });
-
-  it("does not add thread parameters when the message is the thread parent", () => {
-    expect(
-      buildSlackPermalink({
-        teamUrl: "https://acme.slack.com/",
-        channelId: "C012AB3CD",
-        messageTs: "1234567890.123456",
-        threadTs: "1234567890.123456",
-      })
-    ).toBe("https://acme.slack.com/archives/C012AB3CD/p1234567890123456");
-  });
 });
 
 describe("getSlackTeamUrl", () => {

--- a/front/lib/api/actions/servers/slack/permalink.test.ts
+++ b/front/lib/api/actions/servers/slack/permalink.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock Slack WebClient
+const mockAuthTest = vi.fn();
+
+vi.mock("@slack/web-api", () => {
+  return {
+    WebClient: class MockWebClient {
+      auth = {
+        test: mockAuthTest,
+      };
+    },
+  };
+});
+
+// Import after mocking
+import {
+  buildSlackPermalink,
+  getSlackTeamUrl,
+} from "@app/lib/api/actions/servers/slack/helpers";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("buildSlackPermalink", () => {
+  it("builds an archive permalink from channel id and message ts", () => {
+    expect(
+      buildSlackPermalink({
+        teamUrl: "https://acme.slack.com/",
+        channelId: "C012AB3CD",
+        messageTs: "1234567890.123456",
+      })
+    ).toBe("https://acme.slack.com/archives/C012AB3CD/p1234567890123456");
+  });
+
+  it("handles a team URL without a trailing slash", () => {
+    expect(
+      buildSlackPermalink({
+        teamUrl: "https://acme.slack.com",
+        channelId: "C012AB3CD",
+        messageTs: "1234567890.123456",
+      })
+    ).toBe("https://acme.slack.com/archives/C012AB3CD/p1234567890123456");
+  });
+
+  it("adds thread parameters for thread replies", () => {
+    expect(
+      buildSlackPermalink({
+        teamUrl: "https://acme.slack.com/",
+        channelId: "C012AB3CD",
+        messageTs: "1234567891.000200",
+        threadTs: "1234567890.123456",
+      })
+    ).toBe(
+      "https://acme.slack.com/archives/C012AB3CD/p1234567891000200?thread_ts=1234567890.123456&cid=C012AB3CD"
+    );
+  });
+
+  it("does not add thread parameters when the message is the thread parent", () => {
+    expect(
+      buildSlackPermalink({
+        teamUrl: "https://acme.slack.com/",
+        channelId: "C012AB3CD",
+        messageTs: "1234567890.123456",
+        threadTs: "1234567890.123456",
+      })
+    ).toBe("https://acme.slack.com/archives/C012AB3CD/p1234567890123456");
+  });
+});
+
+describe("getSlackTeamUrl", () => {
+  it("returns the team URL from auth.test", async () => {
+    mockAuthTest.mockResolvedValue({
+      ok: true,
+      url: "https://acme.slack.com/",
+    });
+
+    const teamUrl = await getSlackTeamUrl({ accessToken: "xoxp-test-token" });
+
+    expect(teamUrl).toBe("https://acme.slack.com/");
+  });
+
+  it("returns null when auth.test does not return a URL", async () => {
+    mockAuthTest.mockResolvedValue({ ok: true });
+
+    const teamUrl = await getSlackTeamUrl({ accessToken: "xoxp-test-token" });
+
+    expect(teamUrl).toBeNull();
+  });
+
+  it("returns null when auth.test fails", async () => {
+    mockAuthTest.mockRejectedValue(new Error("invalid_auth"));
+
+    const teamUrl = await getSlackTeamUrl({ accessToken: "xoxp-test-token" });
+
+    expect(teamUrl).toBeNull();
+  });
+});

--- a/front/lib/api/actions/servers/slack_personal/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.ts
@@ -11,6 +11,7 @@ import type { AgentLoopRunContext, ToolContext } from "@app/lib/actions/types";
 import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import { SLACK_SEARCH_ACTION_NUM_RESULTS } from "@app/lib/actions/utils";
 import {
+  buildSlackPermalink,
   executeArchiveChannel,
   executeCreateChannel,
   executeGetChannelCanvases,
@@ -25,6 +26,7 @@ import {
   executeSetUserStatus,
   executeWriteCanvas,
   getSlackClient,
+  getSlackTeamUrl,
   isSlackMissingScope,
   resolveChannelDisplayName,
   resolveChannelId,
@@ -826,6 +828,10 @@ export function createSlackPersonalTools(
         accessToken,
       });
 
+      // Fetch the team URL once to construct message permalinks
+      // (conversations.history does not return them).
+      const teamUrl = await getSlackTeamUrl({ accessToken });
+
       const { citationsOffset } = isAgentLoopRunContext(toolContext.runContext)
         ? toolContext.runContext.stepContext
         : { citationsOffset: 0 };
@@ -847,6 +853,14 @@ export function createSlackPersonalTools(
           return {
             ts: match.ts,
             reply_count: match.reply_count,
+            permalink:
+              teamUrl && match.ts
+                ? buildSlackPermalink({
+                    teamUrl,
+                    channelId,
+                    messageTs: match.ts,
+                  })
+                : undefined,
             authorName: authorName ?? "Unknown",
             // Reconstruct readable text from blocks/attachments: app/bot messages
             // (Datadog, Zendesk, ...) often have an empty `text` and put content in


### PR DESCRIPTION
## Description

`list_messages` builds its search-result resources from mapped thread objects that never carried a `permalink`, so `buildSearchResults` always fell back to `uri: ""`. Every list_messages citation shipped with an empty link.

conversations.history does not return permalinks, so we now fetch the workspace URL once (auth.test) and construct the archive URL (`<team>/archives/<channelId>/p<ts>`), same format chat.getPermalink returns. If the team URL cannot be resolved, the permalink is omitted like before rather than failing the tool.

## Tests

Added unit tests for `buildSlackPermalink` (dot-stripped ts, trailing slash handling, thread params) and `getSlackTeamUrl` (ok, missing url, API failure).

## Risk

Low: one extra auth.test call per list_messages invocation; failure degrades to today's behavior (empty uri).

## Deploy Plan

Standard deploy.