### PR TITLE
[viz] feat: persist the frame SWR cache across opens

### DIFF
--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -680,7 +680,7 @@ export function VisualizationWrapper({
         </div>
       )}
       <VizContext.Provider value={vizContextValue}>
-        <PodFunctionHooksProvider dataAPI={api.data}>
+        <PodFunctionHooksProvider dataAPI={api.data} identifier={identifier}>
           {isEditable ? <EditableFrame>{runner}</EditableFrame> : runner}
         </PodFunctionHooksProvider>
       </VizContext.Provider>

--- a/viz/app/lib/frame-cache-persistence.test.ts
+++ b/viz/app/lib/frame-cache-persistence.test.ts
@@ -112,20 +112,20 @@ describe("FrameCachePersistence", () => {
 
   it("keeps only the most recently updated entries", () => {
     const cache = new Map<string, unknown>();
-    let clock = 1_000;
-    const persistence = makePersistence({ cache, nowMs: () => clock });
+    let clockMs = 1_000;
+    const persistence = makePersistence({ cache, nowMs: () => clockMs });
 
     for (let i = 0; i < FRAME_CACHE_MAX_ENTRIES + 10; i++) {
       const key = `key-${i}`;
       cache.set(key, { data: i });
-      clock += 1;
+      clockMs += 1;
       persistence.recordEntry(key);
     }
     persistence.flush();
 
     const hydrated = makePersistence({
       cache: new Map(),
-      nowMs: () => clock,
+      nowMs: () => clockMs,
     }).hydrate();
     expect(hydrated.size).toBe(FRAME_CACHE_MAX_ENTRIES);
     expect(hydrated.has("key-0")).toBe(false);
@@ -139,17 +139,17 @@ describe("FrameCachePersistence", () => {
       ["new-big", { data: bigValue }],
       ["newest-small", { data: "small" }],
     ]);
-    let clock = 1_000;
-    const persistence = makePersistence({ cache, nowMs: () => clock });
+    let clockMs = 1_000;
+    const persistence = makePersistence({ cache, nowMs: () => clockMs });
     for (const key of ["old-big", "new-big", "newest-small"]) {
-      clock += 1;
+      clockMs += 1;
       persistence.recordEntry(key);
     }
     persistence.flush();
 
     const hydrated = makePersistence({
       cache: new Map(),
-      nowMs: () => clock,
+      nowMs: () => clockMs,
     }).hydrate();
     expect(hydrated.has("newest-small")).toBe(true);
     expect(hydrated.has("new-big")).toBe(true);

--- a/viz/app/lib/frame-cache-persistence.test.ts
+++ b/viz/app/lib/frame-cache-persistence.test.ts
@@ -1,0 +1,248 @@
+// @vitest-environment jsdom
+
+import {
+  FRAME_CACHE_MAX_ENTRIES,
+  FRAME_CACHE_MAX_ENTRY_AGE_MS,
+  FRAME_CACHE_MAX_FRAMES,
+  FRAME_CACHE_MAX_ITEM_SIZE_BYTES,
+  FRAME_CACHE_WRITE_DEBOUNCE_MS,
+  FrameCachePersistence,
+  frameCacheStorageKey,
+} from "@viz/app/lib/frame-cache-persistence";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const STORAGE_KEY = frameCacheStorageKey("viz-fil_1", "usr_123");
+
+function makePersistence({
+  cache = new Map<string, unknown>(),
+  storage = window.localStorage,
+  storageKey = STORAGE_KEY,
+  nowMs,
+}: {
+  cache?: Map<string, unknown>;
+  storage?: Storage;
+  storageKey?: string;
+  nowMs?: () => number;
+} = {}) {
+  return new FrameCachePersistence({ cache, storage, storageKey, nowMs });
+}
+
+function seedItem(
+  storageKey: string,
+  entries: [string, { data: unknown; updatedAtMs: number }][],
+  updatedAtMs = Date.now()
+) {
+  window.localStorage.setItem(
+    storageKey,
+    JSON.stringify({ updatedAtMs, entries })
+  );
+}
+
+describe("FrameCachePersistence", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("round-trips recorded entries through storage", () => {
+    const cache = new Map<string, unknown>([["key-a", { data: [{ id: 1 }] }]]);
+    const persistence = makePersistence({ cache });
+
+    persistence.recordEntry("key-a");
+    persistence.flush();
+
+    const rehydrated = makePersistence({ cache: new Map() }).hydrate();
+    expect(rehydrated.get("key-a")).toEqual([{ id: 1 }]);
+  });
+
+  it("debounces writes and flushes on the timer", () => {
+    vi.useFakeTimers();
+    const cache = new Map<string, unknown>([["key-a", { data: "value" }]]);
+    const persistence = makePersistence({ cache });
+
+    persistence.recordEntry("key-a");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    vi.advanceTimersByTime(FRAME_CACHE_WRITE_DEBOUNCE_MS);
+    expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+  });
+
+  it("skips recorded keys without data and non-state cache values", () => {
+    const cache = new Map<string, unknown>([
+      ["key-loading", { isValidating: true }],
+      ["key-primitive", 42],
+    ]);
+    const persistence = makePersistence({ cache });
+
+    persistence.recordEntry("key-loading");
+    persistence.recordEntry("key-primitive");
+    persistence.recordEntry("key-missing");
+    persistence.flush();
+
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("drops expired entries at hydration", () => {
+    const nowMs = 1_000_000_000;
+    seedItem(STORAGE_KEY, [
+      ["fresh", { data: "fresh", updatedAtMs: nowMs - 1_000 }],
+      [
+        "expired",
+        { data: "old", updatedAtMs: nowMs - FRAME_CACHE_MAX_ENTRY_AGE_MS - 1 },
+      ],
+    ]);
+
+    const hydrated = makePersistence({ nowMs: () => nowMs }).hydrate();
+
+    expect(hydrated.get("fresh")).toBe("fresh");
+    expect(hydrated.has("expired")).toBe(false);
+  });
+
+  it("discards and removes malformed items", () => {
+    window.localStorage.setItem(STORAGE_KEY, "{not json");
+    expect(makePersistence().hydrate().size).toBe(0);
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ bad: "shape" }));
+    expect(makePersistence().hydrate().size).toBe(0);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("keeps only the most recently updated entries", () => {
+    const cache = new Map<string, unknown>();
+    let clock = 1_000;
+    const persistence = makePersistence({ cache, nowMs: () => clock });
+
+    for (let i = 0; i < FRAME_CACHE_MAX_ENTRIES + 10; i++) {
+      const key = `key-${i}`;
+      cache.set(key, { data: i });
+      clock += 1;
+      persistence.recordEntry(key);
+    }
+    persistence.flush();
+
+    const hydrated = makePersistence({
+      cache: new Map(),
+      nowMs: () => clock,
+    }).hydrate();
+    expect(hydrated.size).toBe(FRAME_CACHE_MAX_ENTRIES);
+    expect(hydrated.has("key-0")).toBe(false);
+    expect(hydrated.has(`key-${FRAME_CACHE_MAX_ENTRIES + 9}`)).toBe(true);
+  });
+
+  it("drops least recently updated entries until the payload fits", () => {
+    const bigValue = "x".repeat(FRAME_CACHE_MAX_ITEM_SIZE_BYTES / 2);
+    const cache = new Map<string, unknown>([
+      ["old-big", { data: bigValue }],
+      ["new-big", { data: bigValue }],
+      ["newest-small", { data: "small" }],
+    ]);
+    let clock = 1_000;
+    const persistence = makePersistence({ cache, nowMs: () => clock });
+    for (const key of ["old-big", "new-big", "newest-small"]) {
+      clock += 1;
+      persistence.recordEntry(key);
+    }
+    persistence.flush();
+
+    const hydrated = makePersistence({
+      cache: new Map(),
+      nowMs: () => clock,
+    }).hydrate();
+    expect(hydrated.has("newest-small")).toBe(true);
+    expect(hydrated.has("new-big")).toBe(true);
+    expect(hydrated.has("old-big")).toBe(false);
+  });
+
+  it("forgets dropped entries", () => {
+    seedItem(STORAGE_KEY, [
+      ["kept", { data: "kept", updatedAtMs: Date.now() }],
+      ["dropped", { data: "dropped", updatedAtMs: Date.now() }],
+    ]);
+    const persistence = makePersistence();
+    persistence.hydrate();
+
+    persistence.dropEntry("dropped");
+    persistence.flush();
+
+    const hydrated = makePersistence({ cache: new Map() }).hydrate();
+    expect(hydrated.has("kept")).toBe(true);
+    expect(hydrated.has("dropped")).toBe(false);
+  });
+
+  it("evicts other frames' items on quota pressure", () => {
+    const otherKey = frameCacheStorageKey("viz-fil_other", "usr_123");
+    seedItem(otherKey, [["k", { data: "other", updatedAtMs: 1 }]], 1);
+
+    // Storage stub that refuses writes while the other frame's item is present.
+    let denyWrites = true;
+    const storage: Storage = {
+      get length() {
+        return window.localStorage.length;
+      },
+      key: (i: number) => window.localStorage.key(i),
+      getItem: (k: string) => window.localStorage.getItem(k),
+      removeItem: (k: string) => {
+        window.localStorage.removeItem(k);
+        denyWrites = false;
+      },
+      setItem: (k: string, v: string) => {
+        if (denyWrites) {
+          throw new Error("QuotaExceededError");
+        }
+        window.localStorage.setItem(k, v);
+      },
+      clear: () => window.localStorage.clear(),
+    };
+
+    const cache = new Map<string, unknown>([["key-a", { data: "value" }]]);
+    const persistence = makePersistence({ cache, storage });
+    persistence.recordEntry("key-a");
+    persistence.flush();
+
+    expect(window.localStorage.getItem(otherKey)).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+  });
+
+  it("caps the number of persisted frames on the origin", () => {
+    for (let i = 0; i < FRAME_CACHE_MAX_FRAMES + 2; i++) {
+      seedItem(
+        frameCacheStorageKey(`viz-fil_${i}`, "usr_123"),
+        [["k", { data: i, updatedAtMs: i + 1 }]],
+        i + 1
+      );
+    }
+
+    const cache = new Map<string, unknown>([["key-a", { data: "value" }]]);
+    const persistence = makePersistence({ cache });
+    persistence.recordEntry("key-a");
+    persistence.flush();
+
+    const frameKeys: string[] = [];
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const key = window.localStorage.key(i);
+      if (key?.startsWith("dust:frameCache:v1:")) {
+        frameKeys.push(key);
+      }
+    }
+    expect(frameKeys.length).toBe(FRAME_CACHE_MAX_FRAMES);
+    // The oldest seeded items are gone, the fresh write survives.
+    expect(
+      window.localStorage.getItem(frameCacheStorageKey("viz-fil_0", "usr_123"))
+    ).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+  });
+
+  it("stops persisting after dispose", () => {
+    const cache = new Map<string, unknown>([["key-a", { data: "value" }]]);
+    const persistence = makePersistence({ cache });
+    persistence.dispose();
+
+    persistence.recordEntry("key-a");
+    persistence.flush();
+
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/viz/app/lib/frame-cache-persistence.ts
+++ b/viz/app/lib/frame-cache-persistence.ts
@@ -1,0 +1,324 @@
+import { z } from "zod";
+
+/**
+ * Cross-open persistence for the Frame SWR cache.
+ *
+ * Each (frame, viewer) pair owns one localStorage item holding the last known output of the
+ * frame's persisted Pod Function reads. On the next open the entries are served as SWR
+ * fallback data so the frame paints instantly while `revalidateIfStale` refreshes in the
+ * background. Persistence is strictly best-effort: any storage failure silently degrades to
+ * the previous per-mount behavior.
+ *
+ * The viz origin is shared by every workspace and viewer, so items are namespaced by frame
+ * identifier AND viewer user id, and nothing is ever persisted for unauthenticated viewers.
+ */
+
+// Versioned prefix: bumping the version orphans (and eventually evicts) incompatible items.
+const FRAME_CACHE_STORAGE_KEY_PREFIX = "dust:frameCache:v1:";
+
+export const FRAME_CACHE_WRITE_DEBOUNCE_MS = 1_000;
+
+// Per-frame entry count cap; least-recently-updated entries are evicted first.
+export const FRAME_CACHE_MAX_ENTRIES = 50;
+
+// Per-frame serialized payload cap. localStorage stores UTF-16 code units; we approximate
+// 1 char ≈ 1 byte and compare the cap against the serialized string length.
+export const FRAME_CACHE_MAX_ITEM_SIZE_BYTES = 512 * 1024;
+
+// Cap on the number of persisted frame items across the shared viz origin.
+export const FRAME_CACHE_MAX_FRAMES = 20;
+
+// Entries older than this are dropped at hydration; stale-by-a-week data is worthless and
+// only holds quota.
+export const FRAME_CACHE_MAX_ENTRY_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+const PersistedEntrySchema = z.object({
+  data: z.unknown(),
+  updatedAtMs: z.number(),
+});
+
+type PersistedEntry = z.infer<typeof PersistedEntrySchema>;
+
+const PersistedFrameCacheSchema = z.object({
+  updatedAtMs: z.number(),
+  entries: z.array(z.tuple([z.string(), PersistedEntrySchema])),
+});
+
+export function frameCacheStorageKey(
+  identifier: string,
+  userId: string
+): string {
+  return `${FRAME_CACHE_STORAGE_KEY_PREFIX}${identifier}:${userId}`;
+}
+
+// The SWR provider map stores one state object per serialized key; only `data` is persisted.
+function isSWRStateWithData(state: unknown): state is { data: unknown } {
+  return typeof state === "object" && state !== null && "data" in state;
+}
+
+interface FrameCachePersistenceOptions {
+  // The live SWR provider map, read at flush time so writes always see the latest data.
+  cache: ReadonlyMap<string, unknown>;
+  storage: Storage;
+  storageKey: string;
+  // Injectable clock for tests.
+  nowMs?: () => number;
+}
+
+export class FrameCachePersistence {
+  private readonly cache: ReadonlyMap<string, unknown>;
+  private readonly storage: Storage;
+  private readonly storageKey: string;
+  private readonly nowMs: () => number;
+
+  // Entries carried over from the persisted item (and previous flushes). Keys recorded this
+  // session overwrite their baseline entry at flush; unrecorded baseline entries are kept so
+  // inputs that vary between sessions survive until LRU eviction or expiry.
+  private baseline = new Map<string, PersistedEntry>();
+  private readonly recordedAtMs = new Map<string, number>();
+  private readonly droppedKeys = new Set<string>();
+  private writeTimer: ReturnType<typeof setTimeout> | null = null;
+  private disabled = false;
+
+  constructor({
+    cache,
+    storage,
+    storageKey,
+    nowMs,
+  }: FrameCachePersistenceOptions) {
+    this.cache = cache;
+    this.storage = storage;
+    this.storageKey = storageKey;
+    this.nowMs = nowMs ?? Date.now;
+  }
+
+  /**
+   * Load the persisted entries for this (frame, viewer) pair, dropping expired ones.
+   * Returns serialized SWR key -> data, ready to be used as SWR fallback.
+   */
+  hydrate(): Map<string, unknown> {
+    const hydrated = new Map<string, unknown>();
+
+    // localStorage access and JSON parsing can both throw (storage disabled, corrupted
+    // payload); persistence is best-effort so start cold instead of surfacing the error.
+    try {
+      const raw = this.storage.getItem(this.storageKey);
+      if (raw === null) {
+        return hydrated;
+      }
+
+      const parsed = PersistedFrameCacheSchema.safeParse(JSON.parse(raw));
+      if (!parsed.success) {
+        this.storage.removeItem(this.storageKey);
+        return hydrated;
+      }
+
+      const expiryCutoffMs = this.nowMs() - FRAME_CACHE_MAX_ENTRY_AGE_MS;
+      for (const [key, entry] of parsed.data.entries) {
+        if (entry.updatedAtMs >= expiryCutoffMs && entry.data !== undefined) {
+          this.baseline.set(key, entry);
+          hydrated.set(key, entry.data);
+        }
+      }
+    } catch (_error) {
+      return hydrated;
+    }
+
+    return hydrated;
+  }
+
+  /**
+   * Mark a serialized SWR key as persistable and freshly used, then schedule a debounced
+   * write. Only recorded keys ever pick up new data; unrecorded SWR keys (identity,
+   * mutations) never reach storage.
+   */
+  recordEntry(serializedKey: string): void {
+    if (this.disabled) {
+      return;
+    }
+
+    this.droppedKeys.delete(serializedKey);
+    this.recordedAtMs.set(serializedKey, this.nowMs());
+    this.scheduleWrite();
+  }
+
+  /**
+   * Remove a key from persistence (opt-out hooks). Also forgets any previously persisted
+   * entry for the key.
+   */
+  dropEntry(serializedKey: string): void {
+    if (this.disabled) {
+      return;
+    }
+
+    if (
+      this.baseline.has(serializedKey) ||
+      this.recordedAtMs.has(serializedKey)
+    ) {
+      this.baseline.delete(serializedKey);
+      this.recordedAtMs.delete(serializedKey);
+      this.droppedKeys.add(serializedKey);
+      this.scheduleWrite();
+    }
+  }
+
+  /** Write now, canceling any pending debounced write. */
+  flush(): void {
+    if (this.writeTimer !== null) {
+      clearTimeout(this.writeTimer);
+      this.writeTimer = null;
+    }
+    if (this.disabled) {
+      return;
+    }
+
+    // Serialization and storage writes touch environment-controlled surfaces (quota, private
+    // browsing, non-JSON data injected via mutate); degrade to no persistence on failure.
+    try {
+      this.writeToStorage();
+    } catch (_error) {
+      this.disabled = true;
+    }
+  }
+
+  dispose(): void {
+    if (this.writeTimer !== null) {
+      clearTimeout(this.writeTimer);
+      this.writeTimer = null;
+    }
+    this.disabled = true;
+  }
+
+  private scheduleWrite(): void {
+    if (this.writeTimer !== null) {
+      return;
+    }
+
+    this.writeTimer = setTimeout(() => {
+      this.writeTimer = null;
+      this.flush();
+    }, FRAME_CACHE_WRITE_DEBOUNCE_MS);
+  }
+
+  private writeToStorage(): void {
+    const merged = new Map(this.baseline);
+    this.recordedAtMs.forEach((recordedAtMs, key) => {
+      const state = this.cache.get(key);
+      if (isSWRStateWithData(state) && state.data !== undefined) {
+        merged.set(key, { data: state.data, updatedAtMs: recordedAtMs });
+      }
+    });
+    this.droppedKeys.forEach((key) => {
+      merged.delete(key);
+    });
+
+    // Most recently updated first, then apply the entry-count cap.
+    let entries = Array.from(merged.entries())
+      .sort(([, a], [, b]) => b.updatedAtMs - a.updatedAtMs)
+      .slice(0, FRAME_CACHE_MAX_ENTRIES);
+
+    let payload = this.serialize(entries);
+    // Byte cap: drop least-recently-updated entries until the payload fits.
+    while (
+      payload.length > FRAME_CACHE_MAX_ITEM_SIZE_BYTES &&
+      entries.length > 0
+    ) {
+      entries = entries.slice(0, -1);
+      payload = this.serialize(entries);
+    }
+
+    this.baseline = new Map(entries);
+
+    if (entries.length === 0) {
+      this.storage.removeItem(this.storageKey);
+      return;
+    }
+
+    if (!this.trySetItem(payload)) {
+      // Quota pressure: evict other frames' items, oldest first, and retry after each.
+      const evictable = this.listFrameItems().filter(
+        (item) => item.key !== this.storageKey
+      );
+      let written = false;
+      for (const item of evictable) {
+        this.storage.removeItem(item.key);
+        if (this.trySetItem(payload)) {
+          written = true;
+          break;
+        }
+      }
+      if (!written) {
+        this.disabled = true;
+        return;
+      }
+    }
+
+    this.pruneFrameCount();
+  }
+
+  private serialize(entries: [string, PersistedEntry][]): string {
+    return JSON.stringify({ updatedAtMs: this.nowMs(), entries });
+  }
+
+  private trySetItem(payload: string): boolean {
+    // setItem throws on quota exhaustion; the caller handles eviction.
+    try {
+      this.storage.setItem(this.storageKey, payload);
+      return true;
+    } catch (_error) {
+      return false;
+    }
+  }
+
+  // Every frame item on the origin, least recently updated first. Unparseable items sort
+  // first so they are evicted before valid ones.
+  private listFrameItems(): { key: string; updatedAtMs: number }[] {
+    const items: { key: string; updatedAtMs: number }[] = [];
+    for (let i = 0; i < this.storage.length; i++) {
+      const key = this.storage.key(i);
+      if (key === null || !key.startsWith(FRAME_CACHE_STORAGE_KEY_PREFIX)) {
+        continue;
+      }
+
+      let updatedAtMs = 0;
+      // Other items may be corrupted or from another version; treat them as oldest.
+      try {
+        const raw = this.storage.getItem(key);
+        const parsed = PersistedFrameCacheSchema.safeParse(
+          raw === null ? null : JSON.parse(raw)
+        );
+        if (parsed.success) {
+          updatedAtMs = parsed.data.updatedAtMs;
+        }
+      } catch (_error) {
+        // Keep updatedAtMs at 0 so the item is evicted first.
+      }
+
+      items.push({ key, updatedAtMs });
+    }
+
+    return items.sort((a, b) => a.updatedAtMs - b.updatedAtMs);
+  }
+
+  private pruneFrameCount(): void {
+    // Cheap key count first: parsing every frame item on each flush would be wasteful.
+    let frameKeyCount = 0;
+    for (let i = 0; i < this.storage.length; i++) {
+      const key = this.storage.key(i);
+      if (key !== null && key.startsWith(FRAME_CACHE_STORAGE_KEY_PREFIX)) {
+        frameKeyCount += 1;
+      }
+    }
+    if (frameKeyCount <= FRAME_CACHE_MAX_FRAMES) {
+      return;
+    }
+
+    const items = this.listFrameItems();
+
+    for (const item of items.slice(0, items.length - FRAME_CACHE_MAX_FRAMES)) {
+      if (item.key !== this.storageKey) {
+        this.storage.removeItem(item.key);
+      }
+    }
+  }
+}

--- a/viz/app/lib/pod-function-hooks.test.tsx
+++ b/viz/app/lib/pod-function-hooks.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { frameCacheStorageKey } from "@viz/app/lib/frame-cache-persistence";
 import {
   PodFunctionHooksProvider,
   usePodFunction,
@@ -9,7 +10,8 @@ import {
 } from "@viz/app/lib/pod-function-hooks";
 import type { VisualizationDataAPI } from "@viz/app/lib/visualization-api";
 import { createElement, type PropsWithChildren } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { unstable_serialize } from "swr";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 function deferred<T>() {
   let resolve: (value: T) => void = () => undefined;
@@ -37,9 +39,13 @@ function makeDataAPI(
   };
 }
 
-function makeWrapper(dataAPI: VisualizationDataAPI) {
+function makeWrapper(dataAPI: VisualizationDataAPI, identifier?: string) {
   return function Wrapper({ children }: PropsWithChildren) {
-    return createElement(PodFunctionHooksProvider, { dataAPI }, children);
+    return createElement(
+      PodFunctionHooksProvider,
+      { dataAPI, identifier },
+      children
+    );
   };
 }
 
@@ -467,5 +473,190 @@ describe("usePodFunctionMutation", () => {
     });
     expect(result.current.list.data).toEqual([{ id: 1 }, { id: 2 }]);
     expect(callFunction).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("cross-open cache persistence", () => {
+  const IDENTIFIER = "viz-fil_1";
+  const USER_ID = "usr_123";
+  const SLUG = "vlt_123/list-comments";
+  const INPUT = { threadId: "thread-1" };
+  const SERIALIZED_KEY = unstable_serialize(["pod-function", SLUG, INPUT]);
+  const STORAGE_KEY = frameCacheStorageKey(IDENTIFIER, USER_ID);
+
+  function makeAuthenticatedDataAPI(
+    callFunction: VisualizationDataAPI["callFunction"]
+  ): VisualizationDataAPI {
+    const dataAPI = makeDataAPI(callFunction);
+    dataAPI.getUserIdentity = vi.fn().mockResolvedValue({
+      isAuthenticated: true,
+      isWorkspaceMember: true,
+      user: {
+        sId: USER_ID,
+        firstName: "Ada",
+        lastName: "Lovelace",
+        fullName: "Ada Lovelace",
+        image: null,
+      },
+    });
+    return dataAPI;
+  }
+
+  function seedPersistedEntry(
+    storageKey: string,
+    serializedKey: string,
+    data: unknown
+  ) {
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        updatedAtMs: Date.now(),
+        entries: [[serializedKey, { data, updatedAtMs: Date.now() }]],
+      })
+    );
+  }
+
+  function countFrameItems(): number {
+    let count = 0;
+    for (let i = 0; i < window.localStorage.length; i++) {
+      if (window.localStorage.key(i)?.startsWith("dust:frameCache:")) {
+        count += 1;
+      }
+    }
+    return count;
+  }
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("paints persisted data before the first fetch resolves", async () => {
+    seedPersistedEntry(STORAGE_KEY, SERIALIZED_KEY, [{ id: "persisted" }]);
+    const request = deferred<unknown>();
+    const callFunction = vi.fn().mockReturnValue(request.promise);
+    const dataAPI = makeAuthenticatedDataAPI(callFunction);
+
+    const { result, unmount } = renderHook(() => usePodFunction(SLUG, INPUT), {
+      wrapper: makeWrapper(dataAPI, IDENTIFIER),
+    });
+
+    // Hydration lands right after identity resolves, while the fetch is in flight.
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ id: "persisted" }]);
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isValidating).toBe(true);
+
+    request.resolve([{ id: "fresh" }]);
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ id: "fresh" }]);
+    });
+    expect(callFunction).toHaveBeenCalledTimes(1);
+
+    // There is no test auto-cleanup here: unmount so this provider's pagehide listener
+    // cannot fire in later tests.
+    unmount();
+  });
+
+  it("persists fetched data for the next open", async () => {
+    const callFunction = vi.fn().mockResolvedValue([{ id: 1 }]);
+    const dataAPI = makeAuthenticatedDataAPI(callFunction);
+
+    const { result, unmount } = renderHook(() => usePodFunction(SLUG, INPUT), {
+      wrapper: makeWrapper(dataAPI, IDENTIFIER),
+    });
+    await waitFor(() => expect(result.current.data).toEqual([{ id: 1 }]));
+
+    // pagehide forces the debounced write; retry until the boot and record effects landed.
+    await waitFor(() => {
+      window.dispatchEvent(new Event("pagehide"));
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      expect(raw).not.toBeNull();
+    });
+
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const persisted = raw === null ? null : JSON.parse(raw);
+    expect(persisted?.entries).toEqual([
+      [SERIALIZED_KEY, { data: [{ id: 1 }], updatedAtMs: expect.any(Number) }],
+    ]);
+    unmount();
+  });
+
+  it("never persists for unauthenticated viewers", async () => {
+    const callFunction = vi.fn().mockResolvedValue([{ id: 1 }]);
+    // makeDataAPI's identity is unauthenticated.
+    const dataAPI = makeDataAPI(callFunction);
+
+    const { result, unmount } = renderHook(() => usePodFunction(SLUG, INPUT), {
+      wrapper: makeWrapper(dataAPI, IDENTIFIER),
+    });
+    await waitFor(() => expect(result.current.data).toEqual([{ id: 1 }]));
+    await act(async () => {});
+
+    window.dispatchEvent(new Event("pagehide"));
+    unmount();
+    expect(countFrameItems()).toBe(0);
+  });
+
+  it("never serves another viewer's entries", async () => {
+    seedPersistedEntry(
+      frameCacheStorageKey(IDENTIFIER, "usr_other"),
+      SERIALIZED_KEY,
+      [{ id: "other-user" }]
+    );
+    const request = deferred<unknown>();
+    const callFunction = vi.fn().mockReturnValue(request.promise);
+    const dataAPI = makeAuthenticatedDataAPI(callFunction);
+
+    const { result, unmount } = renderHook(() => usePodFunction(SLUG, INPUT), {
+      wrapper: makeWrapper(dataAPI, IDENTIFIER),
+    });
+
+    // Let identity resolution and hydration settle: no fallback may appear.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(true);
+
+    request.resolve([{ id: "fresh" }]);
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ id: "fresh" }]);
+    });
+    unmount();
+  });
+
+  it("does not persist opted-out reads and clears their leftovers", async () => {
+    seedPersistedEntry(STORAGE_KEY, SERIALIZED_KEY, [{ id: "stale" }]);
+    const callFunction = vi.fn().mockResolvedValue([{ id: "fresh" }]);
+    const dataAPI = makeAuthenticatedDataAPI(callFunction);
+
+    const { result, unmount } = renderHook(
+      () => usePodFunction(SLUG, INPUT, { persist: false }),
+      { wrapper: makeWrapper(dataAPI, IDENTIFIER) }
+    );
+    await waitFor(() => expect(result.current.data).toEqual([{ id: "fresh" }]));
+
+    // The pre-existing entry is dropped rather than refreshed.
+    await waitFor(() => {
+      window.dispatchEvent(new Event("pagehide"));
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+    unmount();
+  });
+
+  it("keeps the cache per-mount without an identifier", async () => {
+    const callFunction = vi.fn().mockResolvedValue([{ id: 1 }]);
+    const dataAPI = makeAuthenticatedDataAPI(callFunction);
+
+    const { result, unmount } = renderHook(() => usePodFunction(SLUG, INPUT), {
+      wrapper: makeWrapper(dataAPI),
+    });
+    await waitFor(() => expect(result.current.data).toEqual([{ id: 1 }]));
+    await act(async () => {});
+
+    window.dispatchEvent(new Event("pagehide"));
+    unmount();
+    expect(countFrameItems()).toBe(0);
   });
 });

--- a/viz/app/lib/pod-function-hooks.tsx
+++ b/viz/app/lib/pod-function-hooks.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { normalizeSandboxFunctionCallError } from "@viz/app/lib/data-apis/sandbox-function-call-error";
+import {
+  FrameCachePersistence,
+  frameCacheStorageKey,
+} from "@viz/app/lib/frame-cache-persistence";
 import { POD_FUNCTION_REFERENCE_REGEX } from "@viz/app/lib/pod-function-slug";
 import type { VisualizationDataAPI } from "@viz/app/lib/visualization-api";
 import type { UserIdentityState } from "@viz/app/types";
@@ -15,15 +19,27 @@ import {
   useRef,
   useState,
 } from "react";
-import useSWR, { type KeyedMutator, SWRConfig } from "swr";
+import useSWR, { type KeyedMutator, SWRConfig, unstable_serialize } from "swr";
 import useSWRMutation from "swr/mutation";
 
 interface PodFunctionContextValue {
   dataAPI: VisualizationDataAPI;
+  persistence: FrameCachePersistence | null;
 }
 
-interface PodFunctionHooksProviderProps extends PodFunctionContextValue {
+interface PodFunctionHooksProviderProps {
   children?: ReactNode;
+  dataAPI: VisualizationDataAPI;
+  // Stable identifier of the rendered content (e.g. "viz-<fileId>"). When set and the viewer
+  // is an authenticated workspace member, function outputs persist across opens in
+  // localStorage, namespaced by identifier and viewer. Absent: per-mount cache only.
+  identifier?: string;
+}
+
+export interface UsePodFunctionOptions {
+  // Set to false for must-be-fresh data: the result is then never persisted to, nor served
+  // from, the cross-open cache. The per-mount SWR cache still applies.
+  persist?: boolean;
 }
 
 export interface UsePodFunctionResult {
@@ -53,6 +69,8 @@ const POD_FUNCTION_QUERY_DEDUPING_INTERVAL_MS = 2_000;
 
 const PodFunctionContext = createContext<PodFunctionContextValue | null>(null);
 
+const EMPTY_FALLBACK: Record<string, unknown> = {};
+
 async function noopMutate(): Promise<undefined> {
   return undefined;
 }
@@ -76,13 +94,105 @@ function resolvePodFunction(slug: string | null): {
   return { functionId: slug };
 }
 
+function getLocalStorage(): Storage | null {
+  // Accessing localStorage can throw (disabled storage, sandboxed iframe without
+  // allow-same-origin); persistence is best-effort so treat that as unavailable.
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch (_error) {
+    return null;
+  }
+}
+
+interface PersistedCacheState {
+  fallback: Record<string, unknown>;
+  persistence: FrameCachePersistence;
+}
+
 export function PodFunctionHooksProvider({
   children,
   dataAPI,
+  identifier,
 }: PodFunctionHooksProviderProps) {
   const [cache] = useState(() => new Map());
-  const swrConfig = useMemo(() => ({ provider: () => cache }), [cache]);
-  const contextValue = useMemo(() => ({ dataAPI }), [dataAPI]);
+  const [persisted, setPersisted] = useState<PersistedCacheState | null>(null);
+
+  // Boot the cross-open cache: resolve the viewer, then hydrate their persisted entries as
+  // SWR fallback. Hooks mount and fetch immediately; hydration only fills the interim
+  // renders, so a slow or silent host merely leaves the cache cold.
+  useEffect(() => {
+    if (!identifier) {
+      return;
+    }
+    const storage = getLocalStorage();
+    if (!storage) {
+      return;
+    }
+
+    let cancelled = false;
+    let persistence: FrameCachePersistence | null = null;
+    const flushNow = () => persistence?.flush();
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        flushNow();
+      }
+    };
+
+    const boot = async () => {
+      let identity: UserIdentityState;
+      try {
+        identity = await dataAPI.getUserIdentity();
+      } catch (_error) {
+        // No host answered (headless render, legacy embedder): stay cold.
+        return;
+      }
+      if (cancelled || !identity.isAuthenticated) {
+        // The viz origin is shared: never persist anything for unauthenticated viewers.
+        return;
+      }
+
+      persistence = new FrameCachePersistence({
+        cache,
+        storage,
+        storageKey: frameCacheStorageKey(identifier, identity.user.sId),
+      });
+      const hydrated = persistence.hydrate();
+
+      // Debounced writes lose the tail on navigation; flush when the page hides.
+      window.addEventListener("pagehide", flushNow);
+      document.addEventListener("visibilitychange", onVisibilityChange);
+
+      setPersisted({
+        fallback: Object.fromEntries(hydrated),
+        persistence,
+      });
+    };
+    void boot();
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener("pagehide", flushNow);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      if (persistence) {
+        persistence.flush();
+        persistence.dispose();
+      }
+    };
+  }, [dataAPI, identifier, cache]);
+
+  // The SWR provider is only read when SWRConfig mounts; later value updates only carry the
+  // fallback, which hooks re-read on every render.
+  const swrConfig = useMemo(
+    () => ({
+      provider: () => cache,
+      fallback: persisted?.fallback ?? EMPTY_FALLBACK,
+    }),
+    [cache, persisted]
+  );
+  const contextValue = useMemo(
+    () => ({ dataAPI, persistence: persisted?.persistence ?? null }),
+    [dataAPI, persisted]
+  );
 
   return createElement(
     PodFunctionContext.Provider,
@@ -102,9 +212,11 @@ function usePodFunctionContext(): PodFunctionContextValue {
 
 export function usePodFunction(
   slug: string | null,
-  input: unknown
+  input: unknown,
+  options?: UsePodFunctionOptions
 ): UsePodFunctionResult {
-  const { dataAPI } = usePodFunctionContext();
+  const { dataAPI, persistence } = usePodFunctionContext();
+  const persistEnabled = options?.persist ?? true;
   const resolution = useMemo(() => resolvePodFunction(slug), [slug]);
   const functionId = resolution.functionId;
   const key: PodFunctionQueryKey | null = functionId
@@ -132,10 +244,29 @@ export function usePodFunction(
   );
   const mutate = functionId ? result.mutate : noopMutate;
 
+  const serializedKey = key === null ? null : unstable_serialize(key);
+  const data = key === null ? undefined : result.data;
+
+  useEffect(() => {
+    if (!persistence || serializedKey === null) {
+      return;
+    }
+    if (!persistEnabled) {
+      // Opt-out also clears anything a previous (persisting) version of the frame stored.
+      persistence.dropEntry(serializedKey);
+      return;
+    }
+    if (data !== undefined) {
+      persistence.recordEntry(serializedKey);
+    }
+  }, [persistence, persistEnabled, serializedKey, data]);
+
   return {
-    data: key === null ? undefined : result.data,
+    data,
     error: resolution.error ?? (key === null ? undefined : result.error),
-    isLoading: key !== null && result.isLoading,
+    // Fallback (and previous-key) data counts as loaded: frames branch on isLoading for
+    // skeletons, and painting cached data is the point of the cross-open cache.
+    isLoading: key !== null && result.isLoading && data === undefined,
     isValidating: key !== null && result.isValidating,
     mutate,
   };


### PR DESCRIPTION
## Description

Every frame open started from an empty per-mount SWR cache (`useState(() => new Map())`), so even fully-cached dashboards showed skeletons and refetched everything on every open.

This backs the cache with a localStorage item per (frame identifier, viewer):

- On mount the provider resolves the viewer via `getUserIdentity`, then hydrates that viewer's persisted entries and serves them through SWR `fallback`. Mounted hooks paint cached data while their already-in-flight fetch revalidates; `revalidateIfStale: true` keeps paint-then-revalidate.
- The viz origin is shared, so nothing is ever persisted for unauthenticated viewers and entries are namespaced by frame identifier AND viewer user id. Hydration only happens after the host confirms the identity, so another user's entries are never painted.
- Write-through is debounced (1s) with flushes on pagehide, tab hide, and unmount. Caps: 50 entries and 512KB per frame (LRU eviction), 20 frames per origin, 7 day entry expiry, and eviction of other frames' items under quota pressure. All storage failures silently degrade to the previous per-mount behavior.
- `usePodFunction` gains `{ persist: false }` for must-be-fresh reads: never persisted, never served from the cross-open cache, and leftovers persisted by earlier versions of the frame are cleared.
- `isLoading` is now false whenever the hook has data to show (fallback or previous-key data). Frames branch on `isLoading` for skeletons, and painting cached data is the point of the cache.

Only inputs a frame actually reads get persisted: hooks record their serialized SWR key on data arrival, so identity and mutation keys never reach storage.

## Tests

Unit tests for the persistence module (round-trip, expiry, malformed payloads, LRU/size/frame-count caps, quota eviction, dispose) and hook-level tests (paint persisted data before first fetch resolves, persist for next open, unauthenticated viewers and other viewers' namespaces untouched, opt-out drops leftovers, no identifier keeps per-mount behavior).

## Risk

Medium-low. Persistence is opt-in by construction (identifier present + authenticated viewer) and every storage failure falls back to today's behavior. The visible behavior change is intended: frames paint last-known data and revalidate instead of showing a skeleton. Must-be-fresh frames can set `{ persist: false }`. Rollback is safe; stale items expire after 7 days or are LRU-evicted.

## Deploy Plan

Standard deploy.