### PR TITLE
[front] feat: accept an explicit dustPod on sandbox_functions tools

### DIFF
--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -1,3 +1,4 @@
+import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   POD_DATABASE_NAME_REGEX,
@@ -5,9 +6,22 @@ import {
   SANDBOX_FUNCTION_SLUG_REGEX,
   SANDBOX_FUNCTION_SLUG_SEGMENT_REGEX,
 } from "@app/types/api/sandbox_functions";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { z } from "zod";
 
 export const SANDBOX_FUNCTIONS_SERVER_NAME = "sandbox_functions" as const;
+
+// Every tool on this server resolves its pod the same way, so they share one optional dustPod
+// input mirroring pod_manager's: pass it to target a pod from any conversation, omit it to fall
+// back to the conversation's pod.
+const dustPodSchema = ConfigurableToolInputSchemas[
+  INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD
+]
+  .optional()
+  .describe(
+    "Optional Pod to target, will fallback to the conversation's Pod. Reuse a dustPod value " +
+      "from pod_manager's list tool; do not invent this URI."
+  );
 
 export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
   {
@@ -16,7 +30,9 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
       "List the pod functions published in the current pod, with their " +
       "slug and description. Use the get tool to retrieve a function's input " +
       "and output schemas.",
-    schema: {},
+    schema: {
+      dustPod: dustPodSchema,
+    },
     stake: "never_ask",
     displayLabels: {
       running: "Listing pod functions...",
@@ -34,6 +50,7 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
         .string()
         .min(1)
         .describe("The slug of the pod function, as shown by the list tool."),
+      dustPod: dustPodSchema,
     },
     stake: "never_ask",
     displayLabels: {
@@ -89,6 +106,7 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
             "interaction or on a poll `fast`, and isolate `dsbx tools` calls in their own " +
             "`durable` functions."
         ),
+      dustPod: dustPodSchema,
     },
     stake: "low",
     displayLabels: {
@@ -110,6 +128,7 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
         .describe(
           "The slug of the pod function to unpublish, as shown by the list tool."
         ),
+      dustPod: dustPodSchema,
     },
     stake: "high",
     displayLabels: {
@@ -138,6 +157,7 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
         .describe(
           "The function's input payload as a JSON object, matching its input schema (see the get tool)."
         ),
+      dustPod: dustPodSchema,
     },
     stake: "low",
     displayLabels: {
@@ -165,6 +185,7 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
         .optional()
         .default(5)
         .describe("Maximum number of recent invocations to return."),
+      dustPod: dustPodSchema,
     },
     stake: "never_ask",
     displayLabels: {
@@ -177,7 +198,9 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
   {
     name: "db_list",
     description: "List the pod's SQLite databases and their sizes.",
-    schema: {},
+    schema: {
+      dustPod: dustPodSchema,
+    },
     stake: "never_ask",
     displayLabels: {
       running: "Listing pod databases...",
@@ -194,6 +217,7 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
         .string()
         .regex(POD_DATABASE_NAME_REGEX)
         .describe("The database name, as shown by the db_list tool."),
+      dustPod: dustPodSchema,
     },
     stake: "never_ask",
     displayLabels: {
@@ -219,6 +243,7 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
           "A SINGLE SQL statement (SELECT or INSERT/UPDATE/DELETE); multiple statements " +
             "are rejected, issue one call per statement."
         ),
+      dustPod: dustPodSchema,
     },
     stake: "never_ask",
     displayLabels: {
@@ -247,6 +272,7 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
           "Scoped path to the database's drizzle schema file in the pod, as shown by the " +
             "files tools (e.g. `pod-<id>/MyApp/databases/chat.db.ts`)."
         ),
+      dustPod: dustPodSchema,
     },
     stake: "never_ask",
     displayLabels: {

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -20,7 +20,7 @@ const dustPodSchema = ConfigurableToolInputSchemas[
   .optional()
   .describe(
     "Optional Pod to target, will fallback to the conversation's Pod. Reuse a dustPod value " +
-      "from pod_manager's list tool; do not invent this URI."
+      "from pod_manager's list_pods tool; do not invent this URI."
   );
 
 export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [

--- a/front/lib/api/actions/servers/sandbox_functions/tools/call.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/call.ts
@@ -1,4 +1,5 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { DustPodConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   ToolHandlerExtra,
   ToolHandlerResult,
@@ -10,10 +11,21 @@ import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_res
 import { Err, Ok } from "@app/types/shared/result";
 
 export async function callHandler(
-  { slug, input }: { slug: string; input?: Record<string, unknown> },
+  {
+    slug,
+    input,
+    dustPod,
+  }: {
+    slug: string;
+    input?: Record<string, unknown>;
+    dustPod?: DustPodConfigurationType;
+  },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getPod(auth, { toolContext: { runContext } });
+  const podResult = await getPod(auth, {
+    toolContext: { runContext },
+    dustPod,
+  });
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/db_list.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/db_list.ts
@@ -1,3 +1,4 @@
+import type { DustPodConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   ToolHandlerExtra,
   ToolHandlerResult,
@@ -23,10 +24,13 @@ export function formatDatabasesList(databases: LiveDatabaseEntry[]): string {
 }
 
 export async function dbListHandler(
-  _params: Record<string, never>,
+  { dustPod }: { dustPod?: DustPodConfigurationType },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getPod(auth, { toolContext: { runContext } });
+  const podResult = await getPod(auth, {
+    toolContext: { runContext },
+    dustPod,
+  });
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/db_query.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/db_query.ts
@@ -1,3 +1,4 @@
+import type { DustPodConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   ToolHandlerExtra,
   ToolHandlerResult,
@@ -28,12 +29,17 @@ export function formatQueryResult(result: QueryDatabaseResult): string {
 }
 
 export async function dbQueryHandler(
-  { database, sql }: { database: string; sql: string },
+  {
+    database,
+    sql,
+    dustPod,
+  }: { database: string; sql: string; dustPod?: DustPodConfigurationType },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
   // Write gate: db_query runs DML, not just reads.
   const podResult = await getWritablePodContext(auth, {
     toolContext: { runContext },
+    dustPod,
   });
   if (podResult.isErr()) {
     return new Err(podResult.error);

--- a/front/lib/api/actions/servers/sandbox_functions/tools/db_reconcile.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/db_reconcile.ts
@@ -1,3 +1,4 @@
+import type { DustPodConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   ToolHandlerExtra,
   ToolHandlerResult,
@@ -21,11 +22,16 @@ export function formatReconcileResult(result: ReconcileDatabaseResult): string {
 }
 
 export async function dbReconcileHandler(
-  { database, path }: { database: string; path: string },
+  {
+    database,
+    path,
+    dustPod,
+  }: { database: string; path: string; dustPod?: DustPodConfigurationType },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
   const podResult = await getWritablePodContext(auth, {
     toolContext: { runContext },
+    dustPod,
   });
   if (podResult.isErr()) {
     return new Err(podResult.error);

--- a/front/lib/api/actions/servers/sandbox_functions/tools/db_schema.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/db_schema.ts
@@ -1,3 +1,4 @@
+import type { DustPodConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   ToolHandlerExtra,
   ToolHandlerResult,
@@ -8,10 +9,13 @@ import { getDatabaseSchemaOnSandbox } from "@app/lib/api/sandbox_functions/dsbx_
 import { Err, Ok } from "@app/types/shared/result";
 
 export async function dbSchemaHandler(
-  { database }: { database: string },
+  { database, dustPod }: { database: string; dustPod?: DustPodConfigurationType },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getPod(auth, { toolContext: { runContext } });
+  const podResult = await getPod(auth, {
+    toolContext: { runContext },
+    dustPod,
+  });
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/db_schema.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/db_schema.ts
@@ -9,7 +9,10 @@ import { getDatabaseSchemaOnSandbox } from "@app/lib/api/sandbox_functions/dsbx_
 import { Err, Ok } from "@app/types/shared/result";
 
 export async function dbSchemaHandler(
-  { database, dustPod }: { database: string; dustPod?: DustPodConfigurationType },
+  {
+    database,
+    dustPod,
+  }: { database: string; dustPod?: DustPodConfigurationType },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
   const podResult = await getPod(auth, {

--- a/front/lib/api/actions/servers/sandbox_functions/tools/get.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/get.ts
@@ -1,4 +1,5 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { DustPodConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   ToolHandlerExtra,
   ToolHandlerResult,
@@ -18,10 +19,13 @@ export function formatSandboxFunction(fn: SandboxFunctionResource): string {
 }
 
 export async function getHandler(
-  { slug }: { slug: string },
+  { slug, dustPod }: { slug: string; dustPod?: DustPodConfigurationType },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getPod(auth, { toolContext: { runContext } });
+  const podResult = await getPod(auth, {
+    toolContext: { runContext },
+    dustPod,
+  });
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/inspect_invocations.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/inspect_invocations.ts
@@ -1,4 +1,5 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { DustPodConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   ToolHandlerExtra,
   ToolHandlerResult,
@@ -27,10 +28,17 @@ export function formatSandboxFunctionInvocations(
 }
 
 export async function inspectInvocationsHandler(
-  { slug, limit }: { slug: string; limit: number },
+  {
+    slug,
+    limit,
+    dustPod,
+  }: { slug: string; limit: number; dustPod?: DustPodConfigurationType },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getPod(auth, { toolContext: { runContext } });
+  const podResult = await getPod(auth, {
+    toolContext: { runContext },
+    dustPod,
+  });
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/list.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/list.test.ts
@@ -1,11 +1,27 @@
-import { formatSandboxFunctionsList } from "@app/lib/api/actions/servers/sandbox_functions/tools/list";
+import { makePodConfigurationURI } from "@app/lib/actions/mcp_internal_actions/pod_configuration_uri";
+import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { AgentLoopRunContext } from "@app/lib/actions/types";
+import {
+  formatSandboxFunctionsList,
+  listHandler,
+} from "@app/lib/api/actions/servers/sandbox_functions/tools/list";
 import type { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { getTestStreamEndpoint } from "@app/tests/utils/models";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import {
+  isAgentMessageType,
+  isUserMessageType,
+} from "@app/types/assistant/conversation";
 import { sandboxFunctionContentType } from "@app/types/files";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { describe, expect, it } from "vitest";
 
@@ -94,5 +110,110 @@ describe("formatSandboxFunctionsList", () => {
 
     expect(out).toContain("greet");
     expect(out).toContain("translate-text");
+  });
+});
+
+describe("listHandler with a caller-supplied dustPod", () => {
+  // Builds a ToolHandlerExtra for an agent loop running in a conversation that is NOT in a pod,
+  // mirroring the pod_manager tools test setup.
+  async function makeNonPodAgentLoopExtra(
+    auth: Authenticator
+  ): Promise<ToolHandlerExtra> {
+    const workspace = auth.getNonNullableWorkspace();
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const userMessage = conversation.content.flat().find(isUserMessageType);
+    const agentMessage = conversation.content.flat().find(isAgentMessageType);
+    assert(userMessage);
+    assert(agentMessage);
+
+    const { action } = await AgentMCPActionFactory.create(auth, {
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId: agentMessage.agentMessageId,
+      functionCallName: "list",
+      toolName: "list",
+      mcpServerName: "sandbox_functions",
+    });
+    const { model, ...agentConfiguration } = agent;
+    const runContext: AgentLoopRunContext = {
+      contextType: "agent_loop",
+      action,
+      agentConfiguration,
+      modelInfo: {
+        endpoint: getTestStreamEndpoint(model.modelId),
+        ...model,
+      },
+      agentMessage,
+      conversation,
+      stepContext: {
+        citationsCount: 0,
+        citationsOffset: 0,
+        retrievalTopK: 10,
+        resumeState: null,
+        websearchResultCount: 0,
+      },
+      toolConfiguration: action.toolConfiguration,
+      userMessage,
+    };
+
+    return {
+      auth,
+      requestId: "sandbox-functions-list-dust-pod-test",
+      runContext,
+      sendNotification: async () => {},
+      sendRequest: async () => {
+        throw new Error("Unexpected MCP request");
+      },
+      signal: new AbortController().signal,
+    };
+  }
+
+  it("fails outside a pod conversation when no dustPod is provided", async () => {
+    const { authenticator: auth } = await createResourceTest({
+      role: "admin",
+    });
+    const extra = await makeNonPodAgentLoopExtra(auth);
+
+    const result = await listHandler({}, extra);
+
+    assert(result.isErr());
+    expect(result.error.message).toContain("not in a Pod");
+  });
+
+  it("resolves the pod from dustPod outside a pod conversation", async () => {
+    const {
+      authenticator: auth,
+      user,
+      workspace,
+    } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace, user.id);
+    await auth.refresh();
+    await makeFunction(auth, pod, {
+      slug: "greet",
+      description: "Greet a user by name.",
+    });
+    const extra = await makeNonPodAgentLoopExtra(auth);
+
+    const result = await listHandler(
+      {
+        dustPod: {
+          uri: makePodConfigurationURI(workspace.sId, pod.sId),
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD,
+        },
+      },
+      extra
+    );
+
+    assert(result.isOk());
+    const content = result.value[0];
+    assert(content?.type === "text");
+    expect(content.text).toContain("- greet: Greet a user by name.");
   });
 });

--- a/front/lib/api/actions/servers/sandbox_functions/tools/list.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/list.test.ts
@@ -1,6 +1,4 @@
 import { makePodConfigurationURI } from "@app/lib/actions/mcp_internal_actions/pod_configuration_uri";
-import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { AgentLoopRunContext } from "@app/lib/actions/types";
 import {
   formatSandboxFunctionsList,
   listHandler,
@@ -8,17 +6,13 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
-import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
-import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import {
+  makeExtra,
+  setupPlainConversation,
+} from "@app/tests/utils/conversation_test_factories";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import { getTestStreamEndpoint } from "@app/tests/utils/models";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import {
-  isAgentMessageType,
-  isUserMessageType,
-} from "@app/types/assistant/conversation";
 import { sandboxFunctionContentType } from "@app/types/files";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import assert from "assert";
@@ -114,92 +108,25 @@ describe("formatSandboxFunctionsList", () => {
 });
 
 describe("listHandler with a caller-supplied dustPod", () => {
-  // Builds a ToolHandlerExtra for an agent loop running in a conversation that is NOT in a pod,
-  // mirroring the pod_manager tools test setup.
-  async function makeNonPodAgentLoopExtra(
-    auth: Authenticator
-  ): Promise<ToolHandlerExtra> {
-    const workspace = auth.getNonNullableWorkspace();
-    const agent = await AgentConfigurationFactory.createTestAgent(auth);
-    const conversation = await ConversationFactory.create(auth, {
-      agentConfigurationId: agent.sId,
-      messagesCreatedAt: [new Date()],
-    });
-
-    const userMessage = conversation.content.flat().find(isUserMessageType);
-    const agentMessage = conversation.content.flat().find(isAgentMessageType);
-    assert(userMessage);
-    assert(agentMessage);
-
-    const { action } = await AgentMCPActionFactory.create(auth, {
-      workspace,
-      conversationModelId: conversation.id,
-      agentMessageModelId: agentMessage.agentMessageId,
-      functionCallName: "list",
-      toolName: "list",
-      mcpServerName: "sandbox_functions",
-    });
-    const { model, ...agentConfiguration } = agent;
-    const runContext: AgentLoopRunContext = {
-      contextType: "agent_loop",
-      action,
-      agentConfiguration,
-      modelInfo: {
-        endpoint: getTestStreamEndpoint(model.modelId),
-        ...model,
-      },
-      agentMessage,
-      conversation,
-      stepContext: {
-        citationsCount: 0,
-        citationsOffset: 0,
-        retrievalTopK: 10,
-        resumeState: null,
-        websearchResultCount: 0,
-      },
-      toolConfiguration: action.toolConfiguration,
-      userMessage,
-    };
-
-    return {
-      auth,
-      requestId: "sandbox-functions-list-dust-pod-test",
-      runContext,
-      sendNotification: async () => {},
-      sendRequest: async () => {
-        throw new Error("Unexpected MCP request");
-      },
-      signal: new AbortController().signal,
-    };
-  }
-
   it("fails outside a pod conversation when no dustPod is provided", async () => {
-    const { authenticator: auth } = await createResourceTest({
-      role: "admin",
-    });
-    const extra = await makeNonPodAgentLoopExtra(auth);
+    const { auth, conversation } = await setupPlainConversation();
 
-    const result = await listHandler({}, extra);
+    const result = await listHandler({}, makeExtra(auth, conversation));
 
     assert(result.isErr());
     expect(result.error.message).toContain("not in a Pod");
   });
 
   it("resolves the pod from dustPod outside a pod conversation", async () => {
-    const {
-      authenticator: auth,
-      user,
-      workspace,
-    } = await createResourceTest({
-      role: "admin",
-    });
+    const { auth, conversation } = await setupPlainConversation();
+    const workspace = auth.getNonNullableWorkspace();
+    const user = auth.getNonNullableUser();
     const pod = await SpaceFactory.project(workspace, user.id);
     await auth.refresh();
     await makeFunction(auth, pod, {
       slug: "greet",
       description: "Greet a user by name.",
     });
-    const extra = await makeNonPodAgentLoopExtra(auth);
 
     const result = await listHandler(
       {
@@ -208,7 +135,7 @@ describe("listHandler with a caller-supplied dustPod", () => {
           mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD,
         },
       },
-      extra
+      makeExtra(auth, conversation)
     );
 
     assert(result.isOk());

--- a/front/lib/api/actions/servers/sandbox_functions/tools/list.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/list.ts
@@ -1,3 +1,4 @@
+import type { DustPodConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   ToolHandlerExtra,
   ToolHandlerResult,
@@ -22,10 +23,13 @@ export function formatSandboxFunctionsList(
 }
 
 export async function listHandler(
-  _params: Record<string, never>,
+  { dustPod }: { dustPod?: DustPodConfigurationType },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getPod(auth, { toolContext: { runContext } });
+  const podResult = await getPod(auth, {
+    toolContext: { runContext },
+    dustPod,
+  });
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
@@ -1,4 +1,5 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { DustPodConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   ToolHandlerExtra,
   ToolHandlerResult,
@@ -16,16 +17,19 @@ export async function publishHandler(
     executionMode,
     path,
     slug,
+    dustPod,
   }: {
     description: string;
     executionMode: SandboxFunctionExecutionMode;
     path: string;
     slug: string;
+    dustPod?: DustPodConfigurationType;
   },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
   const podResult = await getWritablePodContext(auth, {
     toolContext: { runContext },
+    dustPod,
   });
   if (podResult.isErr()) {
     return new Err(podResult.error);

--- a/front/lib/api/actions/servers/sandbox_functions/tools/unpublish.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/unpublish.ts
@@ -1,4 +1,5 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { DustPodConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   ToolHandlerExtra,
   ToolHandlerResult,
@@ -8,11 +9,12 @@ import { unpublishSandboxFunction } from "@app/lib/api/sandbox_functions/unpubli
 import { Err, Ok } from "@app/types/shared/result";
 
 export async function unpublishHandler(
-  { slug }: { slug: string },
+  { slug, dustPod }: { slug: string; dustPod?: DustPodConfigurationType },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
   const podResult = await getWritablePodContext(auth, {
     toolContext: { runContext },
+    dustPod,
   });
   if (podResult.isErr()) {
     return new Err(podResult.error);

--- a/front/lib/resources/skill/code_defined/global/pod_functions.test.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.test.ts
@@ -1,0 +1,50 @@
+import { podFunctionsSkill } from "@app/lib/resources/skill/code_defined/global/pod_functions";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
+import { describe, expect, it } from "vitest";
+
+function agentLoopData({
+  spaceId,
+  hasConfiguredPod,
+}: {
+  spaceId: string | null;
+  hasConfiguredPod: boolean;
+}): AgentLoopExecutionData {
+  return {
+    agentConfiguration: {
+      actions: [
+        {
+          dustProject: hasConfiguredPod
+            ? { workspaceId: "w-id", projectId: "pod-id" }
+            : null,
+        },
+      ],
+    },
+    conversation: { spaceId },
+  } as unknown as AgentLoopExecutionData;
+}
+
+describe("podFunctionsSkill.isDisabledForAgentLoop", () => {
+  it("keeps the skill in a pod conversation", () => {
+    expect(
+      podFunctionsSkill.isDisabledForAgentLoop(
+        agentLoopData({ spaceId: "vlt_123", hasConfiguredPod: false })
+      )
+    ).toBe(false);
+  });
+
+  it("hides the skill outside a pod conversation when no pod is configured", () => {
+    expect(
+      podFunctionsSkill.isDisabledForAgentLoop(
+        agentLoopData({ spaceId: null, hasConfiguredPod: false })
+      )
+    ).toBe(true);
+  });
+
+  it("keeps the skill outside a pod conversation when the agent has a configured pod", () => {
+    expect(
+      podFunctionsSkill.isDisabledForAgentLoop(
+        agentLoopData({ spaceId: null, hasConfiguredPod: true })
+      )
+    ).toBe(false);
+  });
+});

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -453,10 +453,22 @@ the platform only tells you the caller is a workspace member, not what they are 
 
     return !flags.includes("sandbox_functions");
   },
-  // Functions are Pod-scoped, so the skill is hidden outside a Pod conversation.
-  isDisabledForAgentLoop: (agentLoopData) =>
-    !agentLoopData.conversation ||
-    !isPodConversation(agentLoopData.conversation),
+  // Functions are Pod-scoped, so the skill is hidden outside a Pod conversation — unless the
+  // agent explicitly targets a Pod through one of its actions' Pod configuration, in which case
+  // the tools can resolve that Pod via their `dustPod` input from any conversation.
+  isDisabledForAgentLoop: (agentLoopData) => {
+    if (
+      agentLoopData.conversation &&
+      isPodConversation(agentLoopData.conversation)
+    ) {
+      return false;
+    }
+
+    // Client-side MCP server configurations carry no Pod configuration.
+    return !agentLoopData.agentConfiguration.actions.some(
+      (action) => "dustProject" in action && action.dustProject !== null
+    );
+  },
   // Equipped in Pod conversations but not auto-enabled.
   getAutoEnabledOrEquippedForAgentLoop: () => "equipped",
 } as const satisfies GlobalSkillDefinition;


### PR DESCRIPTION
## Description

Publishing or reconciling pod functions only worked from inside a pod conversation, so build conversations had to delegate publishes to spawned pod conversations. The pod resolution helpers (`getPod` / `getWritablePodContext`) already take a `dustPod` input; only the `sandbox_functions` tool schemas and call sites lacked it.

- Add pod_manager's optional `dustPod` input to every `sandbox_functions` tool (list, get, publish, unpublish, call, inspect_invocations, db_list, db_schema, db_query, db_reconcile) and pass it through to the pod resolution helpers. Omitting it keeps the current conversation-pod fallback.
- Relax the pod_functions skill agent-loop gate: the skill stays available outside pod conversations when the agent has a pod explicitly configured on one of its actions, since the tools can then target that pod via `dustPod`.

Permissioning is unchanged: the resolved pod still goes through the existing canRead/canWrite checks, and unreadable pods report as not found.

## Tests

Added a handler-level test that lists a pod's functions from a non-pod conversation via `dustPod` (and errors without it), plus unit tests for the skill gate.

## Risk

Low. The new input is optional so existing calls behave the same, and pod access checks were already enforced in the shared helpers.

## Deploy Plan

Standard deploy.