### PR TITLE
Support true unlimited per-user spend limit, bypassing group/default caps

### DIFF
--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
@@ -19,6 +19,7 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 export const UpdateUserSpendLimitBodySchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("default") }),
   z.object({ kind: z.literal("unlimited") }),
   z.object({
     kind: z.literal("limited"),

--- a/front-api/routes/w/[wId]/members/bulk-spend-limit.ts
+++ b/front-api/routes/w/[wId]/members/bulk-spend-limit.ts
@@ -14,6 +14,7 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 const LimitSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("default") }),
   z.object({ kind: z.literal("unlimited") }),
   z.object({
     kind: z.literal("limited"),

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -371,9 +371,9 @@ export function UsagePage() {
   const handleAllowUnlimitedSpendRequest = useCallback(
     async (request: MembershipUpgradeRequestType) => {
       const confirmed = await confirm({
-        title: "Use workspace default",
-        message: `Remove ${request.requester.name}'s custom spend limit? They'll fall back to their group or workspace default cap.`,
-        validateLabel: "Use workspace default",
+        title: "Allow unlimited spend",
+        message: `Let ${request.requester.name} draw from the credit pool with no cap, limited only by what the workspace has available?`,
+        validateLabel: "Allow unlimited spend",
         validateVariant: "primary",
       });
       if (!confirmed) {

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -35,10 +35,10 @@ import { useForm } from "react-hook-form";
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
-type SpendLimitKind = "default" | "override";
+type SpendLimitKind = "default" | "unlimited" | "override";
 
 function isSpendLimitKind(value: string): value is SpendLimitKind {
-  return value === "default" || value === "override";
+  return value === "default" || value === "unlimited" || value === "override";
 }
 
 interface EditSpendLimitModalProps {
@@ -125,6 +125,10 @@ export function EditSpendLimitModal({
         });
         break;
       case "unlimited":
+        setKind(forceOverride ? "override" : "unlimited");
+        overrideForm.reset({ creditsInput: "", expiryMode: "never" });
+        break;
+      case "default":
         setKind(forceOverride ? "override" : "default");
         overrideForm.reset({ creditsInput: "", expiryMode: "never" });
         break;
@@ -171,6 +175,9 @@ export function EditSpendLimitModal({
 
     switch (kind) {
       case "default":
+        await submitLimit({ kind: "default" });
+        return;
+      case "unlimited":
         await submitLimit({ kind: "unlimited" });
         return;
       case "override":
@@ -274,6 +281,11 @@ export function EditSpendLimitModal({
                 value="default"
                 id="spend-limit-default"
                 label="Use workspace default"
+              />
+              <RadioGroupItem
+                value="unlimited"
+                id="spend-limit-unlimited"
+                label="Allow unlimited spend"
               />
               <RadioGroupItem
                 value="override"

--- a/front/components/workspace/ManageUpgradeRequestModal.tsx
+++ b/front/components/workspace/ManageUpgradeRequestModal.tsx
@@ -44,9 +44,9 @@ export function ManageUpgradeRequestModal({
     {
       key: "allow-unlimited-spend",
       icon: Infinity,
-      label: "Use workspace default",
+      label: "Allow unlimited spend",
       description:
-        "Remove this member's custom limit; they'll fall back to their group or workspace default cap.",
+        "Let this member draw from the credit pool with no cap, limited only by what the workspace has available.",
       onClick: () => request && onAllowUnlimitedSpend(request),
     },
     {

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -835,6 +835,7 @@ export async function fetchRemainingCapCreditsPercentageForUser({
   userId,
   seatType,
   poolCapOverrideAwuCredits,
+  poolCapOverrideUnlimited,
   groupCapAwuCredits,
   defaultPoolCapAwuCredits,
 }: {
@@ -843,6 +844,7 @@ export async function fetchRemainingCapCreditsPercentageForUser({
   userId: string;
   seatType: MembershipSeatType | null | undefined;
   poolCapOverrideAwuCredits: number | null;
+  poolCapOverrideUnlimited: boolean;
   // Max group cap (pool-only, excluding seat allowance) across the user's
   // groups; null when none carry a cap.
   groupCapAwuCredits: number | null;
@@ -898,6 +900,9 @@ export async function fetchRemainingCapCreditsPercentageForUser({
 
   const spendLimitAwuCredits = resolveEffectiveSpendLimitAwuCredits({
     overrideAwuCredits,
+    // "none" seat users have no pool access, so their unlimited override (if
+    // any) is irrelevant too.
+    overrideUnlimited: poolCapOverrideUnlimited && seatType !== "none",
     groupCapAwuCredits: groupCapTotalAwuCredits,
     defaultAwuCredits,
   });
@@ -977,6 +982,10 @@ export async function getEffectiveSpendCapAwuCreditsForUser(
 
   return resolveEffectiveSpendLimitAwuCredits({
     overrideAwuCredits,
+    // "none" seat users have no pool access, so their unlimited override (if
+    // any) is irrelevant too.
+    overrideUnlimited:
+      membership.poolCapOverrideUnlimited && membership.seatType !== "none",
     groupCapAwuCredits,
     defaultAwuCredits,
   });
@@ -1226,14 +1235,21 @@ export async function getMemberUsage({
         (seatAllowanceBySeatType[normalizedSeatType] ?? 0)
       : null;
 
+  // "none" seat users have no pool access, so their unlimited override (if
+  // any) is irrelevant too.
+  const overrideUnlimited =
+    membership.poolCapOverrideUnlimited && membership.seatType !== "none";
+
   const spendLimitSource = resolveEffectiveSpendLimitSource({
     overrideAwuCredits,
+    overrideUnlimited,
     groupCapAwuCredits,
     defaultAwuCredits: effectiveDefaultAwuCredits,
   });
 
   const spendLimitAwuCredits = resolveEffectiveSpendLimitAwuCredits({
     overrideAwuCredits,
+    overrideUnlimited,
     groupCapAwuCredits,
     defaultAwuCredits: effectiveDefaultAwuCredits,
   });
@@ -1840,8 +1856,14 @@ export async function getMembersUsage({
           (seatAllowanceBySeatType[normalizedSeatType] ?? 0)
         : null;
 
+    // "none" seat users have no pool access, so their unlimited override (if
+    // any) is irrelevant too.
+    const overrideUnlimited =
+      membership.poolCapOverrideUnlimited && membership.seatType !== "none";
+
     const spendLimitSource = resolveEffectiveSpendLimitSource({
       overrideAwuCredits,
+      overrideUnlimited,
       groupCapAwuCredits,
       defaultAwuCredits: effectiveDefaultAwuCredits,
     });
@@ -1895,6 +1917,7 @@ export async function getMembersUsage({
         scheduledSeatChangeAt: scheduled?.startAt.toISOString() ?? null,
         spendLimitAwuCredits: resolveEffectiveSpendLimitAwuCredits({
           overrideAwuCredits,
+          overrideUnlimited,
           groupCapAwuCredits,
           defaultAwuCredits: effectiveDefaultAwuCredits,
         }),

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -38,11 +38,13 @@ import type { LightWorkspaceType } from "@app/types/user";
 /**
  * Resolve the effective pool credit limit for a user.
  *
- * Priority: per-user override > max group cap > workspace default. When nothing
- * is configured, defaults to 0 (no pool access). Unlimited pool is not
- * supported. All values are pool-only (excluding seat allowance).
+ * Priority: an explicit unlimited override bypasses everything else > per-user
+ * override amount > max group cap > workspace default. When nothing is
+ * configured, defaults to 0 (no pool access). All values are pool-only
+ * (excluding seat allowance).
  *
- * Returns `number`: the pool credit limit (0 = no pool access).
+ * Returns `null` when the user has unbounded pool access (explicit unlimited
+ * override), otherwise the pool credit limit (0 = no pool access).
  */
 function resolvePoolLimitForUser({
   workspace,
@@ -54,7 +56,7 @@ function resolvePoolLimitForUser({
   membership: MembershipResource;
   groupCapAwuCredits: number | null;
   defaultPoolCapAwuCredits: number;
-}): number {
+}): number | null {
   if (!workspace.metronomeCustomerId) {
     return 0;
   }
@@ -67,6 +69,7 @@ function resolvePoolLimitForUser({
   // shared ladder: per-user override > max group cap > workspace default.
   return resolveEffectiveSpendLimitAwuCredits({
     overrideAwuCredits: membership.poolCapOverrideAwuCredits,
+    overrideUnlimited: membership.poolCapOverrideUnlimited,
     groupCapAwuCredits,
     defaultAwuCredits: defaultPoolCapAwuCredits,
   });
@@ -156,6 +159,7 @@ export async function dispatchSeatBalanceExhausted({
       userId,
       seatType: membership.seatType,
       poolCapOverrideAwuCredits: membership.poolCapOverrideAwuCredits,
+      poolCapOverrideUnlimited: membership.poolCapOverrideUnlimited,
       groupCapAwuCredits,
       defaultPoolCapAwuCredits,
     });
@@ -242,6 +246,7 @@ export async function dispatchSeatBalanceResolved({
     userId,
     seatType: membership.seatType,
     poolCapOverrideAwuCredits: membership.poolCapOverrideAwuCredits,
+    poolCapOverrideUnlimited: membership.poolCapOverrideUnlimited,
     groupCapAwuCredits: await fetchMaxGroupPoolCapForUser({
       workspace: lightWorkspace,
       userModelId: membership.userId,
@@ -364,6 +369,7 @@ export async function dispatchPerUserCapResolved({
     userId,
     seatType: membership.seatType,
     poolCapOverrideAwuCredits: membership.poolCapOverrideAwuCredits,
+    poolCapOverrideUnlimited: membership.poolCapOverrideUnlimited,
     groupCapAwuCredits: await fetchMaxGroupPoolCapForUser({
       workspace: lightWorkspace,
       userModelId: membership.userId,
@@ -395,12 +401,14 @@ async function resolveLiveUserBalance({
   userId,
   seatType,
   poolCapOverrideAwuCredits,
+  poolCapOverrideUnlimited,
   groupCapAwuCredits,
 }: {
   workspace: WorkspaceResource;
   userId: string;
   seatType: MembershipSeatType | null;
   poolCapOverrideAwuCredits: number | null;
+  poolCapOverrideUnlimited: boolean;
   groupCapAwuCredits: number | null;
 }): Promise<LiveUserSeatBalance | undefined> {
   const { metronomeCustomerId } = workspace;
@@ -423,6 +431,7 @@ async function resolveLiveUserBalance({
     userId,
     seatType,
     poolCapOverrideAwuCredits,
+    poolCapOverrideUnlimited,
     groupCapAwuCredits,
     defaultPoolCapAwuCredits: creditUsageConfig?.defaultPoolCapAwuCredits ?? 0,
     metronomeCustomerId,

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -404,14 +404,27 @@ async function handlePerUserSpendThresholdEvent({
     creditUsageConfig?.defaultPoolCapAwuCredits ?? 0;
   const poolCap = resolveEffectiveSpendLimitAwuCredits({
     overrideAwuCredits: membership.poolCapOverrideAwuCredits,
+    overrideUnlimited: membership.poolCapOverrideUnlimited,
     groupCapAwuCredits,
     defaultAwuCredits: defaultPoolCapAwuCredits,
   });
   const capSource = resolveEffectiveSpendLimitSource({
     overrideAwuCredits: membership.poolCapOverrideAwuCredits,
+    overrideUnlimited: membership.poolCapOverrideUnlimited,
     groupCapAwuCredits,
     defaultAwuCredits: defaultPoolCapAwuCredits,
   });
+
+  if (poolCap === null) {
+    // Explicitly granted unlimited pool access — no numeric threshold can
+    // ever match, so any per-user/seat-type-default/group alert firing for
+    // this user is stale and should not (re-)cap them.
+    logger.info(
+      { eventId: event.id, workspaceId: workspace.sId, userId, capSource },
+      "[Metronome Webhook] per-user spend threshold: user has unlimited pool access, ignoring"
+    );
+    return new Ok(undefined);
+  }
 
   let seatAllowance = 0;
   try {

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -417,6 +417,7 @@ export async function reconcileUser({
     // Pool-only values persisted in the DB; the live-inputs helper adds the
     // seat allowance back to get the total threshold.
     poolCapOverrideAwuCredits: membership.poolCapOverrideAwuCredits,
+    poolCapOverrideUnlimited: membership.poolCapOverrideUnlimited,
     groupCapAwuCredits,
     defaultPoolCapAwuCredits: creditUsageConfig?.defaultPoolCapAwuCredits ?? 0,
     metronomeCustomerId,
@@ -633,12 +634,14 @@ export async function reconcileWorkspaceUserCreditStates({
       groupCapByUserModelId.get(membership.userId) ?? null;
     const poolCapAwuCredits = resolveEffectiveSpendLimitAwuCredits({
       overrideAwuCredits: membership.poolCapOverrideAwuCredits,
+      overrideUnlimited: membership.poolCapOverrideUnlimited,
       groupCapAwuCredits,
       defaultAwuCredits: defaultPoolCapAwuCredits,
     });
-    const effectiveCapAwuCredits = normalizedSeatType
-      ? poolCapAwuCredits + (seatAllowances[normalizedSeatType] ?? 0)
-      : null;
+    const effectiveCapAwuCredits =
+      normalizedSeatType && poolCapAwuCredits !== null
+        ? poolCapAwuCredits + (seatAllowances[normalizedSeatType] ?? 0)
+        : null;
     // Seat balance comes from `listMetronomeSeatBalances` for pro/max; free
     // seats read their per-user credit balance instead (not a seat balance).
     // Pro/max read their seat balance. `expectedUserCreditState` decides routing

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -134,16 +134,24 @@ export async function getUserSpendLimit(
 
   const nextCreditResetAt = await resolveNextCreditResetAt(workspace);
 
-  if (!membership || membership.poolCapOverrideAwuCredits === null) {
+  if (!membership) {
+    return new Ok({ kind: "default", nextCreditResetAt });
+  }
+
+  if (membership.poolCapOverrideAwuCredits !== null) {
+    return new Ok({
+      kind: "limited",
+      awuCredits: membership.poolCapOverrideAwuCredits,
+      expiresAt: membership.poolCapOverrideExpiresAt?.getTime() ?? null,
+      nextCreditResetAt,
+    });
+  }
+
+  if (membership.poolCapOverrideUnlimited) {
     return new Ok({ kind: "unlimited", nextCreditResetAt });
   }
 
-  return new Ok({
-    kind: "limited",
-    awuCredits: membership.poolCapOverrideAwuCredits,
-    expiresAt: membership.poolCapOverrideExpiresAt?.getTime() ?? null,
-    nextCreditResetAt,
-  });
+  return new Ok({ kind: "default", nextCreditResetAt });
 }
 
 /**
@@ -254,12 +262,17 @@ export async function setUserSpendLimit(
       limit.kind === "limited" && limit.expiresAt
         ? new Date(limit.expiresAt)
         : null,
+    poolCapOverrideUnlimited: limit.kind === "unlimited",
   });
 
   const revert = () =>
     membership.revertPoolCapOverride(previousPoolCapOverride);
 
   switch (limit.kind) {
+    // Neither has a numeric per-user threshold to enforce at the Metronome
+    // layer — the DB override (cleared above) is what actually distinguishes
+    // them for effective-cap resolution.
+    case "default":
     case "unlimited": {
       const clearResult = await revertOnSyncFailure(
         await clearMetronomePerUserCapAlert({
@@ -386,8 +399,7 @@ export async function setUserSpendLimit(
     context: auditContext,
     metadata: {
       kind: limit.kind,
-      awu_credits:
-        limit.kind === "limited" ? String(limit.awuCredits) : "unlimited",
+      awu_credits: limit.kind === "limited" ? String(limit.awuCredits) : "",
       expires_at:
         limit.kind === "limited" && limit.expiresAt
           ? new Date(limit.expiresAt).toISOString()

--- a/front/lib/metronome/live_user_credit_inputs.test.ts
+++ b/front/lib/metronome/live_user_credit_inputs.test.ts
@@ -62,6 +62,7 @@ describe("fetchLiveUserCreditInputs", () => {
       userId: USER_ID,
       seatType: "max",
       poolCapOverrideAwuCredits: null,
+      poolCapOverrideUnlimited: false,
       groupCapAwuCredits: null,
       defaultPoolCapAwuCredits: 0,
       metronomeCustomerId: CUSTOMER_ID,
@@ -95,6 +96,7 @@ describe("fetchLiveUserCreditInputs", () => {
       // Pool-only override from the membership; no contract resolves for
       // "ws_test" so the seat allowance is 0 and the total cap equals it.
       poolCapOverrideAwuCredits: 50000,
+      poolCapOverrideUnlimited: false,
       groupCapAwuCredits: null,
       defaultPoolCapAwuCredits: 0,
       metronomeCustomerId: CUSTOMER_ID,
@@ -120,6 +122,7 @@ describe("fetchLiveUserCreditInputs", () => {
       userId: USER_ID,
       seatType: "max",
       poolCapOverrideAwuCredits: null,
+      poolCapOverrideUnlimited: false,
       // No override → the group cap wins over the workspace default. No contract
       // resolves for "ws_test" so the seat allowance is 0 and the total cap
       // equals the group cap.
@@ -146,6 +149,7 @@ describe("fetchLiveUserCreditInputs", () => {
       userId: USER_ID,
       seatType: "max",
       poolCapOverrideAwuCredits: 50000,
+      poolCapOverrideUnlimited: false,
       groupCapAwuCredits: 30000,
       defaultPoolCapAwuCredits: 10000,
       metronomeCustomerId: CUSTOMER_ID,
@@ -155,6 +159,30 @@ describe("fetchLiveUserCreditInputs", () => {
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
       expect(result.value.effectiveCapAwuCredits).toBe(50000);
+      expect(result.value.capSource).toBe("override");
+    }
+  });
+
+  it("bypasses the group cap and default when explicitly unlimited", async () => {
+    mockListMetronomeSeatBalances.mockResolvedValue(
+      new Ok(seatBalance(0, 40000))
+    );
+
+    const result = await fetchLiveUserCreditInputs({
+      workspaceId: "ws_test",
+      userId: USER_ID,
+      seatType: "max",
+      poolCapOverrideAwuCredits: null,
+      poolCapOverrideUnlimited: true,
+      groupCapAwuCredits: 30000,
+      defaultPoolCapAwuCredits: 10000,
+      metronomeCustomerId: CUSTOMER_ID,
+      metronomeContractId: CONTRACT_ID,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.effectiveCapAwuCredits).toBeNull();
       expect(result.value.capSource).toBe("override");
     }
   });
@@ -169,6 +197,7 @@ describe("fetchLiveUserCreditInputs", () => {
       userId: USER_ID,
       seatType: "max",
       poolCapOverrideAwuCredits: null,
+      poolCapOverrideUnlimited: false,
       groupCapAwuCredits: null,
       defaultPoolCapAwuCredits: 0,
       metronomeCustomerId: CUSTOMER_ID,

--- a/front/lib/metronome/live_user_credit_inputs.ts
+++ b/front/lib/metronome/live_user_credit_inputs.ts
@@ -84,6 +84,7 @@ export async function fetchLiveUserCreditInputs({
   userId,
   seatType,
   poolCapOverrideAwuCredits,
+  poolCapOverrideUnlimited,
   groupCapAwuCredits,
   defaultPoolCapAwuCredits,
   metronomeCustomerId,
@@ -93,6 +94,7 @@ export async function fetchLiveUserCreditInputs({
   userId: string;
   seatType: MembershipSeatType | null;
   poolCapOverrideAwuCredits: number | null;
+  poolCapOverrideUnlimited: boolean;
   // Max group cap (pool-only, excluding seat allowance) across the user's
   // groups; null when none carry a cap.
   groupCapAwuCredits: number | null;
@@ -154,11 +156,13 @@ export async function fetchLiveUserCreditInputs({
     // ladder).
     const poolCapAwuCredits = resolveEffectiveSpendLimitAwuCredits({
       overrideAwuCredits: poolCapOverrideAwuCredits,
+      overrideUnlimited: poolCapOverrideUnlimited,
       groupCapAwuCredits,
       defaultAwuCredits: defaultPoolCapAwuCredits,
     });
     capSource = resolveEffectiveSpendLimitSource({
       overrideAwuCredits: poolCapOverrideAwuCredits,
+      overrideUnlimited: poolCapOverrideUnlimited,
       groupCapAwuCredits,
       defaultAwuCredits: defaultPoolCapAwuCredits,
     });
@@ -175,7 +179,8 @@ export async function fetchLiveUserCreditInputs({
         )
       );
     }
-    effectiveCapAwuCredits = poolCapAwuCredits + seatAllowance;
+    effectiveCapAwuCredits =
+      poolCapAwuCredits === null ? null : poolCapAwuCredits + seatAllowance;
 
     if (metronomeContractId) {
       const usageResult = await fetchPerUserAwuUsage({

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -44,13 +44,14 @@ export type UserCreditContext = {
   remainingCapCreditsPercentage?: number | null;
   /**
    * The user's effective pool budget in AWU credits: `0` = no pool access
-   * (e.g. free seats), `> 0` = capped pool. Unlimited is not supported. A
-   * property of the user's situation (like `remainingCapCreditsPercentage`), so
-   * it lives in the context — it's what the `seat_balance_exhausted` guards use
-   * to route `capped` vs `on_pool`, with no seat-type special-casing. Absent
-   * for events that don't carry a resolved pool limit.
+   * (e.g. free seats), `> 0` = capped pool, `null` = explicit unlimited
+   * override (unbounded). A property of the user's situation (like
+   * `remainingCapCreditsPercentage`), so it lives in the context — it's what
+   * the `seat_balance_exhausted` guards use to route `capped` vs `on_pool`,
+   * with no seat-type special-casing. Absent for events that don't carry a
+   * resolved pool limit.
    */
-  poolLimitAwuCredits?: number;
+  poolLimitAwuCredits?: number | null;
 };
 
 type UserCreditEvent =
@@ -71,7 +72,7 @@ type UserCreditEvent =
    * This user's personal seat balance is exhausted. The next state is decided
    * by `ctx.poolLimitAwuCredits`:
    *   - `0` (no pool access, e.g. free seats) → `capped`
-   *   - `> 0` (or absent) → `on_pool` (band depends on cap usage)
+   *   - `> 0`, `null` (unlimited), or absent → `on_pool` (band depends on cap usage)
    */
   | { type: "seat_balance_exhausted" }
   /**

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -65,6 +65,7 @@ export type MembershipsPaginationParams = {
 export type PoolCapOverrideSnapshot = {
   poolCapOverrideAwuCredits: number | null;
   poolCapOverrideExpiresAt: Date | null;
+  poolCapOverrideUnlimited: boolean;
 };
 
 type MembershipsWithTotal = {
@@ -1609,9 +1610,11 @@ export class MembershipResource extends BaseResource<MembershipModel> {
 
   /**
    * Update the per-user pool cap override (in AWU credits, seat allowance
-   * excluded) of an active membership in place. `null` clears the override,
-   * letting the seat-type default apply. Callers are responsible for syncing
-   * the derived Metronome alerts.
+   * excluded) of an active membership in place. `null` amount with
+   * `poolCapOverrideUnlimited` false clears the override, letting the group
+   * cap / seat-type default apply. `null` amount with `poolCapOverrideUnlimited`
+   * true grants unbounded pool access, bypassing the group cap and default
+   * entirely. Callers are responsible for syncing the derived Metronome alerts.
    *
    * `poolCapOverrideExpiresAt` schedules an automatic revert back to the
    * seat-type default (see the `spend_limit_expiration` Temporal sweep).
@@ -1622,9 +1625,11 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     {
       poolCapOverrideAwuCredits,
       poolCapOverrideExpiresAt,
+      poolCapOverrideUnlimited,
     }: {
       poolCapOverrideAwuCredits: number | null;
       poolCapOverrideExpiresAt?: Date | null;
+      poolCapOverrideUnlimited?: boolean;
     },
     transaction?: Transaction
   ): Promise<void> {
@@ -1632,6 +1637,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       {
         poolCapOverrideAwuCredits,
         poolCapOverrideExpiresAt: poolCapOverrideExpiresAt ?? null,
+        poolCapOverrideUnlimited: poolCapOverrideUnlimited ?? false,
       },
       transaction
     );
@@ -1644,6 +1650,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     return {
       poolCapOverrideAwuCredits: this.poolCapOverrideAwuCredits,
       poolCapOverrideExpiresAt: this.poolCapOverrideExpiresAt,
+      poolCapOverrideUnlimited: this.poolCapOverrideUnlimited,
     };
   }
 
@@ -1756,6 +1763,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
           // it's the pool-only portion, independent of the seat allowance.
           poolCapOverrideAwuCredits: this.poolCapOverrideAwuCredits,
           poolCapOverrideExpiresAt: this.poolCapOverrideExpiresAt,
+          poolCapOverrideUnlimited: this.poolCapOverrideUnlimited,
         },
         { transaction }
       );

--- a/front/lib/resources/storage/models/membership.ts
+++ b/front/lib/resources/storage/models/membership.ts
@@ -32,6 +32,11 @@ export class MembershipModel extends WorkspaceAwareModel<MembershipModel> {
   // Meaningless — and ignored by enforcement — when
   // `poolCapOverrideAwuCredits` is null.
   declare poolCapOverrideExpiresAt: Date | null;
+  // True when the admin explicitly granted unbounded pool access (bypassing
+  // the group cap and seat-type default entirely), as opposed to
+  // `poolCapOverrideAwuCredits` being null because no override was ever set.
+  // Meaningless when `poolCapOverrideAwuCredits` is non-null.
+  declare poolCapOverrideUnlimited: CreationOptional<boolean>;
 
   declare userId: ForeignKey<UserModel["id"]>;
   declare user: NonAttribute<UserModel>;
@@ -88,6 +93,11 @@ MembershipModel.init(
       type: DataTypes.DATE,
       allowNull: true,
       defaultValue: null,
+    },
+    poolCapOverrideUnlimited: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
   },
   {

--- a/front/lib/spend_limits/effective.test.ts
+++ b/front/lib/spend_limits/effective.test.ts
@@ -9,6 +9,7 @@ describe("resolveEffectiveSpendLimitAwuCredits", () => {
     expect(
       resolveEffectiveSpendLimitAwuCredits({
         overrideAwuCredits: 100,
+        overrideUnlimited: false,
         groupCapAwuCredits: 200,
         defaultAwuCredits: 300,
       })
@@ -17,6 +18,7 @@ describe("resolveEffectiveSpendLimitAwuCredits", () => {
     expect(
       resolveEffectiveSpendLimitAwuCredits({
         overrideAwuCredits: null,
+        overrideUnlimited: false,
         groupCapAwuCredits: 200,
         defaultAwuCredits: 300,
       })
@@ -25,6 +27,7 @@ describe("resolveEffectiveSpendLimitAwuCredits", () => {
     expect(
       resolveEffectiveSpendLimitAwuCredits({
         overrideAwuCredits: null,
+        overrideUnlimited: false,
         groupCapAwuCredits: null,
         defaultAwuCredits: 300,
       })
@@ -35,6 +38,7 @@ describe("resolveEffectiveSpendLimitAwuCredits", () => {
     expect(
       resolveEffectiveSpendLimitAwuCredits({
         overrideAwuCredits: null,
+        overrideUnlimited: false,
         groupCapAwuCredits: null,
         defaultAwuCredits: null,
       })
@@ -45,10 +49,22 @@ describe("resolveEffectiveSpendLimitAwuCredits", () => {
     expect(
       resolveEffectiveSpendLimitAwuCredits({
         overrideAwuCredits: null,
+        overrideUnlimited: false,
         groupCapAwuCredits: 0,
         defaultAwuCredits: 300,
       })
     ).toBe(0);
+  });
+
+  it("bypasses the group cap and default entirely when explicitly unlimited", () => {
+    expect(
+      resolveEffectiveSpendLimitAwuCredits({
+        overrideAwuCredits: null,
+        overrideUnlimited: true,
+        groupCapAwuCredits: 200,
+        defaultAwuCredits: 300,
+      })
+    ).toBeNull();
   });
 });
 
@@ -57,6 +73,7 @@ describe("resolveEffectiveSpendLimitSource", () => {
     expect(
       resolveEffectiveSpendLimitSource({
         overrideAwuCredits: 100,
+        overrideUnlimited: false,
         groupCapAwuCredits: 200,
         defaultAwuCredits: 300,
       })
@@ -65,6 +82,7 @@ describe("resolveEffectiveSpendLimitSource", () => {
     expect(
       resolveEffectiveSpendLimitSource({
         overrideAwuCredits: null,
+        overrideUnlimited: false,
         groupCapAwuCredits: 200,
         defaultAwuCredits: 300,
       })
@@ -73,6 +91,7 @@ describe("resolveEffectiveSpendLimitSource", () => {
     expect(
       resolveEffectiveSpendLimitSource({
         overrideAwuCredits: null,
+        overrideUnlimited: false,
         groupCapAwuCredits: null,
         defaultAwuCredits: 300,
       })
@@ -81,9 +100,21 @@ describe("resolveEffectiveSpendLimitSource", () => {
     expect(
       resolveEffectiveSpendLimitSource({
         overrideAwuCredits: null,
+        overrideUnlimited: false,
         groupCapAwuCredits: null,
         defaultAwuCredits: null,
       })
     ).toBe("none");
+  });
+
+  it("reports 'override' when explicitly unlimited even without a group/default cap", () => {
+    expect(
+      resolveEffectiveSpendLimitSource({
+        overrideAwuCredits: null,
+        overrideUnlimited: true,
+        groupCapAwuCredits: 200,
+        defaultAwuCredits: 300,
+      })
+    ).toBe("override");
   });
 });

--- a/front/lib/spend_limits/effective.ts
+++ b/front/lib/spend_limits/effective.ts
@@ -8,29 +8,26 @@ export type EffectiveSpendLimitSource =
 
 type SpendLimitAlertState = CustomerAlert["customer_status"];
 
-// Priority: per-user `override` > the highest of the user's `group` caps >
-// seat-type `default`. `groupCapAwuCredits` is the max cap across the groups the
-// user belongs to (null when none of them carry a cap). All three values must be
-// expressed in the same unit (all pool-only, or all pool + seat allowance).
-export function resolveEffectiveSpendLimitAwuCredits(args: {
-  overrideAwuCredits: number | null;
-  groupCapAwuCredits: number | null;
-  defaultAwuCredits: number;
-}): number;
-export function resolveEffectiveSpendLimitAwuCredits(args: {
-  overrideAwuCredits: number | null;
-  groupCapAwuCredits: number | null;
-  defaultAwuCredits: number | null;
-}): number | null;
+// Priority: an explicit `overrideUnlimited` bypasses everything below it (no
+// cap at all) > per-user `override` amount > the highest of the user's `group`
+// caps > seat-type `default`. `groupCapAwuCredits` is the max cap across the
+// groups the user belongs to (null when none of them carry a cap). All three
+// numeric values must be expressed in the same unit (all pool-only, or all
+// pool + seat allowance).
 export function resolveEffectiveSpendLimitAwuCredits({
   overrideAwuCredits,
+  overrideUnlimited,
   groupCapAwuCredits,
   defaultAwuCredits,
 }: {
   overrideAwuCredits: number | null;
+  overrideUnlimited: boolean;
   groupCapAwuCredits: number | null;
   defaultAwuCredits: number | null;
 }): number | null {
+  if (overrideUnlimited) {
+    return null;
+  }
   if (overrideAwuCredits !== null) {
     return overrideAwuCredits;
   }
@@ -40,19 +37,21 @@ export function resolveEffectiveSpendLimitAwuCredits({
   return defaultAwuCredits;
 }
 
-// Where the effective spend limit comes from: a user-specific `override`, a
-// `group` cap, the seat-type `default`, or `none` when nothing is configured
-// (unlimited).
+// Where the effective spend limit comes from: a user-specific `override`
+// (amount-capped or explicitly unlimited), a `group` cap, the seat-type
+// `default`, or `none` when nothing is configured (unlimited).
 export function resolveEffectiveSpendLimitSource({
   overrideAwuCredits,
+  overrideUnlimited,
   groupCapAwuCredits,
   defaultAwuCredits,
 }: {
   overrideAwuCredits: number | null;
+  overrideUnlimited: boolean;
   groupCapAwuCredits: number | null;
   defaultAwuCredits: number | null;
 }): EffectiveSpendLimitSource {
-  if (overrideAwuCredits !== null) {
+  if (overrideUnlimited || overrideAwuCredits !== null) {
     return "override";
   }
   if (groupCapAwuCredits !== null) {

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -676,8 +676,11 @@ export function useUpdateUserSpendLimit({
       const body = PutUserSpendLimitResponseSchema.parse(await res.json());
       let description: string;
       switch (limit.kind) {
+        case "default":
+          description = `${memberName}'s custom spend limit has been removed.`;
+          break;
         case "unlimited":
-          description = `${memberName}'s spend limit has been removed.`;
+          description = `${memberName} can now draw from the credit pool with no cap.`;
           break;
         case "limited":
           description = `${memberName}'s spend limit has been set to ${limit.awuCredits.toLocaleString("en-US")} credits.`;

--- a/front/migrations/pre-deploy/20260811153827_add_pool_cap_override_unlimited_to_memberships.sql
+++ b/front/migrations/pre-deploy/20260811153827_add_pool_cap_override_unlimited_to_memberships.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."memberships" ADD COLUMN "poolCapOverrideUnlimited" boolean DEFAULT false NOT NULL;

--- a/front/types/api/users/spend_limit.ts
+++ b/front/types/api/users/spend_limit.ts
@@ -7,11 +7,15 @@ export const SPEND_LIMIT_EXPIRY_KINDS = [
 export type SpendLimitExpiryKind = (typeof SPEND_LIMIT_EXPIRY_KINDS)[number];
 
 export type UserSpendLimit =
+  // No override: falls back to the group cap / seat-type default.
+  | { kind: "default" }
+  // Explicit override bypassing the group cap and seat-type default entirely
+  // — bounded only by the workspace's available credit pool.
   | { kind: "unlimited" }
   | {
       kind: "limited";
       awuCredits: number;
-      // Epoch ms at which the override auto-reverts to unlimited. Omitted/null
+      // Epoch ms at which the override auto-reverts to the default. Omitted/null
       // means it never expires.
       expiresAt?: number | null;
     };


### PR DESCRIPTION
Support true unlimited per-user spend limit, bypassing group/default caps

Drop 'Use workspace default' from upgrade-request approval (doesn't resolve the request)

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
