### PR TITLE
[dsbx] feat: accept the pod_editor_required user identity policy in the functions-runner

### DIFF
--- a/cli/dust-sandbox/functions-runner/fixtures/pod-editor.ts
+++ b/cli/dust-sandbox/functions-runner/fixtures/pod-editor.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const schema = {
+  description: "Refresh the pod cache",
+  userIdentity: "pod_editor_required",
+  input: z.object({}),
+  output: z.object({ refreshed: z.boolean() }),
+};
+
+export default {
+  async fetch(): Promise<Response> {
+    return Response.json({ refreshed: true });
+  },
+};

--- a/cli/dust-sandbox/functions-runner/schema.test.ts
+++ b/cli/dust-sandbox/functions-runner/schema.test.ts
@@ -51,6 +51,11 @@ describe("getFunctionSchema", () => {
     await expect(getFunctionSchema(fx("nope.ts"))).rejects.toThrow();
   });
 
+  test("accepts the pod_editor_required user identity policy", async () => {
+    const s = await getFunctionSchema(fx("pod-editor.ts"));
+    expect(s.userIdentity).toBe("pod_editor_required");
+  });
+
   test("rejects an unknown user identity policy", async () => {
     await expect(
       getFunctionSchema(fx("invalid-user-identity.ts"))

--- a/cli/dust-sandbox/functions-runner/schema.ts
+++ b/cli/dust-sandbox/functions-runner/schema.ts
@@ -9,7 +9,8 @@ export interface FunctionSchema {
   userIdentity:
     | "optional"
     | "workspace_user_required"
-    | "interactive_workspace_user_required";
+    | "interactive_workspace_user_required"
+    | "pod_editor_required";
   input_schema: Record<string, unknown> | null;
   output_schema: Record<string, unknown> | null;
 }
@@ -22,12 +23,14 @@ function parseUserIdentityPolicy(
   }
   if (
     value === "workspace_user_required" ||
-    value === "interactive_workspace_user_required"
+    value === "interactive_workspace_user_required" ||
+    value === "pod_editor_required"
   ) {
     return value;
   }
   throw new Error(
-    "`schema.userIdentity` must be `optional`, `workspace_user_required`, or `interactive_workspace_user_required`"
+    "`schema.userIdentity` must be `optional`, `workspace_user_required`, " +
+      "`interactive_workspace_user_required`, or `pod_editor_required`"
   );
 }
 


### PR DESCRIPTION
## Description

Adds `pod_editor_required` to the set of `schema.userIdentity` values the functions-runner accepts when extracting a function's contract. The runner only parses and forwards the policy string; enforcement lands in front separately.

Without this, a publish that declares the new policy throws at schema extraction, so the runner has to accept the value before front starts allowing it.

## Tests

Added a fixture + test covering the new policy; `bun test` in `cli/dust-sandbox/functions-runner` passes.

## Risk

Low: purely additive parsing. Functions using the new policy stay deny-by-default at invocation time until the front enforcement ships (unknown policies fail closed there).

## Deploy Plan

Deploy with the next dsbx image release. Must be live before front accepts publishes declaring `pod_editor_required`.