### PR TITLE
[front] feat: machine-readable offload descriptor and parse-safe stub for offloaded tool outputs

### DIFF
--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -282,6 +282,45 @@ mod tests {
     }
 
     #[test]
+    fn call_tool_result_preserves_block_meta_offload_descriptor() {
+        // Offloaded tool outputs carry a machine-readable descriptor in the block's `_meta`
+        // (key "tt.dust/offload"); the CLI must pass it through verbatim so in-sandbox
+        // consumers can resolve the full content.
+        let poll_body = r#"{
+            "status":"success",
+            "action":{
+                "status":"succeeded",
+                "output":[{
+                    "type":"resource",
+                    "resource":{"uri":"pod-x/.tool_outputs/fn/1_tool.json","mimeType":"text/plain","text":"snippet"},
+                    "_meta":{"tt.dust/offload":{"fullContentPath":"pod-x/.tool_outputs/fn/1_tool.json","totalBytes":123456,"contentType":"application/json"}}
+                }]
+            }
+        }"#;
+        let resp = parse_action_poll_response(poll_body).expect("should parse");
+        let content = match resp {
+            ActionPollResponse::Success { content, .. } => content,
+            _ => panic!("expected success"),
+        };
+
+        let result = CallToolResult {
+            content,
+            is_error: false,
+        };
+        let value: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&result).expect("should serialize"))
+                .expect("should round-trip");
+
+        let descriptor = &value["content"][0]["_meta"]["tt.dust/offload"];
+        assert_eq!(
+            descriptor["fullContentPath"],
+            "pod-x/.tool_outputs/fn/1_tool.json"
+        );
+        assert_eq!(descriptor["totalBytes"], 123456);
+        assert_eq!(descriptor["contentType"], "application/json");
+    }
+
+    #[test]
     fn call_tool_result_preserves_unknown_block_types_when_serialized() {
         let result = CallToolResult {
             content: vec![serde_json::json!({

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.test.ts
@@ -116,6 +116,44 @@ describe("GET /api/v1/w/[wId]/sandbox/actions/[aId] (function invocation)", () =
     expect(body.action.output).toEqual(content);
   });
 
+  it("serves content block _meta (offload descriptor) verbatim", async () => {
+    const { auth, token, workspace, action } = await setupWithAction();
+
+    // Shape produced by the tool-output offload path: a snippet resource block carrying the
+    // machine-readable descriptor in _meta. The route must serve it verbatim so in-sandbox
+    // consumers can resolve the full content.
+    const content = [
+      {
+        type: "resource" as const,
+        resource: {
+          uri: "pod-spc_x/.tool_outputs/fn/1_tool.json",
+          mimeType: "text/plain",
+          text: '{"__dust_offloaded__":true}\n[Full content archived at pod-spc_x/.tool_outputs/fn/1_tool.json]',
+        },
+        _meta: {
+          "tt.dust/offload": {
+            fullContentPath: "pod-spc_x/.tool_outputs/fn/1_tool.json",
+            totalBytes: 123456,
+            contentType: "application/json",
+          },
+        },
+      },
+    ];
+    const writeResult = await action.createOutputItems(
+      auth,
+      content.map((c) => ({ content: c }))
+    );
+    expect(writeResult.isOk()).toBe(true);
+    await action.markAsSucceeded({ executionDurationMs: 42 });
+
+    const response = await getSandboxAction(workspace, token, action.sId);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("success");
+    expect(body.action.output).toEqual(content);
+  });
+
   it("scopes actions to the token's invocation", async () => {
     const { auth, token, workspace, view, sandboxFunction, action } =
       await setupWithAction();

--- a/front/lib/actions/action_output_limits.ts
+++ b/front/lib/actions/action_output_limits.ts
@@ -9,6 +9,23 @@ export const FILE_OFFLOAD_FILE_SIZE_BYTES = 20 * 1024 * 1024; // 20MB for non-im
 
 export const FILE_OFFLOAD_SNIPPET_LENGTH = 8_000; // Approximately 2K tokens.
 
+// Key of the machine-readable offload descriptor in a content block's `_meta`. Attached to every
+// block whose full text was offloaded to the run context's file system, so code consumers
+// (function code via `@dust/pod`, future SDKs) can read the full content back without parsing the
+// human-facing "[Full content archived at ...]" sentence. Reverse-domain prefixed per the MCP
+// `_meta` naming convention.
+export const TOOL_OUTPUT_OFFLOAD_META_KEY = "tt.dust/offload";
+
+// The descriptor stored under TOOL_OUTPUT_OFFLOAD_META_KEY. This is a wire contract consumed
+// in-sandbox (`@dust/pod` carries its own copy of the shape): fields are append-only.
+export interface ToolOutputOffloadDescriptor {
+  // Scoped path of the archived full content (e.g. "pod-{pId}/.tool_outputs/{slug}/{file}"),
+  // resolvable in-sandbox under the /files gcsfuse mount.
+  fullContentPath: string;
+  totalBytes: number;
+  contentType: string;
+}
+
 // Hard limits for remote MCP server tool results.
 // When any content block exceeds these sizes, the entire tool result is rejected.
 const REMOTE_MAX_TEXT_SIZE_BYTES = 2 * 1024 * 1024; // 2MB.

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -802,9 +802,7 @@ describe("processToolResults", () => {
     // sentence conversation snippets carry (existing function code regexes it).
     const lines = stored.resource.text.split("\n");
     expect(lines).toHaveLength(2);
-    expect(lines[1]).toBe(
-      `[Full content archived at ${stored.resource.uri}]`
-    );
+    expect(lines[1]).toBe(`[Full content archived at ${stored.resource.uri}]`);
 
     // The stub itself parses and points at the full content, like the _meta descriptor.
     expect(lines[0].length).toBeLessThanOrEqual(FILE_OFFLOAD_SNIPPET_LENGTH);

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -1,6 +1,7 @@
 import {
   FILE_OFFLOAD_SNIPPET_LENGTH,
   FILE_OFFLOAD_TEXT_SIZE_BYTES,
+  TOOL_OUTPUT_OFFLOAD_META_KEY,
 } from "@app/lib/actions/action_output_limits";
 import type {
   InternalServerSideMCPToolConfigurationType,
@@ -301,6 +302,13 @@ describe("processToolResults", () => {
       expect(stored.resource.uri).toMatch(
         new RegExp(`${TOOL_OUTPUTS_FOLDER_NAME}/`)
       );
+
+      // The machine-readable counterpart of the archive sentence rides the block's _meta.
+      expect(stored._meta?.[TOOL_OUTPUT_OFFLOAD_META_KEY]).toEqual({
+        fullContentPath: stored.resource.uri,
+        totalBytes: Buffer.byteLength(largeText, "utf8"),
+        contentType: "text/plain",
+      });
     }
 
     // Offloaded to DustFileSystem, so generatedFiles is empty.
@@ -770,6 +778,162 @@ describe("processToolResults", () => {
     expect(refetched?.outputGcsPath).toBe(
       `w/${workspace.sId}/mcp_output_items/${action.sId}/output.json`
     );
+  });
+
+  it("should replace the head of offloaded JSON with a parse-safe stub in a sandbox function run context", async () => {
+    const { auth, toolContext } = await setupSandboxFunctionTest();
+
+    const largeJson = JSON.stringify({
+      data: "x".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES),
+    });
+
+    const { outputItems } = await processToolResults(auth, {
+      localLogger: logger.child({ test: true }),
+      toolContext,
+      toolCallResultContent: [{ type: "text", text: largeJson }],
+    });
+
+    expect(outputItems).toHaveLength(1);
+    const stored = outputItems[0].content;
+    expect(stored.type).toBe("resource");
+    assert(stored.type === "resource" && "text" in stored.resource);
+
+    // The stub is a single JSON line followed by the archive sentence, byte-identical to the
+    // sentence conversation snippets carry (existing function code regexes it).
+    const lines = stored.resource.text.split("\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toBe(
+      `[Full content archived at ${stored.resource.uri}]`
+    );
+
+    // The stub itself parses and points at the full content, like the _meta descriptor.
+    expect(lines[0].length).toBeLessThanOrEqual(FILE_OFFLOAD_SNIPPET_LENGTH);
+    const stub = JSON.parse(lines[0]);
+    expect(stub.__dust_offloaded__).toBe(true);
+    expect(stub.fullContentPath).toBe(stored.resource.uri);
+    expect(stub.totalBytes).toBe(Buffer.byteLength(largeJson, "utf8"));
+    expect(stub.head.length).toBeGreaterThan(0);
+    expect(largeJson.startsWith(stub.head)).toBe(true);
+
+    expect(stored._meta?.[TOOL_OUTPUT_OFFLOAD_META_KEY]).toEqual({
+      fullContentPath: stored.resource.uri,
+      totalBytes: Buffer.byteLength(largeJson, "utf8"),
+      contentType: "application/json",
+    });
+
+    // The descriptor survives output-item persistence: it is part of the single GCS object
+    // recorded on the sandbox action.
+    const outputWrite = fileStorageMock.saveFileCalls.find((call) =>
+      call.filePath.endsWith("/output.json")
+    );
+    expect(outputWrite).toBeDefined();
+    const persisted = JSON.parse(outputWrite?.content.toString() ?? "");
+    expect(persisted[0]._meta?.[TOOL_OUTPUT_OFFLOAD_META_KEY]).toEqual({
+      fullContentPath: stored.resource.uri,
+      totalBytes: Buffer.byteLength(largeJson, "utf8"),
+      contentType: "application/json",
+    });
+  });
+
+  it("should keep the plain snippet for offloaded non-JSON text in a sandbox function run context", async () => {
+    const { auth, toolContext } = await setupSandboxFunctionTest();
+
+    const largeText = "x".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES + 1);
+
+    const { outputItems } = await processToolResults(auth, {
+      localLogger: logger.child({ test: true }),
+      toolContext,
+      toolCallResultContent: [{ type: "text", text: largeText }],
+    });
+
+    expect(outputItems).toHaveLength(1);
+    const stored = outputItems[0].content;
+    expect(stored.type).toBe("resource");
+    assert(stored.type === "resource" && "text" in stored.resource);
+
+    // Non-JSON content keeps today's exact snippet shape: raw head, truncation marker, sentence.
+    expect(
+      stored.resource.text.startsWith(
+        largeText.substring(0, FILE_OFFLOAD_SNIPPET_LENGTH)
+      )
+    ).toBe(true);
+    expect(stored.resource.text).toContain("... (truncated)");
+    expect(stored.resource.text).toContain(
+      `[Full content archived at ${stored.resource.uri}]`
+    );
+    expect(stored.resource.text).not.toContain("__dust_offloaded__");
+
+    expect(stored._meta?.[TOOL_OUTPUT_OFFLOAD_META_KEY]).toEqual({
+      fullContentPath: stored.resource.uri,
+      totalBytes: Buffer.byteLength(largeText, "utf8"),
+      contentType: "text/plain",
+    });
+  });
+
+  it("should keep today's snippet for offloaded JSON in an agent loop run context", async () => {
+    const { auth, toolContext } = await setupTest();
+
+    const largeJson = JSON.stringify({
+      data: "x".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES),
+    });
+
+    const { outputItems } = await processToolResults(auth, {
+      localLogger: logger.child({ test: true }),
+      toolContext,
+      toolCallResultContent: [{ type: "text", text: largeJson }],
+    });
+
+    expect(outputItems).toHaveLength(1);
+    const stored = outputItems[0].content;
+    expect(stored.type).toBe("resource");
+    assert(stored.type === "resource" && "text" in stored.resource);
+
+    // Conversation snippets are untouched by the parse-safe stub: raw head + sentence.
+    expect(
+      stored.resource.text.startsWith(
+        largeJson.substring(0, FILE_OFFLOAD_SNIPPET_LENGTH)
+      )
+    ).toBe(true);
+    expect(stored.resource.text).not.toContain("__dust_offloaded__");
+    expect(stored.resource.text).toContain(
+      `[Full content archived at ${stored.resource.uri}]`
+    );
+
+    // The descriptor is attached in every run context.
+    expect(stored._meta?.[TOOL_OUTPUT_OFFLOAD_META_KEY]).toEqual({
+      fullContentPath: stored.resource.uri,
+      totalBytes: Buffer.byteLength(largeJson, "utf8"),
+      contentType: "application/json",
+    });
+  });
+
+  it("should attach the offload descriptor to offloaded resource text blocks", async () => {
+    const { auth, toolContext } = await setupTest();
+
+    const largeResourceText = "y".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES + 1);
+
+    const { outputItems } = await processToolResults(auth, {
+      localLogger: logger.child({ test: true }),
+      toolContext,
+      toolCallResultContent: [
+        {
+          type: "resource",
+          resource: { uri: "file://test.txt", text: largeResourceText },
+        },
+      ],
+    });
+
+    expect(outputItems).toHaveLength(1);
+    const stored = outputItems[0].content;
+    expect(stored.type).toBe("resource");
+    assert(stored.type === "resource" && "text" in stored.resource);
+
+    const descriptor = stored._meta?.[TOOL_OUTPUT_OFFLOAD_META_KEY];
+    expect(descriptor).toMatchObject({
+      totalBytes: Buffer.byteLength(largeResourceText, "utf8"),
+      contentType: "text/plain",
+    });
+    expect(stored.resource.text).toContain("[Full content archived at ");
   });
 
   it("should throw and leave the action without an output path when the sandbox output write fails", async () => {

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -1,4 +1,8 @@
-import { FILE_OFFLOAD_SNIPPET_LENGTH } from "@app/lib/actions/action_output_limits";
+import type { ToolOutputOffloadDescriptor } from "@app/lib/actions/action_output_limits";
+import {
+  FILE_OFFLOAD_SNIPPET_LENGTH,
+  TOOL_OUTPUT_OFFLOAD_META_KEY,
+} from "@app/lib/actions/action_output_limits";
 import type {
   MCPToolConfigurationType,
   ToolNotificationEvent,
@@ -19,9 +23,14 @@ import type {
   ActionGeneratedFileType,
   ToolContext,
   ToolOutputItemType,
+  ToolRunContext,
 } from "@app/lib/actions/types";
-import { isAgentLoopRunContext } from "@app/lib/actions/types";
+import {
+  isAgentLoopRunContext,
+  isSandboxFunctionRunContext,
+} from "@app/lib/actions/types";
 import { isInternalServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
+import type { PersistedToolOutput } from "@app/lib/api/files/action_output_fs";
 import { persistToolOutput } from "@app/lib/api/files/action_output_fs";
 import { processAndStoreFromUrl } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
@@ -74,15 +83,79 @@ function getFileName(resource: { uri: string }): string {
 /**
  * Builds the model-visible snippet for a content block whose full text was offloaded to the
  * file system by persistToolOutput. The scoped path pointer is what lets the model read the
- * rest of the content back, so it must always be present.
+ * rest of the content back, so it must always be present. The
+ * "[Full content archived at <path>]" sentence is a stable contract — existing function code
+ * regexes it — and must stay byte-identical across variants.
+ *
+ * In a sandbox function run context, JSON content gets a parse-safe stub instead of the blind
+ * character cut: code that strips the archive sentence and JSON.parses the rest gets an explicit
+ * offload pointer object instead of JSON cut mid-string. Conversation (agent loop) snippets are
+ * untouched.
  */
-function makeOffloadedSnippet(text: string, scopedPath: string): string {
+function makeOffloadedSnippet(
+  text: string,
+  offload: PersistedToolOutput,
+  runContext: ToolRunContext
+): string {
+  const archiveSentence = `[Full content archived at ${offload.scopedPath}]`;
+
+  if (
+    isSandboxFunctionRunContext(runContext) &&
+    offload.contentType === "application/json"
+  ) {
+    return `${makeParseSafeOffloadStub(text, offload)}\n${archiveSentence}`;
+  }
+
   const head = text.substring(0, FILE_OFFLOAD_SNIPPET_LENGTH);
   // The offload threshold is in bytes while the snippet cut is in characters, so multibyte
   // content can be offloaded without losing any character here — only claim truncation when
   // characters were actually dropped.
   const truncatedSuffix = head.length < text.length ? "... (truncated)" : "";
-  return `${head}${truncatedSuffix}\n[Full content archived at ${scopedPath}]`;
+  return `${head}${truncatedSuffix}\n${archiveSentence}`;
+}
+
+/**
+ * Serializes the parse-safe stub that replaces the head of offloaded JSON content for sandbox
+ * function consumers. The serialized stub is capped at FILE_OFFLOAD_SNIPPET_LENGTH characters
+ * (like the plain head cut): JSON escaping can inflate the head, so trim by the measured overage
+ * until it fits — every head character serializes to at least one character, so this converges
+ * in a few rounds.
+ */
+function makeParseSafeOffloadStub(
+  text: string,
+  offload: PersistedToolOutput
+): string {
+  let head = text.substring(0, FILE_OFFLOAD_SNIPPET_LENGTH);
+  for (;;) {
+    const serialized = JSON.stringify({
+      __dust_offloaded__: true,
+      fullContentPath: offload.scopedPath,
+      totalBytes: offload.totalBytes,
+      head,
+    });
+    const overageChars = serialized.length - FILE_OFFLOAD_SNIPPET_LENGTH;
+    if (overageChars <= 0 || head.length === 0) {
+      return serialized;
+    }
+    head = head.substring(0, Math.max(0, head.length - overageChars));
+  }
+}
+
+/**
+ * Builds the `_meta` payload attached to every offloaded content block: the machine-readable
+ * counterpart of the archive sentence, letting code consumers locate the full content without
+ * parsing the snippet text.
+ */
+function makeOffloadMeta(offload: PersistedToolOutput): {
+  [TOOL_OUTPUT_OFFLOAD_META_KEY]: ToolOutputOffloadDescriptor;
+} {
+  return {
+    [TOOL_OUTPUT_OFFLOAD_META_KEY]: {
+      fullContentPath: offload.scopedPath,
+      totalBytes: offload.totalBytes,
+      contentType: offload.contentType,
+    },
+  };
 }
 
 export async function processToolNotification(
@@ -225,7 +298,8 @@ export async function processToolResults(
           if (res.value !== null) {
             const snippet = makeOffloadedSnippet(
               block.text,
-              res.value.scopedPath
+              res.value,
+              runContext
             );
             return {
               content: {
@@ -235,6 +309,7 @@ export async function processToolResults(
                   mimeType: "text/plain",
                   text: snippet,
                 },
+                _meta: makeOffloadMeta(res.value),
               },
               file: null,
             };
@@ -412,7 +487,7 @@ export async function processToolResults(
           if (res.value !== null) {
             const snippet =
               text !== null
-                ? makeOffloadedSnippet(text, res.value.scopedPath)
+                ? makeOffloadedSnippet(text, res.value, runContext)
                 : "";
             return {
               content: {
@@ -421,6 +496,7 @@ export async function processToolResults(
                   ...sanitizedResource,
                   text: snippet,
                 },
+                _meta: makeOffloadMeta(res.value),
               },
               file: null,
             };

--- a/front/lib/api/files/action_output_fs/index.ts
+++ b/front/lib/api/files/action_output_fs/index.ts
@@ -22,10 +22,13 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { slugify } from "@app/types/shared/utils/string_utils";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
-interface PersistedToolOutput {
+export interface PersistedToolOutput {
   contentType: AllSupportedFileContentType;
   fileName: string;
   scopedPath: string;
+  // Byte size of the persisted content, surfaced in the offload descriptor attached to the
+  // replacement snippet block.
+  totalBytes: number;
 }
 
 /**
@@ -221,6 +224,7 @@ export async function persistToolOutput(
       fileName,
       scopedPath: result.value,
       contentType: storageContentType,
+      totalBytes: Buffer.byteLength(content, "utf8"),
     });
   }
 
@@ -240,7 +244,12 @@ export async function persistToolOutput(
       return result;
     }
 
-    return new Ok({ fileName, scopedPath: result.value, contentType });
+    return new Ok({
+      fileName,
+      scopedPath: result.value,
+      contentType,
+      totalBytes: Buffer.byteLength(block.text, "utf8"),
+    });
   }
 
   // Resource blocks whose text exceeds the offload threshold.
@@ -261,7 +270,12 @@ export async function persistToolOutput(
       return result;
     }
 
-    return new Ok({ fileName, scopedPath: result.value, contentType });
+    return new Ok({
+      fileName,
+      scopedPath: result.value,
+      contentType,
+      totalBytes: Buffer.byteLength(text, "utf8"),
+    });
   }
 
   return new Ok(null);


### PR DESCRIPTION
## Description

Tool outputs above 20KB are offloaded to the run context's file system and replaced inline by an 8000-char snippet plus a "[Full content archived at <path>]" sentence. Code consuming those blocks from inside a sandbox (function code) has to regex that sentence; missing it silently persists a snippet cut mid-JSON as data.

Two additive changes to the offload path:

- Every offloaded content block now carries a machine-readable descriptor in its `_meta`, under the `tt.dust/offload` key: `{fullContentPath, totalBytes, contentType}`. Consumers can locate and read the full content without parsing the snippet text.
- In sandbox function run contexts, when the offloaded text is JSON, the blind head cut is replaced by a parse-safe stub (`{"__dust_offloaded__":true, "fullContentPath":..., "totalBytes":..., "head":...}`, capped at the snippet length) followed by the unchanged archive sentence. A consumer that strips the sentence and JSON.parses the rest now gets an explicit pointer instead of corrupt JSON.

The archive sentence stays byte-identical in all contexts, and conversation (agent loop) snippets are untouched, so existing consumers keep working as-is.

## Tests

- New tests in `mcp_execution.test.ts`: stub parses and points at the archived file (sandbox function + JSON), non-JSON and conversation snippets byte-stable, descriptor attached in all contexts and present in the persisted output object.
- New route test: the descriptor survives `GET /v1/w/[wId]/sandbox/actions/[aId]` serialization verbatim.
- New dsbx (Rust) test: content block `_meta` round-trips through the poll/serialize path untouched, so no CLI change is needed.

## Risk

Low. Additive `_meta` on stored content blocks (schemas are non-strict, model rendering drops block-level `_meta`). The stub only changes snippet text for sandbox-function consumers of JSON content, which was unusable when cut mid-string anyway.

## Deploy Plan

Standard deploy.