### PR TITLE
[front] feat: add Apps tab to Pods

### DIFF
--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -121,7 +121,7 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_metadata", () => {
       lastTodoAnalysisAt: null,
       pinnedFramePath: null,
       frameTabs: [],
-      tabsOrder: ["conversations", "tasks", "files", "connected_data"],
+      tabsOrder: ["conversations", "tasks", "files", "apps", "connected_data"],
       sId: expect.anything(),
       spaceId: space.sId,
       todoGenerationEnabled: false,

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/index.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/index.test.ts
@@ -1,0 +1,269 @@
+import type { Authenticator } from "@app/lib/auth";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { frameContentType, sandboxFunctionContentType } from "@app/types/files";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/lock", () => ({
+  executeWithLock: vi.fn(async (_lockName: string, fn: () => unknown) => fn()),
+}));
+
+const EMPTY_SCHEMA = { type: "object", properties: {} } as const;
+
+async function setupPod() {
+  const { workspace, user, auth } = await createPrivateApiMockRequest({
+    role: "admin",
+  });
+  const pod = await SpaceFactory.project(workspace, user.id);
+
+  return { workspace, user, auth, pod };
+}
+
+/**
+ * A GCS object as the pod file-system backend sees it. The backend lists recursively, so folder
+ * placeholders (names ending in `/`) are what make a directory exist.
+ */
+function gcsObject(
+  workspaceId: string,
+  podId: string,
+  relPath: string,
+  contentType = "text/plain"
+) {
+  return {
+    name: `w/${workspaceId}/pods/${podId}/files/${relPath}`,
+    metadata: {
+      contentType,
+      size: "100",
+      updated: new Date().toISOString(),
+    },
+  };
+}
+
+async function publishFunction(
+  authenticator: Authenticator,
+  pod: SpaceResource,
+  { slug, fileName }: { slug: string; fileName: string }
+) {
+  const file = await FileFactory.create(authenticator, null, {
+    contentType: sandboxFunctionContentType,
+    fileName,
+    fileSize: 100,
+    status: "created",
+    useCase: "project_context",
+    useCaseMetadata: { spaceId: pod.sId },
+  });
+
+  return SandboxFunctionResource.makeNew(authenticator, {
+    space: pod,
+    file,
+    slug,
+    description: `Function ${slug}.`,
+    inputSchema: EMPTY_SCHEMA,
+    outputSchema: EMPTY_SCHEMA,
+  });
+}
+
+describe("GET /api/w/:wId/pods/:podId/apps", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fileStorageMock.reset();
+  });
+
+  it("returns an empty list for a Pod with no app", async () => {
+    const { workspace, pod } = await setupPod();
+
+    const res = await honoApp.request(
+      `/api/w/${workspace.sId}/pods/${pod.sId}/apps`
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.apps).toEqual([]);
+  });
+
+  it("lists an app with its Frame, functions and databases joined on the app prefix", async () => {
+    const { workspace, pod, auth } = await setupPod();
+
+    fileStorageMock.setFilesByPrefix(() => [
+      gcsObject(workspace.sId, pod.sId, "TaskList/"),
+      gcsObject(workspace.sId, pod.sId, "TaskList/functions/"),
+      gcsObject(
+        workspace.sId,
+        pod.sId,
+        "TaskList/TaskList.tsx",
+        frameContentType
+      ),
+      gcsObject(workspace.sId, pod.sId, "TaskList/functions/add-task.ts"),
+    ]);
+    fileStorageMock.setSubdirectoryNames(() => ["tasklist__tasks.db"]);
+
+    await publishFunction(auth, pod, {
+      slug: "tasklist__add-task",
+      fileName: "add-task.ts",
+    });
+
+    const res = await honoApp.request(
+      `/api/w/${workspace.sId}/pods/${pod.sId}/apps`
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.apps).toHaveLength(1);
+
+    const [app] = body.apps;
+    expect(app.prefix).toBe("tasklist");
+    expect(app.name).toBe("TaskList");
+    expect(app.folderPath).toBe(`pod-${pod.sId}/TaskList`);
+    // The app is the surrounding context, so names show bare while the addressable full
+    // slug/on-disk name is still carried on the wire.
+    expect(app.functions).toEqual([
+      expect.objectContaining({
+        slug: "tasklist__add-task",
+        name: "add-task",
+      }),
+    ]);
+    expect(app.databases).toEqual([
+      { name: "tasks", onDiskName: "tasklist__tasks" },
+    ]);
+    expect(app.frames).toHaveLength(1);
+    expect(app.frames[0].fileName).toBe("TaskList.tsx");
+    expect(app.fileCount).toBe(2);
+  });
+
+  it("attributes a database created before app namespacing via its schema file", async () => {
+    const { workspace, pod } = await setupPod();
+
+    fileStorageMock.setFilesByPrefix(() => [
+      gcsObject(workspace.sId, pod.sId, "ProductManager/"),
+      gcsObject(
+        workspace.sId,
+        pod.sId,
+        "ProductManager/databases/products.db.ts"
+      ),
+    ]);
+    // Bare filename, so the name alone cannot say which app owns it.
+    fileStorageMock.setSubdirectoryNames(() => ["products.db"]);
+
+    const res = await honoApp.request(
+      `/api/w/${workspace.sId}/pods/${pod.sId}/apps`
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.apps).toHaveLength(1);
+    expect(body.apps[0].prefix).toBe("productmanager");
+    expect(body.apps[0].databases).toEqual([
+      { name: "products", onDiskName: "products" },
+    ]);
+  });
+
+  it("leaves an unprefixed database no app declares in the unfiled app", async () => {
+    const { workspace, pod } = await setupPod();
+
+    fileStorageMock.setSubdirectoryNames(() => ["orphaned.db"]);
+
+    const res = await honoApp.request(
+      `/api/w/${workspace.sId}/pods/${pod.sId}/apps`
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.apps).toHaveLength(1);
+    expect(body.apps[0].prefix).toBe("");
+    expect(body.apps[0].databases).toEqual([
+      { name: "orphaned", onDiskName: "orphaned" },
+    ]);
+  });
+
+  it("ignores a pod-root folder that is not app-shaped", async () => {
+    const { workspace, pod } = await setupPod();
+
+    fileStorageMock.setFilesByPrefix(() => [
+      gcsObject(workspace.sId, pod.sId, "Documents/"),
+      gcsObject(workspace.sId, pod.sId, "Documents/notes.md"),
+    ]);
+
+    const res = await honoApp.request(
+      `/api/w/${workspace.sId}/pods/${pod.sId}/apps`
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.apps).toEqual([]);
+  });
+
+  it("collects artifacts published from the Pod root into the unfiled app", async () => {
+    const { workspace, pod, auth } = await setupPod();
+
+    await publishFunction(auth, pod, {
+      slug: "orphan",
+      fileName: "orphan.ts",
+    });
+
+    const res = await honoApp.request(
+      `/api/w/${workspace.sId}/pods/${pod.sId}/apps`
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.apps).toHaveLength(1);
+    expect(body.apps[0].prefix).toBe("");
+    expect(body.apps[0].name).toBeNull();
+    expect(
+      body.apps[0].functions.map((fn: { slug: string }) => fn.slug)
+    ).toEqual(["orphan"]);
+  });
+
+  it("reports folders that normalize onto the same app prefix as one colliding app", async () => {
+    const { workspace, pod, auth } = await setupPod();
+
+    fileStorageMock.setFilesByPrefix(() => [
+      gcsObject(workspace.sId, pod.sId, "Task List/"),
+      gcsObject(workspace.sId, pod.sId, "Task List/functions/"),
+      gcsObject(workspace.sId, pod.sId, "Task-List/"),
+      gcsObject(workspace.sId, pod.sId, "Task-List/functions/"),
+    ]);
+
+    await publishFunction(auth, pod, {
+      slug: "task-list__add-task",
+      fileName: "add-task.ts",
+    });
+
+    const res = await honoApp.request(
+      `/api/w/${workspace.sId}/pods/${pod.sId}/apps`
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.apps).toHaveLength(1);
+    expect(body.apps[0].prefix).toBe("task-list");
+    expect(body.apps[0].collidingFolderNames.sort()).toEqual([
+      "Task List",
+      "Task-List",
+    ]);
+  });
+
+  it("still lists an app whose folder is gone but whose functions are published", async () => {
+    const { workspace, pod, auth } = await setupPod();
+
+    await publishFunction(auth, pod, {
+      slug: "ghostapp__list",
+      fileName: "list.ts",
+    });
+
+    const res = await honoApp.request(
+      `/api/w/${workspace.sId}/pods/${pod.sId}/apps`
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.apps).toHaveLength(1);
+    expect(body.apps[0].prefix).toBe("ghostapp");
+    expect(body.apps[0].folderPath).toBeNull();
+  });
+});

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/index.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/index.ts
@@ -1,0 +1,34 @@
+import { listPodApps } from "@app/lib/api/projects/apps";
+import type { GetPodAppsResponseBody } from "@app/types/api/pod_apps";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { withSpace } from "@front-api/middlewares/with_space";
+
+// Mounted under /api/w/:wId/pods/:podId/apps.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  withSpace({ requireCanRead: true, routeParam: "podId" }),
+  async (ctx): HandlerResult<GetPodAppsResponseBody> => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
+
+    const appsResult = await listPodApps(auth, space);
+    if (appsResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: appsResult.error.message,
+        },
+      });
+    }
+
+    return ctx.json({ apps: appsResult.value });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/pods/[podId]/index.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/index.ts
@@ -1,8 +1,11 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
+
+import apps from "./apps";
 import tasks from "./tasks";
 
 const app = workspaceApp();
 
+app.route("/apps", apps);
 app.route("/tasks", tasks);
 
 export default app;

--- a/front/components/pages/pod/PodPage.tsx
+++ b/front/components/pages/pod/PodPage.tsx
@@ -34,6 +34,7 @@ import {
   NavTabPill,
   NavTabPillList,
   NavTabPillTrigger,
+  PuzzlePiece01,
   Settings01,
   Spinner,
 } from "@dust-tt/sparkle";
@@ -52,6 +53,10 @@ const SYSTEM_TAB_TRIGGERS = {
     label: "Files",
     icon: Folder,
   },
+  apps: {
+    label: "Apps",
+    icon: PuzzlePiece01,
+  },
   connected_data: {
     label: "Connected Data",
     icon: CloudArrowLeftRight,
@@ -64,6 +69,7 @@ export function PodPage() {
   const { hasFeature } = useFeatureFlags();
   const podId = useActivePodId();
   const hasFrameTabs = hasFeature("pod_frame_tabs");
+  const hasApps = hasFeature("sandbox_functions");
   const [editingFrameTab, setEditingFrameTab] = useState<PodFrameTab | null>(
     null
   );
@@ -111,14 +117,17 @@ export function PodPage() {
     [frameTabs, hasFrameTabs, podInfo?.tabsOrder]
   );
 
-  const includeConnectedData = !!podInfo?.isAdminControlled;
+  const navVisibility = useMemo(
+    () => ({
+      includeConnectedData: !!podInfo?.isAdminControlled,
+      includeApps: hasApps,
+    }),
+    [podInfo?.isAdminControlled, hasApps]
+  );
 
   const navItemsBeforeSettings = useMemo(
-    () =>
-      buildPodNavItemsBeforeSettings(frameTabs, tabsOrder, {
-        includeConnectedData,
-      }),
-    [frameTabs, tabsOrder, includeConnectedData]
+    () => buildPodNavItemsBeforeSettings(frameTabs, tabsOrder, navVisibility),
+    [frameTabs, tabsOrder, navVisibility]
   );
 
   // Drop frame-tab selection when the flag is off or the tab was removed
@@ -249,7 +258,7 @@ export function PodPage() {
           frameTabs={frameTabs}
           tabsOrder={tabsOrder}
           isEditor={podInfo.isEditor}
-          includeConnectedData={includeConnectedData}
+          navVisibility={navVisibility}
           tab={editingFrameTab}
           isOpen
           onClose={() => setEditingFrameTab(null)}

--- a/front/components/pod/PodPageContent.tsx
+++ b/front/components/pod/PodPageContent.tsx
@@ -1,5 +1,6 @@
 import type { TaskOwnerFilter } from "@app/components/assistant/conversation/space/conversations/project_tasks/projectTasksListScope";
 import { ManageUsersPanel } from "@app/components/assistant/conversation/space/ManageUsersPanel";
+import { PodAppsTab } from "@app/components/pod/apps/PodAppsTab";
 import { PodConnectedDataTab } from "@app/components/pod/connected_data/PodConnectedDataTab";
 import { PodConversationsTab } from "@app/components/pod/conversation/PodConversationsTab";
 import { PodFilesTab } from "@app/components/pod/files/PodFilesTab";
@@ -218,6 +219,9 @@ export function PodPageContent({
       </NavTabPillContent>
       <NavTabPillContent value="files">
         <PodFilesTab owner={owner} pod={podInfo} />
+      </NavTabPillContent>
+      <NavTabPillContent value="apps">
+        <PodAppsTab owner={owner} pod={podInfo} />
       </NavTabPillContent>
       {podInfo.isAdminControlled && (
         <NavTabPillContent value="connected_data">

--- a/front/components/pod/apps/PodAppDetail.tsx
+++ b/front/components/pod/apps/PodAppDetail.tsx
@@ -1,0 +1,135 @@
+import type { PodApp, PodAppFrame } from "@app/types/api/pod_apps";
+import {
+  Button,
+  Chip,
+  ContentMessage,
+  Eye,
+  ScrollArea,
+} from "@dust-tt/sparkle";
+
+interface PodAppDetailProps {
+  app: PodApp;
+  onOpenFrame: (frame: PodAppFrame) => void;
+}
+
+interface DetailSectionProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+function DetailSection({ title, children }: DetailSectionProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="label-xs uppercase text-muted-foreground dark:text-muted-foreground-night">
+        {title}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+interface EmptySectionTextProps {
+  children: React.ReactNode;
+}
+
+function EmptySectionText({ children }: EmptySectionTextProps) {
+  return (
+    <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+      {children}
+    </span>
+  );
+}
+
+export function PodAppDetail({ app, onOpenFrame }: PodAppDetailProps) {
+  return (
+    <ScrollArea className="h-full">
+      <div className="flex flex-col gap-6 px-6 py-5">
+        <div className="flex flex-col gap-1">
+          <h3 className="heading-lg">{app.name ?? "Unfiled"}</h3>
+          <span className="copy-xs text-muted-foreground dark:text-muted-foreground-night">
+            {app.folderPath ??
+              "Published from the Pod root, so these are not owned by an app folder."}
+          </span>
+        </div>
+
+        {app.collidingFolderNames.length > 0 && (
+          <ContentMessage variant="warning" title="Colliding app folders">
+            {app.collidingFolderNames.join(", ")} all resolve to the same app
+            name (<span className="font-mono">{app.prefix}</span>), so they
+            share these published functions and databases. Rename all but one,
+            then re-publish its functions.
+          </ContentMessage>
+        )}
+
+        <DetailSection title="Frames">
+          {app.frames.length === 0 ? (
+            <EmptySectionText>No Frame in this app.</EmptySectionText>
+          ) : (
+            <div className="flex flex-col gap-1">
+              {app.frames.map((frame) => (
+                <div key={frame.path} className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="xs"
+                    icon={Eye}
+                    label={frame.fileName}
+                    // A Frame source with no FileResource row has no content to render.
+                    disabled={!frame.fileId}
+                    tooltip={
+                      frame.fileId
+                        ? "Open Frame"
+                        : "This Frame cannot be opened"
+                    }
+                    onClick={() => onOpenFrame(frame)}
+                  />
+                  {frame.isPublished ? (
+                    <Chip size="xs" color="success" label="Published" />
+                  ) : (
+                    <Chip size="xs" color="primary" label="Not published" />
+                  )}
+                  {frame.isPinnedAsTab && (
+                    <Chip size="xs" color="info" label="Pinned as tab" />
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </DetailSection>
+
+        <DetailSection title="Functions">
+          {app.functions.length === 0 ? (
+            <EmptySectionText>No published function.</EmptySectionText>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {app.functions.map((fn) => (
+                <div key={fn.slug} className="flex flex-col gap-0.5">
+                  <div className="flex items-center gap-2">
+                    <span className="copy-sm font-mono">{fn.name}</span>
+                    <Chip size="xs" color="primary" label={fn.executionMode} />
+                  </div>
+                  <span className="copy-xs text-muted-foreground dark:text-muted-foreground-night">
+                    {fn.description}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </DetailSection>
+
+        <DetailSection title="Databases">
+          {app.databases.length === 0 ? (
+            <EmptySectionText>No database.</EmptySectionText>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {app.databases.map((db) => (
+                <span key={db.onDiskName} className="copy-sm font-mono">
+                  {db.name}
+                </span>
+              ))}
+            </div>
+          )}
+        </DetailSection>
+      </div>
+    </ScrollArea>
+  );
+}

--- a/front/components/pod/apps/PodAppList.tsx
+++ b/front/components/pod/apps/PodAppList.tsx
@@ -1,0 +1,93 @@
+import type { CustomResourceIconType } from "@app/components/resources/resources_icon_names";
+import { getIcon } from "@app/components/resources/resources_icons";
+import type { PodApp } from "@app/types/api/pod_apps";
+import { Chip, cn, Icon, ScrollArea } from "@dust-tt/sparkle";
+
+interface PodAppListProps {
+  apps: PodApp[];
+  selectedPrefix: string | null;
+  onSelect: (prefix: string) => void;
+  iconByFramePath: Map<string, CustomResourceIconType>;
+  defaultIcon: CustomResourceIconType;
+}
+
+/**
+ * An app's icon is the one its pinned Frame tab already carries, so the Apps tab and the nav tab
+ * agree on how an app looks. Apps with no pinned Frame fall back to a shared default.
+ */
+function appIcon(
+  app: PodApp,
+  iconByFramePath: Map<string, CustomResourceIconType>,
+  defaultIcon: CustomResourceIconType
+): CustomResourceIconType {
+  for (const frame of app.frames) {
+    const icon = iconByFramePath.get(frame.path);
+    if (icon) {
+      return icon;
+    }
+  }
+
+  return defaultIcon;
+}
+
+function appSummary(app: PodApp): string {
+  const parts = [
+    `${app.functions.length} ${app.functions.length === 1 ? "function" : "functions"}`,
+  ];
+  if (app.databases.length > 0) {
+    parts.push(
+      `${app.databases.length} ${app.databases.length === 1 ? "db" : "dbs"}`
+    );
+  }
+
+  return parts.join(" · ");
+}
+
+export function PodAppList({
+  apps,
+  selectedPrefix,
+  onSelect,
+  iconByFramePath,
+  defaultIcon,
+}: PodAppListProps) {
+  return (
+    <ScrollArea className="h-full">
+      <div className="flex flex-col">
+        {apps.map((app) => {
+          const isSelected = app.prefix === selectedPrefix;
+
+          return (
+            <button
+              key={app.prefix}
+              type="button"
+              onClick={() => onSelect(app.prefix)}
+              className={cn(
+                "flex flex-col gap-1 border-b border-border px-4 py-3 text-left",
+                "hover:bg-muted-background dark:border-border-night",
+                "dark:hover:bg-muted-background-night",
+                isSelected &&
+                  "bg-muted-background dark:bg-muted-background-night"
+              )}
+            >
+              <div className="flex items-center gap-2">
+                <Icon
+                  visual={getIcon(appIcon(app, iconByFramePath, defaultIcon))}
+                  size="sm"
+                />
+                <span className="grow truncate copy-sm font-semibold">
+                  {app.name ?? "Unfiled"}
+                </span>
+                {app.functions.length === 0 && app.databases.length === 0 && (
+                  <Chip size="xs" color="primary" label="Draft" />
+                )}
+              </div>
+              <span className="copy-xs text-muted-foreground dark:text-muted-foreground-night">
+                {appSummary(app)}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </ScrollArea>
+  );
+}

--- a/front/components/pod/apps/PodAppsTab.tsx
+++ b/front/components/pod/apps/PodAppsTab.tsx
@@ -1,0 +1,106 @@
+import { PodAppDetail } from "@app/components/pod/apps/PodAppDetail";
+import { PodAppList } from "@app/components/pod/apps/PodAppList";
+import { PodFrameSheet } from "@app/components/pod/files/PodFrameSheet";
+import type { CustomResourceIconType } from "@app/components/resources/resources_icon_names";
+import { usePodApps } from "@app/lib/swr/pods";
+import type { PodAppFrame } from "@app/types/api/pod_apps";
+import { DEFAULT_POD_FRAME_TAB_ICON } from "@app/types/pod_frame_tab";
+import type { PodType } from "@app/types/space";
+import type { WorkspaceType } from "@app/types/user";
+import { ContentMessage, Spinner } from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
+
+interface PodAppsTabProps {
+  owner: WorkspaceType;
+  pod: PodType;
+}
+
+// NavTabPillContent is a bare Radix Tabs.Content with no forceMount, so this only mounts while the
+// Apps tab is active — hence no `disabled` flag on the hook below.
+export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
+  const { apps, isPodAppsLoading, isPodAppsError } = usePodApps({
+    owner,
+    podId: pod.sId,
+  });
+
+  const [selectedPrefix, setSelectedPrefix] = useState<string | null>(null);
+  const [framePreview, setFramePreview] = useState<PodAppFrame | null>(null);
+
+  const iconByFramePath = useMemo(
+    () =>
+      new Map<string, CustomResourceIconType>(
+        (pod.frameTabs ?? []).map((tab) => [tab.path, tab.icon])
+      ),
+    [pod.frameTabs]
+  );
+
+  // Selection follows the list until the user picks something, so the detail pane is never blank and
+  // a refresh that drops the selected app falls back rather than showing nothing.
+  const selectedApp =
+    apps.find((app) => app.prefix === selectedPrefix) ?? apps[0] ?? null;
+
+  if (isPodAppsLoading) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isPodAppsError) {
+    return (
+      <div className="px-6 py-8">
+        <ContentMessage variant="warning" title="Could not load apps">
+          Something went wrong while listing this Pod's apps. Try reloading the
+          page.
+        </ContentMessage>
+      </div>
+    );
+  }
+
+  if (apps.length === 0) {
+    return (
+      <div className="flex h-full w-full items-center justify-center px-6 py-8">
+        <p className="max-w-md text-center copy-sm text-muted-foreground dark:text-muted-foreground-night">
+          No app in this Pod yet. Ask an agent in this Pod to build one — a
+          Frame with the functions and databases behind it — and it will show up
+          here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 w-full flex-1 overflow-hidden">
+      <div className="w-72 min-w-56 shrink-0 border-r border-border dark:border-border-night">
+        <PodAppList
+          apps={apps}
+          selectedPrefix={selectedApp?.prefix ?? null}
+          onSelect={setSelectedPrefix}
+          iconByFramePath={iconByFramePath}
+          defaultIcon={DEFAULT_POD_FRAME_TAB_ICON}
+        />
+      </div>
+      <div className="min-w-0 flex-1">
+        {selectedApp && (
+          <PodAppDetail app={selectedApp} onOpenFrame={setFramePreview} />
+        )}
+      </div>
+
+      <PodFrameSheet
+        owner={owner}
+        fileId={framePreview?.fileId ?? null}
+        framePath={framePreview?.path ?? null}
+        fileName={framePreview?.fileName}
+        podId={pod.sId}
+        pinnedFramePath={pod.pinnedFramePath ?? null}
+        frameTabs={pod.frameTabs ?? []}
+        tabsOrder={pod.tabsOrder ?? []}
+        isEditor={pod.isEditor}
+        isArchived={!!pod.archivedAt}
+        isOpen={framePreview !== null}
+        onClose={() => setFramePreview(null)}
+      />
+    </div>
+  );
+}

--- a/front/components/pod/files/EditPodFrameTabDialog.tsx
+++ b/front/components/pod/files/EditPodFrameTabDialog.tsx
@@ -1,10 +1,11 @@
 import { isCustomResourceIconType } from "@app/components/resources/resources_icon_names";
 import { getIcon } from "@app/components/resources/resources_icons";
 import { usePodFrameTabs } from "@app/hooks/usePodFrameTabs";
-import type { PodFrameTab } from "@app/types/pod_frame_tab";
+import type { PodFrameTab, PodNavVisibility } from "@app/types/pod_frame_tab";
 import {
   buildPodNavItemsBeforeSettings,
   DEFAULT_POD_FRAME_TAB_ICON,
+  DEFAULT_POD_NAV_VISIBILITY,
   MAX_POD_FRAME_TAB_TITLE_LENGTH,
 } from "@app/types/pod_frame_tab";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -33,7 +34,7 @@ interface EditPodFrameTabDialogProps {
   frameTabs: PodFrameTab[];
   tabsOrder?: string[];
   isEditor: boolean;
-  includeConnectedData?: boolean;
+  navVisibility?: PodNavVisibility;
   tab: PodFrameTab;
   mode?: "create" | "edit";
   isOpen: boolean;
@@ -46,7 +47,7 @@ export function EditPodFrameTabDialog({
   frameTabs,
   tabsOrder,
   isEditor,
-  includeConnectedData = false,
+  navVisibility = DEFAULT_POD_NAV_VISIBILITY,
   tab,
   mode = "edit",
   isOpen,
@@ -74,11 +75,8 @@ export function EditPodFrameTabDialog({
   const [isMoving, setIsMoving] = useState(false);
 
   const navItems = useMemo(
-    () =>
-      buildPodNavItemsBeforeSettings(frameTabs, navOrder, {
-        includeConnectedData,
-      }),
-    [frameTabs, includeConnectedData, navOrder]
+    () => buildPodNavItemsBeforeSettings(frameTabs, navOrder, navVisibility),
+    [frameTabs, navVisibility, navOrder]
   );
   const tabIndex = navItems.findIndex(
     (item) => item.kind === "frame" && item.tab.path === tab.path
@@ -134,7 +132,7 @@ export function EditPodFrameTabDialog({
       return;
     }
     setIsMoving(true);
-    await moveFrameTab(tab.path, direction, { includeConnectedData });
+    await moveFrameTab(tab.path, direction, navVisibility);
     setIsMoving(false);
   };
 

--- a/front/hooks/usePodFrameTabs.ts
+++ b/front/hooks/usePodFrameTabs.ts
@@ -2,7 +2,7 @@ import { ConfirmContext } from "@app/components/Confirm";
 import type { CustomResourceIconType } from "@app/components/resources/resources_icon_names";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useUpdatePodMetadata } from "@app/lib/swr/pods";
-import type { PodFrameTab } from "@app/types/pod_frame_tab";
+import type { PodFrameTab, PodNavVisibility } from "@app/types/pod_frame_tab";
 import {
   DEFAULT_POD_FRAME_TAB_ICON,
   MAX_POD_FRAME_TAB_TITLE_LENGTH,
@@ -208,15 +208,18 @@ export function usePodFrameTabs({
     async (
       path: string,
       direction: "left" | "right",
-      { includeConnectedData }: { includeConnectedData: boolean }
+      visibility: PodNavVisibility
     ) => {
       if (!isEditor) {
         return false;
       }
 
-      const nextNavOrder = moveFrameTabInTabsOrder(navOrder, path, direction, {
-        includeConnectedData,
-      });
+      const nextNavOrder = moveFrameTabInTabsOrder(
+        navOrder,
+        path,
+        direction,
+        visibility
+      );
       if (!nextNavOrder) {
         return false;
       }

--- a/front/hooks/useScopedUIPreferences.ts
+++ b/front/hooks/useScopedUIPreferences.ts
@@ -8,6 +8,7 @@ const SYSTEM_POD_TABS = [
   "conversations",
   "tasks",
   "files",
+  "apps",
   "connected_data",
   "settings",
 ] as const;

--- a/front/hooks/useSpaceProjectTabs.ts
+++ b/front/hooks/useSpaceProjectTabs.ts
@@ -11,6 +11,7 @@ export type SystemPodTab =
   | "conversations"
   | "tasks"
   | "files"
+  | "apps"
   | "connected_data"
   | "settings";
 
@@ -27,6 +28,7 @@ const CONNECTED_DATA_QUERY_PARAMS = ["dsvId", "parentId", "q"] as const;
 
 const SYSTEM_POD_TAB_HASHES = new Set<string>([
   "files",
+  "apps",
   "settings",
   "conversations",
   "tasks",

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -1,0 +1,462 @@
+import { DustFileSystem } from "@app/lib/api/file_system";
+import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
+import { getPodStateBasePath } from "@app/lib/api/files/mount_path";
+import {
+  appPrefixFromPodDatabaseName,
+  podDatabaseNameWithoutAppPrefix,
+} from "@app/lib/api/sandbox_functions/db_naming";
+import {
+  normalizeAppPrefix,
+  SANDBOX_FUNCTION_SLUG_SEPARATOR,
+} from "@app/lib/api/sandbox_functions/slug";
+import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type {
+  FileSystemEntry,
+  FileSystemFileEntry,
+} from "@app/types/api/file_system/types";
+import type {
+  PodApp,
+  PodAppDatabase,
+  PodAppFrame,
+  PodAppFunction,
+} from "@app/types/api/pod_apps";
+import { isInteractiveContentType } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+/**
+ * The prefix of the synthetic app collecting everything published from the pod root, which has no
+ * app folder (`deriveAppPrefix` returns null for those paths). Empty so it can never collide with a
+ * real prefix, which `normalizeAppPrefix` guarantees is non-empty.
+ */
+export const UNFILED_POD_APP_PREFIX = "";
+
+/** A litestream replica directory is named after the database file it replicates. */
+const POD_DATABASE_FILE_SUFFIX = ".db";
+
+/** Subfolders whose presence marks a pod-root folder as app-shaped. */
+const APP_SHAPED_SUBFOLDERS = ["functions", "databases"];
+
+/** The app subfolder holding one drizzle schema file per database. */
+const APP_DATABASES_SUBFOLDER = "databases";
+
+/** Suffix of a database's schema file, e.g. `chat.db.ts` declares the `chat` database. */
+const POD_DATABASE_SCHEMA_FILE_SUFFIX = ".db.ts";
+
+/**
+ * A folder's accumulated file-system facts, before published functions and databases are joined in.
+ */
+type AppFolder = {
+  name: string;
+  path: string;
+  fileCount: number;
+  frameEntries: FileSystemFileEntry[];
+  hasAppShapedSubfolder: boolean;
+  /**
+   * App-relative names of the databases this folder declares, one per `databases/{name}.db.ts`. Used
+   * to attribute databases whose on-disk name carries no app prefix.
+   */
+  declaredDatabaseNames: Set<string>;
+};
+
+/**
+ * Path segments of a pod entry relative to the pod root, e.g. `MyApp/functions/list-notes.ts` for
+ * `pod-{podId}/MyApp/functions/list-notes.ts`.
+ */
+function relativeSegments(entry: FileSystemEntry, podRoot: string): string[] {
+  if (!entry.path.startsWith(`${podRoot}/`)) {
+    return [];
+  }
+
+  return entry.path
+    .slice(podRoot.length + 1)
+    .split("/")
+    .filter((segment) => segment.length > 0);
+}
+
+/**
+ * Group a pod's recursive file listing by the folder each entry sits in at the pod root. Entries
+ * directly at the root belong to no app, so they are skipped: anything published from there surfaces
+ * under the unfiled app instead.
+ */
+function collectAppFolders(
+  entries: FileSystemEntry[],
+  podRoot: string
+): Map<string, AppFolder> {
+  const folders = new Map<string, AppFolder>();
+
+  const folderFor = (name: string): AppFolder => {
+    const existing = folders.get(name);
+    if (existing) {
+      return existing;
+    }
+
+    const folder: AppFolder = {
+      name,
+      path: `${podRoot}/${name}`,
+      fileCount: 0,
+      frameEntries: [],
+      hasAppShapedSubfolder: false,
+      declaredDatabaseNames: new Set(),
+    };
+    folders.set(name, folder);
+
+    return folder;
+  };
+
+  for (const entry of entries) {
+    const segments = relativeSegments(entry, podRoot);
+    if (segments.length === 0) {
+      continue;
+    }
+
+    if (entry.isDirectory) {
+      // A folder placeholder at the root is a candidate app even while empty.
+      if (segments.length === 1) {
+        folderFor(segments[0]);
+      } else if (
+        segments.length === 2 &&
+        APP_SHAPED_SUBFOLDERS.includes(segments[1])
+      ) {
+        folderFor(segments[0]).hasAppShapedSubfolder = true;
+      }
+      continue;
+    }
+
+    // Files directly at the pod root belong to no app folder.
+    if (segments.length === 1) {
+      continue;
+    }
+
+    const folder = folderFor(segments[0]);
+    folder.fileCount += 1;
+
+    // A file inside an app subfolder implies that subfolder, whether or not GCS holds a placeholder
+    // object for it.
+    if (APP_SHAPED_SUBFOLDERS.includes(segments[1])) {
+      folder.hasAppShapedSubfolder = true;
+    }
+
+    // Only a Frame at the top of the app folder is the app's own Frame; anything deeper is a detail
+    // of how the app is laid out.
+    if (segments.length === 2 && isInteractiveContentType(entry.contentType)) {
+      folder.frameEntries.push(entry);
+    }
+
+    if (
+      segments.length === 3 &&
+      segments[1] === APP_DATABASES_SUBFOLDER &&
+      entry.fileName.endsWith(POD_DATABASE_SCHEMA_FILE_SUFFIX)
+    ) {
+      folder.declaredDatabaseNames.add(
+        entry.fileName.slice(
+          0,
+          entry.fileName.length - POD_DATABASE_SCHEMA_FILE_SUFFIX.length
+        )
+      );
+    }
+  }
+
+  return folders;
+}
+
+/**
+ * Resolve the Frame entries of every app folder to their FileResource, in one query, so each Frame
+ * can report its sId and whether it has been published.
+ */
+async function resolveFramesByFolderName(
+  auth: Authenticator,
+  dustFs: DustFileSystem,
+  folders: AppFolder[],
+  pinnedFramePaths: Set<string>
+): Promise<Map<string, PodAppFrame[]>> {
+  const mountPathByEntryPath = new Map<string, string>();
+  for (const folder of folders) {
+    for (const entry of folder.frameEntries) {
+      const mountPath = dustFs.toMountFilePath(entry.path);
+      if (mountPath) {
+        mountPathByEntryPath.set(entry.path, mountPath);
+      }
+    }
+  }
+
+  const files = await FileResource.fetchByMountFilePaths(
+    auth,
+    Array.from(mountPathByEntryPath.values())
+  );
+  const fileByMountPath = new Map(
+    files.flatMap((file) =>
+      file.mountFilePath ? [[file.mountFilePath, file] as const] : []
+    )
+  );
+
+  const framesByFolderName = new Map<string, PodAppFrame[]>();
+  for (const folder of folders) {
+    framesByFolderName.set(
+      folder.name,
+      folder.frameEntries.map((entry) => {
+        const mountPath = mountPathByEntryPath.get(entry.path);
+        const file = mountPath ? fileByMountPath.get(mountPath) : undefined;
+
+        return {
+          fileId: file?.sId ?? null,
+          fileName: entry.fileName,
+          path: entry.path,
+          isPublished: file?.isPublishedFrame() ?? false,
+          isPinnedAsTab: pinnedFramePaths.has(entry.path),
+        };
+      })
+    );
+  }
+
+  return framesByFolderName;
+}
+
+/**
+ * The pod's database names as they exist on disk. Read from the litestream replica prefix in GCS
+ * rather than from the sandbox, so listing apps never has to wake a sleeping pod. A database created
+ * seconds ago may not be replicated yet.
+ */
+async function listPodDatabaseOnDiskNames(
+  auth: Authenticator,
+  pod: SpaceResource
+): Promise<string[]> {
+  const replicaNames = await getPrivateUploadBucket().listSubdirectoryNames({
+    prefix: getPodStateBasePath({
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      podId: pod.sId,
+    }),
+  });
+
+  // A replica directory is named after the database FILE it replicates, so drop the `.db`.
+  return replicaNames
+    .filter((name) => name.endsWith(POD_DATABASE_FILE_SUFFIX))
+    .map((name) =>
+      name.slice(0, name.length - POD_DATABASE_FILE_SUFFIX.length)
+    );
+}
+
+/**
+ * Group the pod's databases by the app prefix that owns each one.
+ *
+ * A namespaced database carries its app in its filename, so its prefix decides. A database created
+ * before app namespacing has a bare filename instead, and the only remaining evidence of ownership is
+ * the schema file that declares it — `<AppName>/databases/{name}.db.ts`. This mirrors how
+ * `resolvePodDatabaseName` resolves the same case at reconcile time, so the tab attributes a legacy
+ * database to exactly the app that keeps writing to it.
+ *
+ * Two apps declaring the same bare name genuinely share that one database (the transitional case
+ * `resolvePodDatabaseName` documents), so it is reported under both rather than arbitrarily assigned.
+ * A bare database no app declares falls back to the unfiled app.
+ */
+function groupDatabasesByAppPrefix(
+  onDiskNames: string[],
+  foldersByPrefix: Map<string, AppFolder[]>
+): Map<string, PodAppDatabase[]> {
+  const byPrefix = new Map<string, PodAppDatabase[]>();
+
+  const attribute = (prefix: string, database: PodAppDatabase) => {
+    byPrefix.set(prefix, [...(byPrefix.get(prefix) ?? []), database]);
+  };
+
+  for (const onDiskName of onDiskNames) {
+    const database = {
+      name: podDatabaseNameWithoutAppPrefix(onDiskName),
+      onDiskName,
+    };
+
+    const prefixFromName = appPrefixFromPodDatabaseName(onDiskName);
+    if (prefixFromName !== null) {
+      attribute(prefixFromName, database);
+      continue;
+    }
+
+    const declaringPrefixes = [...foldersByPrefix].filter(([, folders]) =>
+      folders.some((folder) => folder.declaredDatabaseNames.has(onDiskName))
+    );
+    if (declaringPrefixes.length === 0) {
+      attribute(UNFILED_POD_APP_PREFIX, database);
+      continue;
+    }
+
+    for (const [prefix] of declaringPrefixes) {
+      attribute(prefix, database);
+    }
+  }
+
+  return byPrefix;
+}
+
+/** The pod's published functions, grouped by the app prefix each one's slug carries. */
+function groupFunctionsByAppPrefix(
+  sandboxFunctions: SandboxFunctionResource[]
+): Map<string, PodAppFunction[]> {
+  const byPrefix = new Map<string, PodAppFunction[]>();
+
+  for (const sandboxFunction of sandboxFunctions) {
+    const separatorIndex = sandboxFunction.slug.indexOf(
+      SANDBOX_FUNCTION_SLUG_SEPARATOR
+    );
+    const prefix =
+      separatorIndex > 0
+        ? sandboxFunction.slug.slice(0, separatorIndex)
+        : UNFILED_POD_APP_PREFIX;
+
+    byPrefix.set(prefix, [
+      ...(byPrefix.get(prefix) ?? []),
+      sandboxFunction.toPodAppJSON(),
+    ]);
+  }
+
+  return byPrefix;
+}
+
+/**
+ * List a Pod's apps.
+ *
+ * An app is not a stored record: it is a folder at the pod root, identified by the app prefix
+ * `deriveAppPrefix` derives from its name — the very prefix that already namespaces the app's
+ * published function slugs and database filenames. This assembles that view from three sources (the
+ * pod's files, its published functions, its replicated databases) and joins them on that prefix, so
+ * it stays consistent with what publish and reconcile do by construction.
+ *
+ * A folder qualifies as an app when it holds a `functions/` or `databases/` subfolder, or a Frame at
+ * its top, or any published function or database under its prefix. A prefix that owns published
+ * artifacts but has no folder left is still listed, since those artifacts are live and would
+ * otherwise be invisible; so is anything published from the pod root, gathered into a synthetic
+ * unfiled app.
+ */
+export async function listPodApps(
+  auth: Authenticator,
+  pod: SpaceResource
+): Promise<Result<PodApp[], Error>> {
+  if (!pod.isProject()) {
+    return new Err(new Error("Apps are only available for Pod spaces."));
+  }
+
+  const fsResult = await DustFileSystem.forPod(auth, pod);
+  if (fsResult.isErr()) {
+    return new Err(new Error("Failed to initialise file system."));
+  }
+  const dustFs = fsResult.value;
+
+  const podRoot = `${SCOPED_PREFIX_POD}${pod.sId}`;
+  // A pod listing is recursive, so this single call covers every folder and file at any depth.
+  const listResult = await dustFs.list(podRoot);
+  if (listResult.isErr()) {
+    return new Err(listResult.error);
+  }
+
+  const [sandboxFunctions, databaseOnDiskNames, metadata] = await Promise.all([
+    SandboxFunctionResource.listBySpace(auth, pod),
+    listPodDatabaseOnDiskNames(auth, pod),
+    ProjectMetadataResource.fetchBySpace(auth, pod),
+  ]);
+
+  const functionsByPrefix = groupFunctionsByAppPrefix(sandboxFunctions);
+  const pinnedFramePaths = new Set(
+    (metadata?.frameTabs ?? []).map((tab) => tab.path)
+  );
+
+  const folders = Array.from(
+    collectAppFolders(listResult.value, podRoot).values()
+  );
+  const framesByFolderName = await resolveFramesByFolderName(
+    auth,
+    dustFs,
+    folders,
+    pinnedFramePaths
+  );
+
+  // Several folder names can normalize onto one prefix (`Task List` and `Task-List` both give
+  // `task-list`), and such folders genuinely share published slugs and databases. Group by prefix so
+  // the collision is reported rather than silently producing two apps that own the same artifacts.
+  const foldersByPrefix = new Map<string, AppFolder[]>();
+  for (const folder of folders) {
+    const prefix = normalizeAppPrefix(folder.name);
+    if (!prefix) {
+      continue;
+    }
+    foldersByPrefix.set(prefix, [
+      ...(foldersByPrefix.get(prefix) ?? []),
+      folder,
+    ]);
+  }
+
+  // Needs foldersByPrefix: a database created before app namespacing has no prefix in its filename,
+  // so only the schema file that declares it says which app owns it.
+  const databasesByPrefix = groupDatabasesByAppPrefix(
+    databaseOnDiskNames,
+    foldersByPrefix
+  );
+
+  const realPrefixes = new Set([
+    ...foldersByPrefix.keys(),
+    ...functionsByPrefix.keys(),
+    ...databasesByPrefix.keys(),
+  ]);
+  realPrefixes.delete(UNFILED_POD_APP_PREFIX);
+
+  const apps: PodApp[] = [];
+
+  for (const prefix of realPrefixes) {
+    const prefixFolders = foldersByPrefix.get(prefix) ?? [];
+    const functions = functionsByPrefix.get(prefix) ?? [];
+    const databases = databasesByPrefix.get(prefix) ?? [];
+    const frames = prefixFolders.flatMap(
+      (folder) => framesByFolderName.get(folder.name) ?? []
+    );
+
+    const isApp =
+      prefixFolders.some((folder) => folder.hasAppShapedSubfolder) ||
+      frames.length > 0 ||
+      functions.length > 0 ||
+      databases.length > 0;
+    if (!isApp) {
+      continue;
+    }
+
+    const [primaryFolder] = prefixFolders;
+    apps.push({
+      prefix,
+      // With no folder left, the prefix is the only name the app still has.
+      name: primaryFolder?.name ?? prefix,
+      folderPath: primaryFolder?.path ?? null,
+      frames,
+      functions,
+      databases,
+      fileCount: prefixFolders.reduce(
+        (total, folder) => total + folder.fileCount,
+        0
+      ),
+      collidingFolderNames:
+        prefixFolders.length > 1 ? prefixFolders.map((f) => f.name) : [],
+    });
+  }
+
+  apps.sort((a, b) => (a.name ?? "").localeCompare(b.name ?? ""));
+
+  // Artifacts published from the pod root have no folder to be found under, so they get a synthetic
+  // app rather than disappearing from the listing. Appended after the sort so it always sits last.
+  const unfiledFunctions = functionsByPrefix.get(UNFILED_POD_APP_PREFIX) ?? [];
+  const unfiledDatabases = databasesByPrefix.get(UNFILED_POD_APP_PREFIX) ?? [];
+  if (unfiledFunctions.length > 0 || unfiledDatabases.length > 0) {
+    apps.push({
+      prefix: UNFILED_POD_APP_PREFIX,
+      name: null,
+      folderPath: null,
+      frames: [],
+      functions: unfiledFunctions,
+      databases: unfiledDatabases,
+      fileCount: 0,
+      collidingFolderNames: [],
+    });
+  }
+
+  return new Ok(apps);
+}

--- a/front/lib/api/sandbox_functions/db_naming.test.ts
+++ b/front/lib/api/sandbox_functions/db_naming.test.ts
@@ -1,4 +1,6 @@
 import {
+  appPrefixFromPodDatabaseName,
+  podDatabaseNameWithoutAppPrefix,
   podDatabasePrefixFromPodPath,
   podDatabasePrefixFromSlug,
   resolvePodDatabaseName,
@@ -69,6 +71,33 @@ describe("podDatabasePrefixFromSlug", () => {
 
   it("has no prefix for a function published outside an app folder", () => {
     expect(podDatabasePrefixFromSlug("greet")).toBeNull();
+  });
+});
+
+describe("appPrefixFromPodDatabaseName", () => {
+  it("round-trips the prefix a slug's app produces", () => {
+    // The Apps tab joins databases onto functions on the app prefix, so this must invert exactly
+    // what podDatabasePrefixFromSlug produces.
+    expect(appPrefixFromPodDatabaseName("task_list__tasks")).toBe("task-list");
+    expect(podDatabasePrefixFromSlug("task-list__add-task")).toBe(
+      "task_list__"
+    );
+  });
+
+  it("has no app prefix for a database created before namespacing", () => {
+    expect(appPrefixFromPodDatabaseName("chat")).toBeNull();
+  });
+});
+
+describe("podDatabaseNameWithoutAppPrefix", () => {
+  it("strips the app prefix, leaving the name the schema file declares", () => {
+    expect(podDatabaseNameWithoutAppPrefix("people_tracker__people")).toBe(
+      "people"
+    );
+  });
+
+  it("returns the whole name for a database with no app prefix", () => {
+    expect(podDatabaseNameWithoutAppPrefix("chat")).toBe("chat");
   });
 });
 

--- a/front/lib/api/sandbox_functions/db_naming.ts
+++ b/front/lib/api/sandbox_functions/db_naming.ts
@@ -85,6 +85,37 @@ export function podDatabasePrefixFromPodPath({
 }
 
 /**
+ * The app prefix (function-slug form) an on-disk database name belongs to, or `null` for a database
+ * with no app prefix — either created before namespacing, or owned by an app whose name cannot start
+ * a database name (see `podDatabasePrefixFromAppPrefix`).
+ *
+ * The inverse of `podDatabasePrefixFromAppPrefix`, which is injective because `deriveAppPrefix`
+ * never emits an underscore, so every underscore here came from a hyphen.
+ */
+export function appPrefixFromPodDatabaseName(name: string): string | null {
+  const separatorIndex = name.indexOf(POD_DATABASE_PREFIX_SEPARATOR);
+  if (separatorIndex <= 0) {
+    return null;
+  }
+
+  return name.slice(0, separatorIndex).replace(/_/g, "-");
+}
+
+/**
+ * A database's app-relative name, i.e. the on-disk name with its app prefix removed. This is the name
+ * the schema file declares and `db()` opens, so it is also the right thing to show inside an app.
+ * Returns the whole name for a database with no app prefix.
+ */
+export function podDatabaseNameWithoutAppPrefix(name: string): string {
+  const separatorIndex = name.indexOf(POD_DATABASE_PREFIX_SEPARATOR);
+  if (separatorIndex <= 0) {
+    return name;
+  }
+
+  return name.slice(separatorIndex + POD_DATABASE_PREFIX_SEPARATOR.length);
+}
+
+/**
  * Pick the database file `name` refers to, given the names currently on disk.
  *
  * `name` is the database's app-relative name as the schema file declares it (`chat`). An

--- a/front/lib/api/sandbox_functions/slug.test.ts
+++ b/front/lib/api/sandbox_functions/slug.test.ts
@@ -1,4 +1,7 @@
-import { deriveSandboxFunctionSlug } from "@app/lib/api/sandbox_functions/slug";
+import {
+  deriveSandboxFunctionSlug,
+  sandboxFunctionNameFromSlug,
+} from "@app/lib/api/sandbox_functions/slug";
 import { describe, expect, it } from "vitest";
 
 const POD_ID = "vlt_abc123";
@@ -112,5 +115,28 @@ describe("deriveSandboxFunctionSlug", () => {
     const result = derive(`pod-${POD_ID}/TaskList/functions/x.ts`, "Add_Task");
 
     expect(result.isErr()).toBe(true);
+  });
+});
+
+describe("sandboxFunctionNameFromSlug", () => {
+  it("inverts the slug composition for an app's function", () => {
+    const slug = derive(
+      `pod-${POD_ID}/PeopleTracker2/functions/add-person.ts`,
+      "add-person"
+    );
+    if (slug.isErr()) {
+      throw slug.error;
+    }
+
+    expect(slug.value).toBe("peopletracker2__add-person");
+    expect(sandboxFunctionNameFromSlug(slug.value)).toBe("add-person");
+  });
+
+  it("returns the whole slug for a function published outside an app folder", () => {
+    expect(sandboxFunctionNameFromSlug("greet")).toBe("greet");
+  });
+
+  it("keeps hyphens in a multi-word app's function name", () => {
+    expect(sandboxFunctionNameFromSlug("task-list__add-task")).toBe("add-task");
   });
 });

--- a/front/lib/api/sandbox_functions/slug.ts
+++ b/front/lib/api/sandbox_functions/slug.ts
@@ -14,7 +14,7 @@ export const SANDBOX_FUNCTION_SLUG_SEPARATOR = "__";
  * splitting, so `TaskList` becomes `tasklist` rather than `task-list`: a predictable rule beats a
  * prettier heuristic that has to decide what to do with `MyAPIApp`.
  */
-function normalizeAppPrefix(folderName: string): string {
+export function normalizeAppPrefix(folderName: string): string {
   return folderName
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
@@ -72,6 +72,22 @@ export function deriveAppPrefix({
   }
 
   return new Ok(prefix);
+}
+
+/**
+ * The bare function name inside its app, i.e. the slug with its app prefix removed. Returns the whole
+ * slug for a function published from the pod root, which has no prefix.
+ *
+ * For display only, where the app is already the surrounding context. Everything that addresses a
+ * function — `get`, `call`, `unpublish`, a Frame's reference — must keep using the full slug.
+ */
+export function sandboxFunctionNameFromSlug(slug: string): string {
+  const separatorIndex = slug.indexOf(SANDBOX_FUNCTION_SLUG_SEPARATOR);
+  if (separatorIndex <= 0) {
+    return slug;
+  }
+
+  return slug.slice(separatorIndex + SANDBOX_FUNCTION_SLUG_SEPARATOR.length);
 }
 
 /**

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -8,6 +8,7 @@ import { frameContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isString } from "@app/types/shared/utils/general";
 import { stripNullBytes } from "@app/types/shared/utils/string_utils";
 import type { Bucket, File, SaveOptions } from "@google-cloud/storage";
 import { RETRYABLE_ERR_FN_DEFAULT, Storage } from "@google-cloud/storage";
@@ -344,6 +345,72 @@ export class FileStorage {
     } while (pageToken);
 
     return { files: allFiles, pageFetchCount };
+  }
+
+  /**
+   * The `prefixes` of a delimited list response, i.e. the common prefixes GCS rolled up. The Node
+   * client types the raw API response as `{}`, so read the field defensively rather than asserting a
+   * shape the types do not promise.
+   */
+  private extractCommonPrefixes(apiResponse: unknown): string[] {
+    if (
+      !apiResponse ||
+      typeof apiResponse !== "object" ||
+      !("prefixes" in apiResponse)
+    ) {
+      return [];
+    }
+
+    const { prefixes } = apiResponse;
+
+    return Array.isArray(prefixes) ? prefixes.filter(isString) : [];
+  }
+
+  /**
+   * Names of the immediate "subdirectories" under `prefix`, using a GCS delimited list so the
+   * objects inside them are never enumerated. Use this instead of `getAllFilesByPrefix` whenever the
+   * directory names are all you need and the subtrees can be large.
+   */
+  async listSubdirectoryNames({
+    prefix,
+    pageSize = 1000,
+  }: {
+    prefix: string;
+    pageSize?: number;
+  }): Promise<string[]> {
+    const normalizedPrefix = prefix.endsWith("/") ? prefix : `${prefix}/`;
+    const names: string[] = [];
+    let pageToken: string | undefined;
+
+    do {
+      const [, nextQuery, apiResponse] = await this.bucket.getFiles({
+        prefix: normalizedPrefix,
+        delimiter: "/",
+        maxResults: pageSize,
+        pageToken,
+        autoPaginate: false,
+      });
+
+      for (const commonPrefix of this.extractCommonPrefixes(apiResponse)) {
+        const name = commonPrefix
+          .slice(normalizedPrefix.length)
+          .replace(/\/$/, "");
+        if (name) {
+          names.push(name);
+        }
+      }
+
+      const nextToken =
+        nextQuery &&
+        typeof nextQuery === "object" &&
+        "pageToken" in nextQuery &&
+        nextQuery.pageToken
+          ? String(nextQuery.pageToken)
+          : undefined;
+      pageToken = nextToken || undefined;
+    } while (pageToken);
+
+    return names;
   }
 
   async getSortedFileVersions({

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -688,6 +688,17 @@ export class FileResource extends BaseResource<FileModel> {
   }
 
   /**
+   * Whether this is a frame that has been published, i.e. a built bundle exists for it. Reads the
+   * same `frameBundleRootPath` signal as `getRenderableVersion`, kept here so callers never have to
+   * know which field carries it.
+   */
+  isPublishedFrame(): boolean {
+    return (
+      this.isInteractiveContent && !!this.useCaseMetadata?.frameBundleRootPath
+    );
+  }
+
+  /**
    * The version the viz engine should render for a frame. A published frame's bundle is stored
    * as the processed version. Until a frame is published (no bundle) the source ("original")
    * renders. Non-frame files always render their original, so this is safe to call generically.

--- a/front/lib/resources/project_metadata_resource.test.ts
+++ b/front/lib/resources/project_metadata_resource.test.ts
@@ -124,6 +124,7 @@ describe("ProjectMetadataResource", () => {
         "conversations",
         "tasks",
         "files",
+        "apps",
         "connected_data",
       ]);
       expect(json.defaultSkillIds).toEqual([]);

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -3,6 +3,7 @@ import type {
   PokePodFunctionDetails,
 } from "@app/lib/api/poke/projects";
 import { SandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
+import { sandboxFunctionNameFromSlug } from "@app/lib/api/sandbox_functions/slug";
 import { authorizeSandboxFunctionInvocation } from "@app/lib/api/sandbox_functions/workspace_user";
 import type { Authenticator } from "@app/lib/auth";
 import { executeWithLock } from "@app/lib/lock";
@@ -24,6 +25,7 @@ import {
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import type { PodAppFunction } from "@app/types/api/pod_apps";
 import type {
   PostSandboxFunctionInvocationRequestBody,
   SandboxFunctionExecutionMode,
@@ -561,6 +563,17 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       createdAt: this.createdAt.toISOString(),
       updatedAt: this.updatedAt.toISOString(),
       author: author ? author.fullName() : null,
+    };
+  }
+
+  // What the Pod's Apps tab shows for a function it lists under its app. Carries both the full slug
+  // (which addresses the function) and the bare name (which is all the app's own view needs to show).
+  toPodAppJSON(): PodAppFunction {
+    return {
+      slug: this.slug,
+      name: sandboxFunctionNameFromSlug(this.slug),
+      description: this.description,
+      executionMode: this.executionMode,
     };
   }
 

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -26,6 +26,7 @@ import type {
   FileSystemEntry,
   GetSpaceFilesResponseBody,
 } from "@app/types/api/file_system/types";
+import type { GetPodAppsResponseBody, PodApp } from "@app/types/api/pod_apps";
 import type {
   GetPodMetadataResponseBody,
   PatchPodMetadataResponseBody,
@@ -111,6 +112,32 @@ export function usePodContextAttachments({
     isPodContextAttachmentsError: !!error,
     mutatePodContextAttachments: mutate,
     refreshPodContextAttachments,
+  };
+}
+
+export function usePodApps({
+  owner,
+  podId,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  podId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const podAppsFetcher: Fetcher<GetPodAppsResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    !podId ? null : `/api/w/${owner.sId}/pods/${podId}/apps`,
+    podAppsFetcher,
+    { disabled, keepPreviousData: true }
+  );
+
+  return {
+    apps: data?.apps ?? emptyArray<PodApp>(),
+    isPodAppsLoading: !disabled && !error && !data,
+    isPodAppsError: !!error,
+    mutatePodApps: mutate,
   };
 }
 

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -47,6 +47,11 @@ class FileStorageMock {
     () => null;
   private _copyFileShouldFail: (src: string, dest: string) => boolean = () =>
     false;
+  private _filesByPrefix: (
+    prefix: string
+  ) => { name: string; metadata: Record<string, unknown> }[] | null = () =>
+    null;
+  private _subdirectoryNames: (prefix: string) => string[] | null = () => null;
 
   get writeStreamCalls(): readonly WriteStreamCall[] {
     return this._writeStreamCalls;
@@ -115,6 +120,26 @@ class FileStorageMock {
   }
 
   /**
+   * Controls what `bucket.getAllFilesByPrefix({ prefix })` resolves to, keyed by the prefix. Return
+   * null (the default) to resolve an empty list. Reset between tests via `reset()`.
+   */
+  setFilesByPrefix(
+    fn: (
+      prefix: string
+    ) => { name: string; metadata: Record<string, unknown> }[] | null
+  ): void {
+    this._filesByPrefix = fn;
+  }
+
+  /**
+   * Controls what `bucket.listSubdirectoryNames({ prefix })` resolves to, keyed by the prefix.
+   * Return null (the default) to resolve an empty list. Reset between tests via `reset()`.
+   */
+  setSubdirectoryNames(fn: (prefix: string) => string[] | null): void {
+    this._subdirectoryNames = fn;
+  }
+
+  /**
    * Makes `fetchFileContent(path)` throw a GCS-shaped not-found error
    * (`{ code: 404 }`) for matching paths that were not previously written via
    * `uploadRawContentToBucket` and have no `setFileContent` override. Enables
@@ -147,6 +172,8 @@ class FileStorageMock {
     this._contentForPath = () => null;
     this._sortedFileVersions = () => null;
     this._copyFileShouldFail = () => false;
+    this._filesByPrefix = () => null;
+    this._subdirectoryNames = () => null;
   }
 
   /**
@@ -313,9 +340,15 @@ class FileStorageMock {
         }
       }),
       deleteFiles: vi.fn().mockResolvedValue(undefined),
-      getAllFilesByPrefix: vi
-        .fn()
-        .mockResolvedValue({ files: [], pageFetchCount: 1 }),
+      getAllFilesByPrefix: vi.fn(({ prefix }: { prefix: string }) =>
+        Promise.resolve({
+          files: this._filesByPrefix(prefix) ?? [],
+          pageFetchCount: 1,
+        })
+      ),
+      listSubdirectoryNames: vi.fn(({ prefix }: { prefix: string }) =>
+        Promise.resolve(this._subdirectoryNames(prefix) ?? [])
+      ),
       getSortedFileVersions: vi.fn(({ filePath }: { filePath: string }) =>
         Promise.resolve(new Ok(this._sortedFileVersions(filePath) ?? []))
       ),

--- a/front/types/api/pod_apps.ts
+++ b/front/types/api/pod_apps.ts
@@ -1,0 +1,66 @@
+import type { SandboxFunctionExecutionMode } from "@app/types/api/sandbox_functions";
+
+/**
+ * A Pod app is a folder at the pod root that owns a Frame, published functions and databases. It has
+ * no record of its own: the folder IS the app, and its identity is the app prefix `deriveAppPrefix`
+ * computes from the folder name — the same prefix that already namespaces published function slugs
+ * and database filenames. So these types describe a view assembled at read time, never stored.
+ */
+
+export type PodAppFrame = {
+  /** sId of the Frame's FileResource, or null for a source file with no row yet. */
+  fileId: string | null;
+  fileName: string;
+  /** Canonical scoped path, e.g. `pod-{podId}/MyApp/MyApp.tsx`. */
+  path: string;
+  /** Whether the Frame has been published (a built bundle exists). */
+  isPublished: boolean;
+  /** Whether the Frame is pinned as one of the Pod's nav tabs. */
+  isPinnedAsTab: boolean;
+};
+
+export type PodAppFunction = {
+  /**
+   * Full published slug, app prefix included, e.g. `myapp__list-notes`. This is what addresses the
+   * function everywhere — `call`, `unpublish`, a Frame's reference.
+   */
+  slug: string;
+  /** The slug without its app prefix, e.g. `list-notes`. Display only. */
+  name: string;
+  description: string;
+  executionMode: SandboxFunctionExecutionMode;
+};
+
+export type PodAppDatabase = {
+  /**
+   * App-relative name, e.g. `chat` — what the schema file declares and `db()` opens.
+   */
+  name: string;
+  /** On-disk name, app prefix included, e.g. `myapp__chat`. What the db tools address. */
+  onDiskName: string;
+};
+
+export type PodApp = {
+  /**
+   * The normalized app prefix, which is this app's identifier — apps have no sId. Empty string for
+   * the synthetic "unfiled" app collecting artifacts published from the pod root.
+   */
+  prefix: string;
+  /** The folder name as authored (`TaskList`), or null for the unfiled app. */
+  name: string | null;
+  /** Canonical scoped path of the app folder, or null for the unfiled app. */
+  folderPath: string | null;
+  frames: PodAppFrame[];
+  functions: PodAppFunction[];
+  databases: PodAppDatabase[];
+  fileCount: number;
+  /**
+   * Folder names that normalize onto this same prefix. More than one means the folders silently
+   * share published slugs and databases, so the UI warns instead of merging them quietly.
+   */
+  collidingFolderNames: string[];
+};
+
+export type GetPodAppsResponseBody = {
+  apps: PodApp[];
+};

--- a/front/types/pod_frame_tab.ts
+++ b/front/types/pod_frame_tab.ts
@@ -12,6 +12,7 @@ export const POD_NAV_SYSTEM_TABS_BEFORE_SETTINGS = [
   "conversations",
   "tasks",
   "files",
+  "apps",
   "connected_data",
 ] as const;
 
@@ -94,26 +95,48 @@ export function normalizeTabsOrder(
   return result;
 }
 
+/**
+ * Which conditional system tabs this Pod currently shows. Connected Data depends on the Pod being
+ * admin-controlled, Apps on a workspace feature flag. Both must be honoured everywhere tab order is
+ * computed, so neighbour-swapping never moves a frame past a tab the user cannot see.
+ */
+export type PodNavVisibility = {
+  includeConnectedData: boolean;
+  includeApps: boolean;
+};
+
+/** Neither conditional tab shown — the safe default for callers that do not know yet. */
+export const DEFAULT_POD_NAV_VISIBILITY: PodNavVisibility = {
+  includeConnectedData: false,
+  includeApps: false,
+};
+
 export function visibleTabsOrder(
   tabsOrder: string[],
-  { includeConnectedData }: { includeConnectedData: boolean }
+  { includeConnectedData, includeApps }: PodNavVisibility
 ): string[] {
-  return tabsOrder.filter(
-    (id) => id !== "connected_data" || includeConnectedData
-  );
+  return tabsOrder.filter((id) => {
+    if (id === "connected_data") {
+      return includeConnectedData;
+    }
+    if (id === "apps") {
+      return includeApps;
+    }
+    return true;
+  });
 }
 
 export function buildPodNavItemsBeforeSettings(
   frameTabs: PodFrameTab[],
   tabsOrder: string[],
-  { includeConnectedData }: { includeConnectedData: boolean }
+  visibility: PodNavVisibility
 ): PodNavItemBeforeSettings[] {
   const byPath = new Map(frameTabs.map((tab) => [tab.path, tab]));
   const normalized = normalizeTabsOrder(
     tabsOrder,
     frameTabs.map((tab) => tab.path)
   );
-  const visible = visibleTabsOrder(normalized, { includeConnectedData });
+  const visible = visibleTabsOrder(normalized, visibility);
 
   const items: PodNavItemBeforeSettings[] = [];
   for (const entry of visible) {
@@ -134,9 +157,9 @@ export function moveFrameTabInTabsOrder(
   tabsOrder: string[],
   path: string,
   direction: "left" | "right",
-  { includeConnectedData }: { includeConnectedData: boolean }
+  visibility: PodNavVisibility
 ): string[] | null {
-  const visible = visibleTabsOrder(tabsOrder, { includeConnectedData });
+  const visible = visibleTabsOrder(tabsOrder, visibility);
   const index = visible.indexOf(path);
   if (index < 0) {
     return null;


### PR DESCRIPTION
## Description

A Pod app — a Frame plus the functions and databases behind it — had no first-class presence in the UI. There was no way to enumerate a Pod's apps: you had to dig through old conversations to find them. This adds an **Apps tab**.

An app stays a **derived** concept rather than becoming a new record. It is a folder at the pod root, identified by the app prefix [`deriveAppPrefix`](https://github.com/dust-tt/dust/blob/main/front/lib/api/sandbox_functions/slug.ts) already computes from the folder name — the very prefix that namespaces published function slugs and database filenames since #30263. The tab is simply a third consumer of that one authority, so there is no schema change, no migration, and nothing new for agents to declare.

`listPodApps` joins three sources on that prefix in a constant number of calls:

| Source | Call |
|---|---|
| Pod files | one `dustFs.list()` (pod listings are recursive, so one call covers every depth) |
| Published functions | `SandboxFunctionResource.listBySpace` |
| Databases | one delimited GCS list of the litestream replica prefix |

Reading databases from the replica rather than from the sandbox means listing apps never has to wake a sleeping pod. A delimited list is used so the thousands of LTX objects under the prefix are never enumerated.

A folder qualifies as an app when it holds a `functions/` or `databases/` subfolder, a Frame at its top, or any published artifact under its prefix — so half-built apps show up too, which are exactly the ones currently lost in old conversations.

## Pre-existing ambiguities this surfaces

Rather than hiding these, the tab reports them:

- **Colliding folders.** `Task List` and `Task-List` both normalize to `task-list`, so they genuinely share published slugs and databases today. They are shown as one app with a warning instead of silently rendering two apps that own the same artifacts.
- **Pod-root artifacts.** Functions published outside any app folder have no prefix, so they are gathered into a synthetic "unfiled" app instead of being invisible.
- **Legacy databases.** A database created before app namespacing has a bare filename (`products`, not `productmanager__products`), so its name cannot say who owns it. These are attributed via the schema file that declares them (`ProductManager/databases/products.db.ts`), mirroring how `resolvePodDatabaseName` resolves the same case at reconcile time. Two apps declaring the same bare name are both credited, since they really do share that one file.

## Display

Functions and databases show their **bare** names (`add-person`, not `peopletracker2__add-person`) since the app is already the surrounding context. The addressable full slug and on-disk name stay on the wire for anything that needs to reference them. Frames open in the existing `PodFrameSheet`, so sharing, pinning and export come along for free.

The tab is gated on the `sandbox_functions` feature flag.

## Notes for reviewers

- `includeConnectedData` was generalized into a `PodNavVisibility` object. Without it, frame-tab neighbour-swapping could move a tab past an Apps tab the user cannot see.
- `FileStorage.listSubdirectoryNames` is new: a delimited GCS list returning only directory names.
- Existing pods with a stored `tabsOrder` will get Apps at the far right, since `normalizeTabsOrder` appends missing system tabs. New pods get it right after Files. Happy to insert positionally instead if preferred.
- `fileCount` is on the payload but unused by the UI; the delete confirmation in the follow-up needs it.

## Risk

Low. Additive and read-only — one new GET endpoint and one new tab. No writes, no schema change.

## Tests

8 new functional tests on the endpoint covering the happy path, non-app folders, the unfiled app, colliding prefixes, an app whose folder is gone but whose functions are still published, and both legacy-database cases. Unit tests for the two new naming helpers.
