### PR TITLE
[front] One snippet path for offloaded tool output

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.test.ts
@@ -181,7 +181,7 @@ describe("GET /api/v1/w/[wId]/sandbox/actions/[aId] (function invocation)", () =
         resource: {
           uri: "pod-spc_x/.tool_outputs/fn/1_tool.json",
           mimeType: "text/plain",
-          text: '{"__dust_offloaded__":true}\n[Full content archived at pod-spc_x/.tool_outputs/fn/1_tool.json]',
+          text: '{"items":[{"id":1... (truncated)\n[Full content archived at pod-spc_x/.tool_outputs/fn/1_tool.json]',
         },
         _meta: {
           "tt.dust/offload": {

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -780,9 +780,11 @@ describe("processToolResults", () => {
     );
   });
 
-  it("should replace the head of offloaded JSON with a parse-safe stub in a sandbox function run context", async () => {
+  it("should use the same snippet shape and descriptor in a sandbox function run context", async () => {
     const { auth, toolContext } = await setupSandboxFunctionTest();
 
+    // JSON content: there is a single snippet path, so the snippet is a plain head cut here
+    // too. Code consumers read the full content back through the _meta descriptor.
     const largeJson = JSON.stringify({
       data: "x".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES),
     });
@@ -798,20 +800,10 @@ describe("processToolResults", () => {
     expect(stored.type).toBe("resource");
     assert(stored.type === "resource" && "text" in stored.resource);
 
-    // The stub is a single JSON line followed by the archive sentence, byte-identical to the
-    // sentence conversation snippets carry (existing function code regexes it).
-    const lines = stored.resource.text.split("\n");
-    expect(lines).toHaveLength(2);
-    expect(lines[1]).toBe(`[Full content archived at ${stored.resource.uri}]`);
-
-    // The stub itself parses and points at the full content, like the _meta descriptor.
-    expect(lines[0].length).toBeLessThanOrEqual(FILE_OFFLOAD_SNIPPET_LENGTH);
-    const stub = JSON.parse(lines[0]);
-    expect(stub.__dust_offloaded__).toBe(true);
-    expect(stub.fullContentPath).toBe(stored.resource.uri);
-    expect(stub.totalBytes).toBe(Buffer.byteLength(largeJson, "utf8"));
-    expect(stub.head.length).toBeGreaterThan(0);
-    expect(largeJson.startsWith(stub.head)).toBe(true);
+    expect(stored.resource.text).toBe(
+      `${largeJson.substring(0, FILE_OFFLOAD_SNIPPET_LENGTH)}... (truncated)\n` +
+        `[Full content archived at ${stored.resource.uri}]`
+    );
 
     expect(stored._meta?.[TOOL_OUTPUT_OFFLOAD_META_KEY]).toEqual({
       fullContentPath: stored.resource.uri,
@@ -820,85 +812,13 @@ describe("processToolResults", () => {
     });
 
     // The descriptor survives output-item persistence: it is part of the single GCS object
-    // recorded on the sandbox action.
+    // recorded on the sandbox action, which is what the function invocation reads.
     const outputWrite = fileStorageMock.saveFileCalls.find((call) =>
       call.filePath.endsWith("/output.json")
     );
     expect(outputWrite).toBeDefined();
     const persisted = JSON.parse(outputWrite?.content.toString() ?? "");
     expect(persisted[0]._meta?.[TOOL_OUTPUT_OFFLOAD_META_KEY]).toEqual({
-      fullContentPath: stored.resource.uri,
-      totalBytes: Buffer.byteLength(largeJson, "utf8"),
-      contentType: "application/json",
-    });
-  });
-
-  it("should keep the plain snippet for offloaded non-JSON text in a sandbox function run context", async () => {
-    const { auth, toolContext } = await setupSandboxFunctionTest();
-
-    const largeText = "x".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES + 1);
-
-    const { outputItems } = await processToolResults(auth, {
-      localLogger: logger.child({ test: true }),
-      toolContext,
-      toolCallResultContent: [{ type: "text", text: largeText }],
-    });
-
-    expect(outputItems).toHaveLength(1);
-    const stored = outputItems[0].content;
-    expect(stored.type).toBe("resource");
-    assert(stored.type === "resource" && "text" in stored.resource);
-
-    // Non-JSON content keeps today's exact snippet shape: raw head, truncation marker, sentence.
-    expect(
-      stored.resource.text.startsWith(
-        largeText.substring(0, FILE_OFFLOAD_SNIPPET_LENGTH)
-      )
-    ).toBe(true);
-    expect(stored.resource.text).toContain("... (truncated)");
-    expect(stored.resource.text).toContain(
-      `[Full content archived at ${stored.resource.uri}]`
-    );
-    expect(stored.resource.text).not.toContain("__dust_offloaded__");
-
-    expect(stored._meta?.[TOOL_OUTPUT_OFFLOAD_META_KEY]).toEqual({
-      fullContentPath: stored.resource.uri,
-      totalBytes: Buffer.byteLength(largeText, "utf8"),
-      contentType: "text/plain",
-    });
-  });
-
-  it("should keep today's snippet for offloaded JSON in an agent loop run context", async () => {
-    const { auth, toolContext } = await setupTest();
-
-    const largeJson = JSON.stringify({
-      data: "x".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES),
-    });
-
-    const { outputItems } = await processToolResults(auth, {
-      localLogger: logger.child({ test: true }),
-      toolContext,
-      toolCallResultContent: [{ type: "text", text: largeJson }],
-    });
-
-    expect(outputItems).toHaveLength(1);
-    const stored = outputItems[0].content;
-    expect(stored.type).toBe("resource");
-    assert(stored.type === "resource" && "text" in stored.resource);
-
-    // Conversation snippets are untouched by the parse-safe stub: raw head + sentence.
-    expect(
-      stored.resource.text.startsWith(
-        largeJson.substring(0, FILE_OFFLOAD_SNIPPET_LENGTH)
-      )
-    ).toBe(true);
-    expect(stored.resource.text).not.toContain("__dust_offloaded__");
-    expect(stored.resource.text).toContain(
-      `[Full content archived at ${stored.resource.uri}]`
-    );
-
-    // The descriptor is attached in every run context.
-    expect(stored._meta?.[TOOL_OUTPUT_OFFLOAD_META_KEY]).toEqual({
       fullContentPath: stored.resource.uri,
       totalBytes: Buffer.byteLength(largeJson, "utf8"),
       contentType: "application/json",

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -82,13 +82,13 @@ function getFileName(resource: { uri: string }): string {
 /**
  * Builds the model-visible snippet for a content block whose full text was offloaded to the
  * file system by persistToolOutput. The scoped path pointer is what lets the model read the
- * rest of the content back, so it must always be present. The
- * "[Full content archived at <path>]" sentence is a stable contract and must stay
- * byte-identical.
+ * rest of the content back, so it must always be present, and the
+ * "[Full content archived at <path>]" sentence stays byte-identical so the model reads the
+ * same wording everywhere.
  *
  * One snippet shape for every consumer: the snippet is for humans and models reading the
- * conversation, never a machine contract. Code consumers (function code via `@dust/pod`) read
- * the full content back through the `_meta` descriptor instead of parsing this text.
+ * conversation, never something to parse. Code consumers (function code via `@dust/pod`) read
+ * the full content back through the `_meta` descriptor instead.
  */
 function makeOffloadedSnippet(
   text: string,

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -23,7 +23,6 @@ import type {
   ActionGeneratedFileType,
   ToolContext,
   ToolOutputItemType,
-  ToolRunContext,
 } from "@app/lib/actions/types";
 import {
   isAgentLoopRunContext,
@@ -84,27 +83,18 @@ function getFileName(resource: { uri: string }): string {
  * Builds the model-visible snippet for a content block whose full text was offloaded to the
  * file system by persistToolOutput. The scoped path pointer is what lets the model read the
  * rest of the content back, so it must always be present. The
- * "[Full content archived at <path>]" sentence is a stable contract — existing function code
- * regexes it — and must stay byte-identical across variants.
+ * "[Full content archived at <path>]" sentence is a stable contract and must stay
+ * byte-identical.
  *
- * In a sandbox function run context, JSON content gets a parse-safe stub instead of the blind
- * character cut: code that strips the archive sentence and JSON.parses the rest gets an explicit
- * offload pointer object instead of JSON cut mid-string. Conversation (agent loop) snippets are
- * untouched.
+ * One snippet shape for every consumer: the snippet is for humans and models reading the
+ * conversation, never a machine contract. Code consumers (function code via `@dust/pod`) read
+ * the full content back through the `_meta` descriptor instead of parsing this text.
  */
 function makeOffloadedSnippet(
   text: string,
-  offload: PersistedToolOutput,
-  runContext: ToolRunContext
+  offload: PersistedToolOutput
 ): string {
   const archiveSentence = `[Full content archived at ${offload.scopedPath}]`;
-
-  if (
-    isSandboxFunctionRunContext(runContext) &&
-    offload.contentType === "application/json"
-  ) {
-    return `${makeParseSafeOffloadStub(text, offload)}\n${archiveSentence}`;
-  }
 
   const head = text.substring(0, FILE_OFFLOAD_SNIPPET_LENGTH);
   // The offload threshold is in bytes while the snippet cut is in characters, so multibyte
@@ -112,33 +102,6 @@ function makeOffloadedSnippet(
   // characters were actually dropped.
   const truncatedSuffix = head.length < text.length ? "... (truncated)" : "";
   return `${head}${truncatedSuffix}\n${archiveSentence}`;
-}
-
-/**
- * Serializes the parse-safe stub that replaces the head of offloaded JSON content for sandbox
- * function consumers. The serialized stub is capped at FILE_OFFLOAD_SNIPPET_LENGTH characters
- * (like the plain head cut): JSON escaping can inflate the head, so trim by the measured overage
- * until it fits — every head character serializes to at least one character, so this converges
- * in a few rounds.
- */
-function makeParseSafeOffloadStub(
-  text: string,
-  offload: PersistedToolOutput
-): string {
-  let head = text.substring(0, FILE_OFFLOAD_SNIPPET_LENGTH);
-  for (;;) {
-    const serialized = JSON.stringify({
-      __dust_offloaded__: true,
-      fullContentPath: offload.scopedPath,
-      totalBytes: offload.totalBytes,
-      head,
-    });
-    const overageChars = serialized.length - FILE_OFFLOAD_SNIPPET_LENGTH;
-    if (overageChars <= 0 || head.length === 0) {
-      return serialized;
-    }
-    head = head.substring(0, Math.max(0, head.length - overageChars));
-  }
 }
 
 /**
@@ -300,11 +263,7 @@ export async function processToolResults(
           // If persistToolOutput wrote this block to DustFileSystem (too large), return a resource
           // block pointing at the scoped path. The model reads it via the `cat` tool.
           if (res.value !== null) {
-            const snippet = makeOffloadedSnippet(
-              block.text,
-              res.value,
-              runContext
-            );
+            const snippet = makeOffloadedSnippet(block.text, res.value);
             return {
               content: {
                 type: "resource",
@@ -490,9 +449,7 @@ export async function processToolResults(
           // Large resource text was already offloaded by persistToolOutput above.
           if (res.value !== null) {
             const snippet =
-              text !== null
-                ? makeOffloadedSnippet(text, res.value, runContext)
-                : "";
+              text !== null ? makeOffloadedSnippet(text, res.value) : "";
             return {
               content: {
                 type: block.type,


### PR DESCRIPTION
## Description

Offloaded tool outputs (>20KB) carry a machine-readable descriptor in the block's `_meta` (`tt.dust/offload`), which is how code consumers read the full content back. On top of that, sandbox function run contexts got a "parse-safe stub" that replaced the snippet head for JSON content, so code stripping the archive sentence and JSON.parsing the rest would get a pointer object instead of JSON cut mid-string.

That only helped hand-written function code that parses the snippet, which nothing should do (and in a prod repro the guard did not even fire). Dropped, so there is one snippet path for every consumer: head, `... (truncated)`, archive sentence. The `_meta` descriptor and the archive sentence are unchanged.

## Tests

The three run-context-dependent snippet tests collapse into one that pins the single snippet shape and checks the descriptor still rides the block and survives output-item persistence.

## Risk

Low. Only the sandbox function JSON snippet changes shape, and nothing reads it programmatically.

## Deploy Plan

Standard deploy.