### PR TITLE
Fix activation Get Started UX: conversation list radius, layout centering, button shape

### DIFF
--- a/front/components/pages/workspace/GetStartedPage/ActivationRunningBanner.tsx
+++ b/front/components/pages/workspace/GetStartedPage/ActivationRunningBanner.tsx
@@ -27,7 +27,6 @@ export function ActivationRunningBanner({
         <Button
           variant="outline"
           size="sm"
-          isRounded
           label="Go to conversation"
           iconRight={ArrowRight}
           onClick={() =>

--- a/front/components/pages/workspace/GetStartedPage/RecentConversations.tsx
+++ b/front/components/pages/workspace/GetStartedPage/RecentConversations.tsx
@@ -25,10 +25,7 @@ function RecentConversationRow({
 
   return (
     <ConversationListItem
-      className={cn(
-        "rounded-2xl border-x-0 hover:bg-hover",
-        activeConversationId === conversation.id && "bg-selected"
-      )}
+      className={cn(activeConversationId === conversation.id && "bg-selected")}
       conversation={{
         id: conversation.id,
         title: conversation.title,

--- a/front/components/pages/workspace/GetStartedPage/WorkAreaSection.tsx
+++ b/front/components/pages/workspace/GetStartedPage/WorkAreaSection.tsx
@@ -119,7 +119,7 @@ export function WorkAreaSection({
   );
 
   return (
-    <div className="mt-12 rounded-2xl border border-border bg-background px-6 pb-8 pt-6 shadow-sm">
+    <div className="mt-12 rounded-2xl border border-border bg-background px-6 pb-4 pt-6 shadow-sm">
       <h2 className="text-xl font-semibold leading-7 tracking-tight text-foreground">
         Your work
       </h2>

--- a/front/components/pages/workspace/GetStartedPage/index.tsx
+++ b/front/components/pages/workspace/GetStartedPage/index.tsx
@@ -196,7 +196,7 @@ export function GetStartedPage() {
             disabled={isActivationPodLoading}
           />
 
-          <div className="mt-12 rounded-2xl border border-border bg-background px-6 pb-8 pt-6 shadow-sm">
+          <div className="mt-12 rounded-2xl border border-border bg-background px-6 pb-4 pt-6 shadow-sm">
             <h2 className="text-xl font-semibold leading-7 tracking-tight text-foreground">
               Ideas for right now
             </h2>

--- a/front/components/pages/workspace/GetStartedPage/index.tsx
+++ b/front/components/pages/workspace/GetStartedPage/index.tsx
@@ -168,7 +168,7 @@ export function GetStartedPage() {
               : "/static/activation/for-you-orb-small.svg"
           }
         />
-        <div className="relative ml-[9%] w-[53%] pb-16 pt-[15vh]">
+        <div className="relative mx-auto w-full max-w-2xl px-4 pb-16 pt-[15vh] sm:px-8 lg:mx-0 lg:ml-[9%] lg:w-[53%] lg:max-w-none lg:px-0">
           <div className="flex flex-col gap-1">
             <h1 className="text-5xl font-medium leading-[52px] tracking-[-0.06em] text-foreground">
               Welcome back, {firstName}.


### PR DESCRIPTION
## Summary
- A few ux improvements based on feedback
- Remove `rounded-2xl`/`border-x-0`/`hover:bg-hover` CSS overrides from `ConversationListItem` in `RecentConversations` — the outer `overflow-hidden rounded-xl` container handles clipping; per-item `rounded-2xl` caused visible corner artifacts at item junctions
- Add `lg:` responsive breakpoint to the main content column so it centers full-width on smaller screens instead of staying fixed at `ml-[9%] w-[53%]`
- Remove `isRounded` from the "Go to conversation" button in `ActivationRunningBanner` so it uses the standard `rounded-xl` shape instead of a pill

## Testing
<img width="879" height="851" alt="Screenshot 2026-08-12 at 10 43 51 AM" src="https://github.com/user-attachments/assets/06158c7f-f86a-4e60-8bbf-51b85cca0bda" />

## Risk
Low

## Deploy
1. Deploy fornt
