### PR TITLE
[front] enh: polish conversation credit usage UI

### DIFF
--- a/front/components/assistant/conversation/CreditCostPopover.accessibility.test.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.accessibility.test.tsx
@@ -64,7 +64,7 @@ describe("CreditCostPopover accessibility", () => {
     await user.keyboard("{Enter}");
 
     expect(
-      await screen.findByRole("dialog", { name: "Credit usage" })
+      await screen.findByRole("dialog", { name: "Message credits" })
     ).toBeInTheDocument();
     expect(trigger).toHaveAttribute("aria-expanded", "true");
 
@@ -72,7 +72,7 @@ describe("CreditCostPopover accessibility", () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByRole("dialog", { name: "Credit usage" })
+        screen.queryByRole("dialog", { name: "Message credits" })
       ).not.toBeInTheDocument();
       expect(trigger).toHaveFocus();
     });

--- a/front/components/assistant/conversation/CreditCostPopover.accessibility.test.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.accessibility.test.tsx
@@ -3,14 +3,15 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockUseAgentMessageConsumption } = vi.hoisted(() => ({
+const { mockOpenPanel, mockUseAgentMessageConsumption } = vi.hoisted(() => ({
+  mockOpenPanel: vi.fn(),
   mockUseAgentMessageConsumption: vi.fn(),
 }));
 
 vi.mock(
   "@app/components/assistant/conversation/ConversationSidePanelContext",
   () => ({
-    useConversationSidePanelContext: () => ({ openPanel: vi.fn() }),
+    useConversationSidePanelContext: () => ({ openPanel: mockOpenPanel }),
   })
 );
 
@@ -31,6 +32,7 @@ vi.mock("@app/components/resources/resources_icons", () => ({
 
 describe("CreditCostPopover accessibility", () => {
   beforeEach(() => {
+    mockOpenPanel.mockReset();
     mockUseAgentMessageConsumption.mockReturnValue({
       consumption: {
         billedCredits: 10,
@@ -45,7 +47,7 @@ describe("CreditCostPopover accessibility", () => {
     });
   });
 
-  it("opens from the keyboard and restores focus when closed", async () => {
+  it("restores focus on Escape but not when opening conversation credits", async () => {
     const user = userEvent.setup();
     render(
       <CreditCostPopover
@@ -83,5 +85,21 @@ describe("CreditCostPopover accessibility", () => {
       ).not.toBeInTheDocument();
       expect(trigger).toHaveFocus();
     });
+
+    await user.keyboard("{Enter}");
+    await user.click(
+      await screen.findByRole("button", { name: "Conversation credits" })
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Message credits" })
+      ).not.toBeInTheDocument();
+      expect(trigger).not.toHaveFocus();
+      expect(
+        screen.queryByText("View credit breakdown")
+      ).not.toBeInTheDocument();
+    });
+    expect(mockOpenPanel).toHaveBeenCalledWith({ type: "credits" });
   });
 });

--- a/front/components/assistant/conversation/CreditCostPopover.accessibility.test.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.accessibility.test.tsx
@@ -7,6 +7,13 @@ const { mockUseAgentMessageConsumption } = vi.hoisted(() => ({
   mockUseAgentMessageConsumption: vi.fn(),
 }));
 
+vi.mock(
+  "@app/components/assistant/conversation/ConversationSidePanelContext",
+  () => ({
+    useConversationSidePanelContext: () => ({ openPanel: vi.fn() }),
+  })
+);
+
 vi.mock("@app/hooks/conversations/useAgentMessageConsumption", () => ({
   useAgentMessageConsumption: mockUseAgentMessageConsumption,
 }));

--- a/front/components/assistant/conversation/CreditCostPopover.test.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.test.tsx
@@ -4,9 +4,17 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import type { ComponentProps, ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockUseAgentMessageConsumption } = vi.hoisted(() => ({
+const { mockOpenPanel, mockUseAgentMessageConsumption } = vi.hoisted(() => ({
+  mockOpenPanel: vi.fn(),
   mockUseAgentMessageConsumption: vi.fn(),
 }));
+
+vi.mock(
+  "@app/components/assistant/conversation/ConversationSidePanelContext",
+  () => ({
+    useConversationSidePanelContext: () => ({ openPanel: mockOpenPanel }),
+  })
+);
 
 vi.mock("@app/hooks/conversations/useAgentMessageConsumption", () => ({
   useAgentMessageConsumption: mockUseAgentMessageConsumption,
@@ -24,6 +32,11 @@ vi.mock("@app/components/resources/resources_icons", () => ({
 
 vi.mock("@dust-tt/sparkle", () => ({
   ShapesPlus: () => null,
+  Button: ({ label, onClick }: { label: string; onClick: () => void }) => (
+    <button type="button" onClick={onClick}>
+      {label}
+    </button>
+  ),
   Chip: ({ label }: { label: string }) => <span>{label}</span>,
   Icon: () => null,
   PopoverRoot: ({
@@ -74,10 +87,11 @@ const defaultProps: ComponentProps<typeof CreditCostPopover> = {
 
 describe("CreditCostPopover", () => {
   beforeEach(() => {
+    mockOpenPanel.mockReset();
     mockUseAgentMessageConsumption.mockReset();
   });
 
-  it("shows the three largest tool contributions and groups the remaining tools", () => {
+  it("shows the tool breakdown and opens conversation credits", () => {
     mockUseAgentMessageConsumption.mockReturnValue({
       consumption: {
         billedCredits: 12,
@@ -112,6 +126,12 @@ describe("CreditCostPopover", () => {
     expect(screen.getByText("15 credits")).toBeInTheDocument();
     expect(screen.getByText("Agent work and context")).toBeInTheDocument();
     expect(screen.getByText("Sub-agents")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Conversation credits" })
+    );
+
+    expect(mockOpenPanel).toHaveBeenCalledWith({ type: "credits" });
   });
 
   it("shows an additive breakdown without a separate savings adjustment", () => {

--- a/front/components/assistant/conversation/CreditCostPopover.test.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.test.tsx
@@ -39,6 +39,7 @@ vi.mock("@dust-tt/sparkle", () => ({
   ),
   Chip: ({ label }: { label: string }) => <span>{label}</span>,
   Icon: () => null,
+  Plus: () => null,
   PopoverRoot: ({
     children,
     onOpenChange,

--- a/front/components/assistant/conversation/CreditCostPopover.test.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.test.tsx
@@ -24,6 +24,7 @@ vi.mock("@app/components/resources/resources_icons", () => ({
 
 vi.mock("@dust-tt/sparkle", () => ({
   ShapesPlus: () => null,
+  Chip: ({ label }: { label: string }) => <span>{label}</span>,
   Icon: () => null,
   PopoverRoot: ({
     children,
@@ -104,14 +105,12 @@ describe("CreditCostPopover", () => {
     expect(screen.getByText("Web tool")).toBeInTheDocument();
     expect(screen.queryByText("File tool")).not.toBeInTheDocument();
     expect(screen.queryByText("Title tool")).not.toBeInTheDocument();
-    expect(screen.getByText("Other tools")).toBeInTheDocument();
-    expect(screen.getByText("2 tools, 2 uses")).toBeInTheDocument();
-    expect(screen.getByText("Credit breakdown")).toBeInTheDocument();
+    expect(screen.getByText("2 other tools")).toBeInTheDocument();
+    expect(screen.getAllByText("2 uses")).toHaveLength(2);
+    expect(screen.getByText("Message credits")).toBeInTheDocument();
+    expect(screen.getByText("Charged")).toBeInTheDocument();
+    expect(screen.getByText("15 credits")).toBeInTheDocument();
     expect(screen.getByText("Agent work and context")).toBeInTheDocument();
-    expect(
-      screen.getByText("Longer conversations require more context to process")
-    ).toBeInTheDocument();
-    expect(screen.getByText("This message")).toBeInTheDocument();
     expect(screen.getByText("Sub-agents")).toBeInTheDocument();
   });
 
@@ -135,7 +134,7 @@ describe("CreditCostPopover", () => {
 
     render(<CreditCostPopover {...defaultProps} />);
 
-    expect(screen.getByText("Credit breakdown")).toBeInTheDocument();
+    expect(screen.getByText("Message credits")).toBeInTheDocument();
     expect(screen.queryByText("Saved through reuse")).not.toBeInTheDocument();
     expect(screen.getByText("3 credits")).toBeInTheDocument();
     expect(screen.getByText("7 credits")).toBeInTheDocument();

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -15,7 +15,7 @@ import {
   Tooltip,
 } from "@dust-tt/sparkle";
 import type { ComponentType, ReactElement } from "react";
-import { useId, useState } from "react";
+import { useId, useRef, useState } from "react";
 
 const MAX_VISIBLE_TOOLS = 3;
 
@@ -86,6 +86,7 @@ export function CreditCostPopover({
   const headingId = useId();
   const [hasOpened, setHasOpened] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
+  const preventTriggerFocusOnCloseRef = useRef(false);
   const { openPanel } = useConversationSidePanelContext();
   const { consumption, isConsumptionLoading, mutateConsumption } =
     useAgentMessageConsumption({
@@ -146,6 +147,12 @@ export function CreditCostPopover({
         align="start"
         className="w-80 rounded-2xl px-3 py-2 shadow-sm"
         preventAutoFocusOnClose={false}
+        onCloseAutoFocus={(event) => {
+          if (preventTriggerFocusOnCloseRef.current) {
+            event.preventDefault();
+            preventTriggerFocusOnCloseRef.current = false;
+          }
+        }}
       >
         <h2
           id={headingId}
@@ -225,6 +232,7 @@ export function CreditCostPopover({
             label="Conversation credits"
             className="w-full"
             onClick={() => {
+              preventTriggerFocusOnCloseRef.current = true;
               setIsOpen(false);
               openPanel({ type: "credits" });
             }}

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -86,6 +86,7 @@ export function CreditCostPopover({
   const headingId = useId();
   const [hasOpened, setHasOpened] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
+  // Avoid reopening the trigger tooltip when switching to the credits drawer.
   const preventTriggerFocusOnCloseRef = useRef(false);
   const { openPanel } = useConversationSidePanelContext();
   const { consumption, isConsumptionLoading, mutateConsumption } =

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -143,7 +143,7 @@ export function CreditCostPopover({
         role="dialog"
         aria-labelledby={headingId}
         align="start"
-        className="w-[min(20rem,calc(100vw-1rem))] p-3"
+        className="w-80 rounded-2xl px-3 py-2"
         preventAutoFocusOnClose={false}
       >
         <h2
@@ -199,7 +199,7 @@ export function CreditCostPopover({
               {remainingTools.length > 0 && (
                 <CreditDetailRow
                   label={`${remainingTools.length} other ${remainingTools.length === 1 ? "tool" : "tools"}`}
-                  description={`${remainingToolCallCount} ${remainingToolCallCount === 1 ? "use" : "uses"}`}
+                  description={toolUsageLabel(remainingToolCallCount)}
                   value={formatCreditValue(remainingToolCredits)}
                   icon={InternalActionIcons.ToolsIcon}
                 />
@@ -217,9 +217,9 @@ export function CreditCostPopover({
           )}
         </section>
 
-        <div className="-mx-3 -mb-3 border-t border-border px-3 py-1">
+        <div className="-mx-3 -mb-2 border-t border-border px-3 py-1">
           <Button
-            variant="ghost"
+            variant="highlight-ghost"
             size="sm"
             label="Conversation credits"
             className="w-full"

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -4,6 +4,7 @@ import { useAgentMessageConsumption } from "@app/hooks/conversations/useAgentMes
 import { formatCreditValue } from "@app/lib/client/credits";
 import type { AgentMessageConsumptionToolDetails } from "@app/types/assistant/agent_message_consumption";
 import {
+  Chip,
   Icon,
   PopoverContent,
   PopoverRoot,
@@ -41,23 +42,25 @@ function CreditDetailRow({
   value,
 }: CreditDetailRowProps) {
   return (
-    <div className="grid min-h-9 grid-cols-[minmax(0,1fr)_auto] items-start gap-x-3 rounded-lg px-2 py-1.5 text-sm">
-      <dt className="flex min-w-0 items-start gap-2 font-medium text-foreground">
+    <div className="grid min-h-10 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 text-sm">
+      <dt className="flex min-w-0 items-center gap-2 font-medium text-foreground">
         {icon && (
           <Icon
             visual={icon}
             size="xs"
-            className="mt-0.5 shrink-0 text-muted-foreground"
+            className="shrink-0 text-muted-foreground"
           />
         )}
-        <span>{label}</span>
+        <span className="truncate">{label}</span>
+        {description && (
+          <Chip
+            size="mini"
+            label={description}
+            className="shrink-0 font-normal"
+          />
+        )}
       </dt>
-      <dd className="shrink-0 text-muted-foreground">{value}</dd>
-      {description && (
-        <dd className="col-start-1 text-xs text-muted-foreground">
-          {description}
-        </dd>
-      )}
+      <dd className="shrink-0 tabular-nums text-muted-foreground">{value}</dd>
     </div>
   );
 }
@@ -136,47 +139,32 @@ export function CreditCostPopover({
         role="dialog"
         aria-labelledby={headingId}
         align="start"
-        className="w-80 p-2"
+        className="w-[min(24rem,calc(100vw-1rem))] p-4"
         preventAutoFocusOnClose={false}
       >
-        <h2 id={headingId} className="px-2 py-1 text-sm font-semibold">
-          Credit usage
+        <h2
+          id={headingId}
+          className="mb-1 text-sm font-semibold text-muted-foreground"
+        >
+          Message credits
         </h2>
-        <section aria-labelledby={`${headingId}-charged`}>
-          <h3
-            id={`${headingId}-charged`}
-            className="px-2 py-1 text-xs font-medium text-muted-foreground"
-          >
-            Charged
-          </h3>
+        <section aria-label="Charge summary">
           <dl>
             <CreditDetailRow
-              label="This message"
-              value={formatCreditValue(ownCredits)}
+              label="Charged"
+              value={formatCreditValue(totalCredits)}
             />
-            {childCredits > 0 && (
-              <CreditDetailRow
-                label="Sub-agents"
-                value={formatCreditValue(childCredits)}
-              />
-            )}
           </dl>
         </section>
 
-        <hr className="my-1 border-t border-border" />
+        <hr className="-mx-4 border-t border-border" />
 
-        <section aria-labelledby={`${headingId}-breakdown`}>
-          <h3
-            id={`${headingId}-breakdown`}
-            className="px-2 py-1 text-xs font-medium text-muted-foreground"
-          >
-            Credit breakdown
-          </h3>
+        <section aria-label="Credit breakdown">
           {isConsumptionLoading && !consumption ? (
             <div
               aria-busy="true"
               aria-live="polite"
-              className="flex min-h-9 items-center px-2 py-1.5 text-sm text-muted-foreground"
+              className="flex min-h-10 items-center text-sm text-muted-foreground"
             >
               <span className="flex-1">Loading details</span>
               <span className="h-3 w-8 animate-pulse rounded bg-muted-foreground/20" />
@@ -185,10 +173,16 @@ export function CreditCostPopover({
             <dl>
               <CreditDetailRow
                 label="Agent work and context"
-                description="Longer conversations require more context to process"
                 value={formatCreditValue(details.agentWorkCredits)}
                 icon={InternalActionIcons.ActionBrainIcon}
               />
+              {childCredits > 0 && (
+                <CreditDetailRow
+                  label="Sub-agents"
+                  value={formatCreditValue(childCredits)}
+                  icon={InternalActionIcons.ActionRobotIcon}
+                />
+              )}
               {visibleTools.map((tool) => (
                 <CreditDetailRow
                   key={`${tool.internalMCPServerName ?? "external"}:${tool.toolName}:${tool.label}`}
@@ -200,15 +194,15 @@ export function CreditCostPopover({
               ))}
               {remainingTools.length > 0 && (
                 <CreditDetailRow
-                  label="Other tools"
-                  description={`${remainingTools.length} ${remainingTools.length === 1 ? "tool" : "tools"}, ${remainingToolCallCount} ${remainingToolCallCount === 1 ? "use" : "uses"}`}
+                  label={`${remainingTools.length} other ${remainingTools.length === 1 ? "tool" : "tools"}`}
+                  description={`${remainingToolCallCount} ${remainingToolCallCount === 1 ? "use" : "uses"}`}
                   value={formatCreditValue(remainingToolCredits)}
                   icon={InternalActionIcons.ToolsIcon}
                 />
               )}
             </dl>
           ) : (
-            <div className="px-2 py-1.5 text-sm">
+            <div className="py-2 text-sm">
               <p className="font-medium text-foreground">
                 Detailed explanation unavailable
               </p>

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -1,7 +1,7 @@
 import { getActionStepIcon } from "@app/components/assistant/conversation/actions/inline/utils";
 import { InternalActionIcons } from "@app/components/resources/resources_icons";
 import { useAgentMessageConsumption } from "@app/hooks/conversations/useAgentMessageConsumption";
-import { formatCredits } from "@app/lib/client/credits";
+import { formatCreditValue } from "@app/lib/client/credits";
 import type { AgentMessageConsumptionToolDetails } from "@app/types/assistant/agent_message_consumption";
 import {
   Icon,
@@ -14,10 +14,6 @@ import type { ComponentType, ReactElement } from "react";
 import { useId, useState } from "react";
 
 const MAX_VISIBLE_TOOLS = 3;
-
-function formatCreditValue(credits: number): string {
-  return `${formatCredits(credits)} credits`;
-}
 
 function toolDescription(tool: AgentMessageConsumptionToolDetails): string {
   const descriptions = [

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -42,7 +42,7 @@ function CreditDetailRow({
   value,
 }: CreditDetailRowProps) {
   return (
-    <div className="grid min-h-10 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 text-sm">
+    <div className="grid min-h-9 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 text-sm">
       <dt className="flex min-w-0 items-center gap-2 font-medium text-foreground">
         {icon && (
           <Icon
@@ -139,7 +139,7 @@ export function CreditCostPopover({
         role="dialog"
         aria-labelledby={headingId}
         align="start"
-        className="w-[min(24rem,calc(100vw-1rem))] p-4"
+        className="w-[min(20rem,calc(100vw-1rem))] p-3"
         preventAutoFocusOnClose={false}
       >
         <h2
@@ -157,14 +157,14 @@ export function CreditCostPopover({
           </dl>
         </section>
 
-        <hr className="-mx-4 border-t border-border" />
+        <hr className="-mx-3 border-t border-border" />
 
         <section aria-label="Credit breakdown">
           {isConsumptionLoading && !consumption ? (
             <div
               aria-busy="true"
               aria-live="polite"
-              className="flex min-h-10 items-center text-sm text-muted-foreground"
+              className="flex min-h-9 items-center text-sm text-muted-foreground"
             >
               <span className="flex-1">Loading details</span>
               <span className="h-3 w-8 animate-pulse rounded bg-muted-foreground/20" />

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   Chip,
   Icon,
+  Plus,
   PopoverContent,
   PopoverRoot,
   PopoverTrigger,
@@ -201,7 +202,7 @@ export function CreditCostPopover({
                   label={`${remainingTools.length} other ${remainingTools.length === 1 ? "tool" : "tools"}`}
                   description={toolUsageLabel(remainingToolCallCount)}
                   value={formatCreditValue(remainingToolCredits)}
-                  icon={InternalActionIcons.ToolsIcon}
+                  icon={Plus}
                 />
               )}
             </dl>

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -144,7 +144,7 @@ export function CreditCostPopover({
         role="dialog"
         aria-labelledby={headingId}
         align="start"
-        className="w-80 rounded-2xl px-3 py-2"
+        className="w-80 rounded-2xl px-3 py-2 shadow-sm"
         preventAutoFocusOnClose={false}
       >
         <h2

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -1,9 +1,11 @@
 import { getActionStepIcon } from "@app/components/assistant/conversation/actions/inline/utils";
+import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { InternalActionIcons } from "@app/components/resources/resources_icons";
 import { useAgentMessageConsumption } from "@app/hooks/conversations/useAgentMessageConsumption";
-import { formatCreditValue } from "@app/lib/client/credits";
+import { formatCreditValue, toolUsageLabel } from "@app/lib/client/credits";
 import type { AgentMessageConsumptionToolDetails } from "@app/types/assistant/agent_message_consumption";
 import {
+  Button,
   Chip,
   Icon,
   PopoverContent,
@@ -17,9 +19,7 @@ import { useId, useState } from "react";
 const MAX_VISIBLE_TOOLS = 3;
 
 function toolDescription(tool: AgentMessageConsumptionToolDetails): string {
-  const descriptions = [
-    `${tool.callCount} ${tool.callCount === 1 ? "use" : "uses"}`,
-  ];
+  const descriptions = [toolUsageLabel(tool.callCount)];
 
   if (tool.pending) {
     descriptions.push("Still running");
@@ -60,7 +60,7 @@ function CreditDetailRow({
           />
         )}
       </dt>
-      <dd className="shrink-0 tabular-nums text-muted-foreground">{value}</dd>
+      <dd className="shrink-0 text-muted-foreground">{value}</dd>
     </div>
   );
 }
@@ -84,6 +84,8 @@ export function CreditCostPopover({
 }: CreditCostPopoverProps) {
   const headingId = useId();
   const [hasOpened, setHasOpened] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const { openPanel } = useConversationSidePanelContext();
   const { consumption, isConsumptionLoading, mutateConsumption } =
     useAgentMessageConsumption({
       conversationId,
@@ -119,7 +121,9 @@ export function CreditCostPopover({
 
   return (
     <PopoverRoot
+      open={isOpen}
       onOpenChange={(open) => {
+        setIsOpen(open);
         if (!open) {
           return;
         }
@@ -212,6 +216,19 @@ export function CreditCostPopover({
             </div>
           )}
         </section>
+
+        <div className="-mx-3 -mb-3 border-t border-border px-3 py-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            label="Conversation credits"
+            className="w-full"
+            onClick={() => {
+              setIsOpen(false);
+              openPanel({ type: "credits" });
+            }}
+          />
+        </div>
       </PopoverContent>
     </PopoverRoot>
   );

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.test.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.test.tsx
@@ -70,7 +70,7 @@ describe("ConversationCreditUsageBreakdown", () => {
     expect(screen.queryByText("File tool")).not.toBeInTheDocument();
     expect(screen.queryByText("Title tool")).not.toBeInTheDocument();
     expect(screen.getByText("Other tools")).toBeInTheDocument();
-    expect(screen.getByText("2 tool uses")).toBeInTheDocument();
+    expect(screen.getByText("2 uses")).toBeInTheDocument();
     expect(screen.getByText("GPT-5 Mini")).toBeInTheDocument();
     expect(screen.getByText("15 credits")).toBeInTheDocument();
     expect(screen.queryByText("Research agent")).not.toBeInTheDocument();

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
@@ -16,7 +16,7 @@ import type { ComponentType } from "react";
 const MAX_VISIBLE_TOOLS = 3;
 
 function toolUsageLabel(callCount: number): string {
-  return `${callCount} tool ${callCount === 1 ? "use" : "uses"}`;
+  return `${callCount} use${pluralize(callCount)}`;
 }
 
 interface CreditBreakdownCardProps {
@@ -50,7 +50,7 @@ function CreditBreakdownCard({
         />
       </div>
       <div className="min-w-0">
-        <p className="text-base font-semibold text-foreground">
+        <p className="text-base font-semibold tabular-nums text-foreground">
           {formatCreditValue(value)}
         </p>
         {description && (
@@ -134,7 +134,7 @@ function ModelRow({ isDark, model }: ModelRowProps) {
           {model.displayName}
         </span>
       </div>
-      <span className="shrink-0 text-base font-semibold text-muted-foreground">
+      <span className="shrink-0 text-base font-semibold tabular-nums text-muted-foreground">
         {formatCreditValue(model.attributedCredits)}
       </span>
     </div>
@@ -186,7 +186,7 @@ function AgentBreakdown({ agent }: AgentBreakdownProps) {
             {agent.name}
           </h3>
         </div>
-        <span className="shrink-0 text-xs text-muted-foreground">
+        <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
           {formatCreditValue(agent.billedCredits)}
         </span>
       </div>
@@ -215,7 +215,7 @@ export function ConversationCreditUsageBreakdown({
         <div>
           <h2 className="text-sm font-semibold text-foreground">Total</h2>
           <div className="mt-1 flex items-end gap-1">
-            <span className="text-2xl font-semibold leading-8 text-foreground">
+            <span className="text-2xl font-semibold leading-8 tabular-nums text-foreground">
               {formatCredits(billedCredits)}
             </span>
             <span className="pb-1 text-sm text-muted-foreground">

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
@@ -2,7 +2,11 @@ import { getActionStepIcon } from "@app/components/assistant/conversation/action
 import { getModelLogoByModelId } from "@app/components/providers/types";
 import { InternalActionIcons } from "@app/components/resources/resources_icons";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import { formatCredits, formatCreditValue } from "@app/lib/client/credits";
+import {
+  formatCredits,
+  formatCreditValue,
+  toolUsageLabel,
+} from "@app/lib/client/credits";
 import type {
   ConversationConsumptionAgentDetails,
   ConversationConsumptionDetails,
@@ -14,10 +18,6 @@ import { Avatar, Chip, DustLogoSquare, Icon } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
 
 const MAX_VISIBLE_TOOLS = 3;
-
-function toolUsageLabel(callCount: number): string {
-  return `${callCount} use${pluralize(callCount)}`;
-}
 
 interface CreditBreakdownCardProps {
   description?: string;
@@ -50,7 +50,7 @@ function CreditBreakdownCard({
         />
       </div>
       <div className="min-w-0">
-        <p className="text-base font-semibold tabular-nums text-foreground">
+        <p className="text-base font-semibold text-foreground">
           {formatCreditValue(value)}
         </p>
         {description && (
@@ -134,7 +134,7 @@ function ModelRow({ isDark, model }: ModelRowProps) {
           {model.displayName}
         </span>
       </div>
-      <span className="shrink-0 text-base font-semibold tabular-nums text-muted-foreground">
+      <span className="shrink-0 text-base font-semibold text-muted-foreground">
         {formatCreditValue(model.attributedCredits)}
       </span>
     </div>
@@ -186,7 +186,7 @@ function AgentBreakdown({ agent }: AgentBreakdownProps) {
             {agent.name}
           </h3>
         </div>
-        <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+        <span className="shrink-0 text-xs text-muted-foreground">
           {formatCreditValue(agent.billedCredits)}
         </span>
       </div>
@@ -215,7 +215,7 @@ export function ConversationCreditUsageBreakdown({
         <div>
           <h2 className="text-sm font-semibold text-foreground">Total</h2>
           <div className="mt-1 flex items-end gap-1">
-            <span className="text-2xl font-semibold leading-8 tabular-nums text-foreground">
+            <span className="text-2xl font-semibold leading-8 text-foreground">
               {formatCredits(billedCredits)}
             </span>
             <span className="pb-1 text-sm text-muted-foreground">

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsagePanel.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsagePanel.tsx
@@ -27,7 +27,7 @@ export function ConversationCreditUsagePanel({
     <div className="flex h-panel flex-col">
       <ConversationSidePanelHeader onClose={closePanel}>
         <span className="text-sm font-medium text-foreground">
-          Conversation credit usage
+          Conversation credits
         </span>
       </ConversationSidePanelHeader>
       <div className="min-h-0 flex-1 overflow-y-auto">

--- a/front/lib/client/credits.ts
+++ b/front/lib/client/credits.ts
@@ -13,6 +13,10 @@ export function formatCreditValue(credits: number): string {
   return `${formatCredits(credits)} credit${pluralize(credits)}`;
 }
 
+export function toolUsageLabel(callCount: number): string {
+  return `${callCount} use${pluralize(callCount)}`;
+}
+
 // Short recurring-period label for a fair-use timeframe (e.g. "per day").
 // Returns an empty string for the "lifetime" sentinel, which has no period.
 export function formatFairUseTimeframe(


### PR DESCRIPTION
## Description

Follows the Figma [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=12988-2134&t=2n1GWLkKmUJnwSY0-11)

This PR makes the credit message and conversation breakdowns more compact (more or less same information, but more compact).

The message popover uses tighter sizing and spacing, drops a few messages, shows tool usage counts as chips, etc.... The copy in the conversation side panel is also updated.

Before
<img width="396" height="392" alt="image" src="https://github.com/user-attachments/assets/34667169-4cd7-4ee1-b597-a0c2f9cbd801" />

After
<img width="393" height="336" alt="image" src="https://github.com/user-attachments/assets/0ef9ca1f-b193-4db1-94d9-d12297ead9f9" />


## Tests

- Updated existing component and accessibility coverage.

## Risk

- Low. Conversation credit UI only.

## Deploy Plan

- Deploy front.