### PR TITLE
Even when feature flag is off, allow to use auto models

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -166,6 +166,7 @@ import {
   isUserMention,
   toMentionType,
 } from "@app/types/assistant/mentions";
+import { isModelStreamId } from "@app/types/assistant/models/auto";
 import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import type {
   ContentFragmentContextType,
@@ -781,12 +782,15 @@ export async function postUserMessage(
     const supportedModelConfig = getSupportedModelConfig(agentConfig.model);
     if (
       !supportedModelConfig ||
-      !isModelAvailable(supportedModelConfig, {
-        featureFlags,
-        plan,
-        regionalModelsOnly: owner.regionalModelsOnly,
-        region: regionConfig.getCurrentRegion(),
-      })
+      !(
+        isModelStreamId(supportedModelConfig.modelId) ||
+        isModelAvailable(supportedModelConfig, {
+          featureFlags,
+          plan,
+          regionalModelsOnly: owner.regionalModelsOnly,
+          region: regionConfig.getCurrentRegion(),
+        })
+      )
     ) {
       return new Err({
         status_code: 400,

--- a/front/lib/api/assistant/models.test.ts
+++ b/front/lib/api/assistant/models.test.ts
@@ -325,11 +325,11 @@ describe("resolveModel", () => {
     });
   });
 
-  it("falls back to a preferred large model when the agent is on auto without models_picker", async () => {
+  it("resolves an auto agent through the stream even without models_picker", async () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const getAutoModelSpy = vi.spyOn(enabledModels, "getAutoModelForAuth");
+    const getModelForStreamSpy = vi.spyOn(enabledModels, "getModelForStream");
 
     const { resolvedModel, modelResolutionMethod } = await resolveModel(auth, {
       configuration: makeAgentConfiguration({
@@ -339,13 +339,13 @@ describe("resolveModel", () => {
       featureFlags: [],
     });
 
-    expect(getAutoModelSpy).not.toHaveBeenCalled();
-    expect(modelResolutionMethod).toBe("agent");
+    expect(getModelForStreamSpy).toHaveBeenCalledWith(auth, AUTO_MODEL_ID);
+    expect(modelResolutionMethod).toBe("auto");
+    expect(resolvedModel.modelId).not.toBe(AUTO_MODEL_ID);
     expect(resolvedModel).toEqual({
-      providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
-      modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
-      reasoningEffort:
-        CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort,
+      providerId: GPT_5_6_LUNA_MODEL_CONFIG.providerId,
+      modelId: GPT_5_6_LUNA_MODEL_CONFIG.modelId,
+      reasoningEffort: "high",
     });
   });
 });

--- a/front/lib/api/assistant/resolve_model.ts
+++ b/front/lib/api/assistant/resolve_model.ts
@@ -67,13 +67,22 @@ export async function resolveModel(
       m.modelId === configuration.model.modelId
   );
 
-  let enabled = selectEnabledModel(
-    auth,
-    removeNulls([userConfig, agentConfig, ...PREFERRED_LARGE_MODEL_CONFIGS]),
-    {
-      featureFlags,
-    }
-  );
+  const requestedConfig = userConfig ?? agentConfig;
+
+  let enabled =
+    requestedConfig && isModelStreamId(requestedConfig.modelId)
+      ? requestedConfig
+      : selectEnabledModel(
+          auth,
+          removeNulls([
+            userConfig,
+            agentConfig,
+            ...PREFERRED_LARGE_MODEL_CONFIGS,
+          ]),
+          {
+            featureFlags,
+          }
+        );
 
   // Effort chosen by a stream tier (Fast/Standard/Complex) for its resolved
   // model. When set, it takes precedence over any effort carried by the


### PR DESCRIPTION
## Description

Teaches the message pipeline to treat "auto" stream tiers (Fast / Standard / Complex) as
first-class model selections. These tiers are virtual selectors rather than concrete supported
models, so the usual availability checks don't apply to them.

- `postUserMessage` (`conversation.ts`): a config whose `modelId` is a stream tier id now passes
  validation without going through `isModelAvailable`. Concrete models still follow the existing
  availability logic.
- `resolveModel` (`resolve_model.ts`): when the requested config (user override, else agent) is a
  stream tier id, we use it directly and skip `selectEnabledModel`; otherwise resolution is
  unchanged.

Part of the ongoing model picker tiers work.

## Tests

<!-- No specific tests to run. -->

## Risk

Low. Both changes are gated behind `isModelStreamId`, which only matches the new virtual stream
tier ids. Existing concrete-model paths keep their current validation and resolution behavior.

## Deploy Plan

<!-- Nothing specific. -->
