### PR TITLE
[dust-hive] enh: open Kibana for a hive

### DIFF
--- a/x/henry/dust-hive/README.md
+++ b/x/henry/dust-hive/README.md
@@ -186,6 +186,7 @@ external workspace is archived.
 | `status [NAME]` | Show service health |
 | `logs [NAME] [SERVICE] [-f]` | View service logs |
 | `url [NAME]` | Print front URL |
+| `kibana [NAME]` | Start Kibana for a warm environment and open it in the default browser |
 
 ### Utilities
 

--- a/x/henry/dust-hive/completions/dust-hive.bash
+++ b/x/henry/dust-hive/completions/dust-hive.bash
@@ -300,7 +300,7 @@ _dust_hive_complete() {
 
   # Top-level command completion
   if [[ -z "$cmd" ]]; then
-    local commands="spawn adopt open reload restart warm cool start stop up down destroy unregister list status logs url cd setup doctor cache refresh forward sync temporal seed-config feed flag help"
+    local commands="spawn adopt open reload restart warm cool start stop up down destroy unregister list status logs url kibana cd setup doctor cache refresh forward sync temporal seed-config feed flag help"
     COMPREPLY=($(compgen -W "$commands" -- "$cur"))
     return
   fi
@@ -432,6 +432,15 @@ _dust_hive_complete() {
           ;;
         *)
           COMPREPLY=($(compgen -W "$(_dust_hive_envs)" -- "$cur"))
+          ;;
+      esac
+      ;;
+    kibana)
+      case "$cur" in
+        -*)
+          ;;
+        *)
+          COMPREPLY=($(compgen -W "$(_dust_hive_warm_envs)" -- "$cur"))
           ;;
       esac
       ;;

--- a/x/henry/dust-hive/completions/dust-hive.zsh
+++ b/x/henry/dust-hive/completions/dust-hive.zsh
@@ -292,6 +292,7 @@ _dust-hive() {
         'status:Show service health'
         'logs:Show service logs'
         'url:Print front URL'
+        'kibana:Open Kibana for a warm environment'
         'cd:Print worktree path'
         'setup:Check prerequisites and guide initial setup'
         'doctor:Check prerequisites (non-interactive)'
@@ -429,6 +430,9 @@ _dust-hive() {
           ;;
         url|cd)
           _arguments '1::name:_dust_hive_envs'
+          ;;
+        kibana)
+          _arguments '1::name:_dust_hive_warm_envs'
           ;;
         setup)
           _arguments \

--- a/x/henry/dust-hive/docker-compose.yml
+++ b/x/henry/dust-hive/docker-compose.yml
@@ -58,6 +58,21 @@ services:
       timeout: 10s
       retries: 10
 
+  kibana:
+    profiles: ["kibana"]
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    image: docker.elastic.co/kibana/kibana:8.11.3
+    environment:
+      - SERVER_NAME=kibana
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -s -I http://kibana:5601 | grep -q 'HTTP/1.1 302 Found'" ]
+      interval: 10s
+      timeout: 10s
+      retries: 20
+
   apache-tika:
     image: apache/tika:3.2.3.0-full
     volumes:

--- a/x/henry/dust-hive/src/commands/kibana.ts
+++ b/x/henry/dust-hive/src/commands/kibana.ts
@@ -1,0 +1,26 @@
+import { withEnvironment } from "../lib/commands";
+import { startKibana, writeDockerComposeOverride } from "../lib/docker";
+import { logger } from "../lib/logger";
+import { openUrl } from "../lib/platform";
+import { CommandError, Err, Ok } from "../lib/result";
+import { getStateInfo } from "../lib/state";
+
+export const kibanaCommand = withEnvironment("kibana", async (env) => {
+  const stateInfo = await getStateInfo(env);
+  if (stateInfo.state !== "warm") {
+    return Err(
+      new CommandError(
+        `Environment is ${stateInfo.state}, not warm. Run 'dust-hive warm ${env.name}' first.`
+      )
+    );
+  }
+
+  await writeDockerComposeOverride(env.name, env.ports);
+  await startKibana(env);
+
+  const url = `http://localhost:${env.ports.kibana}`;
+  logger.info(`Opening ${url}`);
+  openUrl(url);
+
+  return Ok(undefined);
+});

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -12,6 +12,7 @@ import { envGetCommand, envListCommand, envSetCommand, envUnsetCommand } from ".
 import { feedCommand } from "./commands/feed";
 import { flagCommand } from "./commands/flag";
 import { forwardCommand, forwardStatusCommand, forwardStopCommand } from "./commands/forward";
+import { kibanaCommand } from "./commands/kibana";
 import { listCommand } from "./commands/list";
 import { logsCommand } from "./commands/logs";
 import { openCommand } from "./commands/open";
@@ -311,6 +312,12 @@ cli
 cli.command("url [name]", "Print front URL").action(async (name: string | undefined) => {
   await prepareAndRun(urlCommand(name));
 });
+
+cli
+  .command("kibana [name]", "Open Kibana for a warm environment")
+  .action(async (name: string | undefined) => {
+    await prepareAndRun(kibanaCommand(name));
+  });
 
 cli
   .command("cd [name]", "Print worktree path (use with: cd $(dust-hive cd <env>))")

--- a/x/henry/dust-hive/src/lib/docker.ts
+++ b/x/henry/dust-hive/src/lib/docker.ts
@@ -21,6 +21,9 @@ export interface DockerComposeOverride {
       ports: string[];
       volumes: string[];
     };
+    kibana: {
+      ports: string[];
+    };
     "apache-tika": {
       ports: string[];
     };
@@ -61,6 +64,9 @@ export function generateDockerComposeOverride(
       elasticsearch: {
         ports: [`${ports.elasticsearch}:9200`],
         volumes: [`${getVolumeName(name, "elasticsearch")}:/usr/share/elasticsearch/data`],
+      },
+      kibana: {
+        ports: [`${ports.kibana}:5601`],
       },
       "apache-tika": {
         ports: [`${ports.apacheTika}:9998`],
@@ -150,6 +156,47 @@ export async function startDocker(env: Environment): Promise<void> {
   logger.success("Docker containers started");
 }
 
+const KIBANA_WAIT_TIMEOUT_SECONDS = 300;
+
+export async function startKibana(env: Environment): Promise<void> {
+  logger.step(`Starting Kibana for '${env.name}'...`);
+
+  const projectName = getDockerProjectName(env.name);
+  const overridePath = getDockerOverridePath(env.name);
+  const basePath = getDockerComposePath();
+
+  const proc = Bun.spawn(
+    [
+      "docker",
+      "compose",
+      "--profile",
+      "kibana",
+      "-f",
+      basePath,
+      "-f",
+      overridePath,
+      "-p",
+      projectName,
+      "up",
+      "-d",
+      "--wait",
+      "--wait-timeout",
+      String(KIBANA_WAIT_TIMEOUT_SECONDS),
+      "kibana",
+    ],
+    { stdout: "pipe", stderr: "pipe" }
+  );
+
+  const stderr = await new Response(proc.stderr).text();
+  await proc.exited;
+
+  if (proc.exitCode !== 0) {
+    throw new Error(`Failed to start Kibana: ${stderr.trim() || "unknown error"}`);
+  }
+
+  logger.success("Kibana is ready");
+}
+
 // Pause docker-compose containers (stop without removing)
 // Returns true if paused successfully, false if docker-compose failed
 // Use this for cool operations - faster restart since containers don't need to be recreated
@@ -160,7 +207,19 @@ export async function pauseDocker(envName: string): Promise<boolean> {
   const overridePath = getDockerOverridePath(envName);
   const basePath = getDockerComposePath();
 
-  const args = ["docker", "compose", "-f", basePath, "-f", overridePath, "-p", projectName, "stop"];
+  const args = [
+    "docker",
+    "compose",
+    "--profile",
+    "kibana",
+    "-f",
+    basePath,
+    "-f",
+    overridePath,
+    "-p",
+    projectName,
+    "stop",
+  ];
 
   const proc = Bun.spawn(args, {
     stdout: "pipe",
@@ -190,7 +249,19 @@ export async function stopDocker(
   const overridePath = getDockerOverridePath(envName);
   const basePath = getDockerComposePath();
 
-  const args = ["docker", "compose", "-f", basePath, "-f", overridePath, "-p", projectName, "down"];
+  const args = [
+    "docker",
+    "compose",
+    "--profile",
+    "kibana",
+    "-f",
+    basePath,
+    "-f",
+    overridePath,
+    "-p",
+    projectName,
+    "down",
+  ];
 
   if (options.removeVolumes) {
     args.push("-v");

--- a/x/henry/dust-hive/src/lib/platform.ts
+++ b/x/henry/dust-hive/src/lib/platform.ts
@@ -70,6 +70,22 @@ export function getProcessCommand(pid: number): string | null {
   return stdout.length > 0 ? stdout : null;
 }
 
+export function openUrl(url: string): void {
+  const command = isMacOS() ? "open" : "xdg-open";
+  const result = spawnSync(command, [url], { encoding: "utf-8" });
+
+  if (result.error) {
+    if (isErrnoException(result.error) && result.error.code === "ENOENT") {
+      throw new Error(`${command} not found in PATH`);
+    }
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`${command} failed: ${result.stderr?.trim() || "unknown error"}`);
+  }
+}
+
 // ============================================================================
 // Port Detection Abstraction
 // ============================================================================

--- a/x/henry/dust-hive/src/lib/ports.ts
+++ b/x/henry/dust-hive/src/lib/ports.ts
@@ -10,7 +10,8 @@ import { isProcessRunning, killProcess } from "./process";
 // Port offsets from base (spec-defined).
 // Offsets chosen so base_port + offset resembles standard ports:
 // postgres: 432 -> 10432 (resembles 5432), redis: 379 -> 10379 (resembles 6379),
-// qdrant: 333 -> 10333 (resembles 6333 HTTP), elasticsearch: 200 -> 10200 (resembles 9200)
+// qdrant: 333 -> 10333 (resembles 6333 HTTP), elasticsearch: 200 -> 10200 (resembles 9200),
+// kibana: 601 -> 10601 (resembles 5601)
 // `front` (offset 0) is the public/main port; it now hosts the in-hive HTTP
 // proxy that routes /api/* to front-api and everything else to marketing.
 export const PORT_OFFSETS = {
@@ -28,6 +29,7 @@ export const PORT_OFFSETS = {
   qdrantHttp: 333,
   qdrantGrpc: 334,
   elasticsearch: 200,
+  kibana: 601,
   apacheTika: 998,
 } as const;
 
@@ -54,6 +56,7 @@ const PortAllocationSchema = z
     qdrantHttp: z.number(),
     qdrantGrpc: z.number(),
     elasticsearch: z.number(),
+    kibana: z.number().optional(),
     apacheTika: z.number(),
   })
   .transform((data) => ({
@@ -63,6 +66,7 @@ const PortAllocationSchema = z
     viz: data.viz ?? data.base + PORT_OFFSETS.viz,
     frontSpaPoke: data.frontSpaPoke ?? data.base + PORT_OFFSETS.frontSpaPoke,
     frontSpaApp: data.frontSpaApp ?? data.base + PORT_OFFSETS.frontSpaApp,
+    kibana: data.kibana ?? data.base + PORT_OFFSETS.kibana,
   }));
 
 export type PortAllocation = z.output<typeof PortAllocationSchema>;
@@ -85,6 +89,7 @@ export function calculatePorts(base: number): PortAllocation {
     qdrantHttp: base + PORT_OFFSETS.qdrantHttp,
     qdrantGrpc: base + PORT_OFFSETS.qdrantGrpc,
     elasticsearch: base + PORT_OFFSETS.elasticsearch,
+    kibana: base + PORT_OFFSETS.kibana,
     apacheTika: base + PORT_OFFSETS.apacheTika,
   };
   for (const port of Object.values(ports)) {

--- a/x/henry/dust-hive/tests/lib/docker.test.ts
+++ b/x/henry/dust-hive/tests/lib/docker.test.ts
@@ -16,6 +16,7 @@ describe("docker", () => {
       expect(override.services.redis.ports).toEqual(["10379:6379"]);
       expect(override.services.qdrant.ports).toEqual(["10333:6333", "10334:6334"]);
       expect(override.services.elasticsearch.ports).toEqual(["10200:9200"]);
+      expect(override.services.kibana.ports).toEqual(["10601:5601"]);
       expect(override.services["apache-tika"].ports).toEqual(["10998:9998"]);
     });
 

--- a/x/henry/dust-hive/tests/lib/ports.test.ts
+++ b/x/henry/dust-hive/tests/lib/ports.test.ts
@@ -19,6 +19,7 @@ describe("ports", () => {
       expect(ports.qdrantHttp).toBe(10333);
       expect(ports.qdrantGrpc).toBe(10334);
       expect(ports.elasticsearch).toBe(10200);
+      expect(ports.kibana).toBe(10601);
       expect(ports.apacheTika).toBe(10998);
     });
 
@@ -52,6 +53,7 @@ describe("ports", () => {
       expect(ports.qdrantHttp).toBe(base + PORT_OFFSETS.qdrantHttp);
       expect(ports.qdrantGrpc).toBe(base + PORT_OFFSETS.qdrantGrpc);
       expect(ports.elasticsearch).toBe(base + PORT_OFFSETS.elasticsearch);
+      expect(ports.kibana).toBe(base + PORT_OFFSETS.kibana);
       expect(ports.apacheTika).toBe(base + PORT_OFFSETS.apacheTika);
     });
   });


### PR DESCRIPTION
## Description

Inspecting Elasticsearch data for a hive currently requires manually starting and wiring Kibana to the correct Docker project.

We're starting to use ES in front more and more, creating a need for inspecting what happens in a hive's ES.

This PR adds `dust-hive kibana [name]` for warm environments. The command assigns a hive-specific port, starts an opt-in Kibana Compose profile connected to that hive Elasticsearch service, waits for it to become healthy, and opens it in the default browser. Existing hive overrides are refreshed automatically, and Kibana participates in the normal cool and stop lifecycle.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- No deploy.
