### PR TITLE
[dsbx] fix: drain-safe runner stdout and honest truncation classification

### DIFF
--- a/cli/dust-sandbox/functions-runner/emit.ts
+++ b/cli/dust-sandbox/functions-runner/emit.ts
@@ -1,0 +1,43 @@
+// Drain-safe stdout emission for the runner's one-line JSON envelopes.
+//
+// runner.ts ends with `process.exit(await main())`, and process.exit does NOT
+// drain queued asynchronous stdout writes: on a pipe, `process.stdout.write`
+// buffers whatever the kernel cannot take immediately, and exiting drops those
+// bytes, cutting a large envelope mid-JSON while the process still exits with
+// the handler's code. The reader (dsbx, or front through it) then sees a
+// JSON-prefixed line that does not parse.
+//
+// Writing synchronously to fd 1 hands every byte to the kernel before
+// returning: the loop covers partial writes, and retries EAGAIN for the case
+// where fd 1 is a non-blocking pipe whose buffer is full (the reader will
+// drain it). Once this returns, no queued write remains for exit to drop.
+//
+// The warm server (serve.ts) replies over a unix socket and has its own
+// drain-safe path (writeThenEnd/drainPending).
+
+import { writeSync } from "node:fs";
+
+function isRetryableWriteError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error.code === "EAGAIN" || error.code === "EINTR")
+  );
+}
+
+/** Serialize `envelope` and write it to stdout as one line, synchronously. */
+export function emitEnvelopeLine(envelope: unknown): void {
+  const bytes = Buffer.from(`${JSON.stringify(envelope)}\n`, "utf8");
+  let offset = 0;
+  while (offset < bytes.length) {
+    try {
+      offset += writeSync(1, bytes, offset, bytes.length - offset);
+    } catch (error) {
+      if (isRetryableWriteError(error)) {
+        continue;
+      }
+      throw error;
+    }
+  }
+}

--- a/cli/dust-sandbox/functions-runner/fixtures/big-output.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/big-output.ts
@@ -1,0 +1,7 @@
+// Returns a payload far larger than any kernel pipe buffer, so an exit that
+// drops queued stdout writes truncates the result envelope mid-JSON.
+export default {
+  async fetch(): Promise<Response> {
+    return Response.json({ big: "x".repeat(2 * 1024 * 1024) });
+  },
+};

--- a/cli/dust-sandbox/functions-runner/runner.test.ts
+++ b/cli/dust-sandbox/functions-runner/runner.test.ts
@@ -39,6 +39,20 @@ describe("runner run", () => {
     expect(JSON.parse(stdout).output.mode).toBe(0o660);
   });
 
+  test("delivers a 2MB result envelope intact", async () => {
+    // Regression: process.exit does not drain queued async stdout writes, so a
+    // large envelope written with process.stdout.write was cut mid-JSON. The
+    // envelope must reach the reader whole, whatever its size.
+    const { stdout, code } = await run(
+      ["run", fx("big-output.ts")],
+      JSON.stringify({ url: "http://localhost/" })
+    );
+    expect(code).toBe(0);
+    const out = JSON.parse(stdout);
+    expect(out.ok).toBe(true);
+    expect(out.output.big.length).toBe(2 * 1024 * 1024);
+  });
+
   test("exits 1 with ok:false when handler throws", async () => {
     const { stdout, code } = await run(
       ["run", fx("throws.ts")],

--- a/cli/dust-sandbox/functions-runner/runner.ts
+++ b/cli/dust-sandbox/functions-runner/runner.ts
@@ -16,6 +16,7 @@ import { errorEnvelope, podDatabaseMaxSizeBytes } from "./db/common.ts";
 import { runQuery } from "./db/query.ts";
 import { reconcile } from "./db/reconcile.ts";
 import { generateSchemaFileText } from "./db/schema.ts";
+import { emitEnvelopeLine } from "./emit.ts";
 import { invoke } from "./invoke.ts";
 import { BadInputError, parseInput, type RequestInput } from "./protocol.ts";
 import { getFunctionSchema } from "./schema.ts";
@@ -41,25 +42,21 @@ async function runHandler(handlerPath: string): Promise<number> {
     input = parseInput(raw);
   } catch (e) {
     const message = e instanceof BadInputError ? e.message : String(e);
-    process.stdout.write(
-      `${JSON.stringify({ ok: false, error: { code: "bad_input", message } })}\n`
-    );
+    emitEnvelopeLine({ ok: false, error: { code: "bad_input", message } });
     return 2;
   }
   const out = await invoke(handlerPath, input);
-  process.stdout.write(`${JSON.stringify(out)}\n`);
+  emitEnvelopeLine(out);
   return out.ok ? 0 : 1;
 }
 
 async function getHandler(handlerPath: string): Promise<number> {
   try {
     const schema = await getFunctionSchema(handlerPath);
-    process.stdout.write(`${JSON.stringify(schema)}\n`);
+    emitEnvelopeLine(schema);
     return 0;
   } catch (e) {
-    process.stdout.write(
-      `${JSON.stringify({ error: e instanceof Error ? e.message : String(e) })}\n`
-    );
+    emitEnvelopeLine({ error: e instanceof Error ? e.message : String(e) });
     return 1;
   }
 }
@@ -67,29 +64,25 @@ async function getHandler(handlerPath: string): Promise<number> {
 async function buildHandler(args: string[]): Promise<number> {
   const [srcPath, outBundlePath, outSchemaPath] = args;
   if (!srcPath || !outBundlePath || !outSchemaPath) {
-    process.stdout.write(
-      `${JSON.stringify({
-        ok: false,
-        error: {
-          kind: "bad_args",
-          message: "usage: runner build <src> <outBundle> <outSchema>",
-        },
-      })}\n`
-    );
+    emitEnvelopeLine({
+      ok: false,
+      error: {
+        kind: "bad_args",
+        message: "usage: runner build <src> <outBundle> <outSchema>",
+      },
+    });
     return 2;
   }
   const result = await build(srcPath, outBundlePath, outSchemaPath);
-  process.stdout.write(`${JSON.stringify(result)}\n`);
+  emitEnvelopeLine(result);
   return result.ok ? 0 : 1;
 }
 
 function emitDbBadArgs(usage: string): number {
-  process.stdout.write(
-    `${JSON.stringify({
-      ok: false,
-      error: { kind: "bad_args", message: usage },
-    })}\n`
-  );
+  emitEnvelopeLine({
+    ok: false,
+    error: { kind: "bad_args", message: usage },
+  });
   return 2;
 }
 
@@ -103,10 +96,10 @@ async function dbReconcileHandler(args: string[]): Promise<number> {
   }
   const result = await reconcile(dbPath, schemaFile);
   if (result.isErr()) {
-    process.stdout.write(`${JSON.stringify(errorEnvelope(result.error))}\n`);
+    emitEnvelopeLine(errorEnvelope(result.error));
     return 1;
   }
-  process.stdout.write(`${JSON.stringify({ ok: true, ...result.value })}\n`);
+  emitEnvelopeLine({ ok: true, ...result.value });
   return 0;
 }
 
@@ -117,11 +110,11 @@ async function dbSchemaHandler(args: string[]): Promise<number> {
   }
   const result = generateSchemaFileText(dbPath);
   if (result.isErr()) {
-    process.stdout.write(`${JSON.stringify(errorEnvelope(result.error))}\n`);
+    emitEnvelopeLine(errorEnvelope(result.error));
     return 1;
   }
   await Bun.write(outSchemaTs, result.value);
-  process.stdout.write(`${JSON.stringify({ ok: true })}\n`);
+  emitEnvelopeLine({ ok: true });
   return 0;
 }
 
@@ -136,18 +129,16 @@ async function dbQueryHandler(args: string[]): Promise<number> {
   }
   const maxSizeBytes = podDatabaseMaxSizeBytes();
   if (maxSizeBytes.isErr()) {
-    process.stdout.write(
-      `${JSON.stringify(errorEnvelope(maxSizeBytes.error))}\n`
-    );
+    emitEnvelopeLine(errorEnvelope(maxSizeBytes.error));
     return 1;
   }
   const sql = await Bun.stdin.text();
   const result = runQuery(dbPath, sql, maxSizeBytes.value, spillDir);
   if (result.isErr()) {
-    process.stdout.write(`${JSON.stringify(errorEnvelope(result.error))}\n`);
+    emitEnvelopeLine(errorEnvelope(result.error));
     return 1;
   }
-  process.stdout.write(`${JSON.stringify({ ok: true, ...result.value })}\n`);
+  emitEnvelopeLine({ ok: true, ...result.value });
   return 0;
 }
 

--- a/cli/dust-sandbox/src/commands/function/envelope.rs
+++ b/cli/dust-sandbox/src/commands/function/envelope.rs
@@ -68,11 +68,15 @@ impl ResultEnvelope {
     }
 
     pub fn stdout_invocation_failed(message: impl Into<String>) -> Self {
+        Self::stdout_error("invocation_failed", message)
+    }
+
+    pub fn stdout_error(code: &str, message: impl Into<String>) -> Self {
         Self::stdout_outcome(
             serde_json::json!({
                 "ok": false,
                 "error": {
-                    "code": "invocation_failed",
+                    "code": code,
                     "message": message.into(),
                 }
             }),

--- a/cli/dust-sandbox/src/commands/function/mod.rs
+++ b/cli/dust-sandbox/src/commands/function/mod.rs
@@ -31,9 +31,10 @@ const FUNCTION_WORKING_DIR_ENV: &str = "DUST_FUNCTION_WORKING_DIR";
 /// TODO(SANDBOX FUNCTION) Consider adding a dedicated node_modules dedicated to sandbox functions.
 const FUNCTIONS_GLOBAL_NODE_MODULES: &str = "/opt/npm-global/lib/node_modules";
 
-/// The function bundle runner, pre-bundled (Zod inlined) at dev time and
-/// committed. Embedded so `dsbx` is a single binary; cross-compilation does
-/// not need `bun`.
+/// The function bundle runner, a generated build artifact (Zod inlined), NOT
+/// committed: `bun run build` in `functions-runner/` produces it before dsbx
+/// compiles (see build.rs). Embedded so `dsbx` is a single binary;
+/// cross-compilation does not need `bun`.
 const RUNNER_JS: &str = include_str!("../../../functions-runner/runner.js");
 
 /// The unprivileged, egress-proxied user the sandbox runs agent code as (the

--- a/cli/dust-sandbox/src/commands/function/run.rs
+++ b/cli/dust-sandbox/src/commands/function/run.rs
@@ -156,6 +156,28 @@ fn stdout_result(
         Ok(outcome) => (ResultEnvelope::stdout_outcome(outcome, Some(timings_ms)), 0),
         Err(_) => {
             let snippet = truncate_chars(line, NON_JSON_SNIPPET_MAX_CHARS);
+            if line.starts_with('{') || line.starts_with('[') {
+                // A JSON-prefixed line that does not parse is a runner envelope
+                // cut in transit, not a function printing prose: the function
+                // ran, its result was lost. Classify honestly, and keep the
+                // payload prefix out of the error message — a snippet of valid
+                // JSON inside an error string reads like a wrapping bug and
+                // sends builders chasing the wrong problem. The raw prefix
+                // goes to stderr for the logs instead.
+                let bytes_read = response.len();
+                eprintln!("dsbx: truncated function output (read {bytes_read} bytes): {snippet}");
+                return (
+                    ResultEnvelope::stdout_error(
+                        "output_truncated",
+                        format!(
+                            "function output was truncated in transit (read {bytes_read} bytes, \
+                             runner exit {runner_exit_code}); return a smaller payload or write \
+                             large data to a pod file"
+                        ),
+                    ),
+                    0,
+                );
+            }
             (
                 ResultEnvelope::stdout_invocation_failed(format!(
                     "function produced non-JSON output (runner exit {runner_exit_code}): {snippet}"
@@ -231,6 +253,43 @@ mod tests {
             .expect("invocation_failed message is a string");
         assert!(message.contains("runner exit 1"));
         assert!(message.contains("not-json"));
+    }
+
+    #[test]
+    fn stdout_result_classifies_a_cut_json_line_as_output_truncated() {
+        // A JSON-prefixed line that fails to parse is a truncated envelope:
+        // the code is output_truncated, the message carries the byte count and
+        // never the payload prefix (which reads like a wrapping bug).
+        let cut = "{\"ok\":true,\"output\":{\"hello\":\"wor".to_string();
+        let bytes_read = cut.len();
+        let (envelope, code) = stdout_result(Ok((0, Some(cut))), timings(1, 1));
+        assert_eq!(code, 0);
+        assert_eq!(envelope.outcome["error"]["code"], "output_truncated");
+        let message = envelope.outcome["error"]["message"]
+            .as_str()
+            .expect("output_truncated message is a string");
+        assert!(message.contains(&format!("read {bytes_read} bytes")));
+        assert!(message.contains("runner exit 0"));
+        assert!(!message.contains("{\"ok\""));
+
+        // Same for an array-prefixed line.
+        let (envelope, _) = stdout_result(Ok((0, Some("[1,2,".to_string()))), timings(1, 1));
+        assert_eq!(envelope.outcome["error"]["code"], "output_truncated");
+    }
+
+    #[test]
+    fn stdout_result_keeps_the_snippet_for_genuinely_non_json_output() {
+        let (envelope, code) = stdout_result(
+            Ok((0, Some("some stray log line\n".to_string()))),
+            timings(1, 1),
+        );
+        assert_eq!(code, 0);
+        assert_eq!(envelope.outcome["error"]["code"], "invocation_failed");
+        let message = envelope.outcome["error"]["message"]
+            .as_str()
+            .expect("invocation_failed message is a string");
+        assert!(message.contains("non-JSON output"));
+        assert!(message.contains("some stray log line"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes the top Pod-function prod failure: large results cut mid-JSON on the cold path.

- The cold runner ends with `process.exit`, which drops queued async stdout writes. A ~250KB result envelope was cut mid-JSON while the runner exited 0. All runner stdout envelopes (run/get/build/db handlers) now go through one synchronous fd-1 write helper that loops over partial writes and retries EAGAIN, so exit can never drop envelope bytes. The warm socket path already drains (`writeThenEnd`/`drainPending`).
- When the last stdout line still fails to parse and starts with `{` or `[`, dsbx now mints `output_truncated` with the byte count read, instead of `function produced non-JSON output (...)` with a 512-char prefix of the valid payload embedded in the error message (which reads like an envelope-wrapping bug). The raw prefix goes to stderr for logs. Genuinely non-JSON lines (stray prints) keep the existing message and snippet.
- Fixes the stale comment claiming `runner.js` is committed (it is a generated bundle, see `build.rs`).

Depends on #30333 (front must accept the `output_truncated` code before a dsbx release ships this).

## Tests

- New 2MB round-trip regression test in `runner.test.ts`, confirmed red before the drain fix (envelope cut mid-string) and green after.
- `run.rs` tests: cut JSON line and cut array line classify as `output_truncated` with byte count and no payload prefix; non-JSON line keeps the current message.

## Risk

Low: emission becomes synchronous (same bytes, same line), and the new classification only changes the error code/message for envelopes that were already failing.

## Deploy Plan

No image change until the next dsbx release + `DSBX_CLI_VERSION` bump, which must happen after #30333 is deployed.