### PR TITLE
Force Kimi K3 temperature to zero

### DIFF
--- a/front/lib/llms/providers/fireworks/models/kimi_k3.ts
+++ b/front/lib/llms/providers/fireworks/models/kimi_k3.ts
@@ -26,8 +26,8 @@ export function WithDustMoonshotAiKimiK3Config<
     // onto the class statics.
     static readonly modelConfig = FIREWORKS_KIMI_K3_MODEL_CONFIG;
 
-    // K3 has no `medium`: fold low/medium/high onto its low/high/max. Force
-    // temperature 0 on every request for deterministic sampling.
+    // K3 has no `medium`: fold low/medium/high onto its low/high/max. Use the
+    // lowest Fireworks-supported temperature on every request.
     static readonly configParsers = [
       forceTemperatureToZero,
       mapReasoningEffortToLowHighMax,

--- a/front/lib/llms/providers/fireworks/models/kimi_k3.ts
+++ b/front/lib/llms/providers/fireworks/models/kimi_k3.ts
@@ -1,4 +1,7 @@
-import { mapReasoningEffortToLowHighMax } from "@app/lib/llms/stream/types/configuration";
+import {
+  forceTemperatureToZero,
+  mapReasoningEffortToLowHighMax,
+} from "@app/lib/llms/stream/types/configuration";
 import { FIREWORKS_KIMI_K3_MODEL_CONFIG } from "@app/types/assistant/models/fireworks";
 
 export function WithDustMoonshotAiKimiK3Config<
@@ -23,8 +26,12 @@ export function WithDustMoonshotAiKimiK3Config<
     // onto the class statics.
     static readonly modelConfig = FIREWORKS_KIMI_K3_MODEL_CONFIG;
 
-    // K3 has no `medium`: fold low/medium/high onto its low/high/max.
-    static readonly configParsers = [mapReasoningEffortToLowHighMax];
+    // K3 has no `medium`: fold low/medium/high onto its low/high/max. Force
+    // temperature 0 on every request for deterministic sampling.
+    static readonly configParsers = [
+      forceTemperatureToZero,
+      mapReasoningEffortToLowHighMax,
+    ];
   }
 
   return DustMoonshotAiKimiK3;

--- a/front/lib/llms/stream/types/configuration.ts
+++ b/front/lib/llms/stream/types/configuration.ts
@@ -64,10 +64,10 @@ export function forceTemperatureToOne<C extends InputConfig>(config: C): C {
   return { ...config, temperature: 1 };
 }
 
-// `configParsers` helper: Fireworks accepts temperatures from 0 to 2 and
-// documents 0 as deterministic. Kimi K3 uses 0 as a Dust product choice, so
-// keep that policy in the llms layer rather than narrowing the endpoint schema,
-// which mirrors the provider API.
+// `configParsers` helper: Fireworks accepts temperatures from 0 to 2. Kimi K3
+// uses the lowest supported temperature as a Dust product choice, so keep that
+// policy in the llms layer rather than narrowing the endpoint schema, which
+// mirrors the provider API.
 // Verified 2026-08-11: https://docs.fireworks.ai/api-reference/post-responses
 export function forceTemperatureToZero<C extends InputConfig>(config: C): C {
   return { ...config, temperature: 0 };

--- a/front/lib/llms/stream/types/configuration.ts
+++ b/front/lib/llms/stream/types/configuration.ts
@@ -64,6 +64,15 @@ export function forceTemperatureToOne<C extends InputConfig>(config: C): C {
   return { ...config, temperature: 1 };
 }
 
+// `configParsers` helper: Fireworks accepts temperatures from 0 to 2 and
+// documents 0 as deterministic. Kimi K3 uses 0 as a Dust product choice, so
+// keep that policy in the llms layer rather than narrowing the endpoint schema,
+// which mirrors the provider API.
+// Verified 2026-08-11: https://docs.fireworks.ai/api-reference/post-responses
+export function forceTemperatureToZero<C extends InputConfig>(config: C): C {
+  return { ...config, temperature: 0 };
+}
+
 // `configParsers` helper: some models cannot turn thinking off but do accept a
 // minimum thinking level (Gemini 3.5 Flash-Lite and 3.6 Flash reject
 // `thinkingBudget: 0` yet accept the `MINIMAL` thinking level). Their endpoint

--- a/front/lib/model_constructors/providers/fireworks/models/kimi_k3.test.ts
+++ b/front/lib/model_constructors/providers/fireworks/models/kimi_k3.test.ts
@@ -3,6 +3,7 @@
 import { MODEL_PRICING } from "@app/lib/api/assistant/token_pricing";
 import { DustMoonshotAiKimiK3GlobalFireworksStream } from "@app/lib/llms/stream/endpoints/moonshot_ai_kimi_k3_global_fireworks";
 import { MoonshotAiKimiK3GlobalFireworksStream } from "@app/lib/model_constructors/stream/endpoints/moonshot_ai_kimi_k3_global_fireworks";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
 import {
   FIREWORKS_KIMI_K3_MODEL_CONFIG,
   FIREWORKS_KIMI_K3_MODEL_ID,
@@ -74,6 +75,24 @@ describe("Kimi K3 model configuration", () => {
     });
     expect(FIREWORKS_KIMI_K3_MODEL_CONFIG.useNativeLightReasoning).toBe(true);
     expect(FIREWORKS_KIMI_K3_MODEL_CONFIG.defaultReasoningEffort).toBe("light");
+  });
+
+  it("forces every Dust request to temperature zero", () => {
+    const config: InputConfig = {
+      reasoning: { effort: "medium" },
+      temperature: 0.7,
+    };
+
+    const parsedConfig =
+      DustMoonshotAiKimiK3GlobalFireworksStream.configParsers.reduce(
+        (currentConfig, parser) => parser(currentConfig),
+        config
+      );
+
+    expect(parsedConfig).toEqual({
+      reasoning: { effort: "high" },
+      temperature: 0,
+    });
   });
 
   it("caps the legacy model config to match, leaving a 192k prompt budget", () => {


### PR DESCRIPTION
## Description

Force Kimi K3 requests through Fireworks to use temperature 0 at the Dust configuration boundary. Keep the provider schema unchanged because Fireworks accepts a wider range.

## Tests

Added a regression test and ran the live 46-case Kimi K3 Fireworks endpoint suite.

## Risk

Low. The change is limited to Kimi K3 request sampling and is safe to revert.

## Deploy Plan

Standard deploy.