### PR TITLE
Add skipThreadReplies column to slack_channels

### DIFF
--- a/connectors/migrations/pre-deploy/20260811142504_add_skip_thread_replies_to_slack_channels.sql
+++ b/connectors/migrations/pre-deploy/20260811142504_add_skip_thread_replies_to_slack_channels.sql
@@ -1,0 +1,3 @@
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."slack_channels" ADD COLUMN "skipThreadReplies" boolean DEFAULT false NOT NULL;

--- a/connectors/migrations/pre-deploy/20260811142504_add_skip_thread_replies_to_slack_channels.sql
+++ b/connectors/migrations/pre-deploy/20260811142504_add_skip_thread_replies_to_slack_channels.sql
@@ -1,3 +1,3 @@
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."slack_channels" ADD COLUMN "skipThreadReplies" boolean DEFAULT false NOT NULL;
+ALTER TABLE "public"."slack_channels" ADD COLUMN "autoRespondWithoutMentionSkipThreadReplies" boolean DEFAULT false NOT NULL;

--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -145,6 +145,7 @@ export class SlackChannelModel extends ConnectorBaseModel<SlackChannelModel> {
   declare permission: ConnectorPermission;
   declare agentConfigurationId: CreationOptional<string | null>;
   declare autoRespondWithoutMention: CreationOptional<boolean>;
+  declare skipThreadReplies: CreationOptional<boolean>;
 }
 SlackChannelModel.init(
   {
@@ -184,6 +185,11 @@ SlackChannelModel.init(
       allowNull: true,
     },
     autoRespondWithoutMention: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    skipThreadReplies: {
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,

--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -145,7 +145,7 @@ export class SlackChannelModel extends ConnectorBaseModel<SlackChannelModel> {
   declare permission: ConnectorPermission;
   declare agentConfigurationId: CreationOptional<string | null>;
   declare autoRespondWithoutMention: CreationOptional<boolean>;
-  declare skipThreadReplies: CreationOptional<boolean>;
+  declare autoRespondWithoutMentionSkipThreadReplies: CreationOptional<boolean>;
 }
 SlackChannelModel.init(
   {
@@ -189,7 +189,7 @@ SlackChannelModel.init(
       allowNull: false,
       defaultValue: false,
     },
-    skipThreadReplies: {
+    autoRespondWithoutMentionSkipThreadReplies: {
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,


### PR DESCRIPTION
## Summary
- In response to a customer ask.
- This boolean will be used to determine if the slack auto responder should respond to ALL messages or just the first message in a new thread

## Deploy
1. Migration
2. Deploy front

## Testing

- Ran migration

## Risk

Low 