### PR TITLE
[front] feat: delete a Pod app

### DIFF
--- a/front-api/routes/w/[wId]/pods/[podId]/apps/delete.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/delete.test.ts
@@ -1,0 +1,253 @@
+import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import type { Authenticator } from "@app/lib/auth";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { frameContentType, sandboxFunctionContentType } from "@app/types/files";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/lock", () => ({
+  executeWithLock: vi.fn(async (_lockName: string, fn: () => unknown) => fn()),
+}));
+
+vi.mock("@app/lib/api/sandbox/lifecycle", () => ({
+  ensurePodSandboxReady: vi.fn(),
+}));
+
+const EMPTY_SCHEMA = { type: "object", properties: {} } as const;
+
+/** Records every command front runs on the sandbox, answering db execs with an ok envelope. */
+function mockSandboxExec(sandbox: SandboxResource): string[] {
+  const commands: string[] = [];
+  vi.spyOn(sandbox, "exec").mockImplementation(async (_auth, command) => {
+    commands.push(command);
+    return new Ok({
+      exitCode: 0,
+      stdout: `${JSON.stringify({ ok: true })}\n`,
+      stderr: "",
+    });
+  });
+  return commands;
+}
+
+async function setupPod() {
+  const { workspace, user, auth } = await createPrivateApiMockRequest({
+    role: "admin",
+  });
+  const pod = await SpaceFactory.project(workspace, user.id);
+  const sandbox = await SandboxResource.makeNew(auth, {
+    providerId: "test-provider-id",
+    status: "running",
+    baseImage: "dust-base",
+    version: "0.0.0-test",
+  });
+  vi.mocked(ensurePodSandboxReady).mockResolvedValue(
+    new Ok({ sandbox, freshlyCreated: false })
+  );
+
+  return { workspace, user, auth, pod, sandbox };
+}
+
+function gcsObject(
+  workspaceId: string,
+  podId: string,
+  relPath: string,
+  contentType = "text/plain"
+) {
+  return {
+    name: `w/${workspaceId}/pods/${podId}/files/${relPath}`,
+    metadata: {
+      contentType,
+      size: "100",
+      updated: new Date().toISOString(),
+    },
+  };
+}
+
+async function publishFunction(
+  auth: Authenticator,
+  pod: SpaceResource,
+  { slug, fileName }: { slug: string; fileName: string }
+) {
+  const file = await FileFactory.create(auth, null, {
+    contentType: sandboxFunctionContentType,
+    fileName,
+    fileSize: 100,
+    status: "created",
+    useCase: "project_context",
+    useCaseMetadata: { spaceId: pod.sId },
+  });
+
+  return SandboxFunctionResource.makeNew(auth, {
+    space: pod,
+    file,
+    slug,
+    description: `Function ${slug}.`,
+    inputSchema: EMPTY_SCHEMA,
+    outputSchema: EMPTY_SCHEMA,
+  });
+}
+
+describe("DELETE /api/w/:wId/pods/:podId/apps/:prefix", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fileStorageMock.reset();
+  });
+
+  it("unpublishes the app's functions and reports what it removed", async () => {
+    const { workspace, pod, auth, sandbox } = await setupPod();
+    const commands = mockSandboxExec(sandbox);
+
+    fileStorageMock.setFilesByPrefix(() => [
+      gcsObject(workspace.sId, pod.sId, "TaskList/"),
+      gcsObject(
+        workspace.sId,
+        pod.sId,
+        "TaskList/TaskList.tsx",
+        frameContentType
+      ),
+      gcsObject(workspace.sId, pod.sId, "TaskList/functions/add-task.ts"),
+    ]);
+    fileStorageMock.setSubdirectoryNames(() => ["tasklist__tasks.db"]);
+    await publishFunction(auth, pod, {
+      slug: "tasklist__add-task",
+      fileName: "add-task.ts",
+    });
+
+    const res = await honoApp.request(
+      `/api/w/${workspace.sId}/pods/${pod.sId}/apps/tasklist`,
+      { method: "DELETE" }
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.app.prefix).toBe("tasklist");
+    expect(body.app.deletedFunctionSlugs).toEqual(["tasklist__add-task"]);
+    expect(body.app.deletedDatabaseNames).toEqual(["tasklist__tasks"]);
+    expect(body.app.deletedFolderNames).toEqual(["TaskList"]);
+
+    // The published function row is gone, so nothing can invoke the app any more.
+    const remaining = await SandboxFunctionResource.listBySpace(auth, pod);
+    expect(remaining).toHaveLength(0);
+
+    // The live database file and both SQLite sidecars are removed, addressed by on-disk name under
+    // the databases dir. Paths are shell-escaped, hence matching on the bare path text.
+    const removeCommand = commands.find((command) =>
+      command.includes("/bin/rm -f --")
+    );
+    expect(removeCommand).toBeDefined();
+    expect(removeCommand).toContain("/pod-state/databases/tasklist__tasks.db");
+    expect(removeCommand).toContain(
+      "/pod-state/databases/tasklist__tasks.db-wal"
+    );
+    expect(removeCommand).toContain(
+      "/pod-state/databases/tasklist__tasks.db-shm"
+    );
+  });
+
+  it("deletes the live database before wiping its replica", async () => {
+    const { workspace, pod, sandbox } = await setupPod();
+
+    const order: string[] = [];
+    vi.spyOn(sandbox, "exec").mockImplementation(async (_auth, command) => {
+      if (command.includes("/bin/rm -f --")) {
+        order.push("live");
+      }
+      return new Ok({
+        exitCode: 0,
+        stdout: `${JSON.stringify({ ok: true })}\n`,
+        stderr: "",
+      });
+    });
+
+    fileStorageMock.setFilesByPrefix(() => [
+      gcsObject(workspace.sId, pod.sId, "TaskList/"),
+      gcsObject(workspace.sId, pod.sId, "TaskList/databases/tasks.db.ts"),
+    ]);
+    fileStorageMock.setSubdirectoryNames(() => ["tasklist__tasks.db"]);
+    fileStorageMock.setOnDeleteByPrefix((prefix) => {
+      if (prefix.includes("tasklist__tasks.db/")) {
+        order.push("replica");
+      }
+    });
+
+    const res = await honoApp.request(
+      `/api/w/${workspace.sId}/pods/${pod.sId}/apps/tasklist`,
+      { method: "DELETE" }
+    );
+
+    expect(res.status).toBe(200);
+    // A live litestream re-replicates a database it can still see, so this order is load-bearing.
+    expect(order).toEqual(["live", "replica"]);
+  });
+
+  it("fails when the replica survives, rather than reporting a delete that would come back", async () => {
+    const { workspace, pod, sandbox } = await setupPod();
+    mockSandboxExec(sandbox);
+
+    fileStorageMock.setFilesByPrefix(() => [
+      gcsObject(workspace.sId, pod.sId, "TaskList/"),
+      gcsObject(workspace.sId, pod.sId, "TaskList/databases/tasks.db.ts"),
+    ]);
+    // The replica listing keeps reporting the database even after the prefix delete, which is what a
+    // silently-failed wipe looks like — the pod's next cold start would restore it.
+    fileStorageMock.setSubdirectoryNames(() => ["tasklist__tasks.db"]);
+    fileStorageMock.setIgnoreDeleteByPrefixInListings(true);
+
+    const res = await honoApp.request(
+      `/api/w/${workspace.sId}/pods/${pod.sId}/apps/tasklist`,
+      { method: "DELETE" }
+    );
+
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 404 for an app the Pod does not have", async () => {
+    const { workspace, pod } = await setupPod();
+
+    const res = await honoApp.request(
+      `/api/w/${workspace.sId}/pods/${pod.sId}/apps/nosuchapp`,
+      { method: "DELETE" }
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it("refuses to delete artifacts published outside an app folder", async () => {
+    const { workspace, pod, auth } = await setupPod();
+    await publishFunction(auth, pod, {
+      slug: "orphan",
+      fileName: "orphan.ts",
+    });
+
+    // The unfiled app's prefix is empty, so it cannot even be addressed as a path segment; a bare
+    // prefix-less delete must not be mistaken for one.
+    const res = await honoApp.request(
+      `/api/w/${workspace.sId}/pods/${pod.sId}/apps/`,
+      { method: "DELETE" }
+    );
+
+    expect(res.status).toBe(404);
+
+    // And the function survives.
+    const remaining = await SandboxFunctionResource.listBySpace(auth, pod);
+    expect(remaining).toHaveLength(1);
+  });
+
+  it("rejects a prefix that is not app-prefix shaped", async () => {
+    const { workspace, pod } = await setupPod();
+
+    const res = await honoApp.request(
+      `/api/w/${workspace.sId}/pods/${pod.sId}/apps/${encodeURIComponent("../secrets")}`,
+      { method: "DELETE" }
+    );
+
+    expect([400, 404]).toContain(res.status);
+  });
+});

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/index.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/index.ts
@@ -1,8 +1,14 @@
-import { listPodApps } from "@app/lib/api/projects/apps";
-import type { GetPodAppsResponseBody } from "@app/types/api/pod_apps";
+import { deletePodApp, listPodApps } from "@app/lib/api/projects/apps";
+import type {
+  DeletePodAppResponseBody,
+  GetPodAppsResponseBody,
+} from "@app/types/api/pod_apps";
+import { DeletePodAppParamsSchema } from "@app/types/api/pod_apps";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
 
 // Mounted under /api/w/:wId/pods/:podId/apps.
@@ -28,6 +34,62 @@ app.get(
     }
 
     return ctx.json({ apps: appsResult.value });
+  }
+);
+
+/** @ignoreswagger */
+app.delete(
+  "/:prefix",
+  validate("param", DeletePodAppParamsSchema),
+  withSpace({ requireCanWrite: true, routeParam: "podId" }),
+  async (ctx): HandlerResult<DeletePodAppResponseBody> => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
+    const { prefix } = ctx.req.valid("param");
+
+    const deleteResult = await deletePodApp(auth, space, prefix);
+    if (deleteResult.isErr()) {
+      switch (deleteResult.error.code) {
+        case "not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "space_not_found",
+              message: deleteResult.error.message,
+            },
+          });
+        case "not_a_pod":
+        case "cannot_delete_unfiled":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: deleteResult.error.message,
+            },
+          });
+        case "sandbox_unavailable":
+          // Databases can only be removed on a live sandbox, and the delete is safe to retry.
+          return apiError(ctx, {
+            status_code: 503,
+            api_error: {
+              type: "service_unavailable",
+              message: deleteResult.error.message,
+            },
+          });
+        case "internal":
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: deleteResult.error.message,
+            },
+          });
+        default:
+          assertNever(deleteResult.error.code);
+      }
+    }
+
+    return ctx.json({ app: deleteResult.value });
   }
 );
 

--- a/front/components/pod/apps/DeletePodAppDialog.tsx
+++ b/front/components/pod/apps/DeletePodAppDialog.tsx
@@ -1,0 +1,192 @@
+import { useDeletePodApp } from "@app/lib/swr/pods";
+import type { PodApp } from "@app/types/api/pod_apps";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  ContentMessage,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Spinner,
+} from "@dust-tt/sparkle";
+import type { ChangeEvent } from "react";
+import { useCallback, useState } from "react";
+
+const CONFIRM_WORD = "delete";
+
+interface DeletePodAppDialogProps {
+  owner: LightWorkspaceType;
+  podId: string;
+  app: PodApp;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+interface InventoryLineProps {
+  label: string;
+  items: string[];
+}
+
+/** One line per artifact kind, naming what goes rather than just counting it. */
+function InventoryLine({ label, items }: InventoryLineProps) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <li>
+      <span className="font-semibold">
+        {items.length} {label}
+      </span>
+      <span className="text-muted-foreground dark:text-muted-foreground-night">
+        {" — "}
+        {items.join(", ")}
+      </span>
+    </li>
+  );
+}
+
+export function DeletePodAppDialog({
+  owner,
+  podId,
+  app,
+  isOpen,
+  onClose,
+}: DeletePodAppDialogProps) {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+  const doDelete = useDeletePodApp({ owner, podId });
+
+  const appName = app.name ?? app.prefix;
+  const sharedFrames = app.frames.filter((frame) => frame.isPublished);
+
+  const onDelete = useCallback(async () => {
+    setIsDeleting(true);
+    const result = await doDelete(app);
+    setIsDeleting(false);
+    if (result.isOk()) {
+      onClose();
+    }
+  }, [app, doDelete, onClose]);
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          setConfirmText("");
+          onClose();
+        }
+      }}
+    >
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>{`Delete ${appName}?`}</DialogTitle>
+        </DialogHeader>
+        {isDeleting ? (
+          <DialogContainer className="flex flex-col items-center gap-3 py-8">
+            <Spinner variant="dark" size="md" />
+            {/* Removing the databases needs a live sandbox, so a sleeping Pod is woken first. */}
+            <p className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+              Deleting {appName}. This waits for the Pod's Computer to be ready,
+              so it can take a moment.
+            </p>
+          </DialogContainer>
+        ) : (
+          <>
+            <DialogContainer className="flex flex-col gap-4">
+              <div className="flex flex-col gap-2">
+                <p className="copy-sm">This permanently removes:</p>
+                <ul className="flex flex-col gap-1 pl-4 copy-sm list-disc">
+                  <InventoryLine
+                    label={
+                      app.functions.length === 1 ? "function" : "functions"
+                    }
+                    items={app.functions.map((fn) => fn.name)}
+                  />
+                  <InventoryLine
+                    label={
+                      app.databases.length === 1 ? "database" : "databases"
+                    }
+                    items={app.databases.map((db) => db.name)}
+                  />
+                  <InventoryLine
+                    label={app.frames.length === 1 ? "Frame" : "Frames"}
+                    items={app.frames.map((frame) => frame.fileName)}
+                  />
+                  {app.fileCount > 0 && (
+                    <li>
+                      <span className="font-semibold">
+                        {app.fileCount} {app.fileCount === 1 ? "file" : "files"}
+                      </span>
+                      <span className="text-muted-foreground dark:text-muted-foreground-night">
+                        {" — "}
+                        {app.collidingFolderNames.length > 0
+                          ? app.collidingFolderNames.join(", ")
+                          : appName}
+                      </span>
+                    </li>
+                  )}
+                </ul>
+              </div>
+
+              {app.databases.length > 0 && (
+                <ContentMessage
+                  variant="warning"
+                  title="Data cannot be recovered"
+                >
+                  The {app.databases.length === 1 ? "database" : "databases"}{" "}
+                  above and everything stored in{" "}
+                  {app.databases.length === 1 ? "it" : "them"} are deleted for
+                  good, including the replicated copy.
+                </ContentMessage>
+              )}
+
+              {sharedFrames.length > 0 && (
+                <ContentMessage
+                  variant="warning"
+                  title="Shared links will break"
+                >
+                  {sharedFrames.length === 1
+                    ? "This app's Frame has been published, so anyone holding its link loses access."
+                    : "This app's Frames have been published, so anyone holding their links loses access."}
+                </ContentMessage>
+              )}
+
+              <p className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+                Type <strong>{CONFIRM_WORD}</strong> below to confirm.
+              </p>
+              <Input
+                name="delete-app-confirm"
+                value={confirmText}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setConfirmText(e.target.value)
+                }
+                placeholder={`Type ${CONFIRM_WORD} to confirm`}
+                containerClassName="w-full"
+              />
+            </DialogContainer>
+            <DialogFooter
+              leftButtonProps={{
+                label: "Cancel",
+                variant: "outline",
+                onClick: onClose,
+              }}
+              rightButtonProps={{
+                label: "Delete permanently",
+                variant: "warning",
+                disabled: confirmText.trim().toLowerCase() !== CONFIRM_WORD,
+                onClick: () => {
+                  void onDelete();
+                },
+              }}
+            />
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/pod/apps/PodAppDetail.tsx
+++ b/front/components/pod/apps/PodAppDetail.tsx
@@ -5,11 +5,14 @@ import {
   ContentMessage,
   Eye,
   ScrollArea,
+  Trash01,
 } from "@dust-tt/sparkle";
 
 interface PodAppDetailProps {
   app: PodApp;
   onOpenFrame: (frame: PodAppFrame) => void;
+  /** Absent when the viewer cannot delete (no write access, or the unfiled app). */
+  onDelete?: () => void;
 }
 
 interface DetailSectionProps {
@@ -40,16 +43,32 @@ function EmptySectionText({ children }: EmptySectionTextProps) {
   );
 }
 
-export function PodAppDetail({ app, onOpenFrame }: PodAppDetailProps) {
+export function PodAppDetail({
+  app,
+  onOpenFrame,
+  onDelete,
+}: PodAppDetailProps) {
   return (
     <ScrollArea className="h-full">
       <div className="flex flex-col gap-6 px-6 py-5">
-        <div className="flex flex-col gap-1">
-          <h3 className="heading-lg">{app.name ?? "Unfiled"}</h3>
-          <span className="copy-xs text-muted-foreground dark:text-muted-foreground-night">
-            {app.folderPath ??
-              "Published from the Pod root, so these are not owned by an app folder."}
-          </span>
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex min-w-0 flex-col gap-1">
+            <h3 className="heading-lg">{app.name ?? "Unfiled"}</h3>
+            <span className="copy-xs text-muted-foreground dark:text-muted-foreground-night">
+              {app.folderPath ??
+                "Published from the Pod root, so these are not owned by an app folder."}
+            </span>
+          </div>
+          {onDelete && (
+            <Button
+              variant="warning"
+              size="xs"
+              icon={Trash01}
+              label="Delete"
+              tooltip="Delete this app and everything it owns"
+              onClick={onDelete}
+            />
+          )}
         </div>
 
         {app.collidingFolderNames.length > 0 && (

--- a/front/components/pod/apps/PodAppsTab.tsx
+++ b/front/components/pod/apps/PodAppsTab.tsx
@@ -1,9 +1,11 @@
+import { DeletePodAppDialog } from "@app/components/pod/apps/DeletePodAppDialog";
 import { PodAppDetail } from "@app/components/pod/apps/PodAppDetail";
 import { PodAppList } from "@app/components/pod/apps/PodAppList";
 import { PodFrameSheet } from "@app/components/pod/files/PodFrameSheet";
 import type { CustomResourceIconType } from "@app/components/resources/resources_icon_names";
 import { usePodApps } from "@app/lib/swr/pods";
-import type { PodAppFrame } from "@app/types/api/pod_apps";
+import type { PodApp, PodAppFrame } from "@app/types/api/pod_apps";
+import { UNFILED_POD_APP_PREFIX } from "@app/types/api/pod_apps";
 import { DEFAULT_POD_FRAME_TAB_ICON } from "@app/types/pod_frame_tab";
 import type { PodType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
@@ -23,8 +25,13 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
     podId: pod.sId,
   });
 
+  const canDelete = pod.isEditor && !pod.archivedAt;
+
   const [selectedPrefix, setSelectedPrefix] = useState<string | null>(null);
   const [framePreview, setFramePreview] = useState<PodAppFrame | null>(null);
+  const [appPendingDeletion, setAppPendingDeletion] = useState<PodApp | null>(
+    null
+  );
 
   const iconByFramePath = useMemo(
     () =>
@@ -83,9 +90,30 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
       </div>
       <div className="min-w-0 flex-1">
         {selectedApp && (
-          <PodAppDetail app={selectedApp} onOpenFrame={setFramePreview} />
+          <PodAppDetail
+            app={selectedApp}
+            onOpenFrame={setFramePreview}
+            // The unfiled app is a presentation device, not a folder, so there is nothing
+            // coherent to delete.
+            onDelete={
+              canDelete && selectedApp.prefix !== UNFILED_POD_APP_PREFIX
+                ? () => setAppPendingDeletion(selectedApp)
+                : undefined
+            }
+          />
         )}
       </div>
+
+      {appPendingDeletion && (
+        <DeletePodAppDialog
+          key={appPendingDeletion.prefix}
+          owner={owner}
+          podId={pod.sId}
+          app={appPendingDeletion}
+          isOpen
+          onClose={() => setAppPendingDeletion(null)}
+        />
+      )}
 
       <PodFrameSheet
         owner={owner}

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -1,14 +1,18 @@
 import { DustFileSystem } from "@app/lib/api/file_system";
 import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
 import { getPodStateBasePath } from "@app/lib/api/files/mount_path";
+import { deleteProjectFile } from "@app/lib/api/projects/context";
+import { deletePodDatabaseReplica } from "@app/lib/api/sandbox/db";
 import {
   appPrefixFromPodDatabaseName,
   podDatabaseNameWithoutAppPrefix,
 } from "@app/lib/api/sandbox_functions/db_naming";
+import { deleteDatabaseOnSandbox } from "@app/lib/api/sandbox_functions/dsbx_db";
 import {
   normalizeAppPrefix,
   SANDBOX_FUNCTION_SLUG_SEPARATOR,
 } from "@app/lib/api/sandbox_functions/slug";
+import { unpublishSandboxFunction } from "@app/lib/api/sandbox_functions/unpublish_sandbox_function";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -25,16 +29,11 @@ import type {
   PodAppFrame,
   PodAppFunction,
 } from "@app/types/api/pod_apps";
+import { UNFILED_POD_APP_PREFIX } from "@app/types/api/pod_apps";
 import { isInteractiveContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-
-/**
- * The prefix of the synthetic app collecting everything published from the pod root, which has no
- * app folder (`deriveAppPrefix` returns null for those paths). Empty so it can never collide with a
- * real prefix, which `normalizeAppPrefix` guarantees is non-empty.
- */
-export const UNFILED_POD_APP_PREFIX = "";
+import { removeNulls } from "@app/types/shared/utils/general";
 
 /** A litestream replica directory is named after the database file it replicates. */
 const POD_DATABASE_FILE_SUFFIX = ".db";
@@ -459,4 +458,162 @@ export async function listPodApps(
   }
 
   return new Ok(apps);
+}
+
+export type PodAppDeleteErrorCode =
+  | "not_a_pod"
+  | "not_found"
+  | "cannot_delete_unfiled"
+  | "sandbox_unavailable"
+  | "internal";
+
+export class PodAppDeleteError extends Error {
+  constructor(
+    readonly code: PodAppDeleteErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "PodAppDeleteError";
+  }
+}
+
+export interface DeletePodAppResult {
+  prefix: string;
+  name: string | null;
+  deletedFunctionSlugs: string[];
+  deletedDatabaseNames: string[];
+  deletedFolderNames: string[];
+}
+
+/**
+ * Delete a Pod app: its published functions, its databases (live files and replicas), its shared
+ * Frames and pinned tabs, and finally its source folder.
+ *
+ * **The step order is the design.** Two constraints fix it:
+ *
+ *  - Functions go first, so no invocation can arrive while the data underneath it is being removed.
+ *  - A database's live files must go before its replica, because a running litestream keeps
+ *    replicating a database it can still see (the same hazard the pod-scrub path notes).
+ *
+ * And the source folder goes LAST on purpose. Every step is idempotent, and the folder is what makes
+ * the app appear in the Apps tab, so a failure part-way through leaves the app still listed and
+ * simply re-deletable. Deleting the folder first would instead leave an invisible half-deleted app.
+ *
+ * Deleting databases needs a live sandbox, so this wakes a sleeping pod (`execDbCommand` does it) and
+ * can take as long as a cold start.
+ */
+export async function deletePodApp(
+  auth: Authenticator,
+  pod: SpaceResource,
+  prefix: string
+): Promise<Result<DeletePodAppResult, PodAppDeleteError>> {
+  if (!pod.isProject()) {
+    return new Err(
+      new PodAppDeleteError("not_a_pod", "Apps only exist on Pod spaces.")
+    );
+  }
+
+  // The unfiled app is a presentation device, not a folder: its artifacts each belong to whoever
+  // published them at the pod root, so there is nothing coherent to delete.
+  if (prefix === UNFILED_POD_APP_PREFIX) {
+    return new Err(
+      new PodAppDeleteError(
+        "cannot_delete_unfiled",
+        "Artifacts published outside an app folder cannot be deleted as an app."
+      )
+    );
+  }
+
+  const appsResult = await listPodApps(auth, pod);
+  if (appsResult.isErr()) {
+    return new Err(new PodAppDeleteError("internal", appsResult.error.message));
+  }
+
+  const app = appsResult.value.find((candidate) => candidate.prefix === prefix);
+  if (!app) {
+    return new Err(
+      new PodAppDeleteError("not_found", `No app '${prefix}' in this Pod.`)
+    );
+  }
+
+  // 1. Unpublish first: stop new invocations before their data goes away.
+  for (const fn of app.functions) {
+    const unpublishResult = await unpublishSandboxFunction(auth, {
+      space: pod,
+      slug: fn.slug,
+    });
+    // Already gone is fine — this whole flow is meant to be safe to retry.
+    if (unpublishResult.isErr() && unpublishResult.error.code !== "not_found") {
+      return new Err(
+        new PodAppDeleteError("internal", unpublishResult.error.message)
+      );
+    }
+  }
+
+  // 2. Live database files, then 3. their replicas. Wakes the pod if it is asleep.
+  for (const database of app.databases) {
+    const deleteLiveResult = await deleteDatabaseOnSandbox(auth, {
+      space: pod,
+      database: database.onDiskName,
+    });
+    if (deleteLiveResult.isErr()) {
+      return new Err(
+        new PodAppDeleteError(
+          deleteLiveResult.error.code === "sandbox_unavailable"
+            ? "sandbox_unavailable"
+            : "internal",
+          deleteLiveResult.error.message
+        )
+      );
+    }
+
+    const deleteReplicaResult = await deletePodDatabaseReplica(auth, pod, {
+      database: database.onDiskName,
+    });
+    if (deleteReplicaResult.isErr()) {
+      return new Err(
+        new PodAppDeleteError("internal", deleteReplicaResult.error.message)
+      );
+    }
+  }
+
+  // 4. Drop the Frames' pinned tabs before their files go, mirroring the delete_frame poke plugin.
+  const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+  if (metadata) {
+    for (const frame of app.frames) {
+      if (frame.isPinnedAsTab) {
+        await metadata.removeFramePath(frame.path);
+      }
+    }
+  }
+
+  // 5. Source folder last. `deleteProjectFile` recurses and deletes each FileResource underneath,
+  // which is what revokes the Frames' share tokens along with them. Colliding folders all normalize
+  // onto this one prefix, so every one of them belongs to the app being deleted.
+  const folderNames =
+    app.collidingFolderNames.length > 0
+      ? app.collidingFolderNames
+      : removeNulls([app.name]);
+  for (const folderName of folderNames) {
+    const deleteFolderResult = await deleteProjectFile(auth, {
+      space: pod,
+      relativeFilePath: folderName,
+    });
+    if (deleteFolderResult.isErr()) {
+      return new Err(
+        new PodAppDeleteError("internal", deleteFolderResult.error.message)
+      );
+    }
+  }
+
+  const deletedFunctionSlugs = app.functions.map((fn) => fn.slug);
+  const deletedDatabaseNames = app.databases.map((db) => db.onDiskName);
+
+  return new Ok({
+    prefix: app.prefix,
+    name: app.name,
+    deletedFunctionSlugs,
+    deletedDatabaseNames,
+    deletedFolderNames: folderNames,
+  });
 }

--- a/front/lib/api/sandbox/db.ts
+++ b/front/lib/api/sandbox/db.ts
@@ -722,3 +722,52 @@ export async function deletePodStatePrefix(
     return new Err(normalizeError(err));
   }
 }
+
+/**
+ * Delete ONE database's litestream replica: the GCS prefix the directory watcher keys on that
+ * database's filename.
+ *
+ * The replica is the durable copy of a pod database, and `setupPodStateOnColdStart` restores every
+ * replica it finds. So a replica that survives resurrects a database whose live files were deleted —
+ * which makes this the step that actually makes a database deletion stick.
+ *
+ * Call it AFTER the live files are gone: a running litestream keeps replicating a database it can
+ * still see, so wiping the prefix first just gets it recreated. The delete is verified by re-listing,
+ * because a silently-surviving replica is indistinguishable from success until the pod next boots.
+ */
+export async function deletePodDatabaseReplica(
+  auth: Authenticator,
+  space: SpaceResource,
+  { database }: { database: string }
+): Promise<Result<void, Error>> {
+  if (!isValidPodDatabaseName(database)) {
+    return new Err(new Error(`Invalid pod database name: '${database}'.`));
+  }
+
+  const statePrefix = getPodStateBasePath({
+    workspaceId: auth.getNonNullableWorkspace().sId,
+    podId: space.sId,
+  });
+  const replicaDirName = `${database}.db`;
+
+  try {
+    const bucket = getPrivateUploadBucket();
+    await bucket.deleteByPrefix(`${statePrefix}${replicaDirName}/`);
+
+    const remaining = await bucket.listSubdirectoryNames({
+      prefix: statePrefix,
+    });
+    if (remaining.includes(replicaDirName)) {
+      return new Err(
+        new Error(
+          `Replica of pod database '${database}' still present after deletion; ` +
+            "the database would be restored on the pod's next cold start."
+        )
+      );
+    }
+
+    return new Ok(undefined);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}

--- a/front/lib/api/sandbox_functions/dsbx_db.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.ts
@@ -3,10 +3,12 @@ import path from "node:path";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
 import {
+  POD_SANDBOX_DATABASES_DIR,
   podDatabaseExecEnvVars,
   TOOL_OUTPUTS_FOLDER_NAME,
 } from "@app/lib/api/files/mount_path";
 import { getRedisStreamClient } from "@app/lib/api/redis";
+import { isValidPodDatabaseName } from "@app/lib/api/sandbox/db";
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import {
@@ -327,6 +329,92 @@ export async function reconcileDatabaseFromPodPath(
   } finally {
     await distributedUnlock(client, lockName, lockValue);
   }
+}
+
+/** Absolute path so the command never resolves `rm` through a workload-influenced PATH. */
+const RM_BIN_PATH = "/bin/rm";
+
+/**
+ * SQLite sidecars that belong to a database file and must go with it. `@dust/pod` runs with
+ * `wal_autocheckpoint=0`, so recent rows can live entirely in `-wal`: leaving it behind would let a
+ * later reconcile of the same name recover data this delete was meant to destroy.
+ */
+const POD_DATABASE_SIDECAR_SUFFIXES = ["-wal", "-shm"];
+
+// `rm` prints nothing on success, so the command appends the envelope itself. Under `set -euo
+// pipefail` a failed `rm` never reaches the echo, leaving no envelope for parseDbEnvelope to find —
+// which is what turns the failure into an error rather than a silent success.
+const deleteEnvelopeSchema = z.union([
+  z.object({ ok: z.literal(true) }),
+  dbErrorEnvelopeSchema,
+]);
+
+/**
+ * Remove a live pod database and its SQLite sidecars from the databases directory.
+ *
+ * Deliberately NOT a dsbx subcommand: dsbx is the agent-facing CLI, and a destructive database
+ * primitive there would be discoverable from inside the sandbox. Front builds the command instead, so
+ * this adds no surface a workload can reach. It grants no new capability either — the databases dir is
+ * group-writable by `agent` (mode 2770), so workload code can already unlink its own database files.
+ *
+ * Idempotent: `rm -f` succeeds when the files are already gone, so a caller working from a replica
+ * listing never has to check what is live first.
+ *
+ * Only the LIVE files go. The litestream replica is the durable copy, so a caller deleting a database
+ * for good must also wipe its replica prefix (`deletePodDatabaseReplica`), or the next cold-start
+ * restore brings the database back.
+ */
+export async function deleteDatabaseOnSandbox(
+  auth: Authenticator,
+  { space, database }: { space: SpaceResource; database: string }
+): Promise<Result<void, SandboxFunctionError>> {
+  // The name contract (`^[a-z][a-z0-9_]{0,63}$`) admits no separator or dot, so a validated name
+  // cannot escape the databases directory. The same guard runs on the replica path.
+  if (!isValidPodDatabaseName(database)) {
+    return new Err(
+      new SandboxFunctionError(
+        "internal",
+        `Invalid pod database name: '${database}'.`
+      )
+    );
+  }
+
+  const dbPath = `${POD_SANDBOX_DATABASES_DIR}/${database}.db`;
+  // `rm` unlinks a symlink itself rather than following it, so a link planted in the
+  // workload-writable databases dir cannot make this reach a foreign file.
+  const paths = [
+    dbPath,
+    ...POD_DATABASE_SIDECAR_SUFFIXES.map((suffix) => `${dbPath}${suffix}`),
+  ].map((path) => shellEscape(path));
+
+  const result = await execDbCommand(auth, space, {
+    // `--` stops the paths from being read as flags.
+    command: [
+      "set -euo pipefail",
+      `${RM_BIN_PATH} -f -- ${paths.join(" ")}`,
+      `echo '{"ok":true}'`,
+    ].join("\n"),
+    schema: deleteEnvelopeSchema,
+    what: `remove pod database ${database}`,
+  });
+  if (result.isErr()) {
+    return result;
+  }
+  const { envelope } = result.value;
+
+  if ("ok" in envelope && envelope.ok) {
+    logger.info(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        podId: space.sId,
+        database,
+      },
+      "Pod database deleted: removed live files"
+    );
+    return new Ok(undefined);
+  }
+
+  return new Err(dbErrorToSandboxFunctionError(database, envelope, "internal"));
 }
 
 // Success mirrors the `dsbx db list` envelope in cli/dust-sandbox/src/commands/db/list.rs.

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -141,6 +141,54 @@ export function usePodApps({
   };
 }
 
+export function useDeletePodApp({
+  owner,
+  podId,
+}: {
+  owner: LightWorkspaceType;
+  podId: string;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutatePodApps } = usePodApps({ owner, podId, disabled: true });
+
+  return async (app: PodApp): Promise<Result<void, Error>> => {
+    const appName = app.name ?? app.prefix;
+
+    try {
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/pods/${podId}/apps/${encodeURIComponent(app.prefix)}`,
+        { method: "DELETE" }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: `Failed to delete ${appName}`,
+          description: errorData.message,
+        });
+        return new Err(new Error(errorData.message));
+      }
+
+      sendNotification({
+        type: "success",
+        title: `${appName} deleted`,
+      });
+      await mutatePodApps();
+
+      return new Ok(undefined);
+    } catch (e) {
+      const errorMessage = normalizeError(e).message;
+      sendNotification({
+        type: "error",
+        title: `Failed to delete ${appName}`,
+        description: errorMessage,
+      });
+      return new Err(new Error(errorMessage));
+    }
+  };
+}
+
 export function usePodFiles({
   owner,
   podId,

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -52,6 +52,9 @@ class FileStorageMock {
   ) => { name: string; metadata: Record<string, unknown> }[] | null = () =>
     null;
   private _subdirectoryNames: (prefix: string) => string[] | null = () => null;
+  private _deletedPrefixes: string[] = [];
+  private _onDeleteByPrefix: (prefix: string) => void = () => {};
+  private _ignoreDeleteByPrefixInListings = false;
 
   get writeStreamCalls(): readonly WriteStreamCall[] {
     return this._writeStreamCalls;
@@ -140,6 +143,22 @@ class FileStorageMock {
   }
 
   /**
+   * Observe every `bucket.deleteByPrefix(prefix)` call, e.g. to assert the order of a delete
+   * sequence. Reset between tests via `reset()`.
+   */
+  setOnDeleteByPrefix(fn: (prefix: string) => void): void {
+    this._onDeleteByPrefix = fn;
+  }
+
+  /**
+   * Make `listSubdirectoryNames` ignore prior `deleteByPrefix` calls, so a prefix keeps being listed
+   * after it was deleted. Simulates a silently-failed prefix wipe. Reset between tests via `reset()`.
+   */
+  setIgnoreDeleteByPrefixInListings(ignore: boolean): void {
+    this._ignoreDeleteByPrefixInListings = ignore;
+  }
+
+  /**
    * Makes `fetchFileContent(path)` throw a GCS-shaped not-found error
    * (`{ code: 404 }`) for matching paths that were not previously written via
    * `uploadRawContentToBucket` and have no `setFileContent` override. Enables
@@ -174,6 +193,9 @@ class FileStorageMock {
     this._copyFileShouldFail = () => false;
     this._filesByPrefix = () => null;
     this._subdirectoryNames = () => null;
+    this._deletedPrefixes.length = 0;
+    this._onDeleteByPrefix = () => {};
+    this._ignoreDeleteByPrefixInListings = false;
   }
 
   /**
@@ -333,6 +355,8 @@ class FileStorageMock {
         return Promise.resolve(undefined);
       }),
       deleteByPrefix: vi.fn(async (prefix: string) => {
+        this._deletedPrefixes.push(prefix);
+        this._onDeleteByPrefix(prefix);
         for (const path of [...this._objectStore.keys()]) {
           if (path.startsWith(prefix)) {
             this._objectStore.delete(path);
@@ -346,9 +370,16 @@ class FileStorageMock {
           pageFetchCount: 1,
         })
       ),
-      listSubdirectoryNames: vi.fn(({ prefix }: { prefix: string }) =>
-        Promise.resolve(this._subdirectoryNames(prefix) ?? [])
-      ),
+      listSubdirectoryNames: vi.fn(({ prefix }: { prefix: string }) => {
+        const normalized = prefix.endsWith("/") ? prefix : `${prefix}/`;
+        const names = (this._subdirectoryNames(prefix) ?? []).filter(
+          (name) =>
+            this._ignoreDeleteByPrefixInListings ||
+            (!this._deletedPrefixes.includes(`${normalized}${name}/`) &&
+              !this._deletedPrefixes.includes(normalized))
+        );
+        return Promise.resolve(names);
+      }),
       getSortedFileVersions: vi.fn(({ filePath }: { filePath: string }) =>
         Promise.resolve(new Ok(this._sortedFileVersions(filePath) ?? []))
       ),

--- a/front/types/api/pod_apps.ts
+++ b/front/types/api/pod_apps.ts
@@ -1,4 +1,5 @@
 import type { SandboxFunctionExecutionMode } from "@app/types/api/sandbox_functions";
+import { z } from "zod";
 
 /**
  * A Pod app is a folder at the pod root that owns a Frame, published functions and databases. It has
@@ -6,6 +7,14 @@ import type { SandboxFunctionExecutionMode } from "@app/types/api/sandbox_functi
  * computes from the folder name — the same prefix that already namespaces published function slugs
  * and database filenames. So these types describe a view assembled at read time, never stored.
  */
+
+/**
+ * The prefix of the synthetic app collecting everything published from the pod root, which has no app
+ * folder. Empty so it can never collide with a real prefix, which `normalizeAppPrefix` guarantees is
+ * non-empty. Lives here rather than in `lib/api` so components can branch on it without pulling
+ * server-only modules into the browser bundle.
+ */
+export const UNFILED_POD_APP_PREFIX = "";
 
 export type PodAppFrame = {
   /** sId of the Frame's FileResource, or null for a source file with no row yet. */
@@ -63,4 +72,26 @@ export type PodApp = {
 
 export type GetPodAppsResponseBody = {
   apps: PodApp[];
+};
+
+/**
+ * An app's prefix is its identifier — apps have no sId, since the folder is the app. Constrained to
+ * what `normalizeAppPrefix` can produce, so a path segment can never smuggle anything else in.
+ */
+export const DeletePodAppParamsSchema = z.object({
+  prefix: z
+    .string()
+    .min(1)
+    .max(128)
+    .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/),
+});
+
+export type DeletePodAppResponseBody = {
+  app: {
+    prefix: string;
+    name: string | null;
+    deletedFunctionSlugs: string[];
+    deletedDatabaseNames: string[];
+    deletedFolderNames: string[];
+  };
 };


### PR DESCRIPTION
## Description

Completes the other half of the original ask (#30334 added the Apps tab; this deletes one). An app delete removes its published functions, its databases — live files *and* replicas — its shared Frames and pinned tabs, and finally its source folder.

## The step order is the design

Two constraints fix it, and both are easy to get wrong:

1. **Functions first.** Unpublishing before touching data means no invocation can arrive while the data underneath it is being removed.
2. **Live database files before replicas.** A running litestream re-replicates a database it can still see, so wiping the replica prefix first just gets it recreated — the same hazard the pod-scrub path already notes.

**And the source folder goes last, deliberately.** Every step is idempotent, and the folder is what makes the app appear in the Apps tab. So a failure part-way through leaves the app *still listed and simply re-deletable* — retry is clicking Delete again. Deleting the folder first would invert that into an invisible half-deleted app. Both orderings are pinned by tests.

## UX

Removing databases needs a live sandbox, so a sleeping pod is woken and the dialog says so rather than showing a bare spinner through a cold start.

The confirmation names what goes — functions, databases, Frames, file count — rather than only counting it, and warns separately about data that cannot be recovered and about published Frame links that will break. It requires typing `delete`, following `DeletePodDialog`.

Deletion is refused for the synthetic **unfiled** app: it is a presentation device, not a folder, and its artifacts each belong to whoever published them at the pod root, so there is nothing coherent to delete.

## Risk

Medium — it destroys data by design. Mitigated by the ordering above (a partial failure is visible and retryable rather than silent), the replica verification, and the typed confirmation. Reads and the Apps tab itself are untouched. No sandbox image or dsbx release is involved.

## Tests

Six functional tests on the endpoint: the happy path asserting the function row is gone and that the database file plus both sidecars are removed by on-disk path, the live-before-replica ordering, the surviving-replica failure, 404 for an unknown app, refusal for pod-root artifacts (asserting the function survives), and rejection of a non-app-shaped prefix. Existing suite green on the current `main` base: the 8 GET tests from #30334, plus 64 front tests across `lib/api/projects` and the audit schema checks.
