### PR TITLE
[front] feat: pod_editor_required identity policy + isPodEditor in the identity envelope

### DIFF
--- a/cli/dust-sandbox/pod/identity.test.ts
+++ b/cli/dust-sandbox/pod/identity.test.ts
@@ -28,7 +28,24 @@ describe("currentUser", () => {
     process.env[POD_WORKSPACE_ID_ENV] = "w_current";
     process.env[POD_USER_IDENTITY_ENV] = JSON.stringify(identity);
 
-    expect(currentUser()).toEqual(identity.user);
+    expect(currentUser()).toEqual({ ...identity.user, isPodEditor: false });
+  });
+
+  test("reads the pod editor bit from the envelope", () => {
+    process.env[POD_WORKSPACE_ID_ENV] = "w_current";
+    process.env[POD_USER_IDENTITY_ENV] = JSON.stringify({
+      ...identity,
+      isPodEditor: true,
+    });
+
+    expect(currentUser()).toEqual({ ...identity.user, isPodEditor: true });
+  });
+
+  test("defaults the pod editor bit to false when the envelope omits it", () => {
+    process.env[POD_WORKSPACE_ID_ENV] = "w_current";
+    process.env[POD_USER_IDENTITY_ENV] = JSON.stringify(identity);
+
+    expect(currentUser()?.isPodEditor).toBe(false);
   });
 
   test("returns null for a userless invocation", () => {
@@ -70,7 +87,7 @@ describe("currentUser inside an invocation context", () => {
       contextEnv(JSON.stringify(identity)),
       () => currentUser()
     );
-    expect(user).toEqual(identity.user);
+    expect(user).toEqual({ ...identity.user, isPodEditor: false });
   });
 
   test("a userless context returns null even when process.env has an identity", () => {

--- a/cli/dust-sandbox/pod/identity.ts
+++ b/cli/dust-sandbox/pod/identity.ts
@@ -11,15 +11,16 @@ export interface WorkspaceUserIdentity {
   readonly lastName: string | null;
   readonly fullName: string;
   readonly image: string | null;
-}
-
-interface WorkspaceUserIdentityEnvelope {
-  workspaceId: string;
-  user: WorkspaceUserIdentity;
+  // Whether the caller is an editor of the Pod this function belongs to (workspace admins
+  // included). Gate refresh-style mutations on it; viewers only read.
+  readonly isPodEditor: boolean;
 }
 
 const workspaceUserIdentityEnvelopeSchema = z.object({
   workspaceId: z.string(),
+  // Optional so envelopes written before the field existed still parse; absent means false,
+  // the restrictive reading.
+  isPodEditor: z.boolean().optional(),
   user: z.object({
     sId: z.string(),
     firstName: z.string(),
@@ -28,6 +29,10 @@ const workspaceUserIdentityEnvelopeSchema = z.object({
     image: z.string().nullable(),
   }),
 });
+
+type WorkspaceUserIdentityEnvelope = z.infer<
+  typeof workspaceUserIdentityEnvelopeSchema
+>;
 
 export class PodUserIdentityError extends Error {
   override readonly name = "PodUserIdentityError";
@@ -71,5 +76,6 @@ export function currentUser(): WorkspaceUserIdentity | null {
     lastName: value.user.lastName,
     fullName: value.user.fullName,
     image: value.user.image,
+    isPodEditor: value.isPodEditor ?? false,
   });
 }

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -97,10 +97,12 @@ afterEach(() => {
 
 async function setupSandboxFunction({
   addCallerToSpace = true,
+  addCallerToEditors = false,
   withSandboxFunctionsFeatureFlag = true,
   userIdentity = "optional",
 }: {
   addCallerToSpace?: boolean;
+  addCallerToEditors?: boolean;
   withSandboxFunctionsFeatureFlag?: boolean;
   userIdentity?: SandboxFunctionUserIdentityPolicy;
 } = {}) {
@@ -145,6 +147,20 @@ async function setupSandboxFunction({
       user: user.toJSON(),
     });
     expect(addMemberResult.isOk()).toBe(true);
+  }
+  if (addCallerToEditors) {
+    const [editorGroup] = await space.fetchGroupResources(adminAuth, {
+      groupReferences: space.groups.filter(
+        (group) => group.groupKind === "space_editors"
+      ),
+    });
+    if (!editorGroup) {
+      throw new Error("Expected the project editor group to exist.");
+    }
+    const addEditorResult = await editorGroup.dangerouslyAddMember(adminAuth, {
+      user: user.toJSON(),
+    });
+    expect(addEditorResult.isOk()).toBe(true);
   }
   const callerAuth = await Authenticator.fromUserIdAndWorkspaceId(
     user.sId,
@@ -477,6 +493,42 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
 
     expect(response.status).toBe(201);
     expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledOnce();
+  });
+
+  it("allows a pod editor to invoke a pod-editor-required function", async () => {
+    // Editors are not in the member group ("a user cannot be both a member and an editor").
+    const { workspace, sandboxFunction } = await setupSandboxFunction({
+      userIdentity: "pod_editor_required",
+      addCallerToSpace: false,
+      addCallerToEditors: true,
+    });
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+    });
+
+    expect(response.status).toBe(201);
+    expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledOnce();
+  });
+
+  it("denies a pod member who is not an editor on a pod-editor-required function", async () => {
+    const { workspace, sandboxFunction } = await setupSandboxFunction({
+      userIdentity: "pod_editor_required",
+    });
+
+    const response = await postInvocation({
+      workspaceId: workspace.sId,
+      functionIdOrSlug: sandboxFunction.sId,
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toMatchObject({
+      error: {
+        type: "user_authentication_required",
+      },
+    });
+    expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
   });
 
   it("records an OAuth invocation as delegated", async () => {

--- a/front/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe.test.ts
+++ b/front/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe.test.ts
@@ -17,9 +17,20 @@ describe("getAuthenticatedFrameUserIdentity", () => {
     expect(getAuthenticatedFrameUserIdentity(authContext, "w_current")).toEqual(
       {
         workspaceId: "w_current",
+        isPodEditor: false,
         user: authContext.user,
       }
     );
+  });
+
+  it("forwards the pod editorship flag when the host knows it", () => {
+    expect(
+      getAuthenticatedFrameUserIdentity(authContext, "w_current", true)
+    ).toEqual({
+      workspaceId: "w_current",
+      isPodEditor: true,
+      user: authContext.user,
+    });
   });
 
   it("returns no identity for an auth context from another workspace", () => {

--- a/front/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe.tsx
@@ -15,7 +15,10 @@ interface WorkspaceAuthIdentity {
 
 export function getAuthenticatedFrameUserIdentity(
   authContext: WorkspaceAuthIdentity | null,
-  workspaceId: string
+  workspaceId: string,
+  // Editorship of the pod hosting the frame, when the host knows it (pod tabs, pinned banner,
+  // frame sheet). Display-only: invocations are re-authorized server-side.
+  isPodEditor = false
 ): ScopedWorkspaceUserIdentity | undefined {
   if (
     !authContext ||
@@ -27,6 +30,7 @@ export function getAuthenticatedFrameUserIdentity(
 
   return {
     workspaceId,
+    isPodEditor,
     user: {
       sId: authContext.user.sId,
       firstName: authContext.user.firstName,
@@ -41,16 +45,22 @@ interface AuthenticatedVisualizationActionIframeProps
   extends Omit<
     VisualizationActionIframeProps,
     "canInvokeFunctions" | "scopedUserIdentity" | "viewer"
-  > {}
+  > {
+  isPodEditor?: boolean;
+}
 
 export const AuthenticatedVisualizationActionIframe = forwardRef<
   HTMLIFrameElement,
   AuthenticatedVisualizationActionIframeProps
->(function AuthenticatedVisualizationActionIframe(props, ref) {
+>(function AuthenticatedVisualizationActionIframe(
+  { isPodEditor, ...props },
+  ref
+) {
   const authContext = useContext(AuthContext);
   const scopedUserIdentity = getAuthenticatedFrameUserIdentity(
     authContext,
-    props.workspaceId
+    props.workspaceId,
+    isPodEditor
   );
 
   return (

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.test.ts
@@ -24,17 +24,41 @@ describe("getFrameRuntimeAccess", () => {
       userIdentity: {
         isAuthenticated: true,
         isWorkspaceMember: true,
+        isPodEditor: false,
+        user,
+      },
+    });
+  });
+
+  it("forwards pod editorship from the scoped identity", () => {
+    expect(
+      getFrameRuntimeAccess("w_current", true, {
+        ...scopedUserIdentity,
+        isPodEditor: true,
+      })
+    ).toEqual({
+      canInvokeFunctions: true,
+      userIdentity: {
+        isAuthenticated: true,
+        isWorkspaceMember: true,
+        isPodEditor: true,
         user,
       },
     });
   });
 
   it("fails closed for an identity from another workspace", () => {
-    expect(getFrameRuntimeAccess("w_other", true, scopedUserIdentity)).toEqual({
+    expect(
+      getFrameRuntimeAccess("w_other", true, {
+        ...scopedUserIdentity,
+        isPodEditor: true,
+      })
+    ).toEqual({
       canInvokeFunctions: false,
       userIdentity: {
         isAuthenticated: false,
         isWorkspaceMember: false,
+        isPodEditor: false,
         user: null,
       },
     });
@@ -48,6 +72,7 @@ describe("getFrameRuntimeAccess", () => {
       userIdentity: {
         isAuthenticated: true,
         isWorkspaceMember: true,
+        isPodEditor: false,
         user,
       },
     });

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -91,11 +91,13 @@ export function getFrameRuntimeAccess(
       ? {
           isAuthenticated: true,
           isWorkspaceMember: true,
+          isPodEditor: scopedUserIdentity.isPodEditor ?? false,
           user: scopedUserIdentity.user,
         }
       : {
           isAuthenticated: false,
           isWorkspaceMember: false,
+          isPodEditor: false,
           user: null,
         };
 

--- a/front/components/pod/PodFrameTabContent.tsx
+++ b/front/components/pod/PodFrameTabContent.tsx
@@ -49,6 +49,7 @@ export function PodFrameTabContent({
           fileContent={fileContent}
           vizUrl={vizUrl}
           identifier={`viz-frame-tab-${fileId}`}
+          isPodEditor={podInfo.isEditor}
         />
       </div>
     </div>

--- a/front/components/pod/PodFrameVisualization.tsx
+++ b/front/components/pod/PodFrameVisualization.tsx
@@ -8,6 +8,7 @@ interface PodFrameVisualizationProps {
   fileContent: string;
   vizUrl: string;
   identifier: string;
+  isPodEditor?: boolean;
 }
 
 /**
@@ -20,6 +21,7 @@ export function PodFrameVisualization({
   fileContent,
   vizUrl,
   identifier,
+  isPodEditor,
 }: PodFrameVisualizationProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
@@ -36,6 +38,7 @@ export function PodFrameVisualization({
       conversationId={null}
       spaceId={spaceId}
       isInDrawer={true}
+      isPodEditor={isPodEditor}
       ref={iframeRef}
     />
   );

--- a/front/components/pod/conversation/PodPinnedBanner.tsx
+++ b/front/components/pod/conversation/PodPinnedBanner.tsx
@@ -202,6 +202,7 @@ export function PodPinnedBanner({ owner, podInfo }: PodPinnedBannerProps) {
     fileContent,
     vizUrl,
     identifier: `viz-banner-${fileId}`,
+    isPodEditor: podInfo.isEditor,
   };
 
   const controlsProps = {

--- a/front/components/pod/files/PodFrameSheet.tsx
+++ b/front/components/pod/files/PodFrameSheet.tsx
@@ -162,6 +162,7 @@ export function PodFrameSheet({
                 conversationId={null}
                 spaceId={fileMetadata?.useCaseMetadata.spaceId}
                 isInDrawer={true}
+                isPodEditor={isEditor}
                 ref={iframeRef}
               />
             )

--- a/front/lib/api/sandbox_functions/workspace_user.test.ts
+++ b/front/lib/api/sandbox_functions/workspace_user.test.ts
@@ -1,0 +1,125 @@
+import { authorizeSandboxFunctionInvocation } from "@app/lib/api/sandbox_functions/workspace_user";
+import { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { LightWorkspaceType } from "@app/types/user";
+import { describe, expect, it } from "vitest";
+
+async function setup() {
+  const { workspace, authenticator: adminAuth } = await createResourceTest({
+    role: "admin",
+  });
+  const space = await SpaceFactory.project(workspace);
+  return { workspace, adminAuth, space };
+}
+
+async function makeWorkspaceMember(
+  workspace: LightWorkspaceType
+): Promise<UserResource> {
+  const user = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, user, { role: "user" });
+  return user;
+}
+
+async function addToSpaceGroup(
+  adminAuth: Authenticator,
+  space: SpaceResource,
+  groupKind: "regular_auto" | "space_editors",
+  user: UserResource
+): Promise<void> {
+  const [group] = await space.fetchGroupResources(adminAuth, {
+    groupReferences: space.groups.filter(
+      (reference) => reference.groupKind === groupKind
+    ),
+  });
+  if (!group) {
+    throw new Error(`Expected the ${groupKind} group to exist.`);
+  }
+  const addMemberResult = await group.dangerouslyAddMember(adminAuth, {
+    user: user.toJSON(),
+  });
+  expect(addMemberResult.isOk()).toBe(true);
+}
+
+async function authorizePodEditorRequired(
+  auth: Authenticator,
+  space: SpaceResource
+) {
+  return authorizeSandboxFunctionInvocation(auth, {
+    userIdentity: "pod_editor_required",
+    origin: "interactive_session",
+    space,
+  });
+}
+
+describe("authorizeSandboxFunctionInvocation with pod_editor_required", () => {
+  it("authorizes a member of the pod editor group", async () => {
+    const { workspace, adminAuth, space } = await setup();
+    const editor = await makeWorkspaceMember(workspace);
+    await addToSpaceGroup(adminAuth, space, "space_editors", editor);
+    const editorAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      editor.sId,
+      workspace.sId
+    );
+
+    const authorization = await authorizePodEditorRequired(editorAuth, space);
+
+    expect(authorization.authorized).toBe(true);
+    if (authorization.authorized) {
+      expect(authorization.user?.sId).toBe(editor.sId);
+    }
+  });
+
+  it("denies a pod member who is not an editor", async () => {
+    const { workspace, adminAuth, space } = await setup();
+    const member = await makeWorkspaceMember(workspace);
+    await addToSpaceGroup(adminAuth, space, "regular_auto", member);
+    const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      member.sId,
+      workspace.sId
+    );
+
+    const authorization = await authorizePodEditorRequired(memberAuth, space);
+
+    expect(authorization.authorized).toBe(false);
+    if (!authorization.authorized) {
+      expect(authorization.errorMessage).toContain("editor");
+    }
+  });
+
+  it("denies a workspace member outside the pod", async () => {
+    const { workspace, space } = await setup();
+    const outsider = await makeWorkspaceMember(workspace);
+    const outsiderAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      outsider.sId,
+      workspace.sId
+    );
+
+    const authorization = await authorizePodEditorRequired(outsiderAuth, space);
+
+    expect(authorization.authorized).toBe(false);
+  });
+
+  it("authorizes a workspace admin through their role", async () => {
+    const { adminAuth, space } = await setup();
+
+    const authorization = await authorizePodEditorRequired(adminAuth, space);
+
+    expect(authorization.authorized).toBe(true);
+  });
+
+  it("denies a userless caller", async () => {
+    const { workspace, space } = await setup();
+    const userlessAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+
+    const authorization = await authorizePodEditorRequired(userlessAuth, space);
+
+    expect(authorization.authorized).toBe(false);
+  });
+});

--- a/front/lib/api/sandbox_functions/workspace_user.ts
+++ b/front/lib/api/sandbox_functions/workspace_user.ts
@@ -1,5 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import type {
   SandboxFunctionInvocationOrigin,
@@ -32,9 +33,12 @@ export async function authorizeSandboxFunctionInvocation(
   {
     userIdentity,
     origin,
+    space,
   }: {
     userIdentity: SandboxFunctionUserIdentityPolicy | null;
     origin: SandboxFunctionInvocationOrigin;
+    // The pod the function belongs to, for policies scoped to the caller's standing in it.
+    space: SpaceResource;
   }
 ): Promise<SandboxFunctionAuthorization> {
   const user = await getAuthenticatedWorkspaceUser(auth);
@@ -61,6 +65,19 @@ export async function authorizeSandboxFunctionInvocation(
             authorized: false,
             errorMessage:
               "This Pod Function requires a logged-in workspace member in a live Dust session.",
+          };
+    }
+    case "pod_editor_required": {
+      // Editorship matches the `isEditor` the pod UI serializes: members of the pod's editor
+      // group, plus workspace admins via their role (`canWrite` would not do: the pod member
+      // group also holds write on the space, so it cannot separate editors from viewers).
+      const authorized = user !== null && space.canAdministrate(auth);
+      return authorized
+        ? { authorized: true, user }
+        : {
+            authorized: false,
+            errorMessage:
+              "This Pod Function requires an editor of its Pod (or a workspace admin).",
           };
     }
     default:

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -740,6 +740,8 @@ describe("SandboxFunctionInvocationResource", () => {
       JSON.parse(opts?.envVars?.DUST_POD_USER_IDENTITY ?? "")
     ).toMatchObject({
       workspaceId: authenticator.getNonNullableWorkspace().sId,
+      // The executor is a workspace admin, an editor of every pod.
+      isPodEditor: true,
       user: {
         sId: authenticator.getNonNullableUser().sId,
         fullName: authenticator.getNonNullableUser().fullName(),

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -29,6 +29,7 @@ import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import {
   SandboxFunctionInvocationModel,
   SandboxFunctionModel,
@@ -224,7 +225,8 @@ function buildSandboxFunctionRunCommand(slug: string): string {
 function getSandboxFunctionUserIdentity(
   auth: Authenticator,
   user: UserResource | null,
-  invocation: SandboxFunctionInvocationResource
+  invocation: SandboxFunctionInvocationResource,
+  space: SpaceResource
 ) {
   const workspace = auth.getNonNullableWorkspace();
   if (
@@ -237,6 +239,9 @@ function getSandboxFunctionUserIdentity(
 
   return {
     workspaceId: workspace.sId,
+    // Same predicate as the `isEditor` the pod UI serializes: pod editor group members plus
+    // workspace admins via role.
+    isPodEditor: space.canAdministrate(auth),
     user: {
       sId: user.sId,
       firstName: user.firstName,
@@ -588,6 +593,9 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
         const authorization = await authorizeSandboxFunctionInvocation(auth, {
           userIdentity: persistedFunction.userIdentity,
           origin: this.origin ?? "delegated",
+          // The space is fixed at creation, so the in-memory copy is safe to reuse alongside
+          // the re-fetched row.
+          space: sandboxFunction.space,
         });
         return { persistedFunction, authorization };
       };
@@ -669,7 +677,8 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
       const userIdentity = getSandboxFunctionUserIdentity(
         auth,
         authorization.user,
-        this
+        this,
+        sandboxFunction.space
       );
 
       const execStartedAtMs = Date.now();

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -77,6 +77,10 @@ function userIdentityPolicyStrength(
       return 1;
     case "interactive_workspace_user_required":
       return 2;
+    case "pod_editor_required":
+      // Strictest audience: editors only. Ranking it above the session-bound policy means a
+      // publish moving to it always commits the policy before exposing the new bundle.
+      return 3;
     default:
       return assertNever(policy);
   }
@@ -541,6 +545,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     const authorization = await authorizeSandboxFunctionInvocation(auth, {
       userIdentity: this.userIdentity,
       origin,
+      space: this.space,
     });
     if (!authorization.authorized) {
       return new Err(

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -18,6 +18,7 @@ export const SANDBOX_FUNCTION_USER_IDENTITY_POLICIES = [
   "optional",
   "workspace_user_required",
   "interactive_workspace_user_required",
+  "pod_editor_required",
 ] as const;
 
 export type SandboxFunctionUserIdentityPolicy =

--- a/front/types/assistant/visualization.ts
+++ b/front/types/assistant/visualization.ts
@@ -35,16 +35,22 @@ export type UserIdentityState =
   | {
       isAuthenticated: true;
       isWorkspaceMember: true;
+      // Whether the viewer is an editor of the Pod hosting the Frame. Display-only: functions
+      // resolve the caller server-side, never from what the Frame sends.
+      isPodEditor: boolean;
       user: WorkspaceUserIdentity;
     }
   | {
       isAuthenticated: false;
       isWorkspaceMember: false;
+      isPodEditor: false;
       user: null;
     };
 
 export interface ScopedWorkspaceUserIdentity {
   workspaceId: string;
+  // Optional: only hosts rendering inside a pod know editorship; absent means false.
+  isPodEditor?: boolean;
   user: WorkspaceUserIdentity;
 }
 

--- a/viz/app/lib/data-apis/cache-data-api.ts
+++ b/viz/app/lib/data-apis/cache-data-api.ts
@@ -54,6 +54,7 @@ export class CacheDataAPI implements VisualizationDataAPI {
     return {
       isAuthenticated: false,
       isWorkspaceMember: false,
+      isPodEditor: false,
       user: null,
     };
   }

--- a/viz/app/lib/data-apis/rpc-data-api.test.ts
+++ b/viz/app/lib/data-apis/rpc-data-api.test.ts
@@ -26,12 +26,52 @@ describe("sandbox function data APIs", () => {
     expect(sendMessage).toHaveBeenCalledWith("getUserIdentity", null);
   });
 
+  it("defaults pod editorship to false for hosts that omit it", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({
+      isAuthenticated: true,
+      isWorkspaceMember: true,
+      user: {
+        sId: "usr_123",
+        firstName: "Ada",
+        lastName: "Lovelace",
+        fullName: "Ada Lovelace",
+        image: null,
+      },
+    });
+    const api = new RPCDataAPI(sendMessage);
+
+    await expect(api.getUserIdentity()).resolves.toMatchObject({
+      isPodEditor: false,
+    });
+  });
+
+  it("keeps pod editorship from hosts that provide it", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({
+      isAuthenticated: true,
+      isWorkspaceMember: true,
+      isPodEditor: true,
+      user: {
+        sId: "usr_123",
+        firstName: "Ada",
+        lastName: "Lovelace",
+        fullName: "Ada Lovelace",
+        image: null,
+      },
+    });
+    const api = new RPCDataAPI(sendMessage);
+
+    await expect(api.getUserIdentity()).resolves.toMatchObject({
+      isPodEditor: true,
+    });
+  });
+
   it("returns no identity from the public cache", async () => {
     const api = new CacheDataAPI();
 
     await expect(api.getUserIdentity()).resolves.toEqual({
       isAuthenticated: false,
       isWorkspaceMember: false,
+      isPodEditor: false,
       user: null,
     });
   });

--- a/viz/app/lib/data-apis/rpc-data-api.ts
+++ b/viz/app/lib/data-apis/rpc-data-api.ts
@@ -38,10 +38,16 @@ export class RPCDataAPI implements VisualizationDataAPI {
 
   async getUserIdentity() {
     const identity = await this.sendMessage("getUserIdentity", null);
+    // Hosts deployed before the field existed answer without it; absent means false. Rebuild
+    // the anonymous state rather than passing it through so the field is present either way.
     if (!identity.isAuthenticated) {
-      return identity;
+      return {
+        isAuthenticated: false as const,
+        isWorkspaceMember: false as const,
+        isPodEditor: false as const,
+        user: null,
+      };
     }
-    // Hosts deployed before the field existed answer without it; absent means false.
     return { ...identity, isPodEditor: identity.isPodEditor === true };
   }
 

--- a/viz/app/lib/data-apis/rpc-data-api.ts
+++ b/viz/app/lib/data-apis/rpc-data-api.ts
@@ -37,7 +37,12 @@ export class RPCDataAPI implements VisualizationDataAPI {
   }
 
   async getUserIdentity() {
-    return this.sendMessage("getUserIdentity", null);
+    const identity = await this.sendMessage("getUserIdentity", null);
+    if (!identity.isAuthenticated) {
+      return identity;
+    }
+    // Hosts deployed before the field existed answer without it; absent means false.
+    return { ...identity, isPodEditor: identity.isPodEditor === true };
   }
 
   async fetchFile(fileId: string): Promise<File | null> {

--- a/viz/app/lib/pod-function-hooks.tsx
+++ b/viz/app/lib/pod-function-hooks.tsx
@@ -160,6 +160,7 @@ export function useUserIdentity(): UseUserIdentityResult {
       error: result.error,
       isAuthenticated: false,
       isWorkspaceMember: false,
+      isPodEditor: false,
       isLoading: !result.error,
       user: null,
     };

--- a/viz/app/types.ts
+++ b/viz/app/types.ts
@@ -23,11 +23,15 @@ export type UserIdentityState =
   | {
       isAuthenticated: true;
       isWorkspaceMember: true;
+      // Whether the viewer is an editor of the Pod hosting the Frame. Display-only: functions
+      // resolve the caller server-side, never from what the Frame sends.
+      isPodEditor: boolean;
       user: WorkspaceUserIdentity;
     }
   | {
       isAuthenticated: false;
       isWorkspaceMember: false;
+      isPodEditor: false;
       user: null;
     };
 


### PR DESCRIPTION
## Description

Adds a `pod_editor_required` user identity policy for Pod Functions, enabling the "editors refresh, viewers read the cache" pattern:

- The policy authorizes a workspace member who can administrate the function's pod: pod editor group members, plus workspace admins via role. This is the same predicate the pod UI serializes as `isEditor` (`space.canAdministrate`). `canWrite` would not work here: the pod member group also holds write on the space, so it cannot separate editors from viewers.
- `authorizeSandboxFunctionInvocation` now receives the function's space (it previously saw only policy + origin).
- The per-invocation identity envelope carries `isPodEditor`, and `currentUser()` in `@dust/pod` exposes it. The field is optional in the zod schema: envelopes written by older front parse as `false`.
- Frame side, `UserIdentityState` gains a display-only `isPodEditor` (functions always resolve the caller server-side). Pod hosts (frame tabs, pinned banner, frame sheet) thread the pod's `isEditor` into the scoped identity; conversation/public hosts and the SSR cache answer `false`, and the viz RPC data API normalizes answers from hosts that predate the field.

Old front deploys deny the unknown policy at invocation time (the existing fail-closed arm), so a mixed-version deploy fails closed rather than open.

Stacked on #30357 (runner accepts the policy string).

## Tests

- New `workspace_user.test.ts` matrix: pod editor / pod member non-editor / member outside the pod / workspace admin / userless caller.
- Endpoint tests: pod editor gets 201, non-editor pod member gets 401.
- Envelope round-trip: front test asserts `isPodEditor` in `DUST_POD_USER_IDENTITY`; `@dust/pod` tests cover present/absent parsing; viz tests cover host answers with and without the field.

## Risk

Low: additive on every wire shape; no existing policy changes behavior. The only sequencing constraint is the runner (see below).

## Deploy Plan

1. #30357 must be live in the dsbx image first: the current runner throws at schema extraction on the unknown policy, so publishes declaring `pod_editor_required` fail at build until then.
2. Deploy front. Do not advertise the policy in builder-facing prompt surfaces until both are out.