### PR TITLE
[dsbx] feat: tools.call() typed async tool client in @dust/pod

### DIFF
--- a/cli/dust-sandbox/pod/index.ts
+++ b/cli/dust-sandbox/pod/index.ts
@@ -7,8 +7,10 @@
  * - `podEnv(name)`: the invocation's environment (./context.ts).
  * - `resolveToolTextContent(block)`: full text of a tool output block,
  *   resolving offloaded content through its descriptor (./tool_output.ts).
+ * - `tools.call(server, tool, args)`: workspace tool calls (./tools.ts).
  */
 export * from "./context.ts";
 export * from "./db.ts";
 export * from "./identity.ts";
 export * from "./tool_output.ts";
+export * from "./tools.ts";

--- a/cli/dust-sandbox/pod/package.json
+++ b/cli/dust-sandbox/pod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust/pod",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "description": "Runtime library for code running in a Dust pod sandbox.",
   "type": "module",

--- a/cli/dust-sandbox/pod/tools.test.ts
+++ b/cli/dust-sandbox/pod/tools.test.ts
@@ -1,0 +1,619 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  runWithInvocationEnv,
+  TOOLS_API_URL_ENV,
+  TOOLS_SANDBOX_TOKEN_ENV,
+  ToolCallError,
+  ToolCallResult,
+  tools,
+} from "@dust/pod";
+
+const BASE_URL = "https://front.test/api/v1/w/w_test";
+
+// The server-view resolution cache is keyed by token and persists for the
+// process (module state), so every test uses a unique token to stay isolated.
+let tokenCounter = 0;
+function uniqueToken(): string {
+  tokenCounter += 1;
+  return `sandbox-token-${tokenCounter}`;
+}
+
+interface RecordedRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+type FetchHandler = (request: RecordedRequest) => Response | Promise<Response>;
+
+let requests: RecordedRequest[];
+let handler: FetchHandler;
+
+const realFetch = globalThis.fetch;
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function serverViewsResponse(views: { sId: string; name: string }[]): Response {
+  return jsonResponse(200, {
+    serverViews: views.map(({ sId, name }) => ({
+      sId,
+      server: { name, sId: `srv_${name}`, tools: [] },
+    })),
+  });
+}
+
+/**
+ * Route requests like the front sandbox-actions API: GET /sandbox/actions
+ * lists server views, POST /sandbox/actions/call creates an action, GET
+ * /sandbox/actions/{aId} polls it. Tests override `handler` (or the
+ * per-route helpers' response queues) to shape each scenario.
+ */
+function installFetchMock(): void {
+  const mocked: typeof fetch = Object.assign(
+    async (input: string | URL | Request, init?: RequestInit) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      const headers: Record<string, string> = {};
+      for (const [key, value] of new Headers(init?.headers).entries()) {
+        headers[key] = value;
+      }
+      const request: RecordedRequest = {
+        method: init?.method ?? "GET",
+        url,
+        headers,
+        body:
+          typeof init?.body === "string" ? JSON.parse(init.body) : undefined,
+      };
+      requests.push(request);
+      return handler(request);
+    },
+    { preconnect: realFetch.preconnect }
+  );
+  globalThis.fetch = mocked;
+}
+
+/** Sequence responses: each call consumes the next entry; the last repeats. */
+function sequence(...responses: (Response | Error)[]): FetchHandler {
+  let index = 0;
+  return () => {
+    const step = responses[Math.min(index, responses.length - 1)];
+    index += 1;
+    if (step instanceof Error) {
+      throw step;
+    }
+    // Response bodies are single-use; clone so a repeated final entry works.
+    return step.clone();
+  };
+}
+
+/**
+ * Standard happy-path routing: resolution finds `serverName`, the call
+ * returns `actionId`, and polling replays `pollResponses` in order (last
+ * repeats).
+ */
+function routeToolCall({
+  serverName,
+  viewId,
+  actionId,
+  pollResponses,
+}: {
+  serverName: string;
+  viewId: string;
+  actionId: string;
+  pollResponses: (Response | Error)[];
+}): void {
+  const poll = sequence(...pollResponses);
+  handler = (request) => {
+    if (request.method === "GET" && request.url.includes("?server=")) {
+      return serverViewsResponse([{ sId: viewId, name: serverName }]);
+    }
+    if (request.method === "POST" && request.url.endsWith("/actions/call")) {
+      return jsonResponse(202, { status: "pending", actionId });
+    }
+    if (request.method === "GET" && request.url.endsWith(`/${actionId}`)) {
+      return poll(request);
+    }
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  };
+}
+
+function successPoll(
+  output: unknown[],
+  {
+    actionStatus = "succeeded",
+    structuredContent,
+  }: { actionStatus?: string; structuredContent?: unknown } = {}
+): Response {
+  return jsonResponse(200, {
+    status: "success",
+    action: {
+      status: actionStatus,
+      output,
+      ...(structuredContent === undefined ? {} : { structuredContent }),
+    },
+  });
+}
+
+async function expectToolCallError(
+  promise: Promise<unknown>
+): Promise<ToolCallError> {
+  try {
+    await promise;
+  } catch (err) {
+    expect(err).toBeInstanceOf(ToolCallError);
+    if (err instanceof ToolCallError) {
+      return err;
+    }
+  }
+  throw new Error("Expected the call to throw a ToolCallError");
+}
+
+beforeEach(() => {
+  requests = [];
+  handler = () => {
+    throw new Error("No fetch handler installed for this test");
+  };
+  installFetchMock();
+  process.env[TOOLS_API_URL_ENV] = BASE_URL;
+  process.env[TOOLS_SANDBOX_TOKEN_ENV] = uniqueToken();
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  delete process.env[TOOLS_API_URL_ENV];
+  delete process.env[TOOLS_SANDBOX_TOKEN_ENV];
+});
+
+describe("tools.call", () => {
+  test("resolves the server, POSTs JSON args verbatim, and returns the result", async () => {
+    routeToolCall({
+      serverName: "slack_personal",
+      viewId: "msv_1",
+      actionId: "act_1",
+      pollResponses: [successPoll([{ type: "text", text: "hello" }])],
+    });
+
+    const args = {
+      query: "release notes",
+      limit: 20,
+      exhaustive: false,
+      channels: ["C123", "C456"],
+      filter: { after: "2026-01-01" },
+    };
+    const result = await tools.call("slack_personal", "search_messages", args);
+
+    expect(result).toBeInstanceOf(ToolCallResult);
+    expect(result.isError).toBe(false);
+    expect(result.content).toEqual([{ type: "text", text: "hello" }]);
+    expect(result.structuredContent).toBeUndefined();
+
+    // Wire shape: server resolution, then the call with args as a real JSON
+    // object (numbers stay numbers, booleans stay booleans, no __file__).
+    const [listRequest, callRequest] = requests;
+    expect(listRequest?.url).toBe(
+      `${BASE_URL}/sandbox/actions?server=slack_personal&light=true`
+    );
+    expect(callRequest?.url).toBe(`${BASE_URL}/sandbox/actions/call`);
+    expect(callRequest?.body).toEqual({
+      serverViewId: "msv_1",
+      toolName: "search_messages",
+      arguments: args,
+    });
+    expect(callRequest?.headers["authorization"]).toBe(
+      `Bearer ${process.env[TOOLS_SANDBOX_TOKEN_ENV]}`
+    );
+  });
+
+  test("omitted args are sent as an empty object", async () => {
+    routeToolCall({
+      serverName: "fathom",
+      viewId: "msv_f",
+      actionId: "act_f",
+      pollResponses: [successPoll([])],
+    });
+
+    await tools.call("fathom", "list_meetings");
+
+    const callRequest = requests.find((r) => r.method === "POST");
+    expect(callRequest?.body).toEqual({
+      serverViewId: "msv_f",
+      toolName: "list_meetings",
+      arguments: {},
+    });
+  });
+
+  test("keeps polling while the action is pending", async () => {
+    routeToolCall({
+      serverName: "hubspot",
+      viewId: "msv_h",
+      actionId: "act_h",
+      pollResponses: [
+        jsonResponse(202, { status: "pending", actionId: "act_h" }),
+        successPoll([{ type: "text", text: "done" }]),
+      ],
+    });
+
+    const result = await tools.call("hubspot", "search_crm_objects", {
+      query: "acme",
+    });
+
+    expect(result.text()).toBe("done");
+    const polls = requests.filter((r) => r.url.endsWith("/act_h"));
+    expect(polls.length).toBe(2);
+  });
+
+  test("an errored action resolves with isError true instead of throwing", async () => {
+    routeToolCall({
+      serverName: "hubspot",
+      viewId: "msv_h",
+      actionId: "act_err",
+      pollResponses: [
+        successPoll([{ type: "text", text: "boom" }], {
+          actionStatus: "errored",
+        }),
+      ],
+    });
+
+    const result = await tools.call("hubspot", "search_crm_objects", {});
+    expect(result.isError).toBe(true);
+    expect(result.text()).toBe("boom");
+  });
+
+  test("a rejected action throws a terminal `rejected` error", async () => {
+    routeToolCall({
+      serverName: "hubspot",
+      viewId: "msv_h",
+      actionId: "act_rej",
+      pollResponses: [jsonResponse(403, { status: "rejected" })],
+    });
+
+    const error = await expectToolCallError(
+      tools.call("hubspot", "search_crm_objects", {})
+    );
+    expect(error.code).toBe("rejected");
+    expect(error.retryable).toBe(false);
+  });
+
+  test("passes structuredContent through when the platform delivers one", async () => {
+    const structured = { meetings: [{ id: 1 }], nextCursor: null };
+    routeToolCall({
+      serverName: "fathom",
+      viewId: "msv_f",
+      actionId: "act_s",
+      pollResponses: [
+        successPoll([{ type: "text", text: "1 meeting" }], {
+          structuredContent: structured,
+        }),
+      ],
+    });
+
+    const result = await tools.call("fathom", "list_meetings", {});
+    expect(result.structuredContent).toEqual(structured);
+    expect(result.json()).toEqual(structured);
+  });
+});
+
+describe("environment handling", () => {
+  test("throws missing_env without DUST_API_URL", async () => {
+    delete process.env[TOOLS_API_URL_ENV];
+    const error = await expectToolCallError(tools.call("slack", "search", {}));
+    expect(error.code).toBe("missing_env");
+    expect(error.retryable).toBe(false);
+    expect(error.message).toContain(TOOLS_API_URL_ENV);
+    expect(requests.length).toBe(0);
+  });
+
+  test("throws missing_env without DUST_SANDBOX_TOKEN", async () => {
+    delete process.env[TOOLS_SANDBOX_TOKEN_ENV];
+    const error = await expectToolCallError(tools.call("slack", "search", {}));
+    expect(error.code).toBe("missing_env");
+    expect(error.message).toContain(TOOLS_SANDBOX_TOKEN_ENV);
+  });
+
+  test("reads the invocation context env, not process.env, inside a context", async () => {
+    routeToolCall({
+      serverName: "slack",
+      viewId: "msv_ctx",
+      actionId: "act_ctx",
+      pollResponses: [successPoll([])],
+    });
+
+    const contextToken = uniqueToken();
+    await runWithInvocationEnv(
+      {
+        [TOOLS_API_URL_ENV]: BASE_URL,
+        [TOOLS_SANDBOX_TOKEN_ENV]: contextToken,
+      },
+      () => tools.call("slack", "search", {})
+    );
+
+    // Every request authenticates with the context token even though
+    // process.env carries a different one.
+    for (const request of requests) {
+      expect(request.headers["authorization"]).toBe(`Bearer ${contextToken}`);
+    }
+  });
+});
+
+describe("server-name resolution", () => {
+  test("throws server_not_found when the server is not available", async () => {
+    handler = () => serverViewsResponse([]);
+    const error = await expectToolCallError(
+      tools.call("nonexistent", "some_tool", {})
+    );
+    expect(error.code).toBe("server_not_found");
+    expect(error.retryable).toBe(false);
+    expect(error.message).toContain("nonexistent");
+  });
+
+  test("caches resolution per invocation token", async () => {
+    routeToolCall({
+      serverName: "slack",
+      viewId: "msv_c",
+      actionId: "act_c",
+      pollResponses: [successPoll([])],
+    });
+
+    await tools.call("slack", "search", {});
+    await tools.call("slack", "list", {});
+
+    const listings = requests.filter((r) => r.url.includes("?server="));
+    expect(listings.length).toBe(1);
+  });
+
+  test("a new invocation token re-resolves", async () => {
+    routeToolCall({
+      serverName: "slack",
+      viewId: "msv_c",
+      actionId: "act_c",
+      pollResponses: [successPoll([])],
+    });
+
+    await tools.call("slack", "search", {});
+    process.env[TOOLS_SANDBOX_TOKEN_ENV] = uniqueToken();
+    await tools.call("slack", "search", {});
+
+    const listings = requests.filter((r) => r.url.includes("?server="));
+    expect(listings.length).toBe(2);
+  });
+
+  test("a failed resolution is not cached", async () => {
+    let listCalls = 0;
+    handler = (request) => {
+      if (request.url.includes("?server=")) {
+        listCalls += 1;
+        if (listCalls === 1) {
+          return jsonResponse(500, {
+            error: { type: "internal_server_error", message: "boom" },
+          });
+        }
+        return serverViewsResponse([{ sId: "msv_r", name: "slack" }]);
+      }
+      if (request.method === "POST") {
+        return jsonResponse(202, { status: "pending", actionId: "act_r" });
+      }
+      return successPoll([]);
+    };
+
+    const first = await expectToolCallError(tools.call("slack", "search", {}));
+    expect(first.code).toBe("server_error");
+    expect(first.retryable).toBe(true);
+
+    const result = await tools.call("slack", "search", {});
+    expect(result.isError).toBe(false);
+    expect(listCalls).toBe(2);
+  });
+
+  test("a network failure during resolution is retryable", async () => {
+    handler = () => {
+      throw new TypeError("Unable to connect");
+    };
+    const error = await expectToolCallError(tools.call("slack", "search", {}));
+    expect(error.code).toBe("network_error");
+    expect(error.retryable).toBe(true);
+  });
+});
+
+describe("HTTP error classification", () => {
+  async function callFailingWith(status: number, body: unknown) {
+    handler = (request) => {
+      if (request.url.includes("?server=")) {
+        return serverViewsResponse([{ sId: "msv_e", name: "slack" }]);
+      }
+      return jsonResponse(status, body);
+    };
+    return expectToolCallError(tools.call("slack", "search", {}));
+  }
+
+  test("401 -> invalid_token, terminal (per-invocation JWT)", async () => {
+    const error = await callFailingWith(401, {
+      error: {
+        type: "invalid_sandbox_token_error",
+        message: "The sandbox token is invalid or expired.",
+      },
+    });
+    expect(error.code).toBe("invalid_token");
+    expect(error.retryable).toBe(false);
+    expect(error.status).toBe(401);
+  });
+
+  test("403 -> permission_denied surfacing front's message", async () => {
+    const error = await callFailingWith(403, {
+      error: {
+        type: "invalid_request_error",
+        message:
+          "This Pod function is published as fast and cannot call tools. " +
+          "Publish it with executionMode `durable` to let it call tools.",
+      },
+    });
+    expect(error.code).toBe("permission_denied");
+    expect(error.retryable).toBe(false);
+    expect(error.message).toContain("published as fast");
+  });
+
+  test("400 -> invalid_request", async () => {
+    const error = await callFailingWith(400, {
+      error: { type: "invalid_request_error", message: "Unknown tool." },
+    });
+    expect(error.code).toBe("invalid_request");
+    expect(error.retryable).toBe(false);
+  });
+
+  test("404 -> not_found", async () => {
+    const error = await callFailingWith(404, {
+      error: { type: "invalid_request_error", message: "No such view." },
+    });
+    expect(error.code).toBe("not_found");
+    expect(error.retryable).toBe(false);
+  });
+
+  test("429 -> rate_limited, retryable", async () => {
+    const error = await callFailingWith(429, {
+      error: { type: "rate_limit_error", message: "Slow down." },
+    });
+    expect(error.code).toBe("rate_limited");
+    expect(error.retryable).toBe(true);
+  });
+
+  test("a non-JSON error body is classified by status with a snippet", async () => {
+    handler = (request) => {
+      if (request.url.includes("?server=")) {
+        return serverViewsResponse([{ sId: "msv_e", name: "slack" }]);
+      }
+      return new Response("Bad Gateway", { status: 502 });
+    };
+    const error = await expectToolCallError(tools.call("slack", "search", {}));
+    expect(error.code).toBe("server_error");
+    expect(error.retryable).toBe(true);
+    expect(error.message).toContain("Bad Gateway");
+  });
+
+  test("a network failure on the POST is not retryable (call may exist)", async () => {
+    handler = (request) => {
+      if (request.url.includes("?server=")) {
+        return serverViewsResponse([{ sId: "msv_e", name: "slack" }]);
+      }
+      throw new TypeError("socket closed");
+    };
+    const error = await expectToolCallError(tools.call("slack", "search", {}));
+    expect(error.code).toBe("network_error");
+    expect(error.retryable).toBe(false);
+  });
+
+  test("an unparseable success body is invalid_response", async () => {
+    handler = (request) => {
+      if (request.url.includes("?server=")) {
+        return serverViewsResponse([{ sId: "msv_e", name: "slack" }]);
+      }
+      return new Response("not json", { status: 200 });
+    };
+    const error = await expectToolCallError(tools.call("slack", "search", {}));
+    expect(error.code).toBe("invalid_response");
+    expect(error.retryable).toBe(false);
+  });
+});
+
+describe("polling resilience", () => {
+  test("retries transient network errors while polling, then succeeds", async () => {
+    routeToolCall({
+      serverName: "slack",
+      viewId: "msv_p",
+      actionId: "act_p",
+      pollResponses: [
+        new TypeError("connection reset"),
+        successPoll([{ type: "text", text: "recovered" }]),
+      ],
+    });
+
+    const result = await tools.call("slack", "search", {});
+    expect(result.text()).toBe("recovered");
+    const polls = requests.filter((r) => r.url.endsWith("/act_p"));
+    expect(polls.length).toBe(2);
+  });
+
+  test("an API error while polling is terminal, not retried", async () => {
+    routeToolCall({
+      serverName: "slack",
+      viewId: "msv_p",
+      actionId: "act_term",
+      pollResponses: [
+        jsonResponse(404, {
+          error: { type: "action_not_found", message: "Action not found." },
+        }),
+      ],
+    });
+
+    const error = await expectToolCallError(tools.call("slack", "search", {}));
+    expect(error.code).toBe("not_found");
+    const polls = requests.filter((r) => r.url.endsWith("/act_term"));
+    expect(polls.length).toBe(1);
+  });
+
+  test("times out when the action stays pending past the deadline", async () => {
+    routeToolCall({
+      serverName: "slack",
+      viewId: "msv_p",
+      actionId: "act_slow",
+      pollResponses: [
+        jsonResponse(202, { status: "pending", actionId: "act_slow" }),
+      ],
+    });
+
+    const error = await expectToolCallError(
+      tools.call("slack", "search", {}, { timeoutMs: 0 })
+    );
+    expect(error.code).toBe("timeout");
+    expect(error.retryable).toBe(false);
+  });
+});
+
+describe("ToolCallResult helpers", () => {
+  test("text() concatenates text blocks and text resources", () => {
+    const result = new ToolCallResult({
+      content: [
+        { type: "text", text: "first" },
+        { type: "image", data: "...", mimeType: "image/png" },
+        { type: "resource", resource: { uri: "u", text: "second" } },
+        { type: "resource", resource: { uri: "u", blob: "..." } },
+        "not a block",
+      ],
+      isError: false,
+    });
+    expect(result.text()).toBe("first\nsecond");
+  });
+
+  test("json() parses the concatenated text", () => {
+    const result = new ToolCallResult({
+      content: [{ type: "text", text: '{"results": [1, 2], "paging": null}' }],
+      isError: false,
+    });
+    expect(result.json()).toEqual({ results: [1, 2], paging: null });
+  });
+
+  test("json() throws on non-JSON text", () => {
+    const result = new ToolCallResult({
+      content: [{ type: "text", text: "3 results found" }],
+      isError: false,
+    });
+    expect(() => result.json()).toThrow(SyntaxError);
+  });
+
+  test("json() prefers structuredContent when present", () => {
+    const result = new ToolCallResult({
+      content: [{ type: "text", text: "human summary" }],
+      isError: false,
+      structuredContent: { ok: true },
+    });
+    expect(result.json()).toEqual({ ok: true });
+  });
+});

--- a/cli/dust-sandbox/pod/tools.ts
+++ b/cli/dust-sandbox/pod/tools.ts
@@ -1,0 +1,570 @@
+// Typed client for calling workspace tools (MCP servers) from pod function
+// code.
+//
+// `tools.call(server, tool, args)` POSTs `sandbox/actions/call` with the
+// arguments as a real JSON object and polls `sandbox/actions/{aId}` until the
+// action completes, mirroring the dsbx CLI transport (src/api/client.rs)
+// without shelling out: no argv size limits, no scalar coercion, no stdout
+// parsing, and the wait is async so a resident worker serving concurrent
+// invocations is never blocked on a child process.
+//
+// Auth and routing come from the invocation environment (DUST_API_URL is
+// workspace-scoped, DUST_SANDBOX_TOKEN is minted per invocation), read through
+// podEnv() so concurrent invocations in one process stay isolated.
+//
+// Tool outputs above front's offload threshold arrive as a truncated snippet
+// block plus an archive pointer into the pod filesystem. text()/json() return
+// the blocks as delivered; transparent archive resolution will build on the
+// resolveToolTextContent helper once it lands in this package.
+
+import { z } from "zod";
+
+import { podEnv } from "./context.ts";
+
+export const TOOLS_API_URL_ENV = "DUST_API_URL";
+export const TOOLS_SANDBOX_TOKEN_ENV = "DUST_SANDBOX_TOKEN";
+
+// Poll cadence mirrors the dsbx CLI client (src/api/client.rs): 500 ms
+// interval, 10-minute hard cap so a wedged action cannot pin an invocation
+// forever, and bounded retries with exponential backoff on transient network
+// errors (re-polling an action id is idempotent).
+const POLL_INTERVAL_MS = 500;
+const POLL_MAX_DURATION_MS = 10 * 60 * 1000;
+const HTTP_REQUEST_TIMEOUT_MS = 30 * 1000;
+const POLL_MAX_CONSECUTIVE_NETWORK_ERRORS = 30;
+const POLL_RETRY_BACKOFF_BASE_MS = 500;
+const POLL_RETRY_BACKOFF_CAP_MS = 5 * 1000;
+
+// Server-name resolution is cached per invocation: the sandbox token is minted
+// once per invocation, so keying by token scopes entries to exactly one
+// invocation on both the cold and warm paths. FIFO eviction keeps the map
+// bounded in a long-lived resident worker.
+const SERVER_VIEW_CACHE_MAX_ENTRIES = 256;
+
+export type ToolCallErrorCode =
+  | "missing_env"
+  | "server_not_found"
+  | "invalid_token"
+  | "permission_denied"
+  | "rejected"
+  | "invalid_request"
+  | "not_found"
+  | "rate_limited"
+  | "server_error"
+  | "network_error"
+  | "invalid_response"
+  | "timeout";
+
+/**
+ * Transport-level failure of a tool call. Tool-level failures (the tool ran
+ * and reported an error) are NOT thrown: they come back as a ToolCallResult
+ * with `isError: true`.
+ *
+ * `retryable` means "issuing the same tools.call() again is safe and has a
+ * chance of succeeding". It is false when the failure is deterministic
+ * (bad request, unknown server), when the invocation's token cannot recover
+ * (tokens are minted once per invocation and expire on their own schedule),
+ * and when the underlying action may already exist or still be running
+ * (a retry would start a duplicate tool call).
+ */
+export class ToolCallError extends Error {
+  override readonly name = "ToolCallError";
+  readonly code: ToolCallErrorCode;
+  readonly retryable: boolean;
+  /** HTTP status of the failing response, when the failure was an HTTP error. */
+  readonly status?: number;
+
+  constructor(
+    code: ToolCallErrorCode,
+    message: string,
+    { retryable, status }: { retryable: boolean; status?: number }
+  ) {
+    super(message);
+    this.code = code;
+    this.retryable = retryable;
+    this.status = status;
+  }
+}
+
+/**
+ * Result of a completed tool call: the raw MCP content blocks exactly as the
+ * platform delivered them, plus convenience accessors.
+ */
+export class ToolCallResult {
+  /** Raw content blocks, verbatim (text, resource, image, ... blocks). */
+  readonly content: readonly unknown[];
+  /** True when the tool ran and reported an error. */
+  readonly isError: boolean;
+  /**
+   * Machine-readable output, when the platform delivers one. Absent today;
+   * carried so results are forward-compatible with structured tool output.
+   */
+  readonly structuredContent?: unknown;
+
+  constructor({
+    content,
+    isError,
+    structuredContent,
+  }: {
+    content: readonly unknown[];
+    isError: boolean;
+    structuredContent?: unknown;
+  }) {
+    this.content = content;
+    this.isError = isError;
+    this.structuredContent = structuredContent;
+  }
+
+  /**
+   * Concatenate the text carried by the content blocks (`text` blocks and
+   * embedded text resources), separated by newlines. Non-text blocks are
+   * skipped.
+   */
+  text(): string {
+    const parts: string[] = [];
+    for (const block of this.content) {
+      if (!isRecord(block)) {
+        continue;
+      }
+      if (block.type === "text" && typeof block.text === "string") {
+        parts.push(block.text);
+      } else if (
+        block.type === "resource" &&
+        isRecord(block.resource) &&
+        typeof block.resource.text === "string"
+      ) {
+        parts.push(block.resource.text);
+      }
+    }
+    return parts.join("\n");
+  }
+
+  /**
+   * Parse the result as JSON: `structuredContent` when present, otherwise
+   * `JSON.parse(this.text())`. Throws a SyntaxError when the text is not
+   * valid JSON — callers mixing prose and JSON blocks should read `content`
+   * directly instead.
+   */
+  json(): unknown {
+    if (this.structuredContent !== undefined) {
+      return this.structuredContent;
+    }
+    return JSON.parse(this.text());
+  }
+}
+
+export interface ToolCallOptions {
+  /**
+   * Cap on the total time spent waiting for the tool result. Defaults to the
+   * 10-minute poll ceiling. The invocation's own execution deadline is
+   * typically tighter.
+   */
+  timeoutMs?: number;
+}
+
+interface ToolsClientConfig {
+  readonly baseUrl: string;
+  readonly token: string;
+}
+
+const serverViewsResponseSchema = z.object({
+  serverViews: z.array(
+    z.object({
+      sId: z.string(),
+      server: z.object({ name: z.string() }),
+    })
+  ),
+});
+
+const callPostResponseSchema = z.object({
+  status: z.literal("pending"),
+  actionId: z.string(),
+});
+
+const apiErrorEnvelopeSchema = z.object({
+  error: z.object({
+    type: z.string().optional(),
+    message: z.string().optional(),
+  }),
+});
+
+const pollResponseSchema = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("pending") }),
+  z.object({ status: z.literal("rejected") }),
+  z.object({
+    status: z.literal("success"),
+    action: z.object({
+      status: z.string(),
+      output: z.array(z.unknown()).nullish(),
+      structuredContent: z.unknown().optional(),
+    }),
+  }),
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function errorMessageOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function tryParseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+function requiredEnv(name: string): string {
+  const value = podEnv(name);
+  if (!value) {
+    throw new ToolCallError(
+      "missing_env",
+      `${name} is not set: tools.call() only works inside a pod function invocation.`,
+      { retryable: false }
+    );
+  }
+  return value;
+}
+
+/**
+ * Classify a failing (or unparseable) HTTP response into a ToolCallError.
+ * Front error bodies are `{error: {type, message}}`; the message is surfaced
+ * verbatim when present so the caller sees the platform's explanation (e.g.
+ * the fast-function tool refusal).
+ */
+function errorFromResponse(
+  context: string,
+  status: number,
+  bodyText: string
+): ToolCallError {
+  let detail = bodyText.slice(0, 500);
+  const envelope = apiErrorEnvelopeSchema.safeParse(tryParseJson(bodyText));
+  if (envelope.success) {
+    const { type, message } = envelope.data.error;
+    detail = message ?? type ?? detail;
+  }
+
+  if (status >= 200 && status < 300) {
+    return new ToolCallError(
+      "invalid_response",
+      `${context} returned an unparseable body: ${detail}`,
+      { retryable: false, status }
+    );
+  }
+
+  const message = `${context} returned ${status}: ${detail}`;
+  if (status === 401) {
+    // Tokens are minted once per invocation with a short expiry; a fresh one
+    // only exists in a fresh invocation, so retrying here is futile.
+    return new ToolCallError("invalid_token", message, {
+      retryable: false,
+      status,
+    });
+  }
+  if (status === 403) {
+    return new ToolCallError("permission_denied", message, {
+      retryable: false,
+      status,
+    });
+  }
+  if (status === 404) {
+    return new ToolCallError("not_found", message, {
+      retryable: false,
+      status,
+    });
+  }
+  if (status === 429) {
+    return new ToolCallError("rate_limited", message, {
+      retryable: true,
+      status,
+    });
+  }
+  if (status >= 500) {
+    return new ToolCallError("server_error", message, {
+      retryable: true,
+      status,
+    });
+  }
+  return new ToolCallError("invalid_request", message, {
+    retryable: false,
+    status,
+  });
+}
+
+interface HttpResponse {
+  readonly status: number;
+  readonly ok: boolean;
+  readonly bodyText: string;
+}
+
+/**
+ * One HTTP round-trip. Network failures (DNS, refused connection, per-request
+ * timeout) reject with the underlying error; callers classify them because
+ * retryability depends on the request's idempotency.
+ */
+async function httpRequest(
+  config: ToolsClientConfig,
+  method: "GET" | "POST",
+  path: string,
+  body?: unknown
+): Promise<HttpResponse> {
+  const response = await fetch(`${config.baseUrl}/${path}`, {
+    method,
+    headers: {
+      authorization: `Bearer ${config.token}`,
+      "content-type": "application/json",
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    signal: AbortSignal.timeout(HTTP_REQUEST_TIMEOUT_MS),
+  });
+  const bodyText = await response.text();
+  return { status: response.status, ok: response.ok, bodyText };
+}
+
+const serverViewIdCache = new Map<string, Promise<string>>();
+
+function resolveServerViewId(
+  config: ToolsClientConfig,
+  server: string
+): Promise<string> {
+  const key = `${config.token}\u0000${server}`;
+  const cached = serverViewIdCache.get(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const promise = fetchServerViewId(config, server);
+  serverViewIdCache.set(key, promise);
+  // Failures are not cached: a transient listing error must not poison every
+  // later call of the invocation.
+  promise.catch(() => serverViewIdCache.delete(key));
+  while (serverViewIdCache.size > SERVER_VIEW_CACHE_MAX_ENTRIES) {
+    const oldest = serverViewIdCache.keys().next().value;
+    if (oldest === undefined) {
+      break;
+    }
+    serverViewIdCache.delete(oldest);
+  }
+  return promise;
+}
+
+async function fetchServerViewId(
+  config: ToolsClientConfig,
+  server: string
+): Promise<string> {
+  const path = `sandbox/actions?server=${encodeURIComponent(server)}&light=true`;
+  let response: HttpResponse;
+  try {
+    response = await httpRequest(config, "GET", path);
+  } catch (err) {
+    // Listing is read-only, so re-calling after a network failure is safe.
+    throw new ToolCallError(
+      "network_error",
+      `GET ${path} failed: ${errorMessageOf(err)}`,
+      { retryable: true }
+    );
+  }
+  if (!response.ok) {
+    throw errorFromResponse(`GET ${path}`, response.status, response.bodyText);
+  }
+
+  const parsed = serverViewsResponseSchema.safeParse(
+    tryParseJson(response.bodyText)
+  );
+  if (!parsed.success) {
+    throw errorFromResponse(`GET ${path}`, response.status, response.bodyText);
+  }
+
+  const view = parsed.data.serverViews.find((v) => v.server.name === server);
+  if (view === undefined) {
+    throw new ToolCallError(
+      "server_not_found",
+      `Server '${server}' not found: it is not available to this pod.`,
+      { retryable: false }
+    );
+  }
+  return view.sId;
+}
+
+async function postToolCall(
+  config: ToolsClientConfig,
+  {
+    serverViewId,
+    toolName,
+    args,
+  }: {
+    serverViewId: string;
+    toolName: string;
+    args: Record<string, unknown>;
+  }
+): Promise<string> {
+  const path = "sandbox/actions/call";
+  let response: HttpResponse;
+  try {
+    response = await httpRequest(config, "POST", path, {
+      serverViewId,
+      toolName,
+      arguments: args,
+    });
+  } catch (err) {
+    // The POST is not idempotent (each one creates an action) and a request
+    // that failed in flight may still have been processed, so a blind retry
+    // could run the tool twice.
+    throw new ToolCallError(
+      "network_error",
+      `POST ${path} failed: ${errorMessageOf(err)}`,
+      { retryable: false }
+    );
+  }
+  if (!response.ok) {
+    throw errorFromResponse(`POST ${path}`, response.status, response.bodyText);
+  }
+
+  const parsed = callPostResponseSchema.safeParse(
+    tryParseJson(response.bodyText)
+  );
+  if (!parsed.success) {
+    throw errorFromResponse(`POST ${path}`, response.status, response.bodyText);
+  }
+  return parsed.data.actionId;
+}
+
+function timeoutError(actionId: string, timeoutMs: number): ToolCallError {
+  // The action may still complete server-side; retrying would start a
+  // duplicate tool call on top of it.
+  return new ToolCallError(
+    "timeout",
+    `Timed out waiting for action ${actionId} after ${timeoutMs} ms.`,
+    { retryable: false }
+  );
+}
+
+async function pollActionResult(
+  config: ToolsClientConfig,
+  {
+    actionId,
+    deadlineMs,
+    timeoutMs,
+  }: { actionId: string; deadlineMs: number; timeoutMs: number }
+): Promise<ToolCallResult> {
+  const path = `sandbox/actions/${actionId}`;
+  let consecutiveNetworkErrors = 0;
+
+  for (;;) {
+    let response: HttpResponse;
+    try {
+      response = await httpRequest(config, "GET", path);
+      consecutiveNetworkErrors = 0;
+    } catch (err) {
+      // Transient network errors are retried: action ids are durable and
+      // re-polling one is idempotent. HTTP-level errors below are terminal.
+      consecutiveNetworkErrors += 1;
+      if (consecutiveNetworkErrors > POLL_MAX_CONSECUTIVE_NETWORK_ERRORS) {
+        throw new ToolCallError(
+          "network_error",
+          `Polling action ${actionId} failed after ` +
+            `${POLL_MAX_CONSECUTIVE_NETWORK_ERRORS} consecutive network ` +
+            `errors: ${errorMessageOf(err)}`,
+          // The tool call may still be running server-side.
+          { retryable: false }
+        );
+      }
+      if (Date.now() >= deadlineMs) {
+        throw timeoutError(actionId, timeoutMs);
+      }
+      const backoffMs = Math.min(
+        POLL_RETRY_BACKOFF_BASE_MS *
+          2 ** Math.min(consecutiveNetworkErrors - 1, 4),
+        POLL_RETRY_BACKOFF_CAP_MS
+      );
+      await sleep(backoffMs);
+      continue;
+    }
+
+    const parsed = pollResponseSchema.safeParse(
+      tryParseJson(response.bodyText)
+    );
+    if (!parsed.success) {
+      // Error envelopes (and anything else unparseable) end the poll: the
+      // classifier maps front's `{error: {...}}` bodies to a typed error.
+      throw errorFromResponse(
+        `GET ${path}`,
+        response.status,
+        response.bodyText
+      );
+    }
+
+    const poll = parsed.data;
+    switch (poll.status) {
+      case "pending": {
+        if (Date.now() >= deadlineMs) {
+          throw timeoutError(actionId, timeoutMs);
+        }
+        await sleep(POLL_INTERVAL_MS);
+        continue;
+      }
+      case "rejected":
+        throw new ToolCallError(
+          "rejected",
+          `Action ${actionId} was rejected.`,
+          { retryable: false }
+        );
+      case "success":
+        return new ToolCallResult({
+          content: poll.action.output ?? [],
+          isError: poll.action.status === "errored",
+          structuredContent: poll.action.structuredContent,
+        });
+      default: {
+        const exhaustive: never = poll;
+        throw new ToolCallError(
+          "invalid_response",
+          `Unexpected poll status: ${JSON.stringify(exhaustive)}`,
+          { retryable: false }
+        );
+      }
+    }
+  }
+}
+
+export const tools = {
+  /**
+   * Call a workspace tool and wait for its result.
+   *
+   * @param server the tool server name, as listed by `dsbx tools` (e.g.
+   *   "slack_personal").
+   * @param tool the tool name on that server.
+   * @param args the tool arguments as a plain JSON object, passed to the
+   *   server verbatim — no stringification, no scalar coercion.
+   * @throws ToolCallError on transport failures. A tool that ran and reported
+   *   an error resolves normally with `isError: true`.
+   */
+  async call(
+    server: string,
+    tool: string,
+    args?: Record<string, unknown>,
+    options?: ToolCallOptions
+  ): Promise<ToolCallResult> {
+    const config: ToolsClientConfig = {
+      baseUrl: requiredEnv(TOOLS_API_URL_ENV).replace(/\/+$/, ""),
+      token: requiredEnv(TOOLS_SANDBOX_TOKEN_ENV),
+    };
+    const timeoutMs = options?.timeoutMs ?? POLL_MAX_DURATION_MS;
+    const deadlineMs = Date.now() + timeoutMs;
+
+    const serverViewId = await resolveServerViewId(config, server);
+    const actionId = await postToolCall(config, {
+      serverViewId,
+      toolName: tool,
+      args: args ?? {},
+    });
+    return pollActionResult(config, { actionId, deadlineMs, timeoutMs });
+  },
+};

--- a/front/lib/api/sandbox/image/pod_package.ts
+++ b/front/lib/api/sandbox/image/pod_package.ts
@@ -9,7 +9,7 @@ import path from "path";
 // external and resolve through NODE_PATH, like zod) and copy a flat
 // {package.json, index.js} into the image's global node_modules.
 export const POD_PACKAGE_NAME = "@dust/pod";
-export const POD_PACKAGE_VERSION = "0.1.1";
+export const POD_PACKAGE_VERSION = "0.2.0";
 export const POD_PACKAGE_IMAGE_DIR = `/opt/npm-global/lib/node_modules/${POD_PACKAGE_NAME}`;
 
 let podPackageSrcDir: string | undefined;

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -646,7 +646,7 @@ describe("sandbox image registry", () => {
         expect.objectContaining({ name: "drizzle-orm", version: "0.45.2" }),
         expect.objectContaining({ name: "drizzle-kit", version: "0.31.10" }),
         expect.objectContaining({ name: "@libsql/client", version: "0.17.4" }),
-        expect.objectContaining({ name: "@dust/pod", version: "0.1.1" }),
+        expect.objectContaining({ name: "@dust/pod", version: "0.2.0" }),
       ])
     );
   });


### PR DESCRIPTION
## Description

Pod functions that call workspace tools each vendor a ~90-line sync `spawnSync("dsbx")` shim: busy-wait backoff, stderr regexing, temp-file `__file__:` args, and in a resident worker the sync spawn blocks the single JS thread serving every concurrent invocation.

This adds `pod/tools.ts` to `@dust/pod`:

- `await tools.call(server, tool, args)` POSTs `sandbox/actions/call` and polls `sandbox/actions/{aId}`, mirroring the dsbx CLI client's cadence (500 ms interval, 10 min cap, bounded backoff on transient network errors while polling).
- Args are sent as a real JSON object: no argv limits, no scalar coercion, no `__file__:` indirection.
- Returns `{content, structuredContent?, isError}` with `text()`/`json()` helpers. Tool-level errors resolve with `isError: true`; transport failures throw a typed `ToolCallError{code, retryable}` (401 is terminal since tokens are minted once per invocation, POST network failures are marked non-retryable since the action may already exist).
- Server-name -> serverViewId resolution via the existing `GET sandbox/actions` listing, cached per invocation token.

Bumps `POD_PACKAGE_VERSION` to 0.2.0. Another in-flight PR also bumps it, whichever lands second may need a trivial rebase.

Follow-up (separate PR): resolve offloaded archive pointers inside `text()`/`json()` once the `resolveToolTextContent` helper lands; until then blocks are returned as delivered.

## Tests

`bun test` unit tests with a mocked fetch covering the wire shape (args verbatim, auth header), pending -> success polling, rejected/errored actions, HTTP error classification per status, network-error retry while polling, per-invocation caching (including no caching of failures and invocation-context env isolation), timeout, and the `text()`/`json()` helpers.

## Risk

Low, purely additive: a new module in `@dust/pod` plus a version bump. Existing shims keep shelling out to the same endpoints. Long-lived pods only see the new export after an image refresh.

## Deploy Plan

Standard deploy. Ships to sandboxes with the next image rebuild.