### PR TITLE
fix: prevent "Today (partial)" reference line label from being clippe…

### DIFF
--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -1,7 +1,4 @@
-import {
-  CHART_HEIGHT,
-  CONVERSATION_FILES_AGGREGATE_KEY,
-} from "@app/components/agent_builder/observability/constants";
+import { CONVERSATION_FILES_AGGREGATE_KEY } from "@app/components/agent_builder/observability/constants";
 import { useObservabilityContext } from "@app/components/agent_builder/observability/ObservabilityContext";
 import {
   getIndexedBaseColor,
@@ -9,6 +6,7 @@ import {
 } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { CHART_HEIGHT } from "@app/components/charts/constants";
 import type { DatasourceRetrievalTreemapNode } from "@app/components/charts/DatasourceRetrievalTreemapContent";
 import { DatasourceRetrievalTreemapContent } from "@app/components/charts/DatasourceRetrievalTreemapContent";
 import {

--- a/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
+++ b/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
@@ -1,6 +1,5 @@
 import { FeedbackDistributionTooltip } from "@app/components/agent_builder/observability/charts/ChartsTooltip";
 import {
-  CHART_HEIGHT,
   FEEDBACK_DISTRIBUTION_LEGEND,
   FEEDBACK_DISTRIBUTION_PALETTE,
 } from "@app/components/agent_builder/observability/constants";
@@ -12,6 +11,7 @@ import {
 } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { legendFromConstant } from "@app/components/charts/ChartLegend";
+import { CHART_HEIGHT, CHART_MARGIN } from "@app/components/charts/constants";
 import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import {
   useAgentFeedbackDistribution,
@@ -113,10 +113,7 @@ export function FeedbackDistributionChart({
       height={CHART_HEIGHT}
       legendItems={legendItems}
     >
-      <LineChart
-        data={data}
-        margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
-      >
+      <LineChart data={data} margin={CHART_MARGIN}>
         <CartesianGrid vertical={false} className="stroke-border" />
         <XAxis
           dataKey="date"

--- a/front/components/agent_builder/observability/charts/LatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/LatencyChart.tsx
@@ -1,5 +1,4 @@
 import {
-  CHART_HEIGHT,
   LATENCY_LEGEND,
   LATENCY_PALETTE,
 } from "@app/components/agent_builder/observability/constants";
@@ -12,6 +11,7 @@ import { padSeriesToTimeRange } from "@app/components/agent_builder/observabilit
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { legendFromConstant } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { CHART_HEIGHT, CHART_MARGIN } from "@app/components/charts/constants";
 import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import type { AgentVersionMarker } from "@app/lib/api/assistant/observability/version_markers";
 import { useAgentVersionMarkers } from "@app/lib/swr/assistants";
@@ -166,10 +166,7 @@ export function LatencyChart({
       height={CHART_HEIGHT}
       legendItems={legendItems}
     >
-      <LineChart
-        data={data}
-        margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
-      >
+      <LineChart data={data} margin={CHART_MARGIN}>
         <defs>
           <linearGradient
             id="fillAverage"

--- a/front/components/agent_builder/observability/charts/PodUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/PodUsageChart.tsx
@@ -1,5 +1,4 @@
 import {
-  CHART_HEIGHT,
   OTHER_LABEL,
   UNKNOWN_LABEL,
 } from "@app/components/agent_builder/observability/constants";
@@ -7,6 +6,7 @@ import { useObservabilityContext } from "@app/components/agent_builder/observabi
 import { getIndexedColor } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { CHART_HEIGHT } from "@app/components/charts/constants";
 import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import { useAgentPodUsage } from "@app/lib/swr/assistants";
 import { isString } from "@app/types/shared/utils/general";

--- a/front/components/agent_builder/observability/charts/SkillUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/SkillUsageChart.tsx
@@ -1,5 +1,4 @@
 import { ChartsTooltip } from "@app/components/agent_builder/observability/charts/ChartsTooltip";
-import { CHART_HEIGHT } from "@app/components/agent_builder/observability/constants";
 import {
   useSkillSourceData,
   useSkillVersionData,
@@ -14,6 +13,7 @@ import { getIndexedColor } from "@app/components/agent_builder/observability/uti
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { RoundedBarShape } from "@app/components/charts/ChartShapes";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { CHART_HEIGHT, CHART_MARGIN } from "@app/components/charts/constants";
 import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import {
   Button,
@@ -280,7 +280,7 @@ export function SkillUsageChart({
       {skillMode === "version" ? (
         <BarChart
           data={versionData.chartData}
-          margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
+          margin={CHART_MARGIN}
           stackOffset="expand"
         >
           <CartesianGrid vertical={false} className="stroke-border" />
@@ -348,10 +348,7 @@ export function SkillUsageChart({
           ))}
         </BarChart>
       ) : (
-        <BarChart
-          data={filteredSourceItems}
-          margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
-        >
+        <BarChart data={filteredSourceItems} margin={CHART_MARGIN}>
           <CartesianGrid vertical={false} className="stroke-border" />
           <XAxis
             dataKey="skillName"

--- a/front/components/agent_builder/observability/charts/SourceChart.tsx
+++ b/front/components/agent_builder/observability/charts/SourceChart.tsx
@@ -1,4 +1,3 @@
-import { CHART_HEIGHT } from "@app/components/agent_builder/observability/constants";
 import { useObservabilityContext } from "@app/components/agent_builder/observability/ObservabilityContext";
 import {
   buildSourceChartData,
@@ -6,6 +5,7 @@ import {
 } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { CHART_HEIGHT } from "@app/components/charts/constants";
 import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import { useAgentContextOrigin } from "@app/lib/swr/assistants";
 import { isString } from "@app/types/shared/utils/general";

--- a/front/components/agent_builder/observability/charts/ToolExecutionTimeChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolExecutionTimeChart.tsx
@@ -1,5 +1,4 @@
 import {
-  CHART_HEIGHT,
   MAX_TOOLS_DISPLAYED,
   TOOL_EXECUTION_TIME_LEGEND,
   TOOL_EXECUTION_TIME_PALETTE,
@@ -11,6 +10,7 @@ import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { legendFromConstant } from "@app/components/charts/ChartLegend";
 import { RoundedBarShape } from "@app/components/charts/ChartShapes";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { CHART_HEIGHT, CHART_MARGIN } from "@app/components/charts/constants";
 import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import type { ToolLatencyView } from "@app/lib/api/assistant/observability/tool_latency";
 import {
@@ -259,10 +259,7 @@ export function ToolExecutionTimeChart({
         </div>
       }
     >
-      <BarChart
-        data={displayData}
-        margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
-      >
+      <BarChart data={displayData} margin={CHART_MARGIN}>
         <CartesianGrid vertical={false} className="stroke-border" />
         <XAxis
           dataKey="label"

--- a/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
@@ -1,5 +1,4 @@
 import { ChartsTooltip } from "@app/components/agent_builder/observability/charts/ChartsTooltip";
-import { CHART_HEIGHT } from "@app/components/agent_builder/observability/constants";
 import { useToolUsageData } from "@app/components/agent_builder/observability/hooks";
 import { useObservabilityContext } from "@app/components/agent_builder/observability/ObservabilityContext";
 import type {
@@ -9,6 +8,7 @@ import type {
 import { getIndexedColor } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { RoundedBarShape } from "@app/components/charts/ChartShapes";
+import { CHART_HEIGHT, CHART_MARGIN } from "@app/components/charts/constants";
 import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import { useAgentMcpConfigurations } from "@app/lib/swr/assistants";
 import { ButtonsSwitch, ButtonsSwitchList, cn } from "@dust-tt/sparkle";
@@ -128,11 +128,7 @@ export function ToolUsageChart({
       height={CHART_HEIGHT}
       legendItems={legendItems}
     >
-      <BarChart
-        data={chartData}
-        margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
-        stackOffset="expand"
-      >
+      <BarChart data={chartData} margin={CHART_MARGIN} stackOffset="expand">
         <CartesianGrid vertical={false} className="stroke-border" />
         <XAxis
           dataKey="label"

--- a/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
@@ -1,5 +1,4 @@
 import {
-  CHART_HEIGHT,
   USAGE_METRICS_LEGEND,
   USAGE_METRICS_PALETTE,
 } from "@app/components/agent_builder/observability/constants";
@@ -13,6 +12,7 @@ import {
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { legendFromConstant } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { CHART_HEIGHT, CHART_MARGIN } from "@app/components/charts/constants";
 import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import type { AgentVersionMarker } from "@app/lib/api/assistant/observability/version_markers";
 import {
@@ -178,10 +178,7 @@ export function UsageMetricsChart({
       height={CHART_HEIGHT}
       legendItems={legendItems}
     >
-      <LineChart
-        data={data}
-        margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
-      >
+      <LineChart data={data} margin={CHART_MARGIN}>
         <defs>
           {/* Gradients use currentColor; color is set via classes */}
           <linearGradient

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -54,8 +54,6 @@ export const COST_PALETTE = {
   totalCredits: "text-orange-400",
 } as const;
 
-export const CHART_HEIGHT = 260;
-
 export const INDEXED_BASE_COLORS = [
   "orange",
   "golden",

--- a/front/components/charts/ChartContainer.tsx
+++ b/front/components/charts/ChartContainer.tsx
@@ -1,6 +1,6 @@
-import { CHART_HEIGHT } from "@app/components/agent_builder/observability/constants";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartLegend } from "@app/components/charts/ChartLegend";
+import { CHART_HEIGHT } from "@app/components/charts/constants";
 import {
   Button,
   Maximize01,

--- a/front/components/charts/constants.ts
+++ b/front/components/charts/constants.ts
@@ -1,0 +1,8 @@
+export const CHART_HEIGHT = 260;
+
+export const CHART_MARGIN = {
+  top: 10,
+  right: 30,
+  left: 10,
+  bottom: 20,
+} as const;

--- a/front/components/pages/workspace/developers/SelfImprovingSkillsConsumptionSection.tsx
+++ b/front/components/pages/workspace/developers/SelfImprovingSkillsConsumptionSection.tsx
@@ -1,10 +1,8 @@
-import {
-  CHART_HEIGHT,
-  COST_PALETTE,
-} from "@app/components/agent_builder/observability/constants";
+import { COST_PALETTE } from "@app/components/agent_builder/observability/constants";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { CHART_HEIGHT, CHART_MARGIN } from "@app/components/charts/constants";
 import { ConsumptionProgressBarWithNumbers } from "@app/components/pages/workspace/developers/ConsumptionProgressBar";
 import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
 import type { ReinforcementBillingUnit } from "@app/lib/reinforcement/enforcement";
@@ -290,10 +288,7 @@ function SelfImprovingSpendChart({
         </DropdownMenu>
       }
     >
-      <ChartComponent
-        data={chartData}
-        margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
-      >
+      <ChartComponent data={chartData} margin={CHART_MARGIN}>
         <CartesianGrid vertical={false} className="stroke-border" />
         <XAxis
           dataKey="timestamp"

--- a/front/components/poke/analytics/PokeWorkspaceUsageChart.tsx
+++ b/front/components/poke/analytics/PokeWorkspaceUsageChart.tsx
@@ -1,13 +1,13 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
 import {
   ACTIVE_USERS_PALETTE,
-  CHART_HEIGHT,
   USAGE_METRICS_PALETTE,
 } from "@app/components/agent_builder/observability/constants";
 import { padSeriesToTimeRange } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { CHART_HEIGHT, CHART_MARGIN } from "@app/components/charts/constants";
 import { formatShortDate } from "@app/lib/utils/timestamps";
 import {
   usePokeWorkspaceActiveUsersMetrics,
@@ -356,10 +356,7 @@ export function PokeWorkspaceUsageChart({
       legendItems={legendItems}
       additionalControls={controls}
     >
-      <LineChart
-        data={data}
-        margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
-      >
+      <LineChart data={data} margin={CHART_MARGIN}>
         <CartesianGrid vertical={false} className="stroke-border" />
         <XAxis
           dataKey="date"

--- a/front/components/poke/plugins/components/DatasourceRetrievalTreemapPluginChart.tsx
+++ b/front/components/poke/plugins/components/DatasourceRetrievalTreemapPluginChart.tsx
@@ -1,13 +1,11 @@
-import {
-  CHART_HEIGHT,
-  DEFAULT_PERIOD_DAYS,
-} from "@app/components/agent_builder/observability/constants";
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import {
   getIndexedBaseColor,
   getIndexedColor,
 } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { CHART_HEIGHT } from "@app/components/charts/constants";
 import type { DatasourceRetrievalTreemapNode } from "@app/components/charts/DatasourceRetrievalTreemapContent";
 import { DatasourceRetrievalTreemapContent } from "@app/components/charts/DatasourceRetrievalTreemapContent";
 import { usePokeAgentDatasourceRetrieval } from "@app/poke/swr/agent_details";

--- a/front/components/poke/plugins/components/WorkspaceDatasourceRetrievalTreemapPluginChart.tsx
+++ b/front/components/poke/plugins/components/WorkspaceDatasourceRetrievalTreemapPluginChart.tsx
@@ -1,10 +1,8 @@
-import {
-  CHART_HEIGHT,
-  DEFAULT_PERIOD_DAYS,
-} from "@app/components/agent_builder/observability/constants";
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getIndexedColor } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { CHART_HEIGHT } from "@app/components/charts/constants";
 import type { DatasourceRetrievalTreemapNode } from "@app/components/charts/DatasourceRetrievalTreemapContent";
 import { DatasourceRetrievalTreemapContent } from "@app/components/charts/DatasourceRetrievalTreemapContent";
 import { usePokeWorkspaceDatasourceRetrieval } from "@app/poke/swr/workspace_info";

--- a/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
+++ b/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
@@ -1,6 +1,5 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
 import {
-  CHART_HEIGHT,
   COST_PALETTE,
   OTHER_LABEL,
 } from "@app/components/agent_builder/observability/constants";
@@ -12,6 +11,7 @@ import {
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { CHART_HEIGHT, CHART_MARGIN } from "@app/components/charts/constants";
 import { AnalyticsFilterDropdown } from "@app/components/workspace/analytics/AnalyticsFilterDropdown";
 import type { AnalyticsFilter } from "@app/components/workspace/analytics/analyticsFilter";
 import {
@@ -362,7 +362,7 @@ function UsageChartBars({
       data={chartData}
       width={width}
       height={height}
-      margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
+      margin={CHART_MARGIN}
     >
       <CartesianGrid vertical={false} className="stroke-border" />
       <XAxis

--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -1,5 +1,4 @@
 import {
-  CHART_HEIGHT,
   COST_PALETTE,
   OTHER_LABEL,
   USER_MESSAGE_ORIGIN_LABELS,
@@ -12,6 +11,7 @@ import {
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { CHART_HEIGHT, CHART_MARGIN } from "@app/components/charts/constants";
 import type {
   AvailableGroup,
   GetWorkspaceProgrammaticCostResponse,
@@ -730,10 +730,7 @@ export function BaseProgrammaticCostChart({
       legendItems={legendItems}
       isAllowFullScreen
     >
-      <ChartComponent
-        data={chartData}
-        margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
-      >
+      <ChartComponent data={chartData} margin={CHART_MARGIN}>
         <CartesianGrid vertical={false} className="stroke-border" />
         <XAxis
           dataKey="timestamp"

--- a/front/components/workspace/analytics/WorkspaceSkillUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceSkillUsageChart.tsx
@@ -1,11 +1,11 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
-import { CHART_HEIGHT } from "@app/components/agent_builder/observability/constants";
 import {
   getDayTimestamps,
   getIndexedColor,
 } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { CHART_HEIGHT, CHART_MARGIN } from "@app/components/charts/constants";
 import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
@@ -355,10 +355,7 @@ export function WorkspaceSkillUsageChart({
         </div>
       }
     >
-      <LineChart
-        data={data}
-        margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
-      >
+      <LineChart data={data} margin={CHART_MARGIN}>
         <CartesianGrid vertical={false} className="stroke-border" />
         <XAxis
           dataKey="date"

--- a/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
@@ -1,11 +1,11 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
-import { CHART_HEIGHT } from "@app/components/agent_builder/observability/constants";
 import {
   getDayTimestamps,
   getIndexedColor,
 } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { CHART_HEIGHT, CHART_MARGIN } from "@app/components/charts/constants";
 import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
@@ -344,10 +344,7 @@ export function WorkspaceToolUsageChart({
         </div>
       }
     >
-      <LineChart
-        data={data}
-        margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
-      >
+      <LineChart data={data} margin={CHART_MARGIN}>
         <CartesianGrid vertical={false} className="stroke-border" />
         <XAxis
           dataKey="date"

--- a/front/components/workspace/analytics/WorkspaceUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceUsageChart.tsx
@@ -1,13 +1,13 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
 import {
   ACTIVE_USERS_PALETTE,
-  CHART_HEIGHT,
   USAGE_METRICS_PALETTE,
 } from "@app/components/agent_builder/observability/constants";
 import { padSeriesToTimeRange } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { CHART_HEIGHT, CHART_MARGIN } from "@app/components/charts/constants";
 import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
@@ -359,10 +359,7 @@ export function WorkspaceUsageChart({
       legendItems={legendItems}
       additionalControls={controls}
     >
-      <LineChart
-        data={data}
-        margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
-      >
+      <LineChart data={data} margin={CHART_MARGIN}>
         <CartesianGrid vertical={false} className="stroke-border" />
         <XAxis
           dataKey="date"

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -1,7 +1,7 @@
-import { CHART_HEIGHT } from "@app/components/agent_builder/observability/constants";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { CHART_HEIGHT, CHART_MARGIN } from "@app/components/charts/constants";
 import { useConsumptionTimeseries } from "@app/hooks/useConsumptionTimeseries";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { formatConsumptionDate } from "@app/lib/analytics/consumption_period";
@@ -214,10 +214,7 @@ export function ConsumptionChart({
       height={CHART_HEIGHT}
       legendItems={legendItems}
     >
-      <BarChart
-        data={chartData}
-        margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
-      >
+      <BarChart data={chartData} margin={{ ...CHART_MARGIN, top: 24 }}>
         <CartesianGrid vertical={false} className="stroke-border" />
         <XAxis
           dataKey="timestamp"


### PR DESCRIPTION
## Description

Until now, the “Today (partial)” reference-line label in the workspace consumption chart could be clipped because the chart’s top margin was too small.

**Before:**
<img width="1135" height="500" alt="Capture d’écran 2026-08-12 à 09 51 50" src="https://github.com/user-attachments/assets/0be52ff7-57be-46d6-b519-6eb31aca5ed5" />

**After:**
<img width="1125" height="498" alt="Capture d’écran 2026-08-12 à 09 52 08" src="https://github.com/user-attachments/assets/d6613152-5c9c-40a4-8a40-7cb64f957c4b" />

**Centralize chart layout constants for better modularity**

Chart height and margin values were previously duplicated and hardcoded across individual chart components, leading to clunky, ad-hoc imports between files. This PR centralizes those shared constants in front/components/charts/constants.ts so charts pull from a single source instead of reaching into each other or repeating values.

Updates the observability, Poke analytics, and workspace analytics charts to consume the shared constants
This is purely a layout and constants-refactoring change, chart data, series, legends, and interactions are unchanged.

## Tests

## Risk

This is a frontend-only change with no backend, data-model, or migration impact. The main risk is a visual regression in one of the charts touched by the shared-constant import updates. Existing chart dimensions and margins are preserved except for the intentional consumption-chart top-margin increase, and the change can be safely reverted without cleanup.

## Deploy Plan

- Deploy front