### PR TITLE
[dust/pod] feat: resolveToolTextContent for offloaded tool outputs

### DIFF
--- a/cli/dust-sandbox/pod/index.ts
+++ b/cli/dust-sandbox/pod/index.ts
@@ -5,7 +5,10 @@
  * - `db(name)`: the pod's SQLite state databases, through Drizzle (./db.ts).
  * - `currentUser()`: the workspace-scoped user attributed to this invocation.
  * - `podEnv(name)`: the invocation's environment (./context.ts).
+ * - `resolveToolTextContent(block)`: full text of a tool output block,
+ *   resolving offloaded content through its descriptor (./tool_output.ts).
  */
 export * from "./context.ts";
 export * from "./db.ts";
 export * from "./identity.ts";
+export * from "./tool_output.ts";

--- a/cli/dust-sandbox/pod/package.json
+++ b/cli/dust-sandbox/pod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust/pod",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Runtime library for code running in a Dust pod sandbox.",
   "type": "module",

--- a/cli/dust-sandbox/pod/tool_output.test.ts
+++ b/cli/dust-sandbox/pod/tool_output.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  resolveToolTextContent,
+  TOOL_OUTPUT_OFFLOAD_META_KEY,
+  ToolOutputResolutionError,
+} from "@dust/pod";
+
+let mountRootDir: string;
+
+beforeEach(() => {
+  mountRootDir = mkdtempSync(join(tmpdir(), "dust-pod-tool-output-test-"));
+});
+
+afterEach(() => {
+  rmSync(mountRootDir, { recursive: true, force: true });
+});
+
+// Writes an archived tool output under the fake mount root, like front does
+// through the GCS API, and returns the descriptor-carrying block.
+function makeOffloadedBlock(
+  scopedPath: string,
+  content: string | null,
+  descriptorOverrides: Record<string, unknown> = {}
+) {
+  if (content !== null) {
+    const path = join(mountRootDir, scopedPath);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, content);
+  }
+  return {
+    type: "resource",
+    resource: {
+      uri: scopedPath,
+      mimeType: "text/plain",
+      text: `snippet...\n[Full content archived at ${scopedPath}]`,
+    },
+    _meta: {
+      [TOOL_OUTPUT_OFFLOAD_META_KEY]: {
+        fullContentPath: scopedPath,
+        totalBytes: content === null ? 0 : Buffer.byteLength(content, "utf8"),
+        contentType: "application/json",
+        ...descriptorOverrides,
+      },
+    },
+  };
+}
+
+describe("inline passthrough", () => {
+  test("returns the text of a text block without a descriptor", async () => {
+    const text = '{"ok":true}';
+    expect(await resolveToolTextContent({ type: "text", text })).toBe(text);
+  });
+
+  test("returns the resource text of an embedded resource without a descriptor", async () => {
+    const text = "resource body";
+    const block = {
+      type: "resource",
+      resource: { uri: "file://x.txt", mimeType: "text/plain", text },
+    };
+    expect(await resolveToolTextContent(block)).toBe(text);
+  });
+
+  test("ignores unrelated _meta keys", async () => {
+    const block = {
+      type: "text",
+      text: "hello",
+      _meta: { "tt.dust/other": { a: 1 } },
+    };
+    expect(await resolveToolTextContent(block)).toBe("hello");
+  });
+
+  test("throws a typed error when the block carries no text and no descriptor", async () => {
+    expect(
+      resolveToolTextContent({ type: "image", data: "...", mimeType: "image/png" })
+    ).rejects.toThrow(ToolOutputResolutionError);
+  });
+
+  test("throws a typed error on a non-object block", async () => {
+    expect(resolveToolTextContent("just a string")).rejects.toThrow(
+      ToolOutputResolutionError
+    );
+  });
+});
+
+describe("descriptor resolution", () => {
+  test("reads the full content from the mount, not the inline snippet", async () => {
+    const full = JSON.stringify({ items: Array.from({ length: 50 }, (_, i) => i) });
+    const block = makeOffloadedBlock("pod-spc_x/.tool_outputs/fn/1_tool.json", full);
+
+    const resolved = await resolveToolTextContent(block, { mountRootDir });
+
+    expect(resolved).toBe(full);
+    expect(resolved).not.toContain("[Full content archived at ");
+  });
+
+  test("uses an absolute fullContentPath as-is", async () => {
+    const full = "absolute content";
+    const scopedPath = "pod-spc_x/.tool_outputs/fn/2_tool.json";
+    const absolutePath = join(mountRootDir, scopedPath);
+    mkdirSync(dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, full);
+
+    const block = makeOffloadedBlock(scopedPath, null, {
+      fullContentPath: absolutePath,
+    });
+
+    // No mountRootDir override: the absolute path must not be re-rooted.
+    expect(await resolveToolTextContent(block)).toBe(full);
+  });
+
+  test("throws a typed error on a malformed descriptor", async () => {
+    const block = makeOffloadedBlock("pod-spc_x/.tool_outputs/fn/3_tool.json", "x", {
+      fullContentPath: undefined,
+    });
+
+    expect(resolveToolTextContent(block, { mountRootDir })).rejects.toThrow(
+      ToolOutputResolutionError
+    );
+  });
+});
+
+describe("mount staleness retry", () => {
+  test("retries until the file appears", async () => {
+    const scopedPath = "pod-spc_x/.tool_outputs/fn/4_tool.json";
+    const full = '{"late":true}';
+    const block = makeOffloadedBlock(scopedPath, null);
+
+    // Simulate gcsfuse staleness: the file only becomes visible after a beat.
+    setTimeout(() => {
+      const path = join(mountRootDir, scopedPath);
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, full);
+    }, 60);
+
+    const resolved = await resolveToolTextContent(block, {
+      mountRootDir,
+      maxAttempts: 10,
+      retryDelayMs: 25,
+    });
+
+    expect(resolved).toBe(full);
+  });
+
+  test("throws a typed error naming the path on retry exhaustion", async () => {
+    const scopedPath = "pod-spc_x/.tool_outputs/fn/5_tool.json";
+    const block = makeOffloadedBlock(scopedPath, null);
+
+    const startedAtMs = Date.now();
+    let caught: unknown;
+    try {
+      await resolveToolTextContent(block, {
+        mountRootDir,
+        maxAttempts: 3,
+        retryDelayMs: 20,
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(ToolOutputResolutionError);
+    if (caught instanceof ToolOutputResolutionError) {
+      expect(caught.message).toContain(join(mountRootDir, scopedPath));
+      expect(caught.message).toContain("3 attempts");
+    }
+    // Two inter-attempt delays of 20 ms must have elapsed.
+    expect(Date.now() - startedAtMs).toBeGreaterThanOrEqual(40);
+  });
+});

--- a/cli/dust-sandbox/pod/tool_output.test.ts
+++ b/cli/dust-sandbox/pod/tool_output.test.ts
@@ -73,13 +73,17 @@ describe("inline passthrough", () => {
   });
 
   test("throws a typed error when the block carries no text and no descriptor", async () => {
-    expect(
-      resolveToolTextContent({ type: "image", data: "...", mimeType: "image/png" })
+    await expect(
+      resolveToolTextContent({
+        type: "image",
+        data: "...",
+        mimeType: "image/png",
+      })
     ).rejects.toThrow(ToolOutputResolutionError);
   });
 
   test("throws a typed error on a non-object block", async () => {
-    expect(resolveToolTextContent("just a string")).rejects.toThrow(
+    await expect(resolveToolTextContent("just a string")).rejects.toThrow(
       ToolOutputResolutionError
     );
   });
@@ -87,8 +91,13 @@ describe("inline passthrough", () => {
 
 describe("descriptor resolution", () => {
   test("reads the full content from the mount, not the inline snippet", async () => {
-    const full = JSON.stringify({ items: Array.from({ length: 50 }, (_, i) => i) });
-    const block = makeOffloadedBlock("pod-spc_x/.tool_outputs/fn/1_tool.json", full);
+    const full = JSON.stringify({
+      items: Array.from({ length: 50 }, (_, i) => i),
+    });
+    const block = makeOffloadedBlock(
+      "pod-spc_x/.tool_outputs/fn/1_tool.json",
+      full
+    );
 
     const resolved = await resolveToolTextContent(block, { mountRootDir });
 
@@ -112,13 +121,15 @@ describe("descriptor resolution", () => {
   });
 
   test("throws a typed error on a malformed descriptor", async () => {
-    const block = makeOffloadedBlock("pod-spc_x/.tool_outputs/fn/3_tool.json", "x", {
-      fullContentPath: undefined,
-    });
-
-    expect(resolveToolTextContent(block, { mountRootDir })).rejects.toThrow(
-      ToolOutputResolutionError
+    const block = makeOffloadedBlock(
+      "pod-spc_x/.tool_outputs/fn/3_tool.json",
+      "x",
+      { fullContentPath: undefined }
     );
+
+    await expect(
+      resolveToolTextContent(block, { mountRootDir })
+    ).rejects.toThrow(ToolOutputResolutionError);
   });
 });
 

--- a/cli/dust-sandbox/pod/tool_output.ts
+++ b/cli/dust-sandbox/pod/tool_output.ts
@@ -1,0 +1,157 @@
+// Resolution of tool output text content.
+//
+// Tool outputs above front's offload threshold are not delivered inline: the
+// full content is archived as a pod file and the inline text is replaced by a
+// snippet ending with a human-facing "[Full content archived at <path>]"
+// sentence. Offloaded blocks carry a machine-readable descriptor under the
+// "tt.dust/offload" key of their `_meta` (front owns the write side; the
+// descriptor shape is append-only). `resolveToolTextContent()` is the read
+// side: inline text passthrough when no descriptor is present, otherwise the
+// archived file is read back from the gcsfuse mount with a bounded retry
+// covering mount metadata-cache staleness. Never parse the snippet text or
+// the archive sentence: the descriptor is the contract.
+
+import { readFile } from "node:fs/promises";
+import { z } from "zod";
+
+/**
+ * Key of the offload descriptor in a content block's `_meta`. Owned by front
+ * (`TOOL_OUTPUT_OFFLOAD_META_KEY` in `front/lib/actions/action_output_limits.ts`);
+ * this is the in-sandbox copy of the wire contract.
+ */
+export const TOOL_OUTPUT_OFFLOAD_META_KEY = "tt.dust/offload";
+
+/**
+ * Absolute in-sandbox directory the scoped file mounts live under: a
+ * descriptor's `fullContentPath` (e.g. "pod-{pId}/.tool_outputs/{slug}/{file}")
+ * resolves to `/files/pod-{pId}/...`.
+ */
+const MOUNT_ROOT_DIR = "/files";
+
+const DEFAULT_MAX_ATTEMPTS = 5;
+const DEFAULT_RETRY_DELAY_MS = 1000;
+
+const offloadDescriptorSchema = z.object({
+  fullContentPath: z.string().min(1),
+  totalBytes: z.number(),
+  contentType: z.string(),
+});
+
+export type ToolOutputOffloadDescriptor = z.infer<
+  typeof offloadDescriptorSchema
+>;
+
+// Lenient view of a content block as printed by `dsbx tools exec --json`:
+// only the fields resolution needs, unknown fields ignored.
+const contentBlockSchema = z.object({
+  text: z.string().optional(),
+  resource: z
+    .object({
+      text: z.string().optional(),
+    })
+    .optional(),
+  _meta: z.record(z.string(), z.unknown()).optional(),
+});
+
+export class ToolOutputResolutionError extends Error {
+  override readonly name = "ToolOutputResolutionError";
+}
+
+export interface ResolveToolTextContentOptions {
+  /**
+   * Directory the scoped file mounts live under (default "/files").
+   * Overridable for tests; production code should not set it.
+   */
+  mountRootDir?: string;
+  /** Read attempts before giving up on an offloaded path (default 5). */
+  maxAttempts?: number;
+  /** Delay between read attempts (default 1000 ms). */
+  retryDelayMs?: number;
+}
+
+/**
+ * Return the full text content of a tool output content block.
+ *
+ * - Block without an offload descriptor: the inline text (`text` for text
+ *   blocks, `resource.text` for embedded resources) is returned as-is.
+ * - Block with an offload descriptor in `_meta`: the archived full content is
+ *   read from the mount and returned; the inline snippet is never used.
+ *
+ * @throws ToolOutputResolutionError when the block carries no text and no
+ *   descriptor, when the descriptor is malformed, or when the archived file
+ *   cannot be read after the bounded retry (the message names the path).
+ */
+export async function resolveToolTextContent(
+  block: unknown,
+  options: ResolveToolTextContentOptions = {}
+): Promise<string> {
+  const parsedBlock = contentBlockSchema.safeParse(block);
+  if (!parsedBlock.success) {
+    throw new ToolOutputResolutionError(
+      "Tool output block is not a content block object."
+    );
+  }
+
+  const rawDescriptor = parsedBlock.data._meta?.[TOOL_OUTPUT_OFFLOAD_META_KEY];
+  if (rawDescriptor === undefined) {
+    const inlineText = parsedBlock.data.text ?? parsedBlock.data.resource?.text;
+    if (inlineText === undefined) {
+      throw new ToolOutputResolutionError(
+        "Tool output block carries no text content and no offload descriptor."
+      );
+    }
+    return inlineText;
+  }
+
+  const parsedDescriptor = offloadDescriptorSchema.safeParse(rawDescriptor);
+  if (!parsedDescriptor.success) {
+    throw new ToolOutputResolutionError(
+      `Tool output block carries an invalid offload descriptor under ` +
+        `"${TOOL_OUTPUT_OFFLOAD_META_KEY}"; this is a platform contract ` +
+        `violation, report it rather than working around it.`
+    );
+  }
+
+  return readOffloadedContent(parsedDescriptor.data, options);
+}
+
+async function readOffloadedContent(
+  descriptor: ToolOutputOffloadDescriptor,
+  options: ResolveToolTextContentOptions
+): Promise<string> {
+  const {
+    mountRootDir = MOUNT_ROOT_DIR,
+    maxAttempts = DEFAULT_MAX_ATTEMPTS,
+    retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+  } = options;
+
+  const path = descriptor.fullContentPath.startsWith("/")
+    ? descriptor.fullContentPath
+    : `${mountRootDir}/${descriptor.fullContentPath}`;
+
+  // The archived file is written through the GCS API while this reads through
+  // the gcsfuse mount, whose metadata cache can lag behind the write: retry a
+  // bounded number of times instead of failing on the first missing read.
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await readFile(path, "utf-8");
+    } catch (err) {
+      lastError = err;
+    }
+    if (attempt < maxAttempts) {
+      await sleep(retryDelayMs);
+    }
+  }
+
+  const reason =
+    lastError instanceof Error ? lastError.message : String(lastError);
+  throw new ToolOutputResolutionError(
+    `Could not read the offloaded tool output at ${path} after ` +
+      `${maxAttempts} attempts (the file mount can lag behind writes): ${reason}`
+  );
+}
+
+function sleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}

--- a/front/lib/api/sandbox/image/pod_package.ts
+++ b/front/lib/api/sandbox/image/pod_package.ts
@@ -9,7 +9,7 @@ import path from "path";
 // external and resolve through NODE_PATH, like zod) and copy a flat
 // {package.json, index.js} into the image's global node_modules.
 export const POD_PACKAGE_NAME = "@dust/pod";
-export const POD_PACKAGE_VERSION = "0.1.0";
+export const POD_PACKAGE_VERSION = "0.1.1";
 export const POD_PACKAGE_IMAGE_DIR = `/opt/npm-global/lib/node_modules/${POD_PACKAGE_NAME}`;
 
 let podPackageSrcDir: string | undefined;

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -646,7 +646,7 @@ describe("sandbox image registry", () => {
         expect.objectContaining({ name: "drizzle-orm", version: "0.45.2" }),
         expect.objectContaining({ name: "drizzle-kit", version: "0.31.10" }),
         expect.objectContaining({ name: "@libsql/client", version: "0.17.4" }),
-        expect.objectContaining({ name: "@dust/pod", version: "0.1.0" }),
+        expect.objectContaining({ name: "@dust/pod", version: "0.1.1" }),
       ])
     );
   });


### PR DESCRIPTION
## Description

Stacked on #30336, which attaches a machine-readable descriptor (`_meta["tt.dust/offload"] = {fullContentPath, totalBytes, contentType}`) to every offloaded tool output block.

This adds the in-sandbox read side to `@dust/pod`: `resolveToolTextContent(block)`.

- No descriptor: returns the inline text (`text` for text blocks, `resource.text` for embedded resources) as-is.
- Descriptor present: reads the archived full content from the `/files` mount and returns it, retrying up to 5 times, 1s apart, to cover gcsfuse metadata-cache staleness (the file is written through the GCS API, read through the mount). On exhaustion, throws a typed `ToolOutputResolutionError` naming the path.
- Malformed descriptor or a block with neither text nor descriptor: typed error, no silent snippet fallback.

This replaces per-function regexing of the "[Full content archived at ...]" sentence, which silently persisted mid-JSON snippets as data when the regex missed or the mount lagged. It is also the seam a future `tools.call()` client resolves through.

`POD_PACKAGE_VERSION` bumped to 0.1.1. Long-lived pods pick the new package up on image refresh.

## Tests

`bun test` unit tests: inline passthrough (text/resource/unrelated `_meta`), descriptor resolution from a fake mount root, absolute-path passthrough, malformed descriptor, retry-until-visible, retry exhaustion (typed error names the path, delays actually elapse).

## Risk

Low: new export only, no behavior change for existing `@dust/pod` surfaces. Ships to sandboxes only after the descriptor write side (#30336) is deployed and an image refresh picks up the version bump.

## Deploy Plan

Merge after #30336. Standard deploy; new package version lands in sandbox images on the next image build.