### PR TITLE
[front] feat: resolve app-relative pod function references in the Frame host

### DIFF
--- a/front-api/routes/v1/public/frames/[token]/index.test.ts
+++ b/front-api/routes/v1/public/frames/[token]/index.test.ts
@@ -10,6 +10,7 @@ import type { UserResource } from "@app/lib/resources/user_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { FileShareScope } from "@app/types/files";
 import { frameContentType } from "@app/types/files";
@@ -77,6 +78,66 @@ describe("GET /api/v1/public/frames/[token]", () => {
     }
     return honoApp.request(`/api/v1/public/frames/${token}`, { headers });
   };
+
+  describe("framePath for a Pod app Frame", () => {
+    // A shared Frame that lives in an app folder must resolve its app's functions by bare name just
+    // as it does when opened from the Pod, so the response has to tell it which app it belongs to.
+    const createPodAppFrame = async () => {
+      const pod = await SpaceFactory.project(workspace, user.id);
+      const file = await FileFactory.create(auth, user, {
+        contentType: frameContentType,
+        fileName: "TaskList.tsx",
+        fileSize: 100,
+        status: "ready",
+        useCase: "project_context",
+        useCaseMetadata: { spaceId: pod.sId },
+        mountFilePath: `w/${workspace.sId}/pods/${pod.sId}/files/TaskList/TaskList.tsx`,
+      });
+
+      await file.setShareScope(auth, "workspace_and_emails");
+      const shareInfo = await file.getShareInfo();
+      const token = shareInfo!.shareUrl.split("/").at(-1)!;
+
+      // The Authenticator caches its group memberships, and `auth` predates this pod, so it would
+      // not be able to read it. Rebuild one that can.
+      const podAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      return { pod, file, token, podAuth };
+    };
+
+    it("returns the scoped path for a viewer who can read the Pod", async () => {
+      const { pod, token, podAuth } = await createPodAppFrame();
+      vi.mocked(resolveOptionalAuth).mockResolvedValue(podAuth);
+
+      const response = await requestFrame(token);
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.framePath).toBe(`pod-${pod.sId}/TaskList/TaskList.tsx`);
+    });
+
+    it("withholds it from a viewer who cannot read the Pod", async () => {
+      const { file, token } = await createPodAppFrame();
+      vi.mocked(resolveOptionalAuth).mockResolvedValue(null);
+
+      const sessionToken = await createGrantAndSession(
+        file,
+        "external@example.com"
+      );
+      const response = await requestFrame(token, {
+        cookies: { dust_frame_session: sessionToken },
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      // Such a viewer cannot invoke the Pod's functions either, so there is no reason to hand them
+      // the Pod's layout.
+      expect(body.framePath).toBeNull();
+    });
+  });
 
   describe("workspace_and_emails scope", () => {
     it("allows logged-in workspace member without a grant", async () => {

--- a/front-api/routes/v1/public/frames/[token]/index.ts
+++ b/front-api/routes/v1/public/frames/[token]/index.ts
@@ -229,6 +229,10 @@ app.get(
       // Lets the frame enable member-only tools (e.g. callFunction) client-side;
       // real authorization still happens server-side on invocation.
       isAuthenticatedMember: !!user,
+      // Lets a shared Frame in an app folder resolve bare function references, exactly as it does
+      // when opened from the Pod. Withheld from viewers who cannot read the Pod, who cannot invoke
+      // its functions either.
+      framePath: canRead && auth ? file.toScopedPath(auth) : null,
     });
   }
 );

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -10,6 +10,11 @@ import type {
 import { clientFetch } from "@app/lib/egress/client";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import datadogLogger from "@app/logger/datadogLogger";
+import type { PodFunctionScope } from "@app/types/api/pod_function_reference";
+import {
+  podFunctionScopeFromFramePath,
+  resolvePodFunctionReference,
+} from "@app/types/api/pod_function_reference";
 import type {
   PostSandboxFunctionInvocationRequestBody,
   PostSandboxFunctionInvocationResponseBody,
@@ -381,6 +386,7 @@ function useVisualizationDataHandler({
   createSandboxFunctionInvocation,
   getFileBlob,
   onEditText,
+  podFunctionScope,
   setCodeDrawerOpened,
   setContentHeight,
   setErrorMessage,
@@ -398,6 +404,7 @@ function useVisualizationDataHandler({
     Result<PostSandboxFunctionInvocationResponseBody, SandboxFunctionCallError>
   >;
   getFileBlob: (fileId: string) => Promise<Blob | null>;
+  podFunctionScope: PodFunctionScope | null;
   onEditText?: EditTextFn;
   setCodeDrawerOpened: (v: SetStateAction<boolean>) => void;
   setContentHeight: (v: SetStateAction<number>) => void;
@@ -467,8 +474,27 @@ function useVisualizationDataHandler({
 
       switch (data.command) {
         case "callFunction": {
-          const invocationRes = await createSandboxFunctionInvocation(
+          // A Frame in an app folder may name its own functions by bare slug; qualify it here, the
+          // only layer that both knows which Frame is calling and is trusted about it.
+          const referenceRes = resolvePodFunctionReference(
             data.params.functionIdOrSlug,
+            podFunctionScope
+          );
+          if (referenceRes.isErr()) {
+            sendErrorToIframe(
+              data,
+              {
+                code: "not_supported",
+                message: referenceRes.error.message,
+              },
+              event.source,
+              { conversationId, workspaceId }
+            );
+            break;
+          }
+
+          const invocationRes = await createSandboxFunctionInvocation(
+            referenceRes.value,
             data.params.input
           );
 
@@ -575,6 +601,7 @@ function useVisualizationDataHandler({
     downloadFileFromBlob,
     getFileBlob,
     onEditText,
+    podFunctionScope,
     setContentHeight,
     setErrorMessage,
     setCodeDrawerOpened,
@@ -621,6 +648,12 @@ export interface VisualizationActionIframeProps {
   agentConfigurationId: string | null;
   canInvokeFunctions: boolean;
   conversationId: string | null;
+  /**
+   * Canonical scoped path of the Frame being rendered (`pod-{podId}/MyApp/MyApp.tsx`), when the host
+   * knows it. Only Pod hosts do, and it is what lets a Frame in an app folder call its functions by
+   * bare name; without it, relative references are refused.
+   */
+  framePath?: string | null;
   isEditable?: boolean;
   isInDrawer?: boolean;
   onEditText?: EditTextFn;
@@ -644,6 +677,13 @@ export const VisualizationActionIframe = forwardRef<
   const [retryClicked, setRetryClicked] = useState(false);
   const [isCodeDrawerOpen, setCodeDrawerOpened] = useState(false);
   const vizIframeRef = useRef<HTMLIFrameElement | null>(null);
+
+  // Only Pod hosts pass a frame path, so only Frames in an app folder get a scope; everything else
+  // resolves to null and must use fully qualified references.
+  const podFunctionScope = useMemo(
+    () => podFunctionScopeFromFramePath(props.framePath),
+    [props.framePath]
+  );
 
   // In-flight sandbox function invocations. Each entry mounts a
   // SandboxFunctionInvocation; the resolver of the pending `callFunction` promise is kept
@@ -880,6 +920,7 @@ export const VisualizationActionIframe = forwardRef<
     createSandboxFunctionInvocation,
     getFileBlob,
     onEditText,
+    podFunctionScope,
     setCodeDrawerOpened,
     setContentHeight,
     setErrorMessage,

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -460,6 +460,7 @@ export function FrameRenderer({
               conversationId={conversation?.sId ?? null}
               isEditable={true}
               spaceId={frameSpaceId ?? undefined}
+              framePath={framePath}
               isInDrawer={true}
               onEditText={handleEditText}
               ref={iframeRef}

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
@@ -71,6 +71,7 @@ export function PublicFrameRenderer({
     error,
     accessToken,
     isAuthenticatedMember,
+    framePath,
   } = usePublicFrame({
     shareToken,
   });
@@ -149,6 +150,7 @@ export function PublicFrameRenderer({
             canInvokeFunctions={publicUserIdentity !== undefined}
             scopedUserIdentity={publicUserIdentity}
             viewer={viewer}
+            framePath={framePath}
             isInDrawer
           />
         </div>

--- a/front/components/pod/PodFrameTabContent.tsx
+++ b/front/components/pod/PodFrameTabContent.tsx
@@ -50,6 +50,7 @@ export function PodFrameTabContent({
           vizUrl={vizUrl}
           identifier={`viz-frame-tab-${fileId}`}
           isPodEditor={podInfo.isEditor}
+          framePath={tab.path}
         />
       </div>
     </div>

--- a/front/components/pod/PodFrameVisualization.tsx
+++ b/front/components/pod/PodFrameVisualization.tsx
@@ -9,6 +9,8 @@ interface PodFrameVisualizationProps {
   vizUrl: string;
   identifier: string;
   isPodEditor?: boolean;
+  /** Scoped path of the Frame, so one inside an app folder can call its functions by bare name. */
+  framePath?: string | null;
 }
 
 /**
@@ -22,6 +24,7 @@ export function PodFrameVisualization({
   vizUrl,
   identifier,
   isPodEditor,
+  framePath,
 }: PodFrameVisualizationProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
@@ -37,6 +40,7 @@ export function PodFrameVisualization({
       }}
       conversationId={null}
       spaceId={spaceId}
+      framePath={framePath}
       isInDrawer={true}
       isPodEditor={isPodEditor}
       ref={iframeRef}

--- a/front/components/pod/conversation/PodPinnedBanner.tsx
+++ b/front/components/pod/conversation/PodPinnedBanner.tsx
@@ -203,6 +203,7 @@ export function PodPinnedBanner({ owner, podInfo }: PodPinnedBannerProps) {
     vizUrl,
     identifier: `viz-banner-${fileId}`,
     isPodEditor: podInfo.isEditor,
+    framePath: pinnedFramePath,
   };
 
   const controlsProps = {

--- a/front/components/pod/files/PodFrameSheet.tsx
+++ b/front/components/pod/files/PodFrameSheet.tsx
@@ -161,6 +161,7 @@ export function PodFrameSheet({
                 key={`viz-${fileId}`}
                 conversationId={null}
                 spaceId={fileMetadata?.useCaseMetadata.spaceId}
+                framePath={framePath}
                 isInDrawer={true}
                 isPodEditor={isEditor}
                 ref={iframeRef}

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -8,10 +8,7 @@ import {
   podDatabaseNameWithoutAppPrefix,
 } from "@app/lib/api/sandbox_functions/db_naming";
 import { deleteDatabaseOnSandbox } from "@app/lib/api/sandbox_functions/dsbx_db";
-import {
-  normalizeAppPrefix,
-  SANDBOX_FUNCTION_SLUG_SEPARATOR,
-} from "@app/lib/api/sandbox_functions/slug";
+import { SANDBOX_FUNCTION_SLUG_SEPARATOR } from "@app/lib/api/sandbox_functions/slug";
 import { unpublishSandboxFunction } from "@app/lib/api/sandbox_functions/unpublish_sandbox_function";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
@@ -30,6 +27,7 @@ import type {
   PodAppFunction,
 } from "@app/types/api/pod_apps";
 import { UNFILED_POD_APP_PREFIX } from "@app/types/api/pod_apps";
+import { normalizeAppPrefix } from "@app/types/api/pod_function_reference";
 import { isInteractiveContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";

--- a/front/lib/api/sandbox_functions/slug.ts
+++ b/front/lib/api/sandbox_functions/slug.ts
@@ -2,24 +2,12 @@ import {
   parseCanonicalScopedPath,
   resolveCanonicalScopedPath,
 } from "@app/lib/api/files/mount_path";
+import { normalizeAppPrefix } from "@app/types/api/pod_function_reference";
 import { SANDBOX_FUNCTION_SLUG_SEGMENT_REGEX } from "@app/types/api/sandbox_functions";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
 export const SANDBOX_FUNCTION_SLUG_SEPARATOR = "__";
-
-/**
- * Normalize an app folder name into one slug segment: lowercase, every run of characters outside
- * `[a-z0-9]` collapsed to a hyphen, no leading or trailing hyphen. Deliberately no camel-case
- * splitting, so `TaskList` becomes `tasklist` rather than `task-list`: a predictable rule beats a
- * prettier heuristic that has to decide what to do with `MyAPIApp`.
- */
-export function normalizeAppPrefix(folderName: string): string {
-  return folderName
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
 
 /**
  * Derive the app prefix a pod path belongs to: the normalized first path segment under the pod

--- a/front/lib/swr/frames.ts
+++ b/front/lib/swr/frames.ts
@@ -29,6 +29,8 @@ export function usePublicFrame({ shareToken }: { shareToken: string | null }) {
 
   return {
     frameMetadata: data?.file,
+    // Set only when the viewer can read the Pod; null for a Frame outside one.
+    framePath: data?.framePath ?? null,
     // Set only if user is a conversation participant.
     conversationUrl: data?.conversationUrl ?? null,
     // Set only if user can read the project.

--- a/front/tests/utils/FileFactory.ts
+++ b/front/tests/utils/FileFactory.ts
@@ -22,6 +22,7 @@ export class FileFactory {
       useCase,
       useCaseMetadata = null,
       snippet = null,
+      mountFilePath = null,
     }: {
       contentType: AllSupportedFileContentType;
       fileName: string;
@@ -30,6 +31,9 @@ export class FileFactory {
       useCase: FileUseCase;
       useCaseMetadata?: FileUseCaseMetadata | null;
       snippet?: string | null;
+      // GCS mount path. Production assigns it while copying the file into its mount; set it here for
+      // tests that need the file to have a scoped path (`toScopedPath`).
+      mountFilePath?: string | null;
     }
   ) {
     const workspace = await auth.getNonNullableWorkspace();
@@ -43,6 +47,7 @@ export class FileFactory {
       useCase,
       useCaseMetadata,
       snippet,
+      mountFilePath,
     });
 
     if (status === "ready") {

--- a/front/types/api/pod_function_reference.test.ts
+++ b/front/types/api/pod_function_reference.test.ts
@@ -1,0 +1,151 @@
+import { deriveSandboxFunctionSlug } from "@app/lib/api/sandbox_functions/slug";
+import {
+  isRelativePodFunctionReference,
+  normalizeAppPrefix,
+  podFunctionScopeFromFramePath,
+  resolvePodFunctionReference,
+} from "@app/types/api/pod_function_reference";
+import { describe, expect, it } from "vitest";
+
+// viz cannot be imported by alias from front; the same relative hop as sandbox_functions.test.ts.
+import { POD_FUNCTION_REFERENCE_REGEX } from "../../../viz/app/lib/pod-function-slug";
+
+const POD_ID = "vlt_abc123";
+
+describe("podFunctionScopeFromFramePath", () => {
+  it("derives the scope from the Frame's app folder", () => {
+    expect(
+      podFunctionScopeFromFramePath(`pod-${POD_ID}/TaskList/TaskList.tsx`)
+    ).toEqual({ podId: POD_ID, appPrefix: "tasklist" });
+  });
+
+  it("uses the app folder, not the folder the Frame sits in", () => {
+    // Only the first segment under the pod root names the app, matching deriveAppPrefix.
+    expect(
+      podFunctionScopeFromFramePath(`pod-${POD_ID}/TaskList/ui/Board.tsx`)
+    ).toEqual({ podId: POD_ID, appPrefix: "tasklist" });
+  });
+
+  it("has no scope for a Frame at the Pod root", () => {
+    // Nothing namespaces it, so it has no app to resolve bare names against.
+    expect(
+      podFunctionScopeFromFramePath(`pod-${POD_ID}/Dashboard.tsx`)
+    ).toBeNull();
+  });
+
+  it("has no scope for a conversation Frame or a missing path", () => {
+    expect(
+      podFunctionScopeFromFramePath("conversation-abc/Dashboard.tsx")
+    ).toBeNull();
+    expect(podFunctionScopeFromFramePath(null)).toBeNull();
+    expect(podFunctionScopeFromFramePath(undefined)).toBeNull();
+  });
+
+  it("has no scope when the app folder normalizes to nothing", () => {
+    expect(
+      podFunctionScopeFromFramePath(`pod-${POD_ID}/---/Frame.tsx`)
+    ).toBeNull();
+  });
+});
+
+describe("resolvePodFunctionReference", () => {
+  const scope = { podId: POD_ID, appPrefix: "tasklist" };
+
+  it("expands a bare name against the Frame's app", () => {
+    const result = resolvePodFunctionReference("add-task", scope);
+
+    expect(result.isOk()).toBe(true);
+    expect(result.isOk() && result.value).toBe(`${POD_ID}/tasklist__add-task`);
+  });
+
+  it("agrees with the slug publish derives for the same app folder", () => {
+    // The whole point: the reference a Frame writes must resolve to the slug publish created from
+    // that Frame's own app folder. If these drifted, the Frame would call a function that does not
+    // exist.
+    const published = deriveSandboxFunctionSlug({
+      sourcePath: `pod-${POD_ID}/TaskList/functions/add-task.ts`,
+      podId: POD_ID,
+      name: "add-task",
+    });
+    if (published.isErr()) {
+      throw published.error;
+    }
+
+    const frameScope = podFunctionScopeFromFramePath(
+      `pod-${POD_ID}/TaskList/TaskList.tsx`
+    );
+    const resolved = resolvePodFunctionReference("add-task", frameScope);
+
+    expect(resolved.isOk() && resolved.value).toBe(
+      `${POD_ID}/${published.value}`
+    );
+  });
+
+  it("passes an absolute reference through untouched", () => {
+    const reference = `${POD_ID}/other-app__list-notes`;
+    const result = resolvePodFunctionReference(reference, scope);
+
+    expect(result.isOk() && result.value).toBe(reference);
+  });
+
+  it("passes an absolute reference through even with no scope", () => {
+    // Conversation Frames and Pod-root Frames keep working exactly as before.
+    const reference = `${POD_ID}/list-notes`;
+    const result = resolvePodFunctionReference(reference, null);
+
+    expect(result.isOk() && result.value).toBe(reference);
+  });
+
+  it("refuses a bare name when the Frame has no app folder", () => {
+    const result = resolvePodFunctionReference("add-task", null);
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() && result.error.message).toContain(
+      "only works from a Frame that lives in an app folder"
+    );
+  });
+
+  it("refuses a reference that is neither form rather than forwarding it", () => {
+    for (const reference of ["Add_Task", "add task", "", "tasklist__add"]) {
+      expect(resolvePodFunctionReference(reference, scope).isErr()).toBe(true);
+    }
+  });
+});
+
+describe("isRelativePodFunctionReference", () => {
+  it("accepts a bare slug segment only", () => {
+    expect(isRelativePodFunctionReference("add-task")).toBe(true);
+    expect(isRelativePodFunctionReference("greet")).toBe(true);
+    // A prefixed-but-podless form is deliberately not relative: dropping the prefix is the point.
+    expect(isRelativePodFunctionReference("tasklist__add-task")).toBe(false);
+    expect(isRelativePodFunctionReference("vlt_x/add-task")).toBe(false);
+  });
+});
+
+describe("relative references and the viz grammar", () => {
+  it("are rejected by the fully qualified regex viz applies today", () => {
+    // The hazard this feature has to clear: viz turns a reference its regex rejects into a null SWR
+    // key, so the Frame silently issues no request. Until POD_FUNCTION_REFERENCE_REGEX is widened in
+    // viz (step 2), no Frame may use the relative form — this test pins that dependency so the
+    // rollout order cannot be forgotten.
+    expect(POD_FUNCTION_REFERENCE_REGEX.test("add-task")).toBe(false);
+    expect(POD_FUNCTION_REFERENCE_REGEX.test(`${POD_ID}/add-task`)).toBe(true);
+  });
+});
+
+describe("normalizeAppPrefix", () => {
+  it("lowercases without camel-case splitting", () => {
+    expect(normalizeAppPrefix("TaskList")).toBe("tasklist");
+    expect(normalizeAppPrefix("MyAPIApp")).toBe("myapiapp");
+  });
+
+  it("collapses non-alphanumeric runs to single hyphens", () => {
+    expect(normalizeAppPrefix("Task List")).toBe("task-list");
+    expect(normalizeAppPrefix("Task__List")).toBe("task-list");
+    expect(normalizeAppPrefix("-Task-")).toBe("task");
+  });
+
+  it("is empty when there is nothing to normalize", () => {
+    expect(normalizeAppPrefix("---")).toBe("");
+  });
+});

--- a/front/types/api/pod_function_reference.ts
+++ b/front/types/api/pod_function_reference.ts
@@ -1,0 +1,136 @@
+import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+/**
+ * The reference a Frame passes to `usePodFunction`, and how a relative one resolves.
+ *
+ * **Absolute** — `<podId>/<slug>`. Works from any Frame, including conversation Frames, and is the
+ * only form that can name a function in another Pod. Unchanged, and still what a Frame outside an app
+ * folder must use.
+ *
+ * **Relative** — a bare `<name>` with no `/`. Resolves against the app folder the calling Frame lives
+ * in, so `list-notes` inside `pod-x/TaskList/TaskList.tsx` means `pod-x/tasklist__list-notes`. This is
+ * what makes an app copyable and renamable: the Frame's source says nothing about which app it belongs
+ * to, so the same reference follows the folder it ends up in, instead of silently continuing to call
+ * the original app's functions.
+ *
+ * The two forms are unambiguous by construction: absolute always contains `/`, relative never does. A
+ * prefixed-but-podless `tasklist__list-notes` is deliberately NOT a relative reference — dropping the
+ * prefix is the entire point, and accepting a third form would just be another thing to reason about.
+ *
+ * Resolution happens in the host that renders the Frame, because that is the only layer that both
+ * knows which Frame is calling and is trusted about it: the Frame itself does not know its own path,
+ * and the invocation request carries no Frame identity. This module is the shared contract so the host
+ * and front's own path derivation compute the same prefix from the same folder name.
+ *
+ * (`@app/lib/api/file_system/types` is import-free, so importing it here keeps this module safe to
+ * pull into the browser bundle.)
+ */
+
+/** One slug segment: lowercase alphanumeric with single hyphen separators, e.g. `list-notes`. */
+const SLUG_SEGMENT_PATTERN = "[a-z0-9]+(?:-[a-z0-9]+)*";
+
+/** A relative reference is exactly one slug segment, with no `/` and no `__` app prefix. */
+export const POD_FUNCTION_RELATIVE_REFERENCE_REGEX = new RegExp(
+  `^${SLUG_SEGMENT_PATTERN}$`
+);
+
+/** The app folder a Frame lives in, as the host knows it. */
+export type PodFunctionScope = {
+  podId: string;
+  appPrefix: string;
+};
+
+/**
+ * Normalize an app folder name into one slug segment: lowercase, every run of characters outside
+ * `[a-z0-9]` collapsed to a hyphen, no leading or trailing hyphen. Deliberately no camel-case
+ * splitting, so `TaskList` becomes `tasklist` rather than `task-list`: a predictable rule beats a
+ * prettier heuristic that has to decide what to do with `MyAPIApp`.
+ *
+ * The single authority for turning a folder name into an app prefix, shared by publish (through
+ * `deriveAppPrefix`), pod database naming, and the host's reference resolution. If these ever
+ * disagreed, a Frame would resolve to a function that does not exist.
+ */
+export function normalizeAppPrefix(folderName: string): string {
+  return folderName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/** Whether `reference` is the relative form, i.e. resolvable only against an app folder. */
+export function isRelativePodFunctionReference(reference: string): boolean {
+  return POD_FUNCTION_RELATIVE_REFERENCE_REGEX.test(reference);
+}
+
+/**
+ * The scope a Frame at `framePath` calls functions in, or null when it has no app folder to resolve
+ * against — a Frame at the Pod root, or any path that is not a Pod scoped path at all.
+ *
+ * `framePath` is a canonical scoped path, e.g. `pod-{podId}/TaskList/TaskList.tsx`. A Frame must sit
+ * at least one folder deep for that folder to be its app.
+ */
+export function podFunctionScopeFromFramePath(
+  framePath: string | null | undefined
+): PodFunctionScope | null {
+  if (!framePath || !framePath.startsWith(SCOPED_PREFIX_POD)) {
+    return null;
+  }
+
+  const [podScope, ...rest] = framePath.split("/");
+  const podId = podScope.slice(SCOPED_PREFIX_POD.length);
+  if (!podId) {
+    return null;
+  }
+
+  const segments = rest.filter((segment) => segment.length > 0);
+  // Fewer than two segments means the Frame file sits directly at the Pod root, so it owns no app.
+  if (segments.length < 2) {
+    return null;
+  }
+
+  const appPrefix = normalizeAppPrefix(segments[0]);
+  if (!appPrefix) {
+    return null;
+  }
+
+  return { podId, appPrefix };
+}
+
+/**
+ * Qualify a Frame's function reference for invocation.
+ *
+ * Absolute references pass through untouched. A relative one is expanded against `scope`, and refused
+ * when the Frame has none — which is what confines relative references to Frames that live in an app
+ * folder. Anything that is neither form is refused rather than forwarded, so a malformed reference
+ * fails loudly instead of reaching the API as a nonsense slug.
+ */
+export function resolvePodFunctionReference(
+  reference: string,
+  scope: PodFunctionScope | null
+): Result<string, Error> {
+  if (reference.includes("/")) {
+    return new Ok(reference);
+  }
+
+  if (!isRelativePodFunctionReference(reference)) {
+    return new Err(
+      new Error(
+        `'${reference}' is not a pod function reference: expected '<podId>/<slug>', ` +
+          "or a bare function name inside an app folder."
+      )
+    );
+  }
+
+  if (!scope) {
+    return new Err(
+      new Error(
+        `Cannot resolve '${reference}': a bare function name only works from a Frame that lives ` +
+          "in an app folder. Use the fully qualified '<podId>/<slug>' reference instead."
+      )
+    );
+  }
+
+  return new Ok(`${scope.podId}/${scope.appPrefix}__${reference}`);
+}

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -3203,6 +3203,10 @@ export const PublicFrameResponseBodySchema = z.object({
   projectUrl: z.string().nullable(),
   file: FileTypeSchema,
   isAuthenticatedMember: z.boolean().optional(),
+  // Scoped path of the Frame, so a shared Frame that lives in a Pod app folder can call that app's
+  // functions by bare name. Only sent to a viewer who can read the Pod: nobody else can invoke a pod
+  // function anyway, so there is no reason to hand out the Pod's layout.
+  framePath: z.string().nullable().optional(),
 });
 
 export type PublicFrameResponseBodyType = z.infer<


### PR DESCRIPTION
## Why

Groundwork for cloning and renaming Pod apps. A Frame addresses its functions by a fully qualified `<podId>/<slug>`, and the slug carries the app prefix — so a copied app's Frame keeps calling the **original** app's functions, and therefore reads and writes the original's data.

Renaming an app has the same root cause. Fixing it once unblocks both.

## What changes

A second reference form — a bare `<name>` with no `/`, resolved against the app folder the calling Frame lives in:

```tsx
usePodFunction("list-notes", { threadId })        // relative: resolves within this app
usePodFunction(`${podId}/tasklist__list-notes`)   // absolute: unchanged
```

`list-notes` inside `pod-x/TaskList/TaskList.tsx` means `pod-x/tasklist__list-notes`, so the same source follows whichever app it ends up in. Copying an app then needs no Frame edit at all.

The two forms are unambiguous by construction: absolute always contains `/`, relative never does. A prefixed-but-podless `tasklist__add-task` is deliberately **not** relative — dropping the prefix is the point, and a third form would just be another thing to reason about.

## "Only frames in apps", for free

The scope falls out of the Frame's own path, so nothing needs an allowlist:

| Frame | Scope | Bare references |
|---|---|---|
| In an app folder (`pod-x/TaskList/TaskList.tsx`) | derived from its path | resolve |
| At the Pod root | none | refused, `not_supported` |
| In a conversation, not from a Pod | none | refused, `not_supported` |

**Every host that can render a Pod app Frame passes `framePath`**, which took three different answers:

- `PodFrameSheet`, `PodFrameTabContent`, `PodPinnedBanner` — already hold the path.
- `FrameRenderer` (conversation side panel) — already computed a `framePath` from the pod file listing and simply never passed it on.
- `PublicFrameRenderer` (`/share/frame/<token>`) — had nothing to derive from, since the public response returns a `FileType` carrying neither a path nor `useCaseMetadata`. The response now includes the Frame's scoped path.

`VisualizationBlock` and the blocked-action cards pass nothing and behave exactly as before.

### The shared-Frame case is easy to get wrong

A shared Frame *does* live in an app folder — only the host was ignorant of it. Getting this wrong is not a subtle degradation: the Frame throws `SandboxFunctionCallError` on its first call, so an app works from the Apps tab and breaks the moment it is shared, which is exactly when it has an audience.

The new `framePath` field is **withheld from viewers who cannot read the Pod**. They cannot invoke a pod function anyway, so sending it would hand out the Pod's layout for nothing — and note that with relative references the Frame's source no longer contains the pod id, so this keeps that closed rather than reopening it. Additive and optional on a public endpoint, per BACK12.

## Rollout order is load-bearing

1. **front** (this PR) — host resolution and the shared normalizer. Inert.
2. **viz** — widen `POD_FUNCTION_REFERENCE_REGEX`, pass the bare form through.
3. **skill** — teach the agent to use relative references inside an app folder, and bump the version. This is what turns adoption on, so it gates everything behind both halves being live.

## Risk

Low. Purely additive: with no `framePath` the resolver returns absolute references untouched, which is every existing call site. Nothing emits the relative form until steps 2 and 3 land.

## Tests

Two functional tests on the share endpoint: the scoped path is returned to a viewer who can read the Pod, and withheld from an external granted viewer who cannot.

16 unit tests on the contract: scope derivation (app folder, nested Frame, Pod root, conversation, unnormalizable folder), resolution (bare expansion, absolute pass-through with and without scope, refusal without scope, refusal of malformed references), the prefix agreement with publish, and the viz-grammar dependency above. Existing suite green: 93 tests across `types/api`, `lib/api/sandbox_functions/slug` and `lib/api/projects`. All three workspaces typecheck.

