### PR TITLE
[front] fix: namespace local sandbox image builds so CI cannot skip a region

### DIFF
--- a/.github/workflows/sandbox-img-registry.yml
+++ b/.github/workflows/sandbox-img-registry.yml
@@ -116,6 +116,7 @@ jobs:
               --tag "$tag" \
               --docker-registry us-central1-docker.pkg.dev/or1g1n-186209/dust-sbx \
               --confirm \
+              --release \
               $REBUILD_FLAG
           done < <(jq -c '.[]' "$GITHUB_WORKSPACE/build-matrix.json")
 

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -636,6 +636,13 @@ const config = {
       ) === "true"
     );
   },
+  // Namespaces sandbox image aliases built outside CI (e.g. "david"), so a
+  // developer iterating on the image never publishes over the release alias
+  // that `sandbox_image_check.ts` uses to decide whether a region needs a
+  // build. Only honored at runtime when isDevelopment().
+  getSandboxDevImageSuffix: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("SBX_DEV_IMAGE_SUFFIX");
+  },
   getSandboxGcpArtifactServiceAccountPath: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable(
       "SBX_GCP_ARTIFACT_SERVICE_ACCOUNT"

--- a/front/lib/api/sandbox/image/index.test.ts
+++ b/front/lib/api/sandbox/image/index.test.ts
@@ -1,10 +1,78 @@
 import {
   createToolManifest,
+  devSandboxImageId,
+  formatSandboxImageId,
+  getSandboxImage,
+  getSandboxImageFromRegistry,
   getToolsForProvider,
   toolManifestToYAML,
 } from "@app/lib/api/sandbox/image";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const DEV_SUFFIX = "test-dev";
+
+function releaseImageId() {
+  const imageResult = getSandboxImageFromRegistry({ name: "dust-base" });
+  if (imageResult.isErr()) {
+    throw imageResult.error;
+  }
+  const { imageId } = imageResult.value;
+  if (!imageId) {
+    throw new Error("dust-base is not registered");
+  }
+  return imageId;
+}
+
+describe("dev sandbox image alias", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("namespaces the release tag so the two aliases never collide", () => {
+    const release = releaseImageId();
+    const dev = devSandboxImageId(release, DEV_SUFFIX);
+
+    expect(dev.imageName).toBe(release.imageName);
+    expect(dev.tag).toBe(`${release.tag}-${DEV_SUFFIX}`);
+    expect(formatSandboxImageId(dev)).not.toBe(formatSandboxImageId(release));
+    // E2B only accepts lowercase alphanumerics, hyphens and our `_` separator.
+    expect(formatSandboxImageId(dev)).toMatch(/^[a-z0-9-]+_[a-z0-9-]+$/);
+  });
+
+  it("keeps the release alias when no suffix is configured", () => {
+    const release = releaseImageId();
+
+    // The common local setup: no image of your own, run what CI published.
+    expect(devSandboxImageId(release, undefined)).toEqual(release);
+    expect(devSandboxImageId(release, "")).toEqual(release);
+  });
+
+  it("resolves the dev alias in development when a suffix is set", () => {
+    vi.stubEnv("IS_DEVELOPMENT", "true");
+    vi.stubEnv("SBX_DEV_IMAGE_SUFFIX", DEV_SUFFIX);
+
+    const imageResult = getSandboxImage();
+    if (imageResult.isErr()) {
+      throw imageResult.error;
+    }
+
+    expect(imageResult.value.imageId?.tag).toBe(
+      `${releaseImageId().tag}-${DEV_SUFFIX}`
+    );
+  });
+
+  it("keeps the release alias outside development even when a suffix is set", () => {
+    vi.stubEnv("SBX_DEV_IMAGE_SUFFIX", DEV_SUFFIX);
+
+    const imageResult = getSandboxImage();
+    if (imageResult.isErr()) {
+      throw imageResult.error;
+    }
+
+    expect(imageResult.value.imageId?.tag).toBe(releaseImageId().tag);
+  });
+});
 
 describe("getToolsForProvider", () => {
   it("filters dsbx from manifest inputs when requested", async () => {

--- a/front/lib/api/sandbox/image/index.ts
+++ b/front/lib/api/sandbox/image/index.ts
@@ -6,7 +6,10 @@ import {
 } from "@app/lib/api/sandbox/image/registry";
 import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
 import type { ToolEntry } from "@app/lib/api/sandbox/image/types";
-import { DSBX_TOOL_NAME } from "@app/lib/api/sandbox/image/types";
+import {
+  DSBX_TOOL_NAME,
+  devSandboxImageId,
+} from "@app/lib/api/sandbox/image/types";
 import type { Authenticator } from "@app/lib/auth";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import { isDevelopment } from "@app/types/shared/env";
@@ -56,6 +59,21 @@ export function filterDsbxToolEntries(
   return tools.filter((tool) => tool.name !== DSBX_TOOL_NAME);
 }
 
+// Dev-only: resolve the developer's own image alias, so a locally built image
+// can be exercised without publishing over the release alias. Set
+// SBX_DEV_IMAGE_SUFFIX and build with `sandbox_image_build.ts` (no --release).
+// Leave it unset to run against the release image CI built.
+function withDevImageId(image: SandboxImage): SandboxImage {
+  const { imageId } = image;
+  if (!imageId) {
+    return image;
+  }
+
+  return image.register(
+    devSandboxImageId(imageId, config.getSandboxDevImageSuffix())
+  );
+}
+
 export function getSandboxImage(
   _auth?: Authenticator
 ): Result<SandboxImage, Error> {
@@ -68,7 +86,7 @@ export function getSandboxImage(
     return imageResult;
   }
 
-  const image = imageResult.value;
+  const image = withDevImageId(imageResult.value);
 
   // Dev-only: bypass all egress restrictions. Pairs with skipping the dsbx
   // forwarder + tearing down in-sandbox nftables in tools/index.ts.
@@ -109,5 +127,8 @@ export type {
   ToolProfile,
   ToolRuntime,
 } from "@app/lib/api/sandbox/image/types";
-export { formatSandboxImageId } from "@app/lib/api/sandbox/image/types";
+export {
+  devSandboxImageId,
+  formatSandboxImageId,
+} from "@app/lib/api/sandbox/image/types";
 export { getRegisteredImages, getSandboxImageFromRegistry };

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.73",
+      tag: "0.8.79",
     });
   });
 

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,7 +26,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.73";
+const DUST_BASE_IMAGE_VERSION = "0.8.79";
 const DSBX_CLI_VERSION = "0.1.47";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -13,6 +13,26 @@ export function formatSandboxImageId(id: SandboxImageId): string {
   return `${sanitize(id.imageName)}_${sanitize(id.tag)}`;
 }
 
+// Builds outside CI publish under a per-developer alias instead of the release
+// one. `sandbox_image_check.ts` reads "an alias with this tag exists" as "this
+// version was built from main", so a locally built image sitting on the release
+// alias makes CI skip that region's build and leaves the region running
+// unmerged code. Both the build script and the dev-time image resolution go
+// through here so the two always agree on the alias.
+//
+// No suffix means no local image to point at: the id is returned untouched so
+// local runs use the release image built by CI. That is the common case.
+export function devSandboxImageId(
+  id: SandboxImageId,
+  devSuffix: string | undefined
+): SandboxImageId {
+  if (!devSuffix) {
+    return id;
+  }
+
+  return { ...id, tag: `${id.tag}-${devSuffix}` };
+}
+
 // ---------------------------------------------------------------------------
 // Tool Names
 // ---------------------------------------------------------------------------

--- a/front/scripts/sandbox_image_build.ts
+++ b/front/scripts/sandbox_image_build.ts
@@ -41,8 +41,8 @@ function resolveImageId(
   if (!devSuffix) {
     logger.error(
       "Set SBX_DEV_IMAGE_SUFFIX (e.g. your username) in front/.env.local to " +
-        "build a sandbox image locally, or pass --release to publish the " +
-        `release alias '${formatSandboxImageId(releaseImageId)}' (CI only).`
+        "build a sandbox image locally, or pass --release if you intend " +
+        "to deploy the image in production."
     );
     process.exit(1);
   }

--- a/front/scripts/sandbox_image_build.ts
+++ b/front/scripts/sandbox_image_build.ts
@@ -1,6 +1,7 @@
 import config from "@app/lib/api/config";
 import type { SandboxImageId } from "@app/lib/api/sandbox/image";
 import {
+  devSandboxImageId,
   formatSandboxImageId,
   getSandboxImageFromRegistry,
 } from "@app/lib/api/sandbox/image";
@@ -22,6 +23,31 @@ interface BuildArgs {
   dockerRegistry: string;
   rebuild: boolean;
   confirm: boolean;
+  release: boolean;
+}
+
+// The release alias is CI's to publish: `sandbox_image_check.ts` treats its
+// presence as "this version was built from main" and skips the region's build
+// otherwise. Local builds are namespaced per developer instead.
+function resolveImageId(
+  releaseImageId: SandboxImageId,
+  release: boolean
+): SandboxImageId {
+  if (release) {
+    return releaseImageId;
+  }
+
+  const devSuffix = config.getSandboxDevImageSuffix();
+  if (!devSuffix) {
+    logger.error(
+      "Set SBX_DEV_IMAGE_SUFFIX (e.g. your username) in front/.env.local to " +
+        "build a sandbox image locally, or pass --release to publish the " +
+        `release alias '${formatSandboxImageId(releaseImageId)}' (CI only).`
+    );
+    process.exit(1);
+  }
+
+  return devSandboxImageId(releaseImageId, devSuffix);
 }
 
 async function promptYesNo(question: string): Promise<boolean> {
@@ -58,11 +84,15 @@ async function buildImage(args: BuildArgs): Promise<void> {
     dockerRegistry,
     rebuild,
     confirm,
+    release,
   } = args;
 
-  const imageId: SandboxImageId = { imageName, tag };
+  const imageId = resolveImageId({ imageName, tag }, release);
 
-  logger.info({ imageName, tag }, "Starting sandbox image build");
+  logger.info(
+    { imageId: formatSandboxImageId(imageId), release },
+    "Starting sandbox image build"
+  );
 
   const existsResult = await templateExists(imageId);
   if (existsResult.isErr()) {
@@ -204,6 +234,14 @@ yargs(hideBin(process.argv))
     default: false,
     describe: "Skip all interactive prompts",
   })
+  .option("release", {
+    type: "boolean",
+    default: false,
+    describe:
+      "Publish under the release alias (CI only). Without it, the build is " +
+      "namespaced with SBX_DEV_IMAGE_SUFFIX so it cannot mask a missing " +
+      "release build",
+  })
   .help("h")
   .alias("h", "help")
   .parseAsync()
@@ -215,6 +253,7 @@ yargs(hideBin(process.argv))
       dockerRegistry: getDockerRegistry(args["docker-registry"]),
       rebuild: args.rebuild,
       confirm: args.confirm,
+      release: args.release,
     });
     process.exit(0);
   })


### PR DESCRIPTION
## What was happening

The Sandbox Image Registry workflow builds an image for one region and silently skips the other — e.g. [run 31461680537](https://github.com/dust-tt/dust/actions/runs/31461680537), where US built `dust-base_0-8-73` and EU reported it as already existing.

`sandbox_image_check.ts` decides "already built" by asking E2B whether a template with alias `dust-base_<tag>` exists. That treats the alias as proof the version was built from `main`, which is only true if CI is the sole creator of release aliases. Nothing enforced that.

To exercise a locally modified image you had to publish it under the exact alias the registry names, since `getSandboxImage()` had no dev override and the runtime resolves `formatSandboxImageId(config.imageId)`. `sandbox_image_build.ts` then refuses to overwrite an existing alias without `--rebuild`, so while iterating the path of least resistance was to bump `DUST_BASE_IMAGE_VERSION` again. That burned release numbers ahead of `main`.

Evidence from the two E2B regions (`createdAt` on the template records):

| tag | EU created | US created | landed in main |
|---|---|---|---|
| `0-8-71` | Aug 10 19:27:23 | Aug 10 19:27:30 | Aug 10 17:21 |
| `0-8-72` | **Aug 10 21:24:14** | Aug 10 22:11:01 | Aug 10 22:09 |
| `0-8-73` | **Aug 10 21:30:14** | Aug 11 05:28:06 | Aug 11 05:26 |
| `0-8-74` | Aug 10 21:30:53 | — | never |
| `0-8-75` | Aug 10 21:34:16 | — | never |
| `0-8-76` | Aug 10 21:46:20 | — | never |
| `0-8-78` | Aug 11 09:21:24 | — | never |

US timestamps match the CI build steps to the second. The EU ones for `0-8-72`/`0-8-73` precede CI by 47 minutes and 8 hours, and `0.8.74`–`0.8.78` appear in no commit on any branch — they came from uncommitted working trees. `sandbox-img-registry.yml` is the only workflow that touches E2B, and no run of it happened in those windows.

Consequence: when `main` landed on a version already burned in EU, the EU check reported it existing, the EU build was skipped, and EU kept serving an image built from an unmerged working tree while US got the one built from the merged commit. Same tag, different contents, no signal anywhere.

## The fix

- `sandbox_image_build.ts` gains `--release`, which the workflow passes. Without it the build is namespaced with `SBX_DEV_IMAGE_SUFFIX`, and it fails fast if that is unset rather than guessing.
- `getSandboxImage()` resolves the same dev alias in development, so a locally built image is actually usable — this closes the trap that forced the behaviour. It sits inside the existing `isDevelopment()` guard, so the suffix cannot take effect in production. Every sandbox-creating path already routes through `getSandboxImage()`, so they all pick it up.
- `devSandboxImageId()` holds the naming convention in one place, so the published alias and the resolved alias cannot drift.

Local iteration no longer requires bumping the version at all: keep `DUST_BASE_IMAGE_VERSION` at main's value, set `SBX_DEV_IMAGE_SUFFIX=<you>`, and build `dust-base_<version>-<you>`.

| local setup | resolves to |
|---|---|
| `SBX_DEV_IMAGE_SUFFIX` unset (default) | `dust-base_0-8-79` — the CI-built image |
| `SBX_DEV_IMAGE_SUFFIX=david` | `dust-base_0-8-79-david` — your own build |
| production, suffix set anyway | `dust-base_0-8-79` — suffix ignored |

## Heads-up: this bumps dust-base to 0.8.79

EU still holds orphaned `0-8-76` and `0-8-78` (E2B refused to delete them — paused and running sandboxes still reference them, and no sandboxes were killed). `main` was at `0.8.73`, so the next bump to `0.8.74` would have skipped EU again. Versions only increase, so moving past the burned range retires the landmine by construction. `0.8.77` was never burned but `0.8.78` was, hence `0.8.79`.

This means a fresh `dust-base` build in both regions on the next front deploy. A rebuild is never bit-identical — apt and npm resolution can drift — so it is a small but real image change, deliberately incurred rather than driven by an image change. Same risk profile as any routine bump.

## Testing

- 4 new tests in `lib/api/sandbox/image/index.test.ts`, 51ms total, no DB or network. They cover: the dev alias never collides with the release alias and is a valid E2B alias; no suffix keeps the release alias (the common local case); development plus suffix resolves the dev alias; and production ignores the suffix.
- Confirmed non-vacuous — reverting the one-line runtime change fails with `expected '0.8.73' to be '0.8.73-test-dev'`.
- Full sandbox suite passes (198 tests / 18 files), `npx tsgo --noEmit` clean, biome clean.
- All three build-script paths exercised against the real script: refusal with exit 1 when no suffix is set, `dust-base_0-8-73-david` with a suffix, `dust-base_0-8-73` with `--release`.
