### PR TITLE
dsbx: resolve offloaded tool output under tools --json

### DIFF
--- a/cli/dust-sandbox/src/api/error.rs
+++ b/cli/dust-sandbox/src/api/error.rs
@@ -50,6 +50,8 @@ impl ApiErrorCode {
     /// Distinct process exit codes so non-`--json` consumers can classify
     /// without parsing anything. 1 stays the generic failure (including a tool
     /// result with `isError: true`); 2 is reserved by clap for usage errors.
+    /// 15 is allocated outside this enum, to offloaded tool output resolution
+    /// failures (`OffloadResolutionError::EXIT_CODE`).
     pub fn exit_code(&self) -> i32 {
         match self {
             ApiErrorCode::InvalidRequest => 10,

--- a/cli/dust-sandbox/src/api/mod.rs
+++ b/cli/dust-sandbox/src/api/mod.rs
@@ -4,4 +4,4 @@ mod types;
 
 pub use client::DustApiClient;
 pub use error::DustApiError;
-pub use types::{parse_content_block, ContentBlock};
+pub use types::{parse_content_block, CallToolResult, ContentBlock};

--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -13,7 +13,7 @@ pub use forward::cmd_forward;
 pub use function::{cmd_function_build, cmd_function_get, cmd_function_run};
 pub use healthcheck::cmd_healthcheck;
 pub use resolve::cmd_resolve;
-pub use tools::{cmd_exec, cmd_list_servers, cmd_list_tools};
+pub use tools::{cmd_exec, cmd_list_servers, cmd_list_tools, OffloadResolutionError};
 pub use version::cmd_version;
 
 /// Serializes tests that mutate process-global environment variables (e.g.

--- a/cli/dust-sandbox/src/commands/tools/exec.rs
+++ b/cli/dust-sandbox/src/commands/tools/exec.rs
@@ -1,9 +1,7 @@
 use anyhow::{bail, Context};
 
+use super::offload::{resolve_offloaded_content, OffloadResolutionError, ResolveOptions};
 use crate::api::{parse_content_block, CallToolResult, ContentBlock, DustApiClient, DustApiError};
-use crate::commands::tools::offload::{
-    resolve_offloaded_content, OffloadResolutionError, ResolveOptions,
-};
 
 const MAX_FILE_ARG_SIZE_BYTES: u64 = 100 * 1024 * 1024;
 
@@ -123,34 +121,23 @@ async fn run_exec(
 fn format_content_plain(content: &[serde_json::Value]) -> String {
     let mut out = String::new();
     for value in content {
-        match parse_content_block(value) {
-            ContentBlock::Text { text } => {
-                out.push_str(&format!("{text}\n"));
-            }
-            ContentBlock::Image { mime_type, .. } => {
-                out.push_str(&format!("[image: {mime_type}]\n"));
-            }
-            ContentBlock::Audio { mime_type, .. } => {
-                out.push_str(&format!("[audio: {mime_type}]\n"));
-            }
-            ContentBlock::Resource { resource } => {
-                if let Some(text) = &resource.text {
-                    out.push_str(&format!("{text}\n"));
-                } else if resource.blob.is_some() {
-                    out.push_str(&format!("[binary resource: {}]\n", resource.uri));
-                } else {
-                    out.push_str(&format!("[resource: {}]\n", resource.uri));
-                }
-            }
-            ContentBlock::ResourceLink { uri, name } => {
-                if let Some(name) = name {
-                    out.push_str(&format!("[resource link: {name} - {uri}]\n"));
-                } else {
-                    out.push_str(&format!("[resource link: {uri}]\n"));
-                }
-            }
-            ContentBlock::Unknown => {}
-        }
+        let line = match parse_content_block(value) {
+            ContentBlock::Text { text } => text,
+            ContentBlock::Image { mime_type, .. } => format!("[image: {mime_type}]"),
+            ContentBlock::Audio { mime_type, .. } => format!("[audio: {mime_type}]"),
+            ContentBlock::Resource { resource } => match (resource.text, resource.blob) {
+                (Some(text), _) => text,
+                (None, Some(_)) => format!("[binary resource: {}]", resource.uri),
+                (None, None) => format!("[resource: {}]", resource.uri),
+            },
+            ContentBlock::ResourceLink { uri, name } => match name {
+                Some(name) => format!("[resource link: {name} - {uri}]"),
+                None => format!("[resource link: {uri}]"),
+            },
+            ContentBlock::Unknown => continue,
+        };
+        out.push_str(&line);
+        out.push('\n');
     }
     out
 }

--- a/cli/dust-sandbox/src/commands/tools/exec.rs
+++ b/cli/dust-sandbox/src/commands/tools/exec.rs
@@ -1,6 +1,9 @@
 use anyhow::{bail, Context};
 
-use crate::api::{parse_content_block, ContentBlock, DustApiClient, DustApiError};
+use crate::api::{parse_content_block, CallToolResult, ContentBlock, DustApiClient, DustApiError};
+use crate::commands::tools::offload::{
+    resolve_offloaded_content, OffloadResolutionError, ResolveOptions,
+};
 
 const MAX_FILE_ARG_SIZE_BYTES: u64 = 100 * 1024 * 1024;
 
@@ -28,11 +31,15 @@ pub async fn cmd_exec(
 }
 
 /// The `{"error":{code,message,retryable,status?}}` stdout envelope for a
-/// failed `tools --json` execution. API failures carry their typed
-/// classification; anything else is `unknown` and not retryable.
+/// failed `tools --json` execution. API failures and offloaded-output
+/// resolution failures carry their typed classification; anything else is
+/// `unknown` and not retryable.
 fn error_envelope_json(err: &anyhow::Error) -> serde_json::Value {
     if let Some(api_error) = err.downcast_ref::<DustApiError>() {
         return api_error.to_envelope_json();
+    }
+    if let Some(offload_error) = err.downcast_ref::<OffloadResolutionError>() {
+        return offload_error.to_envelope_json();
     }
     serde_json::json!({
         "error": {
@@ -82,49 +89,70 @@ async fn run_exec(
 
     let resp = client.call_tool(&view.s_id, tool_name, arguments).await?;
 
+    let is_error = resp.result.is_error;
+
     if json {
-        println!("{}", serde_json::to_string_pretty(&resp.result)?);
+        // `--json` is a machine contract: content blocks whose full text was
+        // offloaded by front get their archived content read back and
+        // substituted, so the emitted JSON is complete rather than a snippet.
+        let content = resolve_offloaded_content(&resp.result.content, &ResolveOptions::default())
+            .await
+            .map_err(anyhow::Error::new)?;
+        let result = CallToolResult {
+            content,
+            ..resp.result
+        };
+        println!("{}", serde_json::to_string_pretty(&result)?);
     } else {
-        // All content blocks (text and sentinel markers) go to stdout so a
-        // caller capturing stdout sees the full tool output. stderr is
-        // reserved for ambient diagnostics.
-        for value in &resp.result.content {
-            match parse_content_block(value) {
-                ContentBlock::Text { text } => {
-                    println!("{text}");
-                }
-                ContentBlock::Image { mime_type, .. } => {
-                    println!("[image: {mime_type}]");
-                }
-                ContentBlock::Audio { mime_type, .. } => {
-                    println!("[audio: {mime_type}]");
-                }
-                ContentBlock::Resource { resource } => {
-                    if let Some(text) = &resource.text {
-                        println!("{text}");
-                    } else if resource.blob.is_some() {
-                        println!("[binary resource: {}]", resource.uri);
-                    } else {
-                        println!("[resource: {}]", resource.uri);
-                    }
-                }
-                ContentBlock::ResourceLink { uri, name } => {
-                    if let Some(name) = name {
-                        println!("[resource link: {name} - {uri}]");
-                    } else {
-                        println!("[resource link: {uri}]");
-                    }
-                }
-                ContentBlock::Unknown => {}
-            }
-        }
+        // Model-facing rendering: offloaded blocks keep their snippet and the
+        // "[Full content archived at ...]" sentence, which is how the model
+        // learns where to read the rest.
+        print!("{}", format_content_plain(&resp.result.content));
     }
 
-    if resp.result.is_error {
+    if is_error {
         std::process::exit(1);
     }
 
     Ok(())
+}
+
+/// Plain-text rendering of a tool result. All content blocks (text and
+/// sentinel markers) go to stdout so a caller capturing stdout sees the full
+/// tool output. stderr is reserved for ambient diagnostics.
+fn format_content_plain(content: &[serde_json::Value]) -> String {
+    let mut out = String::new();
+    for value in content {
+        match parse_content_block(value) {
+            ContentBlock::Text { text } => {
+                out.push_str(&format!("{text}\n"));
+            }
+            ContentBlock::Image { mime_type, .. } => {
+                out.push_str(&format!("[image: {mime_type}]\n"));
+            }
+            ContentBlock::Audio { mime_type, .. } => {
+                out.push_str(&format!("[audio: {mime_type}]\n"));
+            }
+            ContentBlock::Resource { resource } => {
+                if let Some(text) = &resource.text {
+                    out.push_str(&format!("{text}\n"));
+                } else if resource.blob.is_some() {
+                    out.push_str(&format!("[binary resource: {}]\n", resource.uri));
+                } else {
+                    out.push_str(&format!("[resource: {}]\n", resource.uri));
+                }
+            }
+            ContentBlock::ResourceLink { uri, name } => {
+                if let Some(name) = name {
+                    out.push_str(&format!("[resource link: {name} - {uri}]\n"));
+                } else {
+                    out.push_str(&format!("[resource link: {uri}]\n"));
+                }
+            }
+            ContentBlock::Unknown => {}
+        }
+    }
+    out
 }
 
 /// Resolve the `--args-json` value: `-` reads the whole payload from stdin
@@ -898,6 +926,68 @@ mod tests {
         assert_eq!(envelope["error"]["message"], "no tools for fast functions");
         assert_eq!(envelope["error"]["retryable"], false);
         assert_eq!(envelope["error"]["status"], 403);
+    }
+
+    #[test]
+    fn error_envelope_carries_typed_offload_resolution_error() {
+        let err = anyhow::Error::new(OffloadResolutionError::new(
+            "could not read the offloaded tool output at /files/pod-x/.tool_outputs/f/1.json"
+                .to_string(),
+        ))
+        .context("tools exec");
+
+        let envelope = error_envelope_json(&err);
+        assert_eq!(envelope["error"]["code"], "tool_output_unavailable");
+        assert!(envelope["error"]["message"]
+            .as_str()
+            .expect("message")
+            .contains("/files/pod-x/.tool_outputs/f/1.json"));
+        assert_eq!(envelope["error"]["retryable"], true);
+    }
+
+    // --- plain-text (model-facing) rendering ---
+
+    #[test]
+    fn plain_rendering_keeps_the_offloaded_snippet_and_archive_sentence() {
+        // The default mode is model-facing: the snippet plus the archive
+        // sentence is how the model learns where to read the rest, so no
+        // resolution happens here.
+        let scoped_path = "pod-vlt_1/.tool_outputs/my-fn/1_search.json";
+        let snippet =
+            format!("head of payload... (truncated)\n[Full content archived at {scoped_path}]");
+        let content = vec![serde_json::json!({
+            "type": "resource",
+            "resource": { "uri": scoped_path, "mimeType": "text/plain", "text": snippet },
+            "_meta": {
+                "tt.dust/offload": {
+                    "fullContentPath": scoped_path,
+                    "totalBytes": 121_700,
+                    "contentType": "application/json",
+                }
+            },
+        })];
+
+        let rendered = format_content_plain(&content);
+        assert_eq!(
+            rendered,
+            format!("head of payload... (truncated)\n[Full content archived at {scoped_path}]\n")
+        );
+    }
+
+    #[test]
+    fn plain_rendering_covers_every_block_shape() {
+        let content = vec![
+            serde_json::json!({ "type": "text", "text": "hello" }),
+            serde_json::json!({ "type": "image", "data": "AA", "mimeType": "image/png" }),
+            serde_json::json!({ "type": "resource", "resource": { "uri": "u", "blob": "AA" } }),
+            serde_json::json!({ "type": "resource_link", "uri": "u", "name": "n" }),
+            serde_json::json!({ "type": "future_block" }),
+        ];
+
+        assert_eq!(
+            format_content_plain(&content),
+            "hello\n[image: image/png]\n[binary resource: u]\n[resource link: n - u]\n"
+        );
     }
 
     #[test]

--- a/cli/dust-sandbox/src/commands/tools/mod.rs
+++ b/cli/dust-sandbox/src/commands/tools/mod.rs
@@ -1,7 +1,7 @@
 mod exec;
 mod list_servers;
 mod list_tools;
-pub mod offload;
+mod offload;
 
 pub use exec::cmd_exec;
 pub use list_servers::cmd_list_servers;

--- a/cli/dust-sandbox/src/commands/tools/mod.rs
+++ b/cli/dust-sandbox/src/commands/tools/mod.rs
@@ -1,7 +1,9 @@
 mod exec;
 mod list_servers;
 mod list_tools;
+pub mod offload;
 
 pub use exec::cmd_exec;
 pub use list_servers::cmd_list_servers;
 pub use list_tools::cmd_list_tools;
+pub use offload::OffloadResolutionError;

--- a/cli/dust-sandbox/src/commands/tools/offload.rs
+++ b/cli/dust-sandbox/src/commands/tools/offload.rs
@@ -1,0 +1,461 @@
+// Resolution of offloaded tool output content blocks.
+//
+// Tool outputs above front's offload threshold are not delivered inline: the
+// full content is archived as a pod file and the inline text is replaced by a
+// snippet ending with a human-facing "[Full content archived at <path>]"
+// sentence. That truncation exists to protect a model's context window, so it
+// stays in the default (model-facing) rendering — but `--json` is a machine
+// contract with no model on the other end, and emitting a cut-off body there
+// hands consumers invalid data (JSON tool output no longer parses).
+//
+// Offloaded blocks carry a machine-readable descriptor under the
+// "tt.dust/offload" key of their `_meta` (front owns the write side in
+// `front/lib/actions/mcp_execution.ts`; the descriptor shape is append-only).
+// This module is the read side: blocks without a descriptor pass through
+// untouched, blocks with one get the archived file read back from the gcsfuse
+// mount and substituted into their text. Never parse the snippet text or the
+// archive sentence: the descriptor is the contract.
+//
+// The TypeScript counterpart is `resolveToolTextContent` in
+// `cli/dust-sandbox/pod/tool_output.ts`; both must keep the same semantics.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// Key of the offload descriptor in a content block's `_meta`. Owned by front
+/// (`TOOL_OUTPUT_OFFLOAD_META_KEY` in
+/// `front/lib/actions/action_output_limits.ts`); this is the CLI-side copy of
+/// the wire contract.
+const TOOL_OUTPUT_OFFLOAD_META_KEY: &str = "tt.dust/offload";
+
+/// Absolute in-sandbox directory the scoped file mounts live under: a
+/// descriptor's `fullContentPath` (e.g. "pod-{pId}/.tool_outputs/{slug}/{file}")
+/// resolves to `/files/pod-{pId}/...`.
+const MOUNT_ROOT_DIR: &str = "/files";
+
+const DEFAULT_MAX_ATTEMPTS: u32 = 5;
+const DEFAULT_RETRY_DELAY_MS: u64 = 1_000;
+
+/// Failure to resolve an offloaded tool output under `--json`. Kept typed so
+/// `tools --json` can emit it in the stdout error envelope and exit with a
+/// distinct code: degrading to the truncated snippet instead would silently
+/// hand the consumer the invalid payload this resolution exists to remove.
+#[derive(Debug)]
+pub struct OffloadResolutionError {
+    message: String,
+}
+
+impl OffloadResolutionError {
+    /// Stable classification for the `--json` stdout envelope; append-only,
+    /// like the API error codes.
+    pub const CODE: &'static str = "tool_output_unavailable";
+
+    /// Distinct process exit code, continuing the allocation documented on
+    /// `ApiErrorCode::exit_code`.
+    pub const EXIT_CODE: i32 = 15;
+
+    pub(crate) fn new(message: String) -> Self {
+        Self { message }
+    }
+
+    /// The `{"error":{code,message,retryable}}` stdout envelope, mirroring
+    /// `DustApiError::to_envelope_json`. No `status`: nothing HTTP failed.
+    pub fn to_envelope_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "error": {
+                "code": Self::CODE,
+                "message": self.message,
+                // The archive is written through GCS and read back through the
+                // gcsfuse mount, whose metadata cache can lag: a later call can
+                // succeed even though this one exhausted its bounded retry.
+                "retryable": true,
+            }
+        })
+    }
+}
+
+impl fmt::Display for OffloadResolutionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for OffloadResolutionError {}
+
+/// Knobs of the archive read. Production code uses `Default`; tests point the
+/// mount elsewhere and shorten the retry.
+pub struct ResolveOptions {
+    pub mount_root_dir: PathBuf,
+    pub max_attempts: u32,
+    pub retry_delay_ms: u64,
+}
+
+impl Default for ResolveOptions {
+    fn default() -> Self {
+        Self {
+            mount_root_dir: PathBuf::from(MOUNT_ROOT_DIR),
+            max_attempts: DEFAULT_MAX_ATTEMPTS,
+            retry_delay_ms: DEFAULT_RETRY_DELAY_MS,
+        }
+    }
+}
+
+/// Returns the content array with every offloaded block's snippet replaced by
+/// the archived full content. Blocks without a descriptor are returned as-is.
+pub async fn resolve_offloaded_content(
+    content: &[serde_json::Value],
+    options: &ResolveOptions,
+) -> Result<Vec<serde_json::Value>, OffloadResolutionError> {
+    // Sequential: a tool result holds a handful of blocks, and at most a few
+    // of them are offloaded.
+    let mut resolved = Vec::with_capacity(content.len());
+    for block in content {
+        resolved.push(resolve_block(block, options).await?);
+    }
+    Ok(resolved)
+}
+
+async fn resolve_block(
+    block: &serde_json::Value,
+    options: &ResolveOptions,
+) -> Result<serde_json::Value, OffloadResolutionError> {
+    let descriptor = match block
+        .get("_meta")
+        .and_then(|meta| meta.get(TOOL_OUTPUT_OFFLOAD_META_KEY))
+    {
+        Some(descriptor) => descriptor,
+        None => return Ok(block.clone()),
+    };
+
+    let path = archive_path(descriptor, &options.mount_root_dir)?;
+    let full_content = read_archived_content(&path, options).await?;
+
+    Ok(with_full_text(block, full_content))
+}
+
+/// Absolute path of the archived content. `fullContentPath` is a scoped path
+/// ("pod-{pId}/...") resolved under the mount root; an already-absolute value
+/// is used as-is.
+fn archive_path(
+    descriptor: &serde_json::Value,
+    mount_root_dir: &Path,
+) -> Result<PathBuf, OffloadResolutionError> {
+    // Only `fullContentPath` is load-bearing here; the descriptor's other
+    // fields (totalBytes, contentType) are informational and travel through to
+    // the consumer untouched.
+    let full_content_path = descriptor
+        .get("fullContentPath")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            OffloadResolutionError::new(format!(
+                "tool output block carries an invalid offload descriptor under \
+                 \"{TOOL_OUTPUT_OFFLOAD_META_KEY}\" (no fullContentPath); this is a platform \
+                 contract violation, report it rather than working around it"
+            ))
+        })?;
+
+    if full_content_path.starts_with('/') {
+        return Ok(PathBuf::from(full_content_path));
+    }
+    Ok(mount_root_dir.join(full_content_path))
+}
+
+async fn read_archived_content(
+    path: &Path,
+    options: &ResolveOptions,
+) -> Result<String, OffloadResolutionError> {
+    // The archived file is written through the GCS API while this reads it
+    // through the gcsfuse mount, whose metadata cache can lag behind the
+    // write: retry a bounded number of times instead of failing on the first
+    // missing read.
+    let mut last_error: Option<std::io::Error> = None;
+    for attempt in 1..=options.max_attempts {
+        match tokio::fs::read_to_string(path).await {
+            Ok(content) => return Ok(content),
+            Err(err) => last_error = Some(err),
+        }
+        if attempt < options.max_attempts {
+            tokio::time::sleep(Duration::from_millis(options.retry_delay_ms)).await;
+        }
+    }
+
+    let reason = match last_error {
+        Some(err) => err.to_string(),
+        None => "no read attempt was made".to_string(),
+    };
+    Err(OffloadResolutionError::new(format!(
+        "could not read the offloaded tool output at {} after {} attempts (the file mount can \
+         lag behind writes): {reason}",
+        path.display(),
+        options.max_attempts
+    )))
+}
+
+/// Substitutes the resolved content into the block's text field. Front emits
+/// offloaded blocks as embedded resources (both the text and the resource
+/// branch of `processToolResults`), so `resource.text` is the live shape;
+/// top-level `text` is handled too so a future front branch that offloads a
+/// plain text block resolves the same way.
+fn with_full_text(block: &serde_json::Value, full_content: String) -> serde_json::Value {
+    let mut resolved = block.clone();
+    let text = serde_json::Value::String(full_content);
+
+    if let Some(resource) = resolved
+        .get_mut("resource")
+        .and_then(|resource| resource.as_object_mut())
+    {
+        resource.insert("text".to_string(), text);
+        return resolved;
+    }
+
+    if let Some(object) = resolved.as_object_mut() {
+        object.insert("text".to_string(), text);
+    }
+    resolved
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_options(mount_root_dir: &Path) -> ResolveOptions {
+        ResolveOptions {
+            mount_root_dir: mount_root_dir.to_path_buf(),
+            // Keep the retry shape (more than one attempt) without the wall
+            // clock cost.
+            max_attempts: 3,
+            retry_delay_ms: 0,
+        }
+    }
+
+    fn write_archive(mount_root_dir: &Path, scoped_path: &str, content: &str) {
+        let path = mount_root_dir.join(scoped_path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create archive dir");
+        }
+        std::fs::write(&path, content).expect("write archive");
+    }
+
+    fn offload_meta(scoped_path: &str, total_bytes: usize) -> serde_json::Value {
+        serde_json::json!({
+            TOOL_OUTPUT_OFFLOAD_META_KEY: {
+                "fullContentPath": scoped_path,
+                "totalBytes": total_bytes,
+                "contentType": "application/json",
+            }
+        })
+    }
+
+    /// A resource block as front emits it for an offloaded output: the snippet
+    /// plus the archive sentence in `resource.text`, descriptor in `_meta`.
+    fn offloaded_resource_block(scoped_path: &str, snippet: &str) -> serde_json::Value {
+        serde_json::json!({
+            "type": "resource",
+            "resource": {
+                "uri": scoped_path,
+                "mimeType": "text/plain",
+                "text": format!("{snippet}... (truncated)\n[Full content archived at {scoped_path}]"),
+            },
+            "_meta": offload_meta(scoped_path, snippet.len()),
+        })
+    }
+
+    #[tokio::test]
+    async fn resolves_resource_block_to_full_content() {
+        let mount = tempfile::tempdir().expect("tempdir");
+        let scoped_path = "pod-vlt_1/.tool_outputs/my-fn/1_search.json";
+        let full_content = r#"{"results":[{"id":1},{"id":2}]}"#;
+        write_archive(mount.path(), scoped_path, full_content);
+
+        let block = offloaded_resource_block(scoped_path, "{\"results\":[{\"id\":1");
+        let resolved = resolve_offloaded_content(&[block], &test_options(mount.path()))
+            .await
+            .expect("should resolve");
+
+        assert_eq!(resolved[0]["resource"]["text"], full_content);
+        // The descriptor and the rest of the block travel through untouched.
+        assert_eq!(
+            resolved[0]["_meta"][TOOL_OUTPUT_OFFLOAD_META_KEY]["fullContentPath"],
+            scoped_path
+        );
+        assert_eq!(resolved[0]["resource"]["uri"], scoped_path);
+    }
+
+    #[tokio::test]
+    async fn resolves_text_block_to_full_content() {
+        let mount = tempfile::tempdir().expect("tempdir");
+        let scoped_path = "pod-vlt_1/.tool_outputs/my-fn/2_fetch.json";
+        let full_content = "line one\nline two\n";
+        write_archive(mount.path(), scoped_path, full_content);
+
+        let block = serde_json::json!({
+            "type": "text",
+            "text": format!("line on... (truncated)\n[Full content archived at {scoped_path}]"),
+            "_meta": offload_meta(scoped_path, full_content.len()),
+        });
+        let resolved = resolve_offloaded_content(&[block], &test_options(mount.path()))
+            .await
+            .expect("should resolve");
+
+        assert_eq!(resolved[0]["text"], full_content);
+    }
+
+    #[tokio::test]
+    async fn resolved_json_output_parses_and_carries_no_truncation_marker() {
+        // The regression this exists for: a payload past front's 20KB text
+        // offload threshold arrives as a snippet that does not parse as JSON.
+        let mount = tempfile::tempdir().expect("tempdir");
+        let scoped_path = "pod-vlt_1/.tool_outputs/my-fn/3_big.json";
+        let rows: Vec<serde_json::Value> = (0..400)
+            .map(|i| serde_json::json!({ "id": i, "body": "x".repeat(64) }))
+            .collect();
+        let full_content =
+            serde_json::to_string(&serde_json::json!({ "rows": rows })).expect("should serialize");
+        assert!(full_content.len() > 20 * 1024);
+        write_archive(mount.path(), scoped_path, &full_content);
+
+        // Front's snippet: the head of the payload, cut mid-JSON.
+        let snippet = &full_content[..8_000];
+        let block = offloaded_resource_block(scoped_path, snippet);
+        let resolved = resolve_offloaded_content(&[block], &test_options(mount.path()))
+            .await
+            .expect("should resolve");
+
+        let text = resolved[0]["resource"]["text"]
+            .as_str()
+            .expect("resolved text");
+        assert!(!text.contains("(truncated)"));
+        assert!(!text.contains("[Full content archived at"));
+        let parsed: serde_json::Value = serde_json::from_str(text).expect("should parse as JSON");
+        assert_eq!(parsed["rows"].as_array().expect("rows").len(), 400);
+    }
+
+    #[tokio::test]
+    async fn passes_blocks_without_descriptor_through_untouched() {
+        let mount = tempfile::tempdir().expect("tempdir");
+        let blocks = vec![
+            serde_json::json!({ "type": "text", "text": "small inline output" }),
+            serde_json::json!({
+                "type": "resource",
+                "resource": { "uri": "file://x", "text": "inline resource body" },
+                "_meta": { "tt.dust/other": { "k": 1 } },
+            }),
+            serde_json::json!({ "type": "future_block", "payload": { "k": 1 } }),
+        ];
+
+        let resolved = resolve_offloaded_content(&blocks, &test_options(mount.path()))
+            .await
+            .expect("should resolve");
+
+        assert_eq!(resolved, blocks);
+    }
+
+    #[tokio::test]
+    async fn resolves_only_the_offloaded_block_of_a_mixed_result() {
+        let mount = tempfile::tempdir().expect("tempdir");
+        let scoped_path = "pod-vlt_1/.tool_outputs/my-fn/4_mixed.json";
+        write_archive(mount.path(), scoped_path, "archived body");
+
+        let blocks = vec![
+            serde_json::json!({ "type": "text", "text": "inline" }),
+            offloaded_resource_block(scoped_path, "archived"),
+        ];
+        let resolved = resolve_offloaded_content(&blocks, &test_options(mount.path()))
+            .await
+            .expect("should resolve");
+
+        assert_eq!(resolved[0]["text"], "inline");
+        assert_eq!(resolved[1]["resource"]["text"], "archived body");
+    }
+
+    #[tokio::test]
+    async fn missing_archive_errors_instead_of_emitting_the_snippet() {
+        let mount = tempfile::tempdir().expect("tempdir");
+        let scoped_path = "pod-vlt_1/.tool_outputs/my-fn/5_missing.json";
+        let block = offloaded_resource_block(scoped_path, "head of the payload");
+
+        let err = resolve_offloaded_content(&[block], &test_options(mount.path()))
+            .await
+            .expect_err("should fail");
+
+        let message = err.to_string();
+        assert!(message.contains(scoped_path), "message: {message}");
+        assert!(message.contains("3 attempts"), "message: {message}");
+
+        let envelope = err.to_envelope_json();
+        assert_eq!(envelope["error"]["code"], "tool_output_unavailable");
+        assert_eq!(envelope["error"]["retryable"], true);
+        assert!(envelope["error"].get("status").is_none());
+    }
+
+    #[tokio::test]
+    async fn archive_visible_on_a_later_attempt_resolves() {
+        // Mirrors gcsfuse metadata-cache staleness: the file shows up after the
+        // first read fails.
+        let mount = tempfile::tempdir().expect("tempdir");
+        let scoped_path = "pod-vlt_1/.tool_outputs/my-fn/6_late.json";
+        let mount_path = mount.path().to_path_buf();
+        let late_writer = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(30)).await;
+            write_archive(&mount_path, scoped_path, "late body");
+        });
+
+        let options = ResolveOptions {
+            mount_root_dir: mount.path().to_path_buf(),
+            max_attempts: 10,
+            retry_delay_ms: 10,
+        };
+        let block = offloaded_resource_block(scoped_path, "late");
+        let resolved = resolve_offloaded_content(&[block], &options)
+            .await
+            .expect("should resolve");
+
+        late_writer.await.expect("writer should finish");
+        assert_eq!(resolved[0]["resource"]["text"], "late body");
+    }
+
+    #[tokio::test]
+    async fn malformed_descriptor_errors() {
+        let mount = tempfile::tempdir().expect("tempdir");
+        let block = serde_json::json!({
+            "type": "resource",
+            "resource": { "uri": "x", "text": "snippet" },
+            "_meta": { TOOL_OUTPUT_OFFLOAD_META_KEY: { "totalBytes": 1 } },
+        });
+
+        let err = resolve_offloaded_content(&[block], &test_options(mount.path()))
+            .await
+            .expect_err("should fail");
+        assert!(
+            err.to_string().contains("invalid offload descriptor"),
+            "message: {err}"
+        );
+    }
+
+    #[test]
+    fn archive_path_resolves_scoped_path_under_the_mount() {
+        let descriptor = serde_json::json!({
+            "fullContentPath": "pod-vlt_1/.tool_outputs/my-fn/7.json",
+        });
+        let path = archive_path(&descriptor, Path::new("/files")).expect("should resolve");
+        assert_eq!(
+            path,
+            PathBuf::from("/files/pod-vlt_1/.tool_outputs/my-fn/7.json")
+        );
+    }
+
+    #[test]
+    fn archive_path_keeps_absolute_paths() {
+        let descriptor = serde_json::json!({ "fullContentPath": "/files/pod-vlt_1/x.json" });
+        let path = archive_path(&descriptor, Path::new("/files")).expect("should resolve");
+        assert_eq!(path, PathBuf::from("/files/pod-vlt_1/x.json"));
+    }
+
+    #[test]
+    fn archive_path_rejects_empty_path() {
+        let descriptor = serde_json::json!({ "fullContentPath": "" });
+        assert!(archive_path(&descriptor, Path::new("/files")).is_err());
+    }
+}

--- a/cli/dust-sandbox/src/commands/tools/offload.rs
+++ b/cli/dust-sandbox/src/commands/tools/offload.rs
@@ -17,7 +17,9 @@
 // archive sentence: the descriptor is the contract.
 //
 // The TypeScript counterpart is `resolveToolTextContent` in
-// `cli/dust-sandbox/pod/tool_output.ts`; both must keep the same semantics.
+// `cli/dust-sandbox/pod/tool_output.ts`; both must keep the same resolution
+// semantics (descriptor over snippet, mount-relative path, bounded retry).
+// The few deliberate divergences are called out where they happen.
 
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -135,15 +137,21 @@ async fn resolve_block(
 }
 
 /// Absolute path of the archived content. `fullContentPath` is a scoped path
-/// ("pod-{pId}/...") resolved under the mount root; an already-absolute value
-/// is used as-is.
+/// ("pod-{pId}/...") resolved under the mount root.
+///
+/// The path is confined to the mount root: `_meta` is not fully trusted input,
+/// since front passes some remote MCP resource blocks through verbatim
+/// (`processToolResults`), so a third-party server can forge a descriptor.
+/// Nothing privileged is crossed (dsbx runs as the workload user), but there is
+/// no reason to let a forged descriptor aim the read outside the file mounts.
 fn archive_path(
     descriptor: &serde_json::Value,
     mount_root_dir: &Path,
 ) -> Result<PathBuf, OffloadResolutionError> {
     // Only `fullContentPath` is load-bearing here; the descriptor's other
-    // fields (totalBytes, contentType) are informational and travel through to
-    // the consumer untouched.
+    // fields (totalBytes, contentType) are informational. The TypeScript
+    // counterpart validates all three through zod — the divergence is
+    // deliberate: this side reads only what it uses.
     let full_content_path = descriptor
         .get("fullContentPath")
         .and_then(|value| value.as_str())
@@ -156,10 +164,27 @@ fn archive_path(
             ))
         })?;
 
-    if full_content_path.starts_with('/') {
-        return Ok(PathBuf::from(full_content_path));
+    // An absolute value is accepted as long as it already points inside the
+    // mount (front only ever emits scoped relative paths).
+    let path = if full_content_path.starts_with('/') {
+        PathBuf::from(full_content_path)
+    } else {
+        mount_root_dir.join(full_content_path)
+    };
+
+    let escapes_mount = path
+        .components()
+        .any(|component| matches!(component, std::path::Component::ParentDir))
+        || !path.starts_with(mount_root_dir);
+    if escapes_mount {
+        return Err(OffloadResolutionError::new(format!(
+            "the offload descriptor points at {}, outside the {} file mounts; refusing to read it",
+            path.display(),
+            mount_root_dir.display()
+        )));
     }
-    Ok(mount_root_dir.join(full_content_path))
+
+    Ok(path)
 }
 
 async fn read_archived_content(
@@ -168,12 +193,19 @@ async fn read_archived_content(
 ) -> Result<String, OffloadResolutionError> {
     // The archived file is written through the GCS API while this reads it
     // through the gcsfuse mount, whose metadata cache can lag behind the
-    // write: retry a bounded number of times instead of failing on the first
-    // missing read.
+    // write: a missing file is retried a bounded number of times instead of
+    // failing on the first read. Any other failure (permissions, non-UTF-8
+    // content) is terminal, so retrying it would only burn the retry budget.
     let mut last_error: Option<std::io::Error> = None;
     for attempt in 1..=options.max_attempts {
         match tokio::fs::read_to_string(path).await {
             Ok(content) => return Ok(content),
+            Err(err) if err.kind() != std::io::ErrorKind::NotFound => {
+                return Err(OffloadResolutionError::new(format!(
+                    "could not read the offloaded tool output at {}: {err}",
+                    path.display()
+                )));
+            }
             Err(err) => last_error = Some(err),
         }
         if attempt < options.max_attempts {
@@ -197,10 +229,26 @@ async fn read_archived_content(
 /// offloaded blocks as embedded resources (both the text and the resource
 /// branch of `processToolResults`), so `resource.text` is the live shape;
 /// top-level `text` is handled too so a future front branch that offloads a
-/// plain text block resolves the same way.
+/// plain text block resolves the same way. (The TypeScript counterpart reads
+/// top-level `text` first; the order only matters for blocks carrying both,
+/// which front never emits.)
+///
+/// The descriptor is dropped from `_meta`: it means "the inline text is a
+/// snippet, the full content lives at this path", which stops being true once
+/// substituted. Leaving it would make a downstream resolver read the file a
+/// second time and throw when it is gone. The archive path stays reachable
+/// through the block's `resource.uri`, which front sets to the same scoped
+/// path.
 fn with_full_text(block: &serde_json::Value, full_content: String) -> serde_json::Value {
     let mut resolved = block.clone();
     let text = serde_json::Value::String(full_content);
+
+    if let Some(meta) = resolved
+        .get_mut("_meta")
+        .and_then(|meta| meta.as_object_mut())
+    {
+        meta.remove(TOOL_OUTPUT_OFFLOAD_META_KEY);
+    }
 
     if let Some(resource) = resolved
         .get_mut("resource")
@@ -275,12 +323,60 @@ mod tests {
             .expect("should resolve");
 
         assert_eq!(resolved[0]["resource"]["text"], full_content);
-        // The descriptor and the rest of the block travel through untouched.
-        assert_eq!(
-            resolved[0]["_meta"][TOOL_OUTPUT_OFFLOAD_META_KEY]["fullContentPath"],
-            scoped_path
-        );
+        // The descriptor is dropped (the text is no longer a snippet); the rest
+        // of the block, including the archive path in `uri`, is untouched.
+        assert!(resolved[0]["_meta"]
+            .get(TOOL_OUTPUT_OFFLOAD_META_KEY)
+            .is_none());
         assert_eq!(resolved[0]["resource"]["uri"], scoped_path);
+    }
+
+    #[tokio::test]
+    async fn resolution_keeps_other_meta_keys() {
+        let mount = tempfile::tempdir().expect("tempdir");
+        let scoped_path = "pod-vlt_1/.tool_outputs/my-fn/8_meta.json";
+        write_archive(mount.path(), scoped_path, "body");
+
+        let mut block = offloaded_resource_block(scoped_path, "bo");
+        block["_meta"]["tt.dust/other"] = serde_json::json!({ "k": 1 });
+        let resolved = resolve_offloaded_content(&[block], &test_options(mount.path()))
+            .await
+            .expect("should resolve");
+
+        assert_eq!(resolved[0]["_meta"]["tt.dust/other"]["k"], 1);
+    }
+
+    #[tokio::test]
+    async fn unreadable_archive_fails_without_burning_the_retry_budget() {
+        // Only a missing file is a mount-staleness candidate; a directory (or a
+        // permission error) is terminal and must not be retried.
+        let mount = tempfile::tempdir().expect("tempdir");
+        let scoped_path = "pod-vlt_1/.tool_outputs/my-fn/9_dir.json";
+        std::fs::create_dir_all(mount.path().join(scoped_path)).expect("create dir");
+
+        let block = offloaded_resource_block(scoped_path, "head");
+        let err = resolve_offloaded_content(&[block], &test_options(mount.path()))
+            .await
+            .expect_err("should fail");
+
+        let message = err.to_string();
+        assert!(message.contains(scoped_path), "message: {message}");
+        assert!(!message.contains("attempts"), "message: {message}");
+    }
+
+    #[tokio::test]
+    async fn descriptor_pointing_outside_the_mount_is_refused() {
+        let mount = tempfile::tempdir().expect("tempdir");
+        let block = serde_json::json!({
+            "type": "resource",
+            "resource": { "uri": "x", "text": "snippet" },
+            "_meta": offload_meta("pod-vlt_1/../../../etc/passwd", 0),
+        });
+
+        let err = resolve_offloaded_content(&[block], &test_options(mount.path()))
+            .await
+            .expect_err("should fail");
+        assert!(err.to_string().contains("outside the"), "message: {err}");
     }
 
     #[tokio::test]
@@ -456,6 +552,18 @@ mod tests {
     #[test]
     fn archive_path_rejects_empty_path() {
         let descriptor = serde_json::json!({ "fullContentPath": "" });
+        assert!(archive_path(&descriptor, Path::new("/files")).is_err());
+    }
+
+    #[test]
+    fn archive_path_rejects_traversal_out_of_the_mount() {
+        let descriptor = serde_json::json!({ "fullContentPath": "pod-vlt_1/../../etc/passwd" });
+        assert!(archive_path(&descriptor, Path::new("/files")).is_err());
+    }
+
+    #[test]
+    fn archive_path_rejects_absolute_path_outside_the_mount() {
+        let descriptor = serde_json::json!({ "fullContentPath": "/etc/passwd" });
         assert!(archive_path(&descriptor, Path::new("/files")).is_err());
     }
 }

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -165,6 +165,21 @@ mod tests {
         Cli::command().debug_assert();
     }
 
+    #[test]
+    fn exit_code_classifies_typed_errors() {
+        let api_error = anyhow::Error::new(api::DustApiError::from_http_response(429, "slow down"))
+            .context("POST /sandbox/actions/call");
+        assert_eq!(exit_code_for(&api_error), 13);
+
+        let offload_error = anyhow::Error::new(commands::OffloadResolutionError::new(
+            "could not read the offloaded tool output at /files/pod-x/y.json".to_string(),
+        ))
+        .context("tools exec");
+        assert_eq!(exit_code_for(&offload_error), 15);
+
+        assert_eq!(exit_code_for(&anyhow::anyhow!("boom")), 1);
+    }
+
     struct ToolsFields {
         json: bool,
         args_json: Option<String>,

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -72,13 +72,19 @@ async fn main() {
     }
 }
 
-/// Typed API failures exit with their stable per-code exit codes; everything
-/// else keeps the generic 1 (2 is reserved by clap for usage errors).
+/// Typed failures exit with their stable per-code exit codes; everything else
+/// keeps the generic 1 (2 is reserved by clap for usage errors).
 fn exit_code_for(error: &anyhow::Error) -> i32 {
-    error
-        .downcast_ref::<api::DustApiError>()
-        .map(|api_error| api_error.code.exit_code())
-        .unwrap_or(1)
+    if let Some(api_error) = error.downcast_ref::<api::DustApiError>() {
+        return api_error.code.exit_code();
+    }
+    if error
+        .downcast_ref::<commands::OffloadResolutionError>()
+        .is_some()
+    {
+        return commands::OffloadResolutionError::EXIT_CODE;
+    }
+    1
 }
 
 async fn run() -> anyhow::Result<()> {


### PR DESCRIPTION
## Description

`dsbx tools --json` was emitting truncated tool output. When a result block goes past front's 20KB text threshold, front archives the full content to the pod filesystem and hands back an 8KB snippet plus a `[Full content archived at <path>]` sentence, with a machine-readable descriptor on the block's `_meta` (`tt.dust/offload`). `--json` printed that verbatim, so a machine contract was shipping bodies that do not parse (prod repro: a 121,700-byte result arrived as an 8,157-byte fragment).

The truncation is context-window protection for a model. `--json` exists to be parsed, so it is the wrong boundary for it.

Under `--json` only, each block carrying the descriptor now gets its archive read back from the `/files` mount and substituted into its text (`resource.text`, or top-level `text`), with the same bounded retry as `pod/tool_output.ts` for gcsfuse metadata staleness. If the read never lands, it fails instead of degrading back to the snippet, which is the bug class this removes. The descriptor is dropped from the resolved block since the inline text is no longer a snippet.

Default (non-`--json`) mode is untouched: it is model-facing and keeps the snippet plus the archive sentence, which is how the model learns where to `cat` the rest.

New in the `tools --json` stdout envelope: `code: tool_output_unavailable` (retryable, no `status`) with exit code 15. Both are append-only additions to the existing contract.

The archive path is confined to the mount root. `_meta` is not fully trusted input: front passes some remote MCP resource blocks through verbatim, so a third-party server can forge a descriptor. Nothing privileged is crossed (dsbx runs as the workload user), but a forged path should not aim the read outside the file mounts.

This also makes the Rust path the single implementation: `@dust/pod`'s `tools.call()` will delegate to `dsbx tools --json` rather than reimplementing the POST+poll protocol in TypeScript, so archive resolution lives in one place.

## Tests

Unit tests cover both block shapes, passthrough for blocks with no descriptor, mixed results, a file that only appears on a later attempt, a malformed descriptor, path traversal out of the mount, an unreadable (non-missing) archive failing fast, and a missing archive erroring instead of emitting the snippet. One fixture is a >20KB JSON payload with a snippet cut mid-JSON, asserting the resolved text parses and carries no truncation marker. Also asserted that plain-text rendering still prints the snippet and archive sentence.

## Risk

Low, and confined to `--json`. Two behavior changes worth naming: a call that used to return truncated-but-successful output can now fail with the typed error after ~5s of retries, and that failure also reaches an agent shelling out `dsbx tools --json` from the Computer, not only programmatic callers. The agent gets the error envelope on stdout with the path in the message. Rollback is a version pin.

## Deploy Plan

Needs a dsbx release and a `DSBX_CLI_VERSION` bump to reach pods. No front change.