### PR TITLE
[front] feat: classify Pod function exec timeouts as invocation_timeout

### DIFF
--- a/front/lib/api/sandbox/provider.ts
+++ b/front/lib/api/sandbox/provider.ts
@@ -111,6 +111,18 @@ export class SandboxNotFoundError extends Error {
   }
 }
 
+/**
+ * Returned when a command ran past the timeout the caller handed to exec/execRoot. Carries the
+ * budget so callers can name it instead of forwarding provider SDK text (which suggests SDK
+ * options only Dust platform code could act on) to their own callers.
+ */
+export class SandboxExecTimeoutError extends Error {
+  constructor(readonly timeoutMs: number) {
+    super(`Sandbox command did not finish within ${timeoutMs}ms.`);
+    this.name = "SandboxExecTimeoutError";
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Provider interface
 // ---------------------------------------------------------------------------

--- a/front/lib/api/sandbox/provider.ts
+++ b/front/lib/api/sandbox/provider.ts
@@ -123,6 +123,12 @@ export class SandboxExecTimeoutError extends Error {
   }
 }
 
+export function isSandboxExecTimeoutError(
+  error: unknown
+): error is SandboxExecTimeoutError {
+  return error instanceof SandboxExecTimeoutError;
+}
+
 // ---------------------------------------------------------------------------
 // Provider interface
 // ---------------------------------------------------------------------------

--- a/front/lib/api/sandbox/providers/e2b.test.ts
+++ b/front/lib/api/sandbox/providers/e2b.test.ts
@@ -86,7 +86,7 @@ import {
   SANDBOX_AGENT_SERVICE_HOME,
   SANDBOX_ROOT_SAFE_PATH,
 } from "../hardening";
-import { SandboxExecTimeoutError } from "../provider";
+import { isSandboxExecTimeoutError } from "../provider";
 import { rootCommand } from "../root_command";
 import { E2BSandboxProvider } from "./e2b";
 
@@ -626,8 +626,7 @@ describe("E2BSandboxProvider", () => {
     if (result.isOk()) {
       throw new Error("expected an error");
     }
-    expect(result.error).toBeInstanceOf(SandboxExecTimeoutError);
-    if (!(result.error instanceof SandboxExecTimeoutError)) {
+    if (!isSandboxExecTimeoutError(result.error)) {
       throw new Error("expected a SandboxExecTimeoutError");
     }
     expect(result.error.timeoutMs).toBe(10_000);
@@ -655,7 +654,7 @@ describe("E2BSandboxProvider", () => {
     if (result.isOk()) {
       throw new Error("expected an error");
     }
-    if (!(result.error instanceof SandboxExecTimeoutError)) {
+    if (!isSandboxExecTimeoutError(result.error)) {
       throw new Error("expected a SandboxExecTimeoutError");
     }
     expect(result.error.timeoutMs).toBe(60_000);

--- a/front/lib/api/sandbox/providers/e2b.test.ts
+++ b/front/lib/api/sandbox/providers/e2b.test.ts
@@ -64,9 +64,12 @@ vi.mock("e2b", () => {
 
   class NotFoundError extends Error {}
 
+  class TimeoutError extends Error {}
+
   return {
     CommandExitError,
     NotFoundError,
+    TimeoutError,
     Sandbox: {
       connect: mockConnect,
       create: mockCreate,
@@ -75,7 +78,7 @@ vi.mock("e2b", () => {
   };
 });
 
-import { CommandExitError, NotFoundError } from "e2b";
+import { CommandExitError, NotFoundError, TimeoutError } from "e2b";
 
 import {
   SANDBOX_AGENT_PROXIED_SAFE_PATH,
@@ -83,6 +86,7 @@ import {
   SANDBOX_AGENT_SERVICE_HOME,
   SANDBOX_ROOT_SAFE_PATH,
 } from "../hardening";
+import { SandboxExecTimeoutError } from "../provider";
 import { rootCommand } from "../root_command";
 import { E2BSandboxProvider } from "./e2b";
 
@@ -597,6 +601,64 @@ describe("E2BSandboxProvider", () => {
     expect(mockCommandHandleWait).toHaveBeenCalledTimes(1);
     expect(mockHandleKill).not.toHaveBeenCalled();
     expect(mockCloseStdin).not.toHaveBeenCalled();
+  });
+
+  it("returns a typed timeout error carrying the budget when a command runs past it", async () => {
+    mockCommandHandleWait.mockRejectedValueOnce(
+      new TimeoutError(
+        "[deadline_exceeded] the operation timed out: This error is likely due to exceeding " +
+          "'timeoutMs'. You can pass the timeout value in 'timeoutMs' when making the request."
+      )
+    );
+    const provider = new E2BSandboxProvider({
+      apiKey: "api-key",
+      domain: undefined,
+    });
+
+    const result = await provider.exec(
+      "provider-id",
+      "/opt/bin/dsbx function run slow-function",
+      { timeoutMs: 10_000, user: "agent-proxied" },
+      { workspaceId: "workspace-id" }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("expected an error");
+    }
+    expect(result.error).toBeInstanceOf(SandboxExecTimeoutError);
+    if (!(result.error instanceof SandboxExecTimeoutError)) {
+      throw new Error("expected a SandboxExecTimeoutError");
+    }
+    expect(result.error.timeoutMs).toBe(10_000);
+    // The SDK's advice ("pass 'timeoutMs'") targets this file, not our callers.
+    expect(result.error.message).not.toContain("timeoutMs");
+  });
+
+  it("reports the SDK's own default budget when a command without timeoutMs times out", async () => {
+    mockCommandHandleWait.mockRejectedValueOnce(
+      new TimeoutError("[deadline_exceeded] the operation timed out")
+    );
+    const provider = new E2BSandboxProvider({
+      apiKey: "api-key",
+      domain: undefined,
+    });
+
+    const result = await provider.exec(
+      "provider-id",
+      "/opt/bin/dsbx function run slow-function",
+      { user: "agent-proxied" },
+      { workspaceId: "workspace-id" }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("expected an error");
+    }
+    if (!(result.error instanceof SandboxExecTimeoutError)) {
+      throw new Error("expected a SandboxExecTimeoutError");
+    }
+    expect(result.error.timeoutMs).toBe(60_000);
   });
 
   describe("connection reuse", () => {

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -21,6 +21,7 @@ import type {
 } from "@app/lib/api/sandbox/provider";
 import {
   isSandboxExecUser,
+  SandboxExecTimeoutError,
   SandboxNotFoundError,
   traceSandboxOperation,
 } from "@app/lib/api/sandbox/provider";
@@ -36,7 +37,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { CommandHandle } from "e2b";
-import { CommandExitError, NotFoundError, Sandbox } from "e2b";
+import { CommandExitError, NotFoundError, Sandbox, TimeoutError } from "e2b";
 
 const ONE_HOUR_MS = 60 * 60 * 1_000;
 
@@ -50,6 +51,13 @@ const SANDBOX_LIFETIME_MS = 24 * ONE_HOUR_MS;
 
 /** Timeout for individual API calls to E2B (create, connect, etc.). */
 const REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * The E2B SDK's own command timeout when the caller passes no `timeoutMs`
+ * (`Commands.defaultProcessConnectionTimeout`). Only used to report the budget a command that
+ * timed out without an explicit `timeoutMs` was actually running under.
+ */
+const E2B_DEFAULT_COMMAND_TIMEOUT_MS = 60_000;
 const LOCAL_ACCOUNT_HARDENING_TIMEOUT_MS = 120_000;
 
 /**
@@ -565,6 +573,16 @@ export class E2BSandboxProvider implements SandboxProvider {
               stdout: err.stdout,
               stderr: err.stderr,
             });
+          }
+          // The SDK throws TimeoutError when the command runs past its `timeoutMs`. Keep the
+          // classification (and the budget) instead of erasing it into a generic Error whose
+          // message carries SDK advice ("pass 'timeoutMs'") that only this file could act on.
+          if (err instanceof TimeoutError) {
+            return new Err(
+              new SandboxExecTimeoutError(
+                commandOpts.timeoutMs ?? E2B_DEFAULT_COMMAND_TIMEOUT_MS
+              )
+            );
           }
           return new Err(normalizeError(err));
         }

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -2,6 +2,7 @@ import { formatSandboxFunctionInvocations } from "@app/lib/api/actions/servers/s
 import { generateSandboxFunctionInvocationToken } from "@app/lib/api/sandbox/access_tokens";
 import { SandboxNotRunningError } from "@app/lib/api/sandbox/errors";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import { SandboxExecTimeoutError } from "@app/lib/api/sandbox/provider";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
 import type { NormalizedSandboxFunctionOutcome } from "@app/lib/api/sandbox_functions/result_envelope";
 import { Authenticator } from "@app/lib/auth";
@@ -1091,6 +1092,54 @@ describe("SandboxFunctionInvocationResource", () => {
       code: "invocation_failed",
       message: "function produced no output",
     });
+  });
+
+  it("classifies a provider exec timeout as invocation_timeout naming the budgets", async () => {
+    const { authenticator, sandboxFunction, sandbox, invocation } =
+      await setupExecutionTest();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Err(new SandboxExecTimeoutError(120_000))
+    );
+
+    // The invocation ran and timed out: the outcome is recorded here, not returned as an error
+    // for the caller (or a workflow retry) to re-run a function that may have written already.
+    const executionResult = await invocation.execute(authenticator);
+    expect(executionResult.isOk()).toBe(true);
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.status).toBe("errored");
+    expect(refetched?.error).toEqual({
+      code: "invocation_timeout",
+      message:
+        "The Pod function did not return within 120s: fast functions must return within 10s " +
+        "and durable functions within 120s. Reduce the work, or split it into a durable " +
+        "refresh and a fast read.",
+    });
+  });
+
+  it("returns non-timeout exec failures to the caller unclassified", async () => {
+    const { authenticator, sandboxFunction, sandbox, invocation } =
+      await setupExecutionTest();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Err(new Error("connection reset"))
+    );
+
+    const executionResult = await invocation.execute(authenticator);
+    expect(executionResult.isErr()).toBe(true);
+    if (executionResult.isOk()) {
+      throw new Error("expected an error");
+    }
+    expect(executionResult.error.message).toBe("connection reset");
+
+    // The caller owns the terminal transition on this path.
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.status).toBe("created");
   });
 });
 

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -15,6 +15,7 @@ import {
 import { isSandboxNotRunningError } from "@app/lib/api/sandbox/errors";
 import { recordSandboxFunctionRun } from "@app/lib/api/sandbox/instrumentation";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import { SandboxExecTimeoutError } from "@app/lib/api/sandbox/provider";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import { podDatabasePrefixFromSlug } from "@app/lib/api/sandbox_functions/db_naming";
 import { SandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
@@ -709,19 +710,42 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
           status: "error",
           durationMs: Date.now() - execStartedAtMs,
         });
-        if (inline) {
-          // An inline exec that fails is usually one that ran past its ceiling, but nothing in the
-          // provider result says so: the timeout is handed to the sandbox provider and comes back
-          // as an ordinary failure. Log the whole class rather than guess, so we can see how often
-          // a fast function is simply too slow before deciding whether that should move it to
-          // durable the way a refused tool call does.
+        // The provider reports a command that ran past the budget this call handed it as a typed
+        // timeout. The function ran (and may already have written to pod state), so record the
+        // terminal outcome here with a stable code and a message naming the real ceilings,
+        // instead of forwarding provider SDK text to callers and frames.
+        if (execResult.error instanceof SandboxExecTimeoutError) {
           logger.info(
             {
               workspaceId: auth.getNonNullableWorkspace().sId,
               sandboxFunctionId: sandboxFunction.sId,
               slug: sandboxFunction.slug,
               invocationId: this.sId,
-              timeoutMs: SANDBOX_FUNCTION_INLINE_EXEC_TIMEOUT_MS,
+              inline,
+              timeoutMs: execResult.error.timeoutMs,
+            },
+            "Pod function execution timed out"
+          );
+          await this.fail({
+            code: "invocation_timeout",
+            message:
+              `The Pod function did not return within ${Math.round(execResult.error.timeoutMs / 1000)}s: ` +
+              `fast functions must return within ${SANDBOX_FUNCTION_INLINE_EXEC_TIMEOUT_MS / 1000}s ` +
+              `and durable functions within ${SANDBOX_FUNCTION_EXEC_TIMEOUT_MS / 1000}s. ` +
+              "Reduce the work, or split it into a durable refresh and a fast read.",
+          });
+          return new Ok(undefined);
+        }
+        if (inline) {
+          // Timeouts are classified above, so what lands here is the rest of the exec-failure
+          // class. Log it so we can see what else makes inline invocations fail before deciding
+          // whether anything should move to durable the way a refused tool call does.
+          logger.info(
+            {
+              workspaceId: auth.getNonNullableWorkspace().sId,
+              sandboxFunctionId: sandboxFunction.sId,
+              slug: sandboxFunction.slug,
+              invocationId: this.sId,
               error: execResult.error.message,
             },
             "Inline Pod function execution failed"

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -15,7 +15,7 @@ import {
 import { isSandboxNotRunningError } from "@app/lib/api/sandbox/errors";
 import { recordSandboxFunctionRun } from "@app/lib/api/sandbox/instrumentation";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
-import { SandboxExecTimeoutError } from "@app/lib/api/sandbox/provider";
+import { isSandboxExecTimeoutError } from "@app/lib/api/sandbox/provider";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import { podDatabasePrefixFromSlug } from "@app/lib/api/sandbox_functions/db_naming";
 import { SandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
@@ -714,7 +714,7 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         // timeout. The function ran (and may already have written to pod state), so record the
         // terminal outcome here with a stable code and a message naming the real ceilings,
         // instead of forwarding provider SDK text to callers and frames.
-        if (execResult.error instanceof SandboxExecTimeoutError) {
+        if (isSandboxExecTimeoutError(execResult.error)) {
           logger.info(
             {
               workspaceId: auth.getNonNullableWorkspace().sId,

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -105,6 +105,7 @@ export const SANDBOX_FUNCTION_RUNNER_ERROR_CODES = [
 // upstream classification to forward.
 type SandboxFunctionFrontErrorCode =
   | "invocation_failed"
+  | "invocation_timeout"
   | "transport_error"
   | "not_supported";
 


### PR DESCRIPTION
## Description

A Pod function invocation that ran past its exec budget was failed with the raw E2B SDK message ("This error is likely due to exceeding 'timeoutMs'. You can pass the timeout value in 'timeoutMs' when making the request. Use '0' to disable the timeout."), advice only platform code can act on, stored verbatim and rendered on user-facing Frame error cards.

- E2B provider: catch the SDK's `TimeoutError` in `runCommand` and return a typed `SandboxExecTimeoutError` carrying the budget the command actually ran under, instead of erasing it through `normalizeError`.
- `SandboxFunctionInvocationResource.execute()`: on a typed timeout, record the terminal outcome with a stable `invocation_timeout` code and a message naming the real ceilings (fast functions must return within 10s, durable within 120s, reduce the work or split it). The invocation ran and may have written to pod state, so it is failed rather than returned as an error for a retry path to re-run.
- Add `invocation_timeout` to the front error code union.

## Tests

Added provider tests (TimeoutError maps to the typed error with explicit and SDK-default budgets) and resource tests (timeout classifies as `invocation_timeout` with the budget message, non-timeout exec failures still return to the caller unclassified).

## Risk

Low. Messages only get shorter and gain a stable code; frames treat error codes as open strings. Behavior change: a timed-out durable invocation no longer throws out of the workflow activity after being failed, it is recorded terminal directly (retrying an invocation that already ran could repeat its writes, and the retry would skip on terminal status anyway).

## Deploy Plan

Standard deploy.