### PR TITLE
[dsbx] Use named stdout file descriptor

### DIFF
--- a/cli/dust-sandbox/functions-runner/emit.ts
+++ b/cli/dust-sandbox/functions-runner/emit.ts
@@ -32,7 +32,12 @@ export function emitEnvelopeLine(envelope: unknown): void {
   let offset = 0;
   while (offset < bytes.length) {
     try {
-      offset += writeSync(1, bytes, offset, bytes.length - offset);
+      offset += writeSync(
+        process.stdout.fd,
+        bytes,
+        offset,
+        bytes.length - offset
+      );
     } catch (error) {
       if (isRetryableWriteError(error)) {
         continue;


### PR DESCRIPTION
## Description

Follow-up to #30344. Replace the magic stdout file descriptor `1` with `process.stdout.fd`.

## Tests

`bun test runner.test.ts`

## Risk

Low. This resolves to the same file descriptor and keeps the synchronous write path unchanged.

## Deploy Plan

Standard deploy.
