### PR TITLE
[dsbx] feat: add db delete command

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.47"
+version = "0.1.48"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/src/commands/db/delete.rs
+++ b/cli/dust-sandbox/src/commands/db/delete.rs
@@ -1,0 +1,149 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Result};
+
+use super::{db_file_path, emit_error};
+
+/// SQLite sidecars that belong to a database file and must go with it. `@dust/pod` runs with
+/// `wal_autocheckpoint=0`, so recent rows can live entirely in `-wal`: leaving it behind would let a
+/// later reconcile of the same name recover data this delete was meant to destroy.
+const DB_FILE_SIDECAR_SUFFIXES: [&str; 2] = ["-wal", "-shm"];
+
+/// Delete a live pod database and its SQLite sidecars, reporting the files removed as a one-line
+/// JSON envelope.
+///
+/// Idempotent: a name with nothing on disk succeeds with an empty `removed` list, so a caller
+/// working from a replica listing never has to check what is live first.
+///
+/// This removes only the LIVE files. The litestream replica is the durable copy and outlives them,
+/// so a caller deleting a database for good must wipe that replica prefix too — otherwise the next
+/// cold-start restore brings the database back.
+pub fn cmd_db_delete(name: &str) -> Result<()> {
+    let db_path = db_file_path(name)?;
+    let removed = remove_database_files(&db_path)
+        .map_err(|e| emit_error(anyhow!("cannot delete {}: {e}", db_path.display())))?;
+
+    println!("{}", serde_json::json!({ "ok": true, "removed": removed }));
+    Ok(())
+}
+
+/// The database file's own path plus one path per sidecar suffix. Built by appending to the OsString
+/// rather than formatting a display string, which would be lossy for a non-UTF8 directory.
+fn database_file_paths(db_path: &Path) -> Vec<PathBuf> {
+    let mut paths = vec![db_path.to_path_buf()];
+    for suffix in DB_FILE_SIDECAR_SUFFIXES {
+        let mut with_suffix = db_path.as_os_str().to_os_string();
+        with_suffix.push(suffix);
+        paths.push(PathBuf::from(with_suffix));
+    }
+    paths
+}
+
+/// Remove the database and its sidecars, returning the file names actually removed, in the order
+/// attempted. A file that is already gone is skipped rather than failing the delete.
+fn remove_database_files(db_path: &Path) -> std::io::Result<Vec<String>> {
+    let mut removed: Vec<String> = Vec::new();
+
+    for path in database_file_paths(db_path) {
+        // `remove_file` unlinks a symlink itself and never follows it to its target, so a link
+        // planted in the workload-writable databases dir cannot make this delete reach a foreign
+        // file (the same reasoning as the no-follow guards in `db list`).
+        match std::fs::remove_file(&path) {
+            Ok(()) => {
+                if let Some(file_name) = path.file_name().and_then(|n| n.to_str()) {
+                    removed.push(file_name.to_string());
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn removes_the_database_with_its_sidecars() -> Result<()> {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("chat.db");
+        std::fs::write(&db_path, b"main")?;
+        std::fs::write(dir.path().join("chat.db-wal"), b"wal")?;
+        std::fs::write(dir.path().join("chat.db-shm"), b"shm")?;
+
+        let removed = remove_database_files(&db_path)?;
+
+        assert_eq!(removed, vec!["chat.db", "chat.db-wal", "chat.db-shm"]);
+        assert!(!db_path.exists());
+        assert!(!dir.path().join("chat.db-wal").exists());
+        assert!(!dir.path().join("chat.db-shm").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn reports_only_the_files_that_existed() -> Result<()> {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("notes.db");
+        std::fs::write(&db_path, b"main")?;
+
+        let removed = remove_database_files(&db_path)?;
+
+        assert_eq!(removed, vec!["notes.db"]);
+        Ok(())
+    }
+
+    #[test]
+    fn a_database_that_is_already_gone_is_not_an_error() -> Result<()> {
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        // Idempotent: front deletes by name read from the replica, which may have no live file.
+        let removed = remove_database_files(&dir.path().join("missing.db"))?;
+
+        assert!(removed.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn leaves_other_databases_untouched() -> Result<()> {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("chat.db");
+        std::fs::write(&db_path, b"main")?;
+        // A sibling whose name merely starts with the deleted one must survive.
+        std::fs::write(dir.path().join("chat_v2.db"), b"other")?;
+        std::fs::write(dir.path().join("notes.db"), b"other")?;
+
+        remove_database_files(&db_path)?;
+
+        assert!(dir.path().join("chat_v2.db").exists());
+        assert!(dir.path().join("notes.db").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn unlinks_a_planted_symlink_without_touching_its_target() -> Result<()> {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let outside = dir.path().join("outside.txt");
+        std::fs::write(&outside, b"secret")?;
+        let db_path = dir.path().join("chat.db");
+        // The databases dir is workload-writable, so a hostile link can sit at a database's path.
+        std::os::unix::fs::symlink(&outside, &db_path)?;
+
+        let removed = remove_database_files(&db_path)?;
+
+        assert_eq!(removed, vec!["chat.db"]);
+        assert!(!db_path.exists());
+        assert!(outside.exists(), "the link's target must survive");
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_a_name_outside_the_contract() {
+        // Path traversal and hostile names are refused before any file is touched.
+        assert!(cmd_db_delete("../../etc/passwd").is_err());
+        assert!(cmd_db_delete("Chat").is_err());
+        assert!(cmd_db_delete("").is_err());
+    }
+}

--- a/cli/dust-sandbox/src/commands/db/mod.rs
+++ b/cli/dust-sandbox/src/commands/db/mod.rs
@@ -15,11 +15,13 @@ use clap::Subcommand;
 
 use super::function::spawn_runner;
 
+mod delete;
 mod list;
 mod query;
 mod reconcile;
 mod schema;
 
+pub use delete::cmd_db_delete;
 pub use list::cmd_db_list;
 pub use query::cmd_db_query;
 pub use reconcile::cmd_db_reconcile;
@@ -55,6 +57,11 @@ pub enum DbCommand {
     List,
     /// Execute one SQL statement (from stdin) against a pod database (SELECT/DML; DDL is refused)
     Query {
+        /// Database name (resolved to <name>.db in ${DUST_POD_DATABASES_DIR})
+        name: String,
+    },
+    /// Delete a pod database and its SQLite sidecars (live files only; not the replica)
+    Delete {
         /// Database name (resolved to <name>.db in ${DUST_POD_DATABASES_DIR})
         name: String,
     },

--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -7,7 +7,7 @@ pub mod resolve;
 pub mod tools;
 mod version;
 
-pub use db::{cmd_db_list, cmd_db_query, cmd_db_reconcile, cmd_db_schema};
+pub use db::{cmd_db_delete, cmd_db_list, cmd_db_query, cmd_db_reconcile, cmd_db_schema};
 pub use env::cmd_env;
 pub use forward::cmd_forward;
 pub use function::{cmd_function_build, cmd_function_get, cmd_function_run};

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -93,6 +93,7 @@ async fn run() -> anyhow::Result<()> {
             }
             commands::db::DbCommand::List => commands::cmd_db_list()?,
             commands::db::DbCommand::Query { name } => commands::cmd_db_query(&name).await?,
+            commands::db::DbCommand::Delete { name } => commands::cmd_db_delete(&name)?,
         },
         Commands::Tools {
             json,
@@ -294,6 +295,23 @@ mod tests {
             },
             _ => panic!("expected db"),
         }
+    }
+
+    #[test]
+    fn db_delete_parses() {
+        let cli = Cli::try_parse_from(["dsbx", "db", "delete", "chat"]).expect("parse");
+        match cli.command {
+            Commands::Db { command } => match command {
+                commands::db::DbCommand::Delete { name } => assert_eq!(name, "chat"),
+                _ => panic!("expected delete"),
+            },
+            _ => panic!("expected db"),
+        }
+    }
+
+    #[test]
+    fn db_delete_requires_a_name() {
+        assert!(Cli::try_parse_from(["dsbx", "db", "delete"]).is_err());
     }
 
     #[test]

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.79",
+      tag: "0.8.80",
     });
   });
 
@@ -457,7 +457,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.47/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.48/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,8 +26,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.79";
-const DSBX_CLI_VERSION = "0.1.47";
+const DUST_BASE_IMAGE_VERSION = "0.8.80";
+const DSBX_CLI_VERSION = "0.1.48";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
 // the stable identity used when creating the workload account.


### PR DESCRIPTION
## Description

First step toward deleting a Pod app (#30334 added the Apps tab; deleting one is the other half of the original ask). An app delete has to remove the app's live SQLite files, and `dsbx` had no way to do that — `reconcile`/`schema`/`list`/`query` only ever create or read.

`dsbx db delete <name>` removes `{name}.db` along with its `-wal` and `-shm` sidecars, reporting the files it removed in the same one-line JSON envelope the other `db` subcommands use.

The sidecars are the load-bearing detail: `@dust/pod` runs with `wal_autocheckpoint=0`, so recent rows can live entirely in the WAL. Leaving it behind would let a later reconcile of the same name recover data the delete was meant to destroy.

## Safety

- **Name validation** goes through the existing `db_file_path`, so path traversal and names outside the frozen `^[a-z][a-z0-9_]{0,63}$` contract are refused before any file is touched.
- **Symlinks are not followed.** `remove_file` unlinks the link itself, so a link planted in the workload-writable databases dir cannot make the delete reach a foreign file — the same property the no-follow guards in `db list` rely on. Covered by a test asserting the target survives.
- **Runs unprivileged.** `/pod-state/databases` is `dust-state:agent` mode 2770 and `agent-proxied` is a supplementary member of group `agent`, so this needs no root and SEC3 does not come into play.

## Semantics worth noting

**Idempotent.** A name with nothing on disk succeeds with an empty `removed` list, so the eventual caller — which works from the litestream replica listing, not from what is live — never has to check first.

**Live files only.** The replica is the durable copy and outlives them, so deleting a database for good also means wiping that replica prefix; otherwise the next cold-start restore brings the database back. The doc comment says so at the call site, since that ordering is easy to get wrong.

## Versions

Bumps dsbx to `0.1.48` and dust-base to `0.8.80` across all four places, following d223899986: `Cargo.toml`, `Cargo.lock`, `registry.ts` and `registry.test.ts`.

## Risk

Very low. Purely additive — a new subcommand that **nothing calls yet**. The front-side delete flow (unpublish functions, wipe replicas, revoke shares, remove tabs, delete sources, itemized confirmation, audit event) builds on this in a follow-up, once this is in an image.

## Tests

Six inline tests on the removal logic: db plus sidecars, only-what-existed reporting, the already-gone case, siblings with a shared name prefix surviving, the planted-symlink case, and rejection of hostile names. Two CLI parse tests. Full suite: 296 Rust tests green, `cargo fmt --check` and `clippy --all-targets` clean, and the 20 front image-registry tests pass against the new pins.
