### PR TITLE
Track every non-batch LLM call for billing reconciliation

### DIFF
--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -3,6 +3,7 @@ import {
   contributeFreeUsageCostForUser,
   isFreeUsageContext,
 } from "@app/lib/api/llm/free_usage";
+import { LLMRunLifecycle } from "@app/lib/api/llm/run_lifecycle";
 import type { LLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import {
   createLLMTraceId,
@@ -145,13 +146,6 @@ export abstract class LLM<
       yield* this.completeStream(streamParameters, metadata);
       return;
     }
-
-    // Free (unbilled) usage — utility operations and free-origin agent calls
-    // (e.g. sidekick). Enforcement of the per-user daily cost cap happens above
-    // the router (before getStreamLLM); here we only record the call's cost into
-    // the counter after it completes (see below), alongside usage recording.
-    const isFreeUsage = isFreeUsageContext(this.context);
-    const user = this.authenticator.user();
 
     const { conversation, prompt, specifications, previousMessageId } =
       streamParameters;
@@ -362,48 +356,6 @@ export abstract class LLM<
               errorType: buffer.error.type,
               errorMessage: buffer.error.message,
             },
-          });
-        }
-
-        const run = await RunResource.makeNew({
-          appId: null,
-          dustRunId: this.traceId,
-          runType: "deploy",
-          // Assumption made that this class exclusively uses Dust credentials.
-          useWorkspaceCredentials: false,
-          workspaceId: this.authenticator.getNonNullableWorkspace().id,
-        });
-
-        // Tag free (unbilled) usage at creation — utility operations and
-        // free-origin agent calls (e.g. sidekick). Paid agent_conversation runs
-        // are left untagged here and classified (user/programmatic) by the usage
-        // queue, which knows the triggering message origin.
-        const usageType = isFreeUsage ? USAGE_TYPE_FREE : undefined;
-
-        // Run usage is only populated if the run is successful.
-        if (buffer.runTokenUsage) {
-          const costMicroUsd = await run.recordTokenUsage(
-            this.authenticator,
-            buffer.runTokenUsage,
-            this.modelId,
-            { inferenceRegion: this.metadata.inferenceRegion, usageType }
-          );
-
-          // Record this free call's cost into the per-user daily free-usage
-          // counter (enforced above the router, before the call).
-          if (isFreeUsage && user && costMicroUsd) {
-            await contributeFreeUsageCostForUser(
-              this.authenticator.getNonNullableWorkspace(),
-              user.id,
-              costMicroUsd
-            );
-          }
-        }
-
-        const simulatedRunUsages = this.getSimulatedRunUsages();
-        if (simulatedRunUsages) {
-          await run.recordRunUsage(this.authenticator, simulatedRunUsages, {
-            usageType,
           });
         }
 
@@ -753,14 +705,57 @@ export abstract class LLM<
     streamParameters: LLMStreamParameters,
     metadata?: LLMStreamMetadata
   ): AsyncGenerator<LLMEvent> {
-    const payload = await this.buildStreamRequestPayload(
-      streamParameters,
-      metadata
-    );
+    // Persist first: if this fails, no provider request is made. Every provider
+    // attempt therefore starts with a durable run and pending usage row.
+    const usageType = this.getUsageType();
+    const lifecycle = await LLMRunLifecycle.start(this.authenticator, {
+      dustRunId: this.traceId,
+      inferenceProvider: this.metadata.inferenceProvider,
+      inferenceRegion: this.metadata.inferenceRegion,
+      modelId: this.modelId,
+      providerId: this.modelConfig.providerId,
+      region: this.metadata.region ?? null,
+      usageType,
+    });
 
-    // Update the generation span with the actual payload.
-    this.generation?.update({ input: payload });
+    try {
+      const payload = await this.buildStreamRequestPayload(
+        streamParameters,
+        metadata
+      );
 
-    yield* this.sendRequest(payload);
+      // Update the generation span with the actual payload.
+      this.generation?.update({ input: payload });
+
+      const simulatedRunUsages = this.getSimulatedRunUsages();
+      if (simulatedRunUsages) {
+        await lifecycle.recordRunUsages(simulatedRunUsages);
+      }
+
+      for await (const event of this.sendRequest(payload)) {
+        if (event.type === "token_usage") {
+          const costMicroUsd = await lifecycle.recordTokenUsage(event.content);
+          const user = this.authenticator.user();
+          if (usageType === USAGE_TYPE_FREE && user && costMicroUsd) {
+            await contributeFreeUsageCostForUser(
+              this.authenticator.getNonNullableWorkspace(),
+              user.id,
+              costMicroUsd
+            );
+          }
+        }
+        yield event;
+      }
+    } finally {
+      await lifecycle.close();
+    }
+  }
+
+  private getUsageType() {
+    // Calls without tracing context cannot be attributed to a billable agent conversation,
+    // so keep them free until the caller provides that context.
+    return !this.context || isFreeUsageContext(this.context)
+      ? USAGE_TYPE_FREE
+      : undefined;
   }
 }

--- a/front/lib/api/llm/run_lifecycle.test.ts
+++ b/front/lib/api/llm/run_lifecycle.test.ts
@@ -1,0 +1,237 @@
+import { getStreamLLM } from "@app/lib/api/llm";
+import { LLMRunLifecycle } from "@app/lib/api/llm/run_lifecycle";
+import { createLLMTraceId } from "@app/lib/api/llm/traces/buffer";
+import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
+import { DustNoopNoopGlobalNoopStream } from "@app/lib/llms/stream/endpoints/noop_noop_global_noop";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import { RunResource } from "@app/lib/resources/run_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { GPT_5_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
+import { describe, expect, it } from "vitest";
+
+class ThrowingNoopStream extends DustNoopNoopGlobalNoopStream {
+  override async *streamRaw(): AsyncGenerator<string> {
+    throw new Error("Provider failed before reporting usage");
+  }
+}
+
+class TokenUsageNoopStream extends DustNoopNoopGlobalNoopStream {
+  override async *rawStreamOutputToEvents(
+    raw: AsyncGenerator<string>
+  ): AsyncGenerator<ModelResponseEvent> {
+    for await (const event of super.rawStreamOutputToEvents(raw)) {
+      if (event.type === "success") {
+        yield {
+          type: "token_usage",
+          content: {
+            longCacheCreated: 0,
+            shortCacheCreated: 0,
+            cacheCreated: 0,
+            cacheHit: 10,
+            standardInput: 90,
+            totalOutput: 25,
+          },
+          metadata: event.metadata,
+        };
+      }
+      yield event;
+    }
+  }
+}
+
+function makeStreamParameters(content = "hello"): LLMStreamParameters {
+  return {
+    conversation: {
+      messages: [
+        {
+          role: "user",
+          name: "user",
+          content: [{ type: "text", text: content }],
+        },
+      ],
+    },
+    prompt: "",
+    specifications: [],
+  };
+}
+
+function makeNoopLLM(
+  auth: Awaited<ReturnType<typeof createResourceTest>>["authenticator"],
+  endpoint: typeof DustNoopNoopGlobalNoopStream = DustNoopNoopGlobalNoopStream
+) {
+  const llm = getStreamLLM(auth, {
+    credentials: {},
+    modelInfo: { endpoint, temperature: 0 },
+  });
+  if (!llm) {
+    throw new Error("Expected the noop LLM to be available");
+  }
+  return llm;
+}
+
+function makeLifecycleParameters() {
+  return {
+    dustRunId: createLLMTraceId(generateRandomModelSId()),
+    inferenceProvider: "openai-responses",
+    inferenceRegion: "global" as const,
+    modelId: GPT_5_MINI_MODEL_CONFIG.modelId,
+    providerId: GPT_5_MINI_MODEL_CONFIG.providerId,
+    region: "us" as const,
+  };
+}
+
+describe("LLMRunLifecycle", () => {
+  it("atomically creates a run and a pending usage attempt", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const parameters = makeLifecycleParameters();
+
+    const lifecycle = await LLMRunLifecycle.start(auth, parameters);
+
+    const run = await RunResource.fetchByDustRunId(auth, {
+      dustRunId: parameters.dustRunId,
+    });
+    if (!run) {
+      throw new Error("Expected the LLM run to exist");
+    }
+    expect(await run.listRunUsages(auth)).toEqual([]);
+    expect(await run.listRunUsageAttempts(auth)).toMatchObject([
+      {
+        promptTokens: 0,
+        completionTokens: 0,
+        inferenceProvider: "openai-responses",
+        isBatch: false,
+        region: "us",
+        usageState: "pending",
+      },
+    ]);
+
+    await lifecycle.close();
+    expect(await run.listRunUsageAttempts(auth)).toMatchObject([
+      { usageState: "unavailable" },
+    ]);
+  });
+
+  it("finalizes the pending attempt when the provider reports usage", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const parameters = makeLifecycleParameters();
+    const lifecycle = await LLMRunLifecycle.start(auth, parameters);
+
+    await lifecycle.recordTokenUsage({
+      inputTokens: 120,
+      totalOutputTokens: 30,
+      totalTokens: 150,
+    });
+    await lifecycle.close();
+
+    const run = await RunResource.fetchByDustRunId(auth, {
+      dustRunId: parameters.dustRunId,
+    });
+    if (!run) {
+      throw new Error("Expected the LLM run to exist");
+    }
+    expect(await run.listRunUsageAttempts(auth)).toMatchObject([
+      {
+        promptTokens: 120,
+        completionTokens: 30,
+        usageState: "reported",
+      },
+    ]);
+    expect(await run.listRunUsages(auth)).toHaveLength(1);
+  });
+});
+
+describe("non-batch LLM run persistence", () => {
+  it("finalizes usage from the provider stream", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const llm = makeNoopLLM(auth, TokenUsageNoopStream);
+
+    for await (const _event of llm.stream(makeStreamParameters())) {
+      // Consume the stream fully so the provider reports usage.
+    }
+
+    const run = await RunResource.fetchByDustRunId(auth, {
+      dustRunId: llm.getTraceId(),
+    });
+    if (!run) {
+      throw new Error("Expected a run for the successful provider call");
+    }
+    expect(await run.listRunUsageAttempts(auth)).toMatchObject([
+      {
+        promptTokens: 100,
+        completionTokens: 25,
+        inferenceProvider: "noop",
+        isBatch: false,
+        region: "global",
+        usageState: "reported",
+      },
+    ]);
+  });
+
+  it("records simulated usage without a tracing context", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const llm = makeNoopLLM(auth);
+
+    for await (const _event of llm.stream(
+      makeStreamParameters("consume $1.25")
+    )) {
+      // Consume the stream fully so the noop request completes.
+    }
+
+    const run = await RunResource.fetchByDustRunId(auth, {
+      dustRunId: llm.getTraceId(),
+    });
+    if (!run) {
+      throw new Error("Expected a run for the successful provider call");
+    }
+    expect(await run.listRunUsageAttempts(auth)).toMatchObject([
+      {
+        costMicroUsd: 1_250_000,
+        isBatch: false,
+        usageState: "reported",
+        usageType: "free",
+      },
+    ]);
+  });
+
+  it("preserves an unavailable attempt when the provider fails", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const llm = makeNoopLLM(auth, ThrowingNoopStream);
+
+    const events = [];
+    for await (const event of llm.stream(makeStreamParameters())) {
+      events.push(event);
+    }
+    expect(events.at(-1)?.type).toBe("error");
+
+    const run = await RunResource.fetchByDustRunId(auth, {
+      dustRunId: llm.getTraceId(),
+    });
+    if (!run) {
+      throw new Error("Expected a run for the failed provider call");
+    }
+    expect(await run.listRunUsageAttempts(auth)).toMatchObject([
+      { isBatch: false, usageState: "unavailable" },
+    ]);
+    expect(await run.listRunUsages(auth)).toEqual([]);
+  });
+
+  it("closes the pending attempt when the stream consumer cancels", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const llm = makeNoopLLM(auth);
+    const stream = llm.stream(makeStreamParameters());
+
+    expect((await stream.next()).done).toBe(false);
+    await stream.return(undefined);
+
+    const run = await RunResource.fetchByDustRunId(auth, {
+      dustRunId: llm.getTraceId(),
+    });
+    if (!run) {
+      throw new Error("Expected a run for the cancelled provider call");
+    }
+    expect(await run.listRunUsageAttempts(auth)).toMatchObject([
+      { isBatch: false, usageState: "unavailable" },
+    ]);
+  });
+});

--- a/front/lib/api/llm/run_lifecycle.ts
+++ b/front/lib/api/llm/run_lifecycle.ts
@@ -1,0 +1,90 @@
+import type { InferenceRegionType } from "@app/lib/api/assistant/token_pricing";
+import type { TokenUsage } from "@app/lib/api/llm/types/events";
+import type { Authenticator } from "@app/lib/auth";
+import type { UsageType } from "@app/lib/metronome/types";
+import type { Region } from "@app/lib/model_constructors/types/regions";
+import type { RunUsageType } from "@app/lib/resources/run_resource";
+import { RunResource } from "@app/lib/resources/run_resource";
+import type {
+  ModelIdType,
+  ModelProviderIdType,
+} from "@app/types/assistant/models/types";
+import type { ModelId } from "@app/types/shared/model_id";
+
+interface LLMRunLifecycleParameters {
+  dustRunId: string;
+  inferenceProvider: string;
+  inferenceRegion: InferenceRegionType;
+  modelId: ModelIdType;
+  providerId: ModelProviderIdType;
+  region: Region | null;
+  usageType?: UsageType;
+}
+
+/**
+ * Durable lifecycle for one non-batch LLM inference.
+ *
+ * Starting atomically creates the run and a pending usage row. Closing without reported usage marks
+ * the attempt unavailable instead of silently losing it or treating it as zero-cost usage.
+ */
+export class LLMRunLifecycle {
+  private constructor(
+    private readonly auth: Authenticator,
+    private readonly run: RunResource,
+    private readonly runUsageModelId: ModelId,
+    private readonly parameters: LLMRunLifecycleParameters
+  ) {}
+
+  static async start(
+    auth: Authenticator,
+    parameters: LLMRunLifecycleParameters
+  ): Promise<LLMRunLifecycle> {
+    const { run, runUsageModelId } = await RunResource.makeNewWithPendingUsage(
+      {
+        appId: null,
+        dustRunId: parameters.dustRunId,
+        runType: "deploy",
+        useWorkspaceCredentials: false,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      {
+        inferenceProvider: parameters.inferenceProvider,
+        modelId: parameters.modelId,
+        providerId: parameters.providerId,
+        region: parameters.region,
+        usageType: parameters.usageType,
+      }
+    );
+
+    return new this(auth, run, runUsageModelId, parameters);
+  }
+
+  async recordTokenUsage(usage: TokenUsage): Promise<number | undefined> {
+    return this.run.finalizePendingTokenUsage(
+      this.auth,
+      this.runUsageModelId,
+      usage,
+      this.parameters.modelId,
+      {
+        inferenceRegion: this.parameters.inferenceRegion,
+        usageType: this.parameters.usageType,
+      }
+    );
+  }
+
+  async recordRunUsages(usages: RunUsageType[]): Promise<void> {
+    await this.run.finalizePendingRunUsage(
+      this.auth,
+      this.runUsageModelId,
+      usages,
+      { usageType: this.parameters.usageType }
+    );
+  }
+
+  async close(): Promise<void> {
+    await this.run.markPendingRunUsageUnavailable(
+      this.auth,
+      this.runUsageModelId
+    );
+  }
+}

--- a/front/lib/api/llm/traces/buffer.ts
+++ b/front/lib/api/llm/traces/buffer.ts
@@ -333,10 +333,6 @@ export class LLMTraceBuffer {
     return this.outputByteSize;
   }
 
-  get runTokenUsage(): TokenUsage | undefined {
-    return this.tokenUsage;
-  }
-
   get currentOutput(): LLMTraceOutput {
     const processedEvents = this.getProcessedEvents();
 

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -4,14 +4,17 @@ import type { TokenUsage } from "@app/lib/api/llm/types/events";
 import type { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import type { UsageType } from "@app/lib/metronome/types";
+import type { Region } from "@app/lib/model_constructors/types/regions";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { AppModel } from "@app/lib/resources/storage/models/apps";
+import type { RunUsageState } from "@app/lib/resources/storage/models/runs";
 import {
   RunModel,
   RunUsageModel,
 } from "@app/lib/resources/storage/models/runs";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { getRunExecutionsDeletionCutoffDate } from "@app/temporal/hard_delete/utils";
@@ -51,10 +54,28 @@ export interface RunUsageType {
 }
 
 export interface RunUsageWithRunKeyType extends RunUsageType {
+  inferenceProvider: string | null;
+  region: Region | null;
   runKey: string | null;
   runUsageModelId: ModelId;
   runModelId: ModelId;
   usageType: UsageType | null;
+}
+
+export interface RunUsageAttemptType extends RunUsageType {
+  inferenceProvider: string | null;
+  region: Region | null;
+  runUsageModelId: ModelId;
+  usageState: RunUsageState | null;
+  usageType: UsageType | null;
+}
+
+interface PendingRunUsageParameters {
+  inferenceProvider: string;
+  modelId: ModelIdType;
+  providerId: ModelProviderIdType;
+  region: Region | null;
+  usageType?: UsageType;
 }
 
 type FetchRunOptions<T extends boolean> = {
@@ -79,6 +100,40 @@ export class RunResource extends BaseResource<RunModel> {
     const run = await RunResource.model.create(blob);
 
     return new this(RunResource.model, run.get());
+  }
+
+  static async makeNewWithPendingUsage(
+    blob: CreationAttributes<RunModel>,
+    usage: PendingRunUsageParameters
+  ): Promise<{ run: RunResource; runUsageModelId: ModelId }> {
+    return withTransaction(async (transaction) => {
+      const runModel = await RunResource.model.create(blob, { transaction });
+      const runUsageModel = await RunUsageModel.create(
+        {
+          runId: runModel.id,
+          workspaceId: blob.workspaceId,
+          providerId: usage.providerId,
+          inferenceProvider: usage.inferenceProvider,
+          region: usage.region,
+          modelId: usage.modelId,
+          promptTokens: 0,
+          completionTokens: 0,
+          reasoningTokens: null,
+          cachedTokens: null,
+          cacheCreationTokens: null,
+          costMicroUsd: 0,
+          isBatch: false,
+          usageType: usage.usageType ?? null,
+          usageState: "pending",
+        },
+        { transaction }
+      );
+
+      return {
+        run: new this(RunResource.model, runModel.get()),
+        runUsageModelId: runUsageModel.id,
+      };
+    });
   }
 
   private static getOptions<T extends boolean>(
@@ -260,6 +315,9 @@ export class RunResource extends BaseResource<RunModel> {
       where: {
         runId: { [Op.in]: runModelIds },
         workspaceId: auth.getNonNullableWorkspace().id,
+        // Pending and unavailable attempts are reconciliation records, not
+        // billable usage. Null supports rows written during rolling deploys.
+        [Op.or]: [{ usageState: "reported" }, { usageState: null }],
       },
     });
 
@@ -269,6 +327,8 @@ export class RunResource extends BaseResource<RunModel> {
       runKey: runKeyByModelId.get(usage.runId) ?? null,
       completionTokens: usage.completionTokens,
       reasoningTokens: usage.reasoningTokens,
+      inferenceProvider: usage.inferenceProvider,
+      region: usage.region,
       modelId: usage.modelId as ModelIdType,
       promptTokens: usage.promptTokens,
       providerId: usage.providerId as ModelProviderIdType,
@@ -414,6 +474,8 @@ export class RunResource extends BaseResource<RunModel> {
           runId: this.id,
           workspaceId: this.workspaceId,
           providerId,
+          inferenceProvider: null,
+          region: null,
           modelId,
           promptTokens,
           completionTokens,
@@ -423,10 +485,15 @@ export class RunResource extends BaseResource<RunModel> {
           costMicroUsd,
           isBatch,
           usageType: usageType ?? null,
+          usageState: "reported",
         })
       )
     );
 
+    this.emitRunUsageMetrics(usages);
+  }
+
+  private emitRunUsageMetrics(usages: RunUsageType[]): void {
     for (const usage of usages) {
       const tags = [
         `provider_id:${usage.providerId}`,
@@ -487,11 +554,133 @@ export class RunResource extends BaseResource<RunModel> {
       usageType?: UsageType;
     } = {}
   ) {
+    const runUsage = this.tokenUsageToRunUsage(usage, modelId, {
+      isBatch,
+      inferenceRegion,
+    });
+    if (!runUsage) {
+      return;
+    }
+
+    await this.recordRunUsage(auth, [runUsage], { usageType });
+
+    // Return the computed cost so callers can meter it (e.g. the free-usage cost
+    // cap). The result is undefined when the model is unknown and nothing was recorded.
+    return runUsage.costMicroUsd;
+  }
+
+  async markPendingRunUsageUnavailable(
+    auth: Authenticator,
+    runUsageModelId: ModelId
+  ): Promise<void> {
+    await RunUsageModel.update(
+      { usageState: "unavailable" },
+      {
+        where: {
+          id: runUsageModelId,
+          runId: this.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+          usageState: "pending",
+        },
+      }
+    );
+  }
+
+  async finalizePendingRunUsage(
+    auth: Authenticator,
+    runUsageModelId: ModelId,
+    usages: RunUsageType[],
+    { usageType }: { usageType?: UsageType } = {}
+  ): Promise<boolean> {
+    const [firstUsage, ...additionalUsages] = usages;
+    if (!firstUsage) {
+      return false;
+    }
+
+    const [updatedCount] = await RunUsageModel.update(
+      {
+        providerId: firstUsage.providerId,
+        modelId: firstUsage.modelId,
+        promptTokens: firstUsage.promptTokens,
+        completionTokens: firstUsage.completionTokens,
+        reasoningTokens: firstUsage.reasoningTokens,
+        cachedTokens: firstUsage.cachedTokens,
+        cacheCreationTokens: firstUsage.cacheCreationTokens ?? null,
+        costMicroUsd: firstUsage.costMicroUsd,
+        isBatch: firstUsage.isBatch,
+        usageType: usageType ?? null,
+        usageState: "reported",
+      },
+      {
+        where: {
+          id: runUsageModelId,
+          runId: this.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+          usageState: "pending",
+        },
+      }
+    );
+
+    // Provider streams report usage once. Treat repeated finalization as an
+    // idempotent replay instead of inserting duplicate billable rows.
+    if (updatedCount === 0) {
+      return false;
+    }
+
+    if (additionalUsages.length > 0) {
+      await this.recordRunUsage(auth, additionalUsages, { usageType });
+    }
+    this.emitRunUsageMetrics([firstUsage]);
+    return true;
+  }
+
+  async finalizePendingTokenUsage(
+    auth: Authenticator,
+    runUsageModelId: ModelId,
+    usage: TokenUsage,
+    modelId: ModelIdType,
+    {
+      inferenceRegion = "global",
+      usageType,
+    }: {
+      inferenceRegion?: InferenceRegionType;
+      usageType?: UsageType;
+    } = {}
+  ): Promise<number | undefined> {
+    const runUsage = this.tokenUsageToRunUsage(usage, modelId, {
+      isBatch: false,
+      inferenceRegion,
+    });
+    if (!runUsage) {
+      return undefined;
+    }
+
+    const wasFinalized = await this.finalizePendingRunUsage(
+      auth,
+      runUsageModelId,
+      [runUsage],
+      { usageType }
+    );
+    return wasFinalized ? runUsage.costMicroUsd : undefined;
+  }
+
+  private tokenUsageToRunUsage(
+    usage: TokenUsage,
+    modelId: ModelIdType,
+    {
+      isBatch,
+      inferenceRegion,
+    }: {
+      isBatch: boolean;
+      inferenceRegion: InferenceRegionType;
+    }
+  ): RunUsageType | null {
     const modelConfig = getModelConfigByModelId(modelId);
 
     if (!modelConfig) {
       logger.warn({ modelId }, "Unsupported model for usage recording");
-      return;
+
+      return null;
     }
 
     // totalOutputTokens is the canonical inclusive billed output total. Any
@@ -507,27 +696,17 @@ export class RunResource extends BaseResource<RunModel> {
       inferenceRegion,
     });
 
-    await this.recordRunUsage(
-      auth,
-      [
-        {
-          cacheCreationTokens: usage.cacheCreationTokens,
-          cachedTokens: usage.cachedTokens ?? null,
-          completionTokens: usage.totalOutputTokens,
-          reasoningTokens: usage.reasoningTokens ?? null,
-          modelId: modelConfig.modelId,
-          promptTokens: usage.inputTokens,
-          providerId: modelConfig.providerId,
-          costMicroUsd: usageCostMicroUsd,
-          isBatch,
-        },
-      ],
-      { usageType }
-    );
-
-    // Return the computed cost so callers can meter it (e.g. the free-usage cost
-    // cap); undefined above when the model is unknown and nothing was recorded.
-    return usageCostMicroUsd;
+    return {
+      cacheCreationTokens: usage.cacheCreationTokens,
+      cachedTokens: usage.cachedTokens ?? null,
+      completionTokens: usage.totalOutputTokens,
+      reasoningTokens: usage.reasoningTokens ?? null,
+      modelId: modelConfig.modelId,
+      promptTokens: usage.inputTokens,
+      providerId: modelConfig.providerId,
+      costMicroUsd: usageCostMicroUsd,
+      isBatch,
+    };
   }
 
   async listRunUsages(auth: Authenticator): Promise<RunUsageType[]> {
@@ -536,6 +715,35 @@ export class RunResource extends BaseResource<RunModel> {
     });
 
     return usages.map(({ runModelId, ...usage }) => usage);
+  }
+
+  async listRunUsageAttempts(
+    auth: Authenticator
+  ): Promise<RunUsageAttemptType[]> {
+    const usages = await RunUsageModel.findAll({
+      where: {
+        runId: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      order: [["id", "ASC"]],
+    });
+
+    return usages.map((usage) => ({
+      runUsageModelId: usage.id,
+      completionTokens: usage.completionTokens,
+      reasoningTokens: usage.reasoningTokens,
+      inferenceProvider: usage.inferenceProvider,
+      region: usage.region,
+      modelId: usage.modelId as ModelIdType,
+      promptTokens: usage.promptTokens,
+      providerId: usage.providerId as ModelProviderIdType,
+      cachedTokens: usage.cachedTokens,
+      cacheCreationTokens: usage.cacheCreationTokens,
+      costMicroUsd: usage.costMicroUsd,
+      isBatch: usage.isBatch,
+      usageType: usage.usageType,
+      usageState: usage.usageState,
+    }));
   }
 }
 

--- a/front/lib/resources/storage/models/runs.ts
+++ b/front/lib/resources/storage/models/runs.ts
@@ -1,9 +1,12 @@
 import type { UsageType } from "@app/lib/metronome/types";
+import type { Region } from "@app/lib/model_constructors/types/regions";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { AppModel } from "@app/lib/resources/storage/models/apps";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+
+export type RunUsageState = "pending" | "reported" | "unavailable";
 
 export class RunModel extends WorkspaceAwareModel<RunModel> {
   declare createdAt: CreationOptional<Date>;
@@ -74,8 +77,15 @@ RunModel.belongsTo(AppModel, {
 export class RunUsageModel extends WorkspaceAwareModel<RunUsageModel> {
   declare runId: ForeignKey<RunModel["id"]>;
 
-  declare providerId: string; //ModelProviderIdType;
-  declare modelId: string; //ModelIdType;
+  // Historical identifiers: values remain valid after a provider or model is removed from the
+  // active application unions.
+  declare providerId: string;
+  // Serving host used for the inference (for example "agent-platform"), as distinct from
+  // providerId, which identifies the model/pricing provider.
+  declare inferenceProvider: string | null;
+  // Physical endpoint region used for the inference and provider billing.
+  declare region: Region | null;
+  declare modelId: string;
 
   declare promptTokens: number;
   declare completionTokens: number;
@@ -86,6 +96,7 @@ export class RunUsageModel extends WorkspaceAwareModel<RunUsageModel> {
 
   declare costMicroUsd: number;
   declare isBatch: boolean;
+
   // Billing usage type (free / user / programmatic). Internal/utility LLM
   // operations are tagged free at creation (they are never billed); agent
   // conversation runs are tagged by the usage queue from the triggering
@@ -93,6 +104,9 @@ export class RunUsageModel extends WorkspaceAwareModel<RunUsageModel> {
   // briefly null between creation and the usage queue, and legacy/app runs are
   // never tagged.
   declare usageType: UsageType | null;
+  // Pending and unavailable rows represent provider attempts for which usage has not been
+  // reported. Null is accepted during the rolling deployment.
+  declare usageState: RunUsageState | null;
 }
 
 RunUsageModel.init(
@@ -100,6 +114,16 @@ RunUsageModel.init(
     providerId: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    inferenceProvider: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
+    },
+    region: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
     },
     modelId: {
       type: DataTypes.STRING,
@@ -142,6 +166,11 @@ RunUsageModel.init(
       type: DataTypes.STRING,
       allowNull: true,
       defaultValue: null,
+    },
+    usageState: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: "reported",
     },
   },
   {

--- a/front/migrations/pre-deploy/20260812095255_add_llm_run_usage_lifecycle.sql
+++ b/front/migrations/pre-deploy/20260812095255_add_llm_run_usage_lifecycle.sql
@@ -1,0 +1,20 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."run_usages" ADD COLUMN "usageState" character varying(255) COLLATE "pg_catalog"."default" DEFAULT 'reported'::character varying;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."run_usages" ADD COLUMN "inferenceProvider" character varying(255) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying;
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."run_usages" ADD COLUMN "region" character varying(255) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We are currently falling short on capturing all LLMs calls. This PR makes sure every non-batch LLM call is recorded, including calls that fail before returning usage or are cancelled while streaming.

A pending usage record is created before contacting the provider, then completed when token usage is received. If no
usage is reported, it is marked unavailable instead of silently disappearing. The record also stores the actual
inference provider and endpoint region, which are needed to reconcile our data with provider bills.

Batch calls are intentionally left unchanged and unresolved usage records remain excluded from billing totals. A follow up PR will come.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

 - [ ] Apply SQL migration
 - [ ] Deploy front