### PR TITLE
[front] feat: idempotency key on sandbox actions call

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/actions/call.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/call.test.ts
@@ -1,4 +1,6 @@
+import { generateSandboxFunctionInvocationToken } from "@app/lib/api/sandbox/access_tokens";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
@@ -332,6 +334,134 @@ describe("POST /api/v1/w/[wId]/sandbox/actions/call (function invocation)", () =
     });
 
     expect(response.status).toBe(400);
+  });
+
+  it("replays the existing action when the same idempotency key is resent", async () => {
+    const { auth, token, workspace, invocation, view } = await setupWithView();
+
+    const body = {
+      serverViewId: view.sId,
+      toolName: "generate_random_number",
+      arguments: { max: 10 },
+      idempotencyKey: "retry-1",
+    };
+
+    const first = await callSandboxTool(workspace, token, body);
+    expect(first.status).toBe(202);
+    const firstBody = await first.json();
+
+    const second = await callSandboxTool(workspace, token, body);
+    expect(second.status).toBe(202);
+    const secondBody = await second.json();
+
+    expect(secondBody).toEqual({
+      status: "pending",
+      actionId: firstBody.actionId,
+    });
+    const actions = await SandboxFunctionMCPActionResource.listByInvocation(
+      auth,
+      invocation
+    );
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.idempotencyKey).toBe("retry-1");
+    // The replay must not re-execute the tool.
+    expect(vi.mocked(launchSandboxFunctionToolWorkflow)).toHaveBeenCalledTimes(
+      1
+    );
+  });
+
+  it("creates one action per distinct idempotency key", async () => {
+    const { auth, token, workspace, invocation, view } = await setupWithView();
+
+    const first = await callSandboxTool(workspace, token, {
+      serverViewId: view.sId,
+      toolName: "generate_random_number",
+      arguments: { max: 10 },
+      idempotencyKey: "key-a",
+    });
+    const second = await callSandboxTool(workspace, token, {
+      serverViewId: view.sId,
+      toolName: "generate_random_number",
+      arguments: { max: 10 },
+      idempotencyKey: "key-b",
+    });
+
+    const firstBody = await first.json();
+    const secondBody = await second.json();
+    expect(secondBody.actionId).not.toBe(firstBody.actionId);
+    const actions = await SandboxFunctionMCPActionResource.listByInvocation(
+      auth,
+      invocation
+    );
+    expect(actions).toHaveLength(2);
+    expect(vi.mocked(launchSandboxFunctionToolWorkflow)).toHaveBeenCalledTimes(
+      2
+    );
+  });
+
+  it("scopes idempotency keys to the invocation", async () => {
+    const context = await setupWithView();
+
+    const secondInvocation = await SandboxFunctionInvocationResource.makeNew(
+      context.auth,
+      { sandboxFunction: context.sandboxFunction, input: undefined }
+    );
+    const secondToken = await generateSandboxFunctionInvocationToken(
+      context.auth,
+      {
+        sandbox: context.sandbox,
+        sandboxFunction: {
+          sId: context.sandboxFunction.sId,
+          space: { sId: context.podSpace.sId },
+        },
+        invocationId: secondInvocation.sId,
+        execId: `test-function-exec-2-${context.sandbox.sId}`,
+        noTools: false,
+      }
+    );
+
+    const body = {
+      serverViewId: context.view.sId,
+      toolName: "generate_random_number",
+      arguments: { max: 10 },
+      idempotencyKey: "shared-key",
+    };
+
+    const first = await callSandboxTool(context.workspace, context.token, body);
+    expect(first.status).toBe(202);
+    const firstBody = await first.json();
+
+    const second = await callSandboxTool(context.workspace, secondToken, body);
+    expect(second.status).toBe(202);
+    const secondBody = await second.json();
+
+    // Same key, different invocation: no collision, each invocation gets its own action.
+    expect(secondBody.actionId).not.toBe(firstBody.actionId);
+    expect(vi.mocked(launchSandboxFunctionToolWorkflow)).toHaveBeenCalledTimes(
+      2
+    );
+  });
+
+  it("creates a new action per call when no idempotency key is sent", async () => {
+    const { auth, token, workspace, invocation, view } = await setupWithView();
+
+    const body = {
+      serverViewId: view.sId,
+      toolName: "generate_random_number",
+      arguments: { max: 10 },
+    };
+
+    const first = await callSandboxTool(workspace, token, body);
+    const second = await callSandboxTool(workspace, token, body);
+
+    const firstBody = await first.json();
+    const secondBody = await second.json();
+    expect(secondBody.actionId).not.toBe(firstBody.actionId);
+    const actions = await SandboxFunctionMCPActionResource.listByInvocation(
+      auth,
+      invocation
+    );
+    expect(actions).toHaveLength(2);
   });
 
   it("reports a view outside the pod and global spaces as not found", async () => {

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
@@ -36,6 +36,7 @@ app.post(
       serverViewId,
       toolName,
       arguments: toolArgs,
+      idempotencyKey,
     } = ctx.req.valid("json");
 
     // Sandbox function invocations have no conversation: the action and any approval event are
@@ -85,6 +86,7 @@ app.post(
         serverViewId,
         toolName,
         rawInputs: toolArgs ?? {},
+        idempotencyKey,
       });
 
       if (result.isErr()) {
@@ -128,6 +130,8 @@ app.post(
       });
     }
 
+    // `idempotencyKey` only deduplicates function-invocation calls today: child actions live on
+    // the agent-loop's action model, which does not carry the key.
     const result = await createSandboxChildAction(auth, {
       parentActionId: claims.actionId,
       agentId: claims.aId,

--- a/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
+++ b/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
@@ -210,6 +210,10 @@ export async function createSandboxFunctionMCPAction(
   // Replay: a retried POST carrying the same idempotency key returns the original action instead
   // of creating (and executing) a second one. The client polls the action for its actual state,
   // whatever it is by now — including errored, which is what an honest replay reports.
+  //
+  // Lookup-then-create is deliberately best-effort: two concurrent POSTs with the same key can
+  // both miss and create two actions. The retrying clients replay sequentially, and a unique
+  // index would forbid legitimate key reuse after the window.
   if (idempotencyKey !== undefined) {
     const existingAction =
       await SandboxFunctionMCPActionResource.fetchByIdempotencyKey(auth, {

--- a/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
+++ b/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
@@ -18,11 +18,17 @@ import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_fu
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import logger from "@app/logger/logger";
 import { launchSandboxFunctionToolWorkflow } from "@app/temporal/sandbox_functions/client";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import omit from "lodash/omit";
+
+// How long a client idempotency key is remembered. Keys are scoped to the invocation, which is
+// itself bounded by the exec timeouts, so this only needs to cover a client retrying a POST whose
+// response was lost — 10 minutes matches the dsbx poll cap and is generous for that.
+const SANDBOX_ACTION_IDEMPOTENCY_WINDOW_MS = 10 * 60 * 1000;
 
 class SandboxFunctionMCPActionError extends Error {
   constructor(
@@ -120,6 +126,7 @@ export async function createSandboxFunctionMCPAction(
     serverViewId,
     toolName,
     rawInputs,
+    idempotencyKey,
   }: {
     sandboxFunctionId: string;
     invocationId: string;
@@ -127,6 +134,7 @@ export async function createSandboxFunctionMCPAction(
     serverViewId: string;
     toolName: string;
     rawInputs: Record<string, unknown>;
+    idempotencyKey?: string;
   }
 ): Promise<Result<{ actionId: string }, SandboxFunctionMCPActionError>> {
   const validateInputsResult = validateToolInputs(rawInputs);
@@ -199,6 +207,33 @@ export async function createSandboxFunctionMCPAction(
     );
   }
 
+  // Replay: a retried POST carrying the same idempotency key returns the original action instead
+  // of creating (and executing) a second one. The client polls the action for its actual state,
+  // whatever it is by now — including errored, which is what an honest replay reports.
+  if (idempotencyKey !== undefined) {
+    const existingAction =
+      await SandboxFunctionMCPActionResource.fetchByIdempotencyKey(auth, {
+        invocation,
+        mcpServerView: view,
+        toolName,
+        idempotencyKey,
+        createdAfter: new Date(
+          Date.now() - SANDBOX_ACTION_IDEMPOTENCY_WINDOW_MS
+        ),
+      });
+    if (existingAction) {
+      logger.info(
+        {
+          actionId: existingAction.sId,
+          invocationId: invocation.sId,
+          toolName,
+        },
+        "Replayed sandbox function MCP action for idempotency key"
+      );
+      return new Ok({ actionId: existingAction.sId });
+    }
+  }
+
   const toolConfiguration = toolConfigurationRes.value;
   const { status: executionStatus } = await getExecutionStatusFromConfig(auth, {
     actionConfiguration: toolConfiguration,
@@ -229,6 +264,7 @@ export async function createSandboxFunctionMCPAction(
       MCP_TOOL_CONFIGURATION_FIELDS_TO_OMIT
     ),
     status: actionStatus,
+    idempotencyKey,
   });
 
   switch (actionStatus) {

--- a/front/lib/resources/sandbox_function_mcp_action_resource.ts
+++ b/front/lib/resources/sandbox_function_mcp_action_resource.ts
@@ -89,6 +89,7 @@ export class SandboxFunctionMCPActionResource extends BaseResource<SandboxFuncti
       inputs,
       toolConfiguration,
       status,
+      idempotencyKey,
     }: {
       invocation: SandboxFunctionInvocationResource;
       mcpServerView: MCPServerViewResource;
@@ -96,6 +97,7 @@ export class SandboxFunctionMCPActionResource extends BaseResource<SandboxFuncti
       inputs: Record<string, unknown>;
       toolConfiguration: LightMCPToolConfigurationType;
       status: "running" | "blocked_validation_required";
+      idempotencyKey?: string;
     },
     transaction?: Transaction
   ): Promise<SandboxFunctionMCPActionResource> {
@@ -117,6 +119,7 @@ export class SandboxFunctionMCPActionResource extends BaseResource<SandboxFuncti
         inputs,
         toolConfiguration,
         status,
+        idempotencyKey: idempotencyKey ?? null,
       },
       { transaction }
     );
@@ -155,6 +158,45 @@ export class SandboxFunctionMCPActionResource extends BaseResource<SandboxFuncti
 
     const [action] = await this.baseFetch(auth, {
       where: { id: actionModelId },
+    });
+
+    return action ?? null;
+  }
+
+  // Most recent action created with this idempotency key for the invocation, if any within the
+  // window. The key is scoped to (invocation, server view, tool): a key accidentally reused for a
+  // different tool creates a fresh action rather than replaying an unrelated one, and reuse
+  // across invocations never collides. Rides the (workspaceId, sandboxFunctionInvocationId)
+  // index — an invocation only ever holds a handful of actions.
+  static async fetchByIdempotencyKey(
+    auth: Authenticator,
+    {
+      invocation,
+      mcpServerView,
+      toolName,
+      idempotencyKey,
+      createdAfter,
+    }: {
+      invocation: SandboxFunctionInvocationResource;
+      mcpServerView: MCPServerViewResource;
+      toolName: string;
+      idempotencyKey: string;
+      createdAfter: Date;
+    }
+  ): Promise<SandboxFunctionMCPActionResource | null> {
+    const [action] = await this.baseFetch(auth, {
+      where: {
+        sandboxFunctionInvocationId: invocation.id,
+        mcpServerViewId: mcpServerView.id,
+        toolName,
+        idempotencyKey,
+        createdAt: { [Op.gte]: createdAfter },
+      },
+      order: [
+        ["createdAt", "DESC"],
+        ["id", "DESC"],
+      ],
+      limit: 1,
     });
 
     return action ?? null;

--- a/front/lib/resources/storage/models/sandbox_function_mcp_action.ts
+++ b/front/lib/resources/storage/models/sandbox_function_mcp_action.ts
@@ -32,6 +32,10 @@ export class SandboxFunctionMCPActionModel extends WorkspaceAwareModel<SandboxFu
   declare status: ToolExecutionBaseStatus;
   declare outputGcsPath: string | null;
   declare executionDurationMs: number | null;
+  // Client-provided key deduplicating replayed `sandbox/actions/call` POSTs: a replay with the
+  // same key (scoped to the invocation) returns the original action instead of creating a second
+  // one. Null when the client did not send a key.
+  declare idempotencyKey: string | null;
 
   declare sandboxFunctionInvocation: NonAttribute<SandboxFunctionInvocationModel>;
   declare mcpServerView: NonAttribute<MCPServerViewModel>;
@@ -84,6 +88,11 @@ SandboxFunctionMCPActionModel.init(
     },
     executionDurationMs: {
       type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
+    },
+    idempotencyKey: {
+      type: DataTypes.STRING(255),
       allowNull: true,
       defaultValue: null,
     },

--- a/front/migrations/pre-deploy/20260811150000_add_idempotency_key_to_sandbox_function_mcp_actions.sql
+++ b/front/migrations/pre-deploy/20260811150000_add_idempotency_key_to_sandbox_function_mcp_actions.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_function_mcp_actions" ADD COLUMN "idempotencyKey" character varying(255) COLLATE "pg_catalog"."default";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -3659,6 +3659,9 @@ export const CallMCPToolRequestBodySchema = z.object({
   serverViewId: z.string(),
   toolName: z.string(),
   arguments: z.record(z.unknown()).optional(),
+  // Optional client-chosen key deduplicating replayed calls: a retried POST carrying the same key
+  // returns the already-created action instead of creating (and executing) a new one.
+  idempotencyKey: z.string().min(1).max(255).optional(),
 });
 
 export type CallMCPToolRequestBodyType = z.infer<


### PR DESCRIPTION
## Description

POST /v1/w/[wId]/sandbox/actions/call creates a fresh action on every request, so a client retrying a POST whose response was lost duplicates the tool call (and its execution).

Accept an optional `idempotencyKey` in the body. On the function-invocation path, a replay with the same key returns the already-created action instead of creating a new one; the client then polls the action for its actual state. The key is stored on the action row and scoped to (invocation, server view, tool) within a 10 minute window, so reuse across invocations never collides and a key accidentally reused for a different tool creates a fresh action rather than replaying an unrelated one.

The field is optional, older clients are unaffected. The exec-token (conversation sandbox) path accepts the field but does not dedupe: child actions live on the agent-loop action model, which does not carry the key.

## Tests

Endpoint tests: same key twice returns the same action and launches the workflow once; distinct keys create distinct actions; the same key on two invocations of the same function does not collide; no key keeps the current one-action-per-call behavior. Applied the migration SQL against a scratch database.

## Risk

Low: additive optional field, additive nullable column. The replay lookup rides the existing (workspaceId, sandboxFunctionInvocationId) index.

## Deploy Plan

Run the pre-deploy migration (nullable column add), then standard deploy.