### PR TITLE
[front] enh: bound Pod function error messages delivered to callers

### DIFF
--- a/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.test.ts
@@ -1,5 +1,6 @@
 import { callSandboxFunction } from "@app/lib/api/sandbox_functions/call_sandbox_function";
 import type { SandboxFunctionInvocationStreamEvent } from "@app/lib/api/sandbox_functions/events";
+import { SANDBOX_FUNCTION_DELIVERED_ERROR_MESSAGE_MAX_CHARS } from "@app/lib/api/sandbox_functions/result_envelope";
 import { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
@@ -172,6 +173,53 @@ describe("callSandboxFunction", () => {
       message: "boom",
       status: 503,
     });
+  });
+
+  it("bounds a stream-delivered error message to the delivery cap", async () => {
+    const { auth, fn, invocationId } = await setup();
+    const longMessage = "x".repeat(
+      SANDBOX_FUNCTION_DELIVERED_ERROR_MESSAGE_MAX_CHARS * 20
+    );
+    vi.mocked(getSandboxFunctionInvocationEvents).mockReturnValue(
+      eventStream({
+        type: "sandbox_function_invocation_error",
+        created: 0,
+        invocationId,
+        functionId: "sfn_x",
+        error: { code: "invocation_failed", message: longMessage },
+      })
+    );
+
+    const result = await callSandboxFunction(auth, fn, { name: "x" });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("invocation_failed");
+    expect(result.error.message).toHaveLength(
+      SANDBOX_FUNCTION_DELIVERED_ERROR_MESSAGE_MAX_CHARS
+    );
+    expect(result.error.message.endsWith("...")).toBe(true);
+  });
+
+  it("bounds the message of an invoke that fails before executing", async () => {
+    const { auth, fn } = await setup();
+    const longMessage = "y".repeat(
+      SANDBOX_FUNCTION_DELIVERED_ERROR_MESSAGE_MAX_CHARS * 20
+    );
+    vi.spyOn(fn, "invoke").mockResolvedValue(new Err(new Error(longMessage)));
+
+    const result = await callSandboxFunction(auth, fn, { name: "x" });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+    expect(result.error.code).toBe("invocation_failed");
+    expect(result.error.message).toHaveLength(
+      SANDBOX_FUNCTION_DELIVERED_ERROR_MESSAGE_MAX_CHARS
+    );
   });
 
   it("fails closed on a policy introduced by a newer application version", async () => {

--- a/front/lib/api/sandbox_functions/call_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/call_sandbox_function.ts
@@ -1,5 +1,6 @@
 import { isSandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
 import { getSandboxFunctionInvocationEvents } from "@app/lib/api/sandbox_functions/events";
+import { boundSandboxFunctionCallError } from "@app/lib/api/sandbox_functions/result_envelope";
 import type { Authenticator } from "@app/lib/auth";
 import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type {
@@ -29,15 +30,21 @@ export async function callSandboxFunction(
   });
   if (invocationResult.isErr()) {
     if (isSandboxFunctionInvocationError(invocationResult.error)) {
-      return new Err({
-        code: invocationResult.error.code,
-        message: invocationResult.error.message,
-      });
+      return new Err(
+        boundSandboxFunctionCallError({
+          code: invocationResult.error.code,
+          message: invocationResult.error.message,
+        })
+      );
     }
-    return new Err({
-      code: "invocation_failed",
-      message: invocationResult.error.message,
-    });
+    // The unclassified message may be a raw provider or runner dump; the full text is already
+    // in the failure-path logs, so deliver a bounded copy only.
+    return new Err(
+      boundSandboxFunctionCallError({
+        code: "invocation_failed",
+        message: invocationResult.error.message,
+      })
+    );
   }
   const invocation = invocationResult.value;
   const { sId: invocationId } = invocation;
@@ -50,7 +57,7 @@ export async function callSandboxFunction(
       case "succeeded":
         return new Ok(settled.result);
       case "errored":
-        return new Err(settled.error);
+        return new Err(boundSandboxFunctionCallError(settled.error));
       default:
         assertNever(settled);
     }
@@ -63,7 +70,7 @@ export async function callSandboxFunction(
       signal: AbortSignal.timeout(CALL_RESULT_WAIT_TIMEOUT_MS),
     })) {
       if (data.type === "sandbox_function_invocation_error") {
-        return new Err(data.error);
+        return new Err(boundSandboxFunctionCallError(data.error));
       }
 
       if (data.type !== "sandbox_function_invocation_result") {
@@ -73,10 +80,12 @@ export async function callSandboxFunction(
       return new Ok(data.result);
     }
   } catch (error) {
-    return new Err({
-      code: "transport_error",
-      message: `Failed to receive sandbox function events: ${normalizeError(error).message}`,
-    });
+    return new Err(
+      boundSandboxFunctionCallError({
+        code: "transport_error",
+        message: `Failed to receive sandbox function events: ${normalizeError(error).message}`,
+      })
+    );
   }
 
   return new Err({

--- a/front/lib/api/sandbox_functions/result_envelope.test.ts
+++ b/front/lib/api/sandbox_functions/result_envelope.test.ts
@@ -1,5 +1,6 @@
 import {
   normalizeSandboxFunctionResult,
+  SANDBOX_FUNCTION_DELIVERED_ERROR_MESSAGE_MAX_CHARS,
   SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSION,
 } from "@app/lib/api/sandbox_functions/result_envelope";
 import { describe, expect, it } from "vitest";
@@ -198,6 +199,47 @@ describe("normalizeSandboxFunctionResult", () => {
       ok: false,
       error: { code: "threw", message: "boom" },
     });
+  });
+
+  it("bounds threw messages, which the function authors, to the delivered cap", () => {
+    const longMessage = "x".repeat(
+      SANDBOX_FUNCTION_DELIVERED_ERROR_MESSAGE_MAX_CHARS * 20
+    );
+
+    const normalized = normalizeSandboxFunctionResult({
+      protocolVersion: 3,
+      delivery: "stdout",
+      outcome: { ok: false, error: { code: "threw", message: longMessage } },
+    });
+    if (normalized.ok) {
+      throw new Error("expected an error outcome");
+    }
+    expect(normalized.error.code).toBe("threw");
+    expect(normalized.error.message).toHaveLength(
+      SANDBOX_FUNCTION_DELIVERED_ERROR_MESSAGE_MAX_CHARS
+    );
+    expect(normalized.error.message.endsWith("...")).toBe(true);
+
+    // The legacy arm carries the same function-authored message.
+    const legacy = normalizeSandboxFunctionResult({
+      ok: false,
+      error: { kind: "threw", message: longMessage },
+    });
+    if (legacy.ok) {
+      throw new Error("expected an error outcome");
+    }
+    expect(legacy.error.message).toHaveLength(
+      SANDBOX_FUNCTION_DELIVERED_ERROR_MESSAGE_MAX_CHARS
+    );
+
+    // Short threw messages pass through untouched.
+    expect(
+      normalizeSandboxFunctionResult({
+        protocolVersion: 3,
+        delivery: "stdout",
+        outcome: { ok: false, error: { code: "threw", message: "boom" } },
+      })
+    ).toEqual({ ok: false, error: { code: "threw", message: "boom" } });
   });
 
   it("fails malformed envelopes with the stable invalid-envelope message", () => {

--- a/front/lib/api/sandbox_functions/result_envelope.ts
+++ b/front/lib/api/sandbox_functions/result_envelope.ts
@@ -15,6 +15,28 @@ export const SUPPORTED_SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSIONS = [
 // Cap on the rejected-payload snippet included in logs.
 const REJECTED_ENVELOPE_LOG_SNIPPET_MAX_CHARS = 512;
 
+// Cap on error messages delivered to callers and frames. Thrown errors can embed entire tool
+// stderr dumps, and frames render `message` on user-facing error cards. The full text stays
+// available for debugging: execute() logs the raw runner stdout/stderr on every failure, and
+// `inspect_invocations` reads the persisted invocation record.
+export const SANDBOX_FUNCTION_DELIVERED_ERROR_MESSAGE_MAX_CHARS = 1_000;
+
+/**
+ * Bound a call error's message for delivery. Callers hand the returned error to frames and
+ * tool outputs; the original, unbounded text belongs in logs only.
+ */
+export function boundSandboxFunctionCallError(
+  error: SandboxFunctionCallError
+): SandboxFunctionCallError {
+  return {
+    ...error,
+    message: truncate(
+      error.message,
+      SANDBOX_FUNCTION_DELIVERED_ERROR_MESSAGE_MAX_CHARS
+    ),
+  };
+}
+
 export type NormalizedSandboxFunctionOutcome =
   | { ok: true; output: unknown }
   | { ok: false; error: SandboxFunctionCallError };
@@ -129,7 +151,14 @@ function normalizeRunnerOutcome(
 ): NormalizedSandboxFunctionOutcome {
   const current = SandboxFunctionRunnerOutputSchema.safeParse(result);
   if (current.success) {
-    return current.data;
+    const outcome = current.data;
+    // `threw` is the only code whose message is authored by the function itself (the thrown
+    // error's message), which in practice embeds whole tool stderr dumps. Bound it before it is
+    // persisted and delivered; runner-minted messages on the other codes are short prose.
+    if (!outcome.ok && outcome.error.code === "threw") {
+      return { ok: false, error: boundSandboxFunctionCallError(outcome.error) };
+    }
+    return outcome;
   }
 
   const legacy = LegacySandboxFunctionRunnerOutputSchema.safeParse(result);
@@ -143,12 +172,16 @@ function normalizeRunnerOutcome(
   }
 
   if (!legacy.data.ok) {
+    const error = {
+      code: legacy.data.error.kind,
+      message: legacy.data.error.message,
+    };
     return {
       ok: false,
-      error: {
-        code: legacy.data.error.kind,
-        message: legacy.data.error.message,
-      },
+      error:
+        legacy.data.error.kind === "threw"
+          ? boundSandboxFunctionCallError(error)
+          : error,
     };
   }
 


### PR DESCRIPTION
## Description

Frames render `error.message` from Pod function call errors on user-facing cards, and a function that throws puts whatever it wants in there. In prod we have seen triple-nested dsbx stderr dumps and other multi-KB payloads delivered verbatim.

Cap delivered messages at 1,000 chars (`SANDBOX_FUNCTION_DELIVERED_ERROR_MESSAGE_MAX_CHARS`):

- `result_envelope.ts`: bound the `threw` code, the only one whose message is authored by function code, in both the current and the legacy envelope arms, so neither the persisted error nor the published event carries an unbounded payload.
- `call_sandbox_function.ts`: bound every error handed back to the caller (invoke failures, settled outcomes, stream events, transport errors).

Full text stays available for debugging: the exec path already logs raw runner stdout/stderr on every failure (16 KB caps).

## Tests

Added tests pinning the cap on the `threw` normalization (current and legacy arms, short messages untouched) and on the delivery paths in `callSandboxFunction` (stream-delivered error, failed invoke).

## Risk

Low. Messages only get shorter; codes and shapes are unchanged. A frame that parsed content out of long error messages would break, but that pattern is exactly what this prevents.

## Deploy Plan

Standard deploy.