### PR TITLE
[front] fix: handle authentication errors in Snowflake MCP

### DIFF
--- a/front/lib/api/actions/servers/snowflake/tools/index.test.ts
+++ b/front/lib/api/actions/servers/snowflake/tools/index.test.ts
@@ -1,0 +1,97 @@
+import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { makePersonalAuthenticationError } from "@app/lib/actions/mcp_internal_actions/utils";
+import { TOOLS } from "@app/lib/api/actions/servers/snowflake/tools";
+import type { Authenticator } from "@app/lib/auth";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { Err } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { listDatabasesMock } = vi.hoisted(() => ({
+  listDatabasesMock: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/actions/servers/snowflake/client", () => ({
+  SnowflakeClient: class {
+    listDatabases = listDatabasesMock;
+  },
+}));
+
+function getListDatabasesTool() {
+  const tool = TOOLS.find(({ name }) => name === "list_databases");
+  if (!tool) {
+    throw new Error("Snowflake list_databases tool not found");
+  }
+  return tool;
+}
+
+function createRequestFailedError(statusCode: number): Error {
+  return Object.assign(new Error(`Snowflake API returned ${statusCode}`), {
+    name: "RequestFailedError",
+    response: { statusCode },
+  });
+}
+
+function createTestExtra(auth: Authenticator): ToolHandlerExtra {
+  return {
+    auth,
+    authInfo: {
+      token: "snowflake-token",
+      clientId: "snowflake-client",
+      scopes: [],
+      extra: {
+        snowflake_account: "test-account",
+        snowflake_warehouse: "test-warehouse",
+      },
+    },
+    requestId: "snowflake-auth-error-test",
+    // @ts-expect-error These focused error-path tests do not require a run context.
+    runContext: undefined,
+    sendNotification: async () => {},
+    sendRequest: async () => {
+      throw new Error("Unexpected MCP request");
+    },
+    signal: new AbortController().signal,
+  };
+}
+
+describe("Snowflake tools", () => {
+  beforeEach(() => {
+    listDatabasesMock.mockReset();
+  });
+
+  it.each([
+    401, 403,
+  ])("returns a personal authentication error for HTTP %s", async (statusCode) => {
+    listDatabasesMock.mockResolvedValue(
+      new Err(createRequestFailedError(statusCode))
+    );
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    const result = await getListDatabasesTool().handler(
+      {},
+      createTestExtra(authenticator)
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual(
+        makePersonalAuthenticationError("snowflake").content
+      );
+    }
+  });
+
+  it("keeps non-authentication failures as MCP errors", async () => {
+    listDatabasesMock.mockResolvedValue(new Err(createRequestFailedError(500)));
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    const result = await getListDatabasesTool().handler(
+      {},
+      createTestExtra(authenticator)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe("Snowflake API returned 500");
+    }
+  });
+});

--- a/front/lib/api/actions/servers/snowflake/tools/index.ts
+++ b/front/lib/api/actions/servers/snowflake/tools/index.ts
@@ -1,6 +1,10 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  ToolHandlerResult,
+  ToolHandlers,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { makePersonalAuthenticationError } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { ToolContext } from "@app/lib/actions/types";
 import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import { SnowflakeClient } from "@app/lib/api/actions/servers/snowflake/client";
@@ -20,6 +24,21 @@ import { fromError } from "zod-validation-error";
 const CONNECTION_ERROR = new MCPError(
   "Snowflake connection not configured. Please connect your Snowflake account."
 );
+
+function handleSnowflakeError(error: Error): ToolHandlerResult {
+  if (
+    error.name === "RequestFailedError" &&
+    "response" in error &&
+    typeof error.response === "object" &&
+    error.response !== null &&
+    "statusCode" in error.response &&
+    (error.response.statusCode === 401 || error.response.statusCode === 403)
+  ) {
+    return new Ok(makePersonalAuthenticationError("snowflake").content);
+  }
+
+  return new Err(new MCPError(error.message));
+}
 
 interface SnowflakeQueryTagMetadata {
   workspace_id: string;
@@ -145,7 +164,7 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
 
     const result = await clientRes.value.listDatabases();
     if (result.isErr()) {
-      return new Err(new MCPError(result.error.message));
+      return handleSnowflakeError(result.error);
     }
 
     const databases = result.value;
@@ -173,7 +192,7 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
 
     const result = await clientRes.value.listSchemas(database);
     if (result.isErr()) {
-      return new Err(new MCPError(result.error.message));
+      return handleSnowflakeError(result.error);
     }
 
     const schemas = result.value;
@@ -201,7 +220,7 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
 
     const result = await clientRes.value.listTables(database, schema);
     if (result.isErr()) {
-      return new Err(new MCPError(result.error.message));
+      return handleSnowflakeError(result.error);
     }
 
     const tables = result.value;
@@ -232,7 +251,7 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
 
     const result = await clientRes.value.describeTable(database, schema, table);
     if (result.isErr()) {
-      return new Err(new MCPError(result.error.message));
+      return handleSnowflakeError(result.error);
     }
 
     const columns = result.value;
@@ -276,7 +295,7 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
       semantic_view
     );
     if (result.isErr()) {
-      return new Err(new MCPError(result.error.message));
+      return handleSnowflakeError(result.error);
     }
 
     const { dimensions, metrics } = result.value;
@@ -317,7 +336,7 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
       max_rows ?? MAX_QUERY_ROWS
     );
     if (result.isErr()) {
-      return new Err(new MCPError(result.error.message));
+      return handleSnowflakeError(result.error);
     }
 
     const { columns, rows, rowCount } = result.value;

--- a/front/lib/api/actions/servers/snowflake/tools/index.ts
+++ b/front/lib/api/actions/servers/snowflake/tools/index.ts
@@ -25,13 +25,22 @@ const CONNECTION_ERROR = new MCPError(
   "Snowflake connection not configured. Please connect your Snowflake account."
 );
 
-function handleSnowflakeError(error: Error): ToolHandlerResult {
-  if (
+function isSnowflakeRequestFailedError(
+  error: Error
+): error is Error & { response: { statusCode: number } } {
+  return (
     error.name === "RequestFailedError" &&
     "response" in error &&
     typeof error.response === "object" &&
     error.response !== null &&
     "statusCode" in error.response &&
+    typeof error.response.statusCode === "number"
+  );
+}
+
+function handleSnowflakeError(error: Error): ToolHandlerResult {
+  if (
+    isSnowflakeRequestFailedError(error) &&
     (error.response.statusCode === 401 || error.response.statusCode === 403)
   ) {
     return new Ok(makePersonalAuthenticationError("snowflake").content);


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/9960.

Expired or unauthorized Snowflake credentials currently surface as generic MCP failures instead of bubbling up as an authentication error to let the user reconnect.

This PR maps Snowflake SDK's `RequestFailedError`s with HTTP 401 or 403 to the existing personal authentication-required output across all Snowflake tools. Other Snowflake errors keep the existing `MCPError` behavior.

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
