### PR TITLE
[front] enh: advisory lint warnings on pod function publish

### DIFF
--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -109,6 +109,15 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
             "it; it never grants access on its own. A domain the Pod (or workspace) already " +
             "allows is skipped."
         ),
+      confirmFast: z
+        .boolean()
+        .optional()
+        .describe(
+          "Set to true only after a `fast` publish warned that the bundle looks like it calls " +
+            "Dust tools and you verified the match is a false positive: it confirms the `fast` " +
+            "mode and silences that warning. Has no effect on `durable` publishes, and never " +
+            "changes what is published."
+        ),
     },
     stake: "low",
     displayLabels: {

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.test.ts
@@ -237,6 +237,79 @@ describe("publishHandler", () => {
     );
   });
 
+  it("appends the fast tool-call warning without blocking the publish", async () => {
+    const { auth, conversation, projectId } = await setupProjectConversation();
+    vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+      new Ok({
+        bundleCode: 'const res = spawnSync("dsbx", ["tools", "call"]);',
+        userIdentity: "optional",
+        inputSchema,
+        outputSchema,
+      })
+    );
+
+    const result = await publishHandler(
+      {
+        slug: "sync-data",
+        description: "Sync data.",
+        path: `pod-${projectId}/TaskList/functions/sync-data.ts`,
+        executionMode: "fast",
+        defaultStake: "low",
+      },
+      makeExtra(auth, conversation)
+    );
+
+    if (result.isErr()) {
+      throw result.error;
+    }
+    const [block] = result.value;
+    if (block?.type !== "text") {
+      throw new Error("Expected a text block.");
+    }
+    // The publish still lands; the warning rides the result.
+    expect(block.text).toContain(
+      'Published pod function "tasklist__sync-data"'
+    );
+    expect(block.text).toContain("fast_function_called_tools");
+    expect(block.text).toContain("confirmFast");
+  });
+
+  it("silences the fast tool-call warning when confirmFast is passed", async () => {
+    const { auth, conversation, projectId } = await setupProjectConversation();
+    vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+      new Ok({
+        bundleCode: 'const res = spawnSync("dsbx", ["tools", "call"]);',
+        userIdentity: "optional",
+        inputSchema,
+        outputSchema,
+      })
+    );
+
+    const result = await publishHandler(
+      {
+        slug: "sync-data",
+        description: "Sync data.",
+        path: `pod-${projectId}/TaskList/functions/sync-data.ts`,
+        executionMode: "fast",
+        defaultStake: "low",
+        confirmFast: true,
+      },
+      makeExtra(auth, conversation)
+    );
+
+    if (result.isErr()) {
+      throw result.error;
+    }
+    const [block] = result.value;
+    if (block?.type !== "text") {
+      throw new Error("Expected a text block.");
+    }
+    expect(block.text).toContain(
+      'Published pod function "tasklist__sync-data"'
+    );
+    expect(block.text).not.toContain("fast_function_called_tools");
+  });
+
   it("accepts a bare function name but not one that already carries a prefix", () => {
     const metadata = SANDBOX_FUNCTIONS_TOOLS_METADATA.find(
       (tool) => tool.name === "publish"

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
@@ -19,6 +19,7 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export async function publishHandler(
   {
+    confirmFast,
     defaultStake,
     description,
     domains,
@@ -26,6 +27,7 @@ export async function publishHandler(
     path,
     slug,
   }: {
+    confirmFast?: boolean;
     defaultStake: SandboxFunctionStake;
     description: string;
     domains?: string[];
@@ -49,6 +51,7 @@ export async function publishHandler(
     path,
     executionMode,
     defaultStake,
+    confirmFast,
   });
   if (result.isErr()) {
     return new Err(toMCPError(result.error));
@@ -60,7 +63,7 @@ export async function publishHandler(
   //
   // The mode, timestamp and bundle hash are the publisher's receipt: they let the caller confirm
   // this publish landed (list/get echo the same fields) without a second tool call.
-  const { sandboxFunction, byteIdentical } = result.value;
+  const { sandboxFunction, byteIdentical, warnings } = result.value;
   const { slug: publishedSlug } = sandboxFunction;
 
   // Failures become a note, not a publish failure — the function is already
@@ -84,6 +87,9 @@ export async function publishHandler(
         "source file before editing again."
     );
   }
+  // Advisory only: the function is published either way (the lint heuristics have false
+  // positives, and a publish must never be lost to one).
+  lines.push(...warnings);
   if (domainNote) {
     lines.push(domainNote);
   }

--- a/front/lib/api/sandbox_functions/publish_lints.test.ts
+++ b/front/lib/api/sandbox_functions/publish_lints.test.ts
@@ -1,0 +1,140 @@
+import { lintSandboxFunctionPublish } from "@app/lib/api/sandbox_functions/publish_lints";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { describe, expect, it } from "vitest";
+
+const plainInputSchema: JSONSchema = {
+  type: "object",
+  properties: { name: { type: "string" } },
+  required: ["name"],
+};
+
+// The exact shape the skill-mandated shim compiles to (verified against prod bundles).
+const SPAWN_SYNC_BUNDLE = [
+  "var import_child_process = require('child_process');",
+  "function callTool(server, tool, args) {",
+  '  const res = spawnSync("dsbx", cliArgs, { encoding: "utf-8" });',
+  "  return JSON.parse(res.stdout);",
+  "}",
+].join("\n");
+
+describe("lintSandboxFunctionPublish", () => {
+  it("warns when a fast bundle spawns dsbx, naming the call site and the runtime 403", () => {
+    const warnings = lintSandboxFunctionPublish({
+      bundleCode: SPAWN_SYNC_BUNDLE,
+      executionMode: "fast",
+      inputSchema: plainInputSchema,
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('spawnSync("dsbx"');
+    // The call site: spawnSync sits on line 3 of the bundle above.
+    expect(warnings[0]).toContain("bundle line 3");
+    expect(warnings[0]).toContain("fast_function_called_tools");
+    expect(warnings[0]).toContain("confirmFast");
+  });
+
+  it("warns on a shell string invoking dsbx tools", () => {
+    const warnings = lintSandboxFunctionPublish({
+      bundleCode:
+        'execSync(`dsbx tools call gmail create_draft --json "$ARGS"`);',
+      executionMode: "fast",
+      inputSchema: plainInputSchema,
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("dsbx tools");
+  });
+
+  it("does not warn on a durable bundle that calls tools", () => {
+    expect(
+      lintSandboxFunctionPublish({
+        bundleCode: SPAWN_SYNC_BUNDLE,
+        executionMode: "durable",
+        inputSchema: plainInputSchema,
+      })
+    ).toEqual([]);
+  });
+
+  it("does not warn on a fast bundle without tool-call signatures", () => {
+    expect(
+      lintSandboxFunctionPublish({
+        bundleCode: 'export default { fetch: async () => new Response("ok") };',
+        executionMode: "fast",
+        inputSchema: plainInputSchema,
+      })
+    ).toEqual([]);
+  });
+
+  it("is silenced by confirmFast", () => {
+    expect(
+      lintSandboxFunctionPublish({
+        bundleCode: SPAWN_SYNC_BUNDLE,
+        executionMode: "fast",
+        inputSchema: plainInputSchema,
+        confirmFast: true,
+      })
+    ).toEqual([]);
+  });
+
+  it("warns on identity-shaped input properties, pointing at currentUser()", () => {
+    const warnings = lintSandboxFunctionPublish({
+      bundleCode: "export default {};",
+      executionMode: "durable",
+      inputSchema: {
+        type: "object",
+        properties: {
+          goal: { type: "string" },
+          requestedBy: { type: "string" },
+          userId: { type: "string" },
+        },
+      },
+    });
+
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain("`requestedBy`");
+    expect(warnings[1]).toContain("`userId`");
+    for (const warning of warnings) {
+      expect(warning).toContain("currentUser()");
+      expect(warning).toContain("@dust/pod");
+    }
+  });
+
+  it("does not flag properties that merely reference another user", () => {
+    // Exact-match only: `assigneeUserId` legitimately names a different user than the caller.
+    expect(
+      lintSandboxFunctionPublish({
+        bundleCode: "export default {};",
+        executionMode: "durable",
+        inputSchema: {
+          type: "object",
+          properties: { assigneeUserId: { type: "string" } },
+        },
+      })
+    ).toEqual([]);
+  });
+
+  it("confirmFast does not silence identity warnings", () => {
+    const warnings = lintSandboxFunctionPublish({
+      bundleCode: "export default {};",
+      executionMode: "fast",
+      inputSchema: {
+        type: "object",
+        properties: { userId: { type: "string" } },
+      },
+      confirmFast: true,
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("`userId`");
+  });
+
+  it("handles an input schema without properties", () => {
+    expect(
+      lintSandboxFunctionPublish({
+        bundleCode: "export default {};",
+        executionMode: "fast",
+        inputSchema: { type: "object" },
+      })
+    ).toEqual([]);
+  });
+});

--- a/front/lib/api/sandbox_functions/publish_lints.ts
+++ b/front/lib/api/sandbox_functions/publish_lints.ts
@@ -1,0 +1,121 @@
+import type { SandboxFunctionExecutionMode } from "@app/types/api/sandbox_functions";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+
+// Trim the matched snippet so the warning stays one readable line even when the bundle is
+// minified.
+const LINT_SNIPPET_MAX_CHARS = 80;
+
+/**
+ * Signatures of an in-function Dust tool call. Functions call tools by shelling out to the
+ * `dsbx` binary (the skill mandates the pattern), and esbuild keeps string literals intact, so
+ * the built bundle is scannable:
+ * - a spawn-family call whose command is `dsbx` (or its absolute path), e.g.
+ *   `spawnSync("dsbx", ["tools", "call", ...])`;
+ * - a shell string invoking `dsbx tools ...`.
+ *
+ * A string heuristic by design: esbuild output makes AST-precise detection unwinnable, and this
+ * only ever produces a warning, never a refusal.
+ */
+const DSBX_TOOL_CALL_PATTERNS: RegExp[] = [
+  /\b(?:spawn|spawnSync|exec|execSync|execFile|execFileSync)\(\s*["'`](?:\/opt\/bin\/)?dsbx["'`]/,
+  /["'`][^"'`\n]*\bdsbx\s+tools\b/,
+];
+
+/**
+ * Input property names that look like the caller's identity. Function inputs are
+ * caller-controlled, so trusting them for identity lets any caller impersonate any user; the
+ * invoking user must come from `currentUser()` instead. Exact (case-insensitive) matches only:
+ * prefix/suffix matching would flag legitimate references to other users, like `assigneeUserId`.
+ */
+const IDENTITY_INPUT_DENY_LIST = new Set([
+  "userid",
+  "useremail",
+  "requestedby",
+  "requesterid",
+  "requesteremail",
+  "callerid",
+  "calleremail",
+  "onbehalfof",
+  "actinguser",
+  "currentuser",
+  "currentuserid",
+]);
+
+/**
+ * Advisory lint over a successfully built publish. Returns human-readable warnings for the
+ * publish tool to append to its result; never blocks the publish (the heuristics have false
+ * positives, which is exactly why these are warnings).
+ */
+export function lintSandboxFunctionPublish({
+  bundleCode,
+  executionMode,
+  inputSchema,
+  confirmFast = false,
+}: {
+  bundleCode: string;
+  executionMode: SandboxFunctionExecutionMode;
+  inputSchema: JSONSchema;
+  confirmFast?: boolean;
+}): string[] {
+  return [
+    ...lintFastModeToolCalls({ bundleCode, executionMode, confirmFast }),
+    ...lintIdentityShapedInputs(inputSchema),
+  ];
+}
+
+function lintFastModeToolCalls({
+  bundleCode,
+  executionMode,
+  confirmFast,
+}: {
+  bundleCode: string;
+  executionMode: SandboxFunctionExecutionMode;
+  confirmFast: boolean;
+}): string[] {
+  // Only a fast function is denied tools at runtime, and `confirmFast: true` is the publisher
+  // stating the match is a false positive (or accepted), so neither case warns.
+  if (executionMode !== "fast" || confirmFast) {
+    return [];
+  }
+
+  for (const pattern of DSBX_TOOL_CALL_PATTERNS) {
+    const match = pattern.exec(bundleCode);
+    if (match === null) {
+      continue;
+    }
+
+    const line = bundleCode.slice(0, match.index).split("\n").length;
+    const snippet = match[0].slice(0, LINT_SNIPPET_MAX_CHARS);
+    return [
+      `Warning: this function is published as fast but its bundle looks like it calls Dust ` +
+        `tools (\`${snippet}\` at bundle line ${line}). A fast function's tool calls are ` +
+        `refused at runtime with a 403 (fast_function_called_tools), and the function is then ` +
+        `recorded as durable. If it calls \`dsbx tools\`, republish with executionMode ` +
+        `\`durable\`; if this is a false positive, republish with \`confirmFast: true\` to ` +
+        `silence this warning.`,
+    ];
+  }
+
+  return [];
+}
+
+function lintIdentityShapedInputs(inputSchema: JSONSchema): string[] {
+  const properties = inputSchema.properties;
+  if (properties === undefined) {
+    return [];
+  }
+
+  // Top-level properties only: identity-shaped inputs observed in prod (`requestedBy` on
+  // update-goals) are flat, and walking nested schemas would multiply false positives.
+  const flagged = Object.keys(properties).filter((name) =>
+    IDENTITY_INPUT_DENY_LIST.has(name.toLowerCase())
+  );
+
+  return flagged.map(
+    (name) =>
+      `Warning: input property \`${name}\` looks like the caller's identity. Function inputs ` +
+      `are caller-controlled and must not be trusted to identify the user; read the invoking ` +
+      `user from \`currentUser()\` (imported from \`@dust/pod\`) instead. Ignore this if the ` +
+      `property genuinely refers to another user rather than the caller.`
+  );
+}

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.ts
@@ -1,6 +1,7 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { lintSandboxFunctionPublish } from "@app/lib/api/sandbox_functions/publish_lints";
 import { deriveSandboxFunctionSlug } from "@app/lib/api/sandbox_functions/slug";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -13,6 +14,7 @@ import type {
   SandboxFunctionExecutionMode,
   SandboxFunctionStake,
 } from "@app/types/api/sandbox_functions";
+import { DEFAULT_SANDBOX_FUNCTION_EXECUTION_MODE } from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -23,6 +25,9 @@ export type PublishSandboxFunctionResult = {
   // True when a re-publish produced a bundle byte-identical to the one it replaced: the edit the
   // publisher thinks they made did not change the built output. Always false on a first publish.
   byteIdentical: boolean;
+  // Advisory lint findings over the built bundle and contract (see publish_lints.ts). Never
+  // block the publish; the tool appends them to its result text.
+  warnings: string[];
 };
 
 /**
@@ -45,6 +50,7 @@ export async function publishSandboxFunction(
     path: sourcePath,
     executionMode,
     defaultStake,
+    confirmFast,
   }: {
     space: SpaceResource;
     slug: string;
@@ -52,6 +58,9 @@ export async function publishSandboxFunction(
     path: string;
     executionMode?: SandboxFunctionExecutionMode;
     defaultStake?: SandboxFunctionStake;
+    // Publisher's confirmation that a `fast` publish flagged by the tool-call lint is
+    // intentional; suppresses that warning only (see publish_lints.ts).
+    confirmFast?: boolean;
   }
 ): Promise<Result<PublishSandboxFunctionResult, SandboxFunctionError>> {
   // Resolve the model-supplied scoped path (e.g. `pod-{id}/greet.ts`) to its absolute path inside
@@ -94,6 +103,16 @@ export async function publishSandboxFunction(
   const { bundleCode, userIdentity, inputSchema, outputSchema } =
     buildResult.value;
 
+  // Lint the built output rather than the source: the bundle is what runs, and helpers pulled in
+  // from `functions/lib/` only appear here. Runs on the caller's requested mode, i.e. the mode
+  // the function will be stored with.
+  const warnings = lintSandboxFunctionPublish({
+    bundleCode,
+    executionMode: executionMode ?? DEFAULT_SANDBOX_FUNCTION_EXECUTION_MODE,
+    inputSchema,
+    confirmFast,
+  });
+
   // Re-publish overwrites the existing bundle in place so its mount path (<prefix>/<slug>.ts) stays
   // stable; only a first publish creates the backing file.
   const existing = await SandboxFunctionResource.fetchBySpaceAndSlug(
@@ -120,6 +139,7 @@ export async function publishSandboxFunction(
     return new Ok({
       sandboxFunction: existing,
       byteIdentical: updateResult.value.byteIdentical,
+      warnings,
     });
   }
 
@@ -145,7 +165,7 @@ export async function publishSandboxFunction(
     outputSchema,
   });
 
-  return new Ok({ sandboxFunction: created, byteIdentical: false });
+  return new Ok({ sandboxFunction: created, byteIdentical: false, warnings });
 }
 
 async function createBundleFile(


### PR DESCRIPTION
## Description

Two failure classes are only discovered at runtime today: a tool-calling function published as `fast` fails its first invocation with a 403 (self-heal only fixes the next one), and identity-shaped inputs (`requestedBy` on a prod function, `userId`) let any caller impersonate any user.

Publish now lints the built bundle and contract, appending advisory warnings to the tool result:

- `fast` publish whose bundle carries dsbx tool-call signatures (spawn-family call of the `dsbx` binary, or a shell string invoking `dsbx tools`): warns naming the call site (snippet + bundle line) and the `fast_function_called_tools` 403 it will cause. A new optional `confirmFast` input on the publish tool silences this warning for verified false positives.
- Input schema properties matching an identity deny-list (exact, case-insensitive: `userId`, `requestedBy`, `callerId`, ...): warns that inputs are caller-controlled and points at `currentUser()` from `@dust/pod`. Exact matching keeps `assigneeUserId`-style references to other users unflagged.

Warnings never block the publish: both heuristics have false positives by design (string-built commands, literal "dsbx" in strings), and a publish must not be lost to one. The lint runs on the built bundle rather than the source so helpers pulled in from `functions/lib/` are covered.

Stacked on #30337.

## Tests

Unit tests for the lint (spawn signature with call-site line, shell-string signature, durable/fast gating, confirmFast scope, deny-list exact matching incl. the assigneeUserId non-match) plus handler tests that the warning rides the publish result and confirmFast silences it.

## Risk

Low. Advisory text only; publish behavior unchanged. The new `confirmFast` input is optional and additive.

## Deploy Plan

Standard deploy.