### PR TITLE
feat(sidekick): use Fast auto stream on first turn, Standard on follow-ups

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
@@ -6,11 +6,6 @@ import type {
   PrefetchedDataSourcesType,
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
-import {
-  getLargeWhitelistedModel,
-  getSmallWhitelistedModel,
-  selectEnabledModel,
-} from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type {
   AgentConfigurationType,
@@ -18,7 +13,10 @@ import type {
 } from "@app/types/assistant/agent";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import { CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
+import {
+  AUTO_FAST_MODEL_CONFIG,
+  AUTO_MODEL_CONFIG,
+} from "@app/types/assistant/models/auto";
 import { NOOP_MODEL_CONFIG } from "@app/types/assistant/models/noop";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import { SHARED_PROMPT_SECTIONS } from "./agent_suggestions_shared";
@@ -349,17 +347,17 @@ export function _getSidekickGlobalAgent(
 
   // Use noop model for the first turn of a new agent sidekick conversation
   // (static response without calling a real LLM).
-  // Use a fast model for other first turns and the full model for follow-ups.
+  // Use the Fast auto stream for other first turns and the Standard auto stream
+  // for follow-ups. Both sentinels are resolved to a concrete model + effort at
+  // message-send time by resolveModel().
   const isFirstTurn = globalAgentContext?.userMessageRank === 0;
   const isNewAgentFromScratchFirstTurn =
     isFirstTurn && globalAgentContext?.sidekickIsNewAgentFromScratch;
   const modelConfiguration = isNewAgentFromScratchFirstTurn
     ? NOOP_MODEL_CONFIG
     : isFirstTurn
-      ? (selectEnabledModel(auth, [CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG], {
-          featureFlags,
-        }) ?? getSmallWhitelistedModel(auth, undefined, { featureFlags }))
-      : getLargeWhitelistedModel(auth, undefined, { featureFlags });
+      ? AUTO_FAST_MODEL_CONFIG
+      : AUTO_MODEL_CONFIG;
   const model = modelConfiguration
     ? {
         providerId: modelConfiguration.providerId,


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/10044

The Agent Builder Sidekick previously selected concrete models inline: Haiku (small whitelisted model) on the first turn and the workspace's large whitelisted model on follow-ups.

This routes it through the Auto tier streams instead:

- **New-agent-from-scratch first turn** → unchanged (`NOOP_MODEL_CONFIG`, static response, no LLM call).
- **Any other first turn** → the **Fast** stream (`auto_fast`).
- **Follow-up turns** → the **Standard** stream (`auto`).

Both sentinels are resolved to a concrete model + reasoning effort at message-send time by `resolveModel`, which already routes stream ids directly through `getModelForStream` regardless of the `models_picker` flag. So Sidekick gets the tiered routing in every workspace without depending on the picker being enabled.

## Tests

Covered by the existing `resolveModel` suite (`front/lib/api/assistant/models.test.ts`), which already asserts that a stream-configured agent resolves through `getModelForStream` (including without `models_picker`). Sidekick sets its model to `auto_fast` / `auto`, which flow through that same path. `tsgo --noEmit` clean.
