### PR TITLE
Fix published frames breaking when moved or renamed

### DIFF
--- a/front/lib/api/actions/servers/files/tools/delete.test.ts
+++ b/front/lib/api/actions/servers/files/tools/delete.test.ts
@@ -1,9 +1,12 @@
 import { deleteHandler } from "@app/lib/api/actions/servers/files/tools/delete";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { FileResource } from "@app/lib/resources/file_resource";
 import {
   makeExtra,
   setupProjectConversation,
 } from "@app/tests/utils/conversation_test_factories";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { frameContentType } from "@app/types/files";
 import assert from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -11,7 +14,10 @@ vi.mock("@app/lib/file_storage/config", () => ({
   default: { getGcsPrivateUploadsBucket: vi.fn(() => "test-bucket") },
 }));
 vi.mock("@app/lib/api/config", () => ({
-  default: { getApiBaseUrl: vi.fn(() => "https://dust.tt") },
+  default: {
+    getApiBaseUrl: vi.fn(() => "https://dust.tt"),
+    getAppUrl: vi.fn(() => "https://dust.tt"),
+  },
 }));
 
 describe("deleteHandler", () => {
@@ -27,9 +33,13 @@ describe("deleteHandler", () => {
       .mockResolvedValue({ files: [], pageFetchCount: 1 });
 
     vi.mocked(getPrivateUploadBucket).mockReturnValue({
-      file: vi.fn(() => ({ exists: existsMock })),
+      file: vi.fn(() => ({
+        exists: existsMock,
+        delete: vi.fn().mockResolvedValue(undefined),
+      })),
       delete: deleteMock,
       getAllFilesByPrefix: getAllFilesByPrefixMock,
+      copyFile: vi.fn().mockResolvedValue(undefined),
     } as unknown as ReturnType<typeof getPrivateUploadBucket>);
   });
 
@@ -84,6 +94,37 @@ describe("deleteHandler", () => {
     if (result.isErr()) {
       expect(result.error.message).toContain("not found");
     }
+  });
+
+  it("deletes the FileResource and its share record along with a published frame's bytes", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    const conversationId = conversation.sId;
+
+    const frame = await FileFactory.create(auth, null, {
+      contentType: frameContentType,
+      fileName: "app.tsx",
+      fileSize: 100,
+      status: "ready",
+      useCase: "tool_output",
+      useCaseMetadata: { conversationId },
+    });
+    // markAsReady gives every interactive-content file a share token, so an orphaned row here
+    // would mean a live share URL for a file the user deleted.
+    const shareInfo = await frame.getShareInfo();
+    assert(shareInfo);
+    const shareToken = shareInfo.shareUrl.split("/").pop();
+    assert(shareToken);
+
+    const result = await deleteHandler(
+      { path: `conversation-${conversationId}/app.tsx` },
+      makeExtra(auth, conversation)
+    );
+
+    assert(result.isOk());
+    expect(await FileResource.fetchById(auth, frame.sId)).toBeNull();
+    expect((await FileResource.fetchByShareToken(shareToken)).isErr()).toBe(
+      true
+    );
   });
 
   it("returns Err(legacy_path) for a legacy path and instructs the agent to re-list", async () => {

--- a/front/lib/api/actions/servers/files/tools/delete.ts
+++ b/front/lib/api/actions/servers/files/tools/delete.ts
@@ -8,6 +8,7 @@ import {
   requireAgentLoopConversation,
   scopedPathsFromArgs,
 } from "@app/lib/api/actions/servers/files/tools/agent_loop_fs";
+import { deleteCanonicalFile } from "@app/lib/api/files/file_system_ops";
 import { Err, Ok } from "@app/types/shared/result";
 
 export async function deleteHandler(
@@ -28,7 +29,10 @@ export async function deleteHandler(
     return fsResult;
   }
 
-  const deleteResult = await fsResult.value.delete(path);
+  // Goes through deleteCanonicalFile, not the raw filesystem delete: a file backed by a
+  // FileResource (any published Frame, among others) must lose its row and its share token
+  // together with its bytes, or the share URL keeps serving content the user deleted.
+  const deleteResult = await deleteCanonicalFile(auth, fsResult.value, path);
   if (deleteResult.isErr()) {
     const err = deleteResult.error;
     switch (err.code) {

--- a/front/lib/api/files/file_system_ops.test.ts
+++ b/front/lib/api/files/file_system_ops.test.ts
@@ -1,0 +1,186 @@
+import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import {
+  moveCanonicalFile,
+  renameCanonicalFile,
+} from "@app/lib/api/files/file_system_ops";
+import { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import { frameContentType } from "@app/types/files";
+import assert from "assert";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("moveCanonicalFile / renameCanonicalFile FileResource sync", () => {
+  let auth: Authenticator;
+  let conversation: ConversationType;
+  let projectSpace: SpaceResource;
+  let workspaceId: string;
+
+  beforeEach(async () => {
+    const { workspace, user } = await createResourceTest({ role: "admin" });
+    workspaceId = workspace.sId;
+
+    // Create the project space, then re-fetch auth so it knows about the new editor group.
+    projectSpace = await SpaceFactory.project(workspace, user.id);
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+  });
+
+  async function makeFileSystemWithPodMount(): Promise<DustFileSystem> {
+    const fsResult = await DustFileSystem.forAgentLoop(auth, {
+      conversation,
+      scopedPaths: [`pod-${projectSpace.sId}/app.tsx`],
+    });
+    assert(fsResult.isOk());
+    return fsResult.value;
+  }
+
+  async function makePublishedFrame(): Promise<FileResource> {
+    const file = await FileFactory.create(auth, null, {
+      contentType: frameContentType,
+      fileName: "app.tsx",
+      fileSize: 100,
+      status: "ready",
+      useCase: "tool_output",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    // Mirror what publishFrame stores: the entry's directory as bundle root, its
+    // filename as entry rel path (see splitFrameEntryScopedPath).
+    await file.setUseCaseMetadata(auth, {
+      ...(file.useCaseMetadata ?? {}),
+      frameBundleRootPath: `conversation-${conversation.sId}`,
+      frameEntryRelPath: "app.tsx",
+      lastEditedByAgentConfigurationId: "test_agent_config_id",
+    });
+
+    expect(file.mountFilePath).toBe(
+      `w/${workspaceId}/conversations/${conversation.sId}/files/app.tsx`
+    );
+    expect(file.isPublishedFrame()).toBe(true);
+
+    return file;
+  }
+
+  it("keeps a published frame published when moved from conversation to pod", async () => {
+    const file = await makePublishedFrame();
+    const dustFs = await makeFileSystemWithPodMount();
+
+    // The destination must not pre-exist for DustFileSystem.move to proceed.
+    fileStorageMock.setFileExists(
+      (filePath) => !filePath.startsWith(`w/${workspaceId}/pods/`)
+    );
+
+    const result = await moveCanonicalFile(
+      auth,
+      dustFs,
+      `conversation-${conversation.sId}/app.tsx`,
+      `pod-${projectSpace.sId}/app.tsx`
+    );
+    assert(result.isOk());
+
+    const moved = await FileResource.fetchById(auth, file.sId);
+    assert(moved);
+
+    expect(moved.mountFilePath).toBe(
+      `w/${workspaceId}/pods/${projectSpace.sId}/files/app.tsx`
+    );
+    expect(moved.useCase).toBe("project_context");
+    expect(moved.useCaseMetadata?.spaceId).toBe(projectSpace.sId);
+    expect(moved.useCaseMetadata?.conversationId).toBeUndefined();
+
+    // The publish state must survive the move, retargeted to the new location.
+    expect(moved.useCaseMetadata?.frameBundleRootPath).toBe(
+      `pod-${projectSpace.sId}`
+    );
+    expect(moved.useCaseMetadata?.frameEntryRelPath).toBe("app.tsx");
+    expect(moved.useCaseMetadata?.lastEditedByAgentConfigurationId).toBe(
+      "test_agent_config_id"
+    );
+    expect(moved.isPublishedFrame()).toBe(true);
+    expect(moved.getRenderableVersion()).toBe("processed");
+  });
+
+  it("keeps a published frame published when renamed in place", async () => {
+    const file = await makePublishedFrame();
+    const dustFs = await makeFileSystemWithPodMount();
+
+    fileStorageMock.setFileExists(
+      (filePath) => !filePath.endsWith("/main.tsx")
+    );
+
+    const result = await renameCanonicalFile(
+      auth,
+      dustFs,
+      `conversation-${conversation.sId}/app.tsx`,
+      "main.tsx"
+    );
+    assert(result.isOk());
+
+    const renamed = await FileResource.fetchById(auth, file.sId);
+    assert(renamed);
+
+    expect(renamed.mountFilePath).toBe(
+      `w/${workspaceId}/conversations/${conversation.sId}/files/main.tsx`
+    );
+    expect(renamed.useCase).toBe("tool_output");
+    expect(renamed.useCaseMetadata?.conversationId).toBe(conversation.sId);
+    expect(renamed.useCaseMetadata?.frameBundleRootPath).toBe(
+      `conversation-${conversation.sId}`
+    );
+    expect(renamed.useCaseMetadata?.frameEntryRelPath).toBe("main.tsx");
+    expect(renamed.isPublishedFrame()).toBe(true);
+    expect(renamed.getRenderableVersion()).toBe("processed");
+  });
+
+  it("swaps scope metadata and preserves the rest for non-frame files", async () => {
+    const file = await FileFactory.csv(auth, null, {
+      useCase: "tool_output",
+      useCaseMetadata: {
+        conversationId: conversation.sId,
+        generatedTables: ["table_1"],
+      },
+      fileName: "data.csv",
+    });
+    const dustFs = await makeFileSystemWithPodMount();
+
+    fileStorageMock.setFileExists(
+      (filePath) => !filePath.startsWith(`w/${workspaceId}/pods/`)
+    );
+
+    const result = await moveCanonicalFile(
+      auth,
+      dustFs,
+      `conversation-${conversation.sId}/data.csv`,
+      `pod-${projectSpace.sId}/data.csv`
+    );
+    assert(result.isOk());
+
+    const moved = await FileResource.fetchById(auth, file.sId);
+    assert(moved);
+
+    expect(moved.useCase).toBe("project_context");
+    expect(moved.useCaseMetadata?.spaceId).toBe(projectSpace.sId);
+    expect(moved.useCaseMetadata?.conversationId).toBeUndefined();
+    expect(moved.useCaseMetadata?.generatedTables).toEqual(["table_1"]);
+    expect(moved.useCaseMetadata?.frameBundleRootPath).toBeUndefined();
+  });
+});

--- a/front/lib/api/files/file_system_ops.ts
+++ b/front/lib/api/files/file_system_ops.ts
@@ -264,6 +264,47 @@ function inferDestMountInfo(
 }
 
 /**
+ * Compute the useCaseMetadata a linked FileResource carries after its mount file moved or was
+ * renamed to `destScopedPath`.
+ *
+ * Metadata is carried over, not rebuilt: only location-derived fields change. The scope field of
+ * the previous location (conversationId or spaceId) is dropped in favor of the one inferred from
+ * the destination. For published Frames the bundle fields are recomputed against the destination,
+ * keeping the invariant of `splitFrameEntryScopedPath`: the root is the entry's directory and the
+ * entry rel path is its filename. Replacing the metadata wholesale here used to wipe
+ * `frameBundleRootPath`, which flipped `getRenderableVersion` back to "original" and made a
+ * published Frame render as raw source after any move.
+ */
+function translateUseCaseMetadataForMove({
+  previousMetadata,
+  destScopedPath,
+  destScopeMetadata,
+}: {
+  previousMetadata: FileUseCaseMetadata | null;
+  destScopedPath: string;
+  destScopeMetadata: FileUseCaseMetadata;
+}): FileUseCaseMetadata {
+  const translated: FileUseCaseMetadata = {
+    ...(previousMetadata ?? {}),
+    ...destScopeMetadata,
+  };
+
+  if (!("conversationId" in destScopeMetadata)) {
+    delete translated.conversationId;
+  }
+  if (!("spaceId" in destScopeMetadata)) {
+    delete translated.spaceId;
+  }
+
+  if (previousMetadata?.frameBundleRootPath) {
+    translated.frameBundleRootPath = path.posix.dirname(destScopedPath);
+    translated.frameEntryRelPath = path.posix.basename(destScopedPath);
+  }
+
+  return translated;
+}
+
+/**
  * Rename a file at `scopedPath` to `newFileName` (same directory) and sync the
  * linked FileResource record if one exists.
  *
@@ -298,7 +339,11 @@ export async function renameCanonicalFile(
         destFileName: newFileName,
         destMountFilePath: destGcsPath,
         destUseCase: destInfo.useCase,
-        destUseCaseMetadata: destInfo.useCaseMetadata,
+        destUseCaseMetadata: translateUseCaseMetadataForMove({
+          previousMetadata: linkedFileResource.useCaseMetadata,
+          destScopedPath: dest,
+          destScopeMetadata: destInfo.useCaseMetadata,
+        }),
       });
     }
   }
@@ -337,7 +382,11 @@ export async function moveCanonicalFile(
         destFileName,
         destMountFilePath: destGcsPath,
         destUseCase: destInfo.useCase,
-        destUseCaseMetadata: destInfo.useCaseMetadata,
+        destUseCaseMetadata: translateUseCaseMetadataForMove({
+          previousMetadata: linkedFileResource.useCaseMetadata,
+          destScopedPath: dest,
+          destScopeMetadata: destInfo.useCaseMetadata,
+        }),
       });
     }
   }

--- a/front/lib/api/files/file_system_ops.ts
+++ b/front/lib/api/files/file_system_ops.ts
@@ -275,7 +275,7 @@ function inferDestMountInfo(
  * `frameBundleRootPath`, which flipped `getRenderableVersion` back to "original" and made a
  * published Frame render as raw source after any move.
  */
-function translateUseCaseMetadataForMove({
+export function translateUseCaseMetadataForMove({
   previousMetadata,
   destScopedPath,
   destScopeMetadata,

--- a/front/lib/api/projects/context.test.ts
+++ b/front/lib/api/projects/context.test.ts
@@ -1,17 +1,22 @@
 import {
+  addFileToProject,
   removeContentNodesFromProject,
   removeFileFromProject,
 } from "@app/lib/api/projects/context";
 import { MessageModel } from "@app/lib/models/agent/conversation";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { FileModel } from "@app/lib/resources/storage/models/files";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { frameContentType } from "@app/types/files";
 import { beforeEach, describe, expect, it } from "vitest";
 
 describe("removeFileFromProject", () => {
@@ -318,5 +323,71 @@ describe("removeContentNodesFromProject", () => {
       where: { id: superseded.id, workspaceId: workspace.id },
     });
     expect(supersededAfter).toBeNull();
+  });
+});
+
+describe("addFileToProject", () => {
+  it("keeps a published frame published when saved from a conversation into a pod", async () => {
+    const { auth, workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const project = await SpaceFactory.project(workspace, user.id);
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+
+    const frame = await FileFactory.create(auth, user, {
+      contentType: frameContentType,
+      fileName: "app.tsx",
+      fileSize: 100,
+      status: "ready",
+      useCase: "tool_output",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+    // Mirror publishFrame: the entry's directory is the bundle root, its filename the entry.
+    await frame.setUseCaseMetadata(auth, {
+      ...(frame.useCaseMetadata ?? {}),
+      frameBundleRootPath: `conversation-${conversation.sId}`,
+      frameEntryRelPath: "app.tsx",
+    });
+    expect(frame.isPublishedFrame()).toBe(true);
+
+    // The destination must be free for the move to proceed; the storage mock reports every
+    // path as existing by default.
+    fileStorageMock.setFileExists(
+      (filePath) => !filePath.startsWith(`w/${workspace.sId}/pods/`)
+    );
+
+    // This is the "Save to Pod" button on the frame renderer.
+    const res = await addFileToProject(auth, {
+      file: frame,
+      space: project,
+      sourceConversationId: conversation.sId,
+    });
+    if (res.isErr()) {
+      throw new Error(`addFileToProject failed: ${res.error.message}`);
+    }
+
+    const moved = await FileResource.fetchById(auth, frame.sId);
+    expect(moved).not.toBeNull();
+    expect(moved!.useCase).toBe("project_context");
+    expect(moved!.useCaseMetadata?.spaceId).toBe(project.sId);
+    expect(moved!.useCaseMetadata?.sourceConversationId).toBe(conversation.sId);
+    expect(moved!.useCaseMetadata?.conversationId).toBeUndefined();
+
+    // The publish state must survive, retargeted to the pod.
+    expect(moved!.useCaseMetadata?.frameBundleRootPath).toBe(
+      `pod-${project.sId}`
+    );
+    expect(moved!.useCaseMetadata?.frameEntryRelPath).toBe("app.tsx");
+    expect(moved!.isPublishedFrame()).toBe(true);
+    expect(moved!.getRenderableVersion()).toBe("processed");
   });
 });

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -9,6 +9,7 @@ import {
   DustFileSystemError,
   podScopedPath,
 } from "@app/lib/api/file_system/types";
+import { translateUseCaseMetadataForMove } from "@app/lib/api/files/file_system_ops";
 import {
   deleteGCSMountFile,
   moveFile,
@@ -393,10 +394,17 @@ export async function addFileToProject(
       destRelativeFilePath: destFileName,
       destFileName,
       destUseCase: "project_context",
-      destUseCaseMetadata: {
-        spaceId: space.sId,
-        ...(sourceConversationId ? { sourceConversationId } : {}),
-      },
+      // Carried over rather than rebuilt: a published Frame saved into a Pod must keep the
+      // bundle root and entry recorded at publish time, retargeted to the Pod, or it renders
+      // as raw source once it lands there.
+      destUseCaseMetadata: translateUseCaseMetadataForMove({
+        previousMetadata: file.useCaseMetadata,
+        destScopedPath,
+        destScopeMetadata: {
+          spaceId: space.sId,
+          ...(sourceConversationId ? { sourceConversationId } : {}),
+        },
+      }),
     });
     if (moveRes.isErr()) {
       return new Err({


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Moving or renaming a file rebinds its file resource to the new location, but the rebind replaced the use case metadata wholesale with the minimal scope inferred from the destination. For a published frame this wiped the bundle root and entry recorded at publish time, so rendering fell back from the built bundle to the raw source: after moving a frame from a conversation to a pod it rendered as plain tsx and live edits could no longer resolve their build root, which is the exact behavior customers have been reporting.

The rebind now carries the previous metadata over and only changes what the location change implies. The scope field of the old location is dropped in favor of the destination's, and for published frames the bundle root and entry are recomputed against the destination, preserving the invariant set at publish time that the root is the entry's directory and the entry its filename. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
