### PR TITLE
[viz] feat: accept app-relative pod function references

### DIFF
--- a/front/types/api/pod_function_reference.test.ts
+++ b/front/types/api/pod_function_reference.test.ts
@@ -8,7 +8,7 @@ import {
 import { describe, expect, it } from "vitest";
 
 // viz cannot be imported by alias from front; the same relative hop as sandbox_functions.test.ts.
-import { POD_FUNCTION_REFERENCE_REGEX } from "../../../viz/app/lib/pod-function-slug";
+import { isPodFunctionReference } from "../../../viz/app/lib/pod-function-slug";
 
 const POD_ID = "vlt_abc123";
 
@@ -123,13 +123,41 @@ describe("isRelativePodFunctionReference", () => {
 });
 
 describe("relative references and the viz grammar", () => {
-  it("are rejected by the fully qualified regex viz applies today", () => {
-    // The hazard this feature has to clear: viz turns a reference its regex rejects into a null SWR
-    // key, so the Frame silently issues no request. Until POD_FUNCTION_REFERENCE_REGEX is widened in
-    // viz (step 2), no Frame may use the relative form — this test pins that dependency so the
-    // rollout order cannot be forgotten.
-    expect(POD_FUNCTION_REFERENCE_REGEX.test("add-task")).toBe(false);
-    expect(POD_FUNCTION_REFERENCE_REGEX.test(`${POD_ID}/add-task`)).toBe(true);
+  // viz turns a reference its grammar rejects into a null SWR key, so the Frame silently issues no
+  // request at all. The two sides therefore have to agree on exactly which strings are references —
+  // viz decides what reaches the host, this module decides what the host does with it.
+  it("are accepted by viz, so they reach the host to be resolved", () => {
+    expect(isPodFunctionReference("add-task")).toBe(true);
+    expect(isPodFunctionReference(`${POD_ID}/add-task`)).toBe(true);
+  });
+
+  it("agree with this module on what counts as a reference", () => {
+    const references = [
+      "add-task",
+      "greet",
+      `${POD_ID}/add-task`,
+      `${POD_ID}/tasklist__add-task`,
+      // Neither side treats a prefixed-but-podless name as a reference.
+      "tasklist__add-task",
+      "Add_Task",
+      "add task",
+      "",
+    ];
+
+    for (const reference of references) {
+      expect({
+        reference,
+        accepted: isPodFunctionReference(reference),
+      }).toEqual({
+        reference,
+        // The host resolves anything viz forwards; a reference it refuses outright is one viz should
+        // never have sent.
+        accepted: resolvePodFunctionReference(reference, {
+          podId: POD_ID,
+          appPrefix: "tasklist",
+        }).isOk(),
+      });
+    }
   });
 });
 

--- a/viz/app/lib/pod-function-hooks.test.tsx
+++ b/viz/app/lib/pod-function-hooks.test.tsx
@@ -159,16 +159,36 @@ describe("usePodFunction", () => {
     expect(callFunction).not.toHaveBeenCalled();
   });
 
-  it("rejects an unqualified function slug", () => {
-    const callFunction = vi.fn();
+  it("forwards a bare function name for the host to resolve", async () => {
+    // A Frame inside an app folder names its own functions bare; the host qualifies it against that
+    // folder. viz only decides the reference is well formed and passes it on.
+    const callFunction = vi.fn().mockResolvedValue({ comments: [] });
     const { result } = renderHook(
       () => usePodFunction("list-comments", { threadId: "thread-1" }),
       { wrapper: makeWrapper(makeDataAPI(callFunction)) }
     );
 
+    await waitFor(() => {
+      expect(result.current.data).toEqual({ comments: [] });
+    });
+    expect(result.current.error).toBeUndefined();
+    expect(callFunction).toHaveBeenCalledWith("list-comments", {
+      threadId: "thread-1",
+    });
+  });
+
+  it("rejects a reference that is neither form", () => {
+    const callFunction = vi.fn();
+    const { result } = renderHook(
+      // Prefixed but pod-less: not shorthand, since dropping the prefix is what the bare form is for.
+      () => usePodFunction("comments__list", { threadId: "thread-1" }),
+      { wrapper: makeWrapper(makeDataAPI(callFunction)) }
+    );
+
     expect(result.current.error).toEqual(
       new Error(
-        "Pod Function hooks require a fully qualified <podId>/<slug> reference."
+        "Pod Function hooks require a <podId>/<slug> reference, or a bare function name " +
+          "from a Frame that lives in an app folder."
       )
     );
     expect(result.current.isLoading).toBe(false);

--- a/viz/app/lib/pod-function-hooks.tsx
+++ b/viz/app/lib/pod-function-hooks.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { normalizeSandboxFunctionCallError } from "@viz/app/lib/data-apis/sandbox-function-call-error";
-import { POD_FUNCTION_REFERENCE_REGEX } from "@viz/app/lib/pod-function-slug";
+import { isPodFunctionReference } from "@viz/app/lib/pod-function-slug";
 import type { VisualizationDataAPI } from "@viz/app/lib/visualization-api";
 import type { UserIdentityState } from "@viz/app/types";
 import {
@@ -64,11 +64,12 @@ function resolvePodFunction(slug: string | null): {
   if (slug === null) {
     return { functionId: null };
   }
-  if (!POD_FUNCTION_REFERENCE_REGEX.test(slug)) {
+  if (!isPodFunctionReference(slug)) {
     return {
       functionId: null,
       error: new Error(
-        "Pod Function hooks require a fully qualified <podId>/<slug> reference."
+        "Pod Function hooks require a <podId>/<slug> reference, or a bare function name " +
+          "from a Frame that lives in an app folder."
       ),
     };
   }

--- a/viz/app/lib/pod-function-slug.test.ts
+++ b/viz/app/lib/pod-function-slug.test.ts
@@ -1,0 +1,54 @@
+import {
+  isPodFunctionReference,
+  POD_FUNCTION_RELATIVE_REFERENCE_REGEX,
+} from "@viz/app/lib/pod-function-slug";
+import { describe, expect, it } from "vitest";
+
+describe("isPodFunctionReference", () => {
+  it("accepts a fully qualified reference", () => {
+    expect(isPodFunctionReference("vlt_abc123/list-notes")).toBe(true);
+    expect(isPodFunctionReference("vlt_abc123/tasklist__list-notes")).toBe(
+      true
+    );
+  });
+
+  it("accepts a bare name, which the host resolves against the Frame's app", () => {
+    expect(isPodFunctionReference("list-notes")).toBe(true);
+    expect(isPodFunctionReference("greet")).toBe(true);
+  });
+
+  it("rejects a prefixed name with no pod", () => {
+    // Not a third form: dropping the app prefix is the point of the relative reference, so a
+    // prefixed-but-podless string is a mistake rather than shorthand.
+    expect(isPodFunctionReference("tasklist__list-notes")).toBe(false);
+  });
+
+  it("rejects references outside the slug grammar", () => {
+    for (const reference of [
+      "",
+      "List-Notes",
+      "list notes",
+      "list_notes",
+      "-list-notes",
+      "list-notes-",
+      "vlt_abc123/List-Notes",
+      "vlt_abc123/a/b",
+    ]) {
+      expect({
+        reference,
+        accepted: isPodFunctionReference(reference),
+      }).toEqual({ reference, accepted: false });
+    }
+  });
+});
+
+describe("POD_FUNCTION_RELATIVE_REFERENCE_REGEX", () => {
+  it("matches one slug segment and nothing more", () => {
+    expect(POD_FUNCTION_RELATIVE_REFERENCE_REGEX.test("add-task")).toBe(true);
+    expect(POD_FUNCTION_RELATIVE_REFERENCE_REGEX.test("a")).toBe(true);
+    expect(POD_FUNCTION_RELATIVE_REFERENCE_REGEX.test("add--task")).toBe(false);
+    expect(POD_FUNCTION_RELATIVE_REFERENCE_REGEX.test("x/add-task")).toBe(
+      false
+    );
+  });
+});

--- a/viz/app/lib/pod-function-slug.ts
+++ b/viz/app/lib/pod-function-slug.ts
@@ -1,12 +1,24 @@
 /**
- * Grammar of a fully qualified pod function reference, `<podId>/<slug>`, as a Frame passes it to
- * `usePodFunction`.
+ * Grammar of the references a Frame passes to `usePodFunction`.
  *
- * The slug half mirrors SANDBOX_FUNCTION_SLUG_REGEX in front
+ * **Fully qualified** — `<podId>/<slug>`. Works from any Frame, and is the only form that can name a
+ * function in another Pod. The slug half mirrors SANDBOX_FUNCTION_SLUG_REGEX in front
  * (`front/types/api/sandbox_functions.ts`): one optional `<app>__` prefix that publish derives from
- * the source's app folder, then the function's own name. `viz` cannot import from front, so
- * equality is asserted from front's side in `front/types/api/sandbox_functions.test.ts` — the same
- * arrangement as the runner protocol in `cli/dust-sandbox/functions-runner/protocol.ts`.
+ * the source's app folder, then the function's own name.
+ *
+ * **Relative** — a bare `<name>`, no `/` and no `__` prefix. The host resolves it against the app
+ * folder the calling Frame lives in, so `list-notes` inside `pod-x/TaskList/TaskList.tsx` reaches
+ * `pod-x/tasklist__list-notes`. This is what lets an app be copied or renamed without editing the
+ * Frame's source. Only a Frame inside an app folder has a scope to resolve against; anywhere else the
+ * host refuses the call, so a Frame at the Pod root or in a conversation must stay fully qualified.
+ *
+ * The two forms are separate patterns on purpose rather than one with an optional `<podId>/`: that
+ * would also admit a prefixed-but-podless `tasklist__list-notes`, and dropping the prefix is the whole
+ * point of the relative form.
+ *
+ * `viz` cannot import from front, so equality with front's grammar is asserted from front's side in
+ * `front/types/api/sandbox_functions.test.ts` — the same arrangement as the runner protocol in
+ * `cli/dust-sandbox/functions-runner/protocol.ts`.
  *
  * Keeping this in step matters more than it looks: a reference this rejects resolves to a null SWR
  * key, so the Frame silently issues no request at all.
@@ -16,3 +28,15 @@ const SLUG_SEGMENT = "[a-z0-9]+(?:-[a-z0-9]+)*";
 export const POD_FUNCTION_REFERENCE_REGEX = new RegExp(
   `^[^/]+/${SLUG_SEGMENT}(?:__${SLUG_SEGMENT})?$`
 );
+
+export const POD_FUNCTION_RELATIVE_REFERENCE_REGEX = new RegExp(
+  `^${SLUG_SEGMENT}$`
+);
+
+/** Whether `reference` is a reference the host can act on, in either form. */
+export function isPodFunctionReference(reference: string): boolean {
+  return (
+    POD_FUNCTION_REFERENCE_REGEX.test(reference) ||
+    POD_FUNCTION_RELATIVE_REFERENCE_REGEX.test(reference)
+  );
+}


### PR DESCRIPTION
> **Stacked on #30397.** Review that first; this targets its branch, so the diff here is viz-only (plus one front test). Rebase onto `main` once the parent merges.
>
> **Deploy order matters:** viz deploys separately from front, and this half is only correct once #30397 is live. Merge and deploy the parent first.

## Description

Step 2 of making Pod apps copyable and renamable. #30397 taught the Frame host to resolve a bare function name against the app folder the calling Frame lives in, but viz still rejects that form — so nothing can reach the resolver. This widens the grammar.

A reference is now either:

- **`<podId>/<slug>`** — unchanged, works from any Frame, still the only form that can name a function in another Pod.
- **`<name>`** — a bare slug the host qualifies against the Frame's own app folder.

```tsx
usePodFunction("list-notes", { threadId })        // now accepted, resolved by the host
usePodFunction(`${podId}/tasklist__list-notes`)   // unchanged
```

## Why two patterns instead of one optional group

The obvious implementation is to make `<podId>/` optional in the existing regex. That also admits a prefixed-but-podless `tasklist__list-notes` — and dropping the app prefix is the *entire point* of the relative form, so accepting a half-qualified third form would just be another thing to reason about. Keeping them as separate patterns behind one `isPodFunctionReference` predicate makes the rejection explicit and tested.

The division of labour: **viz decides whether a reference is well formed; the host decides what it means.** Only the host knows which Frame is calling, so only it can resolve a relative reference — viz passing the bare string through unchanged is the correct amount of knowledge for this layer.

## Risk

Low, but not zero on its own: this must not ship ahead of #30397, or a bare reference would reach a host that passes it straight to the API as a nonsense slug. Nothing emits relative references either way until step 3 updates the skill.

## Tests

New `viz/app/lib/pod-function-slug.test.ts`: 5 tests over the grammar — qualified, bare, prefixed-podless rejection, malformed inputs, and the relative pattern in isolation. Updated `pod-function-hooks.test.tsx` as described. Full viz suite green (59 tests), front `types/api` green (26 tests), front typechecks.

`npx tsc --noEmit` in viz reports two pre-existing errors in `transformEditableText.test.ts` (a `target`/`downlevelIteration` mismatch — viz builds via `next build`); confirmed present on a clean tree, and none in the files this PR touches.
