### PR TITLE
[front] enh: display skills in conversation credit breakdown

### DIFF
--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -185,6 +185,24 @@
  *         attributedCredits:
  *           type: number
  *           description: Model attribution after reconciling exclusively through its input rows.
+ *     PrivateConversationConsumptionSkillDetails:
+ *       type: object
+ *       required:
+ *         - skillId
+ *         - name
+ *         - icon
+ *         - attributedCredits
+ *       properties:
+ *         skillId:
+ *           type: string
+ *         name:
+ *           type: string
+ *         icon:
+ *           type: string
+ *           nullable: true
+ *         attributedCredits:
+ *           type: number
+ *           description: Full credits of tool calls attributed to this skill. A call can be attributed to multiple skills, so skill credits can overlap.
  *     PrivateConversationConsumptionAgentDetails:
  *       type: object
  *       required:
@@ -232,6 +250,11 @@
  *           type: array
  *           items:
  *             $ref: '#/components/schemas/PrivateConversationConsumptionToolDetails'
+ *         skills:
+ *           type: array
+ *           description: Skills responsible for tool calls in the conversation. Optional for compatibility with older responses.
+ *           items:
+ *             $ref: '#/components/schemas/PrivateConversationConsumptionSkillDetails'
  *         models:
  *           type: array
  *           items:

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.test.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.test.tsx
@@ -45,6 +45,14 @@ describe("ConversationCreditUsageBreakdown", () => {
           attributedCredits: 15,
         },
       ],
+      skills: [
+        {
+          skillId: "skill_1",
+          name: "Research skill",
+          icon: null,
+          attributedCredits: 2.5,
+        },
+      ],
       agents: [
         {
           agentId: "agent_1",
@@ -73,6 +81,9 @@ describe("ConversationCreditUsageBreakdown", () => {
     expect(screen.getByText("2 uses")).toBeInTheDocument();
     expect(screen.getByText("GPT-5 Mini")).toBeInTheDocument();
     expect(screen.getByText("15 credits")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Skills" })).toBeInTheDocument();
+    expect(screen.getByText("Research skill")).toBeInTheDocument();
+    expect(screen.getByText("2.5 credits")).toBeInTheDocument();
     expect(screen.queryByText("Research agent")).not.toBeInTheDocument();
   });
 

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
@@ -7,10 +7,12 @@ import {
   formatCreditValue,
   toolUsageLabel,
 } from "@app/lib/client/credits";
+import { getSkillAvatarIcon } from "@app/lib/skill";
 import type {
   ConversationConsumptionAgentDetails,
   ConversationConsumptionDetails,
   ConversationConsumptionModelDetails,
+  ConversationConsumptionSkillDetails,
   ConversationConsumptionToolDetails,
 } from "@app/types/assistant/conversation_consumption";
 import { pluralize } from "@app/types/shared/utils/string_utils";
@@ -167,6 +169,49 @@ function ModelsBreakdown({ isDark, models }: ModelsBreakdownProps) {
   );
 }
 
+interface SkillRowProps {
+  skill: ConversationConsumptionSkillDetails;
+}
+
+function SkillRow({ skill }: SkillRowProps) {
+  const SkillAvatar = getSkillAvatarIcon(skill.icon);
+
+  return (
+    <div className="flex min-w-0 items-center justify-between gap-3 rounded-xl border border-border bg-background p-2">
+      <div className="flex min-w-0 items-center gap-2">
+        <SkillAvatar size="xs" />
+        <span className="truncate text-base font-medium text-foreground">
+          {skill.name}
+        </span>
+      </div>
+      <span className="shrink-0 text-base font-semibold text-muted-foreground">
+        {formatCreditValue(skill.attributedCredits)}
+      </span>
+    </div>
+  );
+}
+
+interface SkillsBreakdownProps {
+  skills: ConversationConsumptionSkillDetails[];
+}
+
+function SkillsBreakdown({ skills }: SkillsBreakdownProps) {
+  if (skills.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-4">
+      <h3 className="text-xs font-semibold text-muted-foreground">Skills</h3>
+      <div className="space-y-2">
+        {skills.map((skill) => (
+          <SkillRow key={skill.skillId} skill={skill} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
 interface AgentBreakdownProps {
   agent: ConversationConsumptionAgentDetails;
 }
@@ -228,6 +273,8 @@ export function ConversationCreditUsageBreakdown({
           tools={details.tools}
         />
       </section>
+
+      <SkillsBreakdown skills={details.skills ?? []} />
 
       <ModelsBreakdown isDark={isDark} models={details.models} />
 

--- a/front/lib/analytics/agent_message_consumption/tool_documents.ts
+++ b/front/lib/analytics/agent_message_consumption/tool_documents.ts
@@ -8,47 +8,11 @@ import type {
   BilledRunUsage,
 } from "@app/lib/analytics/agent_message_consumption/load";
 import type { MessageConsumptionAllocation } from "@app/lib/api/assistant/agent_message_consumption_attribution/allocation";
+import { skillIdsAttributedToAction } from "@app/lib/api/assistant/agent_message_consumption_attribution/skill_attribution";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { AgentMessageToolConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
-import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { AgentMessageConsumptionAnalyticsToolData } from "@app/types/assistant/analytics";
 import assert from "assert";
-
-function skillExposesAction(
-  skill: SkillResource,
-  action: AgentMCPActionResource
-): boolean {
-  const toolServerId = action.toolConfiguration.toolServerId;
-  const toolName = action.toJSON().toolName;
-
-  return skill.mcpServerConfigurations.some(({ view }) => {
-    if (view.mcpServerId !== toolServerId) {
-      return false;
-    }
-
-    // If the server disables the tool, the skill cannot expose it.
-    return !view.getToolPermissions.some(
-      (permission) => permission.toolName === toolName && !permission.enabled
-    );
-  });
-}
-
-function skillIdsAttributedToAction(
-  skills: SkillResource[],
-  action: AgentMCPActionResource,
-  enabledSkillIds: string[]
-): string[] {
-  // Attribute every skill that exposes the tool and any skill enabled by the action.
-  // The tool document keeps its full credit amount instead of splitting it across these skills.
-  return [
-    ...new Set([
-      ...skills
-        .filter((skill) => skillExposesAction(skill, action))
-        .map((skill) => skill.sId),
-      ...enabledSkillIds,
-    ]),
-  ];
-}
 
 function serverNameForAction(action: AgentMCPActionResource): string {
   const serializedAction = action.toJSON();

--- a/front/lib/api/assistant/agent_message_consumption_attribution/conversation_read.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/conversation_read.test.ts
@@ -2,12 +2,16 @@ import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assi
 import { getConversationConsumption } from "@app/lib/api/assistant/agent_message_consumption_attribution/conversation_read";
 import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { RunFactory } from "@app/tests/utils/RunFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import type { ModelId } from "@app/types/shared/model_id";
 import { describe, expect, it } from "vitest";
 
@@ -16,7 +20,11 @@ const PREVIOUS_ATTRIBUTION_VERSION =
   AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION - 1;
 
 async function setupMessage() {
-  const { authenticator: auth, workspace } = await createResourceTest({});
+  const {
+    authenticator: auth,
+    globalSpace,
+    workspace,
+  } = await createResourceTest({});
   const agentConfiguration = await AgentConfigurationFactory.createTestAgent(
     auth,
     { name: `Consumption ${generateRandomModelSId()}` }
@@ -55,6 +63,7 @@ async function setupMessage() {
 
   return {
     auth,
+    globalSpace,
     workspace,
     conversation,
     run,
@@ -88,15 +97,49 @@ function modelRecords(runUsageModelId: ModelId) {
 }
 
 describe("getConversationConsumption", () => {
-  it("aggregates the exact bill and active attribution by tool, model, and agent", async () => {
+  it("aggregates the exact bill and active attribution by tool, skill, model, and agent", async () => {
     const {
       auth,
+      globalSpace,
       workspace,
       conversation,
       run,
       runUsageModelId,
       agentMessage,
+      agentConfiguration,
     } = await setupMessage();
+    const server = await RemoteMCPServerFactory.create(workspace, {
+      description: "Conversation consumption skill server",
+      name: "Conversation consumption skill server",
+      tools: [
+        {
+          name: "test_tool",
+          description: "Test tool",
+          inputSchema: undefined,
+        },
+      ],
+    });
+    const serverView = await MCPServerViewFactory.create(
+      workspace,
+      server.sId,
+      globalSpace
+    );
+    const skill = await SkillFactory.create(auth, {
+      name: "Research skill",
+      mcpServerViews: [serverView],
+    });
+    const enabledSkill = await skill.upsertToConversation(auth, {
+      conversationId: conversation.id,
+      enabled: true,
+    });
+    if (enabledSkill.isErr()) {
+      throw new Error("Skill could not be enabled for the test conversation");
+    }
+    await SkillResource.snapshotConversationSkillsForMessage(auth, {
+      agentConfigurationId: agentConfiguration.sId,
+      agentMessageId: agentMessage.agentMessageId,
+      conversationId: conversation.id,
+    });
     const { action } = await AgentMCPActionFactory.create(auth, {
       workspace,
       conversationModelId: conversation.id,
@@ -104,6 +147,7 @@ describe("getConversationConsumption", () => {
       status: "succeeded",
       dustRunId: run.dustRunId,
       step: 1,
+      toolServerId: server.sId,
     });
     await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
       conversation,
@@ -148,6 +192,13 @@ describe("getConversationConsumption", () => {
             attributedCredits: BILLED_CREDITS,
             modelId: "gpt-5-mini",
             providerId: "openai",
+          },
+        ],
+        skills: [
+          {
+            skillId: skill.sId,
+            name: "Research skill",
+            attributedCredits: 5,
           },
         ],
         agents: [

--- a/front/lib/api/assistant/agent_message_consumption_attribution/conversation_read.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/conversation_read.ts
@@ -21,6 +21,7 @@ import type {
   ConversationConsumptionSkillDetails,
   ConversationConsumptionToolDetails,
 } from "@app/types/assistant/conversation_consumption";
+import type { ModelId } from "@app/types/shared/model_id";
 
 type MessageDetailsEntry = {
   message: ConversationConsumptionMessageFacts;
@@ -169,7 +170,7 @@ export async function getConversationConsumption(
         serialized.toolName === ENABLE_SKILL_TOOL_NAME
       );
     });
-  const [runs, skillsByAgentMessageId, enableSkillActionsWithOutputs] =
+  const [runs, agentMessageSkills, enableSkillActionsWithOutputs] =
     await Promise.all([
       RunResource.listByDustRunIds(auth, { dustRunIds }),
       SkillResource.listByAgentMessageIds(
@@ -183,6 +184,12 @@ export async function getConversationConsumption(
       }),
     ]);
   const usages = await RunResource.listRunUsagesForRuns(auth, { runs });
+  const skillsByAgentMessageId = new Map<ModelId, SkillResource[]>();
+  for (const { agentMessageId, skill } of agentMessageSkills) {
+    const skills = skillsByAgentMessageId.get(agentMessageId) ?? [];
+    skills.push(skill);
+    skillsByAgentMessageId.set(agentMessageId, skills);
+  }
   const enabledSkillIdsByActionId = new Map(
     enableSkillActionsWithOutputs.flatMap((action) => {
       const skillIds = getEnabledSkillIdsFromAction(action);

--- a/front/lib/api/assistant/agent_message_consumption_attribution/conversation_read.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/conversation_read.ts
@@ -1,18 +1,24 @@
+import { ENABLE_SKILL_TOOL_NAME } from "@app/lib/actions/constants";
+import { SKILL_MANAGEMENT_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
+import { getEnabledSkillIdsFromAction } from "@app/lib/api/assistant/agent_message_consumption_attribution/enabled_skill_footprint";
 import type { MessageConsumptionDetails } from "@app/lib/api/assistant/agent_message_consumption_attribution/message_details";
 import { buildLatestAvailableMessageConsumptionDetails } from "@app/lib/api/assistant/agent_message_consumption_attribution/message_details";
 import { resolveAnalyticsAgentLabels } from "@app/lib/api/assistant/observability/agent_labels";
 import type { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { ConversationConsumptionMessageFacts } from "@app/lib/resources/agent_message_consumption_item_resource";
 import { AgentMessageConsumptionItemResource as ConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { isTerminalAgentMessageStatus } from "@app/types/assistant/conversation";
 import type {
   ConversationConsumptionAgentDetails,
   ConversationConsumptionDetails,
   ConversationConsumptionModelDetails,
   ConversationConsumptionResponse,
+  ConversationConsumptionSkillDetails,
   ConversationConsumptionToolDetails,
 } from "@app/types/assistant/conversation_consumption";
 
@@ -72,9 +78,39 @@ function mergeModelDetails(
   );
 }
 
+function mergeSkillDetails(
+  skillGroups: MessageConsumptionDetails["skills"][],
+  skillsById: ReadonlyMap<string, SkillResource>
+): ConversationConsumptionSkillDetails[] {
+  const skillCredits = new Map<string, number>();
+
+  for (const skill of skillGroups.flat()) {
+    skillCredits.set(
+      skill.skillId,
+      (skillCredits.get(skill.skillId) ?? 0) + skill.attributedCredits
+    );
+  }
+
+  return [...skillCredits.entries()]
+    .map(([skillId, attributedCredits]) => {
+      const skill = skillsById.get(skillId);
+
+      return {
+        skillId,
+        name: skill?.name ?? "Unknown skill",
+        icon: skill?.icon ?? null,
+        attributedCredits,
+      };
+    })
+    .sort((left, right) => right.attributedCredits - left.attributedCredits);
+}
+
 function aggregateMessageDetails(
   details: MessageConsumptionDetails[]
-): Omit<ConversationConsumptionDetails, "agents"> {
+): Pick<
+  ConversationConsumptionDetails,
+  "agentWorkCredits" | "models" | "tools"
+> {
   return {
     agentWorkCredits: details.reduce(
       (total, detail) => total + detail.agentWorkCredits,
@@ -123,8 +159,37 @@ export async function getConversationConsumption(
   const dustRunIds = [
     ...new Set(billedMessages.flatMap((message) => message.dustRunIds)),
   ];
-  const runs = await RunResource.listByDustRunIds(auth, { dustRunIds });
+  const enableSkillActions = billedMessages
+    .flatMap((message) => message.actions)
+    .filter((action) => {
+      const serialized = action.toJSON();
+
+      return (
+        serialized.internalMCPServerName === SKILL_MANAGEMENT_SERVER_NAME &&
+        serialized.toolName === ENABLE_SKILL_TOOL_NAME
+      );
+    });
+  const [runs, skillsByAgentMessageId, enableSkillActionsWithOutputs] =
+    await Promise.all([
+      RunResource.listByDustRunIds(auth, { dustRunIds }),
+      SkillResource.listByAgentMessageIds(
+        auth,
+        billedMessages.map((message) => message.agentMessageModelId),
+        { withToolMetadata: true }
+      ),
+      AgentMCPActionResource.enrichActionsWithOutputItems(auth, {
+        actions: enableSkillActions,
+        ignoreContent: false,
+      }),
+    ]);
   const usages = await RunResource.listRunUsagesForRuns(auth, { runs });
+  const enabledSkillIdsByActionId = new Map(
+    enableSkillActionsWithOutputs.flatMap((action) => {
+      const skillIds = getEnabledSkillIdsFromAction(action);
+
+      return skillIds.length > 0 ? [[action.sId, skillIds] as const] : [];
+    })
+  );
 
   const messageDetails: MessageDetailsEntry[] = billedMessages.map(
     (message) => ({
@@ -135,6 +200,8 @@ export async function getConversationConsumption(
         dustRunIds: message.dustRunIds,
         items: message.items,
         runs,
+        enabledSkillIdsByActionId,
+        skills: skillsByAgentMessageId.get(message.agentMessageModelId) ?? [],
         usages,
       }),
     })
@@ -143,6 +210,25 @@ export async function getConversationConsumption(
   if (completeMessageDetails.length !== messageDetails.length) {
     return { billedCredits, details: null };
   }
+  const skillsById = new Map(
+    [...skillsByAgentMessageId.values()]
+      .flat()
+      .map((skill) => [skill.sId, skill])
+  );
+  const missingSkillIds = [
+    ...new Set(
+      completeMessageDetails.flatMap(({ details }) =>
+        details.skills
+          .map((skill) => skill.skillId)
+          .filter((skillId) => !skillsById.has(skillId))
+      )
+    ),
+  ];
+  const missingSkills = await SkillResource.fetchByIds(auth, missingSkillIds);
+  for (const skill of missingSkills) {
+    skillsById.set(skill.sId, skill);
+  }
+
   const detailsByAgentId = new Map<string, typeof completeMessageDetails>();
   for (const entry of completeMessageDetails) {
     const agentId = entry.message.agentConfigurationId;
@@ -183,6 +269,10 @@ export async function getConversationConsumption(
     details: {
       ...aggregateMessageDetails(
         completeMessageDetails.map(({ details }) => details)
+      ),
+      skills: mergeSkillDetails(
+        completeMessageDetails.map(({ details }) => details.skills),
+        skillsById
       ),
       agents,
     },

--- a/front/lib/api/assistant/agent_message_consumption_attribution/message_details.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/message_details.ts
@@ -7,6 +7,7 @@ import type {
   RunResource,
   RunUsageWithRunKeyType,
 } from "@app/lib/resources/run_resource";
+import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { AgentMCPActionType } from "@app/types/actions";
 import type {
   AgentMessageConsumptionDetails,
@@ -17,9 +18,16 @@ import type {
   ReconciledCreditAmounts,
 } from "./allocation";
 import { buildLatestMessageConsumptionAllocation } from "./allocation";
+import { skillIdsAttributedToAction } from "./skill_attribution";
+
+export type MessageConsumptionSkillDetails = {
+  skillId: string;
+  attributedCredits: number;
+};
 
 export type MessageConsumptionDetails = AgentMessageConsumptionDetails & {
   models: AgentMessageConsumptionModelDetails[];
+  skills: MessageConsumptionSkillDetails[];
 };
 
 function buildConsumptionTotals({
@@ -167,12 +175,66 @@ function buildModelDetails({
   );
 }
 
+function buildSkillDetails({
+  actions,
+  enabledSkillIdsByActionId,
+  items,
+  reconciledCreditAmounts,
+  skills,
+}: {
+  actions: AgentMCPActionResource[];
+  enabledSkillIdsByActionId: ReadonlyMap<string, string[]>;
+  items: AgentMessageConsumptionItemResource[];
+  reconciledCreditAmounts: ReconciledCreditAmounts;
+  skills: SkillResource[];
+}): MessageConsumptionSkillDetails[] {
+  const actionByModelId = new Map(actions.map((action) => [action.id, action]));
+  const skillCredits = new Map<string, number>();
+
+  for (const item of items) {
+    if (item.itemType !== "tool" || item.agentMCPActionId === null) {
+      continue;
+    }
+
+    const action = actionByModelId.get(item.agentMCPActionId);
+    if (!action) {
+      continue;
+    }
+
+    const attributedCredits = microCreditsToCredits(
+      reconciledCreditAmounts.byItem.get(item) ?? 0
+    );
+    for (const skillId of skillIdsAttributedToAction(
+      skills,
+      action,
+      enabledSkillIdsByActionId.get(action.sId) ?? []
+    )) {
+      skillCredits.set(
+        skillId,
+        (skillCredits.get(skillId) ?? 0) + attributedCredits
+      );
+    }
+  }
+
+  return [...skillCredits.entries()]
+    .map(([skillId, attributedCredits]) => ({
+      skillId,
+      attributedCredits,
+    }))
+    .filter((skill) => skill.attributedCredits > 0)
+    .sort((left, right) => right.attributedCredits - left.attributedCredits);
+}
+
 function buildMessageConsumptionDetails({
   actions,
   allocation,
+  enabledSkillIdsByActionId,
+  skills,
 }: {
   actions: AgentMCPActionResource[];
   allocation: MessageConsumptionAllocation;
+  enabledSkillIdsByActionId: ReadonlyMap<string, string[]>;
+  skills: SkillResource[];
 }): MessageConsumptionDetails | null {
   const { attributionVersion, items, messageUsages, reconciledCreditAmounts } =
     allocation;
@@ -193,6 +255,13 @@ function buildMessageConsumptionDetails({
       reconciledCreditAmounts,
     }),
     tools,
+    skills: buildSkillDetails({
+      actions,
+      enabledSkillIdsByActionId,
+      items,
+      reconciledCreditAmounts,
+      skills,
+    }),
     models: buildModelDetails({
       items,
       usages: messageUsages,
@@ -208,6 +277,8 @@ export function buildLatestAvailableMessageConsumptionDetails({
   dustRunIds,
   items,
   runs,
+  enabledSkillIdsByActionId = new Map(),
+  skills = [],
   usages,
 }: {
   actions: AgentMCPActionResource[];
@@ -215,6 +286,8 @@ export function buildLatestAvailableMessageConsumptionDetails({
   dustRunIds: string[];
   items: AgentMessageConsumptionItemResource[];
   runs: RunResource[];
+  enabledSkillIdsByActionId?: ReadonlyMap<string, string[]>;
+  skills?: SkillResource[];
   usages: RunUsageWithRunKeyType[];
 }): MessageConsumptionDetails | null {
   const allocation = buildLatestMessageConsumptionAllocation({
@@ -229,5 +302,10 @@ export function buildLatestAvailableMessageConsumptionDetails({
     return null;
   }
 
-  return buildMessageConsumptionDetails({ actions, allocation });
+  return buildMessageConsumptionDetails({
+    actions,
+    allocation,
+    enabledSkillIdsByActionId,
+    skills,
+  });
 }

--- a/front/lib/api/assistant/agent_message_consumption_attribution/read.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/read.ts
@@ -62,7 +62,7 @@ export async function getAgentMessageConsumption(
     return unavailableResponse;
   }
 
-  const { models: _models, ...messageDetails } = details;
+  const { models: _models, skills: _skills, ...messageDetails } = details;
 
   return {
     billedCredits: facts.billedCredits,

--- a/front/lib/api/assistant/agent_message_consumption_attribution/skill_attribution.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/skill_attribution.ts
@@ -1,0 +1,38 @@
+import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
+
+function skillExposesAction(
+  skill: SkillResource,
+  action: AgentMCPActionResource
+): boolean {
+  const toolServerId = action.toolConfiguration.toolServerId;
+  const toolName = action.toJSON().toolName;
+
+  return skill.mcpServerConfigurations.some(({ view }) => {
+    if (view.mcpServerId !== toolServerId) {
+      return false;
+    }
+
+    // If the server disables the tool, the skill cannot expose it.
+    return !view.getToolPermissions.some(
+      (permission) => permission.toolName === toolName && !permission.enabled
+    );
+  });
+}
+
+export function skillIdsAttributedToAction(
+  skills: SkillResource[],
+  action: AgentMCPActionResource,
+  enabledSkillIds: string[]
+): string[] {
+  // Attribute every skill that exposes the tool and any skill enabled by the action.
+  // The tool keeps its full credit amount instead of splitting it across these skills.
+  return [
+    ...new Set([
+      ...skills
+        .filter((skill) => skillExposesAction(skill, action))
+        .map((skill) => skill.sId),
+      ...enabledSkillIds,
+    ]),
+  ];
+}

--- a/front/lib/resources/agent_message_consumption_item_resource.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.ts
@@ -19,6 +19,7 @@ import type { Attributes, CreationAttributes, Transaction } from "sequelize";
 import { Op, QueryTypes } from "sequelize";
 
 export type ConversationConsumptionMessageFacts = {
+  agentMessageModelId: ModelId;
   agentConfigurationId: string;
   billedCredits: number | null;
   dustRunIds: string[];
@@ -664,13 +665,11 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
 
     return {
       messages: messageFacts.map(
-        ({
-          agentMessageModelId,
-          ...message
-        }): ConversationConsumptionMessageFacts => ({
+        (message): ConversationConsumptionMessageFacts => ({
           ...message,
-          items: itemsByMessageModelId.get(agentMessageModelId) ?? [],
-          actions: actionsByMessageModelId.get(agentMessageModelId) ?? [],
+          items: itemsByMessageModelId.get(message.agentMessageModelId) ?? [],
+          actions:
+            actionsByMessageModelId.get(message.agentMessageModelId) ?? [],
         })
       ),
     };

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -3863,22 +3863,26 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     agentMessageId: ModelId,
     { withToolMetadata = false }: { withToolMetadata?: boolean } = {}
   ): Promise<SkillResource[]> {
-    const skillsByAgentMessageId = await this.listByAgentMessageIds(
+    const agentMessageSkills = await this.listByAgentMessageIds(
       auth,
       [agentMessageId],
       { withToolMetadata }
     );
 
-    return skillsByAgentMessageId.get(agentMessageId) ?? [];
+    return [
+      ...new Map(
+        agentMessageSkills.map(({ skill }) => [skill.sId, skill])
+      ).values(),
+    ];
   }
 
   static async listByAgentMessageIds(
     auth: Authenticator,
     agentMessageIds: ModelId[],
     { withToolMetadata = false }: { withToolMetadata?: boolean } = {}
-  ): Promise<Map<ModelId, SkillResource[]>> {
+  ): Promise<{ agentMessageId: ModelId; skill: SkillResource }[]> {
     if (agentMessageIds.length === 0) {
-      return new Map();
+      return [];
     }
 
     const workspace = auth.getNonNullableWorkspace();
@@ -3898,45 +3902,24 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       withToolMetadata,
     });
     const skillsById = new Map(skills.map((skill) => [skill.sId, skill]));
-    const skillsByAgentMessageId = new Map<ModelId, SkillResource[]>();
-    const seenSkillIdsByAgentMessageId = new Map<ModelId, Set<string>>();
 
-    for (const agentMessageSkill of agentMessageSkills) {
-      const skillId =
-        agentMessageSkill.globalSkillId ??
-        (agentMessageSkill.customSkillId !== null
-          ? this.modelIdToSId({
-              id: agentMessageSkill.customSkillId,
-              workspaceId: workspace.id,
-            })
-          : null);
-      const skill = skillId ? skillsById.get(skillId) : undefined;
-      if (!skill) {
-        continue;
-      }
+    return removeNulls(
+      agentMessageSkills.map((agentMessageSkill) => {
+        const skillId =
+          agentMessageSkill.globalSkillId ??
+          (agentMessageSkill.customSkillId !== null
+            ? this.modelIdToSId({
+                id: agentMessageSkill.customSkillId,
+                workspaceId: workspace.id,
+              })
+            : null);
+        const skill = skillId ? skillsById.get(skillId) : undefined;
 
-      const seenSkillIds =
-        seenSkillIdsByAgentMessageId.get(agentMessageSkill.agentMessageId) ??
-        new Set();
-      if (seenSkillIds.has(skill.sId)) {
-        continue;
-      }
-
-      const messageSkills =
-        skillsByAgentMessageId.get(agentMessageSkill.agentMessageId) ?? [];
-      messageSkills.push(skill);
-      seenSkillIds.add(skill.sId);
-      skillsByAgentMessageId.set(
-        agentMessageSkill.agentMessageId,
-        messageSkills
-      );
-      seenSkillIdsByAgentMessageId.set(
-        agentMessageSkill.agentMessageId,
-        seenSkillIds
-      );
-    }
-
-    return skillsByAgentMessageId;
+        return skill
+          ? { agentMessageId: agentMessageSkill.agentMessageId, skill }
+          : null;
+      })
+    );
   }
 
   static async listByConversationModelId(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -3863,11 +3863,29 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     agentMessageId: ModelId,
     { withToolMetadata = false }: { withToolMetadata?: boolean } = {}
   ): Promise<SkillResource[]> {
+    const skillsByAgentMessageId = await this.listByAgentMessageIds(
+      auth,
+      [agentMessageId],
+      { withToolMetadata }
+    );
+
+    return skillsByAgentMessageId.get(agentMessageId) ?? [];
+  }
+
+  static async listByAgentMessageIds(
+    auth: Authenticator,
+    agentMessageIds: ModelId[],
+    { withToolMetadata = false }: { withToolMetadata?: boolean } = {}
+  ): Promise<Map<ModelId, SkillResource[]>> {
+    if (agentMessageIds.length === 0) {
+      return new Map();
+    }
+
     const workspace = auth.getNonNullableWorkspace();
 
     const where: WhereOptions<AgentMessageSkillModel> = {
       workspaceId: workspace.id,
-      agentMessageId,
+      agentMessageId: { [Op.in]: agentMessageIds },
     };
 
     const agentMessageSkills = await AgentMessageSkillModel.findAll({
@@ -3875,10 +3893,50 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
 
     // Include all statuses for historical accuracy.
-    return this.fetchBySkillReferences(auth, agentMessageSkills, {
+    const skills = await this.fetchBySkillReferences(auth, agentMessageSkills, {
       status: ["active", "archived", "suggested"],
       withToolMetadata,
     });
+    const skillsById = new Map(skills.map((skill) => [skill.sId, skill]));
+    const skillsByAgentMessageId = new Map<ModelId, SkillResource[]>();
+    const seenSkillIdsByAgentMessageId = new Map<ModelId, Set<string>>();
+
+    for (const agentMessageSkill of agentMessageSkills) {
+      const skillId =
+        agentMessageSkill.globalSkillId ??
+        (agentMessageSkill.customSkillId !== null
+          ? this.modelIdToSId({
+              id: agentMessageSkill.customSkillId,
+              workspaceId: workspace.id,
+            })
+          : null);
+      const skill = skillId ? skillsById.get(skillId) : undefined;
+      if (!skill) {
+        continue;
+      }
+
+      const seenSkillIds =
+        seenSkillIdsByAgentMessageId.get(agentMessageSkill.agentMessageId) ??
+        new Set();
+      if (seenSkillIds.has(skill.sId)) {
+        continue;
+      }
+
+      const messageSkills =
+        skillsByAgentMessageId.get(agentMessageSkill.agentMessageId) ?? [];
+      messageSkills.push(skill);
+      seenSkillIds.add(skill.sId);
+      skillsByAgentMessageId.set(
+        agentMessageSkill.agentMessageId,
+        messageSkills
+      );
+      seenSkillIdsByAgentMessageId.set(
+        agentMessageSkill.agentMessageId,
+        seenSkillIds
+      );
+    }
+
+    return skillsByAgentMessageId;
   }
 
   static async listByConversationModelId(

--- a/front/types/assistant/conversation_consumption.ts
+++ b/front/types/assistant/conversation_consumption.ts
@@ -16,6 +16,17 @@ export type ConversationConsumptionModelDetails =
   AgentMessageConsumptionModelDetails;
 
 /**
+ * @swaggerschema PrivateConversationConsumptionSkillDetails (swagger_private_schemas.ts)
+ */
+export type ConversationConsumptionSkillDetails = {
+  skillId: string;
+  name: string;
+  icon: string | null;
+  /** Full credits of the tool calls attributed to this skill. Skills can overlap. */
+  attributedCredits: number;
+};
+
+/**
  * @swaggerschema PrivateConversationConsumptionAgentDetails (swagger_private_schemas.ts)
  */
 export type ConversationConsumptionAgentDetails = {
@@ -34,6 +45,8 @@ export type ConversationConsumptionAgentDetails = {
 export type ConversationConsumptionDetails = {
   agentWorkCredits: number;
   tools: ConversationConsumptionToolDetails[];
+  /** Optional for compatibility with responses produced before skill attribution was exposed. */
+  skills?: ConversationConsumptionSkillDetails[];
   models: ConversationConsumptionModelDetails[];
   agents: ConversationConsumptionAgentDetails[];
 };


### PR DESCRIPTION
## Description

Conversation credit breakdowns show agent work, tools, and models, but not the skills responsible for tool calls.

This adds skills to conversation consumption details using the same attribution rule as consumption analytics, including successful `enable_skill` calls. The credits panel renders each skill's icon, name, and attributed credits between tools and models. Skill credits can overlap when several skills are responsible for the same tool call, and the new response field remains optional for backward compatibility.

## Tests

- Added conversation aggregation coverage for skill attribution.
- Updated credit breakdown rendering coverage.

## Risk

- Low. Limited to the flag-gated conversation consumption details flow.

## Deploy Plan

- Deploy front and front-api.
