### PR TITLE
[front] fix: Fix capabilities picker mounting issue

### DIFF
--- a/front/components/assistant/CapabilitiesPicker.test.tsx
+++ b/front/components/assistant/CapabilitiesPicker.test.tsx
@@ -1,0 +1,227 @@
+import {
+  CapabilitiesPicker,
+  CapabilitySetupDialog,
+} from "@app/components/assistant/CapabilitiesPicker";
+import {
+  DEFAULT_MCP_ACTION_VERSION,
+  DEFAULT_MCP_SERVER_ICON,
+} from "@app/lib/actions/constants";
+import type { MCPServerType, MCPServerViewLightType } from "@app/lib/api/mcp";
+import type { WorkspaceType } from "@app/types/user";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@dust-tt/sparkle";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+const owner = {
+  id: 0,
+  sId: "wId",
+  name: "Workspace",
+  role: "admin",
+  segmentation: null,
+  whiteListedProviders: null,
+  defaultEmbeddingProvider: null,
+  metadata: null,
+  metronomeCustomerId: null,
+  sharingPolicy: "all_scopes",
+  regionalModelsOnly: false,
+} satisfies WorkspaceType;
+
+const uninstalledServer = {
+  name: "notion",
+  version: DEFAULT_MCP_ACTION_VERSION,
+  description: "Search Notion pages.",
+  sId: "server-id",
+  icon: DEFAULT_MCP_SERVER_ICON,
+  authorization: null,
+  tools: [],
+  availability: "manual",
+  allowMultipleInstances: false,
+  documentationUrl: null,
+} satisfies MCPServerType;
+
+vi.mock(import("@app/lib/swr/spaces"), () => ({
+  useSpaces: () => ({
+    spaces: [],
+    isSpacesLoading: false,
+    isSpacesError: null,
+    mutate: vi.fn(async () => undefined),
+  }),
+}));
+
+const createdServerView = {
+  sId: "view-id",
+  name: null,
+  description: "Search Notion pages.",
+  server: {
+    sId: "server-id",
+    name: "notion",
+    description: "Search Notion pages.",
+    icon: DEFAULT_MCP_SERVER_ICON,
+    tools: [],
+  },
+} satisfies MCPServerViewLightType;
+
+vi.mock(import("@app/lib/swr/mcp_servers"), () => ({
+  useJITMCPServerViewsFromSpaces: () => ({
+    serverViews: [],
+    isLoading: false,
+    isError: null,
+    // The created view only shows up in the refetch that follows the creation.
+    mutateServerViews: vi.fn(async () => ({
+      success: true,
+      serverViews: [createdServerView],
+    })),
+  }),
+  useAvailableMCPServers: () => ({
+    availableMCPServers: [{ ...uninstalledServer, views: [] }],
+    isAvailableMCPServersLoading: false,
+    isAvailableMCPServersError: null,
+    mutateAvailableMCPServers: vi.fn(async () => undefined),
+  }),
+}));
+
+vi.mock(import("@app/lib/swr/skill_configurations"), () => ({
+  useSkills: () => ({
+    skills: [],
+    isSkillsError: false,
+    isSkillsLoading: false,
+    mutateSkills: vi.fn(async () => undefined),
+  }),
+}));
+
+vi.mock(import("@app/lib/swr/useIsMobile"), () => ({
+  useIsMobile: () => false,
+}));
+
+vi.mock(import("@app/components/shared/CapabilityDetailsSheets"), () => ({
+  CapabilityDetailsSheets: () => <div />,
+}));
+
+// Stands in for the real dialog, which reports its close right after handing over the created
+// server, before the refetch that resolves its view has settled.
+vi.mock(
+  import("@app/components/actions/mcp/create/CreateMCPServerDialog"),
+  () => ({
+    CreateMCPServerDialog: ({
+      setMCPServerToShow,
+      setIsOpen,
+    }: {
+      setMCPServerToShow: (server: MCPServerType) => void;
+      setIsOpen: (isOpen: boolean) => void;
+    }) => (
+      <button
+        type="button"
+        onClick={() => {
+          setMCPServerToShow(uninstalledServer);
+          setIsOpen(false);
+        }}
+      >
+        Save
+      </button>
+    ),
+  })
+);
+
+// Mirrors how the input bar composes the picker: inside the "+" menu, with the configuration
+// dialog it asks for hosted outside of the menu.
+function PlusMenuHarness() {
+  const [serverToSetup, setServerToSetup] = useState<MCPServerType | null>(
+    null
+  );
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button label="More" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <CapabilitiesPicker
+            type="subdropdown"
+            owner={owner}
+            user={null}
+            selectedMCPServerViews={[]}
+            onSelect={vi.fn()}
+            onSkillSelect={vi.fn()}
+            onSetupServer={setServerToSetup}
+          />
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {serverToSetup && (
+        <div data-testid="setup-dialog">Configure {serverToSetup.name}</div>
+      )}
+    </>
+  );
+}
+
+// Same shape as InputBarButtons: the dialog is dropped as soon as it reports its close.
+function SetupHost({
+  onServerViewAdded,
+}: {
+  onServerViewAdded: (serverView: MCPServerViewLightType) => void;
+}) {
+  const [server, setServer] = useState<MCPServerType | null>(uninstalledServer);
+
+  return (
+    server && (
+      <CapabilitySetupDialog
+        owner={owner}
+        server={server}
+        onClose={() => setServer(null)}
+        onServerViewAdded={onServerViewAdded}
+      />
+    )
+  );
+}
+
+describe("CapabilitiesPicker", () => {
+  beforeAll(() => {
+    // Radix relies on browser APIs that jsdom does not implement.
+    global.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+    Element.prototype.scrollIntoView = vi.fn();
+    Element.prototype.hasPointerCapture = vi.fn(() => false);
+    Element.prototype.releasePointerCapture = vi.fn();
+  });
+
+  it("keeps the tool configuration dialog mounted once the menu closes", async () => {
+    const user = userEvent.setup();
+    render(<PlusMenuHarness />);
+
+    await user.click(screen.getByRole("button", { name: "More" }));
+    await user.click(await screen.findByText("Capabilities"));
+
+    fireEvent.click(await screen.findByText("Notion"));
+
+    await waitFor(() =>
+      expect(screen.queryByText("Search capabilities")).not.toBeInTheDocument()
+    );
+    expect(screen.getByTestId("setup-dialog")).toBeInTheDocument();
+  });
+
+  it("attaches the created tool after its host unmounted it", async () => {
+    const user = userEvent.setup();
+    const onServerViewAdded = vi.fn();
+
+    render(<SetupHost onServerViewAdded={onServerViewAdded} />);
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(
+      screen.queryByRole("button", { name: "Save" })
+    ).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(onServerViewAdded).toHaveBeenCalledWith(createdServerView)
+    );
+  });
+});

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -8,7 +8,6 @@ import {
   getMcpServerViewDisplayName,
 } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
-import type { DefaultRemoteMCPServerConfig } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import { getDefaultRemoteMCPServerByName } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import type { MCPServerType, MCPServerViewLightType } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
@@ -50,7 +49,7 @@ import {
   LoadingBlock,
   ShapesPlus,
 } from "@dust-tt/sparkle";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 interface CapabilityPickerItemBase extends CapabilitySearchIndexItem {
   description?: string;
@@ -169,6 +168,7 @@ interface CapabilitiesPickerProps {
   selectedMCPServerViews: MCPServerViewLightType[];
   onSelect: (serverView: MCPServerViewLightType) => void;
   onSkillSelect: (skill: SkillWithoutInstructionsAndToolsType) => void;
+  onSetupServer: (server: MCPServerType) => void;
   isLoading?: boolean;
   disabled?: boolean;
   buttonSize?: "xs" | "sm" | "md";
@@ -185,6 +185,7 @@ export function CapabilitiesPicker({
   selectedMCPServerViews,
   onSelect,
   onSkillSelect,
+  onSetupServer,
   isLoading = false,
   disabled = false,
   buttonSize = "xs",
@@ -202,12 +203,6 @@ export function CapabilitiesPicker({
   const setIsOpen = isExternallyControlled
     ? (open: boolean) => onExternalOpenChange?.(open)
     : setInternalOpen;
-  const [setupSheetServer, setSetupSheetServer] =
-    useState<MCPServerType | null>(null);
-  const [setupSheetRemoteServerConfig, setSetupSheetRemoteServerConfig] =
-    useState<DefaultRemoteMCPServerConfig | null>(null);
-  const [pendingServerToAdd, setPendingServerToAdd] =
-    useState<MCPServerType | null>(null);
 
   const [selectedSkillIdForDetails, setSelectedSkillIdForDetails] = useState<
     string | null
@@ -224,46 +219,14 @@ export function CapabilitiesPicker({
 
   const isAdmin = owner.role === "admin";
 
-  const {
-    serverViews,
-    isLoading: isServerViewsLoading,
-    mutateServerViews,
-  } = useJITMCPServerViewsFromSpaces(
-    owner,
-    globalSpaces,
-    CAPABILITIES_SWR_OPTIONS
-  );
+  const { serverViews, isLoading: isServerViewsLoading } =
+    useJITMCPServerViewsFromSpaces(
+      owner,
+      globalSpaces,
+      CAPABILITIES_SWR_OPTIONS
+    );
 
   const normalizedSearchText = searchText.trim().toLowerCase();
-
-  // Fallback: add server to conversation when it appears in serverViews.
-  useEffect(() => {
-    if (pendingServerToAdd) {
-      const newServerView = serverViews.find(
-        (v) => v.server.name === pendingServerToAdd.name
-      );
-
-      if (newServerView) {
-        trackEvent({
-          area: TRACKING_AREAS.TOOLS,
-          object: "tool_select",
-          action: TRACKING_ACTIONS.SELECT,
-          extra: {
-            tool_id: newServerView.sId,
-            tool_name: newServerView.server.name,
-            from_setup: true,
-          },
-        });
-        onSelect(newServerView);
-        setPendingServerToAdd(null);
-      }
-    }
-  }, [serverViews, pendingServerToAdd, onSelect]);
-
-  const existingViewNames = useMemo(
-    () => serverViews.map((v) => v.name ?? v.server.name),
-    [serverViews]
-  );
 
   const { availableMCPServers, isAvailableMCPServersLoading } =
     useAvailableMCPServers({
@@ -281,9 +244,6 @@ export function CapabilitiesPicker({
   const isSkillsDataReady = !isSkillsLoading;
   const isToolsDataReady =
     !isServerViewsLoading && (!isAdmin || !isAvailableMCPServersLoading);
-
-  const shouldShowSetupSheet =
-    !!setupSheetServer || !!setupSheetRemoteServerConfig;
 
   const closeDropdown = () => {
     setSearchText("");
@@ -319,18 +279,7 @@ export function CapabilitiesPicker({
   };
 
   const setupServer = (server: MCPServerType) => {
-    const remoteMcpServerConfig = getDefaultRemoteMCPServerByName(server.name);
-
-    if (remoteMcpServerConfig) {
-      // Remote servers always use the remote flow, even if they have OAuth.
-      setSetupSheetServer(null);
-      setSetupSheetRemoteServerConfig(remoteMcpServerConfig);
-    } else {
-      // Internal servers (with or without OAuth)
-      setSetupSheetServer(server);
-      setSetupSheetRemoteServerConfig(null);
-    }
-
+    onSetupServer(server);
     setIsOpen(false);
   };
 
@@ -566,51 +515,6 @@ export function CapabilitiesPicker({
         </ContentWrapper>
       </Wrapper>
 
-      {shouldShowSetupSheet && (
-        <CreateMCPServerDialog
-          owner={owner}
-          internalMCPServer={setupSheetServer ?? undefined}
-          defaultServerConfig={setupSheetRemoteServerConfig ?? undefined}
-          existingViewNames={existingViewNames}
-          setMCPServerToShow={async (createdServer) => {
-            const updatedData = await mutateServerViews();
-
-            const newServerView = updatedData?.serverViews?.find(
-              (v: MCPServerViewLightType) =>
-                v.server.name === createdServer.name
-            );
-
-            if (newServerView) {
-              trackEvent({
-                area: TRACKING_AREAS.TOOLS,
-                object: "tool_select",
-                action: TRACKING_ACTIONS.SELECT,
-                extra: {
-                  tool_id: newServerView.sId,
-                  tool_name: newServerView.server.name,
-                  from_setup: true,
-                },
-              });
-              onSelect(newServerView);
-            } else {
-              setPendingServerToAdd(createdServer);
-            }
-
-            setSetupSheetServer(null);
-            setSetupSheetRemoteServerConfig(null);
-          }}
-          setIsLoading={() => {}}
-          isOpen={shouldShowSetupSheet}
-          setIsOpen={(isOpen) => {
-            if (!isOpen) {
-              setSetupSheetServer(null);
-              setSetupSheetRemoteServerConfig(null);
-              setPendingServerToAdd(null);
-            }
-          }}
-        />
-      )}
-
       <CapabilityDetailsSheets
         owner={owner}
         user={user}
@@ -620,5 +524,73 @@ export function CapabilitiesPicker({
         onCloseTool={() => setSelectedServerViewForDetails(null)}
       />
     </>
+  );
+}
+
+interface CapabilitySetupDialogProps {
+  owner: WorkspaceType;
+  server: MCPServerType;
+  onClose: () => void;
+  onServerViewAdded: (serverView: MCPServerViewLightType) => void;
+}
+
+// Mount outside of the menu the picker lives in: selecting an item closes that menu, which
+// unmounts its content.
+export function CapabilitySetupDialog({
+  owner,
+  server,
+  onClose,
+  onServerViewAdded,
+}: CapabilitySetupDialogProps) {
+  const { spaces: globalSpaces } = useSpaces({
+    workspaceId: owner.sId,
+    kinds: ["global"],
+    swrOptions: CAPABILITIES_SWR_OPTIONS,
+  });
+
+  const { serverViews, mutateServerViews } = useJITMCPServerViewsFromSpaces(
+    owner,
+    globalSpaces,
+    CAPABILITIES_SWR_OPTIONS
+  );
+
+  // Remote servers always use the remote flow, even if they have OAuth.
+  const remoteServerConfig = getDefaultRemoteMCPServerByName(server.name);
+
+  return (
+    <CreateMCPServerDialog
+      owner={owner}
+      internalMCPServer={remoteServerConfig ? undefined : server}
+      defaultServerConfig={remoteServerConfig ?? undefined}
+      existingViewNames={serverViews.map((v) => v.name ?? v.server.name)}
+      setMCPServerToShow={async (newServer) => {
+        const updatedData = await mutateServerViews();
+
+        const newServerView = updatedData?.serverViews?.find(
+          (v: MCPServerViewLightType) => v.server.name === newServer.name
+        );
+
+        if (newServerView) {
+          trackEvent({
+            area: TRACKING_AREAS.TOOLS,
+            object: "tool_select",
+            action: TRACKING_ACTIONS.SELECT,
+            extra: {
+              tool_id: newServerView.sId,
+              tool_name: newServerView.server.name,
+              from_setup: true,
+            },
+          });
+          onServerViewAdded(newServerView);
+        }
+      }}
+      setIsLoading={() => {}}
+      isOpen
+      setIsOpen={(isOpen) => {
+        if (!isOpen) {
+          onClose();
+        }
+      }}
+    />
   );
 }

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -1,5 +1,8 @@
 import { AgentPicker } from "@app/components/assistant/AgentPicker";
-import { CapabilitiesPicker } from "@app/components/assistant/CapabilitiesPicker";
+import {
+  CapabilitiesPicker,
+  CapabilitySetupDialog,
+} from "@app/components/assistant/CapabilitiesPicker";
 import type { InputBarAction } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
 import { InputBarModelPicker } from "@app/components/assistant/conversation/input_bar/InputBarModelPicker";
 import { InputBarPlusMenu } from "@app/components/assistant/conversation/input_bar/InputBarPlusMenu";
@@ -10,7 +13,7 @@ import {
 import type useCustomEditor from "@app/components/editor/input_bar/useCustomEditor";
 import type { Selection } from "@app/components/model_picker/modelPickerUtils";
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
-import type { MCPServerViewLightType } from "@app/lib/api/mcp";
+import type { MCPServerType, MCPServerViewLightType } from "@app/lib/api/mcp";
 import { useAppRouter } from "@app/lib/platform";
 import { useIsMobile, useIsWidthConstrained } from "@app/lib/swr/useIsMobile";
 import { setQueryParam } from "@app/lib/utils/router";
@@ -131,6 +134,8 @@ export const InputBarButtons = React.memo(function InputBarButtons({
   const router = useAppRouter();
   const isMobile = useIsMobile();
   const isWidthConstrained = useIsWidthConstrained();
+  const [serverToSetup, setServerToSetup] =
+    React.useState<MCPServerType | null>(null);
   // Current space is taken from the conversation (if already set) or from the space prop (if provided).
   const spaceId = conversation?.spaceId ?? space?.sId ?? undefined;
 
@@ -234,6 +239,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
       selectedMCPServerViews={selectedMCPServerViews}
       onSelect={onMCPServerViewSelect}
       onSkillSelect={onSkillSelect}
+      onSetupServer={setServerToSetup}
       onOpenChange={onCapabilitiesPickerOpenChange}
       buttonSize={buttonSize}
       disabled={isInputDisabled}
@@ -302,6 +308,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
             selectedMCPServerViews={selectedMCPServerViews}
             onMCPServerViewSelect={onMCPServerViewSelect}
             onSkillSelect={onSkillSelect}
+            onSetupServer={setServerToSetup}
             fileUploaderService={fileUploaderService}
             onNodeSelect={onNodeSelect}
             onNodeUnselect={onNodeUnselect}
@@ -318,6 +325,14 @@ export const InputBarButtons = React.memo(function InputBarButtons({
             onAttachmentsPickerOpenChange={onAttachmentsPickerOpenChange}
           />
         </>
+      )}
+      {serverToSetup && (
+        <CapabilitySetupDialog
+          owner={owner}
+          server={serverToSetup}
+          onClose={() => setServerToSetup(null)}
+          onServerViewAdded={onMCPServerViewSelect}
+        />
       )}
     </>
   );

--- a/front/components/assistant/conversation/input_bar/InputBarPlusMenu.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarPlusMenu.tsx
@@ -9,7 +9,7 @@ import {
   INPUT_BAR_PILL_SURFACE_CLASSNAME,
 } from "@app/components/assistant/conversation/input_bar/inputBarPillStyles";
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
-import type { MCPServerViewLightType } from "@app/lib/api/mcp";
+import type { MCPServerType, MCPServerViewLightType } from "@app/lib/api/mcp";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import type {
   ConversationWithoutContentType,
@@ -50,6 +50,7 @@ interface InputBarPlusMenuProps {
   selectedMCPServerViews: MCPServerViewLightType[];
   onMCPServerViewSelect: (serverView: MCPServerViewLightType) => void;
   onSkillSelect: (skill: SkillWithoutInstructionsAndToolsType) => void;
+  onSetupServer: (server: MCPServerType) => void;
   fileUploaderService: FileUploaderService;
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
@@ -76,6 +77,7 @@ export function InputBarPlusMenu({
   selectedMCPServerViews,
   onMCPServerViewSelect,
   onSkillSelect,
+  onSetupServer,
   fileUploaderService,
   onNodeSelect,
   onNodeUnselect,
@@ -130,6 +132,7 @@ export function InputBarPlusMenu({
       selectedMCPServerViews={selectedMCPServerViews}
       onSelect={onMCPServerViewSelect}
       onSkillSelect={onSkillSelect}
+      onSetupServer={onSetupServer}
       onOpenChange={onCapabilitiesPickerOpenChange}
       buttonSize={buttonSize}
       disabled={disabled}


### PR DESCRIPTION
## Description

The tool config dialog opens and vanishes right away, so you can't configure a tool from
the input bar anymore. Broke this morning with #29247, web only, extension is fine.

The picker now sits inside the + menu content and renders CreateMCPServerDialog in its own
subtree. Radix closes the whole menu when you select an item and unmounts the content, so
the dialog goes with it.

So the picker just reports the server through onSetupServer now, and the creation flow
moved to CapabilitySetupDialog, mounted by InputBarButtons outside both menus.

## Tests

Added a test, it fails if the dialog goes back inside the menu

## Risk

Low
Blast radius: capabilities picker

## Deploy Plan

Deploy front