### PR TITLE
[front] feat: recreate expected-but-missing pod databases on cold start

### DIFF
--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -55,7 +55,10 @@ type SandboxStartupPhase =
   | "pod_state_setup"
   | "pod_state.enumerate"
   | "pod_state.restore_db"
-  | "pod_state.start_daemon";
+  | "pod_state.start_daemon"
+  // Recreate expected-but-missing databases from their schema files (cold
+  // start only, after pod_state_setup).
+  | "pod_state_recovery";
 
 // Opens a parent APM span for a startup phase. The provider.* child spans nest
 // underneath automatically, so this adds semantic grouping (and a per-phase
@@ -159,6 +162,16 @@ export function recordPodStateHealth(status: "success" | "failure"): void {
 // The stable logger.error at the call site carries the database name.
 export function recordPodStateRestoreSkip(): void {
   getStatsDClient().increment("sandbox.pod_state.restore_skipped", 1, [
+    regionTag(),
+  ]);
+}
+
+// A cold start found a database that a schema file expects but that is absent
+// from disk and replica, and recreated it EMPTY by re-running its reconcile.
+// Recreation restores service, not data — alert-worthy alongside
+// sandbox.pod_state.restore_skipped.
+export function recordPodStateColdStartRecreate(): void {
+  getStatsDClient().increment("sandbox.pod_state.cold_start_recreate", 1, [
     regionTag(),
   ]);
 }

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -12,6 +12,9 @@ import {
 import type { SandboxRuntimeOwner } from "@app/lib/api/sandbox/owner";
 import { podSandboxOnlyMounts } from "@app/lib/api/sandbox/pod_mounts";
 import { startTelemetry } from "@app/lib/api/sandbox/telemetry";
+// Deliberately lifecycle-free module (see its module doc): importing it here
+// cannot create a cycle.
+import { recoverMissingPodDatabasesOnColdStart } from "@app/lib/api/sandbox_functions/pod_db_cold_start_recovery";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
@@ -178,6 +181,18 @@ async function ensureOwnerSandboxReady(
           status = "error";
           return podStateResult;
         }
+
+        // Recreate expected-but-missing databases from their schema files
+        // (e.g. a replica lost before its first sync made the restore skip
+        // them). Must run AFTER restore + daemon start so a recreated file
+        // replicates immediately. Best-effort by contract: failures are
+        // logged and metered inside, and never block sandbox readiness.
+        await traceSandboxStartupPhase("pod_state_recovery", () =>
+          recoverMissingPodDatabasesOnColdStart(auth, {
+            sandbox,
+            podId: runtimeOwner.spaceId,
+          })
+        );
       }
 
       const ensureEgressResult = await traceSandboxStartupPhase(

--- a/front/lib/api/sandbox_functions/dsbx_db.test.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.test.ts
@@ -5,8 +5,8 @@ import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import {
   getDatabaseSchemaOnSandbox,
   listDatabasesOnSandbox,
-  reconcileDatabaseOnSandbox,
 } from "@app/lib/api/sandbox_functions/dsbx_db";
+import { reconcileDatabaseOnSandbox } from "@app/lib/api/sandbox_functions/dsbx_db_on_sandbox";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -165,7 +165,8 @@ describe("reconcileDatabaseOnSandbox", () => {
     vi.mocked(syncPodDatabaseAfterCreate).mockResolvedValue(new Ok(undefined));
 
     const result = await reconcileDatabaseOnSandbox(authenticator, {
-      space,
+      sandbox,
+      podId: space.sId,
       ...reconcileArgs,
     });
 
@@ -191,7 +192,8 @@ describe("reconcileDatabaseOnSandbox", () => {
     );
 
     const result = await reconcileDatabaseOnSandbox(authenticator, {
-      space,
+      sandbox,
+      podId: space.sId,
       ...reconcileArgs,
     });
 
@@ -211,7 +213,8 @@ describe("reconcileDatabaseOnSandbox", () => {
     mockReconcileExec(sandbox, { created: false });
 
     const result = await reconcileDatabaseOnSandbox(authenticator, {
-      space,
+      sandbox,
+      podId: space.sId,
       ...reconcileArgs,
     });
 

--- a/front/lib/api/sandbox_functions/dsbx_db.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.ts
@@ -2,23 +2,29 @@ import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
-import {
-  podDatabaseExecEnvVars,
-  TOOL_OUTPUTS_FOLDER_NAME,
-} from "@app/lib/api/files/mount_path";
+import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import { getRedisStreamClient } from "@app/lib/api/redis";
-import { syncPodDatabaseAfterCreate } from "@app/lib/api/sandbox/db";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import {
   podDatabasePrefixFromPodPath,
   resolvePodDatabaseName,
 } from "@app/lib/api/sandbox_functions/db_naming";
-import type { SandboxFunctionErrorCode } from "@app/lib/api/sandbox_functions/errors";
+import type {
+  LiveDatabaseEntry,
+  ReconcileDatabaseResult,
+} from "@app/lib/api/sandbox_functions/dsbx_db_on_sandbox";
+import {
+  DSBX_BIN_PATH,
+  dbErrorEnvelopeSchema,
+  dbErrorToSandboxFunctionError,
+  execDbCommandOnSandbox,
+  listPodDatabases,
+  reconcileDatabaseOnSandbox,
+} from "@app/lib/api/sandbox_functions/dsbx_db_on_sandbox";
 import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import type { StagingHashes } from "@app/lib/api/sandbox_functions/staging_integrity";
 import {
-  splitStagingStdout,
   stagingHashCaptureLines,
   verifyStagingContent,
 } from "@app/lib/api/sandbox_functions/staging_integrity";
@@ -26,68 +32,34 @@ import type { Authenticator } from "@app/lib/auth";
 import { distributedLock, distributedUnlock } from "@app/lib/lock";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { z } from "zod";
 
-import type { DbErrorKind } from "../../../../cli/dust-sandbox/functions-runner/types/db";
+export type { LiveDatabaseEntry, ReconcileDatabaseResult };
 
-const DSBX_BIN_PATH = "/opt/bin/dsbx";
-const DB_EXEC_TIMEOUT_MS = 60 * 1000;
+/**
+ * Pod-level `dsbx db` entry points: ensure the pod sandbox is ready, then run the sandbox-level
+ * command from `dsbx_db_on_sandbox.ts`. Everything model-facing (the db_* tools, publish) goes
+ * through here so a cold pod is brought up transparently.
+ */
 
-// The two error envelopes a dsbx db command can print: the runner's typed `{ok:false}`
-// (DbCommandError in cli/dust-sandbox/functions-runner/db/common.ts) and dsbx's own bare
-// `{error}` (emit_error in cli/dust-sandbox/src/commands/function/mod.rs).
-const dbErrorEnvelopeSchema = z.union([
-  z.object({
-    ok: z.literal(false),
-    error: z.object({ kind: z.string(), message: z.string() }),
-  }),
-  z.object({ error: z.string() }),
-]);
-
-// Runner error kinds the model can fix itself (bad schema, destructive/disallowed DDL, bad SQL,
-// unknown database). Typed by the runner's kind union so a renamed kind fails this typecheck.
-const MODEL_CORRECTABLE_DB_KINDS: ReadonlySet<string> = new Set<DbErrorKind>([
-  "schema_unresolvable",
-  "schema_invalid",
-  "destructive_change",
-  "disallowed_statement",
-  "database_not_found",
-  "query_failed",
-  "empty_sql",
-]);
-
-// `dsbxErrorCode` is the code for dsbx's bare `{error}` envelope: reconcile_blocked where the
-// model supplies the inputs dsbx validates (reconcile takes a model-supplied schema path);
-// internal for list/schema/query, which pre-validate the db name at the tool boundary so only
-// infra failures reach here.
-function dbErrorToSandboxFunctionError(
-  database: string | null,
-  envelope: z.infer<typeof dbErrorEnvelopeSchema>,
-  dsbxErrorCode: SandboxFunctionErrorCode
-): SandboxFunctionError {
-  const prefix = database === null ? "" : `Database "${database}": `;
-  if ("ok" in envelope) {
-    const { kind, message } = envelope.error;
-    // A destructive refusal often just means the schema file lags the live database (a prior
-    // publish applied wider DDL), so it looks like it drops columns it never declared.
-    const driftHint =
-      kind === "destructive_change"
-        ? " If you did not remove anything, the schema file may be behind the live database: " +
-          "declare the missing tables and columns and republish."
-        : "";
-    return new SandboxFunctionError(
-      MODEL_CORRECTABLE_DB_KINDS.has(kind)
-        ? "reconcile_blocked"
-        : "reconcile_failed",
-      `${prefix}${message}${driftHint}`
+/** Ensure the pod sandbox is ready and return it, mapping failure to sandbox_unavailable. */
+async function ensureSandboxForDb(
+  auth: Authenticator,
+  space: SpaceResource
+): Promise<Result<SandboxResource, SandboxFunctionError>> {
+  const ensureResult = await ensurePodSandboxReady(auth, space);
+  if (ensureResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError(
+        "sandbox_unavailable",
+        ensureResult.error.message
+      )
     );
   }
-  return new SandboxFunctionError(dsbxErrorCode, `${prefix}${envelope.error}`);
+  return new Ok(ensureResult.value.sandbox);
 }
 
 // Ensure the pod sandbox is up, run a `dsbx db` command as agent-proxied, and parse its one-line
@@ -95,14 +67,7 @@ function dbErrorToSandboxFunctionError(
 async function execDbCommand<S extends z.ZodTypeAny>(
   auth: Authenticator,
   space: SpaceResource,
-  {
-    command,
-    schema,
-    what,
-    envVars,
-    stdin,
-    stagingCapture = false,
-  }: {
+  opts: {
     command: string;
     schema: S;
     what: string;
@@ -122,159 +87,17 @@ async function execDbCommand<S extends z.ZodTypeAny>(
     SandboxFunctionError
   >
 > {
-  const ensureResult = await ensurePodSandboxReady(auth, space);
-  if (ensureResult.isErr()) {
-    return new Err(
-      new SandboxFunctionError(
-        "sandbox_unavailable",
-        ensureResult.error.message
-      )
-    );
+  const sandboxResult = await ensureSandboxForDb(auth, space);
+  if (sandboxResult.isErr()) {
+    return sandboxResult;
   }
-  const { sandbox } = ensureResult.value;
+  const sandbox = sandboxResult.value;
 
-  const execResult = await sandbox.exec(auth, command, {
-    timeoutMs: DB_EXEC_TIMEOUT_MS,
-    envVars: { ...podDatabaseExecEnvVars(), ...envVars },
-    user: "agent-proxied",
-    stdin,
-  });
-  if (execResult.isErr()) {
-    return new Err(
-      new SandboxFunctionError("internal", execResult.error.message)
-    );
-  }
-
-  // Split only when this exec appended capture lines. Splitting unconditionally would let code
-  // the command imports (e.g. the model-written schema file during reconcile) print a forged
-  // marker line and shadow the real envelope, which is otherwise always the last stdout line.
-  const { dsbxStdout, hashes } = stagingCapture
-    ? splitStagingStdout(execResult.value.stdout)
-    : { dsbxStdout: execResult.value.stdout, hashes: {} };
-  const envelope = parseDbEnvelope(dsbxStdout, schema, what);
-  if (envelope.isErr()) {
-    return envelope;
-  }
-  return new Ok({
-    sandbox,
-    envelope: envelope.value,
-    stagingHashes: hashes,
-    execStderr: execResult.value.stderr,
-  });
-}
-
-// Success mirrors the reconcile result in cli/dust-sandbox/functions-runner/db/reconcile.ts.
-const reconcileEnvelopeSchema = z.union([
-  z.object({
-    ok: z.literal(true),
-    created: z.boolean(),
-    statements: z.array(z.string()),
-  }),
-  dbErrorEnvelopeSchema,
-]);
-
-export interface ReconcileDatabaseResult {
-  /**
-   * The on-disk database name that was reconciled: the app-relative name qualified with the app
-   * prefix (see resolvePodDatabaseName). Reported back because it is what `db_list`, `db_query` and
-   * `db_schema` address the database by, and it is not what the caller passed in.
-   */
-  database: string;
-  created: boolean;
-  statements: string[];
-  /**
-   * Set when the database was created but its first replication sync could not be confirmed: the
-   * DDL did apply, but until replication catches up an unclean sandbox end could lose the file.
-   */
-  replicationWarning?: string;
-}
-
-/**
- * `dsbx db reconcile <name> <schema-file>`: plan the DDL for the database's drizzle schema file,
- * apply it when strictly additive, refuse anything destructive. Runs as `agent-proxied` (the
- * schema file is model-written code that gets imported).
- *
- * Lock-free inner reconcile: `database` must be the resolved on-disk name and callers must
- * serialize concurrent reconciles of one pod themselves (see `reconcileDatabaseFromPodPath`,
- * which holds the per-pod lock and resolves the name inside it).
- */
-export async function reconcileDatabaseOnSandbox(
-  auth: Authenticator,
-  {
-    space,
-    database,
-    schemaFileSandboxPath,
-  }: {
-    space: SpaceResource;
-    database: string;
-    schemaFileSandboxPath: string;
-  }
-): Promise<Result<ReconcileDatabaseResult, SandboxFunctionError>> {
-  const result = await execDbCommand(auth, space, {
-    // `--` stops the model-influenced name and path from being read as flags.
-    command: `set -euo pipefail\n${DSBX_BIN_PATH} db reconcile -- ${shellEscape(database)} ${shellEscape(schemaFileSandboxPath)}`,
-    schema: reconcileEnvelopeSchema,
-    what: `dsbx db reconcile ${database}`,
-  });
+  const result = await execDbCommandOnSandbox(auth, sandbox, opts);
   if (result.isErr()) {
     return result;
   }
-  const { sandbox, envelope } = result.value;
-
-  if ("ok" in envelope && envelope.ok) {
-    if (envelope.statements.length > 0) {
-      logger.info(
-        {
-          workspaceId: auth.getNonNullableWorkspace().sId,
-          podId: space.sId,
-          database,
-          created: envelope.created,
-          statements: envelope.statements,
-        },
-        "Pod database reconciled: applied DDL"
-      );
-    }
-
-    // A freshly created database exists only on the sandbox disk until litestream's first sync:
-    // wait for that sync before reporting success, so "created" means durable. On failure the
-    // reconcile still succeeds (the DDL applied and reconcile is idempotent) but carries a
-    // warning; the pre-sleep sync remains the enforcement point that blocks the pause and pages.
-    let replicationWarning: string | undefined;
-    if (envelope.created) {
-      const syncResult = await syncPodDatabaseAfterCreate(
-        auth,
-        sandbox,
-        database
-      );
-      if (syncResult.isErr()) {
-        logger.error(
-          {
-            workspaceId: auth.getNonNullableWorkspace().sId,
-            podId: space.sId,
-            database,
-            err: syncResult.error,
-          },
-          "Pod database created but its first replication sync could not be confirmed"
-        );
-        replicationWarning =
-          `The database was created and its schema applied, but its first replication sync ` +
-          `could not be confirmed. If the sandbox ends uncleanly before replication catches ` +
-          `up, the database may disappear and need another reconcile.`;
-      }
-    }
-
-    return new Ok({
-      database,
-      created: envelope.created,
-      statements: envelope.statements,
-      ...(replicationWarning !== undefined ? { replicationWarning } : {}),
-    });
-  }
-
-  // A bare `{error}` here is a bad database name or missing schema file, both model-supplied.
-  return new Err(
-    dbErrorToSandboxFunctionError(database, envelope, "reconcile_blocked")
-  );
+  return new Ok({ sandbox, ...result.value });
 }
 
 const RECONCILE_LOCK_ACQUIRE_TIMEOUT_MS = 30_000;
@@ -350,13 +173,20 @@ export async function reconcileDatabaseFromPodPath(
     );
   }
   try {
-    const existingResult = await listDatabasesOnSandbox(auth, { space });
+    const sandboxResult = await ensureSandboxForDb(auth, space);
+    if (sandboxResult.isErr()) {
+      return sandboxResult;
+    }
+    const sandbox = sandboxResult.value;
+
+    const existingResult = await listPodDatabases(auth, { sandbox });
     if (existingResult.isErr()) {
       return new Err(existingResult.error);
     }
 
     return await reconcileDatabaseOnSandbox(auth, {
-      space,
+      sandbox,
+      podId: space.sId,
       database: resolvePodDatabaseName({
         prefix,
         name: database,
@@ -369,43 +199,16 @@ export async function reconcileDatabaseFromPodPath(
   }
 }
 
-// Success mirrors the `dsbx db list` envelope in cli/dust-sandbox/src/commands/db/list.rs.
-const listEnvelopeSchema = z.union([
-  z.object({
-    ok: z.literal(true),
-    databases: z.array(z.object({ name: z.string(), size_bytes: z.number() })),
-  }),
-  dbErrorEnvelopeSchema,
-]);
-
-export interface LiveDatabaseEntry {
-  name: string;
-  sizeBytes: number;
-}
-
 /** `dsbx db list`: enumerate the live `{db}.db` files with their sizes (WAL included). */
 export async function listDatabasesOnSandbox(
   auth: Authenticator,
   { space }: { space: SpaceResource }
 ): Promise<Result<LiveDatabaseEntry[], SandboxFunctionError>> {
-  const result = await execDbCommand(auth, space, {
-    command: `${DSBX_BIN_PATH} db list`,
-    schema: listEnvelopeSchema,
-    what: "dsbx db list",
-  });
-  if (result.isErr()) {
-    return result;
+  const sandboxResult = await ensureSandboxForDb(auth, space);
+  if (sandboxResult.isErr()) {
+    return sandboxResult;
   }
-  const { envelope } = result.value;
-  if ("ok" in envelope && envelope.ok) {
-    return new Ok(
-      envelope.databases.map((db) => ({
-        name: db.name,
-        sizeBytes: db.size_bytes,
-      }))
-    );
-  }
-  return new Err(dbErrorToSandboxFunctionError(null, envelope, "internal"));
+  return listPodDatabases(auth, { sandbox: sandboxResult.value });
 }
 
 // `dsbx db schema` writes the regenerated file and prints only `{ok}`.
@@ -544,47 +347,4 @@ export async function queryDatabaseOnSandbox(
     });
   }
   return new Err(dbErrorToSandboxFunctionError(database, envelope, "internal"));
-}
-
-/**
- * Parse the one-line JSON envelope a dsbx command prints as its last non-empty stdout line
- * (sandbox stdout can carry shell noise and be truncated; big payloads go to files).
- */
-function parseDbEnvelope<S extends z.ZodTypeAny>(
-  stdout: string,
-  schema: S,
-  what: string
-): Result<z.infer<S>, SandboxFunctionError> {
-  const lastLine =
-    stdout
-      .split("\n")
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0)
-      .at(-1) ?? "";
-  if (lastLine.length === 0) {
-    return new Err(
-      new SandboxFunctionError("internal", `${what} produced no output.`)
-    );
-  }
-
-  let json: unknown;
-  try {
-    json = JSON.parse(lastLine);
-  } catch (err) {
-    return new Err(
-      new SandboxFunctionError(
-        "internal",
-        `Unparseable ${what} output: ${normalizeError(err).message}`
-      )
-    );
-  }
-
-  const parsed = schema.safeParse(json);
-  if (!parsed.success) {
-    return new Err(
-      new SandboxFunctionError("internal", `Unexpected ${what} output shape.`)
-    );
-  }
-
-  return new Ok(parsed.data);
 }

--- a/front/lib/api/sandbox_functions/dsbx_db_on_sandbox.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db_on_sandbox.ts
@@ -1,0 +1,341 @@
+import { podDatabaseExecEnvVars } from "@app/lib/api/files/mount_path";
+import { syncPodDatabaseAfterCreate } from "@app/lib/api/sandbox/db";
+import { shellEscape } from "@app/lib/api/sandbox/shell";
+import type { SandboxFunctionErrorCode } from "@app/lib/api/sandbox_functions/errors";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import type { StagingHashes } from "@app/lib/api/sandbox_functions/staging_integrity";
+import { splitStagingStdout } from "@app/lib/api/sandbox_functions/staging_integrity";
+import type { Authenticator } from "@app/lib/auth";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { z } from "zod";
+
+import type { DbErrorKind } from "../../../../cli/dust-sandbox/functions-runner/types/db";
+
+/**
+ * Sandbox-level `dsbx db` plumbing: run a db command against an ALREADY-READY sandbox and parse
+ * its envelope. The pod-level wrappers in `dsbx_db.ts` add `ensurePodSandboxReady` on top; this
+ * module must stay free of any lifecycle import so the cold-start path (which runs INSIDE
+ * sandbox bring-up, where re-entering `ensurePodSandboxReady` would be incorrect) can use it
+ * without an import cycle.
+ */
+
+export const DSBX_BIN_PATH = "/opt/bin/dsbx";
+const DB_EXEC_TIMEOUT_MS = 60 * 1000;
+
+// The two error envelopes a dsbx db command can print: the runner's typed `{ok:false}`
+// (DbCommandError in cli/dust-sandbox/functions-runner/db/common.ts) and dsbx's own bare
+// `{error}` (emit_error in cli/dust-sandbox/src/commands/function/mod.rs).
+export const dbErrorEnvelopeSchema = z.union([
+  z.object({
+    ok: z.literal(false),
+    error: z.object({ kind: z.string(), message: z.string() }),
+  }),
+  z.object({ error: z.string() }),
+]);
+
+// Runner error kinds the model can fix itself (bad schema, destructive/disallowed DDL, bad SQL,
+// unknown database). Typed by the runner's kind union so a renamed kind fails this typecheck.
+const MODEL_CORRECTABLE_DB_KINDS: ReadonlySet<string> = new Set<DbErrorKind>([
+  "schema_unresolvable",
+  "schema_invalid",
+  "destructive_change",
+  "disallowed_statement",
+  "database_not_found",
+  "query_failed",
+  "empty_sql",
+]);
+
+// `dsbxErrorCode` is the code for dsbx's bare `{error}` envelope: reconcile_blocked where the
+// model supplies the inputs dsbx validates (reconcile takes a model-supplied schema path);
+// internal for list/schema/query, which pre-validate the db name at the tool boundary so only
+// infra failures reach here.
+export function dbErrorToSandboxFunctionError(
+  database: string | null,
+  envelope: z.infer<typeof dbErrorEnvelopeSchema>,
+  dsbxErrorCode: SandboxFunctionErrorCode
+): SandboxFunctionError {
+  const prefix = database === null ? "" : `Database "${database}": `;
+  if ("ok" in envelope) {
+    const { kind, message } = envelope.error;
+    // A destructive refusal often just means the schema file lags the live database (a prior
+    // publish applied wider DDL), so it looks like it drops columns it never declared.
+    const driftHint =
+      kind === "destructive_change"
+        ? " If you did not remove anything, the schema file may be behind the live database: " +
+          "declare the missing tables and columns and republish."
+        : "";
+    return new SandboxFunctionError(
+      MODEL_CORRECTABLE_DB_KINDS.has(kind)
+        ? "reconcile_blocked"
+        : "reconcile_failed",
+      `${prefix}${message}${driftHint}`
+    );
+  }
+  return new SandboxFunctionError(dsbxErrorCode, `${prefix}${envelope.error}`);
+}
+
+/**
+ * Run a `dsbx db` command as agent-proxied on the given sandbox and parse its one-line JSON
+ * envelope. The sandbox must already be ready (mounts up, litestream daemon started for
+ * reconciles) — see `execDbCommand` in `dsbx_db.ts` for the readiness-ensuring wrapper.
+ */
+export async function execDbCommandOnSandbox<S extends z.ZodTypeAny>(
+  auth: Authenticator,
+  sandbox: SandboxResource,
+  {
+    command,
+    schema,
+    what,
+    envVars,
+    stdin,
+    stagingCapture = false,
+  }: {
+    command: string;
+    schema: S;
+    what: string;
+    envVars?: Record<string, string>;
+    stdin?: string;
+    // Set only when `command` appends stagingHashCaptureLines.
+    stagingCapture?: boolean;
+  }
+): Promise<
+  Result<
+    {
+      envelope: z.infer<S>;
+      stagingHashes: StagingHashes;
+      execStderr: string;
+    },
+    SandboxFunctionError
+  >
+> {
+  const execResult = await sandbox.exec(auth, command, {
+    timeoutMs: DB_EXEC_TIMEOUT_MS,
+    envVars: { ...podDatabaseExecEnvVars(), ...envVars },
+    user: "agent-proxied",
+    stdin,
+  });
+  if (execResult.isErr()) {
+    return new Err(
+      new SandboxFunctionError("internal", execResult.error.message)
+    );
+  }
+
+  // Split only when this exec appended capture lines. Splitting unconditionally would let code
+  // the command imports (e.g. the model-written schema file during reconcile) print a forged
+  // marker line and shadow the real envelope, which is otherwise always the last stdout line.
+  const { dsbxStdout, hashes } = stagingCapture
+    ? splitStagingStdout(execResult.value.stdout)
+    : { dsbxStdout: execResult.value.stdout, hashes: {} };
+  const envelope = parseDbEnvelope(dsbxStdout, schema, what);
+  if (envelope.isErr()) {
+    return envelope;
+  }
+  return new Ok({
+    envelope: envelope.value,
+    stagingHashes: hashes,
+    execStderr: execResult.value.stderr,
+  });
+}
+
+// Success mirrors the reconcile result in cli/dust-sandbox/functions-runner/db/reconcile.ts.
+const reconcileEnvelopeSchema = z.union([
+  z.object({
+    ok: z.literal(true),
+    created: z.boolean(),
+    statements: z.array(z.string()),
+  }),
+  dbErrorEnvelopeSchema,
+]);
+
+export interface ReconcileDatabaseResult {
+  /**
+   * The on-disk database name that was reconciled: the app-relative name qualified with the app
+   * prefix (see resolvePodDatabaseName). Reported back because it is what `db_list`, `db_query` and
+   * `db_schema` address the database by, and it is not what the caller passed in.
+   */
+  database: string;
+  created: boolean;
+  statements: string[];
+  /**
+   * Set when the database was created but its first replication sync could not be confirmed: the
+   * DDL did apply, but until replication catches up an unclean sandbox end could lose the file.
+   */
+  replicationWarning?: string;
+}
+
+/**
+ * `dsbx db reconcile <name> <schema-file>`: plan the DDL for the database's drizzle schema file,
+ * apply it when strictly additive, refuse anything destructive. Runs as `agent-proxied` (the
+ * schema file is model-written code that gets imported).
+ *
+ * Lock-free inner reconcile: `database` must be the resolved on-disk name and callers must
+ * serialize concurrent reconciles of one pod themselves (see `reconcileDatabaseFromPodPath`,
+ * which holds the per-pod lock and resolves the name inside it). The litestream daemon must be
+ * running, so the post-create sync can confirm the new file reached the replica.
+ */
+export async function reconcileDatabaseOnSandbox(
+  auth: Authenticator,
+  {
+    sandbox,
+    podId,
+    database,
+    schemaFileSandboxPath,
+  }: {
+    sandbox: SandboxResource;
+    podId: string;
+    database: string;
+    schemaFileSandboxPath: string;
+  }
+): Promise<Result<ReconcileDatabaseResult, SandboxFunctionError>> {
+  const result = await execDbCommandOnSandbox(auth, sandbox, {
+    // `--` stops the model-influenced name and path from being read as flags.
+    command: `set -euo pipefail\n${DSBX_BIN_PATH} db reconcile -- ${shellEscape(database)} ${shellEscape(schemaFileSandboxPath)}`,
+    schema: reconcileEnvelopeSchema,
+    what: `dsbx db reconcile ${database}`,
+  });
+  if (result.isErr()) {
+    return result;
+  }
+  const { envelope } = result.value;
+
+  if ("ok" in envelope && envelope.ok) {
+    if (envelope.statements.length > 0) {
+      logger.info(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          podId,
+          database,
+          created: envelope.created,
+          statements: envelope.statements,
+        },
+        "Pod database reconciled: applied DDL"
+      );
+    }
+
+    // A freshly created database exists only on the sandbox disk until litestream's first sync:
+    // wait for that sync before reporting success, so "created" means durable. On failure the
+    // reconcile still succeeds (the DDL applied and reconcile is idempotent) but carries a
+    // warning; the pre-sleep sync remains the enforcement point that blocks the pause and pages.
+    let replicationWarning: string | undefined;
+    if (envelope.created) {
+      const syncResult = await syncPodDatabaseAfterCreate(
+        auth,
+        sandbox,
+        database
+      );
+      if (syncResult.isErr()) {
+        logger.error(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            podId,
+            database,
+            err: syncResult.error,
+          },
+          "Pod database created but its first replication sync could not be confirmed"
+        );
+        replicationWarning =
+          `The database was created and its schema applied, but its first replication sync ` +
+          `could not be confirmed. If the sandbox ends uncleanly before replication catches ` +
+          `up, the database may disappear and need another reconcile.`;
+      }
+    }
+
+    return new Ok({
+      database,
+      created: envelope.created,
+      statements: envelope.statements,
+      ...(replicationWarning !== undefined ? { replicationWarning } : {}),
+    });
+  }
+
+  // A bare `{error}` here is a bad database name or missing schema file, both model-supplied.
+  return new Err(
+    dbErrorToSandboxFunctionError(database, envelope, "reconcile_blocked")
+  );
+}
+
+// Success mirrors the `dsbx db list` envelope in cli/dust-sandbox/src/commands/db/list.rs.
+const listEnvelopeSchema = z.union([
+  z.object({
+    ok: z.literal(true),
+    databases: z.array(z.object({ name: z.string(), size_bytes: z.number() })),
+  }),
+  dbErrorEnvelopeSchema,
+]);
+
+export interface LiveDatabaseEntry {
+  name: string;
+  sizeBytes: number;
+}
+
+/** `dsbx db list` on an already-ready sandbox: the live `{db}.db` files with their sizes. */
+export async function listPodDatabases(
+  auth: Authenticator,
+  { sandbox }: { sandbox: SandboxResource }
+): Promise<Result<LiveDatabaseEntry[], SandboxFunctionError>> {
+  const result = await execDbCommandOnSandbox(auth, sandbox, {
+    command: `${DSBX_BIN_PATH} db list`,
+    schema: listEnvelopeSchema,
+    what: "dsbx db list",
+  });
+  if (result.isErr()) {
+    return result;
+  }
+  const { envelope } = result.value;
+  if ("ok" in envelope && envelope.ok) {
+    return new Ok(
+      envelope.databases.map((db) => ({
+        name: db.name,
+        sizeBytes: db.size_bytes,
+      }))
+    );
+  }
+  return new Err(dbErrorToSandboxFunctionError(null, envelope, "internal"));
+}
+
+/**
+ * Parse the one-line JSON envelope a dsbx command prints as its last non-empty stdout line
+ * (sandbox stdout can carry shell noise and be truncated; big payloads go to files).
+ */
+function parseDbEnvelope<S extends z.ZodTypeAny>(
+  stdout: string,
+  schema: S,
+  what: string
+): Result<z.infer<S>, SandboxFunctionError> {
+  const lastLine =
+    stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .at(-1) ?? "";
+  if (lastLine.length === 0) {
+    return new Err(
+      new SandboxFunctionError("internal", `${what} produced no output.`)
+    );
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(lastLine);
+  } catch (err) {
+    return new Err(
+      new SandboxFunctionError(
+        "internal",
+        `Unparseable ${what} output: ${normalizeError(err).message}`
+      )
+    );
+  }
+
+  const parsed = schema.safeParse(json);
+  if (!parsed.success) {
+    return new Err(
+      new SandboxFunctionError("internal", `Unexpected ${what} output shape.`)
+    );
+  }
+
+  return new Ok(parsed.data);
+}

--- a/front/lib/api/sandbox_functions/pod_db_cold_start_recovery.test.ts
+++ b/front/lib/api/sandbox_functions/pod_db_cold_start_recovery.test.ts
@@ -1,0 +1,198 @@
+import {
+  planPodDatabaseRecovery,
+  recoverMissingPodDatabasesOnColdStart,
+} from "@app/lib/api/sandbox_functions/pod_db_cold_start_recovery";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { Ok } from "@app/types/shared/result";
+import { describe, expect, it, vi } from "vitest";
+
+const POD_ID = "vlt_test";
+const POD_ROOT = `/files/pod-${POD_ID}`;
+
+describe("planPodDatabaseRecovery", () => {
+  it("plans app-prefixed recreates for missing databases only", () => {
+    const findOutput = [
+      `${POD_ROOT}/MyApp/databases/chat.db.ts`,
+      `${POD_ROOT}/MyApp/databases/notes.db.ts`,
+      `${POD_ROOT}/OtherApp/databases/chat.db.ts`,
+    ].join("\n");
+
+    const plan = planPodDatabaseRecovery({
+      schemaFileFindOutput: findOutput,
+      podId: POD_ID,
+      // myapp__chat is live; the other two expected databases are not.
+      liveNames: ["myapp__chat"],
+    });
+
+    expect(plan).toEqual([
+      {
+        database: "myapp__notes",
+        schemaFileSandboxPath: `${POD_ROOT}/MyApp/databases/notes.db.ts`,
+      },
+      {
+        database: "otherapp__chat",
+        schemaFileSandboxPath: `${POD_ROOT}/OtherApp/databases/chat.db.ts`,
+      },
+    ]);
+  });
+
+  it("treats a legacy bare-named database as satisfying an app schema file", () => {
+    const plan = planPodDatabaseRecovery({
+      schemaFileFindOutput: `${POD_ROOT}/MyApp/databases/chat.db.ts`,
+      podId: POD_ID,
+      // Created before app namespacing: the bare file is the one db() opens.
+      liveNames: ["chat"],
+    });
+
+    expect(plan).toEqual([]);
+  });
+
+  it("drops entries that do not match the documented layout or name contract", () => {
+    const findOutput = [
+      // Wrong shape: not under an app's databases/ folder.
+      `${POD_ROOT}/databases/rootlevel.db.ts`,
+      `${POD_ROOT}/MyApp/functions/chat.db.ts`,
+      // Hostile or invalid database names.
+      `${POD_ROOT}/MyApp/databases/Invalid-Name.db.ts`,
+      `${POD_ROOT}/MyApp/databases/.hidden.db.ts`,
+      // Outside the pod root entirely.
+      `/files/pod-other/MyApp/databases/chat.db.ts`,
+      // Valid.
+      `${POD_ROOT}/MyApp/databases/chat.db.ts`,
+      "",
+      "  ",
+    ].join("\n");
+
+    const plan = planPodDatabaseRecovery({
+      schemaFileFindOutput: findOutput,
+      podId: POD_ID,
+      liveNames: [],
+    });
+
+    expect(plan).toEqual([
+      {
+        database: "myapp__chat",
+        schemaFileSandboxPath: `${POD_ROOT}/MyApp/databases/chat.db.ts`,
+      },
+    ]);
+  });
+});
+
+describe("recoverMissingPodDatabasesOnColdStart", () => {
+  async function setupSandbox() {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const sandbox = await SandboxResource.makeNew(authenticator, {
+      providerId: "test-provider-id",
+      status: "running",
+      baseImage: "dust-base",
+      version: "0.0.0-test",
+    });
+    return { authenticator, sandbox };
+  }
+
+  // Dispatch on the command: `dsbx db list`, the schema-file find, and `dsbx db reconcile`
+  // are the three execs the recovery path can run.
+  function mockRecoveryExecs(
+    sandbox: SandboxResource,
+    {
+      liveNames,
+      schemaFiles,
+    }: { liveNames: string[]; schemaFiles: string[] }
+  ) {
+    return vi
+      .spyOn(sandbox, "exec")
+      .mockImplementation(async (_auth, command) => {
+        if (command.includes("db list")) {
+          return new Ok({
+            exitCode: 0,
+            stdout: `${JSON.stringify({
+              ok: true,
+              databases: liveNames.map((name) => ({ name, size_bytes: 1 })),
+            })}\n`,
+            stderr: "",
+          });
+        }
+        if (command.startsWith("/usr/bin/find")) {
+          return new Ok({
+            exitCode: 0,
+            stdout: `${schemaFiles.join("\n")}\n`,
+            stderr: "",
+          });
+        }
+        if (command.includes("db reconcile")) {
+          return new Ok({
+            exitCode: 0,
+            stdout: `${JSON.stringify({ ok: true, created: true, statements: ["CREATE TABLE x (id integer)"] })}\n`,
+            stderr: "",
+          });
+        }
+        throw new Error(`Unexpected exec: ${command}`);
+      });
+  }
+
+  it("reconciles each missing database and syncs the recreated file", async () => {
+    const { authenticator, sandbox } = await setupSandbox();
+    const exec = mockRecoveryExecs(sandbox, {
+      liveNames: [],
+      schemaFiles: [`${POD_ROOT}/MyApp/databases/chat.db.ts`],
+    });
+    const execRoot = vi
+      .spyOn(sandbox, "execRoot")
+      .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" }));
+
+    await recoverMissingPodDatabasesOnColdStart(authenticator, {
+      sandbox,
+      podId: POD_ID,
+    });
+
+    const reconcileCall = exec.mock.calls.find(([, command]) =>
+      command.includes("db reconcile")
+    );
+    expect(reconcileCall).toBeDefined();
+    expect(reconcileCall?.[1]).toContain(
+      `db reconcile -- 'myapp__chat' '${POD_ROOT}/MyApp/databases/chat.db.ts'`
+    );
+    // The created database is synced to the replica (PR: sync-after-create).
+    const syncCall = execRoot.mock.calls.find(([, command]) =>
+      command.command.includes("litestream sync")
+    );
+    expect(syncCall).toBeDefined();
+    expect(syncCall?.[1].command).toContain(
+      "/pod-state/databases/myapp__chat.db"
+    );
+  });
+
+  it("does nothing when every expected database is live", async () => {
+    const { authenticator, sandbox } = await setupSandbox();
+    const exec = mockRecoveryExecs(sandbox, {
+      liveNames: ["myapp__chat"],
+      schemaFiles: [`${POD_ROOT}/MyApp/databases/chat.db.ts`],
+    });
+    const execRoot = vi.spyOn(sandbox, "execRoot");
+
+    await recoverMissingPodDatabasesOnColdStart(authenticator, {
+      sandbox,
+      podId: POD_ID,
+    });
+
+    expect(
+      exec.mock.calls.some(([, command]) => command.includes("db reconcile"))
+    ).toBe(false);
+    expect(execRoot).not.toHaveBeenCalled();
+  });
+
+  it("never fails the cold start when enumeration errors", async () => {
+    const { authenticator, sandbox } = await setupSandbox();
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({ exitCode: 1, stdout: "", stderr: "boom" })
+    );
+
+    await expect(
+      recoverMissingPodDatabasesOnColdStart(authenticator, {
+        sandbox,
+        podId: POD_ID,
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/front/lib/api/sandbox_functions/pod_db_cold_start_recovery.test.ts
+++ b/front/lib/api/sandbox_functions/pod_db_cold_start_recovery.test.ts
@@ -95,10 +95,7 @@ describe("recoverMissingPodDatabasesOnColdStart", () => {
   // are the three execs the recovery path can run.
   function mockRecoveryExecs(
     sandbox: SandboxResource,
-    {
-      liveNames,
-      schemaFiles,
-    }: { liveNames: string[]; schemaFiles: string[] }
+    { liveNames, schemaFiles }: { liveNames: string[]; schemaFiles: string[] }
   ) {
     return vi
       .spyOn(sandbox, "exec")

--- a/front/lib/api/sandbox_functions/pod_db_cold_start_recovery.ts
+++ b/front/lib/api/sandbox_functions/pod_db_cold_start_recovery.ts
@@ -124,8 +124,8 @@ export function planPodDatabaseRecovery({
 
 /**
  * Recreate expected-but-missing pod databases on a freshly cold-started sandbox. Best-effort by
- * contract (see the module doc): never throws, never returns a failure — a pod must come up even
- * when its recovery cannot run.
+ * contract (see the module doc): expected failures are logged and metered, never returned — a pod
+ * must come up even when its recovery cannot run.
  *
  * No per-pod reconcile lock is taken: the DDL is additive and idempotent, and a concurrent tool
  * reconcile either creates the database first (this one becomes a no-op) or briefly contends on

--- a/front/lib/api/sandbox_functions/pod_db_cold_start_recovery.ts
+++ b/front/lib/api/sandbox_functions/pod_db_cold_start_recovery.ts
@@ -1,0 +1,237 @@
+import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
+import { recordPodStateColdStartRecreate } from "@app/lib/api/sandbox/instrumentation";
+import { shellEscape } from "@app/lib/api/sandbox/shell";
+import {
+  podDatabasePrefixFromPodPath,
+  resolvePodDatabaseName,
+} from "@app/lib/api/sandbox_functions/db_naming";
+import {
+  listPodDatabases,
+  reconcileDatabaseOnSandbox,
+} from "@app/lib/api/sandbox_functions/dsbx_db_on_sandbox";
+import type { Authenticator } from "@app/lib/auth";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import logger from "@app/logger/logger";
+import { POD_DATABASE_NAME_REGEX } from "@app/types/api/sandbox_functions";
+
+/**
+ * Cold-start recovery of expected-but-missing pod databases.
+ *
+ * The authoritative description of a pod's databases is its schema files (`<App>/databases/
+ * {db}.db.ts`), which are GCS-durable pod files. The live SQLite files are only as durable as
+ * their litestream replica — a replica lost before its first sync makes the next cold start skip
+ * the database (see `restorePodDatabase`), and the sandbox then comes up "ready" with every
+ * function using that database failing until someone re-runs a reconcile by hand.
+ *
+ * This pass runs at the end of pod-state bring-up, strictly AFTER the restore and the litestream
+ * daemon start (so a recreated file replicates immediately): enumerate schema files under the pod
+ * mount, compute the on-disk name each one is expected to produce, and re-run the reconcile for
+ * any that is missing. Reconcile DDL is additive and idempotent, so the recreate is an EMPTY
+ * database with the right schema — service is restored, data is not; the logs and metric say so
+ * loudly.
+ *
+ * Everything here is best-effort by contract: a pod whose recovery fails must still come up
+ * (functions not using the lost database keep working), so failures are logged and metered, never
+ * propagated. This module is called from sandbox bring-up and must therefore never import the
+ * sandbox lifecycle (`ensurePodSandboxReady`) — it operates on the sandbox it is handed.
+ */
+
+const SCHEMA_FILE_SUFFIX = ".db.ts";
+const SCHEMA_FIND_TIMEOUT_MS = 15_000;
+// Bounds on cold-start work. Recovery normally reconciles nothing; these caps keep a hostile or
+// degenerate pod (thousands of schema files, every database missing) from stalling bring-up.
+const MAX_SCHEMA_FILES = 200;
+const MAX_RECREATED_DATABASES = 20;
+
+export interface PodDatabaseRecoveryPlanEntry {
+  /** The resolved on-disk database name expected to exist. */
+  database: string;
+  /** Absolute in-sandbox path of the schema file that declares it. */
+  schemaFileSandboxPath: string;
+}
+
+/** The pod files gcsfuse mount point inside the sandbox (mirrors dust_file_system.ts). */
+function podMountRoot(podId: string): string {
+  return `/files/${SCOPED_PREFIX_POD}${podId}`;
+}
+
+/**
+ * Decide which databases must be recreated, from raw `find` output over the pod mount and the
+ * live database names. Pure so the resolution rules are testable without a sandbox.
+ *
+ * The find output is workload-influenced (pod files are model/user-written), so every line is
+ * re-validated: exact `<App>/databases/{db}.db.ts` shape under the pod root, database-name
+ * contract, resolvable app prefix. Name resolution mirrors the reconcile path
+ * (`resolvePodDatabaseName`), so legacy bare-named databases still on disk satisfy an
+ * app-prefixed schema file instead of triggering a duplicate prefixed recreate.
+ */
+export function planPodDatabaseRecovery({
+  schemaFileFindOutput,
+  podId,
+  liveNames,
+}: {
+  schemaFileFindOutput: string;
+  podId: string;
+  liveNames: string[];
+}): PodDatabaseRecoveryPlanEntry[] {
+  const podRoot = `${podMountRoot(podId)}/`;
+  const live = new Set(liveNames);
+  const planned = new Map<string, PodDatabaseRecoveryPlanEntry>();
+
+  const lines = schemaFileFindOutput
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .sort()
+    .slice(0, MAX_SCHEMA_FILES);
+
+  for (const line of lines) {
+    if (!line.startsWith(podRoot) || !line.endsWith(SCHEMA_FILE_SUFFIX)) {
+      continue;
+    }
+    const relPath = line.slice(podRoot.length);
+    const segments = relPath.split("/");
+    // Only the documented convention: <App>/databases/{db}.db.ts.
+    if (segments.length !== 3 || segments[1] !== "databases") {
+      continue;
+    }
+    const name = segments[2].slice(0, -SCHEMA_FILE_SUFFIX.length);
+    if (!POD_DATABASE_NAME_REGEX.test(name)) {
+      continue;
+    }
+
+    const prefixResult = podDatabasePrefixFromPodPath({
+      sourcePath: `${SCOPED_PREFIX_POD}${podId}/${relPath}`,
+      podId,
+    });
+    if (prefixResult.isErr()) {
+      continue;
+    }
+
+    const database = resolvePodDatabaseName({
+      prefix: prefixResult.value,
+      name,
+      existingNames: liveNames,
+    });
+    if (live.has(database) || planned.has(database)) {
+      continue;
+    }
+    planned.set(database, { database, schemaFileSandboxPath: line });
+  }
+
+  return [...planned.values()];
+}
+
+/**
+ * Recreate expected-but-missing pod databases on a freshly cold-started sandbox. Best-effort by
+ * contract (see the module doc): never throws, never returns a failure — a pod must come up even
+ * when its recovery cannot run.
+ *
+ * No per-pod reconcile lock is taken: the DDL is additive and idempotent, and a concurrent tool
+ * reconcile either creates the database first (this one becomes a no-op) or briefly contends on
+ * SQLite's busy timeout, in which case the loser is logged and the next cold start retries.
+ */
+export async function recoverMissingPodDatabasesOnColdStart(
+  auth: Authenticator,
+  { sandbox, podId }: { sandbox: SandboxResource; podId: string }
+): Promise<void> {
+  const startMs = performance.now();
+  const childLogger = logger.child({
+    sandboxId: sandbox.sId,
+    workspaceId: auth.getNonNullableWorkspace().sId,
+    podId,
+  });
+
+  const liveResult = await listPodDatabases(auth, { sandbox });
+  if (liveResult.isErr()) {
+    childLogger.error(
+      { err: liveResult.error },
+      "Pod DB cold-start recovery: listing live databases failed — skipping recovery"
+    );
+    return;
+  }
+  const liveNames = liveResult.value.map((entry) => entry.name);
+
+  // Enumerate schema files as agent-proxied (pod files are workload-readable; output is
+  // re-validated in planPodDatabaseRecovery). Depth is pinned to the documented
+  // <App>/databases/{db}.db.ts layout.
+  const findResult = await sandbox.exec(
+    auth,
+    `/usr/bin/find ${shellEscape(podMountRoot(podId))} -mindepth 3 -maxdepth 3 -type f -path ${shellEscape(`*/databases/*${SCHEMA_FILE_SUFFIX}`)}`,
+    { user: "agent-proxied", timeoutMs: SCHEMA_FIND_TIMEOUT_MS }
+  );
+  if (findResult.isErr() || findResult.value.exitCode !== 0) {
+    childLogger.error(
+      {
+        err: findResult.isErr() ? findResult.error : undefined,
+        stderr: findResult.isOk() ? findResult.value.stderr : undefined,
+      },
+      "Pod DB cold-start recovery: schema file enumeration failed — skipping recovery"
+    );
+    return;
+  }
+
+  const plan = planPodDatabaseRecovery({
+    schemaFileFindOutput: findResult.value.stdout,
+    podId,
+    liveNames,
+  });
+  if (plan.length === 0) {
+    childLogger.info(
+      { durationMs: Math.round(performance.now() - startMs) },
+      "Pod DB cold-start recovery: all expected databases present"
+    );
+    return;
+  }
+
+  const bounded = plan.slice(0, MAX_RECREATED_DATABASES);
+  if (bounded.length < plan.length) {
+    childLogger.error(
+      { planned: plan.length, cap: MAX_RECREATED_DATABASES },
+      "Pod DB cold-start recovery: more missing databases than the per-cold-start cap — the rest will be retried on the next cold start"
+    );
+  }
+
+  let recreated = 0;
+  for (const entry of bounded) {
+    const entryStartMs = performance.now();
+    const result = await reconcileDatabaseOnSandbox(auth, {
+      sandbox,
+      podId,
+      database: entry.database,
+      schemaFileSandboxPath: entry.schemaFileSandboxPath,
+    });
+    if (result.isErr()) {
+      childLogger.error(
+        {
+          database: entry.database,
+          schemaFileSandboxPath: entry.schemaFileSandboxPath,
+          err: result.error,
+        },
+        "Pod DB cold-start recovery: recreate failed — functions using this database will fail until a manual reconcile"
+      );
+      continue;
+    }
+    recreated += 1;
+    recordPodStateColdStartRecreate();
+    // error level on purpose: a recreate means the pod lost this database's data.
+    childLogger.error(
+      {
+        database: entry.database,
+        schemaFileSandboxPath: entry.schemaFileSandboxPath,
+        replicationWarning: result.value.replicationWarning,
+        durationMs: Math.round(performance.now() - entryStartMs),
+      },
+      "Pod DB cold-start recovery: expected database was missing — recreated EMPTY from its schema file; previously stored data was NOT recovered"
+    );
+  }
+
+  childLogger.info(
+    {
+      recreated,
+      planned: plan.length,
+      durationMs: Math.round(performance.now() - startMs),
+    },
+    "Pod DB cold-start recovery: done"
+  );
+}


### PR DESCRIPTION
## Description

Stacked on #30335.

When a database's replica is lost (unclean sandbox end before its first sync), cold start restores nothing and the sandbox comes up "ready" with every function using that database throwing "database does not exist" until someone re-runs a reconcile by hand.

The pod's schema files (`<App>/databases/{db}.db.ts`) are GCS-durable, so cold start can recover on its own. After restore + litestream daemon start:

- enumerate schema files under the pod mount (depth-pinned to the documented layout, output re-validated since pod files are workload-written)
- resolve the on-disk name each file expects, with the same rules as the reconcile path (legacy bare-named databases still satisfy an app-prefixed schema file)
- re-run the reconcile for any expected-but-missing database

The recreate is an empty database with the right schema: service is restored, data is not, and the logs (error level) plus a new `sandbox.pod_state.cold_start_recreate` metric say so loudly. The whole pass is best-effort and bounded (200 schema files considered, 20 recreates per cold start, per-exec timeouts, timings logged), so it can never block or stall sandbox bring-up.

Mechanically, the sandbox-level `dsbx db` plumbing moves to a new `dsbx_db_on_sandbox.ts` module with no lifecycle import, so the cold-start path (which runs inside sandbox bring-up) can reconcile without re-entering `ensurePodSandboxReady` and without an import cycle. `dsbx_db.ts` keeps the readiness-ensuring entry points with unchanged signatures, so the db_* tools and the poke route are untouched.

## Tests

Added unit tests for the recovery planner (prefix resolution, legacy bare names, hostile/malformed find output) and functional tests for the recovery pass with mocked sandbox execs (reconcile issued for missing databases, skipped when live, enumeration failure never fails bring-up). Ran the touched front vitest files locally.

## Risk

Low. The pass runs only on pod cold starts, is bounded, and swallows its own failures by contract. A recreate only happens for a database that is already broken (schema file present, no live file), where today's behavior is guaranteed function failures.

## Deploy Plan

Merge after #30335. Standard deploy.