### PR TITLE
feat(sandbox): resolve conversation scope inside the lifecycle lock

### DIFF
--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -106,16 +106,13 @@ vi.mock("@app/logger/logger", () => {
   return { default: logger };
 });
 
-import { Authenticator } from "@app/lib/auth";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { Authenticator } from "@app/lib/auth";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
-import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
-import type { WorkspaceType } from "@app/types/user";
 import {
   ensureConversationSandboxReady,
   ensurePodSandboxReady,
@@ -136,7 +133,6 @@ function createDeferred<T>() {
 
 describe("ensureConversationSandboxReady", () => {
   let auth: Authenticator;
-  let workspace: WorkspaceType;
   let conversation: ConversationType;
   let conversationOwner: {
     kind: "conversation";
@@ -159,7 +155,6 @@ describe("ensureConversationSandboxReady", () => {
     vi.clearAllMocks();
     const testSetup = await createResourceTest({ role: "admin" });
     auth = testSetup.authenticator;
-    workspace = testSetup.workspace;
     const agentConfiguration =
       await AgentConfigurationFactory.createTestAgent(auth);
     conversation = await ConversationFactory.create(auth, {
@@ -174,10 +169,20 @@ describe("ensureConversationSandboxReady", () => {
     sandbox = await SandboxFactory.create(auth, conversation);
 
     mockEnsureSandboxActive.mockResolvedValue(
-      new Ok({ freshlyCreated: false, sandbox, wokeFromSleep: false })
+      new Ok({
+        freshlyCreated: false,
+        sandbox,
+        wokeFromSleep: false,
+        scope: { spaceId: null },
+      })
     );
     mockEnsurePodSandboxActive.mockResolvedValue(
-      new Ok({ freshlyCreated: false, sandbox, wokeFromSleep: false })
+      new Ok({
+        freshlyCreated: false,
+        sandbox,
+        wokeFromSleep: false,
+        scope: undefined,
+      })
     );
     mockPrepareSandboxEgressBeforeMount.mockResolvedValue(new Ok(undefined));
     mockEnsureSandboxEgressOnExec.mockResolvedValue(new Ok(undefined));
@@ -192,7 +197,12 @@ describe("ensureConversationSandboxReady", () => {
 
   it("preps egress, mounts files, and ensures egress on exec for freshly-created sandboxes", async () => {
     mockEnsureSandboxActive.mockResolvedValue(
-      new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
+      new Ok({
+        freshlyCreated: true,
+        sandbox,
+        wokeFromSleep: false,
+        scope: { spaceId: null },
+      })
     );
 
     const result = await ensureConversationSandboxReady(
@@ -228,46 +238,18 @@ describe("ensureConversationSandboxReady", () => {
   });
 
   it("keeps conversation-scoped policy with the Pod as an inherited layer", async () => {
+    // The adapter resolves the pod association under the lifecycle lock and
+    // returns it as the scope; the ready path derives everything from it.
+    // (That resolution is itself pinned in sandbox_resource.test.ts.)
     mockEnsureSandboxActive.mockResolvedValue(
-      new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
+      new Ok({
+        freshlyCreated: true,
+        sandbox,
+        wokeFromSleep: false,
+        scope: { spaceId: "pod-space-id" },
+      })
     );
-    const project = await SpaceFactory.project(workspace);
-    // Space-scoped conversation fetches are permission-filtered, so the test
-    // user must be a member of the project before the authoritative re-read
-    // inside ensureConversationSandboxReady can see the moved conversation.
-    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
-      workspace.sId
-    );
-    const groupReference = project.groups.find((group) =>
-      group.isRegularAuto()
-    );
-    if (!groupReference) {
-      throw new Error("Project space regular group not found");
-    }
-    const [projectGroup] = await project.fetchGroupResources(
-      internalAdminAuth,
-      { groupReferences: [groupReference] }
-    );
-    const addRes = await projectGroup.dangerouslyAddMember(internalAdminAuth, {
-      user: auth.getNonNullableUser().toJSON(),
-    });
-    if (addRes.isErr()) {
-      throw new Error(
-        `Failed to add user to project space group: ${addRes.error.message}`
-      );
-    }
-    await auth.refresh();
-    const conversationResource = await ConversationResource.fetchById(
-      auth,
-      conversation.sId
-    );
-    if (!conversationResource) {
-      throw new Error("Test conversation not found");
-    }
-    await conversationResource.updateSpaceId(auth, project);
 
-    // The caller's snapshot predates the move on purpose: the ready path must
-    // derive the pod scope from the database, not from the caller.
     const result = await ensureConversationSandboxReady(
       auth as never,
       conversation as never
@@ -279,7 +261,7 @@ describe("ensureConversationSandboxReady", () => {
     // land there) while the Pod's policy applies as the inherited layer.
     const podConversationOwner = {
       ...conversationOwner,
-      spaceId: project.sId,
+      spaceId: "pod-space-id",
     };
     expect(mockPrepareSandboxEgressBeforeMount).toHaveBeenCalledWith(
       auth,
@@ -287,27 +269,32 @@ describe("ensureConversationSandboxReady", () => {
       {
         runtimeOwner: podConversationOwner,
         egressPolicyOwnerId: conversation.sId,
-        egressPolicyPodId: project.sId,
+        egressPolicyPodId: "pod-space-id",
       }
     );
     expect(mockEnsureSandboxEgressOnExec).toHaveBeenCalledWith(auth, sandbox, {
       runtimeOwner: podConversationOwner,
       egressPolicyOwnerId: conversation.sId,
-      egressPolicyPodId: project.sId,
+      egressPolicyPodId: "pod-space-id",
       wokeFromSleep: false,
     });
     expect(mockForConversation).toHaveBeenCalledWith(auth, {
       ...conversation,
-      spaceId: project.sId,
+      spaceId: "pod-space-id",
     });
   });
 
-  it("drops a stale pod scope from the caller's snapshot after a move out", async () => {
+  it("derives scope from the lock-resolved value, never the caller's snapshot", async () => {
     mockEnsureSandboxActive.mockResolvedValue(
-      new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
+      new Ok({
+        freshlyCreated: true,
+        sandbox,
+        wokeFromSleep: false,
+        // The lock-resolved scope says standalone…
+        scope: { spaceId: null },
+      })
     );
-    // The database says the conversation is standalone; only the caller's
-    // stale snapshot still carries a pod.
+    // …while the caller's stale snapshot still carries a pod.
     const staleSnapshot = { ...conversation, spaceId: "stale-pod-space-id" };
 
     const result = await ensureConversationSandboxReady(
@@ -324,13 +311,22 @@ describe("ensureConversationSandboxReady", () => {
     expect(
       mockEnsureSandboxEgressOnExec.mock.calls[0][2].egressPolicyPodId
     ).toBeUndefined();
+    expect(mockForConversation).toHaveBeenCalledWith(auth, {
+      ...conversation,
+      spaceId: null,
+    });
   });
 
   it("starts GCS mount before initial egress prep resolves", async () => {
     const prepStarted = createDeferred<void>();
     const prepResult = createDeferred<Result<void, Error>>();
     mockEnsureSandboxActive.mockResolvedValue(
-      new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
+      new Ok({
+        freshlyCreated: true,
+        sandbox,
+        wokeFromSleep: false,
+        scope: { spaceId: null },
+      })
     );
     mockPrepareSandboxEgressBeforeMount.mockImplementation(() => {
       prepStarted.resolve(undefined);
@@ -360,7 +356,12 @@ describe("ensureConversationSandboxReady", () => {
   it("only refreshes the token (no remount) when the sandbox woke from sleep", async () => {
     await sandbox.updateLastRuntimeRefreshAt(new Date());
     mockEnsureSandboxActive.mockResolvedValue(
-      new Ok({ freshlyCreated: false, sandbox, wokeFromSleep: true })
+      new Ok({
+        freshlyCreated: false,
+        sandbox,
+        wokeFromSleep: true,
+        scope: { spaceId: null },
+      })
     );
 
     const result = await ensureConversationSandboxReady(
@@ -421,7 +422,12 @@ describe("ensureConversationSandboxReady", () => {
 
   it("uses pod owner plumbing and pod filesystem mounts for pod sandboxes", async () => {
     mockEnsurePodSandboxActive.mockResolvedValue(
-      new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
+      new Ok({
+        freshlyCreated: true,
+        sandbox,
+        wokeFromSleep: false,
+        scope: undefined,
+      })
     );
 
     const result = await ensurePodSandboxReady(auth as never, pod as never);
@@ -475,7 +481,12 @@ describe("ensureConversationSandboxReady", () => {
 
   it("does not run pod state bring-up for conversation sandboxes", async () => {
     mockEnsureSandboxActive.mockResolvedValue(
-      new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
+      new Ok({
+        freshlyCreated: true,
+        sandbox,
+        wokeFromSleep: false,
+        scope: { spaceId: null },
+      })
     );
 
     const result = await ensureConversationSandboxReady(
@@ -489,7 +500,12 @@ describe("ensureConversationSandboxReady", () => {
 
   it("requests a sandbox kill when pod state cold start fails", async () => {
     mockEnsurePodSandboxActive.mockResolvedValue(
-      new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
+      new Ok({
+        freshlyCreated: true,
+        sandbox,
+        wokeFromSleep: false,
+        scope: undefined,
+      })
     );
     const podStateError = new Error("restore failed");
     mockSetupPodStateOnColdStart.mockResolvedValue(new Err(podStateError));
@@ -542,7 +558,12 @@ describe("ensureConversationSandboxReady", () => {
   it("returns the initial egress prep error after also running the GCS mount", async () => {
     const setupError = new Error("setup failed");
     mockEnsureSandboxActive.mockResolvedValue(
-      new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
+      new Ok({
+        freshlyCreated: true,
+        sandbox,
+        wokeFromSleep: false,
+        scope: { spaceId: null },
+      })
     );
     mockPrepareSandboxEgressBeforeMount.mockResolvedValue(new Err(setupError));
 
@@ -562,7 +583,12 @@ describe("ensureConversationSandboxReady", () => {
   it("returns the initial egress prep error when both initial phases fail", async () => {
     const setupError = new Error("setup failed");
     mockEnsureSandboxActive.mockResolvedValue(
-      new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
+      new Ok({
+        freshlyCreated: true,
+        sandbox,
+        wokeFromSleep: false,
+        scope: { spaceId: null },
+      })
     );
     mockPrepareSandboxEgressBeforeMount.mockResolvedValue(new Err(setupError));
     mockSetupSandboxMount.mockResolvedValue(new Err(new Error("mount failed")));
@@ -582,7 +608,12 @@ describe("ensureConversationSandboxReady", () => {
 
   it("short-circuits when mounting conversation files fails", async () => {
     mockEnsureSandboxActive.mockResolvedValue(
-      new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
+      new Ok({
+        freshlyCreated: true,
+        sandbox,
+        wokeFromSleep: false,
+        scope: { spaceId: null },
+      })
     );
     mockSetupSandboxMount.mockResolvedValue(new Err(new Error("mount failed")));
 
@@ -597,7 +628,12 @@ describe("ensureConversationSandboxReady", () => {
 
   it("short-circuits when DustFileSystem.forConversation fails", async () => {
     mockEnsureSandboxActive.mockResolvedValue(
-      new Ok({ freshlyCreated: true, sandbox, wokeFromSleep: false })
+      new Ok({
+        freshlyCreated: true,
+        sandbox,
+        wokeFromSleep: false,
+        scope: { spaceId: null },
+      })
     );
     mockForConversation.mockResolvedValue(
       new Err(new Error("space not found"))

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -13,7 +13,6 @@ import type { SandboxRuntimeOwner } from "@app/lib/api/sandbox/owner";
 import { podSandboxOnlyMounts } from "@app/lib/api/sandbox/pod_mounts";
 import { startTelemetry } from "@app/lib/api/sandbox/telemetry";
 import type { Authenticator } from "@app/lib/auth";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
 import type {
@@ -24,7 +23,7 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
 
 const SANDBOX_RUNTIME_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 
@@ -33,31 +32,32 @@ export interface EnsureSandboxReadyResult {
   freshlyCreated: boolean;
 }
 
-type SandboxReadyConfig = {
-  ensureActive: () => Promise<Result<EnsureSandboxResult, Error>>;
-  getFileSystem: () => Promise<Result<DustFileSystem, Error>>;
-  runtimeOwner: SandboxRuntimeOwner;
-  // Which owner policy file (`w/{wId}/sandboxes/{ownerId}.json`) this
-  // sandbox's egress is scoped to — the owner's own sId (conversation or
-  // pod space).
-  egressPolicyOwnerId: string;
-  // Inherited pod policy layer for conversation sandboxes running inside a
-  // pod; pod-owned sandboxes carry none (their ownerId already is the pod).
-  egressPolicyPodId?: string;
+type SandboxReadyConfig<TScope> = {
+  ensureActive: () => Promise<Result<EnsureSandboxResult<TScope>, Error>>;
+  // Everything scope-dependent is derived from the scope ensureActive
+  // resolved INSIDE the lifecycle lock — never from state the caller read
+  // before it. A scope transition (conversation move) holds the same lock,
+  // so this config cannot be built from a pod association that a concurrent
+  // move already changed.
+  deriveConfig: (scope: TScope) => {
+    getFileSystem: () => Promise<Result<DustFileSystem, Error>>;
+    runtimeOwner: SandboxRuntimeOwner;
+    // Which owner policy file (`w/{wId}/sandboxes/{ownerId}.json`) this
+    // sandbox's egress is scoped to — the owner's own sId (conversation or
+    // pod space).
+    egressPolicyOwnerId: string;
+    // Inherited pod policy layer for conversation sandboxes running inside a
+    // pod; pod-owned sandboxes carry none (their ownerId already is the pod).
+    egressPolicyPodId?: string;
+  };
 };
 
 // /!\ All sandbox-touching tools must use the owner-specific ready helper rather than calling
 // the owner adapter directly, otherwise the GCS FUSE mount and egress forwarder bring-up will be
 // skipped.
-async function ensureOwnerSandboxReady(
+async function ensureOwnerSandboxReady<TScope>(
   auth: Authenticator,
-  {
-    ensureActive,
-    getFileSystem,
-    runtimeOwner,
-    egressPolicyOwnerId,
-    egressPolicyPodId,
-  }: SandboxReadyConfig
+  { ensureActive, deriveConfig }: SandboxReadyConfig<TScope>
 ): Promise<Result<EnsureSandboxReadyResult, Error>> {
   const startMs = performance.now();
   // cold is unknown until ensureActive returns; if it errors first (rare) we
@@ -76,8 +76,15 @@ async function ensureOwnerSandboxReady(
         return ensureResult;
       }
 
-      const { sandbox, freshlyCreated, wokeFromSleep } = ensureResult.value;
+      const { sandbox, freshlyCreated, wokeFromSleep, scope } =
+        ensureResult.value;
       cold = freshlyCreated;
+      const {
+        getFileSystem,
+        runtimeOwner,
+        egressPolicyOwnerId,
+        egressPolicyPodId,
+      } = deriveConfig(scope);
 
       const shouldRefreshRuntime =
         freshlyCreated ||
@@ -214,41 +221,34 @@ export async function ensureConversationSandboxReady(
   auth: Authenticator,
   conversation: ConversationType
 ): Promise<Result<EnsureSandboxReadyResult, Error>> {
-  // The caller's conversation is typically a snapshot captured at agent-loop
-  // start, and a move — possibly issued by this very agent — can change
-  // spaceId while the loop runs. spaceId is an authorization input (egress
-  // scope, pod env vars, pod mounts), so it is re-read from the database
-  // here rather than trusted from the caller.
-  const freshResource = await ConversationResource.fetchById(
-    auth,
-    conversation.sId
-  );
-  if (!freshResource) {
-    return new Err(new Error(`Conversation ${conversation.sId} not found.`));
-  }
-  const freshConversation = {
-    ...conversation,
-    spaceId: freshResource.spaceSId,
-  };
-
+  // Only the conversation's identity is trusted from the caller: it is
+  // typically an agent-loop snapshot, and a move — possibly issued by this
+  // very agent — can change the pod association mid-loop. The adapter
+  // re-resolves spaceId from the database INSIDE the lifecycle lock, and
+  // everything scope-dependent below derives from that resolved value.
   return ensureOwnerSandboxReady(auth, {
     ensureActive: () =>
-      ConversationSandboxAdapter.ensureSandboxActive(auth, freshConversation),
-    getFileSystem: () =>
-      DustFileSystem.forConversation(auth, freshConversation),
+      ConversationSandboxAdapter.ensureSandboxActive(auth, conversation),
     // Pod-level sandbox config applies to everything running in the Pod: a
     // conversation inside a Pod receives the Pod's env vars and HTTPS
     // secrets at creation, and inherits the Pod's egress policy as a
     // read-only layer (egressPolicyPodId). Its own policy file stays
     // conversation-scoped — on-the-fly domain approvals land there, exactly
     // like conversations outside a Pod.
-    runtimeOwner: {
-      kind: "conversation",
-      conversationId: freshConversation.sId,
-      spaceId: freshConversation.spaceId ?? null,
-    },
-    egressPolicyOwnerId: freshConversation.sId,
-    egressPolicyPodId: freshConversation.spaceId ?? undefined,
+    deriveConfig: (scope) => ({
+      getFileSystem: () =>
+        DustFileSystem.forConversation(auth, {
+          ...conversation,
+          spaceId: scope.spaceId,
+        }),
+      runtimeOwner: {
+        kind: "conversation",
+        conversationId: conversation.sId,
+        spaceId: scope.spaceId,
+      },
+      egressPolicyOwnerId: conversation.sId,
+      egressPolicyPodId: scope.spaceId ?? undefined,
+    }),
   });
 }
 
@@ -260,14 +260,17 @@ export async function ensurePodSandboxReady(
   return ensureOwnerSandboxReady(auth, {
     ensureActive: () =>
       PodSandboxAdapter.ensureSandboxActive(auth, pod, { requireRunning }),
-    getFileSystem: () =>
-      DustFileSystem.forPod(auth, pod, {
-        sandboxOnlyMounts: podSandboxOnlyMounts(pod),
-      }),
-    runtimeOwner: {
-      kind: "pod",
-      spaceId: pod.sId,
-    },
-    egressPolicyOwnerId: pod.sId,
+    // Pods are their own scope and cannot move — the config is static.
+    deriveConfig: () => ({
+      getFileSystem: () =>
+        DustFileSystem.forPod(auth, pod, {
+          sandboxOnlyMounts: podSandboxOnlyMounts(pod),
+        }),
+      runtimeOwner: {
+        kind: "pod",
+        spaceId: pod.sId,
+      },
+      egressPolicyOwnerId: pod.sId,
+    }),
   });
 }

--- a/front/lib/resources/conversation_sandbox_adapter.ts
+++ b/front/lib/resources/conversation_sandbox_adapter.ts
@@ -1,6 +1,6 @@
 import { resolvePodForRuntimeOwner } from "@app/lib/api/sandbox/owner";
 import type { Authenticator } from "@app/lib/auth";
-import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { PodSandboxAdapter } from "@app/lib/resources/pod_sandbox_adapter";
 import type {
   EnsureSandboxResult,
@@ -15,7 +15,7 @@ import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
 
@@ -24,11 +24,13 @@ type ConversationSandboxOwner = Pick<
   "id" | "sId"
 >;
 
-// ensureSandboxActive additionally needs the conversation's space (a string
-// sId, so ConversationResource — whose spaceId is a ModelId — does not
-// qualify) to inject pod-scoped env vars for conversations inside a pod.
-type ConversationSandboxEnsureOwner = ConversationSandboxOwner &
-  Pick<ConversationWithoutContentType, "spaceId">;
+// The conversation's authorization scope, resolved from the database inside
+// the lifecycle lock — never from the caller's conversation object, which is
+// typically an agent-loop snapshot that a concurrent move can invalidate.
+export type ConversationSandboxScope = {
+  // The pod's space sId when the conversation lives in one.
+  spaceId: string | null;
+};
 
 type ConversationSandboxLifecycleOwner = Pick<
   ConversationResource,
@@ -144,13 +146,31 @@ export class ConversationSandboxAdapter {
 
   static async ensureSandboxActive(
     auth: Authenticator,
-    conversation: ConversationSandboxEnsureOwner
-  ): Promise<Result<EnsureSandboxResult, Error>> {
+    conversation: ConversationSandboxOwner
+  ): Promise<Result<EnsureSandboxResult<ConversationSandboxScope>, Error>> {
     return SandboxResource.ensureActive(auth, {
       lockKey: conversation.sId,
+      // Runs under the lifecycle lock: the conversation's pod association is
+      // an authorization input (egress claims, pod env vars, pod mounts) and
+      // a move — which holds the same lock — can change it at any time
+      // before the lock is acquired. Only the conversation's identity is
+      // trusted from the caller.
+      resolveScope: async () => {
+        const fresh = await ConversationResource.fetchById(
+          auth,
+          conversation.sId
+        );
+        if (!fresh) {
+          return new Err(
+            new Error(`Conversation ${conversation.sId} not found.`)
+          );
+        }
+        return new Ok({ spaceId: fresh.spaceSId });
+      },
       // Factory form: the pod-scope loads only run when a sandbox is
       // actually created.
-      envVars: () => this.buildConversationEnvVars(auth, conversation),
+      envVars: (scope) =>
+        this.buildConversationEnvVars(auth, conversation, scope),
       logLabel: "conversation",
       fetchSandbox: () => this.fetchSandbox(auth, conversation),
       createSandbox: (blob) =>
@@ -167,14 +187,15 @@ export class ConversationSandboxAdapter {
   // rule, keeping the file and the env consistent.
   private static async buildConversationEnvVars(
     auth: Authenticator,
-    conversation: ConversationSandboxEnsureOwner
+    conversation: ConversationSandboxOwner,
+    scope: ConversationSandboxScope
   ): Promise<Result<Record<string, string>, Error>> {
     const baseEnv = { CONVERSATION_ID: conversation.sId };
 
     const runtimeOwner = {
       kind: "conversation" as const,
       conversationId: conversation.sId,
-      spaceId: conversation.spaceId ?? null,
+      spaceId: scope.spaceId,
     };
     const podResult = await resolvePodForRuntimeOwner(auth, runtimeOwner);
     if (podResult.isErr()) {

--- a/front/lib/resources/pod_sandbox_adapter.ts
+++ b/front/lib/resources/pod_sandbox_adapter.ts
@@ -162,6 +162,10 @@ export class PodSandboxAdapter {
       auth,
       {
         ...this.toSandboxLifecycleOwner(auth, pod),
+        // Pods are their own scope and cannot move; nothing to re-resolve
+        // under the lock (which also keeps requireRunning's lock-free fast
+        // path sound for pods).
+        resolveScope: async () => new Ok(undefined),
         // Factory form: the loads only run when a sandbox is actually
         // created — ensureActive on an already-running sandbox discards
         // owner env vars, so eager loads would waste two queries per call.

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -1163,9 +1163,22 @@ describe("SandboxResource.ensureActive", () => {
       throw podSecretResult.error;
     }
 
+    // The pod association is resolved from the database under the lifecycle
+    // lock, so the conversation must actually live in the pod — a spaceId on
+    // the passed object would be (correctly) ignored.
+    const conversationResource = await ConversationResource.fetchById(
+      authenticator,
+      conversation.sId
+    );
+    if (!conversationResource) {
+      throw new Error("Test conversation not found");
+    }
+    await conversationResource.updateSpaceId(authenticator, pod);
+    await authenticator.refresh();
+
     const result = await ConversationSandboxAdapter.ensureSandboxActive(
       authenticator,
-      { id: conversation.id, sId: conversation.sId, spaceId: pod.sId }
+      { id: conversation.id, sId: conversation.sId }
     );
     expect(result.isOk()).toBe(true);
 

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -42,10 +42,15 @@ import assert from "assert";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
 import { col, fn, Op, where } from "sequelize";
 
-export interface EnsureSandboxResult {
+export interface EnsureSandboxResult<TScope = undefined> {
   freshlyCreated: boolean;
   sandbox: SandboxResource;
   wokeFromSleep: boolean;
+  // Owner scope resolved inside the lifecycle lock (see
+  // SandboxCreateOwner.resolveScope). Callers must derive every
+  // scope-dependent input (egress claims, mounts, runtime owner) from this,
+  // never from state read before the lock.
+  scope: TScope;
 }
 
 export type SandboxCreateBlob = {
@@ -70,15 +75,22 @@ export type SandboxPreSleepCheck = (
   sandbox: SandboxResource
 ) => Promise<Result<void, Error>>;
 
-type SandboxCreateOwner = SandboxLifecycleOwner & {
+type SandboxCreateOwner<TScope> = SandboxLifecycleOwner & {
   createSandbox: (blob: SandboxCreateBlob) => Promise<SandboxResource>;
+  // Resolves the owner's authorization scope (e.g. a conversation's current
+  // pod association). Runs as the first step INSIDE the lifecycle lock so a
+  // scope transition (a move's destroy + spaceId change, which holds the
+  // same lock) can never interleave between the read and the create/wake it
+  // parameterizes. Owners with immutable scope return a constant.
+  resolveScope: () => Promise<Result<TScope, Error>>;
   // Owner env vars are only consumed when a sandbox is actually created.
   // Owners whose env requires DB reads (e.g. pod env vars) should pass the
   // factory form so ensureActive calls on an already-running sandbox don't
-  // pay for loads that would be discarded.
+  // pay for loads that would be discarded. The factory receives the
+  // lock-resolved scope.
   envVars:
     | Record<string, string>
-    | (() => Promise<Result<Record<string, string>, Error>>);
+    | ((scope: TScope) => Promise<Result<Record<string, string>, Error>>);
   logLabel: string;
 };
 
@@ -464,11 +476,12 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   // Owner env vars come either as a plain record or as a factory for owners
   // whose env requires DB reads — the factory only runs on the create paths,
   // so ensure calls on an already-running sandbox pay nothing.
-  private static async resolveOwnerEnvVars(
-    owner: SandboxCreateOwner
+  private static async resolveOwnerEnvVars<TScope>(
+    owner: SandboxCreateOwner<TScope>,
+    scope: TScope
   ): Promise<Result<Record<string, string>, Error>> {
     return typeof owner.envVars === "function"
-      ? owner.envVars()
+      ? owner.envVars(scope)
       : new Ok(owner.envVars);
   }
 
@@ -540,9 +553,9 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    * destroy-and-recreate of a still-running sandbox: a failure is logged and
    * recreation proceeds.
    */
-  static async ensureActive(
+  static async ensureActive<TScope = undefined>(
     auth: Authenticator,
-    owner: SandboxCreateOwner,
+    owner: SandboxCreateOwner<TScope>,
     opts: {
       beforeSleep?: SandboxPreSleepCheck;
       // Use the sandbox only if it is already running: do not create, wake, or recreate one.
@@ -550,7 +563,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       // cannot wait for.
       requireRunning?: boolean;
     } = {}
-  ): Promise<Result<EnsureSandboxResult, Error>> {
+  ): Promise<Result<EnsureSandboxResult<TScope>, Error>> {
     assert(
       auth.getNonNullableWorkspace().id !== undefined,
       "Cannot ensure sandbox without a workspace"
@@ -587,15 +600,32 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       // Same touch the locked path performs, so the reaper's inactivity clock keeps running for
       // sandboxes served entirely through the fast path. Throttled internally to one write/30s.
       await existing.updateLastActivityAt();
+      // Resolved outside the lock: this path never creates, wakes, or mints,
+      // so the scope parameterizes nothing lifecycle-ordered. requireRunning
+      // callers must therefore have lock-independent (immutable) scope.
+      const fastPathScopeResult = await owner.resolveScope();
+      if (fastPathScopeResult.isErr()) {
+        return fastPathScopeResult;
+      }
       return new Ok({
         sandbox: existing,
         freshlyCreated: false,
         wokeFromSleep: false,
+        scope: fastPathScopeResult.value,
       });
     }
 
     return this.withLifecycleLock(owner.lockKey, async (provider) => {
       const tracingOpts = { workspaceId: auth.getNonNullableWorkspace().sId };
+      // First thing under the lock: a scope transition holds this same lock,
+      // so everything derived from here cannot be invalidated by a
+      // concurrent move.
+      const scopeResult = await owner.resolveScope();
+      if (scopeResult.isErr()) {
+        return scopeResult;
+      }
+      const scope = scopeResult.value;
+
       const existing = await owner.fetchSandbox();
 
       if (!existing) {
@@ -605,7 +635,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         }
 
         const createConfig = imageResult.value.toCreateConfig();
-        const ownerEnvVarsResult = await this.resolveOwnerEnvVars(owner);
+        const ownerEnvVarsResult = await this.resolveOwnerEnvVars(owner, scope);
         if (ownerEnvVarsResult.isErr()) {
           return ownerEnvVarsResult;
         }
@@ -642,7 +672,12 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           "Created new sandbox for owner"
         );
 
-        return new Ok({ sandbox, freshlyCreated: true, wokeFromSleep: false });
+        return new Ok({
+          sandbox,
+          freshlyCreated: true,
+          wokeFromSleep: false,
+          scope,
+        });
       }
 
       let effectiveStatus: SandboxStatus = existing.status;
@@ -749,7 +784,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           }
 
           const createConfig = imageResult.value.toCreateConfig();
-          const ownerEnvVarsResult = await this.resolveOwnerEnvVars(owner);
+          const ownerEnvVarsResult = await this.resolveOwnerEnvVars(
+            owner,
+            scope
+          );
           if (ownerEnvVarsResult.isErr()) {
             return ownerEnvVarsResult;
           }
@@ -809,7 +847,12 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         recordLifecycleOperation("create");
       }
 
-      return new Ok({ sandbox: existing, freshlyCreated, wokeFromSleep });
+      return new Ok({
+        sandbox: existing,
+        freshlyCreated,
+        wokeFromSleep,
+        scope,
+      });
     });
   }
 

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -117,9 +117,13 @@ export type SandboxDeleteOwner = SandboxLifecycleOwner & {
 // expires mid-operation, a concurrent ensure or move can acquire the lock
 // and the scope-serialization guarantee is gone. The cost of a generous TTL
 // is that a crashed holder strands the lock for up to this long; waiters
-// give up at executeWithLock's 30s acquisition timeout well before that.
-// TODO(2026-09-30 SANDBOX): replace with a renewable lease so the TTL can
-// shrink to heartbeat scale.
+// give up at executeWithLock's 30s acquisition timeout well before that,
+// and the kill-requested recovery self-heals once the lease expires. That
+// trade is deliberate: a heartbeat-renewed lease would shrink the stranding
+// window, but the machinery it needs (an extend loop, abort semantics for
+// a lost lease mid-operation) is only worth building if crash-stranded
+// locks show up in practice — a rare event with a bounded,
+// one-conversation blast radius.
 const SANDBOX_LIFECYCLE_LOCK_TTL_MS = 5 * 60 * 1000;
 
 const LAST_ACTIVITY_WRITE_INTERVAL_MS = 30_000;

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -111,6 +111,17 @@ export type SandboxDeleteOwner = SandboxLifecycleOwner & {
 // Activity writes are throttled to this granularity; the reaper's inactivity
 // thresholds are minutes-scale, so a lastActivityAt up to 30s stale is
 // indistinguishable to it.
+// How long an acquired lifecycle lock stays valid. Must comfortably exceed
+// the slowest operation performed under it (provider create/wake and, for
+// scope transitions, provider destroy + the database move) — if the lease
+// expires mid-operation, a concurrent ensure or move can acquire the lock
+// and the scope-serialization guarantee is gone. The cost of a generous TTL
+// is that a crashed holder strands the lock for up to this long; waiters
+// give up at executeWithLock's 30s acquisition timeout well before that.
+// TODO(2026-09-30 SANDBOX): replace with a renewable lease so the TTL can
+// shrink to heartbeat scale.
+const SANDBOX_LIFECYCLE_LOCK_TTL_MS = 5 * 60 * 1000;
+
 const LAST_ACTIVITY_WRITE_INTERVAL_MS = 30_000;
 
 // How long a kill-requested sandbox may keep failing its pre-destroy flush
@@ -464,6 +475,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       undefined,
       {
         traceAcquireResource: "sandbox:lifecycle",
+        lockTtlMs: SANDBOX_LIFECYCLE_LOCK_TTL_MS,
         // Contended by concurrent invocations of the same pod: transitions
         // hold this lock from milliseconds (status checks) to seconds
         // (wake/create), and waiters on the fast side of that range should


### PR DESCRIPTION
## Description

Follow up of `29432`. A conversation's pod association is an authorization input — it drives the sandbox's egress claims, pod env vars, and pod mounts — but it was derived from state read **before** the sandbox lifecycle lock (typically the agent loop's conversation snapshot). A move committing between that read and the lock acquisition could create or wake a sandbox in its pre-move pod: the classic case is an agent moving its own conversation mid-loop and invoking the Computer again with its stale snapshot.

**What this PR does:**

1. `ensureActive` gains a `resolveScope` hook that runs as the **first step inside the lifecycle lock**; the conversation adapter implements it as a fresh DB read of `spaceId`. Since a scope transition (a move) holds the same lock, nothing derived from the resolved scope can be invalidated by a concurrent move.
2. The lock-resolved scope feeds the env-var factory (creation) and is returned on `EnsureSandboxResult`, so the ready path derives the filesystem, runtime owner, and egress claims from it — never from the caller.
3. Callers' conversation objects are trusted for **identity only**: the adapter's input type no longer accepts a `spaceId`, making the stale-snapshot pattern unrepresentable at compile time.
4. Pods resolve a constant scope (they cannot move), which keeps `requireRunning`'s lock-free fast path sound.

The move-side half — strictly destroying the sandbox when the association actually changes — is the stacked `30379`.

> [!NOTE]
> This PR previously carried an `egressTokenScope` fingerprint column (persistent per-sandbox scope state + re-mint-on-mismatch). Review concluded the lifecycle lock and existing columns already provide the guarantee for strict destroy/recreate semantics, so the schema change is gone — this diff replaces it, no migration anywhere in the stack.

## Risk

Worst case, the under-lock conversation fetch fails and sandbox bring-up errors (fail closed — no sandbox runs with unverified scope). One extra indexed read per ensure call, on a path that already does a provider round-trip. Safe to rollback: no schema change, no new state.

## Deploy Plan

- [ ] Deploy front (no ordering constraints)

## Tests

Adapter level: a conversation moved in the database gets the new pod's env vars with no `spaceId` accepted from the caller. Lifecycle level: the ready path derives egress claims, runtime owner, and mounts from the returned scope and ignores stale caller snapshots (both directions: pod gained, pod lost).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
