### PR TITLE
[front] Validate hook-based Pod function references at Frame publish

### DIFF
--- a/front/lib/api/files/content_validation.ts
+++ b/front/lib/api/files/content_validation.ts
@@ -4,7 +4,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import * as ts from "typescript";
 
 export interface ValidationWarning {
-  type: "tailwind" | "typescript";
+  type: "pod_function" | "tailwind" | "typescript";
   message: string;
   oldString?: string;
   suggestion?: string;

--- a/front/lib/api/viz/publish_frame.test.ts
+++ b/front/lib/api/viz/publish_frame.test.ts
@@ -602,9 +602,7 @@ export default function Dashboard() {
     if (result.isOk()) {
       expect(result.value.warnings).toHaveLength(1);
       expect(result.value.warnings[0].type).toBe("pod_function");
-      expect(result.value.warnings[0].message).toContain(
-        "not scoped to a Pod"
-      );
+      expect(result.value.warnings[0].message).toContain("not scoped to a Pod");
     }
   });
 

--- a/front/lib/api/viz/publish_frame.test.ts
+++ b/front/lib/api/viz/publish_frame.test.ts
@@ -399,6 +399,247 @@ export default function Dashboard() {
     }
   });
 
+  it("publishes without warnings when hook-based Pod function references are available in the Frame's Pod", async () => {
+    const { auth, space, user } = await setupPodTestContext();
+    const file = await createFrameFile(auth, { spaceId: space.id });
+    await createPodFunction(auth, {
+      space,
+      user,
+      slug: "list-slide-comments",
+      inputSchema: {
+        type: "object",
+        properties: { slideId: { type: "string" } },
+        required: ["slideId"],
+        additionalProperties: false,
+      },
+    });
+
+    vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
+      Readable.from([Buffer.from("self contained", "utf-8")])
+    );
+
+    const result = await publishFrame(auth, {
+      file,
+      reader: inMemoryReader({
+        // The conditional-null reference is the hooks' supported "disabled" pattern.
+        "Dashboard.tsx": `import { usePodFunction, usePodFunctionMutation } from "@dust/react-hooks";
+import { POD_ID } from "./constants";
+
+export default function Dashboard() {
+  const ready = Math.random() > 0.5;
+  const { data } = usePodFunction(ready ? \`${"${POD_ID}"}/list-slide-comments\` : null, {
+    slideId: "slide-1",
+  });
+  const { trigger } = usePodFunctionMutation(\`${"${POD_ID}"}/list-slide-comments\`);
+  return <button onClick={() => trigger({ slideId: "slide-1" })}>{String(data)}</button>;
+}
+`,
+        "constants.ts": `export const POD_ID = ${JSON.stringify(space.sId)};`,
+      }),
+      entryRelPath: "Dashboard.tsx",
+      rootScopedPath: ROOT,
+    });
+
+    expect(result.isOk(), result.isErr() ? result.error.message : "").toBe(
+      true
+    );
+    if (result.isOk()) {
+      expect(result.value.warnings).toEqual([]);
+    }
+  });
+
+  it("warns without blocking when a usePodFunction reference is unavailable in the Frame's Pod", async () => {
+    const { auth, space } = await setupPodTestContext();
+    const file = await createPodFrameFile(auth, space);
+    vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
+      Readable.from([Buffer.from("self contained", "utf-8")])
+    );
+    const uploadBundleSpy = vi.spyOn(FileResource.prototype, "uploadProcessed");
+
+    const result = await publishFrame(auth, {
+      file,
+      reader: inMemoryReader({
+        "Dashboard.tsx": `import { usePodFunction } from "@dust/react-hooks";
+
+const POD_ID = ${JSON.stringify(space.sId)};
+export default function Dashboard() {
+  const { data } = usePodFunction(\`${"${POD_ID}"}/missing-function\`, {});
+  return <div>{String(data)}</div>;
+}
+`,
+      }),
+      entryRelPath: "Dashboard.tsx",
+      rootScopedPath: ROOT,
+    });
+
+    expect(result.isOk(), result.isErr() ? result.error.message : "").toBe(
+      true
+    );
+    if (result.isOk()) {
+      expect(result.value.warnings).toHaveLength(1);
+      expect(result.value.warnings[0].type).toBe("pod_function");
+      expect(result.value.warnings[0].message).toContain(
+        "Frame references a Pod function that is not available in its Pod"
+      );
+      expect(result.value.warnings[0].message).toContain("missing-function");
+      expect(result.value.warnings[0].message).toContain(
+        "will start blocking publishing"
+      );
+    }
+    // The publish itself goes through: the frame renders the new bundle.
+    expect(uploadBundleSpy).toHaveBeenCalledTimes(1);
+    expect(file.getRenderableVersion()).toBe("processed");
+  });
+
+  it("warns without blocking when usePodFunction input does not match its JSON Schema", async () => {
+    const { auth, space, user } = await setupPodTestContext();
+    const file = await createPodFrameFile(auth, space);
+    await createPodFunction(auth, {
+      space,
+      user,
+      slug: "list-slide-comments",
+      inputSchema: {
+        type: "object",
+        properties: { slideId: { type: "string" } },
+        required: ["slideId"],
+        additionalProperties: false,
+      },
+    });
+    vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
+      Readable.from([Buffer.from("self contained", "utf-8")])
+    );
+
+    const result = await publishFrame(auth, {
+      file,
+      reader: inMemoryReader({
+        "Dashboard.tsx": `import { usePodFunction } from "@dust/react-hooks";
+
+const POD_ID = ${JSON.stringify(space.sId)};
+export default function Dashboard() {
+  const { data } = usePodFunction(\`${"${POD_ID}"}/list-slide-comments\`, {
+    slideId: 42,
+  });
+  return <div>{String(data)}</div>;
+}
+`,
+      }),
+      entryRelPath: "Dashboard.tsx",
+      rootScopedPath: ROOT,
+    });
+
+    expect(result.isOk(), result.isErr() ? result.error.message : "").toBe(
+      true
+    );
+    if (result.isOk()) {
+      expect(result.value.warnings).toHaveLength(1);
+      expect(result.value.warnings[0].type).toBe("pod_function");
+      expect(result.value.warnings[0].message).toContain(
+        "Frame passes input that does not match the Pod function contract"
+      );
+    }
+  });
+
+  it("warns without blocking when a usePodFunctionMutation reference is unavailable in the Frame's Pod", async () => {
+    const { auth, space } = await setupPodTestContext();
+    const file = await createPodFrameFile(auth, space);
+    vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
+      Readable.from([Buffer.from("self contained", "utf-8")])
+    );
+
+    const result = await publishFrame(auth, {
+      file,
+      reader: inMemoryReader({
+        "Dashboard.tsx": `import { usePodFunctionMutation } from "@dust/react-hooks";
+
+const POD_ID = ${JSON.stringify(space.sId)};
+export default function Dashboard() {
+  const { trigger } = usePodFunctionMutation(\`${"${POD_ID}"}/missing-function\`);
+  return <button onClick={() => trigger({})}>Run</button>;
+}
+`,
+      }),
+      entryRelPath: "Dashboard.tsx",
+      rootScopedPath: ROOT,
+    });
+
+    expect(result.isOk(), result.isErr() ? result.error.message : "").toBe(
+      true
+    );
+    if (result.isOk()) {
+      expect(result.value.warnings).toHaveLength(1);
+      expect(result.value.warnings[0].type).toBe("pod_function");
+      expect(result.value.warnings[0].message).toContain(
+        "Frame references a Pod function that is not available in its Pod"
+      );
+    }
+  });
+
+  it("warns without blocking hook-based Pod function references in a Frame without a Pod scope", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const file = await createFrameFile(auth);
+    vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
+      Readable.from([Buffer.from("self contained", "utf-8")])
+    );
+
+    const result = await publishFrame(auth, {
+      file,
+      reader: inMemoryReader({
+        "Dashboard.tsx": `import { usePodFunction } from "@dust/react-hooks";
+
+export default function Dashboard() {
+  const { data } = usePodFunction("spc_test/function", {});
+  return <div>{String(data)}</div>;
+}
+`,
+      }),
+      entryRelPath: "Dashboard.tsx",
+      rootScopedPath: ROOT,
+    });
+
+    expect(result.isOk(), result.isErr() ? result.error.message : "").toBe(
+      true
+    );
+    if (result.isOk()) {
+      expect(result.value.warnings).toHaveLength(1);
+      expect(result.value.warnings[0].type).toBe("pod_function");
+      expect(result.value.warnings[0].message).toContain(
+        "not scoped to a Pod"
+      );
+    }
+  });
+
+  it("still blocks a dangling callFunction reference when hooks are used alongside it", async () => {
+    const { auth, space } = await setupPodTestContext();
+    const file = await createPodFrameFile(auth, space);
+    const uploadBundleSpy = vi.spyOn(FileResource.prototype, "uploadProcessed");
+
+    const result = await publishFrame(auth, {
+      file,
+      reader: inMemoryReader({
+        "Dashboard.tsx": `import { callFunction, usePodFunction } from "@dust/react-hooks";
+
+const POD_ID = ${JSON.stringify(space.sId)};
+export default function Dashboard() {
+  const { data } = usePodFunction(\`${"${POD_ID}"}/also-missing\`, {});
+  const run = () => callFunction(\`${"${POD_ID}"}/missing-function\`, {});
+  return <button onClick={run}>{String(data)}</button>;
+}
+`,
+      }),
+      entryRelPath: "Dashboard.tsx",
+      rootScopedPath: ROOT,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("pod_function_not_found");
+      // Only the callFunction failure blocks; the hook failure stays out of the error.
+      expect(result.error.message).toContain("missing-function");
+      expect(result.error.message).not.toContain("also-missing");
+    }
+    expect(uploadBundleSpy).not.toHaveBeenCalled();
+  });
+
   it("reads only the entry's import graph, ignoring unrelated files in the mount", async () => {
     const { authenticator: auth } = await createResourceTest({});
     const file = await createFrameFile(auth);

--- a/front/lib/api/viz/publish_frame.ts
+++ b/front/lib/api/viz/publish_frame.ts
@@ -160,7 +160,8 @@ export async function publishFrame(
         }
       }
 
-      // 2. Validate Pod function calls before writing.
+      // 2. Validate Pod function calls before writing. `callFunction` failures block; hook-based
+      //    (`usePodFunction`/`usePodFunctionMutation`) failures come back as warnings for now.
       const podFunctionValidation = await validateFramePodFunctionReferences(
         auth,
         {
@@ -176,6 +177,7 @@ export async function publishFrame(
           )
         );
       }
+      warnings.push(...podFunctionValidation.value.warnings);
 
       // 3. Refresh the canonical source from the entry so MCP retrieve and the render fallback
       //    stay in sync with what was published (the entry is always read during the build).

--- a/front/lib/api/viz/validate_frame_pod_functions.ts
+++ b/front/lib/api/viz/validate_frame_pod_functions.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import type { ValidationWarning } from "@app/lib/api/files/content_validation";
 import type { Authenticator } from "@app/lib/auth";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
@@ -26,6 +27,24 @@ const CALL_DIAGNOSTIC_CODES = new Set([
   2769, // No overload accepts the provided arguments.
 ]);
 
+// Names exported by the virtual @dust/react-hooks declaration that take a Pod function reference
+// as their first argument. `callFunction` failures block publishing; hook failures are surfaced
+// as warnings for now (see validateFramePodFunctionReferences) and will start blocking in an
+// upcoming release.
+const CALL_FUNCTION_NAME = "callFunction";
+const POD_FUNCTION_CALLER_NAMES = new Set([
+  CALL_FUNCTION_NAME,
+  "usePodFunction",
+  "usePodFunctionMutation",
+]);
+
+type PodFunctionCallOrigin = "call_function" | "hook";
+
+interface PodFunctionCall {
+  call: ts.CallExpression;
+  origin: PodFunctionCallOrigin;
+}
+
 type FramePodFunctionValidationErrorCode =
   | "invalid_pod_function_input"
   | "pod_function_not_found"
@@ -46,7 +65,12 @@ function isSourceFile(relPath: string): boolean {
   return SOURCE_EXTENSIONS.some((extension) => relPath.endsWith(extension));
 }
 
-function sourceMayCallPodFunction(relPath: string, code: string): boolean {
+// Collects which of the Pod-function-calling exports (`callFunction` and the hooks) a source
+// references, through named imports or namespace access on a `* as` import.
+function collectPodFunctionCallerNames(
+  relPath: string,
+  code: string
+): Set<string> {
   const sourceFile = ts.createSourceFile(
     relPath,
     code,
@@ -54,6 +78,7 @@ function sourceMayCallPodFunction(relPath: string, code: string): boolean {
     false,
     relPath.endsWith("x") ? ts.ScriptKind.TSX : ts.ScriptKind.TS
   );
+  const referencedNames = new Set<string>();
   const namespaceImports = new Set<string>();
 
   for (const statement of sourceFile.statements) {
@@ -67,13 +92,11 @@ function sourceMayCallPodFunction(relPath: string, code: string): boolean {
 
     const bindings = statement.importClause?.namedBindings;
     if (bindings && ts.isNamedImports(bindings)) {
-      if (
-        bindings.elements.some(
-          (element) =>
-            (element.propertyName?.text ?? element.name.text) === "callFunction"
-        )
-      ) {
-        return true;
+      for (const element of bindings.elements) {
+        const importedName = element.propertyName?.text ?? element.name.text;
+        if (POD_FUNCTION_CALLER_NAMES.has(importedName)) {
+          referencedNames.add(importedName);
+        }
       }
     } else if (bindings && ts.isNamespaceImport(bindings)) {
       namespaceImports.add(bindings.name.text);
@@ -81,26 +104,24 @@ function sourceMayCallPodFunction(relPath: string, code: string): boolean {
   }
 
   if (namespaceImports.size === 0) {
-    return false;
+    return referencedNames;
   }
 
-  let found = false;
   const visit = (node: ts.Node): void => {
     if (
       ts.isPropertyAccessExpression(node) &&
       ts.isIdentifier(node.expression) &&
       namespaceImports.has(node.expression.text) &&
-      node.name.text === "callFunction"
+      POD_FUNCTION_CALLER_NAMES.has(node.name.text)
     ) {
-      found = true;
-      return;
+      referencedNames.add(node.name.text);
     }
 
     ts.forEachChild(node, visit);
   };
   visit(sourceFile);
 
-  return found;
+  return referencedNames;
 }
 
 function extensionForPath(filePath: string): ts.Extension {
@@ -184,7 +205,12 @@ async function buildDustReactHooksDeclaration(
     );
   }
 
-  // Return values stay permissive because this pass only validates calls.
+  // Return values stay permissive because this pass only validates calls. The hooks accept a
+  // null reference (the runtime's "disabled" pattern); with a literal null first argument
+  // TypeScript cannot infer TFunction and checks the input against the union of every function's
+  // input type, so a disabled call whose input matches no published function reports an input
+  // mismatch. The realistic disabled pattern (a conditional reference with the real input)
+  // infers and checks cleanly.
   return new Ok(`${declarations.join("\n")}
 export interface PodFunctionMap {
 ${entries.join("\n")}
@@ -194,17 +220,30 @@ export declare function callFunction<TFunction extends keyof PodFunctionMap>(
   functionId: TFunction,
   input: PodFunctionMap[TFunction]
 ): any;
+
+export declare function usePodFunction<TFunction extends keyof PodFunctionMap>(
+  slug: TFunction | null,
+  input: PodFunctionMap[TFunction]
+): any;
+
+export declare function usePodFunctionMutation<TFunction extends keyof PodFunctionMap>(
+  slug: TFunction | null
+): any;
 `);
 }
 
 type ClassifiedDiagnostic = {
   diagnostic: ts.Diagnostic;
+  origin: PodFunctionCallOrigin;
   type: "input" | "reference";
 };
 
+// The first-argument handling applies to every caller shape alike: the Pod function reference is
+// argument 0 for `callFunction(functionId, input)`, `usePodFunction(slug, input)` and
+// `usePodFunctionMutation(slug)`, and the input — when the caller takes one — is argument 1.
 function classifyDiagnostic(
   diagnostic: ts.Diagnostic,
-  call: ts.CallExpression
+  { call, origin }: PodFunctionCall
 ): ClassifiedDiagnostic | undefined {
   if (diagnostic.start === undefined) {
     return undefined;
@@ -217,7 +256,7 @@ function classifyDiagnostic(
     diagnostic.start >= functionArgument.getStart() &&
     diagnostic.start < functionArgument.getEnd()
   ) {
-    return { diagnostic, type: "reference" };
+    return { diagnostic, origin, type: "reference" };
   }
 
   const inputArgument = call.arguments[1];
@@ -227,12 +266,13 @@ function classifyDiagnostic(
     diagnostic.start >= inputArgument.getStart() &&
     diagnostic.start < inputArgument.getEnd()
   ) {
-    return { diagnostic, type: "input" };
+    return { diagnostic, origin, type: "input" };
   }
 
   if (CALL_DIAGNOSTIC_CODES.has(diagnostic.code)) {
     return {
       diagnostic,
+      origin,
       type: functionArgument ? "input" : "reference",
     };
   }
@@ -241,12 +281,13 @@ function classifyDiagnostic(
 }
 
 function classifyDiagnostics(
-  calls: readonly ts.CallExpression[],
+  calls: readonly PodFunctionCall[],
   diagnostics: readonly ts.Diagnostic[]
 ): ClassifiedDiagnostic[] {
   const sortedCalls = [...calls].sort(
     (left, right) =>
-      left.getStart() - right.getStart() || right.getEnd() - left.getEnd()
+      left.call.getStart() - right.call.getStart() ||
+      right.call.getEnd() - left.call.getEnd()
   );
   const sortedDiagnostics = diagnostics
     .filter(
@@ -254,7 +295,7 @@ function classifyDiagnostics(
         diagnostic.start !== undefined
     )
     .sort((left, right) => left.start - right.start);
-  const activeCalls: ts.CallExpression[] = [];
+  const activeCalls: PodFunctionCall[] = [];
   const classified: ClassifiedDiagnostic[] = [];
   let callIndex = 0;
 
@@ -262,12 +303,12 @@ function classifyDiagnostics(
   for (const diagnostic of sortedDiagnostics) {
     while (
       callIndex < sortedCalls.length &&
-      sortedCalls[callIndex].getStart() <= diagnostic.start
+      sortedCalls[callIndex].call.getStart() <= diagnostic.start
     ) {
       const call = sortedCalls[callIndex];
       while (
         activeCalls.length > 0 &&
-        activeCalls[activeCalls.length - 1].getEnd() <= call.getStart()
+        activeCalls[activeCalls.length - 1].call.getEnd() <= call.call.getStart()
       ) {
         activeCalls.pop();
       }
@@ -277,7 +318,7 @@ function classifyDiagnostics(
 
     while (
       activeCalls.length > 0 &&
-      activeCalls[activeCalls.length - 1].getEnd() <= diagnostic.start
+      activeCalls[activeCalls.length - 1].call.getEnd() <= diagnostic.start
     ) {
       activeCalls.pop();
     }
@@ -337,13 +378,55 @@ function resolveRelativeModule(
   };
 }
 
+// Resolves the declared name behind a call whose signature comes from the virtual
+// @dust/react-hooks declaration, so diagnostics can be attributed to `callFunction` (blocking)
+// or to the hooks (warnings for now).
+function podFunctionCallOrigin(
+  signatures: readonly ts.Signature[]
+): PodFunctionCallOrigin | undefined {
+  for (const signature of signatures) {
+    const declaration = signature.declaration;
+    if (
+      !declaration ||
+      declaration.getSourceFile().fileName !== VIRTUAL_DUST_REACT_HOOKS_PATH ||
+      !ts.isFunctionDeclaration(declaration)
+    ) {
+      continue;
+    }
+
+    const declaredName = declaration.name?.text;
+    if (declaredName !== undefined && POD_FUNCTION_CALLER_NAMES.has(declaredName)) {
+      return declaredName === CALL_FUNCTION_NAME ? "call_function" : "hook";
+    }
+  }
+
+  return undefined;
+}
+
+function hookDiagnosticWarning({
+  diagnostic,
+  type,
+}: ClassifiedDiagnostic): ValidationWarning {
+  const headline =
+    type === "reference"
+      ? "Frame references a Pod function that is not available in its Pod"
+      : "Frame passes input that does not match the Pod function contract";
+
+  return {
+    type: "pod_function",
+    message: `${headline} (this check will start blocking publishing in an upcoming release): ${formatDiagnostic(diagnostic)}`,
+  };
+}
+
 async function validateCallFunctionTypes({
   functionContracts,
   sources,
 }: {
   functionContracts: readonly PodFunctionContract[];
   sources: ReadonlyMap<string, string>;
-}): Promise<Result<undefined, FramePodFunctionValidationError>> {
+}): Promise<
+  Result<{ warnings: ValidationWarning[] }, FramePodFunctionValidationError>
+> {
   const virtualSources = new Map<string, string>();
   for (const [relPath, code] of sources) {
     if (isSourceFile(relPath)) {
@@ -413,10 +496,7 @@ async function validateCallFunctionTypes({
     host,
   });
   const checker = program.getTypeChecker();
-  const callFunctionCallsBySource = new Map<
-    ts.SourceFile,
-    ts.CallExpression[]
-  >();
+  const podFunctionCallsBySource = new Map<ts.SourceFile, PodFunctionCall[]>();
 
   for (const sourceFile of program.getSourceFiles()) {
     if (sourceFile.fileName === VIRTUAL_DUST_REACT_HOOKS_PATH) {
@@ -428,16 +508,11 @@ async function validateCallFunctionTypes({
         const signatures = checker
           .getTypeAtLocation(node.expression)
           .getCallSignatures();
-        if (
-          signatures.some(
-            (signature) =>
-              signature.declaration?.getSourceFile().fileName ===
-              VIRTUAL_DUST_REACT_HOOKS_PATH
-          )
-        ) {
-          const calls = callFunctionCallsBySource.get(sourceFile) ?? [];
-          calls.push(node);
-          callFunctionCallsBySource.set(sourceFile, calls);
+        const origin = podFunctionCallOrigin(signatures);
+        if (origin !== undefined) {
+          const calls = podFunctionCallsBySource.get(sourceFile) ?? [];
+          calls.push({ call: node, origin });
+          podFunctionCallsBySource.set(sourceFile, calls);
         }
       }
 
@@ -448,7 +523,7 @@ async function validateCallFunctionTypes({
 
   const diagnosticsBySource = new Map<ts.SourceFile, ts.Diagnostic[]>();
   for (const diagnostic of program.getSemanticDiagnostics()) {
-    if (!diagnostic.file || !callFunctionCallsBySource.has(diagnostic.file)) {
+    if (!diagnostic.file || !podFunctionCallsBySource.has(diagnostic.file)) {
       continue;
     }
 
@@ -457,13 +532,22 @@ async function validateCallFunctionTypes({
     diagnosticsBySource.set(diagnostic.file, diagnostics);
   }
 
-  const diagnostics = Array.from(callFunctionCallsBySource).flatMap(
+  const classified = Array.from(podFunctionCallsBySource).flatMap(
     ([sourceFile, calls]) =>
       classifyDiagnostics(calls, diagnosticsBySource.get(sourceFile) ?? [])
   );
 
-  if (diagnostics.length > 0) {
-    const hasInvalidReference = diagnostics.some(
+  // Rollout: hook-based calls were unchecked until now, so their failures surface as warnings
+  // for one release instead of blocking a republish of an existing frame. Flipping hooks to
+  // blocking means folding the "hook" origin into this blocking set (and dropping the hook-only
+  // downgrade in validateFramePodFunctionReferences).
+  const blockingDiagnostics = classified.filter(
+    ({ origin }) => origin === "call_function"
+  );
+  const hookDiagnostics = classified.filter(({ origin }) => origin === "hook");
+
+  if (blockingDiagnostics.length > 0) {
+    const hasInvalidReference = blockingDiagnostics.some(
       ({ type }) => type === "reference"
     );
     return new Err(
@@ -475,7 +559,7 @@ async function validateCallFunctionTypes({
           hasInvalidReference
             ? "Frame references a Pod function that is not available in its Pod"
             : "Frame passes input that does not match the Pod function contract"
-        }:\n${diagnostics
+        }:\n${blockingDiagnostics
           .slice(0, 5)
           .map(({ diagnostic }) => formatDiagnostic(diagnostic))
           .join("\n")}`
@@ -483,14 +567,23 @@ async function validateCallFunctionTypes({
     );
   }
 
-  return new Ok(undefined);
+  return new Ok({
+    warnings: hookDiagnostics.slice(0, 5).map(hookDiagnosticWarning),
+  });
 }
 
 /**
- * Statically checks Pod function references and the structure of their inputs.
+ * Statically checks Pod function references and the structure of their inputs, for `callFunction`
+ * and the `usePodFunction`/`usePodFunctionMutation` hooks.
  * Pod contracts are authored in Zod, but this check uses their extracted JSON Schema. Runtime-only
  * refinements and value constraints are not always expressible as TypeScript types, so an input can
  * pass here and still fail the authoritative Zod validation when the function runs.
+ *
+ * Rollout: `callFunction` failures block publishing as before. Hook failures — including
+ * frame-level failures (missing Pod scope, schema conversion) of frames that only reach Pod
+ * functions through the hooks — are returned as warnings for one release, because hook-based
+ * frames were previously unchecked and a dangling reference must not hard-fail their next
+ * publish. The blocking flip is a tracked follow-up.
  */
 export async function validateFramePodFunctionReferences(
   auth: Authenticator,
@@ -501,18 +594,42 @@ export async function validateFramePodFunctionReferences(
     file: FileResource;
     sources: ReadonlyMap<string, string>;
   }
-): Promise<Result<undefined, FramePodFunctionValidationError>> {
-  const mayCallPodFunction = Array.from(sources).some(
-    ([relPath, code]) =>
-      isSourceFile(relPath) && sourceMayCallPodFunction(relPath, code)
-  );
-  if (!mayCallPodFunction) {
-    return new Ok(undefined);
+): Promise<
+  Result<{ warnings: ValidationWarning[] }, FramePodFunctionValidationError>
+> {
+  const referencedCallerNames = new Set<string>();
+  for (const [relPath, code] of sources) {
+    if (!isSourceFile(relPath)) {
+      continue;
+    }
+
+    for (const name of collectPodFunctionCallerNames(relPath, code)) {
+      referencedCallerNames.add(name);
+    }
   }
+  if (referencedCallerNames.size === 0) {
+    return new Ok({ warnings: [] });
+  }
+
+  // Hook-only frames get the warning treatment on failures that would otherwise block.
+  const blockOnFailure = referencedCallerNames.has(CALL_FUNCTION_NAME);
+  const frameFailure = (
+    error: FramePodFunctionValidationError
+  ): Result<{ warnings: ValidationWarning[] }, FramePodFunctionValidationError> =>
+    blockOnFailure
+      ? new Err(error)
+      : new Ok({
+          warnings: [
+            {
+              type: "pod_function",
+              message: `${error.message} (this check will start blocking publishing in an upcoming release)`,
+            },
+          ],
+        });
 
   const { spaceId } = await file.resolveFrameScopedPathContext(auth);
   if (!spaceId) {
-    return new Err(
+    return frameFailure(
       new FramePodFunctionValidationError(
         "pod_scope_not_found",
         "Frame uses Pod functions but is not scoped to a Pod."
@@ -522,7 +639,7 @@ export async function validateFramePodFunctionReferences(
 
   const space = await SpaceResource.fetchById(auth, spaceId);
   if (!space || !space.isProject()) {
-    return new Err(
+    return frameFailure(
       new FramePodFunctionValidationError(
         "pod_scope_not_found",
         "The Frame's Pod is not accessible."
@@ -542,5 +659,13 @@ export async function validateFramePodFunctionReferences(
     inputSchema: sandboxFunction.inputSchema,
   }));
 
-  return validateCallFunctionTypes({ functionContracts, sources });
+  const validation = await validateCallFunctionTypes({
+    functionContracts,
+    sources,
+  });
+  if (validation.isErr()) {
+    return frameFailure(validation.error);
+  }
+
+  return validation;
 }

--- a/front/lib/api/viz/validate_frame_pod_functions.ts
+++ b/front/lib/api/viz/validate_frame_pod_functions.ts
@@ -40,6 +40,12 @@ const POD_FUNCTION_CALLER_NAMES = new Set([
 
 type PodFunctionCallOrigin = "call_function" | "hook";
 
+// Appended to every hook-side warning while the rollout lasts.
+const HOOK_BLOCKING_NOTICE =
+  "this check will start blocking publishing in an upcoming release";
+// Cap on the diagnostics reported per publish, for errors and warnings alike.
+const MAX_REPORTED_DIAGNOSTICS = 5;
+
 interface PodFunctionCall {
   call: ts.CallExpression;
   origin: PodFunctionCallOrigin;
@@ -308,7 +314,8 @@ function classifyDiagnostics(
       const call = sortedCalls[callIndex];
       while (
         activeCalls.length > 0 &&
-        activeCalls[activeCalls.length - 1].call.getEnd() <= call.call.getStart()
+        activeCalls[activeCalls.length - 1].call.getEnd() <=
+          call.call.getStart()
       ) {
         activeCalls.pop();
       }
@@ -395,7 +402,10 @@ function podFunctionCallOrigin(
     }
 
     const declaredName = declaration.name?.text;
-    if (declaredName !== undefined && POD_FUNCTION_CALLER_NAMES.has(declaredName)) {
+    if (
+      declaredName !== undefined &&
+      POD_FUNCTION_CALLER_NAMES.has(declaredName)
+    ) {
       return declaredName === CALL_FUNCTION_NAME ? "call_function" : "hook";
     }
   }
@@ -414,7 +424,7 @@ function hookDiagnosticWarning({
 
   return {
     type: "pod_function",
-    message: `${headline} (this check will start blocking publishing in an upcoming release): ${formatDiagnostic(diagnostic)}`,
+    message: `${headline} (${HOOK_BLOCKING_NOTICE}): ${formatDiagnostic(diagnostic)}`,
   };
 }
 
@@ -560,7 +570,7 @@ async function validateCallFunctionTypes({
             ? "Frame references a Pod function that is not available in its Pod"
             : "Frame passes input that does not match the Pod function contract"
         }:\n${blockingDiagnostics
-          .slice(0, 5)
+          .slice(0, MAX_REPORTED_DIAGNOSTICS)
           .map(({ diagnostic }) => formatDiagnostic(diagnostic))
           .join("\n")}`
       )
@@ -568,7 +578,9 @@ async function validateCallFunctionTypes({
   }
 
   return new Ok({
-    warnings: hookDiagnostics.slice(0, 5).map(hookDiagnosticWarning),
+    warnings: hookDiagnostics
+      .slice(0, MAX_REPORTED_DIAGNOSTICS)
+      .map(hookDiagnosticWarning),
   });
 }
 
@@ -615,14 +627,17 @@ export async function validateFramePodFunctionReferences(
   const blockOnFailure = referencedCallerNames.has(CALL_FUNCTION_NAME);
   const frameFailure = (
     error: FramePodFunctionValidationError
-  ): Result<{ warnings: ValidationWarning[] }, FramePodFunctionValidationError> =>
+  ): Result<
+    { warnings: ValidationWarning[] },
+    FramePodFunctionValidationError
+  > =>
     blockOnFailure
       ? new Err(error)
       : new Ok({
           warnings: [
             {
               type: "pod_function",
-              message: `${error.message} (this check will start blocking publishing in an upcoming release)`,
+              message: `${error.message} (${HOOK_BLOCKING_NOTICE})`,
             },
           ],
         });


### PR DESCRIPTION
## Description

`validateFramePodFunctionReferences` only detected `callFunction`, and the virtual `@dust/react-hooks` declaration only declared it. Frames built on `usePodFunction`/`usePodFunctionMutation` (what the skill teaches, and what prod frames actually use) published with zero reference or input checking and only failed at runtime with "Sandbox function not found".

- Detect all three callers in the import scan (named imports and namespace access).
- Declare both hooks in the generated d.ts, typed against `PodFunctionMap`. The ref argument accepts `null` (the hooks' supported disabled pattern); a conditional ref infers cleanly.
- Attribute each classified diagnostic to its caller: `callFunction` failures keep blocking with the same error codes, hook failures come back as `pod_function` publish warnings.
- Rollout: hook-based frames were never validated, so for one release every hook-side failure (dangling ref, bad input, missing Pod scope, schema conversion) is a warning telling the model it will start blocking soon. Flipping hooks to blocking is a follow-up (two marked spots in `validate_frame_pod_functions.ts`).

Known edge, commented in the code: a literal `null` ref with an input that matches no published function reports an input mismatch, because TypeScript cannot infer the function key. Warning-only for now.

## Tests

Added hook cases to `publish_frame.test.ts` mirroring the callFunction ones: valid refs (incl. conditional null) publish with no warnings, dangling `usePodFunction`/`usePodFunctionMutation` refs and bad inputs warn without blocking (bundle still published), hook use without a Pod scope warns, and a dangling `callFunction` still blocks when hooks are present.

## Risk

Low. No frame that publishes today starts failing: callFunction paths are byte-for-byte the same checks, hook paths only add warnings. The blocking flip lands separately.

## Deploy Plan

Standard deploy.