### PR TITLE
[dsbx] Typed error envelope and distinct exit codes for tools failures

### DIFF
--- a/cli/dust-sandbox/src/api/client.rs
+++ b/cli/dust-sandbox/src/api/client.rs
@@ -6,6 +6,7 @@ use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 use serde::{de::DeserializeOwned, Serialize};
 use tokio::time::sleep;
 
+use super::error::DustApiError;
 use super::types::{
     parse_action_poll_response, ActionPollResponse, CallToolPostResponse, CallToolRequest,
     CallToolResponse, CallToolResult, MCPServerView, SandboxServerViewsResponse,
@@ -79,7 +80,11 @@ impl DustApiClient {
         let status = resp.status();
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
-            bail!("GET {url} returned {status}: {body}");
+            return Err(anyhow::Error::new(DustApiError::from_http_response(
+                status.as_u16(),
+                &body,
+            ))
+            .context(format!("GET {url}")));
         }
 
         resp.json::<T>()
@@ -104,7 +109,11 @@ impl DustApiClient {
         let status = resp.status();
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
-            bail!("POST {url} returned {status}: {body}");
+            return Err(anyhow::Error::new(DustApiError::from_http_response(
+                status.as_u16(),
+                &body,
+            ))
+            .context(format!("POST {url}")));
         }
 
         resp.json::<T>()
@@ -144,11 +153,21 @@ impl DustApiClient {
             .await
             .context(format!("failed to read response from GET {url}"))?;
 
+        if !status.is_success() {
+            return Err(anyhow::Error::new(DustApiError::from_http_response(
+                status.as_u16(),
+                &body,
+            ))
+            .context(format!("GET {url}")));
+        }
+
         match parse_action_poll_response(&body) {
             Ok(poll) => Ok(poll),
-            Err(parse_err) if status.is_success() => Err(parse_err)
+            // A 2xx body carrying an error envelope is already typed; anything
+            // else failing to parse is a malformed success body.
+            Err(err) if err.downcast_ref::<DustApiError>().is_some() => Err(err),
+            Err(parse_err) => Err(parse_err)
                 .with_context(|| format!("GET {url} (status {status}) returned unparseable body")),
-            Err(_) => bail!("GET {url} returned {status}: {body}"),
         }
     }
 

--- a/cli/dust-sandbox/src/api/error.rs
+++ b/cli/dust-sandbox/src/api/error.rs
@@ -201,6 +201,19 @@ mod tests {
     }
 
     #[test]
+    fn classifies_not_authenticated_as_invalid_sandbox_token() {
+        // On sandbox endpoints the only credential is the sandbox token, so a
+        // missing/non-sandbox token is the same terminal class as an expired
+        // one; the TTL hint stays scoped to the expiry type.
+        let err = DustApiError::from_http_response(
+            401,
+            r#"{"error":{"type":"not_authenticated","message":"This endpoint requires a sandbox token."}}"#,
+        );
+        assert_eq!(err.code, ApiErrorCode::InvalidSandboxToken);
+        assert!(!err.message.contains("~2-minute TTL"));
+    }
+
+    #[test]
     fn classifies_fast_function_called_tools_by_type() {
         let err = DustApiError::from_http_response(
             403,

--- a/cli/dust-sandbox/src/api/error.rs
+++ b/cli/dust-sandbox/src/api/error.rs
@@ -1,0 +1,299 @@
+use std::fmt;
+
+use serde::Deserialize;
+
+/// Stable, machine-readable classification of a Dust API failure.
+///
+/// The string form (`as_str`) and the exit codes are a contract with sandbox
+/// workloads that shell out to `dsbx tools --json` and parse stdout: both are
+/// append-only. `retryable` states whether retrying the same command from the
+/// same invocation can ever succeed — not whether the caller should retry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApiErrorCode {
+    /// The sandbox token was rejected. Terminal: the token is minted once per
+    /// invocation with a ~2-minute TTL and cannot be refreshed from inside the
+    /// sandbox, so retrying with the same environment is futile.
+    InvalidSandboxToken,
+    /// A function published as `fast` tried to call tools (403). Terminal for
+    /// this invocation: the refusal is carried by the invocation token itself.
+    /// The platform records the function as durable on refusal, so the *next*
+    /// invocation works.
+    FastFunctionCalledTools,
+    /// Any other 4xx: the request as issued will keep failing.
+    InvalidRequest,
+    /// HTTP 429: the request was throttled and can be retried later.
+    RateLimited,
+    /// HTTP 5xx: transient server-side failure.
+    ServerError,
+}
+
+impl ApiErrorCode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ApiErrorCode::InvalidSandboxToken => "invalid_sandbox_token",
+            ApiErrorCode::FastFunctionCalledTools => "fast_function_called_tools",
+            ApiErrorCode::InvalidRequest => "invalid_request",
+            ApiErrorCode::RateLimited => "rate_limited",
+            ApiErrorCode::ServerError => "server_error",
+        }
+    }
+
+    pub fn retryable(&self) -> bool {
+        match self {
+            ApiErrorCode::InvalidSandboxToken
+            | ApiErrorCode::FastFunctionCalledTools
+            | ApiErrorCode::InvalidRequest => false,
+            ApiErrorCode::RateLimited | ApiErrorCode::ServerError => true,
+        }
+    }
+
+    /// Distinct process exit codes so non-`--json` consumers can classify
+    /// without parsing anything. 1 stays the generic failure (including a tool
+    /// result with `isError: true`); 2 is reserved by clap for usage errors.
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            ApiErrorCode::InvalidRequest => 10,
+            ApiErrorCode::InvalidSandboxToken => 11,
+            ApiErrorCode::FastFunctionCalledTools => 12,
+            ApiErrorCode::RateLimited => 13,
+            ApiErrorCode::ServerError => 14,
+        }
+    }
+}
+
+/// A typed error for a front API failure (`{"error":{"type","message"}}` body
+/// or an unparseable non-2xx response). Carried through `anyhow` so callers
+/// can `downcast_ref::<DustApiError>()` — mirroring how transient
+/// `reqwest::Error`s are recognized in the poll loop.
+#[derive(Debug)]
+pub struct DustApiError {
+    pub code: ApiErrorCode,
+    pub message: String,
+    pub status: Option<u16>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiErrorEnvelope {
+    error: ApiErrorBody,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiErrorBody {
+    #[serde(default, rename = "type")]
+    error_type: Option<String>,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+impl DustApiError {
+    /// Build from a non-2xx HTTP response. Parses front's
+    /// `{"error":{"type","message"}}` envelope when present; otherwise
+    /// classifies on the status alone and keeps the raw body as the message.
+    pub fn from_http_response(status: u16, body: &str) -> Self {
+        Self::parse_envelope(Some(status), body)
+            .unwrap_or_else(|| Self::from_api_error(Some(status), None, body))
+    }
+
+    /// Parse a body shaped like front's `{"error":{"type","message"}}`
+    /// envelope. `None` when the body is not an error envelope.
+    pub fn parse_envelope(status: Option<u16>, body: &str) -> Option<Self> {
+        let envelope = serde_json::from_str::<ApiErrorEnvelope>(body).ok()?;
+        Some(Self::from_api_error(
+            status,
+            envelope.error.error_type.as_deref(),
+            envelope
+                .error
+                .message
+                .as_deref()
+                .unwrap_or("unknown API error"),
+        ))
+    }
+
+    /// Build from a parsed front `api_error`. `error_type` is front's
+    /// `error.type` when the body carried one.
+    pub fn from_api_error(status: Option<u16>, error_type: Option<&str>, message: &str) -> Self {
+        let code = classify(status, error_type, message);
+        // Name the token budget so consumers stop retrying a refusal that can
+        // never succeed (the JWT is minted once per invocation with a
+        // ~2-minute TTL). Scoped to the expired/invalid-token type: the other
+        // `invalid_sandbox_token` sources (missing or non-sandbox token) are
+        // configuration errors, not expiries.
+        let message = if error_type == Some("invalid_sandbox_token_error") {
+            format!(
+                "{message} (the sandbox token is minted once per invocation with a ~2-minute \
+                 TTL; retrying within this invocation cannot succeed)"
+            )
+        } else {
+            message.to_string()
+        };
+        Self {
+            code,
+            message,
+            status,
+        }
+    }
+
+    /// The stdout contract under `tools --json`:
+    /// `{"error":{"code","message","retryable","status"?}}`.
+    pub fn to_envelope_json(&self) -> serde_json::Value {
+        let mut error = serde_json::json!({
+            "code": self.code.as_str(),
+            "message": self.message,
+            "retryable": self.code.retryable(),
+        });
+        if let Some(status) = self.status {
+            error["status"] = serde_json::Value::from(status);
+        }
+        serde_json::json!({ "error": error })
+    }
+}
+
+fn classify(status: Option<u16>, error_type: Option<&str>, message: &str) -> ApiErrorCode {
+    match error_type {
+        Some("invalid_sandbox_token_error") | Some("not_authenticated") => {
+            ApiErrorCode::InvalidSandboxToken
+        }
+        Some("fast_function_called_tools") => ApiErrorCode::FastFunctionCalledTools,
+        _ => match status {
+            Some(429) => ApiErrorCode::RateLimited,
+            Some(s) if s >= 500 => ApiErrorCode::ServerError,
+            // Message fallback for fronts that still return the fast-mode
+            // tools refusal as a generic `invalid_request_error`; removable
+            // once `fast_function_called_tools` is served everywhere.
+            Some(403) if message.contains("published as fast") => {
+                ApiErrorCode::FastFunctionCalledTools
+            }
+            _ => ApiErrorCode::InvalidRequest,
+        },
+    }
+}
+
+impl fmt::Display for DustApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.status {
+            Some(status) => write!(
+                f,
+                "API error {status} ({}): {}",
+                self.code.as_str(),
+                self.message
+            ),
+            None => write!(f, "API error ({}): {}", self.code.as_str(), self.message),
+        }
+    }
+}
+
+impl std::error::Error for DustApiError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_invalid_sandbox_token_as_terminal() {
+        let err = DustApiError::from_http_response(
+            401,
+            r#"{"error":{"type":"invalid_sandbox_token_error","message":"The sandbox token is invalid or expired."}}"#,
+        );
+        assert_eq!(err.code, ApiErrorCode::InvalidSandboxToken);
+        assert!(!err.code.retryable());
+        assert_eq!(err.code.exit_code(), 11);
+        assert!(err.message.contains("~2-minute TTL"));
+    }
+
+    #[test]
+    fn classifies_fast_function_called_tools_by_type() {
+        let err = DustApiError::from_http_response(
+            403,
+            r#"{"error":{"type":"fast_function_called_tools","message":"This Pod function is published as fast and cannot call tools."}}"#,
+        );
+        assert_eq!(err.code, ApiErrorCode::FastFunctionCalledTools);
+        assert!(!err.code.retryable());
+        assert_eq!(err.code.exit_code(), 12);
+    }
+
+    #[test]
+    fn classifies_fast_function_called_tools_by_message_fallback() {
+        // Older fronts return the refusal as a generic invalid_request_error.
+        let err = DustApiError::from_http_response(
+            403,
+            r#"{"error":{"type":"invalid_request_error","message":"This Pod function is published as fast and cannot call tools. Publish it with executionMode `durable` to let it call tools."}}"#,
+        );
+        assert_eq!(err.code, ApiErrorCode::FastFunctionCalledTools);
+    }
+
+    #[test]
+    fn classifies_other_403_as_invalid_request() {
+        let err = DustApiError::from_http_response(
+            403,
+            r#"{"error":{"type":"invalid_request_error","message":"Tool not available."}}"#,
+        );
+        assert_eq!(err.code, ApiErrorCode::InvalidRequest);
+        assert!(!err.code.retryable());
+        assert_eq!(err.code.exit_code(), 10);
+    }
+
+    #[test]
+    fn classifies_429_as_retryable() {
+        let err = DustApiError::from_http_response(
+            429,
+            r#"{"error":{"type":"rate_limit_error","message":"Too many requests."}}"#,
+        );
+        assert_eq!(err.code, ApiErrorCode::RateLimited);
+        assert!(err.code.retryable());
+        assert_eq!(err.code.exit_code(), 13);
+    }
+
+    #[test]
+    fn classifies_5xx_as_retryable_server_error() {
+        let err = DustApiError::from_http_response(502, "Bad Gateway");
+        assert_eq!(err.code, ApiErrorCode::ServerError);
+        assert!(err.code.retryable());
+        assert_eq!(err.code.exit_code(), 14);
+        assert_eq!(err.message, "Bad Gateway");
+    }
+
+    #[test]
+    fn non_json_body_keeps_raw_message() {
+        let err = DustApiError::from_http_response(400, "<html>nope</html>");
+        assert_eq!(err.code, ApiErrorCode::InvalidRequest);
+        assert_eq!(err.message, "<html>nope</html>");
+        assert_eq!(err.status, Some(400));
+    }
+
+    #[test]
+    fn envelope_json_shape() {
+        let err = DustApiError::from_http_response(
+            403,
+            r#"{"error":{"type":"fast_function_called_tools","message":"nope"}}"#,
+        );
+        let value = err.to_envelope_json();
+        assert_eq!(value["error"]["code"], "fast_function_called_tools");
+        assert_eq!(value["error"]["message"], "nope");
+        assert_eq!(value["error"]["retryable"], false);
+        assert_eq!(value["error"]["status"], 403);
+    }
+
+    #[test]
+    fn envelope_json_omits_status_when_unknown() {
+        let err = DustApiError::from_api_error(None, None, "boom");
+        let value = err.to_envelope_json();
+        assert!(value["error"].get("status").is_none());
+        assert_eq!(value["error"]["code"], "invalid_request");
+    }
+
+    #[test]
+    fn display_names_status_and_code() {
+        let err = DustApiError::from_http_response(429, "slow down");
+        assert_eq!(err.to_string(), "API error 429 (rate_limited): slow down");
+    }
+
+    #[test]
+    fn downcasts_through_anyhow_context() {
+        let err = anyhow::Error::new(DustApiError::from_http_response(500, "boom"))
+            .context("POST https://dust.tt/api/v1/w/x/sandbox/actions/call");
+        let api = err
+            .downcast_ref::<DustApiError>()
+            .expect("should downcast through context");
+        assert_eq!(api.code, ApiErrorCode::ServerError);
+    }
+}

--- a/cli/dust-sandbox/src/api/mod.rs
+++ b/cli/dust-sandbox/src/api/mod.rs
@@ -1,5 +1,7 @@
 mod client;
+mod error;
 mod types;
 
 pub use client::DustApiClient;
+pub use error::DustApiError;
 pub use types::{parse_content_block, ContentBlock};

--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -81,25 +81,11 @@ struct ActionData {
     output: Option<Vec<serde_json::Value>>,
 }
 
-#[derive(Debug, Deserialize)]
-struct ApiErrorEnvelope {
-    error: ApiErrorBody,
-}
-
-#[derive(Debug, Deserialize)]
-struct ApiErrorBody {
-    #[serde(default)]
-    message: Option<String>,
-}
-
 pub fn parse_action_poll_response(body: &str) -> anyhow::Result<ActionPollResponse> {
-    if let Ok(envelope) = serde_json::from_str::<ApiErrorEnvelope>(body) {
-        let message = envelope
-            .error
-            .message
-            .as_deref()
-            .unwrap_or("unknown API error");
-        anyhow::bail!("API error: {message}");
+    // A body shaped like front's `{"error":{...}}` envelope is an API error
+    // regardless of HTTP status; surface it typed so callers can classify.
+    if let Some(api_error) = super::error::DustApiError::parse_envelope(None, body) {
+        return Err(api_error.into());
     }
 
     let raw: ActionPollResponseRaw = serde_json::from_str(body)
@@ -262,6 +248,12 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.to_string().contains("bad token"));
+        // The envelope surfaces typed so the poll loop treats it as terminal
+        // and `--json` consumers get a classified error.
+        let api_error = err
+            .downcast_ref::<super::super::error::DustApiError>()
+            .expect("should carry a DustApiError");
+        assert_eq!(api_error.message, "bad token");
     }
 
     #[test]

--- a/cli/dust-sandbox/src/commands/tools/exec.rs
+++ b/cli/dust-sandbox/src/commands/tools/exec.rs
@@ -1,10 +1,48 @@
 use anyhow::{bail, Context};
 
-use crate::api::{parse_content_block, ContentBlock, DustApiClient};
+use crate::api::{parse_content_block, ContentBlock, DustApiClient, DustApiError};
 
 const MAX_FILE_ARG_SIZE_BYTES: u64 = 100 * 1024 * 1024;
 
 pub async fn cmd_exec(
+    client: &DustApiClient,
+    server_name: &str,
+    tool_name: &str,
+    raw_args: &[String],
+    json: bool,
+) -> anyhow::Result<()> {
+    match run_exec(client, server_name, tool_name, raw_args, json).await {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            // Under --json, stdout is the machine contract: emit the typed
+            // error envelope there (mirroring `function run`'s emit_error) so
+            // consumers never have to regex stderr prose. The error still
+            // propagates for the stderr diagnostic + non-zero exit.
+            if json {
+                println!("{}", error_envelope_json(&err));
+            }
+            Err(err)
+        }
+    }
+}
+
+/// The `{"error":{code,message,retryable,status?}}` stdout envelope for a
+/// failed `tools --json` execution. API failures carry their typed
+/// classification; anything else is `unknown` and not retryable.
+fn error_envelope_json(err: &anyhow::Error) -> serde_json::Value {
+    if let Some(api_error) = err.downcast_ref::<DustApiError>() {
+        return api_error.to_envelope_json();
+    }
+    serde_json::json!({
+        "error": {
+            "code": "unknown",
+            "message": format!("{err:#}"),
+            "retryable": false,
+        }
+    })
+}
+
+async fn run_exec(
     client: &DustApiClient,
     server_name: &str,
     tool_name: &str,
@@ -692,6 +730,35 @@ mod tests {
             .expect("should parse")
             .expect("should have value");
         assert_eq!(result["count"], 42);
+    }
+
+    // --- error envelope for --json consumers ---
+
+    #[test]
+    fn error_envelope_carries_typed_api_error() {
+        let err = anyhow::Error::new(DustApiError::from_http_response(
+            403,
+            r#"{"error":{"type":"fast_function_called_tools","message":"no tools for fast functions"}}"#,
+        ))
+        .context("POST https://dust.tt/api/v1/w/x/sandbox/actions/call");
+
+        let envelope = error_envelope_json(&err);
+        assert_eq!(envelope["error"]["code"], "fast_function_called_tools");
+        assert_eq!(envelope["error"]["message"], "no tools for fast functions");
+        assert_eq!(envelope["error"]["retryable"], false);
+        assert_eq!(envelope["error"]["status"], 403);
+    }
+
+    #[test]
+    fn error_envelope_falls_back_to_unknown_with_chain() {
+        let err = anyhow::anyhow!("root cause").context("outer context");
+        let envelope = error_envelope_json(&err);
+        assert_eq!(envelope["error"]["code"], "unknown");
+        assert_eq!(envelope["error"]["retryable"], false);
+        let message = envelope["error"]["message"].as_str().expect("message");
+        assert!(message.contains("outer context"));
+        assert!(message.contains("root cause"));
+        assert!(envelope["error"].get("status").is_none());
     }
 
     #[test]

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -37,8 +37,10 @@ enum Commands {
     /// Interact with MCP servers and tools
     Tools {
         /// Emit the tool execution result as JSON (`{ content, isError }`)
-        /// instead of plain text. Must be placed before the positional
-        /// arguments. Ignored when listing servers or tools.
+        /// instead of plain text; failures emit
+        /// `{ error: { code, message, retryable, status? } }` on stdout and
+        /// exit non-zero. Must be placed before the positional arguments.
+        /// Ignored when listing servers or tools.
         #[arg(long)]
         json: bool,
         /// Server name (omit to list all servers)
@@ -56,9 +58,21 @@ async fn main() {
     init_tracing();
 
     if let Err(error) = run().await {
-        error!(error = %error, "dsbx command failed");
-        std::process::exit(1);
+        // `{:#}` prints the whole context chain, not just the outermost
+        // message (typed API errors carry the useful part as the cause).
+        let error_chain = format!("{error:#}");
+        error!(error = %error_chain, "dsbx command failed");
+        std::process::exit(exit_code_for(&error));
     }
+}
+
+/// Typed API failures exit with their stable per-code exit codes; everything
+/// else keeps the generic 1 (2 is reserved by clap for usage errors).
+fn exit_code_for(error: &anyhow::Error) -> i32 {
+    error
+        .downcast_ref::<api::DustApiError>()
+        .map(|api_error| api_error.code.exit_code())
+        .unwrap_or(1)
 }
 
 async fn run() -> anyhow::Result<()> {


### PR DESCRIPTION
## Description

`dsbx tools` failures currently surface as a single bail string ("POST {url} returned {status}: {body}") logged to stderr, exit 1, nothing on stdout. Sandbox functions that shell out to `dsbx tools --json` have to regex stderr prose to figure out what went wrong.

- Parse front's `{"error":{"type","message"}}` body into a typed `DustApiError` in the API client (POST, GET, and the poll path).
- Under `--json`, failures now emit `{"error":{"code","message","retryable","status"?}}` on stdout (same pattern as `function run`'s emit_error contract).
- Distinct exit codes per class: 10 invalid_request, 11 invalid_sandbox_token, 12 fast_function_called_tools, 13 rate_limited, 14 server_error. 1 stays the generic failure, 2 stays clap's usage error.
- `invalid_sandbox_token` is classified terminal and the message names the reason: the JWT is minted once per invocation with a ~2-minute TTL, retrying within the invocation cannot succeed.
- The fast-mode tools-denied 403 gets its own `fast_function_called_tools` code, matched on the stable api_error type, with a message fallback for fronts that still return it as `invalid_request_error`.
- stderr diagnostic now prints the full context chain instead of the outermost message only.

Code strings and exit codes are append-only from here.

## Tests

Unit tests for classification (token, fast-403 by type and by message fallback, 429, 5xx, non-JSON bodies), envelope shape, downcast through anyhow context, and the poll-path envelope. `cargo test --bin dsbx` and the e2e_local test pass locally.

## Risk

Low. Non-json output is unchanged on success; failures keep the stderr line and non-zero exit. Consumers that only check "exit != 0" see no difference. New exit codes only replace the previous blanket 1 for API failures.

## Deploy Plan

Standard dsbx release; picked up by sandbox images on the next bump.