### PR TITLE
[front] feat: read back spilled Pod function results

### DIFF
--- a/front/lib/api/sandbox_functions/result_delivery.test.ts
+++ b/front/lib/api/sandbox_functions/result_delivery.test.ts
@@ -1,5 +1,9 @@
-import { parseStdoutResultEnvelope } from "@app/lib/api/sandbox_functions/result_delivery";
-import { describe, expect, it } from "vitest";
+import {
+  parseStdoutResultEnvelope,
+  resolveSpilledResult,
+} from "@app/lib/api/sandbox_functions/result_delivery";
+import { Err, Ok } from "@app/types/shared/result";
+import { describe, expect, it, vi } from "vitest";
 
 describe("parseStdoutResultEnvelope", () => {
   it("parses the last non-empty stdout line as a v3 envelope", () => {
@@ -16,6 +20,7 @@ describe("parseStdoutResultEnvelope", () => {
     ).toEqual({
       outcome: { ok: true, output: { hello: "world" } },
       timings: null,
+      spill: null,
     });
   });
 
@@ -32,6 +37,7 @@ describe("parseStdoutResultEnvelope", () => {
     ).toEqual({
       outcome: { ok: true, output: 1 },
       timings: { runnerKind: "warm" },
+      spill: null,
     });
   });
 
@@ -50,6 +56,7 @@ describe("parseStdoutResultEnvelope", () => {
     ).toEqual({
       outcome: { ok: false, error: { code: "threw", message: "boom" } },
       timings: null,
+      spill: null,
     });
   });
 
@@ -81,6 +88,32 @@ describe("parseStdoutResultEnvelope", () => {
         },
       },
       timings: null,
+      spill: null,
+    });
+  });
+
+  it("surfaces a spill pointer instead of an outcome", () => {
+    expect(
+      parseStdoutResultEnvelope(
+        JSON.stringify({
+          protocolVersion: 3,
+          delivery: "stdout",
+          outcome: {
+            ok: true,
+            resultFile: "/tmp/dust-fn-results/abc.json",
+            resultBytes: 300_000,
+          },
+          timingsMs: { total: 12, runner: 8, runnerKind: "cold" },
+        })
+      )
+    ).toEqual({
+      outcome: null,
+      spill: {
+        ok: true,
+        resultFile: "/tmp/dust-fn-results/abc.json",
+        resultBytes: 300_000,
+      },
+      timings: { runnerKind: "cold" },
     });
   });
 
@@ -88,10 +121,82 @@ describe("parseStdoutResultEnvelope", () => {
     expect(parseStdoutResultEnvelope("")).toMatchObject({
       outcome: { ok: false, error: { code: "invocation_failed" } },
       timings: null,
+      spill: null,
     });
     expect(parseStdoutResultEnvelope("not-json")).toMatchObject({
       outcome: { ok: false, error: { code: "invocation_failed" } },
       timings: null,
+      spill: null,
     });
+  });
+});
+
+describe("resolveSpilledResult", () => {
+  const spill = {
+    ok: true as const,
+    resultFile: "/tmp/dust-fn-results/abc.json",
+    resultBytes: 300_000,
+  };
+
+  it("reads the file back and normalizes its content like an inline outcome", async () => {
+    const readFile = vi
+      .fn()
+      .mockResolvedValue(
+        new Ok(
+          Buffer.from(
+            JSON.stringify({ ok: true, output: { hello: "big world" } }),
+            "utf8"
+          )
+        )
+      );
+
+    await expect(resolveSpilledResult(spill, readFile)).resolves.toEqual({
+      ok: true,
+      output: { hello: "big world" },
+    });
+    expect(readFile).toHaveBeenCalledWith("/tmp/dust-fn-results/abc.json");
+  });
+
+  it("fails with invocation_failed naming the file when the read fails", async () => {
+    const readFile = vi.fn().mockResolvedValue(new Err(new Error("gone")));
+
+    await expect(resolveSpilledResult(spill, readFile)).resolves.toEqual({
+      ok: false,
+      error: {
+        code: "invocation_failed",
+        message:
+          "Pod function result could not be read back from /tmp/dust-fn-results/abc.json: gone",
+      },
+    });
+  });
+
+  it("fails when the file content is not valid JSON", async () => {
+    const readFile = vi
+      .fn()
+      .mockResolvedValue(
+        new Ok(Buffer.from('{"ok":true,"output":{"cut', "utf8"))
+      );
+
+    await expect(resolveSpilledResult(spill, readFile)).resolves.toMatchObject({
+      ok: false,
+      error: { code: "invocation_failed" },
+    });
+  });
+
+  it("refuses to read a pointer outside the spill directory", async () => {
+    const readFile = vi.fn();
+
+    for (const resultFile of [
+      "/etc/shadow",
+      "/tmp/dust-fn-results/../../etc/shadow",
+    ]) {
+      await expect(
+        resolveSpilledResult({ ...spill, resultFile }, readFile)
+      ).resolves.toMatchObject({
+        ok: false,
+        error: { code: "invocation_failed" },
+      });
+    }
+    expect(readFile).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/sandbox_functions/result_delivery.ts
+++ b/front/lib/api/sandbox_functions/result_delivery.ts
@@ -1,18 +1,35 @@
 import type {
   NormalizedSandboxFunctionOutcome,
+  SandboxFunctionResultSpillPointer,
   SandboxFunctionResultTimings,
 } from "@app/lib/api/sandbox_functions/result_envelope";
 import {
   extractResultEnvelopeTimings,
+  extractResultSpillPointer,
   normalizeSandboxFunctionResult,
+  SANDBOX_FUNCTION_RESULT_SPILL_DIR,
 } from "@app/lib/api/sandbox_functions/result_envelope";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
 
-export interface ParsedStdoutResult {
-  outcome: NormalizedSandboxFunctionOutcome;
+interface ParsedStdoutResultBase {
   // Observational diagnostics from the envelope (runner kind), null when the
   // envelope carried none or could not be parsed. Never affects the outcome.
   timings: SandboxFunctionResultTimings | null;
 }
+
+export type ParsedStdoutResult =
+  | (ParsedStdoutResultBase & {
+      outcome: NormalizedSandboxFunctionOutcome;
+      spill: null;
+    })
+  // The runner spilled an oversized result to a sandbox-local file instead of
+  // inlining it: the caller must read the file back (resolveSpilledResult)
+  // to obtain the outcome. Never emitted by older dsbx versions.
+  | (ParsedStdoutResultBase & {
+      outcome: null;
+      spill: SandboxFunctionResultSpillPointer;
+    });
 
 /**
  * Parse a protocol v3 (or legacy) result envelope from dsbx stdout.
@@ -38,6 +55,7 @@ export function parseStdoutResultEnvelope(stdout: string): ParsedStdoutResult {
         },
       },
       timings: null,
+      spill: null,
     };
   }
 
@@ -54,11 +72,74 @@ export function parseStdoutResultEnvelope(stdout: string): ParsedStdoutResult {
         },
       },
       timings: null,
+      spill: null,
     };
+  }
+
+  const timings = extractResultEnvelopeTimings(json);
+  const spill = extractResultSpillPointer(json);
+  if (spill !== null) {
+    return { outcome: null, spill, timings };
   }
 
   return {
     outcome: normalizeSandboxFunctionResult(json),
-    timings: extractResultEnvelopeTimings(json),
+    timings,
+    spill: null,
   };
+}
+
+function spillReadFailure(
+  spill: SandboxFunctionResultSpillPointer,
+  reason: string
+): NormalizedSandboxFunctionOutcome {
+  logger.warn(
+    { resultFile: spill.resultFile, resultBytes: spill.resultBytes, reason },
+    "Failed to read back a spilled Pod function result"
+  );
+  return {
+    ok: false,
+    error: {
+      code: "invocation_failed",
+      message: `Pod function result could not be read back from ${spill.resultFile}: ${reason}`,
+    },
+  };
+}
+
+/**
+ * Read back a spilled result and normalize its content, exactly as an inline
+ * outcome would have been. `readFile` is the sandbox read (the caller binds
+ * the provider, e.g. `(path) => sandbox.readFile(auth, path)`). Never throws:
+ * any read or parse failure becomes an invocation_failed outcome naming the
+ * file, so a spill failure is loud instead of silently losing the result.
+ */
+export async function resolveSpilledResult(
+  spill: SandboxFunctionResultSpillPointer,
+  readFile: (path: string) => Promise<Result<Buffer, Error>>
+): Promise<NormalizedSandboxFunctionOutcome> {
+  // The pointer rides the exec's stdout, which untrusted function code can
+  // also write to: only paths in the runner's dedicated scratch directory are
+  // ever read back, so a forged pointer cannot name an arbitrary sandbox
+  // file. (Content is additionally normalized below, which fails closed on
+  // anything that is not a runner result envelope.)
+  if (
+    !spill.resultFile.startsWith(SANDBOX_FUNCTION_RESULT_SPILL_DIR) ||
+    spill.resultFile.includes("..")
+  ) {
+    return spillReadFailure(spill, "unexpected result file path");
+  }
+
+  const read = await readFile(spill.resultFile);
+  if (read.isErr()) {
+    return spillReadFailure(spill, read.error.message);
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(read.value.toString("utf8"));
+  } catch {
+    return spillReadFailure(spill, "file content is not valid JSON");
+  }
+
+  return normalizeSandboxFunctionResult(json);
 }

--- a/front/lib/api/sandbox_functions/result_envelope.test.ts
+++ b/front/lib/api/sandbox_functions/result_envelope.test.ts
@@ -1,4 +1,5 @@
 import {
+  extractResultSpillPointer,
   normalizeSandboxFunctionResult,
   SANDBOX_FUNCTION_RESULT_PROTOCOL_VERSION,
 } from "@app/lib/api/sandbox_functions/result_envelope";
@@ -259,6 +260,52 @@ describe("normalizeSandboxFunctionResult", () => {
           message: "Sandbox function returned an invalid result envelope.",
         },
       });
+    }
+  });
+});
+
+describe("extractResultSpillPointer", () => {
+  const pointer = {
+    ok: true,
+    resultFile: "/tmp/dust-fn-results/abc.json",
+    resultBytes: 300_000,
+  };
+
+  it("extracts a pointer from a protocol v3 envelope outcome", () => {
+    expect(
+      extractResultSpillPointer({
+        protocolVersion: 3,
+        delivery: "stdout",
+        outcome: pointer,
+        timingsMs: { total: 12, runner: 8 },
+      })
+    ).toEqual(pointer);
+  });
+
+  it("extracts a bare pointer", () => {
+    expect(extractResultSpillPointer(pointer)).toEqual(pointer);
+  });
+
+  it("tolerates additive fields from a newer dsbx", () => {
+    expect(
+      extractResultSpillPointer({ ...pointer, futureField: "ignored" })
+    ).toEqual(pointer);
+  });
+
+  it("returns null for inline outcomes and legacy shapes", () => {
+    for (const value of [
+      { ok: true, output: { hello: "world" } },
+      { ok: false, error: { code: "threw", message: "boom" } },
+      {
+        protocolVersion: 3,
+        delivery: "stdout",
+        outcome: { ok: true, output: 1 },
+      },
+      { ok: true, response: { status: 200 } },
+      null,
+      "not-an-envelope",
+    ]) {
+      expect(extractResultSpillPointer(value)).toBeNull();
     }
   });
 });

--- a/front/lib/api/sandbox_functions/result_envelope.ts
+++ b/front/lib/api/sandbox_functions/result_envelope.ts
@@ -86,6 +86,38 @@ const ProtocolVersionProbeSchema = z.object({
   protocolVersion: z.number(),
 });
 
+// The only directory a result-spill pointer may name. The runner writes spilled results there
+// (cli/dust-sandbox/functions-runner) and the pointer rides the exec's stdout, which untrusted
+// function code can also write to: restricting read-back to this scratch directory keeps a forged
+// pointer from making front read an arbitrary sandbox file.
+export const SANDBOX_FUNCTION_RESULT_SPILL_DIR = "/tmp/dust-fn-results/";
+
+// A result too large to inline on stdout: the runner writes the full envelope JSON to a
+// sandbox-local scratch file and emits this pointer instead. Deliberately not `.strict()`: a
+// field added by a newer dsbx must not turn a pointer into an invalid-envelope failure.
+const ResultSpillPointerSchema = z.object({
+  ok: z.literal(true),
+  resultFile: z.string().min(1),
+  resultBytes: z.number().int().nonnegative(),
+});
+
+export type SandboxFunctionResultSpillPointer = z.infer<
+  typeof ResultSpillPointerSchema
+>;
+
+/**
+ * Extract a result-spill pointer from a parsed stdout value (a protocol v3 envelope or a bare
+ * runner outcome). Returns null for inline outcomes and for anything an older dsbx emits.
+ */
+export function extractResultSpillPointer(
+  parsedEnvelope: unknown
+): SandboxFunctionResultSpillPointer | null {
+  const envelope = ResultEnvelopeV3Schema.safeParse(parsedEnvelope);
+  const outcome = envelope.success ? envelope.data.outcome : parsedEnvelope;
+  const pointer = ResultSpillPointerSchema.safeParse(outcome);
+  return pointer.success ? pointer.data : null;
+}
+
 // Lenient by design: timings are diagnostics from whatever dsbx version runs in the sandbox, and
 // absence or new shapes must never affect result handling. Only the consumed field is modeled.
 const ResultTimingsSchema = z.object({

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -3,7 +3,10 @@ import { generateSandboxFunctionInvocationToken } from "@app/lib/api/sandbox/acc
 import { SandboxNotRunningError } from "@app/lib/api/sandbox/errors";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
-import type { NormalizedSandboxFunctionOutcome } from "@app/lib/api/sandbox_functions/result_envelope";
+import type {
+  NormalizedSandboxFunctionOutcome,
+  SandboxFunctionResultSpillPointer,
+} from "@app/lib/api/sandbox_functions/result_envelope";
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -86,8 +89,11 @@ const outputSchema: JSONSchema = {
 // Stamped on the function at creation and expected back on every exec envelope.
 const TEST_BUNDLE_SHA256 = "a".repeat(64);
 
-// dsbx always delivers the result on the exec's own stdout, as a protocol v3 envelope.
-function stdoutEnvelope(outcome: NormalizedSandboxFunctionOutcome): string {
+// dsbx always delivers the result on the exec's own stdout, as a protocol v3 envelope. The
+// outcome is either inline or, for an oversized result, a spill pointer to a sandbox file.
+function stdoutEnvelope(
+  outcome: NormalizedSandboxFunctionOutcome | SandboxFunctionResultSpillPointer
+): string {
   return (
     JSON.stringify({ protocolVersion: 3, delivery: "stdout", outcome }) + "\n"
   );
@@ -763,6 +769,83 @@ describe("SandboxFunctionInvocationResource", () => {
       body: JSON.stringify({ message: "hello" }),
       encoding: "utf8",
       bundleSha256: TEST_BUNDLE_SHA256,
+    });
+  });
+
+  it("reads back a spilled result and delivers the full output", async () => {
+    const { authenticator, sandboxFunction, sandbox, invocation } =
+      await setupExecutionTest();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout: stdoutEnvelope({
+          ok: true,
+          resultFile: "/tmp/dust-fn-results/spill.json",
+          resultBytes: 300_000,
+        }),
+        stderr: "",
+      })
+    );
+    const readFileSpy = vi
+      .spyOn(sandbox, "readFile")
+      .mockResolvedValue(
+        new Ok(
+          Buffer.from(
+            JSON.stringify({ ok: true, output: { commentId: "comment-big" } }),
+            "utf8"
+          )
+        )
+      );
+
+    const executionResult = await invocation.execute(authenticator);
+    if (executionResult.isErr()) {
+      throw executionResult.error;
+    }
+
+    expect(readFileSpy).toHaveBeenCalledWith(
+      authenticator,
+      "/tmp/dust-fn-results/spill.json"
+    );
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.status).toBe("succeeded");
+    expect(refetched?.result).toEqual({ commentId: "comment-big" });
+  });
+
+  it("fails the invocation when the spilled result cannot be read back", async () => {
+    const { authenticator, sandboxFunction, sandbox, invocation } =
+      await setupExecutionTest();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout: stdoutEnvelope({
+          ok: true,
+          resultFile: "/tmp/dust-fn-results/spill.json",
+          resultBytes: 300_000,
+        }),
+        stderr: "",
+      })
+    );
+    vi.spyOn(sandbox, "readFile").mockResolvedValue(
+      new Err(new Error("file not found"))
+    );
+
+    const executionResult = await invocation.execute(authenticator);
+    if (executionResult.isErr()) {
+      throw executionResult.error;
+    }
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.status).toBe("errored");
+    expect(refetched?.error).toMatchObject({
+      code: "invocation_failed",
+      message:
+        "Pod function result could not be read back from /tmp/dust-fn-results/spill.json: file not found",
     });
   });
 

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -19,7 +19,10 @@ import { shellEscape } from "@app/lib/api/sandbox/shell";
 import { podDatabasePrefixFromSlug } from "@app/lib/api/sandbox_functions/db_naming";
 import { SandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
-import { parseStdoutResultEnvelope } from "@app/lib/api/sandbox_functions/result_delivery";
+import {
+  parseStdoutResultEnvelope,
+  resolveSpilledResult,
+} from "@app/lib/api/sandbox_functions/result_delivery";
 import {
   authorizeSandboxFunctionInvocation,
   getAuthenticatedWorkspaceUser,
@@ -731,6 +734,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       }
 
       const { exitCode, stdout, stderr } = execResult.value;
+      // Persist from the envelope even on non-zero exit: dsbx may still have
+      // written a well-formed invocation_failed envelope the worker should keep.
+      const parsed = parseStdoutResultEnvelope(stdout);
+      const { timings } = parsed;
       logger.info(
         {
           workspaceId: auth.getNonNullableWorkspace().sId,
@@ -738,13 +745,20 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
           invocationId: this.sId,
           exitCode,
           stdoutBytes: Buffer.byteLength(stdout, "utf8"),
+          ...(parsed.spill === null
+            ? {}
+            : { spilledResultBytes: parsed.spill.resultBytes }),
         },
         "Pod function stdout result delivery"
       );
-      // Persist from the envelope even on non-zero exit: dsbx may still have
-      // written a well-formed invocation_failed envelope the worker should keep.
-      const { outcome: normalized, timings } =
-        parseStdoutResultEnvelope(stdout);
+      // An oversized result was spilled to a sandbox-local file: read it back
+      // through the provider and normalize it exactly like an inline outcome.
+      const normalized =
+        parsed.spill === null
+          ? parsed.outcome
+          : await resolveSpilledResult(parsed.spill, (path) =>
+              sandbox.readFile(auth, path)
+            );
       recordSandboxFunctionRun({
         runnerKind: timings?.runnerKind ?? "unknown",
         status: normalized.ok ? "success" : "error",


### PR DESCRIPTION
## Description

Read side of result spill-to-file for Pod functions. The runner (separate dsbx PR) will write results over an inline cap to a sandbox-local scratch file (`/tmp/dust-fn-results/`) and emit a `{ok, resultFile, resultBytes}` pointer on stdout instead of the payload.

- `parseStdoutResultEnvelope` now surfaces the pointer; the invocation execute path reads the file back via `sandbox.readFile` (same provider mechanism as `build_on_sandbox.ts`) and runs the existing normalization on its content.
- A failed read-back becomes an `invocation_failed` error naming the file: loud, never silent data loss.
- The pointer rides the exec's stdout, which function code can also write to, so read-back is restricted to the runner's scratch directory and the content must still normalize as a result envelope (fails closed on anything else).
- Envelopes from older dsbx never carry pointers: behavior unchanged until the write side ships.

Depends on #30344.

## Tests

Pointer extraction, spill resolution (happy path, read failure, bad JSON, path outside the scratch dir refused before any read), and two execute-path tests (spilled result delivered, read failure fails the invocation).

## Risk

Low: dead code path until the dsbx write side is released; inline results flow exactly as before.

## Deploy Plan

Standard deploy. Must be live before the dsbx release that spills results bumps `DSBX_CLI_VERSION`.