### PR TITLE
[GitHub] fix: update docs deploy action post move to Mintlify

### DIFF
--- a/.github/workflows/deploy-docs-openapi.yml
+++ b/.github/workflows/deploy-docs-openapi.yml
@@ -3,46 +3,23 @@ name: Deploy OpenAPI Docs
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
-  mintlify-openapi:
+  mintlify-deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out Dust
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Validate configuration
+      - name: Trigger Mintlify deployment
         env:
-          DOCS_DEPLOY_TOKEN: ${{ secrets.DOCS_DEPLOY_TOKEN }}
+          MINTLIFY_ADMIN_API_KEY: ${{ secrets.MINTLIFY_ADMIN_API_KEY }}
+          MINTLIFY_PROJECT_ID: ${{ vars.MINTLIFY_PROJECT_ID }}
         run: |
-          if [ -z "${DOCS_DEPLOY_TOKEN}" ]; then
-            echo "::error::DOCS_DEPLOY_TOKEN must have Contents read/write access to dust-tt/new-docs."
+          if [ -z "${MINTLIFY_ADMIN_API_KEY}" ] || [ -z "${MINTLIFY_PROJECT_ID}" ]; then
+            echo "::error::MINTLIFY_ADMIN_API_KEY and MINTLIFY_PROJECT_ID must be configured."
             exit 1
           fi
 
-      - name: Check out docs
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: dust-tt/new-docs
-          token: ${{ secrets.DOCS_DEPLOY_TOKEN }}
-          path: new-docs
-
-      - name: Sync OpenAPI specification
-        run: cp front-api/public/swagger.json new-docs/docs/developer-platform/dust-api-documentation/openapi.json
-
-      - name: Deploy to Mintlify
-        working-directory: new-docs
-        run: |
-          git config user.name "dust-docs-bot"
-          git config user.email "dust-docs-bot@users.noreply.github.com"
-          git add docs/developer-platform/dust-api-documentation/openapi.json
-
-          if git diff --cached --quiet; then
-            echo "OpenAPI documentation is already up to date."
-            exit 0
-          fi
-
-          git commit -m "docs: sync OpenAPI specification"
-          git push
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --url "https://api.mintlify.com/v1/project/update/${MINTLIFY_PROJECT_ID}" \
+            --header "Authorization: Bearer ${MINTLIFY_ADMIN_API_KEY}"

--- a/.github/workflows/deploy-docs-openapi.yml
+++ b/.github/workflows/deploy-docs-openapi.yml
@@ -5,16 +5,44 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
-  rdme-openapi:
+  mintlify-openapi:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repo 📚
+      - name: Check out Dust
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Run `openapi` command 🚀
-        uses: readmeio/rdme@3c41af599df44e516c90ba4107a81c05d4945822 # v10.6.2
+      - name: Validate configuration
+        env:
+          DOCS_DEPLOY_TOKEN: ${{ secrets.DOCS_DEPLOY_TOKEN }}
+        run: |
+          if [ -z "${DOCS_DEPLOY_TOKEN}" ]; then
+            echo "::error::DOCS_DEPLOY_TOKEN must have Contents read/write access to dust-tt/new-docs."
+            exit 1
+          fi
+
+      - name: Check out docs
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          rdme: openapi upload front-api/public/swagger.json --branch=v1.1 --key=${{ secrets.README_API_KEY }} --slug=dust-api-documentation.json
+          repository: dust-tt/new-docs
+          token: ${{ secrets.DOCS_DEPLOY_TOKEN }}
+          path: new-docs
+
+      - name: Sync OpenAPI specification
+        run: cp front-api/public/swagger.json new-docs/docs/developer-platform/dust-api-documentation/openapi.json
+
+      - name: Deploy to Mintlify
+        working-directory: new-docs
+        run: |
+          git config user.name "dust-docs-bot"
+          git config user.email "dust-docs-bot@users.noreply.github.com"
+          git add docs/developer-platform/dust-api-documentation/openapi.json
+
+          if git diff --cached --quiet; then
+            echo "OpenAPI documentation is already up to date."
+            exit 0
+          fi
+
+          git commit -m "docs: sync OpenAPI specification"
+          git push


### PR DESCRIPTION
## Description

The `Deploy OpenAPI Docs` workflow still uploads the specification to ReadMe.io, so successful runs no longer redeploy the Mintlify documentation.

The Mintlify configuration already reads the OpenAPI specification directly from `dust-tt/dust`. This replaces the ReadMe upload with Mintlify's deployment trigger API while keeping the workflow manually dispatched.

## Tests

- Tested locally.

## Risk

- Low. Limited to the manually triggered documentation workflow.

## Deploy Plan

- Add the variables.
