### PR TITLE
fix(dust-hive): create missing front ES indices on first warm

### DIFF
--- a/x/henry/dust-hive/src/lib/init.ts
+++ b/x/henry/dust-hive/src/lib/init.ts
@@ -206,7 +206,9 @@ async function initElasticsearchTS(
   envVars: Record<string, string>
 ): Promise<boolean> {
   const indices = [
+    { name: "agent_document_outputs", version: "1" },
     { name: "agent_message_analytics", version: "2" },
+    { name: "agent_message_consumption_analytics", version: "1" },
     { name: "user_search", version: "1" },
   ];
 


### PR DESCRIPTION
## Description

The hardcoded front index list in `initElasticsearchTS` hadn't been touched since dust-hive creation, so new envs never got `front.agent_document_outputs` or `front.agent_message_consumption_analytics`. Added both.

## Tests

By hand

## Risk

None

## Deploy Plan

Nothing to deploy.