### PR TITLE
[front] Return an absolute conversationUrl from pod_manager includeMessages listing

### DIFF
--- a/front/lib/api/actions/servers/pod_manager/tools/conversation_formatting.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/conversation_formatting.ts
@@ -2,6 +2,8 @@ import {
   countConversationMessages,
   renderConversationAsText,
 } from "@app/lib/api/assistant/conversation/render_as_text";
+import config from "@app/lib/api/config";
+import { getConversationRoute } from "@app/lib/utils/router";
 import type {
   ConversationType,
   LightConversationType,
@@ -34,6 +36,14 @@ function formatConversationForDisplay(
     hasError: conversation.hasError,
     messageCount: countConversationMessages(conversation),
     messages,
+    conversationUrl: getConversationRoute(
+      workspaceId,
+      conversation.sId,
+      undefined,
+      config.getAppUrl()
+    ),
+    // Deprecated: relative path kept for callers that still read `url`. Use the absolute
+    // `conversationUrl` instead.
     url: `/w/${workspaceId}/assistant/${conversation.sId}`,
   };
 }

--- a/front/lib/api/actions/servers/pod_manager/tools/index.test.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.test.ts
@@ -5,8 +5,10 @@ import type {
   SandboxFunctionRunContext,
 } from "@app/lib/actions/types";
 import { createProjectManagerTools } from "@app/lib/api/actions/servers/pod_manager/tools";
+import config from "@app/lib/api/config";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { getConversationRoute } from "@app/lib/utils/router";
 import { processEventForDatabase } from "@app/temporal/agent_loop/activities/common";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
@@ -35,6 +37,16 @@ const ListConversationsOutputSchema = z.object({
   conversations: z.array(
     z.object({
       sId: z.string(),
+    })
+  ),
+});
+
+const ListConversationsWithMessagesOutputSchema = z.object({
+  conversations: z.array(
+    z.object({
+      sId: z.string(),
+      conversationUrl: z.string(),
+      url: z.string(),
     })
   ),
 });
@@ -173,6 +185,38 @@ describe("pod_manager create_conversation", () => {
     expect(
       output.conversations.map((conversation) => conversation.sId)
     ).toContain(createdConversation.sId);
+  });
+
+  it("returns an absolute conversationUrl (and the deprecated relative url) with includeMessages", async () => {
+    const { createdConversation, extra, tools, workspace } =
+      await createConversationFromNestedAgent();
+    const result = await getTool(tools, "list_conversations").handler(
+      { includeMessages: true },
+      extra
+    );
+
+    assert(result.isOk());
+    const content = result.value[0];
+    assert(content?.type === "text");
+    const output = ListConversationsWithMessagesOutputSchema.parse(
+      JSON.parse(content.text)
+    );
+
+    const listedConversation = output.conversations.find(
+      (conversation) => conversation.sId === createdConversation.sId
+    );
+    assert(listedConversation);
+    expect(listedConversation.conversationUrl).toBe(
+      getConversationRoute(
+        workspace.sId,
+        createdConversation.sId,
+        undefined,
+        config.getAppUrl()
+      )
+    );
+    expect(listedConversation.url).toBe(
+      `/w/${workspace.sId}/assistant/${createdConversation.sId}`
+    );
   });
 });
 


### PR DESCRIPTION
## Description

The `includeMessages` variant of `pod_manager.list_conversations` returned a relative `url` while the light variant (and `create_conversation`, `add_message_to_conversation`, `move_conversation`) all return an absolute `conversationUrl` built with `getConversationRoute(..., config.getAppUrl())`. That inconsistency pushed callers into rebuilding conversation URLs by hand with regexes.

Adds the absolute `conversationUrl` to the includeMessages formatting and keeps the old relative `url` key populated during a deprecation window (marked deprecated in a comment).

Stacked on #30330.

## Tests

Added a test asserting the includeMessages listing returns the absolute `conversationUrl` and the unchanged relative `url`.

## Risk

Low: additive field, old key unchanged. Safe to rollback.

## Deploy Plan

Standard deploy.