### PR TITLE
[front] Make analytics consumption header and filters sticky

### DIFF
--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -91,7 +91,7 @@ export function AnalyticsConsumptionPage() {
         />
         <LazyMotion features={domMax}>
           <div className="flex flex-col gap-4">
-            <div className="flex flex-col">
+            <div className="sticky top-0 z-10 flex flex-col bg-background pb-2">
               <div className="flex items-center justify-between gap-4">
                 <h2 className="text-lg font-semibold text-foreground">
                   Explore

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -90,7 +90,7 @@ export function AnalyticsConsumptionPage() {
           filter={scopeFilter}
         />
         <div className="flex flex-col gap-4">
-          <div className="sticky top-0 z-30 flex flex-col bg-background pb-2 pt-4">
+          <div className="sticky top-0 z-30 flex flex-col bg-background pb-4 pt-4">
             <div className="flex items-center justify-between gap-4">
               <h2 className="text-lg font-semibold text-foreground">Explore</h2>
               <UsageFilterPanel

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -89,22 +89,20 @@ export function AnalyticsConsumptionPage() {
           period={period}
           filter={scopeFilter}
         />
-        <LazyMotion features={domMax}>
-          <div className="flex flex-col gap-4">
-            <div className="sticky top-0 z-10 flex flex-col bg-background pb-2">
-              <div className="flex items-center justify-between gap-4">
-                <h2 className="text-lg font-semibold text-foreground">
-                  Explore
-                </h2>
-                <UsageFilterPanel
-                  owner={owner}
-                  period={period}
-                  filter={filter}
-                  onFilterChange={setFilter}
-                />
-              </div>
-              <UsageFilterSummary filter={filter} onFilterChange={setFilter} />
+        <div className="flex flex-col gap-4">
+          <div className="sticky top-0 z-30 flex flex-col bg-background pb-2 pt-4">
+            <div className="flex items-center justify-between gap-4">
+              <h2 className="text-lg font-semibold text-foreground">Explore</h2>
+              <UsageFilterPanel
+                owner={owner}
+                period={period}
+                filter={filter}
+                onFilterChange={setFilter}
+              />
             </div>
+            <UsageFilterSummary filter={filter} onFilterChange={setFilter} />
+          </div>
+          <LazyMotion features={domMax}>
             <m.div
               layout={!shouldReduceMotion}
               transition={{ duration: shouldReduceMotion ? 0 : 0.18 }}
@@ -122,19 +120,19 @@ export function AnalyticsConsumptionPage() {
                 />
               </SafeSuspense>
             </m.div>
+          </LazyMotion>
+          <div className="flex flex-col gap-4">
+            <h3 className="text-base font-semibold text-foreground">
+              Attribution
+            </h3>
+            <ConsumptionAttributionTable
+              workspaceId={owner.sId}
+              period={period}
+              filter={scopeFilter}
+              dimension={dimension}
+              onDimensionChange={handleDimensionChange}
+            />
           </div>
-        </LazyMotion>
-        <div className="flex flex-col gap-4">
-          <h3 className="text-base font-semibold text-foreground">
-            Attribution
-          </h3>
-          <ConsumptionAttributionTable
-            workspaceId={owner.sId}
-            period={period}
-            filter={scopeFilter}
-            dimension={dimension}
-            onDimensionChange={handleDimensionChange}
-          />
         </div>
       </div>
     </Page.Vertical>


### PR DESCRIPTION
## Description

The analytics consumption page now keeps the **Explore** heading, filter button, and active filter summary visible while the overview, chart, and attribution table scroll underneath.

This PR wraps the header and filter summary in a sticky container with an opaque background and appropriate stacking order, while keeping the existing filter behavior, animated overview content, and attribution table unchanged.

**Visual:**
![Analytics consumption sticky header](https://github.com/user-attachments/assets/22e9a400-fdd5-4f05-b29d-1c1ef1a430ab)

## Tests

Local UI test

## Risk

Low-risk, UI-only layout change. 

## Deploy Plan

- Deploy front