### PR TITLE
[front] feat: structured message fields on slack_personal tool outputs

### DIFF
--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -369,6 +369,34 @@ export const isSearchResultResourceType = (
   );
 };
 
+// Slack search results carry additional structured message metadata so programmatic
+// consumers do not have to parse the human-readable `text` field. The extra fields ride
+// the resource `_meta` round-trip for internal servers and are ignored everywhere else.
+export const SlackSearchResultResourceSchema = SearchResultResourceSchema.extend(
+  {
+    author: z
+      .object({ id: z.string().optional(), name: z.string().optional() })
+      .optional(),
+    // For `list_messages`, `name` is the resolved display name and may carry a leading
+    // "#" (channel) or "@" (DM) prefix; search results return the bare channel name.
+    channel: z
+      .object({ id: z.string().optional(), name: z.string().optional() })
+      .optional(),
+    ts: z.string().optional(),
+    threadTs: z.string().optional(),
+    permalink: z.string().optional(),
+    // Display names for user IDs mentioned in the message content (best effort:
+    // unresolvable IDs are omitted).
+    mentionedUsers: z
+      .array(z.object({ id: z.string(), name: z.string() }))
+      .optional(),
+  }
+);
+
+export type SlackSearchResultResourceType = z.infer<
+  typeof SlackSearchResultResourceSchema
+>;
+
 export const WarningResourceSchema = z.object({
   mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.WARNING),
   warningTitle: z.string(),

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -372,8 +372,8 @@ export const isSearchResultResourceType = (
 // Slack search results carry additional structured message metadata so programmatic
 // consumers do not have to parse the human-readable `text` field. The extra fields ride
 // the resource `_meta` round-trip for internal servers and are ignored everywhere else.
-export const SlackSearchResultResourceSchema = SearchResultResourceSchema.extend(
-  {
+export const SlackSearchResultResourceSchema =
+  SearchResultResourceSchema.extend({
     author: z
       .object({ id: z.string().optional(), name: z.string().optional() })
       .optional(),
@@ -390,8 +390,7 @@ export const SlackSearchResultResourceSchema = SearchResultResourceSchema.extend
     mentionedUsers: z
       .array(z.object({ id: z.string(), name: z.string() }))
       .optional(),
-  }
-);
+  });
 
 export type SlackSearchResultResourceType = z.infer<
   typeof SlackSearchResultResourceSchema

--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -15,6 +15,7 @@ import {
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { removeDiacritics } from "@app/lib/utils";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { cacheWithRedis } from "@app/lib/utils/cache";
 import { getConversationRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
@@ -499,17 +500,104 @@ export async function getSlackTeamUrl({
 
 // Builds a Slack archive permalink for a message, matching the format returned by
 // chat.getPermalink (e.g. "https://acme.slack.com/archives/C012AB3CD/p1234567890123456").
+// For thread replies, pass threadTs so the permalink opens the thread view.
 export function buildSlackPermalink({
   teamUrl,
   channelId,
   messageTs,
+  threadTs,
 }: {
   teamUrl: string;
   channelId: string;
   messageTs: string;
+  threadTs?: string;
 }): string {
   const base = teamUrl.endsWith("/") ? teamUrl : `${teamUrl}/`;
-  return `${base}archives/${channelId}/p${messageTs.replace(".", "")}`;
+  const permalink = `${base}archives/${channelId}/p${messageTs.replace(".", "")}`;
+  if (threadTs && threadTs !== messageTs) {
+    return `${permalink}?thread_ts=${threadTs}&cid=${channelId}`;
+  }
+  return permalink;
+}
+
+// Best-effort extraction of Slack user IDs referenced in message text. Matches both the
+// raw mention syntax (`<@U12345678>` / `<@U12345678|name>`) and the rendered form
+// (`@U12345678`) produced by the message formatter.
+export function extractMentionedSlackUserIds(text: string): string[] {
+  const userIds = new Set<string>();
+  for (const match of text.matchAll(/<@([UW][A-Z0-9]{2,})(?:\|[^>]*)?>/g)) {
+    const userId = match[1];
+    if (userId) {
+      userIds.add(userId);
+    }
+  }
+  for (const match of text.matchAll(/(?<![<\w])@([UW][A-Z0-9]{7,})\b/g)) {
+    const userId = match[1];
+    if (userId) {
+      userIds.add(userId);
+    }
+  }
+  return [...userIds];
+}
+
+const USER_DISPLAY_NAME_RESOLUTION_CONCURRENCY = 8;
+// users.info is Tier 4 (100+ req/min): cap resolutions per tool call to stay well below.
+const MAX_USER_DISPLAY_NAME_RESOLUTIONS = 50;
+
+const getCachedUserDisplayName = cacheWithRedis(
+  async ({
+    userId,
+    accessToken,
+  }: {
+    userId: string;
+    accessToken: string;
+    mcpServerId: string;
+  }): Promise<string | null> => {
+    return resolveUserDisplayName({ userId, accessToken });
+  },
+  ({ userId, mcpServerId }) =>
+    `slack_user_display_name_${mcpServerId}_${userId}`,
+  {
+    ttlMs: USER_CACHE_TTL_MS, // 10 minutes
+  }
+);
+
+// Bulk-resolves Slack user IDs to display names (Redis-cached per user). Unresolvable IDs
+// are omitted from the returned map.
+export async function resolveUserDisplayNames({
+  userIds,
+  accessToken,
+  mcpServerId,
+}: {
+  userIds: string[];
+  accessToken: string;
+  mcpServerId: string;
+}): Promise<Map<string, string>> {
+  const uniqueUserIds = [...new Set(userIds)].slice(
+    0,
+    MAX_USER_DISPLAY_NAME_RESOLUTIONS
+  );
+
+  const resolved = await concurrentExecutor(
+    uniqueUserIds,
+    async (userId) => ({
+      userId,
+      name: await getCachedUserDisplayName({
+        userId,
+        accessToken,
+        mcpServerId,
+      }),
+    }),
+    { concurrency: USER_DISPLAY_NAME_RESOLUTION_CONCURRENCY }
+  );
+
+  const displayNamesByUserId = new Map<string, string>();
+  for (const { userId, name } of resolved) {
+    if (name) {
+      displayNamesByUserId.set(userId, name);
+    }
+  }
+  return displayNamesByUserId;
 }
 
 // Format users as Markdown.
@@ -1232,9 +1320,7 @@ export async function executeSearchUser(
     if (result.isErr()) {
       return result;
     }
-    return new Ok([
-      { type: "text" as const, text: formatUsersAsMarkdown([result.value]) },
-    ]);
+    return new Ok(makeSearchUserContent([result.value]));
   }
 
   // Strategy 2: Search by email
@@ -1243,9 +1329,7 @@ export async function executeSearchUser(
     if (result.isErr()) {
       return result;
     }
-    return new Ok([
-      { type: "text" as const, text: formatUsersAsMarkdown([result.value]) },
-    ]);
+    return new Ok(makeSearchUserContent([result.value]));
   }
 
   // Strategy 3: Search by name (slow, asks in chat permission)
@@ -1265,13 +1349,28 @@ export async function executeSearchUser(
     return result;
   }
 
-  const markdown = formatUsersAsMarkdown(result.value);
-  return new Ok([
+  return new Ok(
+    makeSearchUserContent(
+      result.value,
+      `Found ${result.value.length} user(s) matching '${query}':`
+    )
+  );
+}
+
+// Builds search_user output: the human-readable Markdown block (unchanged historical
+// format) followed by a machine-readable JSON block.
+function makeSearchUserContent(
+  users: MinimalUserInfo[],
+  header?: string
+): Array<{ type: "text"; text: string }> {
+  const markdown = formatUsersAsMarkdown(users);
+  return [
     {
       type: "text" as const,
-      text: `Found ${result.value.length} user(s) matching '${query}':\n\n${markdown}`,
+      text: header ? `${header}\n\n${markdown}` : markdown,
     },
-  ]);
+    { type: "text" as const, text: JSON.stringify({ users }) },
+  ];
 }
 
 type ChannelTab = {
@@ -1724,6 +1823,10 @@ export async function executeReadThreadMessages({
   const parentMessage = messages[0];
   const threadReplies = messages.slice(1);
 
+  // conversations.replies does not return permalinks: fetch the team URL once and
+  // construct them. When the team URL cannot be resolved, permalinks are omitted.
+  const teamUrl = await getSlackTeamUrl({ accessToken });
+
   const formattedOutput = {
     parent_message: {
       // Rendered text reconstructs content from blocks/attachments when the top-level
@@ -1735,12 +1838,29 @@ export async function executeReadThreadMessages({
       user: parentMessage?.user ?? "",
       ts: parentMessage?.ts ?? "",
       reply_count: parentMessage?.reply_count ?? 0,
+      permalink:
+        teamUrl && parentMessage?.ts
+          ? buildSlackPermalink({
+              teamUrl,
+              channelId,
+              messageTs: parentMessage.ts,
+            })
+          : undefined,
     },
     thread_replies: threadReplies.map((msg) => ({
       text: renderFormattedMessage(formatSlackMessageForLLM(msg)),
       raw_text: msg.text ?? "",
       user: msg.user ?? "",
       ts: msg.ts ?? "",
+      permalink:
+        teamUrl && msg.ts
+          ? buildSlackPermalink({
+              teamUrl,
+              channelId,
+              messageTs: msg.ts,
+              threadTs,
+            })
+          : undefined,
     })),
     total_messages: messages.length,
     has_more: response.has_more ?? false,

--- a/front/lib/api/actions/servers/slack/search_user.test.ts
+++ b/front/lib/api/actions/servers/slack/search_user.test.ts
@@ -66,6 +66,34 @@ describe("executeSearchUser - Slack Logic", () => {
       expect(result.isOk()).toBe(true);
     });
 
+    it("should append a machine-readable JSON block after the Markdown block", async () => {
+      const mockUser = {
+        id: "U01234ABCD",
+        name: "john.doe",
+        real_name: "John Doe",
+        profile: { email: "john@company.com", display_name: "John" },
+        is_bot: false,
+        deleted: false,
+      };
+
+      mockUsersInfo.mockResolvedValue({
+        ok: true,
+        user: mockUser,
+      });
+
+      const result = await executeSearchUser("U01234ABCD", false, testConfig);
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toHaveLength(2);
+        expect(result.value[0].text).toContain("**ID: U01234ABCD**");
+        const payload = JSON.parse(result.value[1].text);
+        expect(payload.users).toHaveLength(1);
+        expect(payload.users[0].id).toBe("U01234ABCD");
+        expect(payload.users[0].email).toBe("john@company.com");
+      }
+    });
+
     it("should handle @ prefix in user ID", async () => {
       const mockUser = { id: "U01234ABCD", name: "john" };
 

--- a/front/lib/api/actions/servers/slack/structured_message_fields.test.ts
+++ b/front/lib/api/actions/servers/slack/structured_message_fields.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock Slack WebClient
+const mockUsersInfo = vi.fn();
+const mockAuthTest = vi.fn();
+const mockConversationsInfo = vi.fn();
+const mockConversationsReplies = vi.fn();
+
+vi.mock("@slack/web-api", () => {
+  return {
+    WebClient: class MockWebClient {
+      users = {
+        info: mockUsersInfo,
+      };
+      auth = {
+        test: mockAuthTest,
+      };
+      conversations = {
+        info: mockConversationsInfo,
+        replies: mockConversationsReplies,
+      };
+    },
+  };
+});
+
+// Bypass Redis caching so users.info mocks are exercised deterministically.
+vi.mock(import("@app/lib/utils/cache"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    cacheWithRedis: ((fn: unknown) => fn) as typeof actual.cacheWithRedis,
+  };
+});
+
+// Import after mocking
+import {
+  executeReadThreadMessages,
+  extractMentionedSlackUserIds,
+  resolveUserDisplayNames,
+} from "@app/lib/api/actions/servers/slack/helpers";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("extractMentionedSlackUserIds", () => {
+  it("extracts raw mention syntax", () => {
+    expect(
+      extractMentionedSlackUserIds("Hey <@U050CALAKFD> can you review?")
+    ).toEqual(["U050CALAKFD"]);
+  });
+
+  it("extracts raw mention syntax with a username part", () => {
+    expect(extractMentionedSlackUserIds("cc <@U050CALAKFD|jane>")).toEqual([
+      "U050CALAKFD",
+    ]);
+  });
+
+  it("extracts rendered mentions", () => {
+    expect(extractMentionedSlackUserIds("Hey @U050CALAKFD ping")).toEqual([
+      "U050CALAKFD",
+    ]);
+  });
+
+  it("extracts enterprise-grid (W-prefixed) user IDs", () => {
+    expect(extractMentionedSlackUserIds("ping <@W012345678>")).toEqual([
+      "W012345678",
+    ]);
+  });
+
+  it("deduplicates IDs across mention forms", () => {
+    expect(
+      extractMentionedSlackUserIds("<@U050CALAKFD> and @U050CALAKFD again")
+    ).toEqual(["U050CALAKFD"]);
+  });
+
+  it("ignores emails and regular words", () => {
+    expect(
+      extractMentionedSlackUserIds(
+        "mail me at foo@U12345678X.com or say @Update please"
+      )
+    ).toEqual([]);
+  });
+
+  it("returns an empty array when there is no mention", () => {
+    expect(extractMentionedSlackUserIds("no mention here")).toEqual([]);
+  });
+});
+
+describe("resolveUserDisplayNames", () => {
+  const testConfig = {
+    accessToken: "xoxp-test-token",
+    mcpServerId: "test-server-123",
+  };
+
+  it("resolves display names in bulk and dedupes user IDs", async () => {
+    mockUsersInfo.mockImplementation(({ user }: { user: string }) =>
+      Promise.resolve({
+        ok: true,
+        user: {
+          id: user,
+          profile: { display_name: `name-${user}` },
+        },
+      })
+    );
+
+    const displayNamesByUserId = await resolveUserDisplayNames({
+      userIds: ["U01", "U02", "U01"],
+      ...testConfig,
+    });
+
+    expect(mockUsersInfo).toHaveBeenCalledTimes(2);
+    expect(displayNamesByUserId.get("U01")).toBe("name-U01");
+    expect(displayNamesByUserId.get("U02")).toBe("name-U02");
+  });
+
+  it("omits unresolvable user IDs", async () => {
+    mockUsersInfo.mockImplementation(({ user }: { user: string }) => {
+      if (user === "U404") {
+        return Promise.resolve({ ok: false });
+      }
+      return Promise.resolve({
+        ok: true,
+        user: { id: user, real_name: "Jane Doe" },
+      });
+    });
+
+    const displayNamesByUserId = await resolveUserDisplayNames({
+      userIds: ["U01", "U404"],
+      ...testConfig,
+    });
+
+    expect(displayNamesByUserId.get("U01")).toBe("Jane Doe");
+    expect(displayNamesByUserId.has("U404")).toBe(false);
+  });
+});
+
+describe("executeReadThreadMessages permalinks", () => {
+  it("adds per-message permalinks when the team URL is resolvable", async () => {
+    mockConversationsInfo.mockResolvedValue({
+      ok: true,
+      channel: { id: "C012AB3CD", name: "general" },
+    });
+    mockAuthTest.mockResolvedValue({
+      ok: true,
+      url: "https://acme.slack.com/",
+    });
+    mockConversationsReplies.mockResolvedValue({
+      ok: true,
+      messages: [
+        {
+          text: "parent",
+          user: "U01",
+          ts: "1234567890.123456",
+          reply_count: 1,
+        },
+        { text: "reply", user: "U02", ts: "1234567891.000200" },
+      ],
+      has_more: false,
+    });
+
+    const result = await executeReadThreadMessages({
+      channel: "C012AB3CD",
+      threadTs: "1234567890.123456",
+      limit: undefined,
+      cursor: undefined,
+      oldest: undefined,
+      latest: undefined,
+      accessToken: "xoxp-test-token",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const payload = JSON.parse(result.value[1].text);
+      expect(payload.parent_message.permalink).toBe(
+        "https://acme.slack.com/archives/C012AB3CD/p1234567890123456"
+      );
+      expect(payload.thread_replies[0].permalink).toBe(
+        "https://acme.slack.com/archives/C012AB3CD/p1234567891000200?thread_ts=1234567890.123456&cid=C012AB3CD"
+      );
+    }
+  });
+
+  it("omits permalinks when the team URL cannot be resolved", async () => {
+    mockConversationsInfo.mockResolvedValue({
+      ok: true,
+      channel: { id: "C012AB3CD", name: "general" },
+    });
+    mockAuthTest.mockRejectedValue(new Error("invalid_auth"));
+    mockConversationsReplies.mockResolvedValue({
+      ok: true,
+      messages: [
+        {
+          text: "parent",
+          user: "U01",
+          ts: "1234567890.123456",
+          reply_count: 0,
+        },
+      ],
+      has_more: false,
+    });
+
+    const result = await executeReadThreadMessages({
+      channel: "C012AB3CD",
+      threadTs: "1234567890.123456",
+      limit: undefined,
+      cursor: undefined,
+      oldest: undefined,
+      latest: undefined,
+      accessToken: "xoxp-test-token",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const payload = JSON.parse(result.value[1].text);
+      expect(payload.parent_message.permalink).toBeUndefined();
+    }
+  });
+});

--- a/front/lib/api/actions/servers/slack_personal/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.ts
@@ -1,6 +1,6 @@
 import { getConnectionForMCPServer } from "@app/lib/actions/mcp_authentication";
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import type { SearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type { SlackSearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type {
   ToolDefinition,
   ToolHandlers,
@@ -25,12 +25,13 @@ import {
   executeSearchUser,
   executeSetUserStatus,
   executeWriteCanvas,
+  extractMentionedSlackUserIds,
   getSlackClient,
   getSlackTeamUrl,
   isSlackMissingScope,
   resolveChannelDisplayName,
   resolveChannelId,
-  resolveUserDisplayName,
+  resolveUserDisplayNames,
   SLACK_THREAD_LISTING_LIMIT,
 } from "@app/lib/api/actions/servers/slack/helpers";
 import {
@@ -268,6 +269,13 @@ function formatDateForSlackQuery(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
+// Structured message metadata attached to each search result (rides the resource `_meta`
+// round-trip so programmatic consumers do not have to parse the human-readable `text`).
+type SlackStructuredFields = Pick<
+  SlackSearchResultResourceType,
+  "author" | "channel" | "ts" | "threadTs" | "mentionedUsers"
+>;
+
 // Helper function to build search results from matches.
 function buildSearchResults<T>(
   matches: T[],
@@ -277,10 +285,11 @@ function buildSearchResults<T>(
     text: (match: T) => string;
     id: (match: T) => string;
     content: (match: T) => string;
+    structured: (match: T) => SlackStructuredFields;
   }
-): SearchResultResourceType[] {
+): SlackSearchResultResourceType[] {
   return matches.map(
-    (match, index): SearchResultResourceType => ({
+    (match, index): SlackSearchResultResourceType => ({
       mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
       uri: extractors.permalink(match) ?? "",
       text: extractors.text(match),
@@ -289,8 +298,77 @@ function buildSearchResults<T>(
       tags: [],
       ref: refs[index] ?? "",
       chunks: [stripNullBytes(extractors.content(match))],
+      permalink: extractors.permalink(match),
+      ...extractors.structured(match),
     })
   );
+}
+
+// Builds the `mentionedUsers` structured field for a message: user IDs mentioned in the
+// text, with their resolved display names (unresolvable IDs are omitted).
+function makeMentionedUsers(
+  text: string | undefined,
+  displayNamesByUserId: Map<string, string>
+): Array<{ id: string; name: string }> | undefined {
+  if (!text) {
+    return undefined;
+  }
+  const users = extractMentionedSlackUserIds(text).flatMap((userId) => {
+    const name = displayNamesByUserId.get(userId);
+    return name ? [{ id: userId, name }] : [];
+  });
+  return users.length > 0 ? users : undefined;
+}
+
+// Builds search results for search_messages / semantic_search_messages matches, with
+// structured author/channel/ts/permalink fields and bulk-resolved mention display names.
+async function buildMatchSearchResults({
+  matches,
+  refs,
+  accessToken,
+  mcpServerId,
+}: {
+  matches: SlackSearchMatch[];
+  refs: string[];
+  accessToken: string;
+  mcpServerId: string;
+}): Promise<SlackSearchResultResourceType[]> {
+  // Bulk-resolve display names for @-mentions and for authors missing a name, so
+  // consumers do not need one search_user call per user ID.
+  const displayNamesByUserId = await resolveUserDisplayNames({
+    userIds: matches.flatMap((match) => [
+      ...(match.author_id && !match.author_name ? [match.author_id] : []),
+      ...extractMentionedSlackUserIds(match.content ?? ""),
+    ]),
+    accessToken,
+    mcpServerId,
+  });
+
+  return buildSearchResults<SlackSearchMatch>(matches, refs, {
+    permalink: (match) => match.permalink,
+    text: (match) => formatSlackMessageForDisplay(match),
+    id: (match) => match.message_ts ?? "",
+    content: (match) => match.content ?? "",
+    structured: (match) => ({
+      author:
+        match.author_id || match.author_name
+          ? {
+              id: match.author_id,
+              name:
+                match.author_name ??
+                (match.author_id
+                  ? displayNamesByUserId.get(match.author_id)
+                  : undefined),
+            }
+          : undefined,
+      channel:
+        match.channel_id || match.channel_name
+          ? { id: match.channel_id, name: match.channel_name }
+          : undefined,
+      ts: match.message_ts,
+      mentionedUsers: makeMentionedUsers(match.content, displayNamesByUserId),
+    }),
+  });
 }
 
 // Best-effort detection of Slack user IDs (U* or W* for enterprise grid).
@@ -462,16 +540,12 @@ export function createSlackPersonalTools(
           citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
         );
 
-        const searchResults = buildSearchResults<SlackSearchMatch>(
+        const searchResults = await buildMatchSearchResults({
           matches,
           refs,
-          {
-            permalink: (match) => match.permalink,
-            text: (match) => formatSlackMessageForDisplay(match),
-            id: (match) => match.message_ts ?? "",
-            content: (match) => match.content ?? "",
-          }
-        );
+          accessToken,
+          mcpServerId,
+        });
 
         return new Ok(
           searchResults.map((result) => ({
@@ -542,16 +616,12 @@ export function createSlackPersonalTools(
           citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
         );
 
-        const searchResults = buildSearchResults<SlackSearchMatch>(
+        const searchResults = await buildMatchSearchResults({
           matches,
           refs,
-          {
-            permalink: (match) => match.permalink,
-            text: (match) => formatSlackMessageForDisplay(match),
-            id: (match) => match.message_ts ?? "",
-            content: (match) => match.content ?? "",
-          }
-        );
+          accessToken,
+          mcpServerId,
+        });
 
         return new Ok(
           searchResults.map((result) => ({
@@ -841,17 +911,35 @@ export function createSlackPersonalTools(
         citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
       );
 
-      // Resolve user display names for all thread authors.
-      const threadsWithAuthors = await Promise.all(
-        matches.map(async (match) => {
+      // Reconstruct readable text from blocks/attachments: app/bot messages
+      // (Datadog, Zendesk, ...) often have an empty `text` and put content in
+      // `blocks[]`, which would otherwise render as empty for the agent.
+      const renderedMatches = matches.map((match) => ({
+        match,
+        renderedText: renderFormattedMessage(formatSlackMessageForLLM(match)),
+      }));
+
+      // Bulk-resolve display names for message authors and @-mentions. Mentions appear
+      // as `<@U...>` in the raw text and `@U...` in the rendered text.
+      const displayNamesByUserId = await resolveUserDisplayNames({
+        userIds: renderedMatches.flatMap(({ match, renderedText }) => [
+          ...(match.user ? [match.user] : []),
+          ...extractMentionedSlackUserIds(
+            [match.text ?? "", renderedText].join("\n")
+          ),
+        ]),
+        accessToken,
+        mcpServerId,
+      });
+
+      const threadsWithAuthors = renderedMatches.map(
+        ({ match, renderedText }) => {
           const authorName = match.user
-            ? await resolveUserDisplayName({
-                userId: match.user,
-                accessToken,
-              })
+            ? (displayNamesByUserId.get(match.user) ?? null)
             : null;
           return {
             ts: match.ts,
+            threadTs: match.thread_ts,
             reply_count: match.reply_count,
             permalink:
               teamUrl && match.ts
@@ -861,22 +949,25 @@ export function createSlackPersonalTools(
                     messageTs: match.ts,
                   })
                 : undefined,
+            authorId: match.user,
             authorName: authorName ?? "Unknown",
-            // Reconstruct readable text from blocks/attachments: app/bot messages
-            // (Datadog, Zendesk, ...) often have an empty `text` and put content in
-            // `blocks[]`, which would otherwise render as empty for the agent.
-            renderedText: renderFormattedMessage(
-              formatSlackMessageForLLM(match)
+            renderedText,
+            mentionedUsers: makeMentionedUsers(
+              [match.text ?? "", renderedText].join("\n"),
+              displayNamesByUserId
             ),
           };
-        })
+        }
       );
       const searchResults = buildSearchResults<{
         permalink?: string;
         renderedText: string;
         ts?: string;
+        threadTs?: string;
+        authorId?: string;
         authorName: string;
         reply_count?: number;
+        mentionedUsers?: Array<{ id: string; name: string }>;
       }>(threadsWithAuthors, refs, {
         permalink: (match) => match.permalink,
         text: (match) => {
@@ -888,6 +979,18 @@ export function createSlackPersonalTools(
         },
         id: (match) => match.ts ?? "",
         content: (match) => match.renderedText,
+        structured: (match) => ({
+          author: match.authorId
+            ? {
+                id: match.authorId,
+                name: displayNamesByUserId.get(match.authorId),
+              }
+            : undefined,
+          channel: { id: channelId, name: displayName },
+          ts: match.ts,
+          threadTs: match.threadTs,
+          mentionedUsers: match.mentionedUsers,
+        }),
       });
 
       return new Ok(


### PR DESCRIPTION
## Description

Stacked on #30328.

slack_personal message tools only emit prose (`From <author> in #<channel>: ...`), so programmatic consumers regex authors, channels, timestamps and permalinks back out of it, and resolve `@U...` mentions with one `search_user` call per user. This adds machine-readable output next to the existing text, which stays byte-identical:

- `search_messages` / `semantic_search_messages` / `list_messages` results carry `author{id,name}`, `channel{id,name}`, `ts`, `threadTs`, `permalink` and `mentionedUsers` on the search-result resource. The extra fields ride the existing `_meta` round-trip for internal servers (`SlackSearchResultResourceSchema` extends the non-strict `SearchResultResourceSchema`, the type guard and citation rendering are unaffected).
- `@U...` mentions and unnamed authors are resolved server-side in bulk (per-user Redis cache, 10 min TTL, capped at 50 lookups per call). `list_messages` author resolution now goes through the same cache instead of one uncached `users.info` per message.
- `search_user` appends a JSON block (`{users: [...]}`) after the unchanged Markdown block.
- `read_thread_messages` gains per-message `permalink` in its JSON payload (thread replies link into the thread view).

## Tests

Unit tests for mention extraction (raw and rendered syntax, dedupe, no email/word false positives), bulk display-name resolution (dedupe, unresolvable omitted), read_thread_messages permalinks (present and degraded), and the search_user JSON block.

## Risk

Low: all fields are additive, human-facing text is unchanged. Mention resolution adds up to 50 cached users.info calls per search (Tier 4, 100+ req/min).

## Deploy Plan

Standard deploy, after #30328.