### PR TITLE
Plans: Allow to override maxVaultsInWorkspace, maxDataSourcesCount an…

### DIFF
--- a/front/components/poke/pages/PlansPage.tsx
+++ b/front/components/poke/pages/PlansPage.tsx
@@ -6,21 +6,14 @@ import {
   toPlanType,
   useEditingPlan,
 } from "@app/components/poke/plans/form";
+import { NewPlanWarningDialog } from "@app/components/poke/plans/NewPlanWarningDialog";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import { usePokePlans } from "@app/lib/swr/poke";
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
 import type { PlanTypeSchema } from "@app/types/api/poke/plans";
 import type { PlanType } from "@app/types/plan";
-import {
-  Button,
-  Check,
-  Edit04,
-  IconButton,
-  Plus,
-  Spinner,
-  XClose,
-} from "@dust-tt/sparkle";
+import { Check, Edit04, IconButton, Spinner, XClose } from "@dust-tt/sparkle";
 import React from "react";
 import { useSWRConfig } from "swr";
 import type { z } from "zod";
@@ -180,11 +173,8 @@ export function PlansPage() {
         </table>
       </div>
       <div>
-        <Button
-          icon={Plus}
-          label="Create a new plan"
-          variant="outline"
-          onClick={() => createNewPlan()}
+        <NewPlanWarningDialog
+          onConfirm={() => createNewPlan()}
           // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           disabled={editingPlan?.isNewPlan || !!editingPlan}
         />

--- a/front/components/poke/plans/NewPlanWarningDialog.tsx
+++ b/front/components/poke/plans/NewPlanWarningDialog.tsx
@@ -1,0 +1,108 @@
+import {
+  Button,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  Plus,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+interface NewPlanWarningDialogProps {
+  disabled: boolean;
+  onConfirm: () => void;
+}
+
+/**
+ * Gate in front of "Create a new plan": every plan added here is shared by every
+ * workspace subscribed to it and has to be maintained forever, so a negotiated
+ * exception should almost always be a per-workspace override instead.
+ */
+export function NewPlanWarningDialog({
+  disabled,
+  onConfirm,
+}: NewPlanWarningDialogProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          icon={Plus}
+          label="Create a new plan"
+          variant="outline"
+          disabled={disabled}
+        />
+      </DialogTrigger>
+      <DialogContent className="bg-primary-50 sm:max-w-[640px]">
+        <DialogHeader>
+          <DialogTitle>Avoid creating a new plan</DialogTitle>
+          <DialogDescription>
+            Plan limits exist for a reason: they push customers toward the next
+            tier (Business, Enterprise) and keep the platform in a sane state.
+            Every new plan is one more thing to maintain forever, and it is
+            shared by every workspace subscribed to it.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogContainer>
+          <div className="flex flex-col gap-3 text-sm text-muted-foreground">
+            <p>
+              If a specific limit has been negotiated for one customer, prefer
+              subscribing them to an existing plan and overriding just that
+              limit on their workspace:
+            </p>
+            <ul className="flex flex-col gap-2 pl-5">
+              <li className="list-disc">
+                <span className="font-semibold">SSO / SCIM</span> — enable the{" "}
+                <span className="font-mono">allow_sso</span> /{" "}
+                <span className="font-mono">allow_scim</span> feature flags on
+                the workspace.
+              </li>
+              <li className="list-disc">
+                <span className="font-semibold">
+                  Number of seats (# Users, # Free, # Free LT)
+                </span>{" "}
+                — use the{" "}
+                <span className="font-semibold">Override Plan Limits</span> poke
+                plugin on the workspace.
+              </li>
+              <li className="list-disc">
+                <span className="font-semibold">
+                  Number of spaces, data sources and connections
+                </span>{" "}
+                — same{" "}
+                <span className="font-semibold">Override Plan Limits</span>{" "}
+                plugin.
+              </li>
+            </ul>
+            <p>
+              Overrides are workspace-scoped, survive plan changes, and are
+              visible in the workspace's "Plan limitations" tab. If the limit
+              you need is not overridable yet, adding it there is usually a
+              better move than adding a plan.
+            </p>
+          </div>
+        </DialogContainer>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            label="Cancel"
+            onClick={() => setOpen(false)}
+          />
+          <Button
+            variant="warning"
+            label="I understand, create a plan"
+            onClick={() => {
+              setOpen(false);
+              onConfirm();
+            }}
+          />
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -560,9 +560,12 @@ export function PlanLimitationsTable({
               <PokeTableRow>
                 <PokeTableCell>Max number of spaces</PokeTableCell>
                 <PokeTableCell>
-                  {activePlan.limits.vaults.maxVaults === -1
-                    ? "unlimited"
-                    : activePlan.limits.vaults.maxVaults}
+                  <PlanLimitValue
+                    value={activePlan.limits.vaults.maxVaults}
+                    isOverridden={
+                      planLimitOverride?.maxVaultsInWorkspace != null
+                    }
+                  />
                 </PokeTableCell>
               </PokeTableRow>
 
@@ -603,9 +606,26 @@ export function PlanLimitationsTable({
               <PokeTableRow>
                 <PokeTableCell>Max number of data sources</PokeTableCell>
                 <PokeTableCell>
-                  {activePlan.limits.dataSources.count === -1
-                    ? "unlimited"
-                    : activePlan.limits.dataSources.count}
+                  <PlanLimitValue
+                    value={activePlan.limits.dataSources.count}
+                    isOverridden={
+                      planLimitOverride?.maxDataSourcesCount != null
+                    }
+                  />
+                </PokeTableCell>
+              </PokeTableRow>
+
+              <PokeTableRow>
+                <PokeTableCell>
+                  Max number of connections (user-added connectors)
+                </PokeTableCell>
+                <PokeTableCell>
+                  <PlanLimitValue
+                    value={activePlan.limits.connections.count}
+                    isOverridden={
+                      planLimitOverride?.maxConnectionsCount != null
+                    }
+                  />
                 </PokeTableCell>
               </PokeTableRow>
 

--- a/front/lib/api/plan_compatibility.ts
+++ b/front/lib/api/plan_compatibility.ts
@@ -23,7 +23,8 @@ type PlanFitResult = {
  * intentionally not checked here.
  *
  * The workspace's plan-limit overrides apply to `plan` as well (they are
- * workspace-scoped, not plan-scoped), so the seat check uses the effective cap.
+ * workspace-scoped, not plan-scoped), so every overridable limit is checked
+ * against its effective value.
  */
 export async function checkWorkspaceFitsPlanLimits(
   auth: Authenticator,
@@ -37,6 +38,12 @@ export async function checkWorkspaceFitsPlanLimits(
     await WorkspacePlanLimitOverrideResource.fetchByWorkspace({ workspace });
   const maxUsers =
     planLimitOverride?.maxUsersInWorkspace ?? limits.users.maxUsers;
+  const maxVaults =
+    planLimitOverride?.maxVaultsInWorkspace ?? limits.vaults.maxVaults;
+  const maxDataSourcesCount =
+    planLimitOverride?.maxDataSourcesCount ?? limits.dataSources.count;
+  const maxConnectionsCount =
+    planLimitOverride?.maxConnectionsCount ?? limits.connections.count;
 
   if (maxUsers !== -1) {
     const activeSeats = await MembershipResource.countActiveSeatsInWorkspace(
@@ -49,35 +56,35 @@ export async function checkWorkspaceFitsPlanLimits(
     }
   }
 
-  if (limits.vaults.maxVaults !== -1) {
+  if (maxVaults !== -1) {
     const spaces = await SpaceResource.listWorkspaceSpaces(auth);
     const regularSpaceCount = spaces.filter((s) => s.kind === "regular").length;
-    if (regularSpaceCount > limits.vaults.maxVaults) {
+    if (regularSpaceCount > maxVaults) {
       violations.push(
-        `regular spaces (${regularSpaceCount}) exceed plan maxVaults (${limits.vaults.maxVaults})`
+        `regular spaces (${regularSpaceCount}) exceed plan maxVaults (${maxVaults})`
       );
     }
   }
 
-  if (limits.dataSources.count !== -1) {
+  if (maxDataSourcesCount !== -1) {
     const dataSources = await getDataSources(auth);
-    if (dataSources.length > limits.dataSources.count) {
+    if (dataSources.length > maxDataSourcesCount) {
       violations.push(
-        `data sources (${dataSources.length}) exceed plan maxDataSourcesCount (${limits.dataSources.count})`
+        `data sources (${dataSources.length}) exceed plan maxDataSourcesCount (${maxDataSourcesCount})`
       );
     }
   }
 
-  if (limits.connections.count !== -1) {
+  if (maxConnectionsCount !== -1) {
     const dataSources = await getDataSources(auth);
     const connectionsCount = dataSources.filter(
       (ds) =>
         ds.connectorProvider !== null &&
         doesConnectorProviderCountTowardConnectionsLimit(ds.connectorProvider)
     ).length;
-    if (connectionsCount > limits.connections.count) {
+    if (connectionsCount > maxConnectionsCount) {
       violations.push(
-        `connected data sources (${connectionsCount}) exceed plan maxConnectionsCount (${limits.connections.count})`
+        `connected data sources (${connectionsCount}) exceed plan maxConnectionsCount (${maxConnectionsCount})`
       );
     }
   }

--- a/front/lib/api/plan_limit_overrides.test.ts
+++ b/front/lib/api/plan_limit_overrides.test.ts
@@ -21,6 +21,9 @@ function override(partial: Partial<PlanLimitOverride>): PlanLimitOverride {
 const PLAN_MAX_USERS = 4;
 const PLAN_MAX_FREE_USERS = 2;
 const PLAN_MAX_LIFETIME_FREE_USERS = 3;
+const PLAN_MAX_VAULTS = 5;
+const PLAN_MAX_DATA_SOURCES = 6;
+const PLAN_MAX_CONNECTIONS = 3;
 
 describe("workspace plan limit overrides", () => {
   let workspace: LightWorkspaceType;
@@ -31,6 +34,9 @@ describe("workspace plan limit overrides", () => {
       maxUsersInWorkspace: PLAN_MAX_USERS,
       maxFreeUsersInWorkspace: PLAN_MAX_FREE_USERS,
       maxLifetimeFreeUsersInWorkspace: PLAN_MAX_LIFETIME_FREE_USERS,
+      maxVaultsInWorkspace: PLAN_MAX_VAULTS,
+      maxDataSourcesCount: PLAN_MAX_DATA_SOURCES,
+      maxConnectionsCount: PLAN_MAX_CONNECTIONS,
     });
     workspace = await WorkspaceFactory.fromPlan(plan);
     auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
@@ -46,13 +52,41 @@ describe("workspace plan limit overrides", () => {
     return (await activeSubscription()).plan.limits.users;
   }
 
+  async function effectiveLimits() {
+    return (await activeSubscription()).plan.limits;
+  }
+
   it("uses the plan values when the workspace has no override", async () => {
     expect(await getWorkspacePlanLimitOverrides(auth)).toBeNull();
 
-    const limits = await effectiveUserLimits();
-    expect(limits.maxUsers).toBe(PLAN_MAX_USERS);
-    expect(limits.maxFreeUsers).toBe(PLAN_MAX_FREE_USERS);
-    expect(limits.maxLifetimeFreeUsers).toBe(PLAN_MAX_LIFETIME_FREE_USERS);
+    const limits = await effectiveLimits();
+    expect(limits.users.maxUsers).toBe(PLAN_MAX_USERS);
+    expect(limits.users.maxFreeUsers).toBe(PLAN_MAX_FREE_USERS);
+    expect(limits.users.maxLifetimeFreeUsers).toBe(
+      PLAN_MAX_LIFETIME_FREE_USERS
+    );
+    expect(limits.vaults.maxVaults).toBe(PLAN_MAX_VAULTS);
+    expect(limits.dataSources.count).toBe(PLAN_MAX_DATA_SOURCES);
+    expect(limits.connections.count).toBe(PLAN_MAX_CONNECTIONS);
+  });
+
+  it("applies the space, data-source and connection overrides", async () => {
+    const res = await setWorkspacePlanLimitOverrides(
+      auth,
+      override({
+        maxVaultsInWorkspace: 50,
+        maxDataSourcesCount: -1,
+        maxConnectionsCount: 12,
+      })
+    );
+    expect(res.isOk()).toBe(true);
+
+    const limits = await effectiveLimits();
+    expect(limits.vaults.maxVaults).toBe(50);
+    expect(limits.dataSources.count).toBe(-1);
+    expect(limits.connections.count).toBe(12);
+    // Not overridden: still the plan value.
+    expect(limits.users.maxUsers).toBe(PLAN_MAX_USERS);
   });
 
   it("applies the override to the effective plan limits", async () => {

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -27,7 +27,7 @@ export * from "./manage_credit_usage_configuration";
 export * from "./manage_programmatic_usage_configuration";
 export * from "./manage_seat_limits";
 export * from "./manage_workspace_kill_switch";
-export * from "./override_plan_seat_limits";
+export * from "./override_plan_limits";
 export * from "./project_task_details";
 export * from "./reconcile_credit_state";
 export * from "./reinforcement_workflow";

--- a/front/lib/api/poke/plugins/workspaces/override_plan_limits.ts
+++ b/front/lib/api/poke/plugins/workspaces/override_plan_limits.ts
@@ -9,13 +9,19 @@ import { z } from "zod";
 
 const UNLIMITED = -1;
 
-const SeatLimitOverridesSchema = z.object({
+const PlanLimitOverridesSchema = z.object({
   overrideMaxUsers: z.boolean(),
   maxUsers: z.number().int().min(UNLIMITED).optional(),
   overrideMaxFreeUsers: z.boolean(),
   maxFreeUsers: z.number().int().min(UNLIMITED).optional(),
   overrideMaxLifetimeFreeUsers: z.boolean(),
   maxLifetimeFreeUsers: z.number().int().min(UNLIMITED).optional(),
+  overrideMaxVaults: z.boolean(),
+  maxVaults: z.number().int().min(UNLIMITED).optional(),
+  overrideMaxDataSources: z.boolean(),
+  maxDataSources: z.number().int().min(UNLIMITED).optional(),
+  overrideMaxConnections: z.boolean(),
+  maxConnections: z.number().int().min(UNLIMITED).optional(),
 });
 
 function resolveOverride(
@@ -32,19 +38,20 @@ function describeLimit(value: number | null): string {
   return value === UNLIMITED ? "unlimited" : `${value}`;
 }
 
-export const overridePlanSeatLimitsPlugin = createPlugin({
+export const overridePlanLimitsPlugin = createPlugin({
   manifest: {
-    id: "override-plan-seat-limits",
-    name: "Override Plan Seat Limits",
+    id: "override-plan-limits",
+    name: "Override Plan Limits",
     description:
-      "Override this workspace's seat limits without creating a dedicated plan. " +
-      "Each limit falls back to the plan value when its toggle is off. Use -1 for unlimited.",
+      "Override this workspace's seat, space and data-source limits without creating a " +
+      "dedicated plan. Each limit falls back to the plan value when its toggle is off. " +
+      "Use -1 for unlimited.",
     explanation:
       "Overrides are workspace-scoped: they survive plan changes and renewals, and they " +
-      "also win over the trial limits. They cap seat assignment and what the product " +
-      "displays — they do not change what is billed (see 'Manage Seat Limits' for billing " +
-      "floors). Raising the lifetime free-seat cap only affects users onboarded from now " +
-      "on; lowering a cap never revokes existing seats.",
+      "also win over the trial limits. They cap what can be created or assigned and what " +
+      "the product displays — they do not change what is billed (see 'Manage Seat Limits' " +
+      "for billing floors). Raising the lifetime free-seat cap only affects users onboarded " +
+      "from now on; lowering a cap never removes what already exists.",
     resourceTypes: ["workspaces"],
     args: {
       overrideMaxUsers: {
@@ -95,6 +102,56 @@ export const overridePlanSeatLimitsPlugin = createPlugin({
         async: true,
         dependsOn: { field: "overrideMaxLifetimeFreeUsers", value: true },
       },
+      overrideMaxVaults: {
+        type: "boolean",
+        variant: "toggle",
+        label: "Override max spaces",
+        async: true,
+        asyncDescription: true,
+      },
+      maxVaults: {
+        type: "number",
+        variant: "text",
+        label: "Max spaces",
+        description:
+          "Maximum regular spaces in the workspace. -1 for unlimited.",
+        async: true,
+        dependsOn: { field: "overrideMaxVaults", value: true },
+      },
+      overrideMaxDataSources: {
+        type: "boolean",
+        variant: "toggle",
+        label: "Override max data sources",
+        async: true,
+        asyncDescription: true,
+      },
+      maxDataSources: {
+        type: "number",
+        variant: "text",
+        label: "Max data sources",
+        description:
+          "Maximum data sources of any kind — folders, websites and connectors. " +
+          "-1 for unlimited.",
+        async: true,
+        dependsOn: { field: "overrideMaxDataSources", value: true },
+      },
+      overrideMaxConnections: {
+        type: "boolean",
+        variant: "toggle",
+        label: "Override max connections",
+        async: true,
+        asyncDescription: true,
+      },
+      maxConnections: {
+        type: "number",
+        variant: "text",
+        label: "Max connections",
+        description:
+          "Maximum user-added managed connectors (Slack, Notion, GDrive…). Excludes " +
+          "folders, websites, bot integrations and the project connector. -1 for unlimited.",
+        async: true,
+        dependsOn: { field: "overrideMaxConnections", value: true },
+      },
     },
     requiredRoles: ["billing"],
   },
@@ -103,28 +160,40 @@ export const overridePlanSeatLimitsPlugin = createPlugin({
     // These limits are already the effective ones: the override is applied when
     // the plan is resolved for the workspace. So prefilling the number fields
     // with them is correct whether or not an override is in place.
-    const planLimits = auth.getNonNullablePlan().limits.users;
+    const { limits } = auth.getNonNullablePlan();
     const override = await getWorkspacePlanLimitOverrides(auth);
 
     return new Ok({
       overrideMaxUsers: override?.maxUsersInWorkspace != null,
       overrideMaxUsersDescription:
         "Override the plan's max-users cap for this workspace only.",
-      maxUsers: planLimits.maxUsers,
+      maxUsers: limits.users.maxUsers,
       overrideMaxFreeUsers: override?.maxFreeUsersInWorkspace != null,
       overrideMaxFreeUsersDescription:
         "Override the plan's active free-seat cap for this workspace only.",
-      maxFreeUsers: planLimits.maxFreeUsers,
+      maxFreeUsers: limits.users.maxFreeUsers,
       overrideMaxLifetimeFreeUsers:
         override?.maxLifetimeFreeUsersInWorkspace != null,
       overrideMaxLifetimeFreeUsersDescription:
         "Override the plan's lifetime free-seat cap for this workspace only.",
-      maxLifetimeFreeUsers: planLimits.maxLifetimeFreeUsers,
+      maxLifetimeFreeUsers: limits.users.maxLifetimeFreeUsers,
+      overrideMaxVaults: override?.maxVaultsInWorkspace != null,
+      overrideMaxVaultsDescription:
+        "Override the plan's space cap for this workspace only.",
+      maxVaults: limits.vaults.maxVaults,
+      overrideMaxDataSources: override?.maxDataSourcesCount != null,
+      overrideMaxDataSourcesDescription:
+        "Override the plan's data-source cap for this workspace only.",
+      maxDataSources: limits.dataSources.count,
+      overrideMaxConnections: override?.maxConnectionsCount != null,
+      overrideMaxConnectionsDescription:
+        "Override the plan's connection cap for this workspace only.",
+      maxConnections: limits.connections.count,
     });
   },
 
   execute: async (auth, _, args) => {
-    const parseResult = SeatLimitOverridesSchema.safeParse(args);
+    const parseResult = PlanLimitOverridesSchema.safeParse(args);
     if (!parseResult.success) {
       return new Err(
         new Error(
@@ -142,6 +211,12 @@ export const overridePlanSeatLimitsPlugin = createPlugin({
       maxFreeUsers,
       overrideMaxLifetimeFreeUsers,
       maxLifetimeFreeUsers,
+      overrideMaxVaults,
+      maxVaults,
+      overrideMaxDataSources,
+      maxDataSources,
+      overrideMaxConnections,
+      maxConnections,
     } = parseResult.data;
 
     const override: PlanLimitOverride = {
@@ -153,6 +228,15 @@ export const overridePlanSeatLimitsPlugin = createPlugin({
       maxLifetimeFreeUsersInWorkspace: resolveOverride(
         overrideMaxLifetimeFreeUsers,
         maxLifetimeFreeUsers
+      ),
+      maxVaultsInWorkspace: resolveOverride(overrideMaxVaults, maxVaults),
+      maxDataSourcesCount: resolveOverride(
+        overrideMaxDataSources,
+        maxDataSources
+      ),
+      maxConnectionsCount: resolveOverride(
+        overrideMaxConnections,
+        maxConnections
       ),
     };
 
@@ -167,6 +251,9 @@ export const overridePlanSeatLimitsPlugin = createPlugin({
         `Max users: ${describeLimit(override.maxUsersInWorkspace)}.`,
         `Max free seats: ${describeLimit(override.maxFreeUsersInWorkspace)}.`,
         `Max lifetime free seats: ${describeLimit(override.maxLifetimeFreeUsersInWorkspace)}.`,
+        `Max spaces: ${describeLimit(override.maxVaultsInWorkspace)}.`,
+        `Max data sources: ${describeLimit(override.maxDataSourcesCount)}.`,
+        `Max connections: ${describeLimit(override.maxConnectionsCount)}.`,
       ].join(" "),
     });
   },

--- a/front/lib/plans/plan_limit_overrides.test.ts
+++ b/front/lib/plans/plan_limit_overrides.test.ts
@@ -12,6 +12,9 @@ const PLAN = {
   maxUsersInWorkspace: 10,
   maxFreeUsersInWorkspace: 3,
   maxLifetimeFreeUsersInWorkspace: 5,
+  maxVaultsInWorkspace: 2,
+  maxDataSourcesCount: 7,
+  maxConnectionsCount: 4,
 };
 
 function override(partial: Partial<PlanLimitOverride>): PlanLimitOverride {
@@ -35,6 +38,25 @@ describe("applyPlanLimitOverrides", () => {
     expect(res.maxUsersInWorkspace).toBe(500);
     expect(res.maxFreeUsersInWorkspace).toBe(3);
     expect(res.maxLifetimeFreeUsersInWorkspace).toBe(5);
+    expect(res.maxVaultsInWorkspace).toBe(2);
+    expect(res.maxDataSourcesCount).toBe(7);
+    expect(res.maxConnectionsCount).toBe(4);
+  });
+
+  it("overrides the space, data-source and connection limits", () => {
+    const res = applyPlanLimitOverrides(
+      PLAN,
+      override({
+        maxVaultsInWorkspace: 50,
+        maxDataSourcesCount: -1,
+        maxConnectionsCount: 12,
+      })
+    );
+
+    expect(res.maxVaultsInWorkspace).toBe(50);
+    expect(res.maxDataSourcesCount).toBe(-1);
+    expect(res.maxConnectionsCount).toBe(12);
+    expect(res.maxUsersInWorkspace).toBe(10);
   });
 
   it("supports raising a limit to unlimited and lowering it to zero", () => {

--- a/front/lib/plans/plan_limit_overrides.ts
+++ b/front/lib/plans/plan_limit_overrides.ts
@@ -8,6 +8,9 @@ export const OVERRIDABLE_PLAN_LIMITS = [
   "maxUsersInWorkspace",
   "maxFreeUsersInWorkspace",
   "maxLifetimeFreeUsersInWorkspace",
+  "maxVaultsInWorkspace",
+  "maxDataSourcesCount",
+  "maxConnectionsCount",
 ] as const satisfies readonly (keyof PlanAttributes)[];
 
 export type OverridablePlanLimit = (typeof OVERRIDABLE_PLAN_LIMITS)[number];
@@ -22,6 +25,9 @@ export const EMPTY_PLAN_LIMIT_OVERRIDE: PlanLimitOverride = {
   maxUsersInWorkspace: null,
   maxFreeUsersInWorkspace: null,
   maxLifetimeFreeUsersInWorkspace: null,
+  maxVaultsInWorkspace: null,
+  maxDataSourcesCount: null,
+  maxConnectionsCount: null,
 };
 
 export function hasAnyPlanLimitOverride(override: PlanLimitOverride): boolean {

--- a/front/lib/resources/storage/models/workspace_plan_limit_override.ts
+++ b/front/lib/resources/storage/models/workspace_plan_limit_override.ts
@@ -27,6 +27,9 @@ export class WorkspacePlanLimitOverrideModel extends WorkspaceAwareModel<Workspa
   declare maxUsersInWorkspace: CreationOptional<number | null>;
   declare maxFreeUsersInWorkspace: CreationOptional<number | null>;
   declare maxLifetimeFreeUsersInWorkspace: CreationOptional<number | null>;
+  declare maxVaultsInWorkspace: CreationOptional<number | null>;
+  declare maxDataSourcesCount: CreationOptional<number | null>;
+  declare maxConnectionsCount: CreationOptional<number | null>;
 }
 
 WorkspacePlanLimitOverrideModel.init(
@@ -54,6 +57,21 @@ WorkspacePlanLimitOverrideModel.init(
       defaultValue: null,
     },
     maxLifetimeFreeUsersInWorkspace: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
+    },
+    maxVaultsInWorkspace: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
+    },
+    maxDataSourcesCount: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
+    },
+    maxConnectionsCount: {
       type: DataTypes.INTEGER,
       allowNull: true,
       defaultValue: null,

--- a/front/lib/resources/workspace_plan_limit_override_resource.ts
+++ b/front/lib/resources/workspace_plan_limit_override_resource.ts
@@ -18,6 +18,9 @@ function toPlanLimitOverride(
     maxUsersInWorkspace: row.maxUsersInWorkspace,
     maxFreeUsersInWorkspace: row.maxFreeUsersInWorkspace,
     maxLifetimeFreeUsersInWorkspace: row.maxLifetimeFreeUsersInWorkspace,
+    maxVaultsInWorkspace: row.maxVaultsInWorkspace,
+    maxDataSourcesCount: row.maxDataSourcesCount,
+    maxConnectionsCount: row.maxConnectionsCount,
   };
 }
 

--- a/front/migrations/pre-deploy/20260811160000_add_limits_to_workspace_plan_limit_overrides.sql
+++ b/front/migrations/pre-deploy/20260811160000_add_limits_to_workspace_plan_limit_overrides.sql
@@ -1,0 +1,20 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."workspace_plan_limit_overrides" ADD COLUMN "maxVaultsInWorkspace" integer;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."workspace_plan_limit_overrides" ADD COLUMN "maxDataSourcesCount" integer;
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."workspace_plan_limit_overrides" ADD COLUMN "maxConnectionsCount" integer;


### PR DESCRIPTION
## Description

follow up of https://github.com/dust-tt/dust/pull/30316
closes https://github.com/dust-tt/tasks/issues/9961

 - Adds 3 new overridable fields for the plans:
   -  maxVaultsInWorkspace
   - maxDataSourcesCount
   - maxConnectionsCount
 - Add a warning popup when trying to create a new plan to encourage not doing it

<img width="1476" height="902" alt="image" src="https://github.com/user-attachments/assets/a8d9d627-9db6-4e5a-a312-03f73369d33a" />

<img width="1840" height="1276" alt="image" src="https://github.com/user-attachments/assets/ad3f74f4-25b5-40fc-80aa-b1302c957aa4" />

<img width="1126" height="1284" alt="image" src="https://github.com/user-attachments/assets/c4da5c51-4435-49a5-bb56-953d32ce11c8" />


## Tests

tested locally

## Risk

low

## Deploy Plan

lock front
merge
apply migration
deploy front
unlock front
