### PR TITLE
[sandbox] Plumb MCP structuredContent end-to-end to sandbox functions

### DIFF
--- a/cli/dust-sandbox/src/api/client.rs
+++ b/cli/dust-sandbox/src/api/client.rs
@@ -228,9 +228,17 @@ impl DustApiClient {
                 ActionPollResponse::Rejected => {
                     bail!("action {action_id} was rejected");
                 }
-                ActionPollResponse::Success { content, is_error } => {
+                ActionPollResponse::Success {
+                    content,
+                    structured_content,
+                    is_error,
+                } => {
                     return Ok(CallToolResponse {
-                        result: CallToolResult { content, is_error },
+                        result: CallToolResult {
+                            content,
+                            structured_content,
+                            is_error,
+                        },
                     });
                 }
             }

--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -61,6 +61,9 @@ pub enum ActionPollResponse {
         // Raw blocks; the plain-text formatter parses them lazily so JSON
         // mode can emit unknown block types verbatim.
         content: Vec<serde_json::Value>,
+        // Machine-readable payload of the tool result, when the tool
+        // provided one. Passed through verbatim.
+        structured_content: Option<serde_json::Value>,
         is_error: bool,
     },
 }
@@ -79,6 +82,8 @@ struct ActionData {
     status: String,
     #[serde(default)]
     output: Option<Vec<serde_json::Value>>,
+    #[serde(default)]
+    structured_content: Option<serde_json::Value>,
 }
 
 pub fn parse_action_poll_response(body: &str) -> anyhow::Result<ActionPollResponse> {
@@ -97,7 +102,12 @@ pub fn parse_action_poll_response(body: &str) -> anyhow::Result<ActionPollRespon
         ActionPollResponseRaw::Success { action } => {
             let is_error = action.status == "errored";
             let content = action.output.unwrap_or_default();
-            Ok(ActionPollResponse::Success { content, is_error })
+            let structured_content = action.structured_content;
+            Ok(ActionPollResponse::Success {
+                content,
+                structured_content,
+                is_error,
+            })
         }
     }
 }
@@ -123,6 +133,11 @@ pub struct CallToolResponse {
 #[serde(rename_all = "camelCase")]
 pub struct CallToolResult {
     pub content: Vec<serde_json::Value>,
+    // Machine-readable payload of the tool result, when the tool provided
+    // one. Omitted from `--json` output when absent so existing consumers see
+    // unchanged output.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub structured_content: Option<serde_json::Value>,
     pub is_error: bool,
 }
 
@@ -207,11 +222,41 @@ mod tests {
         )
         .expect("should parse");
         match resp {
-            ActionPollResponse::Success { content, is_error } => {
+            ActionPollResponse::Success {
+                content,
+                structured_content,
+                is_error,
+            } => {
                 assert!(!is_error);
                 assert_eq!(content.len(), 1);
                 assert_eq!(content[0]["type"], "text");
                 assert_eq!(content[0]["text"], "hello");
+                assert!(structured_content.is_none());
+            }
+            _ => panic!("expected success"),
+        }
+    }
+
+    #[test]
+    fn parse_success_poll_response_with_structured_content() {
+        let resp = parse_action_poll_response(
+            r#"{
+                "status":"success",
+                "action":{
+                    "status":"succeeded",
+                    "output":[{"type":"text","text":"hello"}],
+                    "structuredContent":{"items":[{"id":1}],"nextCursor":"abc"}
+                }
+            }"#,
+        )
+        .expect("should parse");
+        match resp {
+            ActionPollResponse::Success {
+                structured_content, ..
+            } => {
+                let structured = structured_content.expect("should carry structuredContent");
+                assert_eq!(structured["items"][0]["id"], 1);
+                assert_eq!(structured["nextCursor"], "abc");
             }
             _ => panic!("expected success"),
         }
@@ -260,6 +305,7 @@ mod tests {
     fn call_tool_result_serializes_with_camelcase() {
         let result = CallToolResult {
             content: vec![serde_json::json!({"type": "text", "text": "hello"})],
+            structured_content: None,
             is_error: false,
         };
 
@@ -271,6 +317,27 @@ mod tests {
         assert!(value.get("is_error").is_none());
         assert_eq!(value["content"][0]["type"], "text");
         assert_eq!(value["content"][0]["text"], "hello");
+        // Absent structuredContent is omitted so existing `--json` consumers
+        // see unchanged output.
+        assert!(value.get("structuredContent").is_none());
+        assert!(value.get("structured_content").is_none());
+    }
+
+    #[test]
+    fn call_tool_result_serializes_structured_content_with_camelcase() {
+        let result = CallToolResult {
+            content: vec![serde_json::json!({"type": "text", "text": "hello"})],
+            structured_content: Some(serde_json::json!({"items": [1, 2], "nextCursor": "abc"})),
+            is_error: false,
+        };
+
+        let value: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&result).expect("should serialize"))
+                .expect("should round-trip");
+
+        assert_eq!(value["structuredContent"]["items"][1], 2);
+        assert_eq!(value["structuredContent"]["nextCursor"], "abc");
+        assert!(value.get("structured_content").is_none());
     }
 
     #[test]
@@ -297,6 +364,7 @@ mod tests {
 
         let result = CallToolResult {
             content,
+            structured_content: None,
             is_error: false,
         };
         let value: serde_json::Value =
@@ -319,6 +387,7 @@ mod tests {
                 "type": "future_block",
                 "payload": {"k": 1}
             })],
+            structured_content: None,
             is_error: true,
         };
 

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.test.ts
@@ -114,6 +114,54 @@ describe("GET /api/v1/w/[wId]/sandbox/actions/[aId] (function invocation)", () =
     expect(body.status).toBe("success");
     expect(body.action.status).toBe("succeeded");
     expect(body.action.output).toEqual(content);
+    expect(body.action).not.toHaveProperty("structuredContent");
+  });
+
+  it("returns the structuredContent alongside the output when present", async () => {
+    const { auth, token, workspace, action } = await setupWithAction();
+
+    const content = [{ type: "text" as const, text: "7" }];
+    const structuredContent = { value: 7, unit: "count" };
+    const writeResult = await action.createOutputItems(
+      auth,
+      content.map((c) => ({ content: c })),
+      { structuredContent }
+    );
+    expect(writeResult.isOk()).toBe(true);
+    await action.markAsSucceeded({ executionDurationMs: 42 });
+
+    const response = await getSandboxAction(workspace, token, action.sId);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("success");
+    expect(body.action.output).toEqual(content);
+    expect(body.action.structuredContent).toEqual(structuredContent);
+  });
+
+  it("returns the output of a legacy bare-array GCS object", async () => {
+    const { auth, token, workspace, action } = await setupWithAction();
+
+    // Record the GCS path through the modern write path, then overwrite the object with the
+    // legacy bare-array format written by previous deploys.
+    const content = [{ type: "text" as const, text: "legacy" }];
+    const writeResult = await action.createOutputItems(auth, [
+      { content: { type: "text", text: "placeholder" } },
+    ]);
+    expect(writeResult.isOk()).toBe(true);
+    const [gcsPath] = [...gcsStore.keys()].filter((path) =>
+      path.endsWith(`${action.sId}/output.json`)
+    );
+    expect(gcsPath).toBeDefined();
+    gcsStore.set(gcsPath, Buffer.from(JSON.stringify(content), "utf-8"));
+    await action.markAsSucceeded({ executionDurationMs: 42 });
+
+    const response = await getSandboxAction(workspace, token, action.sId);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.action.output).toEqual(content);
+    expect(body.action).not.toHaveProperty("structuredContent");
   });
 
   it("serves content block _meta (offload descriptor) verbatim", async () => {

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.ts
@@ -38,6 +38,8 @@ type CallToolSandboxFunctionSuccessResponse = {
   status: "success";
   action: SandboxFunctionMCPActionType & {
     output: CallToolResult["content"] | null;
+    // Machine-readable payload of the tool result, when the tool provided one.
+    structuredContent?: CallToolResult["structuredContent"];
   };
 };
 
@@ -99,10 +101,17 @@ app.get(
               },
             });
           }
+          const output = outputResult.value;
           return ctx.json(
             {
               status: "success",
-              action: { ...action.toJSON(), output: outputResult.value },
+              action: {
+                ...action.toJSON(),
+                output: output?.content ?? null,
+                ...(output?.structuredContent !== undefined
+                  ? { structuredContent: output.structuredContent }
+                  : {}),
+              },
             },
             200
           );

--- a/front/lib/actions/action_output_limits.ts
+++ b/front/lib/actions/action_output_limits.ts
@@ -36,6 +36,11 @@ const REMOTE_MAX_RESOURCE_SIZE_BYTES = 20 * 1024 * 1024; // 20MB.
 // Hard limit on the entire array of tool outputs.
 const REMOTE_MAX_TOOL_RESULT_SIZE_BYTES = 50 * 1024 * 1024; // 50MB.
 
+// Hard limit on the `structuredContent` payload of remote MCP tool results. Oversized payloads
+// are dropped (the model-facing content is unaffected) rather than failing the tool call, since
+// they used to be discarded entirely.
+export const REMOTE_MAX_STRUCTURED_CONTENT_SIZE_BYTES = 2 * 1024 * 1024; // 2MB.
+
 export function computeTextByteSize(text: string): number {
   return Buffer.byteLength(text, "utf8");
 }

--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -1,8 +1,10 @@
+import { REMOTE_MAX_STRUCTURED_CONTENT_SIZE_BYTES } from "@app/lib/actions/action_output_limits";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type {
   ClientSideMCPToolConfigurationType,
   LightServerSideMCPToolConfigurationType,
   ServerSideMCPServerConfigurationType,
+  ServerSideMCPToolConfigurationType,
   ToolNotificationEvent,
 } from "@app/lib/actions/mcp";
 import {
@@ -482,28 +484,33 @@ describe("tryCallMCPTool", () => {
     // The in-memory transport strips extra properties from tool results (like the real MCP SDK).
     // withToolResultProcessing (in wrappers) moves extras to _meta before the result goes over
     // the transport, so they survive; tryCallMCPTool then moves _meta back to root.
+    // The handler also returns structuredContent, which must survive the transport round-trip.
     mockSearchFunction.mockResolvedValue(
-      new Ok([
-        {
-          type: "resource" as const,
-          resource: {
-            mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
-            uri: "https://example.com/doc1",
-            text: "Document 1",
-            id: "doc1",
-            ref: "ref1",
-            chunks: ["chunk1", "chunk2"],
-            source: {
-              provider: "slack",
-              data_source_id: "ds1",
-              data_source_view_id: "dsv1",
+      new Ok({
+        content: [
+          {
+            type: "resource" as const,
+            resource: {
+              mimeType:
+                INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
+              uri: "https://example.com/doc1",
+              text: "Document 1",
+              id: "doc1",
+              ref: "ref1",
+              chunks: ["chunk1", "chunk2"],
+              source: {
+                provider: "slack",
+                data_source_id: "ds1",
+                data_source_view_id: "dsv1",
+              },
+              tags: ["tag1"],
+              customProperty: "customValue",
+              anotherExtraProperty: 123,
             },
-            tags: ["tag1"],
-            customProperty: "customValue",
-            anotherExtraProperty: 123,
           },
-        },
-      ])
+        ],
+        structuredContent: { results: [{ id: "doc1" }], resultCount: 1 },
+      })
     );
     const user = await UserFactory.basic();
     const workspace = await WorkspaceFactory.basic();
@@ -829,6 +836,12 @@ describe("tryCallMCPTool", () => {
     // Verify _meta is removed (properties moved back to root)
     expect(resource._meta).toBeUndefined();
 
+    // Verify structuredContent survived the transport round-trip.
+    expect(toolCallResult.structuredContent).toEqual({
+      results: [{ id: "doc1" }],
+      resultCount: 1,
+    });
+
     // Ensure the code path went through withToolResultProcessing (spy is set in wrappers mock so it's in place when search server loads).
     const withToolResultProcessingSpy = withToolResultProcessingSpyRef.current;
     expect(withToolResultProcessingSpy).not.toBeNull();
@@ -895,6 +908,167 @@ describe("postProcessMCPToolResult - structuredContent", () => {
     );
 
     expect(result.content).toHaveLength(0);
+    expect(result.structuredContent).toBeUndefined();
+  });
+
+  it("preserves structuredContent alongside non-empty content for client servers", () => {
+    const result = postProcessMCPToolResult(
+      {
+        content: [{ type: "text", text: "existing result" }],
+        structuredContent: { tables: [{ id: "tbl1" }] },
+      } as ToolCallResult,
+      clientConfig
+    );
+
+    expect(result.content).toEqual([{ type: "text", text: "existing result" }]);
+    expect(result.structuredContent).toEqual({ tables: [{ id: "tbl1" }] });
+  });
+
+  it("preserves structuredContent when falling back to it for empty content", () => {
+    const result = postProcessMCPToolResult(
+      {
+        content: [],
+        structuredContent: { tables: [] },
+      } as ToolCallResult,
+      clientConfig
+    );
+
+    expect(result.content).toEqual([
+      { type: "text", text: JSON.stringify({ tables: [] }) },
+    ]);
+    expect(result.structuredContent).toEqual({ tables: [] });
+  });
+
+  const serverSideConfigBase = {
+    id: -1,
+    sId: "test-sid",
+    type: "mcp_configuration",
+    description: null,
+    inputSchema: { type: "object", properties: {} },
+    dataSources: null,
+    tables: null,
+    childAgentId: null,
+    timeFrame: null,
+    jsonSchema: null,
+    additionalConfiguration: {},
+    mcpServerViewId: "msv_test",
+    dustAppConfiguration: null,
+    secretName: null,
+    dustProject: null,
+    availability: "manual",
+    permission: "never_ask",
+    toolServerId: "srv_test",
+    retryPolicy: "no_retry",
+  } as const;
+
+  function makeServerSideConfig(
+    internalMCPServerId: string | null
+  ): ServerSideMCPToolConfigurationType {
+    if (internalMCPServerId !== null) {
+      return {
+        ...serverSideConfigBase,
+        name: "semantic_search",
+        originalName: "semantic_search",
+        mcpServerName: "search",
+        internalMCPServerId,
+      };
+    }
+    return {
+      ...serverSideConfigBase,
+      name: "test_tool",
+      originalName: "test_tool",
+      mcpServerName: "test_server",
+      internalMCPServerId: null,
+    };
+  }
+
+  it("preserves structuredContent for internal servers alongside the _meta restore", () => {
+    const result = postProcessMCPToolResult(
+      {
+        content: [
+          {
+            type: "resource",
+            resource: {
+              uri: "test://resource",
+              text: "resource text",
+              _meta: { extraField: "extra" },
+            },
+          },
+        ],
+        structuredContent: { count: 3 },
+      } as ToolCallResult,
+      makeServerSideConfig(
+        internalMCPServerNameToSId({
+          name: "search",
+          workspaceId: 1,
+          prefix: 0,
+        })
+      )
+    );
+
+    expect(result.structuredContent).toEqual({ count: 3 });
+    // The _meta restore of extra resource fields is unaffected.
+    const [item] = result.content;
+    if (item.type !== "resource") {
+      throw new Error("Expected a resource item.");
+    }
+    // The resource type is a union without extra fields; extras restored from
+    // _meta need a loose view (same pattern as the tryCallMCPTool test above).
+    const restoredResource = item.resource as any;
+    expect(restoredResource.extraField).toBe("extra");
+    expect(restoredResource._meta).toBeUndefined();
+  });
+
+  it("preserves structuredContent for remote servers within the size limit", () => {
+    const result = postProcessMCPToolResult(
+      {
+        content: [{ type: "text", text: "remote result" }],
+        structuredContent: { items: [1, 2, 3], nextCursor: "abc" },
+      } as ToolCallResult,
+      makeServerSideConfig(null)
+    );
+
+    expect(result.content).toEqual([{ type: "text", text: "remote result" }]);
+    expect(result.structuredContent).toEqual({
+      items: [1, 2, 3],
+      nextCursor: "abc",
+    });
+  });
+
+  it("drops oversized structuredContent from remote servers without failing the call", () => {
+    const result = postProcessMCPToolResult(
+      {
+        content: [{ type: "text", text: "remote result" }],
+        structuredContent: {
+          blob: "x".repeat(REMOTE_MAX_STRUCTURED_CONTENT_SIZE_BYTES + 1),
+        },
+      } as ToolCallResult,
+      makeServerSideConfig(null)
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toEqual([{ type: "text", text: "remote result" }]);
+    expect(result.structuredContent).toBeUndefined();
+  });
+
+  it("keeps oversized structuredContent for internal servers", () => {
+    const result = postProcessMCPToolResult(
+      {
+        content: [{ type: "text", text: "internal result" }],
+        structuredContent: {
+          blob: "x".repeat(REMOTE_MAX_STRUCTURED_CONTENT_SIZE_BYTES + 1),
+        },
+      } as ToolCallResult,
+      makeServerSideConfig(
+        internalMCPServerNameToSId({
+          name: "search",
+          workspaceId: 1,
+          prefix: 0,
+        })
+      )
+    );
+
+    expect(result.structuredContent).toBeDefined();
   });
 });
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -2,8 +2,10 @@
 
 import {
   computeContentSize,
+  computeTextByteSize,
   getRemoteContentMaxSize,
   isWithinRemoteContentLimit,
+  REMOTE_MAX_STRUCTURED_CONTENT_SIZE_BYTES,
 } from "@app/lib/actions/action_output_limits";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import {
@@ -108,6 +110,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { isRecord } from "@app/types/shared/utils/general";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { slugify } from "@app/types/shared/utils/string_utils";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
@@ -829,11 +832,21 @@ export function postProcessMCPToolResult(
   let content: CallToolResult["content"] = (toolCallResult.content ??
     []) as CallToolResult["content"];
 
-  if (content.length === 0 && toolCallResult.structuredContent) {
+  // On the compatibility branch of the SDK result union, `structuredContent` resolves to
+  // `unknown` through the index signature — narrow it back to the object shape.
+  const rawStructuredContent: unknown = toolCallResult.structuredContent;
+  let structuredContent: CallToolResult["structuredContent"] =
+    typeof rawStructuredContent === "object" &&
+    rawStructuredContent !== null &&
+    isRecord(rawStructuredContent)
+      ? rawStructuredContent
+      : undefined;
+
+  if (content.length === 0 && structuredContent) {
     content = [
       {
         type: "text",
-        text: JSON.stringify(toolCallResult.structuredContent),
+        text: JSON.stringify(structuredContent),
       },
     ];
   }
@@ -864,6 +877,20 @@ export function postProcessMCPToolResult(
         ],
       };
     }
+
+    // Drop (rather than fail on) oversized structuredContent from remote servers: it used to be
+    // discarded entirely, so an oversized payload must not start failing tool calls.
+    if (
+      structuredContent !== undefined &&
+      computeTextByteSize(JSON.stringify(structuredContent)) >
+        REMOTE_MAX_STRUCTURED_CONTENT_SIZE_BYTES
+    ) {
+      logger.info(
+        { toolName: toolConfiguration.name },
+        "Dropping oversized structuredContent from remote MCP tool result"
+      );
+      structuredContent = undefined;
+    }
   }
   if (serverType === "internal" || serverType === "client") {
     // The MCP SDK is now stripping extra properties from the tool result (both client and server).
@@ -883,6 +910,7 @@ export function postProcessMCPToolResult(
   return {
     isError: toolCallResult.isError === true ? true : false,
     content,
+    ...(structuredContent !== undefined ? { structuredContent } : {}),
   };
 }
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -110,8 +110,8 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { isRecord } from "@app/types/shared/utils/general";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isRecord } from "@app/types/shared/utils/general";
 import { slugify } from "@app/types/shared/utils/string_utils";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -934,6 +934,34 @@ describe("processToolResults", () => {
     expect(stored.resource.text).toContain("[Full content archived at ");
   });
 
+  it("should persist a versioned envelope when the tool result carries structuredContent in a sandbox function run context", async () => {
+    const { auth, action, toolContext } = await setupSandboxFunctionTest();
+
+    const toolCallResultContent: CallToolResult["content"] = [
+      { type: "text", text: "human-readable result" },
+    ];
+    const structuredContent = { items: [{ id: 1 }], nextCursor: "abc" };
+
+    const { outputItems } = await processToolResults(auth, {
+      localLogger: logger.child({ test: true }),
+      toolContext,
+      toolCallResultContent,
+      toolCallResultStructuredContent: structuredContent,
+    });
+
+    expect(outputItems).toHaveLength(1);
+
+    const outputWrite = fileStorageMock.saveFileCalls.find((call) =>
+      call.filePath.endsWith(`mcp_output_items/${action.sId}/output.json`)
+    );
+    expect(outputWrite).toBeDefined();
+    expect(JSON.parse(outputWrite?.content.toString() ?? "")).toEqual({
+      version: 2,
+      content: toolCallResultContent,
+      structuredContent,
+    });
+  });
+
   it("should throw and leave the action without an output path when the sandbox output write fails", async () => {
     const { auth, action, toolContext } = await setupSandboxFunctionTest();
 

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -256,10 +256,14 @@ export async function processToolResults(
   {
     localLogger,
     toolCallResultContent,
+    toolCallResultStructuredContent,
     toolContext,
   }: {
     localLogger: Logger;
     toolCallResultContent: CallToolResult["content"];
+    // Machine-readable payload of the tool result. Persisted alongside the content for sandbox
+    // function actions; agent-loop actions only persist the model-facing content blocks.
+    toolCallResultStructuredContent?: CallToolResult["structuredContent"];
     toolContext: ToolContext;
   }
 ): Promise<{
@@ -572,14 +576,20 @@ export async function processToolResults(
   );
 
   // Persist the processed contents on the run context's action: per-item rows for agent loop
-  // actions, a single output object for sandbox function actions.
-  const outputRes = await runContext.action.createOutputItems(
-    auth,
-    cleanContent.map((c) => ({
-      content: sanitizeStringsDeep(c.content),
-      fileId: c.file?.id,
-    }))
-  );
+  // actions, a single output object for sandbox function actions. Sandbox function actions also
+  // persist the structuredContent so programmatic consumers get a machine-readable payload.
+  const cleanContentItems = cleanContent.map((c) => ({
+    content: sanitizeStringsDeep(c.content),
+    fileId: c.file?.id,
+  }));
+  const outputRes = isSandboxFunctionRunContext(runContext)
+    ? await runContext.action.createOutputItems(auth, cleanContentItems, {
+        structuredContent:
+          toolCallResultStructuredContent !== undefined
+            ? sanitizeStringsDeep(toolCallResultStructuredContent)
+            : undefined,
+      })
+    : await runContext.action.createOutputItems(auth, cleanContentItems);
 
   // Surfaced as an exception: there is no acceptable degraded state for unpersisted tool outputs.
   if (outputRes.isErr()) {

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -28,8 +28,7 @@ export type ToolHandlerExtra = BaseToolHandlerExtra & {
 
 // Tool handlers return the model-facing content blocks, optionally paired with a
 // machine-readable `structuredContent` payload (MCP `CallToolResult.structuredContent`,
-// preserved end-to-end for programmatic consumers such as sandbox functions). The bare
-// content array remains supported so existing handlers keep compiling unchanged.
+// preserved end-to-end for programmatic consumers such as sandbox functions).
 export type ToolHandlerOutput =
   | CallToolResult["content"]
   | {
@@ -47,13 +46,25 @@ export function normalizeToolHandlerOutput(output: ToolHandlerOutput): {
   return output;
 }
 
-export type ToolHandlerResult = Result<ToolHandlerOutput, MCPError>;
+// Default handler result: the model-facing content blocks alone.
+export type ToolHandlerResult = Result<CallToolResult["content"], MCPError>;
+
+// Handlers that also produce a machine-readable payload return `{content, structuredContent}`
+// and type their result with this instead. Registration accepts both, so returning a bare
+// content array stays valid everywhere.
+export type ToolHandlerResultWithStructuredContent = Result<
+  ToolHandlerOutput,
+  MCPError
+>;
 
 export type ToolHandlers<
   ToolsList extends readonly ToolMeta[],
   // Keep tool names as a separate generic so that generic consumers don't widen them to strings.
   ToolNames extends string = ToolsList[number]["name"],
   THandlerExtra = ToolHandlerExtra,
+  // Servers whose handlers emit `structuredContent` set this to
+  // `ToolHandlerResultWithStructuredContent`.
+  TResult extends ToolHandlerResultWithStructuredContent = ToolHandlerResult,
 > = {
   [ToolName in ToolNames]: (
     // Type the params with the type inferred from the zod schema (z.ZodObject because it's a zod shape, not a schema).
@@ -61,7 +72,7 @@ export type ToolHandlers<
       z.ZodObject<Extract<ToolsList[number], { name: ToolName }>["schema"]>
     >,
     extra: THandlerExtra
-  ) => Promise<ToolHandlerResult>;
+  ) => Promise<TResult>;
 };
 
 export type ClientToolHandlers<
@@ -73,6 +84,7 @@ export interface ToolDefinition<
   TName extends string = string,
   TSchema extends ZodRawShape = ZodRawShape,
   THandlerExtra = ToolHandlerExtra,
+  TResult extends ToolHandlerResultWithStructuredContent = ToolHandlerResult,
 > {
   name: TName;
   enableAlerting?: boolean;
@@ -94,8 +106,17 @@ export interface ToolDefinition<
   handler(
     params: z.infer<z.ZodObject<TSchema>>,
     extra: THandlerExtra
-  ): Promise<ToolHandlerResult>;
+  ): Promise<TResult>;
 }
+
+// Registration is agnostic to whether a handler emits `structuredContent`, so it accepts the
+// widest result type. Definitions built with the default (content-only) result are assignable.
+export type RegistrableToolDefinition = ToolDefinition<
+  string,
+  ZodRawShape,
+  ToolHandlerExtra,
+  ToolHandlerResultWithStructuredContent
+>;
 
 export type ToolMeta<
   TName extends string = string,
@@ -119,10 +140,11 @@ export function buildTools<
   const T extends readonly ToolMeta<TName>[],
   // Internal tools always receive auth and runContext, while client-side tools do not.
   THandlerExtra = ToolHandlerExtra,
+  TResult extends ToolHandlerResultWithStructuredContent = ToolHandlerResult,
 >(
   metadata: T & ValidToolMetadata<T>,
-  handlers: ToolHandlers<T, TName, THandlerExtra>
-): ToolDefinition<TName, ZodRawShape, THandlerExtra>[] {
+  handlers: ToolHandlers<T, TName, THandlerExtra, TResult>
+): ToolDefinition<TName, ZodRawShape, THandlerExtra, TResult>[] {
   return metadata.map((tool) => ({
     ...tool,
     handler: handlers[tool.name],

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -26,7 +26,28 @@ export type ToolHandlerExtra = BaseToolHandlerExtra & {
   runContext: ToolRunContext;
 };
 
-export type ToolHandlerResult = Result<CallToolResult["content"], MCPError>;
+// Tool handlers return the model-facing content blocks, optionally paired with a
+// machine-readable `structuredContent` payload (MCP `CallToolResult.structuredContent`,
+// preserved end-to-end for programmatic consumers such as sandbox functions). The bare
+// content array remains supported so existing handlers keep compiling unchanged.
+export type ToolHandlerOutput =
+  | CallToolResult["content"]
+  | {
+      content: CallToolResult["content"];
+      structuredContent: NonNullable<CallToolResult["structuredContent"]>;
+    };
+
+export function normalizeToolHandlerOutput(output: ToolHandlerOutput): {
+  content: CallToolResult["content"];
+  structuredContent?: CallToolResult["structuredContent"];
+} {
+  if (Array.isArray(output)) {
+    return { content: output };
+  }
+  return output;
+}
+
+export type ToolHandlerResult = Result<ToolHandlerOutput, MCPError>;
 
 export type ToolHandlers<
   ToolsList extends readonly ToolMeta[],

--- a/front/lib/actions/mcp_internal_actions/wrappers.test.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.test.ts
@@ -1,5 +1,5 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import type { ToolHandlerResult } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ToolHandlerResultWithStructuredContent } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { withToolResultProcessing } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import { Err, Ok } from "@app/types/shared/result";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -31,7 +31,9 @@ function expectExtraFieldMovedToMeta(content: CallToolResult["content"]) {
 describe("withToolResultProcessing", () => {
   it("moves extra resource fields to _meta for bare content arrays", async () => {
     const result = await withToolResultProcessing(
-      Promise.resolve<ToolHandlerResult>(new Ok(resourceContent))
+      Promise.resolve<ToolHandlerResultWithStructuredContent>(
+        new Ok(resourceContent)
+      )
     );
 
     expect(result.isOk()).toBe(true);
@@ -46,7 +48,7 @@ describe("withToolResultProcessing", () => {
   it("processes content and preserves structuredContent for structured outputs", async () => {
     const structuredContent = { items: [{ id: 1 }], nextCursor: "abc" };
     const result = await withToolResultProcessing(
-      Promise.resolve<ToolHandlerResult>(
+      Promise.resolve<ToolHandlerResultWithStructuredContent>(
         new Ok({ content: resourceContent, structuredContent })
       )
     );
@@ -64,7 +66,7 @@ describe("withToolResultProcessing", () => {
   it("passes errors through unchanged", async () => {
     const error = new MCPError("boom");
     const result = await withToolResultProcessing(
-      Promise.resolve<ToolHandlerResult>(new Err(error))
+      Promise.resolve<ToolHandlerResultWithStructuredContent>(new Err(error))
     );
 
     expect(result.isErr()).toBe(true);

--- a/front/lib/actions/mcp_internal_actions/wrappers.test.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.test.ts
@@ -1,0 +1,75 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlerResult } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { withToolResultProcessing } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import { Err, Ok } from "@app/types/shared/result";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it } from "vitest";
+
+// Extra fields beyond the SDK resource type are allowed at runtime (passthrough) but not in the
+// inline literal type — build the resource separately to skip excess property checking.
+const resourceWithExtraField = {
+  uri: "test://resource",
+  mimeType: "text/plain",
+  text: "resource text",
+  extraField: "extra value",
+};
+
+const resourceContent: CallToolResult["content"] = [
+  { type: "resource", resource: resourceWithExtraField },
+  { type: "text", text: "plain text" },
+];
+
+function expectExtraFieldMovedToMeta(content: CallToolResult["content"]) {
+  const [resourceItem, textItem] = content;
+  if (resourceItem.type !== "resource") {
+    throw new Error("Expected a resource item.");
+  }
+  expect(resourceItem.resource._meta).toEqual({ extraField: "extra value" });
+  expect(textItem).toEqual({ type: "text", text: "plain text" });
+}
+
+describe("withToolResultProcessing", () => {
+  it("moves extra resource fields to _meta for bare content arrays", async () => {
+    const result = await withToolResultProcessing(
+      Promise.resolve<ToolHandlerResult>(new Ok(resourceContent))
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(Array.isArray(result.value)).toBe(true);
+      if (Array.isArray(result.value)) {
+        expectExtraFieldMovedToMeta(result.value);
+      }
+    }
+  });
+
+  it("processes content and preserves structuredContent for structured outputs", async () => {
+    const structuredContent = { items: [{ id: 1 }], nextCursor: "abc" };
+    const result = await withToolResultProcessing(
+      Promise.resolve<ToolHandlerResult>(
+        new Ok({ content: resourceContent, structuredContent })
+      )
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(Array.isArray(result.value)).toBe(false);
+      if (!Array.isArray(result.value)) {
+        expectExtraFieldMovedToMeta(result.value.content);
+        expect(result.value.structuredContent).toEqual(structuredContent);
+      }
+    }
+  });
+
+  it("passes errors through unchanged", async () => {
+    const error = new MCPError("boom");
+    const result = await withToolResultProcessing(
+      Promise.resolve<ToolHandlerResult>(new Err(error))
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBe(error);
+    }
+  });
+});

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -11,7 +11,6 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
-import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import { errorToString } from "@app/types/shared/utils/error_utils";
 import { truncate } from "@app/types/shared/utils/string_utils";

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -1,8 +1,8 @@
-import type { MCPError } from "@app/lib/actions/mcp_errors";
 import type {
   ToolDefinition,
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { normalizeToolHandlerOutput } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { ToolContext, ToolRunContext } from "@app/lib/actions/types";
 import {
   isAgentLoopRunContext,
@@ -75,31 +75,38 @@ export async function withToolResultProcessing(
 ): Promise<ToolHandlerResult> {
   const result = await resultPromise;
   if (result.isOk()) {
-    return new Ok(
-      result.value.map((item) => {
-        if (item.type === "resource") {
-          // Pickup extra properties compared to the offical SDK speccs at the root level.
-          const officalSDKFields = ["text", "uri", "mimeType", "blob", "_meta"];
-          const extraProperties = Object.fromEntries(
-            Object.entries(item.resource).filter(
-              ([k, v]) => !officalSDKFields.includes(k) && v !== undefined
-            )
-          );
+    const { content, structuredContent } = normalizeToolHandlerOutput(
+      result.value
+    );
+    const processedContent = content.map((item) => {
+      if (item.type === "resource") {
+        // Pickup extra properties compared to the offical SDK speccs at the root level.
+        const officalSDKFields = ["text", "uri", "mimeType", "blob", "_meta"];
+        const extraProperties = Object.fromEntries(
+          Object.entries(item.resource).filter(
+            ([k, v]) => !officalSDKFields.includes(k) && v !== undefined
+          )
+        );
 
-          return {
-            ...item,
-            resource: {
-              ...item.resource,
-              _meta: {
-                ...item.resource._meta,
-                ...extraProperties,
-              },
+        return {
+          ...item,
+          resource: {
+            ...item.resource,
+            _meta: {
+              ...item.resource._meta,
+              ...extraProperties,
             },
-          };
-        } else {
-          return item;
-        }
-      })
+          },
+        };
+      } else {
+        return item;
+      }
+    });
+
+    return new Ok(
+      structuredContent !== undefined
+        ? { content: processedContent, structuredContent }
+        : processedContent
     );
   }
   return result;
@@ -107,7 +114,8 @@ export async function withToolResultProcessing(
 
 /**
  * Wraps a tool callback with logging and monitoring.
- * The tool callback is expected to return a `Result<CallToolResult["content"], MCPError>`,
+ * The tool callback is expected to return a `ToolHandlerResult` (content blocks, optionally
+ * paired with `structuredContent`),
  * Errors are caught and logged unless not tracked, and the error is returned as a text content.
  *
  * The tool name is used as a tag in the DD metric, it's 1 tool name <=> 1 monitor.
@@ -127,7 +135,7 @@ function withToolLogging<T>(
   toolCallback: (
     params: T,
     extra: RequestHandlerExtra<ServerRequest, ServerNotification>
-  ) => Promise<Result<CallToolResult["content"], MCPError>>
+  ) => Promise<ToolHandlerResult>
 ): (
   params: T,
   extra: RequestHandlerExtra<ServerRequest, ServerNotification>
@@ -246,6 +254,14 @@ function withToolLogging<T>(
       "Tool execution success"
     );
 
-    return { isError: false, content: result.value };
+    const { content, structuredContent } = normalizeToolHandlerOutput(
+      result.value
+    );
+
+    return {
+      isError: false,
+      content,
+      ...(structuredContent !== undefined ? { structuredContent } : {}),
+    };
   };
 }

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -1,6 +1,6 @@
 import type {
-  ToolDefinition,
-  ToolHandlerResult,
+  RegistrableToolDefinition,
+  ToolHandlerResultWithStructuredContent,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { normalizeToolHandlerOutput } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { ToolContext, ToolRunContext } from "@app/lib/actions/types";
@@ -29,7 +29,7 @@ export function registerTool(
   auth: Authenticator,
   toolContext: ToolContext | undefined,
   server: McpServer,
-  tool: ToolDefinition,
+  tool: RegistrableToolDefinition,
   { monitoringName }: { monitoringName: string }
 ): void {
   server.registerTool(
@@ -70,8 +70,8 @@ export function registerTool(
 // To keep the same behavior as before, we move the extra properties to the _meta field of each resource item.
 // They will be moved back to the resource items root level in the tool result processing.
 export async function withToolResultProcessing(
-  resultPromise: Promise<ToolHandlerResult>
-): Promise<ToolHandlerResult> {
+  resultPromise: Promise<ToolHandlerResultWithStructuredContent>
+): Promise<ToolHandlerResultWithStructuredContent> {
   const result = await resultPromise;
   if (result.isOk()) {
     const { content, structuredContent } = normalizeToolHandlerOutput(
@@ -113,8 +113,8 @@ export async function withToolResultProcessing(
 
 /**
  * Wraps a tool callback with logging and monitoring.
- * The tool callback is expected to return a `ToolHandlerResult` (content blocks, optionally
- * paired with `structuredContent`),
+ * The tool callback is expected to return content blocks, optionally paired with
+ * `structuredContent`,
  * Errors are caught and logged unless not tracked, and the error is returned as a text content.
  *
  * The tool name is used as a tag in the DD metric, it's 1 tool name <=> 1 monitor.
@@ -134,7 +134,7 @@ function withToolLogging<T>(
   toolCallback: (
     params: T,
     extra: RequestHandlerExtra<ServerRequest, ServerNotification>
-  ) => Promise<ToolHandlerResult>
+  ) => Promise<ToolHandlerResultWithStructuredContent>
 ): (
   params: T,
   extra: RequestHandlerExtra<ServerRequest, ServerNotification>

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -130,6 +130,7 @@ export async function* runToolWithStreaming(
       processToolResults(auth, {
         localLogger,
         toolCallResultContent: toolCallResult.content,
+        toolCallResultStructuredContent: toolCallResult.structuredContent,
         toolContext,
       }),
     {

--- a/front/lib/api/poke/pod_functions.ts
+++ b/front/lib/api/poke/pod_functions.ts
@@ -241,5 +241,11 @@ export async function getProjectPodFunctionMCPActionOutput(
     );
   }
 
-  return new Ok({ output: outputResult.value });
+  const output = outputResult.value;
+  return new Ok({
+    output: output?.content ?? null,
+    ...(output?.structuredContent !== undefined
+      ? { structuredContent: output.structuredContent }
+      : {}),
+  });
 }

--- a/front/lib/api/poke/projects.ts
+++ b/front/lib/api/poke/projects.ts
@@ -116,4 +116,6 @@ export type PokeGetPodFunctionInvocation = {
 
 export type PokeGetPodFunctionMCPActionOutput = {
   output: CallToolResult["content"] | null;
+  // Machine-readable payload of the tool result, when the tool provided one.
+  structuredContent?: CallToolResult["structuredContent"];
 };

--- a/front/lib/resources/sandbox_function_mcp_action_resource.test.ts
+++ b/front/lib/resources/sandbox_function_mcp_action_resource.test.ts
@@ -162,11 +162,96 @@ describe("SandboxFunctionMCPActionResource", () => {
     expect(outputRes.isOk()).toBe(true);
     expect(action.outputGcsPath).toContain(action.sId);
 
+    // Without structuredContent the stored object stays a bare content array, so readers of
+    // older deploys keep working.
+    const storedBuffer = gcsStore.get(
+      action.outputGcsPath ?? "missing-output-path"
+    );
+    expect(JSON.parse(storedBuffer?.toString("utf-8") ?? "")).toEqual(content);
+
     const readBack = await action.readOutput();
     expect(readBack.isOk()).toBe(true);
     if (readBack.isOk()) {
-      expect(readBack.value).toEqual(content);
+      expect(readBack.value).toEqual({ content });
     }
+  });
+
+  it("writes a versioned envelope when the output carries structuredContent", async () => {
+    const { authenticator, invocation, mcpServerView } = await setup();
+    const action = await SandboxFunctionMCPActionFactory.create(authenticator, {
+      invocation,
+      mcpServerView,
+    });
+
+    const content = [{ type: "text" as const, text: "4" }];
+    const structuredContent = { items: [{ id: 1 }], nextCursor: "abc" };
+    const outputRes = await action.createOutputItems(
+      authenticator,
+      content.map((c) => ({ content: c })),
+      { structuredContent }
+    );
+    expect(outputRes.isOk()).toBe(true);
+
+    const storedBuffer = gcsStore.get(
+      action.outputGcsPath ?? "missing-output-path"
+    );
+    expect(JSON.parse(storedBuffer?.toString("utf-8") ?? "")).toEqual({
+      version: 2,
+      content,
+      structuredContent,
+    });
+
+    const readBack = await action.readOutput();
+    expect(readBack.isOk()).toBe(true);
+    if (readBack.isOk()) {
+      expect(readBack.value).toEqual({ content, structuredContent });
+    }
+  });
+
+  it("dual-reads legacy bare-array outputs", async () => {
+    const { authenticator, invocation, mcpServerView } = await setup();
+    const action = await SandboxFunctionMCPActionFactory.create(authenticator, {
+      invocation,
+      mcpServerView,
+    });
+
+    // Persist a modern output to record the GCS path on the row, then overwrite the object with
+    // the legacy bare-array format written by previous deploys.
+    const content = [{ type: "text" as const, text: "legacy" }];
+    const outputRes = await action.createOutputItems(authenticator, [
+      { content: { type: "text", text: "placeholder" } },
+    ]);
+    expect(outputRes.isOk()).toBe(true);
+    gcsStore.set(
+      action.outputGcsPath ?? "missing-output-path",
+      Buffer.from(JSON.stringify(content), "utf-8")
+    );
+
+    const readBack = await action.readOutput();
+    expect(readBack.isOk()).toBe(true);
+    if (readBack.isOk()) {
+      expect(readBack.value).toEqual({ content });
+    }
+  });
+
+  it("errors on an unrecognized output format", async () => {
+    const { authenticator, invocation, mcpServerView } = await setup();
+    const action = await SandboxFunctionMCPActionFactory.create(authenticator, {
+      invocation,
+      mcpServerView,
+    });
+
+    const outputRes = await action.createOutputItems(authenticator, [
+      { content: { type: "text", text: "placeholder" } },
+    ]);
+    expect(outputRes.isOk()).toBe(true);
+    gcsStore.set(
+      action.outputGcsPath ?? "missing-output-path",
+      Buffer.from(JSON.stringify({ not: "an output" }), "utf-8")
+    );
+
+    const readBack = await action.readOutput();
+    expect(readBack.isErr()).toBe(true);
   });
 
   it("marks the action as succeeded or errored with a duration", async () => {

--- a/front/lib/resources/sandbox_function_mcp_action_resource.test.ts
+++ b/front/lib/resources/sandbox_function_mcp_action_resource.test.ts
@@ -245,13 +245,22 @@ describe("SandboxFunctionMCPActionResource", () => {
       { content: { type: "text", text: "placeholder" } },
     ]);
     expect(outputRes.isOk()).toBe(true);
+    const gcsPath = action.outputGcsPath ?? "missing-output-path";
+
     gcsStore.set(
-      action.outputGcsPath ?? "missing-output-path",
+      gcsPath,
       Buffer.from(JSON.stringify({ not: "an output" }), "utf-8")
     );
-
     const readBack = await action.readOutput();
     expect(readBack.isErr()).toBe(true);
+
+    // An envelope with an unknown version fails loudly instead of being silently misparsed.
+    gcsStore.set(
+      gcsPath,
+      Buffer.from(JSON.stringify({ version: 3, content: [] }), "utf-8")
+    );
+    const unknownVersionReadBack = await action.readOutput();
+    expect(unknownVersionReadBack.isErr()).toBe(true);
   });
 
   it("marks the action as succeeded or errored with a duration", async () => {

--- a/front/lib/resources/sandbox_function_mcp_action_resource.ts
+++ b/front/lib/resources/sandbox_function_mcp_action_resource.ts
@@ -29,7 +29,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { removeNulls } from "@app/types/shared/utils/general";
+import { isRecord, removeNulls } from "@app/types/shared/utils/general";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
 import type { Attributes, Transaction } from "sequelize";
@@ -38,6 +38,49 @@ import { Op } from "sequelize";
 // Outputs share the agent MCP output items GCS prefix (`w/<wsId>/...` so workspace relocation
 // transfers the objects), but with one object per action holding the full content array — dsbx
 // consumes the output exactly once as a whole, there is no per-block rendering.
+
+// The output object is either a bare content array (version 1, still the format when the tool
+// result carries no structuredContent so readers of older deploys keep working) or a versioned
+// envelope `{version: 2, content, structuredContent}`. `readOutput` reads both.
+const OUTPUT_ENVELOPE_VERSION = 2;
+
+export type SandboxFunctionMCPActionOutput = {
+  content: CallToolResult["content"];
+  structuredContent?: CallToolResult["structuredContent"];
+};
+
+function parseOutputObject(
+  parsed: unknown
+): Result<SandboxFunctionMCPActionOutput, Error> {
+  // Version 1: a bare content array.
+  if (Array.isArray(parsed)) {
+    return new Ok({ content: parsed });
+  }
+  // Version 2 envelope. The object is written by `createOutputItems` below, so shape validation
+  // stays a light guard (matching the trust level of the version-1 read path).
+  if (
+    parsed !== null &&
+    typeof parsed === "object" &&
+    "content" in parsed &&
+    Array.isArray(parsed.content)
+  ) {
+    const structuredContent =
+      "structuredContent" in parsed &&
+      parsed.structuredContent !== null &&
+      typeof parsed.structuredContent === "object" &&
+      isRecord(parsed.structuredContent)
+        ? parsed.structuredContent
+        : undefined;
+
+    return new Ok({
+      content: parsed.content,
+      ...(structuredContent !== undefined ? { structuredContent } : {}),
+    });
+  }
+  return new Err(
+    new Error("Unrecognized sandbox function MCP action output format.")
+  );
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface SandboxFunctionMCPActionResource
@@ -270,16 +313,28 @@ export class SandboxFunctionMCPActionResource extends BaseResource<SandboxFuncti
   // Writes the full content array to a single GCS object and records its path on the row. Written
   // exactly once, at tool completion. Returns the stored contents in the generic tool output item
   // shape shared with AgentMCPActionResource.createOutputItems.
+  // When the tool result carries a structuredContent payload, the object is a versioned envelope
+  // instead of a bare array; see `parseOutputObject`.
   async createOutputItems(
     auth: Authenticator,
     contents: Array<{
       content: CallToolResult["content"][number];
       fileId?: ModelId;
-    }>
+    }>,
+    options?: { structuredContent?: CallToolResult["structuredContent"] }
   ): Promise<Result<ToolOutputItemType[], Error>> {
     const gcsPath = this.outputGcsPathFor(auth);
     const file = getPrivateUploadBucket().file(gcsPath);
-    const json = JSON.stringify(contents.map((c) => c.content));
+    const content = contents.map((c) => c.content);
+    const json = JSON.stringify(
+      options?.structuredContent !== undefined
+        ? {
+            version: OUTPUT_ENVELOPE_VERSION,
+            content,
+            structuredContent: options.structuredContent,
+          }
+        : content
+    );
 
     const writeResult = await withRetry(() =>
       file.save(Buffer.from(json, "utf-8"), {
@@ -330,7 +385,9 @@ export class SandboxFunctionMCPActionResource extends BaseResource<SandboxFuncti
     );
   }
 
-  async readOutput(): Promise<Result<CallToolResult["content"] | null, Error>> {
+  async readOutput(): Promise<
+    Result<SandboxFunctionMCPActionOutput | null, Error>
+  > {
     if (!this.outputGcsPath) {
       return new Ok(null);
     }
@@ -345,12 +402,15 @@ export class SandboxFunctionMCPActionResource extends BaseResource<SandboxFuncti
       return new Err(downloadResult.error);
     }
 
+    let parsed: unknown;
     try {
       const [buffer] = downloadResult.value;
-      return new Ok(JSON.parse(buffer.toString("utf-8")));
+      parsed = JSON.parse(buffer.toString("utf-8"));
     } catch (err) {
       return new Err(normalizeError(err));
     }
+
+    return parseOutputObject(parsed);
   }
 
   // GCS objects are deleted best-effort AFTER the rows (post-commit when a transaction is

--- a/front/lib/resources/sandbox_function_mcp_action_resource.ts
+++ b/front/lib/resources/sandbox_function_mcp_action_resource.ts
@@ -57,10 +57,13 @@ function parseOutputObject(
     return new Ok({ content: parsed });
   }
   // Version 2 envelope. The object is written by `createOutputItems` below, so shape validation
-  // stays a light guard (matching the trust level of the version-1 read path).
+  // stays a light guard (matching the trust level of the version-1 read path). The version is
+  // checked so a future format bump fails loudly here instead of being silently misparsed.
   if (
     parsed !== null &&
     typeof parsed === "object" &&
+    "version" in parsed &&
+    parsed.version === OUTPUT_ENVELOPE_VERSION &&
     "content" in parsed &&
     Array.isArray(parsed.content)
   ) {


### PR DESCRIPTION
## Description

MCP tools can return a machine-readable `structuredContent` payload next to their content blocks, but front discarded it whenever `content` was non-empty (it was only used as a fallback for empty content). Sandbox functions consuming tool output were left regexing prose out of the model-facing text.

This preserves `structuredContent` through every hop, all additive:

- New `ToolHandlerResultWithStructuredContent`: internal tool handlers can opt into returning `{content, structuredContent}` by parameterising `ToolHandlers` / `buildTools` with it. `ToolHandlerResult` still means content blocks only and stays the default, so every existing server is unchanged; `withToolResultProcessing` and `withToolLogging` thread the payload through to the MCP result.
- `postProcessMCPToolResult` keeps `structuredContent` for internal, client and remote servers. Remote payloads over 2MB are dropped with a log instead of failing the call, since they used to be discarded entirely.
- Sandbox function actions persist `{version: 2, content, structuredContent}` in their GCS output object when the payload is present. Without it the stored object stays a bare array, so readers of older deploys only see the new format on results that actually carry the field. Reads accept both formats.
- `GET /v1/w/{wId}/sandbox/actions/{aId}` exposes optional `structuredContent` next to `output` (poke action output too).
- dsbx: `structured_content` on `CallToolResult` with `#[serde(default)]`, parsed from the poll response and printed as `structuredContent` under `tools --json`. Omitted when absent, so existing consumers see byte-identical output.

Model-facing `content` and agent-loop persistence are untouched.

## Tests

- End-to-end test: a handler returning `{content, structuredContent}` goes through the real in-memory MCP transport and comes out of `tryCallMCPTool` with both the `_meta` extras restore and `structuredContent` intact.
- Per-hop tests: wrappers normalization, postProcess for internal/client/remote incl. the oversized-remote drop, sandbox `output.json` v2 envelope write plus dual-read of legacy bare arrays (resource and route level), dsbx parse/serialize round-trips.

## Risk

Low. Every field is optional and additive; nothing produces `structuredContent` on the internal path yet, so v2 output objects only appear for remote servers that already emit it. Old dsbx ignores the unknown JSON field. Rollback is safe except for outputs written as v2 during the window, which only affects results that carried the new field.

## Deploy Plan

Standard deploy. The dsbx side ships with the next dsbx release, no version pin change here.
