### PR TITLE
[dsbx] feat: spill oversized function results to a file with a 5MB hard cap

### DIFF
--- a/cli/dust-sandbox/functions-runner/emit.test.ts
+++ b/cli/dust-sandbox/functions-runner/emit.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import {
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  applyResultSpillPolicy,
+  RESULT_HARD_CAP_BYTES,
+  RESULT_INLINE_CAP_BYTES,
+} from "./emit.ts";
+import type { Output } from "./protocol.ts";
+
+function outputOfSerializedBytes(targetBytes: number): Output {
+  // {"ok":true,"output":{"big":"…"}} — pad `big` so the serialized envelope
+  // lands exactly on targetBytes.
+  const overhead = JSON.stringify({ ok: true, output: { big: "" } }).length;
+  return { ok: true, output: { big: "x".repeat(targetBytes - overhead) } };
+}
+
+function scratchDir(): string {
+  return mkdtempSync(join(tmpdir(), "dsbx-emit-test-"));
+}
+
+describe("applyResultSpillPolicy", () => {
+  test("returns the outcome unchanged at the inline cap", () => {
+    const out = outputOfSerializedBytes(RESULT_INLINE_CAP_BYTES);
+    const dir = scratchDir();
+    try {
+      expect(applyResultSpillPolicy(out, dir)).toBe(out);
+      expect(readdirSync(dir)).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("spills one byte over the inline cap and points at the file", () => {
+    const out = outputOfSerializedBytes(RESULT_INLINE_CAP_BYTES + 1);
+    const dir = scratchDir();
+    try {
+      const delivered = applyResultSpillPolicy(out, dir);
+      if (!("resultFile" in delivered)) {
+        throw new Error(`expected a pointer, got ${JSON.stringify(delivered)}`);
+      }
+      expect(delivered.ok).toBe(true);
+      expect(delivered.resultBytes).toBe(RESULT_INLINE_CAP_BYTES + 1);
+      expect(delivered.resultFile.startsWith(dir)).toBe(true);
+      expect(readFileSync(delivered.resultFile, "utf8")).toBe(
+        JSON.stringify(out)
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("refuses a result over the hard cap with output_too_large", () => {
+    const out = outputOfSerializedBytes(RESULT_HARD_CAP_BYTES + 1);
+    const dir = scratchDir();
+    try {
+      const delivered = applyResultSpillPolicy(out, dir);
+      if (delivered.ok !== false) {
+        throw new Error("expected an error outcome");
+      }
+      expect(delivered.error.code).toBe("output_too_large");
+      expect(delivered.error.message).toContain(
+        `${RESULT_HARD_CAP_BYTES + 1} bytes`
+      );
+      expect(delivered.error.message).toContain("pod file");
+      // Nothing was written.
+      expect(readdirSync(dir)).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("falls back to inline emission when the spill write fails", () => {
+    const out = outputOfSerializedBytes(RESULT_INLINE_CAP_BYTES + 1);
+    const dir = scratchDir();
+    try {
+      // A spill dir that cannot be created: a path under an existing file.
+      const occupied = join(dir, "not-a-dir");
+      writeFileSync(occupied, "occupied");
+      const delivered = applyResultSpillPolicy(out, join(occupied, "sub"));
+      expect(delivered).toBe(out);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("spills large error outcomes too", () => {
+    const message = "x".repeat(RESULT_INLINE_CAP_BYTES + 1);
+    const out: Output = {
+      ok: false,
+      error: { code: "threw", message },
+    };
+    const dir = scratchDir();
+    try {
+      const delivered = applyResultSpillPolicy(out, dir);
+      if (!("resultFile" in delivered)) {
+        throw new Error("expected a pointer");
+      }
+      expect(JSON.parse(readFileSync(delivered.resultFile, "utf8"))).toEqual(
+        out
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/dust-sandbox/functions-runner/emit.ts
+++ b/cli/dust-sandbox/functions-runner/emit.ts
@@ -15,7 +15,10 @@
 // The warm server (serve.ts) replies over a unix socket and has its own
 // drain-safe path (writeThenEnd/drainPending).
 
-import { writeSync } from "node:fs";
+import { mkdirSync, writeFileSync, writeSync } from "node:fs";
+import { join } from "node:path";
+
+import type { Output } from "./protocol.ts";
 
 function isRetryableWriteError(error: unknown): boolean {
   return (
@@ -24,6 +27,69 @@ function isRetryableWriteError(error: unknown): boolean {
     "code" in error &&
     (error.code === "EAGAIN" || error.code === "EINTR")
   );
+}
+
+// Size policy for run results, cold and warm alike. A result over the inline
+// cap is written to a sandbox-local scratch file and replaced by a pointer:
+// even drain-safe, a multi-megabyte stdout line is a payload the whole
+// delivery chain (exec capture, HTTP callback, event stream) has to carry
+// inline, so past the cap the file is the transport and stdout only names it.
+// Past the hard cap the result is refused outright with an actionable error.
+export const RESULT_INLINE_CAP_BYTES = 256 * 1024;
+export const RESULT_HARD_CAP_BYTES = 5 * 1024 * 1024;
+
+// Mirrors SANDBOX_FUNCTION_RESULT_SPILL_DIR in
+// front/lib/api/sandbox_functions/result_envelope.ts: front refuses to read a
+// pointer outside this directory, so the two must move together.
+export const RESULT_SPILL_DIR = "/tmp/dust-fn-results";
+
+export interface ResultSpillPointer {
+  ok: true;
+  resultFile: string;
+  resultBytes: number;
+}
+
+export type DeliverableOutput = Output | ResultSpillPointer;
+
+/**
+ * Apply the size policy to a run outcome: inline under the cap, spill file +
+ * pointer over it, output_too_large over the hard cap. `spillDir` is
+ * overridable by tests only.
+ */
+export function applyResultSpillPolicy(
+  out: Output,
+  spillDir: string = RESULT_SPILL_DIR
+): DeliverableOutput {
+  const serialized = JSON.stringify(out);
+  const resultBytes = Buffer.byteLength(serialized, "utf8");
+  if (resultBytes <= RESULT_INLINE_CAP_BYTES) {
+    return out;
+  }
+  if (resultBytes > RESULT_HARD_CAP_BYTES) {
+    return {
+      ok: false,
+      error: {
+        code: "output_too_large",
+        message:
+          `function result is ${resultBytes} bytes, over the ` +
+          `${RESULT_HARD_CAP_BYTES}-byte limit; store large data in a pod ` +
+          `file or database and return a pointer to it`,
+      },
+    };
+  }
+  try {
+    mkdirSync(spillDir, { recursive: true });
+    const resultFile = join(spillDir, `${crypto.randomUUID()}.json`);
+    writeFileSync(resultFile, serialized);
+    return { ok: true, resultFile, resultBytes };
+  } catch {
+    // A failed spill write (disk pressure, unwritable dir) must not lose the
+    // result: fall back to inline emission, which the drain-safe stdout
+    // writer (cold) and the backpressure-aware socket path (warm) both
+    // deliver whole regardless of size. The caps are transport hygiene, not
+    // correctness.
+    return out;
+  }
 }
 
 /** Serialize `envelope` and write it to stdout as one line, synchronously. */

--- a/cli/dust-sandbox/functions-runner/fixtures/big-output.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/big-output.ts
@@ -1,7 +1,10 @@
-// Returns a payload far larger than any kernel pipe buffer, so an exit that
-// drops queued stdout writes truncates the result envelope mid-JSON.
+// Returns a payload of `size` bytes (default 2MB), far larger than any kernel
+// pipe buffer: exercises drain-safe emission below the inline cap, the spill
+// pointer above it, and the hard-cap refusal above that.
 export default {
-  async fetch(): Promise<Response> {
-    return Response.json({ big: "x".repeat(2 * 1024 * 1024) });
+  async fetch(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+    const size = Number(url.searchParams.get("size") ?? 2 * 1024 * 1024);
+    return Response.json({ big: "x".repeat(size) });
   },
 };

--- a/cli/dust-sandbox/functions-runner/runner.test.ts
+++ b/cli/dust-sandbox/functions-runner/runner.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
 const runner = join(import.meta.dir, "runner.ts");
@@ -39,10 +40,21 @@ describe("runner run", () => {
     expect(JSON.parse(stdout).output.mode).toBe(0o660);
   });
 
-  test("delivers a 2MB result envelope intact", async () => {
-    // Regression: process.exit does not drain queued async stdout writes, so a
-    // large envelope written with process.stdout.write was cut mid-JSON. The
-    // envelope must reach the reader whole, whatever its size.
+  test("delivers an inline envelope larger than the pipe buffer intact", async () => {
+    // Regression: process.exit does not drain queued async stdout writes, so
+    // an envelope bigger than the kernel pipe buffer (64KB) but under the
+    // inline cap was cut mid-JSON. It must reach the reader whole.
+    const { stdout, code } = await run(
+      ["run", fx("big-output.ts")],
+      JSON.stringify({ url: "http://localhost/?size=200000" })
+    );
+    expect(code).toBe(0);
+    const out = JSON.parse(stdout);
+    expect(out.ok).toBe(true);
+    expect(out.output.big.length).toBe(200_000);
+  });
+
+  test("spills a 2MB result to a file and emits a pointer envelope", async () => {
     const { stdout, code } = await run(
       ["run", fx("big-output.ts")],
       JSON.stringify({ url: "http://localhost/" })
@@ -50,7 +62,25 @@ describe("runner run", () => {
     expect(code).toBe(0);
     const out = JSON.parse(stdout);
     expect(out.ok).toBe(true);
-    expect(out.output.big.length).toBe(2 * 1024 * 1024);
+    expect(out.resultFile).toStartWith("/tmp/dust-fn-results/");
+    const spilled = readFileSync(out.resultFile, "utf8");
+    rmSync(out.resultFile, { force: true });
+    expect(out.resultBytes).toBe(Buffer.byteLength(spilled, "utf8"));
+    const envelope = JSON.parse(spilled);
+    expect(envelope.ok).toBe(true);
+    expect(envelope.output.big.length).toBe(2 * 1024 * 1024);
+  });
+
+  test("refuses a result over the hard cap with output_too_large", async () => {
+    const { stdout, code } = await run(
+      ["run", fx("big-output.ts")],
+      JSON.stringify({ url: `http://localhost/?size=${6 * 1024 * 1024}` })
+    );
+    expect(code).toBe(1);
+    const out = JSON.parse(stdout);
+    expect(out.ok).toBe(false);
+    expect(out.error.code).toBe("output_too_large");
+    expect(out.error.message).toContain("bytes");
   });
 
   test("exits 1 with ok:false when handler throws", async () => {

--- a/cli/dust-sandbox/functions-runner/runner.ts
+++ b/cli/dust-sandbox/functions-runner/runner.ts
@@ -16,7 +16,7 @@ import { errorEnvelope, podDatabaseMaxSizeBytes } from "./db/common.ts";
 import { runQuery } from "./db/query.ts";
 import { reconcile } from "./db/reconcile.ts";
 import { generateSchemaFileText } from "./db/schema.ts";
-import { emitEnvelopeLine } from "./emit.ts";
+import { applyResultSpillPolicy, emitEnvelopeLine } from "./emit.ts";
 import { invoke } from "./invoke.ts";
 import { BadInputError, parseInput, type RequestInput } from "./protocol.ts";
 import { getFunctionSchema } from "./schema.ts";
@@ -46,8 +46,11 @@ async function runHandler(handlerPath: string): Promise<number> {
     return 2;
   }
   const out = await invoke(handlerPath, input);
-  emitEnvelopeLine(out);
-  return out.ok ? 0 : 1;
+  // An oversized result is spilled to a scratch file and replaced by a
+  // pointer envelope; over the hard cap it becomes an output_too_large error.
+  const delivered = applyResultSpillPolicy(out);
+  emitEnvelopeLine(delivered);
+  return delivered.ok ? 0 : 1;
 }
 
 async function getHandler(handlerPath: string): Promise<number> {

--- a/cli/dust-sandbox/functions-runner/serve.test.ts
+++ b/cli/dust-sandbox/functions-runner/serve.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { copyFileSync, mkdtempSync, rmSync, utimesSync } from "node:fs";
+import {
+  copyFileSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -70,6 +76,9 @@ interface WarmReply {
     ok: boolean;
     output?: unknown;
     error?: { code: string };
+    // Present when the result was spilled to a scratch file (see emit.ts).
+    resultFile?: string;
+    resultBytes?: number;
   };
   importKind?: string;
   stale?: boolean;
@@ -160,6 +169,37 @@ describe("runner serve", () => {
       expect(reply.v).toBe(WARM_PROTOCOL_VERSION);
       expect(reply.outcome?.ok).toBe(true);
       expect(reply.outcome?.output).toEqual({ hello: "warm" });
+    } finally {
+      proc.kill();
+    }
+  });
+
+  test("spills an oversized warm result and replies with a pointer", async () => {
+    // Same size policy as the cold runner: a result over the inline cap is
+    // written to the scratch dir and the reply frame carries the pointer.
+    const { proc, socketPath } = await startWorker(fixturesDir);
+    try {
+      const reply = await request(
+        socketPath,
+        warmRequest("big-output", {}, { url: "http://localhost/" })
+      );
+      expect(reply.outcome?.ok).toBe(true);
+      const resultFile = reply.outcome?.resultFile;
+      expect(resultFile).toStartWith("/tmp/dust-fn-results/");
+      if (resultFile === undefined) {
+        throw new Error("expected a spill pointer");
+      }
+      const spilled = readFileSync(resultFile, "utf8");
+      rmSync(resultFile, { force: true });
+      expect(reply.outcome?.resultBytes).toBe(
+        Buffer.byteLength(spilled, "utf8")
+      );
+      const envelope = JSON.parse(spilled) as {
+        ok: boolean;
+        output: { big: string };
+      };
+      expect(envelope.ok).toBe(true);
+      expect(envelope.output.big.length).toBe(2 * 1024 * 1024);
     } finally {
       proc.kill();
     }

--- a/cli/dust-sandbox/functions-runner/serve.test.ts
+++ b/cli/dust-sandbox/functions-runner/serve.test.ts
@@ -9,6 +9,8 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { z } from "zod";
+
 import {
   MAX_CONCURRENT_INVOCATIONS,
   parseWarmRequest,
@@ -194,11 +196,9 @@ describe("runner serve", () => {
       expect(reply.outcome?.resultBytes).toBe(
         Buffer.byteLength(spilled, "utf8")
       );
-      const envelope = JSON.parse(spilled) as {
-        ok: boolean;
-        output: { big: string };
-      };
-      expect(envelope.ok).toBe(true);
+      const envelope = z
+        .object({ ok: z.literal(true), output: z.object({ big: z.string() }) })
+        .parse(JSON.parse(spilled));
       expect(envelope.output.big.length).toBe(2 * 1024 * 1024);
     } finally {
       proc.kill();

--- a/cli/dust-sandbox/functions-runner/serve.ts
+++ b/cli/dust-sandbox/functions-runner/serve.ts
@@ -50,6 +50,7 @@ import { join } from "node:path";
 
 import { z } from "zod";
 
+import { applyResultSpillPolicy } from "./emit.ts";
 import { invoke } from "./invoke.ts";
 import type { RequestInput } from "./protocol.ts";
 import { BadInputError, parseInput } from "./protocol.ts";
@@ -685,11 +686,17 @@ export async function serve(
 
     try {
       const outcome = await invoke(bundle.handlerPath, input, request.env);
+      // Same size policy as the cold runner: one set of numbers everywhere.
+      const delivered = applyResultSpillPolicy(outcome);
       if (deadlineFired) {
         // The client is long gone; nothing useful to write.
         socket.end();
       } else {
-        reply(socket, { v: WARM_PROTOCOL_VERSION, outcome, importKind });
+        reply(socket, {
+          v: WARM_PROTOCOL_VERSION,
+          outcome: delivered,
+          importKind,
+        });
       }
     } finally {
       clearTimeout(deadlineTimer);


### PR DESCRIPTION
## Description

Write side of result spill-to-file, completing the large-output path:

- A run result whose serialized envelope exceeds `RESULT_INLINE_CAP_BYTES` (256KB) is written to `/tmp/dust-fn-results/<uuid>.json` and the wire carries a `{ok, resultFile, resultBytes}` pointer instead. Front (#30348) reads the file back through the provider and normalizes it exactly like an inline outcome.
- Over `RESULT_HARD_CAP_BYTES` (5MB) the result is refused with `output_too_large` and a message telling the function to store large data in a pod file or database and return a pointer.
- One policy for cold and warm: the warm server applies it before its reply frame, so both paths share the same numbers.
- A failed spill write (disk pressure) falls back to inline emission, which the drain-safe stdout writer and the backpressure-aware socket path both deliver whole: the caps are transport hygiene, never data loss.
- No spill-file cleanup: sandbox scratch is ephemeral.

Depends on #30348 (front read side must be deployed before a dsbx release ships this, or spilled results would be lost).

## Tests

Policy unit tests (at-cap inline, cap+1 spills and round-trips, hard-cap+1 refused with nothing written, unwritable spill dir falls back inline, large error outcomes spill too) plus e2e: 200KB stays inline and intact, 2MB run and warm invocations produce pointers whose files round-trip, 6MB is refused with exit 1.

## Risk

Low until released: behavior only changes once a dsbx release with this ships in an image. The main risk is old-front/new-dsbx skew losing spilled results, addressed by the deploy ordering below.

## Deploy Plan

No image change here. The dsbx release + `DSBX_CLI_VERSION` bump happens separately, strictly after #30333 and #30348 are deployed.