### PR TITLE
[front] feat: batched all-or-nothing edits for the files edit tool

### DIFF
--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -372,7 +372,7 @@ const EDIT_TOOL = {
     "`old_string`/`new_string`): an array of replacements applied in order, each matching against " +
     "the result of the previous ones. The batch is all-or-nothing: if any edit fails to match, " +
     "the file is left untouched. " +
-    "Success messages end with the resulting line count and a sha256 prefix of the final content. " +
+    "Success messages include the resulting line count and a sha256 prefix of the final content. " +
     `Files larger than ${CREATE_CONTENT_MAX_BYTES / 1024} KB cannot be edited with this tool, ` +
     `except Frame source files, which get a higher, ${FRAME_SOURCE_MAX_BYTES / 1024} KB cap. ` +
     "Editing a Frame source file updates only its source, never the rendered Frame directly.",

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -368,6 +368,11 @@ const EDIT_TOOL = {
     "`old_string` must match the file content exactly, including whitespace and indentation. " +
     "Fails if `old_string` is not found or if the number of occurrences does not match " +
     "`expected_replacements` (default 1); make `old_string` unique by including surrounding lines. " +
+    "To make several changes to the same file in one call, pass `edits` (instead of " +
+    "`old_string`/`new_string`): an array of replacements applied in order, each matching against " +
+    "the result of the previous ones. The batch is all-or-nothing: if any edit fails to match, " +
+    "the file is left untouched. " +
+    "Success messages end with the resulting line count and a sha256 prefix of the final content. " +
     `Files larger than ${CREATE_CONTENT_MAX_BYTES / 1024} KB cannot be edited with this tool, ` +
     `except Frame source files, which get a higher, ${FRAME_SOURCE_MAX_BYTES / 1024} KB cap. ` +
     "Editing a Frame source file updates only its source, never the rendered Frame directly.",
@@ -380,10 +385,17 @@ const EDIT_TOOL = {
     old_string: z
       .string()
       .min(1)
+      .optional()
       .describe(
-        "Exact text to replace, matching the file content character for character"
+        "Exact text to replace, matching the file content character for character. " +
+          "Required unless `edits` is provided."
       ),
-    new_string: z.string().describe("Text to replace `old_string` with"),
+    new_string: z
+      .string()
+      .optional()
+      .describe(
+        "Text to replace `old_string` with. Required unless `edits` is provided."
+      ),
     expected_replacements: z
       .number()
       .int()
@@ -391,6 +403,33 @@ const EDIT_TOOL = {
       .optional()
       .describe(
         "Number of occurrences expected to be replaced (default 1). The edit fails if the actual count differs."
+      ),
+    edits: z
+      .array(
+        z.object({
+          old_string: z
+            .string()
+            .min(1)
+            .describe(
+              "Exact text to replace, matching the file content (as transformed by the previous edits in the batch) character for character"
+            ),
+          new_string: z.string().describe("Text to replace `old_string` with"),
+          expected_replacements: z
+            .number()
+            .int()
+            .min(1)
+            .optional()
+            .describe(
+              "Number of occurrences expected to be replaced (default 1). The whole batch fails if the actual count differs."
+            ),
+        })
+      )
+      .min(1)
+      .optional()
+      .describe(
+        "Batch of replacements applied in order and written all-or-nothing: either every edit " +
+          "matches and the file is written once, or nothing is written. " +
+          "Use instead of `old_string`/`new_string` for multi-step changes, never alongside them."
       ),
   },
   stake: "never_ask" as const,

--- a/front/lib/api/actions/servers/files/tools/edit.test.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.test.ts
@@ -50,7 +50,9 @@ describe("editHandler", () => {
       text: expect.stringContaining("made 1 replacement"),
     });
     assert(result.value[0].type === "text");
-    expect(result.value[0].text).toMatch(/is now 1 line \(sha256:[0-9a-f]{8}\)/);
+    expect(result.value[0].text).toMatch(
+      /is now 1 line \(sha256:[0-9a-f]{8}\)/
+    );
 
     expect(fileStorageMock.saveFileCalls).toHaveLength(1);
     const { filePath, content, contentType } = fileStorageMock.saveFileCalls[0];

--- a/front/lib/api/actions/servers/files/tools/edit.test.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.test.ts
@@ -49,6 +49,8 @@ describe("editHandler", () => {
       type: "text",
       text: expect.stringContaining("made 1 replacement"),
     });
+    assert(result.value[0].type === "text");
+    expect(result.value[0].text).toMatch(/is now 1 line \(sha256:[0-9a-f]{8}\)/);
 
     expect(fileStorageMock.saveFileCalls).toHaveLength(1);
     const { filePath, content, contentType } = fileStorageMock.saveFileCalls[0];
@@ -235,6 +237,178 @@ describe("editHandler", () => {
     assert(result.isOk());
     expect(fileStorageMock.saveFileCalls[0].content.toString("utf8")).toContain(
       "New"
+    );
+  });
+
+  it("applies a full batch of edits sequentially with a single write", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    mockStoredFile("const a = 1;\nconst b = 2;\nconst c = 3;\n", "text/plain");
+
+    const result = await editHandler(
+      {
+        path: `conversation-${conversation.sId}/notes.txt`,
+        edits: [
+          { old_string: "const a = 1;", new_string: "const a = 10;" },
+          { old_string: "const b = 2;", new_string: "const b = 20;" },
+          { old_string: "const c = 3;", new_string: "const c = 30;" },
+        ],
+      },
+      makeExtra(auth, conversation)
+    );
+
+    assert(result.isOk());
+    assert(result.value[0].type === "text");
+    expect(result.value[0].text).toContain(
+      "made 3 replacements across 3 edits"
+    );
+    expect(result.value[0].text).toMatch(
+      /is now 3 lines \(sha256:[0-9a-f]{8}\)/
+    );
+
+    expect(fileStorageMock.saveFileCalls).toHaveLength(1);
+    expect(fileStorageMock.saveFileCalls[0].content.toString("utf8")).toBe(
+      "const a = 10;\nconst b = 20;\nconst c = 30;\n"
+    );
+  });
+
+  it("matches later batch edits against the output of earlier ones", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    mockStoredFile("hello world\n", "text/plain");
+
+    const result = await editHandler(
+      {
+        path: `conversation-${conversation.sId}/notes.txt`,
+        edits: [
+          { old_string: "hello world", new_string: "hello brave world" },
+          // Only matches after the first edit has been applied in memory.
+          { old_string: "brave world", new_string: "brave new world" },
+        ],
+      },
+      makeExtra(auth, conversation)
+    );
+
+    assert(result.isOk());
+    expect(fileStorageMock.saveFileCalls).toHaveLength(1);
+    expect(fileStorageMock.saveFileCalls[0].content.toString("utf8")).toBe(
+      "hello brave new world\n"
+    );
+  });
+
+  it("leaves the file untouched when a mid-batch edit does not match", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    mockStoredFile("const a = 1;\nconst b = 2;\n", "text/plain");
+
+    const result = await editHandler(
+      {
+        path: `conversation-${conversation.sId}/notes.txt`,
+        edits: [
+          { old_string: "const a = 1;", new_string: "const a = 10;" },
+          { old_string: "const z = 9;", new_string: "const z = 90;" },
+          { old_string: "const b = 2;", new_string: "const b = 20;" },
+        ],
+      },
+      makeExtra(auth, conversation)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("Edit 2 of 3 failed");
+      expect(result.error.message).toContain('"const z = 9;" not found');
+      expect(result.error.message).toContain(
+        "zero edits were applied and the file was not modified"
+      );
+    }
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
+  it("leaves the file untouched when a batch edit occurrence count differs", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    mockStoredFile("a b a\n", "text/plain");
+
+    const result = await editHandler(
+      {
+        path: `conversation-${conversation.sId}/notes.txt`,
+        edits: [
+          { old_string: "b", new_string: "d" },
+          { old_string: "a", new_string: "c" },
+        ],
+      },
+      makeExtra(auth, conversation)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        "Edit 2 of 2 failed: expected 1 replacement, but found 2 occurrences"
+      );
+      expect(result.error.message).toContain(
+        "zero edits were applied and the file was not modified"
+      );
+    }
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
+  it("returns Err when both old_string and edits are provided", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    mockStoredFile("a\n", "text/plain");
+
+    const result = await editHandler(
+      {
+        path: `conversation-${conversation.sId}/notes.txt`,
+        old_string: "a",
+        new_string: "b",
+        edits: [{ old_string: "a", new_string: "b" }],
+      },
+      makeExtra(auth, conversation)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("not both");
+    }
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
+  it("returns Err when neither old_string/new_string nor edits are provided", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    mockStoredFile("a\n", "text/plain");
+
+    const result = await editHandler(
+      {
+        path: `conversation-${conversation.sId}/notes.txt`,
+      },
+      makeExtra(auth, conversation)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        "Pass `old_string` and `new_string`, or an `edits` array."
+      );
+    }
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
+  it("appends the publish reminder after the digest on a batched Frame edit", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    mockStoredFile(
+      "export default function App() { return <h1>Old</h1>; }\n",
+      "application/vnd.dust.frame"
+    );
+
+    const result = await editHandler(
+      {
+        path: `conversation-${conversation.sId}/App.tsx`,
+        edits: [{ old_string: "Old", new_string: "New" }],
+      },
+      makeExtra(auth, conversation)
+    );
+
+    assert(result.isOk());
+    assert(result.value[0].type === "text");
+    expect(result.value[0].text).toMatch(/sha256:[0-9a-f]{8}/);
+    expect(result.value[0].text).toContain(
+      "interactive_content__publish_interactive_content_file"
     );
   });
 

--- a/front/lib/api/actions/servers/files/tools/edit.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.ts
@@ -26,6 +26,44 @@ import {
 } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { pluralize } from "@app/types/shared/utils/string_utils";
+import { createHash } from "crypto";
+
+interface EditSpec {
+  old_string: string;
+  new_string: string;
+  expected_replacements?: number;
+}
+
+// Batch failure messages quote the failing `old_string`; cap the quote so a large
+// mismatched block does not flood the error message.
+const BATCH_ERROR_SNIPPET_MAX_CHARS = 80;
+
+function editSnippet(oldString: string): string {
+  if (oldString.length <= BATCH_ERROR_SNIPPET_MAX_CHARS) {
+    return oldString;
+  }
+  return `${oldString.slice(0, BATCH_ERROR_SNIPPET_MAX_CHARS)}…`;
+}
+
+function countLines(content: string): number {
+  if (content.length === 0) {
+    return 0;
+  }
+  const segments = content.split("\n");
+  // A trailing newline does not start a new line.
+  return content.endsWith("\n") ? segments.length - 1 : segments.length;
+}
+
+// Short digest of the written content (line count + sha256 prefix) appended to every
+// success message, so agents can cheaply confirm the final file state without re-reading it.
+function contentDigest(content: string, buffer: Buffer): string {
+  const lineCount = countLines(content);
+  const hashPrefix = createHash("sha256")
+    .update(buffer)
+    .digest("hex")
+    .slice(0, 8);
+  return `The file is now ${lineCount} line${pluralize(lineCount)} (sha256:${hashPrefix}).`;
+}
 
 export async function editHandler(
   {
@@ -33,14 +71,51 @@ export async function editHandler(
     old_string,
     new_string,
     expected_replacements,
+    edits,
   }: {
     path: string;
-    old_string: string;
-    new_string: string;
+    old_string?: string;
+    new_string?: string;
     expected_replacements?: number;
+    edits?: EditSpec[];
   },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
+  let editSpecs: EditSpec[];
+  const isBatch = edits !== undefined;
+  if (isBatch) {
+    if (
+      old_string !== undefined ||
+      new_string !== undefined ||
+      expected_replacements !== undefined
+    ) {
+      return new Err(
+        new MCPError(
+          "Pass either `old_string`/`new_string` or `edits`, not both. The file was not modified.",
+          { tracked: false }
+        )
+      );
+    }
+    if (edits.length === 0) {
+      return new Err(
+        new MCPError("`edits` must contain at least one edit.", {
+          tracked: false,
+        })
+      );
+    }
+    editSpecs = edits;
+  } else {
+    if (old_string === undefined || new_string === undefined) {
+      return new Err(
+        new MCPError(
+          "Pass `old_string` and `new_string`, or an `edits` array.",
+          { tracked: false }
+        )
+      );
+    }
+    editSpecs = [{ old_string, new_string, expected_replacements }];
+  }
+
   const conversationRes = requireAgentLoopConversation({ runContext });
   if (conversationRes.isErr()) {
     return conversationRes;
@@ -105,33 +180,57 @@ export async function editHandler(
 
   const currentContent = readResult.value.toString("utf8");
 
-  const { updatedContent, occurrences } = getUpdatedContentAndOccurrences({
-    oldString: old_string,
-    newString: new_string,
-    currentContent,
-  });
+  // Apply every edit in memory, in order, each matching against the result of the
+  // previous ones. The file is written only if every edit matches (all-or-nothing).
+  let updatedContent = currentContent;
+  let totalReplacements = 0;
+  for (const [editIndex, edit] of editSpecs.entries()) {
+    const { updatedContent: nextContent, occurrences } =
+      getUpdatedContentAndOccurrences({
+        oldString: edit.old_string,
+        newString: edit.new_string,
+        currentContent: updatedContent,
+      });
 
-  if (occurrences === 0) {
-    return new Err(
-      new MCPError(
-        `String "${old_string}" not found in file. The file may have changed since you last ` +
-          `read it: re-read it with \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CAT_ACTION_NAME)}\` ` +
-          "and retry with the exact current text. Never resend the whole file content.",
-        {
-          tracked: false,
-        }
-      )
-    );
-  }
+    if (occurrences === 0) {
+      const catToolName = getPrefixedToolName(
+        FILES_SERVER_NAME,
+        FILES_CAT_ACTION_NAME
+      );
+      return new Err(
+        new MCPError(
+          isBatch
+            ? `Edit ${editIndex + 1} of ${editSpecs.length} failed: string "${editSnippet(edit.old_string)}" not found. ` +
+              "The batch is all-or-nothing: zero edits were applied and the file was not modified. " +
+              "Each edit matches against the file as transformed by the previous edits in the batch. " +
+              `Re-read the file with \`${catToolName}\` and retry the full batch with the exact current text.`
+            : `String "${edit.old_string}" not found in file. The file may have changed since you last ` +
+              `read it: re-read it with \`${catToolName}\` ` +
+              "and retry with the exact current text. Never resend the whole file content.",
+          {
+            tracked: false,
+          }
+        )
+      );
+    }
 
-  const expectedReplacements = expected_replacements ?? 1;
-  if (occurrences !== expectedReplacements) {
-    return new Err(
-      new MCPError(
-        `Expected ${expectedReplacements} replacements, but found ${occurrences} occurrences`,
-        { tracked: false }
-      )
-    );
+    const expectedReplacements = edit.expected_replacements ?? 1;
+    if (occurrences !== expectedReplacements) {
+      return new Err(
+        new MCPError(
+          isBatch
+            ? `Edit ${editIndex + 1} of ${editSpecs.length} failed: expected ${expectedReplacements} ` +
+              `replacement${pluralize(expectedReplacements)}, but found ${occurrences} ` +
+              `occurrence${pluralize(occurrences)}. The batch is all-or-nothing: zero edits were ` +
+              "applied and the file was not modified."
+            : `Expected ${expectedReplacements} replacements, but found ${occurrences} occurrences`,
+          { tracked: false }
+        )
+      );
+    }
+
+    updatedContent = nextContent;
+    totalReplacements += occurrences;
   }
 
   const updatedBuffer = Buffer.from(updatedContent, "utf8");
@@ -164,7 +263,12 @@ export async function editHandler(
     }
   }
 
-  let text = `Updated \`${path}\`: made ${occurrences} replacement${pluralize(occurrences)}.`;
+  const acrossEdits = isBatch
+    ? ` across ${editSpecs.length} edit${pluralize(editSpecs.length)}`
+    : "";
+  let text =
+    `Updated \`${path}\`: made ${totalReplacements} replacement${pluralize(totalReplacements)}${acrossEdits}. ` +
+    contentDigest(updatedContent, updatedBuffer);
 
   if (isFrameSource) {
     text += ` ${frameSourceUpdatedNotice()}`;

--- a/front/lib/api/actions/servers/files/tools/edit.ts
+++ b/front/lib/api/actions/servers/files/tools/edit.ts
@@ -201,12 +201,12 @@ export async function editHandler(
         new MCPError(
           isBatch
             ? `Edit ${editIndex + 1} of ${editSpecs.length} failed: string "${editSnippet(edit.old_string)}" not found. ` +
-              "The batch is all-or-nothing: zero edits were applied and the file was not modified. " +
-              "Each edit matches against the file as transformed by the previous edits in the batch. " +
-              `Re-read the file with \`${catToolName}\` and retry the full batch with the exact current text.`
+                "The batch is all-or-nothing: zero edits were applied and the file was not modified. " +
+                "Each edit matches against the file as transformed by the previous edits in the batch. " +
+                `Re-read the file with \`${catToolName}\` and retry the full batch with the exact current text.`
             : `String "${edit.old_string}" not found in file. The file may have changed since you last ` +
-              `read it: re-read it with \`${catToolName}\` ` +
-              "and retry with the exact current text. Never resend the whole file content.",
+                `read it: re-read it with \`${catToolName}\` ` +
+                "and retry with the exact current text. Never resend the whole file content.",
           {
             tracked: false,
           }
@@ -220,9 +220,9 @@ export async function editHandler(
         new MCPError(
           isBatch
             ? `Edit ${editIndex + 1} of ${editSpecs.length} failed: expected ${expectedReplacements} ` +
-              `replacement${pluralize(expectedReplacements)}, but found ${occurrences} ` +
-              `occurrence${pluralize(occurrences)}. The batch is all-or-nothing: zero edits were ` +
-              "applied and the file was not modified."
+                `replacement${pluralize(expectedReplacements)}, but found ${occurrences} ` +
+                `occurrence${pluralize(occurrences)}. The batch is all-or-nothing: zero edits were ` +
+                "applied and the file was not modified."
             : `Expected ${expectedReplacements} replacements, but found ${occurrences} occurrences`,
           { tracked: false }
         )


### PR DESCRIPTION
## Description

A multi-step file rewrite is N independent `files.edit` calls today. When one fails mid-sequence (`old_string` not found), the file is left in an intermediate state the agent did not intend, and nothing lets it cheaply confirm what the file now contains.

- `files.edit` gains an optional `edits: [{old_string, new_string, expected_replacements?}]` array. Edits apply sequentially in memory, each matching against the output of the previous one; the file is written only if all of them match.
- On failure the error names the failing edit index and snippet, and states explicitly that zero edits were applied and the file was not modified.
- Every success message now ends with a digest of the final content (line count + sha256 prefix) so agents can verify the result without re-reading the file.
- Single-edit calls (`old_string`/`new_string`) behave exactly as before, apart from the digest suffix. Passing both forms at once is rejected.

## Tests

Added handler tests: full batch success with a single write, sequential matching against earlier edits' output, mid-batch not-found and occurrence-mismatch failures leaving the file untouched, both/neither input forms rejected, digest present on single and batched successes, Frame publish reminder preserved.

## Risk

Low, additive schema change (previously required fields become optional with runtime validation). No behavior change for existing single-edit calls beyond the digest suffix in the success message.

## Deploy Plan

Standard deploy.