### PR TITLE
[front] enh: echo the serving version from pod function publish, list, get and inspect

### DIFF
--- a/front/lib/api/actions/servers/sandbox_functions/tools/get.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/get.test.ts
@@ -60,6 +60,10 @@ describe("formatSandboxFunction", () => {
 
     expect(out).toContain("greet: Greet a user by name.");
     expect(out).toContain("userIdentity: optional");
+    // The serving-version fields mirror the publish tool's receipt. This function was created
+    // without a hash (pre-hash publishes exist in prod), so the field must degrade explicitly.
+    expect(out).toContain(`updatedAt: ${fn.updatedAt.toISOString()}`);
+    expect(out).toContain("bundleSha256: null");
     expect(out).toContain(`input: ${JSON.stringify(fn.inputSchema)}`);
     expect(out).toContain(`output: ${JSON.stringify(fn.outputSchema)}`);
   });

--- a/front/lib/api/actions/servers/sandbox_functions/tools/get.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/get.ts
@@ -12,6 +12,11 @@ export function formatSandboxFunction(fn: SandboxFunctionResource): string {
     `${fn.slug}: ${fn.description}`,
     `userIdentity: ${fn.userIdentity ?? "optional"}`,
     `executionMode: ${fn.executionMode}`,
+    // The timestamp and full bundle hash identify the serving version: they match the publish
+    // tool's echo and the hash stamped on invocations, so a caller can confirm which publish
+    // serves. "null" only for functions last published before hashes existed.
+    `updatedAt: ${fn.updatedAt.toISOString()}`,
+    `bundleSha256: ${fn.bundleSha256 ?? "null"}`,
     `input: ${JSON.stringify(fn.inputSchema)}`,
     `output: ${JSON.stringify(fn.outputSchema)}`,
   ].join("\n");

--- a/front/lib/api/actions/servers/sandbox_functions/tools/list.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/list.test.ts
@@ -52,7 +52,7 @@ describe("formatSandboxFunctionsList", () => {
     );
   });
 
-  it("renders slug and description without schemas", async () => {
+  it("renders slug, mode, timestamp and description without schemas", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",
     });
@@ -65,7 +65,11 @@ describe("formatSandboxFunctionsList", () => {
     const out = formatSandboxFunctionsList([fn]);
 
     expect(out).toContain("Pod functions:");
-    expect(out).toContain("- greet: Greet a user by name.");
+    // The mode and timestamp mirror the publish tool's receipt, so a caller can confirm a
+    // publish landed from the listing.
+    expect(out).toContain(
+      `- greet [${fn.executionMode}, updated ${fn.updatedAt.toISOString()}]: Greet a user by name.`
+    );
     expect(out).toContain("Use the get tool");
     // The verbose schemas live behind the get tool, not the list.
     expect(out).not.toContain("input:");

--- a/front/lib/api/actions/servers/sandbox_functions/tools/list.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/list.ts
@@ -13,7 +13,12 @@ export function formatSandboxFunctionsList(
     return "No pod functions published in this pod.";
   }
 
-  const lines = sandboxFunctions.map((fn) => `- ${fn.slug}: ${fn.description}`);
+  // Mode and timestamp let a caller confirm a publish landed (they mirror the publish tool's
+  // echo) without fetching each function.
+  const lines = sandboxFunctions.map(
+    (fn) =>
+      `- ${fn.slug} [${fn.executionMode}, updated ${fn.updatedAt.toISOString()}]: ${fn.description}`
+  );
 
   return (
     `Pod functions:\n${lines.join("\n")}\n\n` +

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@app/tests/utils/conversation_test_factories";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { Ok } from "@app/types/shared/result";
+import { createHash } from "crypto";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -67,7 +68,7 @@ function firstText(content: Array<{ type: string; text?: string }>): string {
 }
 
 describe("publishHandler", () => {
-  it("reports the app-prefixed slug and the reference a Frame needs", async () => {
+  it("reports the app-prefixed slug, the publish receipt, and the reference a Frame needs", async () => {
     const { auth, conversation, projectId } = await setupProjectConversation();
 
     const result = await publishHandler(
@@ -84,12 +85,54 @@ describe("publishHandler", () => {
     if (result.isErr()) {
       throw result.error;
     }
-    expect(result.value).toEqual([
-      {
-        type: "text",
-        text: `Published pod function "tasklist__add-task". Frames call it by reference "${projectId}/tasklist__add-task".`,
-      },
-    ]);
+    const [block] = result.value;
+    expect(block).toMatchObject({ type: "text" });
+    if (block?.type !== "text") {
+      return;
+    }
+    expect(block.text).toContain('Published pod function "tasklist__add-task"');
+    expect(block.text).toContain(
+      `Frames call it by reference "${projectId}/tasklist__add-task".`
+    );
+    // The receipt names the mode, timestamp and bundle hash so the caller can verify the
+    // publish landed through list/get.
+    expect(block.text).toContain("executionMode: fast");
+    expect(block.text).toContain("updatedAt: ");
+    const expectedShortSha = createHash("sha256")
+      .update("export default {};", "utf8")
+      .digest("hex")
+      .slice(0, 12);
+    expect(block.text).toContain(`bundle: ${expectedShortSha}`);
+    // A first publish must not claim byte-identity with anything.
+    expect(block.text).not.toContain("byte-identical");
+  });
+
+  it("flags a re-publish whose built bundle did not change", async () => {
+    const { auth, conversation, projectId } = await setupProjectConversation();
+    const input = {
+      slug: "add-task",
+      description: "Add a task.",
+      path: `pod-${projectId}/TaskList/functions/add-task.ts`,
+      executionMode: "fast" as const,
+      defaultStake: "low" as const,
+    };
+
+    const first = await publishHandler(input, makeExtra(auth, conversation));
+    if (first.isErr()) {
+      throw first.error;
+    }
+
+    // The mocked build returns the same bundle, so the republish changes nothing: the result
+    // must say so instead of letting the caller believe an edit landed.
+    const second = await publishHandler(input, makeExtra(auth, conversation));
+    if (second.isErr()) {
+      throw second.error;
+    }
+    const [block] = second.value;
+    if (block?.type !== "text") {
+      throw new Error("Expected a text block.");
+    }
+    expect(block.text).toContain("byte-identical to the previous publish");
   });
 
   it("records declared domains as Pod requests, even for an admin publisher", async () => {

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.test.ts
@@ -1,17 +1,17 @@
 import { SANDBOX_FUNCTIONS_TOOLS_METADATA } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 import { publishHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/publish";
 import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
-import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import {
+  computeSandboxFunctionBundleSha256,
+  SandboxFunctionResource,
+  shortSandboxFunctionBundleSha256,
+} from "@app/lib/resources/sandbox_function_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import {
   makeExtra,
   setupProjectConversation,
 } from "@app/tests/utils/conversation_test_factories";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
-import {
-  computeSandboxFunctionBundleSha256,
-  shortSandboxFunctionBundleSha256,
-} from "@app/lib/resources/sandbox_function_resource";
 import { Ok } from "@app/types/shared/result";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { beforeEach, describe, expect, it, vi } from "vitest";

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.test.ts
@@ -8,8 +8,11 @@ import {
   setupProjectConversation,
 } from "@app/tests/utils/conversation_test_factories";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import {
+  computeSandboxFunctionBundleSha256,
+  shortSandboxFunctionBundleSha256,
+} from "@app/lib/resources/sandbox_function_resource";
 import { Ok } from "@app/types/shared/result";
-import { createHash } from "crypto";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -98,10 +101,9 @@ describe("publishHandler", () => {
     // publish landed through list/get.
     expect(block.text).toContain("executionMode: fast");
     expect(block.text).toContain("updatedAt: ");
-    const expectedShortSha = createHash("sha256")
-      .update("export default {};", "utf8")
-      .digest("hex")
-      .slice(0, 12);
+    const expectedShortSha = shortSandboxFunctionBundleSha256(
+      computeSandboxFunctionBundleSha256("export default {};")
+    );
     expect(block.text).toContain(`bundle: ${expectedShortSha}`);
     // A first publish must not claim byte-identity with anything.
     expect(block.text).not.toContain("byte-identical");

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
@@ -8,6 +8,7 @@ import { requestOwnerPolicyDomain } from "@app/lib/api/sandbox/egress_policy";
 import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { publishSandboxFunction } from "@app/lib/api/sandbox_functions/publish_sandbox_function";
 import type { Authenticator } from "@app/lib/auth";
+import { shortSandboxFunctionBundleSha256 } from "@app/lib/resources/sandbox_function_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type {
   SandboxFunctionExecutionMode,
@@ -56,7 +57,11 @@ export async function publishHandler(
   // The slug carries the app prefix publish derived from `path`, so state it rather than letting the
   // model assume the name it passed. The other tools resolve the pod from the run context and take
   // the slug alone; only a Frame needs the qualified reference, so name that consumer.
-  const { slug: publishedSlug } = result.value;
+  //
+  // The mode, timestamp and bundle hash are the publisher's receipt: they let the caller confirm
+  // this publish landed (list/get echo the same fields) without a second tool call.
+  const { sandboxFunction, byteIdentical } = result.value;
+  const { slug: publishedSlug } = sandboxFunction;
 
   // Failures become a note, not a publish failure — the function is already
   // published and its domains can be retried.
@@ -65,15 +70,25 @@ export async function publishHandler(
     domains: domains ?? [],
   });
 
-  return new Ok([
-    {
-      type: "text",
-      text:
-        `Published pod function "${publishedSlug}". Frames call it by reference ` +
-        `"${podResult.value.pod.sId}/${publishedSlug}".` +
-        (domainNote ? `\n${domainNote}` : ""),
-    },
-  ]);
+  const lines = [
+    `Published pod function "${publishedSlug}" ` +
+      `(executionMode: ${sandboxFunction.executionMode}, ` +
+      `updatedAt: ${sandboxFunction.updatedAt.toISOString()}, ` +
+      `bundle: ${shortSandboxFunctionBundleSha256(sandboxFunction.bundleSha256)}). ` +
+      `Frames call it by reference "${podResult.value.pod.sId}/${publishedSlug}".`,
+  ];
+  if (byteIdentical) {
+    lines.push(
+      "The built bundle is byte-identical to the previous publish: if this publish was meant to " +
+        "change the function's behavior, your edit did not land in the built source. Re-read the " +
+        "source file before editing again."
+    );
+  }
+  if (domainNote) {
+    lines.push(domainNote);
+  }
+
+  return new Ok([{ type: "text", text: lines.join("\n") }]);
 }
 
 // Files each declared domain as a Pod request. Bounded to one function's

--- a/front/lib/api/projects/app_archive.ts
+++ b/front/lib/api/projects/app_archive.ts
@@ -563,7 +563,7 @@ export async function importPodApp(
       warnings.push(`Function ${fn.name}: ${publishResult.error.message}`);
       continue;
     }
-    publishedFunctionSlugs.push(publishResult.value.slug);
+    publishedFunctionSlugs.push(publishResult.value.sandboxFunction.slug);
   }
 
   // 4. Databases, reconciled empty from the copied schema files. Data never travels.

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -806,7 +806,7 @@ export async function clonePodApp(
         )
       );
     }
-    publishedFunctionSlugs.push(publishResult.value.slug);
+    publishedFunctionSlugs.push(publishResult.value.sandboxFunction.slug);
   }
 
   // Reconcile the copy's databases from its own schema files, which creates them empty under the

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.test.ts
@@ -93,7 +93,9 @@ describe("publishSandboxFunction", () => {
     if (result.isErr()) {
       return;
     }
-    const fn = result.value;
+    // A first publish has nothing to be identical to.
+    expect(result.value.byteIdentical).toBe(false);
+    const fn = result.value.sandboxFunction;
     expect(fn.slug).toBe("greeter__greet");
     expect(fn.description).toBe("Greet someone.");
     expect(fn.userIdentity).toBe("interactive_workspace_user_required");
@@ -148,7 +150,7 @@ describe("publishSandboxFunction", () => {
     if (durable.isErr()) {
       return;
     }
-    expect(durable.value.executionMode).toBe("durable");
+    expect(durable.value.sandboxFunction.executionMode).toBe("durable");
 
     const fast = await publishSandboxFunction(auth, {
       space,
@@ -161,7 +163,7 @@ describe("publishSandboxFunction", () => {
     if (fast.isErr()) {
       return;
     }
-    expect(fast.value.executionMode).toBe("fast");
+    expect(fast.value.sandboxFunction.executionMode).toBe("fast");
   });
 
   it("returns a re-publish that does not restate the execution mode to the default", async () => {
@@ -195,7 +197,7 @@ describe("publishSandboxFunction", () => {
     if (republished.isErr()) {
       return;
     }
-    expect(republished.value.executionMode).toBe("durable");
+    expect(republished.value.sandboxFunction.executionMode).toBe("durable");
 
     const restated = await publishSandboxFunction(auth, {
       space,
@@ -208,7 +210,7 @@ describe("publishSandboxFunction", () => {
     if (restated.isErr()) {
       return;
     }
-    expect(restated.value.executionMode).toBe("fast");
+    expect(restated.value.sandboxFunction.executionMode).toBe("fast");
   });
 
   it("overwrites the bundle in place on re-publish, keeping one row and the same file", async () => {
@@ -232,7 +234,7 @@ describe("publishSandboxFunction", () => {
     if (first.isErr()) {
       return;
     }
-    const firstFileId = first.value.fileId;
+    const firstFileId = first.value.sandboxFunction.fileId;
     const [firstBundle] = await FileModel.findAll({
       where: { workspaceId: workspace.id },
     });
@@ -262,18 +264,22 @@ describe("publishSandboxFunction", () => {
       return;
     }
 
-    expect(second.value.id).toBe(first.value.id);
-    expect(second.value.description).toBe("v2");
-    expect(second.value.userIdentity).toBe("optional");
+    expect(second.value.sandboxFunction.id).toBe(
+      first.value.sandboxFunction.id
+    );
+    expect(second.value.sandboxFunction.description).toBe("v2");
+    expect(second.value.sandboxFunction.userIdentity).toBe("optional");
+    // The bundle changed, so the publish must not report it as byte-identical.
+    expect(second.value.byteIdentical).toBe(false);
     // The hash follows the bundle: a republish must restamp it, or warm servers holding the old
     // import would keep matching and serve stale code.
-    expect(second.value.bundleSha256).toBe(
+    expect(second.value.sandboxFunction.bundleSha256).toBe(
       createHash("sha256").update("v2", "utf8").digest("hex")
     );
-    expect(second.value.outputSchema).toEqual(newOutputSchema);
+    expect(second.value.sandboxFunction.outputSchema).toEqual(newOutputSchema);
     // The bundle file is reused in place, not replaced: same row, canonical mount path retained, and
     // its version bumped by the re-upload.
-    expect(second.value.fileId).toBe(firstFileId);
+    expect(second.value.sandboxFunction.fileId).toBe(firstFileId);
 
     const listed = await SandboxFunctionResource.listBySpace(auth, space);
     expect(listed).toHaveLength(1);
@@ -285,6 +291,39 @@ describe("publishSandboxFunction", () => {
       `w/${workspace.sId}/pods/${space.sId}/sandbox-functions/greeter__greet.ts`
     );
     expect(files[0].version).toBeGreaterThan(firstVersion ?? 0);
+  });
+
+  it("reports a re-publish whose bundle did not change as byte-identical", async () => {
+    const { space, auth } = await setupPod();
+    vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+      new Ok({
+        bundleCode: "export default {};",
+        userIdentity: "optional",
+        inputSchema,
+        outputSchema,
+      })
+    );
+
+    const first = await publishSandboxFunction(auth, {
+      space,
+      slug: "greet",
+      description: "Greet someone.",
+      path: `pod-${space.sId}/Greeter/functions/greet.ts`,
+    });
+    expect(first.isOk()).toBe(true);
+
+    // Same build output: the publisher's edit did not land, and the result must say so.
+    const republished = await publishSandboxFunction(auth, {
+      space,
+      slug: "greet",
+      description: "Greet someone.",
+      path: `pod-${space.sId}/Greeter/functions/greet.ts`,
+    });
+    expect(republished.isOk()).toBe(true);
+    if (republished.isErr()) {
+      return;
+    }
+    expect(republished.value.byteIdentical).toBe(true);
   });
 
   it("keeps two apps that publish the same name as separate functions", async () => {
@@ -318,11 +357,15 @@ describe("publishSandboxFunction", () => {
     }
 
     // The second publish must not have replaced the first: two rows, two slugs, two bundles.
-    expect(taskList.value.slug).toBe("tasklist__refresh");
-    expect(inbox.value.slug).toBe("inbox__refresh");
-    expect(inbox.value.id).not.toBe(taskList.value.id);
-    expect(taskList.value.description).toBe("Refresh the task list.");
-    expect(inbox.value.description).toBe("Refresh the inbox.");
+    expect(taskList.value.sandboxFunction.slug).toBe("tasklist__refresh");
+    expect(inbox.value.sandboxFunction.slug).toBe("inbox__refresh");
+    expect(inbox.value.sandboxFunction.id).not.toBe(
+      taskList.value.sandboxFunction.id
+    );
+    expect(taskList.value.sandboxFunction.description).toBe(
+      "Refresh the task list."
+    );
+    expect(inbox.value.sandboxFunction.description).toBe("Refresh the inbox.");
 
     const listed = await SandboxFunctionResource.listBySpace(auth, space);
     expect(listed).toHaveLength(2);
@@ -358,7 +401,7 @@ describe("publishSandboxFunction", () => {
     if (result.isErr()) {
       return;
     }
-    expect(result.value.slug).toBe("greet");
+    expect(result.value.sandboxFunction.slug).toBe("greet");
 
     const files = await FileModel.findAll({
       where: { workspaceId: workspace.id },

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.ts
@@ -18,6 +18,13 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
+export type PublishSandboxFunctionResult = {
+  sandboxFunction: SandboxFunctionResource;
+  // True when a re-publish produced a bundle byte-identical to the one it replaced: the edit the
+  // publisher thinks they made did not change the built output. Always false on a first publish.
+  byteIdentical: boolean;
+};
+
 /**
  * Publish a sandbox function: build the source the model wrote to the pod mount, then store the
  * bundle and its extracted contract.
@@ -46,7 +53,7 @@ export async function publishSandboxFunction(
     executionMode?: SandboxFunctionExecutionMode;
     defaultStake?: SandboxFunctionStake;
   }
-): Promise<Result<SandboxFunctionResource, SandboxFunctionError>> {
+): Promise<Result<PublishSandboxFunctionResult, SandboxFunctionError>> {
   // Resolve the model-supplied scoped path (e.g. `pod-{id}/greet.ts`) to its absolute path inside
   // the sandbox, reusing DustFileSystem's traversal and mount checks rather than rebuilding them.
   const fsResult = await DustFileSystem.forPod(auth, space);
@@ -110,7 +117,10 @@ export async function publishSandboxFunction(
       );
     }
 
-    return new Ok(existing);
+    return new Ok({
+      sandboxFunction: existing,
+      byteIdentical: updateResult.value.byteIdentical,
+    });
   }
 
   const fileResult = await createBundleFile(auth, {
@@ -135,7 +145,7 @@ export async function publishSandboxFunction(
     outputSchema,
   });
 
-  return new Ok(created);
+  return new Ok({ sandboxFunction: created, byteIdentical: false });
 }
 
 async function createBundleFile(

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -234,6 +234,11 @@ describe("SandboxFunctionInvocationResource", () => {
         message: "second invocation failed",
       },
     });
+    // These invocations settled without going through execute(), so no bundle hash was stamped
+    // and none must be invented.
+    expect(recentInvocations[0]?.toJSONForLLM()).not.toHaveProperty(
+      "bundleSha256"
+    );
 
     const formatted = formatSandboxFunctionInvocations(
       sandboxFunction.slug,
@@ -705,6 +710,12 @@ describe("SandboxFunctionInvocationResource", () => {
         invocationId: invocation.sId,
       });
     expect(refetchedInvocation?.status).toBe("succeeded");
+    // The terminal blob records which publish served the invocation, and inspect_invocations
+    // reports it so a caller can match invocations to the hash publish/get echo.
+    expect(refetchedInvocation?.bundleSha256).toBe(TEST_BUNDLE_SHA256);
+    expect(refetchedInvocation?.toJSONForLLM()).toMatchObject({
+      bundleSha256: TEST_BUNDLE_SHA256,
+    });
     // execute() itself never touches lastActivityAt: ensurePodSandboxReady's
     // ensureActive already writes it under the lifecycle lock, and a second
     // write per invocation was pure hot-row churn on the sandbox row.

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -136,6 +136,11 @@ const InvocationDataBaseSchema = z.object({
     })
     .optional(),
   result: z.unknown().optional(),
+  // The hash of the bundle the invocation was executed against, recorded by the terminal
+  // transition when the executing instance stamped it. Absent on blobs written before the field
+  // existed, on invocations that never reached execution, and on outcomes delivered through the
+  // in-sandbox HTTP callback (a separately fetched instance settles those).
+  bundleSha256: z.string().optional(),
 });
 
 // Every shape we have ever written, discriminated on `version` so a new one is an added arm rather
@@ -188,6 +193,7 @@ function migrateStoredInvocationData(
 }
 
 interface SandboxFunctionInvocationForLLM {
+  bundleSha256?: string;
   createdAt: string;
   error?: StoredSandboxFunctionCallError;
   input: unknown;
@@ -301,6 +307,14 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
    */
   private lastSettledOutcome: SandboxFunctionInvocationOutcome | undefined;
 
+  /**
+   * The hash of the bundle execute() ran (or attempted to run) this invocation against, read
+   * from the persisted function row at execution time. Only ever set on the instance that
+   * executed; the terminal transitions fold it into the stored blob so `inspect_invocations`
+   * can report which publish served each invocation.
+   */
+  private executedBundleSha256: string | undefined;
+
   settledOutcome(): SandboxFunctionInvocationOutcome | null {
     return this.lastSettledOutcome ?? null;
   }
@@ -349,6 +363,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
 
   get error(): StoredSandboxFunctionCallError | undefined {
     return this.data.error;
+  }
+
+  get bundleSha256(): string | undefined {
+    return this.data.bundleSha256;
   }
 
   // WHERE-guarded compare-and-swap on status. Same pattern as
@@ -484,6 +502,9 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
       input: this.input,
       context: this.context,
+      ...(this.executedBundleSha256 === undefined
+        ? {}
+        : { bundleSha256: this.executedBundleSha256 }),
       // Persist the whole error: the code and status are what `inspect_invocations` needs to say
       // why an invocation failed, and dropping them here would leave the message as the only
       // record of a failure the stream classified precisely.
@@ -530,6 +551,9 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       version: SANDBOX_FUNCTION_INVOCATION_DATA_VERSION,
       input: this.input,
       context: this.context,
+      ...(this.executedBundleSha256 === undefined
+        ? {}
+        : { bundleSha256: this.executedBundleSha256 }),
       result,
     };
     await this.persistTerminalData("succeeded");
@@ -652,6 +676,9 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       // Read from the persisted row rather than the in-memory copy, which may predate a
       // re-publish, since this one gates tool access.
       const noTools = persistedFunction.executionMode === "fast";
+      // Remember which bundle this execution serves, so the terminal transition records the
+      // version behind the outcome.
+      this.executedBundleSha256 = persistedFunction.bundleSha256 ?? undefined;
       const token = await generateSandboxFunctionInvocationToken(auth, {
         sandbox,
         sandboxFunction,
@@ -1418,6 +1445,11 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       invocationId: this.sId,
       status: this.status,
       updatedAt: this.updatedAt.toISOString(),
+      // Which publish served this invocation: comparable against the hash `publish` and `get`
+      // echo. Absent when the invocation predates the stamping or never reached execution.
+      ...(this.bundleSha256 !== undefined
+        ? { bundleSha256: this.bundleSha256 }
+        : {}),
       ...(this.result !== undefined ? { result: this.result } : {}),
       ...(this.error !== undefined ? { error: this.error } : {}),
     };

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -421,6 +421,12 @@ describe("SandboxFunctionResource", () => {
       outputSchema: newOutputSchema,
     });
     expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    // The row was created without a hash (pre-hash publish), so nothing can match: the
+    // re-publish must not be reported as byte-identical.
+    expect(result.value.byteIdentical).toBe(false);
 
     // The row keeps the same bundle file and gets the refreshed contract.
     expect(sandboxFunction.fileId).toBe(firstFile.id);

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -66,6 +66,14 @@ export function computeSandboxFunctionBundleSha256(bundleCode: string): string {
   return createHash("sha256").update(bundleCode, "utf8").digest("hex");
 }
 
+/**
+ * Short prefix of a bundle sha for tool output: enough to tell two publishes apart at a glance,
+ * mirroring short commit hashes. "unknown" covers functions last published before hashes existed.
+ */
+export function shortSandboxFunctionBundleSha256(sha: string | null): string {
+  return sha === null ? "unknown" : sha.slice(0, 12);
+}
+
 export function getSandboxFunctionPublishLockName(
   sandboxFunctionSId: string
 ): string {
@@ -213,6 +221,10 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
    * rewrites the same file (canonical original plus its mount path <prefix>/<slug>.ts) and bumps the
    * version, so the function's storage path stays stable across re-publishes rather than drifting to
    * a disambiguated name. The caller checks write permission.
+   *
+   * Reports whether the new bundle is byte-identical to the one it replaces: a publisher who
+   * edited the source expects the built output to change, and echoing that it did not lets the
+   * caller surface "your edit didn't land" instead of leaving a stale-publish hunt.
    */
   async updateContent(
     auth: Authenticator,
@@ -233,7 +245,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       inputSchema: JSONSchema;
       outputSchema: JSONSchema;
     }
-  ): Promise<Result<undefined, Error>> {
+  ): Promise<Result<{ byteIdentical: boolean }, Error>> {
     try {
       return await executeWithLock(
         getSandboxFunctionPublishLockName(this.sId),
@@ -247,6 +259,12 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
           if (!currentFunction) {
             return new Err(new Error("The Pod Function no longer exists."));
           }
+
+          // Hash of the exact code the upload below writes. Compared against the row re-read
+          // under the lock, not the in-memory copy, so a concurrent publish cannot skew the
+          // byte-identical report. Null on the row (pre-hash publishes) never matches.
+          const bundleSha256 = computeSandboxFunctionBundleSha256(bundleCode);
+          const byteIdentical = currentFunction.bundleSha256 === bundleSha256;
 
           const currentUserIdentity =
             currentFunction.userIdentity ?? "optional";
@@ -280,16 +298,16 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
             userIdentity,
             executionMode,
             defaultStake,
-            // Derived from the exact code the upload above wrote. Landing with the row update
-            // (not before the upload) means a warm server can never be told to expect a bundle
-            // that is not on disk yet; invocations racing this publish carry the old hash and
-            // settle against whichever bundle they were issued for.
-            bundleSha256: computeSandboxFunctionBundleSha256(bundleCode),
+            // The hash lands with the row update (not before the upload), so a warm server can
+            // never be told to expect a bundle that is not on disk yet; invocations racing this
+            // publish carry the old hash and settle against whichever bundle they were issued
+            // for.
+            bundleSha256,
             inputSchema,
             outputSchema,
           });
 
-          return new Ok(undefined);
+          return new Ok({ byteIdentical });
         },
         30_000,
         { lockTtlMs: SANDBOX_FUNCTION_PUBLISH_LOCK_TTL_MS }


### PR DESCRIPTION
## Description

Agents cannot confirm a publish landed or which bundle version serves: the publish tool names only the slug, `list`/`get` show no timestamp or hash, and invocations do not record which bundle they ran against. That bred "smells like a stale publish" hunts even though serving is content-addressed.

- `publish` now returns a receipt: executionMode, updatedAt, short bundle sha, plus a "byte-identical to the previous publish" flag when a re-publish produced the exact same bundle (the publisher's edit did not land). The comparison happens in `updateContent`, under the publish lock, against the row's stored hash.
- `list` shows executionMode and updatedAt per function; `get` shows updatedAt and the full bundle sha.
- `execute()` stamps the bundle sha it runs against; the terminal blob records it and `inspect_invocations` (via `toJSONForLLM`) reports it, so invocations can be matched to publishes.

The stamp is absent for invocations settled through the in-sandbox HTTP callback (a separately fetched instance settles those) and for blobs written before the field existed; the field is optional everywhere.

Stacked on #30326.

## Tests

New cases: byte-identical republish reported at both the lib and the tool level, first publish never byte-identical, pre-hash rows (null sha) never match, executed invocation's blob and `toJSONForLLM` carry the stamped sha, non-executed invocations carry none.

## Risk

Low. Tool-output text and additive optional fields on the stored invocation blob (versioned schema untouched, field optional on both arms).

## Deploy Plan

Standard deploy.