### PR TITLE
[viz] fix: fail callFunction fast when no host window can answer

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -504,6 +504,12 @@ function useVisualizationDataHandler({
           sendResponseToIframe(data, userIdentity, event.source);
           break;
 
+        case "ping":
+          // Liveness probe: the iframe uses the answer to tell a live host from a hostless
+          // (top-level) context where postMessage RPC would hang forever.
+          sendResponseToIframe(data, { ok: true }, event.source);
+          break;
+
         case "getFile":
           const fileBlob = await getFileBlob(data.params.fileId);
 

--- a/front/types/assistant/visualization.ts
+++ b/front/types/assistant/visualization.ts
@@ -92,6 +92,13 @@ const GetCodeToExecuteRequestSchema = VisualizationRPCRequestBaseSchema.extend({
   params: z.null(),
 });
 
+// Liveness probe sent by the iframe when its RPC data API is constructed. The host answers
+// immediately so the iframe can tell a live host from a hostless (top-level) context.
+const PingRequestSchema = VisualizationRPCRequestBaseSchema.extend({
+  command: z.literal("ping"),
+  params: z.null(),
+});
+
 const SetContentHeightRequestSchema = VisualizationRPCRequestBaseSchema.extend({
   command: z.literal("setContentHeight"),
   params: SetContentHeightParamsSchema,
@@ -138,6 +145,7 @@ const VisualizationRPCRequestSchema = z.union([
   GetUserIdentityRequestSchema,
   GetFileRequestSchema,
   GetCodeToExecuteRequestSchema,
+  PingRequestSchema,
   SetContentHeightRequestSchema,
   SetErrorMessageRequestSchema,
   DownloadFileRequestSchema,
@@ -158,6 +166,7 @@ export type VisualizationRPCRequestMap = {
   getUserIdentity: null;
   getFile: GetFileParams;
   getCodeToExecute: null;
+  ping: null;
   setContentHeight: SetContentHeightParams;
   setErrorMessage: SetErrorMessageParams;
   downloadFileRequest: DownloadFileRequestParams;
@@ -172,6 +181,7 @@ export interface CommandResultMap {
   getCodeToExecute: { code: string };
   getFile: { fileBlob: Blob | null };
   downloadFileRequest: { blob: Blob; filename?: string };
+  ping: { ok: true };
   setContentHeight: void;
   setErrorMessage: void;
   displayCode: void;

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -708,6 +708,11 @@ function isOriginAllowed(origin: string, allowedOrigins: string[]): boolean {
 
 export const USER_IDENTITY_RPC_TIMEOUT_MS = 5_000;
 
+// How long the host has to answer the liveness ping sent when the RPC data API is
+// constructed. Hosts answer synchronously from their message listener, so an unanswered
+// ping means the host is either absent or a legacy deploy that predates the command.
+export const HOST_LIVENESS_PING_TIMEOUT_MS = 3_000;
+
 export function makeSendCrossDocumentMessage({
   identifier,
   allowedOrigins,
@@ -754,6 +759,11 @@ export function makeSendCrossDocumentMessage({
           cleanup();
           reject(new Error("Frame host did not provide user identity."));
         }, USER_IDENTITY_RPC_TIMEOUT_MS);
+      } else if (command === "ping") {
+        timeoutId = window.setTimeout(() => {
+          cleanup();
+          reject(new Error("Frame host did not answer the liveness ping."));
+        }, HOST_LIVENESS_PING_TIMEOUT_MS);
       }
       window.parent?.postMessage(
         {

--- a/viz/app/lib/data-apis/rpc-data-api.test.ts
+++ b/viz/app/lib/data-apis/rpc-data-api.test.ts
@@ -84,3 +84,51 @@ describe("sandbox function data APIs", () => {
     });
   });
 });
+
+describe("host liveness", () => {
+  it("pings the host when constructed with a host window", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ ok: true });
+    const api = new RPCDataAPI(sendMessage, { hasHostWindow: true });
+
+    expect(sendMessage).toHaveBeenCalledWith("ping", null);
+    await vi.waitFor(() => expect(api.hostLiveness).toBe("alive"));
+  });
+
+  it("records an unanswered ping without changing call behavior", async () => {
+    const sendMessage = vi.fn().mockImplementation(async (command: string) => {
+      if (command === "ping") {
+        throw new Error("Frame host did not answer the liveness ping.");
+      }
+      return [{ id: 1 }];
+    });
+    const api = new RPCDataAPI(sendMessage, { hasHostWindow: true });
+
+    await vi.waitFor(() => expect(api.hostLiveness).toBe("unresponsive"));
+    // Silent embedded hosts are treated as legacy: calls still go over RPC.
+    await expect(api.callFunction("pod/function")).resolves.toEqual([
+      { id: 1 },
+    ]);
+  });
+
+  it("fails calls fast without a host window instead of hanging", async () => {
+    const sendMessage = vi.fn();
+    const api = new RPCDataAPI(sendMessage, { hasHostWindow: false });
+
+    const promise = api.callFunction("pod/function");
+
+    await expect(promise).rejects.toBeInstanceOf(SandboxFunctionCallError);
+    await expect(promise).rejects.toMatchObject({ code: "not_supported" });
+    // No ping and no call ever leave a hostless window.
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(api.hostLiveness).toBe("unresponsive");
+  });
+
+  it("keeps non-call reads on the RPC channel without a host window", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ code: "<Frame />" });
+    const api = new RPCDataAPI(sendMessage, { hasHostWindow: false });
+
+    // Reads keep their own error handling; only callFunction fails fast.
+    await expect(api.fetchCode()).resolves.toBe("<Frame />");
+    expect(sendMessage).toHaveBeenCalledWith("getCodeToExecute", null);
+  });
+});

--- a/viz/app/lib/data-apis/rpc-data-api.ts
+++ b/viz/app/lib/data-apis/rpc-data-api.ts
@@ -1,10 +1,31 @@
-import { normalizeSandboxFunctionCallError } from "@viz/app/lib/data-apis/sandbox-function-call-error";
+import {
+  normalizeSandboxFunctionCallError,
+  SandboxFunctionCallError,
+} from "@viz/app/lib/data-apis/sandbox-function-call-error";
 import type { VisualizationDataAPI } from "@viz/app/lib/visualization-api";
 import type {
   CommandResultMap,
   VisualizationRPCCommand,
   VisualizationRPCRequestMap,
 } from "@viz/app/types";
+
+export type HostLivenessState = "unknown" | "alive" | "unresponsive";
+
+interface RPCDataAPIOptions {
+  // Whether a separate host window exists to answer RPC messages. Defaults to detecting a
+  // top-level browser window (window.parent === window), where postMessage RPC can never be
+  // answered. SSR constructs the API without a `window` and never calls functions, so the
+  // detection defaults to true there.
+  hasHostWindow?: boolean;
+}
+
+function detectHostWindow(): boolean {
+  if (typeof window === "undefined") {
+    return true;
+  }
+
+  return window.parent !== window;
+}
 
 /**
  * RPC-based data API for client-side components
@@ -16,16 +37,54 @@ export class RPCDataAPI implements VisualizationDataAPI {
     params: VisualizationRPCRequestMap[T]
   ) => Promise<CommandResultMap[T]>;
 
+  private readonly hasHostWindow: boolean;
+  private _hostLiveness: HostLivenessState = "unknown";
+
   constructor(
     sendMessage: <T extends VisualizationRPCCommand>(
       command: T,
       params: VisualizationRPCRequestMap[T]
-    ) => Promise<CommandResultMap[T]>
+    ) => Promise<CommandResultMap[T]>,
+    options?: RPCDataAPIOptions
   ) {
     this.sendMessage = sendMessage;
+    this.hasHostWindow = options?.hasHostWindow ?? detectHostWindow();
+
+    if (this.hasHostWindow) {
+      // Probe host liveness once per mount. The transport bounds the ping with its own
+      // timeout, so this settles either way. An unanswered ping is recorded but does not
+      // change behavior: embedded hosts that predate the ping command are treated as
+      // legacy and keep the pre-ping semantics.
+      void this.probeHostLiveness();
+    } else {
+      this._hostLiveness = "unresponsive";
+    }
+  }
+
+  get hostLiveness(): HostLivenessState {
+    return this._hostLiveness;
+  }
+
+  private async probeHostLiveness(): Promise<void> {
+    try {
+      await this.sendMessage("ping", null);
+      this._hostLiveness = "alive";
+    } catch (_error) {
+      this._hostLiveness = "unresponsive";
+    }
   }
 
   async callFunction(functionId: string, input?: unknown): Promise<unknown> {
+    if (!this.hasHostWindow) {
+      // Top-level window: there is no host to serve the call, so the RPC below would hang
+      // forever (only getUserIdentity has a transport timeout). Fail fast with the code
+      // frames already branch on for hostless contexts.
+      throw new SandboxFunctionCallError({
+        code: "not_supported",
+        message: `Sandbox function ${functionId} cannot be called: no host window is available to serve function calls.`,
+      });
+    }
+
     try {
       return await this.sendMessage("callFunction", {
         functionIdOrSlug: functionId,

--- a/viz/app/types.ts
+++ b/viz/app/types.ts
@@ -61,6 +61,7 @@ export type VisualizationRPCRequestMap = {
   getUserIdentity: null;
   getFile: GetFileParams;
   getCodeToExecute: null;
+  ping: null;
   setContentHeight: SetContentHeightParams;
   setErrorMessage: SetErrorMessageParams;
   downloadFileRequest: DownloadFileRequestParams;
@@ -79,6 +80,7 @@ export interface CommandResultMap {
   getCodeToExecute: { code: string };
   getFile: { fileBlob: Blob | null };
   downloadFileRequest: { blob: Blob; filename?: string };
+  ping: { ok: true };
   setContentHeight: void;
   setErrorMessage: void;
   displayCode: void;


### PR DESCRIPTION
## Description

In hostless contexts (headless render, top-level page) a frame's `callFunction` rides postMessage RPC to a parent that does not exist and hangs forever: only `getUserIdentity` had a transport timeout, and frames grew auto-hide workarounds for exactly this.

- `RPCDataAPI` detects a top-level window (`window.parent === window`) and rejects `callFunction` immediately with code `not_supported`, the code frames already branch on for hostless contexts (same code the public-frame cache API throws).
- On construction with a host window, the API sends a `ping` liveness probe with a 3s transport timeout. Silent embedded hosts are treated as legacy: the probe outcome is recorded but calls keep the pre-ping behavior, so hosts that predate the command see no change.
- The conversation host answers `ping` in its RPC command switch.

Old hosts ignore the unknown `ping` command (it fails zod validation before the switch), and old iframes never send it, so both deploy orders are safe.

## Tests

Added viz unit tests: ping sent on construction, unanswered ping keeps RPC behavior for embedded hosts, hostless `callFunction` rejects with `not_supported` without touching the channel, reads stay on the RPC channel.

## Risk

Low. Fail-fast triggers only when `window.parent === window`, where the call could never succeed. Embedded hosts keep existing behavior regardless of ping outcome.

## Deploy Plan

Standard deploy.