### PR TITLE
feat: let admins filter consumption analytics on every workspace agent

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -6373,6 +6373,7 @@
               "type": "string",
               "enum": [
                 "all",
+                "analytics",
                 "list",
                 "favorites",
                 "published",

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/index.test.ts
@@ -192,7 +192,7 @@ describe("GET /api/w/:wId/assistant/agent_configurations", () => {
     expect(data.error.type).toBe("invalid_request_error");
   });
 
-  it("returns other users' hidden agents for an admin with the admin_internal view", async () => {
+  it("returns other users' hidden agents for an admin with the analytics view", async () => {
     const { workspace } = await createPrivateApiMockRequest({
       method: "GET",
       role: "admin",
@@ -200,7 +200,7 @@ describe("GET /api/w/:wId/assistant/agent_configurations", () => {
     const { agentOwner } = await setupAgentOwner(workspace, "user");
     await setupTestAgents(workspace, agentOwner);
 
-    const response = await listAgents(workspace, { view: "admin_internal" });
+    const response = await listAgents(workspace, { view: "analytics" });
 
     expect(response.status).toBe(200);
     const data: { agentConfigurations: LightAgentConfigurationType[] } =
@@ -213,7 +213,7 @@ describe("GET /api/w/:wId/assistant/agent_configurations", () => {
     ).toEqual(["hidden", "visible"]);
   });
 
-  it("returns agents from spaces the admin cannot read with the admin_internal view", async () => {
+  it("returns agents from spaces the admin cannot read with the analytics view", async () => {
     const { workspace } = await createPrivateApiMockRequest({
       method: "GET",
       role: "admin",
@@ -224,9 +224,13 @@ describe("GET /api/w/:wId/assistant/agent_configurations", () => {
     );
 
     const restrictedSpace = await SpaceFactory.regular(workspace);
-    await restrictedSpace.addMembers(agentOwnerAuth, {
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const addMembersResult = await restrictedSpace.addMembers(adminAuth, {
       userIds: [agentOwner.sId],
     });
+    expect(addMembersResult.isOk()).toBe(true);
     await agentOwnerAuth.refresh();
 
     const restrictedAgent = await AgentConfigurationFactory.createTestAgent(
@@ -238,7 +242,7 @@ describe("GET /api/w/:wId/assistant/agent_configurations", () => {
       }
     );
 
-    const response = await listAgents(workspace, { view: "admin_internal" });
+    const response = await listAgents(workspace, { view: "analytics" });
 
     expect(response.status).toBe(200);
     const data: { agentConfigurations: LightAgentConfigurationType[] } =
@@ -248,10 +252,29 @@ describe("GET /api/w/:wId/assistant/agent_configurations", () => {
     );
   });
 
-  it("returns 404 for admin_internal view without the admin role", async () => {
-    const { workspace, user } = await createPrivateApiMockRequest({
+  it("narrows the analytics view to non-private agents below the admin role", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
       method: "GET",
       role: "manager",
+    });
+    const { agentOwner } = await setupAgentOwner(workspace, "user");
+    await setupTestAgents(workspace, agentOwner);
+
+    const response = await listAgents(workspace, { view: "analytics" });
+
+    expect(response.status).toBe(200);
+    const data: { agentConfigurations: LightAgentConfigurationType[] } =
+      await response.json();
+    expect(
+      data.agentConfigurations
+        .filter((a) => a.scope !== "global")
+        .map((a) => a.scope)
+    ).toEqual(["visible"]);
+  });
+
+  it("returns 404 for admin_internal view without super user", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
     });
 
     await setupTestAgents(workspace, user);

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/index.test.ts
@@ -192,9 +192,66 @@ describe("GET /api/w/:wId/assistant/agent_configurations", () => {
     expect(data.error.type).toBe("invalid_request_error");
   });
 
-  it("returns 404 for admin_internal view without super user", async () => {
+  it("returns other users' hidden agents for an admin with the admin_internal view", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+    const { agentOwner } = await setupAgentOwner(workspace, "user");
+    await setupTestAgents(workspace, agentOwner);
+
+    const response = await listAgents(workspace, { view: "admin_internal" });
+
+    expect(response.status).toBe(200);
+    const data: { agentConfigurations: LightAgentConfigurationType[] } =
+      await response.json();
+    expect(
+      data.agentConfigurations
+        .filter((a) => a.scope !== "global")
+        .map((a) => a.scope)
+        .sort()
+    ).toEqual(["hidden", "visible"]);
+  });
+
+  it("returns agents from spaces the admin cannot read with the admin_internal view", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+    const { agentOwner, agentOwnerAuth } = await setupAgentOwner(
+      workspace,
+      "user"
+    );
+
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    await restrictedSpace.addMembers(agentOwnerAuth, {
+      userIds: [agentOwner.sId],
+    });
+    await agentOwnerAuth.refresh();
+
+    const restrictedAgent = await AgentConfigurationFactory.createTestAgent(
+      agentOwnerAuth,
+      {
+        name: "Test Agent / Restricted space",
+        scope: "hidden",
+        requestedSpaceIds: [restrictedSpace.id],
+      }
+    );
+
+    const response = await listAgents(workspace, { view: "admin_internal" });
+
+    expect(response.status).toBe(200);
+    const data: { agentConfigurations: LightAgentConfigurationType[] } =
+      await response.json();
+    expect(data.agentConfigurations.map((a) => a.sId)).toContain(
+      restrictedAgent.sId
+    );
+  });
+
+  it("returns 404 for admin_internal view without the admin role", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
       method: "GET",
+      role: "manager",
     });
 
     await setupTestAgents(workspace, user);

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/index.ts
@@ -59,7 +59,7 @@ const app = workspaceApp();
  *         description: Filter agents by view
  *         schema:
  *           type: string
- *           enum: [all, list, favorites, published, admin_internal, global, workspace]
+ *           enum: [all, analytics, list, favorites, published, admin_internal, global, workspace]
  *       - in: query
  *         name: limit
  *         required: false
@@ -193,18 +193,12 @@ app.get("/", async (ctx): HandlerResult<GetAgentConfigurationsResponseBody> => {
   let viewParam = view ? view : "all";
   // @ts-expect-error: added for backwards compatibility
   viewParam = viewParam === "assistant-search" ? "list" : viewParam;
-  if (
-    viewParam === "admin_internal" &&
-    !auth.isDustSuperUser() &&
-    !auth.isAdmin()
-  ) {
+  if (viewParam === "admin_internal" && !auth.isDustSuperUser()) {
     return apiError(ctx, {
       status_code: 404,
       api_error: {
         type: "app_auth_error",
-        message:
-          "Only Dust Super Users and workspace admins can see " +
-          "admin_internal agents.",
+        message: "Only Dust Super Users can see admin_internal agents.",
       },
     });
   }
@@ -219,9 +213,6 @@ app.get("/", async (ctx): HandlerResult<GetAgentConfigurationsResponseBody> => {
     sort,
     // Stripped to stay under Next.js' 4MB API response limit.
     omitInstructions: true,
-    // The admin view lists every agent in the workspace, so agents built on
-    // spaces the caller cannot read are listed too.
-    dangerouslySkipPermissionFiltering: viewParam === "admin_internal",
   });
   if (withUsage === "true") {
     const mentionCounts = await runOnRedis(

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/index.ts
@@ -193,12 +193,18 @@ app.get("/", async (ctx): HandlerResult<GetAgentConfigurationsResponseBody> => {
   let viewParam = view ? view : "all";
   // @ts-expect-error: added for backwards compatibility
   viewParam = viewParam === "assistant-search" ? "list" : viewParam;
-  if (viewParam === "admin_internal" && !auth.isDustSuperUser()) {
+  if (
+    viewParam === "admin_internal" &&
+    !auth.isDustSuperUser() &&
+    !auth.isAdmin()
+  ) {
     return apiError(ctx, {
       status_code: 404,
       api_error: {
         type: "app_auth_error",
-        message: "Only Dust Super Users can see admin_internal agents.",
+        message:
+          "Only Dust Super Users and workspace admins can see " +
+          "admin_internal agents.",
       },
     });
   }
@@ -213,6 +219,9 @@ app.get("/", async (ctx): HandlerResult<GetAgentConfigurationsResponseBody> => {
     sort,
     // Stripped to stay under Next.js' 4MB API response limit.
     omitInstructions: true,
+    // The admin view lists every agent in the workspace, so agents built on
+    // spaces the caller cannot read are listed too.
+    dangerouslySkipPermissionFiltering: viewParam === "admin_internal",
   });
   if (withUsage === "true") {
     const mentionCounts = await runOnRedis(

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -27,7 +27,6 @@ import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_
 import { useGroups } from "@app/lib/swr/groups";
 import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
 import type { LightWorkspaceType } from "@app/types/user";
-import { isAdmin } from "@app/types/user";
 import {
   BarChart05,
   Button,
@@ -106,11 +105,6 @@ export function UsageFilterPanel({
       })),
     [workspaceGroups]
   );
-
-  // Private agents are only listed for admins.
-  const agentScopes = isAdmin(owner)
-    ? USAGE_FILTER_AGENT_SCOPES
-    : USAGE_FILTER_AGENT_SCOPES.filter((scope) => scope !== "hidden");
 
   const activeOptions = categoryOptions[activeCategory];
   const filteredOptions = useMemo(() => {
@@ -245,7 +239,7 @@ export function UsageFilterPanel({
             )}
             {activeCategory === "agent" && (
               <UsageFilterAgentScopeControls
-                scopes={agentScopes}
+                scopes={USAGE_FILTER_AGENT_SCOPES}
                 activeScope={activeScope}
                 onScopeChange={setActiveScope}
               />

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -1,11 +1,13 @@
 import type {
   UsageFilter,
+  UsageFilterAgentScope,
   UsageFilterCategory,
   UsageFilterGroup,
   UsageModelTier,
 } from "@app/components/workspace/analytics/usageFilter";
 import {
   toConsumptionScopeFilter,
+  USAGE_FILTER_AGENT_SCOPES,
   USAGE_FILTER_CATEGORIES,
   USAGE_FILTER_CATEGORY_LABEL,
   USAGE_MODEL_TIERS,
@@ -23,10 +25,9 @@ import { useConsumptionFacets } from "@app/hooks/useConsumptionFacets";
 import { useToggleSelectionList } from "@app/hooks/useToggleSelectionList";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { useGroups } from "@app/lib/swr/groups";
-import type { AgentConfigurationScope } from "@app/types/assistant/agent";
-import { AGENT_CONFIGURATION_SCOPES } from "@app/types/assistant/agent";
 import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
 import type { LightWorkspaceType } from "@app/types/user";
+import { isAdmin } from "@app/types/user";
 import {
   BarChart05,
   Button,
@@ -65,9 +66,7 @@ export function UsageFilterPanel({
   } = useUsageFilter(filter);
   const [activeCategory, setActiveCategory] =
     useState<UsageFilterCategory>("agent");
-  const [activeScope, setActiveScope] = useState<AgentConfigurationScope>(
-    AGENT_CONFIGURATION_SCOPES[0]
-  );
+  const [activeScope, setActiveScope] = useState<UsageFilterAgentScope>("all");
   const [activeTier, setActiveTier] = useState<UsageModelTier>(
     USAGE_MODEL_TIERS[0]
   );
@@ -108,6 +107,11 @@ export function UsageFilterPanel({
     [workspaceGroups]
   );
 
+  // Private agents are only listed for admins.
+  const agentScopes = isAdmin(owner)
+    ? USAGE_FILTER_AGENT_SCOPES
+    : USAGE_FILTER_AGENT_SCOPES.filter((scope) => scope !== "hidden");
+
   const activeOptions = categoryOptions[activeCategory];
   const filteredOptions = useMemo(() => {
     const search = searchText.trim().toLowerCase();
@@ -117,10 +121,12 @@ export function UsageFilterPanel({
         : null;
 
     return activeOptions.filter((option) => {
-      if (option.kind === "agent") {
-        if (option.scope === undefined || option.scope !== activeScope) {
-          return false;
-        }
+      if (
+        option.kind === "agent" &&
+        activeScope !== "all" &&
+        option.scope !== activeScope
+      ) {
+        return false;
       }
       if (option.kind === "model" && option.tier !== activeTier) {
         return false;
@@ -239,6 +245,7 @@ export function UsageFilterPanel({
             )}
             {activeCategory === "agent" && (
               <UsageFilterAgentScopeControls
+                scopes={agentScopes}
                 activeScope={activeScope}
                 onScopeChange={setActiveScope}
               />

--- a/front/components/workspace/analytics/usageFilter.ts
+++ b/front/components/workspace/analytics/usageFilter.ts
@@ -2,6 +2,7 @@ import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/
 import { CONSUMPTION_DIMENSION_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
 import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import type { AgentConfigurationScope } from "@app/types/assistant/agent";
+import { AGENT_CONFIGURATION_SCOPES } from "@app/types/assistant/agent";
 import type { ModelMakerIdType } from "@app/types/assistant/models/types";
 import type { ConnectorProvider } from "@app/types/data_source";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
@@ -42,12 +43,21 @@ export const USAGE_FILTER_CATEGORY_SINGULAR_LABEL: Record<
   source: "Source",
 };
 
-export const USAGE_FILTER_SCOPE_LABEL: Record<AgentConfigurationScope, string> =
-  {
-    global: "Company",
-    visible: "Shared",
-    hidden: "Private",
-  };
+// The agent picker's scope tabs: the agent scopes, plus an "all" catch-all that
+// doesn't narrow by scope.
+export const USAGE_FILTER_AGENT_SCOPES = [
+  ...AGENT_CONFIGURATION_SCOPES,
+  "all",
+] as const;
+
+export type UsageFilterAgentScope = (typeof USAGE_FILTER_AGENT_SCOPES)[number];
+
+export const USAGE_FILTER_SCOPE_LABEL: Record<UsageFilterAgentScope, string> = {
+  global: "Company",
+  visible: "Shared",
+  hidden: "Private",
+  all: "All",
+};
 
 export const USAGE_MODEL_TIERS = ["fast", "standard", "complex"] as const;
 

--- a/front/components/workspace/analytics/usageFilter.ts
+++ b/front/components/workspace/analytics/usageFilter.ts
@@ -43,8 +43,6 @@ export const USAGE_FILTER_CATEGORY_SINGULAR_LABEL: Record<
   source: "Source",
 };
 
-// The agent picker's scope tabs: the agent scopes, plus an "all" catch-all that
-// doesn't narrow by scope.
 export const USAGE_FILTER_AGENT_SCOPES = [
   ...AGENT_CONFIGURATION_SCOPES,
   "all",

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterAgentScopeControls.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterAgentScopeControls.tsx
@@ -1,14 +1,15 @@
+import type { UsageFilterAgentScope } from "@app/components/workspace/analytics/usageFilter";
 import { USAGE_FILTER_SCOPE_LABEL } from "@app/components/workspace/analytics/usageFilter";
-import type { AgentConfigurationScope } from "@app/types/assistant/agent";
-import { AGENT_CONFIGURATION_SCOPES } from "@app/types/assistant/agent";
 import { Button, NavigationListLabel } from "@dust-tt/sparkle";
 
 interface UsageFilterAgentScopeControlsProps {
-  activeScope: AgentConfigurationScope;
-  onScopeChange: (scope: AgentConfigurationScope) => void;
+  scopes: readonly UsageFilterAgentScope[];
+  activeScope: UsageFilterAgentScope;
+  onScopeChange: (scope: UsageFilterAgentScope) => void;
 }
 
 export function UsageFilterAgentScopeControls({
+  scopes,
   activeScope,
   onScopeChange,
 }: UsageFilterAgentScopeControlsProps) {
@@ -19,7 +20,7 @@ export function UsageFilterAgentScopeControls({
         className="bg-transparent font-medium"
       />
       <div className="flex items-center gap-1">
-        {AGENT_CONFIGURATION_SCOPES.map((scope) => (
+        {scopes.map((scope) => (
           <Button
             key={scope}
             label={USAGE_FILTER_SCOPE_LABEL[scope]}

--- a/front/lib/api/analytics/consumption/facet_catalog.test.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.test.ts
@@ -1,8 +1,12 @@
 import { listConsumptionFacetCatalog } from "@app/lib/api/analytics/consumption/facet_catalog";
+import { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import { describe, expect, it } from "vitest";
 
 describe("listConsumptionFacetCatalog", () => {
@@ -43,6 +47,52 @@ describe("listConsumptionFacetCatalog", () => {
     );
     expect(catalog.tool).not.toContainEqual(
       expect.objectContaining({ value: server.sId })
+    );
+  });
+
+  it("lists private agents of other users for admins", async () => {
+    const { workspace, authenticator: editorAuth } = await createResourceTest({
+      role: "user",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(editorAuth, {
+      name: "Secret agent",
+      scope: "hidden",
+    });
+    const adminUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
+    const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+
+    const catalog = await listConsumptionFacetCatalog(adminAuth);
+
+    expect(catalog.agent).toContainEqual(
+      expect.objectContaining({ value: agent.sId, label: "Secret agent" })
+    );
+  });
+
+  it("hides private agents of other users below the admin role", async () => {
+    const { workspace, authenticator: editorAuth } = await createResourceTest({
+      role: "user",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(editorAuth, {
+      name: "Secret agent",
+      scope: "hidden",
+    });
+    const managerUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, managerUser, {
+      role: "manager",
+    });
+    const managerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      managerUser.sId,
+      workspace.sId
+    );
+
+    const catalog = await listConsumptionFacetCatalog(managerAuth);
+
+    expect(catalog.agent).not.toContainEqual(
+      expect.objectContaining({ value: agent.sId })
     );
   });
 

--- a/front/lib/api/analytics/consumption/facet_catalog.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.ts
@@ -115,7 +115,7 @@ async function listConsumptionFacetCatalogWithoutTracing(
   const agents = await traceFacetCatalogLoad("agents", () =>
     getAgentConfigurationsForView({
       auth,
-      agentsGetView: "all",
+      agentsGetView: "analytics",
       variant: "extra_light",
       omitInstructions: true,
     })

--- a/front/lib/api/assistant/configuration/views.test.ts
+++ b/front/lib/api/assistant/configuration/views.test.ts
@@ -1,0 +1,132 @@
+import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
+import { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
+import type { LightWorkspaceType } from "@app/types/user";
+import { describe, expect, it } from "vitest";
+
+async function authenticatorForNewMember(
+  workspace: LightWorkspaceType,
+  role: MembershipRoleType
+): Promise<Authenticator> {
+  const user = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, user, { role });
+  return Authenticator.fromUserIdAndWorkspaceId(user.sId, workspace.sId);
+}
+
+async function listAgentIdsForAnalytics(auth: Authenticator) {
+  const agents = await getAgentConfigurationsForView({
+    auth,
+    agentsGetView: "analytics",
+    variant: "light",
+  });
+  return agents.map((agent) => agent.sId);
+}
+
+describe("getAgentConfigurationsForView, 'analytics' view", () => {
+  it("lists private agents of other users for admins", async () => {
+    const { workspace, authenticator: editorAuth } = await createResourceTest({
+      role: "user",
+    });
+    const privateAgent = await AgentConfigurationFactory.createTestAgent(
+      editorAuth,
+      { name: "Secret agent", scope: "hidden" }
+    );
+    const adminAuth = await authenticatorForNewMember(workspace, "admin");
+
+    expect(await listAgentIdsForAnalytics(adminAuth)).toContain(
+      privateAgent.sId
+    );
+  });
+
+  it("hides private agents of other users below the admin role", async () => {
+    const { workspace, authenticator: editorAuth } = await createResourceTest({
+      role: "user",
+    });
+    const privateAgent = await AgentConfigurationFactory.createTestAgent(
+      editorAuth,
+      { name: "Secret agent", scope: "hidden" }
+    );
+    const sharedAgent = await AgentConfigurationFactory.createTestAgent(
+      editorAuth,
+      { name: "Shared agent", scope: "visible" }
+    );
+    const managerAuth = await authenticatorForNewMember(workspace, "manager");
+
+    const agentIds = await listAgentIdsForAnalytics(managerAuth);
+    expect(agentIds).toContain(sharedAgent.sId);
+    expect(agentIds).not.toContain(privateAgent.sId);
+  });
+
+  it("lists agents built on spaces the admin is not a member of", async () => {
+    const { workspace, authenticator: editorAuth } = await createResourceTest({
+      role: "user",
+    });
+    const space = await SpaceFactory.regular(
+      editorAuth.getNonNullableWorkspace()
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(editorAuth, {
+      name: "Restricted agent",
+      scope: "visible",
+      requestedSpaceIds: [space.id],
+    });
+    const adminAuth = await authenticatorForNewMember(workspace, "admin");
+
+    expect(await listAgentIdsForAnalytics(adminAuth)).toContain(agent.sId);
+    // The admin is not a member of the space, so every other view still hides
+    // the agent: only the analytics view opens it up.
+    const listedForAdmin = await getAgentConfigurationsForView({
+      auth: adminAuth,
+      agentsGetView: "all",
+      variant: "light",
+    });
+    expect(listedForAdmin.map((a) => a.sId)).not.toContain(agent.sId);
+  });
+
+  it("hides agents built on unreadable spaces below the admin role", async () => {
+    const { workspace, authenticator: editorAuth } = await createResourceTest({
+      role: "user",
+    });
+    const space = await SpaceFactory.regular(
+      editorAuth.getNonNullableWorkspace()
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(editorAuth, {
+      name: "Restricted agent",
+      scope: "visible",
+      requestedSpaceIds: [space.id],
+    });
+    const managerAuth = await authenticatorForNewMember(workspace, "manager");
+
+    expect(await listAgentIdsForAnalytics(managerAuth)).not.toContain(
+      agent.sId
+    );
+  });
+
+  it("returns the 'all' set to a plain member instead of throwing", async () => {
+    const { workspace, authenticator: editorAuth } = await createResourceTest({
+      role: "user",
+    });
+    await AgentConfigurationFactory.createTestAgent(editorAuth, {
+      name: "Secret agent",
+      scope: "hidden",
+    });
+    await AgentConfigurationFactory.createTestAgent(editorAuth, {
+      name: "Shared agent",
+      scope: "visible",
+    });
+    const memberAuth = await authenticatorForNewMember(workspace, "user");
+
+    const listedForMember = await getAgentConfigurationsForView({
+      auth: memberAuth,
+      agentsGetView: "all",
+      variant: "light",
+    });
+    expect(await listAgentIdsForAnalytics(memberAuth)).toEqual(
+      listedForMember.map((agent) => agent.sId)
+    );
+  });
+});

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -64,6 +64,7 @@ function determineGlobalAgentIdsToFetch(
     case "list":
     case "manage":
     case "all":
+    case "analytics":
     case "favorites":
     case "admin_internal":
       return undefined; // undefined means all global agents will be fetched
@@ -169,6 +170,17 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
         ...baseAgentsSequelizeQuery,
         where: baseWhereConditions,
       });
+
+    // Analytics reports on every agent, so admins get the private ones too.
+    // Everyone else sees what `all` returns.
+    case "analytics":
+      return AgentConfigurationModel.findAll({
+        ...baseAgentsSequelizeQuery,
+        where: auth.isAdmin()
+          ? baseWhereConditions
+          : baseConditionsAndScopesIn(["workspace", "published", "visible"]),
+      });
+
     case "current_user":
       const authorId = auth.getNonNullableUser().id;
       const r = await AgentConfigurationModel.findAll({
@@ -321,7 +333,13 @@ async function fetchWorkspaceAgentConfigurationsForView(
     }
   );
 
-  const allowedAgentModels = dangerouslySkipPermissionFiltering
+  // Analytics counts credits for agents built on spaces an admin cannot read,
+  // so the admin analytics view has to list them as well.
+  const skipPermissionFiltering =
+    dangerouslySkipPermissionFiltering ||
+    (agentsGetView === "analytics" && auth.isAdmin());
+
+  const allowedAgentModels = skipPermissionFiltering
     ? agentModels
     : await filterAgentsByRequestedSpaces(auth, agentModels);
 
@@ -371,8 +389,7 @@ export async function getAgentConfigurationsForView<
     !auth.isAdmin()
   ) {
     throw new Error(
-      "Superuser view is for dust superusers, internal admin auths or " +
-        "workspace admins only."
+      "Superuser view is for dust superusers or internal admin auths only."
     );
   }
 

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -371,7 +371,8 @@ export async function getAgentConfigurationsForView<
     !auth.isAdmin()
   ) {
     throw new Error(
-      "Superuser view is for dust superusers or internal admin auths only."
+      "Superuser view is for dust superusers, internal admin auths or " +
+        "workspace admins only."
     );
   }
 

--- a/front/types/api/agent_configuration.ts
+++ b/front/types/api/agent_configuration.ts
@@ -17,6 +17,7 @@ export const GetAgentConfigurationsQuerySchema = z.object({
     .enum([
       "admin_internal",
       "all",
+      "analytics",
       "archived",
       "current_user",
       "global",

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -87,10 +87,13 @@ export type AgentConfigurationScope =
  *   agents); used e.g. for non-user calls such as API
  * - 'published': Retrieves all published agents.
  * - 'global': Retrieves all agents exclusively with a 'global' scope.
- * - 'admin_internal': Every active agent in the workspace, whatever its scope
- *   and whoever edits it. Gated per surface: Dust superusers in Poke, workspace
- *   admins in the workspace admin views. Space permissions still narrow the
- *   result unless the caller passes `dangerouslySkipPermissionFiltering`.
+ * - 'analytics': Agents the caller may report on, for the workspace analytics
+ *   surfaces. Admins get every active agent in the workspace — whatever its
+ *   scope, whoever edits it, and whether or not they can read the spaces it is
+ *   built on — since analytics reports on all of them. Everyone else gets the
+ *   same set as 'all'. Never fails on permissions: the scope opens up with the
+ *   caller's role.
+ * - 'admin_internal': Grants access to all agents, including private ones.
  * - 'manage': Retrieves all agents for the manage agents view (same as list, but including disabled agents).
  * - 'archived': Retrieves all agents that are archived. Only available to super
  *   users. Intended strictly for internal use with necessary superuser or admin
@@ -102,6 +105,7 @@ export type AgentsGetViewType =
   | "current_user"
   | "list"
   | "all"
+  | "analytics"
   | "published"
   | "global"
   | "admin_internal"

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -87,7 +87,10 @@ export type AgentConfigurationScope =
  *   agents); used e.g. for non-user calls such as API
  * - 'published': Retrieves all published agents.
  * - 'global': Retrieves all agents exclusively with a 'global' scope.
- * - 'admin_internal': Grants access to all agents, including private ones.
+ * - 'admin_internal': Every active agent in the workspace, whatever its scope
+ *   and whoever edits it. Gated per surface: Dust superusers in Poke, workspace
+ *   admins in the workspace admin views. Space permissions still narrow the
+ *   result unless the caller passes `dangerouslySkipPermissionFiltering`.
  * - 'manage': Retrieves all agents for the manage agents view (same as list, but including disabled agents).
  * - 'archived': Retrieves all agents that are archived. Only available to super
  *   users. Intended strictly for internal use with necessary superuser or admin


### PR DESCRIPTION
## Description

The Agents usage panel only listed agents the viewer can already see. The `Private` filter tab was always empty apart from your own private agents, and unpublished or space-restricted agents couldn't be filtered on. We want admins to be able to introspect usage from all agents in the workspace.

Adds a dedicated `analytics` agents view for agents. The panel always asks for that view, the `Private` scope tab is hidden below the admin role, and there's a new `All` scope tab, now the default. Opening the page to more roles later is a change to two predicates in the view, not a new error branch.

One thing to know: an admin can now list name / description / tags / model / requestedSpaceIds for every agent, private ones included.

## Tests

Unit tests + Manually on a hive: seeded a hidden agent owned by another user, in a restricted space, with consumption, it shows in the Agents dimension and is selectable under `Private` and `All` as an admin. The tests also cover the non-admin path: a manager gets the non-private set back, not an error, and sees the anonymised label while an admin sees the real name.

<img width="2656" height="1506" alt="Capture d’écran 2026-08-11 à 16 19 54" src="https://github.com/user-attachments/assets/b64b49f5-bbd4-498a-96ff-90b795c6e4e4" />

## Risk

New read-only view on a private API, admin-only breadth. Existing views behave exactly as before, nothing persisted or migrated, so rollback is a plain revert. The anonymisation only narrows what non-admins already received on the new consumption page; the old Analytics page is untouched.

## Deploy Plan

Deploy front.