### PR TITLE
[front] feat: warn about referencing frames on pod function unpublish and schema-changing republish

### DIFF
--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.test.ts
@@ -1,11 +1,14 @@
 import { SANDBOX_FUNCTIONS_TOOLS_METADATA } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 import { publishHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/publish";
 import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
+import type { Authenticator } from "@app/lib/auth";
 import {
   makeExtra,
   setupProjectConversation,
 } from "@app/tests/utils/conversation_test_factories";
+import { FileFactory } from "@app/tests/utils/FileFactory";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { frameContentType } from "@app/types/files";
 import { Ok } from "@app/types/shared/result";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -58,6 +61,22 @@ beforeEach(() => {
   );
 });
 
+async function makeReferencingFrame(
+  auth: Authenticator,
+  projectId: string,
+  slug: string
+): Promise<void> {
+  const frame = await FileFactory.create(auth, null, {
+    contentType: frameContentType,
+    fileName: "Tasks.tsx",
+    fileSize: 100,
+    status: "created",
+    useCase: "project_context",
+    useCaseMetadata: { spaceId: projectId },
+  });
+  await frame.uploadContent(auth, `callFunction("${projectId}/${slug}", {});`);
+}
+
 describe("publishHandler", () => {
   it("reports the app-prefixed slug and the reference a Frame needs", async () => {
     const { auth, conversation, projectId } = await setupProjectConversation();
@@ -81,6 +100,65 @@ describe("publishHandler", () => {
         text: `Published pod function "tasklist__add-task". Frames call it by reference "${projectId}/tasklist__add-task".`,
       },
     ]);
+  });
+
+  it("warns about referencing frames when a republish changes the input schema", async () => {
+    const { auth, conversation, projectId } = await setupProjectConversation();
+    const extra = makeExtra(auth, conversation);
+    const publishParams = {
+      slug: "add-task",
+      description: "Add a task.",
+      path: `pod-${projectId}/TaskList/functions/add-task.ts`,
+      executionMode: "fast" as const,
+    };
+
+    const first = await publishHandler(publishParams, extra);
+    if (first.isErr()) {
+      throw first.error;
+    }
+    await makeReferencingFrame(auth, projectId, "tasklist__add-task");
+
+    // Same schema: republish stays silent.
+    const unchanged = await publishHandler(publishParams, extra);
+    if (unchanged.isErr()) {
+      throw unchanged.error;
+    }
+    const unchangedContent = unchanged.value[0];
+    expect(unchangedContent?.type).toBe("text");
+    if (unchangedContent?.type !== "text") {
+      return;
+    }
+    expect(unchangedContent.text).not.toContain("Warning");
+
+    // Changed input schema: the referencing frame is called out.
+    vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+      new Ok({
+        bundleCode: "export default {};",
+        userIdentity: "optional",
+        inputSchema: {
+          type: "object",
+          properties: { title: { type: "string" } },
+          required: ["title"],
+        },
+        outputSchema,
+      })
+    );
+    const changed = await publishHandler(publishParams, extra);
+    if (changed.isErr()) {
+      throw changed.error;
+    }
+    const changedContent = changed.value[0];
+    expect(changedContent?.type).toBe("text");
+    if (changedContent?.type !== "text") {
+      return;
+    }
+    expect(changedContent.text).toContain(
+      'Published pod function "tasklist__add-task".'
+    );
+    expect(changedContent.text).toContain(
+      "Warning: the input schema changed and 1 frame(s) reference this function:"
+    );
+    expect(changedContent.text).toContain("Tasks.tsx");
   });
 
   it("accepts a bare function name but not one that already carries a prefix", () => {

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
@@ -5,7 +5,11 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getWritablePodContext } from "@app/lib/api/actions/servers/pod_manager/helpers";
 import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { listFramePathsReferencingSandboxFunction } from "@app/lib/api/sandbox_functions/frame_references";
 import { publishSandboxFunction } from "@app/lib/api/sandbox_functions/publish_sandbox_function";
+import { deriveSandboxFunctionSlug } from "@app/lib/api/sandbox_functions/slug";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { areSchemasEqual } from "@app/lib/utils/json_schemas";
 import type { SandboxFunctionExecutionMode } from "@app/types/api/sandbox_functions";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -30,9 +34,27 @@ export async function publishHandler(
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }
+  const { pod } = podResult.value;
+
+  // Snapshot the previous input schema before publishing: a republish overwrites it in place,
+  // and a schema change can break frames that call this function. The published slug is derived
+  // from `path` the same way publishSandboxFunction derives it; if the derivation fails, publish
+  // reports the invalid path below.
+  const slugResult = deriveSandboxFunctionSlug({
+    sourcePath: path,
+    podId: pod.sId,
+    name: slug,
+  });
+  const previous = slugResult.isOk()
+    ? await SandboxFunctionResource.fetchBySpaceAndSlug(
+        auth,
+        pod,
+        slugResult.value
+      )
+    : null;
 
   const result = await publishSandboxFunction(auth, {
-    space: podResult.value.pod,
+    space: pod,
     slug,
     description,
     path,
@@ -47,10 +69,35 @@ export async function publishHandler(
   // the slug alone; only a Frame needs the qualified reference, so name that consumer.
   const { slug: publishedSlug } = result.value;
 
+  const lines = [
+    `Published pod function "${publishedSlug}". Frames call it by reference "${pod.sId}/${publishedSlug}".`,
+  ];
+
+  // A republish that changed the input schema may have broken frames calling this function:
+  // warn about the ones whose sources reference it, never block.
+  if (
+    previous &&
+    !areSchemasEqual(previous.inputSchema, result.value.inputSchema)
+  ) {
+    const referencingFramePaths =
+      await listFramePathsReferencingSandboxFunction(auth, {
+        space: pod,
+        sandboxFunction: result.value,
+      });
+    if (referencingFramePaths.length > 0) {
+      lines.push(
+        `Warning: the input schema changed and ${referencingFramePaths.length} frame(s) ` +
+          `reference this function: ${referencingFramePaths.join(", ")}. Verify their calls ` +
+          "still match the new schema and re-publish them if needed (this is a text scan of " +
+          "frame sources, so dynamically-built references are not detected)."
+      );
+    }
+  }
+
   return new Ok([
     {
       type: "text",
-      text: `Published pod function "${publishedSlug}". Frames call it by reference "${podResult.value.pod.sId}/${publishedSlug}".`,
+      text: lines.join("\n\n"),
     },
   ]);
 }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/unpublish.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/unpublish.test.ts
@@ -8,7 +8,10 @@ import {
 } from "@app/tests/utils/conversation_test_factories";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
-import { sandboxFunctionContentType } from "@app/types/files";
+import {
+  frameContentType,
+  sandboxFunctionContentType,
+} from "@app/types/files";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -82,6 +85,61 @@ describe("unpublishHandler", () => {
     await expect(
       SandboxFunctionResource.fetchById(auth, sandboxFunction.sId)
     ).resolves.toBeNull();
+  });
+
+  it("warns about pod frames that still reference the unpublished function", async () => {
+    const { auth, conversation, projectId } = await setupProjectConversation();
+    const pod = await SpaceResource.fetchById(auth, projectId);
+    expect(pod).not.toBeNull();
+    if (!pod) {
+      return;
+    }
+    const bundle = await FileFactory.create(auth, null, {
+      contentType: sandboxFunctionContentType,
+      fileName: "greet.ts",
+      fileSize: 100,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+    });
+    await SandboxFunctionResource.makeNew(auth, {
+      space: pod,
+      file: bundle,
+      slug: "greet",
+      description: "Greet someone.",
+      inputSchema,
+      outputSchema,
+    });
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameContentType,
+      fileName: "Greeter.tsx",
+      fileSize: 100,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+    });
+    await frame.uploadContent(auth, `callFunction("${pod.sId}/greet", {});`);
+
+    const result = await unpublishHandler(
+      { slug: "greet" },
+      makeExtra(auth, conversation)
+    );
+
+    if (result.isErr()) {
+      throw result.error;
+    }
+    const content = result.value[0];
+    expect(content?.type).toBe("text");
+    if (content?.type !== "text") {
+      return;
+    }
+    expect(content.text).toContain(
+      'Unpublished pod function "greet" and deleted its invocation history.'
+    );
+    expect(content.text).toContain(
+      "Warning: 1 frame(s) reference this function:"
+    );
+    expect(content.text).toContain("Greeter.tsx");
   });
 
   it("returns an untracked error when the slug is not published", async () => {

--- a/front/lib/api/actions/servers/sandbox_functions/tools/unpublish.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/unpublish.test.ts
@@ -8,10 +8,7 @@ import {
 } from "@app/tests/utils/conversation_test_factories";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
-import {
-  frameContentType,
-  sandboxFunctionContentType,
-} from "@app/types/files";
+import { frameContentType, sandboxFunctionContentType } from "@app/types/files";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/front/lib/api/actions/servers/sandbox_functions/tools/unpublish.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/unpublish.ts
@@ -4,7 +4,9 @@ import type {
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getWritablePodContext } from "@app/lib/api/actions/servers/pod_manager/helpers";
+import { listFramePathsReferencingSandboxFunction } from "@app/lib/api/sandbox_functions/frame_references";
 import { unpublishSandboxFunction } from "@app/lib/api/sandbox_functions/unpublish_sandbox_function";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { Err, Ok } from "@app/types/shared/result";
 
 export async function unpublishHandler(
@@ -17,9 +19,25 @@ export async function unpublishHandler(
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }
+  const { pod } = podResult.value;
+
+  // Scan for referencing frames before the delete: the scan needles include the function's sId,
+  // which is gone once the unpublish succeeds. Warning-only, so a missing function simply skips
+  // the scan and lets unpublishSandboxFunction report not_found.
+  const sandboxFunction = await SandboxFunctionResource.fetchBySpaceAndSlug(
+    auth,
+    pod,
+    slug
+  );
+  const referencingFramePaths = sandboxFunction
+    ? await listFramePathsReferencingSandboxFunction(auth, {
+        space: pod,
+        sandboxFunction,
+      })
+    : [];
 
   const result = await unpublishSandboxFunction(auth, {
-    space: podResult.value.pod,
+    space: pod,
     slug,
   });
   if (result.isErr()) {
@@ -32,10 +50,22 @@ export async function unpublishHandler(
     );
   }
 
+  const lines = [
+    `Unpublished pod function "${result.value.slug}" and deleted its invocation history.`,
+  ];
+  if (referencingFramePaths.length > 0) {
+    lines.push(
+      `Warning: ${referencingFramePaths.length} frame(s) reference this function: ` +
+        `${referencingFramePaths.join(", ")}. Their calls to it will now fail; edit and ` +
+        "re-publish them (this is a text scan of frame sources, so dynamically-built " +
+        "references are not detected)."
+    );
+  }
+
   return new Ok([
     {
       type: "text",
-      text: `Unpublished pod function "${result.value.slug}" and deleted its invocation history.`,
+      text: lines.join("\n\n"),
     },
   ]);
 }

--- a/front/lib/api/sandbox_functions/frame_references.test.ts
+++ b/front/lib/api/sandbox_functions/frame_references.test.ts
@@ -1,0 +1,173 @@
+import { listFramePathsReferencingSandboxFunction } from "@app/lib/api/sandbox_functions/frame_references";
+import type { Authenticator } from "@app/lib/auth";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { frameContentType, sandboxFunctionContentType } from "@app/types/files";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { beforeEach, describe, expect, it } from "vitest";
+
+const inputSchema: JSONSchema = {
+  type: "object",
+  properties: { name: { type: "string" } },
+  required: ["name"],
+};
+
+const outputSchema: JSONSchema = {
+  type: "object",
+  properties: { greeting: { type: "string" } },
+  required: ["greeting"],
+};
+
+async function makeFunction(
+  auth: Authenticator,
+  space: SpaceResource,
+  { slug }: { slug: string }
+): Promise<SandboxFunctionResource> {
+  const file = await FileFactory.create(auth, null, {
+    contentType: sandboxFunctionContentType,
+    fileName: `${slug}.ts`,
+    fileSize: 100,
+    status: "created",
+    useCase: "project_context",
+    useCaseMetadata: { spaceId: space.sId },
+  });
+
+  return SandboxFunctionResource.makeNew(auth, {
+    space,
+    file,
+    slug,
+    description: "A function.",
+    inputSchema,
+    outputSchema,
+  });
+}
+
+async function makeFrame(
+  auth: Authenticator,
+  space: SpaceResource,
+  {
+    fileName,
+    source,
+    publishedBundle,
+  }: { fileName: string; source: string; publishedBundle?: string }
+): Promise<FileResource> {
+  const file = await FileFactory.create(auth, null, {
+    contentType: frameContentType,
+    fileName,
+    fileSize: source.length,
+    status: "created",
+    useCase: "project_context",
+    useCaseMetadata: { spaceId: space.sId },
+  });
+  await file.uploadContent(auth, source);
+
+  if (publishedBundle !== undefined) {
+    // Mirrors publishFrame: the bundle root flips the frame's content version to "processed".
+    await file.setUseCaseMetadata(auth, {
+      ...(file.useCaseMetadata ?? {}),
+      frameBundleRootPath: `pod-${space.sId}/MyApp`,
+    });
+    await file.uploadProcessed(auth, publishedBundle);
+  }
+
+  return file;
+}
+
+beforeEach(() => {
+  fileStorageMock.reset();
+});
+
+describe("listFramePathsReferencingSandboxFunction", () => {
+  it("finds frames referencing the function by qualified reference or sId", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const space = await SpaceFactory.project(workspace);
+    const fn = await makeFunction(authenticator, space, {
+      slug: "myapp__list-notes",
+    });
+
+    await makeFrame(authenticator, space, {
+      fileName: "Notes.tsx",
+      source: `callFunction("${space.sId}/myapp__list-notes", {});`,
+    });
+    await makeFrame(authenticator, space, {
+      fileName: "BySid.tsx",
+      source: `callFunction("${fn.sId}", {});`,
+    });
+    await makeFrame(authenticator, space, {
+      fileName: "Unrelated.tsx",
+      source: `callFunction("${space.sId}/other__fn", {});`,
+    });
+
+    const framePaths = await listFramePathsReferencingSandboxFunction(
+      authenticator,
+      { space, sandboxFunction: fn }
+    );
+
+    expect(framePaths.sort()).toEqual([
+      `pod-${space.sId}/BySid.tsx`,
+      `pod-${space.sId}/Notes.tsx`,
+    ]);
+  });
+
+  it("scans the rendered bundle of a published frame", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const space = await SpaceFactory.project(workspace);
+    const fn = await makeFunction(authenticator, space, {
+      slug: "myapp__list-notes",
+    });
+
+    // The entry source does not carry the reference (it lives in an imported module), but the
+    // rendered bundle inlines every module and does.
+    await makeFrame(authenticator, space, {
+      fileName: "Dashboard.tsx",
+      source: `import { load } from "./lib/load.ts"; export default load;`,
+      publishedBundle: `var ref = "${space.sId}/myapp__list-notes";`,
+    });
+
+    const framePaths = await listFramePathsReferencingSandboxFunction(
+      authenticator,
+      { space, sandboxFunction: fn }
+    );
+
+    expect(framePaths).toEqual([`pod-${space.sId}/Dashboard.tsx`]);
+  });
+
+  it("ignores non-frame pod files containing the reference", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const space = await SpaceFactory.project(workspace);
+    const fn = await makeFunction(authenticator, space, {
+      slug: "myapp__list-notes",
+    });
+
+    const notes = await FileFactory.create(authenticator, null, {
+      contentType: "text/plain",
+      fileName: "notes.txt",
+      fileSize: 100,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: space.sId },
+    });
+    await notes.uploadContent(
+      authenticator,
+      `mentions ${space.sId}/myapp__list-notes in prose`
+    );
+
+    const framePaths = await listFramePathsReferencingSandboxFunction(
+      authenticator,
+      { space, sandboxFunction: fn }
+    );
+
+    expect(framePaths).toEqual([]);
+  });
+});

--- a/front/lib/api/sandbox_functions/frame_references.ts
+++ b/front/lib/api/sandbox_functions/frame_references.ts
@@ -1,0 +1,78 @@
+import { getFileContent } from "@app/lib/api/files/utils";
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import { frameContentType, frameSlideshowContentType } from "@app/types/files";
+import { removeNulls } from "@app/types/shared/utils/general";
+
+// Frame contents are read from file storage; keep the fan-out bounded.
+const FRAME_SCAN_CONCURRENCY = 4;
+
+/**
+ * Best-effort text scan of a pod's frames for references to one of its pod functions.
+ *
+ * Frames reference a function either by its qualified `<podId>/<slug>` reference or by its sId,
+ * always as a string in their source, so a substring scan of each frame's content finds them. For
+ * published frames the scanned content is the rendered bundle, which inlines every module of the
+ * frame's source tree; for never-published frames it is the entry source only. Computed
+ * (dynamically-built) references are missed by design.
+ *
+ * The result feeds a warning appended to the publish/unpublish tool output and must never block
+ * or fail those operations, so any scan failure degrades to an empty result (per-frame read
+ * failures simply drop that frame).
+ */
+export async function listFramePathsReferencingSandboxFunction(
+  auth: Authenticator,
+  {
+    space,
+    sandboxFunction,
+  }: { space: SpaceResource; sandboxFunction: SandboxFunctionResource }
+): Promise<string[]> {
+  const needles = [`${space.sId}/${sandboxFunction.slug}`, sandboxFunction.sId];
+
+  try {
+    const projectFiles = await FileResource.listByProject(auth, {
+      projectId: space.sId,
+    });
+    const frames = projectFiles.filter(
+      (file) =>
+        file.contentType === frameContentType ||
+        file.contentType === frameSlideshowContentType
+    );
+
+    const framePaths = await concurrentExecutor(
+      frames,
+      async (frame) => {
+        // Reads the rendered bundle for published frames, the source otherwise. A failed read
+        // returns null and drops the frame from the scan.
+        const content = await getFileContent(
+          auth,
+          frame,
+          frame.getRenderableVersion()
+        );
+        if (
+          content === null ||
+          !needles.some((needle) => content.includes(needle))
+        ) {
+          return null;
+        }
+
+        return frame.toScopedPath(auth) ?? frame.fileName;
+      },
+      { concurrency: FRAME_SCAN_CONCURRENCY }
+    );
+
+    return removeNulls(framePaths);
+  } catch (error) {
+    // Warning-only path: a scan failure must not fail the mutation it decorates.
+    logger.warn(
+      { error, spaceId: space.sId, slug: sandboxFunction.slug },
+      "Failed to scan pod frames for sandbox function references"
+    );
+
+    return [];
+  }
+}

--- a/front/lib/api/sandbox_functions/frame_references.ts
+++ b/front/lib/api/sandbox_functions/frame_references.ts
@@ -5,7 +5,7 @@ import type { SandboxFunctionResource } from "@app/lib/resources/sandbox_functio
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import { frameContentType, frameSlideshowContentType } from "@app/types/files";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 
 // Frame contents are read from file storage; keep the fan-out bounded.
@@ -37,11 +37,7 @@ export async function listFramePathsReferencingSandboxFunction(
     const projectFiles = await FileResource.listByProject(auth, {
       projectId: space.sId,
     });
-    const frames = projectFiles.filter(
-      (file) =>
-        file.contentType === frameContentType ||
-        file.contentType === frameSlideshowContentType
-    );
+    const frames = projectFiles.filter((file) => file.isInteractiveContent);
 
     const framePaths = await concurrentExecutor(
       frames,
@@ -69,7 +65,11 @@ export async function listFramePathsReferencingSandboxFunction(
   } catch (error) {
     // Warning-only path: a scan failure must not fail the mutation it decorates.
     logger.warn(
-      { error, spaceId: space.sId, slug: sandboxFunction.slug },
+      {
+        err: normalizeError(error),
+        spaceId: space.sId,
+        slug: sandboxFunction.slug,
+      },
       "Failed to scan pod frames for sandbox function references"
     );
 

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -176,7 +176,12 @@ class FileStorageMock {
       copy: vi.fn().mockResolvedValue(undefined),
       createReadStream: vi.fn(() => {
         this._readStreamCalls.push(filePath ?? "unknown");
-        const content = this._contentForPath(filePath ?? "");
+        const content =
+          this._contentForPath(filePath ?? "") ??
+          // Serve read-after-write like fetchFileContent does, so a stream read of content a
+          // test previously uploaded does not hang on the never-ending default stream.
+          this._objectStore.get(filePath ?? "") ??
+          null;
         if (content !== null) {
           return Readable.from([Buffer.from(content, "utf8")]);
         }


### PR DESCRIPTION
## Description

Unpublishing a pod function silently breaks frames that reference it, and a republish that changes the input schema never re-checks them: frame-to-function validation only runs when a frame is published.

- New `listFramePathsReferencingSandboxFunction` helper: best-effort text scan of the pod's frames for the function's qualified `<podId>/<slug>` reference or its sId. Published frames are scanned through their rendered bundle (which inlines every module of the source tree), never-published frames through their entry source.
- The `unpublish` tool appends "N frame(s) reference this function: <paths>" to its result.
- The `publish` tool does the same when a republish changed the input schema (compared with the existing `areSchemasEqual`).
- Warning only, never blocking: scan failures degrade to no warning, and the tool text says dynamically-built references are not detected.

Also fixes the file storage test mock so `createReadStream` serves previously uploaded content (matching `fetchFileContent`), instead of hanging on a never-ending default stream on read-after-write.

## Tests

Added tests for the scan helper (qualified ref, sId ref, rendered-bundle scan, non-frame files ignored) and for the publish/unpublish handlers' warning output, including the silent path when the schema is unchanged.

## Risk

Low. Warning text appended to two tool results; the scan is wrapped so failures cannot fail the underlying publish/unpublish.

## Deploy Plan

Standard deploy.