### PR TITLE
[front] fix: sync reconcile-created pod databases before reporting success

### DIFF
--- a/cli/dust-sandbox/pod/db.ts
+++ b/cli/dust-sandbox/pod/db.ts
@@ -127,8 +127,7 @@ export class PodDatabaseNotDeclaredError extends PodDatabaseError {
     super(
       `Pod database "${dbName}" does not exist (no database file at ${path}). ` +
         `Databases are created by their first reconcile: define the tables in ` +
-        `databases/${dbName}.db.ts, apply it with the db_reconcile tool, and ` +
-        `declare "${dbName}" in the function's schema.databases.`
+        `databases/${dbName}.db.ts and apply it with the db_reconcile tool.`
     );
     this.name = "PodDatabaseNotDeclaredError";
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/db_reconcile.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/db_reconcile.test.ts
@@ -33,4 +33,27 @@ describe("formatReconcileResult", () => {
 
     expect(out).toContain('Database "myapp__chat" created.');
   });
+
+  it("appends the replication warning when the first sync was not confirmed", () => {
+    const out = formatReconcileResult({
+      database: "chat",
+      created: true,
+      statements: [],
+      replicationWarning: "first replication sync could not be confirmed.",
+    });
+
+    expect(out).toContain(
+      "Warning: first replication sync could not be confirmed."
+    );
+  });
+
+  it("emits no warning line by default", () => {
+    const out = formatReconcileResult({
+      database: "chat",
+      created: true,
+      statements: [],
+    });
+
+    expect(out).not.toContain("Warning:");
+  });
 });

--- a/front/lib/api/actions/servers/sandbox_functions/tools/db_reconcile.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/db_reconcile.ts
@@ -17,7 +17,11 @@ export function formatReconcileResult(result: ReconcileDatabaseResult): string {
     result.statements.length === 0
       ? "No schema changes to apply."
       : `Applied:\n${result.statements.map((statement) => `- ${statement}`).join("\n")}`;
-  return `${header}\n${body}`;
+  const warning =
+    result.replicationWarning === undefined
+      ? ""
+      : `\nWarning: ${result.replicationWarning}`;
+  return `${header}\n${body}${warning}`;
 }
 
 export async function dbReconcileHandler(

--- a/front/lib/api/sandbox/db.test.ts
+++ b/front/lib/api/sandbox/db.test.ts
@@ -6,6 +6,7 @@ import {
   syncPodDatabaseAfterCreate,
   syncPodDatabaseToReplica,
 } from "@app/lib/api/sandbox/db";
+import { SandboxNotFoundError } from "@app/lib/api/sandbox/provider";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { Err, Ok } from "@app/types/shared/result";
@@ -137,6 +138,23 @@ describe("syncPodDatabaseAfterCreate", () => {
 
     expect(result.isOk()).toBe(true);
     expect(execRoot).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not retry when the sandbox is gone", async () => {
+    const { authenticator, sandbox } = await setupSandbox();
+    const execRoot = vi
+      .spyOn(sandbox, "execRoot")
+      .mockResolvedValue(new Err(new SandboxNotFoundError("test-provider-id")));
+
+    const result = await syncPodDatabaseAfterCreate(
+      authenticator,
+      sandbox,
+      "chat",
+      { retryDelayMs: 0 }
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(execRoot).toHaveBeenCalledTimes(1);
   });
 
   test("gives up after the bounded attempts and returns the last error", async () => {

--- a/front/lib/api/sandbox/db.test.ts
+++ b/front/lib/api/sandbox/db.test.ts
@@ -3,8 +3,13 @@ import {
   isValidPodDatabaseName,
   parseLiveDatabaseNames,
   parseReplicaDatabaseNames,
+  syncPodDatabaseAfterCreate,
+  syncPodDatabaseToReplica,
 } from "@app/lib/api/sandbox/db";
-import { describe, expect, test } from "vitest";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { Err, Ok } from "@app/types/shared/result";
+import { describe, expect, test, vi } from "vitest";
 
 describe("pod state helpers", () => {
   test("validates database names against the contract shape", () => {
@@ -65,5 +70,93 @@ describe("pod state helpers", () => {
     expect(isFuseStatfsMagic("ef53")).toBe(false);
     expect(isFuseStatfsMagic("794c7630")).toBe(false);
     expect(isFuseStatfsMagic("")).toBe(false);
+  });
+});
+
+async function setupSandbox() {
+  const { authenticator } = await createResourceTest({ role: "admin" });
+  const sandbox = await SandboxResource.makeNew(authenticator, {
+    providerId: "test-provider-id",
+    status: "running",
+    baseImage: "dust-base",
+    version: "0.0.0-test",
+  });
+  return { authenticator, sandbox };
+}
+
+describe("syncPodDatabaseToReplica", () => {
+  test("runs one litestream sync through the daemon socket", async () => {
+    const { authenticator, sandbox } = await setupSandbox();
+    const execRoot = vi
+      .spyOn(sandbox, "execRoot")
+      .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" }));
+
+    const result = await syncPodDatabaseToReplica(authenticator, sandbox, "chat");
+
+    expect(result.isOk()).toBe(true);
+    expect(execRoot).toHaveBeenCalledTimes(1);
+    const command = execRoot.mock.calls[0][1].command;
+    expect(command).toContain("/opt/bin/litestream sync -wait");
+    expect(command).toContain("-socket /run/litestream/litestream.sock");
+    expect(command).toContain("-- /pod-state/databases/chat.db");
+  });
+
+  test("surfaces a non-zero exit as an error", async () => {
+    const { authenticator, sandbox } = await setupSandbox();
+    vi.spyOn(sandbox, "execRoot").mockResolvedValue(
+      new Ok({ exitCode: 1, stdout: "", stderr: "no matching database" })
+    );
+
+    const result = await syncPodDatabaseToReplica(authenticator, sandbox, "chat");
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.message).toContain("litestream sync of chat");
+    expect(result.error.message).toContain("no matching database");
+  });
+});
+
+describe("syncPodDatabaseAfterCreate", () => {
+  test("retries past the watcher discovery delay and succeeds", async () => {
+    const { authenticator, sandbox } = await setupSandbox();
+    const execRoot = vi
+      .spyOn(sandbox, "execRoot")
+      .mockResolvedValueOnce(
+        new Ok({ exitCode: 1, stdout: "", stderr: "no matching database" })
+      )
+      .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" }));
+
+    const result = await syncPodDatabaseAfterCreate(
+      authenticator,
+      sandbox,
+      "chat",
+      { retryDelayMs: 0 }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(execRoot).toHaveBeenCalledTimes(2);
+  });
+
+  test("gives up after the bounded attempts and returns the last error", async () => {
+    const { authenticator, sandbox } = await setupSandbox();
+    const execRoot = vi
+      .spyOn(sandbox, "execRoot")
+      .mockResolvedValue(new Err(new Error("daemon socket unavailable")));
+
+    const result = await syncPodDatabaseAfterCreate(
+      authenticator,
+      sandbox,
+      "chat",
+      { retryDelayMs: 0 }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.message).toContain("daemon socket unavailable");
+    expect(execRoot).toHaveBeenCalledTimes(3);
   });
 });

--- a/front/lib/api/sandbox/db.test.ts
+++ b/front/lib/api/sandbox/db.test.ts
@@ -92,7 +92,11 @@ describe("syncPodDatabaseToReplica", () => {
       .spyOn(sandbox, "execRoot")
       .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" }));
 
-    const result = await syncPodDatabaseToReplica(authenticator, sandbox, "chat");
+    const result = await syncPodDatabaseToReplica(
+      authenticator,
+      sandbox,
+      "chat"
+    );
 
     expect(result.isOk()).toBe(true);
     expect(execRoot).toHaveBeenCalledTimes(1);
@@ -108,7 +112,11 @@ describe("syncPodDatabaseToReplica", () => {
       new Ok({ exitCode: 1, stdout: "", stderr: "no matching database" })
     );
 
-    const result = await syncPodDatabaseToReplica(authenticator, sandbox, "chat");
+    const result = await syncPodDatabaseToReplica(
+      authenticator,
+      sandbox,
+      "chat"
+    );
 
     expect(result.isErr()).toBe(true);
     if (result.isOk()) {

--- a/front/lib/api/sandbox/db.ts
+++ b/front/lib/api/sandbox/db.ts
@@ -1,6 +1,7 @@
 import { getPodStateBasePath } from "@app/lib/api/files/mount_path";
 import {
   recordPodStateHealth,
+  recordPodStateRestoreSkip,
   traceSandboxStartupPhase,
 } from "@app/lib/api/sandbox/instrumentation";
 import { SandboxNotFoundError } from "@app/lib/api/sandbox/provider";
@@ -43,6 +44,9 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
  *    paused; the daemon is restarted and a failure metric is emitted.
  *  - Wake from pause needs nothing: the Firecracker snapshot preserves the
  *    daemon, its control socket, the mounts and the database files.
+ *  - Database creation (`syncPodDatabaseAfterCreate`, called from the
+ *    reconcile path): one sync right after reconcile creates a file, so the
+ *    database reaches GCS before its creation is reported as a success.
  */
 
 export const POD_STATE_DATABASES_DIR = "/pod-state/databases";
@@ -88,6 +92,11 @@ const FUSE_STATFS_MAGIC_HEX = "65735546";
 // is tightly bounded.
 const SYNC_WAIT_TIMEOUT_SECONDS = 10;
 const SYNC_EXEC_TIMEOUT_MS = 15_000;
+// A reconcile-created database is durable only after litestream's first sync,
+// and the daemon's directory watcher discovers new files within seconds — so
+// the first sync attempt can race discovery and is retried briefly.
+const CREATED_DB_SYNC_MAX_ATTEMPTS = 3;
+const CREATED_DB_SYNC_RETRY_DELAY_MS = 2_000;
 // Cheap probes and file operations stay tightly bounded.
 const PROBE_EXEC_TIMEOUT_MS = 10_000;
 // Cold-start restore may pull a large snapshot + LTX chain through gcsfuse.
@@ -337,8 +346,17 @@ async function restorePodDatabase(
     return restoredResult;
   }
   if (restoredResult.value.exitCode !== 0) {
-    logger.warn(
-      { database: name },
+    // Deliberately not a failure (see the -if-replica-exists comment above),
+    // but loud: the skipped database's data — if it ever had any — is not
+    // coming back on its own, and every function using it will fail until a
+    // reconcile recreates it. The metric is what Datadog monitors alert on.
+    recordPodStateRestoreSkip();
+    logger.error(
+      {
+        sandboxId: sandbox.sId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        database: name,
+      },
       "Pod state cold start: replica directory has no restorable backup — skipping database"
     );
     return new Ok(undefined);
@@ -517,29 +535,10 @@ export async function ensurePodStateHealthOnSleep(
 
   // 4. Sync each database through the daemon control socket.
   for (const name of names) {
-    const dbPath = `${POD_STATE_DATABASES_DIR}/${name}.db`;
-    const syncResult = await sandbox.execRoot(
-      auth,
-      rootCommand.exec(LITESTREAM_BIN, [
-        "sync",
-        "-wait",
-        "-timeout",
-        SYNC_WAIT_TIMEOUT_SECONDS,
-        "-socket",
-        LITESTREAM_SOCKET_PATH,
-        "--",
-        dbPath,
-      ]),
-      { timeoutMs: SYNC_EXEC_TIMEOUT_MS }
-    );
+    const syncResult = await syncPodDatabaseToReplica(auth, sandbox, name);
 
-    const failure = syncResult.isErr()
-      ? syncResult.error
-      : syncResult.value.exitCode !== 0
-        ? execFailure(`litestream sync of ${name}`, syncResult.value)
-        : null;
-
-    if (failure) {
+    if (syncResult.isErr()) {
+      const failure = syncResult.error;
       if (failure instanceof SandboxNotFoundError) {
         return new Ok(undefined);
       }
@@ -564,6 +563,71 @@ export async function ensurePodStateHealthOnSleep(
   recordPodStateHealth("success");
 
   return new Ok(undefined);
+}
+
+/**
+ * Sync one database's committed WAL frames to the GCS replica through the
+ * daemon control socket. Requires the litestream daemon to be running (see
+ * the lifecycle in the module doc). A provider error is returned as-is so
+ * callers can special-case `SandboxNotFoundError`.
+ */
+export async function syncPodDatabaseToReplica(
+  auth: Authenticator,
+  sandbox: SandboxResource,
+  name: string
+): Promise<Result<void, Error>> {
+  const dbPath = `${POD_STATE_DATABASES_DIR}/${name}.db`;
+  const syncResult = await sandbox.execRoot(
+    auth,
+    rootCommand.exec(LITESTREAM_BIN, [
+      "sync",
+      "-wait",
+      "-timeout",
+      SYNC_WAIT_TIMEOUT_SECONDS,
+      "-socket",
+      LITESTREAM_SOCKET_PATH,
+      "--",
+      dbPath,
+    ]),
+    { timeoutMs: SYNC_EXEC_TIMEOUT_MS }
+  );
+  if (syncResult.isErr()) {
+    return syncResult;
+  }
+  if (syncResult.value.exitCode !== 0) {
+    return new Err(execFailure(`litestream sync of ${name}`, syncResult.value));
+  }
+  return new Ok(undefined);
+}
+
+/**
+ * Sync a database right after reconcile created its file, so the database is
+ * in GCS before the reconcile reports success. Without this, an unclean
+ * sandbox end before litestream's first sync silently loses the file — and
+ * the next cold start then skips the database by design (no restorable
+ * backup, see `restorePodDatabase`), reproducing "reconciled earlier, missing
+ * now". The daemon's directory watcher discovers new files within seconds,
+ * so a failing sync is retried briefly to ride out the discovery delay.
+ *
+ * `retryDelayMs` is overridable for tests only.
+ */
+export async function syncPodDatabaseAfterCreate(
+  auth: Authenticator,
+  sandbox: SandboxResource,
+  name: string,
+  {
+    retryDelayMs = CREATED_DB_SYNC_RETRY_DELAY_MS,
+  }: { retryDelayMs?: number } = {}
+): Promise<Result<void, Error>> {
+  let attempt = 0;
+  for (;;) {
+    attempt += 1;
+    const syncResult = await syncPodDatabaseToReplica(auth, sandbox, name);
+    if (syncResult.isOk() || attempt >= CREATED_DB_SYNC_MAX_ATTEMPTS) {
+      return syncResult;
+    }
+    await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+  }
 }
 
 async function checkReplicaMountLiveness(

--- a/front/lib/api/sandbox/db.ts
+++ b/front/lib/api/sandbox/db.ts
@@ -626,6 +626,10 @@ export async function syncPodDatabaseAfterCreate(
     if (syncResult.isOk() || attempt >= CREATED_DB_SYNC_MAX_ATTEMPTS) {
       return syncResult;
     }
+    if (syncResult.error instanceof SandboxNotFoundError) {
+      // The sandbox is gone; retrying cannot succeed.
+      return syncResult;
+    }
     await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
   }
 }

--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -152,3 +152,13 @@ export function recordPodStateHealth(status: "success" | "failure"): void {
     `status:${status}`,
   ]);
 }
+
+// Cold-start restore found a replica directory with no restorable backup and
+// skipped the database (see restorePodDatabase): whatever data that database
+// held is not coming back on its own, so this is alert-worthy, not routine.
+// The stable logger.error at the call site carries the database name.
+export function recordPodStateRestoreSkip(): void {
+  getStatsDClient().increment("sandbox.pod_state.restore_skipped", 1, [
+    regionTag(),
+  ]);
+}

--- a/front/lib/api/sandbox_functions/dsbx_db.test.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.test.ts
@@ -1,20 +1,27 @@
 import { createHash } from "node:crypto";
 
+import { syncPodDatabaseAfterCreate } from "@app/lib/api/sandbox/db";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import {
   getDatabaseSchemaOnSandbox,
   listDatabasesOnSandbox,
+  reconcileDatabaseOnSandbox,
 } from "@app/lib/api/sandbox_functions/dsbx_db";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/api/sandbox/lifecycle", () => ({
   ensurePodSandboxReady: vi.fn(),
 }));
+
+vi.mock(import("@app/lib/api/sandbox/db"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, syncPodDatabaseAfterCreate: vi.fn() };
+});
 
 const sha256Hex = (content: string): string =>
   createHash("sha256").update(content).digest("hex");
@@ -130,6 +137,90 @@ describe("getDatabaseSchemaOnSandbox", () => {
     }
     expect(result.error.code).toBe("internal");
     expect(result.error.message).toContain("Missing integrity hash");
+  });
+});
+
+describe("reconcileDatabaseOnSandbox", () => {
+  const reconcileArgs = {
+    database: "myapp__chat",
+    schemaFileSandboxPath: "/files/pod-x/MyApp/databases/chat.db.ts",
+  };
+
+  function mockReconcileExec(
+    sandbox: SandboxResource,
+    { created }: { created: boolean }
+  ) {
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout: `${JSON.stringify({ ok: true, created, statements: [] })}\n`,
+        stderr: "",
+      })
+    );
+  }
+
+  it("waits for the first replication sync when the database was created", async () => {
+    const { authenticator, sandbox, space } = await setup();
+    mockReconcileExec(sandbox, { created: true });
+    vi.mocked(syncPodDatabaseAfterCreate).mockResolvedValue(new Ok(undefined));
+
+    const result = await reconcileDatabaseOnSandbox(authenticator, {
+      space,
+      ...reconcileArgs,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value.created).toBe(true);
+    expect(result.value.replicationWarning).toBeUndefined();
+    expect(syncPodDatabaseAfterCreate).toHaveBeenCalledTimes(1);
+    expect(syncPodDatabaseAfterCreate).toHaveBeenCalledWith(
+      authenticator,
+      sandbox,
+      "myapp__chat"
+    );
+  });
+
+  it("reports a replication warning when the first sync cannot be confirmed", async () => {
+    const { authenticator, sandbox, space } = await setup();
+    mockReconcileExec(sandbox, { created: true });
+    vi.mocked(syncPodDatabaseAfterCreate).mockResolvedValue(
+      new Err(new Error("daemon socket unavailable"))
+    );
+
+    const result = await reconcileDatabaseOnSandbox(authenticator, {
+      space,
+      ...reconcileArgs,
+    });
+
+    // The DDL applied and reconcile is idempotent, so the reconcile still
+    // succeeds — but the caller is told durability is not confirmed yet.
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value.replicationWarning).toContain(
+      "first replication sync could not be confirmed"
+    );
+  });
+
+  it("does not sync when the database already existed", async () => {
+    const { authenticator, sandbox, space } = await setup();
+    mockReconcileExec(sandbox, { created: false });
+
+    const result = await reconcileDatabaseOnSandbox(authenticator, {
+      space,
+      ...reconcileArgs,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value.replicationWarning).toBeUndefined();
+    expect(syncPodDatabaseAfterCreate).not.toHaveBeenCalled();
   });
 });
 

--- a/front/lib/api/sandbox_functions/dsbx_db.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.ts
@@ -7,6 +7,7 @@ import {
   TOOL_OUTPUTS_FOLDER_NAME,
 } from "@app/lib/api/files/mount_path";
 import { getRedisStreamClient } from "@app/lib/api/redis";
+import { syncPodDatabaseAfterCreate } from "@app/lib/api/sandbox/db";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import {
@@ -181,14 +182,23 @@ export interface ReconcileDatabaseResult {
   database: string;
   created: boolean;
   statements: string[];
+  /**
+   * Set when the database was created but its first replication sync could not be confirmed: the
+   * DDL did apply, but until replication catches up an unclean sandbox end could lose the file.
+   */
+  replicationWarning?: string;
 }
 
 /**
  * `dsbx db reconcile <name> <schema-file>`: plan the DDL for the database's drizzle schema file,
  * apply it when strictly additive, refuse anything destructive. Runs as `agent-proxied` (the
  * schema file is model-written code that gets imported).
+ *
+ * Lock-free inner reconcile: `database` must be the resolved on-disk name and callers must
+ * serialize concurrent reconciles of one pod themselves (see `reconcileDatabaseFromPodPath`,
+ * which holds the per-pod lock and resolves the name inside it).
  */
-async function reconcileDatabaseOnSandbox(
+export async function reconcileDatabaseOnSandbox(
   auth: Authenticator,
   {
     space,
@@ -209,7 +219,7 @@ async function reconcileDatabaseOnSandbox(
   if (result.isErr()) {
     return result;
   }
-  const { envelope } = result.value;
+  const { sandbox, envelope } = result.value;
 
   if ("ok" in envelope && envelope.ok) {
     if (envelope.statements.length > 0) {
@@ -224,10 +234,40 @@ async function reconcileDatabaseOnSandbox(
         "Pod database reconciled: applied DDL"
       );
     }
+
+    // A freshly created database exists only on the sandbox disk until litestream's first sync:
+    // wait for that sync before reporting success, so "created" means durable. On failure the
+    // reconcile still succeeds (the DDL applied and reconcile is idempotent) but carries a
+    // warning; the pre-sleep sync remains the enforcement point that blocks the pause and pages.
+    let replicationWarning: string | undefined;
+    if (envelope.created) {
+      const syncResult = await syncPodDatabaseAfterCreate(
+        auth,
+        sandbox,
+        database
+      );
+      if (syncResult.isErr()) {
+        logger.error(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            podId: space.sId,
+            database,
+            err: syncResult.error,
+          },
+          "Pod database created but its first replication sync could not be confirmed"
+        );
+        replicationWarning =
+          `The database was created and its schema applied, but its first replication sync ` +
+          `could not be confirmed. If the sandbox ends uncleanly before replication catches ` +
+          `up, the database may disappear and need another reconcile.`;
+      }
+    }
+
     return new Ok({
       database,
       created: envelope.created,
       statements: envelope.statements,
+      ...(replicationWarning !== undefined ? { replicationWarning } : {}),
     });
   }
 


### PR DESCRIPTION
## Description

A pod database created by `dsbx db reconcile` was only durable after litestream's first background sync. An unclean sandbox end before that silently lost the file, and the next cold start skipped it by design (`-if-replica-exists`), so functions failed with "database does not exist" after an earlier successful reconcile.

- After a reconcile reports `created: true`, run `litestream sync -wait` against the new file before returning, with a short bounded retry to ride out the directory watcher's discovery delay. On persistent failure the reconcile still succeeds (DDL applied, reconcile is idempotent) but the tool result carries an explicit warning.
- Upgrade the cold-start restore skip from `logger.warn` to `logger.error` plus a new `sandbox.pod_state.restore_skipped` metric so it can be alerted on.
- Drop the "declare it in the function's schema.databases" clause from `PodDatabaseNotDeclaredError`: no code path extracts or validates `schema.databases`, so the advice was a no-op.

## Tests

Added coverage for the sync helper retry/bail-out behavior, the reconcile wiring (sync on created, warning on failure, no sync when the database existed), and the warning line in the tool result. Ran the touched front vitest files and the `@dust/pod` bun tests locally.

## Risk

Low. The sync runs only on the created path and its failure never fails the reconcile. Worst case is a few extra bounded execs per database creation.

## Deploy Plan

Standard deploy.