### PR TITLE
Bump dsbx to 0.1.48 and dust-base to 0.8.80

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.47"
+version = "0.1.48"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.47"
+version = "0.1.48"
 edition = "2021"
 
 [[bin]]

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.79",
+      tag: "0.8.80",
     });
   });
 
@@ -457,7 +457,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.47/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.48/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,8 +26,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.79";
-const DSBX_CLI_VERSION = "0.1.47";
+const DUST_BASE_IMAGE_VERSION = "0.8.80";
+const DSBX_CLI_VERSION = "0.1.48";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
 // the stable identity used when creating the workload account.


### PR DESCRIPTION
Pins the sandbox image to a new dsbx CLI and dust-base image carrying the large-output handling work merged since 0.1.47.

## What ships

- Drain-safe runner stdout, so a large result is no longer cut mid-JSON while the runner exits 0, plus `output_truncated` classification when a cut envelope is seen.
- Result spill-to-file above the inline cap, with a 5MB hard cap reported as `output_too_large`.
- Machine-readable offload descriptor on tool output blocks, and a parse-safe stub for offloaded JSON in sandbox-function run contexts.
- `@dust/pod` 0.2.0: `tools.call()` typed async tool client and `resolveToolTextContent()`.
- Typed error envelope and distinct exit codes for `dsbx tools` failures, plus `--args-json` and scalar coercion for `__file__:` args.
- `pod_editor_required` accepted by the functions-runner.
- `structured_content` on `CallToolResult`.

## Prerequisites before merging

1. The dsbx `0.1.48` release must be published (the image build downloads `dsbx-v0.1.48/dsbx-linux-x86_64`).
2. The `dust-base` `0.8.80` image must be built and published.
3. The Pod function result-spill read side must already be deployed, otherwise a spilled result comes back as a pointer that production front does not yet understand.

## After deploy

Open `/poke/kill` and request a kill of older versions for the affected image so existing conversations get sandboxes carrying the new dsbx and `@dust/pod`.