### PR TITLE
Fix Pod mount freshness and isolate warm invocation tokens

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.48"
+version = "0.1.49"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.48"
+version = "0.1.49"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/src/commands/function/warm.rs
+++ b/cli/dust-sandbox/src/commands/function/warm.rs
@@ -52,6 +52,10 @@ use super::RUNNER_JS;
 
 pub const WARM_PROTOCOL_VERSION: u32 = 2;
 
+const WARM_ENABLED_ENV: &str = "DUST_FUNCTION_WARM_ENABLED";
+const SANDBOX_TOKEN_ENV: &str = "DUST_SANDBOX_TOKEN";
+const POD_USER_IDENTITY_ENV: &str = "DUST_POD_USER_IDENTITY";
+
 /// Pool geometry. Four generic workers bound the pod's warm memory (a worker
 /// is one bun process capped at ~300MB RSS with its imported working set,
 /// see serve.ts) regardless of how many functions the pod publishes. Each
@@ -81,6 +85,10 @@ const WARM_RESPONSE_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Connect timeout: the server is either listening or it is not.
 const WARM_CONNECT_TIMEOUT: Duration = Duration::from_millis(250);
+
+fn warm_execution_enabled() -> bool {
+    matches!(std::env::var(WARM_ENABLED_ENV).as_deref(), Ok("1"))
+}
 
 #[derive(Debug, Deserialize)]
 struct WarmFrame {
@@ -341,6 +349,9 @@ fn prune_bundle_cache(dir: &Path, max_age: Duration) {
 /// Tries to run `input` (the raw stdin envelope) against the warm worker on
 /// `name`'s home slot. Never errors: every failure is a `Miss`.
 pub async fn try_warm_run(name: &str, input: &str) -> WarmRun {
+    if !warm_execution_enabled() {
+        return WarmRun::Miss;
+    }
     // The name travels in the warm request and feeds the worker's directory
     // scan, so it is validated here as the cold path's resolve_existing
     // would.
@@ -475,6 +486,9 @@ async fn roundtrip(mut stream: UnixStream, name: &str, input: &str) -> Result<Wa
 /// is its own process group so it survives dsbx exiting and is not
 /// collateral of anything that signals dsbx's group.
 pub fn spawn_worker(name: &str) {
+    if !warm_execution_enabled() {
+        return;
+    }
     if !super::is_valid_name(name) {
         return;
     }
@@ -519,6 +533,11 @@ pub fn spawn_worker(name: &str) {
         .arg(&functions_dir)
         .arg(&socket)
         .env("NODE_PATH", super::harness_node_path())
+        // Bun child processes inherit the worker's native spawn environment, even after
+        // JavaScript deletes process.env entries. Invocation-scoped values are supplied to the
+        // handler through the request context instead and must never enter the resident process.
+        .env_remove(SANDBOX_TOKEN_ENV)
+        .env_remove(POD_USER_IDENTITY_ENV)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(log.map(Stdio::from).unwrap_or_else(Stdio::null))
@@ -556,6 +575,33 @@ mod tests {
 };
 "#;
 
+    fn environment_fixture() -> String {
+        let context_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("pod/context.ts");
+        let context_import = serde_json::to_string(
+            context_path
+                .to_str()
+                .expect("pod context path must be valid UTF-8"),
+        )
+        .expect("serialize pod context import");
+        format!(
+            r#"import {{ podEnv }} from {context_import};
+
+export default {{
+  async fetch() {{
+    const child = Bun.spawnSync(["/usr/bin/env"]);
+    const childEnv = new TextDecoder().decode(child.stdout);
+    return Response.json({{
+      contextToken: podEnv("DUST_SANDBOX_TOKEN") ?? null,
+      contextIdentity: podEnv("DUST_POD_USER_IDENTITY") ?? null,
+      childHasToken: childEnv.includes("DUST_SANDBOX_TOKEN="),
+      childHasIdentity: childEnv.includes("DUST_POD_USER_IDENTITY="),
+    }});
+  }},
+}};
+"#
+        )
+    }
+
     fn restore_env(key: &str, original: Option<std::ffi::OsString>) {
         match original {
             Some(value) => std::env::set_var(key, value),
@@ -581,6 +627,9 @@ mod tests {
         }
         let original_home = std::env::var_os("HOME");
         let original_functions_dir = std::env::var_os("DUST_FUNCTIONS_DIR");
+        let original_warm_enabled = std::env::var_os(WARM_ENABLED_ENV);
+        let original_token = std::env::var_os(SANDBOX_TOKEN_ENV);
+        let original_identity = std::env::var_os(POD_USER_IDENTITY_ENV);
 
         let home = tempfile::tempdir().expect("home tempdir");
         std::env::set_var("HOME", home.path());
@@ -588,6 +637,9 @@ mod tests {
         let handler = bundle_dir.path().join("greet.ts");
         std::fs::write(&handler, HELLO_FIXTURE).expect("fixture");
         std::env::set_var("DUST_FUNCTIONS_DIR", bundle_dir.path());
+        std::env::set_var(WARM_ENABLED_ENV, "1");
+        std::env::set_var(SANDBOX_TOKEN_ENV, "spawn-token");
+        std::env::set_var(POD_USER_IDENTITY_ENV, "spawn-identity");
 
         let input = serde_json::json!({ "url": "http://localhost/?name=warm" }).to_string();
 
@@ -595,6 +647,8 @@ mod tests {
         assert!(matches!(try_warm_run("greet", &input).await, WarmRun::Miss));
 
         spawn_worker("greet");
+        std::env::set_var(SANDBOX_TOKEN_ENV, "invocation-token");
+        std::env::set_var(POD_USER_IDENTITY_ENV, "invocation-identity");
 
         // The worker needs a moment to bind its socket; the first served
         // request pays the bundle import and reports it.
@@ -620,6 +674,29 @@ mod tests {
                 assert_eq!(import_kind, Some(ImportKind::Cached));
             }
             WarmRun::Miss => panic!("second warm attempt missed"),
+        }
+
+        // The handler sees the current invocation's values through AsyncLocalStorage, while a
+        // nested process cannot recover the token or identity that existed when the worker was
+        // spawned.
+        let environment_handler = bundle_dir.path().join("greet__environment.ts");
+        std::fs::write(&environment_handler, environment_fixture()).expect("environment fixture");
+        match try_warm_run("greet__environment", &input).await {
+            WarmRun::Outcome(outcome, _) => {
+                assert_eq!(
+                    outcome,
+                    serde_json::json!({
+                        "ok": true,
+                        "output": {
+                            "contextToken": "invocation-token",
+                            "contextIdentity": "invocation-identity",
+                            "childHasToken": false,
+                            "childHasIdentity": false,
+                        }
+                    })
+                );
+            }
+            WarmRun::Miss => panic!("invocation environment probe missed the warm worker"),
         }
 
         // A second function in the same directory is served by the same
@@ -666,6 +743,24 @@ mod tests {
 
         restore_env("HOME", original_home);
         restore_env("DUST_FUNCTIONS_DIR", original_functions_dir);
+        restore_env(WARM_ENABLED_ENV, original_warm_enabled);
+        restore_env(SANDBOX_TOKEN_ENV, original_token);
+        restore_env(POD_USER_IDENTITY_ENV, original_identity);
+    }
+
+    #[test]
+    fn warm_execution_requires_explicit_opt_in() {
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
+        let original = std::env::var_os(WARM_ENABLED_ENV);
+
+        std::env::remove_var(WARM_ENABLED_ENV);
+        assert!(!warm_execution_enabled());
+        std::env::set_var(WARM_ENABLED_ENV, "0");
+        assert!(!warm_execution_enabled());
+        std::env::set_var(WARM_ENABLED_ENV, "1");
+        assert!(warm_execution_enabled());
+
+        restore_env(WARM_ENABLED_ENV, original);
     }
 
     /// A squatted warm dir (wrong owner is hard to fake unprivileged, but a

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts
@@ -92,7 +92,7 @@ function createPodSandboxAdapter(): GCSSandboxMountAdapter {
 }
 
 describe("buildMountCommand", () => {
-  test("workload profile mounts as root with allow_other and permissive modes", () => {
+  test("workload profile disables caches for shared mutable files", () => {
     const command = renderRootCommand(
       buildMountCommand({ bucket: "bucket-x", target: workloadTarget() })
     );
@@ -103,13 +103,15 @@ describe("buildMountCommand", () => {
     expect(command).toContain("-o allow_other");
     expect(command).toContain("--file-mode=666");
     expect(command).toContain("--dir-mode=777");
-    expect(command).toContain("--kernel-list-cache-ttl-secs=60");
+    expect(command).toContain("--kernel-list-cache-ttl-secs=0");
+    expect(command).toContain("--metadata-cache-ttl-secs=0");
+    expect(command).toContain("--metadata-cache-negative-ttl-secs=0");
     expect(command).toContain("--only-dir w/ws1/pods/spc1/files");
     expect(command).toContain("--enable-hns=false");
     expect(command).toContain("bucket-x /files/pod-spc1");
   });
 
-  test("pod function profile disables list caching for newly published functions", () => {
+  test("pod function profile disables caches for newly published functions", () => {
     const command = renderRootCommand(
       buildMountCommand({
         bucket: "bucket-x",
@@ -126,6 +128,8 @@ describe("buildMountCommand", () => {
 
     expect(command).toContain("-o allow_other,ro");
     expect(command).toContain("--kernel-list-cache-ttl-secs=0");
+    expect(command).toContain("--metadata-cache-ttl-secs=0");
+    expect(command).toContain("--metadata-cache-negative-ttl-secs=0");
     expect(command).toContain("--token-url http://127.0.0.1:987/token/mount-1");
   });
 
@@ -151,6 +155,8 @@ describe("buildMountCommand", () => {
     expect(command).not.toContain("allow_other");
     // Restore must never see a cached LTX listing.
     expect(command).toContain("--kernel-list-cache-ttl-secs=0");
+    expect(command).toContain("--metadata-cache-ttl-secs=0");
+    expect(command).toContain("--metadata-cache-negative-ttl-secs=0");
     expect(command).toContain("--file-mode=600");
     expect(command).toContain("--dir-mode=700");
     expect(command).toContain("--only-dir w/ws1/pods/spc1/state");
@@ -218,8 +224,14 @@ describe("pod sandbox mount wiring", () => {
         command.includes("/sandbox-functions/pods/spc1")
     );
 
-    expect(podFilesCommand).toContain("--kernel-list-cache-ttl-secs=60");
+    expect(podFilesCommand).toContain("--kernel-list-cache-ttl-secs=0");
+    expect(podFilesCommand).toContain("--metadata-cache-ttl-secs=0");
+    expect(podFilesCommand).toContain("--metadata-cache-negative-ttl-secs=0");
     expect(podFunctionsCommand).toContain("--kernel-list-cache-ttl-secs=0");
+    expect(podFunctionsCommand).toContain("--metadata-cache-ttl-secs=0");
+    expect(podFunctionsCommand).toContain(
+      "--metadata-cache-negative-ttl-secs=0"
+    );
   });
 });
 

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
@@ -69,10 +69,11 @@ function tokenUrl(index: number): string {
  * Per-target mount profile.
  *
  * - "workload": root-mounted with `allow_other` so the unprivileged sandbox
- *   users can access it; permissive file/dir modes; 60s kernel list cache
- *   (read-mostly workloads). All agent-facing mounts.
+ *   users can access it; permissive file/dir modes. All agent-facing mounts
+ *   are shared mutable filesystems, so namespace and metadata caching are
+ *   disabled: writes from another sandbox or Front must be visible immediately.
  * - "pod_sandbox_functions": same access model as "workload", but without
- *   kernel list caching so newly published functions are visible immediately.
+ *   caching so newly published or replaced functions are visible immediately.
  * - "pod_state_replica": mounted AS `dust-state` (via runuser) so the FUSE
  *   default — only the mounting user can access the fs — makes it invisible to
  *   every other uid, including the untrusted workload uid 1003 and root. No
@@ -432,8 +433,6 @@ export function buildMountCommand({
       if (target.readOnly) {
         mountOptions.push("ro");
       }
-      const kernelListCacheTtlSeconds =
-        target.mountProfile === "pod_sandbox_functions" ? 0 : 60;
 
       const flags = [
         ...commonFlags,
@@ -441,7 +440,12 @@ export function buildMountCommand({
         mountOptions.join(","),
         "--file-mode=666",
         "--dir-mode=777",
-        `--kernel-list-cache-ttl-secs=${kernelListCacheTtlSeconds}`,
+        // These mounts have multiple independent writers/readers. gcsfuse only invalidates the
+        // client that performed a mutation, so any cache here can hide writes from another
+        // sandbox or from Front.
+        "--kernel-list-cache-ttl-secs=0",
+        "--metadata-cache-ttl-secs=0",
+        "--metadata-cache-negative-ttl-secs=0",
       ];
 
       return rootCommand.stderrToStdout(
@@ -462,6 +466,8 @@ export function buildMountCommand({
         "--file-mode=600",
         "--dir-mode=700",
         "--kernel-list-cache-ttl-secs=0",
+        "--metadata-cache-ttl-secs=0",
+        "--metadata-cache-negative-ttl-secs=0",
       ];
 
       return rootCommand.stderrToStdout(

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.82",
+      tag: "0.8.83",
     });
   });
 
@@ -457,7 +457,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.48/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.49/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,8 +26,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.82";
-const DSBX_CLI_VERSION = "0.1.48";
+const DUST_BASE_IMAGE_VERSION = "0.8.83";
+const DSBX_CLI_VERSION = "0.1.49";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
 // the stable identity used when creating the workload account.

--- a/front/lib/resources/sandbox_function_invocation_resource.test.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.test.ts
@@ -741,6 +741,7 @@ describe("SandboxFunctionInvocationResource", () => {
       // Published outside an app folder, so its databases are unprefixed.
       DUST_POD_DATABASE_PREFIX: "",
       DUST_SANDBOX_TOKEN: "sbt-function-token",
+      DUST_FUNCTION_WARM_ENABLED: "0",
     });
     expect(
       JSON.parse(opts?.envVars?.DUST_POD_USER_IDENTITY ?? "")
@@ -1248,6 +1249,7 @@ describe("SandboxFunctionInvocationResource.createAndStartExecution", () => {
     // the workflow's.
     const [, , execOptions] = execSpy.mock.calls[0]!;
     expect(execOptions?.timeoutMs).toBe(10 * 1000);
+    expect(execOptions?.envVars?.DUST_FUNCTION_WARM_ENABLED).toBe("1");
     // A fast function runs under a token that cannot call tools.
     expect(generateSandboxFunctionInvocationToken).toHaveBeenCalledWith(
       expect.anything(),
@@ -1285,7 +1287,8 @@ describe("SandboxFunctionInvocationResource.createAndStartExecution", () => {
   });
 
   it("runs a durable function under a token that can call tools", async () => {
-    const { authenticator, sandboxFunction } = await setupInlineTest("durable");
+    const { authenticator, sandboxFunction, execSpy } =
+      await setupInlineTest("durable");
 
     const result =
       await SandboxFunctionInvocationResource.createAndStartExecution(
@@ -1302,6 +1305,8 @@ describe("SandboxFunctionInvocationResource.createAndStartExecution", () => {
       expect.anything(),
       expect.objectContaining({ noTools: false })
     );
+    const [, , execOptions] = execSpy.mock.calls[0]!;
+    expect(execOptions?.envVars?.DUST_FUNCTION_WARM_ENABLED).toBe("0");
   });
 
   it("starts the workflow for a durable function", async () => {

--- a/front/lib/resources/sandbox_function_invocation_resource.ts
+++ b/front/lib/resources/sandbox_function_invocation_resource.ts
@@ -84,6 +84,7 @@ const DSBX_BIN_PATH = "/opt/bin/dsbx";
 const SANDBOX_FUNCTION_ERROR_LOG_MAX_CHARS = 16_384;
 const GCS_CONCURRENCY = 4;
 const SANDBOX_FUNCTION_INVOCATION_DATA_VERSION = 2;
+const FUNCTION_WARM_ENABLED_ENV = "DUST_FUNCTION_WARM_ENABLED";
 const POD_USER_IDENTITY_ENV = "DUST_POD_USER_IDENTITY";
 
 // "admin" reads every invocation of the function without resolving a workspace user: poke
@@ -698,6 +699,10 @@ export class SandboxFunctionInvocationResource extends BaseResource<SandboxFunct
             databasePrefix: podDatabasePrefixFromSlug(sandboxFunction.slug),
           }),
           DUST_SANDBOX_TOKEN: token,
+          // Durable functions may still spawn tool clients that inherit the function process's
+          // native environment. Keep them cold until all tool calls read the invocation context;
+          // fast functions cannot call tools and are safe to serve from a resident worker.
+          [FUNCTION_WARM_ENABLED_ENV]: noTools ? "1" : "0",
           // Set this for every invocation so userless calls cannot inherit a sandbox-level value.
           [POD_USER_IDENTITY_ENV]: userIdentity
             ? JSON.stringify(userIdentity)


### PR DESCRIPTION
## Description

- Disable GCSFuse list, metadata, and negative metadata caches on shared Pod and conversation mounts so writes from another sandbox or Front are visible immediately. Independent GCSFuse clients previously retained directory listings and metadata for 60 seconds, plus negative lookups for 5 seconds; only the client performing a local mutation invalidated its entries.
- Make warm function execution an explicit fast-function opt-in. Durable functions stay cold while they may shell out to tool clients.
- Remove the sandbox token and Pod user identity at the warm worker process boundary. Warm handlers receive the current values only through their per-invocation context. This closes the Bun behavior where nested processes inherited the worker's native startup environment even after JavaScript deleted the corresponding `process.env` entries.
- Leave the generated Pod Functions guidance and image-generation context behavior unchanged for their separate work streams.

## Tests

- `npm test -- lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.test.ts lib/resources/sandbox_function_invocation_resource.test.ts` (53 tests)
- `bun test` in `cli/dust-sandbox/functions-runner` (125 tests)
- `cargo test commands::function::warm::tests -- --nocapture` (12 tests)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Biome on the four changed Front files

## Risk

- Disabling GCSFuse caches increases metadata and listing requests. Monitor GCS request volume and mount latency; the flags are independently reversible.
- The Front opt-in must not reach any sandbox running an older dsbx that still inherits invocation secrets into warm workers.

## Deploy Plan

1. Publish the new dsbx and deploy the corresponding sandbox image. With the old Front, the new binary receives no opt-in flag and defaults every function to cold execution.
2. Recreate every existing Pod and conversation sandbox, including sleeping sandboxes, and verify no old-dsbx sandbox remains. This first recycle establishes the token boundary before Front can enable fast-function warming.
3. Deploy Front, which opts only fast functions into warming. Durable functions remain cold.
4. Recreate or remount Pod and conversation sandboxes again so Front supplies the uncached GCSFuse flags. Wake alone preserves existing mounts and is insufficient.
5. Monitor GCS request volume and latency, warm versus cold function-run metrics, and sandbox token errors.