### PR TITLE
[front] Pod Functions skill v7: real budgets, response contract, caching doctrine

### DIFF
--- a/front/lib/api/actions/servers/interactive_content/instructions.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions.ts
@@ -21,11 +21,13 @@ import {
   CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   FRAME_RECREATE_WASTE_RATIONALE,
+  GET_INTERACTIVE_CONTENT_FILE_SHARE_URL_TOOL_NAME,
   PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   RENAME_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   REVERT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
 } from "@app/lib/api/actions/servers/interactive_content/metadata";
+import { SANDBOX_FUNCTIONS_SERVER_NAME } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 
 const FILES_EDIT_TOOL = getPrefixedToolName(
   FILES_SERVER_NAME,
@@ -46,6 +48,10 @@ const FILES_RESOLVE_TOOL = getPrefixedToolName(
 const FILES_MOVE_TOOL = getPrefixedToolName(
   FILES_SERVER_NAME,
   FILES_MOVE_ACTION_NAME
+);
+const POD_FUNCTIONS_CALL_TOOL = getPrefixedToolName(
+  SANDBOX_FUNCTIONS_SERVER_NAME,
+  "call"
 );
 
 const UPDATING_SECTION_LEGACY = `\
@@ -98,7 +104,7 @@ After a Frame is created, its source file is already mounted in the Computer at 
 1. Edit that file in place with your file tools, changing only the parts that need to change. Do not rewrite the whole file for partial changes. When the Computer is not available, edit it with \`${FILES_EDIT_TOOL}\` using its scoped path, e.g. \`conversation-<conversationId>/<FrameName>.tsx\`.
 2. Publish with \`${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\`, passing \`path\` set to the source file's own scoped path (the entry file itself, not the directory holding it), e.g. \`conversation-<conversationId>/<FrameName>.tsx\`.
 
-If an edit fails because the text to replace is not found, the file differs from what you remember: re-read it and retry the targeted edit. Never respond to a failed match by resending the whole file.
+If an edit fails because the text to replace is not found, the file differs from what you remember: re-read it and retry the targeted edit. Never respond to a failed match by resending the whole file. After a batch of edits where any edit failed, re-read the whole file before editing it further, and never publish without re-reading it: the file holds an unknown mix of applied and missing changes.
 
 ${PUBLISH_PARAGRAPH}
 `;
@@ -113,7 +119,7 @@ After a Frame is created, its source file is available to your file tools at \`c
 2. Make targeted edits with \`${FILES_EDIT_TOOL}\`, replacing only the text that changes. Do not rewrite the whole file for partial changes.
 3. Publish with \`${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\`, passing \`path\` set to the source file's own scoped path (the entry file itself, not the directory holding it).
 
-If an edit fails because the text to replace is not found, the file differs from what you remember: re-read it with \`${FILES_CAT_TOOL}\` and retry the targeted edit. Never respond to a failed match by resending the whole file.
+If an edit fails because the text to replace is not found, the file differs from what you remember: re-read it with \`${FILES_CAT_TOOL}\` and retry the targeted edit. Never respond to a failed match by resending the whole file. After a batch of edits where any edit failed, re-read the whole file before editing it further, and never publish without re-reading it: the file holds an unknown mix of applied and missing changes.
 
 Example, updating one value of an existing Frame:
 \`\`\`
@@ -161,6 +167,24 @@ ${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}({
 \`\`\`
 
 From then on, edit the source at its Pod path and publish it again. Anything the Frame imports relatively must live under its folder, which is the bundling root.
+
+After publishing, always fetch the Frame's share URL with \`${GET_INTERACTIVE_CONTENT_FILE_SHARE_URL_TOOL_NAME}\` and hand it to the user: a Pod Frame does not surface itself in this conversation on its own.
+`;
+
+// Pod conversations where pod functions are available. Headless exports of function-backed
+// Frames capture the loading state, so verification must go through the functions themselves.
+const POD_VERIFICATION_SECTION = `\
+### Verifying A Frame
+
+A headless export (PNG or PDF) of a Frame that calls pod functions captures its loading state, not its data, so never use an export to verify one. Verify the data path directly instead: call each pod function the Frame references with \`${POD_FUNCTIONS_CALL_TOOL}\`, using the same inputs the Frame sends, and confirm the outputs match the shapes the Frame consumes. Then send the user the Frame's share URL.
+`;
+
+// Non-Pod conversations. Without this, a Frame asked to hold data silently ends up with a
+// `useState` array that dies on reload, and the user only finds out after entering real data.
+const NON_POD_STATE_SECTION = `\
+### Frame State Outside A Pod
+
+This conversation is not part of a Pod, so a Frame here has no persistence: there is no server-side storage it can write to, and anything held in component state is lost on reload. If the user expects entered data (tasks, notes, entries, edits) to still be there the next time the Frame opens, say so plainly and suggest building the Frame in a Pod, where pod functions and databases hold its data; otherwise keep the Frame read-only or accept per-session state.
 `;
 
 // Pod conversations where pod functions are available. Without this, a Frame asked to hold data
@@ -177,7 +201,8 @@ Keep in component state only what is genuinely throwaway. e.g. the selected tab,
 interface InstructionsVariant {
   updatingSection: string;
   validationFixExample: string;
-  // Pod-specific sections, empty outside a Pod conversation.
+  // Sections that depend on the conversation's Pod context (or its absence). Empty for legacy
+  // conversations without the file system.
   podSections: string;
 }
 
@@ -436,9 +461,12 @@ export const buildInteractiveContentInstructions = ({
         ? [
             POD_APP_SECTION,
             ...(hasPodFunctions
-              ? [podStorageSection(podFunctionsSkillName)]
+              ? [
+                  podStorageSection(podFunctionsSkillName),
+                  POD_VERIFICATION_SECTION,
+                ]
               : []),
           ]
-        : []
+        : [NON_POD_STATE_SECTION]
     ),
   });

--- a/front/lib/api/actions/servers/interactive_content/instructions.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions.ts
@@ -27,6 +27,7 @@ import {
   RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   REVERT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
 } from "@app/lib/api/actions/servers/interactive_content/metadata";
+import type { SANDBOX_FUNCTIONS_TOOLS_METADATA } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 import { SANDBOX_FUNCTIONS_SERVER_NAME } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 
 const FILES_EDIT_TOOL = getPrefixedToolName(
@@ -51,7 +52,7 @@ const FILES_MOVE_TOOL = getPrefixedToolName(
 );
 const POD_FUNCTIONS_CALL_TOOL = getPrefixedToolName(
   SANDBOX_FUNCTIONS_SERVER_NAME,
-  "call"
+  "call" satisfies (typeof SANDBOX_FUNCTIONS_TOOLS_METADATA)[number]["name"]
 );
 
 const UPDATING_SECTION_LEGACY = `\
@@ -181,10 +182,15 @@ A headless export (PNG or PDF) of a Frame that calls pod functions captures its 
 
 // Non-Pod conversations. Without this, a Frame asked to hold data silently ends up with a
 // `useState` array that dies on reload, and the user only finds out after entering real data.
-const NON_POD_STATE_SECTION = `\
+// The Pod suggestion is only made when pod functions are actually available in the workspace.
+const nonPodStateSection = (hasPodFunctions: boolean) => `\
 ### Frame State Outside A Pod
 
-This conversation is not part of a Pod, so a Frame here has no persistence: there is no server-side storage it can write to, and anything held in component state is lost on reload. If the user expects entered data (tasks, notes, entries, edits) to still be there the next time the Frame opens, say so plainly and suggest building the Frame in a Pod, where pod functions and databases hold its data; otherwise keep the Frame read-only or accept per-session state.
+This conversation is not part of a Pod, so a Frame here has no persistence: there is no server-side storage it can write to, and anything held in component state is lost on reload. If the user expects entered data (tasks, notes, entries, edits) to still be there the next time the Frame opens, say so plainly${
+  hasPodFunctions
+    ? " and suggest building the Frame in a Pod, where pod functions and databases hold its data"
+    : ""
+}; otherwise keep the Frame read-only or accept per-session state.
 `;
 
 // Pod conversations where pod functions are available. Without this, a Frame asked to hold data
@@ -467,6 +473,6 @@ export const buildInteractiveContentInstructions = ({
                 ]
               : []),
           ]
-        : [NON_POD_STATE_SECTION]
+        : [nonPodStateSection(hasPodFunctions)]
     ),
   });

--- a/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
@@ -93,6 +93,7 @@ The same decision rule applies regardless of where the data came from:
 - If a declared data array such as \`ITEMS\`, \`STORIES\`, or \`ROWS\` exists, the rendered JSX must consume it. Do not declare correct data and render stale hardcoded content.
 - Never fabricate missing names, numbers, URLs, booleans, totals, or logos. If no source provides a value, omit it or show \`No data available\`.
 - Every async source, including \`useFile\` or \`fetch\`, must expose loading, ok, empty, and error states.
+- Render failures as a compact card: one plain sentence saying what failed, with a retry action where retrying can help. Never render a raw \`error.message\` or stack trace in the main layout.
 - Never block the whole render on \`if (!data) return <p>Loading...</p>\`. Keep the frame shell visible and show state-specific content in the data region.
 - Parse file content inside \`useEffect\` with visible fallback UI. Catch JSON, CSV, and file-read errors.
 - Always use \`papaparse\` for CSV files with \`skipEmptyLines: "greedy"\`.

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -22,7 +22,7 @@ export const REVERT_INTERACTIVE_CONTENT_FILE_TOOL_NAME =
   "revert_interactive_content_file";
 export const RENAME_INTERACTIVE_CONTENT_FILE_TOOL_NAME =
   "rename_interactive_content_file";
-const GET_INTERACTIVE_CONTENT_FILE_SHARE_URL_TOOL_NAME =
+export const GET_INTERACTIVE_CONTENT_FILE_SHARE_URL_TOOL_NAME =
   "get_interactive_content_file_share_url";
 const EXPORT_INTERACTIVE_CONTENT_FILE_TOOL_NAME =
   "export_interactive_content_file";
@@ -251,7 +251,9 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = [
       "Export a Frame as a PNG screenshot or PDF document. " +
       "PNG returns a visual snapshot of the rendered frame. " +
       "PDF renders the frame with optional orientation (portrait/landscape for regular frames, " +
-      "landscape by default for slideshows).",
+      "landscape by default for slideshows). " +
+      "A Frame that calls pod functions exports its loading state, not its data: do not use a " +
+      "PNG export to verify one — call its functions directly instead.",
     schema: {
       file_id: z
         .string()

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -8,7 +8,7 @@ export const SANDBOX_TOOL_NAME = "sandbox" as const;
 // `wrapCommandWithCapture`), which kills the command and returns the captured
 // output when it overruns.
 export const SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS = 60000;
-const SANDBOX_MAX_COMMAND_TIMEOUT_MS = 120000;
+export const SANDBOX_MAX_COMMAND_TIMEOUT_MS = 120000;
 
 // Extra time we add on top of a command's in-container timeout to set the
 // timeout we give the sandbox provider. The in-container `timeout`

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -50,7 +50,8 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
       "must default-export a `fetch(request: Request): Promise<Response>` handler and export a " +
       "`schema` with zod `input` and `output`. Set `schema.userIdentity` to `optional`, " +
       "`workspace_user_required`, or `interactive_workspace_user_required`. It is bundled on the " +
-      "pod sandbox (only `zod` is available to import), and its contract is extracted from the " +
+      "pod sandbox (the external packages available to import are `zod`, `drizzle-orm` and " +
+      "`@dust/pod`), and its contract is extracted from the " +
       "`schema` export. The published slug is prefixed with the app the source lives in, so " +
       "re-publishing the same name from the same app replaces the previous version while another " +
       "app's function of the same name is left alone.",
@@ -81,13 +82,15 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
       executionMode: z
         .enum(SANDBOX_FUNCTION_EXECUTION_MODES)
         .describe(
-          "`fast` runs synchronously and returns in a fraction of the time, but cannot call Dust " +
-            "tools through `dsbx tools`. It can still read and write pod state, run local " +
-            "binaries and make outbound HTTP calls, though those count against its execution " +
-            "ceiling. `durable` is for a function that calls `dsbx tools`, which may wait on the " +
-            "user for approval or authentication. Keep the functions a Frame calls on user " +
-            "interaction or on a poll `fast`, and isolate `dsbx tools` calls in their own " +
-            "`durable` functions."
+          "`durable` if and only if the function calls Dust tools through `dsbx tools` — the " +
+            "mode is determined by what the code does, not by how the function is called, and it " +
+            "is restated on every publish, so derive it from the source (including its helpers) " +
+            "each time rather than from a previous publish. `fast` runs synchronously and " +
+            "returns in a fraction of the time, but `dsbx tools` is refused inside it; it can " +
+            "still read and write pod state, run local binaries and make outbound HTTP calls, " +
+            "though those count against its execution ceiling. Keep the functions a Frame calls " +
+            "on user interaction or on a poll `fast`, and isolate `dsbx tools` calls in their " +
+            "own `durable` functions."
         ),
     },
     stake: "low",

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -121,6 +121,19 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).not.toContain(POD_STORAGE_MARKER);
     expect(instructions).not.toContain(POD_VERIFICATION_MARKER);
     expect(instructions).toContain(NON_POD_STATE_MARKER);
+    expect(instructions).toContain("suggest building the Frame in a Pod");
+  });
+
+  it("omits the Pod suggestion outside a Pod when pod functions are unavailable", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+
+    const instructions = await framesSkill.fetchInstructions(auth, {
+      spaceIds: [],
+      agentLoopData: agentLoopDataInPod(null),
+    });
+
+    expect(instructions).toContain(NON_POD_STATE_MARKER);
+    expect(instructions).not.toContain("suggest building the Frame in a Pod");
   });
 
   it("teaches the Pod app layout and storage decision in a Pod", async () => {
@@ -137,7 +150,7 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain(POD_STORAGE_MARKER);
     expect(instructions).toContain(`\`${POD_FUNCTIONS_SKILL_NAME}\` skill`);
     expect(instructions).toContain(POD_VERIFICATION_MARKER);
-    expect(instructions).toContain("share URL");
+    expect(instructions).toContain("always fetch the Frame's share URL");
     expect(instructions).not.toContain(NON_POD_STATE_MARKER);
   });
 

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -24,6 +24,10 @@ const FILES_FIRST_MARKER =
 // Markers unique to each Pod-only section.
 const POD_APP_MARKER = "### Frames In A Pod";
 const POD_STORAGE_MARKER = "### Where The Frame's Data Lives";
+const POD_VERIFICATION_MARKER = "### Verifying A Frame";
+
+// Marker unique to the non-Pod persistence warning.
+const NON_POD_STATE_MARKER = "### Frame State Outside A Pod";
 
 const FILES_EDIT_TOOL = getPrefixedToolName(
   FILES_SERVER_NAME,
@@ -115,6 +119,8 @@ describe("framesSkill.fetchInstructions", () => {
 
     expect(instructions).not.toContain(POD_APP_MARKER);
     expect(instructions).not.toContain(POD_STORAGE_MARKER);
+    expect(instructions).not.toContain(POD_VERIFICATION_MARKER);
+    expect(instructions).toContain(NON_POD_STATE_MARKER);
   });
 
   it("teaches the Pod app layout and storage decision in a Pod", async () => {
@@ -130,6 +136,9 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain("pod-<podId>/MyApp/MyApp.tsx");
     expect(instructions).toContain(POD_STORAGE_MARKER);
     expect(instructions).toContain(`\`${POD_FUNCTIONS_SKILL_NAME}\` skill`);
+    expect(instructions).toContain(POD_VERIFICATION_MARKER);
+    expect(instructions).toContain("share URL");
+    expect(instructions).not.toContain(NON_POD_STATE_MARKER);
   });
 
   it("omits the storage decision when pod functions are unavailable", async () => {
@@ -142,6 +151,7 @@ describe("framesSkill.fetchInstructions", () => {
 
     expect(instructions).toContain(POD_APP_MARKER);
     expect(instructions).not.toContain(POD_STORAGE_MARKER);
+    expect(instructions).not.toContain(POD_VERIFICATION_MARKER);
   });
 
   it("keeps the legacy flow for a Pod conversation without the file system", async () => {

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -1,3 +1,7 @@
+import {
+  FILE_OFFLOAD_SNIPPET_LENGTH,
+  FILE_OFFLOAD_TEXT_SIZE_BYTES,
+} from "@app/lib/actions/action_output_limits";
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import {
   FILES_MOVE_ACTION_NAME,
@@ -35,6 +39,13 @@ const PUBLISH_FRAME_TOOL = getPrefixedToolName(
 );
 
 export const POD_FUNCTIONS_SKILL_NAME = "Pod Functions";
+
+// The execution budgets quoted in the instructions track the platform constants:
+// SANDBOX_FUNCTION_INLINE_EXEC_TIMEOUT_MS (10 s, fast) and SANDBOX_FUNCTION_EXEC_TIMEOUT_MS
+// (120 s, durable) in `front/lib/resources/sandbox_function_invocation_resource.ts`, and the
+// durable activity's 3-minute startToCloseTimeout in `front/temporal/sandbox_functions/
+// workflows.ts`. The result delivery caps track RESULT_INLINE_CAP_BYTES (256 KB) and
+// RESULT_HARD_CAP_BYTES (5 MB) in the functions runner. Keep them in sync.
 
 export const podFunctionsSkill = {
   sId: "pod_functions",
@@ -99,7 +110,8 @@ source, so the copy's Frame still calls the ORIGINAL app's functions and therefo
 the original's data. After copying \`MyApp/\` to \`MyAppCopy/\`: publish the copy's functions, reconcile
 its databases, then edit the copy's Frame so every function reference carries the new prefix
 (\`myappcopy__list-notes\`, not \`myapp__list-notes\`) and re-publish it. The same applies to renaming
-an app folder.
+an app folder. Finish the port by confirming with \`${toolName("list")}\` that every function is
+published under the new prefix, and smoke-testing each one with a \`${toolName("call")}\`.
 
 #### Authoring a function
 
@@ -147,6 +159,10 @@ publish time: editing a helper changes nothing until you re-publish, and re-publ
 leaves the others on the old copy. After changing a shared helper, re-publish every function that
 imports it.
 
+If a batch of edits to a source file partially fails, re-read the whole file before editing it
+further, and never publish it without re-reading: the file is not in the state you remember, and
+publishing ships whatever mix of applied and missing edits is actually on disk.
+
 The external packages you can import are \`zod\`, \`drizzle-orm\` and \`@dust/pod\`. Other npm packages
 are not available at build time.
 
@@ -170,7 +186,9 @@ Functions of the same Pod can share durable SQLite databases (via \`drizzle-orm\
 - **Name functions that use this db.ts by writting a comment a the top** 
 - **Apply the schema file with \`${toolName("db_reconcile")}\`**; it creates the database and
   applies additive DDL after edits, and enforces the rules below. Publishing does not touch
-  databases; an unreconciled database does not exist at runtime.
+  databases; an unreconciled database does not exist at runtime. Reconcile is idempotent and is
+  also the recovery step: if a function fails because its database is missing (for example after
+  the Pod's Computer was recycled), run it again on the same schema file.
 - **At runtime open a database with \`db(name)\` from \`@dust/pod\`** and query it with the imported
   table objects.
 
@@ -216,10 +234,34 @@ are available under the same substitution rules as the Computer.
 
 \`dsbx\` is available inside a function's own process, the same way it is in the conversation's
 Computer: shell out to \`dsbx tools --json [SERVER_NAME] [TOOL_NAME] [ARGS]...\` and parse its
-stdout (\`{ content, isError }\`) for the result.
+stdout (\`{ content, isError }\`) for the result. Spawn it asynchronously (\`spawn\`, never
+\`spawnSync\`, which blocks the worker thread other invocations share).
 Run \`dsbx tools --help\` from the Computer to explore available
 servers and tools before writing the function. A function that calls \`dsbx tools\` must be
 published as \`durable\`, see below.
+
+A tool result's \`content\` blocks are text written for an agent to read, not an API response, and
+the rendering you see in a conversation is the model-facing rendering, which is not what the
+function receives. Before writing any parsing code, run the tool from a function once and look at
+the real output. Keep all parsing of a given tool's output in one \`functions/lib/\` helper, store
+parsed data with a format version, and on a parse failure keep serving the previously stored data
+instead of persisting a broken parse.
+
+Text blocks over ${FILE_OFFLOAD_TEXT_SIZE_BYTES / 1024} KB never arrive whole: the platform
+offloads them, leaving an ${FILE_OFFLOAD_SNIPPET_LENGTH}-character head cut blindly mid-token plus
+a \`[Full content archived at <path>]\` pointer, while the full content is written to a file
+mounted in the function's own sandbox under \`/files/\`. Always read the archived file — the
+\`@dust/pod\` helper \`resolveToolTextContent\` resolves a content block to its full text where
+available, otherwise read the path the pointer names — and never store or parse the snippet text.
+
+**Never create conversations or invoke agents from a Pod function.** Do not call
+\`pod_manager.create_conversation\`, \`pod_manager.add_message_to_conversation\`, or any
+agent-invocation tool through \`dsbx tools\` from function code — there is no run-status or
+completion signal for a spawned agent, and the platform refuses these calls from functions. If a
+Frame needs agent help, link the user into a conversation instead (deep link / open-conversation
+button). If data must be produced by an agent on a schedule, use a wakeup or trigger that runs
+the agent in a normal conversation, and have that agent write results through a Pod function.
+Reading conversations (\`pod_manager.list_conversations\`) remains fine.
 
 #### Fast and durable functions
 
@@ -228,11 +270,13 @@ split functions up.
 
 - \`fast\`: runs synchronously and returns several times quicker, but **cannot call Dust tools**:
   \`dsbx tools\` is refused inside it. Everything else still works, including Pod state, local
-  binaries and outbound HTTP calls, but those count against the invocation's execution ceiling, so
-  a fast function that waits on a slow endpoint will fail rather than return late.
-- \`durable\`: required for any function that calls \`dsbx tools\`. A tool call can wait on the user
-  for approval or authentication, for as long as they take, so the invocation runs in the
-  background and its result reaches the caller when it is ready.
+  binaries and outbound HTTP calls, but those count against the invocation's 10-second execution
+  ceiling, so a fast function that waits on a slow endpoint will fail rather than return late.
+- \`durable\`: required for any function that calls \`dsbx tools\`, so a tool call can wait on the
+  user for approval or authentication. The invocation runs in the background and its result
+  reaches the caller when it is ready, but it is not unbounded: execution is capped at 120
+  seconds, inside a background envelope of about 3 minutes. Work that cannot fit that budget must
+  be split across invocations.
 
 So the shape of your functions is the real decision:
 
@@ -248,9 +292,29 @@ So the shape of your functions is the real decision:
   above when the data can tolerate being a little stale, not when it cannot.
 - Publishing a function that calls \`dsbx tools\` as \`fast\` is a bug: its tool call is refused at
   run time and the invocation fails.
+- \`executionMode\` is restated on every publish, so a republish can silently demote a \`durable\`
+  function to \`fast\` and re-introduce that bug. Derive the mode from whether the source
+  (including its \`functions/lib/\` helpers) calls \`dsbx tools\`, on every publish, never from
+  memory of a previous publish.
 
 The Frame API is identical for both, but a \`durable\` call takes visibly longer, so give it a
 loading state.
+
+##### Caching fetched data
+
+The durable-writes/fast-reads split stores snapshots, so make freshness visible: store a
+\`fetchedAt\` timestamp with every snapshot and return it from the read, so the Frame can derive
+and show staleness.
+
+Where a snapshot may live follows how the tool that produced it is connected. A tool on a
+*personal* connection runs with the credentials of whoever triggered the durable refresh, so the
+data it returns belongs to that user: key it by \`currentUser().sId\` and declare the function
+\`workspace_user_required\` (see "Knowing who called a function" below), or do not cache it at
+all. Only tools connected at the workspace level, or sources that need no authentication, may
+feed a cache shared by the whole Pod. A read that serves personally-fetched rows must itself be
+at least \`workspace_user_required\` and filter by the caller. Serving one member's
+connected-account data to other members is a data leak, not a caching optimization. When unsure
+how a tool server is connected, check it from the Computer before deciding where its data lives.
 
 #### Publishing, discovering, and invoking
 
@@ -280,6 +344,11 @@ Call a published function directly from this conversation with \`${toolName("cal
 its slug and an input payload matching its \`get\`-reported input schema. Call it yourself whenever
 you need the result now rather than asking a Frame to fetch it for you.
 
+After every publish, verify it: invoke the function once with \`${toolName("call")}\` on realistic
+input and confirm the output reflects your change before reporting success. If behavior is
+identical to before the edit, or the publish reports the new bundle is identical to the previous
+one, your edit did not land: re-read the source file, fix it, and publish again.
+
 To debug a function, use \`${toolName("inspect_invocations")}\` to inspect its most recent inputs,
 results, errors, statuses, and timestamps.
 
@@ -304,6 +373,11 @@ Design the function contract around the Frame interaction, not individual databa
 
 - make reads idempotent and side-effect-free, and return one bounded screen snapshot instead of
   creating waterfalls or N+1 calls;
+- keep outputs bounded: a response is one screen's worth of data (aim for tens of kilobytes),
+  never a raw tool output or a whole dataset. Write large data to pod files or a database and
+  return the slice the caller asked for. Result delivery is capped by the runner (see
+  \`RESULT_INLINE_CAP_BYTES\`, 256 KB inline, and \`RESULT_HARD_CAP_BYTES\`, 5 MB hard) — an
+  output near those caps is a design bug even when it gets through;
 - make mutations return the updated entity or screen snapshot so the Frame can update its cache
   without another function call;
 - keep write operations safe against duplicate interaction, using a stable idempotency key when a
@@ -352,6 +426,13 @@ schemas. Before success, hook \`data\` is \`undefined\`. After success, it conta
 value described by \`schema.output\`. Mutation \`trigger\` accepts \`schema.input\` and resolves to
 the parsed and validated value described by \`schema.output\`.
 
+That is the whole response contract: \`data\` IS the \`schema.output\` value, already validated by
+the platform. It is never a stringified payload to \`JSON.parse\`, never wrapped in \`output\`,
+\`result\`, or \`response.body\`, and never nested inside \`error\`. Do not write unwrapping
+helpers or defensive re-parsing around it: a response that violates this contract is a platform
+bug — reproduce it with \`${toolName("call")}\` and report it rather than coding around it. An
+error's \`message\` is prose for a human, never a payload to salvage data from.
+
 Function call failures are normalized as \`SandboxFunctionCallError\` instances, also exported by
 \`@dust/react-hooks\`. Query failures are exposed through \`error\`. Mutation failures update
 \`error\` and reject \`trigger\`. Each error carries a \`message\`, an optional HTTP \`status\`, and
@@ -360,6 +441,15 @@ open string because it is whatever classified the failure. Branch on the codes y
 fall back to a generic message for the rest. The ones worth branching on are \`invalid_input\` and
 \`invalid_output\` for schema mismatches, \`threw\` when the function threw, \`http_error\` when the
 function's own request failed, \`sandbox_function_not_found\`, and \`not_supported\`.
+
+Render failures as a compact card: one plain sentence saying what failed, with a retry action.
+Never render the raw \`error.message\` in the Frame's main layout — it can be long, technical, and
+platform-flavored. On the function side, throw one-line human-readable messages and keep the
+detail in logs.
+
+When a Frame polls a \`fast\` function to stay fresh, poll on a cadence of tens of seconds.
+Sub-5-second polling is only for short-lived, self-terminating transitions (waiting for one
+in-flight action to complete), never a steady state.
 
 Pod functions in shared Frames are available to authenticated members of the Pod's workspace;
 anonymous viewers cannot call them.
@@ -379,6 +469,11 @@ Declare the policy alongside the input and output schemas:
 - \`"workspace_user_required"\` refuses the call unless it comes from a current member of the Pod's
   workspace. Use it as soon as the function reads or writes anything that belongs to a person, or
   performs an action that should be attributable.
+- \`"interactive_workspace_user_required"\` further refuses any call that does not come from a
+  workspace member in a live interactive Dust session — in practice, a signed-in user acting
+  through a Frame. Calls made by an agent (including \`${toolName("call")}\` from this
+  conversation) or through an API key are refused even when a user is attached. Use it when the
+  action must be performed by the user themselves, in the moment.
 
 \`\`\`ts
 import { z } from "zod";
@@ -420,7 +515,9 @@ const user = currentUser();
 
 Scope rows by \`currentUser().sId\`, which is stable for a user across calls, conversations, and
 Frames. That single column is what turns a shared Pod database into per-user state, so add it when
-you create the table rather than retrofitting it later (schema evolution is additive-only).
+you create the table rather than retrofitting it later (schema evolution is additive-only). The
+same scoping applies to cached tool data: rows fetched through a member's personal connection are
+that member's — see "Caching fetched data" above.
 
 \`\`\`ts
 // MyApp/databases/notes.db.ts
@@ -446,7 +543,7 @@ one \`notes\` function taking an \`action\` field is not. If a capability must b
 subset of members, keep that list in the database and check it against \`currentUser().sId\` —
 the platform only tells you the caller is a workspace member, not what they are allowed to do.`,
   mcpServers: [{ name: SANDBOX_FUNCTIONS_SERVER_NAME }],
-  version: 6,
+  version: 7,
   icon: "PuzzleIcon",
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);

--- a/front/lib/resources/skill/code_defined/global/sandbox.test.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.test.ts
@@ -64,6 +64,18 @@ describe("sandboxSkill", () => {
     expect(instructions).not.toContain("- `dsbx`: Dust CLI");
   });
 
+  it("documents the bash timeout ceiling and waiting etiquette", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+
+    const instructions = await sandboxSkill.fetchInstructions(auth, {
+      spaceIds: [],
+    });
+
+    expect(instructions).toContain("default 60 s, maximum 120 s");
+    expect(instructions).toContain("exit code 124");
+    expect(instructions).toContain("Never use `sleep` to wait");
+  });
+
   it("instructs the model to analyze mounted tabular files with code", async () => {
     const { authenticator: auth } = await createResourceTest({});
 

--- a/front/lib/resources/skill/code_defined/global/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/global/sandbox.ts
@@ -1,3 +1,7 @@
+import {
+  SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS,
+  SANDBOX_MAX_COMMAND_TIMEOUT_MS,
+} from "@app/lib/api/actions/servers/sandbox/metadata";
 import { isDustLikeAgent } from "@app/lib/api/assistant/global_agents/prompt_context";
 import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import { readWorkspacePolicy } from "@app/lib/api/sandbox/egress_policy";
@@ -28,6 +32,8 @@ function buildSandboxInstructionProse({
     'The sandbox provides an isolated Linux environment for running code, scripts, and shell commands. Always call this environment "the Computer" in any text you send to the user.',
     "Use `bash` to run commands and scripts.",
     "The sandbox persists for the conversation duration.",
+    `A bash command is killed when it reaches its \`timeoutMs\` (default ${SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS / 1000} s, maximum ${SANDBOX_MAX_COMMAND_TIMEOUT_MS / 1000} s); exit code 124 means the command hit that ceiling.`,
+    "Never use `sleep` to wait for something outside the command's control (a background job, an external system, another tool's result): a long sleep only burns the timeout. Return instead and check again on a later call, or use a bounded loop of short checks.",
   ];
 
   if (hasDsbxTools) {


### PR DESCRIPTION
## Description

Bumps the Pod Functions skill to v7 and aligns the surrounding prompt surfaces with how the platform actually behaves. Builders in prod pods kept rediscovering these constraints the hard way (envelope-unwrapping armor, sleep-to-wait, durable functions silently republished as fast, personally fetched data served workspace-wide).

Skill (`pod_functions.ts`):

- real execution budgets: 10s fast, 120s durable inside a ~3min background envelope, instead of "for as long as they take"; bounded outputs with the runner delivery caps
- response contract: hook `data` IS the validated `schema.output` value; no unwrapping helpers or `JSON.parse` fallbacks, a violation is a platform bug to report
- tool-output offload contract: blocks over 20KB arrive as an 8000-char snippet plus an archive pointer; read the archived file, never store or parse the snippet
- caching doctrine: data fetched over a personal connection is keyed by `currentUser().sId` and gated `workspace_user_required`, or not cached; shared caches only for workspace-level or unauthenticated sources
- never create conversations or invoke agents from function code (no run status, refused by the platform), with the sanctioned alternatives
- republish-mode trap, verify-after-publish smoke call, re-read the whole file after a partially failed edit batch, reconcile as the recovery step, polling etiquette, compact error cards, `interactive_workspace_user_required` documented

Frames instructions: always hand over the share URL after publishing a Pod Frame, a verification section (exports of function-backed Frames capture the loading state), an explicit "no persistence outside a Pod" section, and the batch-edit re-read rule.

Tool metadata: publish tool's import list fixed (`zod`, `drizzle-orm`, `@dust/pod` instead of only `zod`), `executionMode` description now leads with "durable iff the code calls `dsbx tools`", export tool carries the loading-state caveat.

Sandbox skill: bash timeout ceiling (60s default, 120s max, exit 124) and never sleep-to-wait.

The numbers are interpolated from the platform constants where they exist (`FILE_OFFLOAD_TEXT_SIZE_BYTES`, `FILE_OFFLOAD_SNIPPET_LENGTH`, `SANDBOX_DEFAULT_COMMAND_TIMEOUT_MS`, `SANDBOX_MAX_COMMAND_TIMEOUT_MS`) and otherwise carry a comment pointing at the constant to keep in sync.

## Tests

Extended `frames.test.ts` and `sandbox.test.ts` with markers for the new sections (verification section, non-Pod state section, timeout etiquette). Ran both plus `sandbox_functions/tools/publish.test.ts` locally.

## Risk

Prompt and tool-description text only, no behavior change. Worst case is degraded agent guidance, rolled back by reverting.

## Deploy Plan

Standard deploy.