### PR TITLE
[front] Deny agent invocation from Pod function run contexts

### DIFF
--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -10,6 +10,8 @@ import type {
   FileAuthRequiredOutputResourceType,
   SingleResourceToolOutput,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type { ToolContext } from "@app/lib/actions/types";
+import { isSandboxFunctionRunContext } from "@app/lib/actions/types";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { hasNoRequiredProperties } from "@app/lib/utils/json_schemas";
@@ -23,6 +25,25 @@ export function makeInternalMCPServer(
   const serverInfo = getInternalMCPServerInfo(name);
 
   return new McpServer(serverInfo);
+}
+
+// Returns an MCPError when the tool call originates from a sandbox-function run context, null
+// otherwise. Pod functions must not create conversations or invoke agents: a spawned agent
+// exposes no run-status or completion signal to the function, so the pattern fails silently.
+// Read-only conversation tools (e.g. pod_manager.list_conversations) remain available to
+// functions and must not use this guard.
+export function agentInvocationFromFunctionGuard(
+  toolContext: ToolContext | undefined
+): MCPError | null {
+  if (isSandboxFunctionRunContext(toolContext?.runContext)) {
+    return new MCPError(
+      "Creating conversations or invoking agents from a Pod function is not supported. " +
+        "Link users into a conversation from the Frame instead, or use a wakeup/trigger " +
+        "that runs the agent in a normal conversation.",
+      { tracked: false }
+    );
+  }
+  return null;
 }
 
 // Returns an MCPError when the caller is not a workspace admin, null otherwise.

--- a/front/lib/api/actions/servers/pod_manager/tools/index.test.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.test.ts
@@ -1,14 +1,21 @@
 import { makePodConfigurationURI } from "@app/lib/actions/mcp_internal_actions/pod_configuration_uri";
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopRunContext } from "@app/lib/actions/types";
+import type {
+  AgentLoopRunContext,
+  SandboxFunctionRunContext,
+} from "@app/lib/actions/types";
 import { createProjectManagerTools } from "@app/lib/api/actions/servers/pod_manager/tools";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { processEventForDatabase } from "@app/temporal/agent_loop/activities/common";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { getTestStreamEndpoint } from "@app/tests/utils/models";
+import { SandboxFunctionMCPActionFactory } from "@app/tests/utils/SandboxFunctionMCPActionFactory";
+import { createPersistedSandboxFunctionInvocationTokenTestContext } from "@app/tests/utils/SandboxTokenFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { getAgentLoopData } from "@app/types/assistant/agent_run";
 import {
@@ -277,5 +284,105 @@ describe("pod_manager move_conversation", () => {
       otherConversation.sId
     );
     expect(unmovedConversation?.toJSON().spaceId).toBeNull();
+  });
+});
+
+async function createSandboxFunctionToolsContext() {
+  const context =
+    await createPersistedSandboxFunctionInvocationTokenTestContext();
+  const { auth, workspace, globalSpace, invocation } = context;
+  const server = await InternalMCPServerInMemoryResource.makeNew(auth, {
+    name: "common_utilities",
+    useCase: null,
+  });
+  const view = await MCPServerViewFactory.create(
+    workspace,
+    server.id,
+    globalSpace
+  );
+  const action = await SandboxFunctionMCPActionFactory.create(auth, {
+    invocation,
+    mcpServerView: view,
+  });
+  const runContext: SandboxFunctionRunContext = {
+    contextType: "sandbox_function",
+    action,
+    invocation,
+    toolConfiguration: action.toolConfiguration,
+  };
+  const tools = createProjectManagerTools(auth, { runContext });
+  const extra: ToolHandlerExtra = {
+    auth,
+    requestId: "pod-manager-sandbox-function-test",
+    runContext,
+    sendNotification: async () => {},
+    sendRequest: async () => {
+      throw new Error("Unexpected MCP request");
+    },
+    signal: new AbortController().signal,
+  };
+
+  return { ...context, extra, tools };
+}
+
+describe("pod_manager tools from a sandbox-function run context", () => {
+  it("denies create_conversation with a typed error", async () => {
+    const { extra, tools } = await createSandboxFunctionToolsContext();
+
+    const result = await getTool(tools, "create_conversation").handler(
+      {
+        message: "Spawned from a function",
+        title: "Not allowed",
+      },
+      extra
+    );
+
+    assert(result.isErr());
+    expect(result.error.message).toContain(
+      "Creating conversations or invoking agents from a Pod function is not supported"
+    );
+  });
+
+  it("denies add_message_to_conversation with a typed error", async () => {
+    const { extra, tools } = await createSandboxFunctionToolsContext();
+
+    const result = await getTool(tools, "add_message_to_conversation").handler(
+      {
+        conversationId: "cnv_never_looked_up",
+        message: "Spawned from a function",
+      },
+      extra
+    );
+
+    assert(result.isErr());
+    expect(result.error.message).toContain(
+      "Creating conversations or invoking agents from a Pod function is not supported"
+    );
+  });
+
+  it("still allows the read-only list_conversations", async () => {
+    const { agentConfig, auth, extra, podSpace, tools } =
+      await createSandboxFunctionToolsContext();
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+      spaceId: podSpace.id,
+    });
+
+    const result = await getTool(tools, "list_conversations").handler(
+      {},
+      extra
+    );
+
+    assert(result.isOk());
+    const content = result.value[0];
+    assert(content?.type === "text");
+    const output = ListConversationsOutputSchema.parse(
+      JSON.parse(content.text)
+    );
+
+    expect(
+      output.conversations.map((listedConversation) => listedConversation.sId)
+    ).toContain(conversation.sId);
   });
 });

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -8,10 +8,7 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import { agentInvocationFromFunctionGuard } from "@app/lib/actions/mcp_internal_actions/utils";
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import type { ToolContext } from "@app/lib/actions/types";
-import {
-  isAgentLoopRunContext,
-  isSandboxFunctionRunContext,
-} from "@app/lib/actions/types";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import {
   FILES_LIST_ACTION_NAME,
   FILES_SERVER_NAME,
@@ -1224,7 +1221,8 @@ export function createProjectManagerTools(
 
     create_conversation: async (params) => {
       return withErrorHandling(async () => {
-        const invocationGuardError = agentInvocationFromFunctionGuard(toolContext);
+        const invocationGuardError =
+          agentInvocationFromFunctionGuard(toolContext);
         if (invocationGuardError) {
           return new Err(invocationGuardError);
         }
@@ -1256,11 +1254,6 @@ export function createProjectManagerTools(
           }
           originMessageId = toolContext.runContext.agentMessage.sId;
         }
-        if (isSandboxFunctionRunContext(toolContext?.runContext)) {
-          timezone =
-            toolContext.runContext.invocation.context?.timezone ?? timezone;
-        }
-
         // Get agent configuration name & profile picture URL
         const agentName = isAgentLoopRunContext(toolContext?.runContext)
           ? toolContext.runContext.agentConfiguration.name
@@ -1507,7 +1500,8 @@ export function createProjectManagerTools(
 
     add_message_to_conversation: async (params) => {
       return withErrorHandling(async () => {
-        const invocationGuardError = agentInvocationFromFunctionGuard(toolContext);
+        const invocationGuardError =
+          agentInvocationFromFunctionGuard(toolContext);
         if (invocationGuardError) {
           return new Err(invocationGuardError);
         }

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -5,6 +5,7 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { agentInvocationFromFunctionGuard } from "@app/lib/actions/mcp_internal_actions/utils";
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import type { ToolContext } from "@app/lib/actions/types";
 import {
@@ -1223,6 +1224,11 @@ export function createProjectManagerTools(
 
     create_conversation: async (params) => {
       return withErrorHandling(async () => {
+        const invocationGuardError = agentInvocationFromFunctionGuard(toolContext);
+        if (invocationGuardError) {
+          return new Err(invocationGuardError);
+        }
+
         const contextRes = await getWritablePodContext(auth, {
           toolContext,
           dustPod: params.dustPod,
@@ -1501,6 +1507,11 @@ export function createProjectManagerTools(
 
     add_message_to_conversation: async (params) => {
       return withErrorHandling(async () => {
+        const invocationGuardError = agentInvocationFromFunctionGuard(toolContext);
+        if (invocationGuardError) {
+          return new Err(invocationGuardError);
+        }
+
         const contextRes = await getWritablePodContext(auth, {
           toolContext,
           dustPod: params.dustPod,

--- a/front/lib/api/actions/servers/run_agent/index.test.ts
+++ b/front/lib/api/actions/servers/run_agent/index.test.ts
@@ -1,0 +1,52 @@
+import type { SandboxFunctionRunContext } from "@app/lib/actions/types";
+import { runAgent } from "@app/lib/api/actions/servers/run_agent";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { SandboxFunctionMCPActionFactory } from "@app/tests/utils/SandboxFunctionMCPActionFactory";
+import { createPersistedSandboxFunctionInvocationTokenTestContext } from "@app/tests/utils/SandboxTokenFactory";
+import assert from "assert";
+import { describe, expect, it } from "vitest";
+
+describe("runAgent from a sandbox-function run context", () => {
+  it("returns a typed refusal instead of an internal assertion error", async () => {
+    const { auth, workspace, invocation, globalSpace } =
+      await createPersistedSandboxFunctionInvocationTokenTestContext();
+    const server = await InternalMCPServerInMemoryResource.makeNew(auth, {
+      name: "common_utilities",
+      useCase: null,
+    });
+    const view = await MCPServerViewFactory.create(
+      workspace,
+      server.id,
+      globalSpace
+    );
+    const action = await SandboxFunctionMCPActionFactory.create(auth, {
+      invocation,
+      mcpServerView: view,
+    });
+    const runContext: SandboxFunctionRunContext = {
+      contextType: "sandbox_function",
+      action,
+      invocation,
+      toolConfiguration: action.toolConfiguration,
+    };
+
+    const result = await runAgent(
+      {
+        query: "Summarize the latest updates.",
+        childAgentId: "agent_123",
+        executionMode: "run-agent",
+      },
+      {
+        auth,
+        toolContext: { runContext },
+        toolName: "run_agent",
+      }
+    );
+
+    assert(result.isErr());
+    expect(result.error.message).toContain(
+      "Creating conversations or invoking agents from a Pod function is not supported"
+    );
+  });
+});

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -10,6 +10,7 @@ import type {
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
+  agentInvocationFromFunctionGuard,
   makeInternalMCPServer,
   makeMCPToolExit,
 } from "@app/lib/actions/mcp_internal_actions/utils";
@@ -169,6 +170,13 @@ export const runAgent = async (
     childAgentBlob?: ChildAgentBlob;
   }
 ): Promise<ToolHandlerResult> => {
+  // Pod functions cannot invoke agents: return a typed refusal instead of tripping the
+  // agent-loop assert below into an opaque internal error.
+  const invocationGuardError = agentInvocationFromFunctionGuard(toolContext);
+  if (invocationGuardError) {
+    return new Err(invocationGuardError);
+  }
+
   assert(
     isAgentLoopRunContext(toolContext?.runContext),
     "AgentLoopRunContext expected"


### PR DESCRIPTION
## Description

Pod functions could call `pod_manager.create_conversation` / `add_message_to_conversation` and `run_agent` / `agent_delegation` through `dsbx tools`, but a spawned agent exposes no run-status or completion signal to the function, so builders ended up with wall-clock polling and silent failures. `run_agent` was worse: it hit a bare `assert(isAgentLoopRunContext(...))` and surfaced as an opaque internal error.

This walls the pattern off explicitly:

- `pod_manager.create_conversation` and `add_message_to_conversation` return a typed MCPError when the call originates from a sandbox-function run context, pointing at the supported alternatives (link users into a conversation from the Frame, or use a wakeup/trigger running the agent in a normal conversation).
- `runAgent` (shared by `run_agent` and `agent_delegation`) returns the same typed refusal for sandbox-function contexts instead of tripping the assert.
- Read-only tools (`list_conversations`) stay available to functions.

The guard lives in `mcp_internal_actions/utils.ts` next to `workspaceAdminGuard`.

## Tests

Added tests: both denials from a sandbox-function run context, `list_conversations` still listing pod conversations from that context, and `runAgent` returning the typed refusal instead of an assertion failure. Existing pod_manager tests pass.

## Risk

Pod functions that relied on spawning conversations or invoking agents will now get an explicit error instead of partially working. Known dependents are already degraded in prod; the error message tells the caller what to do instead. Safe to rollback.

## Deploy Plan

Standard deploy.