### PR TITLE
[front] feat: add output_truncated and output_too_large runner error codes

### DIFF
--- a/cli/dust-sandbox/functions-runner/protocol.ts
+++ b/cli/dust-sandbox/functions-runner/protocol.ts
@@ -27,6 +27,14 @@ export const RUNNER_ERROR_CODES = [
   // invoke(): the function is at its concurrency limit and the invocation
   // was refused before anything executed.
   "overloaded",
+  // Minted by dsbx (src/commands/function/run.rs), never by this runner: the
+  // runner's stdout envelope was cut mid-JSON in transit, so the function ran
+  // but its result was lost. Listed here so front's mirror of the wire enum
+  // stays a single aligned list.
+  "output_truncated",
+  // The serialized result exceeds the hard size cap; the function must store
+  // large data in a pod file or database and return a pointer instead.
+  "output_too_large",
 ] as const;
 
 export type ErrorCode = (typeof RUNNER_ERROR_CODES)[number];

--- a/front/lib/api/sandbox_functions/result_delivery.test.ts
+++ b/front/lib/api/sandbox_functions/result_delivery.test.ts
@@ -53,6 +53,37 @@ describe("parseStdoutResultEnvelope", () => {
     });
   });
 
+  it("preserves the output_truncated code dsbx mints for a cut envelope", () => {
+    expect(
+      parseStdoutResultEnvelope(
+        JSON.stringify({
+          protocolVersion: 3,
+          delivery: "stdout",
+          outcome: {
+            ok: false,
+            error: {
+              code: "output_truncated",
+              message:
+                "function output was truncated in transit (read 2097152 bytes, runner exit 0); " +
+                "return a smaller payload or write large data to a pod file",
+            },
+          },
+        })
+      )
+    ).toEqual({
+      outcome: {
+        ok: false,
+        error: {
+          code: "output_truncated",
+          message:
+            "function output was truncated in transit (read 2097152 bytes, runner exit 0); " +
+            "return a smaller payload or write large data to a pod file",
+        },
+      },
+      timings: null,
+    });
+  });
+
   it("returns invocation_failed for empty or non-JSON stdout", () => {
     expect(parseStdoutResultEnvelope("")).toMatchObject({
       outcome: { ok: false, error: { code: "invocation_failed" } },

--- a/front/lib/api/sandbox_functions/result_envelope.test.ts
+++ b/front/lib/api/sandbox_functions/result_envelope.test.ts
@@ -45,6 +45,56 @@ describe("normalizeSandboxFunctionResult", () => {
     });
   });
 
+  it("preserves the large-output error codes from a protocol v3 failure envelope", () => {
+    expect(
+      normalizeSandboxFunctionResult({
+        protocolVersion: 3,
+        delivery: "stdout",
+        outcome: {
+          ok: false,
+          error: {
+            code: "output_truncated",
+            message:
+              "function output was truncated in transit (read 2097152 bytes, runner exit 0); " +
+              "return a smaller payload or write large data to a pod file",
+          },
+        },
+      })
+    ).toEqual({
+      ok: false,
+      error: {
+        code: "output_truncated",
+        message:
+          "function output was truncated in transit (read 2097152 bytes, runner exit 0); " +
+          "return a smaller payload or write large data to a pod file",
+      },
+    });
+
+    expect(
+      normalizeSandboxFunctionResult({
+        protocolVersion: 3,
+        delivery: "stdout",
+        outcome: {
+          ok: false,
+          error: {
+            code: "output_too_large",
+            message:
+              "function result is 6291456 bytes, over the 5242880-byte limit; " +
+              "store large data in a pod file or database and return a pointer to it",
+          },
+        },
+      })
+    ).toEqual({
+      ok: false,
+      error: {
+        code: "output_too_large",
+        message:
+          "function result is 6291456 bytes, over the 5242880-byte limit; " +
+          "store large data in a pod file or database and return a pointer to it",
+      },
+    });
+  });
+
   it("accepts dsbx-minted invocation_failed codes in a protocol v3 outcome", () => {
     expect(
       normalizeSandboxFunctionResult({

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -99,6 +99,13 @@ export const SANDBOX_FUNCTION_RUNNER_ERROR_CODES = [
   // Emitted by the warm server's admission layer when the function is at its
   // concurrency limit and the invocation was refused before anything ran.
   "overloaded",
+  // Minted by dsbx's run wrapper when the runner's stdout envelope was cut
+  // mid-JSON in transit, so the function ran but its result was lost.
+  "output_truncated",
+  // Emitted by the runner when the serialized result exceeds the hard size
+  // cap; the function must store large data in a pod file or database and
+  // return a pointer instead.
+  "output_too_large",
 ] as const;
 
 // Codes minted by front, for failures that happen outside the runner and therefore have no


### PR DESCRIPTION
## Description

Two new stable codes in `SANDBOX_FUNCTION_RUNNER_ERROR_CODES` (and the runner protocol mirror, which is pinned to it by test):

- `output_truncated`: the runner's stdout envelope was cut mid-JSON in transit, so the function ran but its result was lost.
- `output_too_large`: the serialized result exceeds the hard size cap.

Front accepts and preserves these codes through result normalization today; the dsbx-side emitters ship separately and must not reach an image before this is deployed.

## Tests

Normalization tests for both codes in `result_envelope.test.ts` / `result_delivery.test.ts`.

## Risk

Low: additive enum entries, no behavior change until dsbx emits them.

## Deploy Plan

Standard deploy. Must be live before the dsbx release that emits these codes bumps `DSBX_CLI_VERSION`.