### PR TITLE
[front] fix: hide conversation credits button if already open

### DIFF
--- a/front/components/assistant/conversation/CreditCostPopover.test.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.test.tsx
@@ -4,15 +4,28 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import type { ComponentProps, ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockOpenPanel, mockUseAgentMessageConsumption } = vi.hoisted(() => ({
-  mockOpenPanel: vi.fn(),
-  mockUseAgentMessageConsumption: vi.fn(),
-}));
+const { mockOpenPanel, mockSidePanelContext, mockUseAgentMessageConsumption } =
+  vi.hoisted(() => {
+    const mockOpenPanel = vi.fn();
+    const mockSidePanelContext: {
+      currentPanel: "credits" | undefined;
+      openPanel: typeof mockOpenPanel;
+    } = {
+      currentPanel: undefined,
+      openPanel: mockOpenPanel,
+    };
+
+    return {
+      mockOpenPanel,
+      mockSidePanelContext,
+      mockUseAgentMessageConsumption: vi.fn(),
+    };
+  });
 
 vi.mock(
   "@app/components/assistant/conversation/ConversationSidePanelContext",
   () => ({
-    useConversationSidePanelContext: () => ({ openPanel: mockOpenPanel }),
+    useConversationSidePanelContext: () => mockSidePanelContext,
   })
 );
 
@@ -89,6 +102,7 @@ const defaultProps: ComponentProps<typeof CreditCostPopover> = {
 describe("CreditCostPopover", () => {
   beforeEach(() => {
     mockOpenPanel.mockReset();
+    mockSidePanelContext.currentPanel = undefined;
     mockUseAgentMessageConsumption.mockReset();
   });
 
@@ -159,6 +173,21 @@ describe("CreditCostPopover", () => {
     expect(screen.queryByText("Saved through reuse")).not.toBeInTheDocument();
     expect(screen.getByText("3 credits")).toBeInTheDocument();
     expect(screen.getByText("7 credits")).toBeInTheDocument();
+  });
+
+  it("hides the conversation credits button when the credits panel is open", () => {
+    mockSidePanelContext.currentPanel = "credits";
+    mockUseAgentMessageConsumption.mockReturnValue({
+      consumption: { billedCredits: 10, details: null },
+      isConsumptionLoading: false,
+      mutateConsumption: vi.fn(),
+    });
+
+    render(<CreditCostPopover {...defaultProps} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Conversation credits" })
+    ).not.toBeInTheDocument();
   });
 
   it("keeps the exact charge visible when attribution details are unavailable", () => {

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -88,7 +88,7 @@ export function CreditCostPopover({
   const [isOpen, setIsOpen] = useState(false);
   // Avoid reopening the trigger tooltip when switching to the credits drawer.
   const preventTriggerFocusOnCloseRef = useRef(false);
-  const { openPanel } = useConversationSidePanelContext();
+  const { currentPanel, openPanel } = useConversationSidePanelContext();
   const { consumption, isConsumptionLoading, mutateConsumption } =
     useAgentMessageConsumption({
       conversationId,
@@ -226,19 +226,21 @@ export function CreditCostPopover({
           )}
         </section>
 
-        <div className="-mx-3 -mb-2 border-t border-border px-3 py-1">
-          <Button
-            variant="highlight-ghost"
-            size="sm"
-            label="Conversation credits"
-            className="w-full"
-            onClick={() => {
-              preventTriggerFocusOnCloseRef.current = true;
-              setIsOpen(false);
-              openPanel({ type: "credits" });
-            }}
-          />
-        </div>
+        {currentPanel !== "credits" && (
+          <div className="-mx-3 -mb-2 border-t border-border px-3 py-1">
+            <Button
+              variant="highlight-ghost"
+              size="sm"
+              label="Conversation credits"
+              className="w-full"
+              onClick={() => {
+                preventTriggerFocusOnCloseRef.current = true;
+                setIsOpen(false);
+                openPanel({ type: "credits" });
+              }}
+            />
+          </div>
+        )}
       </PopoverContent>
     </PopoverRoot>
   );


### PR DESCRIPTION
## Description

Follow up on comment [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=12988-2134#1880359364).

In the message credit breakdown we have a button to open the conversation breakdown side panel. This PR hides this button if it's already open.

## Tests

- Added a test.

## Risk

- Low.

## Deploy Plan

- Deploy front.
